### PR TITLE
fix(agent): raise from _ensure_db_session instead of swallowing (#18765)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -114,7 +114,12 @@ def run_conversation(
     # Installed once, transparent when streams are healthy, prevents crash on write.
     _install_safe_stdio()
 
-    agent._ensure_db_session()
+    try:
+        agent._ensure_db_session()
+    except Exception:
+        # Session DB unavailable — proceed without persistence rather than
+        # silently dropping the final response (PR #18765 / issue #18765).
+        agent._session_db = None
 
     # Tell auxiliary_client what the live main provider/model are for
     # this turn. Used by tools whose behaviour depends on the active

--- a/run_agent.py
+++ b/run_agent.py
@@ -503,26 +503,19 @@ class AIAgent:
             return None
 
     def _ensure_db_session(self) -> None:
-        """Create session DB row on first use. Disables _session_db on failure."""
+        """Create session DB row on first use. Raises on failure so callers handle it explicitly."""
         if self._session_db_created or not self._session_db:
             return
-        try:
-            self._session_db.create_session(
-                session_id=self.session_id,
-                source=self.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
-                model=self.model,
-                model_config=self._session_init_model_config,
-                system_prompt=self._cached_system_prompt,
-                user_id=None,
-                parent_session_id=self._parent_session_id,
-            )
-            self._session_db_created = True
-        except Exception as e:
-            # Transient failure (e.g. SQLite lock). Keep _session_db alive —
-            # _session_db_created stays False so next run_conversation() retries.
-            logger.warning(
-                "Session DB creation failed (will retry next turn): %s", e
-            )
+        self._session_db.create_session(
+            session_id=self.session_id,
+            source=self.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+            model=self.model,
+            model_config=self._session_init_model_config,
+            system_prompt=self._cached_system_prompt,
+            user_id=None,
+            parent_session_id=self._parent_session_id,
+        )
+        self._session_db_created = True
 
     def reset_session_state(self):
         """Reset all session-scoped token counters to 0 for a fresh session.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -732,6 +732,7 @@ AUTHOR_MAP = {
     "7093928+0xyg3n@users.noreply.github.com": "0xyg3n",
     "nftpoetrist@gmail.com": "nftpoetrist",  # PR #18982
     "millerc79@users.noreply.github.com": "millerc79",  # PR #19033
+    "shellybotmoyer@users.noreply.github.com": "shellybotmoyer",
     "hermes@example.com": "shellybotmoyer",  # PR #18915 (bot-committed)
     "exx@example.com": "exxmen",  # PR #19555
     "hypnosis.mda@gmail.com": "Hypn0sis",


### PR DESCRIPTION
## Summary
Re-applies the fix from PR #18798 (issue #18765) onto the current `origin/main`, which has since refactored `run_conversation` into `agent/conversation_loop.py`.

### Problem
`_ensure_db_session()` silently swallows all exceptions, leaving `_session_db_created=False` and letting the conversation proceed with an uninitialized session. The agent completes API calls (high api_calls count, long elapsed time) but discards the final response — logging `response=0 chars`.

### Changes
1. **`run_agent.py:_ensure_db_session()`**
   - Removes the `try/except` wrapper around `self._session_db.create_session(...)`.
   - Lets the exception propagate to callers.

2. **`agent/conversation_loop.py:run_conversation()`**
   - Wraps `agent._ensure_db_session()` in a `try/except`.
   - On exception, sets `agent._session_db = None` and proceeds without persistence.
   - This matches the intent of the original PR while accounting for the new file layout after the upstream refactor.

### Supersedes
- PR #18798 (DIRTY after upstream refactor)

### Fixes
- Issue #18765
