### PR TITLE
fix(web): expose raw web_extract controls

### DIFF
--- a/tests/tools/test_web_extract_tool_surface.py
+++ b/tests/tools/test_web_extract_tool_surface.py
@@ -1,0 +1,97 @@
+import asyncio
+
+from tools import web_tools
+from tools.registry import registry
+
+
+def test_web_extract_schema_exposes_raw_mode_controls():
+    props = web_tools.WEB_EXTRACT_SCHEMA["parameters"]["properties"]
+
+    assert "urls" in props
+    assert props["urls"]["maxItems"] == 5
+    assert props["use_llm_processing"]["type"] == "boolean"
+    assert props["use_llm_processing"]["default"] is True
+    assert props["min_length"]["type"] == "integer"
+    assert props["min_length"]["default"] == web_tools.DEFAULT_MIN_LENGTH_FOR_SUMMARIZATION
+
+
+def test_web_extract_registry_handler_passes_raw_mode_controls(monkeypatch):
+    calls = []
+
+    async def fake_web_extract_tool(urls, format="markdown", use_llm_processing=True, model=None, min_length=0):
+        calls.append(
+            {
+                "urls": urls,
+                "format": format,
+                "use_llm_processing": use_llm_processing,
+                "model": model,
+                "min_length": min_length,
+            }
+        )
+        return '{"results": []}'
+
+    monkeypatch.setattr(web_tools, "web_extract_tool", fake_web_extract_tool)
+    entry = registry.get_entry("web_extract")
+    assert entry is not None
+
+    result = asyncio.run(entry.handler(
+        {
+            "urls": [
+                "https://one.example",
+                "https://two.example",
+                "https://three.example",
+                "https://four.example",
+                "https://five.example",
+                "https://six.example",
+            ],
+            "use_llm_processing": False,
+            "min_length": 12345,
+        }
+    ))
+
+    assert result == '{"results": []}'
+    assert calls == [
+        {
+            "urls": [
+                "https://one.example",
+                "https://two.example",
+                "https://three.example",
+                "https://four.example",
+                "https://five.example",
+            ],
+            "format": "markdown",
+            "use_llm_processing": False,
+            "model": None,
+            "min_length": 12345,
+        }
+    ]
+
+
+def test_web_extract_registry_handler_defaults_to_llm_processing(monkeypatch):
+    calls = []
+
+    async def fake_web_extract_tool(urls, format="markdown", use_llm_processing=True, model=None, min_length=0):
+        calls.append((urls, format, use_llm_processing, min_length))
+        return '{"results": []}'
+
+    monkeypatch.setattr(web_tools, "web_extract_tool", fake_web_extract_tool)
+    entry = registry.get_entry("web_extract")
+    assert entry is not None
+
+    asyncio.run(entry.handler({"urls": ["https://example.com"], "min_length": "not-an-int"}))
+    asyncio.run(entry.handler({"urls": ["https://example.org"], "use_llm_processing": "definitely"}))
+
+    assert calls == [
+        (
+            ["https://example.com"],
+            "markdown",
+            True,
+            web_tools.DEFAULT_MIN_LENGTH_FOR_SUMMARIZATION,
+        ),
+        (
+            ["https://example.org"],
+            "markdown",
+            True,
+            web_tools.DEFAULT_MIN_LENGTH_FOR_SUMMARIZATION,
+        ),
+    ]

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -1512,7 +1512,7 @@ WEB_SEARCH_SCHEMA = {
 
 WEB_EXTRACT_SCHEMA = {
     "name": "web_extract",
-    "description": "Extract content from web page URLs. Returns page content in markdown format. Also works with PDF URLs (arxiv papers, documents, etc.) — pass the PDF link directly and it converts to markdown text. Pages under 5000 chars return full markdown; larger pages are LLM-summarized and capped at ~5000 chars per page. Pages over 2M chars are refused. If a URL fails or times out, use the browser tool to access it instead.",
+    "description": "Extract content from web page URLs. Returns page content in markdown format. Also works with PDF URLs (arxiv papers, documents, etc.) — pass the PDF link directly and it converts to markdown text. By default, pages under 5000 chars return full markdown and larger pages are LLM-summarized and capped at ~5000 chars per page. For official docs, diagnostics, or source-fidelity/speed-sensitive work, set use_llm_processing=false to return raw extracted markdown without summarization. Pages over 2M chars are refused. If a URL fails or times out, use the browser tool to access it instead.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -1521,11 +1521,53 @@ WEB_EXTRACT_SCHEMA = {
                 "items": {"type": "string"},
                 "description": "List of URLs to extract content from (max 5 URLs per call)",
                 "maxItems": 5
+            },
+            "use_llm_processing": {
+                "type": "boolean",
+                "description": "Whether to summarize/process long pages with an auxiliary LLM. Set false for fast/raw extraction of official docs or diagnostics.",
+                "default": True
+            },
+            "min_length": {
+                "type": "integer",
+                "description": "Minimum content length before LLM summarization is attempted. Raise this to avoid summarizing medium-sized docs pages.",
+                "default": DEFAULT_MIN_LENGTH_FOR_SUMMARIZATION,
+                "minimum": 0
             }
         },
         "required": ["urls"]
     }
 }
+
+def _coerce_bool(value, default: bool = True) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes", "y", "on"}:
+            return True
+        if normalized in {"false", "0", "no", "n", "off"}:
+            return False
+        return default
+    if value is None:
+        return default
+    return bool(value)
+
+
+def _web_extract_handler(args, **kw):
+    urls = args.get("urls", [])[:5] if isinstance(args.get("urls"), list) else []
+    use_llm_processing = _coerce_bool(args.get("use_llm_processing", True), default=True)
+    min_length = args.get("min_length", DEFAULT_MIN_LENGTH_FOR_SUMMARIZATION)
+    try:
+        min_length = int(min_length)
+    except (TypeError, ValueError):
+        min_length = DEFAULT_MIN_LENGTH_FOR_SUMMARIZATION
+    return web_extract_tool(
+        urls,
+        "markdown",
+        use_llm_processing=use_llm_processing,
+        min_length=max(0, min_length),
+    )
+
 
 registry.register(
     name="web_search",
@@ -1541,8 +1583,7 @@ registry.register(
     name="web_extract",
     toolset="web",
     schema=WEB_EXTRACT_SCHEMA,
-    handler=lambda args, **kw: web_extract_tool(
-        args.get("urls", [])[:5] if isinstance(args.get("urls"), list) else [], "markdown"),
+    handler=_web_extract_handler,
     check_fn=check_web_api_key,
     requires_env=_web_requires_env(),
     is_async=True,


### PR DESCRIPTION
## What does this PR do?

Exposes raw-mode controls for the `web_extract` tool so agents can opt out of LLM summarization when source fidelity or speed matters, especially for official docs and diagnostics.

Previously, the registry surface only accepted `urls`, even though the underlying `web_extract_tool()` already supports `use_llm_processing` and `min_length`. This PR wires those options into the public tool schema and handler while preserving existing default behavior.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/web_tools.py`
  - Adds `use_llm_processing` and `min_length` to `WEB_EXTRACT_SCHEMA`.
  - Replaces the inline `web_extract` registry lambda with `_web_extract_handler`.
  - Coerces boolean-like strings for `use_llm_processing`.
  - Coerces invalid `min_length` values back to `DEFAULT_MIN_LENGTH_FOR_SUMMARIZATION`.
  - Caps URL lists at 5, preserving existing behavior.
- `tests/tools/test_web_extract_tool_surface.py`
  - Adds coverage for schema exposure.
  - Adds coverage for handler pass-through of raw-mode controls.
  - Adds coverage for URL capping.
  - Adds coverage for invalid `min_length` fallback.
  - Adds coverage for unrecognized boolean string fallback.

## How to Test

1. Run the targeted web tool tests:

    scripts/run_tests.sh tests/tools/test_web_extract_tool_surface.py tests/tools/test_web_tools_config.py tests/tools/test_web_tools_tavily.py -q

   Expected result: `67 passed`

2. Run lint on the changed files:

    ruff check tools/web_tools.py tests/tools/test_web_extract_tool_surface.py

   Expected result: `All checks passed!`

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Targeted tests:

    ▶ running pytest with 4 workers, hermetic env, in /usr/local/lib/hermes-agent
      (TZ=UTC LANG=C.UTF-8 PYTHONHASHSEED=0; all credential env vars unset)
    ...................................................................      [100%]
    67 passed in 1.89s

Lint:

    All checks passed!
