### PR TITLE
fix(error_classifier): classify xAI Grok entitlement SSE errors as auth, not retryable

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -510,6 +510,35 @@ def classify_api_error(
             should_compress=False,
         )
 
+    # xAI Grok subscription entitlement errors.
+    #
+    # xAI returns "You have either run out of available resources or do not
+    # have an active Grok subscription" through two distinct code paths:
+    #
+    #   • HTTP 403 — status_code is set; _classify_by_status (step 2) routes
+    #     it to FailoverReason.auth correctly, and _is_entitlement_failure
+    #     then prevents the credential-refresh loop.
+    #
+    #   • SSE ``type=error`` frame — surfaced as _StreamErrorEvent with
+    #     status_code=None.  _classify_by_status is skipped entirely, and
+    #     "grok subscription" / "out of available resources" appear in none
+    #     of the message-pattern lists below.  Without this guard the error
+    #     falls through to FailoverReason.unknown (retryable=True), burning
+    #     max_retries before the agent stops — and _is_entitlement_failure
+    #     is never called because it only runs under FailoverReason.auth.
+    #
+    # Both X Premium+ and SuperGrok subscribers hit this path when their
+    # subscription tier does not cover the requested model or feature.
+    if (
+        "do not have an active grok subscription" in error_msg
+        or ("out of available resources" in error_msg and "grok" in error_msg)
+    ):
+        return _result(
+            FailoverReason.auth,
+            retryable=False,
+            should_fallback=True,
+        )
+
     # ── 2. HTTP status code classification ──────────────────────────
 
     if status_code is not None:

--- a/tests/run_agent/test_codex_xai_oauth_recovery.py
+++ b/tests/run_agent/test_codex_xai_oauth_recovery.py
@@ -225,6 +225,62 @@ def test_summarize_api_error_passes_through_unrelated_errors():
 
 
 # ---------------------------------------------------------------------------
+# Fix D: _StreamErrorEvent xAI entitlement classified as auth, not retryable
+#
+# run_codex_create_stream_fallback raises _StreamErrorEvent (status_code=None)
+# when the Responses stream emits a ``type=error`` SSE frame.  Before this
+# fix, classify_api_error had no match for "grok subscription" in its pattern
+# lists, so it returned FailoverReason.unknown (retryable=True) — burning
+# max_retries before the agent stopped.  _is_entitlement_failure was never
+# called because it only runs when FailoverReason.auth is returned.
+# ---------------------------------------------------------------------------
+
+
+def test_classify_api_error_stream_event_grok_subscription_is_auth():
+    """_StreamErrorEvent with xAI subscription message classifies as auth/non-retryable.
+
+    The SSE error path has status_code=None, so _classify_by_status is
+    skipped.  The explicit pattern added at step 1 must fire first and
+    return auth/non-retryable so _is_entitlement_failure can stop the loop.
+    """
+    from run_agent import _StreamErrorEvent
+    from agent.error_classifier import classify_api_error, FailoverReason
+
+    err = _StreamErrorEvent(
+        "You have either run out of available resources or do not have an "
+        "active Grok subscription. Manage subscriptions at https://grok.com",
+        code="The caller does not have permission to execute the specified operation",
+    )
+    result = classify_api_error(err, provider="xai-oauth", model="grok-4.3")
+    assert result.reason == FailoverReason.auth
+    assert result.retryable is False
+    assert result.should_fallback is True
+
+
+def test_classify_api_error_stream_event_resources_exhausted_grok_is_auth():
+    """'out of available resources' + 'grok' variant also classifies as auth."""
+    from run_agent import _StreamErrorEvent
+    from agent.error_classifier import classify_api_error, FailoverReason
+
+    err = _StreamErrorEvent(
+        "You have run out of available resources for Grok.",
+    )
+    result = classify_api_error(err, provider="xai-oauth", model="grok-4.3")
+    assert result.reason == FailoverReason.auth
+    assert result.retryable is False
+
+
+def test_classify_api_error_stream_event_unrelated_not_reclassified():
+    """An unrelated _StreamErrorEvent must not be caught by the xAI guard."""
+    from run_agent import _StreamErrorEvent
+    from agent.error_classifier import classify_api_error, FailoverReason
+
+    err = _StreamErrorEvent("Internal server error — try again later")
+    result = classify_api_error(err, provider="xai-oauth", model="grok-4.3")
+    assert result.reason != FailoverReason.auth
+
+
+# ---------------------------------------------------------------------------
 # Fix C: reasoning replay gating for xai-oauth
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What does this PR do?

**Root cause:** When xAI returns a Grok subscription/entitlement error through
an SSE `type=error` frame (rather than an HTTP 403), `_StreamErrorEvent` is
raised with `status_code=None`. `classify_api_error` skips `_classify_by_status`
entirely and falls through to `_classify_by_message`. Neither the primary Grok
phrase (`"do not have an active Grok subscription"`) nor the variant
(`"out of available resources"`) appears in any `_AUTH_PATTERNS` or other
message-pattern list, so the error lands on `FailoverReason.unknown
(retryable=True)`.

That burns all `max_retries` before the agent stops, and `_is_entitlement_failure`
is never reached because it only runs when `FailoverReason.auth` is returned.

**Fix:** Add an explicit step-1 guard (highest priority, before the
`status_code` branch) in `classify_api_error` that matches both xAI
entitlement phrases and returns `FailoverReason.auth, retryable=False,
should_fallback=True` — identical to what the HTTP 403 path already returns.
`should_rotate_credential` is intentionally omitted (defaults `False`) because
rotating credentials cannot fix a subscription entitlement failure.

| Path | `status_code` | Before | After |
|------|--------------|--------|-------|
| HTTP 403 | set | `auth / retryable=False` ✓ | unchanged |
| SSE `type=error` frame → `_StreamErrorEvent` | `None` | `unknown / retryable=True` ✗ | `auth / retryable=False` ✓ |

## Related Issue

Fixes xAI OAuth entitlement retry loop introduced with the `_StreamErrorEvent`
SSE surface path (#27184).

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `agent/error_classifier.py`: add xAI entitlement phrase guard at step 1 of `classify_api_error` (+8 lines)
- `tests/run_agent/test_codex_xai_oauth_recovery.py`: three regression tests under new `Fix D` section

## How to Test

```
python3.11 -m pytest tests/run_agent/test_codex_xai_oauth_recovery.py -v --override-ini="addopts="
```

## Checklist

- [x] Contributing Guide read | Conventional Commits | No duplicate PR
- [x] Single fix only | Tests added | Platform: macOS
- [x] Docs — N/A | Cross-platform — N/A