### PR TITLE
fix(gateway/discord): propagate leading mention onto continuation chunks (#27265)

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -547,6 +547,70 @@ class DiscordAdapter(BasePlatformAdapter):
     MAX_MESSAGE_LENGTH = 2000
     _SPLIT_THRESHOLD = 1900  # near the 2000-char split point
 
+    # Pattern for leading Discord user/role mentions at the start of a message.
+    # Matches one or more space-separated ``<@123>``, ``<@!123>``, or ``<@&123>``
+    # tokens. ``@everyone`` / ``@here`` are intentionally excluded — propagating
+    # those to every continuation chunk would spam the whole server.
+    _LEADING_MENTION_RE = re.compile(
+        r"^((?:<@!?\d+>|<@&\d+>)(?:\s+(?:<@!?\d+>|<@&\d+>))*)\s+"
+    )
+
+    @classmethod
+    def _extract_leading_mention_prefix(cls, text: str) -> str:
+        """Return the leading user/role mention prefix of *text*, or ``""``.
+
+        Used to propagate target mentions across continuation chunks produced
+        by :meth:`truncate_message`. Without this, a receiving mention-gated
+        Hermes bot (e.g. ``DISCORD_ALLOW_BOTS=mentions``) only ingests the
+        first chunk of a long bot-to-bot handoff and silently drops the rest.
+        See issue #27265.
+        """
+        if not text:
+            return ""
+        match = cls._LEADING_MENTION_RE.match(text)
+        return match.group(1) if match else ""
+
+    @classmethod
+    def _propagate_leading_mentions(
+        cls, chunks: List[str], max_length: int = MAX_MESSAGE_LENGTH
+    ) -> List[str]:
+        """Prepend the first chunk's leading mention prefix to each continuation chunk.
+
+        Discord's 2000-char split means a long bot-to-bot handoff like
+        ``<@target-bot> ...part 1... (1/4)``, ``...part 2... (2/4)`` only
+        mentions ``target-bot`` in the first chunk. A mention-gated receiver
+        therefore ingests part 1 and drops the rest. We replay the same
+        mention prefix at the start of every continuation chunk so
+        mention-gated bots see the full handoff.
+
+        If the resulting chunk would exceed *max_length*, the prefix is
+        skipped for that chunk to avoid breaking the platform limit.
+
+        See issue #27265.
+        """
+        if not chunks:
+            return chunks
+        prefix = cls._extract_leading_mention_prefix(chunks[0])
+        if not prefix:
+            return chunks
+        out = [chunks[0]]
+        prefix_with_sep = f"{prefix} "
+        for chunk in chunks[1:]:
+            # Idempotent — don't double-prepend if upstream already added it.
+            if chunk.startswith(prefix_with_sep) or chunk.startswith(prefix):
+                out.append(chunk)
+                continue
+            new_chunk = f"{prefix_with_sep}{chunk}"
+            if len(new_chunk) <= max_length:
+                out.append(new_chunk)
+            else:
+                # Prefer the original (correct length) over the prefixed
+                # variant that would be rejected by Discord. The receiver
+                # will still miss this chunk, but that's preferable to a
+                # send failure for the whole message.
+                out.append(chunk)
+        return out
+
     # Auto-disconnect from voice channel after this many seconds of inactivity
     VOICE_TIMEOUT = 300
 
@@ -1413,6 +1477,7 @@ class DiscordAdapter(BasePlatformAdapter):
             # Format and split message if needed
             formatted = self.format_message(content)
             chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+            chunks = self._propagate_leading_mentions(chunks)
 
             message_ids = []
             reference = None
@@ -1492,9 +1557,9 @@ class DiscordAdapter(BasePlatformAdapter):
 
         formatted = self.format_message(content)
         chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+        chunks = self._propagate_leading_mentions(chunks)
 
         thread_name = _derive_forum_thread_name(content)
-
         starter_content = chunks[0] if chunks else thread_name
 
         try:

--- a/tests/gateway/test_discord_mention_propagation.py
+++ b/tests/gateway/test_discord_mention_propagation.py
@@ -1,0 +1,131 @@
+"""Tests for Discord continuation-chunk mention propagation (issue #27265).
+
+When a Hermes bot sends a long message addressed to another (mention-gated)
+bot, Discord's 2000-char split causes only the first chunk to carry the
+target mention. A receiving bot with ``DISCORD_ALLOW_BOTS=mentions`` would
+then ingest part 1 and silently drop parts 2..N. The fix prepends the
+leading mention prefix from the first chunk onto every continuation chunk.
+"""
+from __future__ import annotations
+
+from tests.gateway.test_discord_send import _ensure_discord_mock
+
+_ensure_discord_mock()
+
+from gateway.platforms.discord import DiscordAdapter  # noqa: E402
+
+
+class TestExtractLeadingMentionPrefix:
+    def test_single_user_mention(self) -> None:
+        assert (
+            DiscordAdapter._extract_leading_mention_prefix("<@123> hello world")
+            == "<@123>"
+        )
+
+    def test_user_mention_with_bang(self) -> None:
+        assert (
+            DiscordAdapter._extract_leading_mention_prefix("<@!456> ping")
+            == "<@!456>"
+        )
+
+    def test_role_mention(self) -> None:
+        assert (
+            DiscordAdapter._extract_leading_mention_prefix("<@&789> roll call")
+            == "<@&789>"
+        )
+
+    def test_multiple_mentions(self) -> None:
+        assert (
+            DiscordAdapter._extract_leading_mention_prefix(
+                "<@1> <@!2> <@&3> message"
+            )
+            == "<@1> <@!2> <@&3>"
+        )
+
+    def test_no_mention_returns_empty(self) -> None:
+        assert DiscordAdapter._extract_leading_mention_prefix("hello world") == ""
+
+    def test_everyone_not_treated_as_mention(self) -> None:
+        # We deliberately don't propagate @everyone / @here — replaying it on
+        # every chunk would spam the whole server.
+        assert (
+            DiscordAdapter._extract_leading_mention_prefix("@everyone hi") == ""
+        )
+        assert DiscordAdapter._extract_leading_mention_prefix("@here hi") == ""
+
+    def test_empty_string(self) -> None:
+        assert DiscordAdapter._extract_leading_mention_prefix("") == ""
+
+    def test_inline_mention_not_extracted(self) -> None:
+        # Only the very first token counts as a leading prefix.
+        assert (
+            DiscordAdapter._extract_leading_mention_prefix("hi <@123>") == ""
+        )
+
+
+class TestPropagateLeadingMentions:
+    def test_propagates_to_continuation_chunks(self) -> None:
+        chunks = [
+            "<@111> intro line (1/3)",
+            "middle chunk (2/3)",
+            "final chunk (3/3)",
+        ]
+        out = DiscordAdapter._propagate_leading_mentions(chunks)
+        assert out[0] == "<@111> intro line (1/3)"
+        assert out[1] == "<@111> middle chunk (2/3)"
+        assert out[2] == "<@111> final chunk (3/3)"
+
+    def test_single_chunk_unchanged(self) -> None:
+        chunks = ["<@111> short message"]
+        assert DiscordAdapter._propagate_leading_mentions(chunks) == chunks
+
+    def test_no_mention_unchanged(self) -> None:
+        chunks = ["intro (1/2)", "tail (2/2)"]
+        assert DiscordAdapter._propagate_leading_mentions(chunks) == chunks
+
+    def test_idempotent(self) -> None:
+        chunks = [
+            "<@111> first (1/2)",
+            "<@111> already prefixed (2/2)",
+        ]
+        out = DiscordAdapter._propagate_leading_mentions(chunks)
+        assert out == chunks  # no double-prefix
+
+    def test_skips_when_oversize(self) -> None:
+        # Force a small max_length so the prefixed continuation would exceed it.
+        chunks = ["<@1> aaa", "bbbbbbbbbbb"]
+        out = DiscordAdapter._propagate_leading_mentions(chunks, max_length=10)
+        assert out[0] == "<@1> aaa"
+        # Prefixed form "<@1> bbbbbbbbbbb" is 16 chars > 10 → keep original
+        assert out[1] == "bbbbbbbbbbb"
+
+    def test_empty_input(self) -> None:
+        assert DiscordAdapter._propagate_leading_mentions([]) == []
+
+    def test_role_mention_propagation(self) -> None:
+        chunks = ["<@&42> announcement (1/2)", "details (2/2)"]
+        out = DiscordAdapter._propagate_leading_mentions(chunks)
+        assert out[1] == "<@&42> details (2/2)"
+
+    def test_multi_mention_propagation(self) -> None:
+        chunks = ["<@1> <@2> hello (1/2)", "world (2/2)"]
+        out = DiscordAdapter._propagate_leading_mentions(chunks)
+        assert out[1] == "<@1> <@2> world (2/2)"
+
+
+class TestRealTruncate:
+    """End-to-end through ``truncate_message`` + propagation."""
+
+    def test_long_handoff_keeps_mention_on_every_chunk(self) -> None:
+        body = "x" * 5000
+        full = f"<@999> {body}"
+        chunks = DiscordAdapter.truncate_message(
+            full, DiscordAdapter.MAX_MESSAGE_LENGTH
+        )
+        assert len(chunks) > 1, "test setup should produce multiple chunks"
+        out = DiscordAdapter._propagate_leading_mentions(chunks)
+        # Every chunk must mention the target bot
+        for chunk in out:
+            assert chunk.startswith("<@999>"), (
+                f"continuation chunk missing target mention: {chunk[:80]!r}"
+            )


### PR DESCRIPTION
## Summary
- Propagate the leading user/role mention prefix onto every continuation chunk in the Discord send path.
- Without this, a long bot-to-bot handoff split at Discord's 2000-char limit only mentions the target bot in chunk 1. A receiving mention-gated Hermes bot (`DISCORD_ALLOW_BOTS=mentions`) then ingests part 1 and silently drops parts 2..N — the receiving agent acts on an incomplete handoff.
- Applies to both the normal `send()` path and the forum-thread post path.
- `@everyone` / `@here` are deliberately **excluded** — replaying those on every chunk would spam the whole server. Only `<@user>` / `<@!user>` / `<@&role>` mentions are propagated.
- If prepending the prefix would push a chunk past `MAX_MESSAGE_LENGTH`, the original chunk is kept to avoid a send failure (the receiver may miss that one chunk, which beats failing the whole message).

## Implementation
- New `DiscordAdapter._extract_leading_mention_prefix(text)` — pulls the leading `<@...>` token sequence, or empty string.
- New `DiscordAdapter._propagate_leading_mentions(chunks, max_length=...)` — pure function; idempotent so it won't double-prefix chunks that already start with the same mention.
- Called immediately after `truncate_message(...)` in both send paths.

## Test Plan
- [x] `python -m pytest tests/gateway/test_discord_mention_propagation.py -q -o 'addopts='` — **17 passed**
- [x] `python -m pytest tests/gateway/test_discord_send.py tests/gateway/test_discord_reply_mode.py -q -o 'addopts='` — **51 passed** (no regressions in existing send / reply-mode / chunking tests)

Note: the full `tests/gateway/` suite was not run because the broad gateway suite exhausts the macOS file-descriptor limit on this workstation (see #11645 / #27004); the targeted coverage above passed.

Closes #27265