### PR TITLE
fix(gateway): re-read terminal.cwd on session reset; use TERMINAL_CWD in environment hints

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -994,6 +994,28 @@ def _reload_runtime_env_preserving_config_authority() -> None:
     if isinstance(agent_cfg, dict) and "max_turns" in agent_cfg:
         os.environ["HERMES_MAX_ITERATIONS"] = str(agent_cfg["max_turns"])
 
+    # Re-bridge terminal.* so long-lived gateways pick up config changes on
+    # /new or /reset without needing a full restart. Placeholder cwd values
+    # mean "use the startup fallback"; clear any stale explicit bridge first
+    # so explicit -> placeholder updates do not keep the old TERMINAL_CWD.
+    terminal_cfg = cfg.get("terminal")
+    if isinstance(terminal_cfg, dict):
+        raw_cwd = str(terminal_cfg.get("cwd", "")).strip()
+        if "cwd" not in terminal_cfg or raw_cwd in {".", "auto", "cwd"}:
+            os.environ.pop("TERMINAL_CWD", None)
+    else:
+        os.environ.pop("TERMINAL_CWD", None)
+    from hermes_cli.config import apply_terminal_config_to_env
+    apply_terminal_config_to_env(config=cfg, override=True)
+    _apply_terminal_cwd_fallback()
+
+
+def _apply_terminal_cwd_fallback() -> None:
+    configured_cwd = os.environ.get("TERMINAL_CWD", "")
+    if not configured_cwd or configured_cwd in {".", "auto", "cwd"}:
+        fallback = os.getenv("MESSAGING_CWD") or str(Path.home())
+        os.environ["TERMINAL_CWD"] = fallback
+
 
 _DOCKER_VOLUME_SPEC_RE = re.compile(r"^(?P<host>.+):(?P<container>/[^:]+?)(?::(?P<options>[^:]+))?$")
 _DOCKER_MEDIA_OUTPUT_CONTAINER_PATHS = {"/output", "/outputs"}
@@ -1221,10 +1243,7 @@ os.environ["HERMES_EXEC_ASK"] = "1"
 # by the config bridge above).  When it's unset or a placeholder, default
 # to home directory.  MESSAGING_CWD is accepted as a backward-compat
 # fallback (deprecated — the warning above tells users to migrate).
-_configured_cwd = os.environ.get("TERMINAL_CWD", "")
-if not _configured_cwd or _configured_cwd in {".", "auto", "cwd"}:
-    _fallback = os.getenv("MESSAGING_CWD") or str(Path.home())
-    os.environ["TERMINAL_CWD"] = _fallback
+_apply_terminal_cwd_fallback()
 
 from gateway.config import (
     Platform,

--- a/tests/gateway/test_config_cwd_bridge.py
+++ b/tests/gateway/test_config_cwd_bridge.py
@@ -12,6 +12,8 @@ asserting the expected env var outcomes.
 import os
 import json
 
+from hermes_cli.config import apply_terminal_config_to_env
+
 
 def _simulate_config_bridge(cfg: dict, initial_env: dict | None = None):
     """Simulate the gateway config bridge logic from gateway/run.py.
@@ -72,6 +74,27 @@ def _simulate_config_bridge(cfg: dict, initial_env: dict | None = None):
         messaging_cwd = env.get("MESSAGING_CWD") or "/root"  # Path.home() for root
         env["TERMINAL_CWD"] = messaging_cwd
 
+    return env
+
+
+def _apply_terminal_cwd_fallback(env: dict):
+    configured_cwd = env.get("TERMINAL_CWD", "")
+    if not configured_cwd or configured_cwd in {".", "auto", "cwd"}:
+        env["TERMINAL_CWD"] = env.get("MESSAGING_CWD") or "/root"
+
+
+def _simulate_runtime_env_reload(cfg: dict, initial_env: dict | None = None):
+    """Simulate _reload_runtime_env_preserving_config_authority cwd handling."""
+    env = dict(initial_env or {})
+    terminal_cfg = cfg.get("terminal")
+    if isinstance(terminal_cfg, dict):
+        raw_cwd = str(terminal_cfg.get("cwd", "")).strip()
+        if "cwd" not in terminal_cfg or raw_cwd in {".", "auto", "cwd"}:
+            env.pop("TERMINAL_CWD", None)
+    else:
+        env.pop("TERMINAL_CWD", None)
+    apply_terminal_config_to_env(env=env, config=cfg, override=True)
+    _apply_terminal_cwd_fallback(env)
     return env
 
 
@@ -243,3 +266,32 @@ class TestTildeExpansion:
         }
         result = _simulate_config_bridge(cfg)
         assert result["TERMINAL_CWD"] == os.path.expanduser("~/nested")
+
+
+class TestRuntimeReloadTerminalCwd:
+    """Runtime config reload should match startup terminal.cwd fallback rules."""
+
+    def test_runtime_reload_updates_explicit_terminal_cwd(self):
+        cfg = {"terminal": {"cwd": "/new/project", "backend": "docker"}}
+        result = _simulate_runtime_env_reload(
+            cfg,
+            {"TERMINAL_CWD": "/old/project", "TERMINAL_ENV": "local"},
+        )
+        assert result["TERMINAL_CWD"] == "/new/project"
+        assert result["TERMINAL_ENV"] == "docker"
+
+    def test_runtime_reload_placeholder_clears_stale_terminal_cwd(self):
+        cfg = {"terminal": {"cwd": "."}}
+        result = _simulate_runtime_env_reload(
+            cfg,
+            {"TERMINAL_CWD": "/old/project", "MESSAGING_CWD": "/fallback/project"},
+        )
+        assert result["TERMINAL_CWD"] == "/fallback/project"
+
+    def test_runtime_reload_missing_cwd_clears_stale_terminal_cwd(self):
+        cfg = {"terminal": {"backend": "local"}}
+        result = _simulate_runtime_env_reload(
+            cfg,
+            {"TERMINAL_CWD": "/old/project", "MESSAGING_CWD": "/fallback/project"},
+        )
+        assert result["TERMINAL_CWD"] == "/fallback/project"


### PR DESCRIPTION
## Summary

Fixes two related bugs that prevent configured `terminal.cwd` from being used after `/new` or `/reset` in messaging gateway sessions.

## Changes

### 1. `agent/prompt_builder.py` — Use TERMINAL_CWD in environment hints

`build_environment_hints()` now prefers the `TERMINAL_CWD` env var (bridged from config.yaml by the gateway) over `os.getcwd()`, which reflects the daemon's launch directory rather than the user's configured workspace.

### 2. `gateway/run.py` — Re-read terminal.cwd on each turn

`_reload_runtime_env_preserving_config_authority()` (called per-turn) now re-reads `terminal.cwd` from config.yaml and updates the `TERMINAL_CWD` env var. This ensures long-lived gateways pick up config changes on `/new` or `/reset` without needing a restart.

### 3. `tests/agent/test_prompt_builder.py` — Two new tests

- `test_build_environment_hints_prefers_terminal_cwd`: verifies TERMINAL_CWD appears in the system prompt when set
- `test_build_environment_hints_falls_back_to_getcwd`: verifies `os.getcwd()` is used when TERMINAL_CWD is unset

## Root Cause

The comment on #27383 identified the issue: "The `/new` command resets the session but the gateway may not re-read `terminal.cwd` from config for the new session." Additionally, PR #24888 identified that `build_environment_hints()` uses `os.getcwd()` directly instead of checking the `TERMINAL_CWD` env var.

## Testing

All 10 `TestEnvironmentHints` tests pass (including 2 new).

Fixes #27383
References #24882
