### PR TITLE
feat: add Claude operator worker launcher

### DIFF
--- a/hermes_cli/claude_operator.py
+++ b/hermes_cli/claude_operator.py
@@ -269,6 +269,8 @@ def spawn(
     pinned file under ``~/.hermes/claude-operator/prompts/`` so the
     operator (and the Archivist role) can replay or audit it later.
     """
+    validate_permission_mode(permission_mode)
+
     workdir = Path(workdir).expanduser().resolve()
     if not workdir.is_dir():
         raise OperatorError(f"workdir does not exist or is not a directory: {workdir}")

--- a/hermes_cli/claude_operator.py
+++ b/hermes_cli/claude_operator.py
@@ -1,0 +1,542 @@
+"""Claude Code worker operator — launch and manage Claude Code workers in tmux.
+
+Hermes treats Claude Code (and later Codex / Gemini) as a worker fleet. This
+module is the smallest useful primitive for the **Dispatcher** role from
+``operator-plan.md``: spawn a Claude Code worker in a predictably-named tmux
+session, capture its log, and answer ``list``/``status``/``attach``/``stop``.
+
+Safety contract
+---------------
+
+* Default permission mode is ``auto``. The worker auto-accepts edits and
+  most low-risk tool calls but cannot bypass the safety hooks Bryan has
+  installed (pre-push-guardian, worktree-guard, careful, supabase-guard).
+* ``bypassPermissions`` / ``--dangerously-skip-permissions`` is **refused**.
+  Hermes never spawns workers in that mode; the refusal lives in
+  :func:`validate_permission_mode` and is exercised by tests.
+  ``dontAsk`` is also not allowed — Hermes does not blanket-suppress prompts.
+* Production-destructive surfaces (Railway, GitHub PRs, prod DB) are not
+  touched by this module. Workers operate inside a workdir they were given;
+  Hermes' Watcher / Verifier roles enforce the rest.
+
+The module exposes both a pure-logic API (used by tests + future callers)
+and a thin tmux-driven side-effect layer (``spawn``, ``list_sessions``,
+``status``, ``stop``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Optional
+
+from hermes_constants import get_hermes_home
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Tmux session namespace. Every worker session lives under this prefix so
+#: ``list_sessions`` can filter cleanly and ``hermes/_supervisor`` is reserved.
+TMUX_PREFIX = "hermes"
+
+#: Max length for any single slug segment. Keeps tmux session names short
+#: enough for human readability in ``tmux ls``.
+MAX_SLUG_LEN = 24
+
+#: Permission modes that are accepted. Mirrors Claude Code's CLI flag.
+#: ``auto`` is Bryan's required default — auto-accepts edits + low-risk tool
+#: calls without bypassing safety hooks. ``acceptEdits`` is still accepted for
+#: callers that want narrower auto-acceptance; ``default`` falls back to
+#: per-call prompts (used for risky DDL where Hermes forwards prompts to Bryan).
+ALLOWED_PERMISSION_MODES = frozenset({"auto", "acceptEdits", "default", "plan"})
+
+#: Permission modes the operator hard-refuses. Bypass mode defeats the safety
+#: hooks Bryan already has installed. ``dontAsk`` is also refused — Hermes
+#: doesn't blanket-suppress prompts; risky calls must surface to Bryan.
+REFUSED_PERMISSION_MODES = frozenset(
+    {"bypassPermissions", "bypass", "dangerouslySkipPermissions", "dontAsk"}
+)
+
+
+class OperatorError(RuntimeError):
+    """Raised for any operator-level safety or configuration violation."""
+
+
+# ---------------------------------------------------------------------------
+# Pure logic — slug + naming + paths + command construction
+# ---------------------------------------------------------------------------
+
+
+def slugify(value: str, max_len: int = MAX_SLUG_LEN) -> str:
+    """Lower-case kebab-case slug, ASCII-only, bounded by ``max_len``.
+
+    Used for the intent / worker / project segments of a tmux session
+    name. Empty results raise :class:`OperatorError` — every segment must
+    be non-empty so ``list_sessions`` filtering stays unambiguous.
+    """
+    if value is None:
+        raise OperatorError("slug input must not be None")
+    cleaned = re.sub(r"[^a-zA-Z0-9]+", "-", value.strip().lower()).strip("-")
+    cleaned = cleaned[:max_len].strip("-")
+    if not cleaned:
+        raise OperatorError(f"slug is empty after normalization: {value!r}")
+    return cleaned
+
+
+def session_name(project: str, worker: str, intent: str) -> str:
+    """Compose a deterministic tmux session name.
+
+    Shape: ``hermes/<project>/<worker>/<intent>``. Matches the conventions
+    in ``operator-plan.md`` section 4 so Watcher / Narrator / Archivist can
+    identify the project + worker class + intent from the session name
+    without consulting an out-of-band registry.
+    """
+    return "/".join(
+        (TMUX_PREFIX, slugify(project), slugify(worker), slugify(intent))
+    )
+
+
+def operator_home() -> Path:
+    """Root directory for operator-managed artifacts (logs, prompt files)."""
+    return get_hermes_home() / "claude-operator"
+
+
+def _session_safe(name: str) -> str:
+    """Filesystem-safe rendering of a tmux session name (slashes → dashes)."""
+    return name.replace("/", "-")
+
+
+def log_path(name: str) -> Path:
+    """Path to the worker's append-only log file."""
+    return operator_home() / "logs" / f"{_session_safe(name)}.log"
+
+
+def prompt_path(name: str) -> Path:
+    """Path to the worker's pinned initial prompt (for replay / inspection)."""
+    return operator_home() / "prompts" / f"{_session_safe(name)}.md"
+
+
+def validate_permission_mode(mode: str) -> str:
+    """Return ``mode`` if it's allowed; raise :class:`OperatorError` otherwise.
+
+    This is the single chokepoint for the "no bypass" safety contract.
+    Both the CLI surface and any future programmatic caller route through
+    here so the refusal cannot be silently skipped.
+    """
+    if mode in REFUSED_PERMISSION_MODES:
+        raise OperatorError(
+            f"permission mode {mode!r} is refused: Hermes never spawns workers "
+            "in bypass / dontAsk modes. Use 'auto' (default), 'acceptEdits', "
+            "or 'default' (per-call prompts)."
+        )
+    if mode not in ALLOWED_PERMISSION_MODES:
+        raise OperatorError(
+            f"permission mode {mode!r} is unknown. Allowed: "
+            f"{sorted(ALLOWED_PERMISSION_MODES)}"
+        )
+    return mode
+
+
+def build_claude_command(
+    *,
+    workdir: Path,
+    permission_mode: str = "auto",
+    prompt: Optional[str] = None,
+    agent: Optional[str] = None,
+    binary: str = "claude",
+    extra_args: Optional[Iterable[str]] = None,
+) -> list[str]:
+    """Construct the argv for invoking Claude Code.
+
+    The constructed list is what the tmux launcher will exec. Pure: no
+    shell quoting concerns, no environment side effects. Tests assert
+    that ``auto`` lands in the argv by default and that bypass never does.
+    """
+    validate_permission_mode(permission_mode)
+    argv: list[str] = [binary, "--permission-mode", permission_mode]
+    if workdir:
+        argv.extend(["--add-dir", str(workdir)])
+    if agent:
+        argv.extend(["--agent", agent])
+    if extra_args:
+        argv.extend(extra_args)
+    if prompt:
+        argv.append(prompt)
+    return argv
+
+
+def tmux_launch_command(
+    *,
+    session: str,
+    workdir: Path,
+    claude_argv: list[str],
+    log_file: Path,
+    tmux_binary: str = "tmux",
+) -> list[str]:
+    """Compose the tmux argv that creates the detached worker session.
+
+    Uses ``tmux new-session -d`` so the spawn is non-blocking. The worker's
+    stdout/stderr is piped through ``tee -a`` to ``log_file`` for replay.
+    The inner command is a single shell string (tmux requires that for
+    ``new-session``), built with ``shlex.quote`` to keep prompts containing
+    quotes from breaking the launch.
+    """
+    inner = " ".join(shlex.quote(tok) for tok in claude_argv)
+    shell_cmd = (
+        f"cd {shlex.quote(str(workdir))} && "
+        f"{inner} 2>&1 | tee -a {shlex.quote(str(log_file))}"
+    )
+    return [
+        tmux_binary,
+        "new-session",
+        "-d",
+        "-s",
+        session,
+        "-c",
+        str(workdir),
+        shell_cmd,
+    ]
+
+
+def attach_command(session: str, tmux_binary: str = "tmux") -> str:
+    """Shell snippet a human can run to watch a worker live."""
+    return f"{tmux_binary} attach -t {shlex.quote(session)}"
+
+
+# ---------------------------------------------------------------------------
+# Side-effect layer — actually talk to tmux
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class WorkerSession:
+    """One live tmux session managed by the operator."""
+
+    name: str
+    log_file: Path
+    created_at: float
+
+
+def _ensure_tmux(tmux_binary: str = "tmux") -> None:
+    if not shutil.which(tmux_binary):
+        raise OperatorError(
+            f"{tmux_binary!r} not found on PATH. Install tmux (e.g. `brew install tmux`)."
+        )
+
+
+def _ensure_claude(binary: str = "claude") -> None:
+    if not shutil.which(binary):
+        raise OperatorError(
+            f"{binary!r} not found on PATH. Install Claude Code "
+            "(https://docs.claude.com/claude-code) and ensure it's in PATH."
+        )
+
+
+def _prepare_paths(name: str) -> tuple[Path, Path]:
+    log = log_path(name)
+    prompt = prompt_path(name)
+    log.parent.mkdir(parents=True, exist_ok=True)
+    prompt.parent.mkdir(parents=True, exist_ok=True)
+    return log, prompt
+
+
+def spawn(
+    *,
+    project: str,
+    worker: str,
+    intent: str,
+    workdir: Path,
+    prompt: str,
+    permission_mode: str = "auto",
+    agent: Optional[str] = None,
+    binary: str = "claude",
+    tmux_binary: str = "tmux",
+    extra_args: Optional[Iterable[str]] = None,
+) -> WorkerSession:
+    """Spawn a Claude Code worker in a detached tmux session.
+
+    Honors the safety contract: refuses bypass permission modes via
+    :func:`validate_permission_mode`. Writes the initial prompt to a
+    pinned file under ``~/.hermes/claude-operator/prompts/`` so the
+    operator (and the Archivist role) can replay or audit it later.
+    """
+    workdir = Path(workdir).expanduser().resolve()
+    if not workdir.is_dir():
+        raise OperatorError(f"workdir does not exist or is not a directory: {workdir}")
+
+    _ensure_tmux(tmux_binary)
+    _ensure_claude(binary)
+
+    name = session_name(project, worker, intent)
+    if _session_exists(name, tmux_binary=tmux_binary):
+        raise OperatorError(
+            f"tmux session {name!r} already exists. Stop it first or pick a "
+            "different intent slug."
+        )
+
+    log_file, prompt_file = _prepare_paths(name)
+    prompt_file.write_text(prompt, encoding="utf-8")
+
+    claude_argv = build_claude_command(
+        workdir=workdir,
+        permission_mode=permission_mode,
+        prompt=prompt,
+        agent=agent,
+        binary=binary,
+        extra_args=extra_args,
+    )
+    tmux_argv = tmux_launch_command(
+        session=name,
+        workdir=workdir,
+        claude_argv=claude_argv,
+        log_file=log_file,
+        tmux_binary=tmux_binary,
+    )
+    subprocess.run(tmux_argv, check=True)
+
+    return WorkerSession(name=name, log_file=log_file, created_at=time.time())
+
+
+def _session_exists(name: str, tmux_binary: str = "tmux") -> bool:
+    result = subprocess.run(
+        [tmux_binary, "has-session", "-t", name],
+        capture_output=True,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def list_sessions(tmux_binary: str = "tmux") -> list[WorkerSession]:
+    """Return every active ``hermes/...`` tmux session."""
+    if not shutil.which(tmux_binary):
+        return []
+    result = subprocess.run(
+        [tmux_binary, "list-sessions", "-F", "#{session_name}\t#{session_created}"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return []
+    sessions: list[WorkerSession] = []
+    for line in result.stdout.splitlines():
+        if not line.startswith(f"{TMUX_PREFIX}/"):
+            continue
+        try:
+            name, created = line.split("\t", 1)
+            created_at = float(created)
+        except ValueError:
+            continue
+        sessions.append(
+            WorkerSession(
+                name=name,
+                log_file=log_path(name),
+                created_at=created_at,
+            )
+        )
+    return sessions
+
+
+def status(name: str, tail_lines: int = 30, tmux_binary: str = "tmux") -> str:
+    """Return a short human-readable status report for ``name``."""
+    alive = _session_exists(name, tmux_binary=tmux_binary)
+    log_file = log_path(name)
+    parts: list[str] = []
+    parts.append(f"session: {name}")
+    parts.append(f"alive:   {'yes' if alive else 'no'}")
+    parts.append(f"log:     {log_file}")
+    if log_file.exists():
+        try:
+            lines = log_file.read_text(encoding="utf-8", errors="replace").splitlines()
+            tail = lines[-tail_lines:]
+            parts.append("")
+            parts.append(f"--- last {len(tail)} log lines ---")
+            parts.extend(tail)
+        except OSError as exc:
+            parts.append(f"(log read failed: {exc})")
+    else:
+        parts.append("(no log file yet)")
+    return "\n".join(parts)
+
+
+def stop(name: str, tmux_binary: str = "tmux") -> bool:
+    """Kill a tmux session. Returns ``True`` if a session was killed."""
+    if not _session_exists(name, tmux_binary=tmux_binary):
+        return False
+    subprocess.run([tmux_binary, "kill-session", "-t", name], check=True)
+    return True
+
+
+# ---------------------------------------------------------------------------
+# argparse surface — wired into the top-level CLI by main.py
+# ---------------------------------------------------------------------------
+
+
+def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser:
+    """Attach the ``claude-operator`` subcommand tree."""
+    parser = parent_subparsers.add_parser(
+        "claude-operator",
+        help="Spawn and manage Claude Code workers in tmux",
+        description=(
+            "Hermes-managed Claude Code worker fleet. Spawns workers in tmux "
+            "with --permission-mode auto (never bypass / dontAsk). Names "
+            "sessions predictably (hermes/<project>/<worker>/<intent>) so "
+            "list/status/attach all work without an external registry. See "
+            "operator-plan.md for the full role split (Dispatcher / Watcher "
+            "/ Verifier / Archivist / Narrator)."
+        ),
+    )
+    sub = parser.add_subparsers(dest="operator_action")
+
+    p_spawn = sub.add_parser("spawn", help="Launch a Claude Code worker in tmux")
+    p_spawn.add_argument("--project", required=True, help="Project slug (e.g. 'lyra')")
+    p_spawn.add_argument("--worker", default="claude", help="Worker class (default: claude)")
+    p_spawn.add_argument("--intent", required=True, help="Short intent slug (e.g. 'fix-stale-agm')")
+    p_spawn.add_argument("--workdir", required=True, help="Directory the worker operates in (typically a worktree)")
+    p_spawn.add_argument(
+        "--permission-mode",
+        default="auto",
+        help=(
+            "Claude Code permission mode (default: auto). "
+            "Allowed: auto, acceptEdits, default, plan. "
+            "Bypass / dontAsk modes are refused."
+        ),
+    )
+    p_spawn.add_argument("--agent", default=None, help="Optional Claude Code agent preset name")
+    p_spawn.add_argument(
+        "--prompt",
+        default=None,
+        help="Initial prompt text. Mutually exclusive with --prompt-file.",
+    )
+    p_spawn.add_argument(
+        "--prompt-file",
+        default=None,
+        help="Path to a file containing the initial prompt.",
+    )
+    p_spawn.add_argument(
+        "--binary",
+        default="claude",
+        help="Claude Code binary name on PATH (default: claude)",
+    )
+
+    p_list = sub.add_parser("list", aliases=["ls"], help="List active worker sessions")
+    p_list.add_argument("--json", action="store_true", help="Emit JSON instead of plain text")
+
+    p_status = sub.add_parser("status", help="Show status + log tail for one worker")
+    p_status.add_argument("session", help="Full session name (e.g. hermes/lyra/claude/fix-stale-agm)")
+    p_status.add_argument("--tail", type=int, default=30, help="Log tail line count (default: 30)")
+
+    p_attach = sub.add_parser("attach", help="Print the tmux attach command for a worker")
+    p_attach.add_argument("session", help="Full session name")
+
+    p_stop = sub.add_parser("stop", help="Kill a worker's tmux session")
+    p_stop.add_argument("session", help="Full session name")
+
+    return parser
+
+
+def operator_command(args: argparse.Namespace) -> int:
+    """Dispatch ``hermes claude-operator …`` invocations."""
+    action = getattr(args, "operator_action", None)
+    if action == "spawn":
+        return _cmd_spawn(args)
+    if action in ("list", "ls"):
+        return _cmd_list(args)
+    if action == "status":
+        return _cmd_status(args)
+    if action == "attach":
+        return _cmd_attach(args)
+    if action == "stop":
+        return _cmd_stop(args)
+    print(
+        "Usage: hermes claude-operator {spawn|list|status|attach|stop} ...",
+        file=sys.stderr,
+    )
+    return 2
+
+
+def _resolve_prompt(args: argparse.Namespace) -> str:
+    if args.prompt and args.prompt_file:
+        raise OperatorError("--prompt and --prompt-file are mutually exclusive")
+    if args.prompt:
+        return args.prompt
+    if args.prompt_file:
+        return Path(args.prompt_file).expanduser().read_text(encoding="utf-8")
+    raise OperatorError("one of --prompt or --prompt-file is required")
+
+
+def _cmd_spawn(args: argparse.Namespace) -> int:
+    try:
+        prompt = _resolve_prompt(args)
+        session = spawn(
+            project=args.project,
+            worker=args.worker,
+            intent=args.intent,
+            workdir=Path(args.workdir),
+            prompt=prompt,
+            permission_mode=args.permission_mode,
+            agent=args.agent,
+            binary=args.binary,
+        )
+    except OperatorError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    except subprocess.CalledProcessError as exc:
+        print(f"tmux launch failed: {exc}", file=sys.stderr)
+        return 1
+    print(f"spawned: {session.name}")
+    print(f"log:     {session.log_file}")
+    print(f"attach:  {attach_command(session.name)}")
+    return 0
+
+
+def _cmd_list(args: argparse.Namespace) -> int:
+    sessions = list_sessions()
+    if getattr(args, "json", False):
+        import json as _json
+
+        payload = [
+            {
+                "name": s.name,
+                "log_file": str(s.log_file),
+                "created_at": s.created_at,
+            }
+            for s in sessions
+        ]
+        print(_json.dumps(payload, indent=2))
+        return 0
+    if not sessions:
+        print("(no active hermes workers)")
+        return 0
+    for s in sessions:
+        age_s = int(time.time() - s.created_at)
+        print(f"{s.name}  age={age_s}s  log={s.log_file}")
+    return 0
+
+
+def _cmd_status(args: argparse.Namespace) -> int:
+    print(status(args.session, tail_lines=args.tail))
+    return 0
+
+
+def _cmd_attach(args: argparse.Namespace) -> int:
+    print(attach_command(args.session))
+    return 0
+
+
+def _cmd_stop(args: argparse.Namespace) -> int:
+    killed = stop(args.session)
+    if killed:
+        print(f"killed: {args.session}")
+        return 0
+    print(f"no active session: {args.session}", file=sys.stderr)
+    return 1

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5563,6 +5563,13 @@ def cmd_kanban(args):
     return kanban_command(args)
 
 
+def cmd_claude_operator(args):
+    """Claude Code worker fleet — spawn/list/status/attach/stop in tmux."""
+    from hermes_cli.claude_operator import operator_command
+
+    return operator_command(args)
+
+
 def cmd_hooks(args):
     """Shell-hook inspection and management."""
     from hermes_cli.hooks import hooks_command
@@ -9626,8 +9633,8 @@ def _build_provider_choices() -> list[str]:
 # to parse.
 _BUILTIN_SUBCOMMANDS = frozenset(
     {
-        "acp", "auth", "backup", "checkpoints", "claw", "completion",
-        "computer-use",
+        "acp", "auth", "backup", "checkpoints", "claude-operator", "claw",
+        "completion", "computer-use",
         "config", "cron", "curator", "dashboard", "debug", "doctor",
         "dump", "fallback", "gateway", "hooks", "import", "insights",
         "kanban", "login", "logout", "logs", "lsp", "mcp", "memory",
@@ -10531,6 +10538,14 @@ def main():
 
     kanban_parser = _build_kanban_parser(subparsers)
     kanban_parser.set_defaults(func=cmd_kanban)
+
+    # =========================================================================
+    # claude-operator command — Claude Code worker fleet (tmux-managed)
+    # =========================================================================
+    from hermes_cli.claude_operator import build_parser as _build_operator_parser
+
+    operator_parser = _build_operator_parser(subparsers)
+    operator_parser.set_defaults(func=cmd_claude_operator)
 
     # =========================================================================
     # hooks command — shell-hook inspection and management

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5567,7 +5567,7 @@ def cmd_claude_operator(args):
     """Claude Code worker fleet — spawn/list/status/attach/stop in tmux."""
     from hermes_cli.claude_operator import operator_command
 
-    return operator_command(args)
+    sys.exit(operator_command(args))
 
 
 def cmd_hooks(args):

--- a/tests/hermes_cli/test_claude_operator.py
+++ b/tests/hermes_cli/test_claude_operator.py
@@ -1,0 +1,283 @@
+"""Tests for hermes_cli.claude_operator — pure logic + safety contract.
+
+Deliberately avoids tmux integration. The side-effect layer (spawn / stop /
+list_sessions) shells out to ``tmux`` and ``claude``; covering it in unit
+tests would require either a real tmux server or a brittle mock harness.
+The pure pieces below are where every bug actually lands:
+
+* slug normalization (used for tmux session naming + filesystem paths)
+* the safety refusal for bypass / dontAsk permission modes
+* the argv the worker is launched with (auto is the default; bypass and
+  dontAsk must never appear)
+* the tmux launch shell-string (worker output must be tee'd to the log)
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import claude_operator as op
+
+
+# ---------------------------------------------------------------------------
+# Slug + naming
+# ---------------------------------------------------------------------------
+
+
+class TestSlugify:
+    def test_lowercases_and_kebabs(self):
+        assert op.slugify("Fix Stale AGM") == "fix-stale-agm"
+
+    def test_strips_punctuation(self):
+        assert op.slugify("PR #769: rename roster!") == "pr-769-rename-roster"
+
+    def test_collapses_repeats(self):
+        assert op.slugify("a   b___c") == "a-b-c"
+
+    def test_truncates_to_max(self):
+        result = op.slugify("a" * 100, max_len=10)
+        assert len(result) <= 10
+        assert result == "a" * 10
+
+    def test_empty_raises(self):
+        with pytest.raises(op.OperatorError):
+            op.slugify("!!!")
+
+    def test_none_raises(self):
+        with pytest.raises(op.OperatorError):
+            op.slugify(None)  # type: ignore[arg-type]
+
+
+class TestSessionName:
+    def test_shape_matches_plan(self):
+        # operator-plan.md section 4 fixes the shape: hermes/<project>/<worker>/<intent>
+        assert (
+            op.session_name("lyra", "claude", "fix-stale-agm")
+            == "hermes/lyra/claude/fix-stale-agm"
+        )
+
+    def test_normalizes_all_segments(self):
+        assert (
+            op.session_name("Lyra A&R", "Claude Code", "Fix Stale AGM")
+            == "hermes/lyra-a-r/claude-code/fix-stale-agm"
+        )
+
+    def test_supervisor_namespace_is_reserved_only_by_convention(self):
+        # We don't block hermes/_supervisor at the slug layer — supervisor names
+        # would be slugified to "supervisor" anyway. This test pins the behavior
+        # so a future maintainer doesn't add a hidden hard-block here without
+        # also updating the convention in operator-plan.md section 4.
+        assert op.session_name("supervisor", "x", "y") == "hermes/supervisor/x/y"
+
+
+# ---------------------------------------------------------------------------
+# Paths — must scope under HERMES_HOME so profiles isolate workers
+# ---------------------------------------------------------------------------
+
+
+class TestPaths:
+    def test_paths_scope_to_hermes_home(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        name = "hermes/lyra/claude/fix-stale-agm"
+        log = op.log_path(name)
+        prompt = op.prompt_path(name)
+        assert log.is_relative_to(tmp_path)
+        assert prompt.is_relative_to(tmp_path)
+
+    def test_paths_replace_slashes(self, tmp_path, monkeypatch):
+        # Tmux session names contain slashes; filesystem paths must not nest
+        # them as directories or status/list logic would walk into surprises.
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        name = "hermes/lyra/claude/fix-stale-agm"
+        assert "/" not in op.log_path(name).name
+        assert "/" not in op.prompt_path(name).name
+
+
+# ---------------------------------------------------------------------------
+# Safety contract — bypass is refused, period
+# ---------------------------------------------------------------------------
+
+
+class TestPermissionModeSafety:
+    def test_auto_is_allowed(self):
+        # Bryan's required default — auto-accepts without bypassing safety hooks.
+        assert op.validate_permission_mode("auto") == "auto"
+
+    def test_accept_edits_is_allowed(self):
+        assert op.validate_permission_mode("acceptEdits") == "acceptEdits"
+
+    def test_default_is_allowed(self):
+        # Used for risky DDL where Hermes forwards prompts to Bryan.
+        assert op.validate_permission_mode("default") == "default"
+
+    def test_plan_is_allowed(self):
+        assert op.validate_permission_mode("plan") == "plan"
+
+    @pytest.mark.parametrize(
+        "bypass_mode",
+        [
+            "bypassPermissions",
+            "bypass",
+            "dangerouslySkipPermissions",
+            "dontAsk",
+        ],
+    )
+    def test_bypass_and_dontask_modes_are_refused(self, bypass_mode):
+        with pytest.raises(op.OperatorError, match="refused"):
+            op.validate_permission_mode(bypass_mode)
+
+    def test_unknown_mode_is_refused(self):
+        with pytest.raises(op.OperatorError, match="unknown"):
+            op.validate_permission_mode("yolo")
+
+    def test_build_command_refuses_bypass(self, tmp_path):
+        with pytest.raises(op.OperatorError):
+            op.build_claude_command(
+                workdir=tmp_path,
+                permission_mode="bypassPermissions",
+                prompt="hi",
+            )
+
+    def test_build_command_refuses_dontask(self, tmp_path):
+        with pytest.raises(op.OperatorError):
+            op.build_claude_command(
+                workdir=tmp_path,
+                permission_mode="dontAsk",
+                prompt="hi",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Command construction — argv shape, acceptEdits presence, prompt placement
+# ---------------------------------------------------------------------------
+
+
+class TestBuildClaudeCommand:
+    def test_auto_is_default_in_argv(self, tmp_path):
+        argv = op.build_claude_command(workdir=tmp_path, prompt="do thing")
+        assert "--permission-mode" in argv
+        idx = argv.index("--permission-mode")
+        assert argv[idx + 1] == "auto"
+
+    def test_accept_edits_passes_through_when_requested(self, tmp_path):
+        argv = op.build_claude_command(
+            workdir=tmp_path, prompt="do thing", permission_mode="acceptEdits"
+        )
+        idx = argv.index("--permission-mode")
+        assert argv[idx + 1] == "acceptEdits"
+
+    def test_no_bypass_token_ever_in_argv(self, tmp_path):
+        argv = op.build_claude_command(workdir=tmp_path, prompt="do thing")
+        forbidden = {
+            "--dangerously-skip-permissions",
+            "--bypass-permissions",
+            "bypassPermissions",
+            "dontAsk",
+        }
+        assert not (forbidden & set(argv))
+
+    def test_workdir_added_with_add_dir(self, tmp_path):
+        argv = op.build_claude_command(workdir=tmp_path, prompt="do thing")
+        assert "--add-dir" in argv
+        idx = argv.index("--add-dir")
+        assert argv[idx + 1] == str(tmp_path)
+
+    def test_agent_preset_propagates(self, tmp_path):
+        argv = op.build_claude_command(
+            workdir=tmp_path, prompt="x", agent="backend-builder"
+        )
+        assert "--agent" in argv
+        idx = argv.index("--agent")
+        assert argv[idx + 1] == "backend-builder"
+
+    def test_prompt_appended_as_positional(self, tmp_path):
+        argv = op.build_claude_command(workdir=tmp_path, prompt="ship it")
+        # Claude Code consumes the first positional as the initial user message.
+        assert argv[-1] == "ship it"
+
+    def test_extra_args_pass_through(self, tmp_path):
+        argv = op.build_claude_command(
+            workdir=tmp_path, prompt="x", extra_args=["--model", "opus"]
+        )
+        assert "--model" in argv
+        assert "opus" in argv
+
+    def test_binary_overrideable(self, tmp_path):
+        argv = op.build_claude_command(
+            workdir=tmp_path, prompt="x", binary="/usr/local/bin/claude"
+        )
+        assert argv[0] == "/usr/local/bin/claude"
+
+
+# ---------------------------------------------------------------------------
+# Tmux launch composition — log redirection must be present
+# ---------------------------------------------------------------------------
+
+
+class TestTmuxLaunchCommand:
+    def test_tmux_new_session_detached(self, tmp_path):
+        argv = op.tmux_launch_command(
+            session="hermes/lyra/claude/x",
+            workdir=tmp_path,
+            claude_argv=["claude", "--permission-mode", "auto", "go"],
+            log_file=tmp_path / "x.log",
+        )
+        assert argv[0] == "tmux"
+        assert "new-session" in argv
+        assert "-d" in argv
+
+    def test_log_file_teed(self, tmp_path):
+        log = tmp_path / "x.log"
+        argv = op.tmux_launch_command(
+            session="hermes/lyra/claude/x",
+            workdir=tmp_path,
+            claude_argv=["claude", "--permission-mode", "auto", "go"],
+            log_file=log,
+        )
+        shell_cmd = argv[-1]
+        assert "tee -a" in shell_cmd
+        assert str(log) in shell_cmd
+
+    def test_workdir_in_cd(self, tmp_path):
+        argv = op.tmux_launch_command(
+            session="hermes/lyra/claude/x",
+            workdir=tmp_path,
+            claude_argv=["claude", "go"],
+            log_file=tmp_path / "x.log",
+        )
+        shell_cmd = argv[-1]
+        assert f"cd {tmp_path}" in shell_cmd or f"cd '{tmp_path}'" in shell_cmd
+
+    def test_prompts_with_quotes_dont_break_shell(self, tmp_path):
+        # Prompts come from users; they will contain quotes. The launcher must
+        # use shlex.quote so the shell parses them as a single token.
+        prompt = """She said "ship it" and didn't blink"""
+        argv = op.tmux_launch_command(
+            session="hermes/lyra/claude/x",
+            workdir=tmp_path,
+            claude_argv=["claude", "--permission-mode", "auto", prompt],
+            log_file=tmp_path / "x.log",
+        )
+        shell_cmd = argv[-1]
+        # Whichever quoting scheme shlex picked, the prompt is preserved exactly
+        # somewhere in the command.
+        import shlex
+
+        # Re-parse and assert the prompt round-trips as a single argv token.
+        parsed = shlex.split(shell_cmd)
+        assert prompt in parsed
+
+
+# ---------------------------------------------------------------------------
+# Attach command — surface for human-visible watchers
+# ---------------------------------------------------------------------------
+
+
+class TestAttachCommand:
+    def test_attach_quotes_session_name(self):
+        cmd = op.attach_command("hermes/lyra/claude/fix-stale-agm")
+        assert cmd.startswith("tmux attach -t")
+        assert "hermes/lyra/claude/fix-stale-agm" in cmd

--- a/tests/hermes_cli/test_claude_operator.py
+++ b/tests/hermes_cli/test_claude_operator.py
@@ -15,6 +15,8 @@ The pure pieces below are where every bug actually lands:
 from __future__ import annotations
 
 import os
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -148,6 +150,46 @@ class TestPermissionModeSafety:
                 permission_mode="dontAsk",
                 prompt="hi",
             )
+
+    def test_spawn_refuses_bypass_before_environment_checks(self, tmp_path):
+        with pytest.raises(op.OperatorError, match="refused"):
+            op.spawn(
+                project="test",
+                worker="claude",
+                intent="bypass",
+                workdir=tmp_path,
+                prompt="hi",
+                permission_mode="bypassPermissions",
+                binary="definitely-not-a-real-claude-binary",
+                tmux_binary="definitely-not-a-real-tmux-binary",
+            )
+
+    def test_cli_refusal_exits_nonzero(self, tmp_path):
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "hermes_cli.main",
+                "claude-operator",
+                "spawn",
+                "--project",
+                "test",
+                "--intent",
+                "bypass",
+                "--workdir",
+                str(tmp_path),
+                "--permission-mode",
+                "bypassPermissions",
+                "--prompt",
+                "hi",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        assert result.returncode != 0
+        assert "refused" in result.stderr
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `hermes claude-operator` for spawning/listing/status/attaching/stopping Claude Code tmux workers.
- Default workers to `--permission-mode auto` for Bryan's required auto-mode workflow.
- Refuse bypass-style modes: `bypassPermissions`, `bypass`, `dangerouslySkipPermissions`, and `dontAsk`.
- Wire the subcommand into `hermes_cli/main.py` and cover behavior with focused tests.

## Verification
- `bash scripts/run_tests.sh tests/hermes_cli/test_claude_operator.py tests/hermes_cli/test_argparse_flag_propagation.py -q` → 49 passed
- `ruff check hermes_cli/claude_operator.py hermes_cli/main.py tests/hermes_cli/test_claude_operator.py` → all checks passed

## Safety
- No gateway restart.
- No secrets or user config touched.
- No prod systems touched.
