### PR TITLE
Batch salvage group 6 (final): streaming timeout config + docker exit-75 restart + dashboard loopback/base-path

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -33,7 +33,7 @@ from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlparse, parse_qs, urlunparse
 
-from hermes_cli.timeouts import get_provider_request_timeout
+from hermes_cli.timeouts import get_provider_request_timeout, get_provider_stale_timeout
 from agent.error_classifier import classify_api_error, FailoverReason
 from agent.model_metadata import is_local_endpoint
 from agent.message_sanitization import (
@@ -1272,15 +1272,18 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     "Local provider detected (%s) — stream read timeout raised to %.0fs",
                     agent.base_url, _stream_read_timeout,
                 )
+        # Cap connect/pool at 60s even when provider timeout is higher.
+        # connect/pool cover TCP handshake, not model inference.
+        _conn_cap = min(_base_timeout, 60.0) if _provider_timeout_cfg is not None else 30.0
         stream_kwargs = {
             **api_kwargs,
             "stream": True,
             "stream_options": {"include_usage": True},
             "timeout": _httpx.Timeout(
-                connect=30.0,
+                connect=_conn_cap,
                 read=_stream_read_timeout,
                 write=_base_timeout,
-                pool=30.0,
+                pool=_conn_cap,
             ),
         }
         request_client_holder["client"] = agent._create_request_openai_client(
@@ -1868,7 +1871,12 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             if request_client is not None:
                 agent._close_request_openai_client(request_client, reason="stream_request_complete")
 
-    _stream_stale_timeout_base = float(os.getenv("HERMES_STREAM_STALE_TIMEOUT", 180.0))
+    # Provider-configured stale timeout takes priority over env default.
+    _cfg_stale = get_provider_stale_timeout(agent.provider, agent.model)
+    if _cfg_stale is not None:
+        _stream_stale_timeout_base = _cfg_stale
+    else:
+        _stream_stale_timeout_base = float(os.getenv("HERMES_STREAM_STALE_TIMEOUT", 180.0))
     # Local providers (Ollama, oMLX, llama-cpp) can take 300+ seconds
     # for prefill on large contexts.  Disable the stale detector unless
     # the user explicitly set HERMES_STREAM_STALE_TIMEOUT.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8971,13 +8971,15 @@ class GatewayRunner:
             logger.debug("Failed to write restart dedup marker: %s", e)
 
         active_agents = self._running_agent_count()
-        # When running under a service manager (systemd/launchd), use the
-        # service restart path: exit with code 75 so the service manager
-        # restarts us.  The detached subprocess approach (setsid + bash)
-        # doesn't work under systemd because KillMode=mixed kills all
-        # processes in the cgroup, including the detached helper.
+        # When running under a service manager (systemd/launchd) or inside a
+        # Docker/Podman container, use the service restart path: exit with
+        # code 75 so the service manager / container restart policy restarts
+        # us.  The detached subprocess approach (setsid + bash) doesn't work
+        # under systemd (KillMode=mixed kills the cgroup) or Docker (tini
+        # exits when the gateway dies, taking the detached helper with it).
         _under_service = bool(os.environ.get("INVOCATION_ID"))  # systemd sets this
-        if _under_service:
+        _in_container = os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
+        if _under_service or _in_container:
             self.request_restart(detached=False, via_service=True)
         else:
             self.request_restart(detached=True, via_service=False)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4434,4 +4434,7 @@ def start_server(
             )
 
     print(f"  Hermes Web UI → http://{host}:{port}")
-    uvicorn.run(app, host=host, port=port, log_level="warning")
+    # proxy_headers=False so _ws_client_is_allowed sees the real connection peer
+    # rather than X-Forwarded-For's rewritten value (which would defeat the
+    # loopback gate when behind a reverse proxy).
+    uvicorn.run(app, host=host, port=port, log_level="warning", proxy_headers=False)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1155,6 +1155,10 @@ AUTHOR_MAP = {
     "262945885+Mind-Dragon@users.noreply.github.com": "Mind-Dragon",  # PR #26966 salvage
     "soynchuux@gmail.com": "soynchux",  # PR #27060 salvage
     "209694554+soynchux@users.noreply.github.com": "soynchux",
+    # batch salvage (May 2026 LHF run, group 6 — final)
+    "6666242+bird@users.noreply.github.com": "bird",  # PR #25219 (gateway docker exit-75 restart)
+    "david@loadmagic.ai": "davidcampbelldc",  # PR #26834 (web_server proxy_headers=False)
+    "165905879+davidcampbelldc@users.noreply.github.com": "davidcampbelldc",
 }
 
 

--- a/web/src/components/ChatSidebar.tsx
+++ b/web/src/components/ChatSidebar.tsx
@@ -30,6 +30,7 @@ import { Card } from "@/components/ui/card";
 import { ModelPickerDialog } from "@/components/ModelPickerDialog";
 import { ToolCall, type ToolEntry } from "@/components/ToolCall";
 import { GatewayClient, type ConnectionState } from "@/lib/gatewayClient";
+import { HERMES_BASE_PATH } from "@/lib/api";
 
 import { cn } from "@/lib/utils";
 import { AlertCircle, ChevronDown, RefreshCw } from "lucide-react";
@@ -160,7 +161,7 @@ export function ChatSidebar({ channel, className }: ChatSidebarProps) {
     const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
     const qs = new URLSearchParams({ token, channel });
     const ws = new WebSocket(
-      `${proto}//${window.location.host}/api/events?${qs.toString()}`,
+      `${proto}//${window.location.host}${HERMES_BASE_PATH}/api/events?${qs.toString()}`,
     );
 
     // `unmounting` suppresses the banner during cleanup — `ws.close()`

--- a/web/src/lib/gatewayClient.ts
+++ b/web/src/lib/gatewayClient.ts
@@ -13,6 +13,8 @@
  *   await gw.request("prompt.submit", { session_id, text: "hi" })
  */
 
+import { HERMES_BASE_PATH } from "@/lib/api";
+
 export type GatewayEventName =
   | "gateway.ready"
   | "session.info"
@@ -117,7 +119,7 @@ export class GatewayClient {
 
     const scheme = location.protocol === "https:" ? "wss:" : "ws:";
     const ws = new WebSocket(
-      `${scheme}//${location.host}/api/ws?token=${encodeURIComponent(resolved)}`,
+      `${scheme}//${location.host}${HERMES_BASE_PATH}/api/ws?token=${encodeURIComponent(resolved)}`,
     );
     this.ws = ws;
 

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -24,6 +24,7 @@ import { Terminal } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
 import { Button } from "@nous-research/ui/ui/components/button";
 import { Typography } from "@/components/NouiTypography";
+import { HERMES_BASE_PATH } from "@/lib/api";
 import { cn } from "@/lib/utils";
 import { Copy, PanelRight, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -44,7 +45,7 @@ function buildWsUrl(
   const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
   const qs = new URLSearchParams({ token, channel });
   if (resume) qs.set("resume", resume);
-  return `${proto}//${window.location.host}/api/pty?${qs.toString()}`;
+  return `${proto}//${window.location.host}${HERMES_BASE_PATH}/api/pty?${qs.toString()}`;
 }
 
 // Channel id ties this chat tab's PTY child (publisher) to its sidebar


### PR DESCRIPTION
Batch salvage group 6 — final group of the LHF run. 4 low-risk new-contributor PRs onto current `main`.

## Salvaged PRs

| PR | Author | Change |
|---|---|---|
| #25260 | @zccyman | fix(agent): honor provider timeout config in streaming API calls — `connect`/`pool` now respect `request_timeout_seconds` (capped at 60s for TCP handshake safety); stream stale detector now reads `providers.<id>.stale_timeout_seconds` like the non-streaming path |
| #25219 | @bird | fix(gateway): use exit-75 service-restart path in Docker/Podman containers so restart policies actually restart |
| #26834 | @davidcampbelldc | fix(web_server): pass `proxy_headers=False` to `uvicorn.run` so the dashboard's loopback gate sees the real connection peer, not `X-Forwarded-For` |
| #25764 | @wesleysimplicio | fix(dashboard): respect `HERMES_BASE_PATH` in the remaining `/api/events`, `/api/ws`, `/api/pty` WebSocket URLs (sibling fix to earlier base-path work) |

## Salvage-with-redirect: #25260

#25260 targeted `run_agent.py` directly, but the streaming chat-completions path was refactored into `agent/chat_completion_helpers.py` after the PR was opened — the original cherry-pick fails with a major conflict (function turned into a thin forwarder on `main`). The fix moves cleanly to the new location:

- `connect`/`pool` timeout hardening: `connect=_conn_cap, pool=_conn_cap` where `_conn_cap = min(_base_timeout, 60.0) if _provider_timeout_cfg else 30.0`. The 60s cap incorporates the contributor's own review-feedback follow-up commit (`6bfcd26bf`) — they self-reviewed and added it after their initial PR, recognizing that TCP handshake shouldn't wait the inference timeout.
- Stale-stream detector: `_cfg_stale = get_provider_stale_timeout(agent.provider, agent.model)` → if set, use it; else fall back to `HERMES_STREAM_STALE_TIMEOUT` env. Aligns streaming with non-streaming path's priority chain (config > env > default).

Contributor's diagnosis, fix shape, AND review-feedback iteration credited via `Co-authored-by: zccyman`. Two original commits squashed into one final commit applied at the new location.

## Attribution

- 1 PR cherry-picked verbatim (linked noreply): #25219.
- 2 PRs needed re-attribution to noreply form: #26834 (`david@loadmagic.ai` unlinked), #25764 (Siemens Energy work email — same form as their earlier #25777 in group 5).
- 1 PR salvage-with-redirect (#25260) committed by me with `Co-authored-by:` since the text diverged from the contributor's diff (function moved files, 2 commits squashed).
- Final commit adds `AUTHOR_MAP` entries for the 2 new contributors. (@zccyman and @wesleysimplicio already mapped from prior LHF groups.)

## Test plan

- Compile-clean across all 7 touched Python files.
- Targeted: `tests/hermes_cli/test_doctor.py` + `test_status.py` + `test_web_server.py` + filtered `tests/agent/` (stream/doctor/status/web_server) → 323 passed in 11.00s.

Rebase-merge so per-commit contributor authorship survives.

---

## End of LHF run

This closes out the May 2026 low-hanging-fruit salvage run:

| Group | PR | Salvaged | Dropped | Notes |
|---|---|---|---|---|
| 1 | #27247 | 10 | — | docs / community / pricing / metadata (zero behavioral risk) |
| 1.5 | #27271 | — | 2 | reverted hermes-eval + Hermes MemPalace community links (vaporware-shaped repos) |
| 2 | #27292 | 10 | — | clean bug fixes; #26926 redirected to `DeepSeekProfile.default_aux_model` |
| 3 | #27302 | 9 | 1 | #27154 already on main pre-flight |
| 4 | #27308 | 9 | 1 | #27147 already on main pre-flight |
| 5 | #27382 | 10 | — | misc gateway / CLI / metadata fixes |
| 6 | this PR | 4 | — | streaming timeout config, docker restart, dashboard loopback gate / base path |
| — | — | — | 13 | RED + RED-DUP closed with credit + reasoning across the run |

**Final tally: 52 GREEN salvaged + 2 reverted + 13 RED/RED-DUP closed = 67 PRs dispositioned.**
