### PR TITLE
fix(ci): unblock main Tests workflow — 6 unrelated failures across aux model, acp version, gateway test mocks, BUILTIN_SUBCOMMANDS, post_setup parametrize

### DIFF
--- a/acp_registry/agent.json
+++ b/acp_registry/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "hermes-agent",
   "name": "Hermes Agent",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Self-improving open-source AI agent by Nous Research with ACP editor integration, persistent memory, skills, and rich tool support.",
   "repository": "https://github.com/NousResearch/hermes-agent",
   "website": "https://hermes-agent.nousresearch.com/docs/user-guide/features/acp",
@@ -9,7 +9,7 @@
   "license": "MIT",
   "distribution": {
     "uvx": {
-      "package": "hermes-agent[acp]==0.13.0",
+      "package": "hermes-agent[acp]==0.14.0",
       "args": ["hermes-acp"]
     }
   }

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -424,7 +424,7 @@ NOUS_EXTRA_BODY = _nous_extra_body()
 auxiliary_is_nous: bool = False
 
 # Default auxiliary models per provider
-_OPENROUTER_MODEL = "google/gemini-2.5-flash"
+_OPENROUTER_MODEL = "google/gemini-3-flash-preview"
 _NOUS_MODEL = "google/gemini-3-flash-preview"
 _NOUS_DEFAULT_BASE_URL = "https://inference-api.nousresearch.com/v1"
 _ANTHROPIC_DEFAULT_BASE_URL = "https://api.anthropic.com"

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9631,7 +9631,8 @@ _BUILTIN_SUBCOMMANDS = frozenset(
         "config", "cron", "curator", "dashboard", "debug", "doctor",
         "dump", "fallback", "gateway", "hooks", "import", "insights",
         "kanban", "login", "logout", "logs", "lsp", "mcp", "memory",
-        "model", "pairing", "plugins", "postinstall", "profile", "proxy", "sessions", "setup",
+        "model", "pairing", "plugins", "postinstall", "profile", "proxy",
+        "send", "sessions", "setup",
         "skills", "slack", "status", "tools", "uninstall", "update",
         "version", "webhook", "whatsapp", "chat",
         # Help-ish invocations — plugin commands not being listed in

--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -316,6 +316,7 @@ class TestRunBackgroundTask:
         assert mock_adapter.send.call_args.kwargs["metadata"] == {
             "thread_id": "20197",
             "telegram_dm_topic_reply_fallback": True,
+            "direct_messages_topic_id": "20197",
             "telegram_reply_to_message_id": "463",
         }
 

--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -2740,7 +2740,7 @@ class _FakeAiohttpSession:
 
 def _install_fake_aiohttp(monkeypatch, session):
     fake_aiohttp = types.SimpleNamespace(
-        ClientSession=lambda timeout=None: session,
+        ClientSession=lambda timeout=None, **kwargs: session,
         ClientTimeout=lambda total=None: None,
     )
     monkeypatch.setitem(sys.modules, "aiohttp", fake_aiohttp)

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -763,7 +763,7 @@ def _install_fake_aiohttp(monkeypatch, session):
     """Replace ``aiohttp`` in ``sys.modules`` so ``import aiohttp as _aiohttp``
     inside ``_standalone_send`` picks up our fake."""
     fake_aiohttp = types.SimpleNamespace(
-        ClientSession=lambda timeout=None: session,
+        ClientSession=lambda timeout=None, **kwargs: session,
         ClientTimeout=lambda total=None: None,
     )
     monkeypatch.setitem(sys.modules, "aiohttp", fake_aiohttp)

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -408,6 +408,7 @@ async def test_gateway_runner_busy_ack_replies_to_triggering_message_for_telegra
     assert adapter.calls[0]["metadata"] == {
         "thread_id": "20197",
         "telegram_dm_topic_reply_fallback": True,
+        "direct_messages_topic_id": "20197",
         "telegram_reply_to_message_id": "463",
     }
 

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -461,6 +461,7 @@ class TestSendVoiceReply:
         assert call_kwargs["metadata"] == {
             "thread_id": "20197",
             "telegram_dm_topic_reply_fallback": True,
+            "direct_messages_topic_id": "20197",
             "telegram_reply_to_message_id": "462",
         }
 

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -1048,9 +1048,6 @@ def test_reconfigure_browser_provider_overwrites_stale_use_gateway():
 
 
 @pytest.mark.parametrize("provider_name,post_setup_key", [
-    ("Browserbase", "agent_browser"),
-    ("Browser Use", "agent_browser"),
-    ("Firecrawl", "agent_browser"),
     ("Camofox", "camofox"),
 ])
 def test_reconfigure_provider_runs_post_setup_for_env_var_providers(


### PR DESCRIPTION
## Summary
Unblocks main Tests workflow that has been failing for hours. Six logical commits, each scoped to one failure class.

## Root causes
1. **`agent/auxiliary_client.py`** — `_OPENROUTER_MODEL` was set to `google/gemini-2.5-flash` but the intended default is `google/gemini-3-flash-preview` (matches `_NOUS_MODEL`). Production constant fixed; tests already asserted the correct name.
2. **`acp_registry/agent.json`** — manifest still pinned to `0.13.0` while `pyproject.toml` has bumped to `0.14.0`. Updated manifest version + uvx package pin.
3. **`tests/gateway/test_teams.py` + `test_google_chat.py`** — `_install_fake_aiohttp` lambdas don't accept `**kwargs`, so the production `trust_env=True` arg from #27308's parity fix raised `TypeError`. Added `**kwargs` to both fake-session factories.
4. **`tests/gateway/test_{background_command,telegram_thread_fallback,voice_command}.py`** — production now adds `direct_messages_topic_id` to Telegram DM metadata alongside the legacy `telegram_dm_topic_reply_fallback` flag (so synthetic/queued messages route to the right topic). Three test assertions updated to include the new key.
5. **`hermes_cli/main.py`** — `_BUILTIN_SUBCOMMANDS` was missing `send`. The `hermes send` CLI subcommand is live but not in the gating set; plugin discovery couldn't be skipped for it. Added.
6. **`tests/hermes_cli/test_tools_config.py`** — my #27306 (post_setup parity) parametrized over four browser providers, but the catalog was refactored to keep only Camofox + the consolidated Nous Subscription/Local Browser pair (the latter two have no `env_vars` so don't exercise this code path). Pruned the stale parametrize entries to just Camofox.

## Validation
- `scripts/run_tests.sh tests/gateway/test_google_chat.py tests/gateway/test_teams.py tests/hermes_cli/test_tools_config.py tests/hermes_cli/test_startup_plugin_gating.py tests/gateway/test_background_command.py tests/gateway/test_telegram_thread_fallback.py tests/gateway/test_voice_command.py tests/acp/test_registry_manifest.py tests/run_agent/test_provider_parity.py -q` → 646/646 pass.
- `ruff check` clean.

## Remaining main failures (NOT fixed by this PR)
Three failures remain that are unrelated to the salvage train and look like genuine pre-existing production regressions:
- `tests/hermes_cli/test_model_switch_custom_providers.py::test_list_groups_same_name_custom_providers_into_one_row` — `list_authenticated_providers` is leaking the global model catalog into custom-provider rows when grouping by name. Real bug.
- `tests/tools/test_voice_cli_integration.py::TestVprintForceParameter::test_error_messages_use_force_in_run_agent` — expects at least one `_vprint(..., force=True)` for `❌`-prefixed error messages in run_agent.py; found zero. Someone added an error path without `force=True`.
- `tests/run_agent/test_deepseek_reasoning_content_echo.py::TestNeedsKimiToolReasoning::test_non_kimi_provider` — deepseek reasoning-content echo guard regressed.

Each deserves its own targeted PR. Filing follow-ups separately.