### PR TITLE
Fix local backend prompt cache coherence across turns

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -52,7 +52,11 @@ from agent.tool_guardrails import (
 from hermes_cli.config import cfg_get
 from hermes_cli.timeouts import get_provider_request_timeout
 from hermes_constants import get_hermes_home
-from model_tools import check_toolset_requirements, get_tool_definitions
+from model_tools import (
+    check_toolset_requirements,
+    get_tool_definitions,
+    sort_openai_tool_schemas,
+)
 from utils import base_url_host_matches
 
 # Use the same logger name as run_agent so tests patching ``run_agent.logger``
@@ -884,6 +888,7 @@ def init_agent(
     
     # Cached system prompt -- built once per session, only rebuilt on compression
     agent._cached_system_prompt: Optional[str] = None
+    agent._frozen_system_metadata_block: Optional[str] = None
     
     # Filesystem checkpoint manager (transparent — not a tool)
     from tools.checkpoint_manager import CheckpointManager
@@ -1037,6 +1042,7 @@ def init_agent(
             if _tname:
                 agent.valid_tool_names.add(_tname)
                 _existing_tool_names.add(_tname)
+        agent.tools = sort_openai_tool_schemas(agent.tools)
 
     # Skills config: nudge interval for skill creation reminders
     agent._skill_nudge_interval = 10
@@ -1344,6 +1350,7 @@ def init_agent(
                 agent.valid_tool_names.add(_tname)
                 agent._context_engine_tool_names.add(_tname)
                 _existing_tool_names.add(_tname)
+        agent.tools = sort_openai_tool_schemas(agent.tools)
 
     # Notify context engine of session start
     if hasattr(agent, "context_compressor") and agent.context_compressor:

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1777,9 +1777,66 @@ def looks_like_codex_intermediate_ack(
 
 
 
+_THINKING_TAG_RE = re.compile(r"<(?:think|thinking)\b[^>]*>", re.IGNORECASE)
+
+
+def _assistant_content_has_thinking_tag(content: Any) -> bool:
+    if isinstance(content, str):
+        return bool(_THINKING_TAG_RE.search(content))
+    return False
+
+
+def _stored_reasoning_text(source_msg: dict) -> Optional[str]:
+    for key in ("reasoning_content", "reasoning"):
+        value = source_msg.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _with_inline_thinking_for_local_replay(content: Any, reasoning_text: str) -> Any:
+    """Return assistant content with a canonical local replay thinking block."""
+    if not isinstance(content, str):
+        return content
+    reasoning_body = reasoning_text.strip()
+    if not reasoning_body:
+        return content
+    thinking = f"<think>\n{reasoning_body}\n</think>"
+    visible = content.strip()
+    if visible:
+        return f"{thinking}\n\n{visible}"
+    return thinking
+
+
 def copy_reasoning_content_for_api(agent, source_msg: dict, api_msg: dict) -> None:
     """Copy provider-facing reasoning fields onto an API replay message."""
     if source_msg.get("role") != "assistant":
+        return
+
+    if agent._is_local_cache_sensitive_backend():
+        reasoning_text = _stored_reasoning_text(source_msg)
+        content = api_msg.get("content")
+        if content is None:
+            content = source_msg.get("content", "")
+        if isinstance(content, str) and _assistant_content_has_thinking_tag(content):
+            # Raw local content already carries thinking tags; avoid a duplicate.
+            api_msg["content"] = content
+            api_msg.pop("reasoning_content", None)
+        elif reasoning_text:
+            # llama.cpp / ik_llama.cpp cache the generated assistant bytes,
+            # including inline <think> blocks before tool calls.  Their
+            # OpenAI-compatible chat-template path may ignore reasoning_content
+            # on replay, especially for assistant tool_call turns, so put the
+            # stored reasoning back into content for local cache coherence.
+            replay_content = _with_inline_thinking_for_local_replay(
+                content,
+                reasoning_text,
+            )
+            api_msg["content"] = replay_content
+            api_msg.pop("reasoning_content", None)
+        else:
+            api_msg.pop("reasoning_content", None)
+        api_msg.pop("_local_replay_content", None)
         return
 
     # 1. Explicit reasoning_content already set — preserve it verbatim

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -19,6 +19,7 @@ for invariants and PR review criteria.
 from __future__ import annotations
 
 import contextlib
+import copy
 import json
 import logging
 import os
@@ -417,6 +418,18 @@ def _run_review_in_thread(
             # measured impact (~26% end-to-end cost reduction on
             # Sonnet 4.5).
             review_agent._cached_system_prompt = agent._cached_system_prompt
+            # The local OpenAI-compatible tool block is part of llama.cpp's
+            # prompt-cache prefix.  The review fork must not rebuild a subtly
+            # different tool list/order after the parent turn finishes; inherit
+            # the exact parent presentation and let the whitelist below enforce
+            # which tools may actually execute.
+            if isinstance(getattr(agent, "tools", None), list):
+                review_agent.tools = copy.deepcopy(agent.tools)
+                review_agent.valid_tool_names = {
+                    t.get("function", {}).get("name")
+                    for t in review_agent.tools
+                    if isinstance(t, dict) and t.get("function", {}).get("name")
+                }
             # Defensive: pin session_start + session_id to the
             # parent's so any code path that re-renders parts of
             # the system prompt (compression, plugin hooks) still

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -233,6 +233,12 @@ def interruptible_api_call(agent, api_kwargs: dict):
 def build_api_kwargs(agent, api_messages: list) -> dict:
     """Build the keyword arguments dict for the active API mode."""
     tools_for_api = agent.tools
+    if tools_for_api:
+        from model_tools import sort_openai_tool_schemas
+        tools_for_api = sort_openai_tool_schemas(tools_for_api)
+    for msg in api_messages:
+        if isinstance(msg, dict):
+            msg.pop("_local_replay_content", None)
 
     if agent.api_mode == "anthropic_messages":
         _transport = agent._get_transport()

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -16,7 +16,7 @@ Three tiers are joined with ``\\n\\n``:
 * ``context``  — caller-supplied ``system_message`` plus context files
   (AGENTS.md / .cursorrules / etc.) discovered under ``TERMINAL_CWD``.
 * ``volatile`` — memory snapshot, USER.md profile, external memory
-  provider block, timestamp/session/model/provider line.
+  provider block, frozen session/model/provider metadata line.
 
 Pure helpers that read the agent's state.  AIAgent keeps thin forwarders.
 """
@@ -40,6 +40,7 @@ from agent.prompt_builder import (
     TOOL_USE_ENFORCEMENT_GUIDANCE,
     TOOL_USE_ENFORCEMENT_MODELS,
 )
+from model_tools import sort_openai_tool_schemas
 
 
 def _ra():
@@ -57,6 +58,33 @@ def _ra():
     return run_agent
 
 
+def _get_frozen_metadata_block(agent: Any) -> str:
+    """Return the session metadata block, freezing it on first render."""
+    frozen = getattr(agent, "_frozen_system_metadata_block", None)
+    if isinstance(frozen, str) and frozen:
+        return frozen
+
+    from hermes_time import now as _hermes_now
+
+    now = _hermes_now()
+    metadata_lines = [
+        f"Conversation started: {now.strftime('%A, %B %d, %Y')}"
+    ]
+    if agent.pass_session_id and agent.session_id:
+        metadata_lines.append(f"Session ID: {agent.session_id}")
+    if agent.model:
+        metadata_lines.append(f"Model: {agent.model}")
+    if agent.provider:
+        metadata_lines.append(f"Provider: {agent.provider}")
+
+    frozen = "\n".join(metadata_lines)
+    try:
+        agent._frozen_system_metadata_block = frozen
+    except Exception:
+        pass
+    return frozen
+
+
 def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) -> Dict[str, str]:
     """Assemble the system prompt as three ordered parts.
 
@@ -67,7 +95,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
       * ``context``  — context files (AGENTS.md, .cursorrules, etc.)
         and caller-supplied system_message.
       * ``volatile`` — memory snapshot, user profile, external
-        memory provider block, timestamp line.
+        memory provider block, frozen metadata line.
 
     Joined into a single string by :func:`build_system_prompt` and
     cached on ``agent._cached_system_prompt`` for the lifetime of the
@@ -233,7 +261,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         if context_files_prompt:
             context_parts.append(context_files_prompt)
 
-    # ── Volatile tier (changes per session/turn — never cached) ───
+    # ── Volatile tier (memory may change; metadata is frozen per agent) ───
     volatile_parts: List[str] = []
 
     if agent._memory_store:
@@ -256,22 +284,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         except Exception:
             pass
 
-    from hermes_time import now as _hermes_now
-    now = _hermes_now()
-    # Date-only (not minute-precision) so the system prompt is byte-stable
-    # for the full day.  Minute-precision changes invalidate prefix-cache KV
-    # on every rebuild path (compression boundary, fresh-agent gateway turns,
-    # session resume without a stored prompt).  The model can still query the
-    # exact wall-clock time via tools when it actually needs it.
-    # Credit: @iamfoz (PR #20451).
-    timestamp_line = f"Conversation started: {now.strftime('%A, %B %d, %Y')}"
-    if agent.pass_session_id and agent.session_id:
-        timestamp_line += f"\nSession ID: {agent.session_id}"
-    if agent.model:
-        timestamp_line += f"\nModel: {agent.model}"
-    if agent.provider:
-        timestamp_line += f"\nProvider: {agent.provider}"
-    volatile_parts.append(timestamp_line)
+    volatile_parts.append(_get_frozen_metadata_block(agent))
 
     return {
         "stable":   "\n\n".join(p.strip() for p in stable_parts   if p and p.strip()),
@@ -321,7 +334,7 @@ def format_tools_for_system_message(agent: Any) -> str:
 
     # Convert tool definitions to the format expected in trajectories
     formatted_tools = []
-    for tool in agent.tools:
+    for tool in sort_openai_tool_schemas(agent.tools):
         func = tool["function"]
         formatted_tool = {
             "name": func["name"],

--- a/model_tools.py
+++ b/model_tools.py
@@ -253,6 +253,14 @@ _LEGACY_TOOLSET_MAP = {
 _tool_defs_cache: Dict[tuple, List[Dict[str, Any]]] = {}
 
 
+def sort_openai_tool_schemas(tools: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Return OpenAI tool schemas in stable function-name order."""
+    return sorted(
+        tools,
+        key=lambda t: str(t.get("function", {}).get("name", "")),
+    )
+
+
 def _clear_tool_defs_cache() -> None:
     """Drop memoized get_tool_definitions() results. Called when dynamic
     schema dependencies change (e.g. discord capability cache reset,
@@ -456,9 +464,6 @@ def _compute_tool_definitions(
         else:
             print("🛠️  No tools selected (all filtered out or unavailable)")
 
-    global _last_resolved_tool_names
-    _last_resolved_tool_names = [t["function"]["name"] for t in filtered_tools]
-
     # Sanitize schemas for broad backend compatibility. llama.cpp's
     # json-schema-to-grammar converter (used by its OAI server to build
     # GBNF tool-call parsers) rejects some shapes that cloud providers
@@ -470,6 +475,11 @@ def _compute_tool_definitions(
         filtered_tools = sanitize_tool_schemas(filtered_tools)
     except Exception as e:  # pragma: no cover — defensive
         logger.warning("Schema sanitization skipped: %s", e)
+
+    filtered_tools = sort_openai_tool_schemas(filtered_tools)
+
+    global _last_resolved_tool_names
+    _last_resolved_tool_names = [t["function"]["name"] for t in filtered_tools]
 
     return filtered_tools
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -3602,6 +3602,13 @@ class AIAgent:
             or self._needs_mimo_tool_reasoning()
         )
 
+    def _is_local_cache_sensitive_backend(self) -> bool:
+        """Return True for local OpenAI-compatible backends with prefix caches."""
+        provider = (self.provider or "").lower()
+        if provider in {"ollama", "lmstudio"}:
+            return True
+        return bool(self.base_url and is_local_endpoint(self.base_url))
+
     def _needs_kimi_tool_reasoning(self) -> bool:
         """Return True when the current provider is Kimi / Moonshot thinking mode.
 

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -12,6 +12,8 @@ Verifies that the agent cache correctly:
 import hashlib
 import json
 import threading
+from datetime import datetime
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -25,6 +27,29 @@ def _make_runner():
     runner._agent_cache = {}
     runner._agent_cache_lock = threading.Lock()
     return runner
+
+
+def _metadata_agent(session_id="session-1", model="model-a", provider="provider-a"):
+    return SimpleNamespace(
+        load_soul_identity=False,
+        skip_context_files=True,
+        valid_tool_names=set(),
+        provider=provider,
+        model=model,
+        platform="",
+        _tool_use_enforcement="auto",
+        _memory_store=None,
+        _memory_enabled=False,
+        _user_profile_enabled=False,
+        _memory_manager=None,
+        pass_session_id=True,
+        session_id=session_id,
+        _frozen_system_metadata_block=None,
+    )
+
+
+def _metadata_block(prompt_parts):
+    return prompt_parts["volatile"].split("Conversation started: ", 1)[1]
 
 
 class TestAgentConfigSignature:
@@ -440,6 +465,66 @@ class TestAgentCacheLifecycle:
         # Simulate second turn — prompt should be frozen
         prompt2 = agent._cached_system_prompt
         assert prompt1 is prompt2  # same object, not rebuilt
+
+    def test_system_metadata_frozen_across_rebuild(self, monkeypatch):
+        """Compression-style prompt rebuilds reuse the same metadata bytes."""
+        from agent.system_prompt import build_system_prompt_parts
+
+        agent = _metadata_agent()
+        monkeypatch.setattr(
+            "hermes_time.now",
+            lambda: datetime(2026, 1, 1, 9, 0),
+        )
+        first = build_system_prompt_parts(agent)
+
+        monkeypatch.setattr(
+            "hermes_time.now",
+            lambda: datetime(2026, 1, 2, 10, 30),
+        )
+        second = build_system_prompt_parts(agent)
+
+        assert _metadata_block(first) == _metadata_block(second)
+
+    def test_clearing_cached_system_prompt_does_not_refresh_metadata(self, monkeypatch):
+        from agent.system_prompt import build_system_prompt
+
+        agent = _metadata_agent()
+        agent._cached_system_prompt = None
+        monkeypatch.setattr(
+            "hermes_time.now",
+            lambda: datetime(2026, 1, 1, 9, 0),
+        )
+        first = build_system_prompt(agent)
+
+        agent._cached_system_prompt = None
+        monkeypatch.setattr(
+            "hermes_time.now",
+            lambda: datetime(2026, 1, 3, 11, 45),
+        )
+        second = build_system_prompt(agent)
+
+        assert "Thursday, January 01, 2026" in first
+        assert "Thursday, January 01, 2026" in second
+
+    def test_fresh_agent_gets_fresh_metadata(self, monkeypatch):
+        from agent.system_prompt import build_system_prompt
+
+        first_agent = _metadata_agent(session_id="session-a")
+        monkeypatch.setattr(
+            "hermes_time.now",
+            lambda: datetime(2026, 1, 1, 9, 0),
+        )
+        first = build_system_prompt(first_agent)
+
+        second_agent = _metadata_agent(session_id="session-b")
+        monkeypatch.setattr(
+            "hermes_time.now",
+            lambda: datetime(2026, 1, 2, 10, 30),
+        )
+        second = build_system_prompt(second_agent)
+
+        assert "Thursday, January 01, 2026" in first
+        assert "Friday, January 02, 2026" in second
 
     def test_callbacks_update_without_cache_eviction(self):
         """Per-message callbacks can be set on cached agent."""

--- a/tests/run_agent/test_background_review_cache_parity.py
+++ b/tests/run_agent/test_background_review_cache_parity.py
@@ -33,6 +33,11 @@ def _make_agent_stub(agent_cls):
         "PARENT-SYSTEM-PROMPT-BYTES — must be inherited verbatim "
         "for prefix-cache parity"
     )
+    agent.tools = [
+        {"type": "function", "function": {"name": "memory", "description": "m"}},
+        {"type": "function", "function": {"name": "feishu_doc_read", "description": "f"}},
+    ]
+    agent.valid_tool_names = {"memory", "feishu_doc_read"}
     import datetime as _dt
     agent.session_start = _dt.datetime(2026, 1, 1, 12, 0, 0)
     agent._MEMORY_REVIEW_PROMPT = "review memory"
@@ -183,3 +188,60 @@ def test_review_fork_pins_session_start_and_session_id():
         "Review fork did not inherit parent's session_id — "
         "system-prompt rebuild paths would diverge."
     )
+
+
+def test_review_fork_inherits_parent_tool_schema_order():
+    """The review fork must reuse the parent's exact tool presentation.
+
+    Local OpenAI-compatible backends render the ``tools`` request field into
+    the prompt before messages. Rebuilding the review agent's tools after the
+    parent turn can reorder dynamic tools and invalidate llama.cpp prefix
+    checkpoints even when the system prompt is inherited byte-for-byte.
+    """
+    import run_agent
+
+    agent = _make_agent_stub(run_agent.AIAgent)
+    captured = {}
+
+    class _Recorder:
+        def __init__(self, *args, **kwargs):
+            self._cached_system_prompt = None
+            self._memory_write_origin = None
+            self._memory_write_context = None
+            self._memory_store = None
+            self._memory_enabled = None
+            self._user_profile_enabled = None
+            self._memory_nudge_interval = None
+            self._skill_nudge_interval = None
+            self.suppress_status_output = None
+            self.tools = [
+                {"type": "function", "function": {"name": "feishu_doc_read"}},
+                {"type": "function", "function": {"name": "memory"}},
+            ]
+            self.valid_tool_names = {"feishu_doc_read", "memory"}
+
+        def run_conversation(self, *args, **kwargs):
+            captured["tool_names"] = [
+                t["function"]["name"] for t in self.tools
+            ]
+            captured["valid_tool_names"] = set(self.valid_tool_names)
+            raise RuntimeError("stop after recording")
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    with patch.object(run_agent, "AIAgent", _Recorder), \
+         patch("threading.Thread", _SyncThread):
+        agent._spawn_background_review(
+            messages_snapshot=[],
+            review_memory=True,
+            review_skills=False,
+        )
+
+    assert captured["tool_names"] == [
+        t["function"]["name"] for t in agent.tools
+    ]
+    assert captured["valid_tool_names"] == agent.valid_tool_names

--- a/tests/run_agent/test_deepseek_reasoning_content_echo.py
+++ b/tests/run_agent/test_deepseek_reasoning_content_echo.py
@@ -289,6 +289,178 @@ class TestCopyReasoningContentForApi:
         agent._copy_reasoning_content_for_api(source, api_msg)
         assert "reasoning_content" not in api_msg
 
+    def test_local_custom_endpoint_inlines_reasoning_for_template(self) -> None:
+        """Local llama.cpp replay needs the generated <think> bytes in content."""
+        agent = _make_agent(
+            provider="custom",
+            model="qwen3",
+            base_url="http://127.0.0.1:8080/v1",
+        )
+        source = {
+            "role": "assistant",
+            "content": "",
+            "reasoning": "local thought trace",
+        }
+        api_msg = {"role": "assistant", "content": ""}
+
+        agent._copy_reasoning_content_for_api(source, api_msg)
+
+        assert api_msg["content"] == "<think>\nlocal thought trace\n</think>"
+        assert "reasoning_content" not in api_msg
+        assert "_local_replay_content" not in api_msg
+
+    def test_any_local_endpoint_inlines_reasoning_for_template(self) -> None:
+        """Provider labels vary for llama.cpp/ik_llama.cpp; local URL is decisive."""
+        agent = _make_agent(
+            provider="openai",
+            model="qwen3",
+            base_url="http://127.0.0.1:8080/v1",
+        )
+        source = {
+            "role": "assistant",
+            "content": "Visible tool preface.",
+            "reasoning": "local thought trace",
+        }
+        api_msg = {"role": "assistant", "content": "Visible tool preface."}
+
+        agent._copy_reasoning_content_for_api(source, api_msg)
+
+        assert api_msg["content"] == (
+            "<think>\nlocal thought trace\n</think>\n\nVisible tool preface."
+        )
+        assert "reasoning_content" not in api_msg
+        assert "_local_replay_content" not in api_msg
+
+    def test_local_custom_endpoint_inlines_stored_reasoning_content(self) -> None:
+        agent = _make_agent(
+            provider="custom",
+            model="qwen3",
+            base_url="http://192.168.1.10:8080/v1",
+        )
+        source = {
+            "role": "assistant",
+            "content": "Visible answer.",
+            "reasoning_content": "stored local reasoning",
+        }
+        api_msg = {"role": "assistant", "content": "Visible answer."}
+
+        agent._copy_reasoning_content_for_api(source, api_msg)
+
+        assert api_msg["content"] == (
+            "<think>\nstored local reasoning\n</think>\n\nVisible answer."
+        )
+        assert "reasoning_content" not in api_msg
+        assert "_local_replay_content" not in api_msg
+
+    def test_local_custom_endpoint_inlines_reasoning_before_tool_calls(self) -> None:
+        agent = _make_agent(
+            provider="custom",
+            model="qwen3",
+            base_url="http://127.0.0.1:8080/v1",
+        )
+        tool_calls = [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "read_file", "arguments": '{"path":"/tmp/a"}'},
+            }
+        ]
+        source = {
+            "role": "assistant",
+            "content": "",
+            "reasoning_content": "I should read the file first.",
+            "tool_calls": tool_calls,
+        }
+        api_msg = {"role": "assistant", "content": "", "tool_calls": tool_calls}
+
+        agent._copy_reasoning_content_for_api(source, api_msg)
+
+        assert api_msg["content"] == "<think>\nI should read the file first.\n</think>"
+        assert api_msg["tool_calls"] == tool_calls
+        assert "_local_replay_content" not in api_msg
+        assert "reasoning_content" not in api_msg
+
+    def test_local_custom_endpoint_does_not_double_wrap_thinking_tags(self) -> None:
+        agent = _make_agent(
+            provider="custom",
+            model="qwen3",
+            base_url="http://localhost:8080/v1",
+        )
+        content = "<thinking>\nprior thought\n</thinking>\n\nVisible answer."
+        source = {
+            "role": "assistant",
+            "content": content,
+            "reasoning": "stored local reasoning",
+        }
+        api_msg = {"role": "assistant", "content": content}
+
+        agent._copy_reasoning_content_for_api(source, api_msg)
+
+        assert api_msg["content"] == content
+        assert "reasoning_content" not in api_msg
+        assert "_local_replay_content" not in api_msg
+
+    def test_local_custom_endpoint_no_reasoning_leaves_content_alone(self) -> None:
+        agent = _make_agent(
+            provider="custom",
+            model="qwen3",
+            base_url="http://localhost:8080/v1",
+        )
+        source = {"role": "assistant", "content": "Visible answer."}
+        api_msg = {"role": "assistant", "content": "Visible answer."}
+
+        agent._copy_reasoning_content_for_api(source, api_msg)
+
+        assert api_msg == {"role": "assistant", "content": "Visible answer."}
+
+    def test_build_api_kwargs_strips_internal_local_replay_marker(self) -> None:
+        """Legacy local replay markers are internal and must not reach providers."""
+        from agent.chat_completion_helpers import build_api_kwargs
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        agent = _make_agent(
+            provider="custom",
+            model="qwen3",
+            base_url="http://127.0.0.1:8080/v1",
+        )
+        agent.api_mode = "chat_completions"
+        agent.tools = None
+        agent.max_tokens = None
+        agent.reasoning_config = None
+        agent.request_overrides = None
+        agent.session_id = "s1"
+        agent.providers_allowed = []
+        agent.providers_ignored = []
+        agent.providers_order = []
+        agent.provider_sort = ""
+        agent.provider_require_parameters = False
+        agent.provider_data_collection = ""
+        agent.openrouter_min_coding_score = None
+        agent._ollama_num_ctx = None
+        agent._base_url_lower = agent.base_url.lower()
+        agent._base_url_hostname = "127.0.0.1"
+        agent._ephemeral_max_output_tokens = None
+        agent._get_transport = lambda: ChatCompletionsTransport()
+        agent._is_qwen_portal = lambda: False
+        agent._is_openrouter_url = lambda: False
+        agent._supports_reasoning_extra_body = lambda: False
+        agent._prepare_messages_for_non_vision_model = lambda messages: messages
+        agent._resolved_api_call_timeout = lambda: 30
+        agent._max_tokens_param = lambda value: {"max_tokens": value}
+
+        api_messages = [
+            {
+                "role": "assistant",
+                "content": "Visible only",
+                "_local_replay_content": "<think>\nr\n</think>\n\nVisible only",
+            }
+        ]
+
+        kwargs = build_api_kwargs(agent, api_messages)
+
+        assert kwargs["messages"][0]["content"] == "Visible only"
+        assert "_local_replay_content" not in kwargs["messages"][0]
+
 
 class TestBuildAssistantMessageDeepSeekReasoningContent:
     """_build_assistant_message pins replay-safe DeepSeek tool-call state."""

--- a/tests/test_get_tool_definitions_cache_isolation.py
+++ b/tests/test_get_tool_definitions_cache_isolation.py
@@ -52,6 +52,17 @@ class TestQuietModeCacheIsolation:
         cached = next(iter(model_tools._tool_defs_cache.values()))
         assert second is not cached
 
+    def test_tool_names_sorted_on_cache_miss_and_hit(self):
+        """Tool order is part of the OpenAI-compatible payload cache key."""
+        first = model_tools.get_tool_definitions(quiet_mode=True)
+        second = model_tools.get_tool_definitions(quiet_mode=True)
+
+        first_names = [t["function"]["name"] for t in first]
+        second_names = [t["function"]["name"] for t in second]
+
+        assert first_names == sorted(first_names)
+        assert second_names == sorted(second_names)
+
     def test_caller_mutation_does_not_poison_cache(self):
         """Simulate run_agent appending LCM tool schemas to the returned
         list. A second call must NOT see those appended entries."""

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -9,10 +9,32 @@ from model_tools import (
     handle_function_call,
     get_all_tool_names,
     get_toolset_for_tool,
+    sort_openai_tool_schemas,
     _AGENT_LOOP_TOOLS,
     _LEGACY_TOOLSET_MAP,
     TOOL_TO_TOOLSET_MAP,
 )
+
+
+# =========================================================================
+# Tool schema ordering
+# =========================================================================
+
+def test_sort_openai_tool_schemas_preserves_set_and_sorts_by_function_name():
+    tools = [
+        {"type": "function", "function": {"name": "memory_search"}},
+        {"type": "function", "function": {"name": "context_expand"}},
+        {"type": "function", "function": {"name": "browser_navigate"}},
+    ]
+
+    sorted_tools = sort_openai_tool_schemas(tools)
+
+    assert [t["function"]["name"] for t in sorted_tools] == [
+        "browser_navigate",
+        "context_expand",
+        "memory_search",
+    ]
+    assert {id(t) for t in sorted_tools} == {id(t) for t in tools}
 
 
 # =========================================================================


### PR DESCRIPTION
## Summary

Fixes prompt-cache invalidation across user turns for local OpenAI-compatible
backends such as llama.cpp / ik_llama.cpp.

This PR is rebased on latest `origin/main` and keeps upstream's date-only
timestamp improvement while adding the remaining cache-coherence fixes needed
for issue #27339:

- deterministic tool schema ordering
- local assistant reasoning replay with inline `<think>` blocks
- frozen session metadata across system-prompt rebuilds
- background review prompt/tool parity with the parent agent

The reported failure mode was a byte mismatch in replayed chat payloads after an
agent tool loop completed. llama.cpp logs showed examples such as `memory` being
replaced by `feishu_doc_read` at the same prompt position, causing prompt
similarity to drop and downstream checkpoints to be erased.

## Changes

### Stable Tool Ordering

- Adds `sort_openai_tool_schemas()` in `model_tools.py`.
- Sorts OpenAI tool schemas by `function.name` after schema sanitization.
- Updates `_last_resolved_tool_names` after sorting so cache/debug state matches
  actual presentation order.
- Sorts appended memory-provider and context-compressor tools in
  `agent_init.py`.
- Defensively sorts tools at final render/send boundaries:
  - `agent/system_prompt.py::format_tools_for_system_message`
  - `agent/chat_completion_helpers.py::build_api_kwargs`

### Local Backend Reasoning Replay

- Adds `AIAgent._is_local_cache_sensitive_backend()`.
- Treats `ollama`, `lmstudio`, and local/private `base_url` endpoints as
  cache-sensitive local backends.
- For local replay only, reconstructs stored assistant reasoning into canonical
  inline `<think>...</think>` content.
- Avoids sending `reasoning_content` on this local path to prevent duplicate or
  ignored thinking blocks.
- Leaves DeepSeek/Kimi/cloud reasoning echo behavior unchanged.
- Keeps structured `tool_calls` intact to preserve correct tool-result
  continuation.

### Frozen System Metadata

- Freezes the metadata block containing:
  - `Conversation started`
  - `Session ID`
  - `Model`
  - `Provider`
- Uses upstream's date-only `Conversation started` format inside the frozen
  block.
- Reuses the frozen metadata block across system-prompt rebuilds caused by
  compression/invalidation.
- Preserves existing session DB system-prompt snapshot behavior for resumed
  sessions.

### Background Review Cache Parity

- Background review fork already inherited the parent cached system prompt.
- This patch also deep-copies the parent `tools` list and `valid_tool_names`.
- Runtime safety is preserved by the existing memory/skills-only thread-local
  whitelist.
- Prevents post-turn background review from rebuilding a subtly different tool
  schema/order and invalidating local prompt-cache prefixes.

## Test Plan

Ran after rebasing onto latest `origin/main`:

```bash
venv/bin/python -m pytest \
  tests/test_model_tools.py \
  tests/test_get_tool_definitions_cache_isolation.py \
  tests/run_agent/test_deepseek_reasoning_content_echo.py \
  tests/gateway/test_agent_cache.py \
  tests/run_agent/test_background_review_cache_parity.py \
  -q
```

Result:

- `135 passed in 10.03s`

## Notes

Upstream already partially addressed the timestamp vector by switching the
session timestamp to date-only. This PR keeps that behavior and additionally
freezes the full metadata block so model/provider/session text does not shift on
prompt rebuilds.

One known local-backend limitation remains: some llama.cpp/Qwen chat templates
render structured assistant `tool_calls` without preserving assistant `content`
before the tool call. A raw `<tool_call>` content-only workaround improved byte
matching but broke plan/tool-result continuation, so this PR intentionally keeps
structured `tool_calls` intact and prioritizes correct behavior while preserving
the stable prefix up to the tool-call boundary.
