### PR TITLE
fix: avoid BlueBubbles webhook bind in send_message

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -12,6 +12,7 @@ from gateway.config import Platform
 from tools.send_message_tool import (
     _derive_forum_thread_name,
     _parse_target_ref,
+    _send_bluebubbles,
     _send_discord,
     _send_matrix_via_adapter,
     _send_telegram,
@@ -487,6 +488,70 @@ class TestSendToPlatformChunking:
         assert len(sent_calls) >= 3
         assert all(call == [] for call in sent_calls[:-1])
         assert sent_calls[-1] == media
+
+    def test_bluebubbles_standalone_send_does_not_bind_webhook_port(self, monkeypatch):
+        """send_message's BlueBubbles path should not start a second webhook listener."""
+        state = {"connect_called": False, "closed": False}
+
+        class FakeClient:
+            async def aclose(self):
+                state["closed"] = True
+
+        class FakeLimits:
+            pass
+
+        class FakeAdapter:
+            def __init__(self, pconfig):
+                self.client = None
+                self.server_url = pconfig.extra["server_url"]
+                self.password = pconfig.extra["password"]
+                self._private_api_enabled = False
+                self._helper_connected = False
+
+            async def connect(self):
+                state["connect_called"] = True
+                raise OSError("[Errno 48] address already in use")
+
+            async def _api_get(self, path):
+                assert self.client is not None
+                if path == "/api/v1/server/info":
+                    return {"data": {"private_api": True, "helper_connected": True}}
+                return {"status": 200}
+
+            async def send(self, chat_id, message):
+                assert chat_id == "any;+;chat"
+                assert message == "hello"
+                assert self._private_api_enabled is True
+                assert self._helper_connected is True
+                return SimpleNamespace(success=True, message_id="GUID-1", error=None)
+
+        fake_bluebubbles = SimpleNamespace(
+            BlueBubblesAdapter=FakeAdapter,
+            check_bluebubbles_requirements=lambda: True,
+        )
+        fake_httpx = SimpleNamespace(AsyncClient=lambda **_kwargs: FakeClient())
+        fake_limits = SimpleNamespace(platform_httpx_limits=lambda: FakeLimits())
+
+        monkeypatch.setitem(sys.modules, "gateway.platforms.bluebubbles", fake_bluebubbles)
+        monkeypatch.setitem(sys.modules, "httpx", fake_httpx)
+        monkeypatch.setitem(sys.modules, "gateway.platforms._http_client_limits", fake_limits)
+
+        result = asyncio.run(
+            _send_bluebubbles(
+                {"server_url": "http://bb", "password": "pw"},
+                "any;+;chat",
+                "hello",
+            )
+        )
+
+        assert result == {
+            "success": True,
+            "platform": "bluebubbles",
+            "chat_id": "any;+;chat",
+            "message_id": "GUID-1",
+        }
+        assert state["connect_called"] is False
+        assert state["closed"] is True
 
     def test_matrix_media_uses_native_adapter_helper(self):
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1401,19 +1401,39 @@ async def _send_bluebubbles(extra, chat_id, message):
         return {"error": "BlueBubbles adapter not available."}
 
     try:
+        import httpx
         from gateway.config import PlatformConfig
+        from gateway.platforms._http_client_limits import platform_httpx_limits
+
         pconfig = PlatformConfig(extra=extra)
         adapter = BlueBubblesAdapter(pconfig)
-        connected = await adapter.connect()
-        if not connected:
-            return _error("BlueBubbles: failed to connect to server")
+        if not adapter.server_url or not adapter.password:
+            return _error("BlueBubbles: BLUEBUBBLES_SERVER_URL and BLUEBUBBLES_PASSWORD are required")
+
+        # Do not call adapter.connect() here: that starts the inbound webhook
+        # listener and binds BLUEBUBBLES_WEBHOOK_PORT (8645 by default).  The
+        # real gateway already owns that port, so out-of-process send_message
+        # calls must create only a lightweight REST client for outbound sends.
+        limits = platform_httpx_limits()
+        if limits is not None:
+            adapter.client = httpx.AsyncClient(timeout=30.0, limits=limits)
+        else:
+            adapter.client = httpx.AsyncClient(timeout=30.0)
         try:
+            await adapter._api_get("/api/v1/ping")
+            info = await adapter._api_get("/api/v1/server/info")
+            server_data = (info or {}).get("data", {})
+            adapter._private_api_enabled = bool(server_data.get("private_api"))
+            adapter._helper_connected = bool(server_data.get("helper_connected"))
+
             result = await adapter.send(chat_id, message)
             if not result.success:
                 return _error(f"BlueBubbles send failed: {result.error}")
             return {"success": True, "platform": "bluebubbles", "chat_id": chat_id, "message_id": result.message_id}
         finally:
-            await adapter.disconnect()
+            if adapter.client:
+                await adapter.client.aclose()
+                adapter.client = None
     except Exception as e:
         return _error(f"BlueBubbles send failed: {e}")
 


### PR DESCRIPTION
## Summary
- Avoid calling `BlueBubblesAdapter.connect()` from the send_message standalone path
- Create a lightweight REST client for outbound BlueBubbles sends instead of starting a second webhook listener
- Add a regression test that fails if the standalone send path tries to bind the webhook port

## Test Plan
- `python -m pytest tests/tools/test_send_message_tool.py -q -o 'addopts='`\n