### PR TITLE
fix(agent): add bedrock_converse branch in handle_max_iterations

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -971,6 +971,13 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             _ct_sum = agent._get_transport()
             _cnr_sum = _ct_sum.normalize_response(summary_response)
             final_response = (_cnr_sum.content or "").strip()
+        elif agent.api_mode == "bedrock_converse":
+            bedrock_kwargs = agent._build_api_kwargs(api_messages)
+            bedrock_kwargs.pop("toolConfig", None)
+            summary_response = agent._interruptible_api_call(bedrock_kwargs)
+            _ct_sum = agent._get_transport()
+            _cnr_sum = _ct_sum.normalize_response(summary_response)
+            final_response = (_cnr_sum.content or "").strip()
         else:
             summary_kwargs = {
                 "model": agent.model,
@@ -1062,6 +1069,13 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                 retry_response = agent._anthropic_messages_create(_ant_kw2)
                 _retry_result = _tretry.normalize_response(retry_response, strip_tool_prefix=agent._is_anthropic_oauth)
                 final_response = (_retry_result.content or "").strip()
+            elif agent.api_mode == "bedrock_converse":
+                bedrock_kwargs = agent._build_api_kwargs(api_messages)
+                bedrock_kwargs.pop("toolConfig", None)
+                retry_response = agent._interruptible_api_call(bedrock_kwargs)
+                _ct_retry = agent._get_transport()
+                _cnr_retry = _ct_retry.normalize_response(retry_response)
+                final_response = (_cnr_retry.content or "").strip()
             else:
                 summary_kwargs = {
                     "model": agent.model,


### PR DESCRIPTION
## Problem

`handle_max_iterations` in `agent/chat_completion_helpers.py` dispatches `codex_responses` and `anthropic_messages` to their respective native API paths, but falls through to the generic OpenAI-client path for `bedrock_converse`:

```python
if agent.api_mode == "codex_responses":
    ...
else:
    # builds OpenAI summary_kwargs
    if agent.api_mode == "anthropic_messages":
        ...
    else:
        # ← bedrock lands here and calls:
        agent._ensure_primary_openai_client().chat.completions.create(...)
```

Bedrock uses boto3 directly — there is no OpenAI client. The call fails, the outer `except Exception` catches it, and the user sees:

```
I reached the maximum iterations (90) but couldn't summarize. Error: <boto3/httpx error>
```

instead of a real summary. This affects every Bedrock-mode agent that hits `max_iterations`.

## Root Cause

Split Logic Bug — `bedrock_converse` has explicit branches in every other dispatch function in this file:

| Function | `bedrock_converse` handled |
|---|---|
| `build_api_kwargs` (L261) | ✅ |
| `interruptible_api_call` (L110) | ✅ |
| `interruptible_streaming_api_call` (L1165) | ✅ |
| `handle_max_iterations` (L967+) | ❌ before this PR |

## Fix

Add an `elif agent.api_mode == "bedrock_converse":` branch in both the first attempt and the retry path. The branch follows the same pattern already used in the three functions above:

1. Build kwargs via `_build_api_kwargs` (which calls `BedrockTransport.build_kwargs` and embeds `__bedrock_region__` / `__bedrock_converse__` sentinels)
2. Pop `toolConfig` — the Bedrock Converse API key for tool definitions (confirmed in `bedrock_adapter.py` and `transports/bedrock.py`)
3. Call `_interruptible_api_call`, which dispatches to `boto3 client.converse()`
4. Normalize via `BedrockTransport.normalize_response`, which handles the already-normalized `SimpleNamespace` returned by `_interruptible_api_call`

## Test Plan

- [ ] Bedrock-mode agent that hits `max_iterations` now receives a real text summary instead of an error message
- [ ] `toolConfig` is absent from the boto3 `converse()` call so no tool-calling occurs in the summary turn
- [ ] `codex_responses` and `anthropic_messages` paths are unchanged
- [ ] Non-Bedrock agents (OpenAI, Ollama, etc.) are unaffected — they still hit the `else` branch