### PR TITLE
feat: add xAI OAuth manual-code login fallback

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -5264,11 +5264,15 @@ def _login_xai_oauth(
     print()
 
     timeout_seconds = float(getattr(args, "timeout", None) or 20.0)
+    manual_code = bool(getattr(args, "manual_code", False) or getattr(args, "paste_code", False))
     open_browser = not getattr(args, "no_browser", False)
     if _is_remote_session():
         open_browser = False
 
-    creds = _xai_oauth_loopback_login(timeout_seconds=timeout_seconds, open_browser=open_browser)
+    if manual_code:
+        creds = _xai_oauth_manual_code_login(timeout_seconds=timeout_seconds)
+    else:
+        creds = _xai_oauth_loopback_login(timeout_seconds=timeout_seconds, open_browser=open_browser)
     _save_xai_oauth_tokens(
         creds["tokens"],
         discovery=creds.get("discovery"),
@@ -5310,6 +5314,243 @@ def _xai_oauth_build_authorize_url(
         "referrer": "hermes-agent",
     }
     return f"{authorization_endpoint}?{urlencode(authorize_params)}"
+
+
+def _xai_default_loopback_redirect_uri() -> str:
+    return f"http://{XAI_OAUTH_REDIRECT_HOST}:{XAI_OAUTH_REDIRECT_PORT}{XAI_OAUTH_REDIRECT_PATH}"
+
+
+def _xai_parse_pasted_callback(raw: str) -> Dict[str, Optional[str]]:
+    """Parse a manually pasted xAI OAuth callback URL, query string, or code.
+
+    Remote/phone flows often end on a failed ``localhost`` page. The failed URL
+    still contains the authorization ``code`` and usually ``state``. Prefer the
+    full URL/query form so we can validate state; accept a bare code as a last
+    resort for browsers that make copying the full URL awkward.
+    """
+    text = str(raw or "").strip()
+    empty: Dict[str, Optional[str]] = {
+        "code": None,
+        "state": None,
+        "error": None,
+        "error_description": None,
+    }
+    if not text:
+        return empty
+
+    query = ""
+    if text.startswith(("http://", "https://")):
+        parsed = urlparse(text)
+        query = parsed.query
+        if not query and parsed.fragment:
+            fragment = parsed.fragment
+            if "?" in fragment:
+                fragment = fragment.split("?", 1)[1]
+            query = fragment.lstrip("#?")
+    elif text.startswith(("?", "#")):
+        query = text[1:]
+    elif "code=" in text or "error=" in text or "state=" in text:
+        query = text.lstrip("?#")
+    else:
+        parsed = dict(empty)
+        parsed["code"] = text
+        return parsed
+
+    params = parse_qs(query, keep_blank_values=True)
+
+    def _first(name: str) -> Optional[str]:
+        value = params.get(name, [None])[0]
+        if value is None:
+            return None
+        value = str(value).strip()
+        return value or None
+
+    return {
+        "code": _first("code"),
+        "state": _first("state"),
+        "error": _first("error"),
+        "error_description": _first("error_description"),
+    }
+
+
+def _xai_exchange_authorization_code(
+    *,
+    token_endpoint: str,
+    code: str,
+    redirect_uri: str,
+    code_verifier: str,
+    timeout_seconds: float = 20.0,
+) -> Dict[str, Any]:
+    _xai_validate_oauth_endpoint(token_endpoint, field="token_endpoint")
+    try:
+        response = httpx.post(
+            token_endpoint,
+            headers={"Content-Type": "application/x-www-form-urlencoded", "Accept": "application/json"},
+            data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": redirect_uri,
+                "client_id": XAI_OAUTH_CLIENT_ID,
+                "code_verifier": code_verifier,
+            },
+            timeout=max(20.0, timeout_seconds),
+        )
+    except Exception as exc:
+        raise AuthError(
+            f"xAI token exchange failed: {exc}",
+            provider="xai-oauth",
+            code="xai_token_exchange_failed",
+        ) from exc
+    if response.status_code != 200:
+        detail = response.text.strip()
+        raise AuthError(
+            "xAI token exchange failed."
+            + (f" Response: {detail}" if detail else ""),
+            provider="xai-oauth",
+            code="xai_token_exchange_failed",
+        )
+    try:
+        payload = response.json()
+    except Exception as exc:
+        raise AuthError(
+            f"xAI token exchange returned invalid JSON: {exc}",
+            provider="xai-oauth",
+            code="xai_token_exchange_invalid",
+        ) from exc
+    if not isinstance(payload, dict):
+        raise AuthError(
+            "xAI token exchange response was not a JSON object.",
+            provider="xai-oauth",
+            code="xai_token_exchange_invalid",
+        )
+    access_token = str(payload.get("access_token", "") or "").strip()
+    refresh_token = str(payload.get("refresh_token", "") or "").strip()
+    if not access_token:
+        raise AuthError(
+            "xAI token exchange did not return an access_token.",
+            provider="xai-oauth",
+            code="xai_token_exchange_invalid",
+        )
+    if not refresh_token:
+        raise AuthError(
+            "xAI token exchange did not return a refresh_token.",
+            provider="xai-oauth",
+            code="xai_token_exchange_invalid",
+        )
+    return payload
+
+
+def _xai_oauth_credentials_from_token_payload(
+    payload: Dict[str, Any],
+    *,
+    discovery: Dict[str, str],
+    redirect_uri: str,
+    source: str,
+) -> Dict[str, Any]:
+    access_token = str(payload.get("access_token", "") or "").strip()
+    refresh_token = str(payload.get("refresh_token", "") or "").strip()
+    base_url = (
+        os.getenv("HERMES_XAI_BASE_URL", "").strip().rstrip("/")
+        or os.getenv("XAI_BASE_URL", "").strip().rstrip("/")
+        or DEFAULT_XAI_OAUTH_BASE_URL
+    )
+    return {
+        "tokens": {
+            "access_token": access_token,
+            "refresh_token": refresh_token,
+            "id_token": str(payload.get("id_token", "") or "").strip(),
+            "expires_in": payload.get("expires_in"),
+            "token_type": str(payload.get("token_type") or "Bearer").strip() or "Bearer",
+        },
+        "discovery": discovery,
+        "redirect_uri": redirect_uri,
+        "base_url": base_url,
+        "last_refresh": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "source": source,
+    }
+
+
+def _xai_oauth_manual_code_login(
+    *,
+    timeout_seconds: float = 20.0,
+) -> Dict[str, Any]:
+    discovery = _xai_oauth_discovery(timeout_seconds)
+    authorization_endpoint = discovery["authorization_endpoint"]
+    token_endpoint = discovery["token_endpoint"]
+    redirect_uri = _xai_default_loopback_redirect_uri()
+    _xai_validate_loopback_redirect_uri(redirect_uri)
+
+    code_verifier = _oauth_pkce_code_verifier()
+    code_challenge = _oauth_pkce_code_challenge(code_verifier)
+    state = uuid.uuid4().hex
+    nonce = uuid.uuid4().hex
+    authorize_url = _xai_oauth_build_authorize_url(
+        authorization_endpoint=authorization_endpoint,
+        redirect_uri=redirect_uri,
+        code_challenge=code_challenge,
+        state=state,
+        nonce=nonce,
+    )
+
+    print("Open this URL in a browser on any device to authorize Hermes with xAI:")
+    print(authorize_url)
+    print()
+    print("After xAI redirects to localhost, the page may fail to load. That is expected")
+    print("when the browser is on another device. Copy the full failed redirect URL")
+    print("from the address bar and paste it below. If you cannot copy the full URL,")
+    print("paste the one-time authorization code instead.")
+    print()
+    try:
+        pasted = input("Paste full redirect URL or authorization code: ").strip()
+    except KeyboardInterrupt:
+        print("\nLogin cancelled.")
+        raise SystemExit(130)
+    except EOFError as exc:
+        raise AuthError(
+            "xAI authorization failed: no redirect URL or authorization code was pasted.",
+            provider="xai-oauth",
+            code="xai_code_missing",
+        ) from exc
+
+    callback = _xai_parse_pasted_callback(pasted)
+    if callback.get("error"):
+        detail = callback.get("error_description") or callback["error"]
+        raise AuthError(
+            f"xAI authorization failed: {detail}",
+            provider="xai-oauth",
+            code="xai_authorization_failed",
+        )
+    callback_state = callback.get("state")
+    if callback_state is not None and callback_state != state:
+        raise AuthError(
+            "xAI authorization failed: state mismatch.",
+            provider="xai-oauth",
+            code="xai_state_mismatch",
+        )
+    if callback_state is None:
+        print("Warning: no OAuth state was provided; continuing with PKCE-only verification.")
+
+    code = str(callback.get("code") or "").strip()
+    if not code:
+        raise AuthError(
+            "xAI authorization failed: missing authorization code.",
+            provider="xai-oauth",
+            code="xai_code_missing",
+        )
+
+    payload = _xai_exchange_authorization_code(
+        token_endpoint=token_endpoint,
+        code=code,
+        redirect_uri=redirect_uri,
+        code_verifier=code_verifier,
+        timeout_seconds=timeout_seconds,
+    )
+    return _xai_oauth_credentials_from_token_payload(
+        payload,
+        discovery=discovery,
+        redirect_uri=redirect_uri,
+        source="oauth-manual-code",
+    )
 
 
 def _xai_oauth_loopback_login(
@@ -5392,81 +5633,19 @@ def _xai_oauth_loopback_login(
             code="xai_code_missing",
         )
 
-    try:
-        response = httpx.post(
-            token_endpoint,
-            headers={"Content-Type": "application/x-www-form-urlencoded", "Accept": "application/json"},
-            data={
-                "grant_type": "authorization_code",
-                "code": code,
-                "redirect_uri": redirect_uri,
-                "client_id": XAI_OAUTH_CLIENT_ID,
-                "code_verifier": code_verifier,
-            },
-            timeout=max(20.0, timeout_seconds),
-        )
-    except Exception as exc:
-        raise AuthError(
-            f"xAI token exchange failed: {exc}",
-            provider="xai-oauth",
-            code="xai_token_exchange_failed",
-        ) from exc
-    if response.status_code != 200:
-        detail = response.text.strip()
-        raise AuthError(
-            "xAI token exchange failed."
-            + (f" Response: {detail}" if detail else ""),
-            provider="xai-oauth",
-            code="xai_token_exchange_failed",
-        )
-    try:
-        payload = response.json()
-    except Exception as exc:
-        raise AuthError(
-            f"xAI token exchange returned invalid JSON: {exc}",
-            provider="xai-oauth",
-            code="xai_token_exchange_invalid",
-        ) from exc
-    if not isinstance(payload, dict):
-        raise AuthError(
-            "xAI token exchange response was not a JSON object.",
-            provider="xai-oauth",
-            code="xai_token_exchange_invalid",
-        )
-    access_token = str(payload.get("access_token", "") or "").strip()
-    refresh_token = str(payload.get("refresh_token", "") or "").strip()
-    if not access_token:
-        raise AuthError(
-            "xAI token exchange did not return an access_token.",
-            provider="xai-oauth",
-            code="xai_token_exchange_invalid",
-        )
-    if not refresh_token:
-        raise AuthError(
-            "xAI token exchange did not return a refresh_token.",
-            provider="xai-oauth",
-            code="xai_token_exchange_invalid",
-        )
-
-    base_url = (
-        os.getenv("HERMES_XAI_BASE_URL", "").strip().rstrip("/")
-        or os.getenv("XAI_BASE_URL", "").strip().rstrip("/")
-        or DEFAULT_XAI_OAUTH_BASE_URL
+    payload = _xai_exchange_authorization_code(
+        token_endpoint=token_endpoint,
+        code=code,
+        redirect_uri=redirect_uri,
+        code_verifier=code_verifier,
+        timeout_seconds=timeout_seconds,
     )
-    return {
-        "tokens": {
-            "access_token": access_token,
-            "refresh_token": refresh_token,
-            "id_token": str(payload.get("id_token", "") or "").strip(),
-            "expires_in": payload.get("expires_in"),
-            "token_type": str(payload.get("token_type") or "Bearer").strip() or "Bearer",
-        },
-        "discovery": discovery,
-        "redirect_uri": redirect_uri,
-        "base_url": base_url,
-        "last_refresh": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
-        "source": "oauth-loopback",
-    }
+    return _xai_oauth_credentials_from_token_payload(
+        payload,
+        discovery=discovery,
+        redirect_uri=redirect_uri,
+        source="oauth-loopback",
+    )
 
 
 def _codex_device_code_login() -> Dict[str, Any]:

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -336,10 +336,15 @@ def auth_add_command(args) -> None:
         return
 
     if provider == "xai-oauth":
-        creds = auth_mod._xai_oauth_loopback_login(
-            timeout_seconds=getattr(args, "timeout", None) or 20.0,
-            open_browser=not getattr(args, "no_browser", False),
-        )
+        if bool(getattr(args, "manual_code", False) or getattr(args, "paste_code", False)):
+            creds = auth_mod._xai_oauth_manual_code_login(
+                timeout_seconds=getattr(args, "timeout", None) or 20.0,
+            )
+        else:
+            creds = auth_mod._xai_oauth_loopback_login(
+                timeout_seconds=getattr(args, "timeout", None) or 20.0,
+                open_browser=not getattr(args, "no_browser", False),
+            )
         label = (getattr(args, "label", None) or "").strip() or label_from_token(
             creds["tokens"]["access_token"],
             _oauth_default_label(provider, len(pool.entries()) + 1),
@@ -647,7 +652,7 @@ def _interactive_add() -> None:
     auth_add_command(SimpleNamespace(
         provider=provider, auth_type=auth_type, label=label, api_key=None,
         portal_url=None, inference_url=None, client_id=None, scope=None,
-        no_browser=False, timeout=None, insecure=False, ca_bundle=None,
+        no_browser=False, manual_code=False, timeout=None, insecure=False, ca_bundle=None,
     ))
 
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2007,7 +2007,7 @@ def select_provider_and_model(args=None):
     elif selected_provider == "openai-codex":
         _model_flow_openai_codex(config, current_model)
     elif selected_provider == "xai-oauth":
-        _model_flow_xai_oauth(config, current_model)
+        _model_flow_xai_oauth(config, current_model, args=args)
     elif selected_provider == "qwen-oauth":
         _model_flow_qwen_oauth(config, current_model)
     elif selected_provider == "minimax-oauth":
@@ -2889,7 +2889,7 @@ def _model_flow_openai_codex(config, current_model=""):
         print("No change.")
 
 
-def _model_flow_xai_oauth(_config, current_model=""):
+def _model_flow_xai_oauth(_config, current_model="", args=None):
     """xAI Grok OAuth (SuperGrok Subscription) provider: ensure logged in, then pick model."""
     from hermes_cli.auth import (
         get_xai_oauth_auth_status,
@@ -2920,7 +2920,11 @@ def _model_flow_xai_oauth(_config, current_model=""):
             print("Starting a fresh xAI OAuth login...")
             print()
             try:
-                mock_args = argparse.Namespace()
+                mock_args = argparse.Namespace(
+                    manual_code=bool(getattr(args, "manual_code", False)) if args is not None else False,
+                    no_browser=bool(getattr(args, "no_browser", False)) if args is not None else False,
+                    timeout=getattr(args, "timeout", None) if args is not None else None,
+                )
                 _login_xai_oauth(
                     mock_args,
                     PROVIDER_REGISTRY["xai-oauth"],
@@ -2938,7 +2942,11 @@ def _model_flow_xai_oauth(_config, current_model=""):
         print("Not logged into xAI Grok OAuth (SuperGrok Subscription). Starting login...")
         print()
         try:
-            mock_args = argparse.Namespace()
+            mock_args = argparse.Namespace(
+                manual_code=bool(getattr(args, "manual_code", False)) if args is not None else False,
+                no_browser=bool(getattr(args, "no_browser", False)) if args is not None else False,
+                timeout=getattr(args, "timeout", None) if args is not None else None,
+            )
             _login_xai_oauth(mock_args, PROVIDER_REGISTRY["xai-oauth"])
         except SystemExit:
             print("Login cancelled or failed.")
@@ -9772,7 +9780,17 @@ def main():
     model_parser.add_argument(
         "--no-browser",
         action="store_true",
-        help="Do not attempt to open the browser automatically during Nous login",
+        help="Do not attempt to open the browser automatically during OAuth login",
+    )
+    model_parser.add_argument(
+        "--manual-code",
+        "--paste-code",
+        dest="manual_code",
+        action="store_true",
+        help=(
+            "For xAI OAuth, print the authorization URL and prompt for the "
+            "redirect URL/code instead of waiting on a local callback"
+        ),
     )
     model_parser.add_argument(
         "--timeout",
@@ -10176,6 +10194,16 @@ def main():
         help="Do not attempt to open the browser automatically",
     )
     login_parser.add_argument(
+        "--manual-code",
+        "--paste-code",
+        dest="manual_code",
+        action="store_true",
+        help=(
+            "For xAI OAuth, print the authorization URL and prompt for the "
+            "redirect URL/code instead of waiting on a local callback"
+        ),
+    )
+    login_parser.add_argument(
         "--timeout",
         type=float,
         default=15.0,
@@ -10235,6 +10263,16 @@ def main():
         "--no-browser",
         action="store_true",
         help="Do not auto-open a browser for OAuth login",
+    )
+    auth_add.add_argument(
+        "--manual-code",
+        "--paste-code",
+        dest="manual_code",
+        action="store_true",
+        help=(
+            "For xAI OAuth, print the authorization URL and prompt for the "
+            "redirect URL/code instead of waiting on a local callback"
+        ),
     )
     auth_add.add_argument(
         "--timeout", type=float, help="OAuth/network timeout in seconds"

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -310,6 +310,53 @@ def test_auth_add_codex_oauth_persists_pool_entry(tmp_path, monkeypatch):
     assert entry["base_url"] == "https://chatgpt.com/backend-api/codex"
 
 
+def test_auth_add_xai_oauth_manual_code_uses_manual_flow(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+    token = _jwt_with_email("xai@example.com")
+    calls = {}
+
+    def _manual_login(**kwargs):
+        calls["manual_kwargs"] = kwargs
+        return {
+            "tokens": {
+                "access_token": token,
+                "refresh_token": "refresh-token",
+            },
+            "base_url": "https://api.x.ai/v1",
+            "last_refresh": "2026-05-17T10:00:00Z",
+            "source": "oauth-manual-code",
+        }
+
+    monkeypatch.setattr("hermes_cli.auth._xai_oauth_manual_code_login", _manual_login)
+    monkeypatch.setattr(
+        "hermes_cli.auth._xai_oauth_loopback_login",
+        lambda **kwargs: pytest.fail("manual-code auth add must not start loopback login"),
+    )
+
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _Args:
+        provider = "xai-oauth"
+        auth_type = "oauth"
+        api_key = None
+        label = None
+        no_browser = False
+        manual_code = True
+        timeout = 11.0
+
+    auth_add_command(_Args())
+
+    assert calls["manual_kwargs"] == {"timeout_seconds": 11.0}
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    entries = payload["credential_pool"]["xai-oauth"]
+    entry = next(item for item in entries if item["source"] == "manual:xai_pkce")
+    assert entry["label"] == "xai@example.com"
+    assert entry["access_token"] == token
+    assert entry["refresh_token"] == "refresh-token"
+    assert entry["base_url"] == "https://api.x.ai/v1"
+
+
 def test_auth_remove_reindexes_priorities(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     # Prevent pool auto-seeding from host env vars and file-backed sources

--- a/tests/hermes_cli/test_auth_xai_oauth_provider.py
+++ b/tests/hermes_cli/test_auth_xai_oauth_provider.py
@@ -1,12 +1,15 @@
 """Tests for xAI Grok OAuth — tokens stored in Hermes auth store (~/.hermes/auth.json)."""
 
+import argparse
 import base64
 import json
 import time
 from pathlib import Path
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 
+from hermes_cli import auth as auth_mod
 from hermes_cli.auth import (
     AuthError,
     DEFAULT_XAI_OAUTH_BASE_URL,
@@ -260,6 +263,151 @@ def test_xai_oauth_authorize_url_includes_pkce_and_oidc_params():
     assert params["code_challenge_method"] == "S256"
     assert params["state"] == "state-abc"
     assert params["nonce"] == "nonce-def"
+
+
+# ---------------------------------------------------------------------------
+# Manual code paste fallback
+# ---------------------------------------------------------------------------
+
+
+def test_xai_parse_pasted_callback_accepts_full_redirect_url():
+    parsed = auth_mod._xai_parse_pasted_callback(
+        "http://127.0.0.1:56121/callback?code=auth-code&state=state-abc"
+    )
+    assert parsed["code"] == "auth-code"
+    assert parsed["state"] == "state-abc"
+    assert parsed["error"] is None
+
+
+def test_xai_parse_pasted_callback_accepts_query_string():
+    parsed = auth_mod._xai_parse_pasted_callback("?code=auth-code&state=state-abc")
+    assert parsed["code"] == "auth-code"
+    assert parsed["state"] == "state-abc"
+    assert parsed["error"] is None
+
+
+def test_xai_parse_pasted_callback_accepts_bare_code():
+    parsed = auth_mod._xai_parse_pasted_callback("auth-code-without-state")
+    assert parsed["code"] == "auth-code-without-state"
+    assert parsed["state"] is None
+    assert parsed["error"] is None
+
+
+def test_xai_parse_pasted_callback_surfaces_oauth_error():
+    parsed = auth_mod._xai_parse_pasted_callback(
+        "http://127.0.0.1:56121/callback?error=access_denied&error_description=Nope"
+    )
+    assert parsed["code"] is None
+    assert parsed["error"] == "access_denied"
+    assert parsed["error_description"] == "Nope"
+
+
+def test_xai_manual_code_login_uses_same_redirect_uri_for_authorize_and_token(
+    monkeypatch, capsys
+):
+    discovery = {
+        "authorization_endpoint": "https://auth.x.ai/oauth2/authorize",
+        "token_endpoint": "https://auth.x.ai/oauth2/token",
+    }
+    monkeypatch.setattr("hermes_cli.auth._xai_oauth_discovery", lambda timeout: discovery)
+    monkeypatch.setattr("hermes_cli.auth._oauth_pkce_code_verifier", lambda: "verifier")
+    monkeypatch.setattr("hermes_cli.auth._oauth_pkce_code_challenge", lambda verifier: "challenge")
+
+    class _UUID:
+        def __init__(self, value):
+            self.hex = value
+
+    uuids = iter([_UUID("state-abc"), _UUID("nonce-def")])
+    monkeypatch.setattr("hermes_cli.auth.uuid.uuid4", lambda: next(uuids))
+    monkeypatch.setattr(
+        "builtins.input",
+        lambda prompt="": "http://127.0.0.1:56121/callback?code=auth-code&state=state-abc",
+    )
+
+    token_post = {}
+
+    def _fake_post(url, **kwargs):
+        token_post["url"] = url
+        token_post.update(kwargs)
+        return _StubHTTPResponse(
+            200,
+            {
+                "access_token": "access-token",
+                "refresh_token": "refresh-token",
+                "expires_in": 3600,
+                "token_type": "Bearer",
+            },
+        )
+
+    monkeypatch.setattr("hermes_cli.auth.httpx.post", _fake_post)
+
+    creds = auth_mod._xai_oauth_manual_code_login(timeout_seconds=2.0)
+
+    output = capsys.readouterr().out
+    auth_url = next(line for line in output.splitlines() if line.startswith("https://auth.x.ai/"))
+    authorize_params = {k: v[0] for k, v in parse_qs(urlparse(auth_url).query).items()}
+    assert authorize_params["redirect_uri"] == "http://127.0.0.1:56121/callback"
+    assert token_post["url"] == discovery["token_endpoint"]
+    assert token_post["data"]["redirect_uri"] == authorize_params["redirect_uri"]
+    assert token_post["data"]["code_verifier"] == "verifier"
+    assert creds["source"] == "oauth-manual-code"
+    assert creds["tokens"]["access_token"] == "access-token"
+
+
+def test_xai_manual_code_login_rejects_state_mismatch(monkeypatch):
+    discovery = {
+        "authorization_endpoint": "https://auth.x.ai/oauth2/authorize",
+        "token_endpoint": "https://auth.x.ai/oauth2/token",
+    }
+    monkeypatch.setattr("hermes_cli.auth._xai_oauth_discovery", lambda timeout: discovery)
+    monkeypatch.setattr("hermes_cli.auth._oauth_pkce_code_verifier", lambda: "verifier")
+    monkeypatch.setattr("hermes_cli.auth._oauth_pkce_code_challenge", lambda verifier: "challenge")
+
+    class _UUID:
+        def __init__(self, value):
+            self.hex = value
+
+    uuids = iter([_UUID("expected-state"), _UUID("nonce-def")])
+    monkeypatch.setattr("hermes_cli.auth.uuid.uuid4", lambda: next(uuids))
+    monkeypatch.setattr(
+        "builtins.input",
+        lambda prompt="": "http://127.0.0.1:56121/callback?code=auth-code&state=wrong-state",
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth.httpx.post",
+        lambda *args, **kwargs: pytest.fail("state mismatch must not exchange the code"),
+    )
+
+    with pytest.raises(AuthError) as exc:
+        auth_mod._xai_oauth_manual_code_login(timeout_seconds=2.0)
+    assert exc.value.code == "xai_state_mismatch"
+
+
+def test_model_flow_xai_oauth_passes_manual_code_flags_to_login(monkeypatch):
+    from hermes_cli import main as main_mod
+
+    monkeypatch.setattr("hermes_cli.auth.get_xai_oauth_auth_status", lambda: {"logged_in": False})
+    monkeypatch.setattr("hermes_cli.auth._prompt_model_selection", lambda *args, **kwargs: None)
+
+    captured = {}
+
+    def _fake_login(args, pconfig, **kwargs):
+        captured["manual_code"] = getattr(args, "manual_code", False)
+        captured["no_browser"] = getattr(args, "no_browser", False)
+        captured["timeout"] = getattr(args, "timeout", None)
+        captured["force_new_login"] = kwargs.get("force_new_login")
+
+    monkeypatch.setattr("hermes_cli.auth._login_xai_oauth", _fake_login)
+
+    args = argparse.Namespace(manual_code=True, no_browser=True, timeout=7.0)
+    main_mod._model_flow_xai_oauth({}, current_model="", args=args)
+
+    assert captured == {
+        "manual_code": True,
+        "no_browser": True,
+        "timeout": 7.0,
+        "force_new_login": None,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/website/docs/guides/oauth-over-ssh.md
+++ b/website/docs/guides/oauth-over-ssh.md
@@ -6,11 +6,18 @@ description: "How to complete browser-based OAuth (xAI, Spotify) when Hermes run
 
 # OAuth over SSH / Remote Hosts
 
-Some Hermes providers — currently **xAI Grok OAuth** and **Spotify** — use a *loopback redirect* OAuth flow. The auth server (xAI, Spotify) redirects your browser to `http://127.0.0.1:<port>/callback` so a tiny HTTP listener started by the `hermes auth ...` command can grab the authorization code.
+Some Hermes providers use a *loopback redirect* OAuth flow. The auth server redirects your browser to `http://127.0.0.1:<port>/callback` so a tiny HTTP listener started by the `hermes auth ...` command can grab the authorization code.
 
 This works perfectly when Hermes and your browser are on the same machine. It breaks the moment they aren't: your laptop's browser tries to reach `127.0.0.1` on **your laptop**, but the listener is bound to `127.0.0.1` on **the remote server**.
 
-The fix is a one-line SSH local-forward.
+For **xAI Grok OAuth**, the easiest remote fix is now manual-code mode:
+
+```bash
+hermes auth add xai-oauth --manual-code
+# Open the printed URL anywhere, then paste the full failed redirect URL/code.
+```
+
+For providers that still require a live loopback callback, or if you prefer xAI's automatic callback flow, use an SSH local-forward.
 
 ## TL;DR
 
@@ -29,15 +36,15 @@ Port `56121` is what xAI OAuth uses. For Spotify, replace it with `43827`. Herme
 
 ## Which Providers Need This
 
-| Provider | Loopback port | Tunnel needed? |
-|----------|---------------|----------------|
-| `xai-oauth` (Grok SuperGrok) | `56121` | Yes, when Hermes is remote |
-| Spotify | `43827` | Yes, when Hermes is remote |
-| `anthropic` (Claude Pro/Max) | n/a | No — paste-the-code flow |
-| `openai-codex` (ChatGPT Plus/Pro) | n/a | No — device code flow |
-| `minimax`, `nous-portal` | n/a | No — device code flow |
+| Provider | Loopback port | Remote option |
+|----------|---------------|---------------|
+| `xai-oauth` (Grok SuperGrok) | `56121` | Prefer `--manual-code`; tunnel only for automatic callback |
+| Spotify | `43827` | SSH tunnel needed when Hermes is remote |
+| `anthropic` (Claude Pro/Max) | n/a | Paste-the-code flow |
+| `openai-codex` (ChatGPT Plus/Pro) | n/a | Device code flow |
+| `minimax`, `nous-portal` | n/a | Device code flow |
 
-If your provider isn't in the table, you don't need a tunnel.
+If your provider isn't in the table, you probably don't need a tunnel.
 
 ## Why the listener can't just bind 0.0.0.0
 

--- a/website/docs/guides/xai-grok-oauth.md
+++ b/website/docs/guides/xai-grok-oauth.md
@@ -18,7 +18,7 @@ The same OAuth bearer token is also reused by every direct-to-xAI surface in Her
 |------|-------|
 | Provider ID | `xai-oauth` |
 | Display name | xAI Grok OAuth (SuperGrok Subscription) |
-| Auth type | Browser OAuth 2.0 PKCE (loopback callback) |
+| Auth type | Browser OAuth 2.0 PKCE (loopback callback, with manual-code fallback for remote sessions) |
 | Transport | xAI Responses API (`codex_responses`) |
 | Default model | `grok-4.3` |
 | Endpoint | `https://api.x.ai/v1` |
@@ -31,7 +31,8 @@ The same OAuth bearer token is also reused by every direct-to-xAI surface in Her
 - Python 3.9+
 - Hermes Agent installed
 - An active SuperGrok subscription on your xAI account
-- A browser available on the local machine (or use `--no-browser` for remote sessions)
+- A browser on either the Hermes machine or another device
+- For phone/Discord/SSH/headless setup, use `--manual-code` so Hermes prompts you to paste the xAI redirect URL instead of waiting on a local callback
 
 ## Quick Start
 
@@ -57,11 +58,23 @@ You can trigger a login without going through the model picker:
 hermes auth add xai-oauth
 ```
 
-### Remote / headless sessions
+### Remote / phone / headless sessions
 
-On servers, containers, or SSH sessions where no browser is available, Hermes detects the remote environment and prints the authorization URL instead of opening a browser.
+If Hermes is running somewhere other than the browser device — SSH, a container, WSL driven from Discord, or a phone-only setup — use the manual-code fallback:
 
-**Important:** the loopback listener still runs on the remote machine at `127.0.0.1:56121`. The xAI redirect needs to reach *that* listener, so opening the URL on your laptop will fail (`Could not establish connection. We couldn't reach your app.`) unless you forward the port:
+```bash
+hermes auth add xai-oauth --manual-code
+# or, through the provider picker:
+# hermes model --manual-code
+```
+
+Hermes prints the xAI authorize URL. Open it in any browser, approve access, then xAI redirects to `http://127.0.0.1:56121/callback`. On a different device that page may fail to load; that is expected. Copy the full failed redirect URL from the browser address bar and paste it back into Hermes. Hermes validates the OAuth `state` when the full URL is pasted, exchanges the one-time code with the same PKCE verifier and redirect URI, and stores the tokens normally.
+
+If your browser only lets you copy the one-time `code`, you can paste just the code, but the full redirect URL is preferred because it includes `state`.
+
+### SSH tunnel alternative
+
+You can still use the traditional loopback callback flow with an SSH local-forward. This is useful if you want a fully automatic callback or if you are authenticating a provider that does not support manual paste mode.
 
 ```bash
 # In a separate terminal on your local machine:
@@ -74,7 +87,7 @@ hermes auth add xai-oauth --no-browser
 
 Through a jump box / bastion: add `-J jump-user@jump-host`.
 
-See [OAuth over SSH / Remote Hosts](./oauth-over-ssh.md) for the full step-by-step, including ProxyJump chains, mosh/tmux, and ControlMaster gotchas.
+See [OAuth over SSH / Remote Hosts](./oauth-over-ssh.md) for the full tunnel step-by-step, including ProxyJump chains, mosh/tmux, and ControlMaster gotchas.
 
 ## How the Login Works
 
@@ -184,9 +197,9 @@ Hermes refreshes the token before each session and again reactively on a 401. If
 
 ### Authorization timed out
 
-The loopback listener has a finite expiry window (default 180 s). If you don't approve the login in time, Hermes raises a timeout error.
+The loopback listener has a finite expiry window. If you don't approve the login in time, Hermes raises a timeout error.
 
-**Fix:** re-run `hermes auth add xai-oauth` (or `hermes model`). The flow starts fresh.
+**Fix:** re-run `hermes auth add xai-oauth` (or `hermes model`). If the browser is on another device, use `hermes auth add xai-oauth --manual-code` so Hermes prompts for the redirect URL/code instead of waiting for the callback listener.
 
 ### State mismatch (possible CSRF)
 
@@ -194,19 +207,17 @@ Hermes detected that the `state` value returned by the authorization server does
 
 **Fix:** re-run the login. If it persists, check for a proxy or redirect that is modifying the OAuth response.
 
-### Logging in from a remote server
+### Logging in from a remote server or phone
 
-On SSH or container sessions Hermes prints the authorization URL instead of opening a browser. The loopback callback listener still binds `127.0.0.1:56121` on the remote host — your laptop's browser can't reach it without an SSH local-forward:
+Use manual-code mode when the browser is not on the Hermes machine:
 
 ```bash
-# Local machine, separate terminal:
-ssh -N -L 56121:127.0.0.1:56121 user@remote-host
-
-# Remote machine:
-hermes auth add xai-oauth --no-browser
+hermes auth add xai-oauth --manual-code
 ```
 
-Full walkthrough (jump boxes, mosh/tmux, port conflicts): [OAuth over SSH / Remote Hosts](./oauth-over-ssh.md).
+Open the printed URL, approve access, then paste the full failed `127.0.0.1:56121/callback?...` redirect URL back into Hermes. The failed localhost page is expected when using a phone, Discord-driven setup, or a browser on a different computer.
+
+If you prefer the automatic callback flow, use an SSH local-forward and run `hermes auth add xai-oauth --no-browser`; see [OAuth over SSH / Remote Hosts](./oauth-over-ssh.md).
 
 ### "No xAI credentials found" error at runtime
 
@@ -226,7 +237,7 @@ This clears both the singleton OAuth entry in `auth.json` and any credential-poo
 
 ## See Also
 
-- [OAuth over SSH / Remote Hosts](./oauth-over-ssh.md) — required reading if Hermes is on a different machine than your browser
+- [OAuth over SSH / Remote Hosts](./oauth-over-ssh.md) — SSH tunnel alternative when Hermes is on a different machine than your browser
 - [AI Providers reference](../integrations/providers.md)
 - [Environment Variables](../reference/environment-variables.md)
 - [Configuration](../user-guide/configuration.md)


### PR DESCRIPTION
## Summary

- Add `--manual-code` / `--paste-code` for xAI Grok OAuth so remote, phone, Discord, SSH, and headless sessions can complete login without a live loopback callback.
- Let users open the xAI authorize URL on any device, paste the failed localhost redirect URL or one-time code back into Hermes, then complete the normal PKCE token exchange.
- Preserve OAuth protections by reusing the same PKCE verifier and redirect URI, validating `state` when a full redirect URL/query string is pasted, and sharing token exchange validation with the loopback flow.
- Wire the flag through `hermes login`, `hermes auth add`, and `hermes model`.
- Update xAI OAuth and OAuth-over-SSH docs to recommend manual-code mode for phone/remote flows while keeping SSH tunnels as the automatic callback alternative.

## Why

The existing xAI OAuth flow starts a localhost callback listener on the Hermes machine. That works when the browser is also on that machine, but it breaks when Hermes is being driven from Discord, a phone, SSH, WSL, or another remote setup. In those cases, xAI redirects the browser to `127.0.0.1` on the browser device, not the machine running Hermes.

Manual-code mode keeps the existing xAI PKCE flow, but gives the user a way to paste the authorization response back into Hermes when the browser cannot reach the local listener.

## Test plan

- `python -m py_compile hermes_cli/auth.py hermes_cli/auth_commands.py hermes_cli/main.py`
- `python -m pytest tests/hermes_cli/test_auth_xai_oauth_provider.py tests/hermes_cli/test_auth_commands.py tests/hermes_cli/test_auth_loopback_ssh_hint.py tests/hermes_cli/test_argparse_flag_propagation.py -o 'addopts=' -q`
- `python -m pytest tests/hermes_cli/test_auth*.py tests/hermes_cli/test_argparse_flag_propagation.py -o 'addopts=' -q`
- `git diff --check`
