### PR TITLE
[codex] Add bundled skill integrity validation

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -1069,6 +1069,78 @@ def do_audit(name: Optional[str] = None, console: Optional[Console] = None,
         c.print()
 
 
+def do_validate(
+    *,
+    bundled: bool = False,
+    bundled_dir: Optional[Path] = None,
+    json_output: bool = False,
+    checks: Optional[List[str]] = None,
+    console: Optional[Console] = None,
+) -> int:
+    """Run read-only integrity checks against selected skill sources."""
+    c = console or _console
+
+    if not bundled:
+        c.print("[bold red]Error:[/] choose a validation scope, e.g. --bundled\n")
+        return 0
+
+    from tools.bundled_skill_validator import validate_bundled_skills
+    from tools.skills_sync import _get_bundled_dir
+
+    root = Path(bundled_dir) if bundled_dir is not None else _get_bundled_dir()
+    try:
+        issues = validate_bundled_skills(root, checks=checks)
+    except ValueError as exc:
+        c.print(f"[bold red]Error:[/] {exc}\n")
+        return 0
+
+    if json_output:
+        payload = [
+            {
+                "severity": issue.severity,
+                "code": issue.code,
+                "skill": issue.skill,
+                "path": str(_display_issue_path(issue.path, root)),
+                "line": issue.line,
+                "target": issue.target,
+                "message": issue.message,
+            }
+            for issue in issues
+        ]
+        c.print(json.dumps(payload, indent=2, ensure_ascii=False))
+        return len(issues)
+
+    if not issues:
+        c.print("[bold green]Bundled skill validation passed.[/]\n")
+        return 0
+
+    c.print(f"[bold yellow]Bundled skill validation found {len(issues)} issue(s).[/]\n")
+    table = Table()
+    table.add_column("Severity", style="bold")
+    table.add_column("Skill", style="cyan")
+    table.add_column("Issue")
+    table.add_column("Target", style="magenta")
+    table.add_column("Location", style="dim")
+    for issue in issues:
+        table.add_row(
+            issue.severity,
+            issue.skill,
+            issue.code,
+            issue.target,
+            f"{_display_issue_path(issue.path, root)}:{issue.line}",
+        )
+    c.print(table)
+    c.print()
+    return len(issues)
+
+
+def _display_issue_path(path: Path, root: Path) -> Path:
+    try:
+        return path.relative_to(root)
+    except ValueError:
+        return path
+
+
 def do_uninstall(name: str, console: Optional[Console] = None,
                  skip_confirm: bool = False,
                  invalidate_cache: bool = True) -> None:
@@ -1619,6 +1691,12 @@ def skills_command(args) -> None:
     elif action == "audit":
         do_audit(name=getattr(args, "name", None),
                  deep=getattr(args, "deep", False))
+    elif action == "validate":
+        do_validate(
+            bundled=getattr(args, "bundled", False),
+            json_output=getattr(args, "json", False),
+            checks=getattr(args, "check", None),
+        )
     elif action == "uninstall":
         do_uninstall(args.name)
     elif action == "reset":
@@ -1654,7 +1732,7 @@ def skills_command(args) -> None:
             return
         do_tap(tap_action, repo=repo)
     else:
-        _console.print("Usage: hermes skills [browse|search|install|inspect|list|check|update|audit|uninstall|reset|opt-out|opt-in|publish|snapshot|tap]\n")
+        _console.print("Usage: hermes skills [browse|search|install|inspect|list|check|update|audit|validate|uninstall|reset|opt-out|opt-in|publish|snapshot|tap]\n")
         _console.print("Run 'hermes skills <command> --help' for details.\n")
 
 
@@ -1803,6 +1881,22 @@ def handle_skills_slash(cmd: str, console: Optional[Console] = None) -> None:
         deep = "--deep" in args
         do_audit(name=name, console=c, deep=deep)
 
+    elif action == "validate":
+        checks: List[str] = []
+        i = 0
+        while i < len(args):
+            if args[i] == "--check" and i + 1 < len(args):
+                checks.append(args[i + 1])
+                i += 2
+            else:
+                i += 1
+        do_validate(
+            bundled="--bundled" in args,
+            json_output="--json" in args,
+            checks=checks or None,
+            console=c,
+        )
+
     elif action == "uninstall":
         if not args:
             c.print("[bold red]Usage:[/] /skills uninstall <name> [--now]\n")
@@ -1882,6 +1976,7 @@ def _print_skills_help(console: Console) -> None:
         "  [cyan]check[/] [name]                Check hub skills for upstream updates\n"
         "  [cyan]update[/] [name]               Update hub skills with upstream changes\n"
         "  [cyan]audit[/] [name]                Re-scan hub skills for security\n"
+        "  [cyan]validate[/] --bundled          Validate bundled skill integrity\n"
         "  [cyan]uninstall[/] <name>            Remove a hub-installed skill\n"
         "  [cyan]reset[/] <name> [--restore]    Reset bundled-skill tracking (fix 'user-modified' flag)\n"
         "  [cyan]publish[/] <path> --repo <r>   Publish a skill to GitHub via PR\n"

--- a/hermes_cli/subcommands/skills.py
+++ b/hermes_cli/subcommands/skills.py
@@ -135,6 +135,29 @@ def build_skills_parser(subparsers, *, cmd_skills: Callable) -> None:
         help="Run AST-level analysis on Python files (opt-in diagnostic)",
     )
 
+    skills_validate = skills_subparsers.add_parser(
+        "validate", help="Run read-only integrity checks for skills"
+    )
+    skills_validate.add_argument(
+        "--bundled",
+        action="store_true",
+        help="Validate bundled skills shipped with Hermes",
+    )
+    skills_validate.add_argument(
+        "--json",
+        action="store_true",
+        help="Print machine-readable JSON",
+    )
+    skills_validate.add_argument(
+        "--check",
+        action="append",
+        default=None,
+        help=(
+            "Run only a named check. Repeat to select multiple checks. "
+            "Defaults to all local bundled-skill checks."
+        ),
+    )
+
     skills_uninstall = skills_subparsers.add_parser(
         "uninstall", help="Remove a hub-installed skill"
     )

--- a/tests/hermes_cli/test_skills_validate.py
+++ b/tests/hermes_cli/test_skills_validate.py
@@ -1,0 +1,70 @@
+from io import StringIO
+
+from rich.console import Console
+
+from hermes_cli.skills_hub import do_validate
+
+
+def test_do_validate_prints_bundled_skill_issues(tmp_path):
+    skill_dir = tmp_path / "productivity" / "slides"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        """---
+name: slides
+related_skills: [missing-helper]
+---
+
+Run `python scripts/missing.py`.
+""",
+        encoding="utf-8",
+    )
+    out = StringIO()
+    console = Console(file=out, force_terminal=False, color_system=None, width=140)
+
+    count = do_validate(bundled=True, bundled_dir=tmp_path, console=console)
+
+    output = out.getvalue()
+    assert count == 2
+    assert "Bundled skill validation found 2 issue(s)" in output
+    assert "slides" in output
+    assert "missing-file-reference" in output
+    assert "unknown-related-skill" in output
+
+
+def test_do_validate_requires_scope(tmp_path):
+    out = StringIO()
+    console = Console(file=out, force_terminal=False, color_system=None)
+
+    count = do_validate(bundled=False, bundled_dir=tmp_path, console=console)
+
+    assert count == 0
+    assert "--bundled" in out.getvalue()
+
+
+def test_do_validate_can_run_selected_checks(tmp_path):
+    skill_dir = tmp_path / "productivity" / "slides"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        """---
+name: slides
+related_skills: [missing-helper]
+---
+
+Run `python scripts/missing.py`.
+""",
+        encoding="utf-8",
+    )
+    out = StringIO()
+    console = Console(file=out, force_terminal=False, color_system=None, width=140)
+
+    count = do_validate(
+        bundled=True,
+        bundled_dir=tmp_path,
+        checks=["related-skills"],
+        console=console,
+    )
+
+    output = out.getvalue()
+    assert count == 1
+    assert "unknown-related-skill" in output
+    assert "missing-file-reference" not in output

--- a/tests/tools/test_bundled_skill_validator.py
+++ b/tests/tools/test_bundled_skill_validator.py
@@ -1,0 +1,190 @@
+from pathlib import Path
+
+import pytest
+
+from tools.bundled_skill_validator import (
+    available_bundled_skill_checks,
+    validate_bundled_skills,
+)
+
+
+def _write_skill(root: Path, rel: str, body: str) -> Path:
+    skill_dir = root / rel
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(body, encoding="utf-8")
+    return skill_dir
+
+
+def _issue_codes(root: Path) -> set[str]:
+    return {issue.code for issue in validate_bundled_skills(root)}
+
+
+def test_validate_bundled_skills_flags_missing_local_file_references(tmp_path):
+    _write_skill(
+        tmp_path,
+        "productivity/slides",
+        """---
+name: slides
+---
+
+Run `python scripts/build_deck.py`.
+See `references/style.md` before writing.
+""",
+    )
+    (tmp_path / "productivity/slides/scripts").mkdir()
+    (tmp_path / "productivity/slides/scripts/build_deck.py").write_text(
+        "print('ok')\n",
+        encoding="utf-8",
+    )
+
+    issues = validate_bundled_skills(tmp_path)
+
+    assert [(issue.code, issue.target) for issue in issues] == [
+        ("missing-file-reference", "references/style.md")
+    ]
+
+
+def test_validate_bundled_skills_flags_unknown_related_skills(tmp_path):
+    _write_skill(
+        tmp_path,
+        "research/wiki",
+        """---
+name: wiki
+related_skills: [known-skill, missing-skill]
+---
+
+Use the related skills when useful.
+""",
+    )
+    _write_skill(
+        tmp_path,
+        "research/known",
+        """---
+name: known-skill
+---
+
+Known helper.
+""",
+    )
+
+    issues = validate_bundled_skills(tmp_path)
+
+    assert [(issue.code, issue.target) for issue in issues] == [
+        ("unknown-related-skill", "missing-skill")
+    ]
+
+
+def test_validate_bundled_skills_reads_nested_hermes_related_skills(tmp_path):
+    _write_skill(
+        tmp_path,
+        "research/wiki",
+        """---
+name: wiki
+metadata:
+  hermes:
+    related_skills: [known-skill, missing-skill]
+---
+
+Use the related skills when useful.
+""",
+    )
+    _write_skill(
+        tmp_path,
+        "research/known",
+        """---
+name: known-skill
+---
+
+Known helper.
+""",
+    )
+
+    issues = validate_bundled_skills(tmp_path)
+
+    assert [(issue.code, issue.target) for issue in issues] == [
+        ("unknown-related-skill", "missing-skill")
+    ]
+
+
+def test_validate_bundled_skills_flags_unknown_skill_tool_references(tmp_path):
+    _write_skill(
+        tmp_path,
+        "research/paper",
+        """---
+name: paper
+---
+
+Call `skill_view("known-skill")` first.
+Call `skill_view("missing-view")` for diagrams.
+Call `skill_manage("install", "missing-install")` when needed.
+""",
+    )
+    _write_skill(
+        tmp_path,
+        "research/known",
+        """---
+name: known-skill
+---
+
+Known helper.
+""",
+    )
+
+    assert _issue_codes(tmp_path) == {
+        "unknown-skill-view-reference",
+        "unknown-skill-manage-reference",
+    }
+
+
+def test_validate_bundled_skills_flags_hermes_tools_in_bash_fences(tmp_path):
+    _write_skill(
+        tmp_path,
+        "research/wiki",
+        """---
+name: wiki
+---
+
+```bash
+read_file "$WIKI/SCHEMA.md"
+search_files "$WIKI" "topic"
+```
+""",
+    )
+
+    issues = validate_bundled_skills(tmp_path)
+
+    assert [(issue.code, issue.target) for issue in issues] == [
+        ("hermes-tool-in-bash-fence", "read_file"),
+        ("hermes-tool-in-bash-fence", "search_files"),
+    ]
+
+
+def test_validate_bundled_skills_can_run_a_named_check_subset(tmp_path):
+    _write_skill(
+        tmp_path,
+        "productivity/slides",
+        """---
+name: slides
+related_skills: [missing-helper]
+---
+
+Run `python scripts/missing.py`.
+""",
+    )
+
+    issues = validate_bundled_skills(tmp_path, checks=["related-skills"])
+
+    assert available_bundled_skill_checks() == (
+        "local-file-references",
+        "related-skills",
+        "skill-tool-references",
+        "bash-fence-tools",
+    )
+    assert [(issue.code, issue.target) for issue in issues] == [
+        ("unknown-related-skill", "missing-helper")
+    ]
+
+
+def test_validate_bundled_skills_rejects_unknown_check_names(tmp_path):
+    with pytest.raises(ValueError, match="Unknown bundled skill validation check"):
+        validate_bundled_skills(tmp_path, checks=["freshness"])

--- a/tools/bundled_skill_validator.py
+++ b/tools/bundled_skill_validator.py
@@ -1,0 +1,317 @@
+"""Read-only integrity checks for bundled skills."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import re
+from typing import Any, Callable, Sequence
+
+
+@dataclass(frozen=True)
+class SkillValidationIssue:
+    severity: str
+    code: str
+    skill: str
+    path: Path
+    line: int
+    target: str
+    message: str
+
+
+@dataclass(frozen=True)
+class _SkillRecord:
+    name: str
+    path: Path
+    skill_md: Path
+    text: str
+    frontmatter: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class SkillValidationContext:
+    root: Path
+    records: tuple[_SkillRecord, ...]
+    known_names: frozenset[str]
+
+
+SkillValidationCheck = Callable[
+    [_SkillRecord, SkillValidationContext], list[SkillValidationIssue]
+]
+
+
+_LOCAL_REF_RE = re.compile(
+    r"(?<![\w./-])((?:scripts|references|templates)/[A-Za-z0-9][A-Za-z0-9._/-]*)"
+)
+_SKILL_VIEW_RE = re.compile(r"\bskill_view\(\s*[\"']([^\"']+)[\"']")
+_SKILL_MANAGE_RE = re.compile(
+    r"\bskill_manage\(\s*(?:[\"'][^\"']+[\"']\s*,\s*)?[\"']([^\"']+)[\"']"
+)
+_BASH_FENCE_RE = re.compile(r"```(?:bash|sh|shell)\s*\n(.*?)```", re.DOTALL)
+_HERMES_TOOL_NAMES = {
+    "read_file",
+    "search_files",
+    "write_file",
+    "edit_file",
+    "list_files",
+}
+
+
+def validate_bundled_skills(
+    bundled_dir: str | Path,
+    *,
+    checks: Sequence[str] | None = None,
+) -> list[SkillValidationIssue]:
+    """Return deterministic integrity issues for bundled skill markdown.
+
+    These checks intentionally stay local and read-only. They catch drift that
+    does not require model judgment: missing bundled assets, broken skill
+    references, and Hermes tool calls mistakenly presented as shell commands.
+    """
+    root = Path(bundled_dir)
+    records = tuple(_discover_skills(root))
+    context = SkillValidationContext(
+        root=root,
+        records=records,
+        known_names=frozenset(record.name for record in records),
+    )
+    active_checks = _resolve_checks(checks)
+    issues: list[SkillValidationIssue] = []
+
+    for record in records:
+        for check in active_checks:
+            issues.extend(check(record, context))
+
+    return sorted(
+        issues,
+        key=lambda issue: (
+            str(issue.path),
+            issue.line,
+            issue.code,
+            issue.target,
+        ),
+    )
+
+
+def available_bundled_skill_checks() -> tuple[str, ...]:
+    """Return the stable names of bundled-skill validation checks."""
+    return tuple(_CHECKS)
+
+
+def _resolve_checks(checks: Sequence[str] | None) -> tuple[SkillValidationCheck, ...]:
+    if checks is None:
+        return tuple(_CHECKS.values())
+    unknown = [name for name in checks if name not in _CHECKS]
+    if unknown:
+        choices = ", ".join(available_bundled_skill_checks())
+        raise ValueError(f"Unknown bundled skill validation check(s): {', '.join(unknown)}. Choices: {choices}")
+    return tuple(_CHECKS[name] for name in checks)
+
+
+def _discover_skills(root: Path) -> list[_SkillRecord]:
+    records: list[_SkillRecord] = []
+    if not root.exists():
+        return records
+
+    for skill_md in sorted(root.rglob("SKILL.md")):
+        parts = set(skill_md.parts)
+        if ".git" in parts or ".github" in parts or ".hub" in parts:
+            continue
+        text = skill_md.read_text(encoding="utf-8", errors="replace")
+        frontmatter = _read_frontmatter(text)
+        name = str(frontmatter.get("name") or skill_md.parent.name).strip()
+        records.append(
+            _SkillRecord(
+                name=name,
+                path=skill_md.parent,
+                skill_md=skill_md,
+                text=text,
+                frontmatter=frontmatter,
+            )
+        )
+    return records
+
+
+def _read_frontmatter(text: str) -> dict[str, Any]:
+    if not text.startswith("---"):
+        return {}
+    end = text.find("\n---", 3)
+    if end == -1:
+        return {}
+    body = text[3:end].strip()
+    if not body:
+        return {}
+    try:
+        import yaml
+
+        parsed = yaml.safe_load(body)
+    except Exception:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _validate_local_file_refs(
+    record: _SkillRecord, context: SkillValidationContext
+) -> list[SkillValidationIssue]:
+    issues: list[SkillValidationIssue] = []
+    seen: set[tuple[str, int]] = set()
+    for match in _LOCAL_REF_RE.finditer(record.text):
+        target = match.group(1).rstrip(".,;:)]}")
+        line = _line_for_match(record.text, match.start(1))
+        if (target, line) in seen:
+            continue
+        seen.add((target, line))
+        if not (record.path / target).exists():
+            issues.append(
+                SkillValidationIssue(
+                    severity="high",
+                    code="missing-file-reference",
+                    skill=record.name,
+                    path=record.skill_md,
+                    line=line,
+                    target=target,
+                    message=f"References bundled file '{target}', but it does not exist.",
+                )
+            )
+    return issues
+
+
+def _validate_related_skills(
+    record: _SkillRecord, context: SkillValidationContext
+) -> list[SkillValidationIssue]:
+    related = _related_skills(record.frontmatter)
+
+    issues: list[SkillValidationIssue] = []
+    for target in related:
+        target = target.strip()
+        if target and target not in context.known_names:
+            issues.append(
+                SkillValidationIssue(
+                    severity="medium",
+                    code="unknown-related-skill",
+                    skill=record.name,
+                    path=record.skill_md,
+                    line=_frontmatter_line(record.text, "related_skills"),
+                    target=target,
+                    message=f"related_skills references unknown bundled skill '{target}'.",
+                )
+            )
+    return issues
+
+
+def _related_skills(frontmatter: dict[str, Any]) -> list[str]:
+    """Read related skills using the same metadata.hermes fallback as the loader."""
+    hermes_meta: dict[str, Any] = {}
+    metadata = frontmatter.get("metadata")
+    if isinstance(metadata, dict):
+        raw_hermes_meta = metadata.get("hermes", {}) or {}
+        if isinstance(raw_hermes_meta, dict):
+            hermes_meta = raw_hermes_meta
+
+    return _parse_string_list(
+        hermes_meta.get("related_skills") or frontmatter.get("related_skills", "")
+    )
+
+
+def _parse_string_list(value: Any) -> list[str]:
+    if not value:
+        return []
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+
+    text = str(value).strip()
+    if text.startswith("[") and text.endswith("]"):
+        text = text[1:-1]
+    return [item.strip().strip("\"'") for item in text.split(",") if item.strip()]
+
+
+def _validate_skill_tool_refs(
+    record: _SkillRecord, context: SkillValidationContext
+) -> list[SkillValidationIssue]:
+    issues: list[SkillValidationIssue] = []
+    for match in _SKILL_VIEW_RE.finditer(record.text):
+        target = match.group(1).strip()
+        if _should_check_skill_target(target) and target not in context.known_names:
+            issues.append(
+                SkillValidationIssue(
+                    severity="medium",
+                    code="unknown-skill-view-reference",
+                    skill=record.name,
+                    path=record.skill_md,
+                    line=_line_for_match(record.text, match.start(1)),
+                    target=target,
+                    message=f"skill_view references unknown bundled skill '{target}'.",
+                )
+            )
+
+    for match in _SKILL_MANAGE_RE.finditer(record.text):
+        target = match.group(1).strip()
+        if _should_check_skill_target(target) and target not in context.known_names:
+            issues.append(
+                SkillValidationIssue(
+                    severity="medium",
+                    code="unknown-skill-manage-reference",
+                    skill=record.name,
+                    path=record.skill_md,
+                    line=_line_for_match(record.text, match.start(1)),
+                    target=target,
+                    message=f"skill_manage references unknown bundled skill '{target}'.",
+                )
+            )
+    return issues
+
+
+def _validate_bash_fences(
+    record: _SkillRecord, context: SkillValidationContext
+) -> list[SkillValidationIssue]:
+    issues: list[SkillValidationIssue] = []
+    for fence in _BASH_FENCE_RE.finditer(record.text):
+        body = fence.group(1)
+        for tool_name in sorted(_HERMES_TOOL_NAMES):
+            tool_match = re.search(rf"^\s*{re.escape(tool_name)}\b", body, re.MULTILINE)
+            if not tool_match:
+                continue
+            issues.append(
+                SkillValidationIssue(
+                    severity="medium",
+                    code="hermes-tool-in-bash-fence",
+                    skill=record.name,
+                    path=record.skill_md,
+                    line=_line_for_match(record.text, fence.start(1) + tool_match.start()),
+                    target=tool_name,
+                    message=(
+                        f"Hermes tool '{tool_name}' appears in a bash fence; "
+                        "readers may execute it as a shell command."
+                    ),
+                )
+            )
+    return issues
+
+
+_CHECKS: dict[str, SkillValidationCheck] = {
+    "local-file-references": _validate_local_file_refs,
+    "related-skills": _validate_related_skills,
+    "skill-tool-references": _validate_skill_tool_refs,
+    "bash-fence-tools": _validate_bash_fences,
+}
+
+
+def _should_check_skill_target(target: str) -> bool:
+    if not target:
+        return False
+    if "/" in target or ":" in target:
+        return False
+    if target.startswith(("http://", "https://")):
+        return False
+    return True
+
+
+def _line_for_match(text: str, index: int) -> int:
+    return text.count("\n", 0, index) + 1
+
+
+def _frontmatter_line(text: str, key: str) -> int:
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        if line.strip().startswith(f"{key}:"):
+            return lineno
+    return 1

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -1001,6 +1001,7 @@ Subcommands:
 | `check` | Check installed hub skills for upstream updates. |
 | `update` | Reinstall hub skills with upstream changes when available. |
 | `audit` | Re-scan installed hub skills. |
+| `validate` | Run read-only integrity checks for selected skill sources. Use `--bundled` for bundled skills shipped with Hermes. |
 | `uninstall` | Remove a hub-installed skill. |
 | `reset` | Un-stick a bundled skill flagged as `user_modified` by clearing its manifest entry. With `--restore`, also replaces the user copy with the bundled version. |
 | `opt-out` | Stop bundled skills from being seeded into the active profile. Writes a `.no-bundled-skills` marker so the installer, `hermes update`, and any sync skip bundled-skill seeding. Safe by default — nothing on disk is touched. With `--remove`, also deletes already-present bundled skills that are **unmodified** (user-edited, hub-installed, and hand-written skills are never removed; previews and confirms first, `--yes` to skip). |
@@ -1025,6 +1026,9 @@ hermes skills install https://sharethis.chat/SKILL.md                     # Dire
 hermes skills install https://example.com/SKILL.md --name my-skill        # Override name when frontmatter has none
 hermes skills check
 hermes skills update
+hermes skills validate --bundled
+hermes skills validate --bundled --json
+hermes skills validate --bundled --check related-skills
 hermes skills config
 hermes skills reset google-workspace
 hermes skills reset google-workspace --restore --yes

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -461,6 +461,7 @@ hermes skills list --source hub                   # List hub-installed skills
 hermes skills check                               # Check installed hub skills for upstream updates
 hermes skills update                              # Reinstall hub skills with upstream changes when needed
 hermes skills audit                               # Re-scan all hub skills for security
+hermes skills validate --bundled                  # Report bundled skill integrity drift
 hermes skills uninstall k8s                       # Remove a hub skill
 hermes skills reset google-workspace              # Un-stick a bundled skill from "user-modified" (see below)
 hermes skills reset google-workspace --restore    # Also restore the bundled version, deleting your local edits
@@ -833,6 +834,24 @@ The same command works in chat as a slash command:
 Each profile has its own `.bundled_manifest` under its own `HERMES_HOME`, so `hermes -p coder skills reset <name>` only affects that profile.
 :::
 
+## Bundled skill validation (`hermes skills validate --bundled`)
+
+Bundled skills are copied from the Hermes repo into `~/.hermes/skills/`, but they are not curated or patched by the Skill Curator. To inspect them without mutating anything, run:
+
+```bash
+hermes skills validate --bundled
+hermes skills validate --bundled --json
+hermes skills validate --bundled --check related-skills
+```
+
+The validator is intentionally local and read-only. It reports deterministic integrity issues such as missing bundled `scripts/`, `references/`, or `templates/` files, `related_skills` entries that do not resolve to bundled skill names, `skill_view(...)` / `skill_manage(...)` references that point at unknown bundled skills, and Hermes tool names accidentally shown as shell commands inside `bash` fences.
+
+Checks are named units (`local-file-references`, `related-skills`, `skill-tool-references`, `bash-fence-tools`) so future source-aware checks can be added without changing the command shape. For open-source-backed skills that evolve upstream, add a new check and expose it through `--check` instead of baking network freshness into the default local report.
+
+:::note
+This is an integrity report, not the Skill Curator. It does not rewrite bundled skills and it does not perform network freshness checks against third-party APIs or documentation.
+:::
+
 ### Slash commands (inside chat)
 
 All the same commands work with `/skills`:
@@ -841,6 +860,7 @@ All the same commands work with `/skills`:
 /skills browse
 /skills search react --source skills-sh
 /skills search https://mintlify.com/docs --source well-known
+/skills validate --bundled
 /skills inspect skills-sh/vercel-labs/json-render/json-render-react
 /skills install openai/skills/skill-creator --force
 /skills check


### PR DESCRIPTION
## Summary

Adds a read-only bundled skill validator exposed as `hermes skills validate --bundled`. This fills the gap between existing Skill Curator coverage for agent-created skills and hub skill audit/update flows for hub-installed skills.

The validator starts with deterministic local checks for drift that can break bundled skills without needing model judgment or network access:

- missing bundled `scripts/`, `references/`, or `templates/` paths
- `related_skills` entries that do not resolve to bundled skill names
- `skill_view(...)` / `skill_manage(...)` references that point at unknown bundled skills
- Hermes tool names shown as shell commands inside `bash` fences

It also supports `--json` and named `--check` selection so future source-aware freshness checks can be added without making the default local report network-dependent.

## Why

Bundled skills can drift as their backing tools, scripts, and upstream open-source projects evolve. Today Hermes has good provenance boundaries: the curator intentionally avoids bundled and hub-installed skills, and hub audit focuses on installed hub skills. This PR adds a safe inspection path for bundled skills without changing those mutation boundaries.

## Validation

- `uv run --extra dev pytest tests/tools/test_bundled_skill_validator.py tests/hermes_cli/test_skills_validate.py tests/hermes_cli/test_skills_subparser.py -q`
- `uv run --extra dev ruff check tools/bundled_skill_validator.py hermes_cli/skills_hub.py hermes_cli/main.py tests/tools/test_bundled_skill_validator.py tests/hermes_cli/test_skills_validate.py`
- `uv run --extra dev hermes skills validate --help`
- `uv run --extra dev hermes skills validate --bundled --check related-skills --json`
