### PR TITLE
fix(compression): pass platform on compression-boundary session_start (#27633)

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -545,6 +545,7 @@ def compress_context(
                 boundary_reason="compression",
                 old_session_id=_old_sid,
                 conversation_id=getattr(agent, "_gateway_session_key", None),
+                platform=agent.platform or "cli",
             )
     except Exception as _ce_err:
         logger.debug("context engine on_session_start (compression): %s", _ce_err)

--- a/tests/run_agent/test_compression_boundary_hook.py
+++ b/tests/run_agent/test_compression_boundary_hook.py
@@ -127,6 +127,76 @@ class TestCompressionBoundaryHook:
             f"got {comp_calls!r}"
         )
 
+    def test_on_session_start_passes_platform_on_compression(self):
+        """The compression boundary call must include ``platform`` so plugin
+        context engines (e.g. hermes-lcm) that track per-session source
+        lineage don't reset their stored platform to ``""`` / ``"unknown"``
+        on every compression rollover.  Mirrors the initial session-start
+        call in ``agent/agent_init.py`` which already passes ``platform``.
+        """
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = self._make_agent(db)
+            agent.platform = "discord"
+
+            compressor = MagicMock()
+            compressor.compress.return_value = [{"role": "user", "content": "summary"}]
+            compressor.compression_count = 1
+            compressor.last_prompt_tokens = 0
+            compressor.last_completion_tokens = 0
+            compressor._last_summary_error = None
+            agent.context_compressor = compressor
+
+            agent._compress_context(
+                [{"role": "user", "content": "m"}], "sys", approx_tokens=100
+            )
+
+            comp_calls = [
+                c for c in compressor.on_session_start.call_args_list
+                if c.kwargs.get("boundary_reason") == "compression"
+            ]
+            assert comp_calls, "compression boundary call missing"
+            assert comp_calls[-1].kwargs.get("platform") == "discord", (
+                f"Expected platform='discord' on compression boundary, "
+                f"got kwargs={comp_calls[-1].kwargs!r}"
+            )
+
+    def test_on_session_start_falls_back_to_cli_when_platform_unset(self):
+        """When ``agent.platform`` is unset/empty, the compression boundary
+        call should fall back to ``"cli"`` — matching the initial
+        session-start call at ``agent/agent_init.py:1354``.
+        """
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = self._make_agent(db)
+            agent.platform = None
+
+            compressor = MagicMock()
+            compressor.compress.return_value = [{"role": "user", "content": "summary"}]
+            compressor.compression_count = 1
+            compressor.last_prompt_tokens = 0
+            compressor.last_completion_tokens = 0
+            compressor._last_summary_error = None
+            agent.context_compressor = compressor
+
+            agent._compress_context(
+                [{"role": "user", "content": "m"}], "sys", approx_tokens=100
+            )
+
+            comp_calls = [
+                c for c in compressor.on_session_start.call_args_list
+                if c.kwargs.get("boundary_reason") == "compression"
+            ]
+            assert comp_calls, "compression boundary call missing"
+            assert comp_calls[-1].kwargs.get("platform") == "cli", (
+                f"Expected platform='cli' fallback on compression boundary, "
+                f"got kwargs={comp_calls[-1].kwargs!r}"
+            )
+
     def test_hook_failure_does_not_break_compression(self):
         """If the context engine raises from on_session_start, compression still completes."""
         from hermes_state import SessionDB

--- a/tests/run_agent/test_compression_boundary_hook.py
+++ b/tests/run_agent/test_compression_boundary_hook.py
@@ -147,6 +147,10 @@ class TestCompressionBoundaryHook:
             compressor.last_prompt_tokens = 0
             compressor.last_completion_tokens = 0
             compressor._last_summary_error = None
+            # PR #28117 added a post-compress abort branch that short-circuits
+            # before the session-id rotation we assert on. MagicMock attrs
+            # are truthy by default, so pin this explicitly.
+            compressor._last_compress_aborted = False
             agent.context_compressor = compressor
 
             agent._compress_context(
@@ -181,6 +185,10 @@ class TestCompressionBoundaryHook:
             compressor.last_prompt_tokens = 0
             compressor.last_completion_tokens = 0
             compressor._last_summary_error = None
+            # PR #28117 added a post-compress abort branch that short-circuits
+            # before the session-id rotation we assert on. MagicMock attrs
+            # are truthy by default, so pin this explicitly.
+            compressor._last_compress_aborted = False
             agent.context_compressor = compressor
 
             agent._compress_context(


### PR DESCRIPTION
## What does this PR do?

Adds `platform=agent.platform or "cli"` to the context-engine `on_session_start` call fired at the compression boundary in `agent/conversation_compression.py`. Mirrors the canonical pattern already used by the initial session-start at `agent/agent_init.py:1351`. Two new regression tests cover the explicit-platform and `cli` fallback paths.

Root cause: when `_compress_context` rotates `session_id` because of compression, the boundary notification at `agent/conversation_compression.py:373` omits `platform`. Plugin context engines such as `hermes-lcm` cache per-session source lineage in `_session_platform`, and `_apply_session_start_metadata` unconditionally overwrites that field from `kwargs.get("platform")`. So when `platform` is absent on the compression call it gets reset to `""` → normalized to `"unknown"`. Every message ingested after the compression boundary is then attributed to `source='unknown'` instead of the real platform (discord, telegram, cli, …). The reporter saw 806 messages across 4 sessions in a real deployment attributed to `source='unknown'` despite originating from Discord; `lcm_status` source lineage degrades after each compression; `lcm_grep` source filters miss messages.

Mirrors `agent/agent_init.py:1354` precedence: `agent.platform or "cli"`.

## Related Issue

Fixes #27633

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/conversation_compression.py` — one-line change at line 377: pass `platform=agent.platform or "cli"` on the boundary `on_session_start` call, identical to the initial session-start call at `agent/agent_init.py:1354`.
- `tests/run_agent/test_compression_boundary_hook.py` — two new cases: `test_on_session_start_passes_platform_on_compression` (`agent.platform = "discord"` flows through) and `test_on_session_start_falls_back_to_cli_when_platform_unset` (`agent.platform = None` falls back to `"cli"`).

## How to Test

1. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/run_agent/test_compression_boundary_hook.py -v`
2. Expected: 5 passed, 0 failed (includes the 2 new regression cases).
3. Regression guard: temporarily revert the production line; both new tests fail with the exact missing-kwarg signature. Restore — all 5 pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass (5/5)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

- Fixes #27633.
- Follows up on #16306 (teknium1) which introduced the `boundary_reason="compression"` signal but omitted the `platform` kwarg.
- Mirrors `agent/agent_init.py:1354` precedence: `agent.platform or "cli"`.

> Sibling code paths that may need the same fix: the defensive companion on the plugin side — `LCMEngine._apply_session_start_metadata` in `hermes-lcm` should preserve `_session_platform` when `platform` is absent from kwargs, so a regression on this call doesn't silently clobber lineage again. Out of scope for this repo, but worth a follow-up in the LCM plugin.
