### PR TITLE
feat(email): reuse Gmail OAuth token for gateway and send_message

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1431,10 +1431,15 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
 
     # Email
     email_addr = os.getenv("EMAIL_ADDRESS")
-    email_pwd = os.getenv("EMAIL_PASSWORD")
     email_imap = os.getenv("EMAIL_IMAP_HOST")
     email_smtp = os.getenv("EMAIL_SMTP_HOST")
-    if all([email_addr, email_pwd, email_imap, email_smtp]):
+    email_pwd = os.getenv("EMAIL_PASSWORD")
+    gmail_token = get_hermes_home() / "google_token.json"
+    gmail_hosts = {str(email_imap or "").lower(), str(email_smtp or "").lower()}
+    email_oauth_ready = email_addr and email_imap and email_smtp and gmail_token.exists() and (
+        "imap.gmail.com" in gmail_hosts or "smtp.gmail.com" in gmail_hosts
+    )
+    if email_oauth_ready or all([email_addr, email_pwd, email_imap, email_smtp]):
         if Platform.EMAIL not in config.platforms:
             config.platforms[Platform.EMAIL] = PlatformConfig()
         config.platforms[Platform.EMAIL].enabled = True

--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -10,19 +10,23 @@ Environment variables:
     EMAIL_SMTP_HOST     — SMTP server host (e.g., smtp.gmail.com)
     EMAIL_SMTP_PORT     — SMTP server port (default: 587)
     EMAIL_ADDRESS       — Email address for the agent
-    EMAIL_PASSWORD      — Email password or app-specific password
+    EMAIL_PASSWORD      — Email password or app-specific password (legacy IMAP/SMTP path)
     EMAIL_POLL_INTERVAL — Seconds between mailbox checks (default: 15)
     EMAIL_ALLOWED_USERS — Comma-separated list of allowed sender addresses
+    ~/.hermes/google_token.json — Google OAuth token for Gmail API mode
 """
 
 import asyncio
+import base64
 import email as email_lib
+import hashlib
 import imaplib
 import logging
 import os
 import re
 import smtplib
 import ssl
+import time
 import uuid
 from email.header import decode_header
 from email.mime.multipart import MIMEMultipart
@@ -42,6 +46,7 @@ from gateway.platforms.base import (
     cache_image_from_bytes,
 )
 from gateway.config import Platform, PlatformConfig
+from hermes_constants import get_hermes_home
 
 logger = logging.getLogger(__name__)
 # Automated sender patterns — emails from these are silently ignored
@@ -64,6 +69,56 @@ MAX_MESSAGE_LENGTH = 50_000
 
 # Supported image extensions for inline detection
 _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".gif", ".webp"}
+_GMAIL_API_SCOPES = [
+    "https://www.googleapis.com/auth/gmail.readonly",
+    "https://www.googleapis.com/auth/gmail.send",
+    "https://www.googleapis.com/auth/gmail.modify",
+]
+_OUTBOUND_EMAIL_DEDUP_TTL_SECONDS = 120.0
+_OUTBOUND_EMAIL_DEDUP_MAX = 512
+_OUTBOUND_EMAIL_DEDUP_CACHE: Dict[str, tuple[float, str]] = {}
+
+
+def _get_outbound_email_duplicate(key: str) -> Optional[str]:
+    """Return a recent outbound message ID for *key* if it is still within TTL."""
+    now = time.time()
+    stale_keys = [
+        cache_key for cache_key, (ts, _) in _OUTBOUND_EMAIL_DEDUP_CACHE.items()
+        if now - ts >= _OUTBOUND_EMAIL_DEDUP_TTL_SECONDS
+    ]
+    for stale_key in stale_keys:
+        _OUTBOUND_EMAIL_DEDUP_CACHE.pop(stale_key, None)
+
+    cached = _OUTBOUND_EMAIL_DEDUP_CACHE.get(key)
+    if not cached:
+        return None
+    ts, message_id = cached
+    if now - ts >= _OUTBOUND_EMAIL_DEDUP_TTL_SECONDS:
+        _OUTBOUND_EMAIL_DEDUP_CACHE.pop(key, None)
+        return None
+    return message_id
+
+
+def _remember_outbound_email(key: str, message_id: str) -> None:
+    """Store a recent outbound email send for duplicate suppression."""
+    now = time.time()
+    _OUTBOUND_EMAIL_DEDUP_CACHE[key] = (now, message_id)
+    if len(_OUTBOUND_EMAIL_DEDUP_CACHE) <= _OUTBOUND_EMAIL_DEDUP_MAX:
+        return
+
+    sorted_items = sorted(
+        _OUTBOUND_EMAIL_DEDUP_CACHE.items(),
+        key=lambda item: item[1][0],
+        reverse=True,
+    )
+    kept = dict(sorted_items[:_OUTBOUND_EMAIL_DEDUP_MAX])
+    _OUTBOUND_EMAIL_DEDUP_CACHE.clear()
+    _OUTBOUND_EMAIL_DEDUP_CACHE.update(kept)
+
+
+def _clear_outbound_email_dedup_cache() -> None:
+    """Test helper to clear recent outbound email dedup state."""
+    _OUTBOUND_EMAIL_DEDUP_CACHE.clear()
 
 def _send_imap_id(imap: "imaplib.IMAP4") -> None:
     """Send RFC 2971 IMAP ID command identifying this client.
@@ -105,6 +160,12 @@ def check_email_requirements() -> bool:
     pwd = os.getenv("EMAIL_PASSWORD")
     imap = os.getenv("EMAIL_IMAP_HOST")
     smtp = os.getenv("EMAIL_SMTP_HOST")
+    gmail_token = get_hermes_home() / "google_token.json"
+    gmail_hosts = {str(imap or "").lower(), str(smtp or "").lower()}
+    if addr and imap and smtp and gmail_token.exists() and (
+        "imap.gmail.com" in gmail_hosts or "smtp.gmail.com" in gmail_hosts
+    ):
+        return True
     if not all([addr, pwd, imap, smtp]):
         return False
     return True
@@ -242,25 +303,35 @@ def _extract_attachments(
     return attachments
 
 
+def _decode_gmail_raw_message(raw_value: str) -> bytes:
+    """Decode Gmail API raw payload to bytes."""
+    padding = "=" * (-len(raw_value) % 4)
+    return base64.urlsafe_b64decode(raw_value + padding)
+
+
 class EmailAdapter(BasePlatformAdapter):
     """Email gateway adapter using IMAP (receive) and SMTP (send)."""
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.EMAIL)
 
-        self._address = os.getenv("EMAIL_ADDRESS", "")
-        self._password = os.getenv("EMAIL_PASSWORD", "")
-        self._imap_host = os.getenv("EMAIL_IMAP_HOST", "")
-        self._imap_port = int(os.getenv("EMAIL_IMAP_PORT", "993"))
-        self._smtp_host = os.getenv("EMAIL_SMTP_HOST", "")
-        self._smtp_port = int(os.getenv("EMAIL_SMTP_PORT", "587"))
-        self._poll_interval = int(os.getenv("EMAIL_POLL_INTERVAL", "15"))
+        extra = config.extra or {}
+
+        self._address = extra.get("address") or os.getenv("EMAIL_ADDRESS", "")
+        self._password = extra.get("password") or os.getenv("EMAIL_PASSWORD", "")
+        self._imap_host = extra.get("imap_host") or os.getenv("EMAIL_IMAP_HOST", "")
+        self._imap_port = int(str(extra.get("imap_port") or os.getenv("EMAIL_IMAP_PORT", "993")))
+        self._smtp_host = extra.get("smtp_host") or os.getenv("EMAIL_SMTP_HOST", "")
+        self._smtp_port = int(str(extra.get("smtp_port") or os.getenv("EMAIL_SMTP_PORT", "587")))
+        self._poll_interval = int(str(extra.get("poll_interval") or os.getenv("EMAIL_POLL_INTERVAL", "15")))
+        self._gmail_token_path = get_hermes_home() / "google_token.json"
+        self._startup_ms = int(time.time() * 1000)
+        self._use_gmail_api = self._should_use_gmail_api()
 
         # Skip attachments — configured via config.yaml:
         #   platforms:
         #     email:
         #       skip_attachments: true
-        extra = config.extra or {}
         self._skip_attachments = extra.get("skip_attachments", False)
 
         # Track message IDs we've already processed to avoid duplicates
@@ -271,7 +342,55 @@ class EmailAdapter(BasePlatformAdapter):
         # Map chat_id (sender email) -> last subject + message-id for threading
         self._thread_context: Dict[str, Dict[str, str]] = {}
 
-        logger.info("[Email] Adapter initialized for %s", self._address)
+        logger.info(
+            "[Email] Adapter initialized for %s (gmail_api=%s token=%s exists=%s)",
+            self._address,
+            self._use_gmail_api,
+            self._gmail_token_path,
+            self._gmail_token_path.exists(),
+        )
+
+    def _should_use_gmail_api(self) -> bool:
+        """Use Gmail API when a Google OAuth token is available for Gmail hosts."""
+        hosts = {self._imap_host.lower(), self._smtp_host.lower()}
+        if not self._gmail_token_path.exists():
+            return False
+        return "imap.gmail.com" in hosts or "smtp.gmail.com" in hosts
+
+    def _gmail_service(self):
+        """Build an authenticated Gmail API client."""
+        from google.auth.transport.requests import Request
+        from google.oauth2.credentials import Credentials
+        from googleapiclient.discovery import build
+
+        creds = Credentials.from_authorized_user_file(str(self._gmail_token_path), _GMAIL_API_SCOPES)
+        if creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+            self._gmail_token_path.write_text(creds.to_json())
+        if not creds.valid:
+            raise RuntimeError(f"Invalid Gmail OAuth credentials at {self._gmail_token_path}")
+        return build("gmail", "v1", credentials=creds, cache_discovery=False)
+
+    def _prime_seen_gmail_messages(self) -> None:
+        """Record existing unread inbox messages so startup only handles new mail."""
+        service = self._gmail_service()
+        response = service.users().messages().list(
+            userId="me",
+            labelIds=["INBOX", "UNREAD"],
+            maxResults=500,
+        ).execute()
+        for msg in response.get("messages", []):
+            self._seen_uids.add(msg["id"])
+        self._trim_seen_uids()
+
+    def _gmail_mark_read(self, message_id: str) -> None:
+        """Remove Gmail's unread label after successful handling."""
+        service = self._gmail_service()
+        service.users().messages().modify(
+            userId="me",
+            id=message_id,
+            body={"removeLabelIds": ["UNREAD"]},
+        ).execute()
 
     def _trim_seen_uids(self) -> None:
         """Keep only the most recent UIDs to prevent unbounded memory growth.
@@ -295,6 +414,24 @@ class EmailAdapter(BasePlatformAdapter):
 
     async def connect(self) -> bool:
         """Connect to the IMAP server and start polling for new messages."""
+        if self._use_gmail_api:
+            try:
+                service = self._gmail_service()
+                service.users().getProfile(userId="me").execute()
+                self._prime_seen_gmail_messages()
+                logger.info(
+                    "[Email] Gmail API connection test passed. %d existing unread messages skipped.",
+                    len(self._seen_uids),
+                )
+            except Exception as e:
+                logger.error("[Email] Gmail API connection failed: %s", e)
+                return False
+
+            self._running = True
+            self._poll_task = asyncio.create_task(self._poll_loop())
+            print(f"[Email] Connected as {self._address} via Gmail API")
+            return True
+
         try:
             # Test IMAP connection
             imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
@@ -363,6 +500,9 @@ class EmailAdapter(BasePlatformAdapter):
 
     def _fetch_new_messages(self) -> List[Dict[str, Any]]:
         """Fetch new (unseen) messages from IMAP. Runs in executor thread."""
+        if self._use_gmail_api:
+            return self._fetch_new_gmail_messages()
+
         results = []
         try:
             imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
@@ -428,6 +568,70 @@ class EmailAdapter(BasePlatformAdapter):
             logger.error("[Email] IMAP fetch error: %s", e)
         return results
 
+    def _fetch_new_gmail_messages(self) -> List[Dict[str, Any]]:
+        """Fetch new unread Gmail messages via the Gmail API."""
+        results = []
+        try:
+            service = self._gmail_service()
+            response = service.users().messages().list(
+                userId="me",
+                labelIds=["INBOX", "UNREAD"],
+                maxResults=100,
+            ).execute()
+
+            for msg_meta in response.get("messages", []):
+                message_id = msg_meta["id"]
+                if message_id in self._seen_uids:
+                    continue
+                self._seen_uids.add(message_id)
+                if len(self._seen_uids) > self._seen_uids_max:
+                    self._trim_seen_uids()
+
+                msg = service.users().messages().get(
+                    userId="me",
+                    id=message_id,
+                    format="raw",
+                ).execute()
+
+                internal_ms = int(msg.get("internalDate", "0") or 0)
+                if internal_ms and internal_ms <= self._startup_ms:
+                    continue
+
+                raw_email = _decode_gmail_raw_message(msg["raw"])
+                parsed = email_lib.message_from_bytes(raw_email)
+
+                sender_raw = parsed.get("From", "")
+                sender_addr = _extract_email_address(sender_raw)
+                sender_name = _decode_header_value(sender_raw)
+                if "<" in sender_name:
+                    sender_name = sender_name.split("<")[0].strip().strip('"')
+
+                subject = _decode_header_value(parsed.get("Subject", "(no subject)"))
+                in_reply_to = parsed.get("In-Reply-To", "")
+                msg_headers = dict(parsed.items())
+                if _is_automated_sender(sender_addr, msg_headers):
+                    logger.debug("[Email] Skipping automated sender: %s", sender_addr)
+                    continue
+
+                results.append(
+                    {
+                        "uid": message_id,
+                        "sender_addr": sender_addr,
+                        "sender_name": sender_name,
+                        "subject": subject,
+                        "message_id": parsed.get("Message-ID", message_id),
+                        "in_reply_to": in_reply_to,
+                        "body": _extract_text_body(parsed),
+                        "attachments": _extract_attachments(parsed, skip_attachments=self._skip_attachments),
+                        "date": parsed.get("Date", ""),
+                        "gmail_id": message_id,
+                        "gmail_thread_id": msg.get("threadId", ""),
+                    }
+                )
+        except Exception as e:
+            logger.error("[Email] Gmail fetch error: %s", e)
+        return results
+
     async def _dispatch_message(self, msg_data: Dict[str, Any]) -> None:
         """Convert a fetched email into a MessageEvent and dispatch it."""
         sender_addr = msg_data["sender_addr"]
@@ -477,6 +681,7 @@ class EmailAdapter(BasePlatformAdapter):
         self._thread_context[sender_addr] = {
             "subject": subject,
             "message_id": msg_data["message_id"],
+            "thread_id": msg_data.get("gmail_thread_id", ""),
         }
 
         source = self.build_source(
@@ -499,6 +704,9 @@ class EmailAdapter(BasePlatformAdapter):
 
         logger.info("[Email] New message from %s: %s", sender_addr, subject)
         await self.handle_message(event)
+        if self._use_gmail_api and msg_data.get("gmail_id"):
+            loop = asyncio.get_running_loop()
+            await loop.run_in_executor(None, self._gmail_mark_read, msg_data["gmail_id"])
 
     async def send(
         self,
@@ -524,20 +732,33 @@ class EmailAdapter(BasePlatformAdapter):
         body: str,
         reply_to_msg_id: Optional[str] = None,
     ) -> str:
-        """Send an email via SMTP. Runs in executor thread."""
+        """Send an email reply. Runs in executor thread."""
+        if self._use_gmail_api:
+            return self._send_gmail_message(to_addr, body, reply_to_msg_id)
+
+        dedup_key = self._outbound_dedup_key(to_addr, body, reply_to_msg_id=reply_to_msg_id)
+        cached_message_id = _get_outbound_email_duplicate(dedup_key)
+        if cached_message_id:
+            logger.warning(
+                "[Email] Skipping duplicate SMTP send to %s within %.0fs window",
+                to_addr,
+                _OUTBOUND_EMAIL_DEDUP_TTL_SECONDS,
+            )
+            return cached_message_id
+
         msg = MIMEMultipart()
         msg["From"] = self._address
         msg["To"] = to_addr
 
         # Thread context for reply
         ctx = self._thread_context.get(to_addr, {})
+        original_msg_id = reply_to_msg_id or ctx.get("message_id")
         subject = ctx.get("subject", "Hermes Agent")
-        if not subject.startswith("Re:"):
+        if original_msg_id and not subject.startswith("Re:"):
             subject = f"Re: {subject}"
         msg["Subject"] = subject
 
         # Threading headers
-        original_msg_id = reply_to_msg_id or ctx.get("message_id")
         if original_msg_id:
             msg["In-Reply-To"] = original_msg_id
             msg["References"] = original_msg_id
@@ -559,8 +780,120 @@ class EmailAdapter(BasePlatformAdapter):
             except Exception:
                 smtp.close()
 
+        _remember_outbound_email(dedup_key, msg_id)
         logger.info("[Email] Sent reply to %s (subject: %s)", to_addr, subject)
         return msg_id
+
+    def _build_outbound_message(
+        self,
+        to_addr: str,
+        body: str,
+        reply_to_msg_id: Optional[str] = None,
+    ) -> tuple[MIMEMultipart, Dict[str, str], str]:
+        """Build a threaded outbound email message."""
+        msg = MIMEMultipart()
+        msg["From"] = self._address
+        msg["To"] = to_addr
+
+        ctx = self._thread_context.get(to_addr, {})
+        original_msg_id = reply_to_msg_id or ctx.get("message_id")
+        subject = ctx.get("subject", "Hermes Agent")
+        if original_msg_id and not subject.startswith("Re:"):
+            subject = f"Re: {subject}"
+        msg["Subject"] = subject
+
+        if original_msg_id:
+            msg["In-Reply-To"] = original_msg_id
+            msg["References"] = original_msg_id
+
+        msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._address.split('@')[1]}>"
+        msg["Message-ID"] = msg_id
+
+        if body:
+            msg.attach(MIMEText(body, "plain", "utf-8"))
+
+        return msg, ctx, msg_id
+
+    def _outbound_dedup_key(
+        self,
+        to_addr: str,
+        body: str,
+        reply_to_msg_id: Optional[str] = None,
+        file_path: Optional[str] = None,
+        file_name: Optional[str] = None,
+    ) -> str:
+        """Build a stable duplicate-suppression key for outbound email sends."""
+        ctx = self._thread_context.get(to_addr, {})
+        original_msg_id = reply_to_msg_id or ctx.get("message_id", "")
+        subject = ctx.get("subject", "Hermes Agent")
+        if original_msg_id and not subject.startswith("Re:"):
+            subject = f"Re: {subject}"
+        thread_id = ctx.get("thread_id", "")
+        normalized_body = re.sub(r"\s+", " ", (body or "").strip())
+        file_marker = ""
+        if file_path or file_name:
+            file_marker = f"{file_name or ''}|{file_path or ''}"
+        key_material = "\n".join(
+            [
+                self._address.lower(),
+                to_addr.lower(),
+                subject,
+                original_msg_id,
+                thread_id,
+                normalized_body,
+                file_marker,
+            ]
+        )
+        return hashlib.sha256(key_material.encode("utf-8")).hexdigest()
+
+    def _send_gmail_message(
+        self,
+        to_addr: str,
+        body: str,
+        reply_to_msg_id: Optional[str] = None,
+        file_path: Optional[str] = None,
+        file_name: Optional[str] = None,
+    ) -> str:
+        """Send an email through the Gmail API."""
+        dedup_key = self._outbound_dedup_key(
+            to_addr,
+            body,
+            reply_to_msg_id=reply_to_msg_id,
+            file_path=file_path,
+            file_name=file_name,
+        )
+        cached_message_id = _get_outbound_email_duplicate(dedup_key)
+        if cached_message_id:
+            logger.warning(
+                "[Email] Skipping duplicate Gmail send to %s within %.0fs window",
+                to_addr,
+                _OUTBOUND_EMAIL_DEDUP_TTL_SECONDS,
+            )
+            return cached_message_id
+
+        msg, ctx, msg_id = self._build_outbound_message(to_addr, body, reply_to_msg_id)
+
+        if file_path:
+            p = Path(file_path)
+            fname = file_name or p.name
+            with open(p, "rb") as f:
+                part = MIMEBase("application", "octet-stream")
+                part.set_payload(f.read())
+                encoders.encode_base64(part)
+                part.add_header("Content-Disposition", f"attachment; filename={fname}")
+                msg.attach(part)
+
+        raw = base64.urlsafe_b64encode(msg.as_bytes()).decode("ascii").rstrip("=")
+        body_payload = {"raw": raw}
+        if ctx.get("thread_id"):
+            body_payload["threadId"] = ctx["thread_id"]
+
+        service = self._gmail_service()
+        response = service.users().messages().send(userId="me", body=body_payload).execute()
+        response_id = response.get("id", msg_id)
+        _remember_outbound_email(dedup_key, response_id)
+        logger.info("[Email] Sent Gmail API reply to %s (subject: %s)", to_addr, msg["Subject"])
+        return response_id
 
     async def send_typing(self, chat_id: str, metadata: Optional[Dict[str, Any]] = None) -> None:
         """Email has no typing indicator — no-op."""
@@ -716,7 +1049,25 @@ class EmailAdapter(BasePlatformAdapter):
         file_path: str,
         file_name: Optional[str] = None,
     ) -> str:
-        """Send an email with a file attachment via SMTP."""
+        """Send an email with a file attachment."""
+        if self._use_gmail_api:
+            return self._send_gmail_message(to_addr, body, file_name=file_name, file_path=file_path)
+
+        dedup_key = self._outbound_dedup_key(
+            to_addr,
+            body,
+            file_path=file_path,
+            file_name=file_name,
+        )
+        cached_message_id = _get_outbound_email_duplicate(dedup_key)
+        if cached_message_id:
+            logger.warning(
+                "[Email] Skipping duplicate SMTP attachment send to %s within %.0fs window",
+                to_addr,
+                _OUTBOUND_EMAIL_DEDUP_TTL_SECONDS,
+            )
+            return cached_message_id
+
         msg = MIMEMultipart()
         msg["From"] = self._address
         msg["To"] = to_addr
@@ -760,6 +1111,7 @@ class EmailAdapter(BasePlatformAdapter):
             except Exception:
                 smtp.close()
 
+        _remember_outbound_email(dedup_key, msg_id)
         return msg_id
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:

--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -21,6 +21,7 @@ import base64
 import email as email_lib
 import hashlib
 import imaplib
+import json
 import logging
 import os
 import re
@@ -120,6 +121,28 @@ def _clear_outbound_email_dedup_cache() -> None:
     """Test helper to clear recent outbound email dedup state."""
     _OUTBOUND_EMAIL_DEDUP_CACHE.clear()
 
+
+def _load_gmail_token_payload(token_path: Path) -> Dict[str, Any]:
+    """Load a Google authorized-user token payload for scope checks."""
+    try:
+        return json.loads(token_path.read_text())
+    except Exception:
+        return {}
+
+
+def _missing_gmail_scopes_from_payload(payload: Dict[str, Any]) -> List[str]:
+    """Return required Gmail scopes absent from a stored Google token payload."""
+    raw = payload.get("scopes") or payload.get("scope")
+    if not raw:
+        return []
+    granted = {s.strip() for s in (raw.split() if isinstance(raw, str) else raw) if s.strip()}
+    return sorted(scope for scope in _GMAIL_API_SCOPES if scope not in granted)
+
+
+def _missing_gmail_scopes_from_token(token_path: Path) -> List[str]:
+    """Return missing Gmail scopes from a token file, when scope metadata exists."""
+    return _missing_gmail_scopes_from_payload(_load_gmail_token_payload(token_path))
+
 def _send_imap_id(imap: "imaplib.IMAP4") -> None:
     """Send RFC 2971 IMAP ID command identifying this client.
 
@@ -165,7 +188,7 @@ def check_email_requirements() -> bool:
     if addr and imap and smtp and gmail_token.exists() and (
         "imap.gmail.com" in gmail_hosts or "smtp.gmail.com" in gmail_hosts
     ):
-        return True
+        return not _missing_gmail_scopes_from_token(gmail_token)
     if not all([addr, pwd, imap, smtp]):
         return False
     return True
@@ -355,7 +378,17 @@ class EmailAdapter(BasePlatformAdapter):
         hosts = {self._imap_host.lower(), self._smtp_host.lower()}
         if not self._gmail_token_path.exists():
             return False
-        return "imap.gmail.com" in hosts or "smtp.gmail.com" in hosts
+        if "imap.gmail.com" not in hosts and "smtp.gmail.com" not in hosts:
+            return False
+        missing_scopes = _missing_gmail_scopes_from_token(self._gmail_token_path)
+        if missing_scopes:
+            logger.warning(
+                "[Email] Gmail OAuth token at %s is missing required Gmail scopes: %s",
+                self._gmail_token_path,
+                ", ".join(missing_scopes),
+            )
+            return False
+        return True
 
     def _gmail_service(self):
         """Build an authenticated Gmail API client."""
@@ -363,7 +396,13 @@ class EmailAdapter(BasePlatformAdapter):
         from google.oauth2.credentials import Credentials
         from googleapiclient.discovery import build
 
-        creds = Credentials.from_authorized_user_file(str(self._gmail_token_path), _GMAIL_API_SCOPES)
+        missing_scopes = _missing_gmail_scopes_from_token(self._gmail_token_path)
+        if missing_scopes:
+            raise RuntimeError(
+                "Gmail OAuth token is missing required Gmail scopes: "
+                + ", ".join(missing_scopes)
+            )
+        creds = Credentials.from_authorized_user_file(str(self._gmail_token_path))
         if creds.expired and creds.refresh_token:
             creds.refresh(Request())
             self._gmail_token_path.write_text(creds.to_json())
@@ -821,6 +860,7 @@ class EmailAdapter(BasePlatformAdapter):
         reply_to_msg_id: Optional[str] = None,
         file_path: Optional[str] = None,
         file_name: Optional[str] = None,
+        file_paths: Optional[List[str]] = None,
     ) -> str:
         """Build a stable duplicate-suppression key for outbound email sends."""
         ctx = self._thread_context.get(to_addr, {})
@@ -831,7 +871,9 @@ class EmailAdapter(BasePlatformAdapter):
         thread_id = ctx.get("thread_id", "")
         normalized_body = re.sub(r"\s+", " ", (body or "").strip())
         file_marker = ""
-        if file_path or file_name:
+        if file_paths:
+            file_marker = "|".join(str(path) for path in file_paths)
+        elif file_path or file_name:
             file_marker = f"{file_name or ''}|{file_path or ''}"
         key_material = "\n".join(
             [
@@ -853,6 +895,7 @@ class EmailAdapter(BasePlatformAdapter):
         reply_to_msg_id: Optional[str] = None,
         file_path: Optional[str] = None,
         file_name: Optional[str] = None,
+        file_paths: Optional[List[str]] = None,
     ) -> str:
         """Send an email through the Gmail API."""
         dedup_key = self._outbound_dedup_key(
@@ -861,6 +904,7 @@ class EmailAdapter(BasePlatformAdapter):
             reply_to_msg_id=reply_to_msg_id,
             file_path=file_path,
             file_name=file_name,
+            file_paths=file_paths,
         )
         cached_message_id = _get_outbound_email_duplicate(dedup_key)
         if cached_message_id:
@@ -881,6 +925,15 @@ class EmailAdapter(BasePlatformAdapter):
                 part.set_payload(f.read())
                 encoders.encode_base64(part)
                 part.add_header("Content-Disposition", f"attachment; filename={fname}")
+                msg.attach(part)
+
+        for multi_file_path in file_paths or []:
+            p = Path(multi_file_path)
+            with open(p, "rb") as f:
+                part = MIMEBase("application", "octet-stream")
+                part.set_payload(f.read())
+                encoders.encode_base64(part)
+                part.add_header("Content-Disposition", f"attachment; filename={p.name}")
                 msg.attach(part)
 
         raw = base64.urlsafe_b64encode(msg.as_bytes()).decode("ascii").rstrip("=")
@@ -968,7 +1021,20 @@ class EmailAdapter(BasePlatformAdapter):
         body: str,
         file_paths: List[str],
     ) -> str:
-        """Send an email with multiple file attachments via SMTP."""
+        """Send an email with multiple file attachments."""
+        if self._use_gmail_api:
+            return self._send_gmail_message(to_addr, body, file_paths=file_paths)
+
+        dedup_key = self._outbound_dedup_key(to_addr, body, file_paths=file_paths)
+        cached_message_id = _get_outbound_email_duplicate(dedup_key)
+        if cached_message_id:
+            logger.warning(
+                "[Email] Skipping duplicate SMTP multi-attachment send to %s within %.0fs window",
+                to_addr,
+                _OUTBOUND_EMAIL_DEDUP_TTL_SECONDS,
+            )
+            return cached_message_id
+
         msg = MIMEMultipart()
         msg["From"] = self._address
         msg["To"] = to_addr
@@ -1015,6 +1081,7 @@ class EmailAdapter(BasePlatformAdapter):
                 smtp.close()
 
         logger.info("[Email] Sent multi-attachment email to %s (%d files)", to_addr, len(file_paths))
+        _remember_outbound_email(dedup_key, msg_id)
         return msg_id
 
     async def send_document(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5361,7 +5361,10 @@ class GatewayRunner:
         elif platform == Platform.EMAIL:
             from gateway.platforms.email import EmailAdapter, check_email_requirements
             if not check_email_requirements():
-                logger.warning("Email: EMAIL_ADDRESS, EMAIL_PASSWORD, EMAIL_IMAP_HOST, or EMAIL_SMTP_HOST not set")
+                logger.warning(
+                    "Email: EMAIL_ADDRESS, EMAIL_IMAP_HOST, or EMAIL_SMTP_HOST not set "
+                    "(and either EMAIL_PASSWORD or ~/.hermes/google_token.json for Gmail OAuth)"
+                )
                 return None
             return EmailAdapter(config)
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3449,16 +3449,15 @@ _PLATFORMS = [
         "token_var": "EMAIL_ADDRESS",
         "setup_instructions": [
             "1. Use a dedicated email account for your Hermes agent",
-            "2. For Gmail: enable 2FA, then create an App Password at",
-            "   https://myaccount.google.com/apppasswords",
-            "3. For other providers: use your email password or app-specific password",
-            "4. IMAP must be enabled on your email account",
+            "2. For Gmail: prefer OAuth via ~/.hermes/google_token.json",
+            "3. Legacy fallback: use an app password if you want IMAP/SMTP auth",
+            "4. IMAP must be enabled on your email account for the legacy path",
         ],
         "vars": [
             {"name": "EMAIL_ADDRESS", "prompt": "Email address", "password": False,
              "help": "The email address Hermes will use (e.g., hermes@gmail.com)."},
             {"name": "EMAIL_PASSWORD", "prompt": "Email password (or app password)", "password": True,
-             "help": "For Gmail, use an App Password (not your regular password)."},
+             "help": "Optional for Gmail OAuth. For legacy Gmail IMAP/SMTP, use an App Password."},
             {"name": "EMAIL_IMAP_HOST", "prompt": "IMAP host", "password": False,
              "help": "e.g., imap.gmail.com for Gmail, outlook.office365.com for Outlook."},
             {"name": "EMAIL_SMTP_HOST", "prompt": "SMTP host", "password": False,
@@ -3777,7 +3776,9 @@ def _platform_status(platform: dict) -> str:
         pwd = get_env_value("EMAIL_PASSWORD")
         imap = get_env_value("EMAIL_IMAP_HOST")
         smtp = get_env_value("EMAIL_SMTP_HOST")
-        if all([val, pwd, imap, smtp]):
+        oauth_token = get_hermes_home() / "google_token.json"
+        gmail_oauth = bool(val and imap and smtp and oauth_token.exists())
+        if gmail_oauth or all([val, pwd, imap, smtp]):
             return "configured"
         if any([val, pwd, imap, smtp]):
             return "partially configured"

--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -14,7 +14,6 @@ metadata:
   hermes:
     tags: [Google, Gmail, Calendar, Drive, Sheets, Docs, Contacts, Email, OAuth]
     homepage: https://github.com/NousResearch/hermes-agent
-    related_skills: [himalaya]
 ---
 
 # Google Workspace
@@ -56,10 +55,13 @@ Before starting OAuth setup, ask the user TWO questions:
 **Question 1: "What Google services do you need? Just email, or also
 Calendar/Drive/Sheets/Docs?"**
 
-- **Email only** → They don't need this skill at all. Use the `himalaya` skill
-  instead — it works with a Gmail App Password (Settings → Security → App
-  Passwords) and takes 2 minutes to set up. No Google Cloud project needed.
-  Load the himalaya skill and follow its setup instructions.
+- **Email only** → Prefer this skill when Gmail OAuth is already configured.
+  If `~/.hermes/google_token.json` exists, stay on the Gmail OAuth path. Use
+  this skill's Gmail commands for inbox search/read/labels/debugging. For
+  actually sending or replying as Hermes in an interactive conversation, use
+  the `send_message` tool so delivery goes through the platform adapter and
+  outbound dedup guardrails. Do not switch to any separate IMAP/SMTP mail
+  client for Hermes-managed Gmail mailboxes.
 
 - **Email + Calendar** → Continue with this skill, but use
   `--services email,calendar` during auth so the consent screen only asks for
@@ -164,6 +166,48 @@ Should print `AUTHENTICATED`. Setup is complete — token refreshes automaticall
 - If `gws` is installed, `google_api.py` points it at the same `~/.hermes/google_token.json` credentials file. Users do not need to run a separate `gws auth login` flow.
 - To revoke: `$GSETUP --revoke`
 
+### Gmail OAuth for Hermes email delivery
+
+If the user wants Hermes itself to read and send email from a Gmail mailbox
+through the gateway, there is a small but important difference between
+"Google Workspace is authorized" and "Hermes email delivery is configured."
+
+For the Gmail OAuth path, make sure all of the following are true:
+
+1. `~/.hermes/google_token.json` exists and `setup.py --check` prints
+   `AUTHENTICATED`
+2. `EMAIL_ADDRESS` is set to the mailbox Hermes should use
+3. `EMAIL_IMAP_HOST=imap.gmail.com`
+4. `EMAIL_SMTP_HOST=smtp.gmail.com`
+5. `EMAIL_ALLOWED_USERS` is set if the user wants an inbound allowlist
+6. `EMAIL_PASSWORD` is **not required** when the Gmail OAuth token is present
+
+Example `.env` shape:
+
+```bash
+EMAIL_ADDRESS=hermes@example.com
+EMAIL_IMAP_HOST=imap.gmail.com
+EMAIL_SMTP_HOST=smtp.gmail.com
+EMAIL_ALLOWED_USERS=user@example.com,other@example.com
+```
+
+Verification steps:
+
+```bash
+# OAuth token works
+$GSETUP --check
+
+# Gmail API works
+$GAPI gmail search "in:inbox" --max 1
+
+# Gateway sees the mailbox as configured
+hermes gateway status
+```
+
+If `hermes gateway status` still reports email as disconnected, check the env
+first. Missing Gmail hosts are the most common reason Hermes falls back to the
+legacy IMAP/SMTP setup path.
+
 ## Usage
 
 All commands go through the API script. Set `GAPI` as a shorthand:
@@ -173,6 +217,14 @@ GAPI="python ${HERMES_HOME:-$HOME/.hermes}/skills/productivity/google-workspace/
 ```
 
 ### Gmail
+
+For Hermes' own mailbox behavior, prefer this split:
+
+- Use `gmail search` / `gmail get` to inspect or find messages.
+- Use `send_message` for the actual outbound send/reply when the user wants
+  Hermes to email them from the configured mailbox.
+- Use `gmail send` / `gmail reply` here only for explicit low-level Gmail API
+  tasks or debugging, not as the default interactive delivery path.
 
 ```bash
 # Search (returns JSON array with id, from, subject, date, snippet)
@@ -311,10 +363,11 @@ All commands return JSON. Parse with `jq` or read directly. Key fields:
 ## Rules
 
 1. **Never send email, create/delete calendar events, delete Drive files, share files, or modify Docs/Sheets without confirming with the user first.** Show what will be done (recipients, file IDs, content, share role) and ask for approval. For `drive delete`, prefer the default trash (reversible) over `--permanent`.
-2. **Check auth before first use** — run `setup.py --check`. If it fails, guide the user through setup.
-3. **Use the Gmail search syntax reference** for complex queries — load it with `skill_view("google-workspace", file_path="references/gmail-search-syntax.md")`.
-4. **Calendar times must include timezone** — always use ISO 8601 with offset (e.g., `2026-03-01T10:00:00-06:00`) or UTC (`Z`).
-5. **Respect rate limits** — avoid rapid-fire sequential API calls. Batch reads when possible.
+2. **For Hermes mailbox delivery, use `send_message` instead of raw Gmail send/reply commands.** Reserve `gmail send` / `gmail reply` for explicit debugging or low-level API work.
+3. **Check auth before first use** — run `setup.py --check`. If it fails, guide the user through setup.
+4. **Use the Gmail search syntax reference** for complex queries — load it with `skill_view("google-workspace", file_path="references/gmail-search-syntax.md")`.
+5. **Calendar times must include timezone** — always use ISO 8601 with offset (e.g., `2026-03-01T10:00:00-06:00`) or UTC (`Z`).
+6. **Respect rate limits** — avoid rapid-fire sequential API calls. Batch reads when possible.
 
 ## Troubleshooting
 

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -12,7 +12,9 @@ Covers:
 9. Message dispatch and threading
 """
 
+import json
 import os
+import tempfile
 import unittest
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
@@ -88,6 +90,40 @@ class TestCheckRequirements(unittest.TestCase):
     def test_requirements_empty_env(self):
         from gateway.platforms.email import check_email_requirements
         self.assertFalse(check_email_requirements())
+
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "a@gmail.com",
+        "EMAIL_IMAP_HOST": "imap.gmail.com",
+        "EMAIL_SMTP_HOST": "smtp.gmail.com",
+    }, clear=True)
+    def test_gmail_oauth_requires_stored_gmail_scopes(self):
+        from gateway.platforms.email import check_email_requirements
+
+        with tempfile.TemporaryDirectory() as tmp:
+            token_path = Path(tmp) / "google_token.json"
+            token_path.write_text(json.dumps({
+                "token": "tok",
+                "refresh_token": "refresh",
+                "client_id": "client",
+                "client_secret": "secret",
+                "scopes": ["https://www.googleapis.com/auth/gmail.readonly"],
+            }))
+            with patch("gateway.platforms.email.get_hermes_home", return_value=Path(tmp)):
+                self.assertFalse(check_email_requirements())
+
+            token_path.write_text(json.dumps({
+                "token": "tok",
+                "refresh_token": "refresh",
+                "client_id": "client",
+                "client_secret": "secret",
+                "scopes": [
+                    "https://www.googleapis.com/auth/gmail.readonly",
+                    "https://www.googleapis.com/auth/gmail.send",
+                    "https://www.googleapis.com/auth/gmail.modify",
+                ],
+            }))
+            with patch("gateway.platforms.email.get_hermes_home", return_value=Path(tmp)):
+                self.assertTrue(check_email_requirements())
 
 
 class TestHelperFunctions(unittest.TestCase):

--- a/tests/gateway/test_send_multiple_images.py
+++ b/tests/gateway/test_send_multiple_images.py
@@ -461,3 +461,28 @@ class TestEmailMultiImage:
         ) as mock_send:
             _run(adapter.send_multiple_images("user@example.com", []))
         mock_send.assert_not_called()
+
+    def test_multi_attachment_gmail_path_uses_gmail_api(self, adapter, tmp_path):
+        """Gmail OAuth mode sends the multi-attachment batch through Gmail API."""
+        paths = []
+        for i in range(2):
+            p = tmp_path / f"img_{i}.png"
+            p.write_bytes(b"\x89PNG" + b"\x00" * 20)
+            paths.append(str(p))
+
+        adapter._use_gmail_api = True
+        with patch.object(
+            adapter, "_send_gmail_message", MagicMock(return_value="gmail-msg-id")
+        ) as mock_send:
+            result = adapter._send_email_with_attachments(
+                "user@example.com",
+                "images attached",
+                paths,
+            )
+
+        assert result == "gmail-msg-id"
+        mock_send.assert_called_once_with(
+            "user@example.com",
+            "images attached",
+            file_paths=paths,
+        )

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -44,7 +44,6 @@ def _make_config():
         get_home_channel=lambda _platform: None,
     ), telegram_cfg
 
-
 def _install_telegram_mock(monkeypatch, bot):
     parse_mode = SimpleNamespace(MARKDOWN_V2="MarkdownV2", HTML="HTML")
     constants_mod = SimpleNamespace(ParseMode=parse_mode)
@@ -241,6 +240,19 @@ class TestSendMessageTool:
         assert "error" in result
         assert leaked not in result["error"]
         assert "access_token=***" in result["error"]
+
+    def test_shared_email_sender_uses_email_adapter(self):
+        from tools.send_message_tool import _send_email
+
+        with patch("gateway.platforms.email.EmailAdapter._send_email", return_value="<msg@test.com>") as mock_send:
+            result = asyncio.run(
+                _send_email({"address": "hermes@test.com", "smtp_host": "smtp.gmail.com"}, "user@test.com", "Hello")
+            )
+
+        assert result["success"] is True
+        assert result["message_id"] == "<msg@test.com>"
+        assert result["transport"] in {"gmail_api", "smtp"}
+        mock_send.assert_called_once_with("user@test.com", "Hello", None)
 
 
 class TestSendTelegramMediaDelivery:

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -246,13 +246,34 @@ class TestSendMessageTool:
 
         with patch("gateway.platforms.email.EmailAdapter._send_email", return_value="<msg@test.com>") as mock_send:
             result = asyncio.run(
-                _send_email({"address": "hermes@test.com", "smtp_host": "smtp.gmail.com"}, "user@test.com", "Hello")
+                _send_email(
+                    {"address": "hermes@test.com", "smtp_host": "smtp.gmail.com", "password": "secret"},
+                    "user@test.com",
+                    "Hello",
+                )
             )
 
         assert result["success"] is True
         assert result["message_id"] == "<msg@test.com>"
         assert result["transport"] in {"gmail_api", "smtp"}
         mock_send.assert_called_once_with("user@test.com", "Hello", None)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_shared_email_sender_rejects_smtp_without_password_or_gmail_token(self):
+        from tools.send_message_tool import _send_email
+
+        with patch("gateway.platforms.email.EmailAdapter._send_email") as mock_send:
+            result = asyncio.run(
+                _send_email(
+                    {"address": "hermes@test.com", "smtp_host": "smtp.example.com"},
+                    "user@test.com",
+                    "Hello",
+                )
+            )
+
+        assert "error" in result
+        assert "EMAIL_PASSWORD required for SMTP" in result["error"]
+        mock_send.assert_not_called()
 
 
 class TestSendTelegramMediaDelivery:

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1357,35 +1357,29 @@ async def _send_signal(extra, chat_id, message, media_files=None):
 
 
 async def _send_email(extra, chat_id, message):
-    """Send via SMTP (one-shot, no persistent connection needed)."""
-    import smtplib
-    from email.mime.text import MIMEText
-    from email.utils import formatdate
-
-    address = extra.get("address") or os.getenv("EMAIL_ADDRESS", "")
-    password = os.getenv("EMAIL_PASSWORD", "")
-    smtp_host = extra.get("smtp_host") or os.getenv("EMAIL_SMTP_HOST", "")
+    """Send email through the shared gateway adapter path."""
     try:
-        smtp_port = int(os.getenv("EMAIL_SMTP_PORT", "587"))
-    except (ValueError, TypeError):
-        smtp_port = 587
+        from gateway.config import PlatformConfig
+        from gateway.platforms.email import EmailAdapter
 
-    if not all([address, password, smtp_host]):
-        return {"error": "Email not configured (EMAIL_ADDRESS, EMAIL_PASSWORD, EMAIL_SMTP_HOST required)"}
-
-    try:
-        msg = MIMEText(message, "plain", "utf-8")
-        msg["From"] = address
-        msg["To"] = chat_id
-        msg["Subject"] = "Hermes Agent"
-        msg["Date"] = formatdate(localtime=True)
-
-        server = smtplib.SMTP(smtp_host, smtp_port)
-        server.starttls(context=ssl.create_default_context())
-        server.login(address, password)
-        server.send_message(msg)
-        server.quit()
-        return {"success": True, "platform": "email", "chat_id": chat_id}
+        adapter = EmailAdapter(PlatformConfig(enabled=True, extra=extra or {}))
+        if not adapter._address or not adapter._smtp_host:
+            return {
+                "error": (
+                    "Email not configured (EMAIL_ADDRESS and EMAIL_SMTP_HOST required, "
+                    "plus Gmail OAuth token or EMAIL_PASSWORD)"
+                )
+            }
+        loop = asyncio.get_running_loop()
+        message_id = await loop.run_in_executor(None, adapter._send_email, chat_id, message, None)
+        transport = "gmail_api" if adapter._use_gmail_api else "smtp"
+        return {
+            "success": True,
+            "platform": "email",
+            "chat_id": chat_id,
+            "transport": transport,
+            "message_id": message_id,
+        }
     except Exception as e:
         return _error(f"Email send failed: {e}")
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1370,6 +1370,13 @@ async def _send_email(extra, chat_id, message):
                     "plus Gmail OAuth token or EMAIL_PASSWORD)"
                 )
             }
+        if not adapter._use_gmail_api and not adapter._password:
+            return {
+                "error": (
+                    "Email not configured (EMAIL_PASSWORD required for SMTP, or configure "
+                    "Gmail OAuth with ~/.hermes/google_token.json and required Gmail scopes)"
+                )
+            }
         loop = asyncio.get_running_loop()
         message_id = await loop.run_in_executor(None, adapter._send_email, chat_id, message, None)
         transport = "gmail_api" if adapter._use_gmail_api else "smtp"

--- a/website/docs/user-guide/skills/bundled/productivity/productivity-google-workspace.md
+++ b/website/docs/user-guide/skills/bundled/productivity/productivity-google-workspace.md
@@ -21,7 +21,6 @@ Gmail, Calendar, Drive, Docs, Sheets via gws CLI or Python.
 | License | MIT |
 | Platforms | linux, macos, windows |
 | Tags | `Google`, `Gmail`, `Calendar`, `Drive`, `Sheets`, `Docs`, `Contacts`, `Email`, `OAuth` |
-| Related skills | [`himalaya`](/docs/user-guide/skills/bundled/email/email-himalaya) |
 
 ## Reference: full SKILL.md
 
@@ -68,10 +67,13 @@ Before starting OAuth setup, ask the user TWO questions:
 **Question 1: "What Google services do you need? Just email, or also
 Calendar/Drive/Sheets/Docs?"**
 
-- **Email only** → They don't need this skill at all. Use the `himalaya` skill
-  instead — it works with a Gmail App Password (Settings → Security → App
-  Passwords) and takes 2 minutes to set up. No Google Cloud project needed.
-  Load the himalaya skill and follow its setup instructions.
+- **Email only** → Prefer this skill when Gmail OAuth is already configured.
+  If `~/.hermes/google_token.json` exists, stay on the Gmail OAuth path. Use
+  this skill's Gmail commands for inbox search/read/labels/debugging. For
+  actually sending or replying as Hermes in an interactive conversation, use
+  the `send_message` tool so delivery goes through the platform adapter and
+  outbound dedup guardrails. Do not switch to any separate IMAP/SMTP mail
+  client for Hermes-managed Gmail mailboxes.
 
 - **Email + Calendar** → Continue with this skill, but use
   `--services email,calendar` during auth so the consent screen only asks for
@@ -175,6 +177,48 @@ Should print `AUTHENTICATED`. Setup is complete — token refreshes automaticall
 - Pending OAuth session state/verifier are stored temporarily at `~/.hermes/google_oauth_pending.json` until exchange completes.
 - If `gws` is installed, `google_api.py` points it at the same `~/.hermes/google_token.json` credentials file. Users do not need to run a separate `gws auth login` flow.
 - To revoke: `$GSETUP --revoke`
+
+### Gmail OAuth for Hermes email delivery
+
+If the user wants Hermes itself to read and send email from a Gmail mailbox
+through the gateway, there is a small but important difference between
+"Google Workspace is authorized" and "Hermes email delivery is configured."
+
+For the Gmail OAuth path, make sure all of the following are true:
+
+1. `~/.hermes/google_token.json` exists and `setup.py --check` prints
+   `AUTHENTICATED`
+2. `EMAIL_ADDRESS` is set to the mailbox Hermes should use
+3. `EMAIL_IMAP_HOST=imap.gmail.com`
+4. `EMAIL_SMTP_HOST=smtp.gmail.com`
+5. `EMAIL_ALLOWED_USERS` is set if the user wants an inbound allowlist
+6. `EMAIL_PASSWORD` is **not required** when the Gmail OAuth token is present
+
+Example `.env` shape:
+
+```bash
+EMAIL_ADDRESS=hermes@example.com
+EMAIL_IMAP_HOST=imap.gmail.com
+EMAIL_SMTP_HOST=smtp.gmail.com
+EMAIL_ALLOWED_USERS=user@example.com,other@example.com
+```
+
+Verification steps:
+
+```bash
+# OAuth token works
+$GSETUP --check
+
+# Gmail API works
+$GAPI gmail search "in:inbox" --max 1
+
+# Gateway sees the mailbox as configured
+hermes gateway status
+```
+
+If `hermes gateway status` still reports email as disconnected, check the env
+first. Missing Gmail hosts are the most common reason Hermes falls back to the
+legacy IMAP/SMTP setup path.
 
 ## Usage
 

--- a/website/docs/user-guide/skills/google-workspace.md
+++ b/website/docs/user-guide/skills/google-workspace.md
@@ -21,8 +21,47 @@ The setup is fully agent-driven — ask Hermes to set up Google Workspace and it
 4. **Done** — token auto-refreshes from that point on
 
 :::tip Email-only users
-If you only need email (no Calendar/Drive/Sheets), use the **himalaya** skill instead — it works with a Gmail App Password and takes 2 minutes. No Google Cloud project needed.
+If you already have Hermes Gmail OAuth configured, you can use this skill for email-only workflows too. Hermes reuses `~/.hermes/google_token.json` for Gmail search/read/send flows instead of forcing a separate app-password mail client setup.
 :::
+
+## Gmail OAuth for Hermes email delivery
+
+If you want Hermes itself to check and send mail from a Gmail mailbox, you need
+both:
+
+- Google Workspace OAuth set up
+- the Hermes email gateway pointed at Gmail
+
+That setup looks like this:
+
+1. Complete the normal Google Workspace OAuth flow so
+   `~/.hermes/google_token.json` exists
+2. Set these email gateway values in your Hermes env/config:
+
+```bash
+EMAIL_ADDRESS=hermes@example.com
+EMAIL_IMAP_HOST=imap.gmail.com
+EMAIL_SMTP_HOST=smtp.gmail.com
+EMAIL_ALLOWED_USERS=user@example.com,other@example.com
+```
+
+`EMAIL_PASSWORD` is not required for this Gmail OAuth path.
+
+### Verify it
+
+```bash
+# OAuth token is valid
+$GSETUP --check
+
+# Gmail API works
+$GAPI gmail search "in:inbox" --max 1
+
+# Hermes gateway sees email as connected
+hermes gateway status
+```
+
+If Gmail search works but the gateway still says email is disconnected, the
+usual cause is missing `EMAIL_IMAP_HOST` / `EMAIL_SMTP_HOST` values.
 
 ## Gmail
 


### PR DESCRIPTION
## Summary
- reuse an existing `~/.hermes/google_token.json` Gmail OAuth token for the email gateway when Gmail hosts are configured
- route `send_message` email delivery through the shared `EmailAdapter` so Gmail OAuth and duplicate suppression are reused
- update Google Workspace skill/docs to keep Gmail OAuth users on the shared path instead of sending them to a separate IMAP/SMTP client flow

## What changed
- enable the email gateway when Gmail IMAP/SMTP hosts are configured and a Google OAuth token is present, even without `EMAIL_PASSWORD`
- add Gmail API fetch/send/mark-read support inside the email gateway adapter while preserving the legacy SMTP fallback
- make `send_message` email delivery use the shared adapter path so Gmail OAuth works there too
- document the recommended split: use Gmail search/read commands for mailbox inspection, and `send_message` for Hermes-managed outbound email

## Testing
- `python -m py_compile gateway/config.py gateway/platforms/email.py gateway/run.py hermes_cli/gateway.py tools/send_message_tool.py`
- `pytest tests/tools/test_send_message_tool.py -k shared_email_sender_uses_email_adapter`
- `pytest tests/gateway/test_email.py -k "send_email_tool_success or send_email_tool_failure or send_email_tool_not_configured"`

## Notes
- legacy IMAP/SMTP + app-password flows are preserved as fallback behavior
- this PR intentionally excludes any local profile config, OAuth token contents, or user-specific mailbox values
