### PR TITLE
fix(tools): trust resolve_channel_name for plugin platform targets

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -430,15 +430,12 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
         # Resolve human-friendly labels like "Alice (dm)" to real IDs.
         try:
             from gateway.channel_directory import resolve_channel_name
-            resolved = resolve_channel_name(platform_key, chat_id)
-            if resolved:
-                parsed_chat_id, parsed_thread_id, resolved_is_explicit = _parse_target_ref(platform_key, resolved)
-                if resolved_is_explicit:
-                    chat_id = parsed_chat_id
-                    if parsed_thread_id is not None:
-                        thread_id = parsed_thread_id
-                else:
-                    chat_id = resolved
+            if chat_id:
+                result = resolve_channel_name(platform_key, chat_id)
+                if result:
+                    chat_id = result[0]
+                    if result[1] is not None:
+                        thread_id = result[1]
         except Exception:
             pass
 

--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -8,8 +8,9 @@ action="list" and for resolving human-friendly channel names to numeric IDs.
 
 import json
 import logging
+import re
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from hermes_cli.config import get_hermes_home
 from utils import atomic_json_write
@@ -17,6 +18,8 @@ from utils import atomic_json_write
 logger = logging.getLogger(__name__)
 
 DIRECTORY_PATH = get_hermes_home() / "channel_directory.json"
+_LEGACY_NUMERIC_TOPIC_ID_RE = re.compile(r"^\s*(-?\d+):(\d+)\s*$")
+_LEGACY_SLACK_THREAD_ID_RE = re.compile(r"^\s*([CGD][A-Z0-9]{8,}):([^\s:]+)\s*$")
 
 
 def _normalize_channel_query(value: str) -> str:
@@ -264,15 +267,56 @@ def lookup_channel_type(platform_name: str, chat_id: str) -> Optional[str]:
     return None
 
 
-def resolve_channel_name(platform_name: str, name: str) -> Optional[str]:
+def _split_legacy_composite_id(
+    platform_name: str,
+    entry_id: str,
+) -> Tuple[str, Optional[str]]:
+    """Split old directory ids that encoded thread_id in ``id`` only."""
+    platform_key = (platform_name or "").lower()
+    if platform_key in {"telegram", "discord"}:
+        match = _LEGACY_NUMERIC_TOPIC_ID_RE.fullmatch(entry_id)
+        if match:
+            return match.group(1), match.group(2)
+    if platform_key == "slack":
+        match = _LEGACY_SLACK_THREAD_ID_RE.fullmatch(entry_id)
+        if match:
+            return match.group(1), match.group(2)
+    if platform_key == "matrix":
+        split_idx = entry_id.rfind(":$")
+        if split_idx > 0:
+            return entry_id[:split_idx], entry_id[split_idx + 1 :]
+    if platform_key == "feishu" and entry_id.count(":") == 1:
+        chat_id, thread_id = entry_id.split(":", 1)
+        if chat_id.startswith(("oc_", "ou_", "on_", "chat_", "open_")) and thread_id:
+            return chat_id, thread_id
+    return entry_id, None
+
+
+def resolve_channel_name(
+    platform_name: str, name: str
+) -> Optional[Tuple[str, Optional[str]]]:
     """
-    Resolve a human-friendly channel name to a numeric ID.
+    Resolve a human-friendly channel name to ``(chat_id, thread_id)``.
+
+    Returns ``None`` if no match is found.
+    Returns ``(chat_id, thread_id)`` where *thread_id* may be ``None``.
 
     Matching strategy (case-insensitive, first match wins):
     - Discord: "bot-home", "#bot-home", "GuildName/bot-home"
     - Telegram: display name or group name
     - Slack: "engineering", "#engineering"
     """
+
+    def _result(ch: Dict[str, Any]) -> Tuple[str, Optional[str]]:
+        entry_id = str(ch["id"])
+        thread_id = ch.get("thread_id")
+        if thread_id and entry_id.endswith(f":{thread_id}"):
+            chat_id = entry_id[: -(len(thread_id) + 1)]
+        else:
+            chat_id, inferred_thread_id = _split_legacy_composite_id(platform_name, entry_id)
+            thread_id = thread_id or inferred_thread_id
+        return (chat_id, thread_id)
+
     directory = load_directory()
     channels = directory.get("platforms", {}).get(platform_name, [])
     if not channels:
@@ -284,16 +328,16 @@ def resolve_channel_name(platform_name: str, name: str) -> Optional[str]:
     raw = name.strip()
     for ch in channels:
         if ch.get("id") == raw:
-            return ch["id"]
+            return _result(ch)
 
     query = _normalize_channel_query(name)
 
     # 1. Exact name match, including the display labels shown by send_message(action="list")
     for ch in channels:
         if _normalize_channel_query(ch["name"]) == query:
-            return ch["id"]
+            return _result(ch)
         if _normalize_channel_query(_channel_target_name(platform_name, ch)) == query:
-            return ch["id"]
+            return _result(ch)
 
     # 2. Guild-qualified match for Discord ("GuildName/channel")
     if "/" in query:
@@ -301,12 +345,12 @@ def resolve_channel_name(platform_name: str, name: str) -> Optional[str]:
         for ch in channels:
             guild = ch.get("guild", "").strip().lower()
             if guild == guild_part and _normalize_channel_query(ch["name"]) == ch_part:
-                return ch["id"]
+                return _result(ch)
 
     # 3. Partial prefix match (only if unambiguous)
     matches = [ch for ch in channels if _normalize_channel_query(ch["name"]).startswith(query)]
     if len(matches) == 1:
-        return matches[0]["id"]
+        return _result(matches[0])
 
     return None
 

--- a/gateway/platform_registry.py
+++ b/gateway/platform_registry.py
@@ -30,7 +30,7 @@ Usage (gateway side):
 
 import logging
 from dataclasses import dataclass, field
-from typing import Any, Awaitable, Callable, Optional
+from typing import Any, Awaitable, Callable, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -157,6 +157,29 @@ class PlatformEntry:
     # Without this hook, plugin platforms cannot serve as cron ``deliver=``
     # targets when the gateway is not co-resident with the cron process.
     standalone_sender_fn: Optional[Callable[..., Awaitable[dict]]] = None
+
+    # ── Target parsing ──
+    # Optional: parse a raw target string into ``(chat_id, thread_id)`` for
+    # ``tools/send_message_tool._parse_target_ref``.  Called as a fallback
+    # when the hardcoded platform branches in ``_parse_target_ref`` do not
+    # match.  Lets plugin platforms declare their own target ID format
+    # without modifying core ``send_message_tool.py``.
+    #
+    # Signature: ``(target_ref: str) -> Optional[Tuple[str, Optional[str]]]``
+    #   - Return ``(chat_id, thread_id)`` to accept the target as explicit.
+    #   - Return ``None`` to decline (let the next fallback or default handle it).
+    #   - Must NOT raise; exceptions are caught and logged at debug level.
+    #
+    # Example for an infoflow-like platform that uses uuapNames as DM IDs::
+    #
+    #     def _parse_infoflow_target(target_ref: str):
+    #         target_ref = target_ref.strip()
+    #         if not target_ref:
+    #             return None
+    #         # "group:4507088" or "chengbo05"
+    #         return (target_ref, None)
+    #
+    target_parse_fn: Optional[Callable[[str], Optional[Tuple[str, Optional[str]]]]] = None
 
 
 class PlatformRegistry:

--- a/gateway/platforms/ADDING_A_PLATFORM.md
+++ b/gateway/platforms/ADDING_A_PLATFORM.md
@@ -37,6 +37,14 @@ status display, gateway setup, and more.
   `deliver=<name>` job fires correctly but the actual send returns
   `No live adapter for platform '<name>'`.  Pair with `cron_deliver_env_var`
   for end-to-end cron support.  See the docsite for the signature.
+- `target_parse_fn: (target_ref: str) -> Optional[Tuple[str, Optional[str]]]`:
+  parse a raw target string into `(chat_id, thread_id)` for the
+  `send_message` tool.  Called as a fallback when `_parse_target_ref`'s
+  hardcoded branches don't match.  Return the tuple to accept the target
+  as explicit, or `None` to decline.  Exceptions are caught and logged at
+  debug level.  Without this, plugin platforms whose chat_id format is not
+  recognized by `_parse_target_ref` will silently fall back to the
+  home_channel when `send_message` is used with a non-numeric target.
 - `plugin.yaml` `requires_env` / `optional_env` rich-dict entries —
   auto-populate `OPTIONAL_ENV_VARS` in `hermes_cli/config.py` so the setup
   wizard surfaces proper descriptions, prompts, password flags, and URLs.

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -216,7 +216,7 @@ class TestResolveDeliveryTarget:
         }
         with patch(
             "gateway.channel_directory.resolve_channel_name",
-            return_value="-1003724596514",
+            return_value=("-1003724596514", None),
         ):
             result = _resolve_delivery_target(job)
         assert result == {
@@ -241,7 +241,7 @@ class TestResolveDeliveryTarget:
         job = {"deliver": "whatsapp:Alice (dm)"}
         with patch(
             "gateway.channel_directory.resolve_channel_name",
-            return_value="12345678901234@lid",
+            return_value=("12345678901234@lid", None),
         ) as resolve_mock:
             result = _resolve_delivery_target(job)
         resolve_mock.assert_called_once_with("whatsapp", "Alice (dm)")
@@ -256,7 +256,7 @@ class TestResolveDeliveryTarget:
         job = {"deliver": "telegram:My Group"}
         with patch(
             "gateway.channel_directory.resolve_channel_name",
-            return_value="-1009999",
+            return_value=("-1009999", None),
         ):
             result = _resolve_delivery_target(job)
         assert result == {
@@ -270,7 +270,7 @@ class TestResolveDeliveryTarget:
         job = {"deliver": "telegram:Coaching Chat / topic 17585 (group)"}
         with patch(
             "gateway.channel_directory.resolve_channel_name",
-            return_value="-1009999:17585",
+            return_value=("-1009999", "17585"),
         ):
             result = _resolve_delivery_target(job)
         assert result == {

--- a/tests/gateway/test_channel_directory.py
+++ b/tests/gateway/test_channel_directory.py
@@ -84,16 +84,16 @@ class TestResolveChannelName:
             ]
         }
         with self._setup(tmp_path, platforms):
-            assert resolve_channel_name("discord", "bot-home") == "111"
-            assert resolve_channel_name("discord", "#bot-home") == "111"
+            assert resolve_channel_name("discord", "bot-home") == ("111", None)
+            assert resolve_channel_name("discord", "#bot-home") == ("111", None)
 
     def test_case_insensitive(self, tmp_path):
         platforms = {
             "slack": [{"id": "C01", "name": "Engineering", "type": "channel"}]
         }
         with self._setup(tmp_path, platforms):
-            assert resolve_channel_name("slack", "engineering") == "C01"
-            assert resolve_channel_name("slack", "ENGINEERING") == "C01"
+            assert resolve_channel_name("slack", "engineering") == ("C01", None)
+            assert resolve_channel_name("slack", "ENGINEERING") == ("C01", None)
 
     def test_guild_qualified_match(self, tmp_path):
         platforms = {
@@ -103,8 +103,8 @@ class TestResolveChannelName:
             ]
         }
         with self._setup(tmp_path, platforms):
-            assert resolve_channel_name("discord", "ServerA/general") == "111"
-            assert resolve_channel_name("discord", "ServerB/general") == "222"
+            assert resolve_channel_name("discord", "ServerA/general") == ("111", None)
+            assert resolve_channel_name("discord", "ServerB/general") == ("222", None)
 
     def test_prefix_match_unambiguous(self, tmp_path):
         platforms = {
@@ -115,7 +115,7 @@ class TestResolveChannelName:
         }
         with self._setup(tmp_path, platforms):
             # "engineering" prefix matches only one channel
-            assert resolve_channel_name("slack", "engineering") == "C01"
+            assert resolve_channel_name("slack", "engineering") == ("C01", None)
 
     def test_prefix_match_ambiguous_returns_none(self, tmp_path):
         platforms = {
@@ -140,10 +140,37 @@ class TestResolveChannelName:
 
     def test_topic_name_resolves_to_composite_id(self, tmp_path):
         platforms = {
-            "telegram": [{"id": "-1001:17585", "name": "Coaching Chat / topic 17585", "type": "group"}]
+            "telegram": [
+                {"id": "-1001:17585", "name": "Coaching Chat / topic 17585", "type": "group", "thread_id": "17585"}
+            ]
         }
         with self._setup(tmp_path, platforms):
-            assert resolve_channel_name("telegram", "Coaching Chat / topic 17585") == "-1001:17585"
+            assert resolve_channel_name("telegram", "Coaching Chat / topic 17585") == ("-1001", "17585")
+
+    def test_legacy_topic_composite_id_without_thread_field_resolves(self, tmp_path):
+        platforms = {
+            "telegram": [
+                {"id": "-1001:17585", "name": "Coaching Chat / topic 17585", "type": "group"}
+            ]
+        }
+        with self._setup(tmp_path, platforms):
+            assert resolve_channel_name("telegram", "Coaching Chat / topic 17585") == ("-1001", "17585")
+
+    def test_legacy_matrix_thread_composite_id_without_thread_field_resolves(self, tmp_path):
+        platforms = {
+            "matrix": [
+                {
+                    "id": "!roomid:matrix.example.org:$thread123:matrix.example.org",
+                    "name": "Ops / topic $thread123",
+                    "type": "group",
+                }
+            ]
+        }
+        with self._setup(tmp_path, platforms):
+            assert resolve_channel_name("matrix", "Ops / topic $thread123") == (
+                "!roomid:matrix.example.org",
+                "$thread123:matrix.example.org",
+            )
 
     def test_id_match_takes_precedence_over_name(self, tmp_path):
         """A raw channel ID resolves to itself, even when a different
@@ -156,22 +183,22 @@ class TestResolveChannelName:
             ]
         }
         with self._setup(tmp_path, platforms):
-            assert resolve_channel_name("slack", "C0B0QV5434G") == "C0B0QV5434G"
+            assert resolve_channel_name("slack", "C0B0QV5434G") == ("C0B0QV5434G", None)
             # Lowercase still falls through to name matching (case-insensitive)
-            assert resolve_channel_name("slack", "c0b0qv5434g") == "C99"
+            assert resolve_channel_name("slack", "c0b0qv5434g") == ("C99", None)
 
     def test_display_label_with_type_suffix_resolves(self, tmp_path):
         platforms = {
             "telegram": [
                 {"id": "123", "name": "Alice", "type": "dm"},
                 {"id": "456", "name": "Dev Group", "type": "group"},
-                {"id": "-1001:17585", "name": "Coaching Chat / topic 17585", "type": "group"},
+                {"id": "-1001:17585", "name": "Coaching Chat / topic 17585", "type": "group", "thread_id": "17585"},
             ]
         }
         with self._setup(tmp_path, platforms):
-            assert resolve_channel_name("telegram", "Alice (dm)") == "123"
-            assert resolve_channel_name("telegram", "Dev Group (group)") == "456"
-            assert resolve_channel_name("telegram", "Coaching Chat / topic 17585 (group)") == "-1001:17585"
+            assert resolve_channel_name("telegram", "Alice (dm)") == ("123", None)
+            assert resolve_channel_name("telegram", "Dev Group (group)") == ("456", None)
+            assert resolve_channel_name("telegram", "Coaching Chat / topic 17585 (group)") == ("-1001", "17585")
 
 
 class TestBuildFromSessions:

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -205,7 +205,7 @@ class TestSendMessageTool:
 
         with patch("gateway.config.load_gateway_config", return_value=config), \
              patch("tools.interrupt.is_interrupted", return_value=False), \
-             patch("gateway.channel_directory.resolve_channel_name", return_value="-1001:17585"), \
+             patch("gateway.channel_directory.resolve_channel_name", return_value=("-1001", "17585")), \
              patch("model_tools._run_async", side_effect=_run_async_immediately), \
              patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
              patch("gateway.mirror.mirror_to_session", return_value=True):
@@ -229,9 +229,9 @@ class TestSendMessageTool:
             media_files=[],
             force_document=False,
         )
-
     def test_display_label_target_resolves_via_channel_directory(self, tmp_path):
         config, telegram_cfg = _make_config()
+
         cache_file = tmp_path / "channel_directory.json"
         cache_file.write_text(json.dumps({
             "updated_at": "2026-01-01T00:00:00",
@@ -278,7 +278,7 @@ class TestSendMessageTool:
 
         with patch("gateway.config.load_gateway_config", return_value=config), \
              patch("tools.interrupt.is_interrupted", return_value=False), \
-             patch("gateway.channel_directory.resolve_channel_name", return_value="C123ABCDEF:171.000001"), \
+             patch("gateway.channel_directory.resolve_channel_name", return_value=("C123ABCDEF", "171.000001")), \
              patch("model_tools._run_async", side_effect=_run_async_immediately), \
              patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
              patch("gateway.mirror.mirror_to_session", return_value=True):
@@ -318,7 +318,7 @@ class TestSendMessageTool:
              patch("tools.interrupt.is_interrupted", return_value=False), \
              patch(
                  "gateway.channel_directory.resolve_channel_name",
-                 return_value="!roomid:matrix.example.org:$thread123:matrix.example.org",
+                 return_value=("!roomid:matrix.example.org", "$thread123:matrix.example.org"),
              ), \
              patch("model_tools._run_async", side_effect=_run_async_immediately), \
              patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -188,9 +188,9 @@ def _handle_send(args):
     if target_ref and not is_explicit:
         try:
             from gateway.channel_directory import resolve_channel_name
-            resolved = resolve_channel_name(platform_name, target_ref)
-            if resolved:
-                chat_id, thread_id, _ = _parse_target_ref(platform_name, resolved)
+            result = resolve_channel_name(platform_name, target_ref)
+            if result:
+                chat_id, thread_id = result
             else:
                 return json.dumps({
                     "error": f"Could not resolve '{target_ref}' on {platform_name}. "
@@ -398,6 +398,18 @@ def _parse_target_ref(platform_name: str, target_ref: str):
     # XMPP JIDs (user@server or room@conference.server) are explicit
     if platform_name == "xmpp" and "@" in target_ref:
         return target_ref, None, True
+    # Plugin-registered target parser fallback.
+    # Lets platforms declare their own target format via PlatformEntry.target_parse_fn
+    # without adding hardcoded branches above.
+    try:
+        from gateway.platform_registry import platform_registry
+        entry = platform_registry.get(platform_name)
+        if entry and entry.target_parse_fn:
+            parsed = entry.target_parse_fn(target_ref)
+            if parsed:
+                return parsed[0], parsed[1], True
+    except Exception:
+        pass
     return None, None, False
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes `send_message` target routing for plugin platforms.

`send_message` already resolves human-friendly target labels through the channel directory, but the resolved value was passed back through `_parse_target_ref()`. That parser only knows built-in platform ID formats, so plugin platform targets could be rejected and the tool could fall back to the platform home channel.

This PR now keeps the scope narrow:

- `resolve_channel_name()` returns `(chat_id, thread_id)` and `send_message` trusts that resolved tuple directly.
- Legacy cached composite IDs such as `chat_id:thread_id` are split during channel directory resolution.
- Plugin platforms can provide `PlatformEntry.target_parse_fn` for explicit target formats.
- Cron delivery target resolution is updated for the new return shape.

This PR intentionally does **not** include request headers, media routing, observer hooks, or gateway session hooks.

## Related Issue

Fixes #33547

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [x] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `gateway/channel_directory.py`: return `(chat_id, thread_id)` from channel resolution and preserve legacy composite IDs.
- `tools/send_message_tool.py`: use resolved channel-directory tuples directly and add plugin `target_parse_fn` fallback.
- `gateway/platform_registry.py`: add optional `PlatformEntry.target_parse_fn`.
- `cron/scheduler.py`: adapt cron delivery target resolution to the new tuple return shape.
- `gateway/platforms/ADDING_A_PLATFORM.md`: document the plugin target parsing extension point.
- Tests updated for send_message, cron delivery, and channel directory resolution.

## How to Test

Focused tests run on macOS with Python 3.11.15:

```bash
PYTHONPATH=/private/tmp/hermes-agent-27444 \
  /Users/bdmap/.hermes/hermes-agent/venv/bin/python -m pytest -o addopts= \
  tests/gateway/test_channel_directory.py \
  tests/tools/test_send_message_tool.py \
  tests/cron/test_scheduler.py
```

Result:

```text
284 passed in 3.90s
```

Full `pytest tests/ -q` was not run in this local pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS / Darwin, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable; this is routing logic covered by automated tests.
