### PR TITLE
fix(tests/gateway): stabilize xai env resolver + harden PATH probe against stat errors (salvage #26565)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2110,24 +2110,30 @@ def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:
     if project_root is None:
         project_root = PROJECT_ROOT
 
+    def _is_dir(path: Path) -> bool:
+        try:
+            return path.is_dir()
+        except OSError:
+            return False
+
     candidates = []
 
     venv_bin = project_root / "venv" / "bin"
-    if venv_bin.is_dir():
+    if _is_dir(venv_bin):
         candidates.append(str(venv_bin))
     elif sys.prefix != sys.base_prefix:
         candidates.append(str(Path(sys.prefix) / "bin"))
 
     node_bin = project_root / "node_modules" / ".bin"
-    if node_bin.is_dir():
+    if _is_dir(node_bin):
         candidates.append(str(node_bin))
 
     hermes_home = get_hermes_home()
     hermes_node = hermes_home / "node" / "bin"
-    if hermes_node.is_dir():
+    if _is_dir(hermes_node):
         candidates.append(str(hermes_node))
     hermes_nm = hermes_home / "node_modules" / ".bin"
-    if hermes_nm.is_dir():
+    if _is_dir(hermes_nm):
         candidates.append(str(hermes_nm))
 
     return candidates

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -254,8 +254,12 @@ class TestDeveloperRoleSwap:
         assert messages[0]["role"] == "system"
 
     def test_developer_role_via_nous_portal(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
-        agent.model = "gpt-5"
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [
             {"role": "system", "content": "You are helpful."},
             {"role": "user", "content": "hi"},
@@ -346,14 +350,24 @@ class TestBuildApiKwargsAIGateway:
 class TestBuildApiKwargsNousPortal:
     def test_includes_nous_product_tags(self, monkeypatch):
         from agent.portal_tags import nous_portal_tags
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         extra = kwargs.get("extra_body", {})
         assert extra.get("tags") == nous_portal_tags()
 
     def test_uses_chat_completions_format(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         assert "messages" in kwargs

--- a/tests/tools/test_transcription_dotenv_fallback.py
+++ b/tests/tools/test_transcription_dotenv_fallback.py
@@ -58,6 +58,33 @@ class TestProviderSelectionGate:
         finally:
             importlib.reload(tt)
 
+    def test_xai_resolver_import_after_config_env_patch_uses_restored_dotenv_loader(self):
+        """xAI HTTP auth must not cache a temporarily patched env helper."""
+        import importlib
+        import hermes_cli.config as config_mod
+        from tools import xai_http
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(config_mod, "get_env_value", lambda name, default=None: "")
+            xai_http = importlib.reload(xai_http)
+
+        try:
+            with patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                side_effect=RuntimeError("no oauth"),
+            ), patch(
+                "hermes_cli.auth.resolve_xai_oauth_runtime_credentials",
+                return_value={},
+            ), patch(
+                "hermes_cli.config.load_env",
+                return_value={"XAI_API_KEY": "dotenv-secret"},
+            ):
+                creds = xai_http.resolve_xai_http_credentials()
+        finally:
+            importlib.reload(xai_http)
+
+        assert creds["api_key"] == "dotenv-secret"
+
     def test_explicit_groq_sees_dotenv(self):
         from tools import transcription_tools as tt
 

--- a/tools/xai_http.py
+++ b/tools/xai_http.py
@@ -5,12 +5,6 @@ from __future__ import annotations
 import os
 from typing import Dict
 
-try:
-    from hermes_cli.config import get_env_value as _hermes_get_env_value
-except Exception:
-    _hermes_get_env_value = None
-
-
 def get_env_value(name: str, default=None):
     """Read ``name`` from ``~/.hermes/.env`` first, then ``os.environ``.
 
@@ -18,10 +12,14 @@ def get_env_value(name: str, default=None):
     ``tools.xai_http.get_env_value`` to inject dotenv-only secrets into the
     xAI credential resolver.
     """
-    if _hermes_get_env_value is not None:
+    try:
+        from hermes_cli.config import get_env_value as _hermes_get_env_value
+
         value = _hermes_get_env_value(name)
         if value is not None:
             return value
+    except Exception:
+        pass
     return os.environ.get(name, default)
 
 


### PR DESCRIPTION
## Summary
Salvage of #26565 — two related test/runtime stabilizations that w0lfgang88 flagged as the unblocker for several other PRs failing post-#25957.

## Changes

### `tools/xai_http.py` — defer hermes_cli.config import
Module-level `from hermes_cli.config import get_env_value as _hermes_get_env_value` was captured at import time, so test monkeypatches on `hermes_cli.config.get_env_value` were silently bypassed. Move the import inside the function so each call re-resolves and dotenv fallback tests can actually exercise the dotenv path. New regression test in `test_transcription_dotenv_fallback.py`.

### `tests/run_agent/test_provider_parity.py` — explicit model on nous helper
Three tests overrode `agent.model` after `_make_agent()` returned. With the helper's nous→`gpt-5` default already in place, the explicit override is now passed via the `model=` kwarg (same end state, no double assignment). Equivalent behavior, cleaner test code.

### `hermes_cli/gateway.py` — handle stat-error on PATH probes
`_build_service_path_dirs()` called `path.is_dir()` on four candidate directories. If any of those raised `PermissionError` (e.g. EACCES on a stat in restricted root configs, common in containers and test fixtures), the whole gateway probe crashed. Wrap each call in `_is_dir()` that catches `OSError`. Same effective semantics — if we can't stat it, treat it as absent. This is the substantive part of #26640 (which is now superseded — see below).

## Validation
- `scripts/run_tests.sh tests/run_agent/test_provider_parity.py tests/tools/test_transcription_dotenv_fallback.py tests/hermes_cli/test_gateway.py tests/hermes_cli/test_gateway_service.py -q` → 262/263 pass. Single failure (`test_openrouter_always_wins`) is a pre-existing change-detector test on `agent.auxiliary_client` that expects `gemini-3-flash-preview` but main returns `gemini-2.5-flash` — completely unrelated to this PR.

Original PR: #26565 — credit preserved via rebase-merge. Skipped the upstream merge commit from the source branch and cherry-picked the two substantive commits.