### PR TITLE
feat(telegram): route ingress to Hermes profiles

### DIFF
--- a/gateway/profile_router.py
+++ b/gateway/profile_router.py
@@ -1,0 +1,602 @@
+"""Profile-aware ingress routing for gateway messages.
+
+This module implements the first, deliberately conservative slice of the
+"one Telegram bot as ingress router to multiple Hermes profiles" feature:
+route matching plus subprocess dispatch into a target profile's isolated
+``HERMES_HOME``.  Keeping execution in a subprocess avoids mutating process-wide
+profile state in the long-running gateway.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from hermes_constants import get_default_hermes_root
+
+
+_PROFILE_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$")
+
+
+@dataclass(frozen=True)
+class ProfileRoute:
+    """A configured ingress route to a Hermes profile."""
+
+    profile: str
+    name: str = ""
+    chat_id: str | None = None
+    thread_id: str | None = None
+    user_id: str | None = None
+    username: str | None = None
+    chat_type: str | None = None
+    text_prefix: str | None = None
+    command: str | None = None
+    strip_prefix: bool = True
+    pass_media: bool = False
+    timeout_seconds: float = 1800.0
+
+
+@dataclass(frozen=True)
+class RoutedProfilePayload:
+    """Text plus optional CLI media attachment for profile dispatch."""
+
+    text: str
+    image_path: str | None = None
+
+
+def _as_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+def _as_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def is_safe_profile_name(profile: str) -> bool:
+    """Return True when *profile* is a plain Hermes profile directory name.
+
+    Profile routes are configured by operators, but they still feed directly
+    into ``HERMES_HOME`` for a child process. Keep that value constrained to a
+    single profile directory under ``<root>/profiles``: no absolute paths, path
+    separators, ``..`` segments, or shell-ish surprises.
+    """
+    return bool(_PROFILE_NAME_RE.fullmatch(profile or "")) and profile != "default"
+
+
+def load_profile_routes(config: Mapping[str, Any] | None, platform: str = "telegram") -> list[ProfileRoute]:
+    """Load ingress profile routes from config.yaml-shaped data.
+
+    Supported shapes (Telegram first, but platform-parametric for later):
+
+    ```yaml
+    telegram:
+      profile_routes:
+        - profile: sasha
+          chat_id: 12345
+        - profile: research
+          thread_id: 2
+        - profile: coder
+          text_prefix: /coder
+          strip_prefix: true
+    ```
+
+    Also accepts ``gateway.profile_routes.<platform>`` for users who prefer to
+    keep cross-platform routing under one top-level section.
+    """
+    if not isinstance(config, Mapping):
+        return []
+
+    candidates: list[Any] = []
+    platform_cfg = config.get(platform)
+    if isinstance(platform_cfg, Mapping):
+        candidates.extend(_as_list(platform_cfg.get("profile_routes")))
+
+    gateway_cfg = config.get("gateway")
+    if isinstance(gateway_cfg, Mapping):
+        profile_routes = gateway_cfg.get("profile_routes")
+        if isinstance(profile_routes, Mapping):
+            candidates.extend(_as_list(profile_routes.get(platform)))
+        else:
+            candidates.extend(_as_list(profile_routes))
+
+    routes: list[ProfileRoute] = []
+    for idx, raw in enumerate(candidates):
+        if not isinstance(raw, Mapping):
+            continue
+        profile = _as_str(raw.get("profile"))
+        if not profile or not is_safe_profile_name(profile):
+            # The default profile is the current gateway; routing to it would
+            # recurse/duplicate work rather than isolate anything. Unsafe names
+            # are ignored so route config cannot escape <root>/profiles.
+            continue
+        try:
+            timeout = float(raw.get("timeout_seconds", raw.get("timeout", 1800.0)))
+        except (TypeError, ValueError):
+            timeout = 1800.0
+        routes.append(
+            ProfileRoute(
+                profile=profile,
+                name=_as_str(raw.get("name")) or f"route-{idx + 1}",
+                chat_id=_as_str(raw.get("chat_id")),
+                thread_id=_as_str(raw.get("thread_id")),
+                user_id=_as_str(raw.get("user_id")),
+                username=_as_str(raw.get("username")),
+                chat_type=_as_str(raw.get("chat_type")),
+                text_prefix=_as_str(raw.get("text_prefix")),
+                command=_normalize_command(_as_str(raw.get("command"))),
+                strip_prefix=bool(raw.get("strip_prefix", True)),
+                pass_media=bool(raw.get("pass_media", False)),
+                timeout_seconds=max(1.0, timeout),
+            )
+        )
+    return routes
+
+
+def _normalize_command(command: str | None) -> str | None:
+    if not command:
+        return None
+    return command.strip().lstrip("/").split("@", 1)[0].lower() or None
+
+
+def _event_command(event: Any) -> str | None:
+    try:
+        cmd = event.get_command()
+    except Exception:
+        cmd = None
+    return _normalize_command(cmd)
+
+
+def _matches_field(expected: str | None, actual: Any) -> bool:
+    return expected is None or expected == str(actual)
+
+
+def _text_matches_prefix(text: str, prefix: str) -> bool:
+    """Match a route prefix only at a command/token boundary."""
+    stripped = (text or "").strip()
+    if not stripped.startswith(prefix):
+        return False
+    if len(stripped) == len(prefix):
+        return True
+    return stripped[len(prefix)] in {" ", "\t", "\n", "\r", "/", "_"}
+
+
+def match_profile_route(event: Any, routes: Sequence[ProfileRoute]) -> ProfileRoute | None:
+    """Return the first profile route matching a gateway MessageEvent."""
+    source = getattr(event, "source", None)
+    if source is None:
+        return None
+    text = getattr(event, "text", "") or ""
+    cmd = _event_command(event)
+
+    for route in routes:
+        if not _matches_field(route.chat_id, getattr(source, "chat_id", None)):
+            continue
+        if not _matches_field(route.thread_id, getattr(source, "thread_id", None)):
+            continue
+        if not _matches_field(route.user_id, getattr(source, "user_id", None)):
+            continue
+        if not _matches_field(route.chat_type, getattr(source, "chat_type", None)):
+            continue
+        if route.username:
+            actual_username = (getattr(source, "user_name", "") or "").lstrip("@")
+            if route.username.lstrip("@") != actual_username:
+                continue
+        if route.command and route.command != cmd:
+            continue
+        if route.text_prefix and not _text_matches_prefix(text, route.text_prefix):
+            continue
+        return route
+    return None
+
+
+def routed_text(event: Any, route: ProfileRoute) -> str:
+    """Return message text to send to the target profile."""
+    text = getattr(event, "text", "") or ""
+    if route.text_prefix and route.strip_prefix:
+        stripped = text.strip()
+        if _text_matches_prefix(stripped, route.text_prefix):
+            text = stripped[len(route.text_prefix):].lstrip()
+    return text
+
+
+def _is_image_media(mime_type: str, path: str) -> bool:
+    """Return True when a routed media item should be treated as an image."""
+    if (mime_type or "").lower().startswith("image/"):
+        return True
+    return Path(path).suffix.lower() in {".jpg", ".jpeg", ".png", ".gif", ".webp"}
+
+
+def routed_profile_payload(event: Any, route: ProfileRoute) -> RoutedProfilePayload:
+    """Build text and opt-in media attachment for profile subprocess dispatch.
+
+    Media forwarding is intentionally route-local and opt-in via ``pass_media``.
+    The Hermes CLI currently accepts one explicit ``--image`` attachment in
+    single-query mode, so the first image is attached natively and every cached
+    media path is also summarized in text for tools/manual inspection.
+    """
+    text = routed_text(event, route)
+    media_urls = list(getattr(event, "media_urls", None) or [])
+    media_types = list(getattr(event, "media_types", None) or [])
+    if not route.pass_media or not media_urls:
+        return RoutedProfilePayload(text=text)
+
+    first_image: str | None = None
+    lines = ["[Telegram media attachments forwarded by ingress router:]"]
+    for idx, url in enumerate(media_urls, start=1):
+        mime_type = str(media_types[idx - 1]) if idx - 1 < len(media_types) else ""
+        label = "file"
+        note = ""
+        if _is_image_media(mime_type, str(url)):
+            label = "image"
+            if first_image is None:
+                first_image = str(url)
+                note = " (attached via --image)"
+        elif mime_type.startswith("audio/"):
+            label = "audio"
+        elif mime_type.startswith("video/"):
+            label = "video"
+        elif mime_type.startswith(("application/", "text/")):
+            label = "document"
+        mime_note = f"; mime={mime_type}" if mime_type else ""
+        lines.append(f"- {label} {idx}: {url}{note}{mime_note}")
+
+    media_note = "\n".join(lines)
+    if text.strip():
+        text = f"{text.rstrip()}\n\n{media_note}"
+    else:
+        text = f"Please inspect the attached Telegram media.\n\n{media_note}"
+    return RoutedProfilePayload(text=text, image_path=first_image)
+
+
+PROFILE_SCOPED_COMMANDS = frozenset({"new", "reset", "status", "help", "commands"})
+
+
+def parse_profile_scoped_command(event: Any, route: ProfileRoute) -> tuple[str, str] | None:
+    """Parse route-scoped control commands for a prefix route.
+
+    For a route with ``text_prefix: /coder``, accepts conservative forms that
+    are clearly commands rather than ordinary prompts:
+
+    - ``/coder/new``
+    - ``/coder_new`` (Telegram-safe command spelling)
+    - ``/coder /new``
+
+    It intentionally does not treat ``/coder new feature`` as a command; that
+    remains a normal prompt to the coder profile.
+    """
+    prefix = route.text_prefix
+    if not prefix:
+        return None
+    text = (getattr(event, "text", "") or "").strip()
+    if not _text_matches_prefix(text, prefix):
+        return None
+
+    suffix = text[len(prefix):]
+    if not suffix:
+        return None
+
+    command_text: str | None = None
+    if suffix.startswith("/"):
+        command_text = suffix[1:]
+    elif suffix.startswith("_"):
+        command_text = suffix[1:]
+    elif suffix.startswith(" "):
+        stripped = suffix.lstrip()
+        if stripped.startswith("/"):
+            command_text = stripped[1:]
+
+    if not command_text:
+        return None
+
+    parts = command_text.split(maxsplit=1)
+    command = _normalize_command(parts[0])
+    if command not in PROFILE_SCOPED_COMMANDS:
+        return None
+    args = parts[1].strip() if len(parts) > 1 else ""
+    return command, args
+
+
+def profile_home(profile: str, *, root: Path | None = None) -> Path:
+    """Resolve a named Hermes profile to its HERMES_HOME path."""
+    if not is_safe_profile_name(profile):
+        raise ValueError(f"Unsafe Hermes profile name: {profile!r}")
+    base = root or get_default_hermes_root()
+    profiles_dir = (base / "profiles").resolve()
+    home = (profiles_dir / profile).resolve()
+    if home.parent != profiles_dir:
+        raise ValueError(f"Hermes profile escapes profiles directory: {profile!r}")
+    return home
+
+
+def _profile_has_telegram_token(home: Path) -> bool:
+    """Return True if a routed profile appears to own a Telegram bot token.
+
+    Do not return or log token values; this is purely a presence check so the
+    ingress gateway can warn operators about likely 409 long-polling conflicts.
+    """
+    env_path = home / ".env"
+    if env_path.exists():
+        try:
+            for line in env_path.read_text(encoding="utf-8", errors="replace").splitlines():
+                stripped = line.strip()
+                if not stripped or stripped.startswith("#") or "=" not in stripped:
+                    continue
+                key, value = stripped.split("=", 1)
+                if key.strip() == "TELEGRAM_BOT_TOKEN" and value.strip().strip("'\""):
+                    return True
+        except OSError:
+            pass
+
+    config_path = home / "config.yaml"
+    if config_path.exists():
+        try:
+            text = config_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            text = ""
+        # Intentionally shallow: avoid importing yaml on the gateway hot path and
+        # avoid exposing values. This catches the common accidental token clone.
+        if "TELEGRAM_BOT_TOKEN" in text or "bot_token" in text or "telegram_token" in text:
+            return True
+    return False
+
+
+def validate_profile_routes(
+    routes: Sequence[ProfileRoute],
+    *,
+    root: Path | None = None,
+) -> list[str]:
+    """Return non-fatal operator warnings for configured profile routes."""
+    warnings: list[str] = []
+    seen_names: set[str] = set()
+    base = root or get_default_hermes_root()
+
+    for route in routes:
+        if route.name in seen_names:
+            warnings.append(
+                f"duplicate route name '{route.name}' in telegram.profile_routes; "
+                "route/session diagnostics may be ambiguous"
+            )
+        seen_names.add(route.name)
+
+        try:
+            home = profile_home(route.profile, root=base)
+        except ValueError:
+            warnings.append(
+                f"unsafe profile name '{route.profile}' in telegram.profile_routes; route '{route.name}' ignored"
+            )
+            continue
+        if not home.exists():
+            warnings.append(
+                f"profile '{route.profile}' not found at {home}; route '{route.name}' will fail if matched"
+            )
+            continue
+
+        if _profile_has_telegram_token(home):
+            warnings.append(
+                f"profile '{route.profile}' has TELEGRAM_BOT_TOKEN configured; "
+                "routed profiles should not also run Telegram polling with the ingress bot token"
+            )
+
+    return warnings
+
+
+RouteSessionMap = dict[tuple[str, str, str], str]
+
+
+def profile_route_sessions_path(
+    *,
+    root: Path | None = None,
+    path: Path | None = None,
+) -> Path:
+    """Return the persistent route→child-session map path."""
+    if path is not None:
+        return path
+    base = root or get_default_hermes_root()
+    return base / "gateway" / "profile-router-sessions.json"
+
+
+def load_profile_route_sessions(
+    *,
+    root: Path | None = None,
+    path: Path | None = None,
+) -> RouteSessionMap:
+    """Load persisted route→child-session mappings.
+
+    The on-disk shape is a list of records instead of stringified tuple keys so
+    operators can inspect/edit it without knowing Python repr details.
+    Malformed records are ignored; routing can always start fresh.
+    """
+    session_path = profile_route_sessions_path(root=root, path=path)
+    try:
+        raw = json.loads(session_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+    records = raw.get("sessions") if isinstance(raw, dict) else None
+    if not isinstance(records, list):
+        return {}
+
+    sessions: RouteSessionMap = {}
+    for record in records:
+        if not isinstance(record, dict):
+            continue
+        profile = _as_str(record.get("profile"))
+        route = _as_str(record.get("route"))
+        gateway_session_key = _as_str(record.get("gateway_session_key"))
+        child_session_id = _as_str(record.get("child_session_id"))
+        if not (profile and route and gateway_session_key and child_session_id):
+            continue
+        sessions[(profile, route, gateway_session_key)] = child_session_id
+    return sessions
+
+
+def save_profile_route_sessions(
+    sessions: Mapping[tuple[str, str, str], str],
+    *,
+    root: Path | None = None,
+    path: Path | None = None,
+) -> None:
+    """Persist route→child-session mappings atomically."""
+    session_path = profile_route_sessions_path(root=root, path=path)
+    session_path.parent.mkdir(parents=True, exist_ok=True)
+
+    records = []
+    for key, child_session_id in sorted(sessions.items()):
+        if len(key) != 3:
+            continue
+        profile, route, gateway_session_key = key
+        child_session_id = _as_str(child_session_id)
+        if not child_session_id:
+            continue
+        records.append(
+            {
+                "profile": str(profile),
+                "route": str(route),
+                "gateway_session_key": str(gateway_session_key),
+                "child_session_id": child_session_id,
+            }
+        )
+
+    payload = {"version": 1, "sessions": records}
+    tmp_path = session_path.with_name(f".{session_path.name}.{os.getpid()}.{id(payload)}.tmp")
+    try:
+        tmp_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        tmp_path.replace(session_path)
+    finally:
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
+def build_profile_subprocess_command(
+    *,
+    text: str,
+    source_tag: str,
+    resume: str | None = None,
+    image_path: str | None = None,
+) -> list[str]:
+    """Build the Hermes CLI command used for isolated profile dispatch."""
+    executable = shutil.which("hermes")
+    if executable:
+        cmd = [executable, "chat", "--quiet", "--source", source_tag]
+    else:
+        cmd = [sys.executable, "-m", "hermes_cli.main", "chat", "--quiet", "--source", source_tag]
+    if resume:
+        cmd.extend(["--resume", resume])
+    if image_path:
+        cmd.extend(["--image", image_path])
+    cmd.extend(["--query", text])
+    return cmd
+
+
+_SESSION_ID_RE = re.compile(r"(?:Session ID|session_id)[:=]\s*([A-Za-z0-9_.:-]+)")
+
+
+_SAFE_ENV_EXACT_KEYS = {
+    "HOME",
+    "LANG",
+    "LOGNAME",
+    "PATH",
+    "SHELL",
+    "SSL_CERT_FILE",
+    "TERM",
+    "TMPDIR",
+    "USER",
+    "VIRTUAL_ENV",
+    "REQUESTS_CA_BUNDLE",
+}
+_SAFE_ENV_PREFIXES = ("LC_",)
+
+
+def build_profile_subprocess_env(home: Path, parent_env: Mapping[str, str] | None = None) -> dict[str, str]:
+    """Return a sanitized environment for a routed profile child process.
+
+    The ingress gateway may have platform tokens and model/provider credentials
+    in its process environment. A routed profile should load credentials from
+    its own ``HERMES_HOME`` instead of inheriting the gateway's secrets, so this
+    function allowlists only basic process/runtime variables and then sets the
+    target profile home explicitly.
+    """
+    source = parent_env if parent_env is not None else os.environ
+    env: dict[str, str] = {}
+    for key, value in source.items():
+        if key in _SAFE_ENV_EXACT_KEYS or key.startswith(_SAFE_ENV_PREFIXES):
+            env[key] = value
+    env["HERMES_HOME"] = str(home)
+    return env
+
+
+def extract_session_id(output: str) -> str | None:
+    """Best-effort extraction of a session id from quiet CLI output."""
+    match = _SESSION_ID_RE.search(output or "")
+    return match.group(1) if match else None
+
+
+async def dispatch_to_profile(
+    event: Any,
+    route: ProfileRoute,
+    *,
+    root: Path | None = None,
+    resume_session_id: str | None = None,
+) -> tuple[str, str | None]:
+    """Run one message through a target profile in a subprocess.
+
+    Returns ``(response_text, discovered_session_id)``.  The caller owns any
+    persistent route→session mapping; this module stays stateless and easy to
+    test.
+    """
+    home = profile_home(route.profile, root=root)
+    if not home.exists():
+        raise FileNotFoundError(f"Hermes profile '{route.profile}' not found at {home}")
+
+    payload = routed_profile_payload(event, route)
+    text = payload.text
+    if not text:
+        text = " "
+
+    cmd = build_profile_subprocess_command(
+        text=text,
+        source_tag="telegram-router",
+        resume=resume_session_id,
+        image_path=payload.image_path,
+    )
+    env = build_profile_subprocess_env(home)
+
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env=env,
+    )
+    try:
+        stdout_b, stderr_b = await asyncio.wait_for(proc.communicate(), timeout=route.timeout_seconds)
+    except asyncio.TimeoutError:
+        proc.kill()
+        await proc.communicate()
+        raise TimeoutError(f"Profile '{route.profile}' did not respond within {route.timeout_seconds:g}s")
+
+    stdout = stdout_b.decode("utf-8", errors="replace").strip()
+    stderr = stderr_b.decode("utf-8", errors="replace").strip()
+    if proc.returncode != 0:
+        detail = stderr or stdout or f"exit code {proc.returncode}"
+        raise RuntimeError(f"Profile '{route.profile}' failed: {detail}")
+
+    # Quiet single-query mode prints the final response to stdout and the
+    # session_id resume handle to stderr, keeping Telegram replies clean while
+    # still letting the router preserve continuity on later turns.
+    return stdout, extract_session_id("\n".join([stdout, stderr]))

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1260,6 +1260,9 @@ class GatewayRunner:
         # cannot grow unbounded over a long-running gateway lifetime.
         self._session_sources: "OrderedDict[str, SessionSource]" = OrderedDict()
         self._session_sources_max = 512
+        self._profile_router_sessions = None
+        self._profile_router_sessions_path = _hermes_home / "gateway" / "profile-router-sessions.json"
+        self._profile_router_lock = asyncio.Lock()
 
         # Cache AIAgent instances per session to preserve prompt caching.
         # Without this, a new AIAgent is created per message, rebuilding the
@@ -3375,6 +3378,16 @@ class GatewayRunner:
             write_runtime_status(gateway_state="starting", exit_reason=None)
         except Exception:
             pass
+
+        try:
+            from gateway.profile_router import load_profile_routes, validate_profile_routes
+            _profile_routes = load_profile_routes(_load_gateway_config(), platform="telegram")
+            if _profile_routes:
+                logger.info("Telegram profile ingress router: %d route(s) configured", len(_profile_routes))
+                for _warning in validate_profile_routes(_profile_routes):
+                    logger.warning("Telegram profile ingress router config: %s", _warning)
+        except Exception as _e:
+            logger.warning("Telegram profile ingress router config validation failed: %s", _e)
 
         # Log any active supply-chain security advisories. Operators see this
         # in gateway.log and `hermes status` surfaces it; we do NOT block
@@ -5774,6 +5787,136 @@ class GatewayRunner:
 
         await adapter.send(source.chat_id, content, metadata=metadata)
 
+    async def _maybe_route_telegram_profile_message(
+        self,
+        event: MessageEvent,
+        *,
+        is_internal: bool,
+    ) -> Optional[str]:
+        """Optionally route an authorized Telegram message to another profile.
+
+        Returns a response string when a route handled the message, otherwise
+        ``None`` so the default gateway pipeline can continue.
+        """
+        source = event.source
+        if is_internal or source.platform != Platform.TELEGRAM:
+            return None
+
+        try:
+            from hermes_cli.commands import resolve_command as _resolve_gateway_command
+            from gateway.profile_router import (
+                dispatch_to_profile as _dispatch_to_profile,
+                load_profile_route_sessions as _load_profile_route_sessions,
+                load_profile_routes as _load_profile_routes,
+                match_profile_route as _match_profile_route,
+                parse_profile_scoped_command as _parse_profile_scoped_command,
+                save_profile_route_sessions as _save_profile_route_sessions,
+            )
+
+            _profile_routes = _load_profile_routes(_load_gateway_config(), platform="telegram")
+            _profile_route = _match_profile_route(event, _profile_routes)
+            if _profile_route is None:
+                return None
+
+            _cmd = event.get_command()
+            _is_local_gateway_command = False
+            if _cmd and not _profile_route.command and not _profile_route.text_prefix:
+                try:
+                    _is_local_gateway_command = _resolve_gateway_command(_cmd) is not None
+                except Exception:
+                    _is_local_gateway_command = False
+            if _is_local_gateway_command:
+                return None
+
+            _router_lock = getattr(self, "_profile_router_lock", None)
+            if _router_lock is None:
+                _router_lock = asyncio.Lock()
+                self._profile_router_lock = _router_lock
+
+            async with _router_lock:
+                _router_sessions = getattr(self, "_profile_router_sessions", None)
+                _router_sessions_path = getattr(
+                    self,
+                    "_profile_router_sessions_path",
+                    _hermes_home / "gateway" / "profile-router-sessions.json",
+                )
+                if _router_sessions is None:
+                    _router_sessions = _load_profile_route_sessions(path=_router_sessions_path)
+                    self._profile_router_sessions = _router_sessions
+                _route_key = (
+                    _profile_route.profile,
+                    _profile_route.name,
+                    self._session_key_for_source(source),
+                )
+                _scoped_command = _parse_profile_scoped_command(event, _profile_route)
+                if _scoped_command is not None:
+                    _scoped_name, _scoped_args = _scoped_command
+                    if _scoped_name in {"new", "reset"}:
+                        _had_session = _route_key in _router_sessions
+                        _router_sessions.pop(_route_key, None)
+                        try:
+                            _save_profile_route_sessions(_router_sessions, path=_router_sessions_path)
+                        except Exception as _persist_exc:
+                            logger.warning(
+                                "Failed to persist Telegram profile router session map after scoped /%s: %s",
+                                _scoped_name,
+                                _persist_exc,
+                            )
+                        if _had_session:
+                            return (
+                                f"✓ Started a new session for profile `{_profile_route.profile}` "
+                                f"(route `{_profile_route.name}`)."
+                            )
+                        return (
+                            f"✓ Profile `{_profile_route.profile}` route `{_profile_route.name}` "
+                            "is already on a fresh session."
+                        )
+                    if _scoped_name == "status":
+                        _child_session = _router_sessions.get(_route_key)
+                        _status_lines = [
+                            f"Profile route: {_profile_route.name}",
+                            f"Profile: {_profile_route.profile}",
+                            f"Gateway lane: {_route_key[2]}",
+                            f"Child session: {_child_session or '(none yet)'}",
+                        ]
+                        return "\n".join(_status_lines)
+                    if _scoped_name in {"help", "commands"}:
+                        _prefix = _profile_route.text_prefix or f"/{_profile_route.name}"
+                        return (
+                            f"Profile-scoped commands for `{_profile_route.profile}` "
+                            f"(route `{_profile_route.name}`):\n"
+                            f"- `{_prefix}/status` or `{_prefix}_status` — show routed child session\n"
+                            f"- `{_prefix}/new` or `{_prefix}_new` — start a fresh child session\n"
+                            f"- `{_prefix}/help` or `{_prefix}_help` — show this help"
+                        )
+                _resume_session = _router_sessions.get(_route_key)
+                _response, _session_id = await _dispatch_to_profile(
+                    event,
+                    _profile_route,
+                    resume_session_id=_resume_session,
+                )
+                if _session_id:
+                    _router_sessions[_route_key] = _session_id
+                    try:
+                        _save_profile_route_sessions(_router_sessions, path=_router_sessions_path)
+                    except Exception as _persist_exc:
+                        logger.warning(
+                            "Failed to persist Telegram profile router session map: %s",
+                            _persist_exc,
+                        )
+                logger.info(
+                    "Telegram ingress routed chat=%s thread=%s user=%s to profile=%s route=%s",
+                    source.chat_id,
+                    source.thread_id,
+                    source.user_id,
+                    _profile_route.profile,
+                    _profile_route.name,
+                )
+                return _response or None
+        except Exception as exc:
+            logger.error("Telegram profile ingress routing failed: %s", exc, exc_info=True)
+            return "❌ Profile routing failed. Check the gateway logs for details."
+
     async def _handle_message(self, event: MessageEvent) -> Optional[str]:
         """
         Handle an incoming message from any platform.
@@ -5877,6 +6020,18 @@ class GatewayRunner:
                     # Record rate limit so subsequent messages are silently ignored
                     self.pairing_store._record_rate_limit(platform_name, source.user_id)
             return None
+
+        # Optional Telegram ingress router: a single Telegram-facing gateway can
+        # forward selected chats/topics/users/prefixes into another Hermes
+        # profile's isolated HERMES_HOME via subprocess.  Run this after the
+        # owning gateway has authorized the sender, but before default-profile
+        # session/update/clarify handling.
+        _profile_route_response = await self._maybe_route_telegram_profile_message(
+            event,
+            is_internal=is_internal,
+        )
+        if _profile_route_response is not None:
+            return _profile_route_response
         
         # Intercept messages that are responses to a pending /update prompt.
         # The update process (detached) wrote .update_prompt.json; the watcher

--- a/tests/gateway/test_profile_router.py
+++ b/tests/gateway/test_profile_router.py
@@ -1,0 +1,489 @@
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.profile_router import (
+    ProfileRoute,
+    build_profile_subprocess_command,
+    build_profile_subprocess_env,
+    extract_session_id,
+    load_profile_route_sessions,
+    load_profile_routes,
+    match_profile_route,
+    parse_profile_scoped_command,
+    profile_home,
+    profile_route_sessions_path,
+    routed_profile_payload,
+    routed_text,
+    save_profile_route_sessions,
+    validate_profile_routes,
+)
+from gateway.session import SessionSource
+
+
+def _event(text="hello", **source_kwargs):
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id=str(source_kwargs.pop("chat_id", "123")),
+        user_id=str(source_kwargs.pop("user_id", "u1")),
+        user_name=source_kwargs.pop("user_name", "andrei"),
+        thread_id=source_kwargs.pop("thread_id", None),
+        chat_type=source_kwargs.pop("chat_type", "dm"),
+        **source_kwargs,
+    )
+    return MessageEvent(text=text, source=source)
+
+
+def _media_event(text="", media_urls=None, media_types=None, **source_kwargs):
+    event = _event(text, **source_kwargs)
+    event.media_urls = list(media_urls or [])
+    event.media_types = list(media_types or [])
+    return event
+
+
+def test_load_profile_routes_supports_telegram_section():
+    routes = load_profile_routes(
+        {
+            "telegram": {
+                "profile_routes": [
+                    {"profile": "sasha", "chat_id": 123, "text_prefix": "/sasha"},
+                    {"profile": "default", "chat_id": 999},
+                    "not-a-route",
+                ]
+            }
+        }
+    )
+
+    assert routes == [
+        ProfileRoute(
+            profile="sasha",
+            name="route-1",
+            chat_id="123",
+            text_prefix="/sasha",
+        )
+    ]
+
+
+def test_load_profile_routes_rejects_unsafe_profile_names():
+    routes = load_profile_routes(
+        {
+            "telegram": {
+                "profile_routes": [
+                    {"profile": "../escape", "chat_id": 123},
+                    {"profile": "/tmp/escape", "chat_id": 123},
+                    {"profile": "nested/name", "chat_id": 123},
+                    {"profile": "safe.profile-1", "chat_id": 123},
+                ]
+            }
+        }
+    )
+
+    assert [route.profile for route in routes] == ["safe.profile-1"]
+
+
+def test_profile_home_rejects_path_escape_names(tmp_path):
+    for unsafe in ["../escape", "/tmp/escape", "nested/name", "default"]:
+        with pytest.raises(ValueError):
+            profile_home(unsafe, root=tmp_path)
+
+    assert profile_home("safe.profile-1", root=tmp_path) == (tmp_path / "profiles" / "safe.profile-1").resolve()
+
+
+def test_match_profile_route_requires_prefix_boundary():
+    route = ProfileRoute(profile="coder", text_prefix="/coder")
+
+    assert match_profile_route(_event("/coder implement"), [route]) is route
+    assert match_profile_route(_event("/coder/status"), [route]) is route
+    assert match_profile_route(_event("/coder_status"), [route]) is route
+    assert match_profile_route(_event("/coderx should not route"), [route]) is None
+
+
+def test_load_profile_routes_keeps_media_forwarding_opt_in():
+    routes = load_profile_routes(
+        {
+            "telegram": {
+                "profile_routes": [
+                    {"profile": "plain", "chat_id": 123},
+                    {"profile": "media", "chat_id": 456, "pass_media": True},
+                ]
+            }
+        }
+    )
+
+    assert routes[0].pass_media is False
+    assert routes[1].pass_media is True
+
+
+def test_routed_profile_payload_ignores_media_unless_enabled():
+    route = ProfileRoute(profile="coder", text_prefix="/coder", pass_media=False)
+    event = _media_event(
+        "/coder what is this?",
+        media_urls=["/tmp/diagram.png"],
+        media_types=["image/png"],
+    )
+
+    payload = routed_profile_payload(event, route)
+
+    assert payload.text == "what is this?"
+    assert payload.image_path is None
+
+
+def test_routed_profile_payload_forwards_first_image_and_media_notes_when_enabled():
+    route = ProfileRoute(profile="coder", text_prefix="/coder", pass_media=True)
+    event = _media_event(
+        "/coder analyze these",
+        media_urls=["/tmp/first.png", "/tmp/voice.ogg", "/tmp/second.jpg"],
+        media_types=["image/png", "audio/ogg", "image/jpeg"],
+    )
+
+    payload = routed_profile_payload(event, route)
+
+    assert payload.image_path == "/tmp/first.png"
+    assert payload.text.startswith("analyze these")
+    assert "Telegram media attachments" in payload.text
+    assert "attached via --image" in payload.text
+    assert "/tmp/voice.ogg" in payload.text
+    assert "/tmp/second.jpg" in payload.text
+
+
+def test_build_profile_subprocess_command_can_attach_one_image(monkeypatch):
+    monkeypatch.setattr("gateway.profile_router.shutil.which", lambda name: "/usr/bin/hermes")
+
+    cmd = build_profile_subprocess_command(
+        text="describe",
+        source_tag="telegram-router",
+        image_path="/tmp/diagram.png",
+    )
+
+    assert cmd == [
+        "/usr/bin/hermes",
+        "chat",
+        "--quiet",
+        "--source",
+        "telegram-router",
+        "--image",
+        "/tmp/diagram.png",
+        "--query",
+        "describe",
+    ]
+
+
+def test_build_profile_subprocess_env_does_not_inherit_gateway_secrets(tmp_path):
+    home = tmp_path / "profiles" / "coder"
+    parent_env = {
+        "PATH": "/usr/bin",
+        "HOME": "/home/andrei",
+        "LANG": "C.UTF-8",
+        "LC_ALL": "C.UTF-8",
+        "TELEGRAM_BOT_TOKEN": "secret-token",
+        "OPENAI_API_KEY": "provider-secret",
+        "HERMES_HOME": "/home/andrei/.hermes",
+    }
+
+    env = build_profile_subprocess_env(home, parent_env=parent_env)
+
+    assert env["HERMES_HOME"] == str(home)
+    assert env["PATH"] == "/usr/bin"
+    assert env["LC_ALL"] == "C.UTF-8"
+    assert "TELEGRAM_BOT_TOKEN" not in env
+    assert "OPENAI_API_KEY" not in env
+
+
+def test_match_profile_route_by_chat_and_thread():
+    routes = [
+        ProfileRoute(profile="wrong", chat_id="123", thread_id="2"),
+        ProfileRoute(profile="research", chat_id="123", thread_id="7"),
+    ]
+
+    match = match_profile_route(_event(chat_id="123", thread_id="7"), routes)
+
+    assert match is routes[1]
+
+
+def test_match_profile_route_by_command_normalizes_bot_suffix():
+    routes = [ProfileRoute(profile="coder", command="code")]
+
+    match = match_profile_route(_event("/code@HermesBot fix tests"), routes)
+
+    assert match is routes[0]
+
+
+def test_routed_text_strips_prefix_when_enabled():
+    route = ProfileRoute(profile="coder", text_prefix="/coder", strip_prefix=True)
+
+    assert routed_text(_event("/coder implement thing"), route) == "implement thing"
+
+
+def test_routed_text_preserves_prefix_when_disabled():
+    route = ProfileRoute(profile="coder", text_prefix="/coder", strip_prefix=False)
+
+    assert routed_text(_event("/coder implement thing"), route) == "/coder implement thing"
+
+
+def test_extract_session_id_handles_quiet_output():
+    assert extract_session_id("done\nSession ID: 20260517_abc\n") == "20260517_abc"
+    assert extract_session_id("done\nsession_id=abc:def\n") == "abc:def"
+
+
+def test_build_profile_subprocess_command_includes_resume(monkeypatch):
+    monkeypatch.setattr("gateway.profile_router.shutil.which", lambda name: "/usr/bin/hermes")
+
+    cmd = build_profile_subprocess_command(
+        text="hello",
+        source_tag="telegram-router",
+        resume="sess-1",
+    )
+
+    assert cmd == [
+        "/usr/bin/hermes",
+        "chat",
+        "--quiet",
+        "--source",
+        "telegram-router",
+        "--resume",
+        "sess-1",
+        "--query",
+        "hello",
+    ]
+
+
+def test_validate_profile_routes_reports_missing_profiles_and_duplicate_names(tmp_path):
+    existing = tmp_path / "profiles" / "research"
+    existing.mkdir(parents=True)
+    routes = [
+        ProfileRoute(profile="research", name="lane"),
+        ProfileRoute(profile="missing", name="lane"),
+    ]
+
+    warnings = validate_profile_routes(routes, root=tmp_path)
+
+    assert "duplicate route name 'lane'" in "\n".join(warnings)
+    assert "profile 'missing' not found" in "\n".join(warnings)
+
+
+def test_validate_profile_routes_warns_when_target_profile_has_telegram_token(tmp_path):
+    profile_home = tmp_path / "profiles" / "research"
+    profile_home.mkdir(parents=True)
+    (profile_home / ".env").write_text("TELEGRAM_BOT_TOKEN=secret-token\n", encoding="utf-8")
+
+    warnings = validate_profile_routes([ProfileRoute(profile="research", name="research")], root=tmp_path)
+
+    joined = "\n".join(warnings)
+    assert "profile 'research' has TELEGRAM_BOT_TOKEN configured" in joined
+    assert "secret-token" not in joined
+
+
+def test_profile_route_sessions_round_trip_json(tmp_path):
+    sessions = {
+        ("research-agent", "research-topic", "telegram:-100:2:u1"): "session-research",
+        ("coder", "coder-prefix", "telegram:dm:u1"): "session-coder",
+    }
+
+    save_profile_route_sessions(sessions, root=tmp_path)
+
+    path = profile_route_sessions_path(root=tmp_path)
+    assert path == tmp_path / "gateway" / "profile-router-sessions.json"
+    loaded = load_profile_route_sessions(root=tmp_path)
+    assert loaded == sessions
+
+
+def test_profile_route_sessions_ignore_malformed_records(tmp_path):
+    path = profile_route_sessions_path(root=tmp_path)
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        '{"version": 1, "sessions": ['
+        '{"profile": "coder", "route": "coder-prefix", "gateway_session_key": "telegram:1", "child_session_id": "child"},'
+        '{"profile": "missing-session", "route": "bad", "gateway_session_key": "telegram:2"},'
+        '"not-a-record"]}',
+        encoding="utf-8",
+    )
+
+    assert load_profile_route_sessions(root=tmp_path) == {
+        ("coder", "coder-prefix", "telegram:1"): "child"
+    }
+
+
+@pytest.mark.asyncio
+async def test_gateway_routes_authorized_telegram_message(monkeypatch, tmp_path):
+    from gateway import run as gateway_run
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {}
+    runner._profile_router_sessions = {}
+    runner._is_user_authorized = lambda source: True
+    runner._session_key_for_source = lambda source: "telegram:123:u1"
+
+    async def fake_dispatch(event, route, resume_session_id=None):
+        assert route.profile == "sasha"
+        assert resume_session_id is None
+        return "from sasha", "sess-sasha"
+
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {
+        "telegram": {"profile_routes": [{"profile": "sasha", "chat_id": "123"}]}
+    })
+    monkeypatch.setattr("gateway.profile_router.dispatch_to_profile", fake_dispatch)
+
+    response = await gateway_run.GatewayRunner._maybe_route_telegram_profile_message(
+        runner, _event("hi", chat_id="123"), is_internal=False
+    )
+
+    assert response == "from sasha"
+    assert runner._profile_router_sessions[("sasha", "route-1", "telegram:123:u1")] == "sess-sasha"
+
+
+@pytest.mark.asyncio
+async def test_gateway_profile_router_keeps_broad_routes_from_swallowing_local_commands(monkeypatch):
+    from gateway import run as gateway_run
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._profile_router_sessions = {}
+    runner._session_key_for_source = lambda source: "telegram:123:u1"
+
+    async def fail_dispatch(*args, **kwargs):
+        raise AssertionError("local gateway command should not be routed")
+
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {
+        "telegram": {"profile_routes": [{"profile": "sasha", "chat_id": "123"}]}
+    })
+    monkeypatch.setattr("gateway.profile_router.dispatch_to_profile", fail_dispatch)
+
+    response = await gateway_run.GatewayRunner._maybe_route_telegram_profile_message(
+        runner, _event("/help", chat_id="123"), is_internal=False
+    )
+
+    assert response is None
+
+
+@pytest.mark.asyncio
+async def test_gateway_profile_router_resumes_previous_child_session(monkeypatch, tmp_path):
+    from gateway import run as gateway_run
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._profile_router_sessions = None
+    runner._profile_router_sessions_path = tmp_path / "gateway" / "profile-router-sessions.json"
+    runner._session_key_for_source = lambda source: "telegram:123:u1"
+    save_profile_route_sessions(
+        {("sasha", "route-1", "telegram:123:u1"): "child-session"},
+        path=runner._profile_router_sessions_path,
+    )
+
+    async def fake_dispatch(event, route, resume_session_id=None):
+        assert resume_session_id == "child-session"
+        return "resumed", "child-session-2"
+
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {
+        "telegram": {"profile_routes": [{"profile": "sasha", "chat_id": "123"}]}
+    })
+    monkeypatch.setattr("gateway.profile_router.dispatch_to_profile", fake_dispatch)
+
+    response = await gateway_run.GatewayRunner._maybe_route_telegram_profile_message(
+        runner, _event("hi again", chat_id="123"), is_internal=False
+    )
+
+    assert response == "resumed"
+    assert runner._profile_router_sessions[("sasha", "route-1", "telegram:123:u1")] == "child-session-2"
+    assert load_profile_route_sessions(path=runner._profile_router_sessions_path) == {
+        ("sasha", "route-1", "telegram:123:u1"): "child-session-2"
+    }
+
+
+def test_parse_profile_scoped_command_supports_prefix_slash_and_telegram_safe_forms():
+    route = ProfileRoute(profile="coder", name="coder-prefix", text_prefix="/coder")
+
+    assert parse_profile_scoped_command(_event("/coder/new"), route) == ("new", "")
+    assert parse_profile_scoped_command(_event("/coder_new"), route) == ("new", "")
+    assert parse_profile_scoped_command(_event("/coder /status --verbose"), route) == (
+        "status",
+        "--verbose",
+    )
+
+
+def test_parse_profile_scoped_command_ignores_normal_profile_prompts():
+    route = ProfileRoute(profile="coder", name="coder-prefix", text_prefix="/coder")
+
+    assert parse_profile_scoped_command(_event("/coder new feature branch"), route) is None
+    assert parse_profile_scoped_command(_event("/coder implement status command"), route) is None
+
+
+@pytest.mark.asyncio
+async def test_gateway_profile_scoped_new_clears_child_session_without_dispatch(monkeypatch, tmp_path):
+    from gateway import run as gateway_run
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._profile_router_sessions = None
+    runner._profile_router_sessions_path = tmp_path / "gateway" / "profile-router-sessions.json"
+    runner._session_key_for_source = lambda source: "telegram:123:u1"
+    save_profile_route_sessions(
+        {("coder", "coder-prefix", "telegram:123:u1"): "old-child"},
+        path=runner._profile_router_sessions_path,
+    )
+
+    async def fail_dispatch(*args, **kwargs):
+        raise AssertionError("profile-scoped /new should not dispatch to the child agent")
+
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {
+        "telegram": {"profile_routes": [{"name": "coder-prefix", "profile": "coder", "text_prefix": "/coder"}]}
+    })
+    monkeypatch.setattr("gateway.profile_router.dispatch_to_profile", fail_dispatch)
+
+    response = await gateway_run.GatewayRunner._maybe_route_telegram_profile_message(
+        runner, _event("/coder/new", chat_id="123"), is_internal=False
+    )
+
+    assert "Started a new session" in response
+    assert ("coder", "coder-prefix", "telegram:123:u1") not in runner._profile_router_sessions
+    assert load_profile_route_sessions(path=runner._profile_router_sessions_path) == {}
+
+
+@pytest.mark.asyncio
+async def test_gateway_profile_scoped_status_reports_child_session_without_dispatch(monkeypatch, tmp_path):
+    from gateway import run as gateway_run
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._profile_router_sessions = None
+    runner._profile_router_sessions_path = tmp_path / "gateway" / "profile-router-sessions.json"
+    runner._session_key_for_source = lambda source: "telegram:123:u1"
+    save_profile_route_sessions(
+        {("coder", "coder-prefix", "telegram:123:u1"): "child-session"},
+        path=runner._profile_router_sessions_path,
+    )
+
+    async def fail_dispatch(*args, **kwargs):
+        raise AssertionError("profile-scoped /status should not dispatch to the child agent")
+
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {
+        "telegram": {"profile_routes": [{"name": "coder-prefix", "profile": "coder", "text_prefix": "/coder"}]}
+    })
+    monkeypatch.setattr("gateway.profile_router.dispatch_to_profile", fail_dispatch)
+
+    response = await gateway_run.GatewayRunner._maybe_route_telegram_profile_message(
+        runner, _event("/coder_status", chat_id="123"), is_internal=False
+    )
+
+    assert "Profile route: coder-prefix" in response
+    assert "Profile: coder" in response
+    assert "Child session: child-session" in response
+
+
+@pytest.mark.asyncio
+async def test_gateway_profile_router_failure_response_hides_child_error(monkeypatch):
+    from gateway import run as gateway_run
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._profile_router_sessions = {}
+    runner._session_key_for_source = lambda source: "telegram:123:u1"
+
+    async def fail_dispatch(*args, **kwargs):
+        raise RuntimeError("provider token leaked in child stderr: secret-token")
+
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {
+        "telegram": {"profile_routes": [{"profile": "sasha", "chat_id": "123"}]}
+    })
+    monkeypatch.setattr("gateway.profile_router.dispatch_to_profile", fail_dispatch)
+
+    response = await gateway_run.GatewayRunner._maybe_route_telegram_profile_message(
+        runner, _event("hi", chat_id="123"), is_internal=False
+    )
+
+    assert response == "❌ Profile routing failed. Check the gateway logs for details."
+    assert "secret-token" not in response

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -256,6 +256,96 @@ TELEGRAM_HOME_CHANNEL_NAME="My Notes"
 Group chat IDs are negative numbers (e.g., `-1001234567890`). Your personal DM chat ID is the same as your user ID.
 :::
 
+## Profile Ingress Routing
+
+A single Telegram bot can act as the front door for multiple Hermes profiles. The
+main gateway still owns Telegram authorization and polling, then selected
+messages are forwarded to target profiles in isolated subprocesses with their
+own `HERMES_HOME`.
+
+This is useful for OpenClaw-style lanes such as:
+
+- one forum topic routed to a research profile
+- `/coder ...` messages routed to a coding profile
+- a specific DM routed to a specialized assistant profile
+
+Add routes to the Telegram section of `~/.hermes/config.yaml`:
+
+```yaml
+telegram:
+  profile_routes:
+    - name: research-topic
+      profile: research-agent
+      chat_id: "-1001234567890"
+      thread_id: "2"
+
+    - name: coder-prefix
+      profile: coder
+      text_prefix: "/coder"
+      strip_prefix: true
+      pass_media: true  # optional: forward Telegram media paths/first image
+
+    - name: sasha-dm
+      profile: sasha
+      chat_id: "123456789"
+```
+
+Supported selectors:
+
+| Selector | Meaning |
+|---|---|
+| `chat_id` | Telegram chat or supergroup ID. Supergroups usually use the `-100...` form. |
+| `thread_id` | Telegram forum topic/thread ID. |
+| `user_id` | Numeric Telegram sender ID. |
+| `username` | Telegram username, with or without `@`. |
+| `chat_type` | Match DMs vs groups if the source exposes it. |
+| `text_prefix` | Match messages beginning with a prefix such as `/coder`. |
+| `command` | Match a specific slash command. Bot suffixes like `/cmd@MyBot` are normalized. |
+| `pass_media` | Opt-in media forwarding for matched Telegram messages. The first image is attached to the child CLI query; all cached media paths are included as text notes. Defaults to `false`. |
+
+Route behavior:
+
+- The gateway checks normal Telegram authorization first; the router is not a
+  second auth system.
+- Plain gateway commands such as `/help`, `/status`, `/restart`, and `/new` stay
+  local unless the route explicitly matches a `command` or `text_prefix`.
+- Target profiles run via subprocess with `HERMES_HOME` set to
+  `~/.hermes/profiles/<profile>`, so profile config, sessions, memory, and
+  skills stay isolated from the main gateway profile. Profile names must be
+  plain directory names (letters, numbers, `_`, `-`, `.`); path-like names are
+  ignored.
+- The child subprocess gets a sanitized environment. It does not inherit the
+  ingress gateway's Telegram token or provider API keys; the target profile
+  should supply its own credentials via its own profile config / `.env`.
+- The gateway persists the child profile `session_id` for each route lane in
+  `$HERMES_HOME/gateway/profile-router-sessions.json` and passes `--resume` on
+  later routed messages, including after gateway restarts.
+- Prefix routes also get profile-scoped router commands. For a route with
+  `text_prefix: "/coder"`, use `/coder/status` or `/coder_status` to inspect the
+  child session, `/coder/new` or `/coder_new` to start a fresh child session, and
+  `/coder/help` or `/coder_help` for a short command list. `/coder /status` also
+  works. Plain prompts such as `/coder new feature branch` are still sent to the
+  profile as normal text, not treated as commands.
+- Media forwarding is opt-in per route with `pass_media: true`. When enabled,
+  the router includes cached Telegram media paths in the child prompt and passes
+  the first image through the CLI's `--image` attachment path. Additional images,
+  voice/audio, video, and documents are preserved as local path notes for the
+  routed profile to inspect with its normal tools.
+
+Operational notes:
+
+- Only the ingress profile should poll Telegram with a given bot token. Routed
+  profiles should not run their own Telegram gateway using the same token, or
+  Telegram will return polling conflicts.
+- Restart the gateway after changing `profile_routes`.
+- On startup, the gateway logs warnings for missing target profile directories,
+  duplicate route names, and target profiles that appear to have Telegram bot
+  tokens configured.
+- `pass_media` is deliberately off by default. Enable it only for routes whose
+  target profile should see local cached media paths from the ingress gateway.
+  The first image is attached natively; other media are forwarded as path notes,
+  not re-uploaded or copied into the target profile home.
+
 ## Voice Messages
 
 ### Incoming Voice (Speech-to-Text)


### PR DESCRIPTION
## Summary
- Add a Telegram profile ingress router so one Telegram bot/gateway can route selected messages into multiple Hermes profiles behind it.
- Route matching supports chat/topic/user/username/chat type, text prefixes, and commands, with conservative profile-scoped `/prefix/status`, `/prefix/new`, and `/prefix/help` controls.
- Dispatches target profiles through subprocesses with isolated `HERMES_HOME`, sanitized child environments, persisted child `session_id` continuity, and opt-in media forwarding (`pass_media`, first image via `--image`, other media as path notes).
- Document the configuration, operational caveats, and media behavior in the Telegram messaging guide.

## Safety / isolation notes
- Routing happens only after normal Telegram authorization.
- Plain gateway commands remain local unless a route explicitly matches a command or text prefix.
- Profile names are constrained to safe directory names under `~/.hermes/profiles`.
- Child subprocesses do not inherit gateway Telegram/provider secrets from the parent environment; target profiles should load their own credentials from their profile config / `.env`.
- User-facing route failures are generic; detailed child errors stay in gateway logs.

## Test plan
- [x] `venv/bin/python -m pytest tests/gateway/test_profile_router.py -q` → 27 passed
- [x] `venv/bin/python -m py_compile gateway/profile_router.py gateway/run.py tests/gateway/test_profile_router.py`
- [x] `git diff --cached --check`
- [x] Static added-line scan for hardcoded secrets, shell injection, eval/exec, pickle, and SQL string formatting → 0 findings
- [x] Independent pre-commit review pass

## Broader suite note
I also ran `venv/bin/python -m pytest tests/gateway -q`; it had 2 failures in `tests/gateway/test_approve_deny_commands.py::TestBlockingApprovalE2E`. I verified those same two tests fail on a clean `origin/main` worktree on this machine, so they are baseline/environment issues rather than regressions from this PR.
