### PR TITLE
fix(gateway): persist session model and reasoning overrides

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9491,6 +9491,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             None if reasoning_config is None else dict(reasoning_config)
         )
 
+    def _rehydrate_session_reasoning_override(self, session_entry) -> None:
+        """Copy a durable override from an already-loaded routing entry."""
+        session_key = str(getattr(session_entry, "session_key", "") or "")
+        persisted = getattr(session_entry, "reasoning_override", None)
+        if not session_key or persisted is None:
+            return
+        state = self._session_state(session_key)
+        if state.conversation.reasoning_override is None:
+            state.conversation.reasoning_override = dict(persisted)
+
     def _resolve_session_service_tier(
         self,
         source=None,
@@ -18867,6 +18877,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 touch_activity=not bool(getattr(event, "internal", False)),
             )
         session_key = session_entry.session_key
+        self._rehydrate_session_reasoning_override(session_entry)
         if not strict_session and pinned_session_id:
             resolved_entry = await self._resolve_async_delegation_session(
                 session_entry,
@@ -18875,6 +18886,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if resolved_entry is None:
                 return
             session_entry = resolved_entry
+            session_key = session_entry.session_key
+            self._rehydrate_session_reasoning_override(session_entry)
         self._cache_session_source(session_key, source)
         if await asyncio.to_thread(self._is_telegram_topic_lane, source):
             try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8357,6 +8357,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             None if reasoning_config is None else dict(reasoning_config)
         )
 
+    def _rehydrate_session_reasoning_override(self, session_entry) -> None:
+        """Copy a durable override from an already-loaded routing entry."""
+        session_key = str(getattr(session_entry, "session_key", "") or "")
+        persisted = getattr(session_entry, "reasoning_override", None)
+        if not session_key or persisted is None:
+            return
+        state = self._session_state(session_key)
+        if state.conversation.reasoning_override is None:
+            state.conversation.reasoning_override = dict(persisted)
+
     def _resolve_session_service_tier(
         self,
         source=None,
@@ -16747,6 +16757,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         session_entry = await self.async_session_store.get_or_create_session(source)
         session_key = session_entry.session_key
+        self._rehydrate_session_reasoning_override(session_entry)
         pinned_session_id = str(
             (getattr(event, "metadata", None) or {}).get("gateway_session_id") or ""
         ).strip()

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -20,6 +20,8 @@ from datetime import datetime, timedelta
 from dataclasses import dataclass, field, replace
 from typing import Dict, List, Optional, Any
 
+from hermes_constants import VALID_REASONING_EFFORTS
+
 logger = logging.getLogger(__name__)
 
 
@@ -754,6 +756,7 @@ def build_session_context_prompt(
 # written to sessions.json.  On rehydration after a gateway restart the
 # runner re-resolves credentials via the normal runtime provider resolution.
 PERSISTABLE_MODEL_OVERRIDE_KEYS = ("model", "provider", "base_url")
+PERSISTABLE_REASONING_OVERRIDE_KEYS = ("enabled", "effort")
 
 
 def sanitize_model_override(override: Optional[Dict[str, Any]]) -> Optional[Dict[str, str]]:
@@ -771,6 +774,28 @@ def sanitize_model_override(override: Optional[Dict[str, Any]]) -> Optional[Dict
         if k in PERSISTABLE_MODEL_OVERRIDE_KEYS and v not in (None, "")
     }
     return cleaned or None
+
+
+def sanitize_reasoning_override(
+    override: Optional[Dict[str, Any]],
+) -> Optional[Dict[str, Any]]:
+    """Return the credential-free canonical shape for a /reasoning override."""
+    if not isinstance(override, dict):
+        return None
+    enabled = override.get("enabled")
+    if not isinstance(enabled, bool):
+        return None
+    cleaned: Dict[str, Any] = {"enabled": enabled}
+    if enabled:
+        effort = override.get("effort")
+        if effort not in VALID_REASONING_EFFORTS:
+            return None
+        cleaned["effort"] = str(effort)
+    return {
+        key: cleaned[key]
+        for key in PERSISTABLE_REASONING_OVERRIDE_KEYS
+        if key in cleaned
+    }
 
 
 @dataclass
@@ -870,6 +895,9 @@ class SessionEntry:
     # override is rehydrated after a restart and are never written to disk
     # (see sanitize_model_override / SessionStore.set_model_override).
     model_override: Optional[Dict[str, str]] = None
+    # Session-scoped /reasoning override. Only ``enabled`` and a canonical
+    # effort are persisted; arbitrary runtime/provider fields are discarded.
+    reasoning_override: Optional[Dict[str, Any]] = None
 
     def to_dict(self) -> Dict[str, Any]:
         result = {
@@ -914,6 +942,10 @@ class SessionEntry:
             # Defence-in-depth: strip credentials even if a caller stored an
             # unsanitized dict directly on the entry.
             result["model_override"] = sanitize_model_override(self.model_override)
+        if self.reasoning_override is not None:
+            result["reasoning_override"] = sanitize_reasoning_override(
+                self.reasoning_override
+            )
         if self.origin:
             result["origin"] = self.origin.to_dict()
         return result
@@ -1003,6 +1035,9 @@ class SessionEntry:
             reset_had_activity=data.get("reset_had_activity", False),
             prev_session_id=data.get("prev_session_id"),
             model_override=sanitize_model_override(data.get("model_override")),
+            reasoning_override=sanitize_reasoning_override(
+                data.get("reasoning_override")
+            ),
         )
 
 
@@ -2291,10 +2326,11 @@ class SessionStore:
         with self._lock:
             entry.expiry_finalized = True
             if clear_model_override:
-                # Session finalization is a conversation boundary — drop the
-                # persisted /model override too so a later message doesn't
-                # rehydrate it after the in-memory override was popped.
+                # Session finalization is a conversation boundary — drop both
+                # persisted runtime overrides so a later message cannot
+                # rehydrate state already cleared from SessionState.
                 entry.model_override = None
+                entry.reasoning_override = None
             self._save()
         if self._db:
             setter = getattr(self._db, "set_expiry_finalized", None)
@@ -3048,6 +3084,30 @@ class SessionStore:
             if entry is None:
                 return None
             return dict(entry.model_override) if entry.model_override else None
+
+    def set_reasoning_override(
+        self, session_key: str, override: Optional[Dict[str, Any]]
+    ) -> None:
+        """Persist or clear the sanitized session-scoped /reasoning override."""
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            if entry is None:
+                return
+            cleaned = sanitize_reasoning_override(override)
+            if entry.reasoning_override == cleaned:
+                return
+            entry.reasoning_override = cleaned
+            self._save()
+
+    def get_reasoning_override(self, session_key: str) -> Optional[Dict[str, Any]]:
+        """Return the persisted /reasoning override for *session_key*."""
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            if entry is None or entry.reasoning_override is None:
+                return None
+            return dict(entry.reasoning_override)
 
     def suspend_session(self, session_key: str) -> bool:
         """Mark a session as suspended so it auto-resets on next access.

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -20,6 +20,8 @@ from datetime import datetime, timedelta
 from dataclasses import dataclass, field, replace
 from typing import Dict, List, Optional, Any
 
+from hermes_constants import VALID_REASONING_EFFORTS
+
 logger = logging.getLogger(__name__)
 
 
@@ -751,6 +753,7 @@ def build_session_context_prompt(
 # written to sessions.json.  On rehydration after a gateway restart the
 # runner re-resolves credentials via the normal runtime provider resolution.
 PERSISTABLE_MODEL_OVERRIDE_KEYS = ("model", "provider", "base_url")
+PERSISTABLE_REASONING_OVERRIDE_KEYS = ("enabled", "effort")
 
 
 def sanitize_model_override(override: Optional[Dict[str, Any]]) -> Optional[Dict[str, str]]:
@@ -768,6 +771,28 @@ def sanitize_model_override(override: Optional[Dict[str, Any]]) -> Optional[Dict
         if k in PERSISTABLE_MODEL_OVERRIDE_KEYS and v not in (None, "")
     }
     return cleaned or None
+
+
+def sanitize_reasoning_override(
+    override: Optional[Dict[str, Any]],
+) -> Optional[Dict[str, Any]]:
+    """Return the credential-free canonical shape for a /reasoning override."""
+    if not isinstance(override, dict):
+        return None
+    enabled = override.get("enabled")
+    if not isinstance(enabled, bool):
+        return None
+    cleaned: Dict[str, Any] = {"enabled": enabled}
+    if enabled:
+        effort = override.get("effort")
+        if effort not in VALID_REASONING_EFFORTS:
+            return None
+        cleaned["effort"] = str(effort)
+    return {
+        key: cleaned[key]
+        for key in PERSISTABLE_REASONING_OVERRIDE_KEYS
+        if key in cleaned
+    }
 
 
 @dataclass
@@ -867,6 +892,9 @@ class SessionEntry:
     # override is rehydrated after a restart and are never written to disk
     # (see sanitize_model_override / SessionStore.set_model_override).
     model_override: Optional[Dict[str, str]] = None
+    # Session-scoped /reasoning override. Only ``enabled`` and a canonical
+    # effort are persisted; arbitrary runtime/provider fields are discarded.
+    reasoning_override: Optional[Dict[str, Any]] = None
 
     def to_dict(self) -> Dict[str, Any]:
         result = {
@@ -911,6 +939,10 @@ class SessionEntry:
             # Defence-in-depth: strip credentials even if a caller stored an
             # unsanitized dict directly on the entry.
             result["model_override"] = sanitize_model_override(self.model_override)
+        if self.reasoning_override is not None:
+            result["reasoning_override"] = sanitize_reasoning_override(
+                self.reasoning_override
+            )
         if self.origin:
             result["origin"] = self.origin.to_dict()
         return result
@@ -1000,6 +1032,9 @@ class SessionEntry:
             reset_had_activity=data.get("reset_had_activity", False),
             prev_session_id=data.get("prev_session_id"),
             model_override=sanitize_model_override(data.get("model_override")),
+            reasoning_override=sanitize_reasoning_override(
+                data.get("reasoning_override")
+            ),
         )
 
 
@@ -2141,10 +2176,11 @@ class SessionStore:
         with self._lock:
             entry.expiry_finalized = True
             if clear_model_override:
-                # Session finalization is a conversation boundary — drop the
-                # persisted /model override too so a later message doesn't
-                # rehydrate it after the in-memory override was popped.
+                # Session finalization is a conversation boundary — drop both
+                # persisted runtime overrides so a later message cannot
+                # rehydrate state already cleared from SessionState.
                 entry.model_override = None
+                entry.reasoning_override = None
             self._save()
         if self._db:
             setter = getattr(self._db, "set_expiry_finalized", None)
@@ -2826,6 +2862,30 @@ class SessionStore:
             if entry is None:
                 return None
             return dict(entry.model_override) if entry.model_override else None
+
+    def set_reasoning_override(
+        self, session_key: str, override: Optional[Dict[str, Any]]
+    ) -> None:
+        """Persist or clear the sanitized session-scoped /reasoning override."""
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            if entry is None:
+                return
+            cleaned = sanitize_reasoning_override(override)
+            if entry.reasoning_override == cleaned:
+                return
+            entry.reasoning_override = cleaned
+            self._save()
+
+    def get_reasoning_override(self, session_key: str) -> Optional[Dict[str, Any]]:
+        """Return the persisted /reasoning override for *session_key*."""
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            if entry is None or entry.reasoning_override is None:
+                return None
+            return dict(entry.reasoning_override)
 
     def suspend_session(self, session_key: str) -> bool:
         """Mark a session as suspended so it auto-resets on next access.

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3559,7 +3559,23 @@ class GatewaySlashCommandsMixin:
             logger.error("Failed to save config key %s: %s", key_path, e)
             return False
 
-    def _apply_reasoning_selection(
+    async def _persist_session_reasoning_override(
+        self, session_key: str, reasoning_config: Optional[dict]
+    ) -> None:
+        """Write through via AsyncSessionStore when the runner owns a store."""
+        if getattr(self, "session_store", None) is None:
+            return
+        try:
+            await self.async_session_store.set_reasoning_override(
+                session_key, reasoning_config
+            )
+        except Exception:
+            logger.debug(
+                "Failed to persist session reasoning override",
+                exc_info=True,
+            )
+
+    async def _apply_reasoning_selection(
         self,
         session_key: str,
         platform_key: str,
@@ -3594,6 +3610,7 @@ class GatewaySlashCommandsMixin:
             if persist_global:
                 return t("gateway.reasoning.reset_global_unsupported")
             self._set_session_reasoning_override(session_key, None)
+            await self._persist_session_reasoning_override(session_key, None)
             self._reasoning_config = self._load_reasoning_config()
             self._evict_cached_agent(session_key)
             return t("gateway.reasoning.reset_done")
@@ -3606,13 +3623,20 @@ class GatewaySlashCommandsMixin:
         if persist_global:
             if self._save_gateway_config_key("agent.reasoning_effort", value):
                 self._set_session_reasoning_override(session_key, None)
+                await self._persist_session_reasoning_override(
+                    session_key, None
+                )
                 self._evict_cached_agent(session_key)
                 return t("gateway.reasoning.set_global", effort=value)
             self._set_session_reasoning_override(session_key, parsed)
+            await self._persist_session_reasoning_override(
+                session_key, parsed
+            )
             self._evict_cached_agent(session_key)
             return t("gateway.reasoning.set_global_save_failed", effort=value)
 
         self._set_session_reasoning_override(session_key, parsed)
+        await self._persist_session_reasoning_override(session_key, parsed)
         self._evict_cached_agent(session_key)
         return t("gateway.reasoning.set_session", effort=value)
 
@@ -3743,7 +3767,7 @@ class GatewaySlashCommandsMixin:
             _picker_platform_key = _platform_config_key(event.source.platform)
 
             async def _on_reasoning_choice(_chat_id: str, value: str) -> str:
-                return self._apply_reasoning_selection(
+                return await self._apply_reasoning_selection(
                     session_key, _picker_platform_key, value
                 )
 
@@ -3771,7 +3795,7 @@ class GatewaySlashCommandsMixin:
 
         # Typed argument path — same applier the picker uses.
         platform_key = _platform_config_key(event.source.platform)
-        return self._apply_reasoning_selection(
+        return await self._apply_reasoning_selection(
             session_key, platform_key, args, persist_global=persist_global
         )
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3371,7 +3371,23 @@ class GatewaySlashCommandsMixin:
             logger.error("Failed to save config key %s: %s", key_path, e)
             return False
 
-    def _apply_reasoning_selection(
+    async def _persist_session_reasoning_override(
+        self, session_key: str, reasoning_config: Optional[dict]
+    ) -> None:
+        """Write through via AsyncSessionStore when the runner owns a store."""
+        if getattr(self, "session_store", None) is None:
+            return
+        try:
+            await self.async_session_store.set_reasoning_override(
+                session_key, reasoning_config
+            )
+        except Exception:
+            logger.debug(
+                "Failed to persist session reasoning override",
+                exc_info=True,
+            )
+
+    async def _apply_reasoning_selection(
         self,
         session_key: str,
         platform_key: str,
@@ -3406,6 +3422,7 @@ class GatewaySlashCommandsMixin:
             if persist_global:
                 return t("gateway.reasoning.reset_global_unsupported")
             self._set_session_reasoning_override(session_key, None)
+            await self._persist_session_reasoning_override(session_key, None)
             self._reasoning_config = self._load_reasoning_config()
             self._evict_cached_agent(session_key)
             return t("gateway.reasoning.reset_done")
@@ -3418,13 +3435,20 @@ class GatewaySlashCommandsMixin:
         if persist_global:
             if self._save_gateway_config_key("agent.reasoning_effort", value):
                 self._set_session_reasoning_override(session_key, None)
+                await self._persist_session_reasoning_override(
+                    session_key, None
+                )
                 self._evict_cached_agent(session_key)
                 return t("gateway.reasoning.set_global", effort=value)
             self._set_session_reasoning_override(session_key, parsed)
+            await self._persist_session_reasoning_override(
+                session_key, parsed
+            )
             self._evict_cached_agent(session_key)
             return t("gateway.reasoning.set_global_save_failed", effort=value)
 
         self._set_session_reasoning_override(session_key, parsed)
+        await self._persist_session_reasoning_override(session_key, parsed)
         self._evict_cached_agent(session_key)
         return t("gateway.reasoning.set_session", effort=value)
 
@@ -3555,7 +3579,7 @@ class GatewaySlashCommandsMixin:
             _picker_platform_key = _platform_config_key(event.source.platform)
 
             async def _on_reasoning_choice(_chat_id: str, value: str) -> str:
-                return self._apply_reasoning_selection(
+                return await self._apply_reasoning_selection(
                     session_key, _picker_platform_key, value
                 )
 
@@ -3583,7 +3607,7 @@ class GatewaySlashCommandsMixin:
 
         # Typed argument path — same applier the picker uses.
         platform_key = _platform_config_key(event.source.platform)
-        return self._apply_reasoning_selection(
+        return await self._apply_reasoning_selection(
             session_key, platform_key, args, persist_global=persist_global
         )
 

--- a/tests/gateway/test_reasoning_persistence.py
+++ b/tests/gateway/test_reasoning_persistence.py
@@ -1,0 +1,89 @@
+"""Durable, async-safe persistence for session-scoped /reasoning overrides."""
+from unittest.mock import AsyncMock
+import pytest
+from gateway.config import GatewayConfig, Platform
+from gateway.session import SessionSource, SessionStore, sanitize_reasoning_override
+
+def _source():
+    return SessionSource(platform=Platform.TELEGRAM, user_id="u1", chat_id="c1", chat_type="dm")
+
+@pytest.fixture
+def store_factory(tmp_path, monkeypatch):
+    import hermes_state
+    def _disabled(): raise RuntimeError("SQLite disabled in test")
+    monkeypatch.setattr(hermes_state, "SessionDB", _disabled)
+    return lambda: SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+
+def test_round_trips_full_effort_ladder(store_factory):
+    from hermes_constants import VALID_REASONING_EFFORTS
+    store = store_factory(); entry = store.get_or_create_session(_source())
+    for effort in VALID_REASONING_EFFORTS:
+        store.set_reasoning_override(entry.session_key, {"enabled": True, "effort": effort, "unexpected": "discard"})
+        assert store_factory().get_reasoning_override(entry.session_key) == {"enabled": True, "effort": effort}
+
+def test_clear_and_expiry_survive_restart(store_factory):
+    store = store_factory(); entry = store.get_or_create_session(_source())
+    store.set_reasoning_override(entry.session_key, {"enabled": True, "effort": "ultra"})
+    store.set_reasoning_override(entry.session_key, None)
+    assert store_factory().get_reasoning_override(entry.session_key) is None
+    store.set_reasoning_override(entry.session_key, {"enabled": True, "effort": "max"})
+    store.set_expiry_finalized(entry)
+    assert store_factory().get_reasoning_override(entry.session_key) is None
+
+def test_state_db_round_trip_without_json_mirror(tmp_path, monkeypatch):
+    import hermes_state
+
+    real_session_db = hermes_state.SessionDB
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr(
+        hermes_state,
+        "SessionDB",
+        lambda: real_session_db(db_path=db_path),
+    )
+    config = GatewayConfig()
+    config.write_sessions_json = False
+    sessions_dir = tmp_path / "sessions"
+
+    store = SessionStore(sessions_dir=sessions_dir, config=config)
+    entry = store.get_or_create_session(_source())
+    store.set_reasoning_override(
+        entry.session_key, {"enabled": True, "effort": "ultra"}
+    )
+    store._db.close()
+
+    restored = SessionStore(sessions_dir=sessions_dir, config=config)
+    try:
+        assert restored.get_reasoning_override(entry.session_key) == {
+            "enabled": True,
+            "effort": "ultra",
+        }
+    finally:
+        restored._db.close()
+
+
+def test_sanitizer_rejects_malformed_shape():
+    assert sanitize_reasoning_override(None) is None
+    assert sanitize_reasoning_override({"enabled": "false", "effort": "max"}) is None
+    assert sanitize_reasoning_override({"enabled": True, "effort": "unknown"}) is None
+    assert sanitize_reasoning_override({"enabled": False, "effort": "ultra"}) == {"enabled": False}
+
+@pytest.mark.asyncio
+async def test_command_persists_through_async_store():
+    import gateway.run as gateway_run
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._session_reasoning_overrides = {}; runner._reasoning_config = None
+    runner._show_reasoning = False; runner._running_agents = {}
+    runner.session_store = object()
+    runner._async_session_store = AsyncMock()
+    runner._async_session_store._store = runner.session_store
+    runner._evict_cached_agent = lambda _key: None
+    runner._save_gateway_config_key = lambda *_args: True
+    assert await runner._apply_reasoning_selection("agent:main:telegram:dm:u1", "telegram", "ultra")
+    runner._async_session_store.set_reasoning_override.assert_awaited_once_with("agent:main:telegram:dm:u1", {"enabled": True, "effort": "ultra"})
+
+def test_rehydrate_copies_durable_override():
+    import gateway.run as gateway_run
+    runner = object.__new__(gateway_run.GatewayRunner); runner._session_reasoning_overrides = {}
+    entry = type("Entry", (), {"session_key": "agent:main:telegram:dm:u1", "reasoning_override": {"enabled": True, "effort": "max"}})()
+    runner._rehydrate_session_reasoning_override(entry)
+    assert runner._resolve_session_reasoning_config(session_key=entry.session_key) == {"enabled": True, "effort": "max"}


### PR DESCRIPTION
## Summary

Fixes the remaining sibling gap in current `main`: session-scoped `/model` overrides already survive gateway restarts, but `/reasoning` overrides still live only in in-memory `SessionState`.

- Persist sanitized `{enabled, effort}` reasoning overrides on the existing `SessionEntry` routing record.
- Use `AsyncSessionStore` for gateway write-through so JSON/SQLite persistence never blocks the event loop.
- Rehydrate from the already-loaded routing entry at canonical message ingress; the synchronous reasoning resolver continues to read only in-memory `SessionState`.
- Preserve the complete canonical effort ladder from `VALID_REASONING_EFFORTS`, including `max` and `ultra`.
- Reject malformed persisted shapes and discard arbitrary extra fields.
- Clear the durable override on `/reasoning reset`, successful global changes, `/new`/reset and expiry finalization.
- Reuse the existing routing persistence (`state.db` plus optional `sessions.json` mirror); no new tables and no provider credentials are stored.

## Verification

- Immutable committed-tree focused suite: **17 passed**.
- Adjacent reasoning/model/reset/profile-export suite: **20 passed**.
- Real `state.db` round-trip with `gateway.write_sessions_json: false` passes.
- Ruff, `py_compile`, and `git diff --check` pass.

Fixes #26570.
