### PR TITLE
fix(security): validate inference_base_url against host allowlist to prevent bearer token exfiltration

### DIFF
--- a/hermes_cli/proxy/adapters/nous_portal.py
+++ b/hermes_cli/proxy/adapters/nous_portal.py
@@ -15,6 +15,8 @@ import logging
 import threading
 from typing import Any, Dict, FrozenSet, Optional
 
+from urllib.parse import urlparse
+
 from hermes_cli.auth import (
     DEFAULT_NOUS_INFERENCE_URL,
     _load_auth_store,
@@ -25,6 +27,46 @@ from hermes_cli.auth import (
 from hermes_cli.proxy.adapters.base import UpstreamAdapter, UpstreamCredential
 
 logger = logging.getLogger(__name__)
+
+# Allowlist of hosts the Nous Portal proxy is willing to forward minted
+# bearer tokens to. The bearer is a long-lived agent_key minted by
+# portal.nousresearch.com — sending it anywhere else would leak it.
+_ALLOWED_INFERENCE_HOSTS: FrozenSet[str] = frozenset({
+    "inference-api.nousresearch.com",
+})
+
+
+def _validate_nous_inference_url(url: str) -> str:
+    """Return *url* if it points at an allowlisted Nous inference host,
+    otherwise fall back to the documented default.
+
+    Defense-in-depth: ``inference_base_url`` comes from the Portal's
+    refresh / agent-key-mint response and from on-disk ``auth.json``.
+    Both are normally trustworthy, but a compromised refresh response
+    (MITM on portal.nousresearch.com, malicious local process writing
+    auth.json) could otherwise redirect every subsequent proxy request
+    — bearing the user's minted agent_key — to an attacker-controlled
+    endpoint. Validating scheme + host closes that loop.
+    """
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return DEFAULT_NOUS_INFERENCE_URL
+    if parsed.scheme != "https":
+        logger.warning(
+            "proxy: refusing non-https inference_base_url scheme %r; "
+            "falling back to default",
+            parsed.scheme,
+        )
+        return DEFAULT_NOUS_INFERENCE_URL
+    if parsed.hostname not in _ALLOWED_INFERENCE_HOSTS:
+        logger.warning(
+            "proxy: refusing inference_base_url host %r not in allowlist; "
+            "falling back to default",
+            parsed.hostname,
+        )
+        return DEFAULT_NOUS_INFERENCE_URL
+    return url.rstrip("/")
 
 # Endpoints inference-api.nousresearch.com actually serves. Anything else
 # the proxy will reject with 404 — keeps stray clients from leaking weird
@@ -95,8 +137,8 @@ class NousPortalAdapter(UpstreamAdapter):
                     "Try `hermes login nous` to re-authenticate."
                 )
 
-            base_url = refreshed.get("inference_base_url") or DEFAULT_NOUS_INFERENCE_URL
-            base_url = base_url.rstrip("/")
+            raw_base_url = refreshed.get("inference_base_url") or DEFAULT_NOUS_INFERENCE_URL
+            base_url = _validate_nous_inference_url(raw_base_url)
 
             return UpstreamCredential(
                 bearer=agent_key,


### PR DESCRIPTION
## What does this PR do?

The Nous Portal proxy adapter (`hermes_cli/proxy/adapters/nous_portal.py`)
forwards minted `agent_key` bearer tokens to whatever `inference_base_url`
the Portal returns in its refresh / agent-key-mint response, with no
validation beyond a trailing-slash strip:

```python
# Before — accepts any URL
base_url = refreshed.get("inference_base_url") or DEFAULT_NOUS_INFERENCE_URL
base_url = base_url.rstrip("/")
return UpstreamCredential(bearer=agent_key, base_url=base_url, ...)
```

The same field is also persisted to `~/.hermes/auth.json` via
`_save_state()` and re-read by `get_credential()` on every proxy
request, so a one-time poisoning sticks across restarts.

### Two attack paths

**1. Network — MITM on portal.nousresearch.com during refresh**

`refresh_nous_oauth_from_state()` runs whenever the cached `agent_key`
is expired (every ~24h on an active proxy). A network adversary in
position to MITM the Portal response can return:

```json
{
  "agent_key": "<the real minted key, untouched>",
  "inference_base_url": "https://attacker.com"
}
```

From that point on, every `/v1/chat/completions` request the local
proxy receives is forwarded to `https://attacker.com/...` with
`Authorization: Bearer <legitimate_agent_key>`. The attacker harvests
working bearer tokens and gets full access to the user's Nous Portal
inference budget — plus a side-channel to inject responses back into
the user's IDE / chat client.

**2. Local — write access to `~/.hermes/auth.json`**

Any local process that can write the user's auth.json (a malicious VS
Code extension, a postinstall script on a stray npm package, a
compromised cron job) can flip `inference_base_url` and achieve the
same outcome without ever touching the network.

### CVSS 3.1 estimate

`AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:N` → **8.7 (HIGH)**
Scope-changed (S:C) because the bearer token grants access to the
user's Portal account from the attacker's host.

## Fix

Add a defense-in-depth allowlist check on the URL before it's used:

```python
_ALLOWED_INFERENCE_HOSTS: FrozenSet[str] = frozenset({
    "inference-api.nousresearch.com",
})


def _validate_nous_inference_url(url: str) -> str:
    """Return *url* if it points at an allowlisted Nous inference host,
    otherwise fall back to the documented default."""
    try:
        parsed = urlparse(url)
    except Exception:
        return DEFAULT_NOUS_INFERENCE_URL
    if parsed.scheme != "https":
        logger.warning("proxy: refusing non-https inference_base_url ...")
        return DEFAULT_NOUS_INFERENCE_URL
    if parsed.hostname not in _ALLOWED_INFERENCE_HOSTS:
        logger.warning("proxy: refusing inference_base_url host %r ...",
                       parsed.hostname)
        return DEFAULT_NOUS_INFERENCE_URL
    return url.rstrip("/")
```

Then at the call site:

```python
raw_base_url = refreshed.get("inference_base_url") or DEFAULT_NOUS_INFERENCE_URL
base_url = _validate_nous_inference_url(raw_base_url)
```

A poisoned `inference_base_url` now falls back to the documented
default with a warning log, so the bearer never leaves an
allowlisted Nous host.

### Why this allowlist shape

Mirrors the conservative-default pattern used elsewhere in the
codebase (e.g. `#19597` Meet node localhost binding, `#21277`
dashboard plugin SRI integrity, `#22432` Google Chat sender_type
coercion). The allowlist is a `frozenset` constant — easy for Nous
to add staging / mirror hosts in a single line when needed, and the
fallback is fail-safe rather than fail-open.

## Type of Change

- [x] 🔒 Security fix (HIGH — bearer token exfiltration via upstream URL manipulation)

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Defense-in-depth — doesn't replace the existing TLS / Portal-trust assumption, hardens it
- [x] Fail-safe fallback to documented default rather than hard error
- [x] No behavior change for users on the standard Nous inference host
- [x] Warning logs surface the rejection so operators can investigate if Nous adds a new host