### PR TITLE
fix(gateway): prevent interim assistant messages from suppressing final tool result delivery (#27230)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13771,6 +13771,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         result_holder = [None]  # Mutable container for the result
         tools_holder = [None]   # Mutable container for the tool definitions
         stream_consumer_holder = [None]  # Mutable container for stream consumer
+        previewed_response_texts: list[str] = []
         
         # Bridge sync step_callback → async hooks.emit for agent:step events
         _loop_for_step = asyncio.get_running_loop()
@@ -13996,6 +13997,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             def _interim_assistant_cb(text: str, *, already_streamed: bool = False) -> None:
                 if not _run_still_current():
                     return
+                _visible_text = str(text or "").strip()
+                if _visible_text:
+                    previewed_response_texts.append(_visible_text)
                 if _stream_consumer is not None:
                     if already_streamed:
                         _stream_consumer.on_segment_break()
@@ -15326,13 +15330,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 pass
                         except Exception as e:
                             logger.debug("Stream consumer wait before queued message failed: %s", e)
-                    _previewed = bool(result.get("response_previewed"))
+                    first_response = result.get("final_response", "")
+                    _previewed = bool(result.get("response_previewed")) and any(
+                        _preview.strip() == str(first_response or "").strip()
+                        for _preview in previewed_response_texts
+                    )
                     _already_streamed = bool(
                         (_sc and getattr(_sc, "final_response_sent", False))
                         or _previewed
                         or (_sc and getattr(_sc, "final_content_delivered", False))
                     )
-                    first_response = result.get("final_response", "")
                     if first_response and not _already_streamed:
                         try:
                             logger.info(
@@ -15507,8 +15514,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _sc and getattr(_sc, "final_response_sent", False)
             )
             # response_previewed means the interim_assistant_callback already
-            # sent the final text via the adapter (non-streaming path).
-            _previewed = bool(response.get("response_previewed"))
+            # sent the final text via the adapter (non-streaming path). Some
+            # providers also emit real interim acknowledgements before tool
+            # calls; those must not suppress the later tool result. Only trust
+            # response_previewed when the previewed text matches the final body.
+            _previewed = bool(response.get("response_previewed")) and any(
+                _preview.strip() == _final.strip()
+                for _preview in previewed_response_texts
+            )
             _content_delivered = bool(
                 _sc and getattr(_sc, "final_content_delivered", False)
             )

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -602,6 +602,22 @@ class PreviewedResponseAgent:
         }
 
 
+class MisclassifiedInterimPreviewAgent:
+    def __init__(self, **kwargs):
+        self.interim_assistant_callback = kwargs.get("interim_assistant_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        if self.interim_assistant_callback:
+            self.interim_assistant_callback("Okay, searching now.", already_streamed=False)
+        return {
+            "final_response": "Here is the search result.",
+            "response_previewed": True,
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
 class StreamingRefineAgent:
     def __init__(self, **kwargs):
         self.stream_delta_callback = kwargs.get("stream_delta_callback")
@@ -917,6 +933,21 @@ async def test_run_agent_previewed_final_marks_already_sent(monkeypatch, tmp_pat
 
     assert result.get("already_sent") is True
     assert [call["content"] for call in adapter.sent] == ["You're welcome."]
+
+
+@pytest.mark.asyncio
+async def test_run_agent_interim_preview_does_not_suppress_final(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        MisclassifiedInterimPreviewAgent,
+        session_id="sess-interim-preview-not-final",
+        config_data={"display": {"interim_assistant_messages": True}},
+    )
+
+    assert result["final_response"] == "Here is the search result."
+    assert result.get("already_sent") is not True
+    assert [call["content"] for call in adapter.sent] == ["Okay, searching now."]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

When the Telegram gateway sends an interim assistant acknowledgment (e.g. '好的，正在搜索...') followed by a tool call, the `response_previewed` flag was set prematurely, causing the gateway to mark the response as `already_sent=True`. This suppressed the actual final tool result delivery via `adapter.send()`, leaving the user staring at silence.

## Root Cause

The `interim_assistant_callback` fires for intermediate messages (acknowledgments). The `response_previewed` flag was set whenever any text was previewed, regardless of whether it was the actual final answer or just an interim acknowledgment. The `already_sent` suppression logic at line 16541 then skipped the normal delivery path.

## Fix

Track interim assistant text and only trust `response_previewed` when the previewed text exactly matches the final response body. This prevents interim chatty acknowledgments like 'searching...' from suppressing the real tool result.

## Test Plan

- [x] 115 gateway tests pass (`test_run_progress_topics.py`, `test_stream_consumer.py`)
- [x] Regression test: `test_run_agent_interim_preview_does_not_suppress_final`

Fixes #27230