### PR TITLE
feat(api): add session-scoped internal events

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -47,6 +47,8 @@ except ImportError:
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
     BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
     SendResult,
     is_network_accessible,
 )
@@ -669,6 +671,41 @@ class APIServerAdapter(BasePlatformAdapter):
         # in-flight run by run_id.
         self._run_approval_sessions: Dict[str, str] = {}
         self._session_db: Optional[Any] = None  # Lazy-init SessionDB for session continuity
+        self._adapter_registry: Optional[Dict[Platform, BasePlatformAdapter]] = None
+
+    def set_adapter_registry(self, adapters: Dict[Platform, BasePlatformAdapter]) -> None:
+        """Share the live gateway adapter registry for internal event routing."""
+        self._adapter_registry = adapters
+
+    @staticmethod
+    def _render_internal_event(
+        event_type: str,
+        message: Any,
+        metadata: Any,
+    ) -> str:
+        """Render a compact, neutral agent-facing message for an internal event.
+
+        Shape is intentionally generic — a type header, any caller-supplied
+        metadata as ``- key: value`` lines, the free-text message, and a
+        closing instruction.  Event payloads are not schema-validated per
+        ``type``; callers decide what metadata is meaningful.
+        """
+        lines = [f"[Hermes internal event] {event_type}"]
+        if isinstance(metadata, dict):
+            for key, value in metadata.items():
+                if value is None or value == "":
+                    continue
+                lines.append(f"- {key}: {value}")
+        rendered = "\n".join(lines)
+
+        if isinstance(message, str) and message.strip():
+            rendered += f"\n\n{message.strip()}"
+
+        rendered += (
+            "\n\nUse the current conversation context to assess the result "
+            "and report the next step to the user."
+        )
+        return rendered
 
     @staticmethod
     def _parse_cors_origins(value: Any) -> tuple[str, ...]:
@@ -1002,6 +1039,11 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_approval_response": True,
                 "tool_progress_events": True,
                 "approval_events": True,
+                # /internal/events hard-requires an API key (returns 403 when
+                # API_SERVER_KEY is unset), so advertise the feature as usable
+                # only when a key is configured.  The route itself is still
+                # listed under "endpoints" for discovery parity.
+                "internal_events": bool(self._api_key),
                 "session_continuity_header": "X-Hermes-Session-Id",
                 "session_key_header": "X-Hermes-Session-Key",
                 "cors": bool(self._cors_origins),
@@ -1017,8 +1059,144 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_events": {"method": "GET", "path": "/v1/runs/{run_id}/events"},
                 "run_approval": {"method": "POST", "path": "/v1/runs/{run_id}/approval"},
                 "run_stop": {"method": "POST", "path": "/v1/runs/{run_id}/stop"},
+                "internal_events": {"method": "POST", "path": "/internal/events"},
             },
         })
+
+    async def _handle_internal_events(self, request: "web.Request") -> "web.Response":
+        """POST /internal/events — inject a session-scoped internal event.
+
+        Lets trusted local automation or a delegated agent post an event into
+        an *existing* Hermes session so Hermes can resume the original context
+        and report the next step.  This is not a durable queue and does not
+        create sessions: the event re-enters the normal platform adapter
+        pipeline as a ``MessageEvent(internal=True)`` routed to the adapter
+        for the session's stored origin.
+        """
+        # This endpoint injects a MessageEvent(internal=True) into existing
+        # gateway sessions, so it is held stricter than ordinary local API
+        # calls: an API key MUST be configured.  _check_auth() alone would
+        # allow all callers when no key is set (local-only convenience).
+        if not self._api_key:
+            return web.json_response(
+                _openai_error(
+                    "Internal events require API key authentication. "
+                    "Configure API_SERVER_KEY to enable this endpoint.",
+                    code="api_key_required",
+                ),
+                status=403,
+            )
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            body = await request.json()
+        except Exception:
+            return web.json_response(_openai_error("Invalid JSON"), status=400)
+        if not isinstance(body, dict):
+            return web.json_response(_openai_error("Request body must be a JSON object"), status=400)
+
+        event_type = str(body.get("type") or "").strip()
+        if not event_type:
+            return web.json_response(_openai_error("Missing 'type' field"), status=400)
+
+        session_id = str(body.get("session_id") or "").strip()
+        session_key = str(body.get("session_key") or "").strip()
+        if not session_id and not session_key:
+            return web.json_response(_openai_error("Missing 'session_id' or 'session_key' field"), status=400)
+
+        session_store = getattr(self, "_session_store", None)
+        if session_store is None:
+            return web.json_response(
+                _openai_error("Gateway session store is unavailable", code="session_store_unavailable"),
+                status=503,
+            )
+
+        entry_by_id = session_store.get_by_session_id(session_id) if session_id else None
+        entry_by_key = session_store.get_by_session_key(session_key) if session_key else None
+
+        if session_id and session_key:
+            # Both identifiers supplied: fail closed unless they both resolve
+            # and point at the same active entry.  Routing by one while the
+            # other is stale/wrong would silently target a different session.
+            if (
+                entry_by_id is None
+                or entry_by_key is None
+                or entry_by_id.session_key != entry_by_key.session_key
+            ):
+                return web.json_response(
+                    _openai_error(
+                        "session_id and session_key do not identify the same active session",
+                        code="session_identifier_mismatch",
+                    ),
+                    status=409,
+                )
+            entry = entry_by_id
+        else:
+            entry = entry_by_id or entry_by_key
+
+        if entry is None:
+            return web.json_response(_openai_error("Session not found", code="session_not_found"), status=404)
+
+        origin = entry.origin
+        if origin is None or getattr(origin, "platform", None) is None:
+            return web.json_response(
+                _openai_error("Session has no routable origin", code="session_origin_unavailable"),
+                status=422,
+            )
+
+        registry = self._adapter_registry or {}
+        target_adapter = registry.get(origin.platform)
+        if target_adapter is None:
+            return web.json_response(
+                _openai_error(
+                    f"Platform adapter is not connected: {origin.platform.value}",
+                    code="platform_not_connected",
+                ),
+                status=503,
+            )
+
+        event = MessageEvent(
+            text=self._render_internal_event(event_type, body.get("message"), body.get("metadata")),
+            message_type=MessageType.TEXT,
+            source=origin,
+            internal=True,
+        )
+
+        # Dispatch asynchronously so the caller gets a prompt 202; the agent
+        # turn it triggers can take a long time.  Failures can't be surfaced
+        # to the already-answered caller, so they are logged.
+        async def _dispatch() -> None:
+            try:
+                await target_adapter.handle_message(event)
+            except Exception:
+                logger.exception(
+                    "Internal event dispatch failed (type=%s session_id=%s platform=%s)",
+                    event_type,
+                    entry.session_id,
+                    origin.platform.value,
+                )
+
+        task = asyncio.create_task(_dispatch())
+        try:
+            self._background_tasks.add(task)
+        except TypeError:
+            pass
+        if hasattr(task, "add_done_callback"):
+            task.add_done_callback(self._background_tasks.discard)
+
+        return web.json_response(
+            {
+                "object": "hermes.internal_event",
+                "status": "accepted",
+                "type": event_type,
+                "session_id": entry.session_id,
+                "session_key": entry.session_key,
+                "platform": origin.platform.value,
+            },
+            status=202,
+        )
 
     async def _handle_chat_completions(self, request: "web.Request") -> "web.Response":
         """POST /v1/chat/completions — OpenAI Chat Completions format."""
@@ -3406,6 +3584,7 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_post("/v1/responses", self._handle_responses)
             self._app.router.add_get("/v1/responses/{response_id}", self._handle_get_response)
             self._app.router.add_delete("/v1/responses/{response_id}", self._handle_delete_response)
+            self._app.router.add_post("/internal/events", self._handle_internal_events)
             # Cron jobs management API
             self._app.router.add_get("/api/jobs", self._handle_list_jobs)
             self._app.router.add_post("/api/jobs", self._handle_create_job)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3576,6 +3576,9 @@ class GatewayRunner:
             adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
             adapter.set_session_store(self.session_store)
             adapter.set_busy_session_handler(self._handle_active_session_busy_message)
+            set_adapter_registry = getattr(adapter, "set_adapter_registry", None)
+            if callable(set_adapter_registry):
+                set_adapter_registry(self.adapters)
             
             # Try to connect
             logger.info("Connecting to %s...", platform.value)
@@ -4873,6 +4876,9 @@ class GatewayRunner:
                     adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
                     adapter.set_session_store(self.session_store)
                     adapter.set_busy_session_handler(self._handle_active_session_busy_message)
+                    set_adapter_registry = getattr(adapter, "set_adapter_registry", None)
+                    if callable(set_adapter_registry):
+                        set_adapter_registry(self.adapters)
 
                     success = await self._connect_adapter_with_timeout(adapter, platform)
                     if success:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -954,6 +954,27 @@ class SessionStore:
 
         return entry
 
+    def get_by_session_key(self, session_key: str) -> Optional[SessionEntry]:
+        """Return the active entry for a gateway session key, if present."""
+        with self._lock:
+            self._ensure_loaded_locked()
+            return self._entries.get(session_key)
+
+    def get_by_session_id(self, session_id: str) -> Optional[SessionEntry]:
+        """Return the active entry currently pointing at ``session_id``.
+
+        This provides a public lookup for internal event routing and avoids
+        callers reaching into the private ``_entries`` mapping.
+        """
+        if not session_id:
+            return None
+        with self._lock:
+            self._ensure_loaded_locked()
+            for entry in self._entries.values():
+                if entry.session_id == session_id:
+                    return entry
+        return None
+
     def update_session(
         self,
         session_key: str,

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -384,6 +384,7 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_post("/v1/responses", adapter._handle_responses)
     app.router.add_get("/v1/responses/{response_id}", adapter._handle_get_response)
     app.router.add_delete("/v1/responses/{response_id}", adapter._handle_delete_response)
+    app.router.add_post("/internal/events", adapter._handle_internal_events)
     return app
 
 
@@ -430,6 +431,350 @@ class TestAgentExecution:
             conversation_history=[],
             task_id="session-123",
         )
+
+
+class TestInternalEventsEndpoint:
+    @staticmethod
+    def _entry(session_id="sess-123", session_key="agent:main:telegram:group:-1001:5"):
+        from datetime import datetime
+
+        from gateway.session import SessionEntry, SessionSource
+
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-1001",
+            chat_type="group",
+            user_id="user-1",
+            user_name="Tester",
+            thread_id="5",
+        )
+        entry = SessionEntry(
+            session_key=session_key,
+            session_id=session_id,
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            origin=source,
+            platform=Platform.TELEGRAM,
+            chat_type="group",
+        )
+        return entry, source
+
+    @staticmethod
+    def _store(entry):
+        class FakeSessionStore:
+            def get_by_session_id(self, session_id):
+                return entry if entry and session_id == entry.session_id else None
+
+            def get_by_session_key(self, session_key):
+                return entry if entry and session_key == entry.session_key else None
+
+        return FakeSessionStore()
+
+    @staticmethod
+    def _recording_adapter():
+        class FakeTelegramAdapter:
+            def __init__(self):
+                self.events = []
+                self.called = asyncio.Event()
+
+            async def handle_message(self, event):
+                self.events.append(event)
+                self.called.set()
+
+        return FakeTelegramAdapter()
+
+    @pytest.mark.asyncio
+    async def test_agent_completed_event_injects_into_resolved_gateway_session(self):
+        from gateway.platforms.base import MessageEvent, MessageType
+
+        entry, source = self._entry()
+        target = self._recording_adapter()
+
+        adapter = _make_adapter(api_key="sk-secret")
+        adapter.set_session_store(self._store(entry))
+        adapter.set_adapter_registry({Platform.TELEGRAM: target})
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/internal/events",
+                headers={"Authorization": "Bearer sk-secret"},
+                json={
+                    "type": "agent.completed",
+                    "session_id": "sess-123",
+                    "message": "The delegated agent finished successfully.",
+                    "metadata": {"task_id": "abc", "status": "completed"},
+                },
+            )
+            body = await resp.json()
+
+            assert resp.status == 202
+            assert body == {
+                "object": "hermes.internal_event",
+                "status": "accepted",
+                "type": "agent.completed",
+                "session_id": "sess-123",
+                "session_key": "agent:main:telegram:group:-1001:5",
+                "platform": "telegram",
+            }
+
+            # Dispatch is async; wait for the adapter to receive it.
+            await asyncio.wait_for(target.called.wait(), timeout=2)
+
+        assert len(target.events) == 1
+        event = target.events[0]
+        assert isinstance(event, MessageEvent)
+        assert event.message_type is MessageType.TEXT
+        assert event.internal is True
+        assert event.source is source
+        assert event.text == (
+            "[Hermes internal event] agent.completed\n"
+            "- task_id: abc\n"
+            "- status: completed\n\n"
+            "The delegated agent finished successfully.\n\n"
+            "Use the current conversation context to assess the result "
+            "and report the next step to the user."
+        )
+
+    @pytest.mark.asyncio
+    async def test_event_resolves_session_by_session_key(self):
+        entry, _ = self._entry()
+        target = self._recording_adapter()
+
+        adapter = _make_adapter(api_key="sk-secret")
+        adapter.set_session_store(self._store(entry))
+        adapter.set_adapter_registry({Platform.TELEGRAM: target})
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/internal/events",
+                headers={"Authorization": "Bearer sk-secret"},
+                json={
+                    "type": "agent.failed",
+                    "session_key": "agent:main:telegram:group:-1001:5",
+                },
+            )
+            body = await resp.json()
+
+            assert resp.status == 202
+            assert body["session_id"] == "sess-123"
+            await asyncio.wait_for(target.called.wait(), timeout=2)
+
+        assert target.events[0].text.startswith("[Hermes internal event] agent.failed")
+
+    @pytest.mark.asyncio
+    async def test_async_dispatch_failure_is_logged(self):
+        entry, _ = self._entry()
+
+        class FailingAdapter:
+            def __init__(self):
+                self.called = asyncio.Event()
+
+            async def handle_message(self, event):
+                try:
+                    raise RuntimeError("boom")
+                finally:
+                    self.called.set()
+
+        failing = FailingAdapter()
+        adapter = _make_adapter(api_key="sk-secret")
+        adapter.set_session_store(self._store(entry))
+        adapter.set_adapter_registry({Platform.TELEGRAM: failing})
+
+        app = _create_app(adapter)
+        with patch("gateway.platforms.api_server.logger") as mock_logger:
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/internal/events",
+                    headers={"Authorization": "Bearer sk-secret"},
+                    json={"type": "agent.completed", "session_id": "sess-123"},
+                )
+
+                assert resp.status == 202
+                await asyncio.wait_for(failing.called.wait(), timeout=2)
+                # Let _dispatch's except/log run.
+                for _ in range(50):
+                    if mock_logger.exception.called:
+                        break
+                    await asyncio.sleep(0)
+
+        assert mock_logger.exception.called
+
+    @pytest.mark.asyncio
+    async def test_internal_events_rejects_missing_type(self):
+        adapter = _make_adapter(api_key="sk-secret")
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/internal/events",
+                headers={"Authorization": "Bearer sk-secret"},
+                json={"session_id": "sess-123"},
+            )
+            body = await resp.json()
+
+        assert resp.status == 400
+        assert "type" in body["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_internal_events_rejects_missing_session_id(self):
+        adapter = _make_adapter(api_key="sk-secret")
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/internal/events",
+                headers={"Authorization": "Bearer sk-secret"},
+                json={"type": "agent.completed"},
+            )
+            body = await resp.json()
+
+        assert resp.status == 400
+        assert "session_id" in body["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_internal_events_requires_auth(self):
+        entry, _ = self._entry()
+        adapter = _make_adapter(api_key="sk-secret")
+        adapter.set_session_store(self._store(entry))
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/internal/events",
+                json={"type": "agent.completed", "session_id": "sess-123"},
+            )
+
+        assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_internal_events_rejects_unknown_session(self):
+        adapter = _make_adapter(api_key="sk-secret")
+        adapter.set_session_store(self._store(None))
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/internal/events",
+                headers={"Authorization": "Bearer sk-secret"},
+                json={"type": "agent.completed", "session_id": "missing"},
+            )
+            body = await resp.json()
+
+        assert resp.status == 404
+        assert "Session not found" in body["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_internal_events_forbidden_without_api_key(self):
+        # /internal/events injects into existing sessions, so it must reject
+        # callers when no API key is configured — stricter than the local
+        # convenience that _check_auth() grants other endpoints.
+        entry, _ = self._entry()
+        adapter = _make_adapter()  # no api_key
+        adapter.set_session_store(self._store(entry))
+        adapter.set_adapter_registry({Platform.TELEGRAM: self._recording_adapter()})
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/internal/events",
+                json={"type": "agent.completed", "session_id": "sess-123"},
+            )
+            body = await resp.json()
+
+        assert resp.status == 403
+        assert body["error"]["code"] == "api_key_required"
+
+    @pytest.mark.asyncio
+    async def test_internal_events_forbidden_without_api_key_even_with_bearer(self):
+        adapter = _make_adapter()  # no api_key
+        adapter.set_session_store(self._store(self._entry()[0]))
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/internal/events",
+                headers={"Authorization": "Bearer anything"},
+                json={"type": "agent.completed", "session_id": "sess-123"},
+            )
+
+        assert resp.status == 403
+
+    @pytest.mark.asyncio
+    async def test_internal_events_rejects_mismatched_identifiers(self):
+        entry_a, _ = self._entry(session_id="sess-A", session_key="key-A")
+        entry_b, _ = self._entry(session_id="sess-B", session_key="key-B")
+
+        class MismatchStore:
+            def get_by_session_id(self, session_id):
+                return entry_a if session_id == "sess-A" else None
+
+            def get_by_session_key(self, session_key):
+                return entry_b if session_key == "key-B" else None
+
+        adapter = _make_adapter(api_key="sk-secret")
+        adapter.set_session_store(MismatchStore())
+        adapter.set_adapter_registry({Platform.TELEGRAM: self._recording_adapter()})
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/internal/events",
+                headers={"Authorization": "Bearer sk-secret"},
+                json={
+                    "type": "agent.completed",
+                    "session_id": "sess-A",
+                    "session_key": "key-B",
+                },
+            )
+            body = await resp.json()
+
+        assert resp.status == 409
+        assert body["error"]["code"] == "session_identifier_mismatch"
+
+    @pytest.mark.asyncio
+    async def test_internal_events_rejects_when_one_identifier_unresolved(self):
+        # Both supplied, session_id resolves but session_key does not.
+        entry, _ = self._entry()
+        adapter = _make_adapter(api_key="sk-secret")
+        adapter.set_session_store(self._store(entry))
+        adapter.set_adapter_registry({Platform.TELEGRAM: self._recording_adapter()})
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/internal/events",
+                headers={"Authorization": "Bearer sk-secret"},
+                json={
+                    "type": "agent.completed",
+                    "session_id": "sess-123",
+                    "session_key": "not-the-right-key",
+                },
+            )
+            body = await resp.json()
+
+        assert resp.status == 409
+        assert body["error"]["code"] == "session_identifier_mismatch"
+
+    @pytest.mark.asyncio
+    async def test_internal_events_accepts_consistent_identifiers(self):
+        # Both supplied and resolving to the same active entry still works.
+        entry, _ = self._entry()
+        target = self._recording_adapter()
+        adapter = _make_adapter(api_key="sk-secret")
+        adapter.set_session_store(self._store(entry))
+        adapter.set_adapter_registry({Platform.TELEGRAM: target})
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/internal/events",
+                headers={"Authorization": "Bearer sk-secret"},
+                json={
+                    "type": "agent.completed",
+                    "session_id": "sess-123",
+                    "session_key": "agent:main:telegram:group:-1001:5",
+                },
+            )
+            body = await resp.json()
+
+            assert resp.status == 202
+            assert body["session_id"] == "sess-123"
+            await asyncio.wait_for(target.called.wait(), timeout=2)
+
+        assert len(target.events) == 1
 
 
 # ---------------------------------------------------------------------------
@@ -623,6 +968,10 @@ class TestCapabilitiesEndpoint:
             assert data["features"]["run_status"] is True
             assert data["features"]["run_events_sse"] is True
             assert data["features"]["session_continuity_header"] == "X-Hermes-Session-Id"
+            # /internal/events hard-requires an API key, so the feature flag is
+            # False without one even though the route stays listed for discovery.
+            assert data["features"]["internal_events"] is False
+            assert data["endpoints"]["internal_events"]["path"] == "/internal/events"
             assert data["endpoints"]["run_status"]["path"] == "/v1/runs/{run_id}"
 
     @pytest.mark.asyncio
@@ -639,6 +988,8 @@ class TestCapabilitiesEndpoint:
             assert authed.status == 200
             data = await authed.json()
             assert data["auth"]["required"] is True
+            # With a key configured, /internal/events is usable.
+            assert data["features"]["internal_events"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -689,6 +689,54 @@ class TestLoadTranscriptPreferLongerSource:
         assert result[0]["content"] == "db-q"
 
 
+class TestSessionStoreInternalEventLookups:
+    """Public lookup helpers used to route session-scoped internal events."""
+
+    @staticmethod
+    def _store(tmp_path):
+        config = GatewayConfig()
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path / "sessions", config=config)
+        store._db = None
+        store._loaded = True
+        return store
+
+    def test_get_by_session_id_returns_matching_entry(self, tmp_path):
+        store = self._store(tmp_path)
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="chat-1",
+            chat_type="group",
+            thread_id="5",
+            user_id="user-1",
+        )
+        entry = store.get_or_create_session(source)
+
+        assert store.get_by_session_id(entry.session_id) is entry
+
+    def test_get_by_session_id_returns_none_for_unknown_id(self, tmp_path):
+        store = self._store(tmp_path)
+        assert store.get_by_session_id("missing-session") is None
+
+    def test_get_by_session_id_returns_none_for_empty_id(self, tmp_path):
+        store = self._store(tmp_path)
+        assert store.get_by_session_id("") is None
+
+    def test_get_by_session_key_returns_matching_entry(self, tmp_path):
+        store = self._store(tmp_path)
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="chat-1",
+            chat_type="group",
+            thread_id="5",
+            user_id="user-1",
+        )
+        entry = store.get_or_create_session(source)
+
+        assert store.get_by_session_key(entry.session_key) is entry
+        assert store.get_by_session_key("no-such-key") is None
+
+
 class TestSessionStoreSwitchSession:
     """Regression coverage for gateway /resume session switching semantics."""
 


### PR DESCRIPTION
## Summary

Adds a session-scoped `/internal/events` endpoint for trusted local integrations to inject internal agent events into existing Hermes gateway sessions.

This enables completion callbacks from external agents or automation without pretending to be a user message and without requiring platform-specific delivery hacks.

## Design

- Requires API server authentication; requests fail closed when no API key is configured.
- Resolves events only against existing gateway sessions via `session_id` or `session_key`.
- Rejects mismatched `session_id` + `session_key` combinations with `409 Conflict`.
- Dispatches events asynchronously and returns `202 Accepted` after validation.
- Wires live platform adapter registries on both gateway startup and reconnect paths.
- Advertises capability accurately: `features.internal_events` is enabled only when an API key is configured, while the endpoint remains discoverable.

## Tests

- `python -m compileall -q gateway/platforms/api_server.py gateway/run.py gateway/session.py`
- `python -m pytest tests/gateway/test_api_server.py::TestInternalEventsEndpoint tests/gateway/test_api_server.py::TestCapabilitiesEndpoint tests/gateway/test_session.py -q -o 'addopts='`
- Earlier full gateway test pass during the final review cycle: `245 passed`

## Notes

This is intentionally generic: it does not encode any specific agent, platform, callback script, or downstream workflow.
