### PR TITLE
fix(agent): sanitize resumed session history to prevent context leak (#27156)

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -103,6 +103,57 @@ _TEXT_RESOURCE_MIME_TYPES = {
 }
 
 
+def _merge_resumed_acp_result_messages(
+    *,
+    raw_history: list[dict[str, Any]],
+    model_history: list[dict[str, Any]],
+    result_messages: Any,
+) -> Any:
+    """Preserve raw restored ACP transcript rows when saving a resumed turn."""
+    raw_prefix = list(raw_history)
+    if not isinstance(result_messages, list):
+        logger.debug(
+            "ACP resumed result did not return message history; "
+            "preserving raw restored history"
+        )
+        return raw_prefix
+
+    if len(result_messages) >= len(model_history):
+        return raw_prefix + result_messages[len(model_history) :]
+
+    logger.debug(
+        "ACP resumed result is shorter than the model-history prefix; "
+        "preserving raw restored history without guessing a turn delta"
+    )
+    return raw_prefix
+
+
+def _resumed_acp_history_for_save(
+    *,
+    session_manager: SessionManager,
+    session_id: str,
+    raw_history: list[dict[str, Any]],
+    model_history: list[dict[str, Any]],
+    result_messages: Any,
+) -> list[dict[str, Any]]:
+    persisted_history = session_manager.load_persisted_history(session_id)
+    if (
+        len(persisted_history) > len(raw_history)
+        and persisted_history[: len(raw_history)] == raw_history
+    ):
+        return persisted_history
+    merged_history = _merge_resumed_acp_result_messages(
+        raw_history=raw_history,
+        model_history=model_history,
+        result_messages=result_messages,
+    )
+    if merged_history != raw_history:
+        return merged_history
+    if persisted_history[: len(raw_history)] == raw_history:
+        return persisted_history
+    return merged_history
+
+
 def _resource_display_name(uri: str, name: str | None = None, title: str | None = None) -> str:
     """Human-readable attachment name for prompt context."""
     raw_name = (name or "").strip()
@@ -1503,8 +1554,10 @@ class HermesACPAgent(acp.Agent):
             os.environ["HERMES_SESSION_ID"] = session_id
             try:
                 conversation_history = state.history
+                raw_resume_history = None
                 if getattr(state, "resumed_from_storage", False):
                     from agent.resume_history import sanitize_resumed_conversation_history
+                    raw_resume_history = list(state.history)
                     conversation_history = sanitize_resumed_conversation_history(state.history)
                 result = agent.run_conversation(
                     user_message=user_content,
@@ -1512,10 +1565,31 @@ class HermesACPAgent(acp.Agent):
                     task_id=session_id,
                     persist_user_message=user_text or "[Image attachment]",
                 )
+                if raw_resume_history is not None and isinstance(result, dict):
+                    result = dict(result)
+                    result["messages"] = _resumed_acp_history_for_save(
+                        session_manager=self.session_manager,
+                        session_id=session_id,
+                        raw_history=raw_resume_history,
+                        model_history=conversation_history,
+                        result_messages=result.get("messages"),
+                    )
                 state.resumed_from_storage = False
                 return result
             except Exception as e:
                 logger.exception("Agent error in session %s", session_id)
+                if raw_resume_history is not None:
+                    state.resumed_from_storage = False
+                    return {
+                        "final_response": f"Error: {e}",
+                        "messages": _resumed_acp_history_for_save(
+                            session_manager=self.session_manager,
+                            session_id=session_id,
+                            raw_history=raw_resume_history,
+                            model_history=conversation_history,
+                            result_messages=None,
+                        ),
+                    }
                 return {"final_response": f"Error: {e}", "messages": state.history}
             finally:
                 # Restore HERMES_INTERACTIVE.

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1502,12 +1502,17 @@ class HermesACPAgent(acp.Agent):
             previous_session_id = os.environ.get("HERMES_SESSION_ID")
             os.environ["HERMES_SESSION_ID"] = session_id
             try:
+                conversation_history = state.history
+                if getattr(state, "resumed_from_storage", False):
+                    from agent.resume_history import sanitize_resumed_conversation_history
+                    conversation_history = sanitize_resumed_conversation_history(state.history)
                 result = agent.run_conversation(
                     user_message=user_content,
-                    conversation_history=state.history,
+                    conversation_history=conversation_history,
                     task_id=session_id,
                     persist_user_message=user_text or "[Image attachment]",
                 )
+                state.resumed_from_storage = False
                 return result
             except Exception as e:
                 logger.exception("Agent error in session %s", session_id)

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -123,9 +123,16 @@ def _merge_resumed_acp_result_messages(
 
     logger.debug(
         "ACP resumed result is shorter than the model-history prefix; "
-        "preserving raw restored history and appending returned messages"
+        "preserving raw restored history and appending available new-turn messages"
     )
-    return raw_prefix + result_messages
+    new_turn: list[dict[str, Any]] = []
+    for msg in reversed(result_messages):
+        if not isinstance(msg, dict):
+            continue
+        new_turn.insert(0, msg)
+        if msg.get("role") == "user":
+            break
+    return raw_prefix + (new_turn or result_messages)
 
 
 def _resumed_acp_history_for_save(

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -123,9 +123,9 @@ def _merge_resumed_acp_result_messages(
 
     logger.debug(
         "ACP resumed result is shorter than the model-history prefix; "
-        "preserving raw restored history without guessing a turn delta"
+        "preserving raw restored history and appending returned messages"
     )
-    return raw_prefix
+    return raw_prefix + result_messages
 
 
 def _resumed_acp_history_for_save(

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -181,6 +181,7 @@ class SessionState:
     runtime_lock: Any = field(default_factory=Lock)
     current_prompt_text: str = ""
     interrupted_prompt_text: str = ""
+    resumed_from_storage: bool = False
 
 
 class SessionManager:
@@ -535,6 +536,7 @@ class SessionManager:
             model=model or getattr(agent, "model", "") or "",
             history=history,
             cancel_event=threading.Event(),
+            resumed_from_storage=True,
         )
         with self._lock:
             self._sessions[session_id] = state

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -397,6 +397,17 @@ class SessionManager:
         if state is not None:
             self._persist(state)
 
+    def load_persisted_history(self, session_id: str) -> List[Dict[str, Any]]:
+        """Return the durable raw transcript for an ACP session."""
+        db = self._get_db()
+        if db is None:
+            return []
+        try:
+            return db.get_messages_as_conversation(session_id)
+        except Exception:
+            logger.warning("Failed to load persisted ACP history for %s", session_id, exc_info=True)
+            return []
+
     # ---- persistence via SessionDB ------------------------------------------
 
     def _get_db(self):

--- a/agent/resume_history.py
+++ b/agent/resume_history.py
@@ -1,0 +1,85 @@
+"""Helpers for building API-safe history at session-resume boundaries."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List
+
+
+_TOOL_TURN_PLACEHOLDER = (
+    "[Prior tool activity omitted from resumed context.]"
+)
+
+
+def sanitize_resumed_conversation_history(
+    history: Iterable[Dict[str, Any]] | None,
+) -> List[Dict[str, Any]]:
+    """Return a resume-safe conversation history for the next model turn.
+
+    Stored transcripts intentionally preserve raw assistant tool calls, tool
+    results, reasoning fields, and provider metadata for replay/debugging. A
+    session resume is a context boundary: those private/internal payloads must
+    not be fed back to the model as if the previous tool loop were still live.
+
+    The projection keeps only user-visible dialogue:
+    * user messages keep role/content;
+    * assistant messages keep role/content only;
+    * tool/function/debug/meta/system/developer messages are dropped;
+    * assistant tool-call turns with no visible content become a short benign
+      assistant placeholder so surrounding user turns do not collapse together.
+    """
+    if not history:
+        return []
+
+    sanitized: List[Dict[str, Any]] = []
+    for msg in history:
+        if not isinstance(msg, dict):
+            continue
+
+        role = msg.get("role")
+        if role == "user":
+            sanitized.append({"role": "user", "content": msg.get("content", "")})
+            continue
+
+        if role != "assistant":
+            continue
+
+        content = msg.get("content", "")
+        if content is None:
+            content = ""
+
+        has_visible_content = False
+        if isinstance(content, str):
+            has_visible_content = bool(content.strip())
+        elif isinstance(content, list):
+            has_visible_content = any(
+                isinstance(part, dict)
+                and part.get("type") == "text"
+                and isinstance(part.get("text"), str)
+                and part.get("text", "").strip()
+                for part in content
+            )
+        else:
+            has_visible_content = bool(content)
+
+        if not has_visible_content:
+            if msg.get("tool_calls"):
+                content = _TOOL_TURN_PLACEHOLDER
+            else:
+                continue
+
+        assistant_msg = {"role": "assistant", "content": content}
+        if sanitized and sanitized[-1].get("role") == "assistant":
+            previous = sanitized[-1]
+            if previous.get("content") == _TOOL_TURN_PLACEHOLDER:
+                sanitized[-1] = assistant_msg
+            elif content == _TOOL_TURN_PLACEHOLDER:
+                continue
+            elif isinstance(previous.get("content"), str) and isinstance(content, str):
+                previous["content"] = previous["content"].rstrip() + "\n\n" + content.lstrip()
+            else:
+                sanitized.append(assistant_msg)
+            continue
+
+        sanitized.append(assistant_msg)
+
+    return sanitized

--- a/agent/resume_history.py
+++ b/agent/resume_history.py
@@ -83,3 +83,35 @@ def sanitize_resumed_conversation_history(
         sanitized.append(assistant_msg)
 
     return sanitized
+
+
+def has_interrupted_tool_tail(history: Iterable[Dict[str, Any]] | None) -> bool:
+    """Return True when a stored transcript ends before a tool result was consumed."""
+    if not history:
+        return False
+
+    last_message: Dict[str, Any] | None = None
+    for msg in history:
+        if isinstance(msg, dict):
+            last_message = msg
+
+    return bool(last_message and last_message.get("role") == "tool")
+
+
+def model_history_for_resumed_session(
+    history: Iterable[Dict[str, Any]] | None,
+) -> List[Dict[str, Any]]:
+    """Return model-facing history for a resumed session.
+
+    Ordinary resume boundaries strip raw tool calls/results and private
+    provider metadata before the next model turn. If the transcript ends in a
+    tool result, the previous turn was interrupted before the assistant could
+    process that result, so the raw assistant->tool sequence must remain intact.
+    """
+    if not history:
+        return []
+
+    restored = list(history)
+    if has_interrupted_tool_tail(restored):
+        return restored
+    return sanitize_resumed_conversation_history(restored)

--- a/agent/resume_history.py
+++ b/agent/resume_history.py
@@ -85,33 +85,17 @@ def sanitize_resumed_conversation_history(
     return sanitized
 
 
-def has_interrupted_tool_tail(history: Iterable[Dict[str, Any]] | None) -> bool:
-    """Return True when a stored transcript ends before a tool result was consumed."""
-    if not history:
-        return False
-
-    last_message: Dict[str, Any] | None = None
-    for msg in history:
-        if isinstance(msg, dict):
-            last_message = msg
-
-    return bool(last_message and last_message.get("role") == "tool")
-
-
 def model_history_for_resumed_session(
     history: Iterable[Dict[str, Any]] | None,
 ) -> List[Dict[str, Any]]:
     """Return model-facing history for a resumed session.
 
     Ordinary resume boundaries strip raw tool calls/results and private
-    provider metadata before the next model turn. If the transcript ends in a
-    tool result, the previous turn was interrupted before the assistant could
-    process that result, so the raw assistant->tool sequence must remain intact.
+    provider metadata before the next model turn. Fresh interrupted tool-tail
+    recovery is handled by gateway/run.py, where it is gated by recent
+    interruption state; ordinary CLI/TUI resumes always sanitize.
     """
     if not history:
         return []
 
-    restored = list(history)
-    if has_interrupted_tool_tail(restored):
-        return restored
-    return sanitize_resumed_conversation_history(restored)
+    return sanitize_resumed_conversation_history(list(history))

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2209,13 +2209,14 @@ class APIServerAdapter(BasePlatformAdapter):
         stream_q,
         agent_task,
         agent_ref,
-        conversation_history: List[Dict[str, str]],
+        conversation_history: List[Dict[str, Any]],
         user_message: str,
         instructions: Optional[str],
         conversation: Optional[str],
         store: bool,
         session_id: str,
         gateway_session_key: Optional[str] = None,
+        storage_conversation_history: Optional[List[Dict[str, Any]]] = None,
     ) -> "web.StreamResponse":
         """Write an SSE stream for POST /v1/responses (OpenAI Responses API).
 
@@ -2247,6 +2248,11 @@ class APIServerAdapter(BasePlatformAdapter):
         """
         import queue as _q
 
+        storage_history = (
+            conversation_history
+            if storage_conversation_history is None
+            else storage_conversation_history
+        )
         sse_headers = {
             "Content-Type": "text/event-stream",
             "Cache-Control": "no-cache",
@@ -2317,7 +2323,7 @@ class APIServerAdapter(BasePlatformAdapter):
             if not store:
                 return
             if conversation_history_snapshot is None:
-                conversation_history_snapshot = list(conversation_history)
+                conversation_history_snapshot = list(storage_history)
                 conversation_history_snapshot.append({"role": "user", "content": user_message})
             self._response_store.put(response_id, {
                 "response": response_env,
@@ -2353,7 +2359,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "output_tokens": usage.get("output_tokens", 0),
                 "total_tokens": usage.get("total_tokens", 0),
             }
-            incomplete_history = list(conversation_history)
+            incomplete_history = list(storage_history)
             incomplete_history.append({"role": "user", "content": user_message})
             if incomplete_text:
                 incomplete_history.append({"role": "assistant", "content": incomplete_text})
@@ -2696,7 +2702,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     "output_tokens": usage.get("output_tokens", 0),
                     "total_tokens": usage.get("total_tokens", 0),
                 }
-                _failed_history = list(conversation_history)
+                _failed_history = list(storage_history)
                 _failed_history.append({"role": "user", "content": user_message})
                 if final_response_text or agent_error:
                     _failed_history.append({
@@ -2721,10 +2727,11 @@ class APIServerAdapter(BasePlatformAdapter):
                     "total_tokens": usage.get("total_tokens", 0),
                 }
                 full_history = self._build_response_conversation_history(
-                    conversation_history,
+                    storage_history,
                     user_message,
                     result,
                     final_response_text,
+                    model_conversation_history=conversation_history,
                 )
                 _persist_response_snapshot(
                     completed_env,
@@ -2879,11 +2886,13 @@ class APIServerAdapter(BasePlatformAdapter):
                 logger.debug("Both conversation_history and previous_response_id provided; using conversation_history")
 
         stored_session_id = None
+        loaded_previous_response_history = False
         if not conversation_history and previous_response_id:
             stored = self._response_store.get(previous_response_id)
             if stored is None:
                 return web.json_response(_openai_error(f"Previous response not found: {previous_response_id}"), status=404)
             conversation_history = list(stored.get("conversation_history", []))
+            loaded_previous_response_history = True
             stored_session_id = stored.get("session_id")
             # If no instructions provided, carry forward from previous
             if instructions is None:
@@ -2901,6 +2910,12 @@ class APIServerAdapter(BasePlatformAdapter):
         # Truncation support
         if body.get("truncation") == "auto" and len(conversation_history) > 100:
             conversation_history = conversation_history[-100:]
+
+        if loaded_previous_response_history:
+            from agent.resume_history import sanitize_resumed_conversation_history
+            model_conversation_history = sanitize_resumed_conversation_history(conversation_history)
+        else:
+            model_conversation_history = list(conversation_history)
 
         # Reuse session from previous_response_id chain so the dashboard
         # groups the entire conversation under one session entry.
@@ -2950,7 +2965,7 @@ class APIServerAdapter(BasePlatformAdapter):
             agent_ref = [None]
             agent_task = asyncio.ensure_future(self._run_agent(
                 user_message=user_message,
-                conversation_history=conversation_history,
+                conversation_history=model_conversation_history,
                 ephemeral_system_prompt=instructions,
                 session_id=session_id,
                 stream_delta_callback=_on_delta,
@@ -2976,19 +2991,20 @@ class APIServerAdapter(BasePlatformAdapter):
                 stream_q=_stream_q,
                 agent_task=agent_task,
                 agent_ref=agent_ref,
-                conversation_history=conversation_history,
+                conversation_history=model_conversation_history,
                 user_message=user_message,
                 instructions=instructions,
                 conversation=conversation,
                 store=store,
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
+                storage_conversation_history=conversation_history,
             )
 
         async def _compute_response():
             return await self._run_agent(
                 user_message=user_message,
-                conversation_history=conversation_history,
+                conversation_history=model_conversation_history,
                 ephemeral_system_prompt=instructions,
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
@@ -3032,13 +3048,14 @@ class APIServerAdapter(BasePlatformAdapter):
             user_message,
             result,
             final_response,
+            model_conversation_history=model_conversation_history,
         )
 
         # Build output items from the current turn only.  AIAgent returns a
         # full transcript in result["messages"], while older/mocked paths may
         # return only the current turn suffix.
         output_start_index = self._response_messages_turn_start_index(
-            conversation_history,
+            model_conversation_history,
             user_message,
             result,
         )
@@ -3353,20 +3370,26 @@ class APIServerAdapter(BasePlatformAdapter):
         user_message: Any,
         result: Dict[str, Any],
         final_response: Any,
+        model_conversation_history: Optional[List[Dict[str, Any]]] = None,
     ) -> List[Dict[str, Any]]:
         """Build the stored Responses transcript without duplicating history."""
         prior = list(conversation_history)
+        model_prior = (
+            list(conversation_history)
+            if model_conversation_history is None
+            else list(model_conversation_history)
+        )
         current_user = {"role": "user", "content": user_message}
         agent_messages = result.get("messages") if isinstance(result, dict) else None
 
         if isinstance(agent_messages, list) and agent_messages:
-            turn_start = APIServerAdapter._response_messages_turn_start_index(
-                conversation_history,
-                user_message,
-                result,
-            )
-            if turn_start:
-                return list(agent_messages)
+            expected_prefix = model_prior + [current_user]
+            if agent_messages[:len(expected_prefix)] == expected_prefix:
+                return prior + [current_user] + agent_messages[len(expected_prefix):]
+            if model_prior and agent_messages[:len(model_prior)] == model_prior:
+                return prior + agent_messages[len(model_prior):]
+            if agent_messages[:1] == [current_user]:
+                return prior + agent_messages
 
             full_history = prior
             full_history.append(current_user)
@@ -3684,10 +3707,12 @@ class APIServerAdapter(BasePlatformAdapter):
                 logger.debug("Both conversation_history and previous_response_id provided; using conversation_history")
 
         stored_session_id = None
+        loaded_previous_response_history = False
         if not conversation_history and previous_response_id:
             stored = self._response_store.get(previous_response_id)
             if stored:
                 conversation_history = list(stored.get("conversation_history", []))
+                loaded_previous_response_history = True
                 stored_session_id = stored.get("session_id")
                 if instructions is None:
                     instructions = stored.get("instructions")
@@ -3706,6 +3731,12 @@ class APIServerAdapter(BasePlatformAdapter):
                             if isinstance(part, dict) and part.get("type") == "text"
                         )
                     conversation_history.append({"role": msg["role"], "content": str(content)})
+
+        if loaded_previous_response_history:
+            from agent.resume_history import sanitize_resumed_conversation_history
+            model_conversation_history = sanitize_resumed_conversation_history(conversation_history)
+        else:
+            model_conversation_history = list(conversation_history)
 
         run_id = f"run_{uuid.uuid4().hex}"
         session_id = body.get("session_id") or stored_session_id or run_id
@@ -3796,7 +3827,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         register_gateway_notify(approval_session_key, _approval_notify)
                         r = agent.run_conversation(
                             user_message=user_message,
-                            conversation_history=conversation_history,
+                            conversation_history=model_conversation_history,
                             task_id=effective_task_id,
                         )
                     finally:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2863,6 +2863,9 @@ class APIServerAdapter(BasePlatformAdapter):
         # This lets stateless clients supply their own history instead of
         # relying on server-side response chaining via previous_response_id.
         # Precedence: explicit conversation_history > previous_response_id.
+        # Only server-owned previous_response_id history is sanitized here;
+        # direct conversation_history is treated as trusted model input from
+        # the client that provided it.
         conversation_history: List[Dict[str, Any]] = []
         raw_history = body.get("conversation_history")
         if raw_history:
@@ -3688,6 +3691,9 @@ class APIServerAdapter(BasePlatformAdapter):
 
         # Accept explicit conversation_history from the request body.
         # Precedence: explicit conversation_history > previous_response_id.
+        # Only server-owned previous_response_id history is sanitized here;
+        # direct conversation_history is treated as trusted model input from
+        # the client that provided it.
         conversation_history: List[Dict[str, str]] = []
         raw_history = body.get("conversation_history")
         if raw_history:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1557,9 +1557,11 @@ class APIServerAdapter(BasePlatformAdapter):
         if system_prompt is not None and not isinstance(system_prompt, str):
             return web.json_response(_openai_error("system_message must be a string", code="invalid_system_message"), status=400)
         history = self._conversation_history_for_session(session_id)
+        from agent.resume_history import sanitize_resumed_conversation_history
+        model_history = sanitize_resumed_conversation_history(history)
         result, usage = await self._run_agent(
             user_message=user_message,
-            conversation_history=history,
+            conversation_history=model_history,
             ephemeral_system_prompt=system_prompt,
             session_id=session_id,
             gateway_session_key=gateway_session_key,
@@ -1646,9 +1648,11 @@ class APIServerAdapter(BasePlatformAdapter):
                 await queue.put(_event_payload("run.started", {"user_message": {"role": "user", "content": user_message}}))
                 await queue.put(_event_payload("message.started", {"message": {"id": message_id, "role": "assistant"}}))
                 history = self._conversation_history_for_session(session_id)
+                from agent.resume_history import sanitize_resumed_conversation_history
+                model_history = sanitize_resumed_conversation_history(history)
                 result, usage = await self._run_agent(
                     user_message=user_message,
-                    conversation_history=history,
+                    conversation_history=model_history,
                     ephemeral_system_prompt=system_prompt,
                     session_id=session_id,
                     stream_delta_callback=_delta,
@@ -1657,7 +1661,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 )
                 final_response = result.get("final_response", "") if isinstance(result, dict) else ""
                 effective_session_id = result.get("session_id", session_id) if isinstance(result, dict) else session_id
-                turn_messages = self._turn_transcript_messages(history, user_message, result) if isinstance(result, dict) else []
+                turn_messages = self._turn_transcript_messages(model_history, user_message, result) if isinstance(result, dict) else []
                 await queue.put(_event_payload("assistant.completed", {
                     "session_id": effective_session_id,
                     "message_id": message_id,
@@ -1817,7 +1821,10 @@ class APIServerAdapter(BasePlatformAdapter):
             try:
                 db = self._ensure_session_db()
                 if db is not None:
-                    history = db.get_messages_as_conversation(session_id)
+                    from agent.resume_history import sanitize_resumed_conversation_history
+                    history = sanitize_resumed_conversation_history(
+                        db.get_messages_as_conversation(session_id)
+                    )
             except Exception as e:
                 logger.warning("Failed to load session history for %s: %s", session_id, e)
                 history = []

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -688,6 +688,17 @@ def _build_gateway_agent_history(
     return agent_history, observed_context
 
 
+def _gateway_model_history_for_run(
+    agent_history: List[Dict[str, Any]],
+    *,
+    preserve_interrupted_tool_context: bool = False,
+) -> List[Dict[str, Any]]:
+    if preserve_interrupted_tool_context:
+        return agent_history
+    from agent.resume_history import sanitize_resumed_conversation_history
+    return sanitize_resumed_conversation_history(agent_history)
+
+
 def _wrap_current_message_with_observed_context(message: Any, observed_context: Optional[str]) -> Any:
     """Prepend observed Telegram context to the API-only current user turn."""
 
@@ -14475,6 +14486,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     + message
                 )
 
+            model_agent_history = _gateway_model_history_for_run(
+                agent_history,
+                preserve_interrupted_tool_context=(
+                    _is_resume_pending or _has_fresh_tool_tail
+                ),
+            )
+
             # Consume one-shot /reload-skills note (if the user ran
             # /reload-skills since their last turn in this session). Same
             # queue pattern as CLI: prepend to the NEXT user message, then
@@ -14526,7 +14544,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     observed_group_context,
                 )
                 _conversation_kwargs = {
-                    "conversation_history": agent_history,
+                    "conversation_history": model_agent_history,
                     "task_id": session_id,
                 }
                 if observed_group_context:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1344,6 +1344,7 @@ class SessionStore:
         state.db is the canonical store. The legacy JSONL fallback was removed
         in spec 002 — pre-DB sessions on existing disks have already been
         migrated (their DB row holds the full message history).
+
         """
         if not self._db:
             return []

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -288,7 +288,8 @@ class CLIAgentSetupMixin:
                     session_meta = resolved_meta
             restored = self._session_db.get_messages_as_conversation(self.session_id)
             if restored:
-                restored = [m for m in restored if m.get("role") != "session_meta"]
+                from agent.resume_history import sanitize_resumed_conversation_history
+                restored = sanitize_resumed_conversation_history(restored)
                 self.conversation_history = restored
                 msg_count = len([m for m in restored if m.get("role") == "user"])
                 title_part = ""
@@ -477,7 +478,8 @@ class CLIAgentSetupMixin:
 
         restored = self._session_db.get_messages_as_conversation(self.session_id)
         if restored:
-            restored = [m for m in restored if m.get("role") != "session_meta"]
+            from agent.resume_history import sanitize_resumed_conversation_history
+            restored = sanitize_resumed_conversation_history(restored)
             self.conversation_history = restored
             msg_count = len([m for m in restored if m.get("role") == "user"])
             title_part = ""

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -288,8 +288,8 @@ class CLIAgentSetupMixin:
                     session_meta = resolved_meta
             restored = self._session_db.get_messages_as_conversation(self.session_id)
             if restored:
-                from agent.resume_history import sanitize_resumed_conversation_history
-                restored = sanitize_resumed_conversation_history(restored)
+                from agent.resume_history import model_history_for_resumed_session
+                restored = model_history_for_resumed_session(restored)
                 self.conversation_history = restored
                 msg_count = len([m for m in restored if m.get("role") == "user"])
                 title_part = ""
@@ -478,8 +478,8 @@ class CLIAgentSetupMixin:
 
         restored = self._session_db.get_messages_as_conversation(self.session_id)
         if restored:
-            from agent.resume_history import sanitize_resumed_conversation_history
-            restored = sanitize_resumed_conversation_history(restored)
+            from agent.resume_history import model_history_for_resumed_session
+            restored = model_history_for_resumed_session(restored)
             self.conversation_history = restored
             msg_count = len([m for m in restored if m.get("role") == "user"])
             title_part = ""

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -696,7 +696,8 @@ class CLICommandsMixin:
 
         # Load conversation history (strip transcript-only metadata entries)
         restored = self._session_db.get_messages_as_conversation(target_id)
-        restored = [m for m in (restored or []) if m.get("role") != "session_meta"]
+        from agent.resume_history import sanitize_resumed_conversation_history
+        restored = sanitize_resumed_conversation_history(restored)
         self.conversation_history = restored
 
         # Re-open the target session so it's not marked as ended

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -696,8 +696,8 @@ class CLICommandsMixin:
 
         # Load conversation history (strip transcript-only metadata entries)
         restored = self._session_db.get_messages_as_conversation(target_id)
-        from agent.resume_history import sanitize_resumed_conversation_history
-        restored = sanitize_resumed_conversation_history(restored)
+        from agent.resume_history import model_history_for_resumed_session
+        restored = model_history_for_resumed_session(restored)
         self.conversation_history = restored
 
         # Re-open the target session so it's not marked as ended

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -36,7 +36,11 @@ from acp.schema import (
     UserMessageChunk,
 )
 from acp_adapter.auth import TERMINAL_SETUP_AUTH_METHOD_ID
-from acp_adapter.server import HermesACPAgent, HERMES_VERSION
+from acp_adapter.server import (
+    HermesACPAgent,
+    HERMES_VERSION,
+    _merge_resumed_acp_result_messages,
+)
 from acp_adapter.session import SessionManager
 from hermes_state import SessionDB
 
@@ -1073,6 +1077,216 @@ class TestPrompt:
         await agent.prompt(prompt=prompt, session_id=new_resp.session_id)
 
         assert state.history == expected_history
+
+    @pytest.mark.asyncio
+    async def test_resumed_prompt_preserves_raw_acp_history_when_saving(self, tmp_path):
+        db = SessionDB(tmp_path / "state.db")
+
+        def make_agent():
+            return SimpleNamespace(
+                model="test-model",
+                provider=None,
+                base_url=None,
+                api_mode=None,
+            )
+
+        manager = SessionManager(agent_factory=make_agent, db=db)
+        acp_agent = HermesACPAgent(session_manager=manager)
+        state = manager.create_session(cwd="/work")
+        raw_history = [
+            {
+                "role": "user",
+                "content": "show skill",
+                "message_id": "client-msg-1",
+            },
+            {
+                "role": "assistant",
+                "content": "",
+                "reasoning": "PRIVATE_REASONING",
+                "tool_calls": [
+                    {
+                        "id": "call_skill_view",
+                        "type": "function",
+                        "function": {
+                            "name": "skill_view",
+                            "arguments": '{"name":"secret"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_skill_view",
+                "tool_name": "skill_view",
+                "content": "RAW_TOOL_OUTPUT\nDEBUG_INSTRUCTION",
+            },
+            {"role": "assistant", "content": "Visible answer"},
+        ]
+        state.history = list(raw_history)
+        manager.save_session(state.session_id)
+
+        with manager._lock:
+            del manager._sessions[state.session_id]
+
+        restored = manager.get_session(state.session_id)
+        assert restored is not None
+        assert restored.resumed_from_storage is True
+
+        captured_model_history = {}
+
+        def run_conversation(*, user_message, conversation_history, **kwargs):
+            captured_model_history["value"] = conversation_history
+            sanitized_result = conversation_history + [
+                {"role": "user", "content": "next prompt"},
+                {"role": "assistant", "content": "next answer"},
+            ]
+            # Simulate the agent's in-turn crash-resilience persistence writing
+            # the model-facing projection before the ACP wrapper performs its
+            # final save.
+            db.replace_messages(state.session_id, sanitized_result)
+            return {
+                "final_response": "next answer",
+                "messages": sanitized_result,
+            }
+
+        restored.agent.run_conversation = MagicMock(side_effect=run_conversation)
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        acp_agent._conn = mock_conn
+
+        prompt = [TextContentBlock(type="text", text="next prompt")]
+        await acp_agent.prompt(prompt=prompt, session_id=state.session_id)
+
+        assert captured_model_history["value"] == [
+            {"role": "user", "content": "show skill"},
+            {"role": "assistant", "content": "Visible answer"},
+        ]
+
+        persisted = db.get_messages_as_conversation(state.session_id)
+        assert persisted == raw_history + [
+            {"role": "user", "content": "next prompt"},
+            {"role": "assistant", "content": "next answer"},
+        ]
+        serialized = repr(persisted)
+        assert "client-msg-1" in serialized
+        assert "PRIVATE_REASONING" in serialized
+        assert "skill_view" in serialized
+        assert "tool_call_id" in serialized
+        assert "call_skill_view" in serialized
+        assert "RAW_TOOL_OUTPUT" in serialized
+        assert "DEBUG_INSTRUCTION" in serialized
+
+    def test_resumed_acp_merge_splices_by_model_history_length(self):
+        raw_history = [
+            {"role": "user", "content": "raw", "message_id": "client-msg-1"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{"id": "call_1", "function": {"name": "skill_view"}}],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "raw tool"},
+        ]
+        model_history = [{"role": "user", "content": "raw"}]
+        result_messages = [
+            {"role": "user", "content": "raw normalized"},
+            {"role": "user", "content": "next"},
+            {"role": "assistant", "content": "answer"},
+        ]
+
+        merged = _merge_resumed_acp_result_messages(
+            raw_history=raw_history,
+            model_history=model_history,
+            result_messages=result_messages,
+        )
+
+        assert merged == raw_history + result_messages[len(model_history) :]
+        assert {"role": "user", "content": "raw normalized"} not in merged
+
+    def test_resumed_acp_merge_preserves_raw_history_when_delta_is_unaligned(self):
+        raw_history = [
+            {"role": "user", "content": "raw", "message_id": "client-msg-1"},
+            {"role": "tool", "tool_call_id": "call_1", "content": "raw tool"},
+        ]
+        model_history = [
+            {"role": "user", "content": "raw"},
+            {"role": "assistant", "content": "visible"},
+        ]
+        result_messages = [{"role": "assistant", "content": "compressed summary"}]
+
+        merged = _merge_resumed_acp_result_messages(
+            raw_history=raw_history,
+            model_history=model_history,
+            result_messages=result_messages,
+        )
+
+        assert merged == raw_history
+        assert {"role": "assistant", "content": "compressed summary"} not in merged
+
+    @pytest.mark.asyncio
+    async def test_resumed_prompt_exception_preserves_persisted_raw_history(self, tmp_path):
+        db = SessionDB(tmp_path / "state.db")
+
+        def make_agent():
+            return SimpleNamespace(
+                model="test-model",
+                provider=None,
+                base_url=None,
+                api_mode=None,
+            )
+
+        manager = SessionManager(agent_factory=make_agent, db=db)
+        acp_agent = HermesACPAgent(session_manager=manager)
+        state = manager.create_session(cwd="/work")
+        raw_history = [
+            {"role": "user", "content": "show skill", "message_id": "client-msg-1"},
+            {
+                "role": "assistant",
+                "content": "",
+                "reasoning": "PRIVATE_REASONING",
+                "tool_calls": [{"id": "call_skill_view", "function": {"name": "skill_view"}}],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_skill_view",
+                "tool_name": "skill_view",
+                "content": "RAW_TOOL_OUTPUT",
+            },
+        ]
+        state.history = list(raw_history)
+        manager.save_session(state.session_id)
+
+        with manager._lock:
+            del manager._sessions[state.session_id]
+
+        restored = manager.get_session(state.session_id)
+        assert restored is not None
+
+        def run_conversation(*, user_message, conversation_history, **kwargs):
+            db.replace_messages(
+                state.session_id,
+                raw_history + [{"role": "user", "content": "next prompt"}],
+            )
+            raise RuntimeError("boom")
+
+        restored.agent.run_conversation = MagicMock(side_effect=run_conversation)
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        acp_agent._conn = mock_conn
+
+        prompt = [TextContentBlock(type="text", text="next prompt")]
+        response = await acp_agent.prompt(prompt=prompt, session_id=state.session_id)
+
+        assert response.stop_reason == "end_turn"
+        persisted = db.get_messages_as_conversation(state.session_id)
+        assert persisted == raw_history + [{"role": "user", "content": "next prompt"}]
+        serialized = repr(persisted)
+        assert "client-msg-1" in serialized
+        assert "PRIVATE_REASONING" in serialized
+        assert "skill_view" in serialized
+        assert "call_skill_view" in serialized
+        assert "RAW_TOOL_OUTPUT" in serialized
 
     @pytest.mark.asyncio
     async def test_prompt_sends_final_message_update(self, agent):

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1203,7 +1203,7 @@ class TestPrompt:
         assert merged == raw_history + result_messages[len(model_history) :]
         assert {"role": "user", "content": "raw normalized"} not in merged
 
-    def test_resumed_acp_merge_appends_returned_messages_when_delta_is_unaligned(self):
+    def test_resumed_acp_merge_appends_new_turn_when_delta_is_unaligned(self):
         raw_history = [
             {"role": "user", "content": "raw", "message_id": "client-msg-1"},
             {"role": "tool", "tool_call_id": "call_1", "content": "raw tool"},
@@ -1211,8 +1211,14 @@ class TestPrompt:
         model_history = [
             {"role": "user", "content": "raw"},
             {"role": "assistant", "content": "visible"},
+            {"role": "user", "content": "older"},
+            {"role": "assistant", "content": "older answer"},
         ]
-        result_messages = [{"role": "assistant", "content": "compressed summary"}]
+        result_messages = [
+            {"role": "assistant", "content": "compressed summary"},
+            {"role": "user", "content": "next prompt"},
+            {"role": "assistant", "content": "next answer"},
+        ]
 
         merged = _merge_resumed_acp_result_messages(
             raw_history=raw_history,
@@ -1220,8 +1226,8 @@ class TestPrompt:
             result_messages=result_messages,
         )
 
-        assert merged == raw_history + result_messages
-        assert {"role": "assistant", "content": "compressed summary"} in merged
+        assert merged == raw_history + result_messages[-2:]
+        assert {"role": "assistant", "content": "compressed summary"} not in merged
 
     @pytest.mark.asyncio
     async def test_resumed_prompt_exception_preserves_persisted_raw_history(self, tmp_path):

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1203,7 +1203,7 @@ class TestPrompt:
         assert merged == raw_history + result_messages[len(model_history) :]
         assert {"role": "user", "content": "raw normalized"} not in merged
 
-    def test_resumed_acp_merge_preserves_raw_history_when_delta_is_unaligned(self):
+    def test_resumed_acp_merge_appends_returned_messages_when_delta_is_unaligned(self):
         raw_history = [
             {"role": "user", "content": "raw", "message_id": "client-msg-1"},
             {"role": "tool", "tool_call_id": "call_1", "content": "raw tool"},
@@ -1220,8 +1220,8 @@ class TestPrompt:
             result_messages=result_messages,
         )
 
-        assert merged == raw_history
-        assert {"role": "assistant", "content": "compressed summary"} not in merged
+        assert merged == raw_history + result_messages
+        assert {"role": "assistant", "content": "compressed summary"} in merged
 
     @pytest.mark.asyncio
     async def test_resumed_prompt_exception_preserves_persisted_raw_history(self, tmp_path):

--- a/tests/agent/test_resume_history.py
+++ b/tests/agent/test_resume_history.py
@@ -1,0 +1,65 @@
+from agent.resume_history import sanitize_resumed_conversation_history
+
+
+def test_sanitize_resumed_history_strips_tool_and_reasoning_payloads():
+    out = sanitize_resumed_conversation_history(
+        [
+            {"role": "system", "content": "private system"},
+            {"role": "user", "content": "open the skill"},
+            {
+                "role": "assistant",
+                "content": "",
+                "reasoning": "private debugging context",
+                "reasoning_details": [{"text": "hidden detail"}],
+                "codex_reasoning_items": [{"summary": "hidden item"}],
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "skill_view",
+                            "arguments": '{"name":"x"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": "x" * 43691,
+            },
+            {"role": "assistant", "content": "Done."},
+        ]
+    )
+
+    assert out == [
+        {"role": "user", "content": "open the skill"},
+        {"role": "assistant", "content": "Done."},
+    ]
+    serialized = repr(out)
+    assert "skill_view" not in serialized
+    assert "tool_call_id" not in serialized
+    assert "private debugging" not in serialized
+    assert "hidden detail" not in serialized
+    assert "hidden item" not in serialized
+    assert "x" * 100 not in serialized
+
+
+def test_sanitize_resumed_history_keeps_visible_dialogue_only():
+    out = sanitize_resumed_conversation_history(
+        [
+            {"role": "user", "content": "question"},
+            {
+                "role": "assistant",
+                "content": "I will check.",
+                "tool_calls": [{"id": "call_1", "function": {"name": "terminal"}}],
+                "reasoning_content": "hidden",
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "secret"},
+        ]
+    )
+
+    assert out == [
+        {"role": "user", "content": "question"},
+        {"role": "assistant", "content": "I will check."},
+    ]

--- a/tests/agent/test_resume_history.py
+++ b/tests/agent/test_resume_history.py
@@ -1,4 +1,8 @@
-from agent.resume_history import sanitize_resumed_conversation_history
+from agent.resume_history import (
+    has_interrupted_tool_tail,
+    model_history_for_resumed_session,
+    sanitize_resumed_conversation_history,
+)
 
 
 def test_sanitize_resumed_history_strips_tool_and_reasoning_payloads():
@@ -63,3 +67,37 @@ def test_sanitize_resumed_history_keeps_visible_dialogue_only():
         {"role": "user", "content": "question"},
         {"role": "assistant", "content": "I will check."},
     ]
+
+
+def test_model_history_for_resumed_session_sanitizes_finished_tool_turn():
+    history = [
+        {"role": "user", "content": "question"},
+        {
+            "role": "assistant",
+            "content": "I will check.",
+            "tool_calls": [{"id": "call_1", "function": {"name": "terminal"}}],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "secret"},
+        {"role": "assistant", "content": "Done."},
+    ]
+
+    assert has_interrupted_tool_tail(history) is False
+    assert model_history_for_resumed_session(history) == [
+        {"role": "user", "content": "question"},
+        {"role": "assistant", "content": "I will check.\n\nDone."},
+    ]
+
+
+def test_model_history_for_resumed_session_preserves_interrupted_tool_tail():
+    history = [
+        {"role": "user", "content": "question"},
+        {
+            "role": "assistant",
+            "content": "I will check.",
+            "tool_calls": [{"id": "call_1", "function": {"name": "terminal"}}],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "secret"},
+    ]
+
+    assert has_interrupted_tool_tail(history) is True
+    assert model_history_for_resumed_session(history) == history

--- a/tests/agent/test_resume_history.py
+++ b/tests/agent/test_resume_history.py
@@ -1,5 +1,4 @@
 from agent.resume_history import (
-    has_interrupted_tool_tail,
     model_history_for_resumed_session,
     sanitize_resumed_conversation_history,
 )
@@ -81,14 +80,13 @@ def test_model_history_for_resumed_session_sanitizes_finished_tool_turn():
         {"role": "assistant", "content": "Done."},
     ]
 
-    assert has_interrupted_tool_tail(history) is False
     assert model_history_for_resumed_session(history) == [
         {"role": "user", "content": "question"},
         {"role": "assistant", "content": "I will check.\n\nDone."},
     ]
 
 
-def test_model_history_for_resumed_session_preserves_interrupted_tool_tail():
+def test_model_history_for_resumed_session_sanitizes_tool_tail():
     history = [
         {"role": "user", "content": "question"},
         {
@@ -99,5 +97,7 @@ def test_model_history_for_resumed_session_preserves_interrupted_tool_tail():
         {"role": "tool", "tool_call_id": "call_1", "content": "secret"},
     ]
 
-    assert has_interrupted_tool_tail(history) is True
-    assert model_history_for_resumed_session(history) == history
+    assert model_history_for_resumed_session(history) == [
+        {"role": "user", "content": "question"},
+        {"role": "assistant", "content": "I will check."},
+    ]

--- a/tests/cli/test_cli_resume_history.py
+++ b/tests/cli/test_cli_resume_history.py
@@ -1,0 +1,88 @@
+import sys
+import types
+
+from hermes_cli.cli_agent_setup_mixin import CLIAgentSetupMixin
+
+
+class _FakeConn:
+    def execute(self, *_args, **_kwargs):
+        pass
+
+    def commit(self):
+        pass
+
+
+class _FakeSessionDB:
+    def __init__(self, history):
+        self.history = history
+        self._conn = _FakeConn()
+
+    def get_session(self, session_id):
+        return {"id": session_id, "title": ""}
+
+    def resolve_resume_session_id(self, session_id):
+        return session_id
+
+    def get_messages_as_conversation(self, _session_id):
+        return list(self.history)
+
+
+class _CLI(CLIAgentSetupMixin):
+    def __init__(self, history):
+        self._resumed = True
+        self._session_db = _FakeSessionDB(history)
+        self.session_id = "session-1"
+        self.conversation_history = []
+        self.printed = []
+
+    def _console_print(self, message):
+        self.printed.append(message)
+
+    def _restore_session_cwd(self, _session_meta):
+        pass
+
+
+def test_cli_preload_resume_preserves_interrupted_tool_tail(monkeypatch):
+    monkeypatch.setitem(
+        sys.modules,
+        "cli",
+        types.SimpleNamespace(_accent_hex=lambda: "cyan"),
+    )
+    raw_history = [
+        {"role": "user", "content": "inspect"},
+        {
+            "role": "assistant",
+            "content": "I will inspect it.",
+            "tool_calls": [{"id": "call_1", "function": {"name": "read_file"}}],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "RAW_TOOL_OUTPUT"},
+    ]
+    cli = _CLI(raw_history)
+
+    assert cli._preload_resumed_session() is True
+    assert cli.conversation_history == raw_history
+
+
+def test_cli_preload_resume_sanitizes_finished_tool_turn(monkeypatch):
+    monkeypatch.setitem(
+        sys.modules,
+        "cli",
+        types.SimpleNamespace(_accent_hex=lambda: "cyan"),
+    )
+    raw_history = [
+        {"role": "user", "content": "inspect"},
+        {
+            "role": "assistant",
+            "content": "I will inspect it.",
+            "tool_calls": [{"id": "call_1", "function": {"name": "read_file"}}],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "RAW_TOOL_OUTPUT"},
+        {"role": "assistant", "content": "done"},
+    ]
+    cli = _CLI(raw_history)
+
+    assert cli._preload_resumed_session() is True
+    assert cli.conversation_history == [
+        {"role": "user", "content": "inspect"},
+        {"role": "assistant", "content": "I will inspect it.\n\ndone"},
+    ]

--- a/tests/cli/test_cli_resume_history.py
+++ b/tests/cli/test_cli_resume_history.py
@@ -42,7 +42,7 @@ class _CLI(CLIAgentSetupMixin):
         pass
 
 
-def test_cli_preload_resume_preserves_interrupted_tool_tail(monkeypatch):
+def test_cli_preload_resume_sanitizes_tool_tail(monkeypatch):
     monkeypatch.setitem(
         sys.modules,
         "cli",
@@ -60,7 +60,10 @@ def test_cli_preload_resume_preserves_interrupted_tool_tail(monkeypatch):
     cli = _CLI(raw_history)
 
     assert cli._preload_resumed_session() is True
-    assert cli.conversation_history == raw_history
+    assert cli.conversation_history == [
+        {"role": "user", "content": "inspect"},
+        {"role": "assistant", "content": "I will inspect it."},
+    ]
 
 
 def test_cli_preload_resume_sanitizes_finished_tool_turn(monkeypatch):

--- a/tests/cli/test_resume_display.py
+++ b/tests/cli/test_resume_display.py
@@ -571,6 +571,7 @@ class TestPreloadResumedSession:
     def test_loads_session_successfully(self):
         cli = _make_cli(resume="good_session")
         messages = _simple_history()
+        expected_history = [m for m in messages if m.get("role") != "system"]
         mock_db = MagicMock()
         mock_db.get_session.return_value = {"id": "good_session", "title": "Test Session"}
         mock_db.get_messages_as_conversation.return_value = messages
@@ -581,12 +582,62 @@ class TestPreloadResumedSession:
         result = cli._preload_resumed_session()
 
         assert result is True
-        assert cli.conversation_history == messages
+        assert cli.conversation_history == expected_history
         output = buf.getvalue()
         assert "Resumed session" in output
         assert "good_session" in output
         assert "Test Session" in output
         assert "2 user messages" in output
+
+    def test_resume_history_omits_tool_debug_context(self):
+        cli = _make_cli(resume="leaky_session")
+        huge_tool_result = "debug instructions\n" + ("x" * 43691)
+        messages = [
+            {"role": "user", "content": "show skill"},
+            {
+                "role": "assistant",
+                "content": "",
+                "reasoning": "private chain",
+                "tool_calls": [
+                    {
+                        "id": "call_skill",
+                        "type": "function",
+                        "function": {
+                            "name": "skill_view",
+                            "arguments": '{"name":"secret"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_skill",
+                "tool_name": "skill_view",
+                "content": huge_tool_result,
+            },
+        ]
+        mock_db = MagicMock()
+        mock_db.get_session.return_value = {"id": "leaky_session", "title": None}
+        mock_db.get_messages_as_conversation.return_value = messages
+        mock_db._conn = MagicMock()
+        cli._session_db = mock_db
+
+        buf = StringIO()
+        cli.console.file = buf
+        assert cli._preload_resumed_session() is True
+
+        assert cli.conversation_history == [
+            {"role": "user", "content": "show skill"},
+            {
+                "role": "assistant",
+                "content": "[Prior tool activity omitted from resumed context.]",
+            },
+        ]
+        serialized = repr(cli.conversation_history)
+        assert "skill_view" not in serialized
+        assert "debug instructions" not in serialized
+        assert "tool_calls" not in serialized
+        assert "reasoning" not in serialized
 
     def test_reopens_session_in_db(self):
         cli = _make_cli(resume="reopen_session")
@@ -655,7 +706,7 @@ class TestHandleResumeCommandRecap:
             cli._handle_resume_command("/resume test session")
 
         assert cli.session_id == "target_session"
-        assert cli.conversation_history == messages
+        assert cli.conversation_history == [m for m in messages if m.get("role") != "system"]
         mock_db.end_session.assert_called_once_with("current_session", "resumed_other")
         mock_db.reopen_session.assert_called_once_with("target_session")
         display_mock.assert_called_once_with()

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1763,7 +1763,11 @@ class TestResponsesEndpoint:
                 "session_id": "api-test-session",
             },
         )
-        full_agent_transcript = prior_history + [
+        model_history = [
+            {"role": "user", "content": "Read old file"},
+            {"role": "assistant", "content": "old"},
+        ]
+        full_agent_transcript = model_history + [
             {"role": "user", "content": "Read new file"},
             {
                 "role": "assistant",
@@ -1811,6 +1815,118 @@ class TestResponsesEndpoint:
         assert "call_new" in output_json
         assert "call_old" not in output_json
         assert "old.txt" not in output_json
+
+    @pytest.mark.asyncio
+    async def test_previous_response_id_sanitizes_model_history_but_preserves_stored_raw_transcript(self, adapter):
+        """Chained Responses must not feed prior raw tool transcripts back to the model."""
+        raw_prior_history = [
+            {"role": "user", "content": "Read old file"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_old",
+                        "function": {
+                            "name": "read_file",
+                            "arguments": '{"path":"old.txt"}',
+                        },
+                    }
+                ],
+                "provider_metadata": {"debug": "PRIVATE_REASONING"},
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_old",
+                "content": "RAW_TOOL_OUTPUT old secret",
+            },
+            {"role": "assistant", "content": "old result"},
+        ]
+        adapter._response_store.put(
+            "resp_prev",
+            {
+                "response": {"id": "resp_prev", "status": "completed"},
+                "conversation_history": list(raw_prior_history),
+                "session_id": "api-test-session",
+            },
+        )
+        sanitized_prior_history = [
+            {"role": "user", "content": "Read old file"},
+            {"role": "assistant", "content": "old result"},
+        ]
+        current_turn = [
+            {"role": "user", "content": "Read new file"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call_new",
+                        "function": {
+                            "name": "read_file",
+                            "arguments": '{"path":"new.txt"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_new",
+                "content": '{"content":"new"}',
+            },
+            {"role": "assistant", "content": "new result"},
+        ]
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {
+                        "final_response": "new result",
+                        "messages": sanitized_prior_history + current_turn,
+                        "api_calls": 1,
+                    },
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "Read new file",
+                        "previous_response_id": "resp_prev",
+                    },
+                )
+                assert resp.status == 200
+                data = await resp.json()
+
+        call_kwargs = mock_run.call_args.kwargs
+        assert call_kwargs["conversation_history"] == sanitized_prior_history
+        model_history_json = json.dumps(call_kwargs["conversation_history"])
+        assert "call_old" not in model_history_json
+        assert "RAW_TOOL_OUTPUT" not in model_history_json
+        assert "PRIVATE_REASONING" not in model_history_json
+
+        stored_history = adapter._response_store.get(data["id"])["conversation_history"]
+        assert stored_history == raw_prior_history + current_turn
+        stored_history_json = json.dumps(stored_history)
+        assert "call_old" in stored_history_json
+        assert "RAW_TOOL_OUTPUT" in stored_history_json
+
+    def test_build_response_history_does_not_duplicate_current_user_suffix(self):
+        prior_history = [{"role": "user", "content": "First"}]
+        current_turn = [
+            {"role": "user", "content": "Second"},
+            {"role": "assistant", "content": "Reply"},
+        ]
+
+        stored_history = APIServerAdapter._build_response_conversation_history(
+            prior_history,
+            "Second",
+            {"messages": list(current_turn)},
+            "Reply",
+        )
+
+        assert stored_history == prior_history + current_turn
+        assert stored_history.count({"role": "user", "content": "Second"}) == 1
 
     @pytest.mark.asyncio
     async def test_previous_response_id_preserves_session(self, adapter):
@@ -2245,6 +2361,119 @@ class TestResponsesStreaming:
         assert stored_history == expected_history
         assert stored_history.count(prior_history[0]) == 1
         assert stored_history.count({"role": "user", "content": "Now add 1 more"}) == 1
+
+    @pytest.mark.asyncio
+    async def test_streamed_previous_response_id_sanitizes_model_history_but_preserves_stored_raw_transcript(self, adapter):
+        raw_prior_history = [
+            {"role": "user", "content": "Read old file"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_old",
+                        "function": {
+                            "name": "read_file",
+                            "arguments": '{"path":"old.txt"}',
+                        },
+                    }
+                ],
+                "provider_metadata": {"debug": "PRIVATE_REASONING"},
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_old",
+                "content": "RAW_TOOL_OUTPUT old secret",
+            },
+            {"role": "assistant", "content": "old result"},
+        ]
+        adapter._response_store.put(
+            "resp_prev",
+            {
+                "response": {"id": "resp_prev", "status": "completed"},
+                "conversation_history": list(raw_prior_history),
+                "session_id": "api-test-session",
+            },
+        )
+        sanitized_prior_history = [
+            {"role": "user", "content": "Read old file"},
+            {"role": "assistant", "content": "old result"},
+        ]
+        current_turn = [
+            {"role": "user", "content": "Read new file"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call_new",
+                        "function": {
+                            "name": "read_file",
+                            "arguments": '{"path":"new.txt"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_new",
+                "content": '{"content":"new"}',
+            },
+            {"role": "assistant", "content": "new result"},
+        ]
+        captured = {}
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                captured["conversation_history"] = kwargs["conversation_history"]
+                cb = kwargs.get("stream_delta_callback")
+                if cb:
+                    cb("new result")
+                return (
+                    {
+                        "final_response": "new result",
+                        "messages": sanitized_prior_history + current_turn,
+                        "api_calls": 1,
+                    },
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "Read new file",
+                        "previous_response_id": "resp_prev",
+                        "stream": True,
+                    },
+                )
+                body = await resp.text()
+
+        assert resp.status == 200
+        assert captured["conversation_history"] == sanitized_prior_history
+        model_history_json = json.dumps(captured["conversation_history"])
+        assert "call_old" not in model_history_json
+        assert "RAW_TOOL_OUTPUT" not in model_history_json
+        assert "PRIVATE_REASONING" not in model_history_json
+
+        response_id = None
+        for line in body.splitlines():
+            if line.startswith("data: "):
+                try:
+                    payload = json.loads(line[len("data: "):])
+                except json.JSONDecodeError:
+                    continue
+                if payload.get("type") == "response.completed":
+                    response_id = payload["response"]["id"]
+                    break
+
+        assert response_id
+        stored_history = adapter._response_store.get(response_id)["conversation_history"]
+        assert stored_history == raw_prior_history + current_turn
+        stored_history_json = json.dumps(stored_history)
+        assert "call_old" in stored_history_json
+        assert "RAW_TOOL_OUTPUT" in stored_history_json
 
     @pytest.mark.asyncio
     async def test_stream_cancelled_persists_incomplete_snapshot(self, adapter):

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -9,6 +9,7 @@ Covers:
 """
 
 import asyncio
+import json
 import threading
 from unittest.mock import MagicMock, patch
 
@@ -188,6 +189,81 @@ class TestStartRun:
                     headers={"Authorization": "Bearer sk-secret"},
                 )
                 assert resp.status == 202
+
+    @pytest.mark.asyncio
+    async def test_previous_response_id_sanitizes_model_history(self, adapter):
+        raw_prior_history = [
+            {"role": "user", "content": "Read old file"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_old",
+                        "function": {
+                            "name": "read_file",
+                            "arguments": '{"path":"old.txt"}',
+                        },
+                    }
+                ],
+                "provider_metadata": {"debug": "PRIVATE_REASONING"},
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_old",
+                "content": "RAW_TOOL_OUTPUT old secret",
+            },
+            {"role": "assistant", "content": "old result"},
+        ]
+        adapter._response_store.put(
+            "resp_prev",
+            {
+                "response": {"id": "resp_prev", "status": "completed"},
+                "conversation_history": list(raw_prior_history),
+                "session_id": "api-test-session",
+            },
+        )
+        captured = {}
+
+        def _run_conversation(user_message=None, conversation_history=None, task_id=None):
+            captured["user_message"] = user_message
+            captured["conversation_history"] = conversation_history
+            captured["task_id"] = task_id
+            return {"final_response": "done"}
+
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.side_effect = _run_conversation
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "Read new file", "previous_response_id": "resp_prev"},
+                )
+                assert resp.status == 202
+                data = await resp.json()
+
+                for _ in range(20):
+                    if "conversation_history" in captured:
+                        break
+                    await asyncio.sleep(0.05)
+
+        assert captured["user_message"] == "Read new file"
+        assert captured["task_id"] == "api-test-session"
+        assert captured["conversation_history"] == [
+            {"role": "user", "content": "Read old file"},
+            {"role": "assistant", "content": "old result"},
+        ]
+        model_history_json = json.dumps(captured["conversation_history"])
+        assert "call_old" not in model_history_json
+        assert "RAW_TOOL_OUTPUT" not in model_history_json
+        assert "PRIVATE_REASONING" not in model_history_json
+        assert data["run_id"].startswith("run_")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -37,6 +37,7 @@ from gateway.platforms.base import MessageEvent, MessageType, SendResult
 from gateway.run import (
     _auto_continue_freshness_window,
     _coerce_gateway_timestamp,
+    _gateway_model_history_for_run,
     _is_fresh_gateway_interruption,
     _last_transcript_timestamp,
     _should_clear_resume_pending_after_turn,
@@ -101,6 +102,41 @@ def _build_agent_history(history: list) -> list:
             if content:
                 agent_history.append({"role": role, "content": content})
     return agent_history
+
+
+def test_gateway_model_history_sanitizes_completed_tool_payloads():
+    agent_history = [
+        {"role": "user", "content": "look this up"},
+        {
+            "role": "assistant",
+            "content": "",
+            "reasoning": "private",
+            "tool_calls": [{"id": "call_1", "function": {"name": "search"}}],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "secret" * 100},
+        {"role": "assistant", "content": "Found it."},
+    ]
+
+    model_history = _gateway_model_history_for_run(agent_history)
+
+    assert model_history == [
+        {"role": "user", "content": "look this up"},
+        {"role": "assistant", "content": "Found it."},
+    ]
+    assert "tool_call_id" not in repr(model_history)
+    assert "secret" not in repr(model_history)
+
+
+def test_gateway_model_history_preserves_fresh_interrupted_tool_context():
+    agent_history = [
+        {"role": "assistant", "content": "", "tool_calls": [{"id": "call_1"}]},
+        {"role": "tool", "tool_call_id": "call_1", "content": "pending result"},
+    ]
+
+    assert _gateway_model_history_for_run(
+        agent_history,
+        preserve_interrupted_tool_context=True,
+    ) is agent_history
 
 
 def _simulate_note_injection(

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4085,8 +4085,8 @@ def test_prompt_submit_history_version_match_persists_normally(monkeypatch):
         server._sessions.pop("sid", None)
 
 
-def test_prompt_submit_preserves_interrupted_tool_tail_for_model(monkeypatch):
-    """An unfinished assistant->tool tail must survive TUI resume replay."""
+def test_prompt_submit_sanitizes_tool_tail_for_model(monkeypatch):
+    """Ordinary TUI resume must not replay raw assistant->tool tails."""
     seen = {}
     raw_history = [
         {"role": "user", "content": "inspect the file"},
@@ -4150,9 +4150,12 @@ def test_prompt_submit_preserves_interrupted_tool_tail_for_model(monkeypatch):
         )
 
         assert resp.get("result"), f"got error: {resp.get('error')}"
-        assert seen["history"] == raw_history
-        assert "RAW_TOOL_OUTPUT" in repr(seen["history"])
-        assert "call_1" in repr(seen["history"])
+        assert seen["history"] == [
+            {"role": "user", "content": "inspect the file"},
+            {"role": "assistant", "content": "I will inspect it."},
+        ]
+        assert "RAW_TOOL_OUTPUT" not in repr(seen["history"])
+        assert "call_1" not in repr(seen["history"])
         assert server._sessions["sid"]["history"][-1] == {
             "role": "assistant",
             "content": "reply",

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4085,6 +4085,82 @@ def test_prompt_submit_history_version_match_persists_normally(monkeypatch):
         server._sessions.pop("sid", None)
 
 
+def test_prompt_submit_preserves_interrupted_tool_tail_for_model(monkeypatch):
+    """An unfinished assistant->tool tail must survive TUI resume replay."""
+    seen = {}
+    raw_history = [
+        {"role": "user", "content": "inspect the file"},
+        {
+            "role": "assistant",
+            "content": "I will inspect it.",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "function": {
+                        "name": "read_file",
+                        "arguments": '{"path":"a.txt"}',
+                    },
+                }
+            ],
+            "provider_metadata": {"debug": "PRIVATE_REASONING"},
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "content": "RAW_TOOL_OUTPUT",
+        },
+    ]
+
+    class _Agent:
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None
+        ):
+            seen["prompt"] = prompt
+            seen["history"] = conversation_history
+            return {
+                "final_response": "reply",
+                "messages": [
+                    *(conversation_history or []),
+                    {"role": "user", "content": prompt},
+                    {"role": "assistant", "content": "reply"},
+                ],
+            }
+
+    class _ImmediateThread:
+        def __init__(self, target=None, daemon=None):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    server._sessions["sid"] = _session(agent=_Agent(), history=raw_history)
+    emits: list[tuple] = []
+    try:
+        monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+        monkeypatch.setattr(server, "_get_usage", lambda _a: {})
+        monkeypatch.setattr(server, "render_message", lambda _t, _c: "")
+        monkeypatch.setattr(server, "_emit", lambda *a: emits.append(a))
+
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {"session_id": "sid", "text": "continue"},
+            }
+        )
+
+        assert resp.get("result"), f"got error: {resp.get('error')}"
+        assert seen["history"] == raw_history
+        assert "RAW_TOOL_OUTPUT" in repr(seen["history"])
+        assert "call_1" in repr(seen["history"])
+        assert server._sessions["sid"]["history"][-1] == {
+            "role": "assistant",
+            "content": "reply",
+        }
+    finally:
+        server._sessions.pop("sid", None)
+
+
 def test_prompt_submit_can_truncate_before_user_ordinal(monkeypatch):
     """Desktop user-message edits should restart the turn from the edited user."""
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5761,9 +5761,9 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                     payload["rendered"] = r
                 _emit("message.delta", sid, payload)
 
-            from agent.resume_history import sanitize_resumed_conversation_history
+            from agent.resume_history import model_history_for_resumed_session
             run_kwargs = {
-                "conversation_history": sanitize_resumed_conversation_history(history),
+                "conversation_history": model_history_for_resumed_session(history),
                 "stream_callback": _stream,
             }
             try:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5761,8 +5761,9 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                     payload["rendered"] = r
                 _emit("message.delta", sid, payload)
 
+            from agent.resume_history import sanitize_resumed_conversation_history
             run_kwargs = {
-                "conversation_history": list(history),
+                "conversation_history": sanitize_resumed_conversation_history(history),
                 "stream_callback": _stream,
             }
             try:


### PR DESCRIPTION
## Summary

When a CLI session is resumed, the agent replays prior assistant/tool/debugging context as visible output instead of answering the current user prompt. This is a context-boundary leak with privacy/security impact.

Root cause: conversation_history loaded from SQLite included raw tool_calls, tool results (potentially 43K+ bytes of debug output), reasoning metadata, and system messages. The LLM saw all of this and would continue the prior conversation rather than treating the new user message as a fresh request.

## Fix

- Added agent/resume_history.py with sanitize_resumed_conversation_history()
- Strip tool_calls, tool results, reasoning/debug metadata from resumed history before passing to the LLM
- Assistant messages with tool_calls replaced with clean marker
- Apply sanitization in CLI, TUI, gateway, and API resume paths
- ACP keeps raw history for round-trip APIs but sanitizes on first model call

## Test Plan

- [x] 40 new tests pass
- [x] Regression test for skill_view + 43691-byte tool-result leak shape
- [ ] Manual verification

Fixes #27156