### PR TITLE
fix(mcp): narrow time.sleep mock target to tools.mcp_tool to stop background-thread mock pollution

### DIFF
--- a/tests/tools/test_mcp_stability.py
+++ b/tests/tools/test_mcp_stability.py
@@ -135,7 +135,7 @@ class TestStdioPidTracking:
         # bpo-14484). Return True so the SIGKILL escalation fires.
         with patch("tools.mcp_tool.os.kill") as mock_kill, \
              patch("gateway.status._pid_exists", return_value=True), \
-             patch("time.sleep") as mock_sleep:
+             patch("tools.mcp_tool.time.sleep") as mock_sleep:
             _kill_orphaned_mcp_children()
 
         # SIGTERM then SIGKILL; the alive check no longer touches os.kill.
@@ -163,7 +163,7 @@ class TestStdioPidTracking:
         monkeypatch.delattr(signal, "SIGKILL", raising=False)
 
         with patch("tools.mcp_tool.os.kill") as mock_kill, \
-             patch("time.sleep") as mock_sleep:
+             patch("tools.mcp_tool.time.sleep") as mock_sleep:
             _kill_orphaned_mcp_children()
 
         # SIGTERM phase, alive check raises (process gone), no escalation

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3518,7 +3518,6 @@ def _kill_orphaned_mcp_children(include_active: bool = False) -> None:
     sessions can still be in flight.
     """
     import signal as _signal
-    import time as _time
 
     with _lock:
         pids: Dict[int, str] = {}
@@ -3543,7 +3542,7 @@ def _kill_orphaned_mcp_children(include_active: bool = False) -> None:
             pass
 
     # Phase 2: Wait for graceful exit
-    _time.sleep(2)
+    time.sleep(2)
 
     # Phase 3: SIGKILL any survivors
     _sigkill = getattr(_signal, "SIGKILL", _signal.SIGTERM)


### PR DESCRIPTION
## Summary
Final remaining failure on main Tests workflow. `tests/tools/test_mcp_stability.py::TestStdioPidTracking::test_kill_orphaned_uses_sigkill_when_available` got `'sleep' called 225571 times` in CI but passed locally. Classic global-patch interaction with concurrent threads.

## Root cause
`_kill_orphaned_mcp_children()` did `import time as _time` inside the function body and called `_time.sleep(2)`. The test patched the *global* `time.sleep` with `unittest.mock.patch("time.sleep")` — which replaces `time.sleep` for the entire process. Background daemon threads from `tools/process_registry.py:1055` and `tools/terminal_tool.py:1331` (both running periodic 1s-cadence reaper loops) suddenly hit a MagicMock instead of real sleep, looped as fast as possible, and accumulated ~225k spurious `call(1)` entries during the 2s the patch context was open.

Local runs only see this when those background loops are warm; CI runners have them up earlier in the process lifecycle so the race fires reliably.

## Changes
- `tools/mcp_tool.py` — drop the `import time as _time` inside `_kill_orphaned_mcp_children`; use the module-level `time` import (top of file). Production semantics unchanged.
- `tests/tools/test_mcp_stability.py` — both `test_kill_orphaned_*` tests now patch `tools.mcp_tool.time.sleep` instead of `time.sleep`, so the mock is scoped to the production module's `time` reference only. Background threads in other modules sleep normally.

## Validation
- `scripts/run_tests.sh tests/tools/test_mcp_stability.py -q` → 16/16 pass.
- Ruff clean.

After this, main's Tests workflow should be green for the first time in many hours.