### PR TITLE
feat(voice): add Deepgram STT and TTS providers

### DIFF
--- a/agent/tts_registry.py
+++ b/agent/tts_registry.py
@@ -12,7 +12,7 @@ Built-ins-always-win
 --------------------
 Plugin names that collide with a built-in TTS provider (``edge``,
 ``openai``, ``elevenlabs``, ``minimax``, ``gemini``, ``mistral``,
-``xai``, ``piper``, ``kittentts``, ``neutts``) are rejected at
+``xai``, ``piper``, ``kittentts``, ``neutts``, ``deepgram``) are rejected at
 registration with a warning. This invariant is also re-checked at
 dispatch time in :func:`tools.tts_tool._dispatch_to_plugin_provider`.
 
@@ -56,6 +56,7 @@ _BUILTIN_NAMES = frozenset({
     "neutts",
     "kittentts",
     "piper",
+    "deepgram",
 })
 
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1349,13 +1349,19 @@ DEFAULT_CONFIG = {
     
     "stt": {
         "enabled": True,
-        "provider": "local",  # "local" (free, faster-whisper) | "groq" | "openai" (Whisper API) | "mistral" (Voxtral Transcribe)
+        "provider": "local",  # "local" (free, faster-whisper) | "groq" | "openai" (Whisper API) | "deepgram" (Nova STT) | "mistral" (Voxtral Transcribe)
         "local": {
             "model": "base",  # tiny, base, small, medium, large-v3
             "language": "",  # auto-detect by default; set to "en", "es", "fr", etc. to force
         },
         "openai": {
             "model": "whisper-1",  # whisper-1, gpt-4o-mini-transcribe, gpt-4o-transcribe
+        },
+        "deepgram": {
+            "model": "nova-3",  # nova-3, nova-2, nova-2-phonecall, nova-2-meeting, etc.
+            "language": "",  # optional BCP-47 language tag; empty = Deepgram default
+            "smart_format": True,
+            "punctuate": True,
         },
         "mistral": {
             "model": "voxtral-mini-latest",  # voxtral-mini-latest, voxtral-mini-2602
@@ -2688,6 +2694,14 @@ OPTIONAL_ENV_VARS = {
         "description": "Mistral API key for Voxtral TTS and transcription (STT)",
         "prompt": "Mistral API key",
         "url": "https://console.mistral.ai/",
+        "password": True,
+        "category": "tool",
+    },
+    "DEEPGRAM_API_KEY": {
+        "description": "Deepgram API key for Nova speech-to-text transcription",
+        "prompt": "Deepgram API key",
+        "url": "https://console.deepgram.com/",
+        "tools": ["voice_transcription"],
         "password": True,
         "category": "tool",
     },

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1300,9 +1300,9 @@ DEFAULT_CONFIG = {
     # Each provider supports an optional `max_text_length:` override for the
     # per-request input-character cap. Omit it to use the provider's documented
     # limit (OpenAI 4096, xAI 15000, MiniMax 10000, ElevenLabs 5k-40k model-aware,
-    # Gemini 5000, Edge 5000, Mistral 4000, NeuTTS/KittenTTS 2000).
+    # Deepgram 4000, Gemini 5000, Edge 5000, Mistral 4000, NeuTTS/KittenTTS 2000).
     "tts": {
-        "provider": "edge",  # "edge" (free) | "elevenlabs" (premium) | "openai" | "xai" | "minimax" | "mistral" | "gemini" | "neutts" (local) | "kittentts" (local) | "piper" (local)
+        "provider": "edge",  # "edge" (free) | "elevenlabs" (premium) | "openai" | "xai" | "minimax" | "mistral" | "gemini" | "deepgram" | "neutts" (local) | "kittentts" (local) | "piper" (local)
         "edge": {
             "voice": "en-US-AriaNeural",
             # Popular: AriaNeural, JennyNeural, AndrewNeural, BrianNeural, SoniaNeural
@@ -1325,6 +1325,9 @@ DEFAULT_CONFIG = {
         "mistral": {
             "model": "voxtral-mini-tts-2603",
             "voice_id": "c69964a6-ab8b-4f8a-9465-ec0925096ec8",  # Paul - Neutral
+        },
+        "deepgram": {
+            "model": "aura-2-thalia-en",  # Aura-2 voice model, e.g. aura-2-apollo-en
         },
         "neutts": {
             "ref_audio": "",  # Path to reference voice audio (empty = bundled default)
@@ -1349,7 +1352,7 @@ DEFAULT_CONFIG = {
     
     "stt": {
         "enabled": True,
-        "provider": "local",  # "local" (free, faster-whisper) | "groq" | "openai" (Whisper API) | "deepgram" (Nova STT) | "mistral" (Voxtral Transcribe)
+        "provider": "local",  # "local" (free, faster-whisper) | "groq" | "openai" (Whisper API) | "deepgram" (Nova STT) | "mistral" (Voxtral Transcribe) | "xai"
         "local": {
             "model": "base",  # tiny, base, small, medium, large-v3
             "language": "",  # auto-detect by default; set to "en", "es", "fr", etc. to force
@@ -1358,10 +1361,13 @@ DEFAULT_CONFIG = {
             "model": "whisper-1",  # whisper-1, gpt-4o-mini-transcribe, gpt-4o-transcribe
         },
         "deepgram": {
-            "model": "nova-3",  # nova-3, nova-2, nova-2-phonecall, nova-2-meeting, etc.
-            "language": "",  # optional BCP-47 language tag; empty = Deepgram default
-            "smart_format": True,
+            "model": "nova-3",
+            "language": "",       # auto-detect by default; set to "en", "ru", etc. to force
+            "smart_format": True,  # Enables punctuation + readability formatting
             "punctuate": True,
+            "paragraphs": False,
+            "utterances": False,
+            "numerals": False,
         },
         "mistral": {
             "model": "voxtral-mini-latest",  # voxtral-mini-latest, voxtral-mini-2602
@@ -2698,10 +2704,10 @@ OPTIONAL_ENV_VARS = {
         "category": "tool",
     },
     "DEEPGRAM_API_KEY": {
-        "description": "Deepgram API key for Nova speech-to-text transcription",
+        "description": "Deepgram API key for Aura TTS and Nova speech-to-text",
         "prompt": "Deepgram API key",
         "url": "https://console.deepgram.com/",
-        "tools": ["voice_transcription"],
+        "tools": ["voice_transcription", "text_to_speech"],
         "password": True,
         "category": "tool",
     },
@@ -5373,6 +5379,7 @@ def show_config():
     keys = [
         ("OPENROUTER_API_KEY", "OpenRouter"),
         ("VOICE_TOOLS_OPENAI_KEY", "OpenAI (STT/TTS)"),
+        ("DEEPGRAM_API_KEY", "Deepgram"),
         ("EXA_API_KEY", "Exa"),
         ("PARALLEL_API_KEY", "Parallel"),
         ("FIRECRAWL_API_KEY", "Firecrawl"),
@@ -5565,7 +5572,7 @@ def set_config_value(key: str, value: str):
     # Check if it's an API key (goes to .env)
     api_keys = [
         'OPENROUTER_API_KEY', 'OPENAI_API_KEY', 'ANTHROPIC_API_KEY', 'VOICE_TOOLS_OPENAI_KEY',
-        'EXA_API_KEY', 'PARALLEL_API_KEY', 'FIRECRAWL_API_KEY', 'FIRECRAWL_API_URL',
+        'DEEPGRAM_API_KEY', 'EXA_API_KEY', 'PARALLEL_API_KEY', 'FIRECRAWL_API_KEY', 'FIRECRAWL_API_URL',
         'FIRECRAWL_GATEWAY_URL', 'TOOL_GATEWAY_DOMAIN', 'TOOL_GATEWAY_SCHEME',
         'TOOL_GATEWAY_USER_TOKEN', 'TAVILY_API_KEY',
         'BROWSERBASE_API_KEY', 'BROWSERBASE_PROJECT_ID', 'BROWSER_USE_API_KEY',

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -138,6 +138,7 @@ def show_status(args):
         "StepFun Step Plan": "STEPFUN_API_KEY",
         "MiniMax": "MINIMAX_API_KEY",
         "MiniMax-CN": "MINIMAX_CN_API_KEY",
+        "Deepgram": "DEEPGRAM_API_KEY",
         "Firecrawl": "FIRECRAWL_API_KEY",
         "Tavily": "TAVILY_API_KEY",
         "Browser Use": "BROWSER_USE_API_KEY",  # Optional — local browser works without this

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -257,6 +257,15 @@ TOOL_CATEGORIES = {
                 "tts_provider": "gemini",
             },
             {
+                "name": "Deepgram Aura TTS",
+                "badge": "paid",
+                "tag": "Many Aura voices, native Opus output",
+                "env_vars": [
+                    {"key": "DEEPGRAM_API_KEY", "prompt": "Deepgram API key", "url": "https://console.deepgram.com/"},
+                ],
+                "tts_provider": "deepgram",
+            },
+            {
                 "name": "KittenTTS",
                 "badge": "local · free",
                 "tag": "Lightweight local ONNX TTS (~25MB), no API key",

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -1,8 +1,8 @@
-"""Tests for tools.transcription_tools — three-provider STT pipeline.
+"""Tests for tools.transcription_tools — multi-provider STT pipeline.
 
-Covers the full provider matrix (local, groq, openai), fallback chains,
-model auto-correction, config loading, validation edge cases, and
-end-to-end dispatch.  All external dependencies are mocked.
+Covers the provider matrix, fallback chains, model auto-correction, config
+loading, validation edge cases, and end-to-end dispatch.  All external
+dependencies are mocked.
 """
 
 import os
@@ -64,6 +64,7 @@ def clean_env(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("GROQ_API_KEY", raising=False)
     monkeypatch.delenv("MISTRAL_API_KEY", raising=False)
+    monkeypatch.delenv("DEEPGRAM_API_KEY", raising=False)
     monkeypatch.delenv("HERMES_LOCAL_STT_COMMAND", raising=False)
     monkeypatch.delenv("HERMES_LOCAL_STT_LANGUAGE", raising=False)
 
@@ -96,6 +97,34 @@ class TestGetProviderGroq:
              patch("tools.transcription_tools._HAS_OPENAI", False):
             from tools.transcription_tools import _get_provider
             assert _get_provider({"provider": "groq"}) == "none"
+
+
+class TestGetProviderDeepgram:
+    def test_explicit_deepgram_when_key_set(self, monkeypatch):
+        monkeypatch.setenv("DEEPGRAM_API_KEY", "dg-test")
+        from tools.transcription_tools import _get_provider
+
+        assert _get_provider({"provider": "deepgram"}) == "deepgram"
+
+    def test_explicit_deepgram_no_key_returns_none(self, monkeypatch):
+        monkeypatch.delenv("DEEPGRAM_API_KEY", raising=False)
+        from tools.transcription_tools import _get_provider
+
+        assert _get_provider({"provider": "deepgram"}) == "none"
+
+    def test_auto_detect_does_not_use_deepgram_without_explicit_provider(self, monkeypatch):
+        monkeypatch.setenv("DEEPGRAM_API_KEY", "dg-test")
+        monkeypatch.delenv("GROQ_API_KEY", raising=False)
+        monkeypatch.delenv("VOICE_TOOLS_OPENAI_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("XAI_API_KEY", raising=False)
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), \
+             patch("tools.transcription_tools._has_local_command", return_value=False), \
+             patch("tools.transcription_tools._HAS_OPENAI", False), \
+             patch("tools.xai_http.resolve_xai_http_credentials", return_value={}):
+            from tools.transcription_tools import _get_provider
+
+            assert _get_provider({}) == "none"
 
 
 class TestGetProviderFallbackPriority:
@@ -309,6 +338,93 @@ class TestTranscribeGroq:
 
         assert result["success"] is False
         assert "Permission denied" in result["error"]
+
+
+class TestTranscribeDeepgram:
+    def test_no_key(self, monkeypatch):
+        monkeypatch.delenv("DEEPGRAM_API_KEY", raising=False)
+        from tools.transcription_tools import _transcribe_deepgram
+
+        result = _transcribe_deepgram("/tmp/test.ogg", "nova-3")
+
+        assert result["success"] is False
+        assert "DEEPGRAM_API_KEY" in result["error"]
+
+    def test_successful_transcription(self, monkeypatch, sample_wav):
+        monkeypatch.setenv("DEEPGRAM_API_KEY", "dg-test")
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "results": {
+                "channels": [
+                    {"alternatives": [{"transcript": "hello from deepgram"}]}
+                ]
+            }
+        }
+        mock_response.raise_for_status.return_value = None
+
+        with patch("tools.transcription_tools.requests.post", return_value=mock_response) as mock_post:
+            from tools.transcription_tools import _transcribe_deepgram
+
+            result = _transcribe_deepgram(sample_wav, "nova-3")
+
+        assert result == {
+            "success": True,
+            "transcript": "hello from deepgram",
+            "provider": "deepgram",
+        }
+        call = mock_post.call_args
+        assert call.args[0] == "https://api.deepgram.com/v1/listen"
+        assert call.kwargs["headers"]["Authorization"] == "Token dg-test"
+        assert call.kwargs["params"] == {
+            "model": "nova-3",
+            "smart_format": "true",
+            "punctuate": "true",
+        }
+        assert call.kwargs["timeout"] == 120
+
+    def test_config_options_forwarded(self, monkeypatch, sample_wav):
+        monkeypatch.setenv("DEEPGRAM_API_KEY", "dg-test")
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "results": {"channels": [{"alternatives": [{"transcript": "hola"}]}]}
+        }
+        mock_response.raise_for_status.return_value = None
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={
+                "deepgram": {
+                    "language": "es",
+                    "smart_format": False,
+                    "punctuate": True,
+                    "diarize": True,
+                    "base_url": "https://example.deepgram.test/v1",
+                    "timeout": 30,
+                }
+             }), \
+             patch("tools.transcription_tools.requests.post", return_value=mock_response) as mock_post:
+            from tools.transcription_tools import _transcribe_deepgram
+
+            _transcribe_deepgram(sample_wav, "nova-2")
+
+        assert mock_post.call_args.args[0] == "https://example.deepgram.test/v1/listen"
+        assert mock_post.call_args.kwargs["params"] == {
+            "model": "nova-2",
+            "language": "es",
+            "smart_format": "false",
+            "punctuate": "true",
+            "diarize": "true",
+        }
+        assert mock_post.call_args.kwargs["timeout"] == 30
+
+    def test_api_error_returns_failure(self, monkeypatch, sample_wav):
+        monkeypatch.setenv("DEEPGRAM_API_KEY", "dg-test")
+        with patch("tools.transcription_tools.requests.post", side_effect=RuntimeError("boom")):
+            from tools.transcription_tools import _transcribe_deepgram
+
+            result = _transcribe_deepgram(sample_wav, "nova-3")
+
+        assert result["success"] is False
+        assert "Deepgram STT transcription failed" in result["error"]
+
 
 
 # ============================================================================
@@ -855,6 +971,24 @@ class TestTranscribeAudioDispatch:
 
         assert result["success"] is True
         mock_openai.assert_called_once()
+
+
+
+    def test_dispatches_to_deepgram(self, sample_ogg):
+        with patch("tools.transcription_tools._load_stt_config", return_value={
+                "provider": "deepgram",
+                "deepgram": {"model": "nova-2"},
+             }), \
+             patch("tools.transcription_tools._get_provider", return_value="deepgram"), \
+             patch("tools.transcription_tools._transcribe_deepgram",
+                   return_value={"success": True, "transcript": "hi", "provider": "deepgram"}) as mock_deepgram:
+            from tools.transcription_tools import transcribe_audio
+
+            result = transcribe_audio(sample_ogg)
+
+        assert result["success"] is True
+        assert result["provider"] == "deepgram"
+        mock_deepgram.assert_called_once_with(sample_ogg, "nova-2")
 
     def test_no_provider_returns_error(self, sample_ogg):
         with patch("tools.transcription_tools._load_stt_config", return_value={}), \
@@ -1437,3 +1571,17 @@ class TestShellSafety:
         monkeypatch.delenv(LOCAL_STT_COMMAND_ENV, raising=False)
         use_shell = bool(os.getenv(LOCAL_STT_COMMAND_ENV, "").strip())
         assert use_shell is False
+
+
+class TestDeepgramConfigDefaults:
+    def test_default_config_contains_deepgram_stt_section(self):
+        from hermes_cli.config import DEFAULT_CONFIG
+
+        assert "deepgram" in DEFAULT_CONFIG["stt"]
+        assert DEFAULT_CONFIG["stt"]["deepgram"]["model"] == "nova-3"
+
+    def test_deepgram_api_key_registered_as_optional_tool_env(self):
+        from hermes_cli.config import OPTIONAL_ENV_VARS
+
+        assert OPTIONAL_ENV_VARS["DEEPGRAM_API_KEY"]["category"] == "tool"
+        assert OPTIONAL_ENV_VARS["DEEPGRAM_API_KEY"]["password"] is True

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -100,7 +100,7 @@ class TestGetProviderGroq:
             assert _get_provider({"provider": "groq"}) == "none"
 
 
-class TestGetProviderDeepgram:
+class TestGetProviderDeepgramExtended:
     def test_explicit_deepgram_when_key_set(self, monkeypatch):
         monkeypatch.setenv("DEEPGRAM_API_KEY", "dg-test")
         from tools.transcription_tools import _get_provider
@@ -341,7 +341,7 @@ class TestTranscribeGroq:
         assert "Permission denied" in result["error"]
 
 
-class TestTranscribeDeepgram:
+class TestTranscribeDeepgramExtended:
     def test_no_key(self, monkeypatch):
         monkeypatch.delenv("DEEPGRAM_API_KEY", raising=False)
         from tools.transcription_tools import _transcribe_deepgram
@@ -380,6 +380,9 @@ class TestTranscribeDeepgram:
             "model": "nova-3",
             "smart_format": "true",
             "punctuate": "true",
+            "paragraphs": "false",
+            "utterances": "false",
+            "numerals": "false",
         }
         assert call.kwargs["timeout"] == 120
 

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -63,6 +63,7 @@ def clean_env(monkeypatch):
     monkeypatch.delenv("VOICE_TOOLS_OPENAI_KEY", raising=False)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("GROQ_API_KEY", raising=False)
+    monkeypatch.delenv("DEEPGRAM_API_KEY", raising=False)
     monkeypatch.delenv("MISTRAL_API_KEY", raising=False)
     monkeypatch.delenv("DEEPGRAM_API_KEY", raising=False)
     monkeypatch.delenv("HERMES_LOCAL_STT_COMMAND", raising=False)
@@ -1529,6 +1530,122 @@ class TestTranscribeAudioXAIDispatch:
             transcribe_audio(sample_ogg, model="custom-stt")
 
         assert mock_xai.call_args[0][1] == "custom-stt"
+
+
+# ============================================================================
+# Deepgram provider
+# ============================================================================
+
+class TestGetProviderDeepgram:
+    def test_deepgram_when_key_set(self, monkeypatch):
+        monkeypatch.setenv("DEEPGRAM_API_KEY", "dg-test")
+        from tools.transcription_tools import _get_provider
+        assert _get_provider({"provider": "deepgram"}) == "deepgram"
+
+    def test_deepgram_explicit_no_key_returns_none(self, monkeypatch):
+        monkeypatch.delenv("DEEPGRAM_API_KEY", raising=False)
+        from tools.transcription_tools import _get_provider
+        assert _get_provider({"provider": "deepgram"}) == "none"
+
+
+class TestTranscribeDeepgram:
+    def test_success_prefers_paragraph_transcript(self, monkeypatch, sample_wav):
+        monkeypatch.setenv("DEEPGRAM_API_KEY", "dg-test")
+
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {
+            "results": {
+                "channels": [
+                    {
+                        "alternatives": [
+                            {
+                                "transcript": "fallback transcript",
+                                "paragraphs": {"transcript": "paragraph transcript"},
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+
+        captured: dict = {}
+
+        def fake_post(url, **kwargs):
+            captured["url"] = url
+            captured.update(kwargs)
+            return response
+
+        with patch("requests.post", side_effect=fake_post), \
+             patch(
+                 "tools.transcription_tools._load_stt_config",
+                 return_value={
+                     "deepgram": {
+                         "language": "ru",
+                         "smart_format": True,
+                         "paragraphs": True,
+                         "utterances": "yes",
+                     }
+                 },
+             ):
+            from tools.transcription_tools import _transcribe_deepgram
+            result = _transcribe_deepgram(sample_wav, "nova-3")
+
+        assert result == {
+            "success": True,
+            "transcript": "paragraph transcript",
+            "provider": "deepgram",
+        }
+        assert captured["url"] == "https://api.deepgram.com/v1/listen"
+        assert captured["headers"]["Authorization"] == "Token dg-test"
+        assert captured["headers"]["Content-Type"] == "audio/x-wav"
+        assert captured["params"]["model"] == "nova-3"
+        assert captured["params"]["language"] == "ru"
+        assert captured["params"]["smart_format"] == "true"
+        assert captured["params"]["utterances"] == "true"
+
+    def test_api_error_surfaces_detail(self, monkeypatch, sample_wav):
+        monkeypatch.setenv("DEEPGRAM_API_KEY", "dg-test")
+        response = MagicMock()
+        response.status_code = 400
+        response.text = "bad request"
+        response.json.return_value = {"err_msg": "invalid model"}
+
+        with patch("requests.post", return_value=response):
+            from tools.transcription_tools import _transcribe_deepgram
+            result = _transcribe_deepgram(sample_wav, "bad-model")
+
+        assert result["success"] is False
+        assert "invalid model" in result["error"]
+
+
+class TestTranscribeAudioDeepgramDispatch:
+    def test_dispatches_to_deepgram(self, sample_ogg):
+        config = {"provider": "deepgram", "deepgram": {"model": "nova-3"}}
+        with patch("tools.transcription_tools._load_stt_config", return_value=config), \
+             patch("tools.transcription_tools._get_provider", return_value="deepgram"), \
+             patch(
+                 "tools.transcription_tools._transcribe_deepgram",
+                 return_value={"success": True, "transcript": "hi", "provider": "deepgram"},
+             ) as mock_deepgram:
+            from tools.transcription_tools import transcribe_audio
+            result = transcribe_audio(sample_ogg)
+
+        assert result["success"] is True
+        assert result["provider"] == "deepgram"
+        mock_deepgram.assert_called_once_with(sample_ogg, "nova-3")
+
+    def test_model_override_passed_to_deepgram(self, sample_ogg):
+        with patch("tools.transcription_tools._load_stt_config", return_value={"provider": "deepgram"}), \
+             patch("tools.transcription_tools._get_provider", return_value="deepgram"), \
+             patch(
+                 "tools.transcription_tools._transcribe_deepgram",
+                 return_value={"success": True, "transcript": "hi"},
+             ) as mock_deepgram:
+            from tools.transcription_tools import transcribe_audio
+            transcribe_audio(sample_ogg, model="nova-2-phonecall")
+
+        assert mock_deepgram.call_args[0][1] == "nova-2-phonecall"
 
 
 # ============================================================================

--- a/tests/tools/test_tts_deepgram.py
+++ b/tests/tools/test_tts_deepgram.py
@@ -1,0 +1,146 @@
+import json
+from unittest.mock import MagicMock, patch
+
+
+def test_deepgram_is_builtin_with_max_length():
+    from tools.tts_tool import BUILTIN_TTS_PROVIDERS, PROVIDER_MAX_TEXT_LENGTH
+
+    assert "deepgram" in BUILTIN_TTS_PROVIDERS
+    assert PROVIDER_MAX_TEXT_LENGTH["deepgram"] > 0
+
+
+def test_generate_deepgram_tts_writes_mp3(tmp_path, monkeypatch):
+    from tools import tts_tool
+
+    monkeypatch.setenv("DEEPGRAM_API_KEY", "dg-test")
+    output_path = str(tmp_path / "out.mp3")
+
+    response = MagicMock()
+    response.status_code = 200
+    response.content = b"mp3-audio"
+
+    captured: dict = {}
+
+    def fake_post(url, **kwargs):
+        captured["url"] = url
+        captured.update(kwargs)
+        return response
+
+    with patch("requests.post", side_effect=fake_post):
+        result = tts_tool._generate_deepgram_tts("Hello", output_path, {})
+
+    assert result == output_path
+    assert (tmp_path / "out.mp3").read_bytes() == b"mp3-audio"
+    assert captured["url"] == "https://api.deepgram.com/v1/speak"
+    assert captured["headers"]["Authorization"] == "Token dg-test"
+    assert captured["headers"]["Content-Type"] == "application/json"
+    assert captured["params"]["model"] == "aura-2-thalia-en"
+    assert captured["json"] == {"text": "Hello"}
+    assert "encoding" not in captured["params"]
+
+
+def test_generate_deepgram_tts_requests_ogg_opus(tmp_path, monkeypatch):
+    from tools import tts_tool
+
+    monkeypatch.setenv("DEEPGRAM_API_KEY", "dg-test")
+    output_path = str(tmp_path / "voice.ogg")
+
+    response = MagicMock()
+    response.status_code = 200
+    response.content = b"ogg-opus-audio"
+
+    captured: dict = {}
+
+    def fake_post(url, **kwargs):
+        captured.update(kwargs)
+        return response
+
+    config = {"deepgram": {"model": "aura-2-apollo-en"}}
+    with patch("requests.post", side_effect=fake_post):
+        tts_tool._generate_deepgram_tts("Hello", output_path, config)
+
+    assert (tmp_path / "voice.ogg").read_bytes() == b"ogg-opus-audio"
+    assert captured["params"] == {
+        "model": "aura-2-apollo-en",
+        "encoding": "opus",
+        "container": "ogg",
+    }
+
+
+def test_generate_deepgram_tts_surfaces_api_error(tmp_path, monkeypatch):
+    from tools import tts_tool
+
+    monkeypatch.setenv("DEEPGRAM_API_KEY", "dg-test")
+    response = MagicMock()
+    response.status_code = 400
+    response.text = "bad request"
+    response.json.return_value = {"err_msg": "invalid voice"}
+
+    with patch("requests.post", return_value=response):
+        try:
+            tts_tool._generate_deepgram_tts("Hello", str(tmp_path / "out.mp3"), {})
+        except RuntimeError as exc:
+            assert "invalid voice" in str(exc)
+        else:
+            raise AssertionError("expected RuntimeError")
+
+
+def test_text_to_speech_tool_dispatches_to_deepgram(tmp_path, monkeypatch):
+    from tools import tts_tool
+
+    output_path = str(tmp_path / "out.mp3")
+
+    def fake_generate(text, path, config):
+        assert text == "Hello"
+        assert path == output_path
+        assert config["provider"] == "deepgram"
+        with open(path, "wb") as fh:
+            fh.write(b"audio")
+        return path
+
+    monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {"provider": "deepgram"})
+    monkeypatch.setattr(tts_tool, "_generate_deepgram_tts", fake_generate)
+
+    result = json.loads(tts_tool.text_to_speech_tool("Hello", output_path=output_path))
+
+    assert result["success"] is True
+    assert result["provider"] == "deepgram"
+    assert result["voice_compatible"] is False
+
+
+def test_deepgram_tts_telegram_uses_native_voice_opus(tmp_path, monkeypatch):
+    from tools import tts_tool
+
+    def fake_generate(_text, path, _config):
+        with open(path, "wb") as fh:
+            fh.write(b"ogg")
+        return path
+
+    monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {"provider": "deepgram"})
+    monkeypatch.setattr(tts_tool, "_generate_deepgram_tts", fake_generate)
+
+    with patch("gateway.session_context.get_session_env", return_value="telegram"):
+        result = json.loads(tts_tool.text_to_speech_tool("Hello"))
+
+    assert result["success"] is True
+    assert result["provider"] == "deepgram"
+    assert result["file_path"].endswith(".ogg")
+    assert result["voice_compatible"] is True
+    assert result["media_tag"].startswith("[[audio_as_voice]]")
+
+
+def test_check_tts_requirements_sees_deepgram_key(monkeypatch):
+    from tools import tts_tool
+
+    monkeypatch.setenv("DEEPGRAM_API_KEY", "dg-test")
+    with patch.object(tts_tool, "_has_any_command_tts_provider", return_value=False), \
+         patch.object(tts_tool, "_import_edge_tts", side_effect=ImportError), \
+         patch.object(tts_tool, "_import_elevenlabs", side_effect=ImportError), \
+         patch.object(tts_tool, "_import_openai_client", side_effect=ImportError), \
+         patch.object(tts_tool, "_check_neutts_available", return_value=False), \
+         patch.object(tts_tool, "_check_kittentts_available", return_value=False), \
+         patch.object(tts_tool, "_check_piper_available", return_value=False), \
+         patch.object(tts_tool, "resolve_managed_tool_gateway", return_value=None), \
+         patch.object(tts_tool, "resolve_openai_audio_api_key", return_value=None), \
+         patch.object(tts_tool, "resolve_xai_http_credentials", create=True, return_value={}):
+        assert tts_tool.check_tts_requirements() is True

--- a/tests/tools/test_tts_dotenv_fallback.py
+++ b/tests/tools/test_tts_dotenv_fallback.py
@@ -25,6 +25,7 @@ def isolate_env(monkeypatch):
         "XAI_BASE_URL",
         "MINIMAX_API_KEY",
         "MISTRAL_API_KEY",
+        "DEEPGRAM_API_KEY",
         "GEMINI_API_KEY",
         "GEMINI_BASE_URL",
         "GOOGLE_API_KEY",
@@ -169,6 +170,24 @@ class TestDotenvFallbackPerProvider:
 
         assert "GEMINI_API_KEY" in seen_lookups
         assert captured["params"]["key"] == "gemini-dotenv-key"
+
+    def test_deepgram_reads_dotenv_key(self, tmp_path):
+        from tools import tts_tool
+
+        captured: dict = {}
+
+        def fake_post(url, **kwargs):
+            captured["headers"] = kwargs.get("headers", {})
+            response = MagicMock()
+            response.status_code = 200
+            response.content = b"audio"
+            return response
+
+        with patch.object(tts_tool, "get_env_value", return_value="deepgram-dotenv-key"), \
+             patch("requests.post", side_effect=fake_post):
+            tts_tool._generate_deepgram_tts("hi", str(tmp_path / "out.mp3"), {})
+
+        assert captured["headers"]["Authorization"] == "Token deepgram-dotenv-key"
 
 
 class TestRegressionGuard:

--- a/tests/tools/test_tts_max_text_length.py
+++ b/tests/tools/test_tts_max_text_length.py
@@ -111,7 +111,7 @@ class TestResolveMaxTextLength:
 
     def test_all_documented_providers_have_defaults(self):
         expected = {"edge", "openai", "xai", "minimax", "mistral",
-                    "gemini", "elevenlabs", "neutts", "kittentts"}
+                    "gemini", "deepgram", "elevenlabs", "neutts", "kittentts"}
         assert expected.issubset(PROVIDER_MAX_TEXT_LENGTH.keys())
 
 

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -2,12 +2,13 @@
 """
 Transcription Tools Module
 
-Provides speech-to-text transcription with six providers:
+Provides speech-to-text transcription with seven providers:
 
   - **local** (default, free) — faster-whisper running locally, no API key needed.
     Auto-downloads the model (~150 MB for ``base``) on first use.
   - **groq** (free tier) — Groq Whisper API, requires ``GROQ_API_KEY``.
   - **openai** (paid) — OpenAI Whisper API, requires ``VOICE_TOOLS_OPENAI_KEY``.
+  - **deepgram** — Deepgram Nova STT API, requires ``DEEPGRAM_API_KEY``.
   - **mistral** — Mistral Voxtral Transcribe API, requires ``MISTRAL_API_KEY``.
   - **xai** — xAI Grok STT API, requires ``XAI_API_KEY``. High accuracy,
     Inverse Text Normalization, diarization, 21 languages.
@@ -27,6 +28,7 @@ Usage::
 """
 
 import logging
+import mimetypes
 import os
 import shlex
 import shutil
@@ -35,6 +37,8 @@ import tempfile
 from pathlib import Path
 from typing import Optional, Dict, Any
 from urllib.parse import urljoin
+
+import requests
 
 from utils import is_truthy_value
 from tools.managed_tool_gateway import resolve_managed_tool_gateway
@@ -88,6 +92,7 @@ DEFAULT_LOCAL_STT_LANGUAGE = "en"
 DEFAULT_STT_MODEL = os.getenv("STT_OPENAI_MODEL", "whisper-1")
 DEFAULT_GROQ_STT_MODEL = os.getenv("STT_GROQ_MODEL", "whisper-large-v3-turbo")
 DEFAULT_MISTRAL_STT_MODEL = os.getenv("STT_MISTRAL_MODEL", "voxtral-mini-latest")
+DEFAULT_DEEPGRAM_STT_MODEL = os.getenv("STT_DEEPGRAM_MODEL", "nova-3")
 LOCAL_STT_COMMAND_ENV = "HERMES_LOCAL_STT_COMMAND"
 LOCAL_STT_LANGUAGE_ENV = "HERMES_LOCAL_STT_LANGUAGE"
 COMMON_LOCAL_BIN_DIRS = ("/opt/homebrew/bin", "/usr/local/bin")
@@ -95,6 +100,7 @@ COMMON_LOCAL_BIN_DIRS = ("/opt/homebrew/bin", "/usr/local/bin")
 GROQ_BASE_URL = os.getenv("GROQ_BASE_URL", "https://api.groq.com/openai/v1")
 OPENAI_BASE_URL = os.getenv("STT_OPENAI_BASE_URL", "https://api.openai.com/v1")
 XAI_STT_BASE_URL = os.getenv("XAI_STT_BASE_URL", "https://api.x.ai/v1")
+DEEPGRAM_STT_BASE_URL = os.getenv("DEEPGRAM_STT_BASE_URL", "https://api.deepgram.com/v1")
 
 SUPPORTED_FORMATS = {".mp3", ".mp4", ".mpeg", ".mpga", ".m4a", ".wav", ".webm", ".ogg", ".aac", ".flac"}
 LOCAL_NATIVE_AUDIO_FORMATS = {".wav", ".aiff", ".aif"}
@@ -805,6 +811,14 @@ def _get_provider(stt_config: dict) -> str:
             )
             return "none"
 
+        if provider == "deepgram":
+            if get_env_value("DEEPGRAM_API_KEY"):
+                return "deepgram"
+            logger.warning(
+                "STT provider 'deepgram' configured but DEEPGRAM_API_KEY not set"
+            )
+            return "none"
+
         if provider == "xai":
             from tools.xai_http import resolve_xai_http_credentials
 
@@ -1395,6 +1409,100 @@ def _transcribe_mistral(file_path: str, model_name: str) -> Dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+# Provider: Deepgram (Nova STT API)
+# ---------------------------------------------------------------------------
+
+
+def _deepgram_bool(value: Any) -> str:
+    return "true" if is_truthy_value(value, default=True) else "false"
+
+
+def _extract_deepgram_transcript(payload: Dict[str, Any]) -> str:
+    try:
+        channels = payload.get("results", {}).get("channels", [])
+        alternatives = channels[0].get("alternatives", []) if channels else []
+        transcript = alternatives[0].get("transcript", "") if alternatives else ""
+        return str(transcript).strip()
+    except (AttributeError, IndexError, TypeError):
+        return ""
+
+
+def _transcribe_deepgram(file_path: str, model_name: str) -> Dict[str, Any]:
+    """Transcribe using Deepgram's pre-recorded ``POST /v1/listen`` API.
+
+    Requires ``DEEPGRAM_API_KEY``. Deepgram is intentionally explicit opt-in:
+    configure ``stt.provider: deepgram`` rather than relying on auto-detect.
+    """
+    api_key = get_env_value("DEEPGRAM_API_KEY")
+    if not api_key:
+        return {"success": False, "transcript": "", "error": "DEEPGRAM_API_KEY not set"}
+
+    stt_config = _load_stt_config()
+    deepgram_cfg = stt_config.get("deepgram", {})
+    base_url = str(
+        deepgram_cfg.get("base_url")
+        or get_env_value("DEEPGRAM_STT_BASE_URL")
+        or DEEPGRAM_STT_BASE_URL
+    ).strip().rstrip("/")
+
+    params: Dict[str, str] = {
+        "model": model_name,
+        "smart_format": _deepgram_bool(deepgram_cfg.get("smart_format", True)),
+        "punctuate": _deepgram_bool(deepgram_cfg.get("punctuate", True)),
+    }
+    language = str(deepgram_cfg.get("language") or "").strip()
+    if language:
+        params["language"] = language
+    if "diarize" in deepgram_cfg:
+        params["diarize"] = _deepgram_bool(deepgram_cfg.get("diarize"))
+
+    timeout = deepgram_cfg.get("timeout", 120)
+    try:
+        timeout = float(timeout)
+    except (TypeError, ValueError):
+        timeout = 120
+
+    content_type, _ = mimetypes.guess_type(file_path)
+    headers = {
+        "Authorization": f"Token {api_key}",
+        "Content-Type": content_type or "application/octet-stream",
+    }
+
+    try:
+        with open(file_path, "rb") as audio_file:
+            response = requests.post(
+                f"{base_url}/listen",
+                headers=headers,
+                params=params,
+                data=audio_file,
+                timeout=timeout,
+            )
+        response.raise_for_status()
+        payload = response.json()
+        transcript_text = _extract_deepgram_transcript(payload)
+        if not transcript_text:
+            return {
+                "success": False,
+                "transcript": "",
+                "error": "Deepgram STT returned empty transcript",
+            }
+
+        logger.info(
+            "Transcribed %s via Deepgram STT (%s, %d chars)",
+            Path(file_path).name,
+            model_name,
+            len(transcript_text),
+        )
+        return {"success": True, "transcript": transcript_text, "provider": "deepgram"}
+
+    except PermissionError:
+        return {"success": False, "transcript": "", "error": f"Permission denied: {file_path}"}
+    except Exception as e:
+        logger.error("Deepgram STT transcription failed: %s", e, exc_info=True)
+        return {"success": False, "transcript": "", "error": f"Deepgram STT transcription failed: {e}"}
+
+
+# ---------------------------------------------------------------------------
 # Provider: xAI (Grok STT API)
 # ---------------------------------------------------------------------------
 
@@ -1569,6 +1677,11 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
         model_name = model or mistral_cfg.get("model", DEFAULT_MISTRAL_STT_MODEL)
         return _transcribe_mistral(file_path, model_name)
 
+    if provider == "deepgram":
+        deepgram_cfg = stt_config.get("deepgram", {})
+        model_name = model or deepgram_cfg.get("model", DEFAULT_DEEPGRAM_STT_MODEL)
+        return _transcribe_deepgram(file_path, model_name)
+
     if provider == "xai":
         # xAI Grok STT doesn't use a model parameter — pass through for logging
         model_name = model or "grok-stt"
@@ -1623,7 +1736,8 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
         "error": (
             "No STT provider available. Install faster-whisper for free local "
             f"transcription, configure {LOCAL_STT_COMMAND_ENV} or install a local whisper CLI, "
-            "set GROQ_API_KEY for free Groq Whisper, set MISTRAL_API_KEY for Mistral "
+            "set GROQ_API_KEY for free Groq Whisper, set DEEPGRAM_API_KEY and "
+            "stt.provider=deepgram for Deepgram Nova STT, set MISTRAL_API_KEY for Mistral "
             "Voxtral Transcribe, configure xAI OAuth or set XAI_API_KEY for xAI Grok STT, or set VOICE_TOOLS_OPENAI_KEY "
             "or OPENAI_API_KEY for the OpenAI Whisper API."
         ),

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -2,14 +2,14 @@
 """
 Transcription Tools Module
 
-Provides speech-to-text transcription with seven providers:
+Provides speech-to-text transcription with several providers:
 
   - **local** (default, free) — faster-whisper running locally, no API key needed.
     Auto-downloads the model (~150 MB for ``base``) on first use.
   - **groq** (free tier) — Groq Whisper API, requires ``GROQ_API_KEY``.
   - **openai** (paid) — OpenAI Whisper API, requires ``VOICE_TOOLS_OPENAI_KEY``.
-  - **deepgram** — Deepgram Nova STT API, requires ``DEEPGRAM_API_KEY``.
   - **mistral** — Mistral Voxtral Transcribe API, requires ``MISTRAL_API_KEY``.
+  - **deepgram** — Deepgram Speech-to-Text API, requires ``DEEPGRAM_API_KEY``.
   - **xai** — xAI Grok STT API, requires ``XAI_API_KEY``. High accuracy,
     Inverse Text Normalization, diarization, 21 languages.
 
@@ -1413,15 +1413,20 @@ def _transcribe_mistral(file_path: str, model_name: str) -> Dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def _deepgram_bool(value: Any) -> str:
-    return "true" if is_truthy_value(value, default=True) else "false"
+def _deepgram_bool(value: Any, default: bool = True) -> str:
+    return "true" if is_truthy_value(value, default=default) else "false"
 
 
 def _extract_deepgram_transcript(payload: Dict[str, Any]) -> str:
     try:
         channels = payload.get("results", {}).get("channels", [])
         alternatives = channels[0].get("alternatives", []) if channels else []
-        transcript = alternatives[0].get("transcript", "") if alternatives else ""
+        alt0 = alternatives[0] if alternatives else {}
+        paragraphs = alt0.get("paragraphs") or {}
+        paragraph_text = paragraphs.get("transcript")
+        if isinstance(paragraph_text, str) and paragraph_text.strip():
+            return paragraph_text.strip()
+        transcript = alt0.get("transcript", "")
         return str(transcript).strip()
     except (AttributeError, IndexError, TypeError):
         return ""
@@ -1453,8 +1458,12 @@ def _transcribe_deepgram(file_path: str, model_name: str) -> Dict[str, Any]:
     language = str(deepgram_cfg.get("language") or "").strip()
     if language:
         params["language"] = language
-    if "diarize" in deepgram_cfg:
-        params["diarize"] = _deepgram_bool(deepgram_cfg.get("diarize"))
+    for optional_bool in ("diarize", "paragraphs", "utterances", "numerals", "dictation", "detect_language"):
+        if optional_bool in deepgram_cfg:
+            params[optional_bool] = _deepgram_bool(
+                deepgram_cfg.get(optional_bool),
+                default=False,
+            )
 
     timeout = deepgram_cfg.get("timeout", 120)
     try:
@@ -1477,9 +1486,22 @@ def _transcribe_deepgram(file_path: str, model_name: str) -> Dict[str, Any]:
                 data=audio_file,
                 timeout=timeout,
             )
+        status_code = getattr(response, "status_code", 200)
+        if isinstance(status_code, int) and status_code != 200:
+            detail = response.text[:500]
+            try:
+                err_body = response.json()
+                detail = err_body.get("err_msg") or err_body.get("message") or detail
+            except Exception:
+                pass
+            return {
+                "success": False,
+                "transcript": "",
+                "error": f"Deepgram STT API error (HTTP {status_code}): {detail}",
+            }
         response.raise_for_status()
-        payload = response.json()
-        transcript_text = _extract_deepgram_transcript(payload)
+
+        transcript_text = _extract_deepgram_transcript(response.json())
         if not transcript_text:
             return {
                 "success": False,

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -9,6 +9,7 @@ Built-in TTS providers:
 - MiniMax TTS: High-quality with voice cloning, needs MINIMAX_API_KEY
 - Mistral (Voxtral TTS): Multilingual, native Opus, needs MISTRAL_API_KEY
 - Google Gemini TTS: Controllable, 30 prebuilt voices, needs GEMINI_API_KEY
+- Deepgram Aura TTS: Many Aura voices, native Opus, needs DEEPGRAM_API_KEY
 - xAI TTS: Grok voices, uses xAI Grok OAuth credentials or XAI_API_KEY
 - NeuTTS (local, free, no API key): On-device TTS via neutts
 - KittenTTS (local, free, no API key): On-device 25MB model
@@ -177,6 +178,8 @@ DEFAULT_XAI_BASE_URL = "https://api.x.ai/v1"
 DEFAULT_GEMINI_TTS_MODEL = "gemini-2.5-flash-preview-tts"
 DEFAULT_GEMINI_TTS_VOICE = "Kore"
 DEFAULT_GEMINI_TTS_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
+DEFAULT_DEEPGRAM_TTS_MODEL = "aura-2-thalia-en"
+DEFAULT_DEEPGRAM_TTS_BASE_URL = "https://api.deepgram.com/v1"
 # PCM output specs for Gemini TTS (fixed by the API)
 GEMINI_TTS_SAMPLE_RATE = 24000
 GEMINI_TTS_CHANNELS = 1
@@ -202,6 +205,7 @@ PROVIDER_MAX_TEXT_LENGTH: Dict[str, int] = {
     "minimax": 10000,     # https://platform.minimax.io/docs/api-reference/speech-t2a-http (sync)
     "mistral": 4000,      # conservative; no published per-request cap
     "gemini": 5000,       # Gemini TTS caps at ~8k input tokens / ~655s audio
+    "deepgram": 4000,     # conservative; Deepgram recommends chunking long text
     "elevenlabs": 10000,  # fallback when model-aware lookup can't resolve (multilingual_v2)
     "neutts": 2000,       # local model, quality falls off on long text
     "kittentts": 2000,    # local 25MB model
@@ -349,6 +353,7 @@ BUILTIN_TTS_PROVIDERS = frozenset({
     "xai",
     "mistral",
     "gemini",
+    "deepgram",
     "neutts",
     "kittentts",
     "piper",
@@ -1162,6 +1167,65 @@ def _generate_xai_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -
 
 
 # ===========================================================================
+# Provider: Deepgram Aura TTS
+# ===========================================================================
+def _generate_deepgram_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """Generate audio using Deepgram's Text-to-Speech REST API."""
+    import requests
+
+    api_key = (get_env_value("DEEPGRAM_API_KEY") or "").strip()
+    if not api_key:
+        raise ValueError("DEEPGRAM_API_KEY not set. Get one at https://console.deepgram.com/")
+
+    dg_config = tts_config.get("deepgram", {})
+    model = str(dg_config.get("model", DEFAULT_DEEPGRAM_TTS_MODEL)).strip() or DEFAULT_DEEPGRAM_TTS_MODEL
+    base_url = str(
+        dg_config.get("base_url")
+        or get_env_value("DEEPGRAM_TTS_BASE_URL")
+        or DEFAULT_DEEPGRAM_TTS_BASE_URL
+    ).strip().rstrip("/")
+
+    params: Dict[str, Any] = {"model": model}
+    lower_output = output_path.lower()
+    if lower_output.endswith(".ogg"):
+        params.update({"encoding": "opus", "container": "ogg"})
+    elif lower_output.endswith(".wav"):
+        params.update({"encoding": "linear16", "container": "wav"})
+
+    for key in ("encoding", "container", "sample_rate", "bit_rate", "speed"):
+        value = dg_config.get(key)
+        if value not in (None, ""):
+            params[key] = value
+
+    response = requests.post(
+        f"{base_url}/speak",
+        headers={
+            "Authorization": f"Token {api_key}",
+            "Content-Type": "application/json",
+        },
+        params=params,
+        json={"text": text},
+        timeout=60,
+    )
+
+    if response.status_code != 200:
+        detail = response.text[:500]
+        try:
+            err_body = response.json()
+            detail = err_body.get("err_msg") or err_body.get("message") or detail
+        except Exception:
+            pass
+        raise RuntimeError(
+            f"Deepgram TTS API error (HTTP {response.status_code}): {detail}"
+        )
+
+    with open(output_path, "wb") as f:
+        f.write(response.content)
+
+    return output_path
+
+
+# ===========================================================================
 # Provider: MiniMax TTS
 # ===========================================================================
 def _generate_minimax_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
@@ -1909,7 +1973,7 @@ def text_to_speech_tool(
             file_path = out_dir / f"tts_{timestamp}.{fmt}"
         # Use .ogg for Telegram with providers that support native Opus output,
         # otherwise fall back to .mp3 (Edge TTS will attempt ffmpeg conversion later).
-        elif want_opus and provider in {"openai", "elevenlabs", "mistral", "gemini"}:
+        elif want_opus and provider in {"openai", "elevenlabs", "mistral", "gemini", "deepgram"}:
             file_path = out_dir / f"tts_{timestamp}.ogg"
         else:
             file_path = out_dir / f"tts_{timestamp}.mp3"
@@ -1993,6 +2057,10 @@ def text_to_speech_tool(
         elif provider == "gemini":
             logger.info("Generating speech with Google Gemini TTS...")
             _generate_gemini_tts(text, file_str, tts_config)
+
+        elif provider == "deepgram":
+            logger.info("Generating speech with Deepgram Aura TTS...")
+            _generate_deepgram_tts(text, file_str, tts_config)
 
         elif provider == "neutts":
             if not _check_neutts_available():
@@ -2102,7 +2170,7 @@ def text_to_speech_tool(
             if opus_path:
                 file_str = opus_path
                 voice_compatible = True
-        elif provider in {"elevenlabs", "openai", "mistral", "gemini"}:
+        elif provider in {"elevenlabs", "openai", "mistral", "gemini", "deepgram"}:
             voice_compatible = want_opus and file_str.endswith(".ogg")
 
         file_size = os.path.getsize(file_str)
@@ -2182,6 +2250,8 @@ def check_tts_requirements() -> bool:
     except Exception:
         pass
     if get_env_value("GEMINI_API_KEY") or get_env_value("GOOGLE_API_KEY"):
+        return True
+    if get_env_value("DEEPGRAM_API_KEY"):
         return True
     try:
         _import_mistral_client()

--- a/website/docs/integrations/index.md
+++ b/website/docs/integrations/index.md
@@ -68,7 +68,7 @@ Text-to-speech and speech-to-text across all messaging platforms:
 | **xAI TTS** | Good | Paid | `XAI_API_KEY` |
 | **NeuTTS** | Good | Free | None needed |
 
-Speech-to-text supports six providers: local faster-whisper (free, runs on-device), a local command wrapper, Groq, OpenAI Whisper API, Mistral, and xAI. Voice message transcription works across Telegram, Discord, WhatsApp, and other messaging platforms. See [Voice & TTS](/user-guide/features/tts) and [Voice Mode](/user-guide/features/voice-mode) for details.
+Speech-to-text supports seven providers: local faster-whisper (free, runs on-device), a local command wrapper, Groq, OpenAI Whisper API, Deepgram Nova, Mistral, and xAI. Voice message transcription works across Telegram, Discord, WhatsApp, and other messaging platforms. See [Voice & TTS](/user-guide/features/tts) and [Voice Mode](/user-guide/features/voice-mode) for details.
 
 ## IDE & Editor Integration
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1319,11 +1319,16 @@ Hashes are deterministic — the same user always maps to the same hash, so the 
 
 ```yaml
 stt:
-  provider: "local"            # "local" | "groq" | "openai" | "mistral"
+  provider: "local"            # "local" | "groq" | "openai" | "deepgram" | "mistral"
   local:
     model: "base"              # tiny, base, small, medium, large-v3
   openai:
     model: "whisper-1"         # whisper-1 | gpt-4o-mini-transcribe | gpt-4o-transcribe
+  deepgram:
+    model: "nova-3"            # nova-3 | nova-2 | nova-2-phonecall | nova-2-meeting
+    language: ""               # optional BCP-47 language tag; empty = Deepgram default
+    smart_format: true
+    punctuate: true
   # model: "whisper-1"         # Legacy fallback key still respected
 ```
 
@@ -1332,8 +1337,9 @@ Provider behavior:
 - `local` uses `faster-whisper` running on your machine. Install it separately with `pip install faster-whisper`.
 - `groq` uses Groq's Whisper-compatible endpoint and reads `GROQ_API_KEY`.
 - `openai` uses the OpenAI speech API and reads `VOICE_TOOLS_OPENAI_KEY`.
+- `deepgram` uses Deepgram's pre-recorded `/v1/listen` API and reads `DEEPGRAM_API_KEY`. It is explicit opt-in: set `stt.provider: deepgram`.
 
-If the requested provider is unavailable, Hermes falls back automatically in this order: `local` → `groq` → `openai`.
+If no provider is explicitly configured, Hermes auto-detects in this order: `local` → `groq` → `openai` → `xai`.
 
 Groq and OpenAI model overrides are environment-driven:
 

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -386,6 +386,7 @@ Voice messages sent on Telegram, Discord, WhatsApp, Slack, or Signal are automat
 | **Local Whisper** (default) | Good | Free | None needed |
 | **Groq Whisper API** | Good–Best | Free tier | `GROQ_API_KEY` |
 | **OpenAI Whisper API** | Good–Best | Paid | `VOICE_TOOLS_OPENAI_KEY` or `OPENAI_API_KEY` |
+| **Deepgram Nova API** | Good–Best | Paid / trial credits | `DEEPGRAM_API_KEY` |
 
 :::info Zero Config
 Local transcription works out of the box when `faster-whisper` is installed. If that's unavailable, Hermes can also use a local `whisper` CLI from common install locations (like `/opt/homebrew/bin`) or a custom command via `HERMES_LOCAL_STT_COMMAND`.
@@ -396,11 +397,16 @@ Local transcription works out of the box when `faster-whisper` is installed. If 
 ```yaml
 # In ~/.hermes/config.yaml
 stt:
-  provider: "local"           # "local" | "groq" | "openai" | "mistral" | "xai"
+  provider: "local"           # "local" | "groq" | "openai" | "deepgram" | "mistral" | "xai"
   local:
     model: "base"             # tiny, base, small, medium, large-v3
   openai:
     model: "whisper-1"        # whisper-1, gpt-4o-mini-transcribe, gpt-4o-transcribe
+  deepgram:
+    model: "nova-3"           # nova-3, nova-2, nova-2-phonecall, nova-2-meeting
+    language: ""              # optional BCP-47 language tag; empty = Deepgram default
+    smart_format: true
+    punctuate: true
   mistral:
     model: "voxtral-mini-latest"  # voxtral-mini-latest, voxtral-mini-2602
   xai:
@@ -422,6 +428,8 @@ stt:
 **Groq API** — Requires `GROQ_API_KEY`. Good cloud fallback when you want a free hosted STT option.
 
 **OpenAI API** — Accepts `VOICE_TOOLS_OPENAI_KEY` first and falls back to `OPENAI_API_KEY`. Supports `whisper-1`, `gpt-4o-mini-transcribe`, and `gpt-4o-transcribe`.
+
+**Deepgram API** — Requires `DEEPGRAM_API_KEY` and explicitly setting `stt.provider: deepgram`. Calls Deepgram's pre-recorded `/v1/listen` endpoint with `smart_format` and `punctuate` enabled by default. Uses `nova-3` unless you set `stt.deepgram.model`.
 
 **Mistral API (Voxtral Transcribe)** — Requires `MISTRAL_API_KEY`. Uses Mistral's [Voxtral Transcribe](https://docs.mistral.ai/capabilities/audio/speech_to_text/) models. Supports 13 languages, speaker diarization, and word-level timestamps. Install with `pip install hermes-agent[mistral]`.
 


### PR DESCRIPTION
## Summary
- adds Deepgram as a native STT provider selected via `stt.provider: deepgram`
- adds Deepgram Aura as a TTS provider selected via `tts.provider: deepgram`
- wires `DEEPGRAM_API_KEY` into default config, optional env metadata, `hermes tools`, and `hermes status`
- documents Deepgram STT/TTS in the voice docs and integration/configuration pages
- intentionally leaves `hermes setup tts` wizard integration out of this PR so the runtime provider change stays narrow and does not trip the repository supply-chain guard on `*/setup.py` changes

## Behavior
- STT is explicit opt-in only. Hermes does **not** auto-switch to paid Deepgram STT just because `DEEPGRAM_API_KEY` exists.
- STT calls Deepgram pre-recorded `POST /v1/listen` with `Authorization: Token <DEEPGRAM_API_KEY>`.
- STT uses Hermes `get_env_value()`, so keys stored in `~/.hermes/.env` work the same as process env vars.
- TTS calls Deepgram `POST /v1/speak` with `Authorization: Token <DEEPGRAM_API_KEY>`.
- Telegram TTS voice delivery requests native OGG/Opus from Deepgram instead of requiring ffmpeg conversion.

## Why this is not a duplicate of #13852
- rebased on current `main`; #13852 is stale/conflicting
- preserves explicit STT opt-in instead of adding Deepgram to automatic paid fallback
- uses Hermes dotenv-aware key resolution instead of direct `os.getenv()` for provider availability/runtime
- keeps setup-wizard changes out of scope for a cleaner provider/runtime PR
- includes setup/tools/status-adjacent CLI integration and current test coverage against the existing dispatcher signatures

## Related work
- Fixes #10703 for TTS support
- Related to #13852, which is broader but currently stale/conflicting
- Related to #10734, the earlier closed TTS-only PR
- Compatible with #30493; if the STT plugin hook lands first, this can be split or adapted

## Test plan
- `/usr/local/lib/hermes-agent/venv/bin/python -m ruff check tools/transcription_tools.py tools/tts_tool.py hermes_cli/config.py hermes_cli/status.py hermes_cli/tools_config.py tests/tools/test_transcription_tools.py tests/tools/test_tts_deepgram.py tests/tools/test_tts_dotenv_fallback.py tests/tools/test_tts_max_text_length.py` — passes
- `/usr/local/lib/hermes-agent/venv/bin/python -m pytest -q -o addopts="" tests/tools/test_transcription_tools.py tests/tools/test_transcription.py tests/tools/test_transcription_dotenv_fallback.py tests/tools/test_tts_deepgram.py tests/tools/test_tts_dotenv_fallback.py tests/tools/test_tts_max_text_length.py` — 183 passed
- `/usr/local/lib/hermes-agent/venv/bin/python -m pytest -q -o addopts="" tests/hermes_cli/test_config.py tests/hermes_cli/test_config_validation.py tests/hermes_cli/test_config_drift.py tests/hermes_cli/test_config_env_refs.py tests/hermes_cli/test_config_env_expansion.py tests/cli/test_cli_tools_command.py` — 106 passed
- `git diff --check upstream/main...HEAD` — passes

## Sources
- Deepgram pre-recorded STT API: https://developers.deepgram.com/reference/speech-to-text/listen-pre-recorded
- Deepgram TTS API: https://developers.deepgram.com/reference/text-to-speech/speak-request
- Deepgram API authentication: https://developers.deepgram.com/reference/authentication
- Deepgram TTS container/encoding options: https://developers.deepgram.com/docs/tts-container