### PR TITLE
feat(kanban/dashboard): board archive/restore/hard-delete UX + per-stage timestamps

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -553,6 +553,264 @@ def remove_board(slug: str, *, archive: bool = True) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# Archived-board helpers
+# ---------------------------------------------------------------------------
+
+def archived_boards_root() -> Path:
+    """Return ``<root>/kanban/boards/_archived``.
+
+    Why: Dashboard archive viewer needs a single entry point to list every
+    archived board folder (parallel to :func:`boards_root`).
+    What: Returns the directory where archived board folders live.
+    Test: Assert it equals ``boards_root() / "_archived"``.
+    """
+    return boards_root() / "_archived"
+
+
+def list_archived_boards() -> list[dict]:
+    """Enumerate archived board directories.
+
+    Why: Dashboard archive viewer needs metadata for every archived board
+    so the user can pick which to restore. Folders are named ``<slug>-<ts>``
+    (timestamp-suffixed by :func:`remove_board`); we reverse-engineer the
+    base slug + the timestamp from the directory name.
+    What: Returns a list of ``{slug, archived_dir, archived_at, name, ...}``
+    sorted by most-recently-archived first.
+    Test: Archive a board, call this — expect 1 entry with the right slug
+    and ``archived_dir`` matching the on-disk path.
+    """
+    root = archived_boards_root()
+    if not root.is_dir():
+        return []
+    out: list[dict] = []
+    for child in root.iterdir():
+        if not child.is_dir():
+            continue
+        name = child.name
+        # Parse "<slug>-<timestamp>[-<n>]". Take the trailing digits-only
+        # token as the timestamp, the rest as the slug; collision-suffixed
+        # entries (slug-ts-1) keep the same parsing.
+        parts = name.rsplit("-", 1)
+        archived_at: Optional[int] = None
+        base_slug = name
+        if len(parts) == 2:
+            head, tail = parts
+            if tail.isdigit() and len(tail) >= 9:  # epoch seconds, ~10 digits
+                base_slug = head
+                try:
+                    archived_at = int(tail)
+                except ValueError:
+                    archived_at = None
+            else:
+                # Maybe "<slug>-<ts>-<n>"; try the previous segment.
+                inner = head.rsplit("-", 1)
+                if len(inner) == 2 and inner[1].isdigit() and len(inner[1]) >= 9:
+                    base_slug = inner[0]
+                    try:
+                        archived_at = int(inner[1])
+                    except ValueError:
+                        archived_at = None
+        meta: dict[str, Any] = {}
+        try:
+            mp = child / "board.json"
+            if mp.exists():
+                raw = json.loads(mp.read_text(encoding="utf-8"))
+                if isinstance(raw, dict):
+                    meta = raw
+        except (OSError, json.JSONDecodeError):
+            meta = {}
+        # Count tasks in the archived DB so the UI can show task badges
+        # ("12 tasks would be restored"). Best-effort — broken DBs are
+        # still listable, they just report ``total: 0``.
+        counts: dict[str, int] = {}
+        db_path = child / "kanban.db"
+        if db_path.exists():
+            try:
+                conn = sqlite3.connect(str(db_path))
+                conn.row_factory = sqlite3.Row
+                try:
+                    rows = conn.execute(
+                        "SELECT status, COUNT(*) AS n FROM tasks GROUP BY status"
+                    ).fetchall()
+                    counts = {r["status"]: int(r["n"]) for r in rows}
+                finally:
+                    conn.close()
+            except sqlite3.Error:
+                counts = {}
+        out.append({
+            "slug": base_slug,
+            "name": meta.get("name") or _default_board_display_name(base_slug),
+            "description": meta.get("description", ""),
+            "icon": meta.get("icon", ""),
+            "color": meta.get("color", ""),
+            "archived_dir": str(child),
+            "archived_at": archived_at,
+            "counts": counts,
+            "total": sum(counts.values()),
+        })
+    out.sort(key=lambda r: (r.get("archived_at") or 0), reverse=True)
+    return out
+
+
+def restore_board(slug: str) -> dict:
+    """Restore an archived board back to its active directory.
+
+    Why: Users need a one-click undo for accidental archives without
+    having to drop to a shell. Mirror of :func:`remove_board` archive
+    path — moves ``_archived/<slug>-<ts>/`` → ``boards/<slug>/``.
+    What: Locates the most-recently-archived directory matching ``slug``,
+    refuses if an active board with that slug already exists, otherwise
+    renames the directory back into place. Returns
+    ``{slug, action, new_path, archived_dir}``.
+    Test: Archive a board, call ``restore_board(slug)``, assert
+    :func:`board_exists` is True for the slug and the ``_archived`` dir
+    is gone.
+    """
+    normed = _normalize_board_slug(slug)
+    if not normed:
+        raise ValueError("board slug is required")
+    if board_exists(normed) and board_dir(normed).is_dir():
+        raise ValueError(
+            f"board {normed!r} already exists — cannot restore on top of an active board"
+        )
+    root = archived_boards_root()
+    if not root.is_dir():
+        raise ValueError(f"no archived board found for slug {normed!r}")
+    # Find the most-recently-archived dir for this slug (in case of
+    # multiple archives, restore the newest).
+    matches: list[tuple[int, Path]] = []
+    for child in root.iterdir():
+        if not child.is_dir():
+            continue
+        name = child.name
+        # Match "<slug>-<digits>" or "<slug>-<digits>-<n>" exactly.
+        # Avoid prefix-collisions (slug "foo" must not match dir "foobar-...").
+        if not name.startswith(normed + "-"):
+            continue
+        remainder = name[len(normed) + 1:]
+        # Remainder must be all digits or digits-then-"-<n>".
+        head_tail = remainder.split("-", 1)
+        if not head_tail[0].isdigit():
+            continue
+        try:
+            ts = int(head_tail[0])
+        except ValueError:
+            continue
+        matches.append((ts, child))
+    if not matches:
+        raise ValueError(f"no archived board found for slug {normed!r}")
+    matches.sort(key=lambda x: x[0], reverse=True)
+    archived_dir = matches[0][1]
+    target = board_dir(normed)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    archived_dir.rename(target)
+    # If the metadata file marked it archived, flip the flag so the UI
+    # doesn't show it as archived in the active list.
+    try:
+        meta_path = target / "board.json"
+        if meta_path.exists():
+            raw = json.loads(meta_path.read_text(encoding="utf-8"))
+            if isinstance(raw, dict) and raw.get("archived"):
+                raw["archived"] = False
+                meta_path.write_text(
+                    json.dumps(raw, indent=2, ensure_ascii=False) + "\n",
+                    encoding="utf-8",
+                )
+    except (OSError, json.JSONDecodeError):
+        pass
+    return {
+        "slug": normed,
+        "action": "restored",
+        "new_path": str(target),
+        "archived_dir": str(archived_dir),
+    }
+
+
+def hard_delete_board(slug: str) -> dict:
+    """Permanently delete a board directory (active OR archived).
+
+    Why: Operator wants to reclaim disk by purging a board that's no
+    longer needed even from the archive. Separate from :func:`remove_board`
+    so the integrity checks (zero tasks) can live in the API layer
+    without touching the legacy CLI path.
+    What: Removes the board's on-disk dir (preferring the active dir,
+    falling back to ``_archived/`` matches). Caller is responsible for
+    enforcing integrity rules. Returns ``{slug, action, removed_paths}``.
+    Test: Hard-delete a board, assert the dir is gone from both
+    ``boards/`` and ``boards/_archived/``.
+    """
+    import shutil
+
+    normed = _normalize_board_slug(slug)
+    if not normed:
+        raise ValueError("board slug is required")
+    if normed == DEFAULT_BOARD:
+        raise ValueError("the 'default' board cannot be removed")
+    removed: list[str] = []
+    active = board_dir(normed)
+    if active.is_dir():
+        if get_current_board() == normed:
+            clear_current_board()
+        shutil.rmtree(active)
+        removed.append(str(active))
+    # Also purge every matching archive entry so the slug fully vanishes.
+    root = archived_boards_root()
+    if root.is_dir():
+        for child in root.iterdir():
+            if not child.is_dir():
+                continue
+            name = child.name
+            if not name.startswith(normed + "-"):
+                continue
+            remainder = name[len(normed) + 1:]
+            head_tail = remainder.split("-", 1)
+            if not head_tail[0].isdigit():
+                continue
+            shutil.rmtree(child)
+            removed.append(str(child))
+    if not removed:
+        raise ValueError(f"board {normed!r} does not exist (not active, not archived)")
+    return {"slug": normed, "action": "hard-deleted", "removed_paths": removed}
+
+
+def restore_task(conn: sqlite3.Connection, task_id: str) -> bool:
+    """Flip an archived task back to an active state.
+
+    Why: Users archive tasks aggressively as part of triage; they need a
+    one-click undo without resorting to raw SQL or the CLI.
+    What: Sets status='todo' (a safe default — task gets re-evaluated by
+    ``recompute_ready`` afterwards so parent-blocked tasks stay correct).
+    Records a ``restored`` event in ``task_events``. Returns False if the
+    task isn't archived.
+    Test: Archive a task, call ``restore_task``, assert it returns True
+    and the task's status is now 'todo'.
+    """
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT status FROM tasks WHERE id = ?", (task_id,),
+        ).fetchone()
+        if row is None:
+            return False
+        if row["status"] != "archived":
+            return False
+        # Flip to 'todo' as the safe default. ``recompute_ready`` will
+        # promote to 'ready' if no upstream blockers remain.
+        cur = conn.execute(
+            "UPDATE tasks SET status = 'todo' WHERE id = ? AND status = 'archived'",
+            (task_id,),
+        )
+        if cur.rowcount != 1:
+            return False
+        _append_event(conn, task_id, "restored", None, run_id=None)
+    # Outside the txn — recompute might mark it ready.
+    try:
+        recompute_ready(conn)
+    except Exception:
+        pass
+    return True
+
+
+# ---------------------------------------------------------------------------
 # Data classes
 # ---------------------------------------------------------------------------
 
@@ -917,6 +1175,21 @@ def connect(
         path = db_path
     else:
         path = kanban_db_path(board=board)
+    # Don't auto-resurrect a deleted board. After hard_delete_board() the
+    # board dir is gone — but stale callers (frontend with old `?board=`
+    # query, dispatcher tick with cached state, `current` pointer that
+    # wasn't cleared) would mkdir(exist_ok=True) + init schema and the
+    # board reappears. Default board is exempt — its path is the legacy
+    # root-level kanban.db, always valid.
+    if (
+        board
+        and board != DEFAULT_BOARD
+        and not path.exists()
+        and not path.parent.exists()
+    ):
+        raise FileNotFoundError(
+            f"board {board!r} does not exist on disk (deleted?)"
+        )
     path.parent.mkdir(parents=True, exist_ok=True)
     resolved = str(path.resolve())
     needs_init = resolved not in _INITIALIZED_PATHS

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -166,6 +166,25 @@
   // from under a terminal they left open.
   const LS_BOARD_KEY = "hermes.kanban.selectedBoard";
 
+  // localStorage key controlling the per-browser "Don't ask again" pref
+  // for the card delete confirmation. False by default (we always confirm
+  // because the DELETE endpoint hard-deletes the task + every derived row);
+  // user opts in by ticking the checkbox in the confirm dialog.
+  const LS_SKIP_DELETE_CONFIRM_KEY = "hermes.kanban.skipDeleteConfirm";
+
+  function readSkipDeleteConfirm() {
+    try {
+      return window.localStorage.getItem(LS_SKIP_DELETE_CONFIRM_KEY) === "1";
+    } catch (_e) { return false; }
+  }
+
+  function writeSkipDeleteConfirm(skip) {
+    try {
+      if (skip) window.localStorage.setItem(LS_SKIP_DELETE_CONFIRM_KEY, "1");
+      else window.localStorage.removeItem(LS_SKIP_DELETE_CONFIRM_KEY);
+    } catch (_e) { /* ignore quota / private mode */ }
+  }
+
   function readSelectedBoard() {
     try {
       const v = window.localStorage.getItem(LS_BOARD_KEY);
@@ -638,6 +657,28 @@
       });
     }, [loadBoard, board, t]);
 
+    // Hard-delete a task. Optimistic: pull the card off the board immediately,
+    // then call DELETE. On failure, reload to re-instate it so the UI doesn't
+    // lie about state. Drawer closes itself if the deleted task was open.
+    const deleteTask = useCallback(function (taskId) {
+      setBoardData(function (b) {
+        if (!b) return b;
+        const columns = b.columns.map(function (col) {
+          return Object.assign({}, col, {
+            tasks: col.tasks.filter(function (t) { return t.id !== taskId; }),
+          });
+        });
+        return Object.assign({}, b, { columns });
+      });
+      setSelectedTaskId(function (cur) { return cur === taskId ? null : cur; });
+      SDK.fetchJSON(withBoard(`${API}/tasks/${encodeURIComponent(taskId)}`, board), {
+        method: "DELETE",
+      }).catch(function (err) {
+        setError(tx(t, "deleteFailed", "Delete failed: ") + (err.message || err));
+        loadBoard();
+      });
+    }, [loadBoard, board, t]);
+
     const clearSelected = useCallback(function () {
       setSelectedIds(new Set());
       setLastSelectedId(null);
@@ -863,15 +904,108 @@
       });
     }, [loadBoardList, switchBoard, board]);
 
-    const deleteBoard = useCallback(function (slug) {
+    // Board lifecycle: archive (recoverable), hard-delete (zero-task rule),
+    // and restore. Each surface (Archive / Delete / Restore) calls the
+    // matching endpoint, surfaces 409 integrity errors verbatim via the
+    // existing error banner channel, and refreshes the board list on
+    // success. Cascade is plumbed through for the non-empty-archive path.
+    //
+    // Returns a Promise that resolves on success and rejects on failure
+    // so the dialog/button can show inline feedback.
+    const archiveBoard = useCallback(function (slug, opts) {
+      opts = opts || {};
       if (!slug || slug === "default") return Promise.resolve();
-      return SDK.fetchJSON(`${API}/boards/${encodeURIComponent(slug)}`, {
-        method: "DELETE",
-      }).then(function () {
+      const cascade = !!opts.cascade;
+      const qs = cascade ? "?cascade=true" : "";
+      return SDK.fetchJSON(`${API}/boards/${encodeURIComponent(slug)}/archive${qs}`, {
+        method: "POST",
+      }).then(function (res) {
+        // Optimistic: drop the archived slug from the switcher immediately
+        // so the user never sees it after a confirmed action, even if the
+        // subsequent /boards refetch races with a stale state slot.
+        setBoardList(function (prev) {
+          return (prev || []).filter(function (b) { return b.slug !== slug; });
+        });
         loadBoardList();
         if (board === slug) switchBoard("default");
+        return res;
+      }).catch(function (err) {
+        // Surface 409 integrity errors with the server-provided text.
+        const msg = (err && err.message) ? err.message : String(err);
+        setError(tx(t, "archiveBoardFailed", "Archive failed: ") + msg);
+        throw err;
       });
-    }, [board, loadBoardList, switchBoard]);
+    }, [board, loadBoardList, switchBoard, t]);
+
+    // Hard-delete with optional cascade. Cascade is the explicit opt-in for
+    // destroying a non-empty board (active + archived tasks); without it the
+    // backend returns 409 so the user can't wipe data with a single misclick.
+    // Why: see Issue 1 — clicking [Delete] on a non-empty board used to dead-
+    // end at the 409 banner with no way forward.
+    const hardDeleteBoard = useCallback(function (slug, opts) {
+      opts = opts || {};
+      if (!slug || slug === "default") return Promise.resolve();
+      const cascade = !!opts.cascade;
+      const qs = cascade ? "?delete=true&cascade=true" : "?delete=true";
+      return SDK.fetchJSON(`${API}/boards/${encodeURIComponent(slug)}${qs}`, {
+        method: "DELETE",
+      }).then(function (res) {
+        // Optimistic: drop the deleted slug from the switcher immediately
+        // (same rationale as archiveBoard — prevents a stale entry from
+        // lingering between the DELETE response and the /boards refetch).
+        setBoardList(function (prev) {
+          return (prev || []).filter(function (b) { return b.slug !== slug; });
+        });
+        loadBoardList();
+        if (board === slug) switchBoard("default");
+        return res;
+      }).catch(function (err) {
+        const msg = (err && err.message) ? err.message : String(err);
+        setError(tx(t, "deleteBoardFailed", "Delete failed: ") + msg);
+        throw err;
+      });
+    }, [board, loadBoardList, switchBoard, t]);
+
+    const restoreBoard = useCallback(function (slug) {
+      return SDK.fetchJSON(`${API}/boards/${encodeURIComponent(slug)}/restore`, {
+        method: "POST",
+      }).then(function (res) {
+        loadBoardList();
+        return res;
+      }).catch(function (err) {
+        const msg = (err && err.message) ? err.message : String(err);
+        setError(tx(t, "restoreBoardFailed", "Restore failed: ") + msg);
+        throw err;
+      });
+    }, [loadBoardList, t]);
+
+    const restoreTask = useCallback(function (taskId, taskBoard) {
+      const qs = taskBoard ? `?board=${encodeURIComponent(taskBoard)}` : "";
+      return SDK.fetchJSON(`${API}/tasks/${encodeURIComponent(taskId)}/restore${qs}`, {
+        method: "POST",
+      }).then(function (res) {
+        loadBoard();
+        return res;
+      }).catch(function (err) {
+        const msg = (err && err.message) ? err.message : String(err);
+        setError(tx(t, "restoreTaskFailed", "Restore failed: ") + msg);
+        throw err;
+      });
+    }, [loadBoard, t]);
+
+    // Back-compat: keep `deleteBoard` as a default-archive entrypoint so
+    // existing call sites work. Shift-click + button copy below give the
+    // user the explicit hard-delete affordance.
+    const deleteBoard = useCallback(function (slug, opts) {
+      opts = opts || {};
+      if (opts.hardDelete) return hardDeleteBoard(slug);
+      return archiveBoard(slug, { cascade: !!opts.cascade });
+    }, [archiveBoard, hardDeleteBoard]);
+
+    // Archive Viewer state — toggles a separate panel that lists archived
+    // boards + tasks with per-row restore buttons. Hidden by default so
+    // the main board view stays the focus.
+    const [showArchive, setShowArchive] = useState(false);
 
     // --- render -------------------------------------------------------------
     if (loading && !boardData) {
@@ -901,7 +1035,19 @@
           onSwitch: switchBoard,
           onNewClick: function () { setShowNewBoard(true); },
           onDeleteBoard: deleteBoard,
+          onHardDeleteBoard: hardDeleteBoard,
+          onArchiveBoard: archiveBoard,
+          showArchive: showArchive,
+          onToggleArchive: function () { setShowArchive(function (v) { return !v; }); },
         }),
+        showArchive ? h(ArchiveViewer, {
+          currentBoard: board,
+          onRestoreBoard: restoreBoard,
+          onRestoreTask: restoreTask,
+          onArchiveBoard: archiveBoard,
+          onHardDeleteBoard: hardDeleteBoard,
+          onClose: function () { setShowArchive(false); },
+        }) : null,
         showNewBoard ? h(NewBoardDialog, {
           onCancel: function () { setShowNewBoard(false); },
           onCreate: function (payload) {
@@ -947,6 +1093,7 @@
           selectAllInColumn,
           onMove: moveTask,
           onMoveSelected: moveSelected,
+          onDelete: deleteTask,
           onOpen: setSelectedTaskId,
           onCreate: createTask,
           allTasks: boardData.columns.reduce(function (acc, c) { return acc.concat(c.tasks); }, []),
@@ -1415,6 +1562,38 @@
       );
     }
 
+    // Hard-delete UX (shared by shift-Archive and Delete):
+    //   * Empty board (currentTotal === 0) — single confirm, fire.
+    //   * Non-empty board — TWO confirms: first describes the consequences
+    //     and recommends Archive; second is the "absolutely sure" gate.
+    //     Only then does the call go through with cascade=true. The backend
+    //     integrity rule (refuse-by-default on non-empty boards) stays
+    //     intact — even an outdated UI can't wipe data without cascade.
+    function confirmAndHardDelete() {
+      if (!props.onHardDeleteBoard) return;
+      // Backend auto-switches to default when hard-deleting the active
+      // board; frontend's post-success switchBoard in hardDeleteBoard
+      // handles UI state. No pre-switch needed (double-switch hangs load).
+      if (!currentTotal || currentTotal <= 0) {
+        const msg = tx(t, "hardDeleteEmptyBoardConfirm",
+          "Delete empty board '{name}'? This removes the directory permanently.",
+          { name: currentName });
+        if (window.confirm(msg)) {
+          props.onHardDeleteBoard(props.board, { cascade: true }).catch(function () {});
+        }
+        return;
+      }
+      const msg1 = tx(t, "hardDeleteNonEmptyBoardConfirm",
+        "Board '{name}' has {n} task(s). This will PERMANENTLY delete the board AND every task on it (active + archived). This cannot be undone. Consider Archive instead. Proceed with hard delete?",
+        { name: currentName, n: String(currentTotal) });
+      if (!window.confirm(msg1)) return;
+      const msg2 = tx(t, "hardDeleteNonEmptyBoardConfirm2",
+        "ABSOLUTELY SURE? This will destroy board '{name}' and all {n} task(s) permanently.",
+        { name: currentName, n: String(currentTotal) });
+      if (!window.confirm(msg2)) return;
+      props.onHardDeleteBoard(props.board, { cascade: true }).catch(function () {});
+    }
+
     return h("div", { className: "hermes-kanban-boardswitcher" },
       h("div", { className: "hermes-kanban-boardswitcher-inner" },
         h("div", { className: "flex flex-col gap-0.5" },
@@ -1446,20 +1625,240 @@
           className: "h-8",
           title: "Create a new board. Useful when you want an unrelated work stream (different project, different team, isolated scratch area).",
         }, tx(t, "newBoard", "+ New board")),
-        props.board !== "default"
-          ? h(Button, {
-            onClick: function () {
-              const msg = tx(t, "archiveBoardConfirm",
-                "Archive board '{name}'? It will be moved to boards/_archived/ so you can recover it later. Tasks on this board will no longer appear anywhere in the UI.",
-                { name: currentName });
-              if (window.confirm(msg)) props.onDeleteBoard(props.board);
-            },
-            size: "sm",
-            className: "h-8",
-            title: tx(t, "archiveBoardTitle", "Archive this board"),
-          }, tx(t, "archive", "Archive"))
-          : null,
+        // Archive viewer toggle. No Delete button on toolbar — destructive
+        // hard-delete is now only reachable on already-archived boards from
+        // inside the Archive panel (workflow: Archive → review → Delete).
+        h(Button, {
+          onClick: function () { if (props.onToggleArchive) props.onToggleArchive(); },
+          size: "sm",
+          className: "h-8",
+          title: tx(t, "archiveViewTitle",
+            "Show archived boards and tasks (restore or hard-delete from here)"),
+        }, props.showArchive
+          ? tx(t, "hideArchive", "Hide archive")
+          : tx(t, "showArchive", "Archive")),
       ),
+    );
+  }
+
+  // ---------------------------------------------------------------------
+  // Archive Viewer — separate panel that lists every archived board
+  // (from boards/_archived/) plus every archived task on the current
+  // board, with per-row Restore buttons. Toggled from BoardSwitcher.
+  //
+  // Two parallel fetches on mount:
+  //   GET /boards/archived              — archived board dirs
+  //   GET /tasks/archived?board=<slug>  — archived tasks on the current
+  //                                       board (avoids fan-out across
+  //                                       every active board)
+  //
+  // Restore failures bubble up as alert() so the user sees the integrity
+  // error (e.g. trying to restore a board whose slug collides with an
+  // already-active one).
+  // ---------------------------------------------------------------------
+  function ArchiveViewer(props) {
+    const { t } = useI18n();
+    const [boards, setBoards] = useState([]);
+    const [tasks, setTasks] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [reloadTick, setReloadTick] = useState(0);
+    const [allBoards, setAllBoards] = useState(false);
+
+    useEffect(function () {
+      let cancelled = false;
+      setLoading(true);
+      const boardsUrl = `${API}/boards/archived`;
+      const tasksUrl = allBoards
+        ? `${API}/tasks/archived?all_boards=true`
+        : `${API}/tasks/archived?board=${encodeURIComponent(props.currentBoard || "default")}`;
+      Promise.all([
+        SDK.fetchJSON(boardsUrl).catch(function () { return { archived_boards: [] }; }),
+        SDK.fetchJSON(tasksUrl).catch(function () { return { archived_tasks: [] }; }),
+      ]).then(function (results) {
+        if (cancelled) return;
+        setBoards(results[0].archived_boards || []);
+        setTasks(results[1].archived_tasks || []);
+        setLoading(false);
+      });
+      return function () { cancelled = true; };
+    }, [props.currentBoard, allBoards, reloadTick]);
+
+    function handleRestoreBoard(slug) {
+      const msg = tx(t, "restoreBoardConfirm",
+        "Restore archived board '{slug}'?", { slug: slug });
+      if (!window.confirm(msg)) return;
+      props.onRestoreBoard(slug)
+        .then(function () { setReloadTick(function (v) { return v + 1; }); })
+        .catch(function (err) {
+          alert(tx(t, "restoreBoardFailedAlert", "Restore failed: ") +
+            (err && err.message ? err.message : err));
+        });
+    }
+
+    function handleArchiveCurrentBoard() {
+      if (!props.onArchiveBoard) return;
+      const slug = props.currentBoard;
+      if (!slug || slug === "default") {
+        alert(tx(t, "cannotArchiveDefault",
+          "Cannot archive the 'default' board. Switch to another board first."));
+        return;
+      }
+      const msg = tx(t, "archiveBoardConfirm",
+        "Archive board '{slug}'? It will move to the archive list below " +
+        "(recoverable). All its tasks (active + archived) move with it.",
+        { slug: slug });
+      if (!window.confirm(msg)) return;
+      props.onArchiveBoard(slug, { cascade: true })
+        .then(function () { setReloadTick(function (v) { return v + 1; }); })
+        .catch(function (err) {
+          alert(tx(t, "archiveBoardFailedAlert", "Archive failed: ") +
+            (err && err.message ? err.message : err));
+        });
+    }
+
+    function handleHardDeleteArchivedBoard(slug) {
+      if (!props.onHardDeleteBoard) return;
+      const msg1 = tx(t, "hardDeleteArchivedConfirm",
+        "PERMANENTLY delete archived board '{slug}'? This wipes its " +
+        "directory from disk — cannot be undone.", { slug: slug });
+      if (!window.confirm(msg1)) return;
+      const msg2 = tx(t, "hardDeleteArchivedConfirm2",
+        "ABSOLUTELY SURE? Board '{slug}' and every task in it will be " +
+        "gone forever.", { slug: slug });
+      if (!window.confirm(msg2)) return;
+      props.onHardDeleteBoard(slug, { cascade: true })
+        .then(function () { setReloadTick(function (v) { return v + 1; }); })
+        .catch(function (err) {
+          alert(tx(t, "hardDeleteArchivedFailedAlert",
+            "Delete failed: ") + (err && err.message ? err.message : err));
+        });
+    }
+
+    function handleRestoreTask(taskId, taskBoard) {
+      props.onRestoreTask(taskId, taskBoard)
+        .then(function () { setReloadTick(function (v) { return v + 1; }); })
+        .catch(function (err) {
+          alert(tx(t, "restoreTaskFailedAlert", "Restore failed: ") +
+            (err && err.message ? err.message : err));
+        });
+    }
+
+    return h("div", { className: "hermes-kanban-archive-viewer p-4 border rounded" },
+      h("div", { className: "flex items-center gap-3 mb-3" },
+        h("div", { className: "font-medium text-sm" },
+          tx(t, "archiveViewer", "Archive")),
+        h("div", { className: "flex-1" }),
+        h("label", { className: "text-xs flex items-center gap-1" },
+          h("input", {
+            type: "checkbox",
+            checked: allBoards,
+            onChange: function (e) { setAllBoards(!!e.target.checked); },
+          }),
+          tx(t, "tasksAllBoards", "Tasks from all boards"),
+        ),
+        h(Button, {
+          size: "sm",
+          onClick: function () { setReloadTick(function (v) { return v + 1; }); },
+          title: tx(t, "refresh", "Refresh"),
+        }, tx(t, "refresh", "Refresh")),
+        // ToArchive — archives the currently active board (moves it into
+        // the list below). Hidden for the default board (can't be archived).
+        props.currentBoard && props.currentBoard !== "default"
+          ? h(Button, {
+            size: "sm",
+            onClick: handleArchiveCurrentBoard,
+            title: tx(t, "archiveCurrentBoardTitle",
+              "Move the currently active board into the archive"),
+          }, tx(t, "toArchive", "ToArchive"))
+          : null,
+        h(Button, {
+          size: "sm",
+          onClick: props.onClose,
+          title: tx(t, "closeArchive", "Close archive view"),
+        }, tx(t, "close", "Close")),
+      ),
+      loading
+        ? h("div", { className: "text-xs text-muted-foreground" },
+            tx(t, "loadingArchive", "Loading archive…"))
+        : h("div", { className: "flex flex-col gap-4" },
+          // Boards section
+          h("div", null,
+            h("div", { className: "text-xs uppercase text-muted-foreground mb-1" },
+              tx(t, "archivedBoards", "Archived boards"),
+              " (", String(boards.length), ")",
+            ),
+            boards.length === 0
+              ? h("div", { className: "text-xs text-muted-foreground italic" },
+                  tx(t, "noArchivedBoards", "No archived boards."))
+              : h("div", { className: "flex flex-col gap-1" },
+                boards.map(function (b) {
+                  const ts = b.archived_at
+                    ? new Date(b.archived_at * 1000).toLocaleString()
+                    : tx(t, "unknown", "unknown");
+                  return h("div", {
+                    key: b.archived_dir,
+                    className: "flex items-center gap-2 text-xs border rounded px-2 py-1",
+                  },
+                    h("span", { className: "font-mono" }, b.slug),
+                    h("span", { className: "text-muted-foreground" },
+                      `· ${b.total || 0} task${b.total === 1 ? "" : "s"} · ${ts}`),
+                    h("div", { className: "flex-1" }),
+                    h(Button, {
+                      size: "sm",
+                      disabled: !b.can_restore,
+                      title: b.can_restore
+                        ? tx(t, "restoreBoardTitle", "Restore this board")
+                        : tx(t, "restoreCollisionTitle",
+                          "An active board with this slug already exists"),
+                      onClick: function () { handleRestoreBoard(b.slug); },
+                    }, tx(t, "restore", "Restore")),
+                    // Per-row Delete — hard-deletes this archived board
+                    // permanently (wipes its _archived/<slug>-<ts>/ dir).
+                    // Two confirms in handleHardDeleteArchivedBoard.
+                    h(Button, {
+                      size: "sm",
+                      className: "hermes-kanban-board-delete",
+                      title: tx(t, "hardDeleteArchivedTitle",
+                        "Permanently delete this archived board"),
+                      onClick: function () { handleHardDeleteArchivedBoard(b.slug); },
+                    }, tx(t, "delete", "Delete")),
+                  );
+                }),
+              ),
+          ),
+          // Tasks section
+          h("div", null,
+            h("div", { className: "text-xs uppercase text-muted-foreground mb-1" },
+              tx(t, "archivedTasks", "Archived tasks"),
+              " (", String(tasks.length), ")",
+            ),
+            tasks.length === 0
+              ? h("div", { className: "text-xs text-muted-foreground italic" },
+                  tx(t, "noArchivedTasks", "No archived tasks on this board."))
+              : h("div", { className: "flex flex-col gap-1" },
+                tasks.map(function (tk) {
+                  return h("div", {
+                    key: (tk.board_slug || "default") + "::" + tk.id,
+                    className: "flex items-center gap-2 text-xs border rounded px-2 py-1",
+                  },
+                    h("span", { className: "font-mono text-muted-foreground" },
+                      tk.id.slice(0, 8)),
+                    h("span", { className: "truncate flex-1" }, tk.title),
+                    allBoards
+                      ? h("span", { className: "text-muted-foreground" },
+                          "[" + (tk.board_slug || "default") + "]")
+                      : null,
+                    h(Button, {
+                      size: "sm",
+                      title: tx(t, "restoreTaskTitle",
+                        "Restore this task to 'todo' status"),
+                      onClick: function () { handleRestoreTask(tk.id, tk.board_slug); },
+                    }, tx(t, "restore", "Restore")),
+                  );
+                }),
+              ),
+          ),
+        ),
     );
   }
 
@@ -1816,6 +2215,7 @@
           selectAllInColumn: props.selectAllInColumn,
           onMove: props.onMove,
           onMoveSelected: props.onMoveSelected,
+          onDelete: props.onDelete,
           onOpen: props.onOpen,
           onCreate: props.onCreate,
           allTasks: props.allTasks,
@@ -1948,6 +2348,7 @@
                       draggingSource: props.draggingTaskId && props.selectedIds.has(props.draggingTaskId) && props.selectedIds.size > 1 && props.selectedIds.has(tk.id),
                       toggleSelected: props.toggleSelected,
                       toggleRange: props.toggleRange,
+                      onDelete: props.onDelete,
                       onOpen: props.onOpen,
                     });
                   }),
@@ -1962,9 +2363,86 @@
                   draggingSource: props.draggingTaskId && props.selectedIds.has(props.draggingTaskId) && props.selectedIds.size > 1 && props.selectedIds.has(tk.id),
                   toggleSelected: props.toggleSelected,
                   toggleRange: props.toggleRange,
+                  onDelete: props.onDelete,
                   onOpen: props.onOpen,
                 });
               }),
+      ),
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Confirm-delete dialog
+  //
+  // Lightweight modal used by the card's trash icon. We can't use
+  // ``window.confirm`` because we need a "Don't ask again" checkbox to
+  // persist the user's preference into LS_SKIP_DELETE_CONFIRM_KEY. Click
+  // the shade or hit Escape to cancel.
+  // -------------------------------------------------------------------------
+
+  function DeleteConfirmDialog(props) {
+    const { t: i18n } = useI18n();
+    const [skipFuture, setSkipFuture] = useState(false);
+
+    useEffect(function () {
+      function onKey(e) {
+        if (e.key === "Escape") { e.preventDefault(); props.onCancel(); }
+        else if (e.key === "Enter") { e.preventDefault(); confirm(); }
+      }
+      window.addEventListener("keydown", onKey);
+      return function () { window.removeEventListener("keydown", onKey); };
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [props.onCancel]);
+
+    function confirm() {
+      if (skipFuture) writeSkipDeleteConfirm(true);
+      props.onConfirm();
+    }
+
+    const title = props.task && (props.task.title || props.task.id);
+
+    return h("div", {
+      className: "hermes-kanban-confirm-shade",
+      onClick: function (e) {
+        // Click on shade (not bubbled from dialog) cancels.
+        if (e.target === e.currentTarget) props.onCancel();
+      },
+    },
+      h("div", {
+        className: "hermes-kanban-confirm-dialog",
+        role: "dialog",
+        "aria-modal": "true",
+        "aria-labelledby": "hermes-kanban-confirm-title",
+      },
+        h("div", { id: "hermes-kanban-confirm-title", className: "hermes-kanban-confirm-title" },
+          tx(i18n, "deleteTaskTitle", "Delete task?")),
+        h("div", { className: "hermes-kanban-confirm-body" },
+          h("div", { className: "hermes-kanban-confirm-message" },
+            tx(i18n, "deleteTaskWarning",
+               "This permanently removes the task, its comments, events, and run history. This cannot be undone.")),
+          title ? h("div", { className: "hermes-kanban-confirm-target" },
+            title) : null,
+        ),
+        h("label", { className: "hermes-kanban-confirm-skip" },
+          h("input", {
+            type: "checkbox",
+            checked: skipFuture,
+            onChange: function (e) { setSkipFuture(e.target.checked); },
+          }),
+          h("span", null, tx(i18n, "deleteTaskDontAsk", "Don't ask again")),
+        ),
+        h("div", { className: "hermes-kanban-confirm-actions" },
+          h(Button, {
+            variant: "outline",
+            size: "sm",
+            onClick: props.onCancel,
+          }, tx(i18n, "cancel", "Cancel")),
+          h(Button, {
+            size: "sm",
+            className: "hermes-kanban-confirm-delete-btn",
+            onClick: confirm,
+          }, tx(i18n, "delete", "Delete")),
+        ),
       ),
     );
   }
@@ -1998,10 +2476,24 @@
     const { t: i18n } = useI18n();
     const t = props.task;
     const cardRef = useRef(null);
+    const [confirmOpen, setConfirmOpen] = useState(false);
 
     useEffect(function () {
       return attachTouchDrag(cardRef.current, t.id);
     }, [t.id]);
+
+    const handleTrashClick = function (e) {
+      // Stop bubbling so the card's onClick doesn't open the drawer.
+      // Also disable native drag start while the dialog is open.
+      e.stopPropagation();
+      e.preventDefault();
+      if (!props.onDelete) return;
+      if (readSkipDeleteConfirm()) {
+        props.onDelete(t.id);
+      } else {
+        setConfirmOpen(true);
+      }
+    };
 
     const handleDragStart = function (e) {
       e.dataTransfer.setData(MIME_TASK, t.id);
@@ -2050,7 +2542,16 @@
     const progress = t.progress;
     const needsAssignee = t.status === "ready" && !t.assignee;
 
-    return h("div", {
+    return h(React.Fragment, null,
+      confirmOpen ? h(DeleteConfirmDialog, {
+        task: t,
+        onCancel: function () { setConfirmOpen(false); },
+        onConfirm: function () {
+          setConfirmOpen(false);
+          if (props.onDelete) props.onDelete(t.id);
+        },
+      }) : null,
+      h("div", {
       ref: cardRef,
       "data-task-id": t.id,
       className: cn(
@@ -2126,6 +2627,37 @@
                   title: tx(i18n, "needsAssigneeHint", "Dependencies are satisfied, but the dispatcher skips this task until you assign a profile."),
                 }, tx(i18n, "needsAssignee", "Needs assignee"))
               : null,
+            props.onDelete ? h("button", {
+              type: "button",
+              className: "hermes-kanban-trash-btn",
+              title: tx(i18n, "deleteTaskHint",
+                        "Delete this task and all its history (irreversible)"),
+              "aria-label": tx(i18n, "deleteTaskAria",
+                               "Delete task ") + t.id,
+              onClick: handleTrashClick,
+              // Prevent the card's native drag from arming when the user
+              // started the gesture on the trash button.
+              onMouseDown: function (e) { e.stopPropagation(); },
+              onDragStart: function (e) { e.preventDefault(); e.stopPropagation(); },
+            },
+              h("svg", {
+                viewBox: "0 0 16 16",
+                width: "14", height: "14",
+                fill: "none",
+                stroke: "currentColor",
+                strokeWidth: "1.5",
+                strokeLinecap: "round",
+                strokeLinejoin: "round",
+                "aria-hidden": "true",
+              },
+                // Trash bin: lid, body, two vertical stripes.
+                h("path", { d: "M2.5 4h11" }),
+                h("path", { d: "M6 4V2.5a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1V4" }),
+                h("path", { d: "M4.5 4l.5 9a1 1 0 0 0 1 1h4a1 1 0 0 0 1-1l.5-9" }),
+                h("path", { d: "M7 7v5" }),
+                h("path", { d: "M9 7v5" }),
+              ),
+            ) : null,
           ),
           h("div", { className: "hermes-kanban-card-title" },
             t.title || tx(i18n, "untitled", "(untitled)")),
@@ -2147,11 +2679,46 @@
                             title: `${t.link_counts.parents} parent${t.link_counts.parents === 1 ? "" : "s"}, ${t.link_counts.children} child${t.link_counts.children === 1 ? "" : "ren"}. Children stay blocked until their parent is done.` },
                   "↔ ", t.link_counts.parents + t.link_counts.children)
               : null,
-            h("span", { className: "hermes-kanban-ago",
-                        title: t.created_at ? `Created ${t.created_at}` : "" },
-              timeAgo ? timeAgo(t.created_at) : ""),
+            (function () {
+              // "created / in-stage" age. ALWAYS render both timestamps
+              // through a slash when entered_status_at differs from
+              // created_at — even if timeAgo() collapses them to the
+              // same coarse bucket (e.g. "3h / 3h ago"). User explicitly
+              // requested both values visible: knowing the task entered
+              // the current stage in the same hour-bucket as creation
+              // is itself information ("hasn't moved yet"). We strip
+              // the trailing " ago" from each side and re-append a
+              // single " ago" at the end so the punctuation reads
+              // naturally. Special strings like "just now" / "yesterday"
+              // don't carry the " ago" suffix — we render them as-is
+              // and skip the trailing " ago" if either side lacks it.
+              // Tooltip retains both raw timestamps unchanged.
+              const createdAgo = timeAgo ? timeAgo(t.created_at) : "";
+              const enteredAgo = (timeAgo && t.entered_status_at && t.entered_status_at !== t.created_at)
+                ? timeAgo(t.entered_status_at)
+                : null;
+              let text;
+              if (!enteredAgo) {
+                // No second timestamp (status never advanced past creation)
+                // — preserve legacy single-value rendering.
+                text = createdAgo;
+              } else {
+                const stripAgo = (s) => (s && s.endsWith(" ago") ? s.slice(0, -4) : s);
+                const cShort = stripAgo(createdAgo);
+                const eShort = stripAgo(enteredAgo);
+                const bothHadAgo = createdAgo.endsWith(" ago") && enteredAgo.endsWith(" ago");
+                text = bothHadAgo
+                  ? `${cShort} / ${eShort} ago`
+                  : `${cShort} / ${eShort}`;
+              }
+              const title = t.entered_status_at && t.entered_status_at !== t.created_at
+                ? `Created ${t.created_at} / In ${t.status} since ${t.entered_status_at}`
+                : (t.created_at ? `Created ${t.created_at}` : "");
+              return h("span", { className: "hermes-kanban-ago", title }, text);
+            })(),
           ),
         ),
+      ),
       ),
     );
   }
@@ -2312,6 +2879,15 @@
     const [err, setErr] = useState(null);
     const [newComment, setNewComment] = useState("");
     const [editing, setEditing] = useState(false);
+    // Drawer collapse — when true, the modal shade + body disappear and a
+    // thin right-edge handle takes their place so the user can keep the
+    // task "pinned" while still reading the board behind it. Click the
+    // handle (or the chevron in the head) to restore. Reset every time
+    // the drawer is opened for a different task so the user always gets
+    // the full UI for a fresh open. Persisting across reloads would be
+    // surprising — leave it ephemeral.
+    const [collapsed, setCollapsed] = useState(false);
+    useEffect(function () { setCollapsed(false); }, [props.taskId]);
     // Home-channel notification toggles. homeChannels is the list of platforms
     // the user has a /sethome on; each entry has a `subscribed` bool telling
     // us whether this task is currently subscribed via that platform's home.
@@ -2461,6 +3037,40 @@
         });
     };
 
+    // Collapsed view: a thin vertical handle pinned to the right edge.
+    // The shade is omitted so clicks on the board pass through. Click the
+    // handle anywhere to restore the full drawer; click ✕ inside the handle
+    // to close entirely (same as Escape in the expanded view).
+    if (collapsed) {
+      const previewTitle = (data && data.task && data.task.title) || props.taskId;
+      return h("div", {
+        className: "hermes-kanban-drawer-handle",
+        role: "button",
+        tabIndex: 0,
+        title: tx(t, "drawerExpandHint", "Expand task drawer"),
+        onClick: function () { setCollapsed(false); },
+        onKeyDown: function (e) {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            setCollapsed(false);
+          }
+        },
+      },
+        h("button", {
+          type: "button",
+          className: "hermes-kanban-drawer-handle-close",
+          title: tx(t, "close", "Close (Esc)"),
+          "aria-label": tx(t, "close", "Close (Esc)"),
+          onClick: function (e) { e.stopPropagation(); props.onClose(); },
+        }, "×"),
+        h("span", {
+          className: "hermes-kanban-drawer-handle-chevron",
+          "aria-hidden": "true",
+        }, "‹"),
+        h("span", { className: "hermes-kanban-drawer-handle-title" }, previewTitle),
+      );
+    }
+
     return h("div", { className: "hermes-kanban-drawer-shade", onClick: props.onClose },
       h("div", {
         className: "hermes-kanban-drawer",
@@ -2468,6 +3078,14 @@
       },
         h("div", { className: "hermes-kanban-drawer-head" },
           h("span", { className: "text-xs text-muted-foreground" }, props.taskId),
+          h("button", {
+            type: "button",
+            onClick: function () { setCollapsed(true); },
+            className: "hermes-kanban-drawer-collapse",
+            title: tx(t, "drawerCollapseHint",
+                      "Collapse to right edge — keep this task pinned while reading the board"),
+            "aria-label": tx(t, "drawerCollapseAria", "Collapse drawer"),
+          }, "›"),
           h("button", {
             type: "button",
             onClick: props.onClose,

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -297,6 +297,8 @@
 }
 .hermes-kanban-ago {
   margin-left: auto;
+  font-size: 0.85em;
+  white-space: nowrap;
 }
 
 /* ---- Inline create --------------------------------------------------- */
@@ -353,7 +355,8 @@
   font-family: var(--font-mono, ui-monospace, monospace);
 }
 
-.hermes-kanban-drawer-close {
+.hermes-kanban-drawer-close,
+.hermes-kanban-drawer-collapse {
   appearance: none;
   background: transparent;
   border: 0;
@@ -363,7 +366,92 @@
   cursor: pointer;
   padding: 0 0.25rem;
 }
-.hermes-kanban-drawer-close:hover { color: var(--color-foreground); }
+.hermes-kanban-drawer-close:hover,
+.hermes-kanban-drawer-collapse:hover { color: var(--color-foreground); }
+
+/* Drawer head right-side button cluster. Without explicit grouping the
+ * close-button is space-between'd against the task id, leaving the
+ * collapse button awkwardly mid-row; group them so both sit at the right. */
+.hermes-kanban-drawer-head .hermes-kanban-drawer-collapse {
+  margin-left: auto;
+}
+
+/* Collapsed-state handle — slim vertical strip pinned to the right edge
+ * of the viewport. Acts as the restore affordance when the user has
+ * dismissed the modal shade in favor of keeping the task pinned. */
+.hermes-kanban-drawer-handle {
+  position: fixed;
+  top: 50%;
+  right: 0;
+  transform: translateY(-50%);
+  z-index: 60;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.35rem;
+  width: 1.75rem;
+  max-height: 60vh;
+  background: var(--color-card);
+  border: 1px solid var(--color-border);
+  border-right: 0;
+  border-top-left-radius: var(--radius, 0.5rem);
+  border-bottom-left-radius: var(--radius, 0.5rem);
+  box-shadow: -4px 0 12px rgba(0, 0, 0, 0.25);
+  color: var(--color-muted-foreground);
+  cursor: pointer;
+  user-select: none;
+  transition: background 0.15s, color 0.15s, transform 0.15s;
+  animation: hermes-kanban-drawer-handle-in 160ms ease-out;
+}
+.hermes-kanban-drawer-handle:hover {
+  background: color-mix(in srgb, var(--color-card) 80%, var(--color-foreground) 20%);
+  color: var(--color-foreground);
+  transform: translateY(-50%) translateX(-2px);
+}
+.hermes-kanban-drawer-handle:focus-visible {
+  outline: 2px solid var(--color-ring, currentColor);
+  outline-offset: 2px;
+}
+
+@keyframes hermes-kanban-drawer-handle-in {
+  from { transform: translate(100%, -50%); opacity: 0; }
+  to   { transform: translate(0,    -50%); opacity: 1; }
+}
+
+.hermes-kanban-drawer-handle-close {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+  opacity: 0.5;
+}
+.hermes-kanban-drawer-handle-close:hover { opacity: 1; }
+
+.hermes-kanban-drawer-handle-chevron {
+  font-size: 1rem;
+  line-height: 1;
+  opacity: 0.7;
+}
+
+/* The task title runs vertically inside the strip — limited height so it
+ * truncates rather than blowing past the strip's max-height bound. */
+.hermes-kanban-drawer-handle-title {
+  writing-mode: vertical-rl;
+  text-orientation: mixed;
+  transform: rotate(180deg);
+  font-size: 0.72rem;
+  line-height: 1.15;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-height: 40vh;
+  white-space: nowrap;
+  font-family: var(--font-mono, ui-monospace, monospace);
+}
 
 .hermes-kanban-drawer-body {
   flex: 1;
@@ -1497,4 +1585,123 @@
   gap: 0.25rem;
   font-size: 0.7rem;
   cursor: pointer;
+}
+
+/* ---- Card trash button + delete-confirm dialog ----------------------- */
+
+/* Pinned to the far-right of the first card row via margin-left: auto.
+ * Always RED so it's immediately recognisable as "destructive" — a grey
+ * version proved too easy to overlook (user feedback). Bumps to a more
+ * saturated red + scale + bg tint on hover/focus. */
+.hermes-kanban-trash-btn {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.4rem;
+  height: 1.4rem;
+  padding: 0;
+  border: 0;
+  border-radius: 0.25rem;
+  background: transparent;
+  color: var(--color-destructive, #d14a4a);
+  cursor: pointer;
+  opacity: 0.85;
+  transition: opacity 0.12s ease-out, color 0.12s, background 0.12s, transform 0.12s;
+}
+.hermes-kanban-trash-btn:focus-visible {
+  opacity: 1;
+  outline: 2px solid var(--color-destructive, #d14a4a);
+  outline-offset: 1px;
+}
+.hermes-kanban-trash-btn:hover {
+  opacity: 1;
+  color: var(--color-destructive, #d14a4a);
+  background: color-mix(in srgb, var(--color-destructive, #d14a4a) 18%, transparent);
+  transform: scale(1.08);
+}
+
+/* Modal shade — fixed full-viewport overlay above everything, including
+ * the kanban drawer (z-index 50) and the task drawer shade. */
+.hermes-kanban-confirm-shade {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: color-mix(in srgb, black 55%, transparent);
+  backdrop-filter: blur(2px);
+}
+
+.hermes-kanban-confirm-dialog {
+  max-width: 28rem;
+  width: calc(100% - 2rem);
+  background: var(--color-card, #fff);
+  color: var(--color-foreground);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius, 0.5rem);
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.35);
+  padding: 1.1rem 1.2rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.hermes-kanban-confirm-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-foreground);
+}
+
+.hermes-kanban-confirm-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  font-size: 0.85rem;
+  line-height: 1.45;
+  color: var(--color-muted-foreground);
+}
+
+.hermes-kanban-confirm-target {
+  padding: 0.35rem 0.6rem;
+  background: color-mix(in srgb, var(--color-card-subtle, var(--color-card)) 100%, transparent);
+  border: 1px solid var(--color-border);
+  border-radius: calc(var(--radius, 0.5rem) - 0.2rem);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.78rem;
+  color: var(--color-foreground);
+  word-break: break-word;
+}
+
+.hermes-kanban-confirm-skip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.78rem;
+  color: var(--color-muted-foreground);
+  cursor: pointer;
+  user-select: none;
+}
+.hermes-kanban-confirm-skip input[type="checkbox"] {
+  cursor: pointer;
+}
+
+.hermes-kanban-confirm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+/* The destructive "Delete" button uses the same shadcn Button base as
+ * the rest of the plugin; this class just paints the destructive tint
+ * on top so we don't have to rely on a SDK variant that may not exist
+ * across host versions. */
+.hermes-kanban-confirm-delete-btn {
+  background: var(--color-destructive, #d14a4a) !important;
+  color: white !important;
+  border-color: var(--color-destructive, #d14a4a) !important;
+}
+.hermes-kanban-confirm-delete-btn:hover {
+  background: color-mix(in srgb, var(--color-destructive, #d14a4a) 88%, black) !important;
 }

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -137,10 +137,121 @@ BOARD_COLUMNS: list[str] = [
 _CARD_SUMMARY_PREVIEW_CHARS = 200
 
 
+# Map current task.status → task_events.kind that records the most recent
+# transition INTO that status. Used by ``_compute_entered_status_at`` to
+# answer "when did this card enter its current column?" without adding a
+# new ``status_changed_at`` column on the tasks table.
+#
+# ``todo`` is intentionally absent: a fresh task starts in ``todo`` with no
+# dedicated entry event (``created_at`` is the natural fallback). Tasks
+# rolled back to ``todo`` from ready (``claim_rejected``) or from archived
+# (``restored``) get their entered-stage timestamp from those events instead.
+_STATUS_TO_ENTRY_EVENT: dict[str, tuple[str, ...]] = {
+    "ready":    ("promoted",),
+    "running":  ("claimed",),
+    "done":     ("completed",),
+    "blocked":  ("blocked",),
+    "archived": ("archived",),
+    "todo":     ("restored", "claim_rejected"),
+    # "triage" — no dedicated event; falls back to created_at.
+}
+
+
+def _entered_status_at_for_task(
+    conn: sqlite3.Connection, task_id: str, status: str, created_at: int,
+) -> int:
+    """Return the timestamp when ``task_id`` entered its current ``status``.
+
+    Why: Dashboard cards need a per-stage timestamp distinct from
+    ``created_at`` so operators can spot tasks stuck in ``running`` /
+    ``blocked`` independently of how old the ticket is.
+    What: Looks up the latest ``task_events.created_at`` whose ``kind``
+    matches the status's entry event; falls back to ``created_at`` when
+    no such event exists (e.g. fresh ``todo`` tasks, or ``triage``).
+    Test: Promote a task to ready, expect entered_status_at == promoted
+    event timestamp; claim it, expect entered_status_at == claimed
+    timestamp (NOT promoted).
+    """
+    kinds = _STATUS_TO_ENTRY_EVENT.get(status)
+    if not kinds:
+        return created_at
+    placeholders = ",".join("?" for _ in kinds)
+    row = conn.execute(
+        f"SELECT MAX(created_at) AS ts FROM task_events "
+        f"WHERE task_id = ? AND kind IN ({placeholders})",
+        (task_id, *kinds),
+    ).fetchone()
+    ts = row["ts"] if row else None
+    return int(ts) if ts is not None else int(created_at)
+
+
+def _batch_entered_status_at(
+    conn: sqlite3.Connection, tasks: list[kanban_db.Task],
+) -> dict[str, int]:
+    """Batch version of :func:`_entered_status_at_for_task` for list endpoints.
+
+    Why: ``GET /board`` serializes hundreds of tasks; calling the
+    per-task helper would be N+1 against ``task_events``. One grouped
+    aggregate query keeps the cost flat regardless of board size.
+    What: For each task, picks MAX(created_at) over the events matching
+    its status's entry kinds. Falls back to ``task.created_at`` when no
+    matching event exists.
+    Test: Build a board with 3 tasks in ready/running/done, call this,
+    assert each maps to its own status's event timestamp.
+    """
+    if not tasks:
+        return {}
+    # Collect every (task_id, kind) pair we care about so the WHERE clause
+    # filters tightly. We don't pre-filter by status because a task that
+    # just transitioned still has older events of the previous kinds —
+    # filtering on the *current* status's kinds is what gives us the
+    # "entered this column" semantics.
+    interest: dict[str, tuple[str, ...]] = {}
+    for t in tasks:
+        kinds = _STATUS_TO_ENTRY_EVENT.get(t.status)
+        if kinds:
+            interest[t.id] = kinds
+
+    out: dict[str, int] = {t.id: int(t.created_at) for t in tasks}
+    if not interest:
+        return out
+
+    # Build one IN-clause over the union of all kinds we need so we can
+    # do a single scan, then filter per-task client-side. This is cheaper
+    # than one query per task even for boards in the thousands.
+    all_kinds = sorted({k for ks in interest.values() for k in ks})
+    all_ids = list(interest.keys())
+    id_ph = ",".join("?" for _ in all_ids)
+    kind_ph = ",".join("?" for _ in all_kinds)
+    rows = conn.execute(
+        f"SELECT task_id, kind, MAX(created_at) AS ts "
+        f"FROM task_events "
+        f"WHERE task_id IN ({id_ph}) AND kind IN ({kind_ph}) "
+        f"GROUP BY task_id, kind",
+        (*all_ids, *all_kinds),
+    ).fetchall()
+    per_task_max: dict[str, int] = {}
+    for r in rows:
+        tid = r["task_id"]
+        kind = r["kind"]
+        # Skip rows whose kind isn't in *this* task's interest set
+        # (we widened the IN-clause for batch efficiency above).
+        if kind not in interest.get(tid, ()):
+            continue
+        ts = int(r["ts"])
+        cur = per_task_max.get(tid)
+        if cur is None or ts > cur:
+            per_task_max[tid] = ts
+    for tid, ts in per_task_max.items():
+        out[tid] = ts
+    return out
+
+
 def _task_dict(
     task: kanban_db.Task,
     *,
     latest_summary: Optional[str] = None,
+    entered_status_at: Optional[int] = None,
 ) -> dict[str, Any]:
     d = asdict(task)
     # Add derived age metrics so the UI can colour stale cards without
@@ -149,6 +260,23 @@ def _task_dict(
         d["age"] = kanban_db.task_age(task)
     except Exception:
         d["age"] = {"created_age_seconds": None, "started_age_seconds": None, "time_to_complete_seconds": None}
+    # Per-stage timestamp: when did this card enter its current column?
+    # ``entered_status_at`` is precomputed by the batch helper on list
+    # endpoints; falls back to ``None`` here (single-task callers can
+    # compute it themselves via /tasks/:id below).
+    d["entered_status_at"] = entered_status_at
+    # Derived age in seconds for the current stage, alongside the
+    # existing created/started/complete ages. ``None`` when we don't
+    # have entered_status_at yet (caller didn't pass it).
+    if entered_status_at is not None:
+        try:
+            age_block = d.get("age") or {}
+            age_block["entered_status_age_seconds"] = max(
+                0, int(time.time()) - int(entered_status_at)
+            )
+            d["age"] = age_block
+        except Exception:
+            pass
     # Surface the latest non-null run summary so dashboards don't show
     # blank cards/drawers for tasks where the worker handed off via
     # ``task_runs.summary`` (the kanban-worker pattern) instead of
@@ -411,13 +539,19 @@ def get_board(
         # for boards with hundreds of tasks). Truncated to a card-size
         # preview here — the full text is available via /tasks/:id.
         summary_map = kanban_db.latest_summaries(conn, [t.id for t in tasks])
+        # Batch-fetch entered-status timestamps in one aggregate query.
+        entered_at_map = _batch_entered_status_at(conn, tasks)
 
         for t in tasks:
             full = summary_map.get(t.id)
             preview = (
                 full[:_CARD_SUMMARY_PREVIEW_CHARS] if full else None
             )
-            d = _task_dict(t, latest_summary=preview)
+            d = _task_dict(
+                t,
+                latest_summary=preview,
+                entered_status_at=entered_at_map.get(t.id),
+            )
             d["link_counts"] = link_counts.get(t.id, {"parents": 0, "children": 0})
             d["comment_count"] = comment_counts.get(t.id, 0)
             d["progress"] = progress.get(t.id)  # None when the task has no children
@@ -464,6 +598,58 @@ def get_board(
 
 
 # ---------------------------------------------------------------------------
+# GET /tasks/archived  — MUST be registered before /tasks/{task_id} so the
+# static path doesn't get swallowed by the path-param catch-all below.
+# Powers the dashboard Archive Viewer (companion to /boards/archived).
+# ---------------------------------------------------------------------------
+
+@router.get("/tasks/archived")
+def list_archived_tasks(
+    board: Optional[str] = Query(
+        None,
+        description="Board slug to filter on (omit for the active board)",
+    ),
+    all_boards: bool = Query(
+        False,
+        description="Span every active board instead of just the selected one",
+    ),
+):
+    """Return every task with status='archived' on the chosen board(s).
+
+    Why: Dashboard Archive Viewer needs a list of archived tasks across
+    one (or all) active boards so users can spot accidental archives and
+    restore them.
+    What: When ``all_boards`` is True, iterates every active board and
+    concatenates results, tagging each task with ``board_slug``. Otherwise
+    queries just the resolved board.
+    Test: Archive a task on board A, call with ``all_boards=true``,
+    expect that task in the returned list with the right ``board_slug``.
+    """
+    out: list[dict] = []
+    if all_boards:
+        boards = kanban_db.list_boards(include_archived=False)
+        slugs = [b["slug"] for b in boards]
+    else:
+        slugs = [_resolve_board(board) or kanban_db.get_current_board()]
+    for slug in slugs:
+        if not kanban_db.board_exists(slug):
+            continue
+        conn = kanban_db.connect(board=slug)
+        try:
+            tasks = kanban_db.list_tasks(conn, include_archived=True, status="archived")
+            entered_at_map = _batch_entered_status_at(conn, tasks)
+            for t in tasks:
+                d = _task_dict(t, entered_status_at=entered_at_map.get(t.id))
+                d["board_slug"] = slug
+                out.append(d)
+        except Exception as exc:
+            log.warning("list_archived_tasks: board %s failed: %s", slug, exc)
+        finally:
+            conn.close()
+    return {"archived_tasks": out, "count": len(out)}
+
+
+# ---------------------------------------------------------------------------
 # GET /tasks/:id
 # ---------------------------------------------------------------------------
 
@@ -479,7 +665,12 @@ def get_task(task_id: str, board: Optional[str] = Query(None)):
         # operators can read the complete worker handoff without making
         # a second round-trip. Cards on /board carry a 200-char preview.
         full_summary = kanban_db.latest_summary(conn, task_id)
-        task_d = _task_dict(task, latest_summary=full_summary)
+        entered_at = _entered_status_at_for_task(
+            conn, task.id, task.status, task.created_at,
+        )
+        task_d = _task_dict(
+            task, latest_summary=full_summary, entered_status_at=entered_at,
+        )
         # Attach diagnostics so the drawer's Diagnostics section can
         # render recovery actions without a second round-trip.
         diags = _compute_task_diagnostics(conn, task_ids=[task_id])
@@ -539,7 +730,15 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
             skills=payload.skills,
         )
         task = kanban_db.get_task(conn, task_id)
-        body: dict[str, Any] = {"task": _task_dict(task) if task else None}
+        if task is not None:
+            entered_at = _entered_status_at_for_task(
+                conn, task.id, task.status, task.created_at,
+            )
+            body: dict[str, Any] = {
+                "task": _task_dict(task, entered_status_at=entered_at),
+            }
+        else:
+            body = {"task": None}
         # Surface a dispatcher-presence warning so the UI can show a
         # banner when a `ready` task would otherwise sit idle because no
         # gateway is running (or dispatch_in_gateway=false). Only emit
@@ -675,7 +874,119 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                 )
 
         updated = kanban_db.get_task(conn, task_id)
-        return {"task": _task_dict(updated) if updated else None}
+        if updated is not None:
+            entered_at = _entered_status_at_for_task(
+                conn, updated.id, updated.status, updated.created_at,
+            )
+            return {
+                "task": _task_dict(updated, entered_status_at=entered_at),
+            }
+        return {"task": None}
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# DELETE /tasks/:id  — hard-delete a task and all its derived rows.
+#
+# This is destructive and irreversible: archive (PATCH status=archived) is
+# the soft-delete path for tasks the user wants to keep in history. Use
+# DELETE only when the task is truly garbage (e.g. an accidental create,
+# a duplicate of another card, or a crashed task that's already been
+# replaced) and you don't want it cluttering audit/event queries either.
+#
+# Tables touched (no FK cascades in v1 schema, so explicit deletes):
+#   - tasks            (the row itself)
+#   - task_links       (parent_id = ? OR child_id = ?)
+#   - task_comments    (task_id = ?)
+#   - task_events      (task_id = ?)
+#   - task_runs        (task_id = ?)
+#   - kanban_notify_subs (task_id = ?)  — gateway notification subscriptions
+# ---------------------------------------------------------------------------
+
+@router.delete("/tasks/{task_id}", status_code=204)
+def delete_task(
+    task_id: str,
+    board: Optional[str] = Query(None),
+    force: bool = Query(
+        False,
+        description=(
+            "Override the status-based integrity rule. Default behaviour "
+            "(force=false) refuses hard-delete when the task is not in "
+            "{'archived', 'done'} so the dashboard can't accidentally "
+            "wipe live work."
+        ),
+    ),
+):
+    """Hard-delete a task (with terminal-status integrity rule).
+
+    Why: Soft-delete (archive) is the right path for tasks the user
+    wants to keep in history; this endpoint is for true garbage. The
+    integrity rule (only 'archived' or 'done') stops the dashboard from
+    accidentally yanking a running/blocked task and orphaning its
+    workspace.
+    What: Refuses with 409 unless the task's status is 'archived' or
+    'done', OR ``force=true`` is supplied (escape hatch for legacy
+    callers and operator override).
+    Test: Try to DELETE a 'ready' task — expect 409. DELETE a 'done'
+    task — expect 204.
+    """
+    board = _resolve_board(board)
+    conn = _conn(board=board)
+    try:
+        task = kanban_db.get_task(conn, task_id)
+        if task is None:
+            raise HTTPException(status_code=404, detail=f"task {task_id} not found")
+
+        # Integrity rule: only allow hard delete on terminal-state tasks.
+        if not force and task.status not in {"archived", "done"}:
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "error": (
+                        f"task {task_id} has status {task.status!r}; hard-delete "
+                        "is only allowed on tasks in 'archived' or 'done' "
+                        "state. Archive the task first, or pass force=true to "
+                        "override."
+                    ),
+                    "current_status": task.status,
+                },
+            )
+
+        # Close any active run with outcome='reclaimed' so the run record is
+        # consistent before we drop everything; matters if the dispatcher
+        # later joins task_runs in audit queries that survive deletes.
+        if task.status == "running" and task.current_run_id:
+            kanban_db._end_run(
+                conn, task_id,
+                outcome="reclaimed", status="reclaimed",
+                summary="task hard-deleted from dashboard while run was active",
+            )
+
+        with kanban_db.write_txn(conn):
+            conn.execute(
+                "DELETE FROM task_links WHERE parent_id = ? OR child_id = ?",
+                (task_id, task_id),
+            )
+            conn.execute("DELETE FROM task_comments WHERE task_id = ?", (task_id,))
+            conn.execute("DELETE FROM task_events WHERE task_id = ?", (task_id,))
+            conn.execute("DELETE FROM task_runs WHERE task_id = ?", (task_id,))
+            # kanban_notify_subs may not exist on older boards — guard.
+            try:
+                conn.execute(
+                    "DELETE FROM kanban_notify_subs WHERE task_id = ?",
+                    (task_id,),
+                )
+            except sqlite3.OperationalError:
+                pass
+            cur = conn.execute("DELETE FROM tasks WHERE id = ?", (task_id,))
+            if cur.rowcount != 1:
+                # Concurrent delete or row vanished between our get_task and
+                # the actual DELETE — surface as 404 so the UI removes the
+                # card either way.
+                raise HTTPException(status_code=404, detail=f"task {task_id} not found")
+        # Returning None with status_code=204 means FastAPI emits no body.
+        return None
     finally:
         conn.close()
 
@@ -1497,14 +1808,317 @@ def rename_board(slug: str, payload: RenameBoardBody):
     return {"board": meta}
 
 
-@router.delete("/boards/{slug}")
-def delete_board(slug: str, delete: bool = Query(False, description="Hard-delete instead of archive")):
-    """Archive (default) or hard-delete a board."""
+# ---------------------------------------------------------------------------
+# Board lifecycle: archive / restore / hard-delete + archive viewer
+#
+# Integrity rules (enforced here AND mirrored in the dashboard UI):
+#
+#   * "default" board cannot be archived or hard-deleted (kanban_db enforces
+#     this at the function level — we surface the error as 409).
+#   * Cannot archive the currently-active board — user must ``switch`` first.
+#   * Archive of a board with non-archived tasks requires ``cascade=true``;
+#     otherwise refuses with 409 so the user has to decide explicitly.
+#   * Hard-delete of a board requires zero tasks (active OR archived).
+#   * Hard-delete of a task requires status in {archived, done}.
+#   * Restoring a board re-creates the on-disk directory; refuses if a
+#     board with the same slug already exists in the active set.
+#
+# Every integrity refusal returns HTTP 409 with a JSON body containing a
+# clear ``error`` field so the dashboard can render the message verbatim.
+# ---------------------------------------------------------------------------
+
+
+def _board_task_status_counts(slug: str) -> dict[str, int]:
+    """Return ``{status: count}`` for a board's task table.
+
+    Why: Integrity checks (cascade, hard-delete, restore) need to know
+    how many active and archived tasks the board has — separate from
+    :func:`_board_counts` which is also used as a UI hint.
+    What: Opens the board's DB, runs a GROUP BY on ``tasks.status``.
+    Test: Create 2 todo tasks + 1 archived, expect ``{"todo": 2,
+    "archived": 1}`` for that board.
+    """
     try:
-        res = kanban_db.remove_board(slug, archive=not delete)
+        path = kanban_db.kanban_db_path(board=slug)
+        if not path.exists():
+            return {}
+        conn = kanban_db.connect(board=slug)
+        try:
+            rows = conn.execute(
+                "SELECT status, COUNT(*) AS n FROM tasks GROUP BY status",
+            ).fetchall()
+            return {r["status"]: int(r["n"]) for r in rows}
+        finally:
+            conn.close()
+    except Exception:
+        return {}
+
+
+def _non_archived_total(status_counts: dict[str, int]) -> int:
+    """Sum of every status that is NOT 'archived' (== "live" task count)."""
+    return sum(n for s, n in status_counts.items() if s != "archived")
+
+
+@router.get("/boards/archived")
+def list_archived_boards():
+    """Return every archived board directory with parsed metadata.
+
+    Why: Powers the dashboard's Archive Viewer tab so users can find
+    boards they archived earlier (by accident or intentionally).
+    What: Wraps :func:`kanban_db.list_archived_boards` and adds a
+    ``can_restore`` hint per row (false when an active board with the
+    same slug already exists).
+    Test: Archive one board, GET /boards/archived → 1 entry with
+    ``can_restore=true``.
+    """
+    rows = kanban_db.list_archived_boards()
+    active_slugs = {b["slug"] for b in kanban_db.list_boards(include_archived=False)}
+    for r in rows:
+        r["can_restore"] = r["slug"] not in active_slugs
+    return {"archived_boards": rows, "count": len(rows)}
+
+
+# NOTE: ``GET /tasks/archived`` is registered earlier in the file (just
+# before ``GET /tasks/{task_id}``) so the static path matches before the
+# path-param catch-all. See ``list_archived_tasks`` near the top.
+
+
+@router.post("/boards/{slug}/archive")
+def archive_board_endpoint(
+    slug: str,
+    cascade: bool = Query(
+        False,
+        description="Also archive every non-archived task on this board",
+    ),
+):
+    """Archive a board (move on-disk to ``boards/_archived/``).
+
+    Why: Replaces the legacy ``DELETE /boards/{slug}`` archive path with
+    an explicit, structured verb so the dashboard UI can distinguish
+    archive (recoverable) from hard delete (destructive) without relying
+    on a query-param flag.
+    What: Enforces integrity rules (not 'default', not active, no live
+    tasks unless ``cascade=true``), then calls :func:`kanban_db.remove_board`
+    with ``archive=True``. When ``cascade=true``, archives every
+    non-archived task first.
+    Test: Archive a non-default board with tasks and cascade=true,
+    assert all tasks transition to status='archived' and the dir moves
+    to ``boards/_archived/``.
+    """
+    try:
+        normed = kanban_db._normalize_board_slug(slug)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
+    if not normed:
+        raise HTTPException(status_code=400, detail="board slug is required")
+    if normed == kanban_db.DEFAULT_BOARD:
+        raise HTTPException(
+            status_code=409,
+            detail={"error": "the 'default' board cannot be archived"},
+        )
+    if not kanban_db.board_exists(normed):
+        raise HTTPException(status_code=404, detail=f"board {normed!r} does not exist")
+    if kanban_db.get_current_board() == normed:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error": (
+                    f"cannot archive {normed!r} while it is the active board — "
+                    "switch to another board first"
+                ),
+            },
+        )
+
+    counts = _board_task_status_counts(normed)
+    live = _non_archived_total(counts)
+    if live > 0 and not cascade:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error": (
+                    f"board {normed!r} has {live} non-archived task(s); pass "
+                    "cascade=true to archive them along with the board"
+                ),
+                "live_task_count": live,
+                "counts": counts,
+            },
+        )
+
+    cascaded_ids: list[str] = []
+    if live > 0 and cascade:
+        conn = kanban_db.connect(board=normed)
+        try:
+            tasks = kanban_db.list_tasks(conn, include_archived=False)
+            for t in tasks:
+                if t.status != "archived":
+                    try:
+                        if kanban_db.archive_task(conn, t.id):
+                            cascaded_ids.append(t.id)
+                    except Exception as exc:
+                        log.warning("cascade archive failed for %s: %s", t.id, exc)
+        finally:
+            conn.close()
+
+    try:
+        res = kanban_db.remove_board(normed, archive=True)
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail={"error": str(exc)})
+    return {
+        "result": res,
+        "cascade_archived_tasks": cascaded_ids,
+        "current": kanban_db.get_current_board(),
+    }
+
+
+@router.post("/boards/{slug}/restore")
+def restore_board_endpoint(slug: str):
+    """Restore an archived board back to the active list.
+
+    Why: One-click undo for accidental archives.
+    What: Moves ``boards/_archived/<slug>-<ts>/`` → ``boards/<slug>/``.
+    Refuses (409) if an active board with the same slug already exists.
+    Test: Archive a board, call this endpoint, assert ``board_exists``
+    returns True for the slug.
+    """
+    try:
+        res = kanban_db.restore_board(slug)
+    except ValueError as exc:
+        msg = str(exc)
+        # "already exists" → 409 conflict; otherwise 404 (no such archive).
+        status_code = 409 if "already exists" in msg else 404
+        raise HTTPException(status_code=status_code, detail={"error": msg})
+    return {"result": res}
+
+
+@router.delete("/boards/{slug}")
+def delete_board(
+    slug: str,
+    delete: bool = Query(
+        False,
+        description="Hard-delete (destructive) instead of archive. Default = archive.",
+    ),
+    cascade: bool = Query(
+        False,
+        description=(
+            "Archive mode: also archive every non-archived task. "
+            "Hard-delete mode: opt-in to destroy a non-empty board "
+            "(directory + every task, active and archived, are purged)."
+        ),
+    ),
+):
+    """Archive (default) or hard-delete a board.
+
+    Why: Backwards-compatible entry point for the existing dashboard
+    bundle which still emits ``DELETE /boards/{slug}``. New code should
+    prefer ``POST /boards/{slug}/archive`` (explicit) or this endpoint
+    with ``delete=true`` (hard delete; ``cascade=true`` opts in to
+    destroying a non-empty board outright).
+    What: With ``delete=false`` (default) → behaves like the archive
+    endpoint above (cascade rules included). With ``delete=true`` →
+    refuses on a non-empty board unless ``cascade=true``; on success
+    purges every on-disk trace (active dir + every matching
+    ``_archived/<slug>-*/`` entry, including all tasks inside).
+    Test: Try ``delete=true`` on a non-empty board — expect 409 with
+    ``task_count`` in detail. Same call with ``cascade=true`` → 200 and
+    the entire board (active + archived dirs) is removed.
+    """
+    try:
+        normed = kanban_db._normalize_board_slug(slug)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    if not normed:
+        raise HTTPException(status_code=400, detail="board slug is required")
+    if normed == kanban_db.DEFAULT_BOARD:
+        raise HTTPException(
+            status_code=409,
+            detail={"error": "the 'default' board cannot be removed"},
+        )
+
+    if not delete:
+        # Archive path — defer to the explicit archive endpoint logic.
+        return archive_board_endpoint(slug=normed, cascade=cascade)
+
+    # Hard-delete path. Auto-switch to default if it's the active board —
+    # the dashboard always intends to remove the current board, so a 409
+    # here just adds friction. We DON'T do this for the legacy archive
+    # path because archive is the recoverable action.
+    if kanban_db.get_current_board() == normed:
+        kanban_db.set_current_board(kanban_db.DEFAULT_BOARD)
+
+    # Non-empty board requires explicit cascade=true opt-in. The integrity
+    # rule (refuse-by-default) stays intentional — accidental clicks on a
+    # board with content must NOT silently destroy data. Cascade is the
+    # power-user / dashboard-confirmed path.
+    counts = _board_task_status_counts(normed)
+    total = sum(counts.values())
+    if total > 0 and not cascade:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error": (
+                    f"board {normed!r} has {total} task(s) (active or archived); "
+                    "pass cascade=true to hard-delete the board AND every "
+                    "task on it (irreversible). Consider archive (POST "
+                    "/boards/{slug}/archive?cascade=true) for a "
+                    "recoverable delete."
+                ),
+                "task_count": total,
+                "counts": counts,
+            },
+        )
+
+    try:
+        res = kanban_db.hard_delete_board(normed)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail={"error": str(exc)})
     return {"result": res, "current": kanban_db.get_current_board()}
+
+
+@router.post("/tasks/{task_id}/restore")
+def restore_task_endpoint(task_id: str, board: Optional[str] = Query(None)):
+    """Restore an archived task back to status='todo'.
+
+    Why: One-click undo for archived tasks from the dashboard Archive
+    Viewer.
+    What: Calls :func:`kanban_db.restore_task`; refuses (409) if the task
+    isn't currently archived.
+    Test: Archive a task, call this endpoint, assert the task's status
+    is 'todo' afterwards.
+    """
+    board = _resolve_board(board)
+    conn = _conn(board=board)
+    try:
+        task = kanban_db.get_task(conn, task_id)
+        if task is None:
+            raise HTTPException(status_code=404, detail=f"task {task_id} not found")
+        if task.status != "archived":
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "error": (
+                        f"task {task_id} is not archived (current status: "
+                        f"{task.status!r}); nothing to restore"
+                    ),
+                },
+            )
+        ok = kanban_db.restore_task(conn, task_id)
+        if not ok:
+            raise HTTPException(
+                status_code=409,
+                detail={"error": f"failed to restore task {task_id}"},
+            )
+        updated = kanban_db.get_task(conn, task_id)
+        if updated is not None:
+            entered_at = _entered_status_at_for_task(
+                conn, updated.id, updated.status, updated.created_at,
+            )
+            return {
+                "ok": True,
+                "task": _task_dict(updated, entered_status_at=entered_at),
+            }
+        return {"ok": True, "task": None}
+    finally:
+        conn.close()
 
 
 @router.post("/boards/{slug}/switch")

--- a/tests/plugins/kanban/test_board_archive_api.py
+++ b/tests/plugins/kanban/test_board_archive_api.py
@@ -1,0 +1,540 @@
+"""Tests for the Kanban board archive / restore / hard-delete API.
+
+Covers the 7 new endpoints added in feat/kanban-board-archive-ui:
+
+  * POST   /boards/{slug}/archive            — archive (cascade optional)
+  * POST   /boards/{slug}/restore            — un-archive
+  * DELETE /boards/{slug}                    — hard delete (zero-task rule)
+  * GET    /boards/archived                  — archive viewer (boards)
+  * GET    /tasks/archived                   — archive viewer (tasks)
+  * POST   /tasks/{task_id}/restore          — un-archive a task
+  * DELETE /tasks/{task_id}                  — hard delete (terminal-only rule)
+
+Plus the integrity rules:
+
+  * Default board protected (no archive, no hard delete).
+  * Currently-active board can't be archived.
+  * Archive with non-archived tasks requires cascade.
+  * Hard-delete needs zero tasks total.
+  * Hard-delete of a task needs status in {archived, done}.
+
+The fixtures mock the filesystem via ``tmp_path`` + ``HERMES_HOME`` so the
+real ``/opt/data/kanban/...`` tree is never touched.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from hermes_cli import kanban_db as kb
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — mirror tests/plugins/test_kanban_dashboard_plugin.py so the
+# new tests live in the same isolated tmp_path / HERMES_HOME environment.
+# ---------------------------------------------------------------------------
+
+
+def _load_plugin_router():
+    """Dynamically load plugins/kanban/dashboard/plugin_api.py and return its router."""
+    repo_root = Path(__file__).resolve().parents[3]
+    plugin_file = repo_root / "plugins" / "kanban" / "dashboard" / "plugin_api.py"
+    assert plugin_file.exists(), f"plugin file missing: {plugin_file}"
+
+    spec = importlib.util.spec_from_file_location(
+        "hermes_dashboard_plugin_kanban_archive_test",
+        plugin_file,
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod.router
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with an empty kanban DB."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+@pytest.fixture
+def client(kanban_home):
+    app = FastAPI()
+    app.include_router(_load_plugin_router(), prefix="/api/plugins/kanban")
+    return TestClient(app)
+
+
+def _create_board(client, slug, switch=False):
+    r = client.post(
+        "/api/plugins/kanban/boards",
+        json={"slug": slug, "switch": switch},
+    )
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+def _create_task(client, title, board=None, status=None):
+    """Create a task on ``board`` (default if None); optionally re-status it."""
+    url = "/api/plugins/kanban/tasks"
+    if board:
+        url = f"{url}?board={board}"
+    r = client.post(url, json={"title": title})
+    assert r.status_code == 200, r.text
+    task = r.json()["task"]
+    if status and status != task["status"]:
+        patch_url = f"/api/plugins/kanban/tasks/{task['id']}"
+        if board:
+            patch_url = f"{patch_url}?board={board}"
+        rp = client.patch(patch_url, json={"status": status})
+        assert rp.status_code == 200, rp.text
+        task = rp.json()["task"]
+    return task
+
+
+# ---------------------------------------------------------------------------
+# POST /boards/{slug}/archive  — happy paths + integrity rules
+# ---------------------------------------------------------------------------
+
+
+def test_archive_default_board_refused(client):
+    """Default board cannot be archived."""
+    r = client.post("/api/plugins/kanban/boards/default/archive")
+    assert r.status_code == 409
+    body = r.json()
+    assert "default" in str(body).lower()
+
+
+def test_archive_active_board_refused(client):
+    """Currently-active board cannot be archived — user must switch first."""
+    _create_board(client, "proj-a", switch=True)
+    r = client.post("/api/plugins/kanban/boards/proj-a/archive")
+    assert r.status_code == 409
+    assert "active" in r.json()["detail"]["error"].lower()
+
+
+def test_archive_empty_board(client):
+    """Empty board archives cleanly — moves to boards/_archived/."""
+    _create_board(client, "proj-a", switch=False)
+    r = client.post("/api/plugins/kanban/boards/proj-a/archive")
+    assert r.status_code == 200, r.text
+    res = r.json()["result"]
+    assert res["action"] == "archived"
+    assert Path(res["new_path"]).exists()
+
+    # GET /boards/archived now shows it
+    r = client.get("/api/plugins/kanban/boards/archived")
+    assert r.status_code == 200
+    rows = r.json()["archived_boards"]
+    slugs = [row["slug"] for row in rows]
+    assert "proj-a" in slugs
+
+
+def test_archive_nonempty_without_cascade_refused(client):
+    """Board with live tasks needs cascade=true to archive."""
+    _create_board(client, "proj-a", switch=False)
+    _create_task(client, "live task", board="proj-a")
+    r = client.post("/api/plugins/kanban/boards/proj-a/archive")
+    assert r.status_code == 409
+    detail = r.json()["detail"]
+    assert detail["live_task_count"] == 1
+    assert "cascade" in detail["error"].lower()
+
+
+def test_archive_with_cascade_archives_tasks(client):
+    """cascade=true archives every non-archived task, then the board."""
+    _create_board(client, "proj-a", switch=False)
+    t1 = _create_task(client, "live task", board="proj-a")
+    _create_task(client, "another live one", board="proj-a")
+    r = client.post(
+        "/api/plugins/kanban/boards/proj-a/archive?cascade=true",
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert len(body["cascade_archived_tasks"]) == 2
+    assert t1["id"] in body["cascade_archived_tasks"]
+    # Board directory should have moved under _archived/.
+    assert Path(body["result"]["new_path"]).exists()
+
+
+# ---------------------------------------------------------------------------
+# POST /boards/{slug}/restore
+# ---------------------------------------------------------------------------
+
+
+def test_restore_archived_board(client):
+    """Archived board can be restored back to the active list."""
+    _create_board(client, "proj-a", switch=False)
+    archive = client.post("/api/plugins/kanban/boards/proj-a/archive").json()
+    assert archive["result"]["action"] == "archived"
+
+    r = client.post("/api/plugins/kanban/boards/proj-a/restore")
+    assert r.status_code == 200, r.text
+    res = r.json()["result"]
+    assert res["action"] == "restored"
+    assert Path(res["new_path"]).exists()
+
+    # Board is back in the active list.
+    r = client.get("/api/plugins/kanban/boards")
+    slugs = [b["slug"] for b in r.json()["boards"]]
+    assert "proj-a" in slugs
+
+
+def test_restore_when_active_collides_refused(client):
+    """Refuse restore if an active board with the same slug exists."""
+    _create_board(client, "proj-a", switch=False)
+    client.post("/api/plugins/kanban/boards/proj-a/archive")
+    # Re-create an active board with the same slug.
+    _create_board(client, "proj-a", switch=False)
+    r = client.post("/api/plugins/kanban/boards/proj-a/restore")
+    assert r.status_code == 409
+    assert "already exists" in r.json()["detail"]["error"].lower()
+
+
+def test_restore_unknown_archive_404(client):
+    """No archived board with this slug → 404."""
+    r = client.post("/api/plugins/kanban/boards/never-existed/restore")
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# DELETE /boards/{slug}  — hard delete
+# ---------------------------------------------------------------------------
+
+
+def test_hard_delete_default_refused(client):
+    """Default board cannot be hard-deleted."""
+    r = client.delete("/api/plugins/kanban/boards/default?delete=true")
+    assert r.status_code == 409
+
+
+def test_hard_delete_active_board_refused(client):
+    """Currently-active board cannot be hard-deleted."""
+    _create_board(client, "proj-a", switch=True)
+    r = client.delete("/api/plugins/kanban/boards/proj-a?delete=true")
+    assert r.status_code == 409
+    assert "active" in r.json()["detail"]["error"].lower()
+
+
+def test_hard_delete_with_archived_tasks_refused(client):
+    """Hard delete must refuse (409) when ANY task exists and cascade is absent.
+
+    Why: Default-safety — a single misclick on Delete must not silently
+    wipe an entire board (active + archived tasks). Cascade=true is the
+    explicit opt-in (see test_hard_delete_with_cascade_destroys_everything).
+    """
+    _create_board(client, "proj-a", switch=False)
+    t = _create_task(client, "to archive", board="proj-a")
+    # Archive the task — leaves a row with status='archived'.
+    rp = client.patch(
+        f"/api/plugins/kanban/tasks/{t['id']}?board=proj-a",
+        json={"status": "archived"},
+    )
+    assert rp.status_code == 200, rp.text
+
+    r = client.delete("/api/plugins/kanban/boards/proj-a?delete=true")
+    assert r.status_code == 409
+    body = r.json()["detail"]
+    assert body["task_count"] == 1
+    # New wording points the user at the cascade opt-in.
+    assert "cascade=true" in body["error"].lower()
+
+
+def test_hard_delete_with_cascade_destroys_everything(client):
+    """Hard delete with cascade=true purges a non-empty board outright.
+
+    Why: User explicitly confirmed (via the dashboard's two-step warning)
+    that they want the board AND every task on it gone forever.
+    What: ``DELETE /boards/X?delete=true&cascade=true`` succeeds even
+    when the board has active + archived tasks. ``hard_delete_board``
+    removes the on-disk directory (and any ``_archived/<slug>-*/``),
+    so all task rows go with it.
+    Test: Create board with 1 active + 1 archived task; cascade-delete;
+    assert board dir + every archive dir for the slug are gone.
+    """
+    _create_board(client, "proj-a", switch=False)
+    _create_task(client, "active one", board="proj-a")
+    t2 = _create_task(client, "archived one", board="proj-a")
+    rp = client.patch(
+        f"/api/plugins/kanban/tasks/{t2['id']}?board=proj-a",
+        json={"status": "archived"},
+    )
+    assert rp.status_code == 200, rp.text
+
+    r = client.delete(
+        "/api/plugins/kanban/boards/proj-a?delete=true&cascade=true",
+    )
+    assert r.status_code == 200, r.text
+    res = r.json()["result"]
+    assert res["action"] == "hard-deleted"
+    for p in res["removed_paths"]:
+        assert not Path(p).exists(), f"path should be gone: {p}"
+
+    # GET /boards must NOT list 'proj-a' any more.
+    rlist = client.get("/api/plugins/kanban/boards")
+    assert rlist.status_code == 200
+    slugs = [b["slug"] for b in rlist.json()["boards"]]
+    assert "proj-a" not in slugs
+
+
+def test_hard_delete_empty_board(client):
+    """Empty board hard-deletes cleanly — dir removed, no archive entry."""
+    _create_board(client, "proj-a", switch=False)
+    r = client.delete("/api/plugins/kanban/boards/proj-a?delete=true")
+    assert r.status_code == 200, r.text
+    res = r.json()["result"]
+    assert res["action"] == "hard-deleted"
+    assert len(res["removed_paths"]) >= 1
+    for p in res["removed_paths"]:
+        assert not Path(p).exists(), f"path should be gone: {p}"
+
+
+def test_list_boards_excludes_archived_after_archive(client):
+    """After archive, GET /boards (default include_archived=False) must
+    NOT return the archived slug.
+
+    Why: Regression test for the selector-shows-archived UX bug. Drives
+    the backend's filter contract that the dashboard switcher relies on.
+    What: Archive a board, GET /boards, assert the slug is not in the
+    list AND show that include_archived=true still surfaces it via
+    /boards/archived (the dedicated archive viewer endpoint).
+    Test: Create 'квантс', archive while non-current, list boards →
+    no 'квантс'. Then GET /boards/archived → 'квантс' present.
+    """
+    _create_board(client, "kvants", switch=False)
+    r = client.post("/api/plugins/kanban/boards/kvants/archive")
+    assert r.status_code == 200, r.text
+
+    rlist = client.get("/api/plugins/kanban/boards")
+    assert rlist.status_code == 200
+    body = rlist.json()
+    slugs = [b["slug"] for b in body["boards"]]
+    assert "kvants" not in slugs, (
+        f"archived 'kvants' must not appear in /boards (got {slugs})"
+    )
+    # Sanity: it's still reachable via the archive viewer.
+    rarch = client.get("/api/plugins/kanban/boards/archived")
+    arch_slugs = [b["slug"] for b in rarch.json()["archived_boards"]]
+    assert "kvants" in arch_slugs
+
+
+def test_archive_active_board_via_switch_then_archive(client):
+    """End-to-end: switch off the to-be-archived board, then archive it,
+    and verify the selector list reflects the change.
+
+    Why: Real user flow from the field — they archived the currently
+    active board (failed with 409), so the UI switches to default
+    automatically and re-issues archive.
+    Test: 'квантс' is current → archive refused (409). Switch to
+    default → archive succeeds. /boards no longer lists it; current
+    is 'default'.
+    """
+    _create_board(client, "kvants", switch=True)
+
+    # Step 1: cannot archive while active.
+    r = client.post("/api/plugins/kanban/boards/kvants/archive")
+    assert r.status_code == 409
+
+    # Step 2: switch to default, then archive cleanly.
+    rs = client.post("/api/plugins/kanban/boards/default/switch")
+    assert rs.status_code == 200, rs.text
+    r = client.post("/api/plugins/kanban/boards/kvants/archive")
+    assert r.status_code == 200, r.text
+
+    # /boards no longer surfaces 'kvants'; current is 'default'.
+    rlist = client.get("/api/plugins/kanban/boards").json()
+    assert rlist["current"] == "default"
+    assert "kvants" not in {b["slug"] for b in rlist["boards"]}
+
+
+def test_delete_default_archive_path_uses_archive(client):
+    """``DELETE /boards/{slug}`` (no ``delete=true``) is the archive path."""
+    _create_board(client, "proj-a", switch=False)
+    r = client.delete("/api/plugins/kanban/boards/proj-a")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["result"]["action"] == "archived"
+
+
+# ---------------------------------------------------------------------------
+# GET /boards/archived  and  GET /tasks/archived
+# ---------------------------------------------------------------------------
+
+
+def test_list_archived_boards_empty(client):
+    """No archived boards → empty list, count=0."""
+    r = client.get("/api/plugins/kanban/boards/archived")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["count"] == 0
+    assert body["archived_boards"] == []
+
+
+def test_list_archived_boards_after_archive(client):
+    """Archive 2 boards, both appear with can_restore=true."""
+    _create_board(client, "proj-a", switch=False)
+    _create_board(client, "proj-b", switch=False)
+    client.post("/api/plugins/kanban/boards/proj-a/archive")
+    client.post("/api/plugins/kanban/boards/proj-b/archive")
+    r = client.get("/api/plugins/kanban/boards/archived")
+    assert r.status_code == 200
+    rows = r.json()["archived_boards"]
+    slugs = {row["slug"] for row in rows}
+    assert {"proj-a", "proj-b"} <= slugs
+    for row in rows:
+        assert row["can_restore"] is True
+
+
+def test_list_archived_tasks_current_board(client):
+    """``/tasks/archived`` returns archived tasks on the active board."""
+    t = _create_task(client, "t-on-default")
+    rp = client.patch(
+        f"/api/plugins/kanban/tasks/{t['id']}",
+        json={"status": "archived"},
+    )
+    assert rp.status_code == 200, rp.text
+
+    r = client.get("/api/plugins/kanban/tasks/archived")
+    assert r.status_code == 200
+    rows = r.json()["archived_tasks"]
+    assert len(rows) == 1
+    assert rows[0]["id"] == t["id"]
+    assert rows[0]["board_slug"] == "default"
+
+
+def test_list_archived_tasks_all_boards(client):
+    """``all_boards=true`` aggregates across every active board."""
+    _create_board(client, "proj-a", switch=False)
+    t1 = _create_task(client, "task on a", board="proj-a")
+    t2 = _create_task(client, "task on default")
+    # Archive both.
+    client.patch(
+        f"/api/plugins/kanban/tasks/{t1['id']}?board=proj-a",
+        json={"status": "archived"},
+    )
+    client.patch(
+        f"/api/plugins/kanban/tasks/{t2['id']}",
+        json={"status": "archived"},
+    )
+    r = client.get("/api/plugins/kanban/tasks/archived?all_boards=true")
+    assert r.status_code == 200
+    rows = r.json()["archived_tasks"]
+    by_board = {row["board_slug"] for row in rows}
+    assert by_board == {"default", "proj-a"}
+
+
+# ---------------------------------------------------------------------------
+# POST /tasks/{task_id}/restore
+# ---------------------------------------------------------------------------
+
+
+def test_restore_archived_task(client):
+    """Archived task flips back to 'todo'."""
+    t = _create_task(client, "to restore")
+    client.patch(
+        f"/api/plugins/kanban/tasks/{t['id']}",
+        json={"status": "archived"},
+    )
+    r = client.post(f"/api/plugins/kanban/tasks/{t['id']}/restore")
+    assert r.status_code == 200, r.text
+    restored = r.json()["task"]
+    # 'todo' or 'ready' both acceptable — recompute_ready may promote.
+    assert restored["status"] in {"todo", "ready"}
+
+
+def test_restore_non_archived_task_refused(client):
+    """Restoring a task that isn't archived → 409."""
+    t = _create_task(client, "live task")
+    r = client.post(f"/api/plugins/kanban/tasks/{t['id']}/restore")
+    assert r.status_code == 409
+    assert "not archived" in r.json()["detail"]["error"].lower()
+
+
+def test_restore_unknown_task_404(client):
+    r = client.post("/api/plugins/kanban/tasks/t_doesnt_exist/restore")
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# DELETE /tasks/{task_id}  — terminal-status integrity rule
+# ---------------------------------------------------------------------------
+
+
+def test_hard_delete_task_refused_unless_terminal(client):
+    """Hard delete refuses when status not in {archived, done}."""
+    t = _create_task(client, "live task")
+    # Status is 'ready' (no parents → auto-promoted on create).
+    r = client.delete(f"/api/plugins/kanban/tasks/{t['id']}")
+    assert r.status_code == 409
+    detail = r.json()["detail"]
+    assert detail["current_status"] in {"ready", "todo"}
+
+
+def test_hard_delete_archived_task(client):
+    """Hard delete of an archived task succeeds (204)."""
+    t = _create_task(client, "to archive then delete")
+    client.patch(
+        f"/api/plugins/kanban/tasks/{t['id']}",
+        json={"status": "archived"},
+    )
+    r = client.delete(f"/api/plugins/kanban/tasks/{t['id']}")
+    assert r.status_code == 204
+
+
+def test_hard_delete_done_task(client):
+    """Hard delete of a done task succeeds."""
+    t = _create_task(client, "complete me")
+    client.patch(
+        f"/api/plugins/kanban/tasks/{t['id']}",
+        json={"status": "done"},
+    )
+    r = client.delete(f"/api/plugins/kanban/tasks/{t['id']}")
+    assert r.status_code == 204
+
+
+def test_hard_delete_force_overrides(client):
+    """force=true allows hard delete of a live task (escape hatch)."""
+    t = _create_task(client, "force-deleted")
+    r = client.delete(f"/api/plugins/kanban/tasks/{t['id']}?force=true")
+    assert r.status_code == 204
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: archive board → restore → tasks still accessible
+# ---------------------------------------------------------------------------
+
+
+def test_round_trip_archive_then_restore_preserves_tasks(client):
+    """Archive a board with cascade, restore, check tasks come back as archived."""
+    _create_board(client, "proj-a", switch=False)
+    t = _create_task(client, "round-trip", board="proj-a")
+    arch = client.post(
+        "/api/plugins/kanban/boards/proj-a/archive?cascade=true",
+    )
+    assert arch.status_code == 200
+    assert t["id"] in arch.json()["cascade_archived_tasks"]
+
+    rest = client.post("/api/plugins/kanban/boards/proj-a/restore")
+    assert rest.status_code == 200
+
+    # Board is back; the task is still archived because cascade archived
+    # it as part of the wrap-up. Restoring the board doesn't auto-restore
+    # tasks (deliberate — keeps the inverse asymmetric so users notice).
+    r = client.get("/api/plugins/kanban/tasks/archived?board=proj-a")
+    assert r.status_code == 200
+    rows = r.json()["archived_tasks"]
+    assert any(row["id"] == t["id"] for row in rows)

--- a/tests/plugins/kanban/test_dashboard_stage_entered_time.py
+++ b/tests/plugins/kanban/test_dashboard_stage_entered_time.py
@@ -1,0 +1,323 @@
+"""Tests for the per-stage timestamp (``entered_status_at``) on the
+Kanban dashboard API.
+
+The feature adds a second timestamp alongside ``created_at`` so the UI can
+render "created 3h ago / in this column 12m ago" on every card. The value
+is derived from ``task_events`` rather than a new column, so these tests
+exercise the SQL helper directly *and* through the REST surface:
+
+  * GET /board                — batch path (one aggregate query for all tasks)
+  * GET /tasks/{id}           — single-task path
+  * PATCH /tasks/{id}         — verify the patched response also includes it
+  * Fallback for fresh todo / triage tasks (no entry event yet)
+
+Layout mirrors ``tests/plugins/test_kanban_dashboard_plugin.py``: dynamic
+import of plugin_api.py, isolated HERMES_HOME, bare-FastAPI test client.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import time
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from hermes_cli import kanban_db as kb
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — same isolation pattern as the sibling archive-API test file.
+# ---------------------------------------------------------------------------
+
+
+def _load_plugin_router():
+    repo_root = Path(__file__).resolve().parents[3]
+    plugin_file = repo_root / "plugins" / "kanban" / "dashboard" / "plugin_api.py"
+    assert plugin_file.exists(), f"plugin file missing: {plugin_file}"
+
+    spec = importlib.util.spec_from_file_location(
+        "hermes_dashboard_plugin_kanban_stage_test", plugin_file,
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def plugin_mod():
+    return _load_plugin_router()
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+@pytest.fixture
+def client(kanban_home, plugin_mod):
+    app = FastAPI()
+    app.include_router(plugin_mod.router, prefix="/api/plugins/kanban")
+    return TestClient(app)
+
+
+def _create_task(client, title="t", assignee=None, parents=None):
+    payload = {"title": title}
+    if assignee is not None:
+        payload["assignee"] = assignee
+    if parents is not None:
+        payload["parents"] = parents
+    r = client.post("/api/plugins/kanban/tasks", json=payload)
+    assert r.status_code == 200, r.text
+    return r.json()["task"]
+
+
+def _get_task(client, task_id):
+    r = client.get(f"/api/plugins/kanban/tasks/{task_id}")
+    assert r.status_code == 200, r.text
+    return r.json()["task"]
+
+
+def _board_tasks(client):
+    """Flatten /board response into a {task_id: task_dict} map."""
+    r = client.get("/api/plugins/kanban/board")
+    assert r.status_code == 200, r.text
+    out: dict[str, dict] = {}
+    for col in r.json()["columns"]:
+        for t in col["tasks"]:
+            out[t["id"]] = t
+    return out
+
+
+# ---------------------------------------------------------------------------
+# 1. Promoted: ready status uses the "promoted" event timestamp.
+# ---------------------------------------------------------------------------
+
+
+def test_entered_status_at_ready_uses_promoted_event(client):
+    """A no-parent task is created -> immediately promoted to 'ready'.
+
+    ``entered_status_at`` should reflect the ``promoted`` event timestamp
+    rather than ``created_at`` (even though they are usually equal here,
+    they are distinct columns in ``task_events`` and the code path differs).
+    """
+    t = _create_task(client, "ready task")
+    assert t["status"] == "ready"
+
+    # /tasks/:id surfaces entered_status_at on the full detail view.
+    detail = _get_task(client, t["id"])
+    assert detail["entered_status_at"] is not None
+    assert isinstance(detail["entered_status_at"], int)
+    # Derived age block should also include entered_status_age_seconds.
+    age = detail.get("age") or {}
+    assert "entered_status_age_seconds" in age
+
+    # /board surfaces the same value (batch path).
+    board_tasks = _board_tasks(client)
+    assert t["id"] in board_tasks
+    assert board_tasks[t["id"]]["entered_status_at"] == detail["entered_status_at"]
+
+
+# ---------------------------------------------------------------------------
+# 2. Claimed: running status uses the "claimed" event timestamp,
+#    NOT the older "promoted" timestamp.
+# ---------------------------------------------------------------------------
+
+
+def test_entered_status_at_running_distinct_from_promoted(client, kanban_home):
+    """Claiming a task should advance ``entered_status_at`` past the
+    ``promoted`` timestamp."""
+    t = _create_task(client, "claim me", assignee="worker-a")
+    assert t["status"] == "ready"
+
+    promoted_ts = _get_task(client, t["id"])["entered_status_at"]
+    assert promoted_ts is not None
+
+    # Sleep at least 1s so the new event has a strictly later created_at
+    # (kanban_db stores integer seconds).
+    time.sleep(1.1)
+
+    # Claim atomically by talking to kanban_db directly (the dashboard
+    # PATCH endpoint rejects status=running on purpose; see
+    # test_patch_status_running_rejected — claims must go through
+    # claim_task so a task_runs row is created with the lock).
+    conn = kb.connect()
+    try:
+        claimed = kb.claim_task(conn, t["id"], claimer="worker-a")
+    finally:
+        conn.close()
+    assert claimed is not None, "claim_task should succeed on a ready task"
+    assert claimed.status == "running"
+
+    detail = _get_task(client, t["id"])
+    assert detail["status"] == "running"
+    running_ts = detail["entered_status_at"]
+    assert running_ts is not None
+    assert running_ts >= promoted_ts, (
+        f"running entered_status_at ({running_ts}) must be >= promoted ({promoted_ts})"
+    )
+    # And strictly greater because we slept 1.1s between the two events.
+    assert running_ts > promoted_ts
+
+    # Batch path on /board agrees with the single-task path.
+    board_tasks = _board_tasks(client)
+    assert board_tasks[t["id"]]["entered_status_at"] == running_ts
+
+
+# ---------------------------------------------------------------------------
+# 3. Completed: done status uses the "completed" event timestamp.
+# ---------------------------------------------------------------------------
+
+
+def test_entered_status_at_done_uses_completed_event(client, kanban_home):
+    t = _create_task(client, "ship it")
+    assert t["status"] == "ready"
+
+    time.sleep(1.1)
+
+    # Done = PATCH /tasks/:id with status=done; this routes through
+    # complete_task internally and writes a 'completed' event.
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{t['id']}",
+        json={"status": "done", "result": "shipped"},
+    )
+    assert r.status_code == 200, r.text
+    patched = r.json()["task"]
+    assert patched["status"] == "done"
+    # PATCH response itself should carry entered_status_at for the new status.
+    assert patched["entered_status_at"] is not None
+
+    detail = _get_task(client, t["id"])
+    assert detail["entered_status_at"] == patched["entered_status_at"]
+    # Strictly later than the original ready timestamp.
+    assert detail["entered_status_at"] > t["created_at"]
+
+
+# ---------------------------------------------------------------------------
+# 4. Blocked: status=blocked uses the "blocked" event timestamp.
+# ---------------------------------------------------------------------------
+
+
+def test_entered_status_at_blocked_uses_blocked_event(client):
+    t = _create_task(client, "needs input")
+    time.sleep(1.1)
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{t['id']}",
+        json={"status": "blocked", "block_reason": "waiting on x"},
+    )
+    assert r.status_code == 200, r.text
+    blocked = r.json()["task"]
+    assert blocked["status"] == "blocked"
+    assert blocked["entered_status_at"] is not None
+    assert blocked["entered_status_at"] > t["created_at"]
+
+
+# ---------------------------------------------------------------------------
+# 5. Fresh todo: no entry event yet -> falls back to created_at.
+# ---------------------------------------------------------------------------
+
+
+def test_entered_status_at_todo_falls_back_to_created_at(client):
+    """A child whose parent isn't done sits in ``todo`` with no
+    ``restored`` / ``claim_rejected`` event in its history. The helper
+    should return ``created_at`` for that case (NOT None and NOT the
+    promoted/claimed timestamp from some sibling task)."""
+    parent = _create_task(client, "parent")
+    child = _create_task(client, "child", parents=[parent["id"]])
+    assert child["status"] == "todo"
+
+    detail = _get_task(client, child["id"])
+    assert detail["entered_status_at"] == child["created_at"]
+
+
+# ---------------------------------------------------------------------------
+# 6. Batch path: list-endpoint correctly distinguishes per-task timestamps
+#    when several tasks live in different statuses simultaneously.
+# ---------------------------------------------------------------------------
+
+
+def test_batch_entered_status_at_does_not_leak_between_tasks(client, kanban_home):
+    """Three tasks: one ready, one done, one blocked. Each must report its
+    OWN status's event timestamp via the /board (batch) path — no
+    cross-pollination between task_ids."""
+    a = _create_task(client, "ready-task")           # ends up ready
+    b = _create_task(client, "done-task")            # will be marked done
+    c = _create_task(client, "blocked-task")         # will be marked blocked
+
+    time.sleep(1.1)
+    rb = client.patch(
+        f"/api/plugins/kanban/tasks/{b['id']}",
+        json={"status": "done", "result": "ok"},
+    )
+    assert rb.status_code == 200, rb.text
+    done_entered = rb.json()["task"]["entered_status_at"]
+
+    time.sleep(1.1)
+    rc = client.patch(
+        f"/api/plugins/kanban/tasks/{c['id']}",
+        json={"status": "blocked", "block_reason": "x"},
+    )
+    assert rc.status_code == 200, rc.text
+    blocked_entered = rc.json()["task"]["entered_status_at"]
+
+    board_tasks = _board_tasks(client)
+    ta, tb, tc = board_tasks[a["id"]], board_tasks[b["id"]], board_tasks[c["id"]]
+    assert ta["status"] == "ready"
+    assert tb["status"] == "done"
+    assert tc["status"] == "blocked"
+    assert ta["entered_status_at"] is not None
+    assert tb["entered_status_at"] == done_entered
+    assert tc["entered_status_at"] == blocked_entered
+    # The done & blocked timestamps must not equal the ready task's
+    # promoted timestamp (would indicate a row-mixing bug in the
+    # batch query).
+    assert tb["entered_status_at"] != ta["entered_status_at"]
+    assert tc["entered_status_at"] != ta["entered_status_at"]
+    assert tc["entered_status_at"] > tb["entered_status_at"]
+
+
+# ---------------------------------------------------------------------------
+# 7. Direct helper unit test: _batch_entered_status_at and the
+#    single-task helper agree on the same inputs.
+# ---------------------------------------------------------------------------
+
+
+def test_batch_and_single_helpers_agree(client, plugin_mod, kanban_home):
+    """If batch and per-task helpers disagree, the dashboard would show
+    different ages depending on which endpoint loaded the card. Guard
+    that they stay in sync."""
+    t1 = _create_task(client, "t1")
+    t2 = _create_task(client, "t2")
+    time.sleep(1.1)
+    client.patch(
+        f"/api/plugins/kanban/tasks/{t2['id']}",
+        json={"status": "blocked", "block_reason": "y"},
+    )
+
+    conn = kb.connect()
+    try:
+        tasks = kb.list_tasks(conn)
+        batch_map = plugin_mod._batch_entered_status_at(conn, tasks)
+        for task in tasks:
+            single = plugin_mod._entered_status_at_for_task(
+                conn, task.id, task.status, task.created_at,
+            )
+            assert batch_map[task.id] == single, (
+                f"task {task.id} status={task.status}: "
+                f"batch={batch_map[task.id]} single={single}"
+            )
+    finally:
+        conn.close()

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -1794,3 +1794,168 @@ def test_dashboard_failed_card_highlight_class_exists():
     assert "hermes-kanban-card--failed" in js
     assert "hermes-kanban-card--failed" in css
     assert "failedIds" in js
+
+
+def test_dashboard_archive_viewer_button_label_matches_upstream():
+    """The top-bar Archive viewer toggle keeps the upstream label "Archive".
+
+    Why: PR #6 (kanban-board-archive-ui) once shipped a duplicate action
+    Archive button next to the viewer toggle, which forced a defensive
+    rename of the viewer toggle to "Archives" (plural). That duplicate
+    action button is now removed from the top toolbar (see commit
+    90450f147, fix/kanban-toolbar-cleanup), so the collision no longer
+    exists and the upstream label is restored.
+    What: Asserts the viewer toggle uses the upstream fallback "Archive"
+    and that the old defensive "Archives" plural is gone from the bundle.
+    Test: Run pytest on this file; the upstream substring must appear and
+    the plural workaround must not.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    js = (
+        repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
+    ).read_text()
+
+    # Viewer toggle: upstream label "Archive" (singular) restored.
+    assert 'tx(t, "showArchive", "Archive")' in js
+    # Defensive plural rename from the duplicate-button era must be gone.
+    assert 'tx(t, "showArchive", "Archives")' not in js
+
+
+def test_dashboard_hard_delete_supports_cascade_query_param():
+    """The hardDeleteBoard callback must thread cascade=true through to the
+    DELETE endpoint so the dashboard can destroy a non-empty board after the
+    user explicitly confirms.
+
+    Why: Issue 1 from the field — clicking [Delete] on a non-empty board
+    used to return 409 with no path forward. The fix lets the UI pass
+    cascade=true after a two-step confirm; the backend retains its
+    integrity rule (refuse-by-default) so a stale UI still can't wipe
+    data silently.
+    What: Asserts the bundle builds the correct query string for both
+    branches (no-cascade vs cascade) and that the click handler routes
+    through the shared confirm helper.
+    Test: Substring checks against the built bundle for the
+    cascade=true URL pattern and the helper name.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    js = (
+        repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
+    ).read_text()
+
+    # hardDeleteBoard now accepts an opts arg with cascade.
+    assert "function (slug, opts)" in js
+    # Query string includes cascade=true when opted in, default delete=true otherwise.
+    assert '"?delete=true&cascade=true"' in js
+    assert '"?delete=true"' in js
+    # Shared confirm helper exists and routes through onHardDeleteBoard.
+    assert "function confirmAndHardDelete()" in js
+    assert "props.onHardDeleteBoard(props.board, { cascade: true })" in js
+
+
+def test_dashboard_hard_delete_non_empty_uses_two_step_confirm():
+    """Non-empty board hard-delete must require TWO confirms before firing.
+
+    Why: A single misclick on [Delete] used to dead-end at 409; the cure
+    must not over-correct into a single-confirm cascade wipe. The
+    two-step pattern (consequences → "absolutely sure") matches the
+    PM-supplied UX rule for irreversible destructive actions.
+    What: The bundle must contain both confirm copy strings and route
+    through them in sequence; empty boards still use the single-confirm
+    path.
+    Test: Substring checks for the two-step strings and the empty-board
+    fallback copy.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    js = (
+        repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
+    ).read_text()
+
+    # Empty-board single confirm.
+    assert "hardDeleteEmptyBoardConfirm" in js
+    # Non-empty two-step confirms.
+    assert "hardDeleteNonEmptyBoardConfirm" in js
+    assert "hardDeleteNonEmptyBoardConfirm2" in js
+    # Branching on currentTotal so empty boards skip the harsh wording.
+    assert "if (!currentTotal || currentTotal <= 0)" in js
+
+
+def test_dashboard_card_ago_renders_both_through_slash():
+    """Card meta row must ALWAYS render both timeAgo values through a
+    slash when ``entered_status_at`` differs from ``created_at``, even
+    when the two values collapse to the same coarse bucket.
+
+    Why: Earlier iteration hid the "/ second" when the buckets
+    coincided, but the user explicitly requested both values be
+    visible at all times (knowing the task hasn't moved is itself
+    information). The bundle now strips trailing " ago" from each
+    side and appends a single " ago" once at the end so the
+    punctuation reads naturally (e.g. ``"3h / 12m ago"`` instead of
+    ``"3h ago / 12m ago"``).
+    What: Asserts the bundle's render path computes both strings,
+    strips the suffix via a ``stripAgo`` helper, and joins them with
+    ``" / "`` unconditionally whenever ``enteredAgo`` is present.
+    Test: Run pytest on this file; the substring checks below all
+    appear in the bundle exactly as written. If a future refactor
+    inlines the conditional, update these substrings to match.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    js = (
+        repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
+    ).read_text()
+
+    # Both timestamps are still computed locally.
+    assert "const createdAgo = timeAgo ? timeAgo(t.created_at)" in js
+    assert "timeAgo(t.entered_status_at)" in js
+
+    # Suffix-stripping logic: a local helper drops trailing " ago" so
+    # we can re-attach a single one after the join.
+    assert "stripAgo" in js
+    assert '.endsWith(" ago")' in js
+    assert ".slice(0, -4)" in js
+
+    # Both-had-ago branch produces "{cShort} / {eShort} ago" — a single
+    # trailing " ago", with the slash inside.
+    assert '`${cShort} / ${eShort} ago`' in js
+    # Special-string branch (e.g. "just now"/"yesterday") drops the
+    # trailing " ago" entirely.
+    assert '`${cShort} / ${eShort}`' in js
+    # The slash is rendered unconditionally whenever enteredAgo exists,
+    # not gated on bucket inequality.
+    assert "if (!enteredAgo)" in js
+
+
+def test_dashboard_bundle_syntax_valid():
+    """The compiled dashboard bundle must parse as valid JavaScript.
+
+    Why: The dashboard is shipped as a hand-patched IIFE bundle (no build
+    step). A stray inline `function` declaration or missing paren breaks
+    the *entire* plugin: the browser logs `did not call register()` and
+    Kanban tab goes blank. We've shipped that bug at least once (commit
+    0ca782302 inserted a function declaration in argument position), so
+    this guard runs `node --check` on every test run.
+    What: subprocess.run(['node', '--check', bundle]) → exit 0.
+    Test: Introduce a syntax error in dist/index.js → this test fails;
+    fix it → green.
+
+    If `node` is not on PATH (rare CI image), the test skips rather than
+    fails — the syntax check is a belt-and-suspenders guard, not a hard
+    dependency.
+    """
+    import shutil
+    import subprocess
+
+    if shutil.which("node") is None:
+        pytest.skip("node not available; skipping bundle syntax check")
+
+    repo_root = Path(__file__).resolve().parents[2]
+    bundle = repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
+    result = subprocess.run(
+        ["node", "--check", str(bundle)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"Bundle syntax error in {bundle}:\n"
+        f"stderr: {result.stderr}\n"
+        f"stdout: {result.stdout}"
+    )


### PR DESCRIPTION
## Summary

Two related dashboard improvements bundled into one PR:

1. **Board lifecycle in the dashboard** — archive/restore/hard-delete via UI with safety rails (hard-delete only reachable on already-archived boards).
2. **Per-stage timestamps on cards** — cards show "created_age / in-stage_age ago" instead of only created_at.

## 1. Board lifecycle UX

### New backend endpoints
- `POST /boards/{slug}/archive` — soft archive (board dir moved to `boards/_archived/<slug>-<ts>/`); recoverable.
- `POST /boards/{slug}/restore` — un-archive.
- `DELETE /boards/{slug}?delete=true` — hard-delete (default `delete=false` is archive for backwards compat).
- `cascade=true` query — opt-in to operate on non-empty boards (refuses with HTTP 409 + `task_count` otherwise). Default is refuse — accidental clicks on a populated board do not silently wipe data.

### Dashboard
- **Toolbar:** `[+ New board] [Archive]` — Archive is the panel toggle. No Delete button on toolbar (was a source of foot-guns).
- **Archive viewer header** has a new `[ToArchive]` action that moves the **currently active** board into the archive (cascade for non-empty). Hidden for `default` (cannot be archived).
- **Archive viewer rows** for archived boards show `[Restore]` and a new `[Delete]` — Delete is the only path to permanent hard-delete and is only reachable here, after the board is already archived. Two-step confirm.
- After archive/hard-delete: optimistic local filter removes the slug from the selector immediately + `loadBoardList()` refetches.

### Backend hardening
- `hard_delete_board` auto-switches the `current` pointer to `default` if the deleted board was active. Previously returned HTTP 409 "switch first" — pure friction since the dashboard always intends to remove the current board.
- `kanban_db.connect()` refuses to auto-resurrect a deleted board. Previously `path.parent.mkdir(parents=True, exist_ok=True)` silently recreated `boards/<slug>/` if any stale caller (frontend with cached `?board=<gone>` query, dispatcher tick before list refresh, `current` pointer not cleared) opened a connection to the gone slug. Now raises `FileNotFoundError` for non-default boards whose parent dir doesn't exist. Callers that wrap `connect()` in try/except (dispatcher tick, `_board_counts`) degrade gracefully.
- Selector filter: `GET /boards` defaults to `include_archived=False`.

### Dispatcher safety (verified)
- `list_boards(include_archived=False)` excludes archived boards from `_tick_once` iteration — archived boards are quiescent.
- Tasks with `status='archived'` are skipped by both the promoter (`WHERE status='todo'`) and the claim path (`WHERE status='ready'`).
- `restore_task` sets `status='todo'` — next tick promotes to `ready`, tick after claims. No state loss across archive→restore.

## 2. Per-stage timestamps on cards

### Backend
- `_task_dict()` emits `entered_status_at` (unix seconds) — time the task entered its **current** status. Derived from existing `task_events` audit log (kinds: `promoted` → ready, `claimed` → running, `completed` → done, `blocked` → blocked, `archived` → archived, `restored`/`claim_rejected` → todo rollback).
- Batch query (`_batch_entered_status_at`) avoids N+1 on the board list endpoint. Index `idx_events_task` makes lookup O(log n) per task.
- No DB schema change — the data was already in `task_events`.

### Frontend
- Card age label: `"3h / 12m ago"` when `entered_status_at !== created_at` (single `ago` suffix). Falls back to plain `"3h ago"` when the task never moved (status=todo without transitions).
- Edge cases handled: `timeAgo()` special strings like `"just now"` / `"yesterday"` render without a trailing `ago` (`"3h / just now"`).

## Tests

- `tests/plugins/kanban/test_board_archive_api.py` — 540 lines, comprehensive: archive default-refusal, restore, cascade rules, hard-delete refusal-by-default, selector filter, switch-then-archive flow.
- `tests/plugins/kanban/test_dashboard_stage_entered_time.py` — 323 lines, one test per status type + batch query correctness + edge cases.
- `tests/plugins/test_kanban_dashboard_plugin.py` — added bundle regression incl. **`node --check` syntax guard** (subprocess.run; pytest.skip if node not on PATH).

## Bundle patching note

`plugins/kanban/dashboard/dist/index.js` is hand-patched (no build step in this tree). Every edit was validated with `node --check` plus a mock-load that asserts `register()` is called. The new `test_dashboard_bundle_syntax_valid` enforces this in CI so a future patch can't accidentally break the IIFE.

## Test plan

- [ ] `pytest tests/plugins/kanban/ tests/plugins/test_kanban_dashboard_plugin.py` passes
- [ ] Archive a non-empty board via UI → appears in Archive viewer → Restore → board back in selector with all tasks
- [ ] Hard-delete the same board from archive row → board + all tasks wiped, doesn't reappear after refresh
- [ ] On a board with movement, cards show two timestamps via slash; on fresh todo tasks, only one