### PR TITLE
fix(conversation_loop): NameError on rate limit — route _pool_may_recover_from_rate_limit through _ra() (#27465)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2251,7 +2251,13 @@ def run_conversation(
                     # still recover.  See _pool_may_recover_from_rate_limit
                     # for the single-credential-pool and CloudCode-quota
                     # exceptions.  Fixes #11314 and #13636.
-                    pool_may_recover = _pool_may_recover_from_rate_limit(
+                    #
+                    # Use the lazy ``_ra()`` accessor (see the module
+                    # docstring) -- a bare ``_pool_may_recover_from_rate_limit``
+                    # reference raised ``NameError`` on every 429 because the
+                    # function lives in ``run_agent`` and is not imported at
+                    # module scope here.  Fixes #27465.
+                    pool_may_recover = _ra()._pool_may_recover_from_rate_limit(
                         agent._credential_pool,
                         provider=agent.provider,
                         base_url=getattr(agent, "base_url", None),

--- a/tests/agent/test_conversation_loop_pool_recover_reference.py
+++ b/tests/agent/test_conversation_loop_pool_recover_reference.py
@@ -1,0 +1,198 @@
+"""Regression tests for issue #27465.
+
+The conversation_loop's rate-limit branch was calling
+``_pool_may_recover_from_rate_limit(...)`` as a bare name, but the
+function lives in ``run_agent`` and is not imported at module scope.
+Every 429 from a provider therefore crashed the loop with::
+
+    NameError: name '_pool_may_recover_from_rate_limit' is not defined
+
+The fix is to route the call through the existing lazy ``_ra()``
+accessor that the rest of the module uses for ``run_agent`` symbols.
+
+These tests pin:
+
+1. Source invariant -- the broken bare reference must not reappear in
+   ``agent/conversation_loop.py``.
+2. Symbol resolution -- ``_ra()._pool_may_recover_from_rate_limit`` is
+   actually callable end-to-end (no AttributeError, no stale module
+   binding) and produces the documented truthiness on a representative
+   set of credential-pool shapes.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _fake_pool(n_entries: int, has_available: bool = True):
+    """Minimal credential-pool stand-in.
+
+    Matches the shape consumed by ``run_agent._pool_may_recover_from_rate_limit``:
+    ``pool.has_available()`` (boolean) and ``pool.entries()`` (a list whose
+    length is the credential count).  Mirrors the helper used by the
+    existing pool-rotation tests in ``tests/run_agent/test_provider_fallback.py``
+    so the contracts can't drift independently.
+    """
+    pool = MagicMock()
+    pool.entries.return_value = [MagicMock() for _ in range(n_entries)]
+    pool.has_available.return_value = has_available
+    return pool
+
+
+CONVERSATION_LOOP = (
+    Path(__file__).resolve().parents[2] / "agent" / "conversation_loop.py"
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. Source invariant
+# ---------------------------------------------------------------------------
+
+
+def test_conversation_loop_source_exists():
+    """Sanity: the file we're guarding actually exists in this checkout."""
+    assert CONVERSATION_LOOP.is_file(), CONVERSATION_LOOP
+
+
+def test_no_bare_pool_may_recover_call_in_conversation_loop():
+    """The bare ``_pool_may_recover_from_rate_limit(`` call must not return.
+
+    Bare references (without ``_ra().`` or ``run_agent.`` prefix) are
+    what caused #27465.  ``_pool_may_recover`` (the local variable
+    binding) and the docstring comment that mentions the function name
+    are both allowed -- only an actual *call* without a module accessor
+    is forbidden.
+    """
+    src = CONVERSATION_LOOP.read_text(encoding="utf-8")
+    # Match the call form, optionally preceded by `.` (which means it's
+    # already qualified, e.g. ``run_agent._pool_may_recover_from_rate_limit(``
+    # or ``_ra()._pool_may_recover_from_rate_limit(``).  We assert that
+    # there is no occurrence where the function name is called *not* in
+    # an attribute-access context.
+    bare_call_pattern = re.compile(
+        r"(?<![.\w])_pool_may_recover_from_rate_limit\s*\("
+    )
+    matches = bare_call_pattern.findall(src)
+    assert not matches, (
+        "Found bare _pool_may_recover_from_rate_limit() call in "
+        "agent/conversation_loop.py.  This is the #27465 regression: "
+        "the function lives in run_agent, so the call must use the "
+        "_ra() lazy accessor (or `run_agent.` prefix)."
+    )
+
+
+def test_call_site_uses_lazy_accessor():
+    """Spot-check: the surviving call must route through ``_ra()``.
+
+    Confirms the fix is *positively* in place -- not merely that the
+    broken form is absent.
+    """
+    src = CONVERSATION_LOOP.read_text(encoding="utf-8")
+    qualified_pattern = re.compile(
+        r"_ra\(\)\._pool_may_recover_from_rate_limit\s*\("
+    )
+    assert qualified_pattern.search(src), (
+        "Expected at least one ``_ra()._pool_may_recover_from_rate_limit(`` "
+        "call in agent/conversation_loop.py -- the fix for #27465 has "
+        "regressed or been reverted."
+    )
+
+
+def test_conversation_loop_compiles_cleanly():
+    """No SyntaxError / NameError at *import* time.
+
+    Importing ``agent.conversation_loop`` triggers module-level execution
+    only; the rate-limit branch is inside an async function and won't
+    run.  But a future regression that swapped the call to a top-level
+    statement (or reintroduced a syntax error around it) would surface
+    here.
+    """
+    src = CONVERSATION_LOOP.read_text(encoding="utf-8")
+    ast.parse(src, filename=str(CONVERSATION_LOOP))
+
+
+# ---------------------------------------------------------------------------
+# 2. End-to-end symbol resolution via _ra()
+# ---------------------------------------------------------------------------
+
+
+def test_ra_accessor_resolves_pool_may_recover():
+    """``_ra()._pool_may_recover_from_rate_limit`` must be callable."""
+    from agent import conversation_loop
+
+    fn = conversation_loop._ra()._pool_may_recover_from_rate_limit
+    assert callable(fn)
+    # The accessor returns the same module on every call -- otherwise a
+    # future refactor that returned a stale reference would break the
+    # in-loop call.
+    assert (
+        conversation_loop._ra()._pool_may_recover_from_rate_limit
+        is fn
+    )
+
+
+def test_ra_accessor_pool_may_recover_none_pool_returns_false():
+    """No credential pool -> the loop cannot recover via rotation."""
+    from agent import conversation_loop
+
+    fn = conversation_loop._ra()._pool_may_recover_from_rate_limit
+    assert fn(None) is False
+
+
+def test_ra_accessor_pool_may_recover_single_credential_returns_false():
+    """One credential -- no rotation room -- cannot recover."""
+    from agent import conversation_loop
+
+    fn = conversation_loop._ra()._pool_may_recover_from_rate_limit
+    assert fn(_fake_pool(1)) is False
+
+
+def test_ra_accessor_pool_may_recover_multi_credential_returns_true():
+    """Multiple credentials with at least one available -> rotation may save us."""
+    from agent import conversation_loop
+
+    fn = conversation_loop._ra()._pool_may_recover_from_rate_limit
+    assert fn(_fake_pool(3)) is True
+
+
+def test_ra_accessor_pool_may_recover_cooled_down_returns_false():
+    from agent import conversation_loop
+
+    fn = conversation_loop._ra()._pool_may_recover_from_rate_limit
+    assert fn(_fake_pool(5, has_available=False)) is False
+
+
+def test_ra_accessor_pool_may_recover_handles_keyword_args():
+    """The call site passes ``provider=`` and ``base_url=`` kwargs.
+
+    Pin that the function accepts them via the lazy accessor so a future
+    rename of the parameters in ``run_agent`` doesn't silently break the
+    in-loop call (a TypeError would crash the same retry branch as the
+    original NameError did before the fix).
+    """
+    from agent import conversation_loop
+
+    fn = conversation_loop._ra()._pool_may_recover_from_rate_limit
+    result = fn(
+        _fake_pool(2),
+        provider="ollama",
+        base_url="https://ollama.cloud/v1",
+    )
+    assert isinstance(result, bool)
+
+
+def test_ra_accessor_pool_may_recover_cloudcode_returns_false():
+    """CloudCode base_url -> account-wide quota -> rotation can't recover (#13636)."""
+    from agent import conversation_loop
+
+    fn = conversation_loop._ra()._pool_may_recover_from_rate_limit
+    assert fn(
+        _fake_pool(5),
+        base_url="cloudcode-pa://us-central1",
+    ) is False


### PR DESCRIPTION
## What does this PR do?

Fixes the `NameError: name '_pool_may_recover_from_rate_limit' is not defined` crash that hit every 429 from a provider in v0.14.0.

**Root cause:** `agent/conversation_loop.py` at line 2254 called the helper as a bare name:

```python
pool_may_recover = _pool_may_recover_from_rate_limit(
    agent._credential_pool,
    provider=agent.provider,
    base_url=getattr(agent, "base_url", None),
)
```

…but the function is defined in `run_agent.py` and is **not** imported at module scope in `conversation_loop.py`. The result: instead of falling through to the configured fallback provider, every rate-limit error blew up with the `NameError` traceback. Reproduces deterministically against any provider that returns 429 (e.g. Ollama Cloud weekly quota exhaustion, as reported).

**The fix:** route the call through the existing `_ra()` lazy accessor at the top of `conversation_loop.py` that the rest of the module already uses for `run_agent` symbols (`_ra().handle_function_call`, `_ra().AIAgent`, `_ra()._set_interrupt`, etc.). This matches the documented "patch-friendly module reference" idiom in `_ra()`'s docstring at line 76 — callers that `monkeypatch.setattr(run_agent, ...)` continue to see the patched value here too.

One-character intent change, plus a regression-test suite specifically pinned at the two layers that would have caught this before it shipped.

## Related Issue

Closes #27465.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

**Production fix (`agent/conversation_loop.py`, +7 / −1):**

- Replace `_pool_may_recover_from_rate_limit(...)` with `_ra()._pool_may_recover_from_rate_limit(...)` at the only call site, matching the existing pattern at lines 487/489/3699/3748 (`_ra()._set_interrupt`, `_ra().AIAgent`, `_ra().handle_function_call`).
- Add a code comment cross-referencing #27465 so the same regression isn't reintroduced by a future refactor.

**Regression tests (`tests/agent/test_conversation_loop_pool_recover_reference.py`, new file, +198):**

11 tests across two layers.

*Source-invariant layer (catches the original bug shape):*

- `test_conversation_loop_source_exists` — sanity check.
- `test_no_bare_pool_may_recover_call_in_conversation_loop` — regex pins that **no** unqualified `_pool_may_recover_from_rate_limit(` call survives in the file. This is the strongest regression guard — it would have failed on the v0.14.0 release commit.
- `test_call_site_uses_lazy_accessor` — positive assertion that at least one `_ra()._pool_may_recover_from_rate_limit(` call exists, so a future refactor that drops the call entirely (or accidentally renames it) is also caught.
- `test_conversation_loop_compiles_cleanly` — `ast.parse` smoke test.

*Symbol-resolution layer (catches API drift):*

- `test_ra_accessor_resolves_pool_may_recover` — `_ra()._pool_may_recover_from_rate_limit` is callable and stable across calls (no stale module binding).
- `test_ra_accessor_pool_may_recover_none_pool_returns_false`
- `test_ra_accessor_pool_may_recover_single_credential_returns_false` — pin the `entries() <= 1` short-circuit (#11314 contract).
- `test_ra_accessor_pool_may_recover_multi_credential_returns_true`
- `test_ra_accessor_pool_may_recover_cooled_down_returns_false`
- `test_ra_accessor_pool_may_recover_handles_keyword_args` — the call site passes `provider=` and `base_url=`; pin the kwargs surface so a future rename in `run_agent` doesn't silently break the in-loop call with a `TypeError` (same retry branch as the original `NameError`).
- `test_ra_accessor_pool_may_recover_cloudcode_returns_false` — pin the `cloudcode-pa://` exception path (#13636 contract).

The MagicMock-based `_fake_pool` fixture mirrors the canonical helper in `tests/run_agent/test_provider_fallback.py::TestPoolRotationRoom` so the pool contract can't drift independently between the two test files.

## How to Test

1. Set up the venv:
   ```
   python3 -m venv .venv && source .venv/bin/activate && pip install -e ".[all,dev]"
   ```
2. Run the new regression suite:
   ```
   scripts/run_tests.sh tests/agent/test_conversation_loop_pool_recover_reference.py -v
   ```
   Expected: **11 passed**.
3. Verify nothing in the existing `_pool_may_recover_from_rate_limit` direct-test suite broke:
   ```
   scripts/run_tests.sh tests/agent/test_conversation_loop_pool_recover_reference.py tests/agent/test_gemini_fast_fallback.py
   ```
   Expected: **18 passed** (11 new + 7 pre-existing in `test_gemini_fast_fallback.py`).
4. Confirm `agent/conversation_loop.py` imports cleanly and the lazy accessor resolves:
   ```
   python -c "from agent import conversation_loop; \
              print(callable(conversation_loop._ra()._pool_may_recover_from_rate_limit))"
   # -> True
   ```
5. End-to-end smoke (manual): point at a provider you can deliberately rate-limit (or use `monkeypatch.setattr` in a unit test to raise a 429-style error from `client.chat.completions.create`). Pre-fix the agent crashes with `NameError`. Post-fix the loop either falls back to the configured `fallback_model` (when `_pool_may_recover_from_rate_limit` returns `False`) or rotates within the credential pool (when it returns `True`).

The pre-existing `test_provider_fallback.py::TestFallbackChainAdvancement` / `TestFallbackChainDedup` failures (16/22) reproduce identically on `origin/main` with `git stash` of these changes — they are unrelated and not introduced by this PR.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(conversation_loop):`, `test(conversation_loop):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `scripts/run_tests.sh` and all relevant tests pass (11/11 new, no regressions on the related rate-limit test files)
- [x] I've added tests for my changes (11 new test cases pinning both the source shape and the runtime behaviour)
- [x] I've tested on my platform: macOS 15.2 (Darwin 24.6.0), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (one-line fix to an existing call site; no public API changed)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python module-attribute resolution; no platform-specific paths
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/agent/test_conversation_loop_pool_recover_reference.py
4 workers [11 items]
============================== 11 passed in 1.66s ==============================

$ python -c "from agent import conversation_loop; print(callable(conversation_loop._ra()._pool_may_recover_from_rate_limit))"
True
```

**Before / after the call site:**

```diff
-                    pool_may_recover = _pool_may_recover_from_rate_limit(
+                    pool_may_recover = _ra()._pool_may_recover_from_rate_limit(
                         agent._credential_pool,
                         provider=agent.provider,
                         base_url=getattr(agent, "base_url", None),
                     )
```
