### PR TITLE
fix: restored Discord free-response auto-thread override

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -823,6 +823,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["require_mention"] = platform_cfg["require_mention"]
                 if "free_response_channels" in platform_cfg:
                     bridged["free_response_channels"] = platform_cfg["free_response_channels"]
+                if plat == Platform.DISCORD and "auto_thread_channels" in platform_cfg:
+                    bridged["auto_thread_channels"] = platform_cfg["auto_thread_channels"]
                 if "mention_patterns" in platform_cfg:
                     bridged["mention_patterns"] = platform_cfg["mention_patterns"]
                 if "dm_policy" in platform_cfg:
@@ -921,6 +923,11 @@ def load_gateway_config() -> GatewayConfig:
                     os.environ["DISCORD_FREE_RESPONSE_CHANNELS"] = str(frc)
                 if "auto_thread" in discord_cfg and not os.getenv("DISCORD_AUTO_THREAD"):
                     os.environ["DISCORD_AUTO_THREAD"] = str(discord_cfg["auto_thread"]).lower()
+                atc = discord_cfg.get("auto_thread_channels")
+                if atc is not None and not os.getenv("DISCORD_AUTO_THREAD_CHANNELS"):
+                    if isinstance(atc, list):
+                        atc = ",".join(str(v) for v in atc)
+                    os.environ["DISCORD_AUTO_THREAD_CHANNELS"] = str(atc)
                 if "reactions" in discord_cfg and not os.getenv("DISCORD_REACTIONS"):
                     os.environ["DISCORD_REACTIONS"] = str(discord_cfg["reactions"]).lower()
                 # ignored_channels: channels where bot never responds (even when mentioned)

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -3624,6 +3624,24 @@ class DiscordAdapter(BasePlatformAdapter):
             return {part.strip() for part in s.split(",") if part.strip()}
         return set()
 
+    def _discord_auto_thread_channels(self) -> set:
+        """Return free-response channel IDs that should still auto-thread.
+
+        A single ``"*"`` entry forces auto-threading for every eligible server
+        channel, while ``discord.no_thread_channels`` remains a hard opt-out.
+        This is a local compatibility override for workflows that want both
+        mention-free channel posts and per-task thread isolation.
+        """
+        raw = self.config.extra.get("auto_thread_channels")
+        if raw is None:
+            raw = os.getenv("DISCORD_AUTO_THREAD_CHANNELS", "")
+        if isinstance(raw, list):
+            return {str(part).strip() for part in raw if str(part).strip()}
+        s = str(raw).strip() if raw is not None else ""
+        if s:
+            return {part.strip() for part in s.split(",") if part.strip()}
+        return set()
+
     def _discord_thread_require_mention(self) -> bool:
         """Return whether thread participation requires @mention to follow up.
 
@@ -4424,6 +4442,7 @@ class DiscordAdapter(BasePlatformAdapter):
         #   discord.allowed_channels: If set, bot ONLY responds in these channels (whitelist)
         #   discord.no_thread_channels: Channel IDs where bot responds directly without creating thread
         #   discord.auto_thread: Auto-create thread on @mention in channels (default: true)
+        #   discord.auto_thread_channels: Free-response channel IDs that still auto-thread; '*' matches all eligible channels
 
         thread_id = None
         parent_channel_id = None
@@ -4455,6 +4474,8 @@ class DiscordAdapter(BasePlatformAdapter):
             normalized_content = normalized_content.replace(f"<@{self._client.user.id}>", "").strip()
             normalized_content = normalized_content.replace(f"<@!{self._client.user.id}>", "").strip()
             message.content = normalized_content
+        channel_ids: set[str] = set()
+        is_free_channel = False
         if not isinstance(message.channel, discord.DMChannel):
             channel_ids = {str(message.channel.id)}
             if parent_channel_id:
@@ -4509,11 +4530,14 @@ class DiscordAdapter(BasePlatformAdapter):
         # @mention in a text channel so each conversation is isolated (like Slack).
         # Messages already inside threads or DMs are unaffected.
         # no_thread_channels: channels where bot responds directly without thread.
+        # auto_thread_channels: free-response channels that should still start threads.
         auto_threaded_channel = None
         if not is_thread and not isinstance(message.channel, discord.DMChannel):
             no_thread_channels_raw = os.getenv("DISCORD_NO_THREAD_CHANNELS", "")
             no_thread_channels = {ch.strip() for ch in no_thread_channels_raw.split(",") if ch.strip()}
-            skip_thread = bool(channel_ids & no_thread_channels) or is_free_channel
+            auto_thread_channels = self._discord_auto_thread_channels()
+            force_auto_thread = "*" in auto_thread_channels or bool(channel_ids & auto_thread_channels)
+            skip_thread = bool(channel_ids & no_thread_channels) or (is_free_channel and not force_auto_thread)
             auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in {"true", "1", "yes"}
             is_reply_message = getattr(message, "type", None) == discord.MessageType.reply
             if auto_thread and not skip_thread and not is_voice_linked_channel and not is_reply_message:

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -108,6 +108,7 @@ def adapter(monkeypatch):
         "DISCORD_THREAD_REQUIRE_MENTION",
         "DISCORD_FREE_RESPONSE_CHANNELS",
         "DISCORD_AUTO_THREAD",
+        "DISCORD_AUTO_THREAD_CHANNELS",
         "DISCORD_NO_THREAD_CHANNELS",
         "DISCORD_ALLOWED_CHANNELS",
         "DISCORD_IGNORED_CHANNELS",
@@ -547,6 +548,55 @@ async def test_discord_free_response_channel_skips_auto_thread(adapter, monkeypa
     assert event.text == "casual chat in free-response channel"
     assert event.source.chat_type == "group"
 
+
+@pytest.mark.asyncio
+async def test_discord_free_response_channel_can_force_auto_thread(adapter, monkeypatch):
+    """Local override preserves mention-free posts plus per-task thread isolation."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "789")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD_CHANNELS", "789")
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)  # default true
+
+    fake_thread = FakeThread(channel_id=999, name="auto-thread")
+    adapter._auto_create_thread = AsyncMock(return_value=fake_thread)
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=789),
+        content="task in free-response channel",
+    )
+
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_awaited_once()
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "task in free-response channel"
+    assert event.source.chat_type == "thread"
+    assert event.source.thread_id == "999"
+
+
+@pytest.mark.asyncio
+async def test_discord_auto_thread_channels_wildcard_keeps_no_thread_opt_out(adapter, monkeypatch):
+    """'*' forces auto-threading broadly, but no_thread_channels still wins."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "789")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD_CHANNELS", "*")
+    monkeypatch.setenv("DISCORD_NO_THREAD_CHANNELS", "789")
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)  # default true
+
+    adapter._auto_create_thread = AsyncMock(return_value=FakeThread(channel_id=999))
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=789),
+        content="inline despite wildcard",
+    )
+
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_not_awaited()
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_type == "group"
 
 
 

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -97,7 +97,16 @@ class FakeTree:
 
 
 @pytest.fixture
-def adapter():
+def adapter(monkeypatch):
+    for _var in (
+        "DISCORD_ALLOWED_CHANNELS",
+        "DISCORD_IGNORED_CHANNELS",
+        "DISCORD_FREE_RESPONSE_CHANNELS",
+        "DISCORD_NO_THREAD_CHANNELS",
+        "DISCORD_AUTO_THREAD_CHANNELS",
+    ):
+        monkeypatch.delenv(_var, raising=False)
+
     config = PlatformConfig(enabled=True, token="***")
     adapter = DiscordAdapter(config)
     adapter._client = SimpleNamespace(
@@ -765,18 +774,21 @@ def test_discord_auto_thread_config_bridge(monkeypatch, tmp_path):
     hermes_dir.mkdir()
     config_path = hermes_dir / "config.yaml"
     config_path.write_text(yaml.dump({
-        "discord": {"auto_thread": True},
+        "discord": {"auto_thread": True, "auto_thread_channels": ["*"]},
     }))
 
     monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
+    monkeypatch.delenv("DISCORD_AUTO_THREAD_CHANNELS", raising=False)
     monkeypatch.setenv("HERMES_HOME", str(hermes_dir))
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
-    from gateway.config import load_gateway_config
-    load_gateway_config()
+    from gateway.config import Platform, load_gateway_config
+    cfg = load_gateway_config()
 
     import os
     assert os.getenv("DISCORD_AUTO_THREAD") == "true"
+    assert os.getenv("DISCORD_AUTO_THREAD_CHANNELS") == "*"
+    assert cfg.platforms[Platform.DISCORD].extra.get("auto_thread_channels") == ["*"]
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Re-added discord.auto_thread_channels / DISCORD_AUTO_THREAD_CHANNELS support.
- Allows configured free-response channels to still create per-task threads when explicitly opted in.
- Preserves discord.no_thread_channels as the hard opt-out.
- Added regression coverage for the override behaviour.

## Test Plan
- scripts/run_tests.sh tests/gateway/test_discord.py tests/gateway/test_config.py
- git diff --check