### PR TITLE
fix(dashboard): strip glob suffix from plugin tab links to avoid fake 'spec not found' 404

### DIFF
--- a/web/src/pages/PluginsPage.tsx
+++ b/web/src/pages/PluginsPage.tsx
@@ -24,6 +24,17 @@ import { usePageHeader } from "@/contexts/usePageHeader";
 /** Select value for built-in memory (`config` uses empty string). Never use `""` — UI Select maps empty value to an empty label. */
 const MEMORY_PROVIDER_BUILTIN = "__hermes_memory_builtin__";
 
+/**
+ * Strip a trailing React Router glob/param segment from a tab path so it can be
+ * used as a navigation target. A manifest's `tab.path` like `/dashboard/*` or
+ * `/foo/:id` is a route PATTERN, not a navigable URL — clicking through to it
+ * literally triggers the plugin's index parser with name="*" and produces the
+ * "spec not found: *.md" 404. Plugin landing pages (SpecPicker, Registry, …)
+ * live at the unglobbed path, so trim the last `/*` or `/:param` segment.
+ */
+const tabLinkTarget = (p: string): string =>
+  p.replace(/\/[:*][^/]*$/, "").replace(/\/$/, "") || "/";
+
 export default function PluginsPage() {
   const [hub, setHub] = useState<PluginsHubResponse | null>(null);
   const [loading, setLoading] = useState(true);
@@ -346,7 +357,7 @@ export default function PluginsPage() {
                   {!m.tab?.hidden ? (
 
 
-                    <Link className="ml-3 inline-flex items-center gap-1 underline" to={m.tab.path}>
+                    <Link className="ml-3 inline-flex items-center gap-1 underline" to={tabLinkTarget(m.tab.path)}>
 
 
                       <ExternalLink className="h-3 w-3 opacity-65" />
@@ -391,7 +402,7 @@ function PluginRowCard(props: PluginRowCardProps) {
 
   const dm = row.dashboard_manifest;
 
-  const tabPath = dm?.tab && !dm.tab.hidden ? dm.tab.override ?? dm.tab.path : null;
+  const tabPath = dm?.tab && !dm.tab.hidden ? tabLinkTarget(dm.tab.override ?? dm.tab.path) : null;
 
   const busy = rowBusy === row.name;
   const [confirmRemove, setConfirmRemove] = useState(false);


### PR DESCRIPTION
## Symptom

Clicking *Open Tab* (or the underline link in *Other plugins*) on the Plugins page for any plugin whose manifest declares a glob `tab.path` (`postgres-browser`, `hermes-systems`, `azure-blob-browser`) navigates the user to a page that immediately renders:

    Error: 404: {"detail":"spec not found: *.md"}

The error stub appears on **every** plugin shell that uses one of those IIFE renderers.

## Root cause

`PluginsPage.tsx` rendered:

```tsx
<Link to={m.tab.path}>...</Link>                                // line 349
<Link to={dm.tab.override ?? dm.tab.path}>...</Link>            // line 485
```

But `m.tab.path` is a React Router **route pattern** — `/dashboard/*`, `/systems/*`, etc. — used by `App.tsx` to register the route. Navigating to the literal string `/dashboard/*` causes the IIFE plugin (`/Users/alex/.hermes/plugins/postgres-browser/dashboard/dist/index.js`) to parse it with:

```js
/^\/dashboard\/([^/]+)(?:\/table\/(.+))?$/
```

extract `spec="*"`, and fire:

```
GET /api/plugins/postgres-browser/spec?name=*
```

which the backend rejects in `plugins/postgres-browser/dashboard/plugin_api.py`:

```python
raise HTTPException(404, f"spec not found: {name}.md")
```

producing the exact error string. Same shape in `hermes-systems` and `azure-blob-browser`.

## Fix

Add a `tabLinkTarget()` helper that strips a trailing `/:param` or `/*` segment (`/dashboard/*` → `/dashboard`), and apply it at both call sites. Plugin landing pages already exist at the unglobbed path:

- `postgres-browser` → `SpecPicker`
- `hermes-systems` → `Registry`
- `azure-blob-browser` → spec picker

Users now land on a working picker instead of a fake-404 error stub.

`App.tsx` uses `m.tab.path` as a route registration value (not a navigation target), so those call sites are unchanged and still see the glob pattern they need.

## Verification

Built the React bundle and pointed the local Hermes dashboard at it:

- `http://127.0.0.1:9119/systems` → renders `hermes-systems` Registry table (32 specs listed), zero console errors.
- `http://127.0.0.1:9119/dashboard` → renders `azure-blob-browser` spec picker (1 ADLS container listed), zero console errors.
- Both before-fix paths produced `GET .../spec?name=* → 404` in the console and an `Err` component on the page; both now produce 200 / picker UI.

Pure regex helper, eight test cases checked manually:

| in | out |
|---|---|
| `/dashboard/*` | `/dashboard` |
| `/systems/*` | `/systems` |
| `/foo/:id` | `/foo` |
| `/foo/bar` | `/foo/bar` (unchanged) |
| `/` | `/` |
| `/*` | `/` |

## Scope

`web/src/pages/PluginsPage.tsx` only. No backend / plugin manifest / IIFE changes. The body of the kanban task also called out an optional defensive fix in each plugin IIFE's `parsePath` (treat `name === "*"` as `null` and route to the picker) — left for a follow-up card; the host-link fix here is what actually kills the symptom.

Resolves kanban `t_a8dcd3ee` on the `hermes` board.
Source diagnosis: `hermes-ui` board `t_a40c2679` comment thread.