### PR TITLE
fix(simplex): propagate WebSocket send failures to SendResult

### DIFF
--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -480,19 +480,27 @@ class SimplexAdapter(BasePlatformAdapter):
             self._pending_corr_ids -= set(to_remove)
         return corr_id
 
-    async def _send_ws(self, payload: dict) -> None:
-        """Send a JSON payload over the WebSocket, queuing if not yet connected."""
+    async def _send_ws(self, payload: dict) -> bool:
+        """Send a JSON payload over the WebSocket, queuing if not yet connected.
+
+        Returns True on success, False if the socket is unavailable or an
+        error occurs so callers can surface failures instead of silently
+        reporting success.
+        """
         import websockets as _wsexc
         ws = self._ws
         if not ws:
             logger.debug("SimpleX: WS not connected, dropping outbound command")
-            return
+            return False
         try:
             await ws.send(json.dumps(payload))
+            return True
         except _wsexc.ConnectionClosed:
             logger.warning("SimpleX: WS closed while sending")
+            return False
         except Exception as e:
             logger.warning("SimpleX: WS send error: %s", e)
+            return False
 
     async def send(
         self,
@@ -515,7 +523,12 @@ class SimplexAdapter(BasePlatformAdapter):
             "cmd": cmd_str,
         }
 
-        await self._send_ws(payload)
+        ok = await self._send_ws(payload)
+        if not ok:
+            return SendResult(
+                success=False,
+                error="SimpleX: WebSocket send failed — connection unavailable or closed",
+            )
         return SendResult(success=True)
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -242,7 +242,8 @@ async def test_send_when_ws_not_connected_does_not_crash():
     adapter = SimplexAdapter(cfg)
     # No _ws assigned — _send_ws should drop quietly
     result = await adapter.send("contact-42", "hi")
-    assert result.success is True  # send() always returns success — fire-and-forget
+    assert result.success is False
+    assert result.error is not None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

`_send_ws()` previously returned `None` on all error paths, causing `send()` to always return `SendResult(success=True)` even when the WebSocket was closed or unavailable. This masked delivery failures from callers and the gateway.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made
- `_send_ws()` return type changed from `None` to `bool` (True on success, False on error)
- Returns `False` on `ConnectionClosed`, generic `Exception`, and missing WebSocket
- `send()` now checks the bool and returns `SendResult(success=False)` with a descriptive error message when the underlying send fails

## How to Test
1. Start Hermes with SimpleX configured but daemon not running
2. Attempt to send a message
3. Confirm `SendResult(success=False)` is returned instead of `success=True`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] No sensitive data (keys, tokens, secrets) included