### PR TITLE
fix: use _ra() accessor for _pool_may_recover_from_rate_limit

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2251,7 +2251,7 @@ def run_conversation(
                     # still recover.  See _pool_may_recover_from_rate_limit
                     # for the single-credential-pool and CloudCode-quota
                     # exceptions.  Fixes #11314 and #13636.
-                    pool_may_recover = _pool_may_recover_from_rate_limit(
+                    pool_may_recover = _ra()._pool_may_recover_from_rate_limit(
                         agent._credential_pool,
                         provider=agent.provider,
                         base_url=getattr(agent, "base_url", None),


### PR DESCRIPTION
## What does this PR do?

Fixes NameError crash when rate limit recovery triggers. The function `_pool_may_recover_from_rate_limit` was defined in `run_agent.py` but called directly in `conversation_loop.py` without the `_ra()` accessor.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/conversation_loop.py` line 2254: Changed `_pool_may_recover_from_rate_limit(...)` to `_ra()._pool_may_recover_from_rate_limit(...)`

## How to Test

1. Trigger rate limit recovery scenario (rate limit hit during model fallback)
2. Before fix: NameError: name "_pool_may_recover_from_rate_limit" is not defined
3. After fix: Graceful rate limit handling without crash

## Checklist

### Code
- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`)
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix
- [x] I have run `pytest tests/ -q` and all tests pass
- [x] I have tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping
- [x] I have considered cross-platform impact — fix uses existing _ra() accessor pattern already used elsewhere in the codebase