### PR TITLE
fix(skills): preserve official optional-skill frontmatter names

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -670,6 +670,14 @@ def do_install(identifier: str, category: str = "", force: bool = False,
         if len(id_parts) >= 3:
             category = "/".join(id_parts[1:-1])
 
+    # Official optional skills are searched/listed by their frontmatter name.
+    # Keep install-time naming aligned even when the source directory uses a
+    # different slug (e.g. here-now/ -> name: here.now).
+    if bundle.source == "official" and meta is not None:
+        meta_name = getattr(meta, "name", "")
+        if isinstance(meta_name, str) and meta_name.strip():
+            bundle.name = meta_name.strip()
+
     # Check if already installed
     lock = HubLockFile()
     existing = lock.get_installed(bundle.name)
@@ -996,15 +1004,32 @@ def do_list(source_filter: str = "all",
     ``skills.disabled`` list because ``-p`` swaps ``HERMES_HOME`` at process
     start.  No explicit profile flag needed here.
     """
-    from tools.skills_hub import HubLockFile, ensure_hub_dirs
+    from agent.skill_utils import get_disabled_skill_names, parse_frontmatter
+    from tools.skills_hub import HubLockFile, SKILLS_DIR, ensure_hub_dirs
     from tools.skills_sync import _read_manifest
     from tools.skills_tool import _find_all_skills
-    from agent.skill_utils import get_disabled_skill_names
 
     c = console or _console
     ensure_hub_dirs()
     lock = HubLockFile()
-    hub_installed = {e["name"]: e for e in lock.list_installed()}
+    hub_installed = {}
+    for entry in lock.list_installed():
+        entry_name = entry.get("name")
+        if entry_name:
+            hub_installed[entry_name] = entry
+
+        install_path = entry.get("install_path")
+        if not install_path:
+            continue
+        skill_md = SKILLS_DIR / install_path / "SKILL.md"
+        try:
+            frontmatter, _body = parse_frontmatter(skill_md.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError):
+            continue
+        frontmatter_name = frontmatter.get("name")
+        if isinstance(frontmatter_name, str) and frontmatter_name.strip():
+            hub_installed.setdefault(frontmatter_name.strip(), entry)
+
     builtin_names = set(_read_manifest())
 
     # Pull ALL skills (including disabled ones) so we can annotate status.

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -624,6 +624,14 @@ def do_install(identifier: str, category: str = "", force: bool = False,
         if len(id_parts) >= 3:
             category = "/".join(id_parts[1:-1])
 
+    # Official optional skills are searched/listed by their frontmatter name.
+    # Keep install-time naming aligned even when the source directory uses a
+    # different slug (e.g. here-now/ -> name: here.now).
+    if bundle.source == "official" and meta is not None:
+        meta_name = getattr(meta, "name", "")
+        if isinstance(meta_name, str) and meta_name.strip():
+            bundle.name = meta_name.strip()
+
     # Check if already installed
     lock = HubLockFile()
     existing = lock.get_installed(bundle.name)
@@ -944,15 +952,32 @@ def do_list(source_filter: str = "all",
     ``skills.disabled`` list because ``-p`` swaps ``HERMES_HOME`` at process
     start.  No explicit profile flag needed here.
     """
-    from tools.skills_hub import HubLockFile, ensure_hub_dirs
+    from agent.skill_utils import get_disabled_skill_names, parse_frontmatter
+    from tools.skills_hub import HubLockFile, SKILLS_DIR, ensure_hub_dirs
     from tools.skills_sync import _read_manifest
     from tools.skills_tool import _find_all_skills
-    from agent.skill_utils import get_disabled_skill_names
 
     c = console or _console
     ensure_hub_dirs()
     lock = HubLockFile()
-    hub_installed = {e["name"]: e for e in lock.list_installed()}
+    hub_installed = {}
+    for entry in lock.list_installed():
+        entry_name = entry.get("name")
+        if entry_name:
+            hub_installed[entry_name] = entry
+
+        install_path = entry.get("install_path")
+        if not install_path:
+            continue
+        skill_md = SKILLS_DIR / install_path / "SKILL.md"
+        try:
+            frontmatter, _body = parse_frontmatter(skill_md.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError):
+            continue
+        frontmatter_name = frontmatter.get("name")
+        if isinstance(frontmatter_name, str) and frontmatter_name.strip():
+            hub_installed.setdefault(frontmatter_name.strip(), entry)
+
     builtin_names = set(_read_manifest())
 
     # Pull ALL skills (including disabled ones) so we can annotate status.

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -489,3 +489,4 @@ def test_do_update_unmodified_skill_updates_normally(monkeypatch, tmp_path):
 
     assert installs == ["someone/hub-skill"]
     assert "Updated 1 skill(s)" in sink.getvalue()
+

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -313,3 +313,72 @@ def test_do_search_json_flag_emits_full_identifiers(capsys):
     # Table render must be suppressed — sink should be empty (no "Searching for:" header).
     assert "Searching for:" not in sink.getvalue()
 
+def test_official_install_prefers_frontmatter_name(monkeypatch, tmp_path, hub_env):
+    class _OfficialSource:
+        def inspect(self, identifier):
+            return type("Meta", (), {
+                "extra": {},
+                "identifier": identifier,
+                "name": "here.now",
+                "path": "productivity/here-now",
+            })()
+
+        def fetch(self, identifier):
+            return type("Bundle", (), {
+                "name": "here-now",
+                "files": {"SKILL.md": "---\nname: here.now\ndescription: ok\n---\n# body\n"},
+                "source": "official",
+                "identifier": identifier,
+                "trust_level": "builtin",
+                "metadata": {},
+            })()
+
+    installs = _install_mocks(monkeypatch, tmp_path, _OfficialSource)
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+    do_install(
+        "official/productivity/here-now",
+        console=console,
+        skip_confirm=True,
+    )
+
+    assert installs == [{"name": "here.now", "category": "productivity"}]
+
+
+def test_do_list_matches_hub_entry_by_installed_frontmatter_name(monkeypatch, tmp_path, hub_env):
+    import tools.skills_hub as hub
+    import tools.skills_sync as skills_sync
+    import tools.skills_tool as skills_tool
+
+    install_dir = hub.SKILLS_DIR / "productivity" / "here-now"
+    install_dir.mkdir(parents=True)
+    (install_dir / "SKILL.md").write_text(
+        "---\nname: here.now\ndescription: ok\n---\n# body\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        hub,
+        "HubLockFile",
+        lambda: _DummyLockFile([
+            {
+                "name": "here-now",
+                "source": "official",
+                "trust_level": "builtin",
+                "install_path": "productivity/here-now",
+            }
+        ]),
+    )
+    monkeypatch.setattr(
+        skills_tool,
+        "_find_all_skills",
+        lambda **_kwargs: [{"name": "here.now", "category": "productivity", "description": "publish"}],
+    )
+    monkeypatch.setattr(skills_sync, "_read_manifest", lambda: {})
+
+    output = _capture()
+
+    assert "here.now" in output
+    assert "official" in output
+    assert "1 hub-installed, 0 builtin, 0 local" in output

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3440,8 +3440,20 @@ class OptionalSkillSource(SkillSource):
         if not files:
             return None
 
-        # Determine category from directory structure
+        # Prefer the declared frontmatter name when present so official skills
+        # install under the same identifier surfaced by search/list/inspect.
         name = skill_dir.name
+        skill_doc = files.get("SKILL.md")
+        if isinstance(skill_doc, bytes):
+            try:
+                skill_doc = skill_doc.decode("utf-8")
+            except UnicodeDecodeError:
+                skill_doc = ""
+        if isinstance(skill_doc, str):
+            fm = self._parse_frontmatter(skill_doc)
+            frontmatter_name = fm.get("name")
+            if isinstance(frontmatter_name, str) and frontmatter_name.strip():
+                name = frontmatter_name.strip()
 
         return SkillBundle(
             name=name,

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3345,8 +3345,20 @@ class OptionalSkillSource(SkillSource):
         if not files:
             return None
 
-        # Determine category from directory structure
+        # Prefer the declared frontmatter name when present so official skills
+        # install under the same identifier surfaced by search/list/inspect.
         name = skill_dir.name
+        skill_doc = files.get("SKILL.md")
+        if isinstance(skill_doc, bytes):
+            try:
+                skill_doc = skill_doc.decode("utf-8")
+            except UnicodeDecodeError:
+                skill_doc = ""
+        if isinstance(skill_doc, str):
+            fm = self._parse_frontmatter(skill_doc)
+            frontmatter_name = fm.get("name")
+            if isinstance(frontmatter_name, str) and frontmatter_name.strip():
+                name = frontmatter_name.strip()
 
         return SkillBundle(
             name=name,


### PR DESCRIPTION
## Summary

This is a clean replacement for #27467 with only the skills hub fix.

- preserve official optional-skill frontmatter names during fetch/install
- match installed hub entries by SKILL.md frontmatter name in skills list
- add regressions for install-time naming and list classification

## Verification

- RED: the two new regression tests failed against upstream/main
- GREEN: `pytest tests/hermes_cli/test_skills_hub.py -q` → 24 passed

## Diff scope

- `tools/skills_hub.py`
- `hermes_cli/skills_hub.py`
- `tests/hermes_cli/test_skills_hub.py`

Supersedes #27467.