### PR TITLE
fix(agent): trigger preflight compression on few-but-huge sessions

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -73,6 +73,29 @@ from utils import base_url_host_matches, env_var_enabled
 logger = logging.getLogger(__name__)
 
 
+def _should_run_preflight_estimate(
+    messages: List[Dict[str, Any]],
+    protect_first_n: int,
+    protect_last_n: int,
+    threshold_tokens: int,
+) -> bool:
+    """Cheap gate for the (expensive) full preflight token estimate.
+
+    Returns True when either:
+      (a) message count exceeds the protected ranges (the historical gate), or
+      (b) a char-based estimate already crosses the configured threshold —
+          the few-but-huge case from issue #27405 that the count-only gate
+          would silently skip.
+
+    The downstream estimator remains authoritative; this is just a hint.
+    """
+    if len(messages) > protect_first_n + protect_last_n + 1:
+        return True
+    approx_chars = sum(len(str(m.get("content", "") or "")) for m in messages)
+    approx_tokens = approx_chars // 4
+    return approx_tokens >= threshold_tokens
+
+
 def _ra():
     """Lazy reference to ``run_agent`` so callers can patch
     ``run_agent.handle_function_call`` / ``run_agent._set_interrupt`` /
@@ -360,10 +383,14 @@ def run_conversation(
     # while having a large existing session — compress proactively rather
     # than waiting for an API error (which might be caught as a non-retryable
     # 4xx and abort the request entirely).
-    if (
-        agent.compression_enabled
-        and len(messages) > agent.context_compressor.protect_first_n
-                            + agent.context_compressor.protect_last_n + 1
+    # Gate the (expensive) full token estimate behind a cheap pre-check.
+    # See ``_should_run_preflight_estimate`` for the OR semantics that fix
+    # issue #27405 (few-but-huge messages slipping past the count gate).
+    if agent.compression_enabled and _should_run_preflight_estimate(
+        messages,
+        agent.context_compressor.protect_first_n,
+        agent.context_compressor.protect_last_n,
+        agent.context_compressor.threshold_tokens,
     ):
         # Include tool schema tokens — with many tools these can add
         # 20-30K+ tokens that the old sys+msg estimate missed entirely.

--- a/tests/agent/test_preflight_compression_gate.py
+++ b/tests/agent/test_preflight_compression_gate.py
@@ -1,0 +1,87 @@
+"""Regression tests for issue #27405.
+
+The preflight compression gate must trigger when *either* the message
+count exceeds the protected ranges OR the cheap char-based token
+estimate already crosses the configured threshold. Pre-fix, only the
+message-count condition was checked, so a session with a small number
+of huge messages would silently skip compression and eventually hit a
+hard context-overflow error.
+"""
+
+from agent.conversation_loop import _should_run_preflight_estimate
+
+
+# Compressor defaults mirrored in the tests so we don't depend on
+# MINIMUM_CONTEXT_LENGTH / model metadata.
+PROTECT_FIRST_N = 3
+PROTECT_LAST_N = 20
+THRESHOLD_TOKENS = 64_000  # matches the production floor
+
+
+def _msg(content: str) -> dict:
+    return {"role": "user", "content": content}
+
+
+def test_few_messages_huge_content_triggers_gate():
+    """The bug from #27405: 8 messages with one massive content blob."""
+    # ~280K chars in one message ≈ 70K tokens at 4 chars/token.
+    big = "x" * 280_000
+    messages = [_msg("hi")] * 7 + [_msg(big)]
+    assert len(messages) <= PROTECT_FIRST_N + PROTECT_LAST_N + 1  # would fail old gate
+    assert _should_run_preflight_estimate(
+        messages, PROTECT_FIRST_N, PROTECT_LAST_N, THRESHOLD_TOKENS
+    ) is True
+
+
+def test_few_messages_small_content_does_not_trigger():
+    """Regression guard: tiny sessions should not pay the estimator cost."""
+    messages = [_msg("hello world")] * 8
+    assert _should_run_preflight_estimate(
+        messages, PROTECT_FIRST_N, PROTECT_LAST_N, THRESHOLD_TOKENS
+    ) is False
+
+
+def test_many_small_messages_still_triggers_via_count():
+    """The historical path: > protect_first + protect_last + 1 messages."""
+    messages = [_msg("ok")] * (PROTECT_FIRST_N + PROTECT_LAST_N + 2)  # 25
+    assert _should_run_preflight_estimate(
+        messages, PROTECT_FIRST_N, PROTECT_LAST_N, THRESHOLD_TOKENS
+    ) is True
+
+
+def test_content_exactly_at_threshold_triggers():
+    """Boundary: approx_tokens >= threshold should trigger (inclusive)."""
+    # 4 chars per token, so threshold * 4 chars produces exactly threshold tokens.
+    messages = [_msg("x" * (THRESHOLD_TOKENS * 4))]
+    assert _should_run_preflight_estimate(
+        messages, PROTECT_FIRST_N, PROTECT_LAST_N, THRESHOLD_TOKENS
+    ) is True
+
+
+def test_content_just_below_threshold_does_not_trigger():
+    """Boundary: one token below threshold and few messages must not trigger."""
+    messages = [_msg("x" * ((THRESHOLD_TOKENS - 1) * 4))]
+    assert _should_run_preflight_estimate(
+        messages, PROTECT_FIRST_N, PROTECT_LAST_N, THRESHOLD_TOKENS
+    ) is False
+
+
+def test_message_with_none_content_is_treated_as_empty():
+    """Assistant turns mid-tool-call carry content=None — must not crash."""
+    messages = [{"role": "assistant", "content": None}] * 5
+    assert _should_run_preflight_estimate(
+        messages, PROTECT_FIRST_N, PROTECT_LAST_N, THRESHOLD_TOKENS
+    ) is False
+
+
+def test_message_with_list_content_uses_repr_length():
+    """Multimodal content lists are handled by str(); approximate is fine.
+
+    The downstream real estimator is authoritative; the gate just needs to
+    not crash and to err on the side of admitting suspicious payloads.
+    """
+    parts = [{"type": "text", "text": "x" * 300_000}]
+    messages = [{"role": "user", "content": parts}]
+    assert _should_run_preflight_estimate(
+        messages, PROTECT_FIRST_N, PROTECT_LAST_N, THRESHOLD_TOKENS
+    ) is True


### PR DESCRIPTION
## What

Fix the preflight compression gate in `agent/conversation_loop.py` so it triggers based on either message count **or** a cheap char-based token estimate. Previously the count-only gate let sessions with few but very large messages silently skip compression, causing context overflow on the next API call.

Fixes #27405.

## Why

Per the issue: API Server / Open WebUI mode (and any client passing compact history with huge tool_results) creates sessions with <24 messages but >threshold tokens. The old gate `len(messages) > 24` evaluated False and the entire token estimation + compression block was skipped.

The fix adds a small helper `_should_run_preflight_estimate(messages, protect_first, protect_last, threshold)` that returns True on either condition. The downstream `estimate_request_tokens_rough` + `_preflight_tokens >= threshold_tokens` check remains authoritative, so we don't falsely compress small sessions.

## How to test

1. Set `compression.threshold: 0.005` in `~/.hermes/config.yaml` (the `MINIMUM_CONTEXT_LENGTH` floor of 64K still applies).
2. Run a session that loads a large tool result (e.g. resume one containing a >256K-char file read), or send a single user message with >64K tokens.
3. Pre-fix: `grep "Preflight compression" ~/.hermes/logs/agent.log` returns nothing.
4. Post-fix: at least one preflight log line.

Automated coverage in `tests/agent/test_preflight_compression_gate.py`:
- few-and-huge (the bug)
- few-and-small (regression guard)
- many-and-small (count path still works)
- threshold boundary (inclusive)
- `content=None` and multimodal list content (no crash)

## Platforms tested

- Linux (Ubuntu 24.04), Python 3.12

## Out of scope (separate PRs)

- Wiring `ContextCompressor.should_compress()` into the post-response path using real `prompt_tokens` (issue's Fix 2)
- Tuning the 4-chars-per-token heuristic for CJK / code / base64 (issue's Fix 3)
