### PR TITLE
feat(web): persist gateway maintenance action status (phase 1) (#25916)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -662,6 +662,159 @@ _ACTION_LOG_FILES: Dict[str, str] = {
 # report liveness and exit code without shelling out to ``ps``.
 _ACTION_PROCS: Dict[str, subprocess.Popen] = {}
 
+# ---------------------------------------------------------------------------
+# Durable action registry (issue #25916, phase 1)
+#
+# In-memory ``_ACTION_PROCS`` is lost when the web process restarts. Persist
+# a small JSON record per action invocation so ``/api/actions/{name}/status``
+# can still report "running elsewhere" (pid alive after web restart),
+# "completed" (recorded exit code), or "lost" (pid gone, no recorded exit)
+# instead of always collapsing to "never started" after a restart.
+#
+# Phase 1 deliberately limits scope:
+#   * keyed by action ``name`` (single record per action — last invocation wins)
+#   * no retention / cleanup yet
+#   * no per-id polling endpoint yet
+#   * unstructured action classification (mirrors current ``name`` keying)
+#
+# Phase 2 follow-ups (left for separate PRs): action_id per invocation,
+# retention/GC, dashboard surfacing, per-action exclusive-class enforcement
+# beyond the simple ``already_running`` guard.
+# ---------------------------------------------------------------------------
+
+_ACTION_REGISTRY_PATH: Path = get_hermes_home() / "actions.json"
+_ACTION_REGISTRY_LOCK = threading.Lock()
+
+
+def _action_registry_path() -> Path:
+    """Resolve the registry path each call so tests can monkeypatch ``get_hermes_home``."""
+    return get_hermes_home() / "actions.json"
+
+
+def _read_action_registry() -> Dict[str, Dict[str, Any]]:
+    """Load the durable action registry. Returns an empty dict on first run
+    or if the file is unreadable / malformed (logged, never raises)."""
+    path = _action_registry_path()
+    if not path.exists():
+        return {}
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        if isinstance(data, dict):
+            return data
+    except (OSError, ValueError) as exc:
+        _log.warning("Action registry %s unreadable, ignoring: %s", path, exc)
+    return {}
+
+
+def _write_action_registry(registry: Dict[str, Dict[str, Any]]) -> None:
+    """Atomically persist the action registry. Failures are logged, not raised:
+    a status query that can't write back to disk is less bad than a 500 on
+    the dashboard."""
+    path = _action_registry_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(".json.tmp")
+        with open(tmp, "w", encoding="utf-8") as fh:
+            json.dump(registry, fh, indent=2, sort_keys=True)
+        os.replace(tmp, path)
+    except OSError as exc:
+        _log.warning("Failed to persist action registry %s: %s", path, exc)
+
+
+def _record_action_start(name: str, pid: int, log_path: Path) -> None:
+    """Persist a ``running`` record for *name* before the caller relies on it.
+    Overwrites any previous record for the same name (phase-1 single-slot)."""
+    with _ACTION_REGISTRY_LOCK:
+        registry = _read_action_registry()
+        registry[name] = {
+            "name": name,
+            "pid": pid,
+            "start_time": time.time(),
+            "last_update": time.time(),
+            "status": "running",
+            "exit_code": None,
+            "log_path": str(log_path),
+        }
+        _write_action_registry(registry)
+
+
+def _record_action_finished(name: str, exit_code: Optional[int]) -> None:
+    """Update the registry record with a final exit code."""
+    with _ACTION_REGISTRY_LOCK:
+        registry = _read_action_registry()
+        record = registry.get(name)
+        if not record:
+            return
+        record["status"] = "succeeded" if exit_code == 0 else "failed"
+        record["exit_code"] = exit_code
+        record["last_update"] = time.time()
+        registry[name] = record
+        _write_action_registry(registry)
+
+
+def _pid_is_alive(pid: int) -> bool:
+    """Best-effort liveness probe via signal 0. Returns False on PermissionError
+    (different uid) since we'd never have spawned a process we can't signal."""
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return False
+    except OSError:
+        return False
+    return True
+
+
+def _resolve_action_state(name: str) -> Dict[str, Any]:
+    """Determine the current state of an action, blending live Popen handles
+    and the durable registry. Phase 1 distinguishes:
+
+      * ``running``   — Popen still live, or registry pid is alive after restart
+      * ``succeeded`` / ``failed`` — finished with recorded exit code
+      * ``lost``      — registry says running but pid is gone (web crashed
+                        mid-action, or process killed externally)
+      * ``never_started`` — no in-memory handle and no registry record
+    """
+    proc = _ACTION_PROCS.get(name)
+    if proc is not None:
+        exit_code = proc.poll()
+        if exit_code is None:
+            return {"status": "running", "running": True, "exit_code": None, "pid": proc.pid}
+        # Process finished — make sure registry reflects it.
+        _record_action_finished(name, exit_code)
+        return {
+            "status": "succeeded" if exit_code == 0 else "failed",
+            "running": False,
+            "exit_code": exit_code,
+            "pid": proc.pid,
+        }
+
+    # No live Popen handle. Fall back to the durable registry.
+    record = _read_action_registry().get(name)
+    if record is None:
+        return {"status": "never_started", "running": False, "exit_code": None, "pid": None}
+
+    pid = record.get("pid")
+    status = record.get("status", "unknown")
+    if status == "running":
+        if isinstance(pid, int) and _pid_is_alive(pid):
+            # Running in a process the web server doesn't own a handle for —
+            # typically because the web restarted while the action was in flight.
+            return {"status": "running", "running": True, "exit_code": None, "pid": pid}
+        # Registry says running but pid is gone: action was lost during restart.
+        return {"status": "lost", "running": False, "exit_code": None, "pid": pid}
+
+    return {
+        "status": status,
+        "running": False,
+        "exit_code": record.get("exit_code"),
+        "pid": pid,
+    }
+
 
 def _spawn_hermes_action(subcommand: List[str], name: str) -> subprocess.Popen:
     """Spawn ``hermes <subcommand>`` detached and record the Popen handle.
@@ -696,6 +849,7 @@ def _spawn_hermes_action(subcommand: List[str], name: str) -> subprocess.Popen:
 
     proc = subprocess.Popen(cmd, **popen_kwargs)
     _ACTION_PROCS[name] = proc
+    _record_action_start(name, proc.pid, log_path)
     return proc
 
 
@@ -716,6 +870,17 @@ def _tail_lines(path: Path, n: int) -> List[str]:
 @app.post("/api/gateway/restart")
 async def restart_gateway():
     """Kick off a ``hermes gateway restart`` in the background."""
+    state = _resolve_action_state("gateway-restart")
+    if state["running"]:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "ok": False,
+                "name": "gateway-restart",
+                "reason": "already_running",
+                "pid": state.get("pid"),
+            },
+        )
     try:
         proc = _spawn_hermes_action(["gateway", "restart"], "gateway-restart")
     except Exception as exc:
@@ -731,6 +896,17 @@ async def restart_gateway():
 @app.post("/api/hermes/update")
 async def update_hermes():
     """Kick off ``hermes update`` in the background."""
+    state = _resolve_action_state("hermes-update")
+    if state["running"]:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "ok": False,
+                "name": "hermes-update",
+                "reason": "already_running",
+                "pid": state.get("pid"),
+            },
+        )
     try:
         proc = _spawn_hermes_action(["update"], "hermes-update")
     except Exception as exc:
@@ -745,7 +921,12 @@ async def update_hermes():
 
 @app.get("/api/actions/{name}/status")
 async def get_action_status(name: str, lines: int = 200):
-    """Tail an action log and report whether the process is still running."""
+    """Tail an action log and report whether the process is still running.
+
+    Blends the in-memory Popen handle with the durable action registry so the
+    endpoint can distinguish completed/lost/running state even after the web
+    process restarts (issue #25916).
+    """
     log_file_name = _ACTION_LOG_FILES.get(name)
     if log_file_name is None:
         raise HTTPException(status_code=404, detail=f"Unknown action: {name}")
@@ -753,21 +934,14 @@ async def get_action_status(name: str, lines: int = 200):
     log_path = _ACTION_LOG_DIR / log_file_name
     tail = _tail_lines(log_path, min(max(lines, 1), 2000))
 
-    proc = _ACTION_PROCS.get(name)
-    if proc is None:
-        running = False
-        exit_code: Optional[int] = None
-        pid: Optional[int] = None
-    else:
-        exit_code = proc.poll()
-        running = exit_code is None
-        pid = proc.pid
+    state = _resolve_action_state(name)
 
     return {
         "name": name,
-        "running": running,
-        "exit_code": exit_code,
-        "pid": pid,
+        "running": state["running"],
+        "exit_code": state["exit_code"],
+        "pid": state["pid"],
+        "status": state["status"],
         "lines": tail,
     }
 

--- a/tests/hermes_cli/test_web_action_registry.py
+++ b/tests/hermes_cli/test_web_action_registry.py
@@ -1,0 +1,233 @@
+"""Tests for the durable gateway-action registry (issue #25916).
+
+Phase-1 behavior covered:
+
+* ``_record_action_start`` writes a ``running`` record to ``actions.json``.
+* ``_record_action_finished`` updates that record with an exit code.
+* ``_resolve_action_state`` distinguishes ``running`` / ``succeeded`` /
+  ``failed`` / ``lost`` / ``never_started`` across in-memory and on-disk
+  state, including the post-restart case where the in-memory Popen handle
+  is gone but the pid is still alive.
+* ``/api/gateway/restart`` and ``/api/hermes/update`` reject duplicate
+  in-flight invocations with HTTP 409.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# fastapi is an optional dep — skip cleanly if it's not installed.
+fastapi = pytest.importorskip("fastapi")
+
+from hermes_cli import web_server  # noqa: E402
+
+
+@pytest.fixture
+def tmp_hermes_home(tmp_path, monkeypatch):
+    """Isolate the action registry into a tmp_path-scoped HERMES_HOME."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    # Reset in-memory action handles between tests.
+    web_server._ACTION_PROCS.clear()
+    yield tmp_path
+    web_server._ACTION_PROCS.clear()
+
+
+class TestActionRegistryIO:
+    def test_read_empty_when_missing(self, tmp_hermes_home):
+        assert web_server._read_action_registry() == {}
+
+    def test_read_returns_empty_on_malformed(self, tmp_hermes_home):
+        path = web_server._action_registry_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("not json{", encoding="utf-8")
+        assert web_server._read_action_registry() == {}
+
+    def test_write_then_read_roundtrip(self, tmp_hermes_home):
+        web_server._write_action_registry({"x": {"name": "x", "status": "running"}})
+        out = web_server._read_action_registry()
+        assert out["x"]["status"] == "running"
+
+    def test_record_start_writes_running(self, tmp_hermes_home):
+        log_path = tmp_hermes_home / "logs" / "demo.log"
+        web_server._record_action_start("demo", 12345, log_path)
+        registry = web_server._read_action_registry()
+        assert registry["demo"]["status"] == "running"
+        assert registry["demo"]["pid"] == 12345
+        assert registry["demo"]["exit_code"] is None
+        assert registry["demo"]["log_path"] == str(log_path)
+        assert registry["demo"]["start_time"] > 0
+
+    def test_record_finished_updates_exit_code(self, tmp_hermes_home):
+        web_server._record_action_start("demo", 1, tmp_hermes_home / "demo.log")
+        web_server._record_action_finished("demo", 0)
+        rec = web_server._read_action_registry()["demo"]
+        assert rec["status"] == "succeeded"
+        assert rec["exit_code"] == 0
+
+        web_server._record_action_start("demo2", 2, tmp_hermes_home / "demo2.log")
+        web_server._record_action_finished("demo2", 1)
+        rec2 = web_server._read_action_registry()["demo2"]
+        assert rec2["status"] == "failed"
+        assert rec2["exit_code"] == 1
+
+    def test_record_finished_noop_when_missing(self, tmp_hermes_home):
+        # Should not raise or create a stray record.
+        web_server._record_action_finished("never-existed", 0)
+        assert "never-existed" not in web_server._read_action_registry()
+
+
+class TestResolveActionState:
+    def test_never_started(self, tmp_hermes_home):
+        state = web_server._resolve_action_state("gateway-restart")
+        assert state == {
+            "status": "never_started",
+            "running": False,
+            "exit_code": None,
+            "pid": None,
+        }
+
+    def test_live_popen_running(self, tmp_hermes_home):
+        proc = SimpleNamespace(pid=4242, poll=MagicMock(return_value=None))
+        web_server._ACTION_PROCS["gateway-restart"] = proc
+        state = web_server._resolve_action_state("gateway-restart")
+        assert state["running"] is True
+        assert state["status"] == "running"
+        assert state["pid"] == 4242
+
+    def test_live_popen_succeeded_updates_registry(self, tmp_hermes_home):
+        # Pre-seed registry as running so we exercise the update path.
+        web_server._record_action_start("gateway-restart", 7, tmp_hermes_home / "log")
+        proc = SimpleNamespace(pid=7, poll=MagicMock(return_value=0))
+        web_server._ACTION_PROCS["gateway-restart"] = proc
+        state = web_server._resolve_action_state("gateway-restart")
+        assert state == {"status": "succeeded", "running": False, "exit_code": 0, "pid": 7}
+        assert web_server._read_action_registry()["gateway-restart"]["status"] == "succeeded"
+
+    def test_live_popen_failed(self, tmp_hermes_home):
+        web_server._record_action_start("gateway-restart", 7, tmp_hermes_home / "log")
+        proc = SimpleNamespace(pid=7, poll=MagicMock(return_value=2))
+        web_server._ACTION_PROCS["gateway-restart"] = proc
+        state = web_server._resolve_action_state("gateway-restart")
+        assert state == {"status": "failed", "running": False, "exit_code": 2, "pid": 7}
+
+    def test_lost_after_restart(self, tmp_hermes_home):
+        """Registry says running, in-memory Popen is gone, pid is dead."""
+        web_server._record_action_start("hermes-update", 999999, tmp_hermes_home / "log")
+        with patch.object(web_server, "_pid_is_alive", return_value=False):
+            state = web_server._resolve_action_state("hermes-update")
+        assert state["status"] == "lost"
+        assert state["running"] is False
+        assert state["pid"] == 999999
+
+    def test_running_elsewhere_after_restart(self, tmp_hermes_home):
+        """Registry says running, in-memory Popen is gone, pid is still alive
+        (covers the case where the web process restarted mid-action)."""
+        web_server._record_action_start("hermes-update", 1234, tmp_hermes_home / "log")
+        with patch.object(web_server, "_pid_is_alive", return_value=True):
+            state = web_server._resolve_action_state("hermes-update")
+        assert state["status"] == "running"
+        assert state["running"] is True
+        assert state["pid"] == 1234
+
+    def test_finished_record_after_restart(self, tmp_hermes_home):
+        """Registry has a recorded exit code — propagate it even without Popen."""
+        web_server._record_action_start("hermes-update", 1234, tmp_hermes_home / "log")
+        web_server._record_action_finished("hermes-update", 0)
+        state = web_server._resolve_action_state("hermes-update")
+        assert state == {
+            "status": "succeeded",
+            "running": False,
+            "exit_code": 0,
+            "pid": 1234,
+        }
+
+
+class TestPidIsAlive:
+    def test_invalid_pid_returns_false(self):
+        assert web_server._pid_is_alive(0) is False
+        assert web_server._pid_is_alive(-1) is False
+
+    def test_current_process_is_alive(self):
+        # os.getpid() is guaranteed to exist; harmless signal-0 probe.
+        assert web_server._pid_is_alive(os.getpid()) is True
+
+    def test_process_lookup_error_returns_false(self):
+        with patch("os.kill", side_effect=ProcessLookupError):
+            assert web_server._pid_is_alive(99999) is False
+
+    def test_permission_error_returns_false(self):
+        with patch("os.kill", side_effect=PermissionError):
+            assert web_server._pid_is_alive(99999) is False
+
+
+class TestDuplicateActionGuard:
+    """The two POST endpoints reject 409 when the same action is already running."""
+
+    def _client(self):
+        from fastapi.testclient import TestClient
+        from hermes_cli.web_server import _SESSION_HEADER_NAME, _SESSION_TOKEN
+        client = TestClient(web_server.app)
+        client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+        return client
+
+    def test_restart_gateway_rejects_duplicate(self, tmp_hermes_home):
+        proc = SimpleNamespace(pid=4321, poll=MagicMock(return_value=None))
+        web_server._ACTION_PROCS["gateway-restart"] = proc
+        client = self._client()
+        resp = client.post("/api/gateway/restart")
+        assert resp.status_code == 409
+        body = resp.json()["detail"]
+        assert body["reason"] == "already_running"
+        assert body["pid"] == 4321
+        assert body["name"] == "gateway-restart"
+
+    def test_update_rejects_duplicate(self, tmp_hermes_home):
+        proc = SimpleNamespace(pid=8765, poll=MagicMock(return_value=None))
+        web_server._ACTION_PROCS["hermes-update"] = proc
+        client = self._client()
+        resp = client.post("/api/hermes/update")
+        assert resp.status_code == 409
+        body = resp.json()["detail"]
+        assert body["reason"] == "already_running"
+        assert body["pid"] == 8765
+
+    def test_restart_gateway_allows_when_previous_finished(self, tmp_hermes_home):
+        """A previously-finished record must not block a fresh invocation."""
+        web_server._record_action_start("gateway-restart", 1, tmp_hermes_home / "log")
+        web_server._record_action_finished("gateway-restart", 0)
+        client = self._client()
+        with patch.object(web_server, "_spawn_hermes_action") as spawn:
+            spawn.return_value = SimpleNamespace(pid=999)
+            resp = client.post("/api/gateway/restart")
+        assert resp.status_code == 200
+        assert resp.json()["pid"] == 999
+
+
+class TestStatusEndpointSurfacesStatusField:
+    def _client(self):
+        from fastapi.testclient import TestClient
+        from hermes_cli.web_server import _SESSION_HEADER_NAME, _SESSION_TOKEN
+        client = TestClient(web_server.app)
+        client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+        return client
+
+    def test_status_endpoint_returns_status_string(self, tmp_hermes_home):
+        client = self._client()
+        resp = client.get("/api/actions/gateway-restart/status")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["name"] == "gateway-restart"
+        assert body["status"] == "never_started"
+        assert body["running"] is False
+        assert body["lines"] == []
+
+    def test_status_endpoint_unknown_action(self, tmp_hermes_home):
+        client = self._client()
+        resp = client.get("/api/actions/not-a-real-action/status")
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary

Phase-1 fix for the durability gap described in #25916. Adds a small JSON registry at `$HERMES_HOME/actions.json` so `/api/actions/{name}/status` can correctly distinguish completed / lost / running state even after the web process restarts or loses its in-memory `Popen` handle.

## Problem

`gateway-restart` and `hermes-update` were tracked only through `_ACTION_PROCS: Dict[str, subprocess.Popen]`. If the dashboard reconnected after a refresh, the web process restarted, or the in-memory handle was lost for any reason, `/api/actions/{name}/status` collapsed to "never started" — the operator could not tell apart:

- never started
- running elsewhere (detached subprocess survived the web restart)
- completed (success/failure with exit code)
- lost during restart (pid is dead but no recorded exit)

The per-action log file helped but the status model itself was non-durable.

## Fix

Small JSON-backed action registry next to `state.db`:

- New `_read_action_registry` / `_write_action_registry` — atomic write via `os.replace`, lock-guarded with `threading.Lock`, lenient on malformed input (logged, never raises).
- `_record_action_start(name, pid, log_path)` runs *immediately after* spawn so a failed-to-poll status query still has a visible record.
- `_record_action_finished(name, exit_code)` is called whenever `_resolve_action_state` notices a Popen has finished.
- `_pid_is_alive(pid)` uses `os.kill(pid, 0)` to detect "running elsewhere" after a web restart.
- `_resolve_action_state(name)` blends in-memory Popen + on-disk registry into one of: `running` / `succeeded` / `failed` / `lost` / `never_started`.

API changes:

- `POST /api/gateway/restart` and `POST /api/hermes/update` now reject duplicate in-flight invocations with HTTP `409 already_running` (includes the live pid in the detail body).
- `GET /api/actions/{name}/status` returns a new `status` string field alongside the existing `running` / `exit_code` / `pid` / `lines`. The existing fields are unchanged — backward-compatible for the current `web/src/lib/api.ts` callers.

## Scope (deliberately narrow)

The issue lists a larger surface (per-id endpoint, retention, dashboard surfacing, structured exclusive-class enforcement). This PR ships **phase 1** — durable record + restart recovery + duplicate rejection — keyed by the existing action `name` so the dashboard side stays compatible. Phase 2 follow-ups are explicitly called out in the registry section's docstring for the next PR.

## Test Plan

- [x] `python -m pytest tests/hermes_cli/test_web_action_registry.py -q -o 'addopts='` — **22 passed**
  - Registry I/O (read/write/atomic/malformed)
  - `_record_action_start` / `_record_action_finished` semantics
  - `_pid_is_alive` (current pid alive, lookup error, permission error, invalid pid)
  - `_resolve_action_state` across all five outcomes including post-restart `lost` and `running elsewhere`
  - `409 already_running` on both POST endpoints
  - Finished record no longer blocks fresh invocation
  - `GET /api/actions/{name}/status` surfaces the new `status` field
- [x] `python -m pytest tests/hermes_cli/test_web_server.py -q -o 'addopts='` — **144 passed** (no regressions in existing web_server tests)
- [x] `python -m pytest tests/hermes_cli/test_web_server_host_header.py -q -o 'addopts='` — **8 passed**

Closes #25916