### PR TITLE
fix(tui): increase autocomplete limit from 30 to 200, register all TUI-local commands

### DIFF
--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -484,7 +484,7 @@ def test_slash_exec_plugin_handler_error_returns_output(server):
     assert worker.calls == []
 
 
-@pytest.mark.parametrize("cmd", ["retry", "queue hello", "q hello", "steer fix the test", "plan"])
+@pytest.mark.parametrize("cmd", ["retry", "queue hello", "q hello", "steer fix the test", "goal status"])
 def test_slash_exec_rejects_pending_input_commands(server, cmd):
     """slash.exec must reject commands that use _pending_input in the CLI."""
     sid = "test-session"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4382,8 +4382,16 @@ _TUI_HIDDEN: frozenset[str] = frozenset(
 
 _TUI_EXTRA: list[tuple[str, str, str]] = [
     ("/compact", "Toggle compact display mode", "TUI"),
+    ("/details", "Control agent detail visibility", "TUI"),
+    ("/fortune", "Show a random or daily local fortune", "TUI"),
+    ("/heapdump", "Write a V8 heap snapshot + diagnostics", "TUI"),
     ("/logs", "Show recent gateway log lines", "TUI"),
+    ("/mem", "Print live V8 heap + RSS numbers", "TUI"),
     ("/mouse", "Toggle mouse/wheel tracking [on|off|toggle]", "TUI"),
+    ("/replay", "Replay a completed spawn tree", "TUI"),
+    ("/replay-diff", "Diff two completed spawn trees", "TUI"),
+    ("/setup", "Run full setup wizard (launches `hermes setup`)", "TUI"),
+    ("/terminal-setup", "Configure IDE terminal keybindings", "TUI"),
 ]
 
 # Commands that queue messages onto _pending_input in the CLI.
@@ -4395,7 +4403,6 @@ _PENDING_INPUT_COMMANDS: frozenset[str] = frozenset(
         "queue",
         "q",
         "steer",
-        "plan",
         "goal",
     }
 )
@@ -5238,7 +5245,7 @@ def _(rid, params: dict) -> dict:
                 "meta": to_plain_text(c.display_meta) if c.display_meta else "",
             }
             for c in completer.get_completions(doc, None)
-        ][:30]
+        ][:200]
         text_lower = text.lower()
         extras = [
             {
@@ -5252,14 +5259,49 @@ def _(rid, params: dict) -> dict:
                 "meta": "Control agent detail visibility",
             },
             {
+                "text": "/fortune",
+                "display": "/fortune",
+                "meta": "Show a random or daily local fortune",
+            },
+            {
+                "text": "/heapdump",
+                "display": "/heapdump",
+                "meta": "Write a V8 heap snapshot + diagnostics",
+            },
+            {
                 "text": "/logs",
                 "display": "/logs",
                 "meta": "Show recent gateway log lines",
             },
             {
+                "text": "/mem",
+                "display": "/mem",
+                "meta": "Print live V8 heap + RSS numbers",
+            },
+            {
                 "text": "/mouse",
                 "display": "/mouse",
                 "meta": "Toggle mouse/wheel tracking [on|off|toggle]",
+            },
+            {
+                "text": "/replay",
+                "display": "/replay",
+                "meta": "Replay a completed spawn tree",
+            },
+            {
+                "text": "/replay-diff",
+                "display": "/replay-diff",
+                "meta": "Diff two completed spawn trees",
+            },
+            {
+                "text": "/setup",
+                "display": "/setup",
+                "meta": "Run full setup wizard (launches `hermes setup`)",
+            },
+            {
+                "text": "/terminal-setup",
+                "display": "/terminal-setup",
+                "meta": "Configure IDE terminal keybindings",
             },
         ]
         for extra in extras:


### PR DESCRIPTION
## Problem

The `complete.slash` handler capped `SlashCommandCompleter` results at 30 items. With ~158 total completions (60 visible COMMAND_REGISTRY entries + 87 skill commands + 11 TUI-local commands), only the first 30 alphabetically appeared in the autocomplete dropdown. Commands like `/resume`, `/sessions`, `/config`, `/model`, `/help`, `/quit`, plus all `/claude-code` and skill commands were invisible.

This means 80% of commands were silently dropped from autocomplete.

## Changes

1. **Increased autocomplete cap** from 30 → 200 in `complete.slash` handler
2. **Registered 8 missing TUI-local commands** in both `_TUI_EXTRA` and `complete.slash extras` (`/details`, `/fortune`, `/heapdump`, `/mem`, `/replay`, `/replay-diff`, `/setup`, `/terminal-setup`)
3. **Removed dead `plan` entry** from `_PENDING_INPUT_COMMANDS`
4. **Updated test** parametrize to match current `_PENDING_INPUT_COMMANDS`

## Testing

- Ran TUI gateway tests
- Verified autocomplete returns all completions with bare `/` input