### PR TITLE
docs(agents): document run_agent.py module extraction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,7 +229,7 @@ entry points you'll actually edit.
 
 ```
 hermes-agent/
-├── run_agent.py          # AIAgent class — core conversation loop (~12k LOC)
+├── run_agent.py          # AIAgent class — core loop; internals across agent/*.py
 ├── model_tools.py        # Tool orchestration, discover_builtin_tools(), handle_function_call()
 ├── toolsets.py           # Toolset definitions, _HERMES_CORE_TOOLS list
 ├── cli.py                # HermesCLI class — interactive CLI orchestrator (~11k LOC)


### PR DESCRIPTION
## Summary

Refresh the `AGENTS.md` project tree after the `run_agent.py` internals were
split across `agent/*.py` modules.

Current `main` still describes `run_agent.py` as `~12k LOC`; it is now 6,055
lines and continues to change. Since the surrounding section already warns that
file counts shift constantly, this rework removes the brittle numeric estimate
and documents the durable module boundary instead:

```text
├── run_agent.py          # AIAgent class — core loop; internals across agent/*.py
```

This is a one-line documentation-only diff. The unrelated resize and spinner
escape-sequence regions flagged in the earlier review are untouched.

## Validation

- `wc -l run_agent.py` — 6055
- `git diff --check`
