### PR TITLE
fix: bound Slack approval block text

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -264,6 +264,37 @@ _SLACK_PROXY_HOSTS = (
     "wss-primary.slack.com",
 )
 
+# Slack section block text objects are limited to 3,000 characters.
+# Keep approval prompts below that limit even when both the command and
+# explanation are long.
+_SLACK_SECTION_TEXT_LIMIT = 3000
+_SLACK_APPROVAL_REASON_TARGET = 700
+_TRUNCATION_SUFFIX = "\n... [truncated]"
+
+
+def _truncate_for_slack_text_limit(text: str, limit: int) -> str:
+    """Trim text to fit inside a Slack text object budget."""
+    if limit <= 0:
+        return ""
+    if len(text) <= limit:
+        return text
+    if limit <= len(_TRUNCATION_SUFFIX):
+        return text[:limit]
+    return text[: limit - len(_TRUNCATION_SUFFIX)].rstrip() + _TRUNCATION_SUFFIX
+
+
+def _build_slack_approval_section_text(command: str, description: str) -> str:
+    """Build the approval prompt section without exceeding Slack limits."""
+    header = ":warning: *Command Approval Required*\n```"
+    reason_prefix = "```\nReason: "
+    budget = _SLACK_SECTION_TEXT_LIMIT - len(header) - len(reason_prefix)
+    reason_target = min(len(description), _SLACK_APPROVAL_REASON_TARGET)
+    command_budget = max(0, budget - reason_target)
+    cmd_preview = _truncate_for_slack_text_limit(command, command_budget)
+    reason_budget = max(0, budget - len(cmd_preview))
+    description_preview = _truncate_for_slack_text_limit(description, reason_budget)
+    return f"{header}{cmd_preview}{reason_prefix}{description_preview}"
+
 
 def _resolve_slack_proxy_url() -> Optional[str]:
     """Resolve a proxy URL that Slack SDK clients can safely use."""
@@ -2253,7 +2284,8 @@ class SlackAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         try:
-            cmd_preview = command[:2900] + "..." if len(command) > 2900 else command
+            section_text = _build_slack_approval_section_text(command, description)
+            cmd_preview = _truncate_for_slack_text_limit(command, 100)
             thread_ts = self._resolve_thread_ts(None, metadata)
 
             blocks = [
@@ -2261,11 +2293,7 @@ class SlackAdapter(BasePlatformAdapter):
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
-                        "text": (
-                            f":warning: *Command Approval Required*\n"
-                            f"```{cmd_preview}```\n"
-                            f"Reason: {description}"
-                        ),
+                        "text": section_text,
                     },
                 },
                 {

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -142,7 +142,27 @@ class TestSlackExecApproval:
         kwargs = mock_client.chat_postMessage.call_args[1]
         section_text = kwargs["blocks"][0]["text"]["text"]
         assert "..." in section_text
-        assert len(section_text) < 5000
+        assert len(section_text) <= 3000
+
+    @pytest.mark.asyncio
+    async def test_bounds_combined_command_and_reason_block_text(self):
+        adapter = _make_adapter()
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_postMessage = AsyncMock(return_value={"ts": "1.2"})
+
+        await adapter.send_exec_approval(
+            chat_id="C1",
+            command="x" * 5000,
+            session_key="s",
+            description="y" * 5000,
+        )
+
+        kwargs = mock_client.chat_postMessage.call_args[1]
+        section_text = kwargs["blocks"][0]["text"]["text"]
+        assert len(section_text) <= 3000
+        assert section_text.startswith(":warning: *Command Approval Required*")
+        assert "Reason: " in section_text
+        assert "... [truncated]" in section_text
 
 
 # ===========================================================================


### PR DESCRIPTION
## What does this PR do?

Bounds Slack approval Block Kit section text so approval buttons do not fail with Slack `invalid_blocks` errors when the command and/or approval reason is long.

The fix budgets the command preview and reason text together against Slack's 3000-character `section.text.text` limit. It keeps short reasons intact and only truncates the reason when the combined section would exceed Slack's limit.

## Related Issue

N/A — observed Slack approval UI failure from oversized Block Kit section text.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Keep Slack approval Block Kit `section.text.text` within Slack's 3000-character limit.
- Budget command and reason text together instead of truncating only the command preview.
- Preserve the approval reason when short and truncate it only when necessary.
- Add/keep regression coverage in `tests/gateway/test_slack_approval_buttons.py` for long approval text.

## How to Test

1. Run the Slack approval regression tests:
   ```bash
   python -m pytest tests/gateway/test_slack_approval_buttons.py -q -o addopts=
   ```
2. Confirm the tests pass and the generated Slack approval block text remains under the limit for long command/reason inputs.

Latest local verification:

```text
24 passed, 4 warnings in 0.91s
```

The warnings are existing async mock RuntimeWarnings in Slack thread-context tests and are not introduced by this PR.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation and Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted pytest output is included above. No UI screenshot; this is a Slack Block Kit payload-size guard.
