### PR TITLE
fix(compression): use config provider instead of session provider after /model switch (#27538)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1043,13 +1043,11 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         try:
             call_kwargs = {
                 "task": "compression",
-                "main_runtime": {
-                    "model": self.model,
-                    "provider": self.provider,
-                    "base_url": self.base_url,
-                    "api_key": self.api_key,
-                    "api_mode": self.api_mode,
-                },
+                # Do NOT pass main_runtime here — compression must resolve its
+                # provider from auxiliary.compression.provider config, not from
+                # the current session's (potentially /model-switched) provider.
+                # Passing main_runtime caused the switched provider's credentials
+                # to override the configured compression provider.  (#27538)
                 "messages": [{"role": "user", "content": prompt}],
                 "max_tokens": int(summary_budget * 1.3),
                 # timeout resolved from auxiliary.compression.timeout config by call_llm

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -215,7 +215,9 @@ class TestNonStringContent:
         assert "Treat the conversation turns below as source material" in prompt
         assert "structured checkpoint summary" in prompt
 
-    def test_summary_call_passes_live_main_runtime(self):
+    def test_summary_call_does_not_pass_main_runtime(self):
+        """Compression should resolve its provider from config, not from
+        the current session's (potentially /model-switched) provider (#27538)."""
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]
         mock_response.choices[0].message.content = "ok"
@@ -238,13 +240,7 @@ class TestNonStringContent:
         with patch("agent.context_compressor.call_llm", return_value=mock_response) as mock_call:
             c._generate_summary(messages)
 
-        assert mock_call.call_args.kwargs["main_runtime"] == {
-            "model": "gpt-5.4",
-            "provider": "openai-codex",
-            "base_url": "https://chatgpt.com/backend-api/codex",
-            "api_key": "codex-token",
-            "api_mode": "codex_responses",
-        }
+        assert "main_runtime" not in mock_call.call_args.kwargs
 
 
 class TestSummaryFailureCooldown:


### PR DESCRIPTION
## Summary

When `auxiliary.compression.provider` is configured in config.yaml, context compaction still uses the current session provider after a `/model` switch instead of the configured compression provider.

## Problem

`call_llm()` in `context_compressor.py` receives a `main_runtime` dict with the switched provider's credentials. When `_resolve_task_provider_model` falls through to auto-detect or when client creation fails, `_get_cached_client` uses `main_runtime` as fallback — overriding the configured `auxiliary.compression.provider`.

## Solution

Remove `main_runtime` from the compression `call_llm()` kwargs. Compression now resolves its provider purely from `auxiliary.compression.*` config, not from the potentially-switched session provider.

## Files Changed

| File | Change |
|------|--------|
| `agent/context_compressor.py` | Removed `main_runtime` from `call_kwargs` (+5/-7) |
| `tests/agent/test_context_compressor.py` | Updated test to assert `main_runtime` is NOT passed (+7/-9) |

## Test Results

```
82 passed, 0 failed in 13.43s
```

Closes #27538