### PR TITLE
fix: allow null-result skill review outcomes

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4175,10 +4175,8 @@ class AIAgent:
         "command, config step, env var to set) under an existing setup or "
         "troubleshooting skill — never 'this tool does not work' as a "
         "standalone constraint.\n\n"
-        "'Nothing to save.' is a real option but should NOT be the "
-        "default. If the session ran smoothly with no corrections and "
-        "produced no new technique, just say 'Nothing to save.' and stop. "
-        "Otherwise, act."
+        "If no signal fired this session, respond exactly 'No update "
+        "warranted.' — null results are valid."
     )
 
     _COMBINED_REVIEW_PROMPT = (
@@ -4253,8 +4251,10 @@ class AIAgent:
         "troubleshooting skill — never 'this tool does not work' as a "
         "standalone constraint.\n\n"
         "Act on whichever of the two dimensions has real signal. If "
-        "genuinely nothing stands out on either, say 'Nothing to save.' "
-        "and stop — but don't reach for that conclusion as a default."
+        "no skill signal fired this session, respond exactly 'No update "
+        "warranted.' — null results are valid. If genuinely nothing "
+        "stands out on either, say 'Nothing to save.' and stop — but "
+        "don't reach for that conclusion as a default."
     )
 
     @staticmethod

--- a/tests/run_agent/test_review_prompt_class_first.py
+++ b/tests/run_agent/test_review_prompt_class_first.py
@@ -116,10 +116,12 @@ def test_skill_review_prompt_flags_overlap_and_defers_to_curator():
     assert "curator" in prompt.lower(), "must defer consolidation to the curator"
 
 
-def test_skill_review_prompt_still_has_opt_out_clause():
-    """'Nothing to save.' must remain as a real-but-not-default option."""
+def test_skill_review_prompt_has_null_result_clause():
+    """Skill review must allow honest null outcomes, not just memory phrasing."""
     prompt = AIAgent._SKILL_REVIEW_PROMPT
-    assert "Nothing to save." in prompt
+    assert "No update warranted." in prompt
+    assert "null results are valid" in prompt.lower()
+    assert "Nothing to save." not in prompt
 
 
 # ---------------------------------------------------------------------------
@@ -171,6 +173,12 @@ def test_combined_review_prompt_names_three_support_file_kinds():
     assert "references/" in prompt
     assert "templates/" in prompt
     assert "scripts/" in prompt
+
+
+def test_combined_review_prompt_has_null_result_clause():
+    prompt = AIAgent._COMBINED_REVIEW_PROMPT
+    assert "No update warranted." in prompt
+    assert "null results are valid" in prompt.lower()
 
 
 def test_combined_review_prompt_preserves_opt_out_clause():


### PR DESCRIPTION
## Summary\n- Reframe the skill background-review prompt to allow an explicit null outcome when no skill signal fired\n- Keep the memory review's \'Nothing to save.\' clause intact\n- Update prompt-behavior tests to cover the new no-update wording\n\n## Tests\n- /Users/lorenzobartolo/.hermes/hermes-agent/venv/bin/python -m pytest tests/run_agent/test_review_prompt_class_first.py -q\n- /Users/lorenzobartolo/.hermes/hermes-agent/venv/bin/python -m pytest tests/run_agent/test_background_review_toolset_restriction.py tests/run_agent/test_background_review_cache_parity.py -q\n\nCloses #27645