### PR TITLE
fix(backup): constrain quick snapshot restore paths

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -620,7 +620,12 @@ def restore_quick_snapshot(
     """
     home = hermes_home or get_hermes_home()
     root = _quick_snapshot_root(home)
-    snap_dir = root / snapshot_id
+    try:
+        snap_dir = (root / snapshot_id).resolve()
+        snap_dir.relative_to(root.resolve())
+    except (OSError, ValueError):
+        logger.warning("Blocked quick snapshot restore outside snapshot root: %s", snapshot_id)
+        return False
 
     if not snap_dir.is_dir():
         return False
@@ -639,6 +644,11 @@ def restore_quick_snapshot(
             continue
 
         dst = home / rel
+        try:
+            dst.resolve().relative_to(home.resolve())
+        except (OSError, ValueError):
+            logger.warning("Blocked quick snapshot restore path outside Hermes home: %s", rel)
+            continue
         dst.parent.mkdir(parents=True, exist_ok=True)
 
         try:


### PR DESCRIPTION
## Summary
- validate `snapshot_id` resolves under the quick-snapshot root
- block restore targets that resolve outside Hermes home
- fail closed with warning logs instead of restoring arbitrary paths

## Scope
This is a narrow hardening patch for `restore_quick_snapshot()` only.

It does **not** attempt to introduce a broader filesystem policy such as a global read deny-list, declarative `allowed_paths`, or the separate label-side traversal handling discussed elsewhere. The goal here is just to make quick snapshot restore fail closed when untrusted manifest or snapshot path components resolve outside the expected roots.

## Why
`restore_quick_snapshot()` joined untrusted manifest / snapshot path components directly. A crafted snapshot id or manifest entry could escape the intended snapshot root or Hermes home during restore.

The implementation follows the small resolved-path containment pattern (`resolve()` + `relative_to(...)`) already used in other upstream path-traversal fixes, but keeps the change local to quick snapshot restore rather than expanding into a broader path-policy refactor.

## Test Plan
- focused local verification of the patched restore flow

If upstream considers this fully overlapped by existing `restore_quick_snapshot()` work, I am happy to fold/close it rather than keep a parallel fix alive.
