### PR TITLE
Add OpenAI Realtime voice for Discord VC

### DIFF
--- a/gateway/openai_realtime_voice.py
+++ b/gateway/openai_realtime_voice.py
@@ -1,0 +1,690 @@
+"""OpenAI Realtime voice bridge for gateway voice channels.
+
+This module owns the provider-facing session loop. Platform adapters keep
+owning media transport, authorization, and delivery. The bridge consumes PCM
+audio chunks, forwards them to a Realtime session, executes Hermes tools when
+the model asks for a function call, and returns generated PCM audio via a
+callback.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import queue
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Iterable, List, Optional
+from urllib.parse import urlencode
+
+from tools.tool_backend_helpers import resolve_openai_audio_api_key
+
+logger = logging.getLogger(__name__)
+
+DIRECT_REALTIME_WS_URL = "wss://api.openai.com/v1/realtime"
+DEFAULT_REALTIME_MODEL = "gpt-realtime-2"
+DEFAULT_REALTIME_VOICE = "marin"
+DEFAULT_INPUT_SAMPLE_RATE = 24000
+DEFAULT_OUTPUT_SAMPLE_RATE = 24000
+DEFAULT_OUTPUT_FLUSH_BYTES = DEFAULT_OUTPUT_SAMPLE_RATE  # ~0.5s mono s16le
+DEFAULT_VAD_THRESHOLD = 0.55
+DEFAULT_VAD_PREFIX_PADDING_MS = 250
+DEFAULT_VAD_SILENCE_DURATION_MS = 350
+DEFAULT_MANUAL_TURN_TIMEOUT_MS = 700
+DEFAULT_INPUT_SILENCE_THRESHOLD = 120
+DEFAULT_RESPONSE_START_TIMEOUT_MS = 4500
+MAX_RESPONSE_CREATE_ATTEMPTS = 2
+DEFAULT_REALTIME_INSTRUCTIONS = (
+    "You are Hermes speaking in a Discord voice channel. Keep replies concise "
+    "and natural for live conversation. Use the available Hermes tools when a "
+    "request requires current local state, files, commands, memory, or other "
+    "tool-backed information. If the user asks you to use terminal, run a "
+    "command, check pwd, inspect files, or answer what folder/process/state "
+    "Hermes is running from, call the matching Hermes tool before speaking. "
+    "Do not answer those requests from memory. After a tool result, answer "
+    "the user in audio."
+)
+_VALID_AUTH_MODES = {"auto", "direct", "managed", "codex"}
+
+
+@dataclass(frozen=True)
+class RealtimeVoiceConfig:
+    enabled: bool = False
+    model: str = DEFAULT_REALTIME_MODEL
+    voice: str = DEFAULT_REALTIME_VOICE
+    instructions: str = ""
+    reasoning_effort: str = "low"
+    auth_mode: str = "auto"
+    input_sample_rate: int = DEFAULT_INPUT_SAMPLE_RATE
+    output_sample_rate: int = DEFAULT_OUTPUT_SAMPLE_RATE
+    vad_threshold: float = DEFAULT_VAD_THRESHOLD
+    vad_prefix_padding_ms: int = DEFAULT_VAD_PREFIX_PADDING_MS
+    vad_silence_duration_ms: int = DEFAULT_VAD_SILENCE_DURATION_MS
+    manual_turn_timeout_ms: int = DEFAULT_MANUAL_TURN_TIMEOUT_MS
+    input_silence_threshold: int = DEFAULT_INPUT_SILENCE_THRESHOLD
+    response_start_timeout_ms: int = DEFAULT_RESPONSE_START_TIMEOUT_MS
+
+
+@dataclass(frozen=True)
+class RealtimeAuthConfig:
+    api_key: str
+    websocket_url: str
+    mode: str
+
+
+def _is_truthy(value: object, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"1", "true", "yes", "on", "enabled"}
+
+
+def load_realtime_voice_config(user_config: Optional[Dict[str, Any]] = None) -> RealtimeVoiceConfig:
+    """Read ``voice.realtime`` config with Discord-specific overrides."""
+    cfg = user_config or {}
+    voice_cfg = cfg.get("voice") if isinstance(cfg.get("voice"), dict) else {}
+    realtime_cfg = voice_cfg.get("realtime") if isinstance(voice_cfg.get("realtime"), dict) else {}
+    discord_cfg = realtime_cfg.get("discord") if isinstance(realtime_cfg.get("discord"), dict) else {}
+
+    def pick(name: str, default: object = None) -> object:
+        if name in discord_cfg:
+            return discord_cfg.get(name)
+        if name in realtime_cfg:
+            return realtime_cfg.get(name)
+        return default
+
+    enabled = _is_truthy(pick("enabled", False), default=False)
+    auth_mode = str(pick("auth_mode", "auto") or "auto").strip().lower()
+    if auth_mode not in _VALID_AUTH_MODES:
+        auth_mode = "auto"
+
+    return RealtimeVoiceConfig(
+        enabled=enabled,
+        model=str(pick("model", DEFAULT_REALTIME_MODEL) or DEFAULT_REALTIME_MODEL).strip(),
+        voice=str(pick("voice", DEFAULT_REALTIME_VOICE) or DEFAULT_REALTIME_VOICE).strip(),
+        instructions=str(pick("instructions", "") or ""),
+        reasoning_effort=str(pick("reasoning_effort", "low") or "low").strip(),
+        auth_mode=auth_mode,
+        input_sample_rate=int(pick("input_sample_rate", DEFAULT_INPUT_SAMPLE_RATE) or DEFAULT_INPUT_SAMPLE_RATE),
+        output_sample_rate=int(pick("output_sample_rate", DEFAULT_OUTPUT_SAMPLE_RATE) or DEFAULT_OUTPUT_SAMPLE_RATE),
+        vad_threshold=float(pick("vad_threshold", DEFAULT_VAD_THRESHOLD) or DEFAULT_VAD_THRESHOLD),
+        vad_prefix_padding_ms=int(pick("vad_prefix_padding_ms", DEFAULT_VAD_PREFIX_PADDING_MS) or DEFAULT_VAD_PREFIX_PADDING_MS),
+        vad_silence_duration_ms=int(pick("vad_silence_duration_ms", DEFAULT_VAD_SILENCE_DURATION_MS) or DEFAULT_VAD_SILENCE_DURATION_MS),
+        manual_turn_timeout_ms=int(pick("manual_turn_timeout_ms", DEFAULT_MANUAL_TURN_TIMEOUT_MS) or DEFAULT_MANUAL_TURN_TIMEOUT_MS),
+        input_silence_threshold=int(
+            pick(
+                "input_silence_threshold",
+                pick("silence_threshold", voice_cfg.get("silence_threshold", DEFAULT_INPUT_SILENCE_THRESHOLD)),
+            )
+            or DEFAULT_INPUT_SILENCE_THRESHOLD
+        ),
+        response_start_timeout_ms=int(
+            pick("response_start_timeout_ms", DEFAULT_RESPONSE_START_TIMEOUT_MS)
+            or DEFAULT_RESPONSE_START_TIMEOUT_MS
+        ),
+    )
+
+
+def discord_realtime_voice_enabled(user_config: Optional[Dict[str, Any]] = None) -> bool:
+    return load_realtime_voice_config(user_config).enabled
+
+
+def resolve_realtime_auth(config: RealtimeVoiceConfig) -> RealtimeAuthConfig:
+    """Resolve direct OpenAI credentials or Hermes OpenAI Codex/GPT OAuth."""
+    direct_key = resolve_openai_audio_api_key()
+
+    if config.auth_mode == "direct":
+        if direct_key:
+            return RealtimeAuthConfig(
+                api_key=direct_key,
+                websocket_url=os.getenv("OPENAI_REALTIME_WS_URL", DIRECT_REALTIME_WS_URL).strip() or DIRECT_REALTIME_WS_URL,
+                mode="direct",
+            )
+        raise ValueError(
+            "OpenAI Realtime voice direct auth requires VOICE_TOOLS_OPENAI_KEY or OPENAI_API_KEY."
+        )
+
+    if direct_key and config.auth_mode == "auto":
+        return RealtimeAuthConfig(
+            api_key=direct_key,
+            websocket_url=os.getenv("OPENAI_REALTIME_WS_URL", DIRECT_REALTIME_WS_URL).strip() or DIRECT_REALTIME_WS_URL,
+            mode="direct",
+        )
+
+    try:
+        from hermes_cli.auth import resolve_codex_runtime_credentials
+
+        creds = resolve_codex_runtime_credentials(refresh_if_expiring=True)
+        token = str(creds.get("api_key", "") or "").strip()
+    except Exception:
+        token = ""
+    if token:
+        return RealtimeAuthConfig(
+            api_key=token,
+            websocket_url=os.getenv("OPENAI_REALTIME_WS_URL", DIRECT_REALTIME_WS_URL).strip() or DIRECT_REALTIME_WS_URL,
+            mode="managed",
+        )
+
+    raise ValueError(
+        "OpenAI Realtime voice requires VOICE_TOOLS_OPENAI_KEY/OPENAI_API_KEY "
+        "or OpenAI Codex/GPT OAuth credentials from `hermes auth add openai-codex`."
+    )
+
+
+def _require_websocket_connect():
+    try:
+        from websockets.sync.client import connect as ws_connect  # type: ignore
+    except ImportError as exc:
+        raise RuntimeError(
+            "websockets package is required for OpenAI Realtime voice; "
+            "install the messaging extra or run: pip install websockets"
+        ) from exc
+    return ws_connect
+
+
+def discord_pcm_to_realtime_pcm(
+    pcm: bytes,
+    *,
+    src_rate: int = 48000,
+    src_channels: int = 2,
+    dst_rate: int = DEFAULT_INPUT_SAMPLE_RATE,
+) -> bytes:
+    """Convert Discord s16le PCM to mono s16le PCM for Realtime input.
+
+    Discord provides 48kHz stereo PCM. Realtime voice sessions commonly use
+    24kHz mono PCM. This lightweight converter downmixes stereo and keeps
+    every other sample for 48k -> 24k. Other rates fall back to downmix-only.
+    """
+    if not pcm:
+        return b""
+    frame_width = 2 * max(1, int(src_channels))
+    usable = len(pcm) - (len(pcm) % frame_width)
+    if usable <= 0:
+        return b""
+
+    samples: List[int] = []
+    step_frames = 2 if src_rate == 48000 and dst_rate == 24000 else 1
+    for frame_index in range(0, usable // frame_width, step_frames):
+        offset = frame_index * frame_width
+        if src_channels >= 2:
+            left = int.from_bytes(pcm[offset:offset + 2], "little", signed=True)
+            right = int.from_bytes(pcm[offset + 2:offset + 4], "little", signed=True)
+            sample = int((left + right) / 2)
+        else:
+            sample = int.from_bytes(pcm[offset:offset + 2], "little", signed=True)
+        samples.append(max(-32768, min(32767, sample)))
+
+    return b"".join(sample.to_bytes(2, "little", signed=True) for sample in samples)
+
+
+def pcm_rms(pcm: bytes) -> float:
+    """Return RMS amplitude for s16le mono/stereo PCM."""
+    usable = len(pcm) - (len(pcm) % 2)
+    if usable <= 0:
+        return 0.0
+    total = 0
+    count = 0
+    for offset in range(0, usable, 2):
+        sample = int.from_bytes(pcm[offset:offset + 2], "little", signed=True)
+        total += sample * sample
+        count += 1
+    if not count:
+        return 0.0
+    return (total / count) ** 0.5
+
+
+def hermes_tools_to_realtime_tools(tool_schemas: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Convert OpenAI Chat-style function schemas to Realtime function tools."""
+    realtime_tools: List[Dict[str, Any]] = []
+    for schema in tool_schemas or []:
+        fn = schema.get("function") if isinstance(schema, dict) else None
+        if not isinstance(fn, dict):
+            continue
+        name = fn.get("name")
+        if not name:
+            continue
+        realtime_tools.append({
+            "type": "function",
+            "name": name,
+            "description": fn.get("description", ""),
+            "parameters": fn.get("parameters", {"type": "object", "properties": {}}),
+        })
+    return realtime_tools
+
+
+def realtime_session_instructions(config: RealtimeVoiceConfig) -> str:
+    """Return configured Realtime instructions or the Discord voice default."""
+    return config.instructions.strip() or DEFAULT_REALTIME_INSTRUCTIONS
+
+
+class OpenAIRealtimeVoiceSession:
+    """Threaded Realtime session for Discord voice-channel audio."""
+
+    def __init__(
+        self,
+        *,
+        config: RealtimeVoiceConfig,
+        auth: RealtimeAuthConfig,
+        tool_schemas: Iterable[Dict[str, Any]],
+        on_audio_response: Callable[[bytes], None],
+        on_user_audio_start: Optional[Callable[[], None]] = None,
+        task_id: Optional[str] = None,
+        session_id: Optional[str] = None,
+    ) -> None:
+        self.config = config
+        self.auth = auth
+        self._tools = hermes_tools_to_realtime_tools(tool_schemas)
+        self._on_audio_response = on_audio_response
+        self._on_user_audio_start = on_user_audio_start
+        self._task_id = task_id
+        self._session_id = session_id
+        self._ws: Any = None
+        self._send_lock = threading.Lock()
+        self._recv_thread: Optional[threading.Thread] = None
+        self._running = threading.Event()
+        self._response_audio = bytearray()
+        self._errors: "queue.Queue[Exception]" = queue.Queue()
+        self._handled_call_ids: set[str] = set()
+        self._sent_audio_chunks = 0
+        self._received_audio_chunks = 0
+        self._session_updated_logged = False
+        self._last_audio_flush_at = time.monotonic()
+        self._turn_timer: Optional[threading.Timer] = None
+        self._turn_has_audio = False
+        self._last_input_audio_at = 0.0
+        self._response_in_progress = False
+        self._pending_barge_in = False
+        self._barge_in_cancel_sent = False
+        self._response_watchdog_timer: Optional[threading.Timer] = None
+        self._awaiting_response_start = False
+        self._response_create_attempts = 0
+
+    @property
+    def active(self) -> bool:
+        return self._running.is_set()
+
+    def start(self) -> None:
+        connect = _require_websocket_connect()
+        query = urlencode({"model": self.config.model})
+        sep = "&" if "?" in self.auth.websocket_url else "?"
+        url = f"{self.auth.websocket_url}{sep}{query}"
+        headers = [
+            ("Authorization", f"Bearer {self.auth.api_key}"),
+        ]
+        try:
+            self._ws = connect(url, additional_headers=headers)
+        except TypeError:
+            self._ws = connect(url, extra_headers=headers)
+
+        logger.info(
+            "OpenAI Realtime voice connected: mode=%s model=%s tools=%d",
+            self.auth.mode,
+            self.config.model,
+            len(self._tools),
+        )
+        self._running.set()
+        self._send_session_update()
+        self._recv_thread = threading.Thread(
+            target=self._recv_loop,
+            name="hermes-openai-realtime-voice",
+            daemon=True,
+        )
+        self._recv_thread.start()
+
+    def close(self) -> None:
+        self._running.clear()
+        ws = self._ws
+        self._ws = None
+        self._cancel_turn_timer()
+        self._cancel_response_watchdog()
+        if ws is not None:
+            try:
+                ws.close()
+            except Exception:
+                pass
+
+    def send_discord_pcm(self, pcm: bytes) -> None:
+        if not self.active or not pcm:
+            return
+        converted = discord_pcm_to_realtime_pcm(
+            pcm,
+            src_rate=48000,
+            src_channels=2,
+            dst_rate=self.config.input_sample_rate,
+        )
+        if not converted:
+            return
+        rms = pcm_rms(converted)
+        if rms < max(0, int(self.config.input_silence_threshold)):
+            return
+        self._sent_audio_chunks += 1
+        if self._sent_audio_chunks <= 3 or self._sent_audio_chunks in {10, 25, 50, 100}:
+            logger.info(
+                "OpenAI Realtime voice input chunk #%d: discord_bytes=%d realtime_bytes=%d rms=%.1f",
+                self._sent_audio_chunks,
+                len(pcm),
+                len(converted),
+                rms,
+            )
+        if not self._turn_has_audio:
+            if self._response_in_progress:
+                self._pending_barge_in = True
+                logger.info("OpenAI Realtime voice user barge-in detected during response")
+                self._cancel_response_for_barge_in()
+            self._notify_user_audio_start()
+        self._send_json({
+            "type": "input_audio_buffer.append",
+            "audio": base64.b64encode(converted).decode("ascii"),
+        })
+        self._schedule_manual_turn_finalize()
+
+    def _send_session_update(self) -> None:
+        session: Dict[str, Any] = {
+            "type": "realtime",
+            "model": self.config.model,
+            "output_modalities": ["audio"],
+            "audio": {
+                "input": {
+                    "format": {
+                        "type": "audio/pcm",
+                        "rate": self.config.input_sample_rate,
+                    },
+                    "turn_detection": {
+                        "type": "server_vad",
+                        "threshold": self.config.vad_threshold,
+                        "prefix_padding_ms": self.config.vad_prefix_padding_ms,
+                        "silence_duration_ms": self.config.vad_silence_duration_ms,
+                        "create_response": True,
+                        "interrupt_response": True,
+                    },
+                },
+                "output": {
+                    "format": {
+                        "type": "audio/pcm",
+                        "rate": self.config.output_sample_rate,
+                    },
+                    "voice": self.config.voice,
+                },
+            },
+            "tool_choice": "auto",
+        }
+        instructions = realtime_session_instructions(self.config)
+        if instructions:
+            session["instructions"] = instructions
+        if self.config.reasoning_effort:
+            session["reasoning"] = {"effort": self.config.reasoning_effort}
+        if self._tools:
+            session["tools"] = self._tools
+        self._send_json({"type": "session.update", "session": session})
+
+    def _recv_loop(self) -> None:
+        while self._running.is_set() and self._ws is not None:
+            try:
+                raw = self._ws.recv()
+                frame = json.loads(raw) if isinstance(raw, (str, bytes, bytearray)) else raw
+                if isinstance(frame, dict):
+                    self._handle_frame(frame)
+            except Exception as exc:
+                if self._running.is_set():
+                    logger.warning("OpenAI Realtime voice receive loop stopped: %s", exc)
+                    self._errors.put(exc)
+                self._running.clear()
+                break
+
+    def _handle_frame(self, frame: Dict[str, Any]) -> None:
+        ftype = frame.get("type")
+        if ftype in {"response.audio.delta", "response.output_audio.delta"}:
+            self._response_in_progress = True
+            self._mark_response_started()
+            if self._pending_barge_in:
+                return
+            self._turn_has_audio = False
+            b64 = frame.get("delta") or frame.get("audio") or ""
+            if b64:
+                try:
+                    decoded = base64.b64decode(b64)
+                    self._received_audio_chunks += 1
+                    if self._received_audio_chunks <= 3 or self._received_audio_chunks in {10, 25, 50, 100}:
+                        logger.info(
+                            "OpenAI Realtime voice output audio chunk #%d: bytes=%d",
+                            self._received_audio_chunks,
+                            len(decoded),
+                        )
+                    self._response_audio.extend(decoded)
+                    self._maybe_flush_audio_response(reason="stream")
+                except (TypeError, ValueError):
+                    logger.debug("Ignoring invalid realtime audio delta")
+        elif ftype == "session.updated":
+            if not self._session_updated_logged:
+                self._session_updated_logged = True
+                session = frame.get("session") if isinstance(frame.get("session"), dict) else {}
+                logger.info(
+                    "OpenAI Realtime voice session updated: model=%s modalities=%s tools=%d turn_detection=%s",
+                    session.get("model") or self.config.model,
+                    session.get("output_modalities"),
+                    len(self._tools),
+                    (((session.get("audio") or {}).get("input") or {}).get("turn_detection")),
+                )
+        elif ftype in {"input_audio_buffer.speech_started", "input_audio_buffer.speech_stopped"}:
+            logger.info("OpenAI Realtime voice VAD event: %s", ftype)
+        elif ftype in {"response.created", "response.output_item.added"}:
+            self._response_in_progress = True
+            self._mark_response_started()
+            if self._pending_barge_in:
+                self._ensure_turn_timer()
+            else:
+                self._turn_has_audio = False
+                self._cancel_turn_timer()
+            logger.info("OpenAI Realtime voice response event: %s", ftype)
+        elif ftype in {"response.done", "response.audio.done", "response.output_audio.done"}:
+            self._maybe_flush_audio_response(force=True, reason=ftype)
+            if ftype == "response.done":
+                self._response_in_progress = False
+                if self._turn_has_audio:
+                    self._ensure_turn_timer()
+        elif ftype == "response.function_call_arguments.done":
+            self._mark_response_started()
+            self._handle_function_call(
+                name=str(frame.get("name") or ""),
+                call_id=str(frame.get("call_id") or frame.get("item_id") or ""),
+                arguments=frame.get("arguments") or "{}",
+            )
+        elif ftype == "response.output_item.done":
+            item = frame.get("item") or {}
+            if isinstance(item, dict) and item.get("type") == "function_call":
+                self._mark_response_started()
+                self._handle_function_call(
+                    name=str(item.get("name") or ""),
+                    call_id=str(item.get("call_id") or item.get("id") or ""),
+                    arguments=item.get("arguments") or "{}",
+                )
+        elif ftype == "error":
+            self._cancel_response_watchdog()
+            logger.warning("OpenAI Realtime voice error: %s", frame.get("error") or frame)
+
+    def _schedule_manual_turn_finalize(self) -> None:
+        self._turn_has_audio = True
+        self._last_input_audio_at = time.monotonic()
+        if self._turn_timer is not None:
+            return
+        timeout = max(100, int(self.config.manual_turn_timeout_ms)) / 1000.0
+        self._arm_turn_timer(timeout)
+
+    def _arm_turn_timer(self, delay: float) -> None:
+        timer = threading.Timer(max(0.01, delay), self._finalize_input_turn)
+        timer.daemon = True
+        self._turn_timer = timer
+        timer.start()
+
+    def _ensure_turn_timer(self) -> None:
+        if self._turn_timer is not None or not self._turn_has_audio:
+            return
+        timeout = max(100, int(self.config.manual_turn_timeout_ms)) / 1000.0
+        elapsed = time.monotonic() - self._last_input_audio_at
+        self._arm_turn_timer(max(0.01, timeout - elapsed))
+
+    def _cancel_turn_timer(self) -> None:
+        timer = self._turn_timer
+        self._turn_timer = None
+        if timer is not None:
+            timer.cancel()
+
+    def _mark_response_started(self) -> None:
+        self._awaiting_response_start = False
+        self._response_create_attempts = 0
+        self._cancel_response_watchdog()
+
+    def _cancel_response_watchdog(self) -> None:
+        timer = self._response_watchdog_timer
+        self._response_watchdog_timer = None
+        if timer is not None:
+            timer.cancel()
+
+    def _arm_response_watchdog(self) -> None:
+        self._cancel_response_watchdog()
+        timeout = max(500, int(self.config.response_start_timeout_ms)) / 1000.0
+        timer = threading.Timer(timeout, self._response_start_timed_out)
+        timer.daemon = True
+        self._response_watchdog_timer = timer
+        timer.start()
+
+    def _response_start_timed_out(self) -> None:
+        self._response_watchdog_timer = None
+        if not self.active or not self._awaiting_response_start or self._response_in_progress:
+            return
+        if self._response_create_attempts >= MAX_RESPONSE_CREATE_ATTEMPTS:
+            logger.warning(
+                "OpenAI Realtime voice response did not start after %d create attempt(s)",
+                self._response_create_attempts,
+            )
+            self._awaiting_response_start = False
+            return
+        self._response_create_attempts += 1
+        logger.warning(
+            "OpenAI Realtime voice response did not start within %dms; retrying response.create (attempt %d/%d)",
+            self.config.response_start_timeout_ms,
+            self._response_create_attempts,
+            MAX_RESPONSE_CREATE_ATTEMPTS,
+        )
+        self._send_json({"type": "response.create"})
+        self._arm_response_watchdog()
+
+    def _finalize_input_turn(self) -> None:
+        self._turn_timer = None
+        if not self.active or not self._turn_has_audio:
+            return
+        if self._response_in_progress:
+            self._arm_turn_timer(0.1)
+            return
+        timeout = max(100, int(self.config.manual_turn_timeout_ms)) / 1000.0
+        elapsed = time.monotonic() - self._last_input_audio_at
+        if elapsed < timeout:
+            timer = threading.Timer(timeout - elapsed, self._finalize_input_turn)
+            timer.daemon = True
+            self._turn_timer = timer
+            timer.start()
+            return
+        self._turn_has_audio = False
+        self._pending_barge_in = False
+        self._barge_in_cancel_sent = False
+        logger.info(
+            "OpenAI Realtime voice finalizing input turn after %dms silence",
+            self.config.manual_turn_timeout_ms,
+        )
+        self._send_json({"type": "input_audio_buffer.commit"})
+        self._awaiting_response_start = True
+        self._response_create_attempts = 1
+        self._send_json({"type": "response.create"})
+        self._arm_response_watchdog()
+
+    def _cancel_response_for_barge_in(self) -> None:
+        if self._barge_in_cancel_sent:
+            return
+        self._barge_in_cancel_sent = True
+        self._response_audio.clear()
+        logger.info("OpenAI Realtime voice cancelling response for user barge-in")
+        self._send_json({"type": "response.cancel"})
+
+    def _notify_user_audio_start(self) -> None:
+        callback = self._on_user_audio_start
+        if callback is None:
+            return
+        try:
+            callback()
+        except Exception as exc:
+            logger.debug("Realtime voice user-audio callback failed: %s", exc)
+
+    def _maybe_flush_audio_response(self, *, force: bool = False, reason: str = "stream") -> None:
+        if not force and len(self._response_audio) < DEFAULT_OUTPUT_FLUSH_BYTES:
+            return
+        if not self._response_audio:
+            return
+        pcm = bytes(self._response_audio)
+        self._response_audio.clear()
+        self._last_audio_flush_at = time.monotonic()
+        try:
+            logger.info(
+                "OpenAI Realtime voice flushing audio response: bytes=%d reason=%s",
+                len(pcm),
+                reason,
+            )
+            self._on_audio_response(pcm)
+        except Exception as exc:
+            logger.warning("Realtime voice audio callback failed: %s", exc)
+
+    def _handle_function_call(self, *, name: str, call_id: str, arguments: object) -> None:
+        if not name or not call_id:
+            return
+        if call_id in self._handled_call_ids:
+            return
+        self._handled_call_ids.add(call_id)
+        try:
+            args = json.loads(arguments) if isinstance(arguments, str) else arguments
+            if not isinstance(args, dict):
+                args = {}
+        except ValueError:
+            args = {}
+
+        try:
+            from model_tools import handle_function_call
+
+            started_at = time.monotonic()
+            logger.info("OpenAI Realtime voice executing Hermes tool: name=%s call_id=%s", name, call_id)
+            result = handle_function_call(
+                name,
+                args,
+                task_id=self._task_id,
+                tool_call_id=call_id,
+                session_id=self._session_id,
+            )
+            logger.info(
+                "OpenAI Realtime voice completed Hermes tool: name=%s call_id=%s duration_ms=%d result_bytes=%d",
+                name,
+                call_id,
+                int((time.monotonic() - started_at) * 1000),
+                len(result.encode("utf-8") if isinstance(result, str) else str(result).encode("utf-8")),
+            )
+        except Exception as exc:
+            result = json.dumps({"error": str(exc)}, ensure_ascii=False)
+            logger.warning("OpenAI Realtime voice Hermes tool failed: name=%s call_id=%s error=%s", name, call_id, exc)
+
+        self._send_json({
+            "type": "conversation.item.create",
+            "item": {
+                "type": "function_call_output",
+                "call_id": call_id,
+                "output": result,
+            },
+        })
+        self._send_json({"type": "response.create"})
+
+    def _send_json(self, payload: Dict[str, Any]) -> None:
+        ws = self._ws
+        if ws is None:
+            return
+        with self._send_lock:
+            ws.send(json.dumps(payload))

--- a/gateway/openai_realtime_voice.py
+++ b/gateway/openai_realtime_voice.py
@@ -16,11 +16,19 @@ import os
 import queue
 import threading
 import time
+import warnings
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Iterable, List, Optional
 from urllib.parse import urlencode
 
 from tools.tool_backend_helpers import resolve_openai_audio_api_key
+
+try:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        import audioop as _audioop
+except ImportError:  # pragma: no cover - audioop is absent in newer Python runtimes.
+    _audioop = None
 
 logger = logging.getLogger(__name__)
 
@@ -101,6 +109,8 @@ def load_realtime_voice_config(user_config: Optional[Dict[str, Any]] = None) -> 
     auth_mode = str(pick("auth_mode", "auto") or "auto").strip().lower()
     if auth_mode not in _VALID_AUTH_MODES:
         auth_mode = "auto"
+    if auth_mode == "codex":
+        auth_mode = "managed"
 
     return RealtimeVoiceConfig(
         enabled=enabled,
@@ -196,8 +206,7 @@ def discord_pcm_to_realtime_pcm(
     """Convert Discord s16le PCM to mono s16le PCM for Realtime input.
 
     Discord provides 48kHz stereo PCM. Realtime voice sessions commonly use
-    24kHz mono PCM. This lightweight converter downmixes stereo and keeps
-    every other sample for 48k -> 24k. Other rates fall back to downmix-only.
+    24kHz mono PCM.
     """
     if not pcm:
         return b""
@@ -205,6 +214,22 @@ def discord_pcm_to_realtime_pcm(
     usable = len(pcm) - (len(pcm) % frame_width)
     if usable <= 0:
         return b""
+    pcm = pcm[:usable]
+
+    if _audioop is not None:
+        try:
+            if src_channels >= 2:
+                mono = _audioop.tomono(pcm, 2, 0.5, 0.5)
+            else:
+                mono = pcm
+            if src_rate != dst_rate:
+                mono, _ = _audioop.ratecv(mono, 2, 1, int(src_rate), int(dst_rate), None)
+            return mono
+        except Exception:
+            logger.debug(
+                "Falling back to Python PCM conversion",
+                exc_info=True,
+            )
 
     samples: List[int] = []
     step_frames = 2 if src_rate == 48000 and dst_rate == 24000 else 1
@@ -226,6 +251,8 @@ def pcm_rms(pcm: bytes) -> float:
     usable = len(pcm) - (len(pcm) % 2)
     if usable <= 0:
         return 0.0
+    if _audioop is not None:
+        return float(_audioop.rms(pcm[:usable], 2))
     total = 0
     count = 0
     for offset in range(0, usable, 2):

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -20,8 +20,16 @@ import subprocess
 import tempfile
 import threading
 import time
+import warnings
 from collections import defaultdict
 from typing import Callable, Dict, List, Optional, Any, Tuple
+
+try:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        import audioop as _audioop
+except ImportError:  # pragma: no cover - audioop is absent in newer Python runtimes.
+    _audioop = None
 
 logger = logging.getLogger(__name__)
 
@@ -75,7 +83,34 @@ class _RealtimePCMAudioSource(_DiscordAudioSourceBase):
         elif cls._DISCORD_SAMPLE_RATE % sample_rate == 0:
             repeat = max(1, cls._DISCORD_SAMPLE_RATE // sample_rate)
         else:
-            repeat = 1
+            if _audioop is None:
+                logger.warning(
+                    "Cannot resample Realtime PCM from %dHz to Discord %dHz: audioop unavailable",
+                    sample_rate,
+                    cls._DISCORD_SAMPLE_RATE,
+                )
+                return b""
+            source_pcm = pcm[:usable]
+            try:
+                if channels >= 2:
+                    source_pcm = _audioop.tomono(source_pcm, 2, 0.5, 0.5)
+                resampled, _ = _audioop.ratecv(
+                    source_pcm,
+                    2,
+                    1,
+                    sample_rate,
+                    cls._DISCORD_SAMPLE_RATE,
+                    None,
+                )
+                return _audioop.tostereo(resampled, 2, 1.0, 1.0)
+            except Exception:
+                logger.warning(
+                    "Failed to resample Realtime PCM from %dHz to Discord %dHz",
+                    sample_rate,
+                    cls._DISCORD_SAMPLE_RATE,
+                    exc_info=True,
+                )
+                return b""
 
         out = bytearray()
         for offset in range(0, usable, frame_width):
@@ -2361,7 +2396,15 @@ class DiscordAdapter(BasePlatformAdapter):
             vc.play(source, after=_after)
         except asyncio.TimeoutError:
             logger.warning("Realtime voice playback timed out after %ds", self.PLAYBACK_TIMEOUT)
+            if playback_sources.get(guild_id) is source:
+                playback_sources.pop(guild_id, None)
             vc.stop()
+            return False
+        except Exception:
+            logger.exception("Realtime voice playback failed to start")
+            if playback_sources.get(guild_id) is source:
+                playback_sources.pop(guild_id, None)
+            return False
         self._reset_voice_timeout(guild_id)
         return True
 

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -14,6 +14,7 @@ import hashlib
 import json
 import logging
 import os
+import queue
 import struct
 import subprocess
 import tempfile
@@ -42,6 +43,130 @@ except ImportError:
     DiscordMessage = Any
     Intents = Any
     commands = None
+
+
+_DiscordAudioSourceBase = getattr(discord, "AudioSource", object) if DISCORD_AVAILABLE else object
+if not isinstance(_DiscordAudioSourceBase, type):
+    _DiscordAudioSourceBase = object
+
+
+class _RealtimePCMAudioSource(_DiscordAudioSourceBase):
+    """Discord AudioSource for OpenAI Realtime s16le PCM chunks."""
+
+    _DISCORD_SAMPLE_RATE = 48000
+    _DISCORD_CHANNELS = 2
+    _FRAME_BYTES = 3840  # 20ms of 48kHz stereo s16le
+
+    def __init__(self, pcm: bytes, *, sample_rate: int = 24000, channels: int = 1):
+        self._pcm = self._to_discord_pcm(pcm, sample_rate=sample_rate, channels=channels)
+        self._offset = 0
+
+    @classmethod
+    def _to_discord_pcm(cls, pcm: bytes, *, sample_rate: int, channels: int) -> bytes:
+        channels = max(1, int(channels or 1))
+        sample_rate = max(1, int(sample_rate or cls._DISCORD_SAMPLE_RATE))
+        frame_width = 2 * channels
+        usable = len(pcm) - (len(pcm) % frame_width)
+        if usable <= 0:
+            return b""
+
+        if sample_rate == cls._DISCORD_SAMPLE_RATE:
+            repeat = 1
+        elif cls._DISCORD_SAMPLE_RATE % sample_rate == 0:
+            repeat = max(1, cls._DISCORD_SAMPLE_RATE // sample_rate)
+        else:
+            repeat = 1
+
+        out = bytearray()
+        for offset in range(0, usable, frame_width):
+            if channels >= 2:
+                left = int.from_bytes(pcm[offset:offset + 2], "little", signed=True)
+                right = int.from_bytes(pcm[offset + 2:offset + 4], "little", signed=True)
+            else:
+                left = right = int.from_bytes(pcm[offset:offset + 2], "little", signed=True)
+            left_b = left.to_bytes(2, "little", signed=True)
+            right_b = right.to_bytes(2, "little", signed=True)
+            for _ in range(repeat):
+                out.extend(left_b)
+                out.extend(right_b)
+        return bytes(out)
+
+    def read(self) -> bytes:
+        if self._offset >= len(self._pcm):
+            return b""
+        chunk = self._pcm[self._offset:self._offset + self._FRAME_BYTES]
+        self._offset += len(chunk)
+        if len(chunk) < self._FRAME_BYTES:
+            chunk += b"\x00" * (self._FRAME_BYTES - len(chunk))
+        return chunk
+
+    def is_opus(self) -> bool:
+        return False
+
+
+class _RealtimePCMQueueAudioSource(_DiscordAudioSourceBase):
+    """Continuous Discord AudioSource fed by Realtime PCM chunks."""
+
+    _IDLE_TIMEOUT_SECONDS = 0.6
+
+    def __init__(self, pcm: bytes, *, sample_rate: int = 24000, channels: int = 1):
+        self._frames: "queue.Queue[bytes]" = queue.Queue()
+        self._pending = bytearray()
+        self._closed = False
+        self._last_feed_at = time.monotonic()
+        self.feed(pcm, sample_rate=sample_rate, channels=channels)
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    def feed(self, pcm: bytes, *, sample_rate: int = 24000, channels: int = 1) -> None:
+        if self._closed or not pcm:
+            return
+        converted = _RealtimePCMAudioSource._to_discord_pcm(
+            pcm,
+            sample_rate=sample_rate,
+            channels=channels,
+        )
+        if not converted:
+            return
+        self._last_feed_at = time.monotonic()
+        self._pending.extend(converted)
+        frame_size = _RealtimePCMAudioSource._FRAME_BYTES
+        while len(self._pending) >= frame_size:
+            self._frames.put(bytes(self._pending[:frame_size]))
+            del self._pending[:frame_size]
+
+    def close(self) -> None:
+        self._closed = True
+        while True:
+            try:
+                self._frames.get_nowait()
+            except queue.Empty:
+                break
+
+    def read(self) -> bytes:
+        if self._closed:
+            return b""
+        try:
+            return self._frames.get_nowait()
+        except queue.Empty:
+            pass
+
+        idle_for = time.monotonic() - self._last_feed_at
+        frame_size = _RealtimePCMAudioSource._FRAME_BYTES
+        if self._pending and idle_for >= self._IDLE_TIMEOUT_SECONDS:
+            chunk = bytes(self._pending)
+            self._pending.clear()
+            self._closed = True
+            return chunk + (b"\x00" * (frame_size - len(chunk)))
+        if idle_for < self._IDLE_TIMEOUT_SECONDS:
+            return b"\x00" * frame_size
+        self._closed = True
+        return b""
+
+    def is_opus(self) -> bool:
+        return False
 
 import sys
 from pathlib import Path as _Path
@@ -186,9 +311,11 @@ class VoiceReceiver:
 
         # Pause flag: don't capture while bot is playing TTS
         self._paused = False
+        self._stream_callback: Optional[Callable[[int, bytes], None]] = None
 
         # Debug logging counter (instance-level to avoid cross-instance races)
         self._packet_debug_count = 0
+        self._stream_debug_count = 0
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -225,6 +352,10 @@ class VoiceReceiver:
 
     def resume(self):
         self._paused = False
+
+    def set_stream_callback(self, callback: Optional[Callable[[int, bytes], None]]) -> None:
+        """Stream decoded PCM chunks to a realtime voice session."""
+        self._stream_callback = callback
 
     # ------------------------------------------------------------------
     # SSRC -> user_id mapping via SPEAKING opcode hook
@@ -398,12 +529,32 @@ class VoiceReceiver:
             if ssrc not in self._decoders:
                 self._decoders[ssrc] = discord.opus.Decoder()
             pcm = self._decoders[ssrc].decode(decrypted)
+            stream_callback = self._stream_callback
             with self._lock:
-                self._buffers[ssrc].extend(pcm)
+                if stream_callback is None:
+                    self._buffers[ssrc].extend(pcm)
                 self._last_packet_time[ssrc] = time.monotonic()
+                user_id = self._ssrc_to_user.get(ssrc, 0)
         except Exception as e:
             logger.debug("Opus decode error for SSRC %s: %s", ssrc, e)
             return
+
+        if stream_callback is not None:
+            if not user_id:
+                user_id = self._infer_user_for_ssrc(ssrc)
+            if user_id and (not self._allowed_user_ids or str(user_id) in self._allowed_user_ids):
+                try:
+                    self._stream_debug_count += 1
+                    if self._stream_debug_count <= 3 or self._stream_debug_count in {10, 25, 50, 100}:
+                        logger.info(
+                            "VoiceReceiver streaming PCM chunk #%d: user=%s bytes=%d",
+                            self._stream_debug_count,
+                            user_id,
+                            len(pcm),
+                        )
+                    stream_callback(user_id, pcm)
+                except Exception as e:
+                    logger.debug("Voice stream callback failed for user %s: %s", user_id, e)
 
     # ------------------------------------------------------------------
     # Silence detection
@@ -554,6 +705,7 @@ class DiscordAdapter(BasePlatformAdapter):
         super().__init__(config, Platform.DISCORD)
         self._client: Optional[commands.Bot] = None
         self._ready_event = asyncio.Event()
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._allowed_user_ids: set = set()  # For button approval authorization
         self._allowed_role_ids: set = set()  # For DISCORD_ALLOWED_ROLES filtering
         self.gateway_runner = None  # Set by gateway/run.py for cross-platform delivery
@@ -573,6 +725,10 @@ class DiscordAdapter(BasePlatformAdapter):
         self._voice_listen_tasks: Dict[int, asyncio.Task] = {}  # guild_id -> listen loop
         self._voice_input_callback: Optional[Callable] = None  # set by run.py
         self._on_voice_disconnect: Optional[Callable] = None  # set by run.py
+        self._voice_realtime_sessions: Dict[int, Any] = {}  # guild_id -> realtime voice session
+        self._voice_realtime_playback_queues: Dict[int, asyncio.Queue] = {}
+        self._voice_realtime_playback_tasks: Dict[int, asyncio.Task] = {}
+        self._voice_realtime_playback_sources: Dict[int, _RealtimePCMQueueAudioSource] = {}
         # Track threads where the bot has participated so follow-up messages
         # in those threads don't require @mention.  Persisted to disk so the
         # set survives gateway restarts.
@@ -599,6 +755,7 @@ class DiscordAdapter(BasePlatformAdapter):
         if not DISCORD_AVAILABLE:
             logger.error("[%s] discord.py not installed. Run: pip install discord.py", self.name)
             return False
+        self._loop = asyncio.get_running_loop()
 
         # Load opus codec for voice channel support
         if not discord.opus.is_loaded():
@@ -1913,6 +2070,16 @@ class DiscordAdapter(BasePlatformAdapter):
             try:
                 receiver = VoiceReceiver(vc, allowed_user_ids=self._allowed_user_ids)
                 receiver.start()
+                realtime_session = getattr(self, "_voice_realtime_sessions", {}).get(guild_id)
+                if realtime_session is not None and getattr(realtime_session, "active", False):
+                    receiver.set_stream_callback(
+                        lambda user_id, pcm, session=realtime_session: self._send_realtime_voice_pcm(
+                            guild_id,
+                            user_id,
+                            pcm,
+                            session,
+                        )
+                    )
                 self._voice_receivers[guild_id] = receiver
                 self._voice_listen_tasks[guild_id] = asyncio.ensure_future(
                     self._voice_listen_loop(guild_id)
@@ -1925,6 +2092,7 @@ class DiscordAdapter(BasePlatformAdapter):
     async def leave_voice_channel(self, guild_id: int) -> None:
         """Disconnect from the voice channel in a guild."""
         async with self._voice_locks.setdefault(guild_id, asyncio.Lock()):
+            self.clear_voice_realtime_session(guild_id)
             # Stop voice receiver first
             receiver = self._voice_receivers.pop(guild_id, None)
             if receiver:
@@ -1941,6 +2109,261 @@ class DiscordAdapter(BasePlatformAdapter):
                 task.cancel()
             self._voice_text_channels.pop(guild_id, None)
             self._voice_sources.pop(guild_id, None)
+
+    def set_voice_realtime_session(self, guild_id: int, session: Any) -> None:
+        """Attach a Realtime voice session to an active Discord VC."""
+        sessions = getattr(self, "_voice_realtime_sessions", None)
+        if not isinstance(sessions, dict):
+            sessions = {}
+            self._voice_realtime_sessions = sessions
+        previous = sessions.get(guild_id)
+        if previous is not None and previous is not session:
+            try:
+                previous.close()
+            except Exception:
+                pass
+        sessions[guild_id] = session
+        logger.info("Discord Realtime voice session attached: guild=%s active=%s", guild_id, getattr(session, "active", False))
+        receiver = self._voice_receivers.get(guild_id)
+        if receiver:
+            receiver.set_stream_callback(
+                lambda user_id, pcm, realtime_session=session: self._send_realtime_voice_pcm(
+                    guild_id,
+                    user_id,
+                    pcm,
+                    realtime_session,
+                )
+            )
+
+    def _send_realtime_voice_pcm(self, guild_id: int, user_id: int, pcm: bytes, session: Any) -> None:
+        guild = self._client.get_guild(guild_id) if self._client is not None else None
+        if not self._is_allowed_user(str(user_id), guild=guild, is_dm=False):
+            return
+        session.send_discord_pcm(pcm)
+
+    def clear_voice_realtime_session(self, guild_id: int) -> None:
+        """Detach and close any Realtime voice session for a guild."""
+        receiver = self._voice_receivers.get(guild_id)
+        if receiver:
+            receiver.set_stream_callback(None)
+        playback_tasks = getattr(self, "_voice_realtime_playback_tasks", None)
+        if isinstance(playback_tasks, dict):
+            playback_task = playback_tasks.pop(guild_id, None)
+            if playback_task:
+                playback_task.cancel()
+        playback_queues = getattr(self, "_voice_realtime_playback_queues", None)
+        if isinstance(playback_queues, dict):
+            playback_queues.pop(guild_id, None)
+        playback_sources = getattr(self, "_voice_realtime_playback_sources", None)
+        if isinstance(playback_sources, dict):
+            playback_source = playback_sources.pop(guild_id, None)
+            if playback_source:
+                playback_source.close()
+        sessions = getattr(self, "_voice_realtime_sessions", None)
+        if not isinstance(sessions, dict):
+            return
+        session = sessions.pop(guild_id, None)
+        if session is not None:
+            try:
+                session.close()
+                logger.info("Discord Realtime voice session closed: guild=%s", guild_id)
+            except Exception:
+                pass
+
+    def is_voice_realtime_enabled(self, guild_id: int) -> bool:
+        sessions = getattr(self, "_voice_realtime_sessions", None)
+        if not isinstance(sessions, dict):
+            return False
+        session = sessions.get(guild_id)
+        return bool(session is not None and getattr(session, "active", False))
+
+    def queue_realtime_pcm_response(
+        self,
+        guild_id: int,
+        pcm: bytes,
+        *,
+        sample_rate: int = 24000,
+        channels: int = 1,
+    ) -> None:
+        """Schedule Realtime PCM playback on the Discord event loop."""
+        if not pcm:
+            return
+        logger.info("Discord Realtime voice queueing PCM response: guild=%s bytes=%d rate=%d channels=%d", guild_id, len(pcm), sample_rate, channels)
+        loop = self._loop
+        if loop is None or loop.is_closed():
+            logger.warning("Cannot play Realtime voice response: Discord event loop unavailable")
+            return
+        fut = asyncio.run_coroutine_threadsafe(
+            self._enqueue_realtime_pcm_response(
+                guild_id,
+                pcm,
+                sample_rate=sample_rate,
+                channels=channels,
+            ),
+            loop,
+        )
+        fut.add_done_callback(self._log_realtime_playback_done)
+
+    def interrupt_realtime_playback(self, guild_id: int) -> None:
+        """Stop queued/current Realtime playback when the user starts talking."""
+        loop = self._loop
+        if loop is None or loop.is_closed():
+            return
+        fut = asyncio.run_coroutine_threadsafe(
+            self._interrupt_realtime_playback(guild_id),
+            loop,
+        )
+        fut.add_done_callback(self._log_realtime_playback_done)
+
+    async def _interrupt_realtime_playback(self, guild_id: int) -> None:
+        queue = self._voice_realtime_playback_queues.get(guild_id)
+        drained = 0
+        if queue is not None:
+            while True:
+                try:
+                    queue.get_nowait()
+                except asyncio.QueueEmpty:
+                    break
+                else:
+                    drained += 1
+                    queue.task_done()
+
+        vc = self._voice_clients.get(guild_id)
+        stopped = False
+        playback_sources = getattr(self, "_voice_realtime_playback_sources", None)
+        if isinstance(playback_sources, dict):
+            playback_source = playback_sources.pop(guild_id, None)
+            if playback_source:
+                playback_source.close()
+        if vc and vc.is_connected() and vc.is_playing():
+            vc.stop()
+            stopped = True
+
+        if drained or stopped:
+            logger.info(
+                "Discord Realtime voice interrupted playback: guild=%s drained=%d stopped=%s",
+                guild_id,
+                drained,
+                stopped,
+            )
+
+    @staticmethod
+    def _log_realtime_playback_done(future) -> None:
+        if future.cancelled():
+            return
+        try:
+            exc = future.exception()
+        except Exception as e:
+            exc = e
+        if exc:
+            logger.warning("Realtime voice playback failed: %s", exc)
+
+    async def _enqueue_realtime_pcm_response(
+        self,
+        guild_id: int,
+        pcm: bytes,
+        *,
+        sample_rate: int = 24000,
+        channels: int = 1,
+    ) -> None:
+        queue = self._voice_realtime_playback_queues.get(guild_id)
+        if queue is None:
+            queue = asyncio.Queue()
+            self._voice_realtime_playback_queues[guild_id] = queue
+        await queue.put((pcm, sample_rate, channels))
+        task = self._voice_realtime_playback_tasks.get(guild_id)
+        if task is None or task.done():
+            task = asyncio.create_task(self._realtime_playback_worker(guild_id))
+            task.add_done_callback(self._log_realtime_playback_done)
+            self._voice_realtime_playback_tasks[guild_id] = task
+
+    async def _realtime_playback_worker(self, guild_id: int) -> None:
+        queue = self._voice_realtime_playback_queues.get(guild_id)
+        if queue is None:
+            return
+        while True:
+            pcm, sample_rate, channels = await queue.get()
+            try:
+                ok = await self._play_realtime_pcm_response(
+                    guild_id,
+                    pcm,
+                    sample_rate=sample_rate,
+                    channels=channels,
+                )
+                if not ok:
+                    logger.warning("Realtime voice playback skipped: guild=%s not connected", guild_id)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.warning("Realtime voice playback failed: %s", exc)
+            finally:
+                queue.task_done()
+
+    async def _play_realtime_pcm_response(
+        self,
+        guild_id: int,
+        pcm: bytes,
+        *,
+        sample_rate: int = 24000,
+        channels: int = 1,
+    ) -> bool:
+        vc = self._voice_clients.get(guild_id)
+        if not vc or not vc.is_connected():
+            return False
+
+        playback_sources = getattr(self, "_voice_realtime_playback_sources", None)
+        if not isinstance(playback_sources, dict):
+            playback_sources = {}
+            self._voice_realtime_playback_sources = playback_sources
+
+        existing_source = playback_sources.get(guild_id)
+        if existing_source is not None and not existing_source.closed and vc.is_playing():
+            existing_source.feed(pcm, sample_rate=sample_rate, channels=channels)
+            logger.info(
+                "Discord Realtime voice fed PCM stream: guild=%s bytes=%d rate=%d channels=%d",
+                guild_id,
+                len(pcm),
+                sample_rate,
+                channels,
+            )
+            self._reset_voice_timeout(guild_id)
+            return True
+
+        wait_start = time.monotonic()
+        while vc.is_playing():
+            if time.monotonic() - wait_start > self.PLAYBACK_TIMEOUT:
+                logger.warning("Timed out waiting for previous Realtime playback to finish")
+                vc.stop()
+                break
+            await asyncio.sleep(0.02)
+
+        done = asyncio.Event()
+        loop = asyncio.get_running_loop()
+
+        def _after(error):
+            if error:
+                logger.error("Realtime voice playback error: %s", error)
+            current_source = playback_sources.get(guild_id)
+            if current_source is source:
+                playback_sources.pop(guild_id, None)
+            loop.call_soon_threadsafe(done.set)
+
+        source = _RealtimePCMQueueAudioSource(pcm, sample_rate=sample_rate, channels=channels)
+        playback_sources[guild_id] = source
+        logger.info(
+            "Discord Realtime voice playing PCM stream: guild=%s bytes=%d rate=%d channels=%d",
+            guild_id,
+            len(pcm),
+            sample_rate,
+            channels,
+        )
+        try:
+            vc.play(source, after=_after)
+        except asyncio.TimeoutError:
+            logger.warning("Realtime voice playback timed out after %ds", self.PLAYBACK_TIMEOUT)
+            vc.stop()
+        self._reset_voice_timeout(guild_id)
+        return True
 
     # Maximum seconds to wait for voice playback before giving up
     PLAYBACK_TIMEOUT = 120
@@ -2133,6 +2556,9 @@ class DiscordAdapter(BasePlatformAdapter):
                             vc._connection.send_packet(b'\xf8\xff\xfe')
                     except Exception:
                         pass
+
+                if self.is_voice_realtime_enabled(guild_id):
+                    continue
 
                 completed = receiver.check_silence()
                 # Voice inputs always originate from a specific guild

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10156,8 +10156,11 @@ class GatewayRunner:
                     for m in info["members"]:
                         status = t("gateway.voice.speaking") if m.get("is_speaking") else ""
                         lines.append(t("gateway.voice.status_member", name=m['display_name'], status=status))
+                    lines.extend(self._discord_realtime_voice_status_lines(event, adapter, guild_id))
                     return "\n".join(lines)
-            return t("gateway.voice.status_mode", label=labels.get(mode, mode))
+            lines = [t("gateway.voice.status_mode", label=labels.get(mode, mode))]
+            lines.extend(self._discord_realtime_voice_status_lines(event, adapter, guild_id))
+            return "\n".join(lines)
         else:
             # Toggle: off → on, on/all → off
             current = self._voice_mode.get(voice_key, "off")
@@ -10173,6 +10176,44 @@ class GatewayRunner:
                 if adapter:
                     self._set_adapter_auto_tts_disabled(adapter, chat_id, disabled=True)
                 return t("gateway.voice.disabled_short")
+
+    def _discord_realtime_voice_status_lines(
+        self,
+        event: MessageEvent,
+        adapter: Any,
+        guild_id: Optional[int],
+    ) -> List[str]:
+        if _platform_config_key(event.source.platform) != "discord":
+            return []
+        try:
+            from gateway.openai_realtime_voice import (
+                load_realtime_voice_config,
+                resolve_realtime_auth,
+            )
+
+            realtime_config = load_realtime_voice_config(_load_gateway_config())
+            if not realtime_config.enabled:
+                return []
+
+            active = bool(
+                guild_id
+                and hasattr(adapter, "is_voice_realtime_enabled")
+                and adapter.is_voice_realtime_enabled(guild_id)
+            )
+            if active:
+                return [
+                    f"Realtime-2: active ({realtime_config.auth_mode} auth requested)."
+                ]
+
+            try:
+                auth = resolve_realtime_auth(realtime_config)
+            except Exception as e:
+                return [f"Realtime-2: configured but auth is not ready ({e})."]
+
+            return [f"Realtime-2: configured, auth ready via {auth.mode}, not active."]
+        except Exception as e:
+            logger.debug("Failed to build Discord Realtime voice status: %s", e)
+            return []
 
     async def _handle_voice_channel_join(self, event: MessageEvent) -> str:
         """Join the user's current Discord voice channel."""
@@ -10217,13 +10258,109 @@ class GatewayRunner:
             self._voice_mode[self._voice_key(event.source.platform, event.source.chat_id)] = "all"
             self._save_voice_modes()
             self._set_adapter_auto_tts_enabled(adapter, event.source.chat_id, enabled=True)
+            realtime_status = await self._maybe_enable_discord_realtime_voice(
+                event=event,
+                adapter=adapter,
+                guild_id=guild_id,
+            )
+            extra = f"\n{realtime_status}" if realtime_status else ""
             return (
                 f"Joined voice channel **{voice_channel.name}**.\n"
                 f"I'll speak my replies and listen to you. Use /voice leave to disconnect."
+                f"{extra}"
             )
         # Join failed — clear callback
         adapter._voice_input_callback = None
         return "Failed to join voice channel. Check bot permissions (Connect + Speak)."
+
+    async def _maybe_enable_discord_realtime_voice(
+        self,
+        *,
+        event: MessageEvent,
+        adapter: Any,
+        guild_id: int,
+    ) -> Optional[str]:
+        """Start OpenAI Realtime voice for Discord VC when configured."""
+        try:
+            from gateway.openai_realtime_voice import (
+                OpenAIRealtimeVoiceSession,
+                load_realtime_voice_config,
+                resolve_realtime_auth,
+            )
+
+            user_config = _load_gateway_config()
+            realtime_config = load_realtime_voice_config(user_config)
+            if not realtime_config.enabled:
+                return None
+
+            if not hasattr(adapter, "set_voice_realtime_session"):
+                return "Realtime voice is configured, but this Discord adapter cannot attach sessions."
+            if not hasattr(adapter, "queue_realtime_pcm_response"):
+                return "Realtime voice is configured, but this Discord adapter cannot play PCM responses."
+
+            auth = resolve_realtime_auth(realtime_config)
+            logger.info(
+                "Starting Discord Realtime voice: guild=%s model=%s voice=%s auth_mode=%s resolved_auth=%s",
+                guild_id,
+                realtime_config.model,
+                realtime_config.voice,
+                realtime_config.auth_mode,
+                auth.mode,
+            )
+
+            from hermes_cli.tools_config import _get_platform_tools
+            from model_tools import get_tool_definitions
+
+            platform_key = _platform_config_key(event.source.platform)
+            enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
+            agent_cfg = user_config.get("agent") or {}
+            disabled_toolsets = agent_cfg.get("disabled_toolsets") or None
+            tool_schemas = get_tool_definitions(
+                enabled_toolsets=enabled_toolsets,
+                disabled_toolsets=disabled_toolsets,
+                quiet_mode=True,
+            )
+            session_key = self._session_key_for_source(event.source)
+
+            session = OpenAIRealtimeVoiceSession(
+                config=realtime_config,
+                auth=auth,
+                tool_schemas=tool_schemas,
+                on_audio_response=lambda pcm: adapter.queue_realtime_pcm_response(
+                    guild_id,
+                    pcm,
+                    sample_rate=realtime_config.output_sample_rate,
+                    channels=1,
+                ),
+                on_user_audio_start=(
+                    (lambda: adapter.interrupt_realtime_playback(guild_id))
+                    if hasattr(adapter, "interrupt_realtime_playback")
+                    else None
+                ),
+                task_id=f"discord-vc-{guild_id}",
+                session_id=session_key,
+            )
+            await asyncio.to_thread(session.start)
+            adapter.set_voice_realtime_session(guild_id, session)
+            logger.info(
+                "Discord Realtime voice active: guild=%s model=%s tools=%d auth=%s",
+                guild_id,
+                realtime_config.model,
+                len(tool_schemas or []),
+                auth.mode,
+            )
+            return (
+                f"Realtime-2 voice is active using {auth.mode} auth "
+                "with Hermes tool calls enabled."
+            )
+        except Exception as e:
+            logger.warning("Failed to start Discord Realtime voice: %s", e, exc_info=True)
+            if hasattr(adapter, "clear_voice_realtime_session"):
+                try:
+                    adapter.clear_voice_realtime_session(guild_id)
+                except Exception:
+                    pass
+            return f"Realtime voice failed to start ({e}); falling back to classic STT/TTS."
 
     async def _handle_voice_channel_leave(self, event: MessageEvent) -> str:
         """Leave the Discord voice channel."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10308,11 +10308,11 @@ class GatewayRunner:
                 auth.mode,
             )
 
-            from hermes_cli.tools_config import _get_platform_tools
+            from hermes_cli.tools_config import get_platform_tools
             from model_tools import get_tool_definitions
 
             platform_key = _platform_config_key(event.source.platform)
-            enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
+            enabled_toolsets = sorted(get_platform_tools(user_config, platform_key))
             agent_cfg = user_config.get("agent") or {}
             disabled_toolsets = agent_cfg.get("disabled_toolsets") or None
             tool_schemas = get_tool_definitions(

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1130,6 +1130,22 @@ DEFAULT_CONFIG = {
         "beep_enabled": True,         # Play record start/stop beeps in CLI voice mode
         "silence_threshold": 200,     # RMS below this = silence (0-32767)
         "silence_duration": 3.0,      # Seconds of silence before auto-stop
+        "realtime": {
+            "enabled": False,
+            "model": "gpt-realtime-2",
+            "voice": "marin",
+            "instructions": "",
+            "reasoning_effort": "low",
+            "auth_mode": "auto",      # "auto" | "direct" | "managed"
+            "input_sample_rate": 24000,
+            "output_sample_rate": 24000,
+            "vad_threshold": 0.55,
+            "vad_prefix_padding_ms": 250,
+            "vad_silence_duration_ms": 350,
+            "manual_turn_timeout_ms": 700,
+            "input_silence_threshold": 120,
+            "discord": {},            # Optional Discord-specific overrides
+        },
     },
     
     "human_delay": {

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1281,6 +1281,20 @@ def _get_platform_tools(
     return enabled_toolsets
 
 
+def get_platform_tools(
+    config: dict,
+    platform: str,
+    *,
+    include_default_mcp_servers: bool = True,
+) -> Set[str]:
+    """Resolve which individual toolset names are enabled for a platform."""
+    return _get_platform_tools(
+        config,
+        platform,
+        include_default_mcp_servers=include_default_mcp_servers,
+    )
+
+
 def _save_platform_tools(config: dict, platform: str, enabled_toolset_keys: Set[str]):
     """Save the selected toolset keys for a platform to config.
 

--- a/tests/gateway/test_openai_realtime_voice.py
+++ b/tests/gateway/test_openai_realtime_voice.py
@@ -1,0 +1,829 @@
+"""Tests for the Discord OpenAI Realtime voice bridge."""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+
+
+class _FakeWS:
+    def __init__(self, recv_frames=None):
+        self.sent = []
+        self.closed = False
+        self._recv_frames = list(recv_frames or [])
+
+    def send(self, payload):
+        self.sent.append(json.loads(payload))
+
+    def recv(self):
+        if not self._recv_frames:
+            raise RuntimeError("fake ws empty")
+        frame = self._recv_frames.pop(0)
+        return json.dumps(frame) if isinstance(frame, dict) else frame
+
+    def close(self):
+        self.closed = True
+
+
+def test_load_realtime_voice_config_supports_discord_overrides():
+    from gateway.openai_realtime_voice import load_realtime_voice_config
+
+    cfg = {
+        "voice": {
+            "realtime": {
+                "enabled": True,
+                "model": "gpt-realtime-2",
+                "voice": "marin",
+                "discord": {"voice": "cedar", "reasoning_effort": "medium"},
+            },
+        },
+    }
+
+    rt = load_realtime_voice_config(cfg)
+
+    assert rt.enabled is True
+    assert rt.model == "gpt-realtime-2"
+    assert rt.voice == "cedar"
+    assert rt.reasoning_effort == "medium"
+
+
+def test_load_realtime_voice_config_supports_input_silence_threshold():
+    from gateway.openai_realtime_voice import load_realtime_voice_config
+
+    cfg = {
+        "voice": {
+            "silence_threshold": 200,
+            "realtime": {
+                "enabled": True,
+                "input_silence_threshold": 120,
+            },
+        },
+    }
+
+    rt = load_realtime_voice_config(cfg)
+
+    assert rt.input_silence_threshold == 120
+
+
+def test_load_realtime_voice_config_supports_response_start_timeout():
+    from gateway.openai_realtime_voice import load_realtime_voice_config
+
+    cfg = {
+        "voice": {
+            "realtime": {
+                "enabled": True,
+                "response_start_timeout_ms": 2500,
+            },
+        },
+    }
+
+    rt = load_realtime_voice_config(cfg)
+
+    assert rt.response_start_timeout_ms == 2500
+
+
+def test_resolve_realtime_auth_direct(monkeypatch):
+    import gateway.openai_realtime_voice as rt
+
+    monkeypatch.setattr(rt, "resolve_openai_audio_api_key", lambda: "sk-direct")
+
+    auth = rt.resolve_realtime_auth(rt.RealtimeVoiceConfig(auth_mode="auto"))
+
+    assert auth.mode == "direct"
+    assert auth.api_key == "sk-direct"
+    assert auth.websocket_url == rt.DIRECT_REALTIME_WS_URL
+
+
+def test_resolve_realtime_auth_managed_uses_codex_oauth(monkeypatch):
+    import gateway.openai_realtime_voice as rt
+
+    monkeypatch.setattr(rt, "resolve_openai_audio_api_key", lambda: "sk-direct")
+    import hermes_cli.auth as auth_mod
+    monkeypatch.setattr(
+        auth_mod,
+        "resolve_codex_runtime_credentials",
+        lambda **_kw: {"api_key": "codex-oauth-token"},
+    )
+
+    auth = rt.resolve_realtime_auth(rt.RealtimeVoiceConfig(auth_mode="managed"))
+
+    assert auth.mode == "managed"
+    assert auth.api_key == "codex-oauth-token"
+    assert auth.websocket_url == rt.DIRECT_REALTIME_WS_URL
+
+
+def test_resolve_realtime_auth_auto_falls_back_to_codex_oauth(monkeypatch):
+    import gateway.openai_realtime_voice as rt
+    import hermes_cli.auth as auth_mod
+
+    monkeypatch.setattr(rt, "resolve_openai_audio_api_key", lambda: "")
+    monkeypatch.setattr(
+        auth_mod,
+        "resolve_codex_runtime_credentials",
+        lambda **_kw: {"api_key": "codex-oauth-token"},
+    )
+
+    auth = rt.resolve_realtime_auth(rt.RealtimeVoiceConfig(auth_mode="auto"))
+
+    assert auth.mode == "managed"
+    assert auth.api_key == "codex-oauth-token"
+
+
+def test_discord_pcm_to_realtime_pcm_downmixes_and_decimates():
+    from gateway.openai_realtime_voice import discord_pcm_to_realtime_pcm
+
+    frame_1 = (1000).to_bytes(2, "little", signed=True) + (3000).to_bytes(2, "little", signed=True)
+    frame_2 = (5000).to_bytes(2, "little", signed=True) + (7000).to_bytes(2, "little", signed=True)
+
+    converted = discord_pcm_to_realtime_pcm(frame_1 + frame_2)
+
+    assert converted == (2000).to_bytes(2, "little", signed=True)
+
+
+def test_pcm_rms_reads_s16le_samples():
+    from gateway.openai_realtime_voice import pcm_rms
+
+    pcm = (300).to_bytes(2, "little", signed=True) + (-300).to_bytes(2, "little", signed=True)
+
+    assert pcm_rms(pcm) == 300
+
+
+def test_realtime_session_instructions_uses_default_for_empty_config():
+    import gateway.openai_realtime_voice as rt
+
+    instructions = rt.realtime_session_instructions(rt.RealtimeVoiceConfig())
+
+    assert "Discord voice channel" in instructions
+    assert "Hermes tools" in instructions
+    assert "use terminal" in instructions
+    assert "Do not answer those requests from memory" in instructions
+
+
+def test_realtime_session_instructions_preserves_custom_config():
+    import gateway.openai_realtime_voice as rt
+
+    instructions = rt.realtime_session_instructions(
+        rt.RealtimeVoiceConfig(instructions="Be very brief.")
+    )
+
+    assert instructions == "Be very brief."
+
+
+def test_session_start_sends_realtime_update(monkeypatch):
+    import gateway.openai_realtime_voice as rt
+
+    ws = _FakeWS()
+    captured = {}
+
+    def connect(url, **kwargs):
+        captured["url"] = url
+        captured["headers"] = dict(kwargs.get("additional_headers") or kwargs.get("extra_headers") or [])
+        return ws
+
+    monkeypatch.setattr(rt, "_require_websocket_connect", lambda: connect)
+
+    session = rt.OpenAIRealtimeVoiceSession(
+        config=rt.RealtimeVoiceConfig(enabled=True, instructions="Be concise."),
+        auth=rt.RealtimeAuthConfig(api_key="sk-test", websocket_url=rt.DIRECT_REALTIME_WS_URL, mode="direct"),
+        tool_schemas=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "terminal",
+                    "description": "Run a command",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ],
+        on_audio_response=lambda _pcm: None,
+    )
+
+    session.start()
+    session.close()
+
+    assert "model=gpt-realtime-2" in captured["url"]
+    assert captured["headers"]["Authorization"] == "Bearer sk-test"
+    assert "OpenAI-Beta" not in captured["headers"]
+    update = ws.sent[0]
+    assert update["type"] == "session.update"
+    assert update["session"]["model"] == "gpt-realtime-2"
+    assert update["session"]["output_modalities"] == ["audio"]
+    assert update["session"]["audio"]["input"]["format"] == {
+        "type": "audio/pcm",
+        "rate": 24000,
+    }
+    assert update["session"]["audio"]["input"]["turn_detection"] == {
+        "type": "server_vad",
+        "threshold": 0.55,
+        "prefix_padding_ms": 250,
+        "silence_duration_ms": 350,
+        "create_response": True,
+        "interrupt_response": True,
+    }
+    assert update["session"]["audio"]["output"]["format"] == {
+        "type": "audio/pcm",
+        "rate": 24000,
+    }
+    assert update["session"]["audio"]["output"]["voice"] == "marin"
+    assert update["session"]["instructions"] == "Be concise."
+    assert update["session"]["tools"][0]["name"] == "terminal"
+
+
+def test_session_start_sends_default_voice_tool_instructions(monkeypatch):
+    import gateway.openai_realtime_voice as rt
+
+    ws = _FakeWS()
+    monkeypatch.setattr(rt, "_require_websocket_connect", lambda: (lambda *_a, **_kw: ws))
+
+    session = rt.OpenAIRealtimeVoiceSession(
+        config=rt.RealtimeVoiceConfig(enabled=True),
+        auth=rt.RealtimeAuthConfig(api_key="sk-test", websocket_url=rt.DIRECT_REALTIME_WS_URL, mode="direct"),
+        tool_schemas=[],
+        on_audio_response=lambda _pcm: None,
+    )
+
+    session.start()
+    session.close()
+
+    assert "Discord voice channel" in ws.sent[0]["session"]["instructions"]
+    assert "Hermes tools" in ws.sent[0]["session"]["instructions"]
+
+
+def test_send_discord_pcm_appends_base64_audio():
+    import gateway.openai_realtime_voice as rt
+
+    ws = _FakeWS()
+    session = rt.OpenAIRealtimeVoiceSession(
+        config=rt.RealtimeVoiceConfig(enabled=True),
+        auth=rt.RealtimeAuthConfig(api_key="sk-test", websocket_url=rt.DIRECT_REALTIME_WS_URL, mode="direct"),
+        tool_schemas=[],
+        on_audio_response=lambda _pcm: None,
+    )
+    session._ws = ws
+    session._running.set()
+
+    frame = (1000).to_bytes(2, "little", signed=True) + (3000).to_bytes(2, "little", signed=True)
+    session.send_discord_pcm(frame * 2)
+
+    payload = ws.sent[0]
+    assert payload["type"] == "input_audio_buffer.append"
+    assert base64.b64decode(payload["audio"]) == (2000).to_bytes(2, "little", signed=True)
+    session.close()
+
+
+def test_send_discord_pcm_ignores_local_silence():
+    import gateway.openai_realtime_voice as rt
+
+    ws = _FakeWS()
+    session = rt.OpenAIRealtimeVoiceSession(
+        config=rt.RealtimeVoiceConfig(enabled=True, input_silence_threshold=120),
+        auth=rt.RealtimeAuthConfig(api_key="sk-test", websocket_url=rt.DIRECT_REALTIME_WS_URL, mode="direct"),
+        tool_schemas=[],
+        on_audio_response=lambda _pcm: None,
+    )
+    session._ws = ws
+    session._running.set()
+
+    session.send_discord_pcm(b"\x00\x00" * 480)
+
+    assert ws.sent == []
+    assert session._turn_timer is None
+
+
+def test_send_discord_pcm_schedules_turn_for_local_speech():
+    import gateway.openai_realtime_voice as rt
+
+    ws = _FakeWS()
+    session = rt.OpenAIRealtimeVoiceSession(
+        config=rt.RealtimeVoiceConfig(enabled=True, input_silence_threshold=120),
+        auth=rt.RealtimeAuthConfig(api_key="sk-test", websocket_url=rt.DIRECT_REALTIME_WS_URL, mode="direct"),
+        tool_schemas=[],
+        on_audio_response=lambda _pcm: None,
+    )
+    session._ws = ws
+    session._running.set()
+
+    frame = (1000).to_bytes(2, "little", signed=True) + (1000).to_bytes(2, "little", signed=True)
+    session.send_discord_pcm(frame * 2)
+
+    try:
+        assert ws.sent[0]["type"] == "input_audio_buffer.append"
+        assert session._turn_timer is not None
+    finally:
+        session.close()
+
+
+def test_manual_turn_finalize_commits_and_creates_response():
+    import gateway.openai_realtime_voice as rt
+
+    ws = _FakeWS()
+    session = rt.OpenAIRealtimeVoiceSession(
+        config=rt.RealtimeVoiceConfig(enabled=True, manual_turn_timeout_ms=100),
+        auth=rt.RealtimeAuthConfig(api_key="sk-test", websocket_url=rt.DIRECT_REALTIME_WS_URL, mode="direct"),
+        tool_schemas=[],
+        on_audio_response=lambda _pcm: None,
+    )
+    session._ws = ws
+    session._running.set()
+    session._turn_has_audio = True
+    session._last_input_audio_at = rt.time.monotonic() - 1
+
+    session._finalize_input_turn()
+
+    assert [payload["type"] for payload in ws.sent] == [
+        "input_audio_buffer.commit",
+        "response.create",
+    ]
+    assert session._turn_has_audio is False
+
+
+def test_manual_turn_finalize_arms_response_start_watchdog(monkeypatch):
+    import gateway.openai_realtime_voice as rt
+
+    class FakeTimer:
+        def __init__(self, delay, callback):
+            self.delay = delay
+            self.callback = callback
+            self.started = False
+            self.cancelled = False
+
+        def start(self):
+            self.started = True
+
+        def cancel(self):
+            self.cancelled = True
+
+    timers = []
+
+    def fake_timer(delay, callback):
+        timer = FakeTimer(delay, callback)
+        timers.append(timer)
+        return timer
+
+    monkeypatch.setattr(rt.threading, "Timer", fake_timer)
+    ws = _FakeWS()
+    session = rt.OpenAIRealtimeVoiceSession(
+        config=rt.RealtimeVoiceConfig(enabled=True, manual_turn_timeout_ms=100, response_start_timeout_ms=2500),
+        auth=rt.RealtimeAuthConfig(api_key="sk-test", websocket_url=rt.DIRECT_REALTIME_WS_URL, mode="direct"),
+        tool_schemas=[],
+        on_audio_response=lambda _pcm: None,
+    )
+    session._ws = ws
+    session._running.set()
+    session._turn_has_audio = True
+    session._last_input_audio_at = rt.time.monotonic() - 1
+
+    session._finalize_input_turn()
+
+    assert [payload["type"] for payload in ws.sent] == [
+        "input_audio_buffer.commit",
+        "response.create",
+    ]
+    assert session._awaiting_response_start is True
+    assert session._response_create_attempts == 1
+    assert timers[-1].delay == 2.5
+    assert timers[-1].started is True
+
+
+def test_server_vad_speech_stopped_keeps_manual_turn_timer_armed():
+    import gateway.openai_realtime_voice as rt
+
+    class FakeTimer:
+        cancelled = False
+
+        def cancel(self):
+            self.cancelled = True
+
+    session = rt.OpenAIRealtimeVoiceSession(
+        config=rt.RealtimeVoiceConfig(enabled=True),
+        auth=rt.RealtimeAuthConfig(api_key="sk-test", websocket_url=rt.DIRECT_REALTIME_WS_URL, mode="direct"),
+        tool_schemas=[],
+        on_audio_response=lambda _pcm: None,
+    )
+    timer = FakeTimer()
+    session._turn_has_audio = True
+    session._turn_timer = timer
+
+    session._handle_frame({"type": "input_audio_buffer.speech_stopped"})
+
+    assert session._turn_has_audio is True
+    assert session._turn_timer is timer
+    assert timer.cancelled is False
+
+
+def test_response_created_cancels_manual_turn_timer():
+    import gateway.openai_realtime_voice as rt
+
+    class FakeTimer:
+        cancelled = False
+
+        def cancel(self):
+            self.cancelled = True
+
+    session = rt.OpenAIRealtimeVoiceSession(
+        config=rt.RealtimeVoiceConfig(enabled=True),
+        auth=rt.RealtimeAuthConfig(api_key="sk-test", websocket_url=rt.DIRECT_REALTIME_WS_URL, mode="direct"),
+        tool_schemas=[],
+        on_audio_response=lambda _pcm: None,
+    )
+    timer = FakeTimer()
+    session._turn_has_audio = True
+    session._turn_timer = timer
+
+    session._handle_frame({"type": "response.created"})
+
+    assert session._response_in_progress is True
+    assert session._turn_has_audio is False
+    assert session._turn_timer is None
+    assert timer.cancelled is True
+
+
+def test_response_created_cancels_response_start_watchdog():
+    import gateway.openai_realtime_voice as rt
+
+    class FakeTimer:
+        cancelled = False
+
+        def cancel(self):
+            self.cancelled = True
+
+    session = rt.OpenAIRealtimeVoiceSession(
+        config=rt.RealtimeVoiceConfig(enabled=True),
+        auth=rt.RealtimeAuthConfig(api_key="sk-test", websocket_url=rt.DIRECT_REALTIME_WS_URL, mode="direct"),
+        tool_schemas=[],
+        on_audio_response=lambda _pcm: None,
+    )
+    timer = FakeTimer()
+    session._awaiting_response_start = True
+    session._response_create_attempts = 1
+    session._response_watchdog_timer = timer
+
+    session._handle_frame({"type": "response.created"})
+
+    assert session._awaiting_response_start is False
+    assert session._response_create_attempts == 0
+    assert session._response_watchdog_timer is None
+    assert timer.cancelled is True
+
+
+def test_response_start_watchdog_retries_once_then_gives_up(monkeypatch):
+    import gateway.openai_realtime_voice as rt
+
+    class FakeTimer:
+        def __init__(self, delay, callback):
+            self.delay = delay
+            self.callback = callback
+            self.started = False
+
+        def start(self):
+            self.started = True
+
+        def cancel(self):
+            pass
+
+    timers = []
+
+    def fake_timer(delay, callback):
+        timer = FakeTimer(delay, callback)
+        timers.append(timer)
+        return timer
+
+    monkeypatch.setattr(rt.threading, "Timer", fake_timer)
+    ws = _FakeWS()
+    session = rt.OpenAIRealtimeVoiceSession(
+        config=rt.RealtimeVoiceConfig(enabled=True, response_start_timeout_ms=2500),
+        auth=rt.RealtimeAuthConfig(api_key="sk-test", websocket_url=rt.DIRECT_REALTIME_WS_URL, mode="direct"),
+        tool_schemas=[],
+        on_audio_response=lambda _pcm: None,
+    )
+    session._ws = ws
+    session._running.set()
+    session._awaiting_response_start = True
+    session._response_create_attempts = 1
+
+    session._response_start_timed_out()
+
+    assert [payload["type"] for payload in ws.sent] == ["response.create"]
+    assert session._awaiting_response_start is True
+    assert session._response_create_attempts == 2
+    assert timers[-1].delay == 2.5
+    assert timers[-1].started is True
+
+    session._response_start_timed_out()
+
+    assert [payload["type"] for payload in ws.sent] == ["response.create"]
+    assert session._awaiting_response_start is False
+    assert session._response_create_attempts == 2
+
+
+def test_manual_turn_finalize_rearms_while_response_in_progress(monkeypatch):
+    import gateway.openai_realtime_voice as rt
+
+    class FakeTimer:
+        def __init__(self, delay, callback):
+            self.delay = delay
+            self.callback = callback
+            self.started = False
+            self.cancelled = False
+
+        def start(self):
+            self.started = True
+
+        def cancel(self):
+            self.cancelled = True
+
+    timers = []
+
+    def fake_timer(delay, callback):
+        timer = FakeTimer(delay, callback)
+        timers.append(timer)
+        return timer
+
+    monkeypatch.setattr(rt.threading, "Timer", fake_timer)
+    ws = _FakeWS()
+    session = rt.OpenAIRealtimeVoiceSession(
+        config=rt.RealtimeVoiceConfig(enabled=True, manual_turn_timeout_ms=100),
+        auth=rt.RealtimeAuthConfig(api_key="sk-test", websocket_url=rt.DIRECT_REALTIME_WS_URL, mode="direct"),
+        tool_schemas=[],
+        on_audio_response=lambda _pcm: None,
+    )
+    session._ws = ws
+    session._running.set()
+    session._turn_has_audio = True
+    session._last_input_audio_at = rt.time.monotonic() - 1
+    session._response_in_progress = True
+
+    session._finalize_input_turn()
+
+    assert ws.sent == []
+    assert len(timers) == 1
+    assert timers[0].delay == 0.1
+    assert timers[0].started is True
+
+
+def test_response_done_rearms_pending_second_turn(monkeypatch):
+    import gateway.openai_realtime_voice as rt
+
+    class FakeTimer:
+        def __init__(self, delay, callback):
+            self.delay = delay
+            self.callback = callback
+            self.started = False
+
+        def start(self):
+            self.started = True
+
+        def cancel(self):
+            pass
+
+    timers = []
+
+    def fake_timer(delay, callback):
+        timer = FakeTimer(delay, callback)
+        timers.append(timer)
+        return timer
+
+    monkeypatch.setattr(rt.threading, "Timer", fake_timer)
+    session = rt.OpenAIRealtimeVoiceSession(
+        config=rt.RealtimeVoiceConfig(enabled=True, manual_turn_timeout_ms=100),
+        auth=rt.RealtimeAuthConfig(api_key="sk-test", websocket_url=rt.DIRECT_REALTIME_WS_URL, mode="direct"),
+        tool_schemas=[],
+        on_audio_response=lambda _pcm: None,
+    )
+    session._turn_has_audio = True
+    session._last_input_audio_at = rt.time.monotonic() - 1
+    session._response_in_progress = True
+
+    session._handle_frame({"type": "response.done"})
+
+    assert session._response_in_progress is False
+    assert len(timers) == 1
+    assert timers[0].delay == 0.01
+    assert timers[0].started is True
+
+
+def test_late_response_item_does_not_clear_pending_barge_in(monkeypatch):
+    import gateway.openai_realtime_voice as rt
+
+    class FakeTimer:
+        def __init__(self, delay, callback):
+            self.delay = delay
+            self.callback = callback
+            self.started = False
+            self.cancelled = False
+
+        def start(self):
+            self.started = True
+
+        def cancel(self):
+            self.cancelled = True
+
+    timers = []
+
+    def fake_timer(delay, callback):
+        timer = FakeTimer(delay, callback)
+        timers.append(timer)
+        return timer
+
+    monkeypatch.setattr(rt.threading, "Timer", fake_timer)
+    session = rt.OpenAIRealtimeVoiceSession(
+        config=rt.RealtimeVoiceConfig(enabled=True, manual_turn_timeout_ms=100),
+        auth=rt.RealtimeAuthConfig(api_key="sk-test", websocket_url=rt.DIRECT_REALTIME_WS_URL, mode="direct"),
+        tool_schemas=[],
+        on_audio_response=lambda _pcm: None,
+    )
+    session._response_in_progress = True
+    session._turn_has_audio = True
+    session._pending_barge_in = True
+    session._last_input_audio_at = rt.time.monotonic() - 1
+
+    session._handle_frame({"type": "response.output_item.added"})
+
+    assert session._turn_has_audio is True
+    assert session._pending_barge_in is True
+    assert len(timers) == 1
+    assert timers[0].started is True
+
+
+def test_barge_in_cancels_response_and_ignores_stale_audio_delta():
+    import gateway.openai_realtime_voice as rt
+
+    ws = _FakeWS()
+    flushed = []
+    session = rt.OpenAIRealtimeVoiceSession(
+        config=rt.RealtimeVoiceConfig(enabled=True),
+        auth=rt.RealtimeAuthConfig(api_key="sk-test", websocket_url=rt.DIRECT_REALTIME_WS_URL, mode="direct"),
+        tool_schemas=[],
+        on_audio_response=flushed.append,
+    )
+    session._ws = ws
+    session._running.set()
+    session._response_in_progress = True
+    session._response_audio.extend(b"stale")
+
+    frame = (1000).to_bytes(2, "little", signed=True) + (1000).to_bytes(2, "little", signed=True)
+    session.send_discord_pcm(frame * 2)
+    session.send_discord_pcm(frame * 2)
+
+    try:
+        assert [payload["type"] for payload in ws.sent[:3]] == [
+            "response.cancel",
+            "input_audio_buffer.append",
+            "input_audio_buffer.append",
+        ]
+        assert session._pending_barge_in is True
+        assert session._turn_has_audio is True
+        assert session._response_audio == bytearray()
+
+        stale_chunk = b"\x01\x02" * (rt.DEFAULT_OUTPUT_FLUSH_BYTES // 2)
+        session._handle_frame({
+            "type": "response.audio.delta",
+            "delta": base64.b64encode(stale_chunk).decode("ascii"),
+        })
+
+        assert flushed == []
+        assert session._response_audio == bytearray()
+        assert session._turn_has_audio is True
+    finally:
+        session.close()
+
+
+def test_user_audio_start_callback_fires_once_per_turn():
+    import gateway.openai_realtime_voice as rt
+
+    ws = _FakeWS()
+    starts = []
+    session = rt.OpenAIRealtimeVoiceSession(
+        config=rt.RealtimeVoiceConfig(enabled=True),
+        auth=rt.RealtimeAuthConfig(api_key="sk-test", websocket_url=rt.DIRECT_REALTIME_WS_URL, mode="direct"),
+        tool_schemas=[],
+        on_audio_response=lambda _pcm: None,
+        on_user_audio_start=lambda: starts.append("start"),
+    )
+    session._ws = ws
+    session._running.set()
+
+    frame = (1000).to_bytes(2, "little", signed=True) + (1000).to_bytes(2, "little", signed=True)
+    session.send_discord_pcm(frame * 2)
+    session.send_discord_pcm(frame * 2)
+
+    try:
+        assert starts == ["start"]
+    finally:
+        session.close()
+
+
+def test_audio_delta_flushes_incrementally_at_stream_threshold():
+    import gateway.openai_realtime_voice as rt
+
+    flushed = []
+    session = rt.OpenAIRealtimeVoiceSession(
+        config=rt.RealtimeVoiceConfig(enabled=True),
+        auth=rt.RealtimeAuthConfig(api_key="sk-test", websocket_url=rt.DIRECT_REALTIME_WS_URL, mode="direct"),
+        tool_schemas=[],
+        on_audio_response=flushed.append,
+    )
+
+    chunk = b"\x01\x02" * (rt.DEFAULT_OUTPUT_FLUSH_BYTES // 2)
+    session._handle_frame({
+        "type": "response.audio.delta",
+        "delta": base64.b64encode(chunk).decode("ascii"),
+    })
+
+    assert flushed == [chunk]
+    assert session._response_audio == bytearray()
+
+
+def test_audio_done_flushes_remainder_below_stream_threshold():
+    import gateway.openai_realtime_voice as rt
+
+    flushed = []
+    session = rt.OpenAIRealtimeVoiceSession(
+        config=rt.RealtimeVoiceConfig(enabled=True),
+        auth=rt.RealtimeAuthConfig(api_key="sk-test", websocket_url=rt.DIRECT_REALTIME_WS_URL, mode="direct"),
+        tool_schemas=[],
+        on_audio_response=flushed.append,
+    )
+
+    chunk = b"\x01\x02" * 100
+    session._handle_frame({
+        "type": "response.audio.delta",
+        "delta": base64.b64encode(chunk).decode("ascii"),
+    })
+    assert flushed == []
+
+    session._handle_frame({"type": "response.audio.done"})
+
+    assert flushed == [chunk]
+    assert session._response_audio == bytearray()
+
+
+def test_function_call_executes_hermes_tool_and_resumes(monkeypatch, caplog):
+    import gateway.openai_realtime_voice as rt
+    import model_tools
+
+    ws = _FakeWS()
+    monkeypatch.setattr(
+        model_tools,
+        "handle_function_call",
+        lambda name, args, **_kw: json.dumps({"name": name, "args": args}),
+    )
+
+    session = rt.OpenAIRealtimeVoiceSession(
+        config=rt.RealtimeVoiceConfig(enabled=True),
+        auth=rt.RealtimeAuthConfig(api_key="sk-test", websocket_url=rt.DIRECT_REALTIME_WS_URL, mode="direct"),
+        tool_schemas=[],
+        on_audio_response=lambda _pcm: None,
+    )
+    session._ws = ws
+
+    caplog.set_level(logging.INFO, logger="gateway.openai_realtime_voice")
+    session._handle_frame({
+        "type": "response.function_call_arguments.done",
+        "name": "terminal",
+        "call_id": "call_1",
+        "arguments": "{\"cmd\":\"pwd\"}",
+    })
+
+    assert ws.sent[0]["type"] == "conversation.item.create"
+    assert ws.sent[0]["item"]["call_id"] == "call_1"
+    assert json.loads(ws.sent[0]["item"]["output"]) == {"name": "terminal", "args": {"cmd": "pwd"}}
+    assert ws.sent[1]["type"] == "response.create"
+    assert "OpenAI Realtime voice completed Hermes tool: name=terminal call_id=call_1" in caplog.text
+
+
+def test_function_call_duplicate_call_id_executes_once(monkeypatch):
+    import gateway.openai_realtime_voice as rt
+    import model_tools
+
+    ws = _FakeWS()
+    calls = []
+    monkeypatch.setattr(
+        model_tools,
+        "handle_function_call",
+        lambda name, args, **_kw: calls.append((name, args)) or "{}",
+    )
+
+    session = rt.OpenAIRealtimeVoiceSession(
+        config=rt.RealtimeVoiceConfig(enabled=True),
+        auth=rt.RealtimeAuthConfig(api_key="sk-test", websocket_url=rt.DIRECT_REALTIME_WS_URL, mode="direct"),
+        tool_schemas=[],
+        on_audio_response=lambda _pcm: None,
+    )
+    session._ws = ws
+
+    frame = {
+        "type": "response.function_call_arguments.done",
+        "name": "terminal",
+        "call_id": "call_1",
+        "arguments": "{}",
+    }
+    session._handle_frame(frame)
+    session._handle_frame(frame)
+
+    assert calls == [("terminal", {})]
+    assert [payload["type"] for payload in ws.sent] == [
+        "conversation.item.create",
+        "response.create",
+    ]

--- a/tests/gateway/test_openai_realtime_voice.py
+++ b/tests/gateway/test_openai_realtime_voice.py
@@ -83,6 +83,16 @@ def test_load_realtime_voice_config_supports_response_start_timeout():
     assert rt.response_start_timeout_ms == 2500
 
 
+def test_load_realtime_voice_config_aliases_codex_auth_to_managed():
+    from gateway.openai_realtime_voice import load_realtime_voice_config
+
+    cfg = {"voice": {"realtime": {"enabled": True, "auth_mode": "codex"}}}
+
+    rt = load_realtime_voice_config(cfg)
+
+    assert rt.auth_mode == "managed"
+
+
 def test_resolve_realtime_auth_direct(monkeypatch):
     import gateway.openai_realtime_voice as rt
 
@@ -139,6 +149,19 @@ def test_discord_pcm_to_realtime_pcm_downmixes_and_decimates():
     converted = discord_pcm_to_realtime_pcm(frame_1 + frame_2)
 
     assert converted == (2000).to_bytes(2, "little", signed=True)
+
+
+def test_discord_pcm_to_realtime_pcm_resamples_non_default_rate():
+    from gateway.openai_realtime_voice import discord_pcm_to_realtime_pcm
+
+    converted = discord_pcm_to_realtime_pcm(
+        b"\x01\x00" * 160,
+        src_rate=16000,
+        src_channels=1,
+        dst_rate=24000,
+    )
+
+    assert len(converted) >= 470
 
 
 def test_pcm_rms_reads_s16le_samples():

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -857,7 +857,7 @@ class TestVoiceChannelCommands:
                 mode="managed",
             ),
         )
-        monkeypatch.setattr(tools_config, "_get_platform_tools", lambda _config, _platform: {"core"})
+        monkeypatch.setattr(tools_config, "get_platform_tools", lambda _config, _platform: {"core"})
         terminal_schema = {
             "type": "function",
             "function": {
@@ -1432,7 +1432,7 @@ class TestDiscordVoiceChannelMethods:
         await asyncio.wait_for(queue.join(), timeout=1)
         mock_vc.stop.assert_called_once()
 
-    def test_realtime_pcm_audio_source_converts_to_discord_frame(self):
+    def test_realtime_pcm_audio_source_doubles_samples_for_24khz_input(self):
         from gateway.platforms.discord import _RealtimePCMAudioSource
 
         pcm_20ms_24khz_mono = (100).to_bytes(2, "little", signed=True) * 480
@@ -1456,7 +1456,7 @@ class TestDiscordVoiceChannelMethods:
 
         session.send_discord_pcm.assert_called_once_with(b"pcm")
 
-    def test_realtime_pcm_audio_source_converts_to_discord_frames(self):
+    def test_realtime_pcm_audio_source_pads_short_frame(self):
         from gateway.platforms.discord import _RealtimePCMAudioSource
 
         # 10ms of 24kHz mono s16le should upsample to one padded 20ms Discord frame.
@@ -1468,6 +1468,16 @@ class TestDiscordVoiceChannelMethods:
         assert len(frame) == 3840
         assert frame[:8] == b"\x01\x00\x01\x00\x01\x00\x01\x00"
         assert source.read() == b""
+
+    def test_realtime_pcm_audio_source_resamples_non_divisor_rate(self):
+        from gateway.platforms.discord import _RealtimePCMAudioSource
+
+        source = _RealtimePCMAudioSource(b"\x01\x00" * 441, sample_rate=44100, channels=1)
+
+        frame = source.read()
+
+        assert len(frame) == _RealtimePCMAudioSource._FRAME_BYTES
+        assert frame.startswith(b"\x01\x00\x01\x00")
 
     def test_realtime_pcm_queue_audio_source_bridges_partial_chunks(self):
         from gateway.platforms.discord import _RealtimePCMQueueAudioSource
@@ -1536,6 +1546,25 @@ class TestDiscordVoiceChannelMethods:
         assert result is True
         source.feed.assert_called_once_with(b"\x00\x00" * 240, sample_rate=24000, channels=1)
         mock_vc.play.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_realtime_pcm_playback_clears_source_when_play_fails(self):
+        adapter = self._make_adapter()
+        mock_vc = MagicMock()
+        mock_vc.is_connected.return_value = True
+        mock_vc.is_playing.return_value = False
+        mock_vc.play.side_effect = RuntimeError("play failed")
+        adapter._voice_clients[111] = mock_vc
+
+        result = await adapter._play_realtime_pcm_response(
+            111,
+            b"\x00\x00" * 240,
+            sample_rate=24000,
+            channels=1,
+        )
+
+        assert result is False
+        assert 111 not in adapter._voice_realtime_playback_sources
 
     def test_is_allowed_user_not_in_list(self):
         adapter = self._make_adapter()

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -1,5 +1,6 @@
 """Tests for the /voice command and auto voice reply in the gateway."""
 
+import asyncio
 import importlib.util
 import json
 import os
@@ -818,6 +819,89 @@ class TestVoiceChannelCommands:
         assert mock_adapter._voice_sources[111]["chat_type"] == "group"
 
     @pytest.mark.asyncio
+    async def test_join_success_starts_realtime_when_enabled(self, runner, monkeypatch):
+        """Discord VC join attaches Realtime-2 session when config enables it."""
+        from gateway.config import Platform
+        import gateway.openai_realtime_voice as rt
+        import model_tools
+        import hermes_cli.tools_config as tools_config
+
+        started = []
+
+        class FakeRealtimeSession:
+            active = True
+
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+
+            def start(self):
+                started.append(self)
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr(
+            "gateway.run._load_gateway_config",
+            lambda: {
+                "voice": {"realtime": {"enabled": True, "auth_mode": "managed"}},
+                "agent": {},
+            },
+        )
+        monkeypatch.setattr(rt, "OpenAIRealtimeVoiceSession", FakeRealtimeSession)
+        monkeypatch.setattr(
+            rt,
+            "resolve_realtime_auth",
+            lambda _config: rt.RealtimeAuthConfig(
+                api_key="oauth-token",
+                websocket_url=rt.DIRECT_REALTIME_WS_URL,
+                mode="managed",
+            ),
+        )
+        monkeypatch.setattr(tools_config, "_get_platform_tools", lambda _config, _platform: {"core"})
+        terminal_schema = {
+            "type": "function",
+            "function": {
+                "name": "terminal",
+                "description": "Run a command",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        monkeypatch.setattr(model_tools, "get_tool_definitions", lambda **_kw: [terminal_schema])
+
+        mock_channel = MagicMock()
+        mock_channel.name = "General"
+        mock_adapter = AsyncMock()
+        mock_adapter.join_voice_channel = AsyncMock(return_value=True)
+        mock_adapter.get_user_voice_channel = AsyncMock(return_value=mock_channel)
+        mock_adapter.set_voice_realtime_session = MagicMock()
+        mock_adapter.queue_realtime_pcm_response = MagicMock()
+        mock_adapter.interrupt_realtime_playback = MagicMock()
+        mock_adapter._voice_text_channels = {}
+        mock_adapter._voice_sources = {}
+        mock_adapter._voice_input_callback = None
+        mock_adapter._on_voice_disconnect = None
+        event = self._make_discord_event()
+        event.source.platform = Platform.DISCORD
+        runner.adapters[Platform.DISCORD] = mock_adapter
+
+        result = await runner._handle_voice_channel_join(event)
+
+        assert "Realtime-2 voice is active using managed auth" in result
+        assert started
+        assert started[0].kwargs["config"].model == "gpt-realtime-2"
+        assert started[0].kwargs["tool_schemas"] == [terminal_schema]
+        assert mock_adapter.set_voice_realtime_session.call_args.args[0] == 111
+        started[0].kwargs["on_audio_response"](b"pcm")
+        mock_adapter.queue_realtime_pcm_response.assert_called_once_with(
+            111,
+            b"pcm",
+            sample_rate=24000,
+            channels=1,
+        )
+        started[0].kwargs["on_user_audio_start"]()
+        mock_adapter.interrupt_realtime_playback.assert_called_once_with(111)
+
+    @pytest.mark.asyncio
     async def test_join_failure(self, runner):
         """Failed join returns permissions error."""
         mock_channel = MagicMock()
@@ -860,6 +944,64 @@ class TestVoiceChannelCommands:
 
         assert "voice dependencies are missing" in result.lower()
         assert "PyNaCl" in result
+
+    @pytest.mark.asyncio
+    async def test_status_reports_active_realtime(self, runner, monkeypatch):
+        """Discord /voice status shows active Realtime-2 state."""
+        from gateway.config import Platform
+
+        monkeypatch.setattr(
+            "gateway.run._load_gateway_config",
+            lambda: {"voice": {"realtime": {"enabled": True, "auth_mode": "managed"}}},
+        )
+
+        mock_adapter = MagicMock()
+        mock_adapter.get_voice_channel_info.return_value = {
+            "channel_name": "General",
+            "member_count": 0,
+            "members": [],
+        }
+        mock_adapter.is_voice_realtime_enabled.return_value = True
+
+        event = self._make_discord_event("/voice status")
+        event.source.platform = Platform.DISCORD
+        runner.adapters[Platform.DISCORD] = mock_adapter
+
+        result = await runner._handle_voice_command(event)
+
+        assert "Realtime-2: active" in result
+
+    @pytest.mark.asyncio
+    async def test_status_reports_realtime_auth_ready_not_active(self, runner, monkeypatch):
+        """Discord /voice status shows configured-but-not-active Realtime auth readiness."""
+        from gateway.config import Platform
+        import gateway.openai_realtime_voice as rt
+
+        monkeypatch.setattr(
+            "gateway.run._load_gateway_config",
+            lambda: {"voice": {"realtime": {"enabled": True, "auth_mode": "managed"}}},
+        )
+        monkeypatch.setattr(
+            rt,
+            "resolve_realtime_auth",
+            lambda _config: rt.RealtimeAuthConfig(
+                api_key="token",
+                websocket_url=rt.DIRECT_REALTIME_WS_URL,
+                mode="managed",
+            ),
+        )
+
+        mock_adapter = MagicMock()
+        mock_adapter.get_voice_channel_info.return_value = None
+        mock_adapter.is_voice_realtime_enabled.return_value = False
+
+        event = self._make_discord_event("/voice status")
+        event.source.platform = Platform.DISCORD
+        runner.adapters[Platform.DISCORD] = mock_adapter
+
+        result = await runner._handle_voice_command(event)
+
+        assert "Realtime-2: configured, auth ready via managed, not active" in result
 
     # -- _handle_voice_channel_leave --
 
@@ -1081,6 +1223,11 @@ class TestDiscordVoiceChannelMethods:
         adapter._voice_input_callback = None
         adapter._allowed_user_ids = set()
         adapter._running = True
+        adapter._loop = None
+        adapter._voice_realtime_sessions = {}
+        adapter._voice_realtime_playback_queues = {}
+        adapter._voice_realtime_playback_tasks = {}
+        adapter._voice_realtime_playback_sources = {}
         return adapter
 
     def test_is_in_voice_channel_true(self):
@@ -1189,6 +1336,206 @@ class TestDiscordVoiceChannelMethods:
         adapter = self._make_adapter()
         adapter._allowed_user_ids = {"42", "99"}
         assert adapter._is_allowed_user("42") is True
+
+    def test_realtime_voice_pcm_respects_auth_gate(self):
+        adapter = self._make_adapter()
+        adapter._client.get_guild = MagicMock(return_value=MagicMock())
+        adapter._is_allowed_user = MagicMock(return_value=False)
+        session = MagicMock()
+
+        adapter._send_realtime_voice_pcm(111, 42, b"pcm", session)
+
+        adapter._is_allowed_user.assert_called_once()
+        session.send_discord_pcm.assert_not_called()
+
+    def test_set_realtime_session_streams_receiver_pcm_to_session(self):
+        adapter = self._make_adapter()
+        adapter._client.get_guild = MagicMock(return_value=MagicMock())
+        adapter._is_allowed_user = MagicMock(return_value=True)
+        receiver = MagicMock()
+        adapter._voice_receivers[111] = receiver
+        session = MagicMock(active=True)
+
+        adapter.set_voice_realtime_session(111, session)
+
+        callback = receiver.set_stream_callback.call_args.args[0]
+        callback(42, b"pcm")
+
+        session.send_discord_pcm.assert_called_once_with(b"pcm")
+
+    @pytest.mark.asyncio
+    async def test_realtime_playback_worker_stays_alive_for_followup_chunks(self):
+        adapter = self._make_adapter()
+        played = []
+
+        async def fake_play(guild_id, pcm, *, sample_rate=24000, channels=1):
+            played.append((guild_id, pcm, sample_rate, channels))
+            return True
+
+        adapter._play_realtime_pcm_response = fake_play
+
+        await adapter._enqueue_realtime_pcm_response(111, b"first", sample_rate=24000, channels=1)
+        await asyncio.wait_for(adapter._voice_realtime_playback_queues[111].join(), timeout=1)
+        first_task = adapter._voice_realtime_playback_tasks[111]
+        assert not first_task.done()
+
+        await adapter._enqueue_realtime_pcm_response(111, b"second", sample_rate=24000, channels=1)
+        await asyncio.wait_for(adapter._voice_realtime_playback_queues[111].join(), timeout=1)
+
+        assert [item[1] for item in played] == [b"first", b"second"]
+        assert adapter._voice_realtime_playback_tasks[111] is first_task
+
+        adapter.clear_voice_realtime_session(111)
+        await asyncio.sleep(0)
+        assert first_task.cancelled()
+
+    @pytest.mark.asyncio
+    async def test_queue_realtime_pcm_response_enqueues_on_adapter_loop(self):
+        adapter = self._make_adapter()
+        adapter._loop = asyncio.get_running_loop()
+        played = []
+
+        async def fake_play(guild_id, pcm, *, sample_rate=24000, channels=1):
+            played.append((guild_id, pcm, sample_rate, channels))
+            return True
+
+        adapter._play_realtime_pcm_response = fake_play
+
+        adapter.queue_realtime_pcm_response(111, b"pcm", sample_rate=24000, channels=1)
+
+        deadline = time.monotonic() + 1
+        while time.monotonic() < deadline and not played:
+            await asyncio.sleep(0.01)
+
+        assert played == [(111, b"pcm", 24000, 1)]
+        task = adapter._voice_realtime_playback_tasks[111]
+        adapter.clear_voice_realtime_session(111)
+        await asyncio.sleep(0)
+        assert task.cancelled()
+
+    @pytest.mark.asyncio
+    async def test_interrupt_realtime_playback_drains_queue_and_stops_current_audio(self):
+        adapter = self._make_adapter()
+        queue = asyncio.Queue()
+        await queue.put((b"old-1", 24000, 1))
+        await queue.put((b"old-2", 24000, 1))
+        adapter._voice_realtime_playback_queues[111] = queue
+
+        mock_vc = MagicMock()
+        mock_vc.is_connected.return_value = True
+        mock_vc.is_playing.return_value = True
+        adapter._voice_clients[111] = mock_vc
+
+        await adapter._interrupt_realtime_playback(111)
+
+        assert queue.empty()
+        await asyncio.wait_for(queue.join(), timeout=1)
+        mock_vc.stop.assert_called_once()
+
+    def test_realtime_pcm_audio_source_converts_to_discord_frame(self):
+        from gateway.platforms.discord import _RealtimePCMAudioSource
+
+        pcm_20ms_24khz_mono = (100).to_bytes(2, "little", signed=True) * 480
+        source = _RealtimePCMAudioSource(pcm_20ms_24khz_mono, sample_rate=24000, channels=1)
+
+        frame = source.read()
+
+        assert len(frame) == _RealtimePCMAudioSource._FRAME_BYTES
+        assert frame[:8] == (
+            (100).to_bytes(2, "little", signed=True)
+            + (100).to_bytes(2, "little", signed=True)
+        ) * 2
+
+    def test_realtime_voice_pcm_sends_authorized_audio(self):
+        adapter = self._make_adapter()
+        adapter._client.get_guild = MagicMock(return_value=MagicMock())
+        adapter._is_allowed_user = MagicMock(return_value=True)
+        session = MagicMock()
+
+        adapter._send_realtime_voice_pcm(111, 42, b"pcm", session)
+
+        session.send_discord_pcm.assert_called_once_with(b"pcm")
+
+    def test_realtime_pcm_audio_source_converts_to_discord_frames(self):
+        from gateway.platforms.discord import _RealtimePCMAudioSource
+
+        # 10ms of 24kHz mono s16le should upsample to one padded 20ms Discord frame.
+        source = _RealtimePCMAudioSource(b"\x01\x00" * 240, sample_rate=24000, channels=1)
+
+        frame = source.read()
+
+        assert source.is_opus() is False
+        assert len(frame) == 3840
+        assert frame[:8] == b"\x01\x00\x01\x00\x01\x00\x01\x00"
+        assert source.read() == b""
+
+    def test_realtime_pcm_queue_audio_source_bridges_partial_chunks(self):
+        from gateway.platforms.discord import _RealtimePCMQueueAudioSource
+
+        # Two 10ms 24kHz mono chunks should become one continuous 20ms Discord frame
+        # without padding between chunk boundaries.
+        source = _RealtimePCMQueueAudioSource(b"\x01\x00" * 240, sample_rate=24000, channels=1)
+        source.feed(b"\x02\x00" * 240, sample_rate=24000, channels=1)
+
+        frame = source.read()
+
+        assert source.is_opus() is False
+        assert len(frame) == 3840
+        assert frame[:8] == b"\x01\x00\x01\x00\x01\x00\x01\x00"
+        assert frame[-8:] == b"\x02\x00\x02\x00\x02\x00\x02\x00"
+
+    @pytest.mark.asyncio
+    async def test_realtime_pcm_playback_keeps_receiver_active(self):
+        adapter = self._make_adapter()
+        mock_vc = MagicMock()
+        mock_vc.is_connected.return_value = True
+        mock_vc.is_playing.return_value = False
+        captured = {}
+
+        def play(source, after=None):
+            captured["source"] = source
+            if after:
+                after(None)
+
+        mock_vc.play.side_effect = play
+        receiver = MagicMock()
+        adapter._voice_clients[111] = mock_vc
+        adapter._voice_receivers[111] = receiver
+
+        result = await adapter._play_realtime_pcm_response(
+            111,
+            b"\x00\x00" * 240,
+            sample_rate=24000,
+            channels=1,
+        )
+
+        assert result is True
+        assert captured["source"].is_opus() is False
+        receiver.pause.assert_not_called()
+        receiver.resume.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_realtime_pcm_playback_feeds_existing_stream(self):
+        adapter = self._make_adapter()
+        mock_vc = MagicMock()
+        mock_vc.is_connected.return_value = True
+        mock_vc.is_playing.return_value = True
+        adapter._voice_clients[111] = mock_vc
+
+        source = MagicMock()
+        source.closed = False
+        adapter._voice_realtime_playback_sources[111] = source
+
+        result = await adapter._play_realtime_pcm_response(
+            111,
+            b"\x00\x00" * 240,
+            sample_rate=24000,
+            channels=1,
+        )
+
+        assert result is True
+        source.feed.assert_called_once_with(b"\x00\x00" * 240, sample_rate=24000, channels=1)
+        mock_vc.play.assert_not_called()
 
     def test_is_allowed_user_not_in_list(self):
         adapter = self._make_adapter()

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -352,6 +352,40 @@ When the bot joins a voice channel, it:
 4. **Processes** through the full agent pipeline (session, tools, memory)
 5. **Speaks** the reply back in the voice channel via TTS
 
+### Realtime-2 Mode
+
+Discord voice channels can optionally use OpenAI Realtime instead of the classic STT → agent → TTS loop. In Realtime mode, Hermes streams decoded Discord PCM to `gpt-realtime-2`, lets the model call normal Hermes tools, and plays the generated PCM response back into the voice channel.
+
+```yaml
+voice:
+  realtime:
+    enabled: true
+    model: gpt-realtime-2
+    voice: marin
+    auth_mode: managed    # Hermes OpenAI Codex/GPT OAuth; use direct for API-key auth
+    instructions: ""      # Empty uses the Discord voice default
+    manual_turn_timeout_ms: 700
+```
+
+Use `auth_mode: managed` when you want Hermes to reuse its OpenAI Codex/GPT OAuth credentials from `hermes auth add openai-codex`. Use `auth_mode: auto` to prefer direct OpenAI credentials when present and fall back to OpenAI Codex/GPT OAuth. Leaving `instructions` empty uses a built-in Discord voice prompt that tells the model to answer naturally and call Hermes tools when needed.
+
+`/voice status` reports whether Realtime-2 is active, configured but not joined, or blocked on missing managed/direct credentials.
+
+To validate a live Discord Realtime session, restart the gateway, run `/voice join` from a text channel while you are in a VC, speak a short prompt, then ask for a tool-backed action such as "run date". A healthy run writes these log markers to `~/.hermes/logs/gateway.log`:
+
+- `Starting Discord Realtime voice`
+- `OpenAI Realtime voice connected`
+- `OpenAI Realtime voice session updated`
+- `Discord Realtime voice session attached`
+- `VoiceReceiver streaming PCM chunk`
+- `OpenAI Realtime voice input chunk`
+- `OpenAI Realtime voice finalizing input turn` or `OpenAI Realtime voice VAD event: input_audio_buffer.speech_stopped`
+- `OpenAI Realtime voice output audio chunk`
+- `Discord Realtime voice queueing PCM response`
+- `Discord Realtime voice playing PCM stream`
+- `Discord Realtime voice fed PCM stream`
+- `OpenAI Realtime voice executing Hermes tool`
+
 ### Text Channel Integration
 
 When the bot is in a voice channel:
@@ -362,7 +396,7 @@ When the bot is in a voice channel:
 
 ### Echo Prevention
 
-The bot automatically pauses its audio listener while playing TTS replies, preventing it from hearing and re-processing its own output.
+In classic voice mode, the bot pauses its audio listener while playing TTS replies, preventing it from hearing and re-processing its own output. In Realtime-2 mode, Hermes keeps the receiver active so follow-up turns can stream while generated audio is playing.
 
 ### Access Control
 
@@ -388,6 +422,21 @@ voice:
   beep_enabled: true               # Play record start/stop beeps
   silence_threshold: 200           # RMS level (0-32767) below which counts as silence
   silence_duration: 3.0            # Seconds of silence before auto-stop
+  realtime:
+    enabled: false                 # Optional Discord VC Realtime mode
+    model: "gpt-realtime-2"
+    voice: "marin"
+    auth_mode: "auto"              # "auto" | "direct" | "managed"
+    instructions: ""
+    reasoning_effort: "low"
+    input_sample_rate: 24000
+    output_sample_rate: 24000
+    vad_threshold: 0.55
+    vad_prefix_padding_ms: 250
+    vad_silence_duration_ms: 350
+    manual_turn_timeout_ms: 700
+    input_silence_threshold: 120
+    discord: {}                    # Optional Discord-specific overrides
 
 # Speech-to-Text
 stt:
@@ -436,6 +485,9 @@ ELEVENLABS_API_KEY=***             # ElevenLabs (premium quality)
 # Discord voice channel
 DISCORD_BOT_TOKEN=...
 DISCORD_ALLOWED_USERS=...
+
+# OpenAI Realtime direct auth (OpenAI Codex/GPT OAuth does not need this)
+VOICE_TOOLS_OPENAI_KEY=...
 ```
 
 ### STT Provider Comparison


### PR DESCRIPTION
## Summary

- add an OpenAI Realtime voice bridge for Discord voice channels using `gpt-realtime-2`
- support direct OpenAI keys and managed OpenAI Codex/GPT OAuth credentials
- stream Discord PCM into Realtime, play Realtime PCM back into Discord VC, and route Realtime function calls through Hermes tools
- add barge-in handling, provider-side response cancellation, response-start watchdogs, and continuous PCM stream playback to avoid per-chunk buffer artifacts
- document Realtime-2 voice configuration and live validation log markers

## Validation

- `venv/bin/python -m pytest tests/gateway/test_openai_realtime_voice.py tests/gateway/test_voice_command.py -q` -> `225 passed`
- `venv/bin/python -m py_compile gateway/openai_realtime_voice.py gateway/platforms/discord.py gateway/run.py`
- `git diff --check origin/main...HEAD`

## Live Discord smoke

Validated locally in a Discord voice channel with managed auth:

- `/voice join` started Realtime with `model=gpt-realtime-2 voice=marin auth_mode=managed resolved_auth=managed`
- Discord voice PCM streamed into Realtime
- Realtime audio streamed back and played in Discord
- playback used the fixed continuous-stream markers: one `Discord Realtime voice playing PCM stream`, followed by `Discord Realtime voice fed PCM stream`
- barge-in interrupted playback and sent provider-side `response.cancel`
- Realtime invoked a Hermes tool live: `OpenAI Realtime voice executing Hermes tool: name=search_files`
