### PR TITLE
fix(cron): preserve non-ASCII characters in jobs.json

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -433,7 +433,7 @@ def save_jobs(jobs: List[Dict[str, Any]]):
     fd, tmp_path = tempfile.mkstemp(dir=str(JOBS_FILE.parent), suffix='.tmp', prefix='.jobs_')
     try:
         with os.fdopen(fd, 'w', encoding='utf-8') as f:
-            json.dump({"jobs": jobs, "updated_at": _hermes_now().isoformat()}, f, indent=2)
+            json.dump({"jobs": jobs, "updated_at": _hermes_now().isoformat()}, f, indent=2, ensure_ascii=False)
             f.flush()
             os.fsync(f.fileno())
         atomic_replace(tmp_path, JOBS_FILE)

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -243,6 +243,25 @@ class TestJobCRUD:
         job = create_job(prompt="Recurring", schedule="every 1h")
         assert job["repeat"]["times"] is None
 
+    def test_save_jobs_preserves_non_ascii_prompt(self, tmp_cron_dir):
+        """jobs.json should store non-ASCII (e.g. Chinese) text as readable
+        UTF-8, not as \\uXXXX escape sequences. Regression for #26128."""
+        from cron.jobs import JOBS_FILE
+        chinese_prompt = "生成并发送露娜的自拍照片给主人。"
+        create_job(prompt=chinese_prompt, schedule="30m")
+        raw = JOBS_FILE.read_text(encoding="utf-8")
+        assert chinese_prompt in raw, (
+            "Chinese characters should be stored as UTF-8 in jobs.json, "
+            f"but raw file did not contain the literal prompt. Raw start: {raw[:200]!r}"
+        )
+        assert "\\u" not in raw or "生成" in raw, (
+            "jobs.json appears to contain \\uXXXX escapes for non-ASCII text"
+        )
+        # Round-trip: loaded prompt must equal what we wrote.
+        loaded = list_jobs()
+        assert any(j["prompt"] == chinese_prompt for j in loaded)
+
+
     def test_default_delivery_origin(self, tmp_cron_dir):
         job = create_job(
             prompt="Test", schedule="30m",


### PR DESCRIPTION
## Summary
- Writes `cron/jobs.json` with `ensure_ascii=False` so prompts containing non-ASCII text (e.g. Chinese) are stored as readable UTF-8 instead of `\uXXXX` escapes.
- Adds a regression test that creates a cron job with a Chinese prompt and verifies the raw `jobs.json` contains the literal characters and round-trips through `list_jobs()`.

## Root cause
`cron/jobs.py::save_jobs()` called `json.dump(..., indent=2)` without `ensure_ascii=False`. The Python default (`ensure_ascii=True`) escapes all non-ASCII characters, so `cronjob list` / `cronjob update` then surfaced unreadable `\uXXXX` sequences for prompts written in Chinese (and any other non-Latin script).

`cron/jobs.py` only has a single `json.dump` call site, so the fix is one keyword argument.

## Test Plan
- [x] `python -m pytest tests/cron/test_jobs.py::TestJobCRUD -q -o 'addopts='` → 10 passed (including the new `test_save_jobs_preserves_non_ascii_prompt`).

Closes #26128
