### PR TITLE
fix(codex): reset has_tool_calls per retry attempt in run_codex_stream

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -181,16 +181,23 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
 
     active_client = client or agent._ensure_primary_openai_client(reason="codex_stream_direct")
     max_stream_retries = 1
-    has_tool_calls = False
     first_delta_fired = False
     # Accumulate streamed text so we can recover if get_final_response()
     # returns empty output (e.g. chatgpt.com backend-api sends
-    # response.incomplete instead of response.completed).
+    # response.incomplete instead of response.completed). Intentionally
+    # spans retry attempts: if attempt 1 streamed "foo " to the user
+    # before failing transport, the synthesized fallback from attempt 2
+    # combines both so the recovered output matches what the user saw.
     agent._codex_streamed_text_parts: list = []
     for attempt in range(max_stream_retries + 1):
         if agent._interrupt_requested:
             raise InterruptedError("Agent interrupted before Codex stream retry")
         collected_output_items: list = []
+        # Reset per-attempt: a function_call event on a failed attempt
+        # must not suppress text streaming or empty-output synthesis on
+        # the retry, which is a fresh API call with its own tool-call
+        # decisions.
+        has_tool_calls = False
         try:
             with active_client.responses.stream(**api_kwargs) as stream:
                 for event in stream:

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -945,6 +945,155 @@ class TestCodexStreamCallbacks:
 
         assert touch_calls.count("receiving stream response") == len(events)
 
+    def test_codex_stream_resets_has_tool_calls_after_retry(self):
+        """Regression: has_tool_calls must reset per retry attempt.
+
+        If attempt 1 sees a function_call event and then fails with a
+        transport error, attempt 2's output_text.delta events must still
+        be streamed to the user. Without per-attempt reset, the
+        leftover has_tool_calls=True from attempt 1 silently suppressed
+        the retry's text streaming.
+        """
+        from run_agent import AIAgent
+
+        deltas = []
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            stream_delta_callback=lambda t: deltas.append(t),
+        )
+        agent.api_mode = "codex_responses"
+        agent._interrupt_requested = False
+
+        func_call_event = SimpleNamespace(
+            type="response.function_call_arguments.delta",
+            delta="",
+        )
+
+        class _OneEventThenRaise:
+            """Iterator that yields one event then raises ConnectionError."""
+
+            def __init__(self):
+                self._yielded = False
+
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                if self._yielded:
+                    raise ConnectionError("simulated transport drop")
+                self._yielded = True
+                return func_call_event
+
+        stream1 = MagicMock()
+        stream1.__enter__ = MagicMock(return_value=stream1)
+        stream1.__exit__ = MagicMock(return_value=False)
+        stream1.__iter__ = MagicMock(return_value=_OneEventThenRaise())
+
+        text_event = SimpleNamespace(
+            type="response.output_text.delta",
+            delta="bar baz",
+        )
+        final_resp = SimpleNamespace(
+            output=[
+                SimpleNamespace(
+                    type="message",
+                    content=[SimpleNamespace(type="output_text", text="bar baz")],
+                )
+            ],
+            status="completed",
+        )
+        stream2 = MagicMock()
+        stream2.__enter__ = MagicMock(return_value=stream2)
+        stream2.__exit__ = MagicMock(return_value=False)
+        stream2.__iter__ = MagicMock(return_value=iter([text_event]))
+        stream2.get_final_response = MagicMock(return_value=final_resp)
+
+        mock_client = MagicMock()
+        mock_client.responses.stream.side_effect = [stream1, stream2]
+
+        response = agent._run_codex_stream({}, client=mock_client)
+
+        assert "bar baz" in deltas, (
+            f"Retry text delta must be streamed despite attempt 1 seeing a "
+            f"function_call event; got deltas={deltas!r}"
+        )
+        assert response is final_resp
+
+    def test_codex_stream_synthesizes_output_after_retry_with_prior_tool_call(self):
+        """Regression: empty-output synthesis must fire on the retry even
+        if attempt 1 saw a function_call event.
+
+        chatgpt.com backend-api can return an empty output list on
+        get_final_response() while the SSE stream actually delivered
+        output_text deltas. The fallback synthesises the final response
+        from those deltas — but only when has_tool_calls is False. A
+        leftover True from a failed first attempt would skip synthesis
+        and leave final_response.output as [].
+        """
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "codex_responses"
+        agent._interrupt_requested = False
+
+        func_call_event = SimpleNamespace(
+            type="response.function_call_arguments.delta",
+            delta="",
+        )
+
+        class _OneEventThenRaise:
+            def __init__(self):
+                self._yielded = False
+
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                if self._yielded:
+                    raise ConnectionError("simulated transport drop")
+                self._yielded = True
+                return func_call_event
+
+        stream1 = MagicMock()
+        stream1.__enter__ = MagicMock(return_value=stream1)
+        stream1.__exit__ = MagicMock(return_value=False)
+        stream1.__iter__ = MagicMock(return_value=_OneEventThenRaise())
+
+        text_event = SimpleNamespace(
+            type="response.output_text.delta",
+            delta="bar baz",
+        )
+        empty_final = SimpleNamespace(output=[], status="incomplete")
+        stream2 = MagicMock()
+        stream2.__enter__ = MagicMock(return_value=stream2)
+        stream2.__exit__ = MagicMock(return_value=False)
+        stream2.__iter__ = MagicMock(return_value=iter([text_event]))
+        stream2.get_final_response = MagicMock(return_value=empty_final)
+
+        mock_client = MagicMock()
+        mock_client.responses.stream.side_effect = [stream1, stream2]
+
+        response = agent._run_codex_stream({}, client=mock_client)
+
+        assert response.output, (
+            "Synthesis must populate output from streamed text after "
+            "retry; got empty output (has_tool_calls leak from attempt 1)"
+        )
+        assert response.output[0].content[0].text == "bar baz"
+
 
 class TestAnthropicStreamCallbacks:
     """Verify Anthropic streaming refreshes activity on every event."""


### PR DESCRIPTION
## Summary

Reset `has_tool_calls` per retry attempt in `run_codex_stream`. Without this reset, a `function_call` event seen on a failed first attempt silently suppressed text streaming and empty-output synthesis on the retry — even though the retry was a fresh API call with its own tool-call decisions.

## Root cause

In `agent/codex_runtime.py`, `has_tool_calls` was initialised **once** before the per-attempt loop, while `collected_output_items` was correctly reset per attempt:

```python
max_stream_retries = 1
has_tool_calls = False                    # ← initialised once, never reset
first_delta_fired = False
agent._codex_streamed_text_parts: list = []
for attempt in range(max_stream_retries + 1):
    ...
    collected_output_items: list = []     # ← reset per-attempt
    try:
        with active_client.responses.stream(**api_kwargs) as stream:
            for event in stream:
                ...
                if "output_text.delta" in event_type ...:
                    delta_text = getattr(event, "delta", "")
                    if delta_text:
                        agent._codex_streamed_text_parts.append(delta_text)
                    if delta_text and not has_tool_calls:        # ← leak point #1
                        ...
                        agent._fire_stream_delta(delta_text)
                elif "function_call" in event_type:
                    has_tool_calls = True
            final_response = stream.get_final_response()
            _out = getattr(final_response, "output", None)
            if isinstance(_out, list) and not _out:
                if collected_output_items:
                    final_response.output = list(collected_output_items)
                elif agent._codex_streamed_text_parts and not has_tool_calls:   # ← leak point #2
                    # synthesise output from streamed deltas
                    ...
    except (_httpx.RemoteProtocolError, _httpx.ReadTimeout,
            _httpx.ConnectError, ConnectionError) as exc:
        if attempt < max_stream_retries:
            continue
```

When attempt 1 saw a `function_call` event and then failed with a transport error (`RemoteProtocolError`, `ReadTimeout`, `ConnectError`, or `ConnectionError`), the retry started with `has_tool_calls=True` left over from the first attempt. On the retry:

1. **Streaming suppressed.** `if delta_text and not has_tool_calls:` evaluated `False` → `agent._fire_stream_delta(...)` was never called for the retry's text deltas. The user saw no live token streaming for what was actually a clean text-only response.
2. **Synthesis fallback skipped.** `elif agent._codex_streamed_text_parts and not has_tool_calls:` also evaluated `False` → the empty-output synthesis fallback was bypassed. When the chatgpt.com `backend-api/codex` backend returned `response.incomplete` with `output=[]` on the retry, `final_response.output` was returned as `[]` even though the SSE stream had actually delivered valid `output_text.delta` events.

The result: a retry that genuinely succeeded at the protocol level returned an empty output list, and the caller treated it as "no output".

## Fix

Move `has_tool_calls = False` inside the per-attempt block, alongside `collected_output_items: list = []`. Each retry now starts with a fresh tool-call signal:

```python
for attempt in range(max_stream_retries + 1):
    if agent._interrupt_requested:
        raise InterruptedError("Agent interrupted before Codex stream retry")
    collected_output_items: list = []
    # Reset per-attempt: a function_call event on a failed attempt
    # must not suppress text streaming or empty-output synthesis on
    # the retry, which is a fresh API call with its own tool-call
    # decisions.
    has_tool_calls = False
    try:
        ...
```

`agent._codex_streamed_text_parts` is intentionally **not** reset across attempts. Its purpose is to preserve whatever the user already saw streamed so the synthesised fallback matches the visible transcript: if attempt 1 streamed `"foo "` before failing and the retry adds `"bar baz"`, the synthesised final response is `"foo bar baz"` — which is exactly what the user saw on screen. Reset would lose attempt 1's already-streamed prefix.

`first_delta_fired` similarly stays at the function scope: it's a once-per-request UX hook ("first token received → stop the spinner"), not per-attempt.

## Test plan

Two regression tests added under `tests/run_agent/test_streaming.py::TestCodexStreamCallbacks`:

- [x] `test_codex_stream_resets_has_tool_calls_after_retry` — mocks attempt 1 to yield a `response.function_call_arguments.delta` event then raise `ConnectionError`, and attempt 2 to yield a clean `response.output_text.delta` then complete normally. Asserts the retry's text delta reaches `stream_delta_callback`.
- [x] `test_codex_stream_synthesizes_output_after_retry_with_prior_tool_call` — same attempt 1 setup, but attempt 2's `get_final_response()` returns `output=[]`. Asserts the empty-output synthesis fallback populates `final_response.output` from the streamed text deltas.

Both tests **fail** on `main` (confirming they catch the actual regression) and **pass** with the fix applied.

## Verification

Verified locally:

```
$ python -m pytest -o "addopts=" tests/run_agent/test_streaming.py::TestCodexStreamCallbacks -v
tests/run_agent/test_streaming.py::TestCodexStreamCallbacks::test_codex_text_delta_fires_callback PASSED
tests/run_agent/test_streaming.py::TestCodexStreamCallbacks::test_codex_stream_refreshes_activity_on_every_event PASSED
tests/run_agent/test_streaming.py::TestCodexStreamCallbacks::test_codex_remote_protocol_error_falls_back_to_create_stream PASSED
tests/run_agent/test_streaming.py::TestCodexStreamCallbacks::test_codex_create_stream_fallback_refreshes_activity_on_every_event PASSED
tests/run_agent/test_streaming.py::TestCodexStreamCallbacks::test_codex_stream_resets_has_tool_calls_after_retry PASSED
tests/run_agent/test_streaming.py::TestCodexStreamCallbacks::test_codex_stream_synthesizes_output_after_retry_with_prior_tool_call PASSED

6 passed
```

Cross-check on the pre-fix state (regression both new tests catch):

```
FAILED test_codex_stream_resets_has_tool_calls_after_retry          — assert 'bar baz' in []
FAILED test_codex_stream_synthesizes_output_after_retry_with_prior_tool_call
                                                                    — assert []  (got empty output; has_tool_calls leak from attempt 1)
```

Broader codex stream retry suite stays clean:

```
$ python -m pytest -o "addopts=" tests/run_agent/test_run_agent_codex_responses.py -k "run_codex_stream"
3 passed, 60 deselected
```

## Risk / blast radius

Very low. The only behavioural change is that `has_tool_calls` no longer carries state from a failed prior attempt into the retry. Provider/transport combinations that never trigger the retry path (no transport errors, no missing `response.completed` / prelude `response.created` errors) are unaffected — they take a single attempt where `has_tool_calls` already starts at `False`, and the new placement preserves that. No new exceptions caught, no new code paths added, no API surface change.

## Out of scope

- `agent._codex_streamed_text_parts` reset semantics — intentionally preserved across attempts so the synthesised fallback matches the visible streamed transcript. See the fix notes above.
- `first_delta_fired` reset semantics — intentionally preserved as a once-per-request UX hook.
