### PR TITLE
feat: add provider monthly usage analytics

### DIFF
--- a/agent/tool_billing.py
+++ b/agent/tool_billing.py
@@ -1,0 +1,181 @@
+"""Provider-managed monthly usage / billing snapshots for tool providers.
+
+This module intentionally reports only provider API data: no per-call
+persistence, local price tables, or credits-to-USD conversion.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+
+from hermes_cli.config import get_env_value
+
+_EXA_ADMIN_BASE_URL = "https://admin-api.exa.ai/team-management"
+_FIRECRAWL_BASE_URL = "https://api.firecrawl.dev/v2"
+_TAVILY_BASE_URL = "https://api.tavily.com"
+
+
+def _utc_now(now: float | None = None) -> datetime:
+    if now is None:
+        return datetime.now(timezone.utc)
+    return datetime.fromtimestamp(now, tz=timezone.utc)
+
+
+def _month_bounds(now: float | None = None) -> tuple[str, str]:
+    dt = _utc_now(now)
+    start = dt.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    if dt.month == 12:
+        next_month = dt.replace(
+            year=dt.year + 1,
+            month=1,
+            day=1,
+            hour=0,
+            minute=0,
+            second=0,
+            microsecond=0,
+        )
+    else:
+        next_month = dt.replace(month=dt.month + 1, day=1, hour=0, minute=0, second=0, microsecond=0)
+    end_dt = datetime.fromtimestamp(next_month.timestamp() - 1, tz=timezone.utc)
+    return start.isoformat().replace("+00:00", "Z"), end_dt.isoformat().replace("+00:00", "Z")
+
+
+def _fetch_exa_monthly_usage(now: float | None = None) -> dict[str, Any] | None:
+    service_key = get_env_value("EXA_SERVICE_API_KEY") or get_env_value("EXA_API_KEY")
+    api_key_id = get_env_value("EXA_API_KEY_ID")
+    if not service_key or not api_key_id:
+        return None
+
+    start, end = _month_bounds(now)
+    response = httpx.get(
+        f"{_EXA_ADMIN_BASE_URL}/api-keys/{api_key_id}/usage",
+        headers={"x-api-key": service_key},
+        params={"start_date": start, "end_date": end},
+        timeout=30,
+    )
+    response.raise_for_status()
+    data = response.json()
+    fetched_at = now if now is not None else _utc_now().timestamp()
+    return {
+        "provider": "exa",
+        "status": "supported",
+        "scope": "api_key",
+        "unit": "usd",
+        "value": data.get("total_cost_usd", 0),
+        "period": {
+            "kind": "calendar_month",
+            "start": data.get("period", {}).get("start", start),
+            "end": data.get("period", {}).get("end", end),
+        },
+        "breakdown": {"cost_breakdown": data.get("cost_breakdown", [])},
+        "fetched_at": fetched_at,
+        "source": "provider_usage_api",
+    }
+
+
+def _fetch_firecrawl_monthly_usage(now: float | None = None) -> dict[str, Any] | None:
+    api_key = get_env_value("FIRECRAWL_API_KEY")
+    if not api_key:
+        return None
+
+    base_url = (get_env_value("FIRECRAWL_API_URL") or _FIRECRAWL_BASE_URL).rstrip("/")
+    response = httpx.get(
+        f"{base_url}/team/credit-usage",
+        headers={"Authorization": f"Bearer {api_key}"},
+        timeout=30,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    data = payload.get("data", payload)
+    remaining = data.get("remainingCredits", 0) or 0
+    plan = data.get("planCredits", 0) or 0
+    used = max(plan - remaining, 0)
+    fetched_at = now if now is not None else _utc_now().timestamp()
+    return {
+        "provider": "firecrawl",
+        "status": "supported",
+        "scope": "team",
+        "unit": "credits",
+        "value": used,
+        "period": {
+            "kind": "billing_period",
+            "start": data.get("billingPeriodStart"),
+            "end": data.get("billingPeriodEnd"),
+        },
+        "breakdown": {
+            "remainingCredits": remaining,
+            "planCredits": plan,
+        },
+        "fetched_at": fetched_at,
+        "source": "provider_usage_api",
+    }
+
+
+def _fetch_tavily_monthly_usage(now: float | None = None) -> dict[str, Any] | None:
+    api_key = get_env_value("TAVILY_API_KEY")
+    if not api_key:
+        return None
+
+    start, end = _month_bounds(now)
+    headers = {"Authorization": f"Bearer {api_key}"}
+    project_id = get_env_value("TAVILY_PROJECT")
+    if project_id:
+        headers["X-Project-ID"] = project_id
+    response = httpx.get(f"{_TAVILY_BASE_URL}/usage", headers=headers, timeout=30)
+    response.raise_for_status()
+    data = response.json()
+    key_usage = data.get("key") or {}
+    account_usage = data.get("account") or {}
+    scope = "project" if project_id else ("api_key" if key_usage else "account")
+    value = key_usage.get("usage") if key_usage else account_usage.get("plan_usage", 0)
+    fetched_at = now if now is not None else _utc_now().timestamp()
+    return {
+        "provider": "tavily",
+        "status": "supported",
+        "scope": scope,
+        "unit": "usage",
+        "value": value or 0,
+        "period": {
+            "kind": "calendar_month",
+            "start": start,
+            "end": end,
+        },
+        "breakdown": {
+            "search_usage": key_usage.get("search_usage", account_usage.get("search_usage", 0)),
+            "extract_usage": key_usage.get("extract_usage", account_usage.get("extract_usage", 0)),
+            "crawl_usage": key_usage.get("crawl_usage", account_usage.get("crawl_usage", 0)),
+            "map_usage": key_usage.get("map_usage", account_usage.get("map_usage", 0)),
+            "research_usage": key_usage.get("research_usage", account_usage.get("research_usage", 0)),
+            "account_plan_usage": account_usage.get("plan_usage"),
+            "account_paygo_usage": account_usage.get("paygo_usage"),
+            "current_plan": account_usage.get("current_plan"),
+        },
+        "fetched_at": fetched_at,
+        "source": "provider_usage_api",
+    }
+
+
+def get_supported_provider_monthly_usage(now: float | None = None) -> dict[str, Any]:
+    sources: list[dict[str, Any]] = []
+    unsupported: list[dict[str, str]] = []
+
+    for provider, fetcher in [
+        ("exa", _fetch_exa_monthly_usage),
+        ("firecrawl", _fetch_firecrawl_monthly_usage),
+        ("tavily", _fetch_tavily_monthly_usage),
+    ]:
+        try:
+            snapshot = fetcher(now=now)
+        except Exception:
+            snapshot = None
+        if snapshot:
+            sources.append(snapshot)
+        else:
+            unsupported.append({"provider": provider, "reason": "not_configured_or_unavailable"})
+
+    unsupported.append({"provider": "parallel", "reason": "no_documented_usage_api"})
+    sources.sort(key=lambda item: item["provider"])
+    return {"sources": sources, "unsupported": unsupported}

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3010,6 +3010,8 @@ async def get_usage_analytics(days: int = 30):
             },
             "top_skills": [],
         })
+        from agent.tool_billing import get_supported_provider_monthly_usage
+        provider_monthly_usage = get_supported_provider_monthly_usage(now=time.time())
 
         return {
             "daily": daily,
@@ -3017,6 +3019,7 @@ async def get_usage_analytics(days: int = 30):
             "totals": totals,
             "period_days": days,
             "skills": skills,
+            "provider_monthly_usage": provider_monthly_usage,
         }
     finally:
         db.close()

--- a/tests/agent/test_tool_billing.py
+++ b/tests/agent/test_tool_billing.py
@@ -1,0 +1,150 @@
+def _response(payload):
+    class _Resp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return payload
+
+    return _Resp()
+
+
+def test_get_supported_provider_monthly_usage_includes_supported_sources(monkeypatch):
+    from agent import tool_billing
+
+    monkeypatch.setattr(
+        tool_billing,
+        "_fetch_tavily_monthly_usage",
+        lambda now=None: {
+            "provider": "tavily",
+            "status": "supported",
+            "scope": "api_key",
+            "unit": "usage",
+            "value": 150,
+            "period": {
+                "kind": "calendar_month",
+                "start": "2026-04-01T00:00:00Z",
+                "end": "2026-04-30T23:59:59Z",
+            },
+            "breakdown": {"search_usage": 100, "extract_usage": 25},
+            "fetched_at": 1710000000.0,
+            "source": "provider_usage_api",
+        },
+    )
+    monkeypatch.setattr(
+        tool_billing,
+        "_fetch_firecrawl_monthly_usage",
+        lambda now=None: {
+            "provider": "firecrawl",
+            "status": "supported",
+            "scope": "team",
+            "unit": "credits",
+            "value": 250,
+            "period": {
+                "kind": "billing_period",
+                "start": "2026-04-01T00:00:00Z",
+                "end": "2026-04-30T23:59:59Z",
+            },
+            "breakdown": {"remainingCredits": 750, "planCredits": 1000},
+            "fetched_at": 1710000000.0,
+            "source": "provider_usage_api",
+        },
+    )
+    monkeypatch.setattr(tool_billing, "_fetch_exa_monthly_usage", lambda now=None: None)
+
+    result = tool_billing.get_supported_provider_monthly_usage(now=1710000000.0)
+
+    assert [entry["provider"] for entry in result["sources"]] == ["firecrawl", "tavily"]
+    assert result["unsupported"] == [
+        {"provider": "exa", "reason": "not_configured_or_unavailable"},
+        {"provider": "parallel", "reason": "no_documented_usage_api"},
+    ]
+
+
+def test_fetch_tavily_monthly_usage_maps_usage_response(monkeypatch):
+    from agent import tool_billing
+
+    monkeypatch.setattr(
+        tool_billing,
+        "get_env_value",
+        lambda key: "tvly-key" if key == "TAVILY_API_KEY" else None,
+    )
+    monkeypatch.setattr(
+        tool_billing.httpx,
+        "get",
+        lambda *args, **kwargs: _response(
+            {
+                "key": {
+                    "usage": 150,
+                    "search_usage": 100,
+                    "extract_usage": 25,
+                    "crawl_usage": 15,
+                    "map_usage": 7,
+                    "research_usage": 3,
+                },
+                "account": {
+                    "current_plan": "Bootstrap",
+                    "plan_usage": 500,
+                    "paygo_usage": 25,
+                },
+            }
+        ),
+    )
+
+    snapshot = tool_billing._fetch_tavily_monthly_usage(now=1710000000.0)
+
+    assert snapshot is not None
+    assert snapshot["provider"] == "tavily"
+    assert snapshot["scope"] == "api_key"
+    assert snapshot["unit"] == "usage"
+    assert snapshot["value"] == 150
+    assert snapshot["breakdown"]["account_plan_usage"] == 500
+    assert snapshot["breakdown"]["account_paygo_usage"] == 25
+
+
+def test_fetch_firecrawl_monthly_usage_maps_credit_usage(monkeypatch):
+    from agent import tool_billing
+
+    monkeypatch.setattr(
+        tool_billing,
+        "get_env_value",
+        lambda key: "fc-key" if key == "FIRECRAWL_API_KEY" else None,
+    )
+    monkeypatch.setattr(
+        tool_billing.httpx,
+        "get",
+        lambda *args, **kwargs: _response(
+            {
+                "success": True,
+                "data": {
+                    "remainingCredits": 750,
+                    "planCredits": 1000,
+                    "billingPeriodStart": "2026-04-01T00:00:00Z",
+                    "billingPeriodEnd": "2026-04-30T23:59:59Z",
+                },
+            }
+        ),
+    )
+
+    snapshot = tool_billing._fetch_firecrawl_monthly_usage(now=1710000000.0)
+
+    assert snapshot is not None
+    assert snapshot["provider"] == "firecrawl"
+    assert snapshot["scope"] == "team"
+    assert snapshot["unit"] == "credits"
+    assert snapshot["value"] == 250
+    assert snapshot["period"]["start"] == "2026-04-01T00:00:00Z"
+    assert snapshot["breakdown"]["remainingCredits"] == 750
+
+
+def test_fetch_exa_monthly_usage_requires_api_key_id(monkeypatch):
+    from agent import tool_billing
+
+    values = {
+        "EXA_API_KEY": "exa-service-key",
+        "EXA_API_KEY_ID": None,
+        "EXA_SERVICE_API_KEY": None,
+    }
+    monkeypatch.setattr(tool_billing, "get_env_value", lambda key: values.get(key))
+
+    assert tool_billing._fetch_exa_monthly_usage(now=1710000000.0) is None

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -959,9 +959,11 @@ class TestNewEndpoints:
         assert "by_model" in data
         assert "totals" in data
         assert "skills" in data
+        assert "provider_monthly_usage" in data
         assert isinstance(data["daily"], list)
         assert "total_sessions" in data["totals"]
         assert "total_api_calls" in data["totals"]
+        assert set(data["provider_monthly_usage"]) == {"sources", "unsupported"}
         assert data["skills"] == {
             "summary": {
                 "total_skill_loads": 0,

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -482,6 +482,32 @@ export interface AnalyticsSkillsSummary {
   distinct_skills_used: number;
 }
 
+export interface ProviderMonthlyUsageEntry {
+  provider: string;
+  status: string;
+  scope: string;
+  unit: string;
+  value: number;
+  period: {
+    kind: string;
+    start?: string | null;
+    end?: string | null;
+  };
+  breakdown: Record<string, unknown>;
+  fetched_at: number;
+  source: string;
+}
+
+export interface ProviderMonthlyUsageUnsupportedEntry {
+  provider: string;
+  reason: string;
+}
+
+export interface ProviderMonthlyUsageResponse {
+  sources: ProviderMonthlyUsageEntry[];
+  unsupported: ProviderMonthlyUsageUnsupportedEntry[];
+}
+
 export interface AnalyticsResponse {
   daily: AnalyticsDailyEntry[];
   by_model: AnalyticsModelEntry[];
@@ -499,6 +525,7 @@ export interface AnalyticsResponse {
     summary: AnalyticsSkillsSummary;
     top_skills: AnalyticsSkillEntry[];
   };
+  provider_monthly_usage: ProviderMonthlyUsageResponse;
 }
 
 export interface ProfileInfo {

--- a/web/src/pages/AnalyticsPage.tsx
+++ b/web/src/pages/AnalyticsPage.tsx
@@ -392,6 +392,88 @@ function SkillTable({ skills }: { skills: AnalyticsSkillEntry[] }) {
   );
 }
 
+function formatProviderValue(unit: string, value: number): string {
+  if (unit === "usd") return `$${value.toFixed(2)}`;
+  return Number.isInteger(value) ? String(value) : value.toFixed(2);
+}
+
+function ProviderMonthlyUsageSection({
+  data,
+}: {
+  data: AnalyticsResponse["provider_monthly_usage"];
+}) {
+  return (
+    <Card data-testid="provider-monthly-usage">
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <BarChart3 className="h-5 w-5 text-muted-foreground" />
+          <CardTitle className="text-base">Provider monthly usage</CardTitle>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          Provider-managed monthly usage and billing snapshots. Units are
+          displayed as returned by each provider.
+        </p>
+      </CardHeader>
+      <CardContent className="grid gap-4">
+        {data.sources.length === 0 ? (
+          <div className="border border-border p-4 text-sm text-muted-foreground text-center">
+            No configured provider monthly usage API returned data.
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-border text-muted-foreground text-xs">
+                  <th className="text-left py-2 pr-4 font-medium">Provider</th>
+                  <th className="text-left py-2 px-4 font-medium">Scope</th>
+                  <th className="text-left py-2 px-4 font-medium">Unit</th>
+                  <th className="text-right py-2 px-4 font-medium">Value</th>
+                  <th className="text-left py-2 pl-4 font-medium">Period</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.sources.map((entry) => (
+                  <tr
+                    key={entry.provider}
+                    className="border-b border-border/50 hover:bg-secondary/20 transition-colors"
+                  >
+                    <td className="py-2 pr-4 font-mono-ui text-xs">{entry.provider}</td>
+                    <td className="py-2 px-4">
+                      <Badge tone="outline">{entry.scope}</Badge>
+                    </td>
+                    <td className="py-2 px-4">
+                      <Badge tone="secondary">{entry.unit}</Badge>
+                    </td>
+                    <td className="text-right py-2 px-4 font-medium">
+                      {formatProviderValue(entry.unit, entry.value)}
+                    </td>
+                    <td className="py-2 pl-4 text-xs text-muted-foreground">
+                      {entry.period.start ?? "—"} → {entry.period.end ?? "—"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        <div className="grid gap-2">
+          <h3 className="text-sm font-medium text-muted-foreground">
+            Providers without a live usage snapshot
+          </h3>
+          <div className="flex flex-wrap gap-2">
+            {data.unsupported.map((entry) => (
+              <Badge key={entry.provider} tone="outline">
+                {entry.provider}
+              </Badge>
+            ))}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
 export default function AnalyticsPage() {
   const [days, setDays] = useState(30);
   const [data, setData] = useState<AnalyticsResponse | null>(null);
@@ -571,6 +653,7 @@ export default function AnalyticsPage() {
             <TokenBarChart daily={data.daily} />
           </div>
 
+          <ProviderMonthlyUsageSection data={data.provider_monthly_usage} />
           <DailyTable daily={data.daily} />
           <ModelTable models={data.by_model} />
           <SkillTable skills={data.skills.top_skills} />


### PR DESCRIPTION
## Summary
- Add provider-managed monthly usage snapshots for Exa, Firecrawl, and Tavily
- Expose provider_monthly_usage from the analytics usage API without returning secrets
- Show the provider usage snapshot in the existing Analytics dashboard

## Test Plan
- python -m pytest -q -n0 tests/agent/test_tool_billing.py tests/hermes_cli/test_web_server.py
- npm run build