### PR TITLE
fix(achievements): make rescan button force refresh

### DIFF
--- a/plugins/hermes-achievements/dashboard/dist/index.js
+++ b/plugins/hermes-achievements/dashboard/dist/index.js
@@ -590,6 +590,13 @@
         .then(function (payload) { setData(payload); setError((payload && payload.error) || null); })
         .catch(function (err) { setError(String(err)); });
     }
+    function rescan() {
+      setLoading(true);
+      api("/rescan", { method: "POST" })
+        .then(function (payload) { setData(payload); setError((payload && payload.error) || null); })
+        .catch(function (err) { setError(String(err)); })
+        .finally(function () { setLoading(false); });
+    }
     hooks.useEffect(load, []);
 
     // Auto-poll while the backend is still scanning. scan_meta.mode is
@@ -675,7 +682,7 @@
           React.createElement("h1", null, tx(t, "hero.title", "Hermes Achievements")),
           React.createElement("p", null, tx(t, "hero.subtitle", "Collectible Hermes badges earned from real session history. Known unfinished achievements are shown as Discovered; Secret achievements stay hidden until the first matching behavior appears."))
         ),
-        React.createElement(C.Button, { onClick: load, className: "ha-refresh" }, tx(t, "actions.rescan", "Rescan"))
+        React.createElement(C.Button, { onClick: rescan, className: "ha-refresh" }, tx(t, "actions.rescan", "Rescan"))
       ),
       scanBanner,
       error && React.createElement(C.Card, { className: "ha-error" }, React.createElement(C.CardContent, null, String(error))),

--- a/plugins/hermes-achievements/tests/test_achievement_engine.py
+++ b/plugins/hermes-achievements/tests/test_achievement_engine.py
@@ -151,6 +151,22 @@ class AchievementEngineTests(unittest.TestCase):
         stats = plugin_api.analyze_messages("s2", "Real config", [{"content": "edited config.yaml, manifest.json, and .env.local"}])
         self.assertGreaterEqual(stats["config_events"], 3)
 
+    def test_dashboard_rescan_button_forces_backend_rescan(self):
+        dashboard_js = (MODULE_PATH.parent / "dist" / "index.js").read_text()
+
+        self.assertIn('api("/rescan", { method: "POST" })', dashboard_js)
+        self.assertIn('onClick: rescan', dashboard_js)
+
+    def test_dashboard_does_not_call_removed_overview_endpoint(self):
+        dashboard_js = (MODULE_PATH.parent / "dist" / "index.js").read_text()
+        manifest = (MODULE_PATH.parent / "manifest.json").read_text()
+
+        self.assertNotIn('/overview', dashboard_js)
+        self.assertNotIn('sessions:top', dashboard_js)
+        self.assertNotIn('analytics:top', dashboard_js)
+        self.assertNotIn('sessions:top', manifest)
+        self.assertNotIn('analytics:top', manifest)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- wires the Achievements dashboard Rescan button to POST /rescan instead of re-reading /achievements from cache
- adds regression coverage for forced rescan wiring and removed /overview slot surface

## Test Plan
- `PYTHONPATH=. python -m pytest plugins/hermes-achievements/tests/test_achievement_engine.py -q -o 'addopts='`
- `node --check plugins/hermes-achievements/dashboard/dist/index.js`
- `PYTHONPATH=. python -m py_compile plugins/hermes-achievements/dashboard/plugin_api.py plugins/hermes-achievements/tests/test_achievement_engine.py`

## Notes
- Direct push to `NousResearch/hermes-agent` was denied for `mattpartida`, so this PR is from a real fork (`mattpartida/hermes-agent-nous-fork`).
- Attempted broader local `scripts/run_tests.sh` after raising `ulimit`; unrelated existing/environment failures remain outside this achievements patch (e.g. missing `systemctl` on macOS, manifest version mismatch, delegate heartbeat timing).
