### PR TITLE
feat(telegram): add media_write_timeout for large file uploads

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1229,6 +1229,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 "connect_timeout": _env_float("HERMES_TELEGRAM_HTTP_CONNECT_TIMEOUT", 10.0),
                 "read_timeout": _env_float("HERMES_TELEGRAM_HTTP_READ_TIMEOUT", 20.0),
                 "write_timeout": _env_float("HERMES_TELEGRAM_HTTP_WRITE_TIMEOUT", 20.0),
+                "media_write_timeout": _env_float("HERMES_TELEGRAM_HTTP_MEDIA_WRITE_TIMEOUT", 120.0),
             }
 
             disable_fallback = (os.getenv("HERMES_TELEGRAM_DISABLE_FALLBACK_IPS", "").strip().lower() in {"1", "true", "yes", "on"})


### PR DESCRIPTION
## Problem

When sending large documents or videos via Telegram, the default 20-second write timeout frequently causes silent upload failures.

## Solution

- Add  parameter to the Telegram bot client initialization.
- Default bumped from 20s to 120s for media uploads only.
- Fully configurable via  env var.
- Zero impact on text/image posts; fully backward-compatible.

## Change

