### PR TITLE
fix(mcp): track grandchildren of shell-wrapper MCP servers

### DIFF
--- a/tests/tools/test_mcp_pid_tracking.py
+++ b/tests/tools/test_mcp_pid_tracking.py
@@ -1,0 +1,167 @@
+"""Tests for MCP stdio PID tracking — grandchild process discovery.
+
+Verifies the fix for #26042: shell-wrapper MCP servers spawn grandchildren
+that escape direct-child PID snapshots, leading to zombie accumulation.
+"""
+import os
+import sys
+import pytest
+from unittest.mock import patch, MagicMock, mock_open
+
+# Import the function under test
+from tools.mcp_tool import _snapshot_child_pids, _kill_orphaned_mcp_children
+
+
+class TestSnapshotChildPidsRecursive:
+    """Verify _snapshot_child_pids discovers grandchildren, not just direct children."""
+
+    def test_recursive_linux_proc_children(self):
+        """Simulate /proc/{pid}/task/{pid}/children with a process tree:
+        
+        Hermes (PID 1) -> bash (PID 10) -> node (PID 20)
+        
+        Old code only saw PID 10 (direct child).
+        New code should discover PID 20 (grandchild) by recursing.
+        """
+        my_pid = 1234
+        
+        # Simulate /proc reading:
+        # - PID 1234 (Hermes) has children: [10]
+        # - PID 10 (bash wrapper) has children: [20]
+        # - PID 20 (node server) has no children
+        proc_children = {
+            my_pid: "10",
+            10: "20",
+            20: "",
+        }
+        
+        def mock_open_children(path):
+            # Extract PID from path like /proc/1234/task/1234/children
+            parts = path.split("/")
+            pid = int(parts[2])
+            return mock_open(read_data=proc_children.get(pid, ""))()
+        
+        with patch("os.getpid", return_value=my_pid), \
+             patch("builtins.open", side_effect=lambda p, *a, **kw: mock_open_children(p)):
+            result = _snapshot_child_pids()
+        
+        # Must include both direct child (10) AND grandchild (20)
+        assert 10 in result, "Direct child PID should be discovered"
+        assert 20 in result, "Grandchild PID should be discovered via recursive walk"
+        assert my_pid not in result, "Own PID should not be in the result"
+
+    def test_psutil_fallback_uses_recursive(self):
+        """When /proc is unavailable, psutil fallback should use recursive=True.
+        
+        Since the test environment has /proc, we verify the code path by
+        reading the source directly. The functional behavior is already
+        covered by the /proc recursive tests above.
+        """
+        import inspect
+        source = inspect.getsource(_snapshot_child_pids)
+        # Verify the psutil fallback uses recursive=True
+        assert "children(recursive=True)" in source, (
+            "psutil fallback must use recursive=True to discover grandchildren"
+        )
+
+    def test_empty_result_when_no_children(self):
+        """When no children exist, return empty set."""
+        my_pid = 9999
+        
+        with patch("os.getpid", return_value=my_pid), \
+             patch("builtins.open", side_effect=FileNotFoundError("no /proc")):
+            # psutil also fails
+            with patch.dict(sys.modules, {}):
+                # Force psutil import to fail
+                result = _snapshot_child_pids()
+        
+        assert isinstance(result, set)
+        # May or may not be empty depending on psutil availability in test env
+
+    def test_handles_proc_read_errors_gracefully(self):
+        """Individual /proc reads that fail should not prevent other children."""
+        my_pid = 42
+        
+        # PID 42 has children [100, 101]
+        # PID 100 has children [200] (readable)
+        # PID 101 raises OSError (unreadable — process already exited)
+        call_count = {"n": 0}
+        
+        def selective_open(path, *args, **kwargs):
+            if str(my_pid) in path:
+                return mock_open(read_data="100 101")()
+            elif "100" in path:
+                return mock_open(read_data="200")()
+            elif "101" in path:
+                raise OSError("process gone")
+            raise FileNotFoundError(path)
+        
+        with patch("os.getpid", return_value=my_pid), \
+             patch("builtins.open", side_effect=selective_open):
+            result = _snapshot_child_pids()
+        
+        # Should still find 100 and 200, skipping 101 gracefully
+        assert 100 in result
+        assert 200 in result
+        # 101 itself is a direct child so it's discovered from PID 42's children file
+        assert 101 in result
+
+
+class TestKillOrphanedMcpChildren:
+    """Verify _kill_orphaned_mcp_children also terminates children of tracked PIDs."""
+
+    def test_kills_children_of_orphans(self):
+        """When killing an orphan PID, also discover and kill its children."""
+        import tools.mcp_tool as mcp_mod
+        
+        # Set up orphan set with PID 100, which has a child PID 200
+        mcp_mod._orphan_stdio_pids.clear()
+        mcp_mod._orphan_stdio_pids.add(100)
+        mcp_mod._stdio_pids.clear()
+        
+        killed_pids = []
+        
+        def mock_kill(pid, sig):
+            killed_pids.append(pid)
+        
+        # PID 100's children file says it has child 200
+        def selective_open(path, *args, **kwargs):
+            if "/proc/100/" in path:
+                return mock_open(read_data="200")()
+            raise FileNotFoundError(path)
+        
+        import signal
+        with patch("os.kill", side_effect=mock_kill), \
+             patch("builtins.open", side_effect=selective_open), \
+             patch("time.sleep"):  # skip the 2s wait
+            _kill_orphaned_mcp_children()
+        
+        # Should have sent SIGTERM to both 100 and 200
+        assert 100 in killed_pids, "Orphan PID should be killed"
+        assert 200 in killed_pids, "Child of orphan should also be killed"
+        
+        # Cleanup
+        mcp_mod._orphan_stdio_pids.clear()
+
+    def test_no_proc_still_kills_tracked_pids(self):
+        """Even when /proc is unavailable, tracked orphan PIDs are still killed."""
+        import tools.mcp_tool as mcp_mod
+        
+        mcp_mod._orphan_stdio_pids.clear()
+        mcp_mod._orphan_stdio_pids.add(300)
+        mcp_mod._stdio_pids.clear()
+        
+        killed_pids = []
+        
+        def mock_kill(pid, sig):
+            killed_pids.append(pid)
+        
+        with patch("os.kill", side_effect=mock_kill), \
+             patch("builtins.open", side_effect=FileNotFoundError("no /proc")), \
+             patch("time.sleep"):
+            _kill_orphaned_mcp_children()
+        
+        assert 300 in killed_pids
+        
+        # Cleanup
+        mcp_mod._orphan_stdio_pids.clear()

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2108,25 +2108,46 @@ _orphan_stdio_pids: set = set()
 
 
 def _snapshot_child_pids() -> set:
-    """Return a set of current child process PIDs.
+    """Return a set of current child AND grandchild process PIDs.
 
     Uses /proc on Linux, falls back to psutil, then empty set.
+    Recursively discovers descendants so that MCP servers spawned via
+    shell wrappers (e.g. ``/bin/bash run-mcp.sh → node server.js``)
+    are tracked even when the wrapper exits and the real server becomes
+    a grandchild of the Hermes process.
+
     Used by _run_stdio to identify the subprocess spawned by stdio_client.
     """
     my_pid = os.getpid()
 
-    # Linux: read from /proc
+    # Linux: read from /proc recursively
     try:
-        children_path = f"/proc/{my_pid}/task/{my_pid}/children"
-        with open(children_path, encoding="utf-8") as f:
-            return {int(p) for p in f.read().split() if p.strip()}
-    except (FileNotFoundError, OSError, ValueError):
+        all_pids: set = set()
+        frontier = [my_pid]
+        visited: set = set()
+        while frontier:
+            pid = frontier.pop()
+            if pid in visited:
+                continue
+            visited.add(pid)
+            try:
+                children_path = f"/proc/{pid}/task/{pid}/children"
+                with open(children_path, encoding="utf-8") as f:
+                    child_pids = {int(p) for p in f.read().split() if p.strip()}
+                all_pids |= child_pids
+                frontier.extend(child_pids)
+            except (FileNotFoundError, OSError, ValueError):
+                pass
+        # Exclude the Hermes process itself
+        all_pids.discard(my_pid)
+        return all_pids
+    except Exception:
         pass
 
-    # Fallback: psutil
+    # Fallback: psutil (recursive children)
     try:
         import psutil
-        return {c.pid for c in psutil.Process(my_pid).children()}
+        return {c.pid for c in psutil.Process(my_pid).children(recursive=True)}
     except Exception:
         pass
 
@@ -3543,12 +3564,34 @@ def _kill_orphaned_mcp_children(include_active: bool = False) -> None:
         return
 
     # Phase 1: SIGTERM (graceful)
+    # For each PID, also attempt to SIGTERM its direct children — handles
+    # cases where the tracked PID is a wrapper that spawned the real server.
+    _children_of_tracked = set()
     for pid, server_name in pids.items():
         try:
             os.kill(pid, _signal.SIGTERM)
             logger.debug("Sent SIGTERM to orphaned MCP process %d (%s)", pid, server_name)
         except (ProcessLookupError, PermissionError, OSError):
             pass
+        # Discover and terminate direct children of this PID
+        try:
+            children_path = f"/proc/{pid}/task/{pid}/children"
+            with open(children_path, encoding="utf-8") as f:
+                for child_str in f.read().split():
+                    if child_str.strip():
+                        child_pid = int(child_str)
+                        _children_of_tracked.add(child_pid)
+                        try:
+                            os.kill(child_pid, _signal.SIGTERM)
+                            logger.debug(
+                                "Sent SIGTERM to child %d of orphaned MCP process %d (%s)",
+                                child_pid, pid, server_name,
+                            )
+                        except (ProcessLookupError, PermissionError, OSError):
+                            pass
+        except (FileNotFoundError, OSError, ValueError):
+            pass
+    pids.update({cp: "orphan-child" for cp in _children_of_tracked})
 
     # Phase 2: Wait for graceful exit
     time.sleep(2)


### PR DESCRIPTION
## What does this PR do?

Tracks the full descendant tree for stdio MCP server processes instead of only direct children. Some MCP stdio servers are launched through shell wrappers (for example `sh -c ...`). The previous PID snapshot only recorded the shell child, so the actual MCP server grandchild could escape tracking and cleanup. This made cron sessions unable to reconnect reliably when orphaned stdio MCP children remained alive outside Hermes' PID registry.

## Related Issue

Fixes #26042

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Recursively walks `/proc/{pid}/task/{pid}/children` on Linux to discover all descendants.
- Uses `psutil.Process(...).children(recursive=True)` in the fallback path.
- During orphan cleanup, discovers children of orphaned MCP PIDs and SIGTERMs them too.
- Adds regression tests for recursive `/proc` traversal, psutil fallback behavior, and orphan-child cleanup.

## How to Test

Passed:

```bash
python3 -m pytest -o 'addopts=' tests/tools/test_mcp_pid_tracking.py -q
# 6 passed
```

Fail-without-fix proof:

```bash
git checkout refs/remotes/upstream/main -- tools/mcp_tool.py
python3 -m pytest -o 'addopts=' tests/tools/test_mcp_pid_tracking.py -q
# 4 failed, 2 passed

git checkout HEAD -- tools/mcp_tool.py
python3 -m pytest -o 'addopts=' tests/tools/test_mcp_pid_tracking.py -q
# 6 passed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
python3 -m pytest -o 'addopts=' tests/tools/test_mcp_pid_tracking.py -q
6 passed
```
