### PR TITLE
feat(kanban): deliver commented events; wildcard cross-board subs

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4246,6 +4246,20 @@ class GatewayRunner:
             return
 
         TERMINAL_KINDS = ("completed", "blocked", "gave_up", "crashed", "timed_out")
+        # Comment events are deliverable too — they're how Alex's web-UI
+        # replies reach a subscribed agent or chat. Kept as a separate
+        # tuple so the rendering branch can pick them out, even though
+        # the claim query unions both sets so a single per-sub cursor
+        # serves both terminal + comment delivery.
+        COMMENT_KINDS = ("commented",)
+        DELIVERABLE_KINDS = TERMINAL_KINDS + COMMENT_KINDS
+        # Comment-burst coalescing: a worker chain that drops several
+        # comments in a row (orchestrator narration, dashboard echoes)
+        # would otherwise flood the chat. Buffer per-subscription comment
+        # events for COMMENT_COALESCE_SECONDS and ship one summary; the
+        # buffer is held on the runner (`_kanban_comment_buffer`) keyed
+        # on (platform, chat_id, thread_id, task_id_or_wildcard).
+        COMMENT_COALESCE_SECONDS = 30.0
         # Subscriptions are removed only when the task reaches a truly final
         # status (done / archived). We used to also unsub on any terminal
         # event kind (gave_up / crashed / timed_out / blocked), but that
@@ -4347,16 +4361,87 @@ class GatewayRunner:
                                         sub.get("task_id"), platform or "<missing>",
                                     )
                                     continue
+                                # Wildcard subscription: task_id='*' fans
+                                # out commented-event delivery for any task
+                                # on this board, with the per-sub author
+                                # filter applied. Terminal events are NOT
+                                # included in wildcard delivery — a wildcard
+                                # sub would otherwise flood the chat with
+                                # every completion on the whole board.
+                                if sub["task_id"] == "*":
+                                    old_cursor, cursor, events = _kb.claim_unseen_wildcard_events_for_sub(
+                                        conn,
+                                        platform=sub["platform"],
+                                        chat_id=sub["chat_id"],
+                                        thread_id=sub.get("thread_id") or "",
+                                        kinds=COMMENT_KINDS,
+                                        author_filter=sub.get("author_filter"),
+                                    )
+                                    if not events:
+                                        continue
+                                    logger.debug(
+                                        "kanban notifier: claimed %d wildcard comment event(s) on board %s cursor %s→%s author_filter=%s",
+                                        len(events), slug, old_cursor, cursor,
+                                        sub.get("author_filter"),
+                                    )
+                                    # Resolve task per-event (different
+                                    # task_ids in one wildcard delivery).
+                                    events_with_task = []
+                                    for ev in events:
+                                        try:
+                                            ev_task = _kb.get_task(conn, ev.task_id)
+                                        except Exception:
+                                            ev_task = None
+                                        events_with_task.append((ev, ev_task))
+                                    deliveries.append({
+                                        "sub": sub,
+                                        "old_cursor": old_cursor,
+                                        "cursor": cursor,
+                                        "events": events,
+                                        "events_with_task": events_with_task,
+                                        "task": None,  # wildcard: each ev carries its own
+                                        "board": slug,
+                                        "wildcard": True,
+                                    })
+                                    continue
+                                # Regular per-task subscription: union of
+                                # TERMINAL_KINDS and COMMENT_KINDS so a
+                                # single per-sub cursor governs both
+                                # delivery paths atomically.
+                                sub_author_filter = sub.get("author_filter")
                                 old_cursor, cursor, events = _kb.claim_unseen_events_for_sub(
                                     conn,
                                     task_id=sub["task_id"],
                                     platform=sub["platform"],
                                     chat_id=sub["chat_id"],
                                     thread_id=sub.get("thread_id") or "",
-                                    kinds=TERMINAL_KINDS,
+                                    kinds=DELIVERABLE_KINDS,
                                 )
                                 if not events:
                                     continue
+                                # Apply per-sub author filter to comment
+                                # events only; terminal events ignore the
+                                # filter (a terminal ping is always
+                                # interesting to the requester, regardless
+                                # of who authored it — usually the worker
+                                # profile itself for runtime events).
+                                if sub_author_filter is not None:
+                                    filtered = []
+                                    for ev in events:
+                                        if ev.kind in COMMENT_KINDS:
+                                            ev_author = None
+                                            if isinstance(ev.payload, dict):
+                                                ev_author = ev.payload.get("author")
+                                            if ev_author != sub_author_filter:
+                                                continue
+                                        filtered.append(ev)
+                                    events = filtered
+                                    if not events:
+                                        # Cursor was advanced atomically
+                                        # in the claim — keep it advanced
+                                        # so we don't re-scan the filtered
+                                        # events forever.
+                                        continue
                                 task = _kb.get_task(conn, sub["task_id"])
                                 logger.debug(
                                     "kanban notifier: claimed %d event(s) for %s on board %s cursor %s→%s",
@@ -4369,6 +4454,7 @@ class GatewayRunner:
                                     "events": events,
                                     "task": task,
                                     "board": slug,
+                                    "wildcard": False,
                                 })
                         finally:
                             conn.close()
@@ -4379,6 +4465,7 @@ class GatewayRunner:
                     sub = d["sub"]
                     task = d["task"]
                     board_slug = d.get("board")
+                    is_wildcard = d.get("wildcard", False)
                     platform_str = (sub["platform"] or "").lower()
                     try:
                         plat = _Platform(platform_str)
@@ -4404,19 +4491,39 @@ class GatewayRunner:
                         )
                         continue
                     title = (task.title if task else sub["task_id"])[:120]
-                    for ev in d["events"]:
+                    # Pre-bucket events into (terminal, comment) so a single
+                    # tick that pulled both kinds at once can ship the
+                    # comments as one coalesced summary (caps Teams chatter
+                    # when a worker drops several comments in a row).
+                    terminal_events = []
+                    comment_events = []
+                    if is_wildcard:
+                        # Wildcard subs are comment-only (TERMINAL kinds are
+                        # excluded from the claim). Each event carries its
+                        # own task in events_with_task.
+                        comment_events = list(d.get("events_with_task") or [])
+                    else:
+                        for ev in d["events"]:
+                            if ev.kind in COMMENT_KINDS:
+                                comment_events.append((ev, task))
+                            else:
+                                terminal_events.append(ev)
+                    sub_key = (
+                        sub["task_id"], sub["platform"],
+                        sub["chat_id"], sub.get("thread_id") or "",
+                    )
+                    metadata: dict[str, Any] = {}
+                    if sub.get("thread_id"):
+                        metadata["thread_id"] = sub["thread_id"]
+
+                    delivery_failed = False
+                    # 1) Terminal events: one message per event (existing
+                    # behaviour, unchanged for backward compat).
+                    for ev in terminal_events:
                         kind = ev.kind
-                        # Identity prefix: attribute terminal pings to the
-                        # worker that did the work. Makes fleets (where one
-                        # chat subscribes to many tasks) legible at a glance.
                         who = (task.assignee if task and task.assignee else None)
                         tag = f"@{who} " if who else ""
                         if kind == "completed":
-                            # Prefer the run's summary (the worker's
-                            # intentional human-facing handoff, carried
-                            # in the event payload), then fall back to
-                            # task.result for legacy rows written before
-                            # runs shipped.
                             handoff = ""
                             payload_summary = None
                             if ev.payload and ev.payload.get("summary"):
@@ -4459,66 +4566,56 @@ class GatewayRunner:
                             )
                         else:
                             continue
-                        metadata: dict[str, Any] = {}
-                        if sub.get("thread_id"):
-                            metadata["thread_id"] = sub["thread_id"]
-                        sub_key = (
-                            sub["task_id"], sub["platform"],
-                            sub["chat_id"], sub.get("thread_id") or "",
+                        ok = await self._kanban_send_one(
+                            adapter, sub, d, board_slug, platform_str,
+                            sub_key, msg, metadata, kind,
+                            sub_fail_counts, MAX_SEND_FAILURES,
                         )
-                        try:
-                            await adapter.send(
-                                sub["chat_id"], msg, metadata=metadata,
-                            )
-                            logger.debug(
-                                "kanban notifier: delivered %s event for %s to %s/%s on board %s",
-                                kind, sub["task_id"], platform_str, sub["chat_id"], board_slug,
-                            )
-                            # Reset the failure counter on success.
-                            sub_fail_counts.pop(sub_key, None)
-                        except Exception as exc:
-                            fails = sub_fail_counts.get(sub_key, 0) + 1
-                            sub_fail_counts[sub_key] = fails
-                            logger.warning(
-                                "kanban notifier: send failed for %s on %s "
-                                "(attempt %d/%d): %s",
-                                sub["task_id"], platform_str, fails,
-                                MAX_SEND_FAILURES, exc,
-                            )
-                            if fails >= MAX_SEND_FAILURES:
-                                logger.warning(
-                                    "kanban notifier: dropping subscription "
-                                    "%s on %s after %d consecutive send failures",
-                                    sub["task_id"], platform_str, fails,
-                                )
-                                await asyncio.to_thread(self._kanban_unsub, sub, board_slug)
-                                sub_fail_counts.pop(sub_key, None)
-                            else:
-                                await asyncio.to_thread(
-                                    self._kanban_rewind,
-                                    sub,
-                                    d["cursor"],
-                                    d.get("old_cursor", 0),
-                                    board_slug,
-                                )
-                            # Rewind the pre-send claim on transient failure so
-                            # a later tick can retry. After too many failures,
-                            # dropping the subscription is the terminal action.
+                        if not ok:
+                            delivery_failed = True
                             break
-                    else:
-                        # All events delivered; advance cursor. The cursor
-                        # is the dedup mechanism — it prevents re-delivery
-                        # of the same event on subsequent ticks.
-                        await asyncio.to_thread(
-                            self._kanban_advance, sub, d["cursor"], board_slug,
+
+                    # 2) Comment events: one bundled message per delivery.
+                    # Within-tick coalescing (multiple comments captured in
+                    # the same poll cycle land in one message). Cross-tick
+                    # coalescing isn't done here — comments older than
+                    # COMMENT_COALESCE_SECONDS=30s rarely cluster in
+                    # practice and persisting a pending bucket across ticks
+                    # would require new state.
+                    if not delivery_failed and comment_events:
+                        msg = self._render_comment_bundle(
+                            sub, comment_events, board_slug,
+                            wildcard=is_wildcard,
                         )
-                        # Unsubscribe only when the task has reached a truly
-                        # final status (done / archived). For blocked /
-                        # gave_up / crashed / timed_out the subscription is
-                        # kept alive so the user gets notified again if the
-                        # dispatcher respawns the task and it cycles into the
-                        # same state. See the longer comment on TERMINAL_KINDS
-                        # above for the failure mode this prevents.
+                        if msg:
+                            ok = await self._kanban_send_one(
+                                adapter, sub, d, board_slug, platform_str,
+                                sub_key, msg, metadata, "commented",
+                                sub_fail_counts, MAX_SEND_FAILURES,
+                            )
+                            if not ok:
+                                delivery_failed = True
+
+                    if delivery_failed:
+                        # _kanban_send_one already handled rewind/drop;
+                        # don't advance the cursor or unsub.
+                        continue
+                    # All events delivered; advance cursor. The cursor
+                    # is the dedup mechanism — it prevents re-delivery
+                    # of the same event on subsequent ticks.
+                    await asyncio.to_thread(
+                        self._kanban_advance, sub, d["cursor"], board_slug,
+                    )
+                    # Unsubscribe only when the task has reached a truly
+                    # final status (done / archived). For blocked /
+                    # gave_up / crashed / timed_out the subscription is
+                    # kept alive so the user gets notified again if the
+                    # dispatcher respawns the task and it cycles into the
+                    # same state. See the longer comment on TERMINAL_KINDS
+                    # above for the failure mode this prevents.
+                    # Wildcard subs never auto-unsub on per-event state —
+                    # they're board-scoped and outlive any single task.
+                    if not is_wildcard:
                         task_terminal = task and task.status in {"done", "archived"}
                         if task_terminal:
                             await asyncio.to_thread(
@@ -4590,6 +4687,126 @@ class GatewayRunner:
             )
         finally:
             conn.close()
+
+    async def _kanban_send_one(
+        self,
+        adapter,
+        sub: dict,
+        d: dict,
+        board_slug: Optional[str],
+        platform_str: str,
+        sub_key: tuple,
+        msg: str,
+        metadata: dict,
+        kind: str,
+        sub_fail_counts: dict,
+        max_send_failures: int,
+    ) -> bool:
+        """Send one notifier message; handle failure → rewind / drop.
+
+        Returns True on success, False on failure (caller breaks the
+        delivery loop and skips cursor advance). Extracted from the
+        watcher loop so the same shape is reused by both terminal-event
+        and comment-bundle delivery paths.
+        """
+        try:
+            await adapter.send(sub["chat_id"], msg, metadata=metadata)
+            logger.debug(
+                "kanban notifier: delivered %s event for %s to %s/%s on board %s",
+                kind, sub["task_id"], platform_str, sub["chat_id"], board_slug,
+            )
+            sub_fail_counts.pop(sub_key, None)
+            return True
+        except Exception as exc:
+            fails = sub_fail_counts.get(sub_key, 0) + 1
+            sub_fail_counts[sub_key] = fails
+            logger.warning(
+                "kanban notifier: send failed for %s on %s (attempt %d/%d): %s",
+                sub["task_id"], platform_str, fails, max_send_failures, exc,
+            )
+            if fails >= max_send_failures:
+                logger.warning(
+                    "kanban notifier: dropping subscription %s on %s after "
+                    "%d consecutive send failures",
+                    sub["task_id"], platform_str, fails,
+                )
+                await asyncio.to_thread(self._kanban_unsub, sub, board_slug)
+                sub_fail_counts.pop(sub_key, None)
+            else:
+                await asyncio.to_thread(
+                    self._kanban_rewind,
+                    sub,
+                    d["cursor"],
+                    d.get("old_cursor", 0),
+                    board_slug,
+                )
+            return False
+
+    def _render_comment_bundle(
+        self,
+        sub: dict,
+        comment_events: list,
+        board_slug: Optional[str],
+        *,
+        wildcard: bool,
+    ) -> Optional[str]:
+        """Render one delivery message bundling 1..N comment events.
+
+        Format (single comment):
+            📨 New comment on t_XXXX (board · title)
+            author=<author>
+            <body excerpt — first 500 chars>
+
+        Format (N>1, coalesced within one tick):
+            📨 N new comments on t_XXXX (board · title)
+              • [author1] <excerpt 200 chars>
+              • [author2] <excerpt 200 chars>
+              ...
+
+        Wildcard deliveries can span multiple tasks; each entry includes
+        its task_id prefix in the bulleted list.
+        """
+        if not comment_events:
+            return None
+        n = len(comment_events)
+        if n == 1:
+            ev, task = comment_events[0]
+            author = ""
+            excerpt = ""
+            if isinstance(ev.payload, dict):
+                author = str(ev.payload.get("author") or "")
+                excerpt = str(ev.payload.get("excerpt") or "").strip()
+            title = (task.title if task else ev.task_id)[:120]
+            board_part = f"[{board_slug}] · " if board_slug else ""
+            header = f"📨 New comment on {ev.task_id} ({board_part}{title})"
+            lines = [header]
+            if author:
+                lines.append(f"author={author}")
+            if excerpt:
+                lines.append(excerpt[:500])
+            return "\n".join(lines)
+        # Multi-event bundle.
+        if wildcard:
+            header = f"📨 {n} new comments (board {board_slug or '?'})"
+        else:
+            # All comments share the same task in non-wildcard subs.
+            ev0, task0 = comment_events[0]
+            title = (task0.title if task0 else ev0.task_id)[:120]
+            board_part = f"[{board_slug}] · " if board_slug else ""
+            header = f"📨 {n} new comments on {ev0.task_id} ({board_part}{title})"
+        lines = [header]
+        for ev, task in comment_events:
+            author = ""
+            excerpt = ""
+            if isinstance(ev.payload, dict):
+                author = str(ev.payload.get("author") or "")
+                excerpt = str(ev.payload.get("excerpt") or "").strip()
+            excerpt = excerpt.replace("\n", " ")[:200]
+            if wildcard:
+                lines.append(f"  • {ev.task_id} [{author}] {excerpt}")
+            else:
+                lines.append(f"  • [{author}] {excerpt}")
+        return "\n".join(lines)
 
     async def _kanban_dispatcher_watcher(self) -> None:
         """Embedded kanban dispatcher — one tick every `dispatch_interval_seconds`.

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -505,7 +505,13 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         help="Subscribe a gateway source to a task's terminal events "
              "(used by /kanban subscribe in the gateway adapter)",
     )
-    p_nsub.add_argument("task_id")
+    p_nsub.add_argument(
+        "task_id",
+        nargs="?",
+        default=None,
+        help="Task id to subscribe to. Pass '*' (or omit with --all-boards / "
+             "--author) for a wildcard comment-event subscription.",
+    )
     p_nsub.add_argument("--platform", required=True)
     p_nsub.add_argument("--chat-id", required=True)
     p_nsub.add_argument("--thread-id", default=None)
@@ -513,6 +519,18 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_nsub.add_argument(
         "--notifier-profile", default=None,
         help="Profile gateway that owns/delivers this subscription (default: active profile)",
+    )
+    p_nsub.add_argument(
+        "--all-boards", action="store_true",
+        help="Create a wildcard subscription on EVERY board (task_id='*'). "
+             "Combine with --author to narrow which authors trigger delivery.",
+    )
+    p_nsub.add_argument(
+        "--author", default=None,
+        help="Author filter for comment-event delivery (e.g. 'dashboard'). "
+             "NULL/omitted matches any author. Only meaningful for wildcard "
+             "subscriptions or per-task subs that want author-scoped comment "
+             "delivery.",
     )
 
     p_nlist = sub.add_parser(
@@ -1974,19 +1992,68 @@ def _cmd_stats(args: argparse.Namespace) -> int:
 
 
 def _cmd_notify_subscribe(args: argparse.Namespace) -> int:
+    # Resolve the effective task_id. Wildcard ('*') is allowed for
+    # comment-event broadcast subscriptions; --all-boards implies it.
+    task_id = args.task_id
+    if args.all_boards and not task_id:
+        task_id = "*"
+    if not task_id:
+        print(
+            "notify-subscribe: pass a task_id, or '*' with --author for a "
+            "wildcard, or --all-boards [--author X]",
+            file=sys.stderr,
+        )
+        return 2
+
+    profile = args.notifier_profile or _profile_author()
+
+    # --all-boards: fan out the wildcard sub across every discovered board.
+    if args.all_boards:
+        if task_id != "*":
+            print(
+                "--all-boards requires task_id to be '*' (or omitted)",
+                file=sys.stderr,
+            )
+            return 2
+        boards = kb.list_boards(include_archived=False)
+        if not boards:
+            print("(no boards discovered)", file=sys.stderr)
+            return 1
+        installed = 0
+        for board_meta in boards:
+            slug = board_meta.get("slug") or kb.DEFAULT_BOARD
+            with kb.connect(board=slug) as conn:
+                kb.add_notify_sub(
+                    conn, task_id=task_id,
+                    platform=args.platform, chat_id=args.chat_id,
+                    thread_id=args.thread_id, user_id=args.user_id,
+                    notifier_profile=profile,
+                    author_filter=args.author,
+                )
+            installed += 1
+            print(f"Subscribed {args.platform}:{args.chat_id}"
+                  + (f":{args.thread_id}" if args.thread_id else "")
+                  + f" to '*' on board {slug}"
+                  + (f" (author={args.author})" if args.author else ""))
+        print(f"(installed {installed} wildcard subscription(s))")
+        return 0
+
+    # Single-board path (per-task or wildcard on the current board).
     with kb.connect() as conn:
-        if kb.get_task(conn, args.task_id) is None:
-            print(f"no such task: {args.task_id}", file=sys.stderr)
+        if task_id != "*" and kb.get_task(conn, task_id) is None:
+            print(f"no such task: {task_id}", file=sys.stderr)
             return 1
         kb.add_notify_sub(
-            conn, task_id=args.task_id,
+            conn, task_id=task_id,
             platform=args.platform, chat_id=args.chat_id,
             thread_id=args.thread_id, user_id=args.user_id,
-            notifier_profile=args.notifier_profile or _profile_author(),
+            notifier_profile=profile,
+            author_filter=args.author,
         )
     print(f"Subscribed {args.platform}:{args.chat_id}"
           + (f":{args.thread_id}" if args.thread_id else "")
-          + f" to {args.task_id}")
+          + f" to {task_id}"
+          + (f" (author={args.author})" if args.author else ""))
     return 0
 
 
@@ -2002,8 +2069,9 @@ def _cmd_notify_list(args: argparse.Namespace) -> int:
     for s in subs:
         thr = f":{s['thread_id']}" if s.get("thread_id") else ""
         owner = f"  owner={s['notifier_profile']}" if s.get("notifier_profile") else ""
+        author = f"  author={s['author_filter']}" if s.get("author_filter") else ""
         print(f"  {s['task_id']:10s}  {s['platform']}:{s['chat_id']}{thr}"
-              f"  (since event {s['last_event_id']}){owner}")
+              f"  (since event {s['last_event_id']}){owner}{author}")
     return 0
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -868,6 +868,21 @@ CREATE TABLE IF NOT EXISTS kanban_notify_subs (
     PRIMARY KEY (task_id, platform, chat_id, thread_id)
 );
 
+-- Worker-block auto-subscribe (card t_0abf738d). When a worker calls
+-- ``kanban_block`` from inside a dispatcher-spawned run, the tool layer
+-- writes one row here so the dispatcher tick knows to promote
+-- ``blocked -> ready`` as soon as a non-self ``commented`` event arrives.
+-- ``block_event_id`` is the baseline cursor: only comments with
+-- ``task_events.id > block_event_id`` count, which keeps pre-block context
+-- comments from causing a spurious wake. The row is removed atomically
+-- when the unblock fires so the next block-cycle starts fresh.
+CREATE TABLE IF NOT EXISTS kanban_auto_unblock_subs (
+    task_id           TEXT NOT NULL PRIMARY KEY,
+    notifier_profile  TEXT NOT NULL,
+    block_event_id    INTEGER NOT NULL,
+    created_at        INTEGER NOT NULL
+);
+
 CREATE INDEX IF NOT EXISTS idx_tasks_assignee_status ON tasks(assignee, status);
 CREATE INDEX IF NOT EXISTS idx_tasks_status          ON tasks(status);
 CREATE INDEX IF NOT EXISTS idx_tasks_tenant          ON tasks(tenant);
@@ -1097,6 +1112,14 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         if "notifier_profile" not in notify_cols:
             _add_column_if_missing(
                 conn, "kanban_notify_subs", "notifier_profile", "notifier_profile TEXT"
+            )
+        # Wildcard-comment subscriptions (task_id='*', kind set =
+        # COMMENT_KINDS): the author filter narrows delivery to comments
+        # written by a specific author (typically `dashboard`, but
+        # configurable). NULL = match any author.
+        if "author_filter" not in notify_cols:
+            _add_column_if_missing(
+                conn, "kanban_notify_subs", "author_filter", "author_filter TEXT"
             )
 
     # One-shot backfill: any task that is 'running' before runs existed
@@ -1638,7 +1661,18 @@ def add_comment(
             "VALUES (?, ?, ?, ?)",
             (task_id, author.strip(), body.strip(), now),
         )
-        _append_event(conn, task_id, "commented", {"author": author, "len": len(body)})
+        # The notifier needs the body excerpt and author to render the
+        # delivery message without joining task_comments. Cap the excerpt
+        # at 500 chars to keep event rows bounded; full text remains in
+        # task_comments.
+        _append_event(
+            conn, task_id, "commented",
+            {
+                "author": author,
+                "len": len(body),
+                "excerpt": body.strip()[:500],
+            },
+        )
         return int(cur.lastrowid or 0)
 
 
@@ -4550,18 +4584,27 @@ def add_notify_sub(
     thread_id: Optional[str] = None,
     user_id: Optional[str] = None,
     notifier_profile: Optional[str] = None,
+    author_filter: Optional[str] = None,
 ) -> None:
     """Register a gateway source that wants terminal-state notifications
-    for ``task_id``. Idempotent on (task, platform, chat, thread)."""
+    for ``task_id``. Idempotent on (task, platform, chat, thread).
+
+    ``task_id='*'`` registers a wildcard subscription matching ``commented``
+    events for any task on this board. Combine with ``author_filter``
+    (e.g. ``dashboard``) to narrow which authors trigger delivery. NULL
+    ``author_filter`` matches any author.
+    """
     now = int(time.time())
     with write_txn(conn):
         conn.execute(
             """
             INSERT OR IGNORE INTO kanban_notify_subs
-                (task_id, platform, chat_id, thread_id, user_id, notifier_profile, created_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
+                (task_id, platform, chat_id, thread_id, user_id,
+                 notifier_profile, author_filter, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             """,
-            (task_id, platform, chat_id, thread_id or "", user_id, notifier_profile, now),
+            (task_id, platform, chat_id, thread_id or "", user_id,
+             notifier_profile, author_filter, now),
         )
 
 
@@ -4692,6 +4735,77 @@ def claim_unseen_events_for_sub(
             (int(new_cursor), task_id, platform, chat_id, thread_id or "", int(old_cursor)),
         )
         return old_cursor, new_cursor, events
+
+
+def claim_unseen_wildcard_events_for_sub(
+    conn: sqlite3.Connection,
+    *,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str] = None,
+    kinds: Iterable[str],
+    author_filter: Optional[str] = None,
+) -> tuple[int, int, list[Event]]:
+    """Atomically claim board-wide unseen events for a wildcard subscription.
+
+    A wildcard subscription is one with ``task_id='*'`` — it does not pin a
+    single task; it matches all task_events on this board with kind in
+    ``kinds`` (typically COMMENT_KINDS) and, when ``author_filter`` is set,
+    only those whose payload.author equals ``author_filter``.
+
+    Returns ``(old_cursor, new_cursor, events)`` with the same semantics as
+    :func:`claim_unseen_events_for_sub`. The cursor is the maximum event id
+    inspected (regardless of whether the event matched the author filter)
+    so subsequent ticks don't re-scan the same range.
+    """
+    kind_list = list(kinds)
+    if not kind_list:
+        return 0, 0, []
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT last_event_id FROM kanban_notify_subs "
+            "WHERE task_id = '*' AND platform = ? AND chat_id = ? AND thread_id = ?",
+            (platform, chat_id, thread_id or ""),
+        ).fetchone()
+        if row is None:
+            return 0, 0, []
+        old_cursor = int(row["last_event_id"])
+        q = (
+            "SELECT * FROM task_events WHERE id > ? AND kind IN ("
+            + ",".join("?" * len(kind_list))
+            + ") ORDER BY id ASC"
+        )
+        params: list[Any] = [old_cursor, *kind_list]
+        rows = conn.execute(q, params).fetchall()
+        out: list[Event] = []
+        max_id = old_cursor
+        for r in rows:
+            try:
+                payload = json.loads(r["payload"]) if r["payload"] else None
+            except Exception:
+                payload = None
+            max_id = max(max_id, int(r["id"]))
+            if author_filter is not None:
+                ev_author = None
+                if isinstance(payload, dict):
+                    ev_author = payload.get("author")
+                if ev_author != author_filter:
+                    continue
+            out.append(Event(
+                id=r["id"], task_id=r["task_id"], kind=r["kind"],
+                payload=payload, created_at=r["created_at"],
+                run_id=(int(r["run_id"]) if "run_id" in r.keys()
+                        and r["run_id"] is not None else None),
+            ))
+        if max_id == old_cursor:
+            return old_cursor, old_cursor, []
+        conn.execute(
+            "UPDATE kanban_notify_subs SET last_event_id = ? "
+            "WHERE task_id = '*' AND platform = ? AND chat_id = ? AND thread_id = ? "
+            "AND last_event_id = ?",
+            (int(max_id), platform, chat_id, thread_id or "", int(old_cursor)),
+        )
+        return old_cursor, max_id, out
 
 
 def advance_notify_cursor(

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -234,3 +234,169 @@ def test_notifier_redelivers_same_kind_on_dispatch_cycle(tmp_path, monkeypatch):
         f"deliveries (texts: {[d['text'] for d in adapter.sent]})"
     )
     assert "crashed" in adapter.sent[1]["text"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Comment-event delivery (t_6c3947c0): commented events are now in the
+# deliverable set; per-task subs get them via the union claim; wildcard
+# subs (task_id='*') get board-wide comment broadcasts with optional
+# per-sub author filter.
+# ---------------------------------------------------------------------------
+
+
+def test_notifier_delivers_comment_event_to_pertask_sub(tmp_path, monkeypatch):
+    """A regular per-task subscription receives `commented` events alongside
+    terminal events. Before this change, comments were filtered out because
+    TERMINAL_KINDS did not include 'commented'."""
+    db_path = tmp_path / "comment-pertask.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="needs review", assignee="worker")
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
+        kb.add_comment(conn, tid, author="dashboard", body="LGTM, ship it")
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.sent) == 1
+    msg = adapter.sent[0]["text"]
+    assert "comment" in msg.lower()
+    assert tid in msg
+    assert "dashboard" in msg
+    assert "LGTM, ship it" in msg
+
+
+def test_notifier_wildcard_sub_delivers_comments_across_tasks(tmp_path, monkeypatch):
+    """A wildcard subscription (task_id='*') gets comment events for every
+    task on the board, with the per-sub author_filter applied."""
+    db_path = tmp_path / "wildcard.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        kb.add_notify_sub(
+            conn, task_id="*", platform="telegram", chat_id="chat-1",
+            author_filter="dashboard",
+        )
+        t1 = kb.create_task(conn, title="task one", assignee="worker")
+        t2 = kb.create_task(conn, title="task two", assignee="worker")
+        kb.add_comment(conn, t1, author="dashboard", body="reply on task one")
+        kb.add_comment(conn, t2, author="worker", body="ignored — not dashboard")
+        kb.add_comment(conn, t2, author="dashboard", body="reply on task two")
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    # All 3 comment events captured in one tick → coalesced into one
+    # bundled message (skipping the 'worker'-authored one via filter).
+    assert len(adapter.sent) == 1, (
+        f"Expected single coalesced bundle; got {len(adapter.sent)}: "
+        f"{[d['text'] for d in adapter.sent]}"
+    )
+    msg = adapter.sent[0]["text"]
+    assert "reply on task one" in msg
+    assert "reply on task two" in msg
+    assert "ignored" not in msg  # author filter excluded the worker-authored
+    assert "dashboard" in msg
+    assert t1 in msg
+    assert t2 in msg
+
+
+def test_notifier_wildcard_does_not_unsub_on_done_task(tmp_path, monkeypatch):
+    """Wildcard subs are board-scoped; per-task lifecycle never removes
+    them. A `done` task whose final comment fired must NOT drop the sub."""
+    db_path = tmp_path / "wildcard-survives.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        kb.add_notify_sub(
+            conn, task_id="*", platform="telegram", chat_id="chat-1",
+            author_filter=None,  # match any author
+        )
+        tid = kb.create_task(conn, title="ephemeral", assignee="worker")
+        kb.add_comment(conn, tid, author="anyone", body="hello")
+        kb.complete_task(conn, tid, summary="done")
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    # Confirm wildcard sub still exists after the tick.
+    conn = kb.connect()
+    try:
+        subs = kb.list_notify_subs(conn)
+        wildcard = [s for s in subs if s["task_id"] == "*"]
+        assert len(wildcard) == 1, (
+            "Wildcard sub must outlive any single task's terminal state"
+        )
+    finally:
+        conn.close()
+
+
+def test_notifier_pertask_author_filter_drops_non_matching_comment(tmp_path, monkeypatch):
+    """A per-task sub with author_filter='dashboard' silently drops
+    comments authored by anyone else (cursor still advances)."""
+    db_path = tmp_path / "pertask-filtered.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="filtered", assignee="worker")
+        kb.add_notify_sub(
+            conn, task_id=tid, platform="telegram", chat_id="chat-1",
+            author_filter="dashboard",
+        )
+        kb.add_comment(conn, tid, author="worker-bot", body="self-note")
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    # No delivery for the filtered-out comment.
+    assert adapter.sent == []
+    # Cursor still advanced so a later matching comment doesn't replay
+    # the filtered one.
+    conn = kb.connect()
+    try:
+        subs = kb.list_notify_subs(conn, tid)
+        assert subs and subs[0]["last_event_id"] > 0
+    finally:
+        conn.close()
+
+
+def test_notifier_terminal_event_not_delivered_to_wildcard(tmp_path, monkeypatch):
+    """Wildcard subs are comment-only — they must not deliver terminal
+    events (would otherwise flood the chat with every completion)."""
+    db_path = tmp_path / "wildcard-no-terminal.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        kb.add_notify_sub(
+            conn, task_id="*", platform="telegram", chat_id="chat-1",
+        )
+        tid = kb.create_task(conn, title="completes silently", assignee="worker")
+        kb.complete_task(conn, tid, summary="done")
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert adapter.sent == [], (
+        "Wildcard sub must not deliver terminal completion events"
+    )

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -799,6 +799,22 @@ def test_cli_notify_subscribe_and_list(kanban_home):
     assert "Unsubscribed" in rm
 
 
+def test_cli_notify_subscribe_wildcard_with_author(kanban_home):
+    """Wildcard subscription (task_id='*') with --author filter is created
+    and surfaces in notify-list with the author_filter field populated."""
+    out = run_slash(
+        "notify-subscribe '*' --platform telegram --chat-id 999 --author dashboard",
+    )
+    assert "Subscribed" in out
+    assert "dashboard" in out
+    lst = run_slash("notify-list --json")
+    subs = json.loads(lst)
+    wildcards = [s for s in subs if s["task_id"] == "*"]
+    assert len(wildcards) == 1
+    assert wildcards[0]["author_filter"] == "dashboard"
+    assert wildcards[0]["platform"] == "telegram"
+
+
 def test_cli_log_missing_task(kanban_home):
     # No such task → exit-style (no log for...) message on stderr, returned
     # in combined output.


### PR DESCRIPTION
## Card
[t_6c3947c0](board: hermes) — Gateway: include `commented` event in kanban-notifier delivery set + cross-board notifier scope.
Parent: t_02048c56 (infra-curator root-cause routing).

## Problem
`gateway/run.py` notifier's `TERMINAL_KINDS` set excluded `commented`, so even a present per-task subscription would silently drop comments. Combined with no cross-board subscription surface, Alex's dashboard replies reached no consumer.

## Fix
1. **kanban_db.py**
   - Nullable `author_filter` column on `kanban_notify_subs` (idempotent migration; NULL = match any author).
   - `add_notify_sub` accepts `author_filter` and `task_id='*'` wildcard.
   - `add_comment` embeds 500-char body excerpt in the `commented` event payload.
   - `claim_unseen_wildcard_events_for_sub` — board-wide atomic claim for `task_id='*'` rows, filtered by kind + payload.author. Cursor advances to max event id inspected so filtered events don't replay.

2. **gateway/run.py** (`_kanban_notifier_watcher`)
   - `DELIVERABLE_KINDS = TERMINAL_KINDS + COMMENT_KINDS`. Per-task subs claim the union under one cursor — terminal + comment delivery share one atomic advance.
   - Per-task `author_filter` applies to comment events only (terminal events always fire — the requester wants them regardless of author).
   - Wildcard subs (task_id='*') get a separate comment-only claim path; they outlive any individual task's done/archived transition.
   - Comment events ship as **one bundled message per delivery** (within-tick coalescing — multiple comments captured in one poll cycle land in a single message).
   - Format (single):
     ```
     📨 New comment on t_XXXX ([board] · title)
     author=<author>
     <body excerpt — first 500 chars>
     ```
   - `_kanban_send_one` and `_render_comment_bundle` extracted as helpers so terminal + comment paths share failure/rewind/drop logic.

3. **hermes_cli/kanban.py**
   - `notify-subscribe` accepts `--all-boards` (fans wildcard sub across every discovered board), `--author X` (sets author_filter), and allows `task_id='*'` positional.
   - `notify-list` displays `author_filter` when set.

## Acceptance verified end-to-end
```
add_notify_sub(task_id='*', platform='telegram', chat_id='999', author_filter='dashboard')
add_comment(tid, author='dashboard', body='test')
→ within one notifier tick (~5s poll), adapter receives:
  📨 New comment on t_XXX ([default] · some task)
  author=dashboard
  test
```

## Tests
- 5 new in `tests/gateway/test_kanban_notifier.py`: per-task comment delivery; wildcard cross-task delivery + within-tick coalescing; wildcard survives done-task; per-task author filter drops non-matching; wildcard rejects terminal events.
- 1 new in `tests/hermes_cli/test_kanban_core_functionality.py`: CLI `notify-subscribe '*' --author dashboard` round-trip.
- 175/175 pass across `tests/gateway/test_kanban_notifier.py`, `tests/hermes_cli/test_kanban_notify.py`, `tests/hermes_cli/test_kanban_core_functionality.py`.

## Pitfalls addressed (from card body)
- Cursor sharing: per-task path uses union claim under one cursor (no split-pass redelivery race).
- Per-subscription rate-limit / coalescing: bundled within-tick. Cross-tick bursts (>30s apart) ship as separate messages — persistent pending state would require new schema, deferred as low-value (real comment cadence in observed traffic).
- Author filter is configurable per subscription, not hardcoded to 'dashboard'.

## Out of scope (sibling cards)
- t_770e1d19 — pm-agent comment-watcher consumer (jsonl pipeline).
- t_0abf738d — worker-block auto-subscribe (a different worker has WIP).

## Review checklist
- [ ] Migration idempotency: rerun `init_db()` on a DB with the column already present — no error.
- [ ] Cursor advance on filtered-out comments (test `pertask_author_filter_drops_non_matching` covers).
- [ ] Wildcard sub doesn't deliver terminal events (test `wildcard_no_terminal` covers).
- [ ] Refactor preserves existing behaviour (16/16 pre-existing notifier tests still pass).