### PR TITLE
fix(npm_install): force NODE_ENV=development during deterministic installs

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5805,6 +5805,7 @@ def _run_npm_install_deterministic(
             encoding="utf-8",
             errors="replace",
             check=False,
+            env={**os.environ, "NODE_ENV": "development"},
         )
         if ci_result.returncode == 0:
             return ci_result
@@ -5819,6 +5820,7 @@ def _run_npm_install_deterministic(
         encoding="utf-8",
         errors="replace",
         check=False,
+        env={**os.environ, "NODE_ENV": "development"},
     )
 
 


### PR DESCRIPTION
Closing as duplicate — PR #25649 addresses the same root cause with a cleaner approach (stripping `NODE_ENV` rather than hardcoding a value). No need for multiple PRs covering the same bug.