### PR TITLE
fix(email): apply existing thread_id session mechanism to email

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -182,6 +182,49 @@ def _extract_email_address(raw: str) -> str:
     return raw.strip().lower()
 
 
+def _extract_email_thread_id(msg: email_lib.message.Message) -> Optional[str]:
+    """
+    Extract a stable thread identifier from an inbound email's RFC 5322 headers.
+
+    Strategy (Root ID via References):
+      1. References header present → take the FIRST <message-id> in the list.
+         This is the root of the conversation; it's preserved by virtually all
+         RFC-compliant MUAs (Gmail, Outlook, Apple Mail, Thunderbird) even when
+         the References list is truncated on very long threads.
+      2. References missing but In-Reply-To present → use that as a fallback
+         for older MUAs (notably legacy Outlook) that don't emit References.
+      3. Neither present → this is the first message of a new thread.
+         Use the message's own Message-ID; subsequent replies will echo it
+         back in their References header.
+      4. Nothing usable → return None (caller falls back to chat_id-only session).
+
+    The returned ID is stripped of angle brackets, casing preserved.
+    """
+    def _first_id(header_value: str) -> Optional[str]:
+        matches = re.findall(r"<([^<>\s]+)>", header_value)
+        return matches[0] if matches else None
+
+    references = msg.get("References", "")
+    if references:
+        root_id = _first_id(references)
+        if root_id:
+            return root_id
+
+    in_reply_to = msg.get("In-Reply-To", "")
+    if in_reply_to:
+        parent_id = _first_id(in_reply_to)
+        if parent_id:
+            return parent_id
+
+    own_id = msg.get("Message-ID") or msg.get("Message-Id") or ""
+    if own_id:
+        root_id = _first_id(own_id)
+        if root_id:
+            return root_id
+
+    return None
+
+
 def _extract_attachments(
     msg: email_lib.message.Message,
     skip_attachments: bool = False,
@@ -400,6 +443,14 @@ class EmailAdapter(BasePlatformAdapter):
                     subject = _decode_header_value(msg.get("Subject", "(no subject)"))
                     message_id = msg.get("Message-ID", "")
                     in_reply_to = msg.get("In-Reply-To", "")
+                    # Extract conversation root ID for per-thread session isolation.
+                    # See _extract_email_thread_id for the strategy.
+                    thread_id = _extract_email_thread_id(msg)
+                    # Capture the full References chain so outbound replies can
+                    # extend it properly (RFC 5322 §3.6.4), instead of overwriting
+                    # it with just the parent Message-ID. Without this, threads
+                    # break after a few back-and-forth exchanges.
+                    references_chain = msg.get("References", "")
                     # Skip automated/noreply senders before any processing
                     msg_headers = dict(msg.items())
                     if _is_automated_sender(sender_addr, msg_headers):
@@ -415,6 +466,8 @@ class EmailAdapter(BasePlatformAdapter):
                         "subject": subject,
                         "message_id": message_id,
                         "in_reply_to": in_reply_to,
+                        "thread_id": thread_id,
+                        "references": references_chain,
                         "body": body,
                         "attachments": attachments,
                         "date": msg.get("Date", ""),
@@ -477,7 +530,28 @@ class EmailAdapter(BasePlatformAdapter):
         self._thread_context[sender_addr] = {
             "subject": subject,
             "message_id": msg_data["message_id"],
+            "references": msg_data.get("references", ""),
         }
+
+        thread_id = msg_data.get("thread_id")
+
+        # FIX: If this is a reply to a Hermes-initiated email (no References header,
+        # but In-Reply-To matches a hermes_root_id we stored), use that root id
+        # so we land in the existing session instead of creating a new one.
+        if not thread_id:
+            in_reply_to = msg_data.get("in_reply_to", "").strip("<>")
+            known_root = self._thread_context.get(sender_addr, {}).get("hermes_root_id", "")
+            if in_reply_to and known_root and in_reply_to == known_root:
+                thread_id = known_root
+                logger.debug("[Email] Matched hermes_root_id=%s for %s → reusing session", thread_id, sender_addr)
+
+        logger.debug(
+            "[Email] Thread routing: from=%s message_id=%s in_reply_to=%s thread_id=%s",
+            sender_addr,
+            msg_data.get("message_id") or "(none)",
+            msg_data.get("in_reply_to") or "(none)",
+            thread_id or "(none, chat_id-only)",
+        )
 
         source = self.build_source(
             chat_id=sender_addr,
@@ -485,6 +559,7 @@ class EmailAdapter(BasePlatformAdapter):
             chat_type="dm",
             user_id=sender_addr,
             user_name=msg_data["sender_name"] or sender_addr,
+            thread_id=thread_id,
         )
 
         event = MessageEvent(
@@ -536,15 +611,33 @@ class EmailAdapter(BasePlatformAdapter):
             subject = f"Re: {subject}"
         msg["Subject"] = subject
 
-        # Threading headers
+        # Threading headers — RFC 5322 §3.6.4 compliant chaining.
+        # In-Reply-To = parent's Message-ID (single value).
+        # References = parent's References chain + parent's Message-ID.
+        # If parent has no References (it was the thread root), References
+        # equals just the parent's Message-ID.
+        # Without this chaining, the inbound References on subsequent replies
+        # would drift, breaking per-thread session isolation downstream.
         original_msg_id = reply_to_msg_id or ctx.get("message_id")
         if original_msg_id:
             msg["In-Reply-To"] = original_msg_id
-            msg["References"] = original_msg_id
+            parent_references = ctx.get("references", "").strip()
+            if parent_references:
+                msg["References"] = f"{parent_references} {original_msg_id}"
+            else:
+                msg["References"] = original_msg_id
 
         msg["Date"] = formatdate(localtime=True)
         msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._address.split('@')[1]}>"
         msg["Message-ID"] = msg_id
+
+        # FIX: When Hermes initiates a thread (no prior context), store its own
+        # Message-ID as the thread root so the first human reply — which will
+        # carry In-Reply-To: <this msg_id> — can be matched back to this session.
+        if not ctx.get("hermes_root_id"):
+            bare_id = msg_id.strip("<>")
+            self._thread_context.setdefault(to_addr, {})["hermes_root_id"] = bare_id
+            logger.debug("[Email] Stored hermes_root_id=%s for %s", bare_id, to_addr)
 
         msg.attach(MIMEText(body, "plain", "utf-8"))
 
@@ -646,10 +739,15 @@ class EmailAdapter(BasePlatformAdapter):
             subject = f"Re: {subject}"
         msg["Subject"] = subject
 
+        # Threading headers — RFC 5322 §3.6.4 compliant chaining.
         original_msg_id = ctx.get("message_id")
         if original_msg_id:
             msg["In-Reply-To"] = original_msg_id
-            msg["References"] = original_msg_id
+            parent_references = ctx.get("references", "").strip()
+            if parent_references:
+                msg["References"] = f"{parent_references} {original_msg_id}"
+            else:
+                msg["References"] = original_msg_id
 
         msg["Date"] = formatdate(localtime=True)
         msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._address.split('@')[1]}>"
@@ -727,10 +825,15 @@ class EmailAdapter(BasePlatformAdapter):
             subject = f"Re: {subject}"
         msg["Subject"] = subject
 
+        # Threading headers — RFC 5322 §3.6.4 compliant chaining.
         original_msg_id = ctx.get("message_id")
         if original_msg_id:
             msg["In-Reply-To"] = original_msg_id
-            msg["References"] = original_msg_id
+            parent_references = ctx.get("references", "").strip()
+            if parent_references:
+                msg["References"] = f"{parent_references} {original_msg_id}"
+            else:
+                msg["References"] = original_msg_id
 
         msg["Date"] = formatdate(localtime=True)
         msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._address.split('@')[1]}>"


### PR DESCRIPTION
The gateway already isolates sessions per conversation on thread-aware platforms — Telegram (forum topics), Discord (threads), Slack (thread_ts) all pass a thread_id to build_source(), which build_session_key() uses to keep parallel conversations separate.

The email adapter wasn't using this mechanism. Every message from a given sender collapsed onto the same session, regardless of which thread it belonged to.

This commit applies the same pattern to email: it uses the root email's Message-ID (extracted from the References header per RFC 5322 §3.6.4) as the thread_id. Each email thread now gets its own session, the same way each Telegram topic or Slack thread already does.

Also fixes the outbound References header, which was overwritten with the parent's Message-ID instead of being extended per RFC 5322 §3.6.4.

Tested with Gmail across multi-turn threads.

## What does this PR do?

Hermes already has a mechanism to bind a session to a specific conversation on thread-aware platforms — Telegram (forum topics), Discord (threads), Slack (`thread_ts`) all pass a `thread_id` to `build_source()`, and the gateway's `build_session_key()` uses it to keep parallel conversations isolated.

The email adapter wasn't using this mechanism. Every message from a given sender — regardless of which thread it belonged to — collapsed onto the same session.

This PR applies the same pattern to email: it uses the root email's `Message-ID` (extracted from the `References` header per RFC 5322 §3.6.4) as the `thread_id`, so each email thread gets its own session, the same way each Telegram topic or Slack thread already does.

### Design choice: Root ID vs Parent ID

The helper deliberately returns the **first** ID in `References` (the conversation root) rather than `In-Reply-To` (the immediate parent).

Root ID is also more resilient: RFC-compliant MUAs preserve the first `References` entry even when they truncate the middle of the chain on very long threads. Parsing uses `re.findall(r"<([^<>\s]+)>", ...)` rather than splitting on whitespace, since some MUAs emit IDs without separators. Angle brackets are stripped so the ID is usable directly as a session-key component; casing is preserved (RFC 5322 treats the local-part as case-sensitive).

### Fallback chain

`_extract_email_thread_id(msg)` follows a 4-step fallback:

1. First `<message-id>` in `References` (Gmail, Outlook, Apple Mail, Thunderbird all preserve this even when truncating long chains)
2. `In-Reply-To` (for legacy Outlook which doesn't emit `References`)
3. The message's own `Message-ID` (first message of a new thread)
4. `None` — caller falls back to chat_id-only session, i.e. previous behavior

### Hermes-initiated threads

Scenario: you're in Hermes TUI (an active session exists). You ask Hermes to send you an email. You reply to that email — your reply becomes the root email of the thread and creates a second session. All subsequent messages from Hermes or from you stay in that second session.

For this to work, `_send_email` stores its own `Message-ID` as `hermes_root_id` in the thread context. When your reply arrives, if `thread_id` is unresolved but `In-Reply-To` matches the stored `hermes_root_id`, the message is routed to the second session — and stays there for all follow-ups in the thread.

## Related Issue

<!-- No existing issue — happy to file one if useful. -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

All changes are in `gateway/platforms/email.py`:

- **New helper** `_extract_email_thread_id(msg)` — extracts a stable thread root from RFC 5322 headers via the 4-step fallback above.
- **`_fetch_new_messages`** — captures `thread_id` and the raw `references_chain` alongside the other inbound metadata.
- **`_dispatch_message`** — stores `references` in `_thread_context`, resolves `thread_id` (with the `hermes_root_id` fallback for replies to Hermes-initiated threads), passes it to `build_source()`, and logs the routing decision at `debug` level.
- **`_send_email`** — extends the inbound `References` chain (chain + parent Message-ID) instead of overwriting it; stores `hermes_root_id` on first outbound message of a thread.
- **`_send_email_with_attachment`** and **`_send_email_with_attachments`** — same `References` chaining fix.

No public API changes. No changes outside `gateway/platforms/email.py`.

## How to Test

1. Configure the email gateway against a Gmail account (`EMAIL_*` env vars).
2. Send Hermes a first email on topic A → a new session is created.
3. Reply within that thread a few times → all replies land in the same session (visible in `gateway.log` with `[Email] Thread routing: ... thread_id=<id>`).
4. Send a brand-new email on topic B from the same sender → a separate session is created (different `thread_id`).
5. Have Hermes initiate a new thread (`send_message`), then reply to that email → the reply matches back to the originating session via `hermes_root_id` (visible in `gateway.log` with `[Email] Matched hermes_root_id=...`).

When `thread_id` resolves to `None` (malformed mail, no usable headers), behavior falls back to the previous chat_id-only session — no regression on the previous baseline.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(email): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04, Gmail IMAP/SMTP

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings on the new helper) — no README/docs/ changes needed
- [x] N/A — no config keys added/changed
- [x] N/A — no architecture or workflow changes
- [x] N/A — change is platform-agnostic (pure Python, no OS-specific code)
- [x] N/A — no tool descriptions/schemas changed


