### PR TITLE
fix(skills): translate skill_view skill_dir for sandbox backends

### DIFF
--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -393,6 +393,126 @@ class TestSkillView:
         assert f"Run {skill_dir}/scripts/do.sh in session-123" in result["content"]
         assert "${HERMES_SKILL_DIR}" not in result["content"]
 
+    def test_skill_view_returns_host_skill_dir_for_local_backend(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill_dir = _make_skill(tmp_path, "local-skill")
+            raw = skill_view("local-skill")
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["skill_dir"] == str(skill_dir)
+        # For local backend, runtime_skill_dir mirrors skill_dir — agents that
+        # branch on this field never see a translated path on the local CLI.
+        assert result["runtime_skill_dir"] == str(skill_dir)
+
+    def test_skill_view_returns_sandbox_skill_dir_for_docker_backend(
+        self, tmp_path, monkeypatch
+    ):
+        """When TERMINAL_ENV=docker, skill_view must surface the sandbox-side
+        path the agent will hit at execute_code time — the host-side path
+        does not exist inside the Podman/Docker sandbox where the skill tree
+        is mounted at ``/root/.hermes/skills`` (see #27491)."""
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        mounts = [
+            {"host_path": str(tmp_path), "container_path": "/root/.hermes/skills"}
+        ]
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch(
+                "tools.credential_files.get_skills_directory_mount",
+                return_value=mounts,
+            ),
+        ):
+            skill_dir = _make_skill(tmp_path, "nextcloud")
+            raw = skill_view("nextcloud")
+        result = json.loads(raw)
+        assert result["success"] is True
+        # Host path is preserved (Python callers in agent/skill_commands.py
+        # still need to read the SKILL.md off disk on the gateway side).
+        assert result["skill_dir"] == str(skill_dir)
+        # Runtime path is rewritten to the canonical sandbox container_base.
+        assert result["runtime_skill_dir"] == "/root/.hermes/skills/nextcloud"
+
+    def test_skill_view_template_substitution_uses_sandbox_path(
+        self, tmp_path, monkeypatch
+    ):
+        """``${HERMES_SKILL_DIR}`` inside SKILL.md must substitute the
+        sandbox path when sandboxed — otherwise the rendered content tells
+        the agent to run ``/opt/data/skills/<name>/scripts/...`` which the
+        sandbox can't see."""
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        mounts = [
+            {"host_path": str(tmp_path), "container_path": "/root/.hermes/skills"}
+        ]
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch(
+                "tools.credential_files.get_skills_directory_mount",
+                return_value=mounts,
+            ),
+            patch(
+                "agent.skill_preprocessing.load_skills_config",
+                return_value={"template_vars": True, "inline_shell": False},
+            ),
+        ):
+            _make_skill(
+                tmp_path,
+                "sandboxed",
+                body="Run ${HERMES_SKILL_DIR}/scripts/do.sh",
+            )
+            raw = skill_view("sandboxed")
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert "Run /root/.hermes/skills/sandboxed/scripts/do.sh" in result["content"]
+        assert "${HERMES_SKILL_DIR}" not in result["content"]
+
+    def test_skill_view_categorized_skill_keeps_subdirs_in_sandbox_path(
+        self, tmp_path, monkeypatch
+    ):
+        """Categorized skills (``<skills>/<category>/<name>``) keep their
+        full relative path inside the sandbox so the mount layout matches
+        ``get_skills_directory_mount()`` exactly."""
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        mounts = [
+            {"host_path": str(tmp_path), "container_path": "/root/.hermes/skills"}
+        ]
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch(
+                "tools.credential_files.get_skills_directory_mount",
+                return_value=mounts,
+            ),
+        ):
+            _make_skill(tmp_path, "nextcloud", category="integration")
+            raw = skill_view("nextcloud")
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert (
+            result["runtime_skill_dir"]
+            == "/root/.hermes/skills/integration/nextcloud"
+        )
+
+    def test_skill_view_runtime_path_falls_back_when_no_mount_matches(
+        self, tmp_path, monkeypatch
+    ):
+        """If ``get_skills_directory_mount()`` returns nothing (e.g. the
+        skills tree on disk doesn't exist yet, so no mount is registered),
+        ``runtime_skill_dir`` must fall back to the host path rather than
+        emit a confidently-wrong sandbox path."""
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch(
+                "tools.credential_files.get_skills_directory_mount",
+                return_value=[],
+            ),
+        ):
+            skill_dir = _make_skill(tmp_path, "stranded")
+            raw = skill_view("stranded")
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["runtime_skill_dir"] == str(skill_dir)
+
     def test_skill_view_applies_inline_shell_when_enabled(self, tmp_path):
         with (
             patch("tools.skills_tool.SKILLS_DIR", tmp_path),

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -376,6 +376,59 @@ def _get_terminal_backend_name() -> str:
     return str(os.getenv("TERMINAL_ENV", "local")).strip().lower() or "local"
 
 
+def _to_runtime_skill_dir(skill_dir: Optional[Path], backend: str) -> Optional[Path]:
+    """Translate a host-side ``skill_dir`` to the path the agent should
+    reference when executing scripts inside the active sandbox.
+
+    When the terminal backend bind-mounts the skill tree (docker, singularity,
+    modal), ``get_skills_directory_mount()`` produces ``host_path``→
+    ``container_path`` pairs.  ``skill_dir`` arrives in the gateway-side host
+    layout (e.g. ``/opt/data/skills/nextcloud`` inside the gateway container),
+    while the agent's ``execute_code`` invocations run in a separate sandbox
+    container where the same skill is mounted at ``/root/.hermes/skills/
+    nextcloud``.  Without translation the agent prefixes script paths with
+    the wrong base and the call fails (#27491).
+
+    Returns ``skill_dir`` unchanged for the ``local`` backend, for backends
+    that don't bind-mount the skill tree (ssh, daytona, vercel_sandbox use
+    file_sync instead and have no stable container_path for skills), and
+    when ``skill_dir`` doesn't fall under any known skills mount (e.g. a
+    transient test path).
+    """
+    if not skill_dir or backend not in {"docker", "singularity", "modal"}:
+        return skill_dir
+    try:
+        from tools.credential_files import get_skills_directory_mount
+
+        mounts = get_skills_directory_mount()
+    except Exception:
+        logger.debug(
+            "Could not enumerate skills mounts for runtime path translation",
+            exc_info=True,
+        )
+        return skill_dir
+    try:
+        skill_resolved = skill_dir.resolve()
+    except Exception:
+        skill_resolved = skill_dir
+    for mount in mounts:
+        host_path = Path(mount["host_path"])
+        try:
+            host_resolved = host_path.resolve()
+        except Exception:
+            host_resolved = host_path
+        try:
+            rel = skill_resolved.relative_to(host_resolved)
+        except ValueError:
+            continue
+        container_path = mount["container_path"].rstrip("/")
+        rel_str = str(rel)
+        if rel_str in {"", "."}:
+            return Path(container_path)
+        return Path(f"{container_path}/{rel_str}")
+    return skill_dir
+
+
 def _is_env_var_persisted(
     var_name: str, env_snapshot: Dict[str, str] | None = None
 ) -> bool:
@@ -1321,6 +1374,11 @@ def skill_view(
                     exc_info=True,
                 )
 
+        # Translate skill_dir into the sandbox-side path the agent will use
+        # at execute_code / terminal time.  Falls back to skill_dir for local
+        # backends and for backends that don't bind-mount the skill tree.
+        runtime_skill_dir = _to_runtime_skill_dir(skill_dir, backend)
+
         rendered_content = content
         if preprocess:
             try:
@@ -1328,7 +1386,7 @@ def skill_view(
 
                 rendered_content = preprocess_skill_content(
                     content,
-                    skill_dir,
+                    runtime_skill_dir,
                     session_id=task_id,
                 )
             except Exception:
@@ -1345,6 +1403,7 @@ def skill_view(
             "content": rendered_content,
             "path": rel_path,
             "skill_dir": str(skill_dir) if skill_dir else None,
+            "runtime_skill_dir": str(runtime_skill_dir) if runtime_skill_dir else None,
             "linked_files": linked_files if linked_files else None,
             "usage_hint": "To view linked files, call skill_view(name, file_path) where file_path is e.g. 'references/api.md' or 'assets/config.yaml'"
             if linked_files


### PR DESCRIPTION
## Summary

When the terminal backend bind-mounts the skill tree into a sandbox (Docker, Singularity, Modal), `skill_view`'s response and the `${HERMES_SKILL_DIR}` template substitution return the **gateway-side host path** (e.g. `/opt/data/skills/nextcloud`). The agent then references that path inside its `execute_code` sandbox, which mounts the same skill at `/root/.hermes/skills/nextcloud` — so any bundled-script invocation fails. This PR adds a `runtime_skill_dir` field that translates the host path through the active mount mapping, and uses the translated path for `${HERMES_SKILL_DIR}` substitution.

Fixes #27491.

## The bug

`tools/skills_tool.py::skill_view()` returns:

```python
result = {
    ...
    "skill_dir": str(skill_dir) if skill_dir else None,
    ...
}
```

where `skill_dir` is the gateway-side absolute path (the gateway runs in Docker with `HERMES_HOME=/opt/data`, so this is `/opt/data/skills/nextcloud`). The reporter (#27491) describes the symptom precisely:

> The agent searches for the script in `skill_dir` which points to `/opt/data/skills/nextcloud`, which does not exist in the sandbox.

The same path is fed into `agent.skill_preprocessing.preprocess_skill_content`, which substitutes it for every `${HERMES_SKILL_DIR}` token in the rendered SKILL.md body — so a skill that documents `bash ${HERMES_SKILL_DIR}/scripts/run.sh` renders the wrong path in the message the agent sees.

The skill tree is actually mounted at `/root/.hermes/skills/<name>` inside the Podman-in-Docker sandbox (the canonical `container_base` used by `tools/credential_files.get_skills_directory_mount()` and consumed by `tools/environments/docker.py`, `tools/environments/singularity.py`, `tools/environments/modal.py`).

## The fix

Add a small helper `_to_runtime_skill_dir(skill_dir, backend)` in `tools/skills_tool.py` that:

1. Returns `skill_dir` unchanged for the `local` backend.
2. For `docker` / `singularity` / `modal` backends, walks the `get_skills_directory_mount()` results, finds the mount whose `host_path` contains `skill_dir`, and rewrites the prefix to that mount's `container_path` (`/root/.hermes/skills/...` or `/root/.hermes/external_skills/<idx>/...` for `skills.external_dirs` entries).
3. Falls back to `skill_dir` when no mount matches — e.g. backends that use `file_sync` instead of bind mounts (`ssh`, `daytona`, `vercel_sandbox`), or when the skills mount registration hasn't run yet.

The skill_view result then exposes both fields:

```python
"skill_dir": str(skill_dir) if skill_dir else None,                    # host path (unchanged)
"runtime_skill_dir": str(runtime_skill_dir) if runtime_skill_dir else None,  # sandbox path (or same for local)
```

…and the runtime path is the one passed into `preprocess_skill_content`, so `${HERMES_SKILL_DIR}` substitution emits the path the agent actually needs at execute-code time.

`skill_dir` is intentionally left as the host path because `agent.skill_commands._load_skill_payload` reads it back as a `Path` to access the SKILL.md on the gateway-side filesystem (see [PR #10587](https://github.com/NousResearch/hermes-agent/pull/10587)) — rewriting it to a sandbox path would break that caller.

## Test plan

- [x] New regression tests in `tests/tools/test_skills_tool.py::TestSkillView`:
  - `test_skill_view_returns_host_skill_dir_for_local_backend` — `runtime_skill_dir == skill_dir == <host path>` when `TERMINAL_ENV=local`.
  - `test_skill_view_returns_sandbox_skill_dir_for_docker_backend` — when `TERMINAL_ENV=docker` and `get_skills_directory_mount()` returns the canonical `host_path → /root/.hermes/skills` mapping, the response has `skill_dir == <host path>` and `runtime_skill_dir == /root/.hermes/skills/nextcloud`.
  - `test_skill_view_template_substitution_uses_sandbox_path` — `${HERMES_SKILL_DIR}` inside SKILL.md substitutes the **sandbox** path under the same backend; the host path no longer appears in the rendered `content`.
  - `test_skill_view_categorized_skill_keeps_subdirs_in_sandbox_path` — categorized skill `integration/nextcloud` ends up at `/root/.hermes/skills/integration/nextcloud` (relative path preserved).
  - `test_skill_view_runtime_path_falls_back_when_no_mount_matches` — empty mount list ⇒ `runtime_skill_dir == skill_dir`; no confidently-wrong sandbox path is emitted.
- [x] Regression guard: against pre-fix code, the four sandbox tests fail because `runtime_skill_dir` is absent from the response and `${HERMES_SKILL_DIR}` substitutes the host path. With the fix, all five pass.
- [x] Focused suite: `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/tools/test_skills_tool.py::TestSkillView -v` — 19 passed.
- [x] Adjacent suites: `tests/tools/test_skills_tool.py tests/agent/test_skill_commands.py tests/tools/test_credential_files.py` — 160 passed.
- [x] `${HERMES_SKILL_DIR}` substitution under the default `local` backend is unchanged (existing `test_skill_view_applies_template_vars` still passes — `runtime_skill_dir == skill_dir` so the rendered string is byte-identical to before).

## Related

- Fixes #27491.
- Builds on [#10587](https://github.com/NousResearch/hermes-agent/pull/10587) (*fix: use absolute skill_dir for external skills*) — that PR added the absolute-host `skill_dir` field; this one adds a sandbox-aware sibling for the agent's runtime view.
- Mount mapping uses the same source of truth (`tools/credential_files.get_skills_directory_mount`) that `tools/environments/docker.py` already feeds to `--volume` flags — so the runtime path matches the actual bind mount.

> Sibling code paths that may need the same fix: `agent/skill_commands._build_skill_message` also surfaces a `[Skill directory: ...]` line constructed from the host `skill_dir`, which has the same wrong-path problem when sandboxed. Intentionally left out of this PR's scope to keep the diff small — happy to widen to that callsite as well if preferred.
