### PR TITLE
feat(discord): add opt-in DM history backfill

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -949,6 +949,11 @@ def load_gateway_config() -> GatewayConfig:
                 hbl = discord_cfg.get("history_backfill_limit")
                 if hbl is not None and not os.getenv("DISCORD_HISTORY_BACKFILL_LIMIT"):
                     os.environ["DISCORD_HISTORY_BACKFILL_LIMIT"] = str(hbl)
+                if "dm_history_backfill" in discord_cfg and not os.getenv("DISCORD_DM_HISTORY_BACKFILL"):
+                    os.environ["DISCORD_DM_HISTORY_BACKFILL"] = str(discord_cfg["dm_history_backfill"]).lower()
+                dm_hbl = discord_cfg.get("dm_history_backfill_limit")
+                if dm_hbl is not None and not os.getenv("DISCORD_DM_HISTORY_BACKFILL_LIMIT"):
+                    os.environ["DISCORD_DM_HISTORY_BACKFILL_LIMIT"] = str(dm_hbl)
                 # allow_mentions: granular control over what the bot can ping.
                 # Safe defaults (no @everyone/roles) are applied in the adapter;
                 # these YAML keys only override when set and let users opt back

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -3652,6 +3652,15 @@ class DiscordAdapter(BasePlatformAdapter):
             return bool(configured)
         return os.getenv("DISCORD_HISTORY_BACKFILL", "true").lower() in {"true", "1", "yes"}
 
+    def _discord_dm_history_backfill(self) -> bool:
+        """Return whether opt-in DM history backfill is enabled."""
+        configured = self.config.extra.get("dm_history_backfill")
+        if configured is not None:
+            if isinstance(configured, str):
+                return configured.lower() not in {"false", "0", "no", "off"}
+            return bool(configured)
+        return os.getenv("DISCORD_DM_HISTORY_BACKFILL", "false").lower() in {"true", "1", "yes", "on"}
+
     def _discord_history_backfill_limit(self) -> int:
         """Return the max number of messages to scan backwards for context.
 
@@ -3672,10 +3681,34 @@ class DiscordAdapter(BasePlatformAdapter):
         except (ValueError, TypeError):
             return 50
 
+    def _discord_dm_history_backfill_limit(self) -> int:
+        """Return the DM history backfill scan cap.
+
+        DMs are private and Discord history fetches are capped at 100 messages,
+        so the opt-in DM path defaults lower than shared-channel backfill and
+        clamps user-provided values to the API's single-request maximum.
+        """
+        configured = self.config.extra.get("dm_history_backfill_limit")
+        if configured is not None:
+            try:
+                value = int(configured)
+            except (ValueError, TypeError):
+                value = 25
+        else:
+            raw = os.getenv("DISCORD_DM_HISTORY_BACKFILL_LIMIT", "25")
+            try:
+                value = int(raw)
+            except (ValueError, TypeError):
+                value = 25
+        return max(0, min(value, 100))
+
     async def _fetch_channel_context(
         self,
         channel: Any,
         before: "DiscordMessage",
+        *,
+        limit: Optional[int] = None,
+        header: str = "[Recent channel messages]",
     ) -> str:
         """Fetch recent channel messages for conversational context.
 
@@ -3691,7 +3724,8 @@ class DiscordAdapter(BasePlatformAdapter):
 
         Returns an empty string if no context is available.
         """
-        limit = self._discord_history_backfill_limit()
+        if limit is None:
+            limit = self._discord_history_backfill_limit()
         if limit <= 0:
             return ""
 
@@ -3762,7 +3796,7 @@ class DiscordAdapter(BasePlatformAdapter):
 
             # channel.history returns newest-first (oldest_first=False); reverse for chronological order
             collected.reverse()
-            return "[Recent channel messages]\n" + "\n".join(collected)
+            return f"{header}\n" + "\n".join(collected)
 
         except discord.Forbidden:
             logger.debug("[%s] Missing permissions to fetch channel history", self.name)
@@ -4722,9 +4756,9 @@ class DiscordAdapter(BasePlatformAdapter):
         # and stop at the first self-message encountered.
         #
         # Threads naturally scope to thread-only history (channel.history()
-        # on a thread returns only that thread's messages).  DMs are skipped
-        # because every DM message triggers the bot — there's no mention gap
-        # to fill; the session transcript already has everything.
+        # on a thread returns only that thread's messages).  DMs remain opt-in:
+        # they contain private history and every recent DM message is sent to
+        # the model when this is enabled.
         #
         # Per-user sessions also benefit: Alice's session is missing the
         # other-channel-participants' context, and her own messages from
@@ -4735,7 +4769,17 @@ class DiscordAdapter(BasePlatformAdapter):
         # to keep the partition rule clean.
         _channel_context = None
         _is_dm = isinstance(message.channel, discord.DMChannel)
-        if not _is_dm:
+        if _is_dm:
+            if self._discord_dm_history_backfill():
+                _backfill_text = await self._fetch_channel_context(
+                    message.channel,
+                    before=message,
+                    limit=self._discord_dm_history_backfill_limit(),
+                    header="[Recent DM messages]",
+                )
+                if _backfill_text:
+                    _channel_context = _backfill_text
+        else:
             _needed_mention = (
                 require_mention
                 and not is_free_channel

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1289,7 +1289,9 @@ DEFAULT_CONFIG = {
         "auto_thread": True,           # Auto-create threads on @mention in channels (like Slack)
         "thread_require_mention": False,  # If True, require @mention in threads too (multi-bot threads)
         "history_backfill": True,         # If True, prepend recent channel scrollback when bot is triggered (recovers messages missed while require_mention gated them out)
-        "history_backfill_limit": 50,     # Max number of recent messages to scan when assembling the backfill block
+        "history_backfill_limit": 50,     # Max number of recent messages to scan when assembling the channel backfill block
+        "dm_history_backfill": False,     # Opt-in: prepend recent DM scrollback before each DM turn (privacy-sensitive)
+        "dm_history_backfill_limit": 25,  # Max recent DM messages to scan (clamped to Discord's 100-message fetch cap)
         "reactions": True,             # Add 👀/✅/❌ reactions to messages during processing
         "channel_prompts": {},         # Per-channel ephemeral system prompts (forum parents apply to child threads)
         # Opt-in DM role-based auth (#12136). By default, DISCORD_ALLOWED_ROLES

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -429,6 +429,26 @@ class TestLoadGatewayConfig:
         assert os.getenv("DISCORD_HISTORY_BACKFILL") == "true"
         assert os.getenv("DISCORD_HISTORY_BACKFILL_LIMIT") == "17"
 
+    def test_bridges_discord_dm_history_backfill_settings_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "discord:\n"
+            "  dm_history_backfill: true\n"
+            "  dm_history_backfill_limit: 25\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("DISCORD_DM_HISTORY_BACKFILL", raising=False)
+        monkeypatch.delenv("DISCORD_DM_HISTORY_BACKFILL_LIMIT", raising=False)
+
+        load_gateway_config()
+
+        assert os.getenv("DISCORD_DM_HISTORY_BACKFILL") == "true"
+        assert os.getenv("DISCORD_DM_HISTORY_BACKFILL_LIMIT") == "25"
+
     def test_bridges_telegram_channel_prompts_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -113,6 +113,8 @@ def adapter(monkeypatch):
         "DISCORD_IGNORED_CHANNELS",
         "DISCORD_HISTORY_BACKFILL",
         "DISCORD_HISTORY_BACKFILL_LIMIT",
+        "DISCORD_DM_HISTORY_BACKFILL",
+        "DISCORD_DM_HISTORY_BACKFILL_LIMIT",
         "DISCORD_ALLOW_BOTS",
     ):
         monkeypatch.delenv(_var, raising=False)
@@ -852,8 +854,8 @@ async def test_discord_per_user_channel_backfills_too(adapter, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_discord_dm_does_not_backfill(adapter, monkeypatch):
-    """DMs skip backfill — every DM triggers the bot, so there's no mention gap."""
+async def test_discord_dm_does_not_backfill_by_default(adapter, monkeypatch):
+    """DM history backfill is privacy-sensitive and stays opt-in."""
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
     adapter.config.extra["history_backfill"] = True
     adapter._fetch_channel_context = AsyncMock(return_value="[Recent channel messages]\n[Alice] context")
@@ -882,5 +884,58 @@ async def test_discord_dm_does_not_backfill(adapter, monkeypatch):
     if adapter.handle_message.await_args is not None:
         event = adapter.handle_message.await_args.args[0]
         assert event.channel_context is None
+
+
+@pytest.mark.asyncio
+async def test_discord_dm_backfill_prepends_context_when_enabled(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    adapter.config.extra["history_backfill"] = True
+    adapter.config.extra["dm_history_backfill"] = True
+    adapter._fetch_channel_context = AsyncMock(return_value="[Recent DM messages]\n[Jezza] earlier DM")
+
+    message = make_message(
+        channel=FakeDMChannel(channel_id=999),
+        content="hello in DM",
+        mentions=[],
+    )
+
+    await adapter._handle_message(message)
+
+    adapter._fetch_channel_context.assert_awaited_once()
+    _, kwargs = adapter._fetch_channel_context.await_args
+    assert kwargs["before"] is message
+    assert kwargs["limit"] == 25
+    assert kwargs["header"] == "[Recent DM messages]"
+    event = adapter.handle_message.await_args.args[0]
+    assert event.channel_context == "[Recent DM messages]\n[Jezza] earlier DM"
+
+
+@pytest.mark.asyncio
+async def test_fetch_channel_context_accepts_dm_limit_and_header(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
+    human = SimpleNamespace(id=56, display_name="Alice", name="Alice", bot=False)
+
+    channel = FakeHistoryChannel(
+        [
+            make_history_message(author=human, content="older", msg_id=1),
+            make_history_message(author=human, content="latest", msg_id=2),
+        ],
+        channel_id=123,
+    )
+
+    result = await adapter._fetch_channel_context(
+        channel,
+        before=make_message(channel=channel, content="trigger"),
+        limit=1,
+        header="[Recent DM messages]",
+    )
+
+    assert result == "[Recent DM messages]\n[Alice] latest"
+
+
+def test_discord_dm_history_backfill_limit_caps_to_discord_fetch_max(adapter):
+    adapter.config.extra["dm_history_backfill_limit"] = 500
+
+    assert adapter._discord_dm_history_backfill_limit() == 100
 
 

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -710,6 +710,10 @@ class TestDiscordChannelPromptsConfig:
     def test_default_config_includes_discord_channel_prompts(self):
         assert DEFAULT_CONFIG["discord"]["channel_prompts"] == {}
 
+    def test_default_config_keeps_discord_dm_history_backfill_opt_in(self):
+        assert DEFAULT_CONFIG["discord"]["dm_history_backfill"] is False
+        assert DEFAULT_CONFIG["discord"]["dm_history_backfill_limit"] == 25
+
     def test_migrate_adds_discord_channel_prompts_default(self, tmp_path):
         config_path = tmp_path / "config.yaml"
         config_path.write_text(

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -286,8 +286,10 @@ Discord behavior is controlled through two files: **`~/.hermes/.env`** for crede
 | `DISCORD_IGNORED_CHANNELS` | No | — | Comma-separated channel IDs where the bot **never** responds, even when `@mentioned`. Takes priority over all other channel settings. |
 | `DISCORD_ALLOWED_CHANNELS` | No | — | Comma-separated channel IDs. When set, the bot **only** responds in these channels (plus DMs if allowed). Overrides `config.yaml` `discord.allowed_channels`. Combine with `DISCORD_IGNORED_CHANNELS` to express allow/deny rules. |
 | `DISCORD_NO_THREAD_CHANNELS` | No | — | Comma-separated channel IDs where the bot responds directly in the channel instead of creating a thread. Only relevant when `DISCORD_AUTO_THREAD` is `true`. |
-| `DISCORD_HISTORY_BACKFILL` | No | `true` | When `true`, prepend recent channel scrollback (since the bot's last response) to the user message when the bot is mentioned. Recovers context the bot would otherwise miss with `require_mention`. Skipped in DMs and free-response channels. Set to `false` to disable. |
+| `DISCORD_HISTORY_BACKFILL` | No | `true` | When `true`, prepend recent channel scrollback (since the bot's last response) to the user message when the bot is mentioned. Recovers context the bot would otherwise miss with `require_mention`. Skipped in DMs unless `DISCORD_DM_HISTORY_BACKFILL` is enabled, and skipped in free-response channels. Set to `false` to disable. |
 | `DISCORD_HISTORY_BACKFILL_LIMIT` | No | `50` | Maximum number of messages to scan backwards when assembling the backfill block. In practice the scan usually stops earlier — at the bot's own last message in the channel. |
+| `DISCORD_DM_HISTORY_BACKFILL` | No | `false` | Opt-in DM scrollback recovery. When `true`, prepend recent DM messages since the bot's last response before each DM turn. Privacy-sensitive: recent private DM text is sent to the model. |
+| `DISCORD_DM_HISTORY_BACKFILL_LIMIT` | No | `25` | Maximum number of recent DM messages to scan. Values are clamped to Discord's 100-message fetch cap. |
 | `DISCORD_REPLY_TO_MODE` | No | `"first"` | Controls reply-reference behavior: `"off"` — never reply to the original message, `"first"` — reply-reference on the first message chunk only (default), `"all"` — reply-reference on every chunk. |
 | `DISCORD_ALLOW_MENTION_EVERYONE` | No | `false` | When `false` (default), the bot cannot ping `@everyone` or `@here` even if its response contains those tokens. Set to `true` to opt back in. See [Mention Control](#mention-control) below. |
 | `DISCORD_ALLOW_MENTION_ROLES` | No | `false` | When `false` (default), the bot cannot ping `@role` mentions. Set to `true` to allow. |
@@ -315,6 +317,8 @@ discord:
   no_thread_channels: []          # Channel IDs where bot responds without threading
   history_backfill: true          # Prepend recent channel scrollback on mention (default: true)
   history_backfill_limit: 50      # Max messages to scan backwards (default: 50)
+  dm_history_backfill: false      # Opt-in recent DM scrollback (default: false)
+  dm_history_backfill_limit: 25   # Max DM messages to scan backwards (default: 25, max: 100)
   channel_prompts: {}             # Per-channel ephemeral system prompts
   allow_mentions:                 # What the bot is allowed to ping (safe defaults)
     everyone: false               # @everyone / @here pings (default: false)
@@ -453,7 +457,7 @@ Behavior by surface:
 
 - **Server channels** (with `require_mention: true`): backfill scans the channel since the bot's last response. Useful when other participants posted while the bot wasn't addressed.
 - **Threads**: backfill scans the thread only — Discord's `channel.history()` on a thread returns only that thread's messages, not the parent channel. This is the right scope because threads are usually self-contained conversations.
-- **DMs**: skipped. Every DM message triggers the bot, so the session transcript is already complete — there's no mention gap to fill.
+- **DMs**: skipped by default. Set `dm_history_backfill: true` for opt-in DM scrollback recovery after restarts or session resets. This is privacy-sensitive because recent private DM text is sent to the model.
 - **Free-response channels** and **bot's own auto-created threads**: skipped for the same reason — no mention gating means no gap.
 
 Per-user sessions (`group_sessions_per_user: true`, the default) also benefit: a user's session is missing the context posted by other channel participants and the user's own messages from before they tagged the bot. Backfill fills both gaps.
@@ -483,6 +487,26 @@ discord:
   history_backfill: true
   history_backfill_limit: 50
 ```
+
+#### `discord.dm_history_backfill`
+
+**Type:** boolean — **Default:** `false`
+
+When enabled, Hermes uses the same recent-history context path for DMs that channel backfill uses for server channels and threads. Before dispatching a DM turn, it scans recent DM history up to the bot's previous response and prepends the collected messages as context.
+
+This is intentionally opt-in because it sends recent private DM text to the model. Enable it only for trusted/authorized DM conversations where that behavior is expected.
+
+```yaml
+discord:
+  dm_history_backfill: true
+  dm_history_backfill_limit: 25
+```
+
+#### `discord.dm_history_backfill_limit`
+
+**Type:** integer — **Default:** `25` — **Maximum:** `100`
+
+Maximum number of recent DM messages to scan when `dm_history_backfill` is enabled. Values above `100` are clamped to Discord's single-request history fetch cap.
 
 #### `group_sessions_per_user`
 


### PR DESCRIPTION
## Summary

- Adds an opt-in Discord DM history backfill path via `discord.dm_history_backfill` / `DISCORD_DM_HISTORY_BACKFILL`.
- Adds `discord.dm_history_backfill_limit` / `DISCORD_DM_HISTORY_BACKFILL_LIMIT`, defaulting to 25 and clamped to Discord's 100-message fetch cap.
- Reuses the existing channel-context injection path so DM scrollback appears as `[Recent DM messages]` before the current DM turn.
- Keeps the feature disabled by default because private DM history is privacy-sensitive.
- Bridges the new config.yaml keys into gateway env defaults and documents the settings.

## Behavior

DMs still do **not** backfill by default. When enabled, the adapter scans recent DM history before the current message, using the same partition rule as channel backfill: stop at the bot's previous response and include the collected messages chronologically as context.

## Test plan

- [x] Verified new tests fail before the implementation:
  - `test_discord_dm_backfill_prepends_context_when_enabled`
  - `test_fetch_channel_context_accepts_dm_limit_and_header`
  - `test_discord_dm_history_backfill_limit_caps_to_discord_fetch_max`
- [x] `python -m pytest tests/gateway/test_discord_free_response.py -q -o 'addopts='`
- [x] `python -m pytest tests/gateway/test_config.py tests/hermes_cli/test_config.py -q -o 'addopts='`
- [x] `python -m py_compile gateway/platforms/discord.py gateway/config.py hermes_cli/config.py`

## Notes

I also checked open PRs for existing Discord DM history/backfill work before opening this. I found related Discord history/backfill fixes, but no open PR adding opt-in DM history backfill.
