### PR TITLE
feat(plugins/memory): bundle the ais provider

### DIFF
--- a/plugins/memory/ais/README.md
+++ b/plugins/memory/ais/README.md
@@ -1,0 +1,70 @@
+# AIS Memory Provider
+
+Cross-session knowledge-graph memory for Hermes — Ed25519 DID key
+auth, RRF hybrid retrieval, temporal reasoning.
+
+## Requirements
+
+- `pip install hermes-memory-ais`
+- An AIS account at [agentsandswarms.ai](https://agentsandswarms.ai)
+- An Ed25519 keypair enrolled once per device via the npm client:
+  ```bash
+  npx aismemory enable-key-auth
+  ```
+
+The same keypair authenticates the npm `aismemory` MCP client, the AIS
+REST API, and this Hermes plugin — one key, all surfaces.
+
+## Setup
+
+```bash
+hermes memory setup    # select "ais"
+```
+
+The wizard prompts for your AIS `userDid` (printed by `npx aismemory whoami`).
+The plugin reads your private key from `~/.aismemory/keys/<userDid>.json`
+and authenticates silently from then on.
+
+## Config
+
+Config file: `$HERMES_HOME/ais.json`
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `user_did` | (required) | Your AIS userDid |
+| `key_path` | `~/.aismemory/keys/<userDid>.json` | Override for non-standard install |
+| `domain` | `ais.agentsandswarms.ai` | AIS domain (override for self-hosted / staging) |
+| `telemetry` | `false` | Opt-in PostHog adoption pings |
+
+## Identity scoping
+
+The plugin creates one AIS agent per Hermes profile, named
+`hermes:<profile>` (e.g. `hermes:coder`). Memories scope to that
+agent only — your AIS account's other agents (the one paired with
+Claude Code, for instance) stay isolated from Hermes traffic.
+`metadata.managedBy = "hermes-memory-plugin"` is stamped on each
+managed agent so direct-API dashboards can filter them out.
+
+## Tools
+
+| Tool | What it does |
+|---|---|
+| `ais_recall` | Search the user's memories for context relevant to a query. |
+| `ais_remember` | Persist a durable fact. |
+| `ais_full_context` | Pull the agent's full snapshot. |
+| `ais_dream` | Trigger memory synthesis. |
+
+Auto behaviors:
+- `prefetch` queues a background recall before each turn.
+- `sync_turn` persists every user/assistant pair as a `conversation` memory.
+- `on_session_end` triggers a dream cycle for synthesis.
+
+## Source
+
+Implementation lives at [rudedoggg/hermes-memory-ais](https://github.com/rudedoggg/hermes-memory-ais).
+File issues there. The wrapper module in this directory exists only
+to integrate with Hermes's plugin discovery; no logic lives in it.
+
+## License
+
+MIT.

--- a/plugins/memory/ais/__init__.py
+++ b/plugins/memory/ais/__init__.py
@@ -1,0 +1,29 @@
+"""AIS Memory Provider — bundled plugin entrypoint.
+
+Re-exports the implementation from the ``hermes-memory-ais`` PyPI
+package. Keeping the bundled wrapper thin means upstream consumers
+don't need to vendor our code; ``pip install hermes-memory-ais``
+provides everything, and this file just hooks it into the plugin
+discovery scanner.
+
+Upstream repo for the implementation:
+https://github.com/rudedoggg/hermes-memory-ais
+"""
+
+from __future__ import annotations
+
+try:
+    from ais import (  # type: ignore[import-not-found]
+        AISMemoryProvider,
+        __version__,
+        register_memory_provider,
+    )
+except ImportError as exc:  # pragma: no cover — covered when extras installed
+    msg = (
+        "hermes-memory-ais is not installed. Run `pip install hermes-memory-ais` "
+        "or `hermes memory setup` and select 'ais'."
+    )
+    raise ImportError(msg) from exc
+
+
+__all__ = ["AISMemoryProvider", "__version__", "register_memory_provider"]

--- a/plugins/memory/ais/plugin.yaml
+++ b/plugins/memory/ais/plugin.yaml
@@ -1,0 +1,13 @@
+name: ais
+version: 0.1.0
+description: "AIS — cross-session knowledge-graph memory with temporal reasoning, RRF hybrid retrieval, and Ed25519 DID key auth."
+
+pip_dependencies:
+  - "hermes-memory-ais>=0.1.0"
+
+requires_env: []
+
+hooks:
+  - on_turn_start
+  - on_session_end
+  - on_session_switch


### PR DESCRIPTION
### Summary

Adds AIS (Agent Identity Service) as a bundled memory provider, taking
the same shape as the existing nine (`mem0`, `supermemory`, `honcho`,
`hindsight`, `holographic`, `byterover`, `openviking`, `retaindb`, …).

The wrapper in `plugins/memory/ais/` is intentionally thin — it
re-exports `register_memory_provider` and `AISMemoryProvider` from the
[`hermes-memory-ais`](https://pypi.org/project/hermes-memory-ais/) PyPI
package. Implementation, tests, CI, and release tagging live in the
[separate repo](https://github.com/rudedoggg/hermes-memory-ais) so this
PR's surface is small and reviewable.

### What is AIS?

AIS is a memory-as-a-service layer for AI agents. Memories are typed
(`fact` / `event` / `lesson` / `context` / `goal` / `task`), versioned
with temporal validity (`valid_from` / `valid_until` / `superseded_by`),
and linked into a typed relationship graph (`RELATED_TO`, `CAUSED_BY`,
`CONTRADICTS`, `ELABORATES`, `SUPERSEDES`, `DEPENDS_ON`). Recall uses
BGE-small dense embeddings, FTS, and knowledge-graph traversal — combined
via RRF hybrid scoring.

### What's new for users

- **Cross-session knowledge graph** — agents accumulate typed
  relationships across conversations, not just flat memory rows.
- **Temporal reasoning** — memories carry validity windows; recall can
  query "what did the user prefer last Tuesday?" not just "what does
  the user prefer?".
- **DID-based key auth** — users enroll an Ed25519 keypair once per
  device via `npx aismemory enable-key-auth`; no browser, no per-session
  OAuth ceremony.

### How users opt in

```bash
pip install hermes-memory-ais  # installed automatically by `hermes memory setup`
npx aismemory enable-key-auth  # one-time keypair enrollment
hermes memory setup            # select "ais"
```

### Identity scoping (important for review)

The plugin creates one AIS agent per Hermes profile, prefixed
`hermes:<profile>` and tagged `metadata.managedBy = "hermes-memory-plugin"`.
Memories scope to that agent only. Users who already use AIS via the
npm client or directly get **completely isolated** memory streams for
their Hermes profiles — no cross-contamination. The `hermes:` prefix
makes Hermes-managed agents visually distinct in AIS dashboards.

### Tool surface

The plugin exposes 4 tools (intentionally minimal, not the 85 AIS
exposes via MCP):

| Tool | Purpose |
|---|---|
| `ais_recall` | Search the user's memories |
| `ais_remember` | Persist a durable fact |
| `ais_full_context` | Pull the agent's full snapshot |
| `ais_dream` | Trigger memory synthesis |

Auto behaviors wired through the ABC hooks:

| Hook | Action |
|---|---|
| `prefetch` / `queue_prefetch` | Background recall before each turn |
| `sync_turn` | Persist conversation turn as `event` memory |
| `on_session_end` | Fire dream synthesis |
| `on_session_switch` | Update session lineage + parent linkage |

### Failure modes + defenses

- **Circuit breaker** trips after 3 consecutive failures, 60s cooldown.
  AIS outages don't accumulate exceptions through background workers.
- **401 retry** — server-side JWT rotation transparently triggers a
  re-handshake.
- **Prompt-injection defense** — `_agent_id` is pinned at `initialize()`.
  The `ais_recall` tool schema has no `agent_id` arg; the LLM can't
  cross over to a different agent within the same session.
- **Tool errors return JSON `{ok: false, error}`** instead of raising,
  so an AIS outage never blows up an LLM turn.

### Tests

The implementation repo has 66 tests covering: Ed25519 sign/verify
round-trip, key-file I/O (v1 schema), challenge/prove auth dance, 401
retry, breaker lifecycle, all 5 client methods with `pytest-httpx` mock
shapes, identity-resolver caching, provider lifecycle hooks, all 4 tool
dispatch paths including breaker-open and exception-becomes-JSON-error
contracts, setup-wizard schema + save_config merge. CI runs `ruff +
ruff format + mypy strict + pytest` on Python 3.11 and 3.12.

### Compatibility

- Python ≥ 3.11 (matches the bundled `mem0` plugin)
- Dependencies pinned narrow: `httpx>=0.27,<1.0`, `cryptography>=42.0`,
  `pydantic>=2.6,<3.0`
- Implements the `MemoryProvider` ABC in `agent/memory_provider.py:42`
  verbatim — no fork, no shim required in this tree

### Checklist

- [x] `plugins/memory/ais/__init__.py` with `register_memory_provider`
- [x] `plugins/memory/ais/plugin.yaml` with name, version, pip_dependencies, hooks
- [x] `plugins/memory/ais/README.md` matching the layout of mem0/supermemory/honcho
- [x] No new top-level dependencies in upstream `hermes-agent`; everything is in the wheel
- [x] Tests live in the implementation repo; CI green at v0.1.0

### Out of scope

- The CLI flow for `npx aismemory enable-key-auth` lives in the npm
  `aismemory` package — already published.
- Server-side AIS endpoints (challenge / did-prove / agents / memory
  / full-context / dream) — already in production at
  `ais.agentsandswarms.ai`.
