### PR TITLE
fix(docker): preload messaging gateway deps via --extra messaging (salvage #26394)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,9 +66,11 @@ RUN npm install --prefer-offline --no-audit && \
 # frontend stats the readme path during dep resolution, so we `touch` an
 # empty placeholder — the real README is restored by `COPY . .` below.
 #
-# `uv sync --frozen --no-install-project --extra all` installs only the
-# deps reachable through the composite `[all]` extra (handpicked set
-# intended for the production image).  We do NOT use `--all-extras`:
+# `uv sync --frozen --no-install-project --extra all --extra messaging`
+# installs the deps reachable through the composite `[all]` extra
+# (handpicked set intended for the production image), plus gateway
+# messaging adapters that should work in the published image without a
+# first-boot lazy install.  We do NOT use `--all-extras`:
 # that would pull in `[rl]` (atroposlib + tinker + torch + wandb from
 # git), `[yc-bench]` (another git dep), and `[termux-all]` (Android
 # redundancy), none of which belong in the published container.
@@ -76,7 +78,7 @@ RUN npm install --prefer-offline --no-audit && \
 # The editable link is created after the source copy below.
 COPY pyproject.toml uv.lock ./
 RUN touch ./README.md
-RUN uv sync --frozen --no-install-project --extra all
+RUN uv sync --frozen --no-install-project --extra all --extra messaging
 
 # ---------- Source code ----------
 # .dockerignore excludes node_modules, so the installs above survive.
@@ -94,10 +96,10 @@ RUN cd web && npm run build && \
 # hermes_cli/main.py succeeds (see #18800). /opt/hermes/web is build-time
 # only (HERMES_WEB_DIST points at hermes_cli/web_dist) and is intentionally
 # not chowned here.
-# The .venv MUST be hermes-writable so lazy_deps.py can install platform
-# packages (discord.py, telegram, slack, etc.) at first gateway boot.
-# Without this, `uv pip install` fails with EACCES and all messaging
-# adapters silently fail to load.  See tools/lazy_deps.py.
+# The .venv MUST remain hermes-writable so lazy_deps.py can install
+# remaining optional platform packages and future pin bumps at first use.
+# Without this, `uv pip install` fails with EACCES and adapters silently
+# fail to load.  See tools/lazy_deps.py.
 USER root
 RUN chmod -R a+rX /opt/hermes && \
     chown -R hermes:hermes /opt/hermes/.venv /opt/hermes/ui-tui /opt/hermes/node_modules

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1161,6 +1161,7 @@ AUTHOR_MAP = {
     "165905879+davidcampbelldc@users.noreply.github.com": "davidcampbelldc",
     "hoangv.pham0803@gmail.com": "hehehe0803",  # PR #26212 salvage (codex kanban writable root)
     "26063003+hehehe0803@users.noreply.github.com": "hehehe0803",
+    "38348871+vaddisrinivas@users.noreply.github.com": "vaddisrinivas",  # PR #26394 salvage (Docker messaging extra)
 }
 
 

--- a/tests/tools/test_dockerfile_pid1_reaping.py
+++ b/tests/tools/test_dockerfile_pid1_reaping.py
@@ -121,6 +121,20 @@ def test_dockerfile_installs_tui_dependencies(dockerfile_text):
     )
 
 
+def test_dockerfile_preinstalls_gateway_messaging_dependencies(dockerfile_text):
+    sync_steps = [
+        step for step in _run_steps(dockerfile_text)
+        if "uv sync" in step and "--no-install-project" in step
+    ]
+
+    assert sync_steps, "Dockerfile must install Python dependencies with uv sync"
+    assert any("--extra messaging" in step for step in sync_steps), (
+        "Published Docker images must preload the [messaging] extra so "
+        "Telegram/Discord gateway adapters do not depend on first-boot "
+        "lazy installation (#24698)."
+    )
+
+
 def test_dockerfile_builds_tui_assets(dockerfile_text):
     assert any(
         "ui-tui" in step and "npm" in step and "run build" in step


### PR DESCRIPTION
## Summary
Salvage of #26394 — published Docker image's `uv sync` only installs the `[all]` extra, leaving messaging adapter deps (python-telegram-bot, discord.py, slack-bolt, etc.) to be lazy-installed at first gateway boot. That works only if the `.venv` is writable AND first-boot lazy install succeeds. Faster, more reliable to bake the deps in.

## Changes
- `Dockerfile` — extend the `uv sync` line to `--extra all --extra messaging`. Adjust the trailing comment about lazy_deps to clarify it now handles only optional/future deps, not the messaging baseline.
- `tests/tools/test_dockerfile_pid1_reaping.py` — regression test asserting `--extra messaging` appears in the no-install-project sync step.

## Validation
- `scripts/run_tests.sh tests/tools/test_dockerfile_pid1_reaping.py -q` → 7/7 pass.
- `[messaging]` extra confirmed present in `pyproject.toml`.

Original PR: #26394 — credit preserved via rebase-merge.