### PR TITLE
fix(tools): defense-in-depth fix for acp_command misuse crashing the gateway

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -485,6 +485,91 @@ class TestToolNamePreservation(unittest.TestCase):
                     f"_saved_tool_names leaked back into wrong scope: {exc}"
                 )
 
+    def test_build_child_agent_ignores_acp_command_when_binary_missing(self):
+        """Regression: _build_child_agent must not force provider='copilot-acp'
+        when the override_acp_command binary is not on PATH.
+
+        Without this guard, a model that hallucinates
+        ``delegate_task(acp_command="copilot")`` on a host without the Copilot
+        CLI installed (Railway / headless containers / fresh VPS) would route
+        the subagent through CopilotACPClient, which spawns the binary via
+        subprocess and raises RuntimeError. After 3 retries the asyncio loop
+        teardown can take the entire gateway down.
+        """
+        parent = _make_mock_parent(depth=0)
+        # The crash scenario is a TG/cron agent on a host with no ACP CLI —
+        # parent itself has no acp_command, so clearing the override must NOT
+        # fall through to a stray parent value.
+        parent.acp_command = None
+        parent.acp_args = []
+        captured = {}
+
+        with patch("run_agent.AIAgent") as MockAgent, \
+             patch("shutil.which", return_value=None) as mock_which:
+            mock_child = MagicMock()
+            MockAgent.return_value = mock_child
+
+            _build_child_agent(
+                task_index=0,
+                goal="search X for crypto twitter",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+                override_acp_command="copilot",
+                override_acp_args=["--foo"],
+            )
+
+            _, kwargs = MockAgent.call_args
+            captured["provider"] = kwargs.get("provider")
+            captured["acp_command"] = kwargs.get("acp_command")
+            captured["acp_args"] = kwargs.get("acp_args")
+
+        mock_which.assert_called_with("copilot")
+        self.assertNotEqual(
+            captured["provider"],
+            "copilot-acp",
+            "missing acp_command binary must NOT force copilot-acp provider",
+        )
+        self.assertIsNone(captured["acp_command"])
+        self.assertEqual(captured["acp_args"], [])
+
+    def test_build_child_agent_honors_acp_command_when_binary_present(self):
+        """When the acp_command binary exists on PATH, behavior is unchanged:
+        provider is forced to copilot-acp and command/args propagate to the
+        child agent. Guards against the missing-binary check accidentally
+        breaking working ACP delegation setups.
+        """
+        parent = _make_mock_parent(depth=0)
+        captured = {}
+
+        with patch("run_agent.AIAgent") as MockAgent, \
+             patch("shutil.which", return_value="/usr/local/bin/copilot"):
+            mock_child = MagicMock()
+            MockAgent.return_value = mock_child
+
+            _build_child_agent(
+                task_index=0,
+                goal="copilot path",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+                override_acp_command="copilot",
+                override_acp_args=["--foo"],
+            )
+
+            _, kwargs = MockAgent.call_args
+            captured["provider"] = kwargs.get("provider")
+            captured["acp_command"] = kwargs.get("acp_command")
+
+        self.assertEqual(captured["provider"], "copilot-acp")
+        self.assertEqual(captured["acp_command"], "copilot")
+
     def test_saved_tool_names_set_on_child_before_run(self):
         """_run_single_child must set _delegate_saved_tool_names on the child
         from model_tools._last_resolved_tool_names before run_conversation."""

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -570,6 +570,69 @@ class TestToolNamePreservation(unittest.TestCase):
         self.assertEqual(captured["provider"], "copilot-acp")
         self.assertEqual(captured["acp_command"], "copilot")
 
+    def test_schema_prunes_acp_command_when_no_acp_binary(self):
+        """Schema-level defense: delegate_task tool schema must NOT advertise
+        acp_command / acp_args to the model when no ACP binary is installed.
+
+        Headless deploys (Railway / Fly / Docker / fresh VPS) typically have
+        none of copilot / claude / codex. Without the schema prune, models
+        occasionally hallucinate ``acp_command="copilot"`` from the field's
+        description and crash subagent runs.
+        """
+        from tools.delegate_tool import _build_dynamic_schema_overrides
+
+        with patch("tools.delegate_tool._acp_binary_available", return_value=False):
+            overrides = _build_dynamic_schema_overrides()
+
+        props = overrides["parameters"]["properties"]
+        self.assertNotIn("acp_command", props, "top-level acp_command must be pruned")
+        self.assertNotIn("acp_args", props, "top-level acp_args must be pruned")
+
+        task_item_props = props["tasks"]["items"]["properties"]
+        self.assertNotIn(
+            "acp_command", task_item_props, "per-task acp_command must be pruned"
+        )
+        self.assertNotIn(
+            "acp_args", task_item_props, "per-task acp_args must be pruned"
+        )
+
+    def test_schema_keeps_acp_command_when_binary_available(self):
+        """Backward compat: when an ACP CLI IS on PATH, schema is unchanged.
+        Users with working ACP setups must still be able to invoke it.
+        """
+        from tools.delegate_tool import _build_dynamic_schema_overrides
+
+        with patch("tools.delegate_tool._acp_binary_available", return_value=True):
+            overrides = _build_dynamic_schema_overrides()
+
+        props = overrides["parameters"]["properties"]
+        self.assertIn("acp_command", props)
+        self.assertIn("acp_args", props)
+
+        task_item_props = props["tasks"]["items"]["properties"]
+        self.assertIn("acp_command", task_item_props)
+        self.assertIn("acp_args", task_item_props)
+
+    def test_acp_binary_available_checks_known_clis(self):
+        """_acp_binary_available must check the known ACP CLI names via
+        shutil.which — guards against typos or accidental list trimming.
+        """
+        from tools.delegate_tool import _KNOWN_ACP_BINARIES, _acp_binary_available
+
+        self.assertIn("copilot", _KNOWN_ACP_BINARIES)
+
+        calls = []
+
+        def fake_which(name):
+            calls.append(name)
+            return None
+
+        with patch("shutil.which", side_effect=fake_which):
+            self.assertFalse(_acp_binary_available())
+
+        for name in _KNOWN_ACP_BINARIES:
+            self.assertIn(name, calls)
+
     def test_saved_tool_names_set_on_child_before_run(self):
         """_run_single_child must set _delegate_saved_tool_names on the child
         from model_tools._last_resolved_tool_names before run_conversation."""

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1029,6 +1029,22 @@ def _build_child_agent(
         effective_api_mode = None  # force re-derivation from provider's defaults
     else:
         effective_api_mode = getattr(parent_agent, "api_mode", None)
+    # Defensive: validate override_acp_command exists on PATH before honoring
+    # it. Models occasionally pass acp_command="copilot" / "claude" / etc. in
+    # delegate_task tool calls despite the schema saying not to, which forces
+    # the subagent onto the copilot-acp transport below and crashes the
+    # gateway when the binary is missing (e.g. headless container deploys).
+    if override_acp_command:
+        import shutil as _shutil
+
+        if not _shutil.which(override_acp_command):
+            logger.warning(
+                "Ignoring acp_command=%r: binary not found on PATH; "
+                "falling back to default transport.",
+                override_acp_command,
+            )
+            override_acp_command = None
+            override_acp_args = None
     effective_acp_command = override_acp_command or getattr(
         parent_agent, "acp_command", None
     )

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2646,6 +2646,30 @@ def _build_role_param_description() -> str:
     )
 
 
+# Known ACP-compatible CLIs that delegate_task can shell out to. Kept
+# narrow on purpose: only the ones agent/copilot_acp_client.py and friends
+# actually understand. Add new entries here when a new ACP CLI ships.
+_KNOWN_ACP_BINARIES: tuple[str, ...] = ("copilot", "claude", "codex")
+
+
+def _acp_binary_available() -> bool:
+    """True iff at least one known ACP CLI is on PATH.
+
+    Used to gate inclusion of ``acp_command`` / ``acp_args`` in the
+    delegate_task schema. On headless hosts (Railway / Fly / Docker /
+    fresh VPS) without any of these binaries, exposing the fields invites
+    the model to hallucinate ``acp_command="copilot"`` from the schema's
+    description, which used to crash subagent runs and take the gateway
+    down. Pruning the fields from the schema removes the temptation.
+
+    Not cached: ``shutil.which`` is cheap and we want the schema to react
+    to mid-session installs without forcing a process restart.
+    """
+    import shutil as _shutil
+
+    return any(_shutil.which(name) for name in _KNOWN_ACP_BINARIES)
+
+
 def _build_dynamic_schema_overrides() -> dict:
     """Return per-call schema overrides reflecting current config.
 
@@ -2662,6 +2686,25 @@ def _build_dynamic_schema_overrides() -> dict:
     }
     overrides_params["properties"]["tasks"]["description"] = _build_tasks_param_description()
     overrides_params["properties"]["role"]["description"] = _build_role_param_description()
+
+    # Prune ACP overrides from the schema when no known ACP CLI is on PATH.
+    # The runtime guard in _build_child_agent remains as defense-in-depth for
+    # internal callers / tests / future code paths that skip the schema layer.
+    if not _acp_binary_available():
+        overrides_params["properties"].pop("acp_command", None)
+        overrides_params["properties"].pop("acp_args", None)
+        tasks_schema = dict(overrides_params["properties"].get("tasks", {}))
+        if "items" in tasks_schema:
+            items = dict(tasks_schema["items"])
+            if "properties" in items:
+                items["properties"] = {
+                    k: v
+                    for k, v in items["properties"].items()
+                    if k not in ("acp_command", "acp_args")
+                }
+            tasks_schema["items"] = items
+            overrides_params["properties"]["tasks"] = tasks_schema
+
     return {
         "description": _build_top_level_description(),
         "parameters": overrides_params,


### PR DESCRIPTION
## TL;DR

Two-layer defense against a real crash mode: models hallucinating `acp_command="copilot"` in `delegate_task` calls on hosts without an ACP CLI, which forces the subagent onto the `copilot-acp` transport and crashes the gateway when the binary isn't found.

- **Layer 1 (schema):** prune `acp_command` / `acp_args` from the tool schema entirely when no ACP binary is on PATH — the model can't hallucinate fields it never sees
- **Layer 2 (runtime):** `shutil.which()` guard in `_build_child_agent` as defense-in-depth for internal callers, tests, and future code paths

## The crash

On a headless deploy (Railway / Fly / Docker / fresh VPS) with no ACP CLI installed:

1. User asks the bot (via Telegram, Discord, etc.) to do something — e.g. *"Search X for crypto twitter trends"*
2. Model decides to delegate and passes `acp_command="copilot"` in the `delegate_task` tool call (yes, despite the schema saying *"Do NOT set unless..."*)
3. `_build_child_agent` unconditionally sets `effective_provider = "copilot-acp"` (line 1052 before this patch)
4. `CopilotACPClient` tries to spawn the `copilot` binary via subprocess → `RuntimeError("Could not start Copilot ACP command 'copilot'...")`
5. After 3 retries, the asyncio cleanup race during error delivery crashes the entire gateway with `cannot schedule new futures after interpreter shutdown`

Real log trace from a production Railway deploy:
```
2026-05-17 11:40:05 WARNING run_agent: API call failed (attempt 1/3) error_type=RuntimeError
   provider=copilot-acp base_url=https://api.x.ai/v1 model=grok-4.3
   summary=Could not start Copilot ACP command 'copilot'. Install GitHub Copilot CLI
   or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH.
[... 2 more retries ...]
2026-05-17 11:46:14 ERROR cron.scheduler: Job 'XXX': delivery error: Telegram send failed:
   Unknown error in HTTP implementation:
   RuntimeError('cannot schedule new futures after interpreter shutdown')
```

Observed with Grok-4.3 (xAI Grok OAuth provider) on the v2026.5.16 release.

## Why two layers

I started with just the runtime guard (commit 1) — small, localized, defensive. After review, that's a band-aid: the model still wastes a tool turn passing a bad arg and gets an opaque silent fallback.

The schema-level prune (commit 2) eliminates the bug at its source — the field literally doesn't appear in the tool schema when no ACP binary is on PATH, so the model can't pass it. The runtime guard stays as defense-in-depth for internal callers / tests / future code paths.

## The fix

### Layer 1: schema-time prune (`tools/delegate_tool.py`)

```python
_KNOWN_ACP_BINARIES: tuple[str, ...] = ("copilot", "claude", "codex")

def _acp_binary_available() -> bool:
    import shutil as _shutil
    return any(_shutil.which(name) for name in _KNOWN_ACP_BINARIES)

def _build_dynamic_schema_overrides() -> dict:
    # ... existing code ...
    if not _acp_binary_available():
        overrides_params["properties"].pop("acp_command", None)
        overrides_params["properties"].pop("acp_args", None)
        # ... and also from tasks.items.properties
```

Intentionally NOT cached: `shutil.which` is cheap and we want mid-session installs to take effect without a process restart.

### Layer 2: runtime guard (`tools/delegate_tool.py` — `_build_child_agent`)

```python
if override_acp_command:
    import shutil as _shutil
    if not _shutil.which(override_acp_command):
        logger.warning("Ignoring acp_command=%r: binary not found on PATH...", override_acp_command)
        override_acp_command = None
        override_acp_args = None
```

## Tests

Five new tests in `tests/tools/test_delegate.py`:

- `test_build_child_agent_ignores_acp_command_when_binary_missing` — runtime guard fallback path
- `test_build_child_agent_honors_acp_command_when_binary_present` — runtime guard backward-compat
- `test_schema_prunes_acp_command_when_no_acp_binary` — schema prune fires
- `test_schema_keeps_acp_command_when_binary_available` — schema unchanged for working setups
- `test_acp_binary_available_checks_known_clis` — guards against typos in the binary list

Full `tests/tools/test_delegate.py` suite: **136/136 pass**.

## Platforms tested

- macOS 14, Python 3.11 (local dev)
- Debian 13 (trixie) Docker container on Railway, Python 3.12 (production reproduction)

## Backwards compatibility

Zero behavior change for users with any of `copilot` / `claude` / `codex` on PATH:
- Schema still includes both `acp_command` and `acp_args`
- Runtime guard's `shutil.which()` check passes, ACP transport works as before

## Out of scope (happy to follow up)

- Adding more entries to `_KNOWN_ACP_BINARIES` as new ACP CLIs ship
- Surfacing a tool-error string back to the model when the runtime guard fires (currently silent fallback — could argue for explicit feedback to help the model self-correct)
- Adding a Sentry/metrics hook for "model attempted unusable acp_command" so operators can spot model regressions