### PR TITLE
feat(transports): add opt-in extra_body.hermes outbound metadata channel

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -200,6 +200,8 @@ def init_agent(
     checkpoint_max_total_size_mb: int = 500,
     checkpoint_max_file_size_mb: int = 10,
     pass_session_id: bool = False,
+    hermes_outbound_metadata: bool = False,
+    command_origin: str = None,
 ):
     """
     Initialize the AI Agent.
@@ -279,6 +281,8 @@ def init_agent(
     agent.skip_context_files = skip_context_files
     agent.load_soul_identity = load_soul_identity
     agent.pass_session_id = pass_session_id
+    agent.hermes_outbound_metadata = hermes_outbound_metadata
+    agent._command_origin = command_origin
     agent._credential_pool = credential_pool
     agent.log_prefix_chars = log_prefix_chars
     agent.log_prefix = f"{log_prefix} " if log_prefix else ""

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -733,6 +733,12 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             anthropic_max_output=_ant_max,
             supports_reasoning=agent._supports_reasoning_extra_body(),
             qwen_session_metadata=_qwen_meta,
+            # Outbound orchestration metadata
+            hermes_outbound_metadata=getattr(agent, "hermes_outbound_metadata", False),
+            hermes_gateway_platform=getattr(agent, "platform", None),
+            hermes_chat_id=getattr(agent, "_chat_id", None),
+            hermes_user_id=getattr(agent, "_user_id", None),
+            hermes_command_origin=getattr(agent, "_command_origin", None),
         )
 
     # ── Legacy flag path ────────────────────────────────────────────
@@ -780,6 +786,12 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         lmstudio_reasoning_options=agent._lmstudio_reasoning_options_cached() if _is_lmstudio else None,
         anthropic_max_output=_ant_max,
         provider_name=agent.provider,
+        # Outbound orchestration metadata
+        hermes_outbound_metadata=getattr(agent, "hermes_outbound_metadata", False),
+        hermes_gateway_platform=getattr(agent, "platform", None),
+        hermes_chat_id=getattr(agent, "_chat_id", None),
+        hermes_user_id=getattr(agent, "_user_id", None),
+        hermes_command_origin=getattr(agent, "_command_origin", None),
     )
 
 
@@ -1414,6 +1426,19 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                         {"id": "pareto-router", "min_coding_score": _ps}
                     ]
 
+            from agent.transports.chat_completions import _add_hermes_metadata
+
+            _add_hermes_metadata(
+                summary_extra_body,
+                {
+                    "hermes_outbound_metadata": getattr(agent, "hermes_outbound_metadata", False),
+                    "session_id": getattr(agent, "session_id", None),
+                    "hermes_gateway_platform": getattr(agent, "platform", None),
+                    "hermes_chat_id": getattr(agent, "chat_id", None),
+                    "hermes_user_id": getattr(agent, "user_id", None),
+                    "hermes_command_origin": getattr(agent, "_command_origin", None),
+                },
+            )
             if summary_extra_body:
                 summary_kwargs["extra_body"] = summary_extra_body
 

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -115,6 +115,30 @@ def _model_consumes_thought_signature(model: Any) -> bool:
     return "gemini" in m or "gemma" in m
 
 
+def _add_hermes_metadata(extra_body: dict, params: dict) -> None:
+    """Inject extra_body.hermes orchestration hints when opt-in flag is set.
+
+    Fields whose value is None are omitted so strict-validating servers
+    (vLLM strict mode, certain proxies) stay compatible when the flag is on.
+    Enabled via extras.hermes_metadata.enabled in the gateway config.yaml.
+    """
+    if not params.get("hermes_outbound_metadata"):
+        return
+    hermes: dict[str, Any] = {}
+    for key, param in (
+        ("session_id", "session_id"),
+        ("gateway_platform", "hermes_gateway_platform"),
+        ("chat_id", "hermes_chat_id"),
+        ("user_id", "hermes_user_id"),
+        ("command_origin", "hermes_command_origin"),
+    ):
+        val = params.get(param)
+        if val is not None:
+            hermes[key] = val
+    if hermes:
+        extra_body["hermes"] = hermes
+
+
 class ChatCompletionsTransport(ProviderTransport):
     """Transport for api_mode='chat_completions'.
 
@@ -445,6 +469,9 @@ class ChatCompletionsTransport(ProviderTransport):
         if additions:
             extra_body.update(additions)
 
+        # Hermes outbound metadata — opt-in, default off
+        _add_hermes_metadata(extra_body, params)
+
         if extra_body:
             api_kwargs["extra_body"] = extra_body
 
@@ -560,6 +587,9 @@ class ChatCompletionsTransport(ProviderTransport):
         additions = params.get("extra_body_additions")
         if additions:
             extra_body.update(additions)
+
+        # Hermes outbound metadata — opt-in, default off
+        _add_hermes_metadata(extra_body, params)
 
         # Request overrides (user config)
         overrides = params.get("request_overrides")

--- a/docs/hermes-outbound-metadata.md
+++ b/docs/hermes-outbound-metadata.md
@@ -1,0 +1,67 @@
+# Hermes Outbound Metadata (`extra_body.hermes`)
+
+Hermes can attach a documented set of orchestration hints to every outgoing
+chat-completions request via `extra_body.hermes`.  A downstream
+OpenAI-compatible proxy or dispatcher can read these hints and apply routing
+policy — model selection, per-user quotas, cost attribution, observability
+tracing — without parsing free text or spinning up one Hermes profile per
+channel.
+
+## Enabling
+
+The feature is **opt-in and disabled by default**.  To enable, add to your
+profile's `config.yaml`:
+
+```yaml
+extras:
+  hermes_metadata:
+    enabled: true
+```
+
+## Fields emitted
+
+When enabled, Hermes adds the following to every `extra_body.hermes` object.
+Fields whose runtime value is `None` (e.g. `chat_id` for the CLI) are omitted
+so strict-validating servers (vLLM strict mode, certain proxies) remain
+compatible.
+
+| Field | Type | Example | Source |
+|---|---|---|---|
+| `session_id` | string | `"20260517_142530_a7f2c1b9"` | session identifier, unique per conversation |
+| `gateway_platform` | string | `"matrix"`, `"discord"`, `"telegram"`, `"cli"` | active platform adapter |
+| `chat_id` | string | `"!room:example.org"`, `"12345"` | `SessionSource.chat_id` — room/channel/DM identifier |
+| `user_id` | string | `"@alice:example.org"`, `"67890"` | `SessionSource.user_id` — sender identifier |
+| `command_origin` | string | `"user"`, `"scheduled"` | how this turn was initiated |
+
+## Wire example
+
+```jsonc
+{
+  "model": "ollama-cloud/glm-5.1",
+  "messages": [...],
+  "extra_body": {
+    "hermes": {
+      "session_id": "20260517_142530_a7f2c1b9",
+      "gateway_platform": "matrix",
+      "chat_id": "!IzxRltiFyqGSkTtDKP:chat.example.eu",
+      "user_id": "@alice:chat.example.eu",
+      "command_origin": "user"
+    }
+  }
+}
+```
+
+## Compatibility note
+
+Some OpenAI-compatible servers (e.g. vLLM in strict mode) reject unknown
+request body fields with HTTP 422.  Because the feature defaults to `false`,
+existing deployments are unaffected.  Enable only when your downstream server
+(LiteLLM, a custom proxy, Helicone, Langfuse, Portkey, …) can tolerate or
+actively consumes the `extra_body.hermes` object.
+
+## Naming alignment
+
+Field names in `extra_body.hermes` mirror `SessionSource` field names
+(`chat_id`, `user_id`) and the `AIAgent.__init__` kwargs (`platform`, `chat_id`,
+`user_id`).  If you are building a companion inbound-headers feature, the
+natural mirror is `X-Hermes-Chat-Id` ↔ `extra_body.hermes.chat_id`, etc.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12599,6 +12599,10 @@ class GatewayRunner:
             agent_cfg = user_config.get("agent") or {}
             disabled_toolsets = agent_cfg.get("disabled_toolsets") or None
 
+            _bg_extras_cfg = user_config.get("extras") or {}
+            _bg_hermes_meta_cfg = _bg_extras_cfg.get("hermes_metadata") or {}
+            _bg_hermes_outbound_metadata = bool(_bg_hermes_meta_cfg.get("enabled", False))
+
             pr = self._provider_routing
             max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
             reasoning_config = self._resolve_session_reasoning_config(source=source)
@@ -12652,6 +12656,8 @@ class GatewayRunner:
                     thread_id=source.thread_id,
                     session_db=self._session_db,
                     fallback_model=self._fallback_model,
+                    hermes_outbound_metadata=_bg_hermes_outbound_metadata,
+                    command_origin="scheduled",
                 )
                 try:
                     return agent.run_conversation(
@@ -16970,6 +16976,10 @@ class GatewayRunner:
         agent_cfg_local = user_config.get("agent") or {}
         disabled_toolsets = agent_cfg_local.get("disabled_toolsets") or None
 
+        _extras_cfg = user_config.get("extras") or {}
+        _hermes_meta_cfg = _extras_cfg.get("hermes_metadata") or {}
+        _hermes_outbound_metadata = bool(_hermes_meta_cfg.get("enabled", False))
+
         display_config = user_config.get("display", {})
         if not isinstance(display_config, dict):
             display_config = {}
@@ -17876,6 +17886,8 @@ class GatewayRunner:
                     gateway_session_key=session_key,
                     session_db=self._session_db,
                     fallback_model=self._fallback_model,
+                    hermes_outbound_metadata=_hermes_outbound_metadata,
+                    command_origin="user",
                 )
                 if _cache_lock and _cache is not None:
                     with _cache_lock:

--- a/run_agent.py
+++ b/run_agent.py
@@ -406,6 +406,8 @@ class AIAgent:
         checkpoint_max_total_size_mb: int = 500,
         checkpoint_max_file_size_mb: int = 10,
         pass_session_id: bool = False,
+        hermes_outbound_metadata: bool = False,
+        command_origin: str = None,
     ):
         """Forwarder — see ``agent.agent_init.init_agent``."""
         from agent.agent_init import init_agent
@@ -476,6 +478,8 @@ class AIAgent:
             checkpoint_max_total_size_mb=checkpoint_max_total_size_mb,
             checkpoint_max_file_size_mb=checkpoint_max_file_size_mb,
             pass_session_id=pass_session_id,
+            hermes_outbound_metadata=hermes_outbound_metadata,
+            command_origin=command_origin,
         )
 
     def _get_session_db_for_recall(self):

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -1,7 +1,12 @@
 """Tests for the ChatCompletionsTransport."""
 
+import asyncio
+import sys
+import threading
+import types
 import pytest
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
 
 from agent.transports import get_transport
 from agent.transports.types import NormalizedResponse
@@ -859,8 +864,6 @@ class TestChatCompletionsCacheStats:
         r = SimpleNamespace(usage=SimpleNamespace(prompt_tokens_details=details))
         result = transport.extract_cache_stats(r)
         assert result == {"cached_tokens": 500, "creation_tokens": 100}
-
-
 class TestChatCompletionsGeminiNativeExtraBodyStrip:
     """Profile extra_body (e.g. Nous portal tags) must not reach a native
     Gemini endpoint — Google's REST API rejects unknown fields with HTTP 400.
@@ -909,3 +912,332 @@ class TestChatCompletionsGeminiNativeExtraBodyStrip:
         )
         eb = kw.get("extra_body")
         assert eb and "tags" in eb
+
+
+class TestHermesOutboundMetadata:
+    """extra_body.hermes opt-in orchestration hints."""
+
+    def test_default_off_profile_path(self, transport):
+        """No extra_body.hermes emitted when flag is absent (default off)."""
+        from providers import get_provider_profile
+        profile = get_provider_profile("openrouter")
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-4o", messages=msgs, provider_profile=profile,
+        )
+        assert "hermes" not in (kw.get("extra_body") or {})
+
+    def test_default_off_legacy_path(self, transport):
+        """No extra_body.hermes emitted on the legacy (unregistered provider) path."""
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(model="gpt-4o", messages=msgs)
+        assert "hermes" not in (kw.get("extra_body") or {})
+
+    def test_all_fields_profile_path(self, transport):
+        """When enabled with all five fields, they appear correctly in extra_body.hermes."""
+        from providers import get_provider_profile
+        profile = get_provider_profile("openrouter")
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-4o", messages=msgs, provider_profile=profile,
+            hermes_outbound_metadata=True,
+            session_id="sess-abc",
+            hermes_gateway_platform="matrix",
+            hermes_chat_id="!room:example.org",
+            hermes_user_id="@alice:example.org",
+            hermes_command_origin="user",
+        )
+        h = kw["extra_body"]["hermes"]
+        assert h["session_id"] == "sess-abc"
+        assert h["gateway_platform"] == "matrix"
+        assert h["chat_id"] == "!room:example.org"
+        assert h["user_id"] == "@alice:example.org"
+        assert h["command_origin"] == "user"
+
+    def test_all_fields_legacy_path(self, transport):
+        """Legacy path also emits extra_body.hermes when enabled."""
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-4o", messages=msgs,
+            hermes_outbound_metadata=True,
+            session_id="sess-xyz",
+            hermes_gateway_platform="discord",
+            hermes_chat_id="12345",
+            hermes_user_id="67890",
+            hermes_command_origin="scheduled",
+        )
+        h = kw["extra_body"]["hermes"]
+        assert h["session_id"] == "sess-xyz"
+        assert h["gateway_platform"] == "discord"
+        assert h["chat_id"] == "12345"
+        assert h["user_id"] == "67890"
+        assert h["command_origin"] == "scheduled"
+
+    def test_none_fields_omitted(self, transport):
+        """Fields whose value is None are omitted so strict servers stay compatible."""
+        from providers import get_provider_profile
+        profile = get_provider_profile("openrouter")
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-4o", messages=msgs, provider_profile=profile,
+            hermes_outbound_metadata=True,
+            session_id="sess-123",
+            # hermes_gateway_platform, hermes_chat_id, hermes_user_id,
+            # hermes_command_origin all absent → omitted from output
+        )
+        h = kw["extra_body"]["hermes"]
+        assert h == {"session_id": "sess-123"}
+        assert "gateway_platform" not in h
+        assert "chat_id" not in h
+        assert "user_id" not in h
+        assert "command_origin" not in h
+
+    def test_no_hermes_block_when_all_none(self, transport):
+        """If all values are None, extra_body.hermes is not emitted at all."""
+        from providers import get_provider_profile
+        profile = get_provider_profile("openrouter")
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-4o", messages=msgs, provider_profile=profile,
+            hermes_outbound_metadata=True,
+            # all fields absent
+        )
+        assert "hermes" not in (kw.get("extra_body") or {})
+
+    def test_coexists_with_other_extra_body_fields(self, transport):
+        """extra_body.hermes doesn't clobber existing extra_body entries."""
+        from providers import get_provider_profile
+        profile = get_provider_profile("openrouter")
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-4o", messages=msgs, provider_profile=profile,
+            provider_preferences={"only": ["openai"]},
+            hermes_outbound_metadata=True,
+            session_id="s1",
+            hermes_gateway_platform="telegram",
+        )
+        eb = kw["extra_body"]
+        assert eb["provider"] == {"only": ["openai"]}
+        assert eb["hermes"]["session_id"] == "s1"
+        assert eb["hermes"]["gateway_platform"] == "telegram"
+
+
+class TestHermesOutboundMetadataSummaryPath:
+    """Iteration-limit summary calls must mirror the transport metadata path."""
+
+    def test_iteration_limit_summary_includes_hermes_metadata(self):
+        from agent.chat_completion_helpers import handle_max_iterations
+
+        captured = {}
+
+        def _create(**kwargs):
+            captured.update(kwargs)
+            return object()
+
+        fake_transport = SimpleNamespace(
+            normalize_response=lambda response: NormalizedResponse(
+                content="summary ok",
+                tool_calls=None,
+                finish_reason="stop",
+            )
+        )
+        fake_agent = SimpleNamespace(
+            model="gpt-4o",
+            provider="openrouter",
+            api_mode="chat_completions",
+            base_url="https://openrouter.ai/api/v1",
+            _base_url_lower="https://openrouter.ai/api/v1",
+            max_tokens=None,
+            max_iterations=1,
+            reasoning_config=None,
+            providers_allowed=None,
+            providers_ignored=None,
+            providers_order=None,
+            provider_sort=None,
+            openrouter_min_coding_score=None,
+            hermes_outbound_metadata=True,
+            session_id="sess-123",
+            platform="matrix",
+            chat_id="!room:example.org",
+            user_id="@alice:example.org",
+            _command_origin="user",
+            _cached_system_prompt="",
+            ephemeral_system_prompt="",
+            prefill_messages=[],
+            _is_anthropic_oauth=False,
+            _should_sanitize_tool_calls=lambda: False,
+            _copy_reasoning_content_for_api=lambda msg, api_msg: None,
+            _sanitize_api_messages=lambda messages: messages,
+            _drop_thinking_only_and_merge_users=lambda messages: messages,
+            _supports_reasoning_extra_body=lambda: False,
+            _resolve_lmstudio_summary_reasoning_effort=lambda: None,
+            _is_openrouter_url=lambda: True,
+            _max_tokens_param=lambda max_tokens: {},
+            _get_transport=lambda: fake_transport,
+            _ensure_primary_openai_client=lambda reason=None: SimpleNamespace(
+                chat=SimpleNamespace(
+                    completions=SimpleNamespace(create=_create)
+                )
+            ),
+        )
+
+        final_response = handle_max_iterations(
+            fake_agent,
+            [{"role": "user", "content": "Hi"}],
+            api_call_count=1,
+        )
+
+        assert final_response == "summary ok"
+        assert captured["extra_body"]["hermes"] == {
+            "session_id": "sess-123",
+            "gateway_platform": "matrix",
+            "chat_id": "!room:example.org",
+            "user_id": "@alice:example.org",
+            "command_origin": "user",
+        }
+
+
+class _CapturingAgent:
+    """Fake gateway agent that records init kwargs for assertions."""
+
+    last_init = None
+
+    def __init__(self, *args, **kwargs):
+        type(self).last_init = dict(kwargs)
+        self.tools = []
+
+    def run_conversation(self, user_message: str, conversation_history=None, task_id=None):
+        return {
+            "final_response": "ok",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+def _make_gateway_runner():
+    import gateway.run as gateway_run
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {}
+    runner.session_store = None
+    runner.config = None
+    runner._voice_mode = {}
+    runner._ephemeral_system_prompt = ""
+    runner._prefill_messages = []
+    runner._reasoning_config = None
+    runner._show_reasoning = False
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._service_tier = None
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._background_tasks = set()
+    runner._session_db = None
+    runner._session_model_overrides = {}
+    runner._session_reasoning_overrides = {}
+    runner._pending_model_notes = {}
+    runner._pending_approvals = {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+    runner._get_or_create_gateway_honcho = lambda session_key: (None, None)
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner.hooks.loaded_hooks = []
+    return runner
+
+
+def _gateway_override():
+    return {
+        "model": "gpt-4o",
+        "provider": "openrouter",
+        "api_key": "***",
+        "base_url": "https://openrouter.ai/api/v1",
+        "api_mode": "chat_completions",
+    }
+
+
+class TestGatewayHermesOutboundMetadata:
+    """Gateway config must plumb the opt-in flag into AIAgent creation."""
+
+    @pytest.mark.asyncio
+    async def test_run_agent_passes_enabled_flag_and_user_origin(self, monkeypatch):
+        import gateway.run as gateway_run
+        from gateway.config import Platform
+        from gateway.session import SessionSource
+
+        monkeypatch.setattr(
+            gateway_run,
+            "_load_gateway_config",
+            lambda: {"extras": {"hermes_metadata": {"enabled": True}}},
+        )
+
+        fake_run_agent = types.ModuleType("run_agent")
+        fake_run_agent.AIAgent = _CapturingAgent
+        monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+        _CapturingAgent.last_init = None
+        runner = _make_gateway_runner()
+
+        source = SessionSource(
+            platform=Platform.LOCAL,
+            chat_id="cli",
+            chat_name="CLI",
+            chat_type="dm",
+            user_id="user-1",
+        )
+        session_key = "agent:main:local:dm"
+        runner._session_model_overrides[session_key] = _gateway_override()
+
+        result = await runner._run_agent(
+            message="ping",
+            context_prompt="",
+            history=[],
+            source=source,
+            session_id="session-1",
+            session_key=session_key,
+        )
+
+        assert result["final_response"] == "ok"
+        assert _CapturingAgent.last_init is not None
+        assert _CapturingAgent.last_init["hermes_outbound_metadata"] is True
+        assert _CapturingAgent.last_init["command_origin"] == "user"
+
+    @pytest.mark.asyncio
+    async def test_background_task_passes_enabled_flag_and_scheduled_origin(self, monkeypatch):
+        import gateway.run as gateway_run
+        from gateway.config import Platform
+        from gateway.session import SessionSource
+
+        monkeypatch.setattr(
+            gateway_run,
+            "_load_gateway_config",
+            lambda: {"extras": {"hermes_metadata": {"enabled": True}}},
+        )
+
+        fake_run_agent = types.ModuleType("run_agent")
+        fake_run_agent.AIAgent = _CapturingAgent
+        monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+        _CapturingAgent.last_init = None
+        runner = _make_gateway_runner()
+
+        adapter = AsyncMock()
+        adapter.send = AsyncMock()
+        adapter.extract_media = MagicMock(return_value=([], "ok"))
+        adapter.extract_images = MagicMock(return_value=([], "ok"))
+        runner.adapters[Platform.TELEGRAM] = adapter
+
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="12345",
+            chat_id="67890",
+            user_name="testuser",
+        )
+        session_key = runner._session_key_for_source(source)
+        runner._session_model_overrides[session_key] = _gateway_override()
+
+        await runner._run_background_task("say hello", source, "bg_test")
+
+        assert _CapturingAgent.last_init is not None
+        assert _CapturingAgent.last_init["hermes_outbound_metadata"] is True
+        assert _CapturingAgent.last_init["command_origin"] == "scheduled"


### PR DESCRIPTION
## What changed and why

Adds a documented `extra_body.hermes` object to every outgoing chat-completions request when `extras.hermes_metadata.enabled: true` is set in `config.yaml` (default: false).

This gives downstream OpenAI-compatible proxies and dispatchers (LiteLLM, Helicone, Langfuse, custom routers) machine-readable orchestration context — session, platform, chat, user, command origin — without parsing free text or spinning up one Hermes profile per channel.

Per the confirmed direction on #22714:
- **`/model` stays** as the human-facing lever; `extra_body.hermes` is the parallel machine-facing channel (pure addition, no removal).
- **`extra_body.hermes` namespace** consistent with existing `extra_body.{provider,thinking,reasoning,plugins}` shape in `agent/transports/chat_completions.py`, and generalises the `session_id` plumbing already shipped via #22808/#22809 for Grok.
- **Opt-in, default off** — strict-validating servers (vLLM strict mode, certain proxies) unaffected.
- **v1 scope**: `session_id`, `gateway_platform`, `chat_id`, `user_id`, `command_origin`. Fields whose runtime value is `None` are omitted so the flag is safe to enable even when some fields are unavailable (e.g., `chat_id` on the CLI).

`user_intent` deferred to v2 (requires a classifier, not just plumbing).

Field names mirror `SessionSource.chat_id` / `AIAgent.__init__` kwargs for naming consistency, and align with @gsskk's inbound-headers PR #24423 (`X-Hermes-Chat-Id` ↔ `extra_body.hermes.chat_id`).

### Files changed

| File | Change |
|---|---|
| `agent/transports/chat_completions.py` | `_add_hermes_metadata()` helper; called from both profile and legacy paths |
| `agent/chat_completion_helpers.py` | Pass `hermes_outbound_metadata` + four context fields to `build_kwargs()` |
| `agent/agent_init.py` | Add `hermes_outbound_metadata: bool` and `command_origin: str` params |
| `run_agent.py` | Forward new params to `init_agent()` |
| `gateway/run.py` | Read `extras.hermes_metadata.enabled` from config; pass to both agent creation sites (`command_origin="user"` for main flow, `"scheduled"` for background tasks) |
| `docs/hermes-outbound-metadata.md` | Opt-in docs with wire example and strict-server caveat |
| `tests/agent/transports/test_chat_completions.py` | 7 new tests: default-off (profile + legacy), all-fields (profile + legacy), None-fields omitted, empty block not emitted, coexists with other extra_body entries |

## How to test

```yaml
# In your gateway profile config.yaml:
extras:
  hermes_metadata:
    enabled: true
```

1. Start the Matrix (or Telegram/Discord) gateway with the config above.
2. Send a message in a connected room.
3. Inspect your downstream proxy/dispatcher logs — the outbound request should include:

```json
{
  "extra_body": {
    "hermes": {
      "session_id": "<session-id>",
      "gateway_platform": "matrix",
      "chat_id": "!room:example.org",
      "user_id": "@alice:example.org",
      "command_origin": "user"
    }
  }
}
```

4. With `enabled: false` (default), confirm no `extra_body.hermes` key appears.
5. Against a strict-validating server (e.g. vLLM strict mode) with `enabled: false` — requests must succeed unchanged.

Unit test coverage: `pytest tests/agent/transports/test_chat_completions.py::TestHermesOutboundMetadata -v`

## What platforms tested on

- macOS (darwin 24.6.0, Python 3.11)
- Unit tests: 395 transport + provider tests pass
- 7 new `TestHermesOutboundMetadata` tests pass
- Pre-existing failures in 5 unrelated tests (`test_background_command`, `test_discord_component_auth`, `test_auxiliary_client`, `test_platform_commands`, `test_registry_manifest`) confirmed pre-existing via `git stash` bisect

Fixes #22714

<!-- autocontrib:worker-id=issue-followup-b92b7cb4 kind=pr-open -->