### PR TITLE
fix(hermes-home): only honour legacy dir layout when it has content

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -228,18 +228,50 @@ def get_hermes_dir(new_subpath: str, old_name: str) -> Path:
     Existing installs that already have the old path (e.g. ``image_cache``)
     keep using it — no migration required.
 
+    A bare empty ``<old_name>/`` directory does **not** count as "the
+    legacy install is in use" — install scaffolds, manual ``mkdir`` work,
+    and cleared-then-abandoned locations all create empty stubs that
+    would otherwise silently shadow real data populated at
+    ``<new_subpath>/``. See #27602 for the pairing-store regression where
+    a dormant empty ``pairing/`` orphaned approved-user data in
+    ``platforms/pairing/``.
+
     Args:
         new_subpath: Preferred path relative to HERMES_HOME (e.g. ``"cache/images"``).
         old_name: Legacy path relative to HERMES_HOME (e.g. ``"image_cache"``).
 
     Returns:
-        Absolute ``Path`` — old location if it exists on disk, otherwise the new one.
+        Absolute ``Path`` — legacy location if it exists with content,
+        otherwise the new location.
     """
     home = get_hermes_home()
     old_path = home / old_name
-    if old_path.exists():
+    if _legacy_path_has_content(old_path):
         return old_path
     return home / new_subpath
+
+
+def _legacy_path_has_content(path: Path) -> bool:
+    """Return ``True`` iff ``path`` exists and has content worth honouring.
+
+    A populated *directory* (any entry inside) counts. A non-directory
+    file at ``path`` also counts — the consumer presumably wrote it.
+    An empty directory does **not** count, so a stale empty
+    legacy stub falls through to the new layout. If enumeration fails
+    (permissions, race), assume occupied so we don't accidentally orphan
+    legacy data.
+    """
+    if not path.exists():
+        return False
+    if not path.is_dir():
+        return True
+    try:
+        next(path.iterdir())
+    except StopIteration:
+        return False
+    except OSError:
+        return True
+    return True
 
 
 def display_hermes_home() -> str:

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -5,6 +5,7 @@ without risk of circular imports.
 """
 
 import os
+import stat
 import sys
 import sysconfig
 from contextvars import ContextVar, Token
@@ -257,13 +258,21 @@ def _legacy_path_has_content(path: Path) -> bool:
     A populated *directory* (any entry inside) counts. A non-directory
     file at ``path`` also counts — the consumer presumably wrote it.
     An empty directory does **not** count, so a stale empty
-    legacy stub falls through to the new layout. If enumeration fails
-    (permissions, race), assume occupied so we don't accidentally orphan
-    legacy data.
+    legacy stub falls through to the new layout. If the path cannot be
+    inspected (``PermissionError`` on ``stat``/``iterdir``, or any other
+    ``OSError`` short of "not found"), assume occupied so we don't
+    accidentally orphan legacy data. Only a genuine
+    ``FileNotFoundError`` counts as absent.
     """
-    if not path.exists():
+    try:
+        st = path.lstat()
+    except FileNotFoundError:
         return False
-    if not path.is_dir():
+    except OSError:
+        # PermissionError on a parent, or any other inspection failure:
+        # treat as occupied rather than silently orphaning legacy data.
+        return True
+    if not stat.S_ISDIR(st.st_mode):
         return True
     try:
         next(path.iterdir())

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -9,6 +9,7 @@ import hermes_constants
 from hermes_constants import (
     VALID_REASONING_EFFORTS,
     get_default_hermes_root,
+    get_hermes_dir,
     get_hermes_home,
     is_container,
     parse_reasoning_effort,
@@ -298,3 +299,107 @@ class TestSecureParentDir:
         assert len(called_with) == 1
         assert called_with[0] == (str(real_dir), 0o700)
 
+
+class TestGetHermesDir:
+    """Tests for ``get_hermes_dir(new_subpath, old_name)``.
+
+    Contract: prefer the legacy ``<old_name>/`` location, but only when
+    it has content. An empty legacy stub must fall through to the new
+    layout so dormant install scaffolds don't orphan populated data at
+    ``<new_subpath>/``. Regression guard for #27602.
+    """
+
+    def _set_home(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    def test_neither_exists_returns_new(self, tmp_path, monkeypatch):
+        self._set_home(tmp_path, monkeypatch)
+        result = get_hermes_dir("platforms/pairing", "pairing")
+        assert result == tmp_path / "platforms/pairing"
+
+    def test_legacy_populated_returns_legacy(self, tmp_path, monkeypatch):
+        self._set_home(tmp_path, monkeypatch)
+        legacy = tmp_path / "image_cache"
+        legacy.mkdir()
+        (legacy / "cached.png").write_bytes(b"x")
+        result = get_hermes_dir("cache/images", "image_cache")
+        assert result == legacy
+
+    def test_legacy_populated_with_subdir_returns_legacy(self, tmp_path, monkeypatch):
+        """Sub-directories count as content (e.g. nested cache layout)."""
+        self._set_home(tmp_path, monkeypatch)
+        legacy = tmp_path / "matrix" / "store"
+        legacy.mkdir(parents=True)
+        (legacy / "session").mkdir()  # subdir, not a file
+        result = get_hermes_dir("platforms/matrix/store", "matrix/store")
+        assert result == legacy
+
+    def test_legacy_empty_returns_new(self, tmp_path, monkeypatch):
+        """The #27602 regression: empty legacy dir orphans populated new dir.
+
+        Without the fix, the resolver returned the empty legacy path
+        unconditionally, causing the pairing store to forget every
+        previously-approved user when an empty ``pairing/`` stub had
+        been pre-created at install time.
+        """
+        self._set_home(tmp_path, monkeypatch)
+        legacy = tmp_path / "pairing"
+        legacy.mkdir()
+        # Populated new layout — this is the data that must not be orphaned.
+        new = tmp_path / "platforms" / "pairing"
+        new.mkdir(parents=True)
+        (new / "telegram-approved.json").write_text("[]")
+        result = get_hermes_dir("platforms/pairing", "pairing")
+        assert result == new
+
+    def test_legacy_empty_and_new_missing_returns_new(self, tmp_path, monkeypatch):
+        """Empty legacy + no new yet — return the new path (will be created lazily).
+
+        Slight behaviour change vs the old resolver (which would return the
+        empty legacy dir): the new path is what every consumer mkdirs into
+        when it doesn't exist, so the next write lands in the canonical
+        location instead of perpetuating the empty stub.
+        """
+        self._set_home(tmp_path, monkeypatch)
+        legacy = tmp_path / "audio_cache"
+        legacy.mkdir()
+        result = get_hermes_dir("cache/audio", "audio_cache")
+        assert result == tmp_path / "cache/audio"
+
+    def test_legacy_is_file_treated_as_content(self, tmp_path, monkeypatch):
+        """A non-directory file at the legacy path counts as occupied.
+
+        Defensive against odd installs where the caller previously wrote a
+        single file instead of a directory. We honour whatever's there.
+        """
+        self._set_home(tmp_path, monkeypatch)
+        legacy = tmp_path / "image_cache"
+        legacy.write_bytes(b"sentinel")
+        result = get_hermes_dir("cache/images", "image_cache")
+        assert result == legacy
+
+    def test_unreadable_legacy_dir_kept(self, tmp_path, monkeypatch):
+        """If we can't enumerate the legacy dir, assume occupied — never
+        accidentally orphan legacy data on a transient permission error.
+        """
+        self._set_home(tmp_path, monkeypatch)
+        legacy = tmp_path / "whatsapp" / "session"
+        legacy.mkdir(parents=True)
+        # Populate the new path too. The point is to verify that an
+        # OSError on iterdir does NOT fall through to the new layout.
+        new = tmp_path / "platforms" / "whatsapp" / "session"
+        new.mkdir(parents=True)
+        (new / "creds.json").write_text("{}")
+
+        real_iterdir = Path.iterdir
+
+        def boom(self):
+            if self == legacy:
+                raise PermissionError("simulated")
+            return real_iterdir(self)
+
+        monkeypatch.setattr(Path, "iterdir", boom)
+        result = get_hermes_dir(
+            "platforms/whatsapp/session", "whatsapp/session"
+        )
+        assert result == legacy

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -403,3 +403,33 @@ class TestGetHermesDir:
             "platforms/whatsapp/session", "whatsapp/session"
         )
         assert result == legacy
+
+    def test_unstatable_legacy_dir_kept(self, tmp_path, monkeypatch):
+        """A ``PermissionError`` raised by the existence check itself (e.g.
+        an unreadable parent) must NOT be read as "absent".
+
+        The old ``Path.exists()``/``Path.is_dir()`` gate swallowed
+        ``PermissionError`` and returned ``False``, so an unreadable legacy
+        dir fell through to the new layout and orphaned legacy data —
+        contradicting the docstring's "assume occupied on errors" intent.
+        With the ``lstat()``-based gate this raises and is caught as
+        occupied. Regression guard for the #27602 follow-up.
+        """
+        self._set_home(tmp_path, monkeypatch)
+        legacy = tmp_path / "pairing"
+        legacy.mkdir()
+        # Populate the new path; it must NOT be selected.
+        new = tmp_path / "platforms" / "pairing"
+        new.mkdir(parents=True)
+        (new / "telegram-approved.json").write_text("[]")
+
+        real_lstat = Path.lstat
+
+        def boom(self):
+            if self == legacy:
+                raise PermissionError("simulated unreadable parent")
+            return real_lstat(self)
+
+        monkeypatch.setattr(Path, "lstat", boom)
+        result = get_hermes_dir("platforms/pairing", "pairing")
+        assert result == legacy

--- a/tests/tools/test_credential_files.py
+++ b/tests/tools/test_credential_files.py
@@ -397,12 +397,22 @@ class TestCacheDirectoryMounts:
         assert mounts[0]["container_path"] == "/root/.hermes/cache/documents"
 
     def test_legacy_dir_names_resolved(self, tmp_path, monkeypatch):
-        """Old-style dir names (e.g. document_cache) are resolved correctly."""
+        """Old-style dir names (e.g. document_cache) are resolved correctly.
+
+        Populates the legacy dirs with a sentinel file so they count as
+        ``has content`` for ``get_hermes_dir``'s populated-legacy check
+        (see #27602 — empty legacy stubs are no longer honoured).
+        """
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()
-        # Use legacy dir name — get_hermes_dir prefers old if it exists
-        (hermes_home / "document_cache").mkdir()
-        (hermes_home / "image_cache").mkdir()
+        # Use legacy dir name with content — get_hermes_dir prefers
+        # populated old over new.
+        legacy_doc = hermes_home / "document_cache"
+        legacy_img = hermes_home / "image_cache"
+        legacy_doc.mkdir()
+        legacy_img.mkdir()
+        (legacy_doc / "cached.txt").write_bytes(b"x")
+        (legacy_img / "cached.png").write_bytes(b"x")
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
         mounts = get_cache_directory_mounts()


### PR DESCRIPTION
## Summary

`get_hermes_dir(new_subpath, old_name)` in `hermes_constants.py` returned the legacy `<old_name>/` path as soon as it *existed* — regardless of whether it had any content. An empty legacy stub (left over from install scaffolds, manual `mkdir`, or a cleared-then-abandoned location) silently shadowed populated data at `<new_subpath>/`. This PR narrows the predicate to `_legacy_path_has_content()` so only *populated* legacy locations win the fallback. Genuine legacy installs are untouched; only the empty-stub regression is fixed.

Fixes #27602.

## The bug

Reported on #27602: a dormant empty `~/.hermes/pairing/` directory (created at install time, never used) made the resolver pick the legacy path even though all approved-user state lived under the new `~/.hermes/platforms/pairing/`. Every previously-approved Telegram/WhatsApp user got re-prompted to pair again after a `hermes update` because the gateway switched to the empty legacy dir mid-session.

```python
# Before:
def get_hermes_dir(new_subpath: str, old_name: str) -> Path:
    home = get_hermes_home()
    old_path = home / old_name
    if old_path.exists():        # ← empty stub also returns here
        return old_path
    return home / new_subpath
```

The same shape is latent across every other caller of `get_hermes_dir`:

| Consumer | Legacy → New |
|---|---|
| `gateway/pairing.py` | `pairing` → `platforms/pairing` |
| `gateway/platforms/base.py` | `image_cache` → `cache/images` |
| `gateway/platforms/base.py` | `audio_cache` → `cache/audio` |
| `gateway/platforms/base.py` | `video_cache` → `cache/videos` |
| `gateway/platforms/base.py` | `document_cache` → `cache/documents` |
| `gateway/platforms/whatsapp.py` | `whatsapp/session` → `platforms/whatsapp/session` |
| `gateway/platforms/matrix.py` | `matrix/store` → `platforms/matrix/store` |
| `tools/browser_tool.py` | `browser_screenshots` → `cache/screenshots` |
| `tools/tts_tool.py` | `audio_cache` / `piper_voices_cache` → `cache/audio` / `cache/piper-voices` |
| `tools/vision_tools.py` | `temp_vision_images` / `temp_video_files` → `cache/vision` / `cache/video` |
| `tools/credential_files.py` | (table-driven mounts, same helper) |

For caches the consequence was mild (regenerate into the empty stub); for state-bearing dirs (pairing, whatsapp session, matrix store, credentials) it silently orphaned user data.

## The fix

Split the predicate into `_legacy_path_has_content()`:

- Path doesn't exist → not honoured (use new layout).
- Path is a non-directory file → honoured (caller previously wrote a file).
- Path is a directory with at least one entry → honoured.
- Path is an *empty* directory → not honoured, fall through to new layout.
- Enumeration raises `OSError` (permission / race) → honoured. Never accidentally orphan legacy data on a transient read failure.

Populated legacy installs continue to win exactly as before. The only behaviour change is the empty-legacy-stub case.

## Contract protected

**Invariant:** `get_hermes_dir(new, old)` returns the legacy `home/old` location iff that location has data the caller previously wrote. An empty stub is not data.

**Known-bad inputs covered by `TestGetHermesDir`:**
- Empty legacy + populated new → returns new (the #27602 regression).
- Empty legacy + missing new → returns new (no perpetuating the stub).
- Both missing → returns new.
- Populated legacy + missing new → returns legacy (backward-compat preserved).
- Populated legacy with sub-directory contents → returns legacy.
- Legacy path is a file (not a dir) → returns legacy.
- Legacy `iterdir()` raises `PermissionError` → returns legacy (fail-closed).

**Negative case:** every existing call site that mkdirs on the result still creates the right path — confirmed via `tests/gateway/test_pairing.py` (29 passed) and `tests/tools/test_credential_files.py` (138 passed; one test that implicitly asserted the empty-legacy semantic was updated to populate the legacy dirs).

## Test plan

- [x] New regression suite `tests/test_hermes_constants.py::TestGetHermesDir` — 7 cases, all pass.
- [x] Adjacent: `tests/gateway/test_pairing.py` — 29 passed.
- [x] Adjacent: `tests/tools/test_credential_files.py` (cache directory mounts) — 138 passed after updating `test_legacy_dir_names_resolved` to populate the legacy dirs (the test was implicitly verifying the buggy "empty dir wins" semantic).
- [x] Adjacent: `tests/tools/test_browser_console.py`, `tests/tools/test_browser_lightpanda.py` — pass.
- [x] Regression guard: against the pre-fix resolver, `test_legacy_empty_returns_new` fails with `assert tmp/pairing == tmp/platforms/pairing` (the empty `pairing/` stub wins). With the fix, it returns the populated `platforms/pairing/`.
- [x] Production behaviour outside the empty-legacy case is unchanged — every existing caller's directory still resolves to the same path it resolved to before.

Test command: `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/test_hermes_constants.py tests/gateway/test_pairing.py tests/tools/test_credential_files.py tests/tools/test_browser_console.py tests/tools/test_browser_lightpanda.py -v`.

## Related

- Fixes #27602.
- Existing exploratory test PRs that exercised the prior (buggy) contract: #21898 and #22319 — neither is a fix; both add tests that pass under both the old and the new contract (they don't exercise the empty-legacy case).

> Sibling code paths that may benefit from the same invariant downstream: the install/scaffold code that creates `~/.hermes/pairing/` at first-boot time (the original empty-stub source per the issue) should arguably stop pre-creating empty legacy dirs at all. Intentionally left out of this PR — happy to widen if preferred, but this resolver-side fix already prevents the data-orphan symptom regardless of what scaffolds.