### PR TITLE
fix(xai-oauth): add --paste-code flag for WSL2 firewall workaround

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2193,7 +2193,47 @@ def _xai_wait_for_callback(
     result: dict[str, Any],
     *,
     timeout_seconds: float = 180.0,
+    allow_stdin_paste: bool = False,
+    paste_port: int | None = None,
+    paste_state: str | None = None,
 ) -> dict[str, Any]:
+    # === PATCH: xai-paste-code (hoyt-2026-05-17) === wait-for-callback
+    # On WSL2 with Hyper-V Firewall default-block policy (Microsoft's current
+    # default with mirrored networking), xAI's redirect to the loopback URI is
+    # silently dropped before reaching the WSL VM. xAI then shows a "Could not
+    # establish connection" page with the auth code as text. When
+    # allow_stdin_paste is True, this function also reads stdin in parallel
+    # and feeds any pasted code into the same callback handler via internal
+    # HTTP — same code path as the listener would take from a real redirect.
+    import sys as _sys
+    import threading as _threading
+    import urllib.request as _urlreq
+
+    stdin_thread = None
+    if allow_stdin_paste and paste_port and paste_state and _sys.stdin and _sys.stdin.isatty():
+        print()
+        print("If your browser shows 'Could not establish connection' with a code,")
+        print("paste the code here and press Enter (or wait for browser callback):")
+        def _stdin_reader():
+            try:
+                line = _sys.stdin.readline().strip()
+                if not line:
+                    return
+                # Strip surrounding quotes / accidental spaces
+                line = line.strip().strip('"').strip("'")
+                if result.get("code") or result.get("error"):
+                    return  # listener already won
+                # Deliver to local listener via internal curl-equivalent
+                url = f"http://127.0.0.1:{paste_port}/callback?code={line}&state={paste_state}"
+                try:
+                    _urlreq.urlopen(url, timeout=5)
+                except Exception:
+                    pass
+            except Exception:
+                pass
+        stdin_thread = _threading.Thread(target=_stdin_reader, daemon=True)
+        stdin_thread.start()
+
     deadline = time.monotonic() + max(5.0, timeout_seconds)
     try:
         while time.monotonic() < deadline:
@@ -5316,7 +5356,9 @@ def _xai_oauth_loopback_login(
     *,
     timeout_seconds: float = 20.0,
     open_browser: bool = True,
+    allow_stdin_paste: bool = False,
 ) -> Dict[str, Any]:
+    # === PATCH: xai-paste-code (hoyt-2026-05-17) === login-signature
     discovery = _xai_oauth_discovery(timeout_seconds)
     authorization_endpoint = discovery["authorization_endpoint"]
     token_endpoint = discovery["token_endpoint"]
@@ -5353,11 +5395,21 @@ def _xai_oauth_loopback_login(
             else:
                 print("Could not open the browser automatically; use the URL above.")
 
+        # Extract port from redirect_uri ("http://127.0.0.1:PORT/callback")
+        _paste_port = None
+        try:
+            from urllib.parse import urlparse as _urlparse
+            _paste_port = _urlparse(redirect_uri).port
+        except Exception:
+            pass
         callback = _xai_wait_for_callback(
             server,
             thread,
             callback_result,
             timeout_seconds=max(30.0, timeout_seconds * 9),
+            allow_stdin_paste=allow_stdin_paste,
+            paste_port=_paste_port,
+            paste_state=state,
         )
     except Exception:
         try:

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -336,9 +336,15 @@ def auth_add_command(args) -> None:
         return
 
     if provider == "xai-oauth":
+        # === PATCH: xai-paste-code (hoyt-2026-05-17) === paste-fallback enabled
+        # by --paste-code OR auto-enabled when --no-browser (WSL2 firewall case).
+        _paste_fallback = bool(getattr(args, "paste_code", False)) or bool(
+            getattr(args, "no_browser", False)
+        )
         creds = auth_mod._xai_oauth_loopback_login(
             timeout_seconds=getattr(args, "timeout", None) or 20.0,
             open_browser=not getattr(args, "no_browser", False),
+            allow_stdin_paste=_paste_fallback,
         )
         label = (getattr(args, "label", None) or "").strip() or label_from_token(
             creds["tokens"]["access_token"],

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10236,6 +10236,15 @@ def main():
         action="store_true",
         help="Do not auto-open a browser for OAuth login",
     )
+    # === PATCH: xai-paste-code (hoyt-2026-05-17) === --paste-code CLI flag
+    auth_add.add_argument(
+        "--paste-code",
+        action="store_true",
+        help=(
+            "Allow pasting the OAuth code via stdin (WSL2/firewall workaround). "
+            "Auto-enabled with --no-browser. xAI Grok OAuth only."
+        ),
+    )
     auth_add.add_argument(
         "--timeout", type=float, help="OAuth/network timeout in seconds"
     )


### PR DESCRIPTION
## Summary

WSL2 ships with the Hyper-V Firewall `DefaultInboundAction=Block` (Microsoft's current default with mirrored networking). xAI's OAuth redirect to `http://127.0.0.1:56121/callback` is silently dropped before reaching the WSL VM. xAI then renders its "Could not establish connection" fallback page showing the auth code as text — but stock Hermes has no way to accept that code, so the listener times out and the code is orphaned.

This PR adds the `--code`-flag-equivalent that PR #27305 mentioned was needed but not yet shipped.

## Changes

- New `--paste-code` flag on `hermes auth add` (auto-enabled when `--no-browser` is set, so the existing remote-session UX gets the fix for free)
- `_xai_wait_for_callback` spins up a daemon thread that reads one line from stdin and feeds the pasted code into the same callback handler via internal HTTP (`127.0.0.1:<port>/callback?code=...&state=...`)
- First-write-wins: whichever channel (browser redirect or stdin paste) delivers a code first short-circuits the wait loop
- No behavior change when the flag is absent — strict superset

## UX

```bash
hermes auth add xai-oauth --type oauth --no-browser --paste-code
# → Open this URL: https://auth.x.ai/...
# → Waiting for callback on http://127.0.0.1:56121/callback
# → If your browser shows "Could not establish connection" with a code,
# → paste the code here and press Enter (or wait for browser callback):
# (user pastes "abc-123-xyz", hits Enter)
# → Login successful!
```

## Why it works

The stdin reader doesn't bypass any OAuth security — the pasted code still flows through the same `_make_xai_callback_handler` that the browser redirect would hit, which validates `state` and exchanges the code via PKCE. We just route the code over loopback inside the same kernel that's running the listener, avoiding the Windows-side firewall entirely.

## Affected platforms

- **WSL2 + Hyper-V Firewall** (this PR's primary target)
- **GCP Cloud Shell / GitHub Codespaces / AWS Instance Connect** — browser-only consoles where there's no `ssh -L` tunnel option (parallel solution to #26923)
- Anywhere a tunnel isn't possible (corporate proxies, ZTNA agents, etc.)

## Refs

- PR #27305 (jett22JOE) — README callout linking community wrapper; mentions a follow-up PR for `--code`. This is that PR.
- Issue #27385 (Jind0la) — macOS variant where the browser callback succeeds locally but Hermes still times out. The stdin-paste path is a clean fallback for this and similar edge cases.
- Issue #26923 (welliv) — remote-console OAuth flow; this is a complementary approach to the manual-code helper proposed there.

## Test plan

- [x] `hermes auth add xai-oauth --type oauth --no-browser --paste-code` on Beelink WSL2 — paste-from-fallback-page completes auth, `auth.json` populated
- [x] `hermes auth add --help` shows the new `--paste-code` flag
- [x] Backwards compat: `hermes auth add xai-oauth --type oauth` without `--paste-code` behaves identically to before
- [x] First-write-wins: if both browser callback AND stdin paste arrive, the handler short-circuits on whichever lands first
- [x] No stdin available (non-TTY background process): paste reader skipped silently, listener runs as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)