### PR TITLE
fix(session): populate model_names list in session log

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1546,9 +1546,20 @@ class AIAgent:
                 except Exception:
                     pass  # corrupted existing file — allow the overwrite
 
+            # Collect all distinct model names used in this session so that
+            # downstream consumers (e.g. the achievements plugin) can identify
+            # open-weight / local models without parsing raw message content.
+            session_model_names: list[str] = []
+            if self.model:
+                session_model_names.append(self.model)
+            for msg in cleaned:
+                mn = msg.get("model")
+                if mn and mn not in session_model_names:
+                    session_model_names.append(mn)
             entry = {
                 "session_id": self.session_id,
                 "model": self.model,
+                "model_names": session_model_names,
                 "base_url": self.base_url,
                 "platform": self.platform,
                 "session_start": self.session_start.isoformat(),


### PR DESCRIPTION
## What does this PR do?

`_save_session_log()` wrote only a single `model` string to the session JSON. Downstream consumers such as the achievements plugin expect a `model_names` list to identify open-weight/local models and track multi-model sessions. Without this field, the `Open Weights Pilgrim` achievement and multi-model tracking never fire even when the user genuinely runs local models.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made
- Collect all distinct model names used in the session into `session_model_names` list (seeded from `self.model`, extended from per-message `model` fields)
- Write `model_names` list alongside the existing `model` string in the session log entry

## How to Test
1. Run a Hermes session with any model (e.g. Ollama local model)
2. Check the session JSON in `~/.hermes/sessions/session_*.json`
3. Confirm `model_names` field is now populated
4. Open dashboard Achievements, Rescan — Open Weights Pilgrim should now count correctly

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] No sensitive data (keys, tokens, secrets) included