### PR TITLE
fix(dashboard): strip glob suffix from sidebar plugin nav links

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -191,6 +191,19 @@ function resolveIcon(name: string): ComponentType<{ className?: string }> {
   return ICON_MAP[name] ?? Puzzle;
 }
 
+/**
+ * Strip a trailing React Router glob/param segment from a tab path so it can
+ * be used as a sidebar navigation target. A manifest's `tab.path` like
+ * `/dashboard/*` or `/foo/:id` is a route PATTERN, not a navigable URL —
+ * navigating literally to `/dashboard/*` lands the IIFE plugin with
+ * spec="*" and produces a fake "spec not found: *.md" 404. The route
+ * registration below MUST keep the glob (React Router needs it to match
+ * `/dashboard/specA`), but the nav link target must be trimmed.
+ */
+function navTargetFromTabPath(p: string): string {
+  return p.replace(/\/[:*][^/]*$/, "").replace(/\/+$/, "") || "/";
+}
+
 function buildNavItems(
   builtIn: NavItem[],
   manifests: PluginManifest[],
@@ -202,7 +215,7 @@ function buildNavItems(
     if (manifest.tab.hidden) continue;
 
     const pluginItem: NavItem = {
-      path: manifest.tab.path,
+      path: navTargetFromTabPath(manifest.tab.path),
       label: manifest.label,
       icon: resolveIcon(manifest.icon),
     };


### PR DESCRIPTION
Sibling fix to 8059f2fc4 (which handled the Plugins page Open-Tab links). The sidebar's per-plugin nav entries are built in `App.tsx` by `buildNavItems()`, which copied `manifest.tab.path` verbatim. That path is a React Router PATTERN (e.g. `/dashboard/*`, `/systems/*`), not a navigable URL.

Clicking 'Systems' in the left nav navigated to literal `/systems/*`, the `hermes-systems` IIFE parsed `spec="*"`, and fetched `GET /api/plugins/hermes-systems/spec?name=*` — backend returned `404 'spec not found: *.md'`. This was the 'junk on EVERY page' symptom, because the sidebar renders on every page.

Adds `navTargetFromTabPath()` helper that trims trailing `/:param` or `/*` segments, applied only at the nav link build site. Route registration (downstream in `App.tsx`) keeps the glob — React Router needs it as a pattern to match real subpaths like `/systems/foo`. The two surfaces have different requirements; this PR fixes only the nav surface.

## Verification

- Sidebar hrefs (after fix): `/systems`, `/honcho-health`, `/timeline`, `/kanban`, `/achievements`, `/quick-glance`, `/example` — zero `*` or `:` in hrefs
- Click into `/systems` renders the `Registry` component
- Zero `spec not found` strings anywhere in the DOM
- Zero console errors

Resolves kanban t_abca1cb8.