### PR TITLE
fix(gateway): explain pending approval when user sends normal text reply

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6316,6 +6316,33 @@ class GatewayRunner:
                     f"mid-turn. Wait for the current response or `/stop` first."
                 )
 
+            # Pending dangerous-command approval guard.
+            #
+            # If the agent thread is blocked inside tools/approval.py waiting
+            # for /approve or /deny, a plain text follow-up cannot resolve the
+            # approval — it would be interrupted/queued/steered into the busy
+            # path and the approval would still time out with the confusing
+            # "BLOCKED: Command timed out. Do NOT retry this command." error.
+            #
+            # /approve and /deny are already dispatched directly above (line
+            # ~6235); /yolo (line ~6285) can unblock approvals; /stop, /new,
+            # /restart, /queue, /steer, /goal, /agents etc. are handled by
+            # their own branches.  Anything that falls through to here while
+            # an approval is live is a normal user message that does NOT
+            # resolve the prompt — tell the user so explicitly instead of
+            # silently dropping it into the busy-input pipeline (#27352).
+            if _tool_approval_live and event.message_type == MessageType.TEXT:
+                logger.debug(
+                    "PRIORITY pending-approval reply for session %s — text follow-up cannot resolve approval",
+                    _quick_key,
+                )
+                return EphemeralReply(
+                    "⏳ A dangerous-command approval is waiting for `/approve` "
+                    "or `/deny`. Your message was not treated as an approval "
+                    "and the command is still blocked — reply with `/approve` "
+                    "or `/deny` first, or `/stop` to cancel."
+                )
+
             if event.message_type == MessageType.PHOTO:
                 logger.debug("PRIORITY photo follow-up for session %s — queueing without interrupt", _quick_key)
                 adapter = self.adapters.get(source.platform)

--- a/tests/gateway/test_pending_approval_text_reply.py
+++ b/tests/gateway/test_pending_approval_text_reply.py
@@ -1,0 +1,146 @@
+"""Regression test for #27352.
+
+When a dangerous-command approval is pending (agent blocked inside
+tools/approval.py) and the user sends a plain text follow-up instead of
+``/approve`` / ``/deny``, the gateway must return an explanatory
+``EphemeralReply`` telling the user what to do.  It must NOT silently route
+the message into the busy-input pipeline (queue/steer/interrupt), because
+none of those paths can resolve the approval — the agent thread is blocked
+on a ``threading.Event`` that only ``/approve`` / ``/deny`` can signal, and
+the user would experience the dangerous command timing out with the
+confusing ``BLOCKED: Command timed out`` message even though they
+responded promptly.
+"""
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Minimal telegram stubs so importing gateway.run works without optional deps.
+_tg = types.ModuleType("telegram")
+_tg.constants = types.ModuleType("telegram.constants")
+_ct = MagicMock()
+_ct.SUPERGROUP = "supergroup"
+_ct.GROUP = "group"
+_ct.PRIVATE = "private"
+_tg.constants.ChatType = _ct
+sys.modules.setdefault("telegram", _tg)
+sys.modules.setdefault("telegram.constants", _tg.constants)
+sys.modules.setdefault("telegram.ext", types.ModuleType("telegram.ext"))
+
+from gateway.platforms.base import (  # noqa: E402
+    MessageEvent,
+    MessageType,
+    SessionSource,
+    build_session_key,
+)
+
+
+def _make_event(text="just go ahead", chat_id="123", platform_val="telegram"):
+    source = SessionSource(
+        platform=MagicMock(value=platform_val),
+        chat_id=chat_id,
+        chat_type="private",
+        user_id="user1",
+    )
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="msg1",
+    )
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._busy_ack_ts = {}
+    runner._draining = False
+    runner.adapters = {}
+    runner.config = MagicMock()
+    runner.session_store = None
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner.hooks.emit_collect = AsyncMock(return_value=[])
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = True
+    runner._is_user_authorized = lambda _source: True
+    runner._check_slash_access = lambda _source, _cmd: None
+    return runner
+
+
+def _make_adapter(platform_val="telegram"):
+    adapter = MagicMock()
+    adapter._pending_messages = {}
+    adapter._send_with_retry = AsyncMock()
+    adapter.config = MagicMock()
+    adapter.config.extra = {}
+    adapter.platform = MagicMock(value=platform_val)
+    return adapter
+
+
+class TestPendingApprovalTextReply:
+    """Plain text during pending approval returns explanatory EphemeralReply."""
+
+    @pytest.mark.asyncio
+    async def test_text_during_pending_approval_returns_explainer_no_interrupt(self):
+        from gateway.run import EphemeralReply, GatewayRunner
+
+        runner = _make_runner()
+        adapter = _make_adapter()
+        event = _make_event(text="yes, but do it another way")
+        sk = build_session_key(event.source)
+
+        running_agent = MagicMock()
+        runner._busy_input_mode = "interrupt"
+        runner._running_agents[sk] = running_agent
+        runner.adapters[event.source.platform] = adapter
+
+        # Pretend a dangerous-command approval is pending.
+        with patch("tools.approval.has_blocking_approval", return_value=True):
+            result = await GatewayRunner._handle_message(runner, event)
+
+        # 1. The user gets an explicit reply (not silence, not None).
+        assert isinstance(result, EphemeralReply)
+        reply_text = str(result)
+        assert "/approve" in reply_text
+        assert "/deny" in reply_text
+
+        # 2. The running agent was NOT interrupted — the approval thread
+        #    needs to keep waiting on its event.
+        running_agent.interrupt.assert_not_called()
+
+        # 3. The text was NOT queued into the busy pipeline.  If it were,
+        #    it would replay as a user turn after the approval times out.
+        assert sk not in adapter._pending_messages
+        assert sk not in runner._pending_messages
+
+    @pytest.mark.asyncio
+    async def test_text_without_pending_approval_falls_through_to_interrupt(self):
+        """Sanity check: without a live approval, behavior is unchanged
+        (interrupt mode still interrupts the running agent on text follow-ups).
+        """
+        from gateway.run import GatewayRunner
+
+        runner = _make_runner()
+        adapter = _make_adapter()
+        event = _make_event(text="continue")
+        sk = build_session_key(event.source)
+
+        running_agent = MagicMock()
+        runner._busy_input_mode = "interrupt"
+        runner._running_agents[sk] = running_agent
+        runner._running_agents_ts[sk] = 0  # past the telegram grace window
+        runner.adapters[event.source.platform] = adapter
+
+        with patch("tools.approval.has_blocking_approval", return_value=False):
+            result = await GatewayRunner._handle_message(runner, event)
+
+        # Falls through to the existing interrupt path.
+        assert result is None
+        running_agent.interrupt.assert_called_once_with("continue")


### PR DESCRIPTION
## Summary
- When a dangerous-command approval is pending (agent thread blocked inside `tools/approval.py`), a normal text reply like `continue`, `yes do it another way`, or `wait check status first` cannot resolve the approval — only `/approve` or `/deny` (or `/yolo`) can.
- Previously, such replies were silently routed into the busy-input pipeline (interrupt / queue / steer). The approval would still time out with the confusing `BLOCKED: Command timed out. Do NOT retry this command.` even though the user had responded promptly.
- This PR adds a guard in `GatewayRunner._handle_message`: when `has_blocking_approval(session_key)` is true and a plain TEXT follow-up reaches the busy fall-through, return an explicit `EphemeralReply` telling the user to use `/approve` / `/deny` / `/stop` instead. Control commands (`/approve`, `/deny`, `/yolo`, `/stop`, `/new`, `/restart`, `/queue`, `/steer`, `/goal`, `/agents`, etc.) are unaffected — they continue to be dispatched by their own branches above the guard.

## Test Plan
- [x] New regression test `tests/gateway/test_pending_approval_text_reply.py` verifies (a) the explainer fires + agent is not interrupted + message is not queued when an approval is pending, and (b) sanity check that without a live approval, interrupt-mode behavior is unchanged.
- [x] `python -m pytest tests/gateway/test_pending_approval_text_reply.py -q -o 'addopts='` → 2 passed
- [x] `python -m pytest tests/gateway/test_busy_session_ack.py tests/gateway/test_busy_session_auth_bypass.py tests/gateway/test_pending_approval_text_reply.py tests/gateway/test_telegram_approval_buttons.py -q -o 'addopts='` → 39 passed

Note: `tests/gateway/` broad-suite was not run because the full gateway suite exhausts the macOS file descriptor limit (#11645 / #27004); targeted tests above cover the changed code path.

Closes #27352
