### PR TITLE
fix(feishu): extract content from nested body in merge_forward messages

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -963,6 +963,81 @@ def _normalize_interactive_message(message_type: str, payload: Dict[str, Any]) -
 # ---------------------------------------------------------------------------
 
 
+def _extract_feishu_forward_body(item: Dict[str, Any], nested_type: str) -> str:
+    """Extract text content from a single entry inside a merge_forward message.
+
+    Feishu merge_forward entries use two distinct layouts:
+
+    1. **Event-content layout** (flat dict from the webhook ``content`` field):
+       ``{"msg_type": "text", "text": "hello"}``
+
+    2. **API-response layout** (nested ``body.content`` from ``im.v1.message.get``):
+       ``{"msg_type": "text", "body": {"content": "{\\"text\\":\\"hello\\"}"}}``
+       where ``body.content`` is itself a JSON string that must be double-parsed.
+
+    We handle both, preferring the flatter layout when available.
+    """
+    # --- Try API-response nested layout first ---
+    body_obj = item.get("body")
+    if isinstance(body_obj, dict):
+        raw_body_content = body_obj.get("content")
+        if isinstance(raw_body_content, str) and raw_body_content:
+            inner = _load_feishu_payload(raw_body_content)
+            if nested_type == "post":
+                parsed = parse_feishu_post_payload(inner)
+                return parsed.text_content
+            return _first_non_empty_text(
+                inner.get("text"),
+                inner.get("summary"),
+                inner.get("preview"),
+                _find_first_text(inner, keys=("text", "content", "summary", "preview", "title")),
+            ) or ""
+
+    # --- Fallback: flat / event-content layout ---
+    if nested_type == "post":
+        return parse_feishu_post_payload(item.get("content") or item).text_content
+
+    return _first_non_empty_text(
+        item.get("text"),
+        item.get("summary"),
+        item.get("preview"),
+        item.get("content"),
+        _find_first_text(item, keys=("text", "content", "summary", "preview", "title")),
+    ) or ""
+
+
+def _extract_feishu_forward_sender(item: Dict[str, Any]) -> str:
+    """Return a human-readable sender label from a merge_forward entry.
+
+    Handles both the flat event layout (``sender_name``) and the API-response
+    layout (``sender.sender_id.open_id`` / ``sender.sender_id.user_id``).
+    """
+    # Flat layout
+    flat = _first_non_empty_text(
+        item.get("sender_name"),
+        item.get("user_name"),
+        item.get("name"),
+    )
+    if flat:
+        return flat
+
+    # API-response layout: sender is a dict
+    sender_obj = item.get("sender")
+    if isinstance(sender_obj, dict):
+        sender_id = sender_obj.get("sender_id") or {}
+        return _first_non_empty_text(
+            sender_id.get("open_id"),
+            sender_id.get("user_id"),
+            sender_id.get("union_id"),
+        ) or ""
+
+    # Last resort: item["sender"] might be a plain string
+    sender_val = item.get("sender")
+    if isinstance(sender_val, str) and sender_val:
+        return sender_val
+    return ""
+
+
 def _collect_forward_entries(payload: Dict[str, Any]) -> List[str]:
     candidates: List[Any] = []
     for key in ("messages", "items", "message_list", "records", "content"):
@@ -976,24 +1051,9 @@ def _collect_forward_entries(payload: Dict[str, Any]) -> List[str]:
             if text:
                 entries.append(f"- {text}")
             continue
-        sender = _first_non_empty_text(
-            item.get("sender_name"),
-            item.get("user_name"),
-            item.get("sender"),
-            item.get("name"),
-        )
+        sender = _extract_feishu_forward_sender(item)
         nested_type = str(item.get("message_type", "") or item.get("msg_type", "")).strip().lower()
-        if nested_type == "post":
-            body = parse_feishu_post_payload(item.get("content") or item).text_content
-        else:
-            body = _first_non_empty_text(
-                item.get("text"),
-                item.get("summary"),
-                item.get("preview"),
-                item.get("content"),
-                _find_first_text(item, keys=("text", "content", "summary", "preview", "title")),
-            )
-        body = _normalize_feishu_text(body)
+        body = _normalize_feishu_text(_extract_feishu_forward_body(item, nested_type))
         if sender and body:
             entries.append(f"- {sender}: {body}")
         elif body:

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -109,6 +109,71 @@ class TestFeishuMessageNormalization(unittest.TestCase):
             "Sprint recap\n- Alice: Please review PR-128\n- Bob: Ship it",
         )
 
+    def test_normalize_merge_forward_api_response_layout(self):
+        """merge_forward with nested body.content (API-response layout)."""
+        from gateway.platforms.feishu import normalize_feishu_message
+
+        normalized = normalize_feishu_message(
+            message_type="merge_forward",
+            raw_content=json.dumps(
+                {
+                    "title": "Design sync",
+                    "message_list": [
+                        {
+                            "msg_type": "text",
+                            "body": {"content": json.dumps({"text": "New mockups are ready"})},
+                            "sender": {
+                                "sender_id": {"open_id": "ou_alice", "user_id": "uid_alice"},
+                                "sender_type": "user",
+                            },
+                        },
+                        {
+                            "msg_type": "text",
+                            "body": {"content": json.dumps({"text": "LGTM"})},
+                            "sender": {
+                                "sender_id": {"open_id": "ou_bob", "user_id": "uid_bob"},
+                                "sender_type": "user",
+                            },
+                        },
+                    ],
+                }
+            ),
+        )
+
+        self.assertEqual(normalized.relation_kind, "merge_forward")
+        # Sender names fall back to open_id when no display name is available
+        self.assertIn("ou_alice: New mockups are ready", normalized.text_content)
+        self.assertIn("ou_bob: LGTM", normalized.text_content)
+
+    def test_normalize_merge_forward_mixed_layouts(self):
+        """merge_forward mixing flat and nested entries gracefully."""
+        from gateway.platforms.feishu import normalize_feishu_message
+
+        normalized = normalize_feishu_message(
+            message_type="merge_forward",
+            raw_content=json.dumps(
+                {
+                    "title": "Mixed",
+                    "message_list": [
+                        # Flat layout
+                        {"sender_name": "Charlie", "text": "Flat entry"},
+                        # API-response layout
+                        {
+                            "msg_type": "text",
+                            "body": {"content": json.dumps({"text": "Nested entry"})},
+                            "sender": {
+                                "sender_id": {"open_id": "ou_dana"},
+                                "sender_type": "user",
+                            },
+                        },
+                    ],
+                }
+            ),
+        )
+
+        self.assertIn("Charlie: Flat entry", normalized.text_content)
+        self.assertIn("ou_dana: Nested entry", normalized.text_content)
+
     def test_normalize_share_chat_exposes_summary_and_metadata(self):
         from gateway.platforms.feishu import normalize_feishu_message
 


### PR DESCRIPTION
## Summary

Fixes [Issue #27477](https://github.com/NousResearch/hermes-agent/issues/27477)

### Root Cause

When a user forwards chat history to Hermes in Feishu, the `merge_forward` message type can arrive in two different content layouts:

1. **Flat event-content layout** — `sender_name`/`text` at the top level of each entry
2. **Nested API-response layout** — content is inside `body.content` (itself a double-JSON-encoded string), sender info is under `sender.sender_id.{open_id,user_id}`

The existing `_collect_forward_entries()` only handled layout #1. When Feishu delivers layout #2 (which is what the webhook actually sends for forwarded messages), the sender and content fields resolve to empty/None, producing the fallback placeholder `[Merged forward message]` instead of the actual chat content.

### Fix

- Added `_extract_feishu_forward_body()` — tries nested `body.content` first (double-parsing the inner JSON), then falls back to flat layout
- Added `_extract_feishu_forward_sender()` — tries `sender_name` → `sender.sender_id` → `sender` string
- Both helpers are fully backward-compatible with the existing flat layout

### Testing

- All **388 existing** feishu tests pass
- Added **2 new tests**:
  - `test_normalize_merge_forward_api_response_layout` — verifies nested layout extraction
  - `test_normalize_merge_forward_mixed_layouts` — verifies mixed flat+nested entries

### Files Changed

- `gateway/platforms/feishu.py` — +77/-17 (new helpers + simplified `_collect_forward_entries`)
- `tests/gateway/test_feishu.py` — +65 (2 new test cases)