### PR TITLE
fix(xai-oauth): show "not received" page when loopback callback has no code (#27385)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2127,10 +2127,37 @@ def _make_xai_callback_handler(expected_path: str) -> tuple[type[BaseHTTPRequest
                 return
 
             params = parse_qs(parsed.query)
-            result["code"] = params.get("code", [None])[0]
-            result["state"] = params.get("state", [None])[0]
-            result["error"] = params.get("error", [None])[0]
-            result["error_description"] = params.get("error_description", [None])[0]
+            code = params.get("code", [None])[0]
+            state = params.get("state", [None])[0]
+            error = params.get("error", [None])[0]
+            error_description = params.get("error_description", [None])[0]
+
+            # Treat a hit on the callback path with neither `code` nor `error`
+            # as a missing OAuth callback (e.g. xAI's auth backend failed to
+            # redirect and the user navigated to the bare loopback URL by hand).
+            # Show an explicit "not received" page rather than the success page —
+            # otherwise the browser claims authorization succeeded while the CLI
+            # is still waiting for a real callback and eventually times out.
+            if code is None and error is None:
+                self.send_response(400)
+                self._maybe_write_cors_headers()
+                self.send_header("Content-Type", "text/html; charset=utf-8")
+                self.end_headers()
+                body = (
+                    "<html><body>"
+                    "<h1>xAI authorization not received.</h1>"
+                    "<p>No authorization code was present in this callback URL. "
+                    "Return to the terminal and re-run "
+                    "<code>hermes auth add xai-oauth</code> to retry.</p>"
+                    "</body></html>"
+                )
+                self.wfile.write(body.encode("utf-8"))
+                return
+
+            result["code"] = code
+            result["state"] = state
+            result["error"] = error
+            result["error_description"] = error_description
 
             self.send_response(200)
             self._maybe_write_cors_headers()

--- a/tests/hermes_cli/test_auth_xai_oauth_provider.py
+++ b/tests/hermes_cli/test_auth_xai_oauth_provider.py
@@ -20,6 +20,7 @@ from hermes_cli.auth import (
     _xai_access_token_is_expiring,
     _xai_callback_cors_origin,
     _xai_oauth_build_authorize_url,
+    _xai_start_callback_server,
     _xai_validate_loopback_redirect_uri,
     get_xai_oauth_auth_status,
     refresh_xai_oauth_pure,
@@ -276,6 +277,84 @@ def test_xai_callback_cors_origin_rejects_unknown_origin():
     assert _xai_callback_cors_origin("https://attacker.example.com") == ""
     assert _xai_callback_cors_origin(None) == ""
     assert _xai_callback_cors_origin("") == ""
+
+
+# ---------------------------------------------------------------------------
+# Loopback callback handler GET responses
+# ---------------------------------------------------------------------------
+
+
+def _get_callback(redirect_uri: str, query: str = "") -> tuple[int, str]:
+    """GET the loopback callback URL with an optional query string."""
+    from urllib.request import Request, urlopen
+    from urllib.error import HTTPError
+
+    target = redirect_uri + (("?" + query) if query else "")
+    req = Request(target, method="GET")
+    try:
+        with urlopen(req, timeout=5.0) as resp:
+            return resp.getcode(), resp.read().decode("utf-8", "replace")
+    except HTTPError as exc:
+        return exc.code, exc.read().decode("utf-8", "replace")
+
+
+def test_xai_callback_handler_returns_400_when_callback_url_lacks_code_and_error():
+    """Bare loopback URL (no code, no error) must not claim authorization received.
+
+    Regression for #27385: when xAI's auth backend fails to redirect and the user
+    manually navigates to http://127.0.0.1:<port>/callback, the handler used to
+    return 200 "xAI authorization received" while the CLI's wait loop still timed
+    out — leaving the user with a contradictory success page and a CLI error.
+    """
+    server, thread, result, redirect_uri = _xai_start_callback_server(preferred_port=0)
+    try:
+        status, body = _get_callback(redirect_uri)
+        assert status == 400
+        assert "not received" in body.lower()
+        assert "hermes auth add xai-oauth" in body
+        # Wait loop must still see no code/error so it raises a real timeout,
+        # rather than treating this empty hit as a successful callback.
+        assert result["code"] is None
+        assert result["error"] is None
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=1.0)
+
+
+def test_xai_callback_handler_accepts_callback_with_code():
+    """A real OAuth redirect (code + state) still records both and shows success."""
+    server, thread, result, redirect_uri = _xai_start_callback_server(preferred_port=0)
+    try:
+        status, body = _get_callback(redirect_uri, query="code=abc&state=xyz")
+        assert status == 200
+        assert "xAI authorization received" in body
+        assert result["code"] == "abc"
+        assert result["state"] == "xyz"
+        assert result["error"] is None
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=1.0)
+
+
+def test_xai_callback_handler_records_error_callback():
+    """A redirect carrying an `error` param must surface the failure page and capture detail."""
+    server, thread, result, redirect_uri = _xai_start_callback_server(preferred_port=0)
+    try:
+        status, body = _get_callback(
+            redirect_uri,
+            query="error=access_denied&error_description=user%20cancelled",
+        )
+        assert status == 200
+        assert "xAI authorization failed" in body
+        assert result["error"] == "access_denied"
+        assert result["error_description"] == "user cancelled"
+        assert result["code"] is None
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=1.0)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- The xAI OAuth loopback handler returned 200 "xAI authorization received" for **any** GET on the expected callback path, even when the URL had no `code` and no `error` (e.g. the user navigated to the bare `http://127.0.0.1:<port>/callback`).
- The CLI's wait loop, meanwhile, kept polling for a real callback and eventually raised `AuthError: xAI authorization timed out`. The user is left with a browser tab that claims success and a terminal that says failure.
- This change returns 400 with an explicit "xAI authorization not received" page when the callback URL carries neither `code` nor `error`. Real OAuth callbacks (success or error) behave exactly as before.

## The bug

In `hermes_cli/auth.py`, `_make_xai_callback_handler.do_GET` parsed the query and unconditionally rendered the success page when `error` was falsy. `parse_qs("")` returns `{}`, so a bare callback URL fell through `params.get("code", [None])[0] is None and params.get("error", [None])[0] is None` and still showed the success message.

#27385 hit this exact path: xAI's auth backend showed a German "We couldn't reach your app" fallback page, the user navigated manually to `http://127.0.0.1:56121/callback`, and the loopback server happily claimed "xAI authorization received" while the CLI was still waiting for a real `code` parameter and ultimately timed out.

## The fix

When neither `code` nor `error` is present, return 400 with a clear "not received" page and a hint to retry `hermes auth add xai-oauth`. `result["code"]` and `result["error"]` remain `None`, so the wait loop still raises a real `AuthError(... xai_callback_timeout)` rather than silently treating a bare hit as a successful callback — semantics for the CLI are unchanged.

CORS headers, the 404-on-wrong-path branch, and the normal success/error paths are untouched.

## Test plan

- [x] Focused regression test: `tests/hermes_cli/test_auth_xai_oauth_provider.py::test_xai_callback_handler_returns_400_when_callback_url_lacks_code_and_error` — boots `_xai_start_callback_server(preferred_port=0)`, GETs the bare callback URL, asserts `status == 400`, body contains "not received" + `hermes auth add xai-oauth`, and that `result["code"]` / `result["error"]` are still `None`.
- [x] Positive regression test: `test_xai_callback_handler_accepts_callback_with_code` — `?code=abc&state=xyz` still returns 200 with the success page and records both.
- [x] Negative regression test: `test_xai_callback_handler_records_error_callback` — `?error=access_denied&error_description=user%20cancelled` still returns 200 with the failure page and records the error details.
- [x] Adjacent suite: `tests/hermes_cli/test_auth_xai_oauth_provider.py` — 66 passed in 12.86s (3 new + 63 pre-existing).
- [x] Regression guard: reverted `hermes_cli/auth.py` and reran the three new tests — the bare-URL test failed with `assert 200 == 400` (the old behavior), while the success and error paths still passed. Restoring the fix flips it back to all 3 passing.

## Related

- Fixes #27385