### PR TITLE
fix(security): redact Fireworks AI API keys in logs

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -103,6 +103,7 @@ _PREFIX_PATTERNS = [
     r"hsk-[A-Za-z0-9]{10,}",            # Hindsight API key
     r"mem0_[A-Za-z0-9]{10,}",           # Mem0 Platform API key
     r"brv_[A-Za-z0-9]{10,}",            # ByteRover API key
+    r"fw_[A-Za-z0-9]{30,}",             # Fireworks AI API key
 ]
 
 # ENV assignment patterns: KEY=value where KEY contains a secret-like name

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -511,3 +511,25 @@ class TestFormBodyRedaction:
         text = "first=1\nsecond=2"
         # Should pass through (still subject to other redactors)
         assert "first=1" in redact_sensitive_text(text)
+
+
+class TestFireworksToken:
+    KEY = "fw_" + "A" * 40
+
+    def test_bare_token_masked(self):
+        result = redact_sensitive_text(f"fireworks error: key {self.KEY}", force=True)
+        assert self.KEY not in result
+        assert "fw_AA" in result
+
+    def test_env_assignment_masked(self):
+        result = redact_sensitive_text(f"FIREWORKS_API_KEY={self.KEY}", force=True)
+        assert self.KEY not in result
+
+    def test_too_short_not_masked(self):
+        short = "fw_tooshort"
+        result = redact_sensitive_text(f"text {short} here", force=True)
+        assert short in result
+
+    def test_prefix_visible_in_masked_output(self):
+        result = redact_sensitive_text(self.KEY, force=True)
+        assert result.startswith("fw_AA")


### PR DESCRIPTION
## Problem

  Fireworks AI is an integrated provider in hermes-agent  `FIREWORKS_API_KEY`
  is passed to the agent environment (`tools/environments/local.py`) and the
  provider is selectable via the model picker (`api.fireworks.ai` in
  `model_metadata.py`, listed in `hermes_cli/models.py`).

  Fireworks API keys follow the format `fw_<40 alphanumeric chars>` and were
  absent from `_PREFIX_PATTERNS` in `agent/redact.py`. The ENV-assignment
  pattern catches `FIREWORKS_API_KEY=fw_...` in config-style output, but a
  raw key appearing in a stack trace, tool error, or debug print passed
  through completely unmasked.

  ## Fix

  Added one pattern to `_PREFIX_PATTERNS`:

  ```python
  r"fw_[A-Za-z0-9]{30,}",    # Fireworks AI API key

  The 30-character minimum prevents false positives on short strings like
  fw_version while covering all real Fireworks keys (which are 40 chars).

  Tests

  Four unit tests added to TestFireworksToken:
  - Bare token in a log string is masked
  - FIREWORKS_API_KEY=<key> assignment is masked
  - Short fw_tooshort is not masked (false-positive guard)
  - Key prefix remains visible in masked output

  All 4 pass.
  ```