### PR TITLE
fix(web): ensure plugin discovery before web_*_tool registry lookups

### DIFF
--- a/tests/tools/test_web_providers.py
+++ b/tests/tools/test_web_providers.py
@@ -380,7 +380,7 @@ class TestDispatchersTriggerPluginDiscovery:
         return _restore
 
     def test_web_extract_tool_runs_discovery_before_registry_lookup(self, monkeypatch):
-        """``web_extract_tool`` must call ``_ensure_plugins_discovered()``
+        """``web_extract_tool`` must invoke ``_ensure_web_plugins_loaded()``
         before looking up the configured backend so the registry is
         populated even from cold-start subprocess contexts.
 
@@ -392,9 +392,9 @@ class TestDispatchersTriggerPluginDiscovery:
         """
         import asyncio
         import json
+        from unittest.mock import MagicMock
         from agent.web_search_provider import WebSearchProvider
         from agent import web_search_registry
-        from hermes_cli import plugins as plugins_mod
         from tools import web_tools
 
         restore = self._clear_registry()
@@ -421,18 +421,24 @@ class TestDispatchersTriggerPluginDiscovery:
                         for u in urls
                     ]
 
-            # Simulate "plugin discovery loads the firecrawl plugin": every
-            # call to the discovery hook registers the provider, mirroring
-            # what ``plugins/web/firecrawl/__init__.py:register`` does at
-            # real-process startup. Discovery must be idempotent, so the
-            # registration is too.
-            def fake_discover(force=False):
+            # Simulate "plugin discovery loads the firecrawl plugin": the
+            # wrapped helper registers the provider, mirroring what
+            # ``plugins/web/firecrawl/__init__.py:register`` does at
+            # real-process startup. Wrapping with ``MagicMock`` lets us
+            # also assert the dispatcher actually invoked the hook — if
+            # a future refactor accidentally drops the call the regression
+            # would otherwise hide behind a still-populated registry.
+            def _register_fake() -> None:
                 if web_search_registry.get_provider("firecrawl") is None:
                     web_search_registry.register_provider(FakeFirecrawl())
-                return plugins_mod.get_plugin_manager()
 
+            mock_hook = MagicMock(wraps=_register_fake)
+            # Patch the helper on ``tools.web_tools`` directly rather than the
+            # underlying ``hermes_cli.plugins._ensure_plugins_discovered`` so
+            # the test stays valid even if the import inside the helper is
+            # later moved to module scope or renamed.
             monkeypatch.setattr(
-                plugins_mod, "_ensure_plugins_discovered", fake_discover
+                web_tools, "_ensure_web_plugins_loaded", mock_hook
             )
             monkeypatch.setattr(
                 web_tools, "_load_web_config",
@@ -448,24 +454,28 @@ class TestDispatchersTriggerPluginDiscovery:
                 )
             ))
 
-            # The dispatcher must NOT have returned the "no provider" error
-            # — that would mean discovery never ran. Firecrawl is now
-            # registered (discovery side-effect) and the extract result
-            # shape is success.
+            # The hook must have been called BEFORE the registry lookup —
+            # that is the invariant under regression test. Without the
+            # explicit ``.called`` assertion the test could pass if the
+            # registry were populated by some unrelated side effect.
+            assert mock_hook.called, (
+                "web_extract_tool must call _ensure_web_plugins_loaded() "
+                "before resolving the registry"
+            )
             assert "No web extract provider configured" not in json.dumps(result)
             assert web_search_registry.get_provider("firecrawl") is not None
         finally:
             restore()
 
     def test_web_search_tool_runs_discovery_before_registry_lookup(self, monkeypatch):
-        """``web_search_tool`` must call ``_ensure_plugins_discovered()``
+        """``web_search_tool`` must invoke ``_ensure_web_plugins_loaded()``
         before the registry lookup for the same reason as the extract
         path (issue #27580 root cause applies to all three dispatchers).
         """
         import json
+        from unittest.mock import MagicMock
         from agent.web_search_provider import WebSearchProvider
         from agent import web_search_registry
-        from hermes_cli import plugins as plugins_mod
         from tools import web_tools
 
         restore = self._clear_registry()
@@ -491,13 +501,13 @@ class TestDispatchersTriggerPluginDiscovery:
                          "position": 0}
                     ]}}
 
-            def fake_discover(force=False):
+            def _register_fake() -> None:
                 if web_search_registry.get_provider("brave-free") is None:
                     web_search_registry.register_provider(FakeBrave())
-                return plugins_mod.get_plugin_manager()
 
+            mock_hook = MagicMock(wraps=_register_fake)
             monkeypatch.setattr(
-                plugins_mod, "_ensure_plugins_discovered", fake_discover
+                web_tools, "_ensure_web_plugins_loaded", mock_hook
             )
             monkeypatch.setattr(
                 web_tools, "_load_web_config",
@@ -506,7 +516,80 @@ class TestDispatchersTriggerPluginDiscovery:
             assert web_search_registry.get_provider("brave-free") is None
 
             result = json.loads(web_tools.web_search_tool("hello", limit=1))
+            assert mock_hook.called, (
+                "web_search_tool must call _ensure_web_plugins_loaded() "
+                "before resolving the registry"
+            )
             assert "No web search provider configured" not in json.dumps(result)
             assert web_search_registry.get_provider("brave-free") is not None
+        finally:
+            restore()
+
+    def test_web_crawl_tool_runs_discovery_before_registry_lookup(self, monkeypatch):
+        """``web_crawl_tool`` must invoke ``_ensure_web_plugins_loaded()``
+        before the registry lookup for the same reason as the extract /
+        search paths — the issue #27580 root cause applies to all three
+        dispatchers, and ``web_crawl_tool`` is the third.
+        """
+        import asyncio
+        import json
+        from unittest.mock import MagicMock
+        from agent.web_search_provider import WebSearchProvider
+        from agent import web_search_registry
+        from tools import web_tools
+
+        restore = self._clear_registry()
+        try:
+            class FakeTavily(WebSearchProvider):
+                @property
+                def name(self) -> str:
+                    return "tavily"
+
+                @property
+                def display_name(self) -> str:
+                    return "Fake Tavily"
+
+                def is_available(self) -> bool:
+                    return True
+
+                def supports_crawl(self) -> bool:
+                    return True
+
+                def crawl(self, url, **kwargs):
+                    return {"results": [
+                        {"url": url, "title": "ok", "content": "ok"}
+                    ]}
+
+            def _register_fake() -> None:
+                if web_search_registry.get_provider("tavily") is None:
+                    web_search_registry.register_provider(FakeTavily())
+
+            mock_hook = MagicMock(wraps=_register_fake)
+            monkeypatch.setattr(
+                web_tools, "_ensure_web_plugins_loaded", mock_hook
+            )
+            monkeypatch.setattr(
+                web_tools, "_load_web_config",
+                lambda: {"crawl_backend": "tavily"},
+            )
+            assert web_search_registry.get_provider("tavily") is None
+
+            result = json.loads(asyncio.run(
+                web_tools.web_crawl_tool(
+                    "https://example.com",
+                    use_llm_processing=False,
+                )
+            ))
+
+            assert mock_hook.called, (
+                "web_crawl_tool must call _ensure_web_plugins_loaded() "
+                "before resolving the registry"
+            )
+            # Either the crawl dispatch path succeeded with the fake
+            # provider, or the test surfaced a different (post-lookup)
+            # error — what we are guarding against is the "no provider"
+            # short-circuit BEFORE discovery ran.
+            assert "No web crawl provider configured" not in json.dumps(result)
+            assert web_search_registry.get_provider("tavily") is not None
         finally:
             restore()

--- a/tests/tools/test_web_providers.py
+++ b/tests/tools/test_web_providers.py
@@ -343,3 +343,170 @@ class TestUnconfiguredErrorEnvelopeParity:
         assert "web_crawl requires Firecrawl" in result["error"]
         # Crucially: no per-page burying
         assert "results" not in result
+
+
+class TestDispatchersTriggerPluginDiscovery:
+    """Regression tests for #27580: each web_*_tool dispatcher must
+    idempotently call ``_ensure_plugins_discovered()`` before consulting
+    ``agent.web_search_registry``.
+
+    Without this, a tool call from a context that hasn't already loaded
+    plugins (subprocess agent runs, delegate children, standalone scripts,
+    test paths that import the registry directly) sees an empty registry
+    and returns the misleading "No web extract provider configured" error
+    even when the user has both the config key set AND the API key
+    exported.
+
+    Mirrors :func:`tools.browser_tool._ensure_browser_plugins_loaded` —
+    every other plugin-backed dispatcher (image_gen, video_gen, browser,
+    skills) already does this.
+    """
+
+    def _clear_registry(self):
+        """Reset the web_search registry to empty and return a callback
+        that restores the original contents. Used in a try/finally so the
+        snapshot is restored even when the dispatcher under test raises."""
+        from agent import web_search_registry
+
+        with web_search_registry._lock:
+            original = dict(web_search_registry._providers)
+            web_search_registry._providers.clear()
+
+        def _restore():
+            with web_search_registry._lock:
+                web_search_registry._providers.clear()
+                web_search_registry._providers.update(original)
+
+        return _restore
+
+    def test_web_extract_tool_runs_discovery_before_registry_lookup(self, monkeypatch):
+        """``web_extract_tool`` must call ``_ensure_plugins_discovered()``
+        before looking up the configured backend so the registry is
+        populated even from cold-start subprocess contexts.
+
+        Without the fix, ``get_provider('firecrawl')`` returns ``None``
+        on a fresh process and the dispatcher emits "No web extract
+        provider configured" despite the user having both
+        ``web.extract_backend: firecrawl`` and ``FIRECRAWL_API_KEY`` set
+        (issue #27580).
+        """
+        import asyncio
+        import json
+        from agent.web_search_provider import WebSearchProvider
+        from agent import web_search_registry
+        from hermes_cli import plugins as plugins_mod
+        from tools import web_tools
+
+        restore = self._clear_registry()
+        try:
+            class FakeFirecrawl(WebSearchProvider):
+                @property
+                def name(self) -> str:
+                    return "firecrawl"
+
+                @property
+                def display_name(self) -> str:
+                    return "Fake Firecrawl"
+
+                def is_available(self) -> bool:
+                    return True
+
+                def supports_extract(self) -> bool:
+                    return True
+
+                async def extract(self, urls, format=None):
+                    return [
+                        {"url": u, "title": "", "content": "ok",
+                         "raw_content": "ok", "metadata": {}}
+                        for u in urls
+                    ]
+
+            # Simulate "plugin discovery loads the firecrawl plugin": every
+            # call to the discovery hook registers the provider, mirroring
+            # what ``plugins/web/firecrawl/__init__.py:register`` does at
+            # real-process startup. Discovery must be idempotent, so the
+            # registration is too.
+            def fake_discover(force=False):
+                if web_search_registry.get_provider("firecrawl") is None:
+                    web_search_registry.register_provider(FakeFirecrawl())
+                return plugins_mod.get_plugin_manager()
+
+            monkeypatch.setattr(
+                plugins_mod, "_ensure_plugins_discovered", fake_discover
+            )
+            monkeypatch.setattr(
+                web_tools, "_load_web_config",
+                lambda: {"extract_backend": "firecrawl"},
+            )
+            # Sanity: registry IS empty before the tool call.
+            assert web_search_registry.get_provider("firecrawl") is None
+
+            result = json.loads(asyncio.run(
+                web_tools.web_extract_tool(
+                    ["https://example.com"],
+                    use_llm_processing=False,
+                )
+            ))
+
+            # The dispatcher must NOT have returned the "no provider" error
+            # — that would mean discovery never ran. Firecrawl is now
+            # registered (discovery side-effect) and the extract result
+            # shape is success.
+            assert "No web extract provider configured" not in json.dumps(result)
+            assert web_search_registry.get_provider("firecrawl") is not None
+        finally:
+            restore()
+
+    def test_web_search_tool_runs_discovery_before_registry_lookup(self, monkeypatch):
+        """``web_search_tool`` must call ``_ensure_plugins_discovered()``
+        before the registry lookup for the same reason as the extract
+        path (issue #27580 root cause applies to all three dispatchers).
+        """
+        import json
+        from agent.web_search_provider import WebSearchProvider
+        from agent import web_search_registry
+        from hermes_cli import plugins as plugins_mod
+        from tools import web_tools
+
+        restore = self._clear_registry()
+        try:
+            class FakeBrave(WebSearchProvider):
+                @property
+                def name(self) -> str:
+                    return "brave-free"
+
+                @property
+                def display_name(self) -> str:
+                    return "Fake Brave"
+
+                def is_available(self) -> bool:
+                    return True
+
+                def supports_search(self) -> bool:
+                    return True
+
+                def search(self, query, limit=5):
+                    return {"success": True, "data": {"web": [
+                        {"title": "ok", "url": "https://x", "description": "",
+                         "position": 0}
+                    ]}}
+
+            def fake_discover(force=False):
+                if web_search_registry.get_provider("brave-free") is None:
+                    web_search_registry.register_provider(FakeBrave())
+                return plugins_mod.get_plugin_manager()
+
+            monkeypatch.setattr(
+                plugins_mod, "_ensure_plugins_discovered", fake_discover
+            )
+            monkeypatch.setattr(
+                web_tools, "_load_web_config",
+                lambda: {"search_backend": "brave-free"},
+            )
+            assert web_search_registry.get_provider("brave-free") is None
+
+            result = json.loads(web_tools.web_search_tool("hello", limit=1))
+            assert "No web search provider configured" not in json.dumps(result)
+            assert web_search_registry.get_provider("brave-free") is not None
+        finally:
+            restore()

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -743,6 +743,31 @@ def clean_base64_images(text: str) -> str:
 # dispatchers in this file resolve them via get_active_*_provider().
 
 
+def _ensure_web_plugins_loaded() -> None:
+    """Idempotently trigger plugin discovery so the web registry is populated.
+
+    Every bundled web provider (brave-free, ddgs, searxng, exa, parallel,
+    tavily, firecrawl) registers itself via ``plugins/web/<vendor>/__init__.py``
+    during plugin discovery. Tool dispatch can be reached from contexts that
+    haven't already triggered discovery — subprocess agent runs, delegate
+    children, standalone scripts, certain test paths — and without it the
+    registry is empty and ``get_provider('firecrawl')`` returns ``None`` even
+    when the user has ``web.extract_backend: firecrawl`` configured and
+    ``FIRECRAWL_API_KEY`` set. The symptom is a misleading "No web extract
+    provider configured" error (issue #27580).
+
+    Mirrors :func:`tools.browser_tool._ensure_browser_plugins_loaded` exactly:
+    the underlying discovery call is idempotent and cheap on subsequent
+    invocations.
+    """
+    try:
+        from hermes_cli.plugins import _ensure_plugins_discovered
+
+        _ensure_plugins_discovered()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Web plugin discovery failed (non-fatal): %s", exc)
+
+
 def web_search_tool(query: str, limit: int = 5) -> str:
     """
     Search the web for information using available search API backend.
@@ -803,6 +828,7 @@ def web_search_tool(query: str, limit: int = 5) -> str:
         # (brave-free, ddgs, searxng, exa, parallel, tavily, firecrawl)
         # now live as plugins; the dispatcher is just a registry lookup +
         # delegation. Sync only — every provider's search() is sync.
+        _ensure_web_plugins_loaded()
         from agent.web_search_registry import (
             get_active_search_provider,
             get_provider as _wsp_get_provider,
@@ -935,6 +961,7 @@ async def web_extract_tool(
             # detect coroutine functions and await; sync functions run
             # inline (the policy gate, SSRF re-check, etc. live inside the
             # provider itself for the firecrawl per-URL loop).
+            _ensure_web_plugins_loaded()
             from agent.web_search_registry import (
                 get_active_extract_provider,
                 get_provider as _wsp_get_provider,
@@ -1187,6 +1214,7 @@ async def web_crawl_tool(
         # dispatches through agent.web_search_registry. The crawl response
         # shape — {"results": [{"url", "title", "content", ...}]} — is then
         # post-processed by the shared LLM-summarization path below.
+        _ensure_web_plugins_loaded()
         from agent.web_search_registry import (
             get_active_crawl_provider,
             get_provider as _wsp_get_provider,

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -765,7 +765,11 @@ def _ensure_web_plugins_loaded() -> None:
 
         _ensure_plugins_discovered()
     except Exception as exc:  # noqa: BLE001
-        logger.debug("Web plugin discovery failed (non-fatal): %s", exc)
+        # Warning, not debug: if a plugin import is genuinely broken the
+        # user otherwise hits the misleading "No web extract provider
+        # configured" error this helper is meant to eliminate, with no
+        # clue in normal logs about the real cause.
+        logger.warning("Web plugin discovery failed (non-fatal): %s", exc)
 
 
 def web_search_tool(query: str, limit: int = 5) -> str:


### PR DESCRIPTION
## Summary

- `tools/web_tools.py` was the only plugin-backed dispatcher that did not call `_ensure_plugins_discovered()` before consulting `agent.web_search_registry`. From cold-start contexts (subprocess agent runs, delegate children, standalone scripts) the registry stays empty and the dispatcher emits the misleading "No web extract provider configured" error even when the user has `web.extract_backend: firecrawl` and `FIRECRAWL_API_KEY` set (issue #27580).
- Add `_ensure_web_plugins_loaded()` that mirrors `tools.browser_tool._ensure_browser_plugins_loaded` exactly, and invoke it at all three registry-lookup sites: `web_search_tool`, `web_extract_tool`, `web_crawl_tool`.

Fixes #27580.

## The bug

The reporter has both the config key and API key set, but `web_extract` returns:

```json
{"success": false, "error": "No web extract provider configured. Set web.extract_backend to firecrawl, tavily, exa, or parallel."}
```

Their debug script confirms `get_provider('firecrawl')` returns `None` despite the plugin being bundled and `FIRECRAWL_API_KEY` being set — i.e. the plugin was never loaded into the registry at import time.

Every other plugin-backed tool dispatcher in the tree (`tools/image_generation_tool.py:874-876`, `tools/video_generation_tool.py:207-209`, `tools/browser_tool.py:469-485`, `tools/skills_tool.py:878-893`) defensively calls `_ensure_plugins_discovered()` (idempotent) before looking up the registry, precisely so that cold-start contexts that haven't gone through `hermes_cli/main.py` or `gateway/config.py` still see registered providers. `tools/web_tools.py` was the lone outlier — the post-#25182 dispatcher just imports the registry and queries it directly.

## The fix

Add `_ensure_web_plugins_loaded()` (24 lines, mirrors `tools.browser_tool._ensure_browser_plugins_loaded`) and call it immediately before each `from agent.web_search_registry import …` in the three dispatchers. Discovery is idempotent so subsequent invocations early-return inside `_ensure_plugins_discovered`.

## Test plan

- [x] **Regression test** — `tests/tools/test_web_providers.py::TestDispatchersTriggerPluginDiscovery` (two tests, one each for `web_extract_tool` and `web_search_tool`). Each test empties the registry, points `_ensure_plugins_discovered` at a fake that registers a provider on first call, and asserts the dispatcher resolves the configured backend instead of returning the bug-report error string.
- [x] **Regression guard** — with the production change reverted (`git stash push tools/web_tools.py`), both new tests fail with the exact bug-report error text:
      ```
      AssertionError: assert 'No web extract provider configured' not in '...'
      ```
      Restoring the fix makes them pass.
- [x] **Adjacent suite** — `tests/tools/test_web_tools_config.py tests/tools/test_web_providers.py tests/tools/test_web_providers_brave_free.py tests/tools/test_web_providers_ddgs.py tests/tools/test_web_providers_searxng.py tests/tools/test_web_tools_tavily.py tests/tools/test_website_policy.py` — 167 passed in 46s (no regressions).
- Run command: `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/tools/test_web_providers.py -v`.

## Related

- The architectural prior comes from PR #25182 (kshitijk4poor) / salvage PR #25448 (teknium1), which migrated all seven web providers into the plugin registry. The dispatcher was rewritten to do `from agent.web_search_registry import get_provider` directly, missing the discovery-before-lookup guard that the other plugin-backed dispatchers already had.