### PR TITLE
fix(mcp): isolate orphan-reap sleep mock

### DIFF
--- a/tests/tools/test_mcp_stability.py
+++ b/tests/tools/test_mcp_stability.py
@@ -135,7 +135,7 @@ class TestStdioPidTracking:
         # bpo-14484). Return True so the SIGKILL escalation fires.
         with patch("tools.mcp_tool.os.kill") as mock_kill, \
              patch("gateway.status._pid_exists", return_value=True), \
-             patch("tools.mcp_tool.time.sleep") as mock_sleep:
+             patch("tools.mcp_tool._orphan_reap_sleep") as mock_sleep:
             _kill_orphaned_mcp_children()
 
         # SIGTERM then SIGKILL; the alive check no longer touches os.kill.
@@ -163,12 +163,12 @@ class TestStdioPidTracking:
         monkeypatch.delattr(signal, "SIGKILL", raising=False)
 
         with patch("tools.mcp_tool.os.kill") as mock_kill, \
-             patch("tools.mcp_tool.time.sleep") as mock_sleep:
+             patch("tools.mcp_tool._orphan_reap_sleep") as mock_sleep:
             _kill_orphaned_mcp_children()
 
         # SIGTERM phase, alive check raises (process gone), no escalation
         mock_kill.assert_any_call(fake_pid, signal.SIGTERM)
-        assert mock_sleep.called
+        mock_sleep.assert_called_once_with(2)
 
         with _lock:
             assert fake_pid not in _orphan_stdio_pids

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3500,6 +3500,18 @@ def shutdown_mcp_servers():
     _stop_mcp_loop()
 
 
+def _orphan_reap_sleep(seconds: float) -> None:
+    """Indirection over ``time.sleep`` for the orphan-reap SIGTERM→SIGKILL gap.
+
+    Tests patch this symbol instead of ``time.sleep`` so unrelated background
+    sleepers (pytest-xdist workers, MCP heartbeat threads, etc.) don't pollute
+    the mock's call list — patching ``time.sleep`` (or ``tools.mcp_tool.time.sleep``,
+    which resolves to the same module attribute) intercepts every thread in the
+    process.
+    """
+    time.sleep(seconds)
+
+
 def _kill_orphaned_mcp_children(include_active: bool = False) -> None:
     """Best-effort graceful shutdown of stdio MCP subprocesses to reap orphans.
 
@@ -3542,7 +3554,7 @@ def _kill_orphaned_mcp_children(include_active: bool = False) -> None:
             pass
 
     # Phase 2: Wait for graceful exit
-    time.sleep(2)
+    _orphan_reap_sleep(2)
 
     # Phase 3: SIGKILL any survivors
     _sigkill = getattr(_signal, "SIGKILL", _signal.SIGTERM)


### PR DESCRIPTION
## Summary
- Replaces the orphan-reap SIGTERM→SIGKILL delay with a private _orphan_reap_sleep indirection so tests can patch only the MCP sleep call instead of global time.sleep.
- Updates MCP stability tests to patch the private helper and assert the intended single 2-second delay on both SIGKILL-present and SIGKILL-absent branches.

## Why
PR #27656 currently includes an unrelated nous_portal security commit because it was based on the wrong branch. This is the same MCP fix rebased cleanly onto current origin/main, with only tools/mcp_tool.py and tests/tools/test_mcp_stability.py changed.

## Verification
- scripts/run_tests.sh tests/tools/test_mcp_stability.py (16 passed)
- Claude worker also reported scripts/run_tests.sh tests/tools/ -k mcp (399 passed) before refusing the force-push needed to rewrite #27656.

Supersedes #27656.