### PR TITLE
fix: use _ra() accessor for _pool_may_recover_from_rate_limit

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2251,7 +2251,7 @@ def run_conversation(
                     # still recover.  See _pool_may_recover_from_rate_limit
                     # for the single-credential-pool and CloudCode-quota
                     # exceptions.  Fixes #11314 and #13636.
-                    pool_may_recover = _pool_may_recover_from_rate_limit(
+                    pool_may_recover = _ra()._pool_may_recover_from_rate_limit(
                         agent._credential_pool,
                         provider=agent.provider,
                         base_url=getattr(agent, "base_url", None),


### PR DESCRIPTION
Fix NameError when rate limit recovery triggers.

In `agent/conversation_loop.py` line 2254, `_pool_may_recover_from_rate_limit` was called directly but defined in `run_agent.py`. Changed to `_ra()._pool_may_recover_from_rate_limit()` to match the pattern used for other run_agent functions:

```python
# Before
pool_may_recover = _pool_may_recover_from_rate_limit(...)

# After
pool_may_recover = _ra()._pool_may_recover_from_rate_limit(...)
```

Fixes NameError: name "_pool_may_recover_from_rate_limit" is not defined