### PR TITLE
fix(fallback): NameError on 429 rate-limit — missing _pool_may_recover_from_rate_limit import

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2251,7 +2251,7 @@ def run_conversation(
                     # still recover.  See _pool_may_recover_from_rate_limit
                     # for the single-credential-pool and CloudCode-quota
                     # exceptions.  Fixes #11314 and #13636.
-                    pool_may_recover = _pool_may_recover_from_rate_limit(
+                    pool_may_recover = _ra()._pool_may_recover_from_rate_limit(
                         agent._credential_pool,
                         provider=agent.provider,
                         base_url=getattr(agent, "base_url", None),

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -305,3 +305,55 @@ class TestFallbackChainDedup:
 
         assert ok is False
         mock_resolve.assert_not_called()
+
+
+# ── Regression: _pool_may_recover_from_rate_limit reachable via _ra() ──
+# The run_agent.py refactor moved the fallback error-handling into
+# agent/conversation_loop.py but initially forgot to import the helper.
+# See https://github.com/NousResearch/hermes-agent/issues/XXXX
+#
+# This test verifies the function is reachable from conversation_loop
+# without a NameError (the _ra() lazy-import pattern must resolve it).
+
+
+class TestPoolMayRecoverReachableFromConversationLoop:
+    """Regression: _pool_may_recover_from_rate_limit must be callable from
+    agent/conversation_loop.py via the ``_ra()`` lazy-import helper.
+
+    The refactored conversation loop calls ``_ra()._pool_may_recover_from_rate_limit``
+    instead of importing the function at module top-level (to avoid circular imports).
+    If the call site reverts to a bare ``_pool_may_recover_from_rate_limit(...)``
+    without an import, a NameError crashes the agent on every 429 rate-limit.
+    """
+
+    def test_ra_resolves_pool_may_recover(self):
+        """``_ra()`` in conversation_loop must resolve _pool_may_recover_from_rate_limit."""
+        from agent.conversation_loop import _ra
+
+        run_agent_mod = _ra()
+        assert hasattr(run_agent_mod, "_pool_may_recover_from_rate_limit"), (
+            "_pool_may_recover_from_rate_limit not found on run_agent module "
+            "via _ra() — the conversation_loop will NameError on 429"
+        )
+        # Also verify it is callable with the expected signature (positional pool
+        # + keyword-only provider/base_url).
+        assert callable(run_agent_mod._pool_may_recover_from_rate_limit)
+
+    def test_call_with_none_returns_false(self):
+        """End-to-end: calling through _ra() with None pool returns False."""
+        from agent.conversation_loop import _ra
+
+        result = _ra()._pool_may_recover_from_rate_limit(None)
+        assert result is False
+
+    def test_call_with_pool_passthrough(self):
+        """End-to-end: credential-pool arguments are forwarded correctly."""
+        from agent.conversation_loop import _ra
+
+        pool = _pool(2)
+        result = _ra()._pool_may_recover_from_rate_limit(
+            pool,
+            provider="test-provider",
+            base_url="https://example.com/v1",
+        )
+        assert result is True


### PR DESCRIPTION
## Bug

After the `run_agent.py` refactor (splitting ~12k LOC into ~15 modules under `agent/`), the fallback rate-limit handling in `agent/conversation_loop.py` calls `_pool_may_recover_from_rate_limit()` as a bare name — but the function is defined in `run_agent.py` and was never imported.

When the primary model returns a 429 (rate limit or billing quota), the agent crashes with:

```
NameError: name '_pool_may_recover_from_rate_limit' is not defined
```

This breaks the entire fallback chain: the user sees the error and `/reset` does not help because the import is missing at module level.

## Root Cause

The call site at `agent/conversation_loop.py:2254` was moved from `run_agent.py` during the refactor but the import was not added. A top-level `from run_agent import _pool_may_recover_from_rate_limit` would risk circular imports since `run_agent.py` imports from `agent/` modules.

## Fix

Use the existing `_ra()` lazy-import helper (already used by other `run_agent` symbols in `conversation_loop.py`, e.g. `_ra()._set_interrupt(...)`, `_ra().AIAgent._get_tool_call_name_static(...)`) to resolve the function at call time:

```python
# Before (crashes):
pool_may_recover = _pool_may_recover_from_rate_limit(...)

# After (works):
pool_may_recover = _ra()._pool_may_recover_from_rate_limit(...)
```

## Testing

Added 3 regression tests in `tests/run_agent/test_provider_fallback.py`:

- `test_ra_resolves_pool_may_recover` — verifies `_ra()` resolves the function
- `test_call_with_none_returns_false` — end-to-end: None pool → False
- `test_call_with_pool_passthrough` — end-to-end: multi-credential pool → True

All 25 tests in the file pass (including 22 pre-existing + 3 new).

## Files Changed

| File | Change |
|------|--------|
| `agent/conversation_loop.py` | `_pool_may_recover_from_rate_limit(` → `_ra()._pool_may_recover_from_rate_limit(` |
| `tests/run_agent/test_provider_fallback.py` | +3 regression tests |