### PR TITLE
fix(api-server): pop runtime model before AIAgent kwargs unpack (#27540)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1056,6 +1056,21 @@ class APIServerAdapter(BasePlatformAdapter):
         reasoning_config = GatewayRunner._load_reasoning_config()
         model = _resolve_gateway_model()
 
+        # `_resolve_runtime_agent_kwargs()` may return a "model" key when the
+        # primary provider auth fails and `_try_resolve_fallback_provider()`
+        # supplies a runtime model override from `fallback_providers[*].model`.
+        # Pop it before **-unpacking into AIAgent so we don't pass `model=`
+        # twice. Mirrors the canonical pattern in
+        # `GatewayRunner._resolve_model_runtime` (gateway/run.py).
+        runtime_model = runtime_kwargs.pop("model", None)
+        if runtime_model:
+            logger.info(
+                "API server: runtime provider supplied explicit model override: %s -> %s",
+                model,
+                runtime_model,
+            )
+            model = runtime_model
+
         user_config = _load_gateway_config()
         enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -371,6 +371,90 @@ class TestAdapterInit:
         assert isinstance(agent, FakeAgent)
         assert captured["max_iterations"] == 200
 
+    def test_create_agent_handles_runtime_model_override_from_fallback(self, monkeypatch):
+        """Regression for #27540: when the primary provider auth fails and
+        ``_try_resolve_fallback_provider`` returns a dict containing a "model"
+        key, ``_create_agent`` must pop it before ``**``-unpacking into
+        ``AIAgent`` — otherwise we pass ``model=`` twice and crash with
+        ``TypeError: AIAgent() got multiple values for keyword argument 'model'``
+        on every turn after fallback kicks in.
+        """
+        captured = {}
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+        # Fallback path: dict includes "model" alongside provider/base_url/api_key.
+        monkeypatch.setattr(
+            "gateway.run._resolve_runtime_agent_kwargs",
+            lambda: {
+                "provider": "openrouter",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_key": "or-fake",
+                "api_mode": None,
+                "model": "openai/gpt-5",
+            },
+        )
+        monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda: "claude-opus-4-7")
+        monkeypatch.setattr("gateway.run._load_gateway_config", lambda: {})
+        monkeypatch.setattr(
+            "gateway.run.GatewayRunner._load_reasoning_config",
+            staticmethod(lambda: None),
+        )
+        monkeypatch.setattr("gateway.run.GatewayRunner._load_fallback_model", staticmethod(lambda: None))
+        monkeypatch.setattr("hermes_cli.tools_config._get_platform_tools", lambda *_: set())
+
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
+
+        # Must NOT raise TypeError("multiple values for keyword argument 'model'").
+        agent = adapter._create_agent(session_id="api-session")
+
+        assert isinstance(agent, FakeAgent)
+        # Fallback's model wins over the gateway default — mirrors
+        # GatewayRunner._resolve_model_runtime behaviour.
+        assert captured["model"] == "openai/gpt-5"
+        assert captured["provider"] == "openrouter"
+        assert captured["base_url"] == "https://openrouter.ai/api/v1"
+
+    def test_create_agent_keeps_gateway_model_when_runtime_omits_model(self, monkeypatch):
+        """Primary-provider path returns no "model" key — gateway-resolved
+        model should pass through unchanged (the common case).
+        """
+        captured = {}
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+        monkeypatch.setattr(
+            "gateway.run._resolve_runtime_agent_kwargs",
+            lambda: {
+                "provider": "anthropic",
+                "api_key": "sk-fake",
+            },
+        )
+        monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda: "claude-opus-4-7")
+        monkeypatch.setattr("gateway.run._load_gateway_config", lambda: {})
+        monkeypatch.setattr(
+            "gateway.run.GatewayRunner._load_reasoning_config",
+            staticmethod(lambda: None),
+        )
+        monkeypatch.setattr("gateway.run.GatewayRunner._load_fallback_model", staticmethod(lambda: None))
+        monkeypatch.setattr("hermes_cli.tools_config._get_platform_tools", lambda *_: set())
+
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
+
+        agent = adapter._create_agent(session_id="api-session")
+
+        assert isinstance(agent, FakeAgent)
+        assert captured["model"] == "claude-opus-4-7"
+        assert captured["provider"] == "anthropic"
+
 
 # ---------------------------------------------------------------------------
 # Auth checking


### PR DESCRIPTION
## What does this PR do?

The api_server gateway adapter crashes with `TypeError: AIAgent() got multiple values for keyword argument 'model'` on the first turn after a fallback provider takes over. `_try_resolve_fallback_provider()` returns a `"model"` key in its kwargs dict, but `_create_agent()` was `**`-unpacking that dict alongside an explicit `model=` argument. This PR pops `"model"` from `runtime_kwargs` first and treats it as an override for the gateway-resolved model — mirroring the canonical `runtime_kwargs.pop("model", None)` pattern already used in `GatewayRunner._resolve_model_runtime` (`gateway/run.py:1867`). With the pop, the fallback's model wins, there's no double-bind, and the override path is logged.

## Related Issue

Fixes #27540

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/api_server.py` — in `_create_agent`, `runtime_model = runtime_kwargs.pop("model", None)`; if present, log `"API server: runtime provider supplied explicit model override: %s -> %s"` and `model = runtime_model` before the `AIAgent(model=model, **runtime_kwargs, ...)` call. Mirrors `GatewayRunner._resolve_model_runtime` (`gateway/run.py:1866-1874`).
- `tests/gateway/test_api_server.py` — new `test_create_agent_handles_runtime_model_override_from_fallback` (runtime returns `{"model": "openai/gpt-5", "provider": "openrouter", ...}` → `_create_agent()` must not raise, `AIAgent(model=...)` receives the fallback model). Plus happy-path `test_create_agent_keeps_gateway_model_when_runtime_omits_model` (runtime omits `"model"` → gateway-resolved model passes through unchanged).

## How to Test

1. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/gateway/test_api_server.py tests/gateway/test_api_server_runs.py -v` — 173 passed.
2. Regression guard: with the production fix reverted, `test_create_agent_handles_runtime_model_override_from_fallback` reproduces the exact `TypeError: ... got multiple values for keyword argument 'model'` from the issue. With the fix applied, all 3 `test_create_agent_*` tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Sibling Audit

> Sibling code paths that may need the same fix: `gateway/run.py:7137` and `gateway/run.py:8299` use `_resolve_runtime_agent_kwargs()` defensively via `.get()` calls only, so they are unaffected. `gateway/platforms/feishu_comment.py:_resolve_model_and_runtime` is consumed by explicit per-key forwarding (no `**`-unpack) so it's also unaffected. No widening needed.
