### PR TITLE
feat(gateway): show reasoning effort in runtime footer

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8826,12 +8826,20 @@ class GatewayRunner:
             _footer_line = ""
             try:
                 from gateway.runtime_footer import build_footer_line as _bfl
+                _reasoning_cfg = self._resolve_session_reasoning_config(source=source)
+                if _reasoning_cfg is None:
+                    _reasoning_effort = "medium"
+                elif _reasoning_cfg.get("enabled") is False:
+                    _reasoning_effort = "none"
+                else:
+                    _reasoning_effort = str(_reasoning_cfg.get("effort") or "medium")
                 _footer_line = _bfl(
                     user_config=_load_gateway_config(),
                     platform_key=_platform_config_key(source.platform),
                     model=agent_result.get("model"),
                     context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                     context_length=agent_result.get("context_length") or None,
+                    reasoning_effort=_reasoning_effort,
                     cwd=os.environ.get("TERMINAL_CWD", ""),
                 )
             except Exception as _footer_err:

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -8,8 +8,8 @@ Config (``~/.hermes/config.yaml``)::
 
     display:
       runtime_footer:
-        enabled: true                       # off by default
-        fields: [model, context_pct, cwd]   # order shown; drop any to hide
+        enabled: true                                  # off by default
+        fields: [model, reasoning, context_pct, cwd]   # order shown; drop any to hide
 
 Per-platform overrides live under ``display.platforms.<platform>.runtime_footer``.
 Users can toggle the global setting with ``/footer on|off`` from both the CLI
@@ -54,6 +54,13 @@ def _model_short(model: Optional[str]) -> str:
     return model.rsplit("/", 1)[-1]
 
 
+def _reasoning_effort_label(reasoning_effort: Optional[str]) -> str:
+    """Return a compact reasoning-effort label for the footer."""
+    if not reasoning_effort:
+        return ""
+    return str(reasoning_effort).strip().lower()
+
+
 def resolve_footer_config(
     user_config: dict[str, Any] | None,
     platform_key: str | None = None,
@@ -94,6 +101,7 @@ def format_runtime_footer(
     model: Optional[str],
     context_tokens: int,
     context_length: Optional[int],
+    reasoning_effort: Optional[str] = None,
     cwd: Optional[str] = None,
     fields: Iterable[str] = _DEFAULT_FIELDS,
 ) -> str:
@@ -108,6 +116,10 @@ def format_runtime_footer(
             m = _model_short(model)
             if m:
                 parts.append(m)
+        elif field == "reasoning":
+            r = _reasoning_effort_label(reasoning_effort)
+            if r:
+                parts.append(r)
         elif field == "context_pct":
             if context_length and context_length > 0 and context_tokens >= 0:
                 pct = max(0, min(100, round((context_tokens / context_length) * 100)))
@@ -130,6 +142,7 @@ def build_footer_line(
     model: Optional[str],
     context_tokens: int,
     context_length: Optional[int],
+    reasoning_effort: Optional[str] = None,
     cwd: Optional[str] = None,
 ) -> str:
     """Top-level entry point used by gateway/run.py.
@@ -143,6 +156,7 @@ def build_footer_line(
         return ""
     return format_runtime_footer(
         model=model,
+        reasoning_effort=reasoning_effort,
         context_tokens=context_tokens,
         context_length=context_length,
         cwd=cwd,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1154,11 +1154,11 @@ DEFAULT_CONFIG = {
         "platforms": {},  # Per-platform display overrides: {"telegram": {"tool_progress": "all"}, "slack": {"tool_progress": "off"}}
         # Gateway runtime-metadata footer appended to the FINAL message of a turn
         # (disabled by default to keep replies minimal). When enabled, renders
-        # e.g. `model · 68% · ~/projects/hermes`. Per-platform overrides go under
+        # e.g. `model · medium · 68% · ~/projects/hermes`. Per-platform overrides go under
         # display.platforms.<platform>.runtime_footer.
         "runtime_footer": {
             "enabled": False,
-            "fields": ["model", "context_pct", "cwd"],  # Order shown; drop any to hide
+            "fields": ["model", "context_pct", "cwd"],  # Optional: add "reasoning" (effort level)
         },
         "copy_shortcut": "auto",  # "auto" (platform default) | "ctrl_c" | "ctrl_shift_c" | "disabled"
     },

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -62,12 +62,25 @@ def test_format_footer_all_fields(monkeypatch, tmp_path):
     (tmp_path / "projects" / "hermes").mkdir(parents=True)
     out = format_runtime_footer(
         model="openrouter/openai/gpt-5.4",
+        reasoning_effort="medium",
         context_tokens=68000,
         context_length=100000,
         cwd=None,  # falls back to TERMINAL_CWD env var
-        fields=("model", "context_pct", "cwd"),
+        fields=("model", "reasoning", "context_pct", "cwd"),
     )
-    assert out == "gpt-5.4 · 68% · ~/projects/hermes"
+    assert out == "gpt-5.4 · medium · 68% · ~/projects/hermes"
+
+
+def test_format_footer_skips_missing_reasoning_effort():
+    out = format_runtime_footer(
+        model="openai/gpt-5.4",
+        reasoning_effort=None,
+        context_tokens=42,
+        context_length=100,
+        cwd="",
+        fields=("model", "reasoning", "context_pct"),
+    )
+    assert out == "gpt-5.4 · 42%"
 
 
 def test_format_footer_skips_missing_context_length():
@@ -223,12 +236,39 @@ def test_build_footer_returns_rendered_when_enabled(monkeypatch, tmp_path):
         user_config={"display": {"runtime_footer": {"enabled": True}}},
         platform_key="telegram",
         model="openai/gpt-5.4",
+        reasoning_effort="medium",
         context_tokens=25, context_length=100,
         cwd=str(tmp_path / "proj"),
     )
     (tmp_path / "proj").mkdir(exist_ok=True)
     assert "gpt-5.4" in out
     assert "25%" in out
+
+
+def test_build_footer_can_render_platform_reasoning_field(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / "proj").mkdir(exist_ok=True)
+    out = build_footer_line(
+        user_config={
+            "display": {
+                "runtime_footer": {"enabled": True},
+                "platforms": {
+                    "telegram": {
+                        "runtime_footer": {
+                            "fields": ["model", "reasoning", "context_pct", "cwd"],
+                        }
+                    },
+                },
+            },
+        },
+        platform_key="telegram",
+        model="openai/gpt-5.4",
+        reasoning_effort="medium",
+        context_tokens=42,
+        context_length=100,
+        cwd=str(tmp_path / "proj"),
+    )
+    assert out == "gpt-5.4 · medium · 42% · ~/proj"
 
 
 def test_build_footer_per_platform_off_suppresses():

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1187,7 +1187,7 @@ display:
   tool_preview_length: 0  # Max chars for tool call previews (0 = no limit, show full paths/commands)
   runtime_footer:         # Gateway: append a runtime-context footer to final replies
     enabled: false
-    fields: ["model", "context_pct", "cwd"]
+    fields: ["model", "context_pct", "cwd"]  # add "reasoning" to show effort level
   file_mutation_verifier: true    # Append an advisory footer when write_file/patch calls failed this turn
   language: en            # UI language for static messages (approval prompts, some gateway replies). en | zh | zh-hant | ja | de | es | fr | tr | uk | af | ko | it | ga | pt | ru | hu
 ```
@@ -1237,15 +1237,17 @@ When `display.runtime_footer.enabled: true`, Hermes appends a small runtime-cont
 display:
   runtime_footer:
     enabled: true
-    fields: ["model", "context_pct", "cwd"]   # any of: model, context_pct, cwd, duration, tokens, cost
+    fields: ["model", "reasoning", "context_pct", "cwd"]   # any of: model, reasoning, context_pct, cwd
 ```
+
+This renders compactly, for example: `gpt-5.4 · medium · 42% · ~/proj`.
 
 The `/footer` slash command toggles this at runtime in any session.
 
 Example footer appended to a Telegram/Discord/Slack reply:
 
 ```
-— claude-opus-4.7 · 12 tool calls · 2m 14s · $0.042
+claude-opus-4.7 · high · 42% · ~/projects/hermes
 ```
 
 Only the **final** message of a turn gets the footer; interim updates stay clean.


### PR DESCRIPTION
## Summary
- add an optional `reasoning` field for `display.runtime_footer.fields`
- pass the session's effective reasoning effort into gateway footer rendering
- document the compact footer format, e.g. `gpt-5.4 · medium · 42% · ~/proj`

## Test Plan
- [x] `python -m pytest tests/gateway/test_runtime_footer.py -q -o 'addopts='`
- [x] `python -m pytest tests/gateway/test_runtime_footer.py tests/gateway/test_reasoning_command.py tests/gateway/test_display_config.py -q -o 'addopts='`
- [x] `python -m py_compile gateway/runtime_footer.py gateway/run.py hermes_cli/config.py`
- [x] `git diff --check`

Closes #27536
