### PR TITLE
feat(model-picker): recently-used models at top of /model picker (CLI + Telegram)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5747,10 +5747,13 @@ class HermesCLI:
             _ask()
         return result[0]
 
-    def _open_model_picker(self, providers: list, current_model: str, current_provider: str, user_provs=None, custom_provs=None) -> None:
+    def _open_model_picker(self, providers: list, current_model: str, current_provider: str, user_provs=None, custom_provs=None, recents: list = None) -> None:
         """Open prompt_toolkit-native /model picker modal."""
         self._capture_modal_input_snapshot()
         default_idx = next((i for i, p in enumerate(providers) if p.get("is_current")), 0)
+        # Shift default if we have recents entries (they come first)
+        if recents:
+            default_idx += len(recents) + 1  # +1 for the divider
         self._model_picker_state = {
             "stage": "provider",
             "providers": providers,
@@ -5759,6 +5762,7 @@ class HermesCLI:
             "current_provider": current_provider,
             "user_provs": user_provs,
             "custom_provs": custom_provs,
+            "_recents": recents or [],
         }
         self._invalidate(min_interval=0.0)
 
@@ -5766,6 +5770,22 @@ class HermesCLI:
         self._model_picker_state = None
         self._restore_modal_input_snapshot()
         self._invalidate(min_interval=0.0)
+
+    def _load_picker_recents(self) -> list:
+        """Load recents for the /model picker, respecting config toggle."""
+        try:
+            from hermes_cli.config import load_config
+            cfg = load_config()
+            limit = cfg.get("display", {}).get("model_recents", 8)
+            if not isinstance(limit, int) or limit <= 0:
+                return []
+        except Exception:
+            limit = 8
+        try:
+            from hermes_cli.model_recents import load_recent_models
+            return load_recent_models(limit=limit)
+        except Exception:
+            return []
 
     @staticmethod
     def _compute_model_picker_viewport(
@@ -5884,10 +5904,45 @@ class HermesCLI:
         stage = state.get("stage")
         if stage == "provider":
             providers = state.get("providers") or []
-            if selected >= len(providers):
+            recents = state.get("_recents") or []
+            recents_count = len(recents)
+            recents_section_height = 0
+            if recents:
+                recents_section_height = recents_count + 2  # header + entries + divider
+            # Determine what was actually selected
+            choice_offset = selected  # index into the virtual choices list
+            if recents and choice_offset < recents_section_height:
+                # Selected a header, divider, or recent entry
+                if choice_offset == 0 or choice_offset == recents_section_height - 1:
+                    self._close_model_picker()  # divider or header — close
+                    return
+                # It's a recents entry (index 1..recents_count)
+                r_idx = choice_offset - 1
+                if r_idx < len(recents):
+                    r = recents[r_idx]
+                    from hermes_cli.model_switch import switch_model
+                    result = switch_model(
+                        raw_input=r["model"],
+                        current_provider=self.provider or "",
+                        current_model=self.model or "",
+                        current_base_url=self.base_url or "",
+                        current_api_key=self.api_key or "",
+                        is_global=persist_global,
+                        explicit_provider=str(r.get("provider", "")),
+                        user_providers=state.get("user_provs"),
+                        custom_providers=state.get("custom_provs"),
+                    )
+                    self._close_model_picker()
+                    self._apply_model_switch_result(result, persist_global)
+                else:
+                    self._close_model_picker()
+                return
+            # Adjust selected for the providers portion
+            provider_idx = selected - recents_section_height
+            if provider_idx >= len(providers):
                 self._close_model_picker()
                 return
-            provider_data = providers[selected]
+            provider_data = providers[provider_idx]
             # Use the curated model list from list_authenticated_providers()
             # (same lists as `hermes model` and gateway pickers).
             # Only fall back to the live provider catalog when the curated
@@ -5914,7 +5969,10 @@ class HermesCLI:
             cancel_idx = len(model_list) + 1
             if selected == back_idx:
                 state["stage"] = "provider"
-                state["selected"] = next((i for i, p in enumerate(state.get("providers") or []) if p.get("slug") == provider_data.get("slug")), 0)
+                recents = state.get("_recents") or []
+                recents_offset = len(recents) + 2 if recents else 0
+                provider_idx = next((i for i, p in enumerate(state.get("providers") or []) if p.get("slug") == provider_data.get("slug")), 0)
+                state["selected"] = provider_idx + recents_offset
                 self._invalidate(min_interval=0.0)
                 return
             if selected >= cancel_idx:
@@ -6000,6 +6058,7 @@ class HermesCLI:
                 provider_display,
                 user_provs=user_provs,
                 custom_provs=custom_provs,
+                recents=self._load_picker_recents(),
             )
             return
 
@@ -11697,7 +11756,17 @@ class HermesCLI:
             if stage == "provider":
                 title = "⚙ Model Picker — Select Provider"
                 choices = []
-                _providers = state.get("providers")
+                _providers = state.get("_providers") if "_providers" in state else state.get("providers")
+                _recents = state.get("_recents") or []
+
+                # Recent models section (injected before providers)
+                if _recents:
+                    choices.append("── RECENT ──────────────")
+                    for r in _recents:
+                        label = f"  {r['model']}  (via {r.get('provider', '?')})"
+                        choices.append(label)
+                    choices.append("── PROVIDERS ───────────")
+
                 for p in _providers if isinstance(_providers, list) else []:
                     count = p.get("total_models", len(p.get("models", [])))
                     label = f"{p['name']} ({count} model{'s' if count != 1 else ''})"

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1639,6 +1639,15 @@ class TelegramAdapter(BasePlatformAdapter):
                 return slug
 
         try:
+            # Load recent models for quick-access buttons
+            _recents = []
+            try:
+                from hermes_cli.model_recents import load_recent_models as _lmr
+                if chat_id:
+                    _recents = _lmr(limit=8)
+            except Exception:
+                pass  # No recency data available yet — graceful degradation
+
             # Build provider buttons — 2 per row
             buttons: list = []
             for p in providers:
@@ -1651,7 +1660,24 @@ class TelegramAdapter(BasePlatformAdapter):
                     InlineKeyboardButton(label, callback_data=f"mp:{p['slug']}")
                 )
 
-            rows = [buttons[i : i + 2] for i in range(0, len(buttons), 2)]
+            # Build recency button rows (one per recent model, max 8 shown)
+            import urllib.parse as _urlparse
+
+            _recents_rows: list = []
+            for _ri in range(min(len(_recents), 8)):
+                entry = _recents[_ri]
+                model_name = entry["model"]
+                # Truncate for button width (Telegram inline buttons have visual limits)
+                label = model_name if len(model_name) <= 28 else model_name[:25] + "..."
+                # Encode model name in callback to handle slashes/spaces safely
+                enc = _urlparse.quote(model_name, safe="")
+                mr_cb = f"mr:{enc}"  # e.g., "mr:gpt-4"
+                if len(mr_cb) <= 64:
+                    _recents_rows.append([InlineKeyboardButton(label, callback_data=mr_cb)])
+            if _recents_rows:
+                _recents_rows.insert(0, [InlineKeyboardButton(f"🕒 Recent ({len(_recents_rows)})", callback_data="mx:noop")])
+
+            rows = list(_recents_rows) + [buttons[i : i + 2] for i in range(0, len(buttons), 2)]
             rows.append([InlineKeyboardButton("✗ Cancel", callback_data="mx")])
             keyboard = InlineKeyboardMarkup(rows)
 
@@ -1681,6 +1707,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 "on_model_selected": on_model_selected,
                 "current_model": current_model,
                 "current_provider": current_provider,
+                "_recents": _recents,  # (N) recent models shown at top
+                "_recents_map": {r["model"]: r["provider"] for r in _recents},  # model→provider lookups
             }
 
             return SendResult(success=True, message_id=str(msg.message_id))
@@ -1906,6 +1934,54 @@ class TelegramAdapter(BasePlatformAdapter):
             )
             await query.answer()
 
+        elif data.startswith("mr:"):
+            # --- Recent model selected: perform switch ---
+            import urllib.parse as _urlparse
+
+            encoded_model = data[3:]
+            try:
+                model_id = _urlparse.unquote(encoded_model)
+            except Exception as e:
+                logger.warning("Recents callback decode failed: %s", e)
+                await query.answer(text="Invalid selection.")
+                return
+
+            # Find provider from stored recency data
+            provider_slug = state.get("_recents_map", {}).get(model_id, "")
+            if not provider_slug:
+                await query.answer(text="Recent model not found.")
+                return
+
+            callback = state.get("on_model_selected")
+            if not callback:
+                await query.answer(text="Picker expired.")
+                return
+
+            try:
+                result_text = await callback(chat_id, model_id, provider_slug)
+            except Exception as exc:
+                logger.error("Model picker recents switch failed: %s", exc)
+                result_text = f"Error switching model: {exc}"
+
+            # Confirm and remove buttons
+            try:
+                await query.edit_message_text(
+                    text=result_text,
+                    parse_mode=ParseMode.MARKDOWN,
+                    reply_markup=None,
+                )
+            except Exception:
+                try:
+                    await query.edit_message_text(
+                        text=result_text,
+                        parse_mode=None,
+                        reply_markup=None,
+                    )
+                except Exception:
+                    pass
+            await query.answer(text="Switched!")
+            self._model_picker_state.pop(chat_id, None)
+
         else:
             # Catch-all (e.g. page counter button "mx:noop")
             await query.answer()
@@ -1926,7 +2002,7 @@ class TelegramAdapter(BasePlatformAdapter):
         query_user_name = getattr(query.from_user, "first_name", None)
 
         # --- Model picker callbacks ---
-        if data.startswith(("mp:", "mm:", "mb", "mx", "mg:")):
+        if data.startswith(("mp:", "mm:", "mb", "mx", "mg:", "mr:")):
             chat_id = str(query.message.chat_id) if query.message else None
             if chat_id:
                 await self._handle_model_picker_callback(query, data, chat_id)

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1660,24 +1660,11 @@ class TelegramAdapter(BasePlatformAdapter):
                     InlineKeyboardButton(label, callback_data=f"mp:{p['slug']}")
                 )
 
-            # Build recency button rows (one per recent model, max 8 shown)
-            import urllib.parse as _urlparse
+            # Add Recents button at the top (if we have recents)
+            if _recents:
+                buttons.insert(0, InlineKeyboardButton(f"🕒 Recents ({len(_recents)})", callback_data="mp:__recents__"))
 
-            _recents_rows: list = []
-            for _ri in range(min(len(_recents), 8)):
-                entry = _recents[_ri]
-                model_name = entry["model"]
-                # Truncate for button width (Telegram inline buttons have visual limits)
-                label = model_name if len(model_name) <= 28 else model_name[:25] + "..."
-                # Encode model name in callback to handle slashes/spaces safely
-                enc = _urlparse.quote(model_name, safe="")
-                mr_cb = f"mr:{enc}"  # e.g., "mr:gpt-4"
-                if len(mr_cb) <= 64:
-                    _recents_rows.append([InlineKeyboardButton(label, callback_data=mr_cb)])
-            if _recents_rows:
-                _recents_rows.insert(0, [InlineKeyboardButton(f"🕒 Recent ({len(_recents_rows)})", callback_data="mx:noop")])
-
-            rows = list(_recents_rows) + [buttons[i : i + 2] for i in range(0, len(buttons), 2)]
+            rows = [buttons[i : i + 2] for i in range(0, len(buttons), 2)]
             rows.append([InlineKeyboardButton("✗ Cancel", callback_data="mx")])
             keyboard = InlineKeyboardMarkup(rows)
 
@@ -1777,6 +1764,46 @@ class TelegramAdapter(BasePlatformAdapter):
         if data.startswith("mp:"):
             # --- Provider selected: show model buttons (page 0) ---
             provider_slug = data[3:]
+            
+            # Special case: Recents pseudo-provider
+            if provider_slug == "__recents__":
+                _recents = state.get("_recents", [])
+                if not _recents:
+                    await query.answer(text="No recent models.")
+                    return
+                
+                # Build a flat list of recent models for display
+                import urllib.parse as _urlparse
+                
+                recent_models: list = []
+                for entry in _recents[:8]:  # Max 8 recents
+                    model_name = entry["model"]
+                    provider = entry.get("provider", "unknown")
+                    # Store provider alongside model for resolution
+                    recent_models.append((model_name, provider))
+                
+                # Store in state for mm: handler to use
+                state["selected_provider"] = "__recents__"
+                state["selected_provider_name"] = "Recents"
+                state["model_list"] = [m[0] for m in recent_models]
+                state["model_providers"] = [m[1] for m in recent_models]  # Parallel list
+                state["model_page"] = 0
+                
+                # Build keyboard using same pattern as normal model list
+                keyboard, page_info = self._build_model_keyboard(state["model_list"], 0)
+                
+                await query.edit_message_text(
+                    text=(
+                        f"⚙ *Model Configuration*\n\n"
+                        f"Provider: *Recents*{page_info}\n"
+                        f"Select a recent model:"
+                    ),
+                    parse_mode=ParseMode.MARKDOWN,
+                    reply_markup=keyboard,
+                )
+                await query.answer()
+                return
+            
             provider = next(
                 (p for p in state["providers"] if p["slug"] == provider_slug),
                 None,
@@ -1858,6 +1885,15 @@ class TelegramAdapter(BasePlatformAdapter):
 
             model_id = model_list[idx]
             provider_slug = state.get("selected_provider", "")
+            
+            # Special handling for Recents mode: look up provider from parallel list
+            if provider_slug == "__recents__":
+                model_providers = state.get("model_providers", [])
+                if idx < len(model_providers):
+                    provider_slug = model_providers[idx]
+                else:
+                    provider_slug = ""
+            
             callback = state.get("on_model_selected")
 
             if not callback:
@@ -1934,54 +1970,6 @@ class TelegramAdapter(BasePlatformAdapter):
             )
             await query.answer()
 
-        elif data.startswith("mr:"):
-            # --- Recent model selected: perform switch ---
-            import urllib.parse as _urlparse
-
-            encoded_model = data[3:]
-            try:
-                model_id = _urlparse.unquote(encoded_model)
-            except Exception as e:
-                logger.warning("Recents callback decode failed: %s", e)
-                await query.answer(text="Invalid selection.")
-                return
-
-            # Find provider from stored recency data
-            provider_slug = state.get("_recents_map", {}).get(model_id, "")
-            if not provider_slug:
-                await query.answer(text="Recent model not found.")
-                return
-
-            callback = state.get("on_model_selected")
-            if not callback:
-                await query.answer(text="Picker expired.")
-                return
-
-            try:
-                result_text = await callback(chat_id, model_id, provider_slug)
-            except Exception as exc:
-                logger.error("Model picker recents switch failed: %s", exc)
-                result_text = f"Error switching model: {exc}"
-
-            # Confirm and remove buttons
-            try:
-                await query.edit_message_text(
-                    text=result_text,
-                    parse_mode=ParseMode.MARKDOWN,
-                    reply_markup=None,
-                )
-            except Exception:
-                try:
-                    await query.edit_message_text(
-                        text=result_text,
-                        parse_mode=None,
-                        reply_markup=None,
-                    )
-                except Exception:
-                    pass
-            await query.answer(text="Switched!")
-            self._model_picker_state.pop(chat_id, None)
-
         else:
             # Catch-all (e.g. page counter button "mx:noop")
             await query.answer()
@@ -2002,7 +1990,7 @@ class TelegramAdapter(BasePlatformAdapter):
         query_user_name = getattr(query.from_user, "first_name", None)
 
         # --- Model picker callbacks ---
-        if data.startswith(("mp:", "mm:", "mb", "mx", "mg:", "mr:")):
+        if data.startswith(("mp:", "mm:", "mb", "mx", "mg:")):
             chat_id = str(query.message.chat_id) if query.message else None
             if chat_id:
                 await self._handle_model_picker_callback(query, data, chat_id)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -851,6 +851,10 @@ DEFAULT_CONFIG = {
             "fields": ["model", "context_pct", "cwd"],  # Order shown; drop any to hide
         },
         "copy_shortcut": "auto",  # "auto" (platform default) | "ctrl_c" | "ctrl_shift_c" | "disabled"
+        # Show recently-used models at the top of the /model picker.
+        # Integer number of recents to display (default 8).  Set to 0 to
+        # disable the section entirely.
+        "model_recents": 8,
     },
 
     # Web dashboard settings

--- a/hermes_cli/model_recents.py
+++ b/hermes_cli/model_recents.py
@@ -1,0 +1,205 @@
+"""Historic model selections store for the /model picker recents section.
+
+Tracks successful model switches so the picker can surface recently
+used models above the full provider list.  Storage is a JSON file in
+the Hermes home directory (profile-aware via ``get_hermes_home()``).
+
+Schema (``model_recents.json``)::
+
+    {
+        "version": 1,
+        "recents": [
+            {
+                "provider": "ollama-launch",
+                "model": "qwen3.6:35b-a3b-mlx-bf16",
+                "last_used": "2026-05-07T13:40:00Z",
+                "count": 12
+            },
+            ...
+        ]
+    }
+
+Entries are ordered by ``last_used`` descending (most recent first).
+The dedup key is ``provider:model`` — re-selecting a model bumps its
+timestamp and count rather than creating a duplicate.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_STORE_FILENAME = "model_recents.json"
+_MAX_STORED = 20  # hard cap on stored entries (never grows unboundedly)
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _store_path() -> Path:
+    """Resolve the full path to the recents store file (profile-aware)."""
+    return get_hermes_home() / _STORE_FILENAME
+
+
+def _time_iso() -> str:
+    """Current UTC timestamp as ISO 8601 string."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _read_store() -> dict[str, Any]:
+    """Read the store file, returning a clean empty structure on any error.
+
+    Tolerates: missing file, invalid JSON, wrong version number, wrong
+    top-level type.  Returns ``{"version": 1, "recents": []}`` on failure
+    so callers always get a sane structure.
+    """
+    path = _store_path()
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return {"version": 1, "recents": []}
+    except OSError as exc:
+        logger.debug("model_recents: failed to read %s: %s", path, exc)
+        return {"version": 1, "recents": []}
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        logger.warning("model_recents: corrupt JSON in %s, resetting: %s", path, exc)
+        return {"version": 1, "recents": []}
+
+    if not isinstance(data, dict):
+        logger.warning("model_recents: store is not a dict, resetting")
+        return {"version": 1, "recents": []}
+
+    version = data.get("version")
+    if version != 1:
+        logger.warning(
+            "model_recents: unknown version %r, resetting", version
+        )
+        return {"version": 1, "recents": []}
+
+    recents = data.get("recents", [])
+    if not isinstance(recents, list):
+        logger.warning("model_recents: recents is not a list, resetting")
+        return {"version": 1, "recents": []}
+
+    return data
+
+
+def _write_store(data: dict[str, Any]) -> None:
+    """Atomically write the store file (tempfile + rename)."""
+    path = _store_path()
+    payload = json.dumps(data, indent=2, ensure_ascii=False)
+    try:
+        # Atomic: write to temp then rename
+        fd, tmp = tempfile.mkstemp(
+            dir=path.parent, prefix=".model_recents_", suffix=".tmp"
+        )
+        try:
+            os.write(fd, payload.encode("utf-8"))
+        finally:
+            os.close(fd)
+        os.replace(tmp, path)
+    except OSError as exc:
+        logger.debug("model_recents: failed to write %s: %s", path, exc)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def record_model_selection(provider: str, model: str) -> None:
+    """Record a successful model switch in the recents store.
+
+    If the provider:model pair already exists, it is moved to the front
+    and its ``last_used`` / ``count`` are updated.  The store is capped
+    at ``_MAX_STORED`` entries (oldest entries beyond the cap are dropped).
+
+    Args:
+        provider: The Hermes provider slug (e.g. ``"ollama-launch"``,
+            ``"openrouter"``, ``"custom:my-endpoint"``).
+        model: The model identifier as stored/displayed (e.g.
+            ``"qwen3.6:35b-a3b-mlx-bf16"``, ``"claude-sonnet-4"``).
+    """
+    data = _read_store()
+    recents: list[dict[str, Any]] = data["recents"]
+    # Dedup key is provider:model
+    now = _time_iso()
+
+    # Find existing entry
+    existing_idx: int | None = None
+    for i, entry in enumerate(recents):
+        if isinstance(entry, dict) and entry.get("provider") == provider and entry.get("model") == model:
+            existing_idx = i
+            break
+
+    if existing_idx is not None:
+        # Bump: update timestamp + count, move to front
+        entry = recents.pop(existing_idx)
+        entry["last_used"] = now
+        entry["count"] = entry.get("count", 1) + 1
+        recents.insert(0, entry)
+    else:
+        # New entry at front
+        recents.insert(
+            0,
+            {
+                "provider": provider,
+                "model": model,
+                "last_used": now,
+                "count": 1,
+            },
+        )
+
+    # Cap to _MAX_STORED
+    del recents[_MAX_STORED:]
+
+    data["recents"] = recents
+    _write_store(data)
+
+
+def load_recent_models(limit: int = 8) -> list[dict[str, Any]]:
+    """Load the N most recent model selections.
+
+    Returns a list of ``{"provider": str, "model": str, "last_used": str,
+    "count": int}`` dicts, ordered by ``last_used`` descending.  Always
+    returns a list (empty on any error).
+
+    Args:
+        limit: Maximum number of entries to return (default 8).
+    """
+    data = _read_store()
+    recents: list[dict[str, Any]] = data.get("recents", [])
+    # Filter out any entries that aren't proper dicts (defensive)
+    clean: list[dict[str, Any]] = []
+    for entry in recents[:limit]:
+        if isinstance(entry, dict) and "provider" in entry and "model" in entry:
+            clean.append(entry)
+        if len(clean) >= limit:
+            break
+    return clean
+
+
+def clear_recent_models() -> None:
+    """Delete the recents store file entirely (resets all history)."""
+    path = _store_path()
+    try:
+        path.unlink(missing_ok=True)
+    except OSError:
+        pass

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1024,6 +1024,11 @@ def switch_model(
         warnings.append(hermes_warn)
 
     # --- Build result ---
+    try:
+        from hermes_cli.model_recents import record_model_selection
+        record_model_selection(target_provider, new_model)
+    except Exception:
+        pass  # never fail a model switch over recents tracking
     return ModelSwitchResult(
         success=True,
         new_model=new_model,

--- a/tests/hermes_cli/test_model_recents.py
+++ b/tests/hermes_cli/test_model_recents.py
@@ -1,0 +1,151 @@
+"""Tests for hermes_cli.model_recents — the recents store for the /model picker."""
+
+import json
+import os
+
+import pytest
+
+from hermes_constants import get_hermes_home
+
+
+@pytest.fixture
+def recents_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with no pre-existing recents file."""
+    home = tmp_path / "hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+
+
+class TestRecordAndLoad:
+    def test_fresh_load_returns_empty(self, recents_home):
+        """Loading with no store file returns empty list."""
+        from hermes_cli.model_recents import load_recent_models
+        result = load_recent_models()
+        assert result == []
+
+    def test_record_one_then_load(self, recents_home):
+        """Recording a single entry then loading returns it."""
+        from hermes_cli.model_recents import record_model_selection, load_recent_models
+        record_model_selection("ollama-launch", "qwen3.6:35b")
+        result = load_recent_models()
+        assert len(result) == 1
+        assert result[0]["provider"] == "ollama-launch"
+        assert result[0]["model"] == "qwen3.6:35b"
+        assert result[0]["count"] == 1
+
+    def test_record_same_dedups_and_increments_count(self, recents_home):
+        """Selecting the same provider:model twice dedups and bumps count."""
+        from hermes_cli.model_recents import record_model_selection, load_recent_models
+        record_model_selection("venice", "claude-opus-4")
+        record_model_selection("venice", "claude-opus-4")
+        result = load_recent_models()
+        assert len(result) == 1
+        assert result[0]["provider"] == "venice"
+        assert result[0]["model"] == "claude-opus-4"
+        assert result[0]["count"] == 2
+
+    def test_second_entry_moves_to_front(self, recents_home):
+        """Re-selecting an older entry moves it to the front."""
+        from hermes_cli.model_recents import record_model_selection, load_recent_models
+        record_model_selection("a", "model-a")
+        record_model_selection("b", "model-b")
+        # Now a is older, b is at front
+        record_model_selection("a", "model-a")
+        result = load_recent_models()
+        assert result[0]["provider"] == "a"
+        assert result[0]["model"] == "model-a"
+        assert result[0]["count"] == 2
+
+    def test_limit_param_caps_return(self, recents_home):
+        """The limit parameter caps the returned list."""
+        from hermes_cli.model_recents import record_model_selection, load_recent_models
+        for i in range(10):
+            record_model_selection(f"prov-{i}", f"model-{i}")
+        result = load_recent_models(limit=3)
+        assert len(result) == 3
+        # Most recent first
+        assert result[0]["model"] == "model-9"
+
+    def test_cap_at_20_stored(self, recents_home):
+        """Store never grows beyond 20 entries."""
+        from hermes_cli.model_recents import record_model_selection, load_recent_models
+        for i in range(25):
+            record_model_selection(f"prov-{i}", f"model-{i}")
+        result = load_recent_models(limit=30)
+        assert len(result) == 20
+        # Most recent 20 only — prov-24 through prov-5
+        assert result[0]["model"] == "model-24"
+        assert result[-1]["model"] == "model-5"
+
+    def test_limit_zero_returns_empty(self, recents_home):
+        """limit=0 returns empty list."""
+        from hermes_cli.model_recents import record_model_selection, load_recent_models
+        record_model_selection("p", "m")
+        result = load_recent_models(limit=0)
+        assert result == []
+
+
+class TestStoreResilience:
+    def test_corrupt_json_resets(self, recents_home):
+        """A corrupt JSON store falls back to empty list."""
+        store_path = get_hermes_home() / "model_recents.json"
+        store_path.write_text("this is not valid json {{{")
+        from hermes_cli.model_recents import load_recent_models, record_model_selection
+        # Load should return empty
+        assert load_recent_models() == []
+        # After recording, everything works normally
+        record_model_selection("p", "m")
+        assert len(load_recent_models()) == 1
+
+    def test_wrong_version_resets(self, recents_home):
+        """Unknown version number resets to empty."""
+        store_path = get_hermes_home() / "model_recents.json"
+        store_path.write_text(json.dumps({"version": 99, "recents": [{"provider": "p", "model": "m", "last_used": "", "count": 1}]}))
+        from hermes_cli.model_recents import load_recent_models
+        assert load_recent_models() == []
+
+    def test_recents_not_a_list_resets(self, recents_home):
+        """Top-level recents is not a list → reset."""
+        store_path = get_hermes_home() / "model_recents.json"
+        store_path.write_text(json.dumps({"version": 1, "recents": "oops_not_a_list"}))
+        from hermes_cli.model_recents import load_recent_models
+        assert load_recent_models() == []
+
+    def test_missing_file_is_fine(self, recents_home):
+        """No file at all → returns empty, no crash."""
+        # recents_home fixture created dir with no file
+        from hermes_cli.model_recents import load_recent_models
+        assert load_recent_models() == []
+
+    def test_atomic_write_no_tempfile_left(self, recents_home):
+        """Successful write doesn't leave temp files behind."""
+        from hermes_cli.model_recents import record_model_selection
+        record_model_selection("p", "m")
+        home = get_hermes_home()
+        tmp_files = list(home.glob(".model_recents_*.tmp"))
+        assert len(tmp_files) == 0, f"temp files left behind: {tmp_files}"
+
+    def test_clear_removes_file(self, recents_home):
+        """clear_recent_models removes the store file."""
+        from hermes_cli.model_recents import (
+            record_model_selection, load_recent_models, clear_recent_models,
+        )
+        record_model_selection("p", "m")
+        assert len(load_recent_models()) == 1
+        clear_recent_models()
+        assert load_recent_models() == []
+        # File is actually gone
+        assert not (get_hermes_home() / "model_recents.json").exists()
+
+
+class TestPathResolution:
+    def test_uses_hermes_home(self, recents_home):
+        """Store path resolves via get_hermes_home(), not hardcoded."""
+        from hermes_cli.model_recents import record_model_selection
+        record_model_selection("p", "m")
+        expected = recents_home / "model_recents.json"
+        assert expected.exists()
+        data = json.loads(expected.read_text())
+        assert data["version"] == 1
+        assert len(data["recents"]) == 1


### PR DESCRIPTION
## Summary

Adds a **Recently Used Models** section to the `/model` picker for both CLI and Telegram platforms. Users with multiple providers (OpenRouter, Venice, Ollama, etc.) no longer need to scroll through long provider menus to switch back to a model they were just using.

## Changes

### New Files
- `hermes_cli/model_recents.py` — Atomic JSON storage for recent model selections
- `tests/hermes_cli/test_model_recents.py` — 14 unit tests for the storage layer

### Modified Files
- `hermes_cli/config.py` — Added `display.model_recents` config key (default: 8, 0 to disable)
- `hermes_cli/model_switch.py` — Records every successful model switch
- `cli.py` — Displays recents in the curses model picker UI
- `gateway/platforms/telegram.py` — Two-level recents navigation for Telegram

## How It Works

### Data Layer
- Stores up to 20 recent selections in `~/.hermes/model_recents.json`
- Deduplicates by `provider:model`; repeat selections move to top and increment counter
- Atomic writes using `tempfile` + `os.rename` (no corruption on crash)
- Profile-aware via `get_hermes_home()`

### CLI
- Recents appear as a numbered list at the top of the `/model` picker
- Selecting one immediately switches to that model

### Telegram (Two-Level Flow)
1. `/model` displays providers with a **"🕒 Recents (N)"** button at top
2. Tap Recents → shows paginated list of up to 8 recent models
3. Select model → switches and confirms

This matches the existing provider→model drill-down pattern users already know.

## Configuration

```yaml
# ~/.hermes/config.yaml
display:
  model_recents: 8  # Number of recents to show (0 = disable)
```

## Testing

```bash
# Unit tests for storage layer
pytest tests/hermes_cli/test_model_recents.py -v
# 14 passed

# Syntax verification
python -m py_compile gateway/platforms/telegram.py
# OK

# Manual testing
hermes gateway restart
# In Telegram: /model → 🕒 Recents → select model
```

## Design Decisions

| Decision | Rationale |
|----------|-----------|
| **Separate JSON file** | Keeps `config.yaml` clean; matches existing pattern for session DB |
| **Atomic writes** | Prevents corruption if process crashes during write |
| **Two-level flow on Telegram** | Keeps main picker clean; matches provider drill-down UX |
| **Parallel `model_providers` list** | Avoids encoding provider in `mm:` callbacks (64-byte limit) |
| `__recents__` pseudo-provider | No new callback prefixes needed; reuses existing routing |

## Backwards Compatibility

- Fully backwards compatible
- Existing `config.yaml` without `display.model_recents` uses default (8)
- Missing `model_recents.json` = no recents shown (graceful degradation)
- No breaking changes to existing APIs or commands

## Related

Closes the gap between CLI and Telegram UX for model switching. Future work could extend this to other platforms (Discord, Slack) using the same storage layer.

---

**Checklist:**
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic
- [x] 14 unit tests added and passing
- [x] Manual testing on Telegram completed
- [x] Backwards compatibility verified
