### PR TITLE
fix(agent): preserve MiniMax auth during client rebuild

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2460,7 +2460,10 @@ class AIAgent:
                 provider = (getattr(self, "provider", "") or "").strip().lower()
                 if provider in {"minimax", "minimax-cn"} and not client_kwargs.get("api_key"):
                     headers = client_kwargs.get("default_headers") or {}
-                    header_key = headers.get("x-api-key") or headers.get("X-Api-Key")
+                    header_key = next(
+                        (value for key, value in headers.items() if str(key).lower() == "x-api-key"),
+                        None,
+                    )
                     env_name = "MINIMAX_CN_API_KEY" if provider == "minimax-cn" else "MINIMAX_API_KEY"
                     client_kwargs["api_key"] = header_key or os.getenv(env_name) or "unused-minimax-sdk-key"
                 new_client = self._create_openai_client(client_kwargs, reason=reason, shared=True)

--- a/run_agent.py
+++ b/run_agent.py
@@ -2456,7 +2456,14 @@ class AIAgent:
         with self._openai_client_lock():
             old_client = getattr(self, "client", None)
             try:
-                new_client = self._create_openai_client(self._client_kwargs, reason=reason, shared=True)
+                client_kwargs = dict(self._client_kwargs)
+                provider = (getattr(self, "provider", "") or "").strip().lower()
+                if provider in {"minimax", "minimax-cn"} and not client_kwargs.get("api_key"):
+                    headers = client_kwargs.get("default_headers") or {}
+                    header_key = headers.get("x-api-key") or headers.get("X-Api-Key")
+                    env_name = "MINIMAX_CN_API_KEY" if provider == "minimax-cn" else "MINIMAX_API_KEY"
+                    client_kwargs["api_key"] = header_key or os.getenv(env_name) or "unused-minimax-sdk-key"
+                new_client = self._create_openai_client(client_kwargs, reason=reason, shared=True)
             except Exception as exc:
                 logger.warning(
                     "Failed to rebuild shared OpenAI client (%s) %s error=%s",

--- a/tests/run_agent/test_create_openai_client_reuse.py
+++ b/tests/run_agent/test_create_openai_client_reuse.py
@@ -161,7 +161,7 @@ def test_replace_primary_openai_client_backfills_minimax_api_key_from_headers():
 
     agent._client_kwargs = {
         "base_url": "https://api.minimax.io/anthropic",
-        "default_headers": {"x-api-key": "mm-header-key"},
+        "default_headers": {"X-API-Key": "mm-header-key"},
     }
 
     with patch("run_agent.OpenAI", _ValidatingFakeOpenAI):
@@ -172,7 +172,7 @@ def test_replace_primary_openai_client_backfills_minimax_api_key_from_headers():
     assert constructed[0]._kwargs["api_key"] == "mm-header-key"
     assert agent._client_kwargs == {
         "base_url": "https://api.minimax.io/anthropic",
-        "default_headers": {"x-api-key": "mm-header-key"},
+        "default_headers": {"X-API-Key": "mm-header-key"},
     }
 
 

--- a/tests/run_agent/test_create_openai_client_reuse.py
+++ b/tests/run_agent/test_create_openai_client_reuse.py
@@ -135,6 +135,78 @@ def test_second_create_does_not_wrap_closed_transport_from_first():
             )
 
 
+def test_replace_primary_openai_client_backfills_minimax_api_key_from_headers():
+    """MiniMax rebuilds must satisfy the OpenAI SDK api_key validator.
+
+    MiniMax Anthropic-compatible endpoints authenticate with ``x-api-key`` in
+    default headers.  A stale-stream rebuild reuses cached ``_client_kwargs``;
+    if that cache has no OpenAI-style ``api_key``, the SDK constructor raises
+    before the header-auth client can recover the session.
+    """
+    agent = _make_agent()
+    agent.provider = "minimax"
+    constructed: list = []
+
+    class _ValidatingFakeOpenAI:
+        def __init__(self, **kwargs):
+            if not kwargs.get("api_key"):
+                raise ValueError("api_key client option must be set")
+            self._kwargs = kwargs
+            self._http_client = kwargs.get("http_client")
+            self._closed = False
+            constructed.append(self)
+
+        def close(self):
+            self._closed = True
+
+    agent._client_kwargs = {
+        "base_url": "https://api.minimax.io/anthropic",
+        "default_headers": {"x-api-key": "mm-header-key"},
+    }
+
+    with patch("run_agent.OpenAI", _ValidatingFakeOpenAI):
+        ok = agent._replace_primary_openai_client(reason="stale_stream_pool_cleanup")
+
+    assert ok
+    assert agent.client is constructed[0]
+    assert constructed[0]._kwargs["api_key"] == "mm-header-key"
+    assert agent._client_kwargs == {
+        "base_url": "https://api.minimax.io/anthropic",
+        "default_headers": {"x-api-key": "mm-header-key"},
+    }
+
+
+def test_replace_primary_openai_client_backfills_minimax_cn_api_key_from_env(monkeypatch):
+    """MiniMax-CN rebuilds can recover when the cached header is absent."""
+    agent = _make_agent()
+    agent.provider = "minimax-cn"
+    constructed: list = []
+
+    class _ValidatingFakeOpenAI:
+        def __init__(self, **kwargs):
+            if not kwargs.get("api_key"):
+                raise ValueError("api_key client option must be set")
+            self._kwargs = kwargs
+            self._http_client = kwargs.get("http_client")
+            self._closed = False
+            constructed.append(self)
+
+        def close(self):
+            self._closed = True
+
+    monkeypatch.setenv("MINIMAX_CN_API_KEY", "mm-cn-env-key")
+    agent._client_kwargs = {
+        "base_url": "https://api.minimaxi.com/anthropic",
+        "default_headers": {},
+    }
+
+    with patch("run_agent.OpenAI", _ValidatingFakeOpenAI):
+        ok = agent._replace_primary_openai_client(reason="stale_stream_pool_cleanup")
+
+    assert ok
+    assert constructed[0]._kwargs["api_key"] == "mm-cn-env-key"
+
+
 def test_replace_primary_openai_client_survives_repeated_rebuilds():
     """Full rebuild path: exercise _replace_primary_openai_client three times
     back-to-back and confirm every resulting ``self.client`` is a fresh,


### PR DESCRIPTION
## What
- Backfills the OpenAI SDK `api_key` for MiniMax/MiniMax-CN shared client rebuilds when cached kwargs only contain header-based auth.
- Keeps the cached `_client_kwargs` immutable by copying before rebuild-time normalization.
- Adds regression coverage for MiniMax `x-api-key` header rebuilds and MiniMax-CN env fallback rebuilds.

## Why
MiniMax Anthropic-compatible endpoints authenticate with `x-api-key`, but the OpenAI SDK constructor still validates that an `api_key` exists. During stale-stream recovery, `_replace_primary_openai_client` can rebuild from cached kwargs without an SDK-style key, leaving workers unable to recover from stalled streams.

## Validation
- `scripts/run_tests.sh tests/run_agent/test_create_openai_client_reuse.py -q` → 4 passed

Refs #27480
