### PR TITLE
feat(plugins): add --format=json and --enabled flags to 'plugins list'

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11075,7 +11075,29 @@ Examples:
     )
     plugins_remove.add_argument("name", help="Plugin directory name to remove")
 
-    plugins_subparsers.add_parser("list", aliases=["ls"], help="List installed plugins")
+    plugins_list = plugins_subparsers.add_parser(
+        "list", aliases=["ls"], help="List installed plugins"
+    )
+    plugins_list.add_argument(
+        "--format",
+        choices=["table", "json"],
+        default="table",
+        help=(
+            "Output format. 'table' (default) renders a Rich human-readable table. "
+            "'json' emits a structured array of {name, version, status, description, source, path} "
+            "objects on stdout — suitable for scripts, CI gates, and agent orchestrators (e.g. "
+            "Hermes hermes-runner-bridge plugin-registration health checks)."
+        ),
+    )
+    plugins_list.add_argument(
+        "--enabled",
+        metavar="NAME",
+        help=(
+            "Check whether a specific plugin is enabled. Exits 0 if NAME is enabled, "
+            "1 otherwise (including if NAME is not installed). Suppresses all output; "
+            "use as a shell gate: `if hermes plugins list --enabled foo; then ... fi`."
+        ),
+    )
 
     plugins_enable = plugins_subparsers.add_parser(
         "enable", help="Enable a disabled plugin"

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -790,20 +790,63 @@ def _discover_all_plugins() -> list:
     return list(seen.values())
 
 
-def cmd_list() -> None:
-    """List all plugins (bundled + user) with enabled/disabled state."""
+def cmd_list(output_format: str = "table", enabled_filter: Optional[str] = None) -> None:
+    """List all plugins (bundled + user) with enabled/disabled state.
+
+    Args:
+        output_format: 'table' (default Rich human-readable table) or 'json'
+            (structured array of plugin objects on stdout, for scripts/agents).
+        enabled_filter: If set, check whether this specific plugin name is
+            enabled. Exit 0 if enabled, 1 otherwise (including not installed).
+            Suppresses all stdout output; intended for shell gates and CI.
+    """
+    import json as _json
+    import sys as _sys
+
+    entries = _discover_all_plugins()
+    enabled = _get_enabled_set()
+    disabled = _get_disabled_set()
+
+    def _status(name: str) -> str:
+        if name in disabled:
+            return "disabled"
+        elif name in enabled:
+            return "enabled"
+        return "not_enabled"
+
+    # --enabled <name>: scripting gate, exit 0/1 with no stdout
+    if enabled_filter is not None:
+        for name, _version, _description, _source, _dir in entries:
+            if name == enabled_filter:
+                _sys.exit(0 if _status(name) == "enabled" else 1)
+        # Plugin name not found among installed
+        _sys.exit(1)
+
+    # --format=json: machine-readable
+    if output_format == "json":
+        result = [
+            {
+                "name": name,
+                "version": str(version) if version else None,
+                "status": _status(name),
+                "description": description,
+                "source": source,
+                "path": str(_dir) if _dir else None,
+            }
+            for name, version, description, source, _dir in entries
+        ]
+        print(_json.dumps(result, indent=2))
+        return
+
+    # Default: human-readable Rich table (existing behavior preserved)
     from rich.console import Console
     from rich.table import Table
 
     console = Console()
-    entries = _discover_all_plugins()
     if not entries:
         console.print("[dim]No plugins installed.[/dim]")
         console.print("[dim]Install with:[/dim] hermes plugins install owner/repo")
         return
-
-    enabled = _get_enabled_set()
-    disabled = _get_disabled_set()
 
     table = Table(title="Plugins", show_lines=False)
     table.add_column("Name", style="bold")
@@ -813,9 +856,10 @@ def cmd_list() -> None:
     table.add_column("Source", style="dim")
 
     for name, version, description, source, _dir in entries:
-        if name in disabled:
+        status_text = _status(name)
+        if status_text == "disabled":
             status = "[red]disabled[/red]"
-        elif name in enabled:
+        elif status_text == "enabled":
             status = "[green]enabled[/green]"
         else:
             status = "[yellow]not enabled[/yellow]"
@@ -1606,7 +1650,10 @@ def plugins_command(args) -> None:
     elif action == "disable":
         cmd_disable(args.name)
     elif action in {"list", "ls"}:
-        cmd_list()
+        cmd_list(
+            output_format=getattr(args, "format", "table"),
+            enabled_filter=getattr(args, "enabled", None),
+        )
     elif action is None:
         cmd_toggle()
     else:


### PR DESCRIPTION
feat(plugins): add --format=json and --enabled flags to 'plugins list'

Adds two scripting-friendly flags to 'hermes plugins list' so that external
orchestrators (Hermes multi-runner-dispatch plugin-registration checks,
post-update sanity scripts, CI gates) can introspect plugin state without
parsing the Rich-formatted human-readable table.

* --format={table,json}
  Default 'table' preserves existing behavior. 'json' emits a structured
  array of {name, version, status, description, source, path} objects
  on stdout. Status values: 'enabled', 'disabled', 'not_enabled'.

* --enabled NAME
  Exit 0 if the named plugin is enabled, 1 otherwise (including not
  installed). Suppresses all output; intended as a shell gate:
    if hermes plugins list --enabled multi-runner-dispatch; then
      dispatch ...
    fi

Motivation: the multi-runner-dispatch plugin's post-update sanity check
(L3 stage in scripts/post-update-sanity.sh) currently awk-parses the
human-readable table to detect plugin-registration status. That parser
is ~80 lines and fragile to upstream rendering changes (box-drawing
characters, column-width drift, etc.). Both new flags retire the awk
fallback path entirely while remaining strictly backward compatible
(default output is unchanged).

No new dependencies. Standard library 'json' + 'sys' imported lazily
inside cmd_list() so non-list invocations stay cheap.

Tested:
* hermes plugins list                                 (table, unchanged)
* hermes plugins list --format=json                   (valid JSON)
* hermes plugins list --enabled multi-runner-dispatch (exit 0 when enabled)
* hermes plugins list --enabled nonexistent-plugin    (exit 1)