### PR TITLE
fix(qqbot): cap _typing_sent_at and _last_msg_id with bounded eviction

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -106,6 +106,9 @@ from gateway.platforms.qqbot.constants import (
     MAX_MESSAGE_LENGTH,
     DEDUP_WINDOW_SECONDS,
     DEDUP_MAX_SIZE,
+    LAST_MSG_CACHE_MAX,
+    TYPING_CACHE_MAX,
+    TYPING_CACHE_WINDOW_SECONDS,
     MSG_TYPE_TEXT,
     MSG_TYPE_MARKDOWN,
     MSG_TYPE_MEDIA,
@@ -861,7 +864,10 @@ class QQAdapter(BasePlatformAdapter):
     async def handle_message(self, event: MessageEvent) -> None:
         """Cache the last message ID per chat, then delegate to base."""
         if event.message_id and event.source.chat_id:
-            self._last_msg_id[event.source.chat_id] = event.message_id
+            chat_id = event.source.chat_id
+            if len(self._last_msg_id) >= LAST_MSG_CACHE_MAX and chat_id not in self._last_msg_id:
+                self._last_msg_id.pop(next(iter(self._last_msg_id)))
+            self._last_msg_id[chat_id] = event.message_id
         await super().handle_message(event)
 
     async def _on_message(self, event_type: str, d: Any) -> None:
@@ -2964,6 +2970,11 @@ class QQAdapter(BasePlatformAdapter):
                 "msg_seq": msg_seq,
             }
             await self._api_request("POST", f"/v2/users/{chat_id}/messages", body)
+            if len(self._typing_sent_at) > TYPING_CACHE_MAX:
+                cutoff = now - TYPING_CACHE_WINDOW_SECONDS
+                self._typing_sent_at = {
+                    k: v for k, v in self._typing_sent_at.items() if v > cutoff
+                }
             self._typing_sent_at[chat_id] = now
         except Exception as exc:
             logger.debug("[%s] send_typing failed: %s", self._log_tag, exc)

--- a/gateway/platforms/qqbot/constants.py
+++ b/gateway/platforms/qqbot/constants.py
@@ -54,6 +54,9 @@ ONBOARD_API_TIMEOUT = 10.0
 MAX_MESSAGE_LENGTH = 4000
 DEDUP_WINDOW_SECONDS = 300
 DEDUP_MAX_SIZE = 1000
+LAST_MSG_CACHE_MAX = 2000
+TYPING_CACHE_MAX = 2000
+TYPING_CACHE_WINDOW_SECONDS = 3600
 
 # ---------------------------------------------------------------------------
 # QQ Bot message types


### PR DESCRIPTION
## Problem

Two per-chat-ID dicts in `QQAdapter` grow without bound for the lifetime of the process:

| Dict | Init | Written | Never evicted |
|---|---|---|---|
| `_last_msg_id` (`Dict[str, str]`) | `__init__` | `handle_message()` on every inbound message | ✗ |
| `_typing_sent_at` (`Dict[str, float]`) | `__init__` | `send_typing_indicator()` on every typing event | ✗ |

Each unique `chat_id` that interacts with the bot adds one entry to both maps. In large-scale QQBot deployments (tens or hundreds of thousands of active chats) this produces steady, unbounded memory growth. The same class already bounds `_seen_messages` with `DEDUP_MAX_SIZE` + `DEDUP_WINDOW_SECONDS`, so the pattern and constants are established — these two maps simply missed the same treatment.

## Fix

**`_last_msg_id`** — FIFO eviction in `handle_message()`:  
When the map reaches `LAST_MSG_CACHE_MAX` (2 000) and a *new* `chat_id` arrives, the oldest entry (Python dict insertion order, 3.7+) is evicted before the new one is inserted. Updating an existing key does not trigger eviction. If the entry has been evicted, `send_typing_indicator()` already guards against `None` with `if not msg_id: return` (line 2946).

**`_typing_sent_at`** — TTL eviction in `send_typing_indicator()`:  
Mirrors the `_seen_messages` lazy-eviction pattern exactly. After a successful API call, if the map exceeds `TYPING_CACHE_MAX` (2 000) entries all entries older than `TYPING_CACHE_WINDOW_SECONDS` (3 600 s / 1 h) are removed before the new timestamp is written. The 1 h window far exceeds any reasonable debounce period, so no live debounce state is lost.

Both constants are placed in `constants.py` alongside `DEDUP_MAX_SIZE` / `DEDUP_WINDOW_SECONDS` so they can be tuned without touching adapter logic.

## Scope

No behaviour change for deployments with fewer than 2 000 distinct active chats. Symmetric with the existing `_seen_messages` eviction in the same class.

## Checklist

- [x] Root cause confirmed via full grep trace of all reads and writes for both dicts
- [x] Fallback safety verified: `_last_msg_id` None → `send_typing_indicator` returns early (line 2946); `_typing_sent_at` miss → debounce `last_sent` defaults to `0.0` (line 2951), safe
- [x] No competitor PR (searched: `qqbot cache`, `qqbot memory`, `qqbot leak`, `qqbot unbounded`, `chat_type`, `typing`, `last_msg_id`)
- [x] Parity with `_seen_messages` eviction already present in this class
- [x] Constants co-located with `DEDUP_MAX_SIZE` in `constants.py`