### PR TITLE
fix: load symlinked skill slash commands

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -61,10 +61,30 @@ def _load_skill_payload(skill_identifier: str, task_id: str | None = None) -> tu
 
         identifier_path = Path(raw_identifier).expanduser()
         if identifier_path.is_absolute():
+            normalized = raw_identifier
+            candidate_roots = [SKILLS_DIR]
             try:
-                normalized = str(identifier_path.resolve().relative_to(SKILLS_DIR.resolve()))
+                from agent.skill_utils import get_external_skills_dirs
+
+                candidate_roots.extend(get_external_skills_dirs())
             except Exception:
-                normalized = raw_identifier
+                pass
+
+            for root in candidate_roots:
+                # Prefer the lexical path first. Directory symlinks under
+                # ~/.hermes/skills intentionally point at shared skill sources;
+                # resolving them before relative_to() makes an installed skill
+                # look "outside" the skills root and breaks /skill-name loading.
+                try:
+                    normalized = str(identifier_path.relative_to(root))
+                    break
+                except Exception:
+                    pass
+                try:
+                    normalized = str(identifier_path.resolve().relative_to(root.resolve()))
+                    break
+                except Exception:
+                    pass
         else:
             normalized = raw_identifier.lstrip("/")
 

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -460,6 +460,21 @@ Generate some audio.
         assert "test-skill" in msg
         assert "do stuff" in msg
 
+    def test_builds_message_for_skill_dir_symlinked_outside_skills_root(self, tmp_path):
+        external_root = tmp_path / "repo"
+        skills_root = tmp_path / "skills"
+        skills_root.mkdir()
+        external_category = _symlink_category(skills_root, external_root, "linked")
+        _make_skill(external_category.parent, "knowledge-brain", category="linked")
+
+        with patch("tools.skills_tool.SKILLS_DIR", skills_root):
+            scan_skill_commands()
+            msg = build_skill_invocation_message("/knowledge-brain", "load context")
+
+        assert msg is not None
+        assert "knowledge-brain" in msg
+        assert "load context" in msg
+
     def test_returns_none_for_unknown(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
             scan_skill_commands()

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -511,6 +511,25 @@ class TestSkillView:
         assert result["success"] is True
         assert result["name"] == "knowledge-brain"
 
+    def test_view_symlinked_category_under_skills_root_is_trusted(self, tmp_path, caplog):
+        external_root = tmp_path / "repo"
+        skills_root = tmp_path / "skills"
+        skills_root.mkdir()
+
+        external_category = _symlink_category(skills_root, external_root, "linked")
+        _make_skill(external_category.parent, "knowledge-brain", category="linked")
+
+        with patch("tools.skills_tool.SKILLS_DIR", skills_root):
+            with caplog.at_level("WARNING", logger="tools.skills_tool"):
+                raw = skill_view("knowledge-brain")
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert not any(
+            "outside the trusted skills directory" in record.getMessage()
+            for record in caplog.records
+        )
+
     def test_not_found_hint_uses_same_order_as_skills_list(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
             _make_skill(tmp_path, "zeta", category="z-cat")

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -1068,12 +1068,20 @@ def skill_view(
         except Exception:
             pass
         for _td in _trusted_dirs:
+            _candidate_paths = [skill_md]
             try:
-                skill_md.resolve().relative_to(_td)
-                _outside_skills_dir = False
+                _candidate_paths.append(skill_md.resolve())
+            except Exception:
+                pass
+            for _candidate in _candidate_paths:
+                try:
+                    _candidate.relative_to(_td)
+                    _outside_skills_dir = False
+                    break
+                except ValueError:
+                    continue
+            if not _outside_skills_dir:
                 break
-            except ValueError:
-                continue
 
         # Security: detect common prompt injection patterns
         # (pattern list at module level as _INJECTION_PATTERNS)


### PR DESCRIPTION
## Summary
- Fix slash skill loading when an installed skill directory under `~/.hermes/skills` is a symlink to a shared skills source
- Normalize absolute slash-command skill dirs lexically against trusted roots before resolving symlinks
- Avoid false-positive trusted-directory warnings for symlinked installed skills

## Test Plan
- `/Users/alanxue/.hermes/hermes-agent/venv/bin/python -m pytest tests/agent/test_skill_commands.py -q`
- `/Users/alanxue/.hermes/hermes-agent/venv/bin/python -m pytest tests/tools/test_skills_tool.py -q`

## Notes
This covers setups that share skills across harnesses, e.g. `~/.hermes/skills/workflow/resume-session -> ~/.claude/skills/resume-session`, where the slash command was visible but invocation returned no loaded skill message because `skill_view` rejected the absolute resolved path.
