### PR TITLE
test(tools): stabilize env-isolation tests

### DIFF
--- a/tests/tools/test_code_execution_modes.py
+++ b/tests/tools/test_code_execution_modes.py
@@ -154,7 +154,10 @@ class TestResolveChildPython(unittest.TestCase):
         import tempfile
         with tempfile.TemporaryDirectory() as td:
             # No bin/python inside — broken venv
-            with patch.dict(os.environ, {"VIRTUAL_ENV": td}):
+            env = dict(os.environ)
+            env["VIRTUAL_ENV"] = td
+            env.pop("CONDA_PREFIX", None)
+            with patch.dict(os.environ, env, clear=True):
                 _is_usable_python.cache_clear()
                 self.assertEqual(_resolve_child_python("project"), sys.executable)
 

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -26,7 +26,9 @@ def _make_fake_popen(captured: dict):
         proc = MagicMock()
         proc.poll.return_value = 0
         proc.returncode = 0
-        proc.stdout = MagicMock(__iter__=lambda s: iter([]), __next__=lambda s: (_ for _ in ()).throw(StopIteration))
+        read_fd, write_fd = os.pipe()
+        os.close(write_fd)
+        proc.stdout = os.fdopen(read_fd, "rb", closefd=True)
         proc.stdin = MagicMock()
         return proc
     return fake_popen


### PR DESCRIPTION
## Summary
- isolate `CONDA_PREFIX` in the broken-virtualenv child-python fallback test
- replace the fake stdout `MagicMock` in local env blocklist tests with a real closed pipe so the drain thread sees a valid fd/EOF

## Verification
- `python -m pytest tests/tools/test_code_execution_modes.py::TestResolveChildPython::test_project_with_broken_venv_falls_back tests/tools/test_local_env_blocklist.py -q` → 19 passed
- `python -m pytest tests/tools/test_terminal_tool.py tests/tools/test_terminal_exit_semantics.py tests/tools/test_terminal_foreground_timeout_cap.py tests/tools/test_terminal_none_command_guard.py tests/tools/test_local_env_blocklist.py tests/tools/test_local_env_cwd_recovery.py tests/tools/test_terminal_config_env_sync.py tests/tools/test_terminal_tool_requirements.py tests/tools/test_code_execution_modes.py tests/tools/test_code_execution.py tests/tools/test_terminal_compound_background.py tests/tools/test_notify_on_complete.py tests/tools/test_watch_patterns.py -q` → 283 passed
