### PR TITLE
fix: surface 'Always Approve' silent-failure when ruamel.yaml is missing (#27660)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2453,45 +2453,71 @@ def _parse_skills_argument(skills: str | list[str] | tuple[str, ...] | None) -> 
     return parsed
 
 
-def save_config_value(key_path: str, value: any) -> bool:
-    """
-    Save a value to the active config file at the specified key path.
-    
-    Respects the same lookup order as load_cli_config():
-    1. ~/.hermes/config.yaml (user config - preferred, used if it exists)
-    2. ./cli-config.yaml (project config - fallback)
-    
-    Args:
-        key_path: Dot-separated path like "agent.system_prompt"
-        value: Value to save
-    
+def save_config_value_detailed(key_path: str, value: any) -> tuple[bool, str | None]:
+    """Like :func:`save_config_value`, but also return a user-friendly error.
+
+    Callers that need to surface persistence failures to the user
+    (e.g. the gateway's destructive-slash "Always Approve" handler --
+    see issue #27660) should prefer this variant so they don't have to
+    grep the logs after a silent ``False`` return.
+
     Returns:
-        True if successful, False otherwise
+        ``(True, None)`` on success.
+        ``(False, "<human readable error>")`` on any failure.  The error
+        string is safe to embed in a chat reply -- it does NOT include a
+        full traceback, just the underlying cause plus an actionable hint
+        when the failure is a missing dependency.
     """
-    # Use the same precedence as load_cli_config: user config first, then project config
     user_config_path = _hermes_home / 'config.yaml'
     project_config_path = Path(__file__).parent / 'cli-config.yaml'
     config_path = user_config_path if user_config_path.exists() else project_config_path
-    
+
     try:
-        # Ensure parent directory exists (for ~/.hermes/config.yaml on first use)
         config_path.parent.mkdir(parents=True, exist_ok=True)
-        
-        # Save back atomically while preserving comments, ordering, quotes, and
-        # readable Unicode in user-edited config.yaml.
-        from utils import atomic_roundtrip_yaml_update
-        atomic_roundtrip_yaml_update(config_path, key_path, value)
-        
-        # Enforce owner-only permissions on config files (contain API keys)
+
+        from utils import atomic_roundtrip_yaml_update, MissingYamlRoundtripDependency
+        try:
+            atomic_roundtrip_yaml_update(config_path, key_path, value)
+        except MissingYamlRoundtripDependency as exc:
+            # Surface the dependency hint instead of the generic
+            # "No module named 'ruamel'" -- see #27660.
+            logger.error("Failed to save config (missing dep): %s", exc)
+            return False, str(exc)
+
         try:
             os.chmod(config_path, 0o600)
         except (OSError, NotImplementedError):
             pass
-        
-        return True
+
+        return True, None
     except Exception as e:
         logger.error("Failed to save config: %s", e)
-        return False
+        return False, f"{type(e).__name__}: {e}"
+
+
+def save_config_value(key_path: str, value: any) -> bool:
+    """
+    Save a value to the active config file at the specified key path.
+
+    Respects the same lookup order as load_cli_config():
+    1. ~/.hermes/config.yaml (user config - preferred, used if it exists)
+    2. ./cli-config.yaml (project config - fallback)
+
+    Args:
+        key_path: Dot-separated path like "agent.system_prompt"
+        value: Value to save
+
+    Returns:
+        True if successful, False otherwise
+
+    Note:
+        For callers that need to surface the failure reason to the user,
+        prefer :func:`save_config_value_detailed` -- it returns the same
+        boolean plus a user-actionable error string.  Existing call sites
+        that only check ``bool`` are unaffected.
+    """
+    ok, _err = save_config_value_detailed(key_path, value)
+    return ok
 
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12246,21 +12246,46 @@ class GatewayRunner:
         async def _on_confirm(choice: str) -> Optional[str]:
             if choice == "cancel":
                 return t("gateway.reload_mcp.cancelled")
+            persist_ok = False
+            persist_err: str | None = None
             if choice == "always":
-                # Persist the opt-out and run the reload.
                 try:
-                    from cli import save_config_value
-                    save_config_value("approvals.mcp_reload_confirm", False)
+                    from cli import save_config_value_detailed
+                    persist_ok, persist_err = save_config_value_detailed(
+                        "approvals.mcp_reload_confirm", False,
+                    )
+                except Exception as exc:
+                    logger.warning("Failed to persist mcp_reload_confirm=false: %s", exc)
+                    persist_err = f"{type(exc).__name__}: {exc}"
+                if persist_ok:
                     logger.info(
                         "User opted out of /reload-mcp confirmation (session=%s)",
                         session_key,
                     )
-                except Exception as exc:
-                    logger.warning("Failed to persist mcp_reload_confirm=false: %s", exc)
-            # once / always → run the reload
+                else:
+                    # See #27660 -- pre-fix this branch never ran because
+                    # save_config_value swallowed ImportError and returned
+                    # False without raising, leaving the user with a
+                    # misleading "opted out" confirmation note.
+                    logger.warning(
+                        "Could not persist mcp_reload_confirm=false "
+                        "(session=%s): %s",
+                        session_key, persist_err,
+                    )
             result = await self._execute_mcp_reload(event)
             if choice == "always":
-                return f"{result}\n\n" + t("gateway.reload_mcp.always_followup")
+                if persist_ok:
+                    return f"{result}\n\n" + t("gateway.reload_mcp.always_followup")
+                # Save failed -- be honest about it instead of claiming
+                # the opt-out worked.
+                return (
+                    f"{result}\n\n"
+                    "⚠️ Could not save the opt-out preference, so the "
+                    "confirmation prompt will keep appearing. "
+                    f"Reason: {persist_err or 'unknown'}\n"
+                    "Fix: add `approvals.mcp_reload_confirm: false` to "
+                    "`~/.hermes/config.yaml` manually."
+                )
             return result
 
         prompt_message = t("gateway.reload_mcp.confirm_prompt")
@@ -12503,30 +12528,57 @@ class GatewayRunner:
         async def _on_confirm(choice: str):
             if choice == "cancel":
                 return f"🟡 /{command} cancelled. Conversation unchanged."
+            # Track persistence outcome so the user-visible note below
+            # reflects what actually happened.  Pre-#27660 this code
+            # always claimed "future runs no confirmation" even when the
+            # save silently failed (e.g. ruamel.yaml missing from venv),
+            # so the user would re-trigger the same prompt forever with
+            # no indication the opt-out hadn't been saved.
+            persist_ok = False
+            persist_err: str | None = None
             if choice == "always":
                 try:
-                    from cli import save_config_value
-                    save_config_value("approvals.destructive_slash_confirm", False)
-                    logger.info(
-                        "User opted out of destructive slash confirm (session=%s)",
-                        session_key,
+                    from cli import save_config_value_detailed
+                    persist_ok, persist_err = save_config_value_detailed(
+                        "approvals.destructive_slash_confirm", False,
                     )
                 except Exception as exc:
                     logger.warning(
                         "Failed to persist destructive_slash_confirm=false: %s", exc,
                     )
+                    persist_err = f"{type(exc).__name__}: {exc}"
+                if persist_ok:
+                    logger.info(
+                        "User opted out of destructive slash confirm (session=%s)",
+                        session_key,
+                    )
+                else:
+                    logger.warning(
+                        "Could not persist destructive_slash_confirm=false "
+                        "(session=%s): %s",
+                        session_key, persist_err,
+                    )
             result = await execute()
             if choice == "always":
-                note = (
-                    "\n\nℹ️ Future /clear, /new, /reset, and /undo will run "
-                    "without confirmation. Re-enable via "
-                    "`approvals.destructive_slash_confirm: true` in config.yaml."
-                )
+                if persist_ok:
+                    note = (
+                        "\n\nℹ️ Future /clear, /new, /reset, and /undo will run "
+                        "without confirmation. Re-enable via "
+                        "`approvals.destructive_slash_confirm: true` in config.yaml."
+                    )
+                else:
+                    note = (
+                        "\n\n⚠️ Could not save the opt-out preference, so the "
+                        "confirmation prompt will keep appearing. "
+                        f"Reason: {persist_err or 'unknown'}\n"
+                        "Fix: add `approvals.destructive_slash_confirm: false` "
+                        "to `~/.hermes/config.yaml` manually."
+                    )
                 if isinstance(result, str):
                     return result + note
-                # EphemeralReply or other — leave untouched; the opt-out note
-                # would otherwise mangle structured replies.  The persist itself
-                # already happened above; user gets the same UX next time.
+                # EphemeralReply or other -- leave untouched; the opt-out note
+                # would otherwise mangle structured replies.  Whether persist
+                # succeeded is already reflected in the gateway log.
                 return result
             return result
 

--- a/tests/cli/test_cli_save_config_value.py
+++ b/tests/cli/test_cli_save_config_value.py
@@ -132,3 +132,127 @@ class TestSaveConfigValueAtomic:
 
         assert result is False
         assert config_env.read_text() == original_content
+
+
+# ---------------------------------------------------------------------------
+# save_config_value_detailed -- structured success/failure for callers that
+# must surface the failure reason to the user (issue #27660).
+# ---------------------------------------------------------------------------
+
+
+class TestSaveConfigValueDetailed:
+    """Pin the tuple-return contract of the detailed variant."""
+
+    @pytest.fixture
+    def config_env(self, tmp_path, monkeypatch):
+        from pathlib import Path
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(yaml.dump({"display": {"skin": "default"}}))
+        monkeypatch.setattr("cli._hermes_home", hermes_home)
+        return config_path
+
+    def test_success_returns_true_none(self, config_env):
+        from cli import save_config_value_detailed
+        ok, err = save_config_value_detailed("display.skin", "mono")
+        assert ok is True
+        assert err is None
+
+    def test_ruamel_missing_returns_actionable_error(self, config_env, monkeypatch):
+        """When ruamel.yaml import fails, the error string must include the
+        pip-install hint so users hit by #27660 can self-heal without
+        reading source.
+        """
+        from utils import MissingYamlRoundtripDependency
+
+        def exploding_import(*_args, **_kwargs):
+            raise MissingYamlRoundtripDependency(
+                ImportError("No module named 'ruamel'")
+            )
+
+        monkeypatch.setattr("utils.atomic_roundtrip_yaml_update", exploding_import)
+
+        from cli import save_config_value_detailed
+        ok, err = save_config_value_detailed("approvals.destructive_slash_confirm", False)
+        assert ok is False
+        assert err is not None
+        assert "ruamel.yaml" in err
+        assert "pip install ruamel.yaml" in err
+        assert "No module named 'ruamel'" in err
+
+    def test_generic_oserror_returns_typed_message(self, config_env, monkeypatch):
+        """Non-dependency errors still produce a useful string."""
+        def exploding(*_a, **_k):
+            raise OSError("disk full")
+
+        monkeypatch.setattr("utils.atomic_roundtrip_yaml_update", exploding)
+
+        from cli import save_config_value_detailed
+        ok, err = save_config_value_detailed("display.skin", "x")
+        assert ok is False
+        assert err is not None
+        assert "OSError" in err
+        assert "disk full" in err
+
+    def test_bool_alias_still_returns_bool_only(self, config_env, monkeypatch):
+        """The bool-only ``save_config_value`` alias must remain
+        backward-compatible -- existing callers reading the return value
+        as a plain ``bool`` keep working."""
+        from utils import MissingYamlRoundtripDependency
+
+        def exploding(*_a, **_k):
+            raise MissingYamlRoundtripDependency(ImportError("missing"))
+
+        monkeypatch.setattr("utils.atomic_roundtrip_yaml_update", exploding)
+
+        from cli import save_config_value
+        assert save_config_value("display.skin", "x") is False
+
+
+# ---------------------------------------------------------------------------
+# Direct tests for utils.atomic_roundtrip_yaml_update's new exception class.
+# ---------------------------------------------------------------------------
+
+
+class TestMissingYamlRoundtripDependency:
+    def test_subclass_of_import_error(self):
+        from utils import MissingYamlRoundtripDependency
+        assert issubclass(MissingYamlRoundtripDependency, ImportError)
+
+    def test_message_includes_install_hint(self):
+        from utils import MissingYamlRoundtripDependency
+        exc = MissingYamlRoundtripDependency(ImportError("No module named 'ruamel'"))
+        assert "ruamel.yaml" in str(exc)
+        assert "pip install ruamel.yaml" in str(exc)
+
+    def test_preserves_original_import_error(self):
+        from utils import MissingYamlRoundtripDependency
+        original = ImportError("No module named 'ruamel'")
+        exc = MissingYamlRoundtripDependency(original)
+        assert exc.original is original
+
+    def test_raised_when_ruamel_unimportable(self, monkeypatch, tmp_path):
+        """End-to-end: simulate ruamel.yaml absent at import time and
+        confirm atomic_roundtrip_yaml_update raises the typed wrapper."""
+        import sys
+        import importlib
+
+        # Pretend the import fails by inserting a sentinel that raises.
+        class _Blocker:
+            def __getattr__(self, _name):
+                raise ImportError("No module named 'ruamel'")
+
+        # Drop any cached real module so the function-local import re-runs.
+        for mod in list(sys.modules):
+            if mod == "ruamel" or mod.startswith("ruamel."):
+                monkeypatch.delitem(sys.modules, mod, raising=False)
+        monkeypatch.setitem(sys.modules, "ruamel", _Blocker())
+
+        from utils import atomic_roundtrip_yaml_update, MissingYamlRoundtripDependency
+
+        with pytest.raises(MissingYamlRoundtripDependency) as excinfo:
+            atomic_roundtrip_yaml_update(tmp_path / "x.yaml", "a.b", 1)
+
+        assert "ruamel.yaml" in str(excinfo.value)
+        assert "pip install ruamel.yaml" in str(excinfo.value)

--- a/tests/gateway/test_destructive_slash_confirm.py
+++ b/tests/gateway/test_destructive_slash_confirm.py
@@ -231,12 +231,20 @@ async def test_resolve_always_persists_opt_out_and_runs_execute(monkeypatch):
 
     saved: dict = {}
 
-    def _fake_save(path, value):
+    def _fake_save_detailed(path, value):
         saved[path] = value
-        return True
+        return True, None
 
+    # Issue #27660 reworked the gateway to call ``save_config_value_detailed``
+    # (which surfaces the failure reason) instead of the bool-only
+    # ``save_config_value``.  Patch the new symbol so this test still
+    # exercises the post-fix code path; keep the bool-only alias patched
+    # too for any indirect callers.
     import cli as cli_mod
-    monkeypatch.setattr(cli_mod, "save_config_value", _fake_save)
+    monkeypatch.setattr(cli_mod, "save_config_value_detailed", _fake_save_detailed)
+    monkeypatch.setattr(
+        cli_mod, "save_config_value", lambda p, v: _fake_save_detailed(p, v)[0]
+    )
 
     execute = AsyncMock(return_value="✨ fresh")
 
@@ -259,3 +267,156 @@ async def test_resolve_always_persists_opt_out_and_runs_execute(monkeypatch):
     assert resolved is not None
     assert "✨ fresh" in resolved
     assert "config.yaml" in resolved
+
+
+# ---------------------------------------------------------------------------
+# Issue #27660 -- "Always Approve" silent-failure regression guard.
+#
+# Before the fix, gateway/run.py's destructive-slash _on_confirm
+# unconditionally logged "User opted out..." and appended the
+# "Future /clear, /new, /reset, /undo will run without confirmation"
+# note even when save_config_value silently failed (e.g. ruamel.yaml
+# missing from venv).  Users could click "Always Approve" indefinitely
+# with no effect.  These tests pin the post-fix behaviour:
+#
+#   1. When persistence fails, the reply tells the user it failed AND
+#      includes the underlying reason.
+#   2. When persistence fails, the misleading "future runs no
+#      confirmation" note must NOT appear.
+#   3. When persistence succeeds, the reply still contains the success
+#      note (existing behaviour preserved).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolve_always_surfaces_persist_failure_to_user(monkeypatch):
+    """Save failure -> user sees ⚠️ message with the failure reason."""
+    from tools import slash_confirm as _slash_confirm_mod
+    runner = _make_runner()
+    runner._read_user_config = lambda: {"approvals": {"destructive_slash_confirm": True}}
+    session_key = build_session_key(_make_source())
+    runner._session_key_for_source = lambda src: session_key
+    _slash_confirm_mod.clear(session_key)
+
+    # Simulate ruamel.yaml missing -- the exact #27660 scenario.
+    def _failing_save(path, value):
+        return False, (
+            "ruamel.yaml is required to update user config files atomically. "
+            "Re-install with: pip install ruamel.yaml==0.18.17. "
+            "Underlying ImportError: No module named 'ruamel'"
+        )
+
+    import cli as cli_mod
+    monkeypatch.setattr(cli_mod, "save_config_value_detailed", _failing_save)
+
+    execute = AsyncMock(return_value="✨ fresh")
+
+    await runner._maybe_confirm_destructive_slash(
+        event=_make_event("/new"),
+        command="new",
+        title="/new",
+        detail="Discards history.",
+        execute=execute,
+    )
+
+    pending = _slash_confirm_mod.get_pending(session_key)
+    assert pending is not None
+    resolved = await _slash_confirm_mod.resolve(
+        session_key, pending["confirm_id"], "always",
+    )
+
+    execute.assert_awaited_once()
+    assert resolved is not None
+    # The user-facing reply must:
+    assert "✨ fresh" in resolved, "the actual command output should still surface"
+    assert "Could not save the opt-out preference" in resolved, (
+        "user must be told the opt-out wasn't saved"
+    )
+    assert "ruamel.yaml" in resolved, "the failure reason must be included"
+    # The pre-fix "future runs will skip the prompt" note must NOT
+    # appear when the save failed -- that was the original bug.
+    assert "without confirmation" not in resolved, (
+        "must not falsely claim future runs will skip the prompt"
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_always_no_warning_when_persist_succeeds(monkeypatch):
+    """Save success -> existing success note appears, no ⚠️."""
+    from tools import slash_confirm as _slash_confirm_mod
+    runner = _make_runner()
+    runner._read_user_config = lambda: {"approvals": {"destructive_slash_confirm": True}}
+    session_key = build_session_key(_make_source())
+    runner._session_key_for_source = lambda src: session_key
+    _slash_confirm_mod.clear(session_key)
+
+    def _ok_save(path, value):
+        return True, None
+
+    import cli as cli_mod
+    monkeypatch.setattr(cli_mod, "save_config_value_detailed", _ok_save)
+
+    execute = AsyncMock(return_value="✨ fresh")
+
+    await runner._maybe_confirm_destructive_slash(
+        event=_make_event("/new"),
+        command="new",
+        title="/new",
+        detail="Discards history.",
+        execute=execute,
+    )
+
+    pending = _slash_confirm_mod.get_pending(session_key)
+    assert pending is not None
+    resolved = await _slash_confirm_mod.resolve(
+        session_key, pending["confirm_id"], "always",
+    )
+
+    execute.assert_awaited_once()
+    assert resolved is not None
+    assert "✨ fresh" in resolved
+    # Existing success branch preserved.
+    assert "without confirmation" in resolved
+    # No misleading warning when the save actually worked.
+    assert "Could not save" not in resolved
+
+
+@pytest.mark.asyncio
+async def test_resolve_always_handles_unexpected_exception(monkeypatch):
+    """If save_config_value_detailed raises (not just returns False), the
+    user still gets a coherent error reply rather than a stack trace
+    bubbling out of the handler."""
+    from tools import slash_confirm as _slash_confirm_mod
+    runner = _make_runner()
+    runner._read_user_config = lambda: {"approvals": {"destructive_slash_confirm": True}}
+    session_key = build_session_key(_make_source())
+    runner._session_key_for_source = lambda src: session_key
+    _slash_confirm_mod.clear(session_key)
+
+    def _exploding_save(path, value):
+        raise RuntimeError("disk caught fire")
+
+    import cli as cli_mod
+    monkeypatch.setattr(cli_mod, "save_config_value_detailed", _exploding_save)
+
+    execute = AsyncMock(return_value="✨ fresh")
+    await runner._maybe_confirm_destructive_slash(
+        event=_make_event("/new"),
+        command="new",
+        title="/new",
+        detail="Discards history.",
+        execute=execute,
+    )
+
+    pending = _slash_confirm_mod.get_pending(session_key)
+    resolved = await _slash_confirm_mod.resolve(
+        session_key, pending["confirm_id"], "always",
+    )
+
+    execute.assert_awaited_once()
+    assert resolved is not None
+    assert "✨ fresh" in resolved
+    assert "Could not save" in resolved
+    assert "RuntimeError" in resolved
+    assert "disk caught fire" in resolved
+    assert "without confirmation" not in resolved

--- a/utils.py
+++ b/utils.py
@@ -188,6 +188,31 @@ def atomic_yaml_write(
         raise
 
 
+class MissingYamlRoundtripDependency(ImportError):
+    """Raised when ``ruamel.yaml`` is not importable.
+
+    Wraps the bare :class:`ImportError` so callers (e.g. the gateway's
+    destructive-slash confirmation flow, see issue #27660) can detect the
+    specific dependency-missing case and surface a user-actionable
+    message instead of a generic "save failed" string.
+
+    The message includes the pip-install hint so users hit by a broken
+    or partial venv can self-heal without having to grep the source.
+    """
+
+    INSTALL_HINT = "Re-install with: pip install ruamel.yaml==0.18.17"
+
+    def __init__(self, original: ImportError) -> None:
+        message = (
+            "ruamel.yaml is required to update user config files atomically "
+            "(this is a declared core dependency in pyproject.toml). "
+            f"{self.INSTALL_HINT}. "
+            f"Underlying ImportError: {original!s}"
+        )
+        super().__init__(message)
+        self.original = original
+
+
 def atomic_roundtrip_yaml_update(
     path: Union[str, Path],
     key_path: str,
@@ -199,9 +224,18 @@ def atomic_roundtrip_yaml_update(
     user-edited config files where comments, ordering, quoting, and Unicode
     should survive a single setting mutation.  Writes still use the same temp
     file + fsync + atomic replace pattern.
+
+    Raises:
+        MissingYamlRoundtripDependency: when ``ruamel.yaml`` is not
+            importable from the current venv (issue #27660).  Bubbles up as
+            a clear, actionable error rather than a generic
+            ``ModuleNotFoundError: No module named 'ruamel'``.
     """
-    from ruamel.yaml import YAML
-    from ruamel.yaml.comments import CommentedMap
+    try:
+        from ruamel.yaml import YAML
+        from ruamel.yaml.comments import CommentedMap
+    except ImportError as exc:
+        raise MissingYamlRoundtripDependency(exc) from exc
 
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## What does this PR do?

Fixes the "Always Approve" silent-failure for destructive slash commands (`/new`, `/reset`, `/undo`, `/clear`) and the parallel `/reload-mcp` flow when `ruamel.yaml` is missing from the active venv.

Before this PR:

- `cli.save_config_value()` called `utils.atomic_roundtrip_yaml_update()` which imports `ruamel.yaml` at function scope. When the import failed, `save_config_value` caught the bare `ImportError`, logged a generic `"Failed to save config"` line at ERROR level, and returned `False`.
- `gateway/run.py`'s `_on_confirm` handler ignored the return value, unconditionally logged `"User opted out of destructive slash confirm"`, and appended `"Future /clear, /new, /reset, and /undo will run without confirmation"` to the user-visible reply.
- Net effect: a user clicking "Always Approve" got the success-shaped reply, the gateway logged "opted out", but `~/.hermes/config.yaml` was never written. The confirmation prompt reappeared on the next `/new`, and the user could click "Always Approve" indefinitely with zero effect.

After this PR the failure is detected, surfaced, and actionable.

## Related Issue

Fixes [#27660](https://github.com/NousResearch/hermes-agent/issues/27660).

The same code shape exists in the `/reload-mcp` confirmation handler (`_handle_mcp_reload`), and is fixed in the same PR to keep the two parallel paths in sync.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

**`utils.py`** — typed exception at the import site:

- Added `MissingYamlRoundtripDependency(ImportError)`. Its message contains the actionable pip-install hint (`pip install ruamel.yaml==0.18.17`) and preserves the original `ImportError` on `.original`.
- `atomic_roundtrip_yaml_update` now wraps the function-local `from ruamel.yaml import YAML` in a `try/except ImportError` and raises `MissingYamlRoundtripDependency` instead of the bare module-not-found.

**`cli.py`** — structured success/failure for callers that need it:

- New `save_config_value_detailed(key, value) -> (bool, str | None)` that surfaces a user-presentable error string on failure (with the install hint when the cause is missing `ruamel.yaml`; with `TypeName: msg` for other exceptions).
- Existing `save_config_value` is preserved as a bool-only alias that delegates to `save_config_value_detailed`. Every existing caller stays binary-compatible.

**`gateway/run.py`** — both destructive-slash and `/reload-mcp` `_on_confirm` handlers:

- Switched to `save_config_value_detailed`.
- `logger.info("User opted out...")` now fires only after persist succeeded; failures get a `logger.warning` with the underlying reason.
- The success/failure branches now produce different user replies:
  - Success: existing `"Future /clear, /new, /reset, and /undo will run without confirmation. Re-enable via approvals.destructive_slash_confirm: true"` note preserved.
  - Failure: replaced with `"⚠️ Could not save the opt-out preference, so the confirmation prompt will keep appearing. Reason: <hint>. Fix: add approvals.destructive_slash_confirm: false to ~/.hermes/config.yaml manually."`
- Unexpected exceptions raised from `save_config_value_detailed` itself (rather than just a `False` return) are also caught and surfaced through the same warning block.

**Tests** — 11 new regression tests, 1 existing test updated:

- `tests/cli/test_cli_save_config_value.py` (+8): `TestSaveConfigValueDetailed` pins the `(bool, str|None)` contract for success and the two failure modes; `TestMissingYamlRoundtripDependency` pins the typed-exception surface (subclass of `ImportError`, message contents, `.original` preservation, end-to-end via `sys.modules['ruamel']` blocker).
- `tests/gateway/test_destructive_slash_confirm.py` (+3): the direct #27660 regression test (failure must surface "Could not save" + the reason, and the misleading "without confirmation" note must be absent); the happy-path regression guard (success keeps the existing note, no warning); a coverage test for the `raise`-instead-of-`return False` path.
- The pre-existing `test_resolve_always_persists_opt_out_and_runs_execute` was updated to patch `save_config_value_detailed` (the new symbol the gateway calls).

## How to Test

1. Check out the branch and set up the venv:

   ```
   python3 -m venv .venv && source .venv/bin/activate && pip install -e ".[all,dev]"
   ```

2. Reproduce the original #27660 scenario locally:

   ```
   pip uninstall -y ruamel.yaml ruamel.yaml.clib
   python -c "from cli import save_config_value_detailed; \
              print(save_config_value_detailed('approvals.destructive_slash_confirm', False))"
   ```

   Expected: `(False, 'ruamel.yaml is required to update user config files atomically (this is a declared core dependency in pyproject.toml). Re-install with: pip install ruamel.yaml==0.18.17. Underlying ImportError: ...')`

   Re-install `ruamel.yaml` and confirm success:

   ```
   pip install ruamel.yaml==0.18.17
   python -c "from cli import save_config_value_detailed; \
              print(save_config_value_detailed('approvals.destructive_slash_confirm', False))"
   ```

   Expected: `(True, None)` and `~/.hermes/config.yaml` updated.

3. Run the new + existing regression tests:

   ```
   scripts/run_tests.sh tests/cli/test_cli_save_config_value.py tests/gateway/test_destructive_slash_confirm.py
   ```

   Expected: 25 passed (14 pre-existing + 11 new).

4. Run the wider approvals/gates suite to confirm no cross-file regression:

   ```
   scripts/run_tests.sh tests/cli/test_cli_save_config_value.py \
                        tests/gateway/test_destructive_slash_confirm.py \
                        tests/hermes_cli/test_destructive_slash_confirm_gate.py \
                        tests/hermes_cli/test_mcp_reload_confirm_gate.py
   ```

   Expected: 35 passed.

5. (Optional) end-to-end against a Telegram bot: with `ruamel.yaml` removed, send `/new`, click "Always Approve", confirm the reply now contains the `"⚠️ Could not save the opt-out preference"` block instead of the misleading success note.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (3 commits: `fix(utils,cli)`, `fix(gateway)`, `test(cli,gateway)`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/cli/test_cli_save_config_value.py tests/gateway/test_destructive_slash_confirm.py` and all tests pass
- [x] I've added tests for my changes (11 new regression tests, 1 existing test migrated)
- [x] I've tested on my platform: macOS 15.2 (Darwin 24.6.0), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings on `MissingYamlRoundtripDependency`, `save_config_value_detailed`, and the updated `save_config_value` describe the new contract.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config-key changes; only persistence-path error handling)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the new code path is pure Python; tests use `tmp_path` + `monkeypatch` and are hermetic.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/cli/test_cli_save_config_value.py tests/gateway/test_destructive_slash_confirm.py
4 workers [25 items]
.........................                                                [100%]
============================== 25 passed in 1.65s ==============================

$ scripts/run_tests.sh tests/cli/test_cli_save_config_value.py \
                       tests/gateway/test_destructive_slash_confirm.py \
                       tests/hermes_cli/test_destructive_slash_confirm_gate.py \
                       tests/hermes_cli/test_mcp_reload_confirm_gate.py
4 workers [35 items]
...................................                                      [100%]
============================== 35 passed in 1.79s ==============================
```

Failure path verified manually (with `ruamel.yaml` uninstalled):

```
>>> save_config_value_detailed("approvals.destructive_slash_confirm", False)
(False,
 "ruamel.yaml is required to update user config files atomically "
 "(this is a declared core dependency in pyproject.toml). "
 "Re-install with: pip install ruamel.yaml==0.18.17. "
 "Underlying ImportError: No module named 'ruamel'")
```
