### PR TITLE
fix(gateway/telegram): include full numbered choices in clarify body

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2270,16 +2270,19 @@ class TelegramAdapter(BasePlatformAdapter):
             }
 
             if choices:
-                # Telegram caps callback_data at 64 bytes; keep "cl:<id>:<idx>"
-                # short.  Button label is also capped (~64 chars in practice).
+                # Render full choices in body since Telegram mobile clips long
+                # inline button labels; buttons carry only the index number.
+                numbered = "\n".join(
+                    f"{idx + 1}. {_html.escape(str(choice))}"
+                    for idx, choice in enumerate(choices)
+                )
+                text = f"❓ {_html.escape(question)}\n\n{numbered}"
+                kwargs["text"] = text
                 rows = []
-                for idx, choice in enumerate(choices):
-                    label = str(choice)
-                    if len(label) > 60:
-                        label = label[:57] + "..."
+                for idx, _choice in enumerate(choices):
                     rows.append([
                         InlineKeyboardButton(
-                            f"{idx + 1}. {label}",
+                            f"{idx + 1}",
                             callback_data=f"cl:{clarify_id}:{idx}",
                         )
                     ])

--- a/tests/gateway/test_telegram_clarify_buttons.py
+++ b/tests/gateway/test_telegram_clarify_buttons.py
@@ -150,18 +150,39 @@ class TestTelegramSendClarify:
         mock_msg.message_id = 102
         adapter._bot.send_message = AsyncMock(return_value=mock_msg)
 
-        long_choice = "x" * 200  # > 60 char cap
-        result = await adapter.send_clarify(
-            chat_id="12345",
-            question="?",
-            choices=[long_choice],
-            clarify_id="cid4",
-            session_key="sk4",
-        )
+        long_choices = [
+            "alpha " + ("x" * 100),
+            "beta "  + ("y" * 100),
+            "gamma " + ("z" * 100),
+            "delta " + ("w" * 100),
+        ]
+        with patch("gateway.platforms.telegram.InlineKeyboardButton") as btn:
+            result = await adapter.send_clarify(
+                chat_id="12345",
+                question="Pick one",
+                choices=long_choices,
+                clarify_id="cid4",
+                session_key="sk4",
+            )
         assert result.success is True
-        # The truncation logic replaces with "..." past 57 chars; we don't
-        # inspect the mock's button labels directly (auto-MagicMock), but
-        # we can verify the call didn't raise on absurdly long input.
+
+        # Full choice text should appear in the message body, one per line.
+        kwargs = adapter._bot.send_message.call_args[1]
+        text = kwargs["text"]
+        for idx, choice in enumerate(long_choices, start=1):
+            assert f"{idx}. {choice}" in text
+
+        # Non-Other button labels must be exactly the index string.
+        labels_by_callback = {}
+        for call in btn.call_args_list:
+            args, kw = call
+            label = args[0] if args else kw.get("text")
+            cb = kw.get("callback_data")
+            labels_by_callback[cb] = label
+        for idx in range(len(long_choices)):
+            assert labels_by_callback[f"cl:cid4:{idx}"] == str(idx + 1)
+        # The "Other" button is preserved unchanged.
+        assert labels_by_callback["cl:cid4:other"] == "✏️ Other (type answer)"
 
     @pytest.mark.asyncio
     async def test_html_escapes_question(self):


### PR DESCRIPTION
## Summary

Fixes #27497.

Telegram inline-button labels are clipped on mobile when `clarify` choices are long, leaving users unable to read the full options. Previously `send_clarify` rendered each option only as an inline-keyboard button (label truncated to 60 chars in code, and further visually truncated by Telegram on mobile), with the message body containing only the question.

This change moves the full option text into the **message body** as a numbered list and shortens inline-button labels to just the option index, so buttons always fit while the full text is readable in the chat.

## Changes

- `gateway/platforms/telegram.py::send_clarify`
  - When `choices` is non-empty, build message text as `❓ <question>\n\n1. <choice1>\n2. <choice2>…`, with each choice HTML-escaped.
  - Inline-button labels become just the index (`"1"`, `"2"`, …) instead of `"{n}. {label}"`.
  - `callback_data` (`cl:<id>:<idx>`, `cl:<id>:other`) is unchanged — callback handling is untouched.
  - Open-ended (no-choices) path is unchanged.
  - "✏️ Other (type answer)" button preserved as-is.

## Tests

- `tests/gateway/test_telegram_clarify_buttons.py::test_truncates_long_choice_label` rewritten to:
  - Pass 4 long choices (>100 chars each).
  - Assert each full `f"{idx}. {choice}"` line appears in the sent body.
  - Assert non-Other button labels are exactly the index string (`"1"`, `"2"`, `"3"`, `"4"`).
  - Assert the "Other" button label is preserved.

```
$ pytest tests/gateway/test_telegram_clarify_buttons.py tests/tools/test_clarify_gateway.py
27 passed in 1.94s
```

## Notes

- HTML escaping is applied to both the question and each choice in the body.
- Callback data length stays well within Telegram's 64-byte cap.
- No change to `clarify_gateway` text-capture path or the "Other" flow.
