### PR TITLE
fix(config): preserve declared custom-provider models fallback

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2989,13 +2989,20 @@ def _normalize_custom_provider_entry(
     if isinstance(models, dict) and models:
         normalized["models"] = models
     elif isinstance(models, list) and models:
-        # Hand-edited configs (and older Hermes versions) write ``models`` as
-        # a plain list of model ids. Preserve them by converting to the dict
-        # shape downstream code expects; otherwise normalize silently drops
-        # the list and /model shows the provider with (0) models.
-        normalized["models"] = {
-            str(m): {} for m in models if isinstance(m, str) and m.strip()
-        }
+        # Preserve both simple ``list[str]`` and enriched ``list[dict]`` forms.
+        # Older/local configs often store model metadata objects here; dropping
+        # them forces downstream pickers to fall back to incomplete endpoint
+        # /models listings.
+        normalized_models: Dict[str, Any] = {}
+        for item in models:
+            if isinstance(item, str) and item.strip():
+                normalized_models[item.strip()] = {}
+            elif isinstance(item, dict):
+                mid = item.get("id") or item.get("name")
+                if isinstance(mid, str) and mid.strip():
+                    normalized_models[mid.strip()] = item
+        if normalized_models:
+            normalized["models"] = normalized_models
 
     context_length = entry.get("context_length")
     if isinstance(context_length, int) and context_length > 0:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1946,6 +1946,7 @@ def select_provider_and_model(args=None):
                 "api_key": entry.get("api_key", ""),
                 "key_env": entry.get("key_env", ""),
                 "model": entry.get("model", ""),
+                "models": entry.get("models", {}) if isinstance(entry.get("models"), dict) else {},
                 "api_mode": entry.get("api_mode", ""),
                 "provider_key": provider_key,
                 "api_key_ref": _lookup_ref(name, provider_key, entry.get("model", "")),
@@ -3847,6 +3848,14 @@ def _model_flow_named_custom(config, provider_info):
     if api_mode:
         fetch_kwargs["api_mode"] = api_mode
     models = fetch_api_models(api_key, base_url, **fetch_kwargs)
+    declared_models = []
+    raw_declared_models = provider_info.get("models")
+    if isinstance(raw_declared_models, dict) and raw_declared_models:
+        declared_models = [mid.strip() for mid in raw_declared_models.keys() if isinstance(mid, str) and mid.strip()]
+
+    if not models and declared_models:
+        models = declared_models
+        print(f"Endpoint /models unavailable; using {len(models)} configured model(s) from config.yaml.")
 
     if models:
         default_idx = 0

--- a/tests/test_custom_provider_model_fallback.py
+++ b/tests/test_custom_provider_model_fallback.py
@@ -12,6 +12,20 @@ class _MenuPickFirst:
         return 0
 
 
+class _MenuChooseDefault:
+    last_items = None
+    last_cursor_index = None
+
+    def __init__(self, items, cursor_index=0, **kwargs):
+        self.items = items
+        self.cursor_index = cursor_index
+        _MenuChooseDefault.last_items = items
+        _MenuChooseDefault.last_cursor_index = cursor_index
+
+    def show(self):
+        return self.cursor_index
+
+
 def test_named_custom_provider_uses_declared_models_when_models_endpoint_unavailable(monkeypatch, capsys):
     provider_info = {
         "name": "cpa-codex",
@@ -52,3 +66,45 @@ def test_named_custom_provider_uses_declared_models_when_models_endpoint_unavail
     assert cfg["model"]["base_url"] == "http://127.0.0.1:8317/v1"
     assert cfg["model"]["api_key"] == "test-key"
     assert saved_custom, "expected selected model to be persisted back to custom_providers"
+
+
+def test_named_custom_provider_preserves_declared_model_metadata_when_models_endpoint_unavailable(monkeypatch, capsys):
+    provider_info = {
+        "name": "cpa-codex",
+        "base_url": "http://127.0.0.1:8317/v1",
+        "api_key": "test-key",
+        "key_env": "",
+        "model": "gpt-5.5",
+        "models": {
+            "gpt-5.4": {"context_length": 128000},
+            "gpt-5.5": {"context_length": 256000, "supports_vision": True},
+            "gpt-5.4-mini": {"context_length": 64000},
+        },
+        "api_mode": "chat_completions",
+        "provider_key": "",
+        "api_key_ref": "",
+    }
+
+    cfg = {"model": {}}
+    saved_models = []
+    saved_custom = []
+
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: cfg)
+    monkeypatch.setattr("hermes_cli.config.save_config", lambda new_cfg: None)
+    monkeypatch.setattr("hermes_cli.auth.deactivate_provider", lambda: None)
+    monkeypatch.setattr("hermes_cli.auth._save_model_choice", lambda model: saved_models.append(model))
+    monkeypatch.setattr("hermes_cli.main._save_custom_provider", lambda *args, **kwargs: saved_custom.append((args, kwargs)))
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", lambda *args, **kwargs: [])
+    monkeypatch.setitem(sys.modules, "simple_term_menu", SimpleNamespace(TerminalMenu=_MenuChooseDefault))
+    monkeypatch.setattr("hermes_cli.curses_ui.flush_stdin", lambda: None)
+
+    _model_flow_named_custom({}, provider_info)
+
+    out = capsys.readouterr().out
+    assert "Endpoint /models unavailable; using 3 configured model(s) from config.yaml." in out
+    assert saved_models == ["gpt-5.5"]
+    assert _MenuChooseDefault.last_cursor_index == 1
+    assert any("gpt-5.5 (current)" in item for item in _MenuChooseDefault.last_items)
+    assert saved_custom == [
+        (("http://127.0.0.1:8317/v1", "test-key", "gpt-5.5"), {"api_mode": "chat_completions"})
+    ]

--- a/tests/test_custom_provider_model_fallback.py
+++ b/tests/test_custom_provider_model_fallback.py
@@ -1,0 +1,54 @@
+import sys
+from types import SimpleNamespace
+
+from hermes_cli.main import _model_flow_named_custom
+
+
+class _MenuPickFirst:
+    def __init__(self, items, **kwargs):
+        self.items = items
+
+    def show(self):
+        return 0
+
+
+def test_named_custom_provider_uses_declared_models_when_models_endpoint_unavailable(monkeypatch, capsys):
+    provider_info = {
+        "name": "cpa-codex",
+        "base_url": "http://127.0.0.1:8317/v1",
+        "api_key": "test-key",
+        "key_env": "",
+        "model": "gpt-5.4",
+        "models": {
+            "gpt-5.4": {},
+            "gpt-5.5": {},
+            "gpt-5.4-mini": {},
+        },
+        "api_mode": "chat_completions",
+        "provider_key": "",
+        "api_key_ref": "",
+    }
+
+    cfg = {"model": {}}
+    saved_models = []
+    saved_custom = []
+
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: cfg)
+    monkeypatch.setattr("hermes_cli.config.save_config", lambda new_cfg: None)
+    monkeypatch.setattr("hermes_cli.auth.deactivate_provider", lambda: None)
+    monkeypatch.setattr("hermes_cli.auth._save_model_choice", lambda model: saved_models.append(model))
+    monkeypatch.setattr("hermes_cli.main._save_custom_provider", lambda *args, **kwargs: saved_custom.append((args, kwargs)))
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", lambda *args, **kwargs: [])
+    monkeypatch.setitem(sys.modules, "simple_term_menu", SimpleNamespace(TerminalMenu=_MenuPickFirst))
+    monkeypatch.setattr("hermes_cli.curses_ui.flush_stdin", lambda: None)
+
+    _model_flow_named_custom({}, provider_info)
+
+    out = capsys.readouterr().out
+    assert "Endpoint /models unavailable; using 3 configured model(s) from config.yaml." in out
+    assert "Found 3 model(s):" in out
+    assert saved_models == ["gpt-5.4"]
+    assert cfg["model"]["provider"] == "custom"
+    assert cfg["model"]["base_url"] == "http://127.0.0.1:8317/v1"
+    assert cfg["model"]["api_key"] == "test-key"
+    assert saved_custom, "expected selected model to be persisted back to custom_providers"


### PR DESCRIPTION
## Summary
- preserve configured declared models for named custom providers when `/models` is unavailable
- keep model selection usable for OpenAI-compatible endpoints that do not expose a discovery endpoint
- preserve richer declared-model config shapes during normalization instead of silently dropping metadata-bearing entries
- add regression coverage for the fallback path

## Scope
This is a small declared-model fallback and normalization fix for named custom providers.

It is intentionally narrower than a full custom-provider routing overhaul: it does not try to solve every auxiliary-path or provider-alias edge case. The focus is making already-declared provider metadata continue to work when endpoint-side model discovery is missing or incomplete.

## Why
Named custom providers can already declare supported models in `config.yaml`. When the endpoint does not implement `/models`, the current flow falls back to an empty selection path even though the config already provides a valid model list.

There is a second reliability issue here as well: local/older configs do not always store `models` in a single canonical shape. Some use `dict`, some use `list[str]`, and some preserve richer `list[dict]` entries. If normalization drops the richer declared-model form, downstream model selection becomes dependent on endpoint discovery even when the config already contains the needed metadata.

This patch keeps the declared models usable instead of treating discovery failure as no models available, while preserving the metadata-bearing declared-model shapes that upstream custom-provider work is gradually relying on.

## Test Plan
- `uv run --no-sync python3 -m pytest tests/test_custom_provider_model_fallback.py -q`

Related to the long-running custom-provider / fallback-model reliability issues around named custom providers, declared models, and incomplete `/models` support.
