### PR TITLE
feat(kanban): add initial status for human-ops cards

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -258,7 +258,7 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     b_rename.add_argument("name", help="New display name")
 
     # --- create ---
-    p_create = sub.add_parser("create", help="Create a new task")
+    p_create = sub.add_parser("create", aliases=["add"], help="Create a new task")
     p_create.add_argument("title", help="Task title")
     p_create.add_argument("--body", default=None, help="Optional opening post")
     p_create.add_argument("--assignee", default=None, help="Profile name to assign")
@@ -294,6 +294,12 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                                "two retries. Omit to use the dispatcher's "
                                "kanban.failure_limit config "
                                f"(default {kb.DEFAULT_FAILURE_LIMIT}).")
+    p_create.add_argument("--initial-status",
+                          choices=sorted(kb.VALID_INITIAL_STATUSES),
+                          default="running",
+                          help="Initial card status. Use 'blocked' for cards "
+                               "that require immediate human ops (R3 gate) "
+                               "to skip the brief running-to-blocked transition.")
     p_create.add_argument("--json", action="store_true", help="Emit JSON output")
 
     # --- list ---
@@ -709,6 +715,7 @@ def kanban_command(args: argparse.Namespace) -> int:
     handlers = {
         "init":     _cmd_init,
         "create":   _cmd_create,
+        "add":      _cmd_create,
         "list":     _cmd_list,
         "ls":       _cmd_list,
         "show":     _cmd_show,
@@ -1077,6 +1084,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             max_runtime_seconds=max_runtime,
             skills=getattr(args, "skills", None) or None,
             max_retries=max_retries,
+            initial_status=getattr(args, "initial_status", "running"),
         )
         task = kb.get_task(conn, task_id)
     if getattr(args, "json", False):
@@ -2214,7 +2222,11 @@ def run_slash(rest: str) -> str:
     kanban_parser.exit_on_error = False  # type: ignore[attr-defined]
     for _action in kanban_parser._actions:
         if isinstance(_action, argparse._SubParsersAction):
+            _seen_subparsers: set[int] = set()
             for _name, _choice in _action.choices.items():
+                if id(_choice) in _seen_subparsers:
+                    continue
+                _seen_subparsers.add(id(_choice))
                 _choice.prog = f"/kanban {_name}"
                 _choice.exit_on_error = False  # type: ignore[attr-defined]
 
@@ -2235,7 +2247,16 @@ def run_slash(rest: str) -> str:
         body = err or out
         return f"⚠ /kanban usage error\n{body}" if body else "⚠ /kanban usage error"
     except argparse.ArgumentError as exc:
-        return f"⚠ /kanban usage error: {exc}"
+        usage = ""
+        if tokens:
+            for _action in kanban_parser._actions:
+                if isinstance(_action, argparse._SubParsersAction):
+                    _choice = _action.choices.get(tokens[0])
+                    if _choice is not None:
+                        usage = _choice.format_usage().rstrip()
+                    break
+        body = f"{usage}\n{exc}" if usage else str(exc)
+        return f"⚠ /kanban usage error\n{body}"
 
     with contextlib.redirect_stdout(buf_out), contextlib.redirect_stderr(buf_err):
         try:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -91,6 +91,7 @@ from toolsets import get_toolset_names
 # ---------------------------------------------------------------------------
 
 VALID_STATUSES = {"triage", "todo", "ready", "running", "blocked", "done", "archived"}
+VALID_INITIAL_STATUSES = {"running", "blocked"}
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
 KNOWN_TOOLSET_NAMES = frozenset(name.casefold() for name in get_toolset_names())
 _IS_WINDOWS = sys.platform == "win32"
@@ -1245,6 +1246,7 @@ def create_task(
     max_runtime_seconds: Optional[int] = None,
     skills: Optional[Iterable[str]] = None,
     max_retries: Optional[int] = None,
+    initial_status: str = "running",
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
 
@@ -1269,10 +1271,19 @@ def create_task(
     ``kanban-worker``. Use this to pin a task to a specialist skill
     (e.g. ``skills=["translation"]`` so the worker loads the
     translation skill regardless of the profile's default config).
+
+    ``initial_status`` controls whether the task enters the usual
+    dispatch path (``"running"``; default, preserving existing
+    ready/todo/triage inference) or is created directly in ``"blocked"``
+    for immediate human-ops review.
     """
     assignee = _canonical_assignee(assignee)
     if not title or not title.strip():
         raise ValueError("title is required")
+    if initial_status not in VALID_INITIAL_STATUSES:
+        raise ValueError(
+            f"initial_status must be one of {sorted(VALID_INITIAL_STATUSES)}"
+        )
     if workspace_kind not in VALID_WORKSPACE_KINDS:
         raise ValueError(
             f"workspace_kind must be one of {sorted(VALID_WORKSPACE_KINDS)}, "
@@ -1347,12 +1358,18 @@ def create_task(
         task_id = _new_task_id()
         try:
             with write_txn(conn):
-                # Determine initial status from parent status, unless the
-                # caller is parking this task in triage for a specifier.
-                if triage:
-                    initial_status = "triage"
+                # Determine task status from parent status, unless the caller
+                # parks it directly in blocked for human-ops review.
+                if initial_status == "blocked":
+                    task_status = "blocked"
+                    if parents:
+                        missing = _find_missing_parents(conn, parents)
+                        if missing:
+                            raise ValueError(f"unknown parent task(s): {', '.join(missing)}")
+                elif triage:
+                    task_status = "triage"
                 else:
-                    initial_status = "ready"
+                    task_status = "ready"
                     if parents:
                         missing = _find_missing_parents(conn, parents)
                         if missing:
@@ -1364,7 +1381,7 @@ def create_task(
                             parents,
                         ).fetchall()
                         if any(r["status"] != "done" for r in rows):
-                            initial_status = "todo"
+                            task_status = "todo"
                 # Even in triage mode we still need to validate parent ids
                 # so the eventual link rows don't dangle.
                 if triage and parents:
@@ -1386,7 +1403,7 @@ def create_task(
                         title.strip(),
                         body,
                         assignee,
-                        initial_status,
+                        task_status,
                         priority,
                         created_by,
                         now,
@@ -1410,7 +1427,7 @@ def create_task(
                     "created",
                     {
                         "assignee": assignee,
-                        "status": initial_status,
+                        "status": task_status,
                         "parents": list(parents),
                         "tenant": tenant,
                         "skills": list(skills_list) if skills_list else None,
@@ -2978,6 +2995,10 @@ def _classify_worker_exit(pid: int) -> "tuple[str, Optional[int]]":
     if entry is None:
         return ("unknown", None)
     raw, _ = entry
+    if not hasattr(os, "WIFEXITED"):
+        if raw == 0:
+            return ("clean_exit", 0)
+        return ("nonzero_exit", int(raw))
     try:
         if os.WIFEXITED(raw):
             code = os.WEXITSTATUS(raw)

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -119,6 +119,30 @@ def test_run_slash_json_output(kanban_home):
     assert payload["status"] == "ready"
 
 
+def test_run_slash_initial_status_default_running(kanban_home):
+    out = kc.run_slash("add 'normal dispatch' --assignee alice --json")
+    payload = json.loads(out)
+    assert payload["title"] == "normal dispatch"
+    assert payload["assignee"] == "alice"
+    assert payload["status"] == "ready"
+
+
+def test_run_slash_initial_status_blocked(kanban_home):
+    out = kc.run_slash(
+        "add 'needs human ops' --assignee alice --initial-status blocked --json"
+    )
+    payload = json.loads(out)
+    assert payload["title"] == "needs human ops"
+    assert payload["assignee"] == "alice"
+    assert payload["status"] == "blocked"
+
+
+def test_run_slash_initial_status_invalid(kanban_home):
+    out = kc.run_slash("add 'bad status' --initial-status foo")
+    assert "usage error" in out.lower()
+    assert "invalid choice" in out
+
+
 def test_run_slash_dispatch_dry_run_counts(kanban_home):
     kc.run_slash("create 'a' --assignee alice")
     kc.run_slash("create 'b' --assignee bob")

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -577,6 +577,7 @@ def _handle_create(args: dict, **kw) -> str:
         return tool_error(bool_error)
     idempotency_key = args.get("idempotency_key")
     max_runtime_seconds = args.get("max_runtime_seconds")
+    initial_status = args.get("initial_status") or "running"
     skills = args.get("skills")
     if isinstance(skills, str):
         # Accept a single skill name as a string for convenience.
@@ -611,6 +612,7 @@ def _handle_create(args: dict, **kw) -> str:
                     if max_runtime_seconds is not None else None
                 ),
                 skills=skills,
+                initial_status=str(initial_status),
                 created_by=os.environ.get("HERMES_PROFILE") or "worker",
             )
             new_task = kb.get_task(conn, new_tid)
@@ -996,6 +998,16 @@ KANBAN_CREATE_SCHEMA = {
                     "Per-task runtime cap. When exceeded, the "
                     "dispatcher SIGTERMs the worker and re-queues the "
                     "task with outcome='timed_out'."
+                ),
+            },
+            "initial_status": {
+                "type": "string",
+                "enum": ["running", "blocked"],
+                "description": (
+                    "Initial card status. Use 'blocked' for tasks that "
+                    "require immediate human ops (R3 gate) to skip the "
+                    "brief running-to-blocked transition. Defaults to "
+                    "'running', which preserves the usual dispatch path."
                 ),
             },
             "skills": {


### PR DESCRIPTION
# feat(kanban): add initial status for human-ops cards

## Why

Human-ops-bound kanban cards can briefly appear as dispatchable work before they are moved to `blocked`. This adds an explicit creation-time path for cards that should start blocked, avoiding the transient running-to-blocked flicker for R3 gate work.

## What

- Added `initial_status: str = "running"` to `hermes_cli.kanban_db.create_task`.
- Added `--initial-status {running,blocked}` to `hermes kanban create`, plus `kanban add` as an alias for the creation command.
- Threaded `initial_status` through the `kanban_create` tool schema and handler for orchestrator-created cards.
- Preserved backward compatibility: `running` keeps the existing upstream dispatch path and ready/todo/triage inference, while `blocked` creates the task directly in `blocked`.
- Included a small Windows classification fix for reaped worker exit status, so the existing protocol-violation kanban regression passes on native Windows.

## Tests

- `uv run --extra dev pytest tests/hermes_cli/test_kanban_cli.py -q`
- `PYTHONUTF8=1 uv run --extra all --extra dev pytest <kanban test files> -q`

Result: `541 passed, 1 skipped` for the focused kanban regression set.

## Compatibility

No breaking change. Existing callers that omit `initial_status` keep the current behavior.
