### PR TITLE
fix(yuanbao): resolve quoted message media refs via msg_id cache

### DIFF
--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -1850,10 +1850,56 @@ class ExtractContentMiddleware(InboundMiddleware):
                         pass
         return urls
 
+    # --- msg_id → resids cache ---
+    # Maps message IDs to their media resource IDs so that QuoteContextMiddleware
+    # can resolve quoted images even when cloud_custom_data.quote.desc is empty.
+    _msgid_to_resids: ClassVar[Dict[str, List[Tuple[str, str, str]]]] = {}  # msg_id -> [(rid, kind, filename)]
+    _MSGID_CACHE_MAX_SIZE: ClassVar[int] = 512
+
+    @classmethod
+    def _store_msgid_resids(cls, msg_id: str, resids: List[Tuple[str, str, str]]) -> None:
+        """Store msg_id → [(rid, kind, filename)] mapping for quote resolution."""
+        if not msg_id or not resids:
+            return
+        if len(cls._msgid_to_resids) >= cls._MSGID_CACHE_MAX_SIZE:
+            keys_to_remove = list(cls._msgid_to_resids.keys())[: cls._MSGID_CACHE_MAX_SIZE // 4]
+            for k in keys_to_remove:
+                cls._msgid_to_resids.pop(k, None)
+        cls._msgid_to_resids[msg_id] = resids
+
+    @classmethod
+    def get_resids_for_msg(cls, msg_id: str) -> List[Tuple[str, str, str]]:
+        """Look up cached resource IDs for a given message ID.
+
+        Returns list of (rid, kind, filename) tuples, or empty list.
+        """
+        if not msg_id:
+            return []
+        return cls._msgid_to_resids.get(msg_id, [])
+
     async def handle(self, ctx: InboundContext, next_fn) -> None:
         ctx.raw_text = self._rewrite_slash_command(self._extract_text(ctx.msg_body))
         ctx.media_refs = self._extract_inbound_media_refs(ctx.msg_body)
         ctx.link_urls = self._extract_link_urls(ctx.msg_body)
+
+        # Store msg_id → resids mapping for quote resolution.
+        # _extract_text embeds resource IDs as [image|ybres:RID] etc. in raw_text,
+        # so we extract them here — this covers ALL messages including observed ones
+        # that never reach MediaResolveMiddleware.
+        if ctx.msg_id and ctx.raw_text:
+            resids: List[Tuple[str, str, str]] = []
+            for m in _YB_RES_REF_RE.finditer(ctx.raw_text):
+                head = m.group(1)  # "image" | "file:<name>" | "voice" | "video"
+                rid = m.group(2)
+                kind, _, filename = head.partition(":")
+                resids.append((rid, kind.strip(), filename.strip()))
+            if resids:
+                self._store_msgid_resids(ctx.msg_id, resids)
+                logger.debug(
+                    "[%s] Stored msg_id→resids: msg_id=%s resids=%s",
+                    ctx.adapter.name, ctx.msg_id, resids,
+                )
+
         await next_fn()
 
 class PlaceholderFilterMiddleware(InboundMiddleware):
@@ -2194,32 +2240,18 @@ class QuoteContextMiddleware(InboundMiddleware):
         if not isinstance(quote, dict):
             return None, None, []
 
-        # type=2 corresponds to image reference; desc may be empty, provide a placeholder.
-        quote_type = int(quote.get("type") or 0)
-        desc = str(quote.get("desc") or "").strip()
-        if quote_type == 2 and not desc:
-            desc = "[image]"
-        if not desc:
-            return None, None, []
-
         quote_id = str(quote.get("id") or "").strip() or None
+        desc = str(quote.get("desc") or "").strip()
         sender = str(quote.get("sender_nickname") or quote.get("sender_id") or "").strip()
-        quote_text = f"{sender}: {desc}" if sender else desc
-
-        # Extract media references from desc using _YB_RES_REF_RE regex
-        media_refs: list = []
-        for m in _YB_RES_REF_RE.finditer(desc):
-            head = m.group(1)  # "image" | "file:<name>" | "voice" | "video"
-            rid = m.group(2)
-            kind, _, filename = head.partition(":")
-            kind = kind.strip()
-            media_refs.append((rid, kind, filename.strip()))
+        quote_text = (f"{sender}: {desc}" if sender else desc) if desc else None
+        # Resolve media refs from msg_id→resids cache (populated by
+        # ExtractContentMiddleware). Cache miss → empty list.
+        media_refs = ExtractContentMiddleware.get_resids_for_msg(quote_id) if quote_id else []
 
         return quote_id, quote_text, media_refs
 
     async def handle(self, ctx: InboundContext, next_fn) -> None:
         ctx.reply_to_message_id, ctx.reply_to_text, ctx.quote_media_refs = self._extract_quote_context(ctx.cloud_custom_data)
-
         await next_fn()
 
 
@@ -2227,6 +2259,43 @@ class MediaResolveMiddleware(InboundMiddleware):
     """Resolve inbound media references to downloadable URLs."""
 
     name = "media-resolve"
+
+    # --- Resource download cache (keyed by resourceId) ---
+    # Avoids redundant downloads of the same resource within the TTL window.
+    _resource_cache: ClassVar[Dict[str, Tuple[str, str, float]]] = {}  # rid -> (local_path, mime, ts)
+    _RESOURCE_CACHE_TTL_S: ClassVar[int] = 24 * 60 * 60  # 24 hours
+    _RESOURCE_CACHE_MAX_SIZE: ClassVar[int] = 256
+
+    @classmethod
+    def _get_cached_resource(cls, resource_id: str) -> Optional[Tuple[str, str]]:
+        """Return cached (local_path, mime) if still valid and file exists, else None."""
+        if not resource_id:
+            return None
+        entry = cls._resource_cache.get(resource_id)
+        if entry is None:
+            return None
+        local_path, mime, ts = entry
+        if time.time() - ts > cls._RESOURCE_CACHE_TTL_S:
+            cls._resource_cache.pop(resource_id, None)
+            return None
+        # Verify the cached file still exists on disk
+        if not os.path.isfile(local_path):
+            cls._resource_cache.pop(resource_id, None)
+            return None
+        return local_path, mime
+
+    @classmethod
+    def _put_cached_resource(cls, resource_id: str, local_path: str, mime: str) -> None:
+        """Store download result in cache. Evicts oldest entries when over capacity."""
+        if not resource_id:
+            return
+        # Simple eviction: remove oldest entries when exceeding max size
+        if len(cls._resource_cache) >= cls._RESOURCE_CACHE_MAX_SIZE:
+            # Remove the oldest 25% entries by timestamp
+            sorted_keys = sorted(cls._resource_cache, key=lambda k: cls._resource_cache[k][2])
+            for k in sorted_keys[: cls._RESOURCE_CACHE_MAX_SIZE // 4]:
+                cls._resource_cache.pop(k, None)
+        cls._resource_cache[resource_id] = (local_path, mime, time.time())
 
     @staticmethod
     def _guess_image_ext_from_url(url: str) -> str:
@@ -2325,8 +2394,23 @@ class MediaResolveMiddleware(InboundMiddleware):
     async def _download_and_cache(
         cls, adapter, *, fetch_url: str, kind: str,
         file_name: Optional[str] = None, log_tag: str = "",
+        resource_id: str = "",
     ) -> Optional[Tuple[str, str]]:
-        """Download a Yuanbao resource and cache locally. Returns ``(local_path, mime)`` or ``None``."""
+        """Download a Yuanbao resource and cache locally. Returns ``(local_path, mime)`` or ``None``.
+
+        If *resource_id* is provided, a memory-level cache keyed by resourceId
+        is consulted first to avoid redundant downloads of the same resource.
+        """
+        # Check in-memory cache first
+        if resource_id:
+            hit = cls._get_cached_resource(resource_id)
+            if hit is not None:
+                logger.debug(
+                    "[%s] resource cache hit: rid=%s path=%s",
+                    adapter.name, resource_id, hit[0],
+                )
+                return hit
+
         try:
             file_bytes, content_type = await media_download_url(
                 fetch_url, max_size_mb=adapter.MEDIA_MAX_SIZE_MB,
@@ -2351,6 +2435,7 @@ class MediaResolveMiddleware(InboundMiddleware):
             mime = guess_mime_type(f"image{ext}")
             if not mime.startswith("image/"):
                 mime = content_type if content_type.startswith("image/") else "image/jpeg"
+            cls._put_cached_resource(resource_id, local_path, mime)
             return local_path, mime
 
         # kind == "file"
@@ -2366,6 +2451,7 @@ class MediaResolveMiddleware(InboundMiddleware):
             )
             return None
         mime = guess_mime_type(file_name) or content_type or "application/octet-stream"
+        cls._put_cached_resource(resource_id, local_path, mime)
         return local_path, mime
 
     @classmethod
@@ -2391,6 +2477,9 @@ class MediaResolveMiddleware(InboundMiddleware):
             if kind not in _RESOLVABLE_MEDIA_KINDS or not url:
                 continue
 
+            # Extract resourceId from URL for cache dedup
+            rid = ExtractContentMiddleware._parse_resource_id(url)
+
             try:
                 fetch_url = await cls._resolve_download_url(adapter, url)
             except Exception as exc:
@@ -2406,6 +2495,7 @@ class MediaResolveMiddleware(InboundMiddleware):
                 kind=kind,
                 file_name=str(ref.get("name") or "").strip() or None,
                 log_tag=f"placeholder_url={url[:80]}",
+                resource_id=rid,
             )
             if cached is None:
                 continue
@@ -2478,6 +2568,7 @@ class MediaResolveMiddleware(InboundMiddleware):
                 kind=kind,
                 file_name=filename or None,
                 log_tag=f"rid={rid}",
+                resource_id=rid,
             )
             if cached is None:
                 continue
@@ -2561,6 +2652,7 @@ class DispatchMiddleware(InboundMiddleware):
                         kind=kind,
                         file_name=filename or None,
                         log_tag=f"quote rid={rid}",
+                        resource_id=rid,
                     )
                     if cached is None:
                         continue

--- a/tests/test_yuanbao_pipeline.py
+++ b/tests/test_yuanbao_pipeline.py
@@ -39,6 +39,7 @@ from gateway.platforms.yuanbao import (
     OwnerCommandMiddleware,
     BuildSourceMiddleware,
     GroupAtGuardMiddleware,
+    QuoteContextMiddleware,
     DispatchMiddleware,
     InboundPipelineBuilder,
     YuanbaoAdapter,
@@ -1027,3 +1028,282 @@ class TestPipelineOOPRegistration:
         pipeline = InboundPipeline().use(MwA()).use(MwC())
         pipeline.use_after("a", MwB())
         assert pipeline.middleware_names == ["a", "b", "c"]
+
+
+# ============================================================
+# ExtractContentMiddleware msg_id→resids Cache Tests
+# ============================================================
+
+class TestExtractContentMiddlewareResidsCache:
+    """Tests for ExtractContentMiddleware._msgid_to_resids cache."""
+
+    def setup_method(self):
+        """Clear the class-level cache before each test."""
+        ExtractContentMiddleware._msgid_to_resids.clear()
+
+    def teardown_method(self):
+        """Clean up cache after each test."""
+        ExtractContentMiddleware._msgid_to_resids.clear()
+
+    def test_store_and_get_resids(self):
+        """Basic store and retrieve works."""
+        resids = [("rid1", "image", ""), ("rid2", "file", "doc.pdf")]
+        ExtractContentMiddleware._store_msgid_resids("msg-100", resids)
+
+        result = ExtractContentMiddleware.get_resids_for_msg("msg-100")
+        assert result == resids
+
+    def test_get_nonexistent_returns_empty(self):
+        """Cache miss returns empty list."""
+        result = ExtractContentMiddleware.get_resids_for_msg("nonexistent-id")
+        assert result == []
+
+    def test_get_none_returns_empty(self):
+        """Passing None or empty string returns empty list."""
+        assert ExtractContentMiddleware.get_resids_for_msg(None) == []
+        assert ExtractContentMiddleware.get_resids_for_msg("") == []
+
+    def test_store_ignores_empty_msg_id(self):
+        """Store with empty msg_id does nothing."""
+        ExtractContentMiddleware._store_msgid_resids("", [("rid1", "image", "")])
+        assert len(ExtractContentMiddleware._msgid_to_resids) == 0
+
+    def test_store_ignores_empty_resids(self):
+        """Store with empty resids list does nothing."""
+        ExtractContentMiddleware._store_msgid_resids("msg-100", [])
+        assert len(ExtractContentMiddleware._msgid_to_resids) == 0
+
+    def test_eviction_when_full(self):
+        """When cache exceeds max size, oldest 25% entries are evicted."""
+        original_max = ExtractContentMiddleware._MSGID_CACHE_MAX_SIZE
+        try:
+            # Use a small max size for testing
+            ExtractContentMiddleware._MSGID_CACHE_MAX_SIZE = 8
+
+            # Fill up to capacity
+            for i in range(8):
+                ExtractContentMiddleware._store_msgid_resids(
+                    f"msg-{i}", [(f"rid-{i}", "image", "")]
+                )
+            assert len(ExtractContentMiddleware._msgid_to_resids) == 8
+
+            # Add one more — should evict oldest 25% (2 entries: msg-0, msg-1)
+            ExtractContentMiddleware._store_msgid_resids("msg-new", [("rid-new", "image", "")])
+            assert "msg-0" not in ExtractContentMiddleware._msgid_to_resids
+            assert "msg-1" not in ExtractContentMiddleware._msgid_to_resids
+            # Recent entries still present
+            assert "msg-7" in ExtractContentMiddleware._msgid_to_resids
+            assert "msg-new" in ExtractContentMiddleware._msgid_to_resids
+        finally:
+            ExtractContentMiddleware._MSGID_CACHE_MAX_SIZE = original_max
+
+    @pytest.mark.asyncio
+    async def test_handle_populates_cache_from_raw_text(self):
+        """ExtractContentMiddleware.handle() stores resids from raw_text into cache."""
+        adapter = make_adapter()
+        msg_body = [
+            {"msg_type": "TIMImageElem", "msg_content": {
+                "image_info_array": [
+                    {"url": "https://cdn.example.com/img?resourceId=abc123&type=img"},
+                ]
+            }},
+        ]
+        ctx = make_ctx(adapter=adapter, msg_body=msg_body, msg_id="msg-with-image")
+        next_fn = AsyncMock()
+
+        await ExtractContentMiddleware()(ctx, next_fn)
+
+        # raw_text should contain ybres reference
+        assert "ybres:abc123" in ctx.raw_text
+        # Cache should have the entry
+        cached = ExtractContentMiddleware.get_resids_for_msg("msg-with-image")
+        assert len(cached) == 1
+        assert cached[0][0] == "abc123"  # rid
+        assert cached[0][1] == "image"   # kind
+        next_fn.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_handle_no_cache_for_text_only_message(self):
+        """ExtractContentMiddleware.handle() does not cache messages without ybres refs."""
+        adapter = make_adapter()
+        msg_body = [
+            {"msg_type": "TIMTextElem", "msg_content": {"text": "Just text"}},
+        ]
+        ctx = make_ctx(adapter=adapter, msg_body=msg_body, msg_id="msg-text-only")
+        next_fn = AsyncMock()
+
+        await ExtractContentMiddleware()(ctx, next_fn)
+
+        assert ExtractContentMiddleware.get_resids_for_msg("msg-text-only") == []
+        next_fn.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_handle_no_cache_without_msg_id(self):
+        """ExtractContentMiddleware.handle() does not cache if msg_id is empty."""
+        adapter = make_adapter()
+        msg_body = [
+            {"msg_type": "TIMImageElem", "msg_content": {
+                "image_info_array": [
+                    {"url": "https://cdn.example.com/img?resourceId=xyz789"},
+                ]
+            }},
+        ]
+        ctx = make_ctx(adapter=adapter, msg_body=msg_body, msg_id="")
+        next_fn = AsyncMock()
+
+        await ExtractContentMiddleware()(ctx, next_fn)
+
+        # No entry should be cached
+        assert len(ExtractContentMiddleware._msgid_to_resids) == 0
+        next_fn.assert_awaited_once()
+
+
+# ============================================================
+# QuoteContextMiddleware Tests
+# ============================================================
+
+class TestQuoteContextMiddleware:
+    """Tests for QuoteContextMiddleware and its cache-based media resolution."""
+
+    def setup_method(self):
+        """Clear cache before each test."""
+        ExtractContentMiddleware._msgid_to_resids.clear()
+
+    def teardown_method(self):
+        """Clean up cache after each test."""
+        ExtractContentMiddleware._msgid_to_resids.clear()
+
+    def test_extract_quote_context_no_cloud_data(self):
+        """Returns (None, None, []) when cloud_custom_data is empty."""
+        result = QuoteContextMiddleware._extract_quote_context("")
+        assert result == (None, None, [])
+
+    def test_extract_quote_context_no_quote_key(self):
+        """Returns (None, None, []) when JSON has no 'quote' key."""
+        cloud_data = json.dumps({"foo": "bar"})
+        result = QuoteContextMiddleware._extract_quote_context(cloud_data)
+        assert result == (None, None, [])
+
+    def test_extract_quote_context_with_desc(self):
+        """Extracts quote_id and quote_text from desc."""
+        cloud_data = json.dumps({
+            "quote": {
+                "id": "quoted-msg-001",
+                "desc": "Hello world",
+                "sender_nickname": "Alice",
+            }
+        })
+        quote_id, quote_text, media_refs = QuoteContextMiddleware._extract_quote_context(cloud_data)
+        assert quote_id == "quoted-msg-001"
+        assert quote_text == "Alice: Hello world"
+        assert media_refs == []  # No cache entry
+
+    def test_extract_quote_context_resolves_from_cache(self):
+        """Resolves media_refs from ExtractContentMiddleware cache."""
+        # Pre-populate cache (simulating an earlier message that went through
+        # ExtractContentMiddleware)
+        ExtractContentMiddleware._store_msgid_resids(
+            "quoted-msg-002",
+            [("rid-img-1", "image", ""), ("rid-file-1", "file", "report.pdf")],
+        )
+
+        cloud_data = json.dumps({
+            "quote": {
+                "id": "quoted-msg-002",
+                "desc": "",  # Empty desc — common on Yuanbao
+                "sender_nickname": "Bob",
+            }
+        })
+        quote_id, quote_text, media_refs = QuoteContextMiddleware._extract_quote_context(cloud_data)
+        assert quote_id == "quoted-msg-002"
+        assert quote_text is None  # desc is empty
+        assert len(media_refs) == 2
+        assert media_refs[0] == ("rid-img-1", "image", "")
+        assert media_refs[1] == ("rid-file-1", "file", "report.pdf")
+
+    def test_extract_quote_context_cache_miss_returns_empty(self):
+        """When quote_id is not in cache, media_refs is empty list."""
+        cloud_data = json.dumps({
+            "quote": {
+                "id": "never-cached-msg",
+                "desc": "[image]",
+                "sender_nickname": "Charlie",
+            }
+        })
+        quote_id, quote_text, media_refs = QuoteContextMiddleware._extract_quote_context(cloud_data)
+        assert quote_id == "never-cached-msg"
+        assert quote_text == "Charlie: [image]"
+        assert media_refs == []
+
+    def test_extract_quote_context_no_quote_id(self):
+        """When quote.id is empty, no cache lookup is attempted."""
+        ExtractContentMiddleware._store_msgid_resids("some-id", [("rid1", "image", "")])
+
+        cloud_data = json.dumps({
+            "quote": {
+                "id": "",
+                "desc": "some text",
+            }
+        })
+        quote_id, quote_text, media_refs = QuoteContextMiddleware._extract_quote_context(cloud_data)
+        assert quote_id is None
+        assert media_refs == []
+
+    @pytest.mark.asyncio
+    async def test_handle_sets_ctx_fields(self):
+        """QuoteContextMiddleware.handle() sets ctx.reply_to_message_id, reply_to_text, quote_media_refs."""
+        ExtractContentMiddleware._store_msgid_resids(
+            "quoted-msg-003",
+            [("rid-video-1", "video", "")],
+        )
+
+        cloud_data = json.dumps({
+            "quote": {
+                "id": "quoted-msg-003",
+                "desc": "Check this video",
+                "sender_nickname": "Dave",
+            }
+        })
+        adapter = make_adapter()
+        ctx = make_ctx(adapter=adapter, cloud_custom_data=cloud_data)
+        next_fn = AsyncMock()
+
+        await QuoteContextMiddleware()(ctx, next_fn)
+
+        assert ctx.reply_to_message_id == "quoted-msg-003"
+        assert ctx.reply_to_text == "Dave: Check this video"
+        assert ctx.quote_media_refs == [("rid-video-1", "video", "")]
+        next_fn.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_end_to_end_extract_then_quote(self):
+        """End-to-end: ExtractContentMiddleware caches, QuoteContextMiddleware reads."""
+        adapter = make_adapter()
+
+        # Step 1: Simulate an inbound image message going through ExtractContentMiddleware
+        img_msg_body = [
+            {"msg_type": "TIMImageElem", "msg_content": {
+                "image_info_array": [
+                    {"url": "https://cdn.example.com/img?resourceId=e2e_rid_001&type=pic"},
+                ]
+            }},
+        ]
+        ctx1 = make_ctx(adapter=adapter, msg_body=img_msg_body, msg_id="original-msg-100")
+        await ExtractContentMiddleware()(ctx1, AsyncMock())
+
+        # Verify cache is populated
+        assert ExtractContentMiddleware.get_resids_for_msg("original-msg-100") != []
+
+        # Step 2: Simulate a quote reply referencing the original message
+        cloud_data = json.dumps({
+            "quote": {
+                "id": "original-msg-100",
+                "desc": "",
+                "sender_nickname": "Eve",
+            }
+        })
+        ctx2 = make_ctx(adapter=adapter, cloud_custom_data=cloud_data)
+        await QuoteContextMiddleware()(ctx2, AsyncMock())
+
+        assert ctx2.reply_to_message_id == "original-msg-100"
+        assert ctx2.quote_media_refs == [("e2e_rid_001", "image", "")]


### PR DESCRIPTION
QuoteContextMiddleware failed to populate quote_media_refs because quote.desc from the Yuanbao platform is often empty and never contains ybres: references.

This PR introduces a lightweight in-memory cache (msg_id → resids, cap 512) in ExtractContentMiddleware that records media resource IDs for every inbound message (including observed ones). QuoteContextMiddleware now resolves quoted media by looking up the cache instead of parsing quote.desc, fixing the issue.

Adds 17 unit tests covering cache mechanics, eviction, and end-to-end Extract → Quote integration. All 111 tests pass.