### PR TITLE
Enforce verified-facts context on clarify calls (t_f2e0e531)

### DIFF
--- a/tests/tools/test_clarify_tool.py
+++ b/tests/tools/test_clarify_tool.py
@@ -10,6 +10,7 @@ from tools.clarify_tool import (
     check_clarify_requirements,
     MAX_CHOICES,
     CLARIFY_SCHEMA,
+    _has_context,
 )
 
 
@@ -193,3 +194,205 @@ class TestClarifySchema:
     def test_max_choices_is_four(self):
         """MAX_CHOICES constant should be 4."""
         assert MAX_CHOICES == 4
+
+    def test_schema_description_mandates_context(self):
+        """Schema must tell the agent context is mandatory and show the chain shape."""
+        desc = CLARIFY_SCHEMA["description"]
+        # Spell out the mandatory rule
+        assert "MANDATORY" in desc or "mandatory" in desc
+        # Spell out the shape so the agent can reproduce it on first try
+        assert "Theme:" in desc
+        assert "Epic:" in desc
+        assert "Task:" in desc
+        assert "→" in desc
+        # Mention the skill so the agent can load it for the full pattern
+        assert "asking-the-user-well" in desc
+
+    def test_question_param_description_mentions_context(self):
+        """The `question` parameter description must remind about the context block."""
+        q_desc = CLARIFY_SCHEMA["parameters"]["properties"]["question"]["description"]
+        assert "context" in q_desc.lower()
+
+
+# =============================================================================
+# Context enforcement (kanban t_f2e0e531)
+# =============================================================================
+
+
+class TestContextDetection:
+    """Tests for the `_has_context` heuristic."""
+
+    def test_short_bare_question_lacks_context(self):
+        ok, reason = _has_context("What color?", None)
+        assert ok is False
+        assert "char" in reason or "line" in reason
+
+    def test_chain_arrow_alone_in_short_question_lacks_context(self):
+        # Has the arrow but is too short to be a real canvas.
+        ok, _ = _has_context("A → B?", None)
+        assert ok is False
+
+    def test_long_question_with_chain_arrow_has_context(self):
+        q = (
+            "Theme: Timeline & Timesheets → Epic: dashboard surface → "
+            "Task: pick canonical Postgres stack → "
+            "Question: which of the three timeline DBs is canonical? "
+            "Stack A (timeline-new) has 1443 tasks; Stack C (work) has 356 "
+            "records and 1793h of Xsolla signals."
+        )
+        ok, reason = _has_context(q, None)
+        assert ok is True, reason
+
+    def test_long_question_with_table_has_context(self):
+        q = (
+            "Decide which loader to ship first. Here are the three candidates:\n\n"
+            "| name | status | rows |\n"
+            "| --- | --- | --- |\n"
+            "| a | ready | 142  |\n"
+            "| b | wip   | 89   |"
+        )
+        ok, reason = _has_context(q, None)
+        assert ok is True, reason
+
+    def test_long_question_with_code_fence_has_context(self):
+        q = (
+            "I need to know which constant to pick. The current code reads:\n\n"
+            "```python\nMAX_CHOICES = 4\nTIMEOUT = 600\n```\n\n"
+            "Should we lift MAX_CHOICES to 6 to fit the new survey shape?"
+        )
+        ok, reason = _has_context(q, None)
+        assert ok is True, reason
+
+    def test_multiline_canvas_without_explicit_marker_has_context(self):
+        # Four lines of substance counts as an embedded canvas.
+        q = (
+            "Looking at the three options below:\n"
+            "first option summary line\n"
+            "second option summary line\n"
+            "third option summary line\n"
+            "which one should ship?"
+        )
+        ok, reason = _has_context(q, None)
+        assert ok is True, reason
+
+    def test_long_question_without_any_marker_lacks_context(self):
+        # Wall of prose with no chain, no structure, no canvas.
+        q = (
+            "I have been thinking a lot about this and would like to ask you "
+            "which approach you would prefer because there are several ways "
+            "we could potentially go forward and I want to make sure we pick "
+            "the one that is best for the project overall and matches your "
+            "intuition about the right shape of the eventual deliverable."
+        )
+        ok, reason = _has_context(q, None)
+        assert ok is False
+        assert "marker" in reason
+
+
+class TestContextEnforcement:
+    """Tests for the agent-path enforcement (require_context=True)."""
+
+    def test_default_does_not_enforce(self):
+        """Direct library callers (require_context=False default) are unchanged."""
+        def cb(q, c):
+            return "blue"
+        result = json.loads(clarify_tool("What color?", callback=cb))
+        # No error — the short bare call still works for direct callers.
+        assert "error" not in result
+        assert result["user_response"] == "blue"
+
+    def test_require_context_rejects_bare_short_call(self):
+        """With require_context=True a bare short question is rejected."""
+        def cb(q, c):
+            return "should not be called"
+        result = json.loads(clarify_tool(
+            "What color?",
+            callback=cb,
+            require_context=True,
+        ))
+        assert "error" in result
+        # The error message tells the agent exactly what to add
+        err = result["error"]
+        assert "context" in err.lower()
+        assert "Theme:" in err
+        assert "Epic:" in err
+        assert "Task:" in err
+        assert "→" in err
+        # And names the skill so the agent can load it
+        assert "asking-the-user-well" in err
+
+    def test_require_context_accepts_question_with_chain(self):
+        """A well-formed chain question with require_context=True succeeds."""
+        captured = {}
+
+        def cb(q, c):
+            captured["q"] = q
+            return "A"
+
+        good_question = (
+            "Theme: Hermes infra → Epic: clarify-with-context → "
+            "Task: ship enforcement → Question: should we enforce now or "
+            "wait for canvas field? Current state: schema has no `context=` "
+            "field yet (t_bcacbcb9 blocked); enforcement on `question` text "
+            "is the only available gate. Risk: false-reject rate ~unknown."
+        )
+        result = json.loads(clarify_tool(
+            good_question,
+            choices=["enforce now", "wait for t_bcacbcb9"],
+            callback=cb,
+            require_context=True,
+        ))
+        assert "error" not in result, result
+        assert result["user_response"] == "A"
+        assert captured["q"] == good_question
+
+    def test_require_context_accepts_canvas_with_table(self):
+        """A multi-line canvas with a markdown table is accepted."""
+        captured = {}
+
+        def cb(q, c):
+            captured["q"] = q
+            return "row 2"
+
+        canvas_question = (
+            "Decide which loader to schedule. Candidates:\n\n"
+            "| name | status |\n"
+            "| --- | --- |\n"
+            "| smb-share | ready |\n"
+            "| sharepoint | wip |\n\n"
+            "Which one ships first?"
+        )
+        result = json.loads(clarify_tool(
+            canvas_question,
+            choices=["smb-share", "sharepoint"],
+            callback=cb,
+            require_context=True,
+        ))
+        assert "error" not in result, result
+        assert result["user_response"] == "row 2"
+
+    def test_rejection_does_not_invoke_callback(self):
+        """A rejected call must not block the user with a prompt."""
+        called = {"n": 0}
+
+        def cb(q, c):
+            called["n"] += 1
+            return "should not happen"
+
+        clarify_tool("?", callback=cb, require_context=True)
+        assert called["n"] == 0
+
+    def test_registry_handler_enforces_context(self):
+        """The handler registered with the tool registry passes require_context=True."""
+        # Re-import the registry entry the agent loop sees.
+        from tools.registry import registry
+        entry = registry.get_entry("clarify")
+        assert entry is not None, "clarify tool not registered"
+
+        # Call the handler with a bare short question — should reject.
+        result = json.loads(entry.handler(
+            {"question": "Pick one"},
+            callback=lambda q, c: "should not run",
+        ))
+        assert "error" in result
+        assert "context" in result["error"].lower()

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -9,6 +9,24 @@ messaging platforms, choices are rendered as a numbered list.
 The actual user-interaction logic lives in the platform layer (cli.py for CLI,
 gateway/run.py for messaging). This module defines the schema, validation, and
 a thin dispatcher that delegates to a platform-provided callback.
+
+Context enforcement (kanban t_f2e0e531)
+----------------------------------------
+Per Alex's standing rule and the `asking-the-user-well` skill, every clarify
+call MUST carry verified-facts context: at minimum a theme → epic → task →
+question chain, ideally with a verified-facts canvas (table, code block, quote)
+that grounds each offered choice in evidence the user can see at-a-glance.
+
+The canonical `context` parameter for an attached canvas is spec'd on kanban
+card `t_bcacbcb9` but not yet shipped. Until that lands, this module enforces
+context inline on the `question` field. Agent-invoked calls (those that come
+through the tool registry, where the handler passes `require_context=True`)
+that lack a detectable context block are rejected with a structured tool_error
+that tells the agent exactly what to add and retry.
+
+Library callers (tests, direct Python use) can call `clarify_tool()` with
+`require_context=False` (the default) to bypass enforcement; the agent path
+always enforces.
 """
 
 import json
@@ -20,10 +38,116 @@ from typing import List, Optional, Callable
 MAX_CHOICES = 4
 
 
+# =============================================================================
+# Context detection
+# =============================================================================
+
+# Markers that indicate the agent included context. Any ONE of these is enough
+# — the heuristic is permissive on purpose; the goal is to catch the obvious
+# context-free calls ("What do you want?", "Pick one", "Yes or no?"), not to
+# police canvas quality.
+_CONTEXT_MARKERS = (
+    # Chain marker (preferred shape — matches the skill's mandatory format)
+    "→",
+    # Header-style markers the skill suggests
+    "Theme:",
+    "Epic:",
+    "Task:",
+    "Context:",
+    "Verified",
+    "Background:",
+    # Markdown structures that imply embedded artifacts
+    "```",      # code fence
+    "| ---",    # markdown table separator
+    "|---",
+    "\n- ",     # bulleted list (multi-line)
+    "\n* ",
+    "\n> ",     # blockquote
+)
+
+# Minimum length below which a question is presumed context-free regardless of
+# markers. A "Yes?" with a single `→` doesn't really carry context.
+_MIN_CONTEXT_LEN = 120
+
+
+def _has_context(question: str, choices: Optional[List[str]]) -> tuple[bool, str]:
+    """Return (has_context, reason_if_missing).
+
+    A question is considered to carry context if it is long enough AND contains
+    at least one structural marker (chain arrow, header label, code/table/list
+    structure). Multi-line questions get a bonus — if the question is ≥4 lines,
+    we accept it on the assumption that the agent embedded a canvas.
+
+    This is a heuristic. It will accept some weak-canvas calls and may reject
+    some genuinely-context-bearing single-line questions. The cost asymmetry
+    favours false-accepts: a rejected call costs one retry, an accepted bad
+    call corrupts the user's session.
+    """
+    q = question or ""
+    qstrip = q.strip()
+    if not qstrip:
+        return False, "empty"
+
+    line_count = qstrip.count("\n") + 1
+
+    # Multi-line questions (≥4 lines) — assume canvas embedded.
+    if line_count >= 4 and len(qstrip) >= 80:
+        return True, ""
+
+    # Short questions — context-free by definition.
+    if len(qstrip) < _MIN_CONTEXT_LEN:
+        return False, (
+            f"question is {len(qstrip)} chars (need ≥{_MIN_CONTEXT_LEN}) and "
+            f"only {line_count} line(s); no canvas detected"
+        )
+
+    # Long enough — require a structural marker.
+    has_marker = any(marker in q for marker in _CONTEXT_MARKERS)
+    if has_marker:
+        return True, ""
+
+    return False, (
+        "question is long enough but lacks any context marker "
+        "(chain arrow '→', a 'Theme:/Epic:/Task:/Context:' header, "
+        "a code fence, table, blockquote, or bulleted list)"
+    )
+
+
+def _missing_context_error(reason: str) -> str:
+    """Build the tool_error payload for a context-free clarify call.
+
+    The error message is the agent's repair instructions — it should be
+    actionable enough that the agent can retry the SAME call with the correct
+    context block, not start a new chain of thought.
+    """
+    msg = (
+        "Clarify call rejected: missing verified-facts context. "
+        f"({reason}.)\n\n"
+        "Per Alex's standing rule and the `asking-the-user-well` skill, every "
+        "clarify call must show the user the context the decision is being "
+        "made in. Until the `context=` canvas field ships (kanban t_bcacbcb9), "
+        "embed the context inline in `question`. Required shape:\n\n"
+        "  Theme: <theme> → Epic: <epic> → Task: <task> → Question: <one-line ask>\n\n"
+        "  <verified-facts slice — table / code block / blockquote / bulleted list>\n\n"
+        "  <one-sentence sharper restatement of the decision>\n\n"
+        "Then re-issue the clarify call. Do NOT split context and question "
+        "across separate messages — the user must see them together. If the "
+        "decision isn't actually grounded in verified facts, do not ask; load "
+        "the docs first (see `read-before-claiming` and `asking-the-user-well`)."
+    )
+    return tool_error(msg)
+
+
+# =============================================================================
+# Tool entry point
+# =============================================================================
+
+
 def clarify_tool(
     question: str,
     choices: Optional[List[str]] = None,
     callback: Optional[Callable] = None,
+    require_context: bool = False,
 ) -> str:
     """
     Ask the user a question, optionally with multiple-choice options.
@@ -35,14 +159,26 @@ def clarify_tool(
         callback: Platform-provided function that handles the actual UI
                   interaction. Signature: callback(question, choices) -> str.
                   Injected by the agent runner (cli.py / gateway).
+        require_context: When True, reject calls whose `question` does not
+                  carry detectable context (theme chain, canvas, code/table).
+                  The tool registry handler passes True so every agent call
+                  is gated; direct library callers (tests) default to False
+                  for backward compatibility.
 
     Returns:
-        JSON string with the user's response.
+        JSON string with the user's response, or a tool_error JSON when the
+        call is rejected for missing context / bad arguments.
     """
     if not question or not question.strip():
         return tool_error("Question text is required.")
 
     question = question.strip()
+
+    # Context enforcement (kanban t_f2e0e531).
+    if require_context:
+        ok, reason = _has_context(question, choices)
+        if not ok:
+            return _missing_context_error(reason)
 
     # Validate and trim choices
     if choices is not None:
@@ -93,6 +229,14 @@ CLARIFY_SCHEMA = {
         "or types their own answer via a 5th 'Other' option.\n"
         "2. **Open-ended** — omit choices entirely. The user types a free-form "
         "response.\n\n"
+        "**MANDATORY context**: every `question` MUST embed a verified-facts "
+        "context block. Required shape:\n\n"
+        "  Theme: <theme> → Epic: <epic> → Task: <task> → Question: <ask>\n\n"
+        "  <verified-facts canvas — table / code block / blockquote / "
+        "bulleted list — the artifact the decision is about>\n\n"
+        "Calls whose `question` is short and lacks a chain arrow, header "
+        "label, or canvas structure are rejected with a retry hint. See the "
+        "`asking-the-user-well` skill for the canvas pattern.\n\n"
         "Use this tool when:\n"
         "- The task is ambiguous and you need the user to choose an approach\n"
         "- You want post-task feedback ('How did that work out?')\n"
@@ -107,7 +251,12 @@ CLARIFY_SCHEMA = {
         "properties": {
             "question": {
                 "type": "string",
-                "description": "The question to present to the user.",
+                "description": (
+                    "The question to present to the user. MUST embed a "
+                    "verified-facts context block (theme → epic → task chain "
+                    "plus a canvas slice). Single-line context-free questions "
+                    "are rejected; re-issue with context inline."
+                ),
             },
             "choices": {
                 "type": "array",
@@ -135,7 +284,9 @@ registry.register(
     handler=lambda args, **kw: clarify_tool(
         question=args.get("question", ""),
         choices=args.get("choices"),
-        callback=kw.get("callback")),
+        callback=kw.get("callback"),
+        # Agent path always enforces context.
+        require_context=True),
     check_fn=check_clarify_requirements,
     emoji="❓",
 )


### PR DESCRIPTION
Closes kanban t_f2e0e531 (https://github.com/NousResearch/hermes-agent — internal board).

## Why

The `asking-the-user-well` skill documents that every clarify call MUST carry a theme → epic → task chain plus a verified-facts canvas slice. Nothing enforced it. Calls without context still reached the user — exactly the failure mode the canvas pattern was designed to prevent.

Two failure modes observed in this thread alone:
- Session 20260515_213851_34ddd6 — 5 clarify calls re-asked the same approval because the sample JSON was never rendered next to the question.
- Session 20260515_221321_bcf7b8 — 14 clarify calls, 4 re-asks of the same routing question, with Graph API output / nginx config / dig results never co-rendered.

## What

`tools/clarify_tool.py`:
- New `_has_context` heuristic that accepts a question if it is either multi-line (≥4 lines, ≥80 chars) OR long (≥120 chars) AND contains a structural marker (chain arrow, Theme/Epic/Task/Context header, code fence, markdown table, blockquote, or multi-line bulleted list).
- New `require_context: bool = False` parameter on `clarify_tool()`. The registry handler passes `True` so every agent-initiated call is gated. Direct Python callers (tests) default to False — backward compatible.
- Rejection returns a `tool_error` whose body is the agent's repair instructions: shows the required chain shape, names the `asking-the-user-well` skill, tells the agent to re-issue with context inline. The user-facing callback is NOT invoked on rejection.
- Schema description rewritten to spell out the mandatory chain shape so the agent gets it right on the first try.

`tests/tools/test_clarify_tool.py`:
- Two new test classes (`TestContextDetection`, `TestContextEnforcement`) covering the heuristic, the gating, the rejection path, the schema rewrite, and the registry handler path.
- Old tests still pass — direct `clarify_tool()` callers see no behavior change.

## Verification

```
pytest tests/tools/test_clarify_tool.py \
       tests/tools/test_clarify_gateway.py \
       tests/gateway/test_telegram_clarify_buttons.py \
       tests/gateway/test_discord_clarify_buttons.py \
       tests/gateway/test_api_server_toolset.py
```

35 unit + 53 integration = 88 passed. Smoke test through `registry.dispatch` confirmed the bare-question rejection path and the contextualised-question success path both work end-to-end.

## Risks (called out in audit doc)

- **False rejects** — a genuinely-grounded short question gets rejected. Mitigation: error is actionable; agent re-issues with context inline. Cost = one retry.
- **False accepts** — long prose with a stray `→` passes. The skill remains the canvas-quality policy doc; this gate only catches the obvious-bad case.
- **Third-party Python callers** — gate defaults OFF on direct calls; only LLM path enforces.

## Out of scope

- Adding the `context=` schema field — that's t_bcacbcb9 (blocked on iteration budget). When it ships, this heuristic becomes `if not args.get("context"): reject` — one-line replacement.
- Canvas-quality policing — the skill is the policy doc; the gate is the floor.

Full audit: `~/SD.agents/memory/clarify-context-audit.md`.