### PR TITLE
fix(agent): forward reasoning_config to background review AIAgent fork

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -390,6 +390,7 @@ def _run_review_in_thread(
                 credential_pool=getattr(agent, "_credential_pool", None),
                 parent_session_id=agent.session_id,
                 skip_memory=True,
+                reasoning_config=getattr(agent, "reasoning_config", None),
             )
             review_agent._memory_write_origin = "background_review"
             review_agent._memory_write_context = "background_review"

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -21,6 +21,7 @@ def _bare_agent() -> AIAgent:
     agent._memory_enabled = True
     agent._user_profile_enabled = False
     agent._cached_system_prompt = "test-cached-system-prompt"
+    agent.reasoning_config = None
     import datetime as _dt
     agent.session_start = _dt.datetime(2026, 1, 1, 12, 0, 0)
     agent._MEMORY_REVIEW_PROMPT = "review memory"
@@ -240,4 +241,57 @@ def test_background_review_fork_skips_external_memory_plugins(monkeypatch):
         "external plugins (honcho, mem0, supermemory, ...).  Without this "
         "the fork leaks harness prompts into the user's real memory "
         "namespace via on_turn_start / prefetch_all / sync_all."
+    )
+
+
+import pytest
+
+
+@pytest.mark.parametrize("reasoning_cfg", [
+    None,
+    {"effort": "xhigh"},
+    {"enabled": False},
+])
+def test_background_review_inherits_reasoning_config(monkeypatch, reasoning_cfg):
+    """The review fork must forward reasoning_config from the parent agent.
+
+    Without this, a session configured for e.g. ``agent.reasoning_effort:
+    xhigh`` would silently fall back to the transport default (``medium``
+    effort) for every background review request — wasting budget and
+    ignoring the user's explicit preference.  Symmetric with api_mode,
+    base_url, and api_key which are already forwarded on the same fork path.
+    """
+    captured_kwargs: dict = {}
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            captured_kwargs.update(kwargs)
+            self._session_messages = []
+
+        def run_conversation(self, **kwargs):
+            pass
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+
+    agent = _bare_agent()
+    agent.reasoning_config = reasoning_cfg
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "hello"}],
+        review_memory=True,
+    )
+
+    assert captured_kwargs.get("reasoning_config") == reasoning_cfg, (
+        f"Background review fork did not inherit reasoning_config={reasoning_cfg!r} "
+        "from the parent agent.  The fork uses the transport default instead, "
+        "which ignores the user's explicit reasoning_effort / reasoning_config "
+        "preference (fixes #18871)."
     )


### PR DESCRIPTION
## What does this PR do?

`_run_review_in_thread()` in `agent/background_review.py` inherits the parent session's `provider`, `model`, `base_url`, `api_key`, and `api_mode` when forking a review agent. `reasoning_config` was not forwarded.

On Codex Responses / OpenRouter routes the missing field causes the forked review agent to fall back to the transport default (`medium` effort), so a session configured for `agent.reasoning_effort: xhigh` still generates medium-effort background review requests — wasting budget and ignoring the user's explicit preference. Symmetric with `api_mode`, `base_url`, and `api_key` already propagated on the same fork path.

One-line fix in `_run_review_in_thread()` — passes `reasoning_config=getattr(agent, "reasoning_config", None)`. When `reasoning_config` is `None` the behaviour is identical to before: harmless no-op for sessions without a reasoning override.

**Note:** Competing PRs #18973 and #20674 both target the old `run_agent.py` location. After today's #27248 refactor (`refactor(run_agent): extract AIAgent internals into agent/ modules`), the background review fork now lives in `agent/background_review.py`. This PR targets the correct new location.

## Related Issue
Fixes #18871

## Type of Change
- [x] 🐛 Bug fix

## Changes Made
- `agent/background_review.py`: add `reasoning_config=getattr(agent, "reasoning_config", None)` to `AIAgent(...)` in `_run_review_in_thread()` (+1 line)
- `tests/run_agent/test_background_review.py`: add `reasoning_config = None` to `_bare_agent()` helper; add `test_background_review_inherits_reasoning_config` parametrized over `None`, `{"effort": "xhigh"}`, and `{"enabled": False}` (+54 lines)

## How to Test
```bash
python3.11 -m pytest tests/run_agent/test_background_review.py -v --override-ini="addopts="
```

## Checklist
### Code
- [x] Contributing Guide read
- [x] Conventional Commits
- [x] No duplicate PR
- [x] Single logical change only
- [x] pytest passing
- [x] Tests added
- [x] Platform: macOS

### Documentation & Housekeeping
- [x] Docs updated — N/A
- [x] cli-config.yaml.example — N/A
- [x] Cross-platform — N/A