### PR TITLE
fix(logging): make rotating handler safe against external rotation (#27649)

### DIFF
--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -296,19 +296,43 @@ def setup_verbose_logging() -> None:
 # ---------------------------------------------------------------------------
 
 class _ManagedRotatingFileHandler(RotatingFileHandler):
-    """RotatingFileHandler that ensures group-writable perms in managed mode.
+    """RotatingFileHandler that ensures group-writable perms in managed mode
+    *and* is safe against external rotation by sibling Hermes processes.
 
     In managed mode (NixOS), the stateDir uses setgid (2770) so new files
     inherit the hermes group. However, both _open() (initial creation) and
-    doRollover() create files via open(), which uses the process umask —
+    doRollover() create files via open(), which uses the process umask --
     typically 0022, producing 0644. This subclass applies chmod 0660 after
     both operations so the gateway and interactive users can share log files.
+
+    External-rotation safety (issue #27649)
+    ---------------------------------------
+    The stdlib ``RotatingFileHandler`` keeps an open file descriptor to
+    the active log file.  When *another* Hermes process rotates the file
+    (renaming ``agent.log`` -> ``agent.log.1``), the open fd in this
+    process still points at the renamed inode -- so subsequent writes
+    silently land in ``agent.log.1`` instead of the live ``agent.log``.
+
+    This subclass periodically compares the inode of the open stream
+    against the inode of ``baseFilename`` on disk; on mismatch the stale
+    stream is closed and a fresh one is opened on ``baseFilename``.  In
+    addition, ``doRollover`` short-circuits when the file has already
+    been rotated externally so we don't clobber the newer ``agent.log``
+    that another process created.
+
+    The check is throttled to one ``os.stat`` per
+    ``_REOPEN_CHECK_INTERVAL`` records to avoid doubling the syscall
+    count on hot debug loggers; tests can lower this attribute to 1 to
+    exercise the path on every emit.
     """
+
+    _REOPEN_CHECK_INTERVAL: int = 16
 
     def __init__(self, *args, **kwargs):
         from hermes_cli.config import is_managed
         self._managed = is_managed()
         super().__init__(*args, **kwargs)
+        self._emit_count = 0
 
     def _chmod_if_managed(self):
         if self._managed:
@@ -322,7 +346,102 @@ class _ManagedRotatingFileHandler(RotatingFileHandler):
         self._chmod_if_managed()
         return stream
 
+    # ------------------------------------------------------------------
+    # External-rotation detection helpers (#27649)
+    # ------------------------------------------------------------------
+    def _stream_inode_key(self):
+        """Return ``(st_dev, st_ino)`` for the open stream, or ``None``.
+
+        Returns ``None`` when the stream is missing, closed, or the
+        platform refuses ``fstat`` -- in which case the caller must
+        treat the inode comparison as inconclusive and skip the
+        reopen (no regression vs pre-#27649 behaviour).
+        """
+        stream = self.stream
+        if stream is None:
+            return None
+        try:
+            st = os.fstat(stream.fileno())
+        except (OSError, AttributeError, ValueError):
+            return None
+        if st.st_ino == 0:
+            # Some Windows + Python combinations return st_ino == 0
+            # for regular files; treat as "unknown" rather than
+            # forcing spurious reopens.
+            return None
+        return (st.st_dev, st.st_ino)
+
+    def _baseFilename_inode_key(self):
+        """Return ``(st_dev, st_ino)`` for ``baseFilename`` on disk."""
+        try:
+            st = os.stat(self.baseFilename)
+        except OSError:
+            return None
+        if st.st_ino == 0:
+            return None
+        return (st.st_dev, st.st_ino)
+
+    def _reopen_if_rotated_externally(self) -> bool:
+        """Close + reopen the stream if another process rotated the file.
+
+        Returns ``True`` if a reopen happened, ``False`` otherwise.
+        Safe to call when the stream is missing -- it becomes a no-op.
+        """
+        current = self._stream_inode_key()
+        on_disk = self._baseFilename_inode_key()
+        if current is None or on_disk is None:
+            return False
+        if current == on_disk:
+            return False
+
+        # Inode mismatch: our open fd points at a rotated backup file
+        # (e.g. ``agent.log.1``).  Close it and reopen ``baseFilename``
+        # so subsequent writes land in the live log.
+        try:
+            self.stream.close()
+        except OSError:
+            pass
+        self.stream = self._open()
+        return True
+
+    def emit(self, record):
+        # Periodic inode check -- bounded by ``_REOPEN_CHECK_INTERVAL``
+        # so this only doubles the syscall count once every N records
+        # under steady-state.  We always check on the very first emit
+        # so a freshly-opened handler immediately notices a pre-existing
+        # rotation rather than waiting N records.
+        self._emit_count += 1
+        if (
+            self._emit_count == 1
+            or (self._emit_count % self._REOPEN_CHECK_INTERVAL) == 0
+        ):
+            try:
+                self._reopen_if_rotated_externally()
+            except Exception:  # pragma: no cover -- defensive: never let
+                # a logging-side check kill the calling code.
+                pass
+        super().emit(record)
+
     def doRollover(self):
+        # If another process already rotated for us, just reopen the
+        # live ``baseFilename`` instead of performing our own rename
+        # (which would otherwise overwrite the newer ``agent.log`` that
+        # the other process just created).  Issue #27649.
+        current = self._stream_inode_key()
+        on_disk = self._baseFilename_inode_key()
+        if (
+            current is not None
+            and on_disk is not None
+            and current != on_disk
+        ):
+            try:
+                self.stream.close()
+            except OSError:
+                pass
+            self.stream = self._open()
+            self._chmod_if_managed()
+            return
+
         super().doRollover()
         self._chmod_if_managed()
 

--- a/tests/test_hermes_logging_multiprocess_rotation.py
+++ b/tests/test_hermes_logging_multiprocess_rotation.py
@@ -1,0 +1,433 @@
+"""Regression tests for issue #27649.
+
+When multiple Hermes processes share ``~/.hermes/logs/agent.log`` and one
+of them rotates the file (renaming it to ``agent.log.1``), the others
+keep an open file descriptor pointing at the renamed inode and silently
+write to the rotated backup file forever.
+
+The fix in ``hermes_logging._ManagedRotatingFileHandler`` is:
+  * compare the open stream's inode against ``baseFilename`` on disk
+    every N records (default 16), close + reopen on mismatch;
+  * short-circuit ``doRollover`` when an external rotation already
+    happened so we never overwrite the newer ``agent.log``.
+
+These tests pin both behaviours and the corner cases (read-only ``st_ino``
+of 0 on Windows, missing/closed stream, throttle interval boundaries,
+chmod-in-managed-mode still applied after the reopen path).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+import hermes_logging
+from hermes_logging import _ManagedRotatingFileHandler
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_handler(path: Path, **kwargs) -> _ManagedRotatingFileHandler:
+    """Construct a handler with sensible defaults for these tests.
+
+    We force ``_REOPEN_CHECK_INTERVAL`` down to 1 by default so every
+    emit exercises the inode-check path; individual tests override it
+    where the throttle itself is under test.
+    """
+    handler = _ManagedRotatingFileHandler(
+        str(path),
+        maxBytes=kwargs.pop("maxBytes", 1024),
+        backupCount=kwargs.pop("backupCount", 3),
+        encoding="utf-8",
+        **kwargs,
+    )
+    handler._REOPEN_CHECK_INTERVAL = 1
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    return handler
+
+
+def _emit(handler: _ManagedRotatingFileHandler, msg: str) -> None:
+    record = logging.LogRecord(
+        name="t", level=logging.INFO, pathname=__file__, lineno=1,
+        msg=msg, args=None, exc_info=None,
+    )
+    handler.emit(record)
+    handler.flush()
+
+
+def _inode(path: Path) -> int:
+    return os.stat(str(path)).st_ino
+
+
+# ---------------------------------------------------------------------------
+# Core regression: external rotation should not split writes.
+# ---------------------------------------------------------------------------
+
+
+class TestExternalRotationReopen:
+    """Pin the #27649 reopen-on-inode-change behaviour."""
+
+    def test_writes_land_in_live_file_after_external_rename(self, tmp_path):
+        """The exact bug from the issue: an external rename moves the
+        live log to ``.1`` and our open fd should follow ``baseFilename``,
+        not the rotated backup."""
+        log = tmp_path / "agent.log"
+        h = _make_handler(log)
+        try:
+            _emit(h, "pre-rotation")
+
+            # Simulate another process rotating: rename agent.log -> agent.log.1
+            # and create a fresh agent.log.  Our open fd now points at the
+            # renamed file (== agent.log.1).
+            rotated = tmp_path / "agent.log.1"
+            os.rename(str(log), str(rotated))
+            log.write_text("")  # fresh active file
+
+            live_inode_before = _inode(log)
+            backup_inode = _inode(rotated)
+            assert live_inode_before != backup_inode
+
+            # The next emit must detect the mismatch and reopen on
+            # ``baseFilename`` -- i.e. write to the new agent.log, not
+            # to agent.log.1.
+            _emit(h, "post-rotation")
+
+            live_text = log.read_text()
+            rotated_text = rotated.read_text()
+
+            assert "post-rotation" in live_text, (
+                "writes after external rotation must land in the live log"
+            )
+            assert "post-rotation" not in rotated_text, (
+                "writes after external rotation must NOT land in the backup"
+            )
+            assert "pre-rotation" in rotated_text, (
+                "the pre-rotation record should still be in the backup"
+            )
+        finally:
+            h.close()
+
+    def test_no_reopen_when_inode_unchanged(self, tmp_path):
+        """Steady state: ``stat()`` shows the same inode, no reopen happens."""
+        log = tmp_path / "agent.log"
+        h = _make_handler(log)
+        try:
+            _emit(h, "a")
+            stream_id_before = id(h.stream)
+            _emit(h, "b")
+            stream_id_after = id(h.stream)
+            assert stream_id_before == stream_id_after, (
+                "no inode change should not provoke a stream reopen"
+            )
+        finally:
+            h.close()
+
+    def test_reopen_helper_returns_true_only_on_mismatch(self, tmp_path):
+        log = tmp_path / "agent.log"
+        h = _make_handler(log)
+        try:
+            _emit(h, "warmup")
+            assert h._reopen_if_rotated_externally() is False
+
+            rotated = tmp_path / "agent.log.1"
+            os.rename(str(log), str(rotated))
+            log.write_text("")
+
+            assert h._reopen_if_rotated_externally() is True
+            # Second call after the reopen should be a no-op again.
+            assert h._reopen_if_rotated_externally() is False
+        finally:
+            h.close()
+
+    def test_reopen_continues_writing_to_baseFilename(self, tmp_path):
+        """After a reopen, baseFilename grows on each subsequent emit."""
+        log = tmp_path / "agent.log"
+        h = _make_handler(log)
+        try:
+            _emit(h, "pre")
+            os.rename(str(log), str(tmp_path / "agent.log.1"))
+            log.write_text("")
+            _emit(h, "one")
+            _emit(h, "two")
+            _emit(h, "three")
+            text = log.read_text()
+            assert "one" in text and "two" in text and "three" in text
+        finally:
+            h.close()
+
+
+# ---------------------------------------------------------------------------
+# doRollover short-circuit -- never clobber a newer ``agent.log``.
+# ---------------------------------------------------------------------------
+
+
+class TestDoRolloverShortCircuit:
+    def test_dorollover_skips_rename_when_already_rotated_externally(self, tmp_path):
+        """If our open fd already points at a rotated backup, our own
+        rollover must NOT rename the newer ``agent.log`` -- that would
+        overwrite the active log that another process just created."""
+        log = tmp_path / "agent.log"
+        h = _make_handler(log)
+        try:
+            _emit(h, "pre")
+
+            # External rotation -- rename our file out from under us.
+            rotated = tmp_path / "agent.log.1"
+            os.rename(str(log), str(rotated))
+            # Another process creates a brand-new active log and writes
+            # something we must not clobber.
+            log.write_text("sibling-process-content\n")
+            sibling_inode = _inode(log)
+            sibling_content = log.read_text()
+
+            # Force our own rollover.  Pre-#27649, this would have
+            # renamed agent.log -> agent.log.1 (overwriting our pre
+            # record) and created a fresh empty agent.log.
+            h.doRollover()
+
+            assert log.exists(), "baseFilename must still exist after the short-circuit"
+            assert log.read_text() == sibling_content, (
+                "the sibling process's content must not be overwritten"
+            )
+            assert _inode(log) == sibling_inode, (
+                "we must not have renamed/recreated the sibling's file"
+            )
+        finally:
+            h.close()
+
+    def test_dorollover_still_rotates_when_no_external_rotation(self, tmp_path):
+        """The short-circuit must NOT break ordinary single-process
+        rotation -- if no one rotated externally, behaviour is unchanged."""
+        log = tmp_path / "agent.log"
+        h = _make_handler(log, maxBytes=10, backupCount=2)
+        try:
+            _emit(h, "a" * 50)
+            h.doRollover()
+            assert log.exists()
+            assert (tmp_path / "agent.log.1").exists()
+        finally:
+            h.close()
+
+
+# ---------------------------------------------------------------------------
+# Throttle / safety / Windows-compat corner cases.
+# ---------------------------------------------------------------------------
+
+
+class TestThrottleAndCorners:
+    def test_first_emit_always_checks(self, tmp_path):
+        """The first emit on a fresh handler must check immediately --
+        otherwise a process that starts AFTER another process has already
+        rotated would write to ``.1`` for N records before noticing."""
+        log = tmp_path / "agent.log"
+        h = _ManagedRotatingFileHandler(
+            str(log), maxBytes=10_000, backupCount=2, encoding="utf-8",
+        )
+        # Default throttle (16) -- but the first emit must still check.
+        try:
+            # Externally rotate BEFORE the first emit.
+            _emit(h, "warmup")  # initial write
+            rotated = tmp_path / "agent.log.1"
+            os.rename(str(log), str(rotated))
+            log.write_text("")
+
+            # Reset the counter so we're at "first emit since check".
+            h._emit_count = 0
+            _emit(h, "first")
+
+            assert "first" in log.read_text()
+            assert "first" not in rotated.read_text()
+        finally:
+            h.close()
+
+    def test_throttle_bounded_window(self, tmp_path):
+        """With ``_REOPEN_CHECK_INTERVAL=N`` writes after rotation may
+        land in the backup for at most N-1 records before the next
+        check.  This pins the boundedness contract advertised in the
+        docstring rather than promising zero lost writes."""
+        log = tmp_path / "agent.log"
+        h = _ManagedRotatingFileHandler(
+            str(log), maxBytes=10_000, backupCount=2, encoding="utf-8",
+        )
+        h._REOPEN_CHECK_INTERVAL = 4
+        h.setFormatter(logging.Formatter("%(message)s"))
+        try:
+            _emit(h, "warmup")
+            os.rename(str(log), str(tmp_path / "agent.log.1"))
+            log.write_text("")
+
+            # We want the inode check to run on the *next* emit.  After
+            # warmup, _emit_count is 1.  Aligning to N means the next
+            # multiple-of-N tick happens at _emit_count == 4 -> we emit
+            # three records to get there.
+            for i in range(3):
+                _emit(h, f"between-{i}")
+            # 4th emit is the boundary -> inode check runs here, reopen.
+            _emit(h, "after-window")
+
+            assert "after-window" in log.read_text()
+        finally:
+            h.close()
+
+    def test_stream_inode_returns_none_when_stream_closed(self, tmp_path):
+        log = tmp_path / "agent.log"
+        h = _make_handler(log)
+        h.stream.close()
+        h.stream = None
+        assert h._stream_inode_key() is None
+        # And the reopen helper must be a no-op rather than crashing.
+        assert h._reopen_if_rotated_externally() is False
+        h.close()
+
+    def test_stream_inode_treats_st_ino_zero_as_unknown(self, tmp_path, monkeypatch):
+        """Windows sometimes returns st_ino == 0 for regular files;
+        we must treat that as 'unknown' rather than reopening on every
+        write."""
+        log = tmp_path / "agent.log"
+        h = _make_handler(log)
+        try:
+            class _ZeroInodeStat:
+                st_dev = 1
+                st_ino = 0
+                st_mode = 0
+                st_size = 0
+                st_atime = 0
+                st_mtime = 0
+                st_ctime = 0
+
+            monkeypatch.setattr(os, "fstat", lambda _fd: _ZeroInodeStat())
+            assert h._stream_inode_key() is None
+        finally:
+            h.close()
+
+    def test_baseFilename_inode_returns_none_when_missing(self, tmp_path):
+        log = tmp_path / "agent.log"
+        h = _make_handler(log)
+        try:
+            log.unlink()
+            assert h._baseFilename_inode_key() is None
+        finally:
+            h.close()
+
+    def test_reopen_is_silent_on_oserror(self, tmp_path, monkeypatch):
+        """``_reopen_if_rotated_externally`` must never propagate an
+        exception -- a broken logging path must not kill the calling
+        code path."""
+        log = tmp_path / "agent.log"
+        h = _make_handler(log)
+        try:
+            _emit(h, "warmup")
+            rotated = tmp_path / "agent.log.1"
+            os.rename(str(log), str(rotated))
+            log.write_text("")
+
+            # Force the close path to raise; the wrapper must swallow.
+            real_close = h.stream.close
+            def _explode():
+                raise OSError("simulated close failure")
+            monkeypatch.setattr(h.stream, "close", _explode)
+
+            # Should not raise.
+            assert h._reopen_if_rotated_externally() is True
+            # And the stream should be re-pointed at baseFilename.
+            assert _inode(Path(h.baseFilename)) == os.fstat(h.stream.fileno()).st_ino
+
+            real_close  # silence unused -- we only kept the ref for clarity
+        finally:
+            h.close()
+
+    def test_emit_exception_in_check_does_not_drop_record(self, tmp_path, monkeypatch):
+        """If the inode check raises unexpectedly, the underlying record
+        must still be written (best-effort fail-open)."""
+        log = tmp_path / "agent.log"
+        h = _make_handler(log)
+        try:
+            def _explode(*_a, **_kw):
+                raise RuntimeError("simulated inode-check failure")
+            monkeypatch.setattr(h, "_reopen_if_rotated_externally", _explode)
+
+            _emit(h, "still-written")
+            assert "still-written" in log.read_text()
+        finally:
+            h.close()
+
+
+# ---------------------------------------------------------------------------
+# Managed-mode permissions are still applied after the reopen path.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    sys.platform.startswith("win"), reason="POSIX file modes only"
+)
+class TestManagedModeChmodAfterReopen:
+    def test_chmod_660_applied_after_external_rotation(self, tmp_path, monkeypatch):
+        """When managed mode is on, the chmod-after-open contract must
+        survive the reopen path -- otherwise a sibling-rotated log
+        ends up with the process umask (0644) and the gateway can't
+        share the file with interactive users."""
+        log = tmp_path / "agent.log"
+        # Pretend we're in managed mode.
+        h = _ManagedRotatingFileHandler(
+            str(log), maxBytes=10_000, backupCount=2, encoding="utf-8",
+        )
+        h._managed = True  # bypass NixOS check
+        h._REOPEN_CHECK_INTERVAL = 1
+        h.setFormatter(logging.Formatter("%(message)s"))
+        try:
+            _emit(h, "warmup")
+
+            os.rename(str(log), str(tmp_path / "agent.log.1"))
+            log.write_text("")
+            os.chmod(str(log), 0o644)  # sibling created with default umask
+
+            _emit(h, "post")
+
+            # After our reopen, the chmod path must have run.
+            mode = os.stat(str(log)).st_mode & 0o777
+            assert mode == 0o660, f"expected 0o660 after reopen, got {oct(mode)}"
+        finally:
+            h.close()
+
+
+# ---------------------------------------------------------------------------
+# Sanity: the handler integrates cleanly with the rest of hermes_logging.
+# ---------------------------------------------------------------------------
+
+
+class TestIntegrationWithSetupLogging:
+    def test_setup_logging_uses_managed_handler(self, tmp_path, monkeypatch):
+        """``setup_logging()`` must still wire ``_ManagedRotatingFileHandler``
+        rather than the bare stdlib class -- otherwise the #27649 fix
+        wouldn't be picked up on real installs."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        monkeypatch.setattr(hermes_logging, "get_hermes_home", lambda: hermes_home)
+        monkeypatch.setattr(
+            hermes_logging, "get_config_path", lambda: hermes_home / "config.yaml",
+        )
+        hermes_logging._logging_initialized = False
+        root = logging.getLogger()
+        previous_handlers = list(root.handlers)
+        try:
+            hermes_logging.setup_logging(force=True)
+            rotating = [
+                h for h in root.handlers
+                if isinstance(h, _ManagedRotatingFileHandler)
+            ]
+            assert len(rotating) >= 1, (
+                "setup_logging must attach the inode-aware managed handler"
+            )
+        finally:
+            for h in list(root.handlers):
+                if h not in previous_handlers:
+                    root.removeHandler(h)
+                    h.close()
+            hermes_logging._logging_initialized = False


### PR DESCRIPTION
## What does this PR do?

Fixes the multi-process log-rotation split reported in [#27649](https://github.com/NousResearch/hermes-agent/issues/27649) without adding a new runtime dependency.

When several Hermes processes share `~/.hermes/logs/agent.log` (e.g. the gateway plus several `hermes --tui` sessions and their `tui_gateway.entry` / `slash_worker` subprocesses) the stdlib `RotatingFileHandler` keeps an open file descriptor pointing at the active inode. If *another* process rotates the file -- renaming `agent.log` -> `agent.log.1` and creating a fresh `agent.log` -- the original fd still resolves to the renamed inode, so:

1. Writes from the older processes silently land in `agent.log.1` forever.
2. Newer processes write to the new `agent.log`.
3. The live log stream gets split across files; tools that follow only `agent.log` miss current activity.
4. Worse, once the older process eventually triggers its *own* rollover, the rename overwrites the newer `agent.log` that a sibling just created.

`hermes_logging._ManagedRotatingFileHandler` now detects external rotation by comparing the open stream's `(st_dev, st_ino)` against `baseFilename` on disk, and reopens the active file when they disagree. The fix is stdlib-only -- no `concurrent-log-handler` dependency.

## Related Issue

Fixes [#27649](https://github.com/NousResearch/hermes-agent/issues/27649).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

**`hermes_logging.py`** -- `_ManagedRotatingFileHandler` is now inode-aware:

- New class attribute `_REOPEN_CHECK_INTERVAL = 16` controls how often the inode check runs (the first emit always checks, then every Nth thereafter).
- New `_stream_inode_key()` / `_baseFilename_inode_key()` helpers return `(st_dev, st_ino)` and treat `st_ino == 0` (Windows + Python combos that don't expose stable inode numbers) and `OSError` as "unknown" rather than triggering spurious reopens.
- New `_reopen_if_rotated_externally()` closes the stale stream and reopens `baseFilename` when the inode-comparison mismatches; returns `True` if a reopen happened.
- `emit()` invokes the check before delegating to the base class; failures in the check path are swallowed so a broken logging path never kills the calling code (fail-open).
- `doRollover()` short-circuits when an external rotation already happened, reopening `baseFilename` instead of renaming it -- preventing the older process from clobbering the newer `agent.log` a sibling just created.
- Managed-mode `chmod 0o660` is re-applied on the reopen path so sibling-rotated files don't get stuck at the process umask (0644).

**`tests/test_hermes_logging_multiprocess_rotation.py`** (new file, 15 regression tests):

- `TestExternalRotationReopen` (4 tests) -- direct #27649 repro plus steady-state guards.
- `TestDoRolloverShortCircuit` (2 tests) -- the rollover-clobber regression.
- `TestThrottleAndCorners` (7 tests) -- first-emit-always-checks, throttle-bounded-window, closed-stream safety, `st_ino == 0` Windows compat, missing-`baseFilename` handling, `OSError` swallowing during close, fail-open of the inode-check path.
- `TestManagedModeChmodAfterReopen` (1 test, POSIX-only) -- chmod survives the reopen.
- `TestIntegrationWithSetupLogging` (1 test) -- `setup_logging()` still wires the managed handler.

## How to Test

1. Check out the branch and set up the venv:

   ```
   python3 -m venv .venv && source .venv/bin/activate && pip install -e ".[all,dev]"
   ```

2. Run the new regression suite alone:

   ```
   scripts/run_tests.sh tests/test_hermes_logging_multiprocess_rotation.py -v
   ```

   Expected: 15 passed.

3. Run the full logging-related suite to confirm no cross-file regression:

   ```
   scripts/run_tests.sh tests/test_hermes_logging.py tests/test_hermes_logging_multiprocess_rotation.py
   ```

   Expected: 65 passed (50 pre-existing + 15 new).

4. (Optional) Reproduce the #27649 scenario manually:

   ```
   python -c "
   import logging, os
   from hermes_logging import _ManagedRotatingFileHandler

   h = _ManagedRotatingFileHandler('/tmp/x.log', maxBytes=1024, backupCount=3)
   h._REOPEN_CHECK_INTERVAL = 1
   logging.getLogger('demo').addHandler(h); logging.getLogger('demo').setLevel(logging.INFO)

   logging.getLogger('demo').info('pre-rotation')
   os.rename('/tmp/x.log', '/tmp/x.log.1')
   open('/tmp/x.log','w').close()
   logging.getLogger('demo').info('post-rotation')
   print('live:', open('/tmp/x.log').read())
   print('backup:', open('/tmp/x.log.1').read())
   "
   ```

   Expected: `post-rotation` shows up in `/tmp/x.log`, not in `/tmp/x.log.1`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (2 commits: `fix(logging)`, `test(logging)`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/test_hermes_logging.py tests/test_hermes_logging_multiprocess_rotation.py` and all tests pass
- [x] I've added tests for my changes (15 new regression tests)
- [x] I've tested on my platform: macOS 15.2 (Darwin 24.6.0), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) -- the class-level docstring on `_ManagedRotatingFileHandler` now documents the external-rotation safety contract and the throttle interval. No user-facing docs are affected (the handler is internal).
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys -- N/A (no config-key changes).
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows -- N/A.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) -- the inode helpers treat `st_ino == 0` and `OSError` as "unknown" (Windows-friendly fallback), and the managed-mode chmod test is gated by `@pytest.mark.skipif(sys.platform.startswith("win"))`.
- [x] I've updated tool descriptions/schemas if I changed tool behavior -- N/A.

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/test_hermes_logging_multiprocess_rotation.py -v
4 workers [15 items]
...............                                                          [100%]
============================== 15 passed in 1.17s ==============================

$ scripts/run_tests.sh tests/test_hermes_logging.py tests/test_hermes_logging_multiprocess_rotation.py
4 workers [65 items]
.................................................................        [100%]
============================== 65 passed in 1.18s ==============================
```

### Limitations (per the issue's "no strong prescription from me" note)

This is a *minimal* stdlib-only fix:

- The inode check is throttled to every 16 records by default. Up to 15 records emitted between checks immediately after an external rotation may still land in the rotated backup. Tests pin this as a bounded contract rather than promising zero loss.
- True multi-process rotation safety (file locking around the rename) is out of scope -- two processes rotating simultaneously can still race. The short-circuit in `doRollover` prevents the worst symptom (a slow process overwriting a fresh `agent.log` written by a faster sibling) but doesn't synchronize the rename itself.
- No new dependency is added (`concurrent-log-handler` was considered and rejected to keep the install footprint minimal).
