### PR TITLE
fix(dashboard): support namespaced plugin route keys

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4177,13 +4177,26 @@ async def post_agent_plugin_install(request: Request, body: _AgentPluginInstallB
 
 
 def _validate_plugin_name(name: str) -> str:
-    """Reject path-traversal attempts in plugin name URL parameters."""
-    if not name or "/" in name or "\\" in name or ".." in name:
+    """Reject path-traversal attempts in plugin name URL parameters.
+
+    Bundled provider plugins are often namespaced (for example
+    ``image_gen/openai-codex``), so the dashboard management routes must accept
+    a slash inside the logical plugin key. Keep rejecting filesystem traversal,
+    absolute paths, backslashes, and empty path components.
+    """
+    if (
+        not name
+        or name.startswith("/")
+        or name.endswith("/")
+        or "\\" in name
+        or ".." in name.split("/")
+        or any(not part for part in name.split("/"))
+    ):
         raise HTTPException(status_code=400, detail="Invalid plugin name.")
     return name
 
 
-@app.post("/api/dashboard/agent-plugins/{name}/enable")
+@app.post("/api/dashboard/agent-plugins/{name:path}/enable")
 async def post_agent_plugin_enable(request: Request, name: str):
     _require_token(request)
     name = _validate_plugin_name(name)
@@ -4195,7 +4208,7 @@ async def post_agent_plugin_enable(request: Request, name: str):
     return result
 
 
-@app.post("/api/dashboard/agent-plugins/{name}/disable")
+@app.post("/api/dashboard/agent-plugins/{name:path}/disable")
 async def post_agent_plugin_disable(request: Request, name: str):
     _require_token(request)
     name = _validate_plugin_name(name)
@@ -4207,7 +4220,7 @@ async def post_agent_plugin_disable(request: Request, name: str):
     return result
 
 
-@app.post("/api/dashboard/agent-plugins/{name}/update")
+@app.post("/api/dashboard/agent-plugins/{name:path}/update")
 async def post_agent_plugin_update(request: Request, name: str):
     _require_token(request)
     name = _validate_plugin_name(name)
@@ -4220,7 +4233,7 @@ async def post_agent_plugin_update(request: Request, name: str):
     return result
 
 
-@app.delete("/api/dashboard/agent-plugins/{name}")
+@app.delete("/api/dashboard/agent-plugins/{name:path}")
 async def delete_agent_plugin(request: Request, name: str):
     _require_token(request)
     name = _validate_plugin_name(name)

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2324,3 +2324,76 @@ class TestPtyWebSocket:
             ):
                 pass
         assert exc.value.code == 4400
+
+
+class TestDashboardAgentPluginRoutes:
+    @pytest.fixture(autouse=True)
+    def _setup(self, monkeypatch, _isolate_hermes_home):
+        from starlette.testclient import TestClient
+        import hermes_cli.web_server as ws
+
+        self.client = TestClient(ws.app)
+        self.headers = {"X-Hermes-Session-Token": ws._SESSION_TOKEN}
+
+    def test_enable_accepts_namespaced_plugin_keys(self, monkeypatch):
+        calls: list[tuple[str, bool]] = []
+
+        def fake_set_enabled(name: str, enabled: bool):
+            calls.append((name, enabled))
+            return {"ok": True, "name": name}
+
+        import hermes_cli.plugins_cmd as plugins_cmd
+
+        monkeypatch.setattr(
+            plugins_cmd,
+            "dashboard_set_agent_plugin_enabled",
+            fake_set_enabled,
+        )
+
+        response = self.client.post(
+            "/api/dashboard/agent-plugins/image_gen%2Fopenai-codex/enable",
+            headers=self.headers,
+        )
+
+        assert response.status_code == 200, response.text
+        assert calls == [("image_gen/openai-codex", True)]
+
+    def test_disable_accepts_namespaced_plugin_keys(self, monkeypatch):
+        calls: list[tuple[str, bool]] = []
+
+        def fake_set_enabled(name: str, enabled: bool):
+            calls.append((name, enabled))
+            return {"ok": True, "name": name}
+
+        import hermes_cli.plugins_cmd as plugins_cmd
+
+        monkeypatch.setattr(
+            plugins_cmd,
+            "dashboard_set_agent_plugin_enabled",
+            fake_set_enabled,
+        )
+
+        response = self.client.post(
+            "/api/dashboard/agent-plugins/video_gen%2Fxai/disable",
+            headers=self.headers,
+        )
+
+        assert response.status_code == 200, response.text
+        assert calls == [("video_gen/xai", False)]
+
+    def test_namespaced_route_rejects_traversal(self, monkeypatch):
+        import hermes_cli.plugins_cmd as plugins_cmd
+
+        monkeypatch.setattr(
+            plugins_cmd,
+            "dashboard_set_agent_plugin_enabled",
+            lambda name, enabled: pytest.fail("should reject before mutating config"),
+        )
+
+        response = self.client.post(
+            "/api/dashboard/agent-plugins/image_gen%2F..%2Fsecret/enable",
+            headers=self.headers,
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Invalid plugin name."


### PR DESCRIPTION
## Summary
- allow Dashboard agent plugin routes to accept namespaced plugin keys such as `image_gen/openai-codex`
- keep plugin-name validation restrictive by rejecting traversal, absolute paths, empty path segments, and backslashes
- add route tests for namespaced enable/disable behavior and invalid traversal rejection

## Problem
The Dashboard agent plugin management endpoints used `{name}` path parameters. That does not route plugin keys containing `/`, so requests for namespaced plugin keys can fail before reaching the handler.

Example affected keys:
- `image_gen/openai-codex`
- `model-providers/openai-codex`
- `video_gen/xai`

## Test plan
- `python -m py_compile hermes_cli/web_server.py tests/hermes_cli/test_web_server.py`
- `PYTEST_ADDOPTS='-n0' python -m pytest tests/hermes_cli/test_web_server.py::TestDashboardAgentPluginRoutes -q`
