### PR TITLE
fix(cli): preserve Ctrl-J newline on macOS

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2137,16 +2137,17 @@ _TERMINAL_INPUT_MODE_RESET_SEQ = (
 def _preserve_ctrl_enter_newline() -> bool:
     """Detect environments where Ctrl+Enter must produce a newline, not submit.
 
-    Native Windows, WSL, SSH sessions, and Windows Terminal all send Ctrl+Enter
-    as bare LF (c-j). On those terminals c-j must NOT be bound to submit;
-    binding it to submit makes Ctrl+Enter (intended as 'newline like Alt+Enter')
-    submit instead. Local POSIX TTYs that deliver Enter as LF (docker exec,
-    some thin PTYs without SSH) still need c-j bound to submit, so we keep
-    that binding for those.
+    Native macOS, native Windows, WSL, SSH sessions, and Windows Terminal all
+    need c-j kept free for the newline handler. On Danny's MacBook, Ctrl+J is
+    the required multiline shortcut. On Windows/WSL/SSH, Ctrl+Enter often arrives
+    as bare LF (c-j). Binding c-j to submit in these contexts makes the intended
+    newline keystroke submit instead. Local POSIX TTYs that deliver Enter as LF
+    (docker exec, some thin PTYs without SSH) still need c-j bound to submit, so
+    we keep that binding for those.
 
     See issue #22379.
     """
-    if sys.platform == "win32":
+    if sys.platform in {"darwin", "win32"}:
         return True
     if any(os.environ.get(v) for v in ("SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY")):
         return True
@@ -5536,7 +5537,7 @@ class HermesCLI:
                 )
 
         _cprint(f"\n  {_DIM}Tip: Just type your message to chat with Hermes!{_RST}")
-        _cprint(f"  {_DIM}Multi-line: Alt+Enter for a new line{_RST}")
+        _cprint(f"  {_DIM}Multi-line: Ctrl+J or Alt+Enter for a new line{_RST}")
         _cprint(f"  {_DIM}Draft editor: Ctrl+G (Alt+G in VSCode/Cursor){_RST}")
         if _is_termux_environment():
             _cprint(f"  {_DIM}Attach image: /image {_termux_example_image_path()} or start your prompt with a local image path{_RST}\n")

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -54,7 +54,7 @@ TIPS = [
     "Combine multiple references: \"Review @file:main.py and @file:test.py for consistency.\"",
 
     # --- Keybindings ---
-    "Alt+Enter inserts a newline for multi-line input. (Windows Terminal intercepts Alt+Enter — use Ctrl+Enter instead.)",
+    "Ctrl+J inserts a newline for multi-line input. Alt+Enter also works when your terminal forwards it.",
     "Ctrl+C interrupts the agent. Double-press within 2 seconds to force exit.",
     "Ctrl+Z suspends Hermes to the background — run fg in your shell to resume.",
     "Tab accepts auto-suggestion ghost text or autocompletes slash commands.",

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -212,6 +212,16 @@ class TestPromptToolkitTerminalCompatibility:
             assert bindings[("c-m",)] is submit_handler
             assert ("c-j",) not in bindings
 
+        # macOS: c-j must stay free because Ctrl+J is Danny's required
+        # multiline shortcut in the MacBook Hermes CLI.
+        with _patch.object(_sys, "platform", "darwin"), \
+             _patch.dict(_os.environ, {}, clear=True):
+            kb = KeyBindings()
+            _bind_prompt_submit_keys(kb, submit_handler)
+            bindings = {tuple(key.value for key in binding.keys): binding.handler for binding in kb.bindings}
+            assert bindings[("c-m",)] is submit_handler
+            assert ("c-j",) not in bindings
+
     def test_cpr_warning_callback_is_disabled(self):
         from cli import _disable_prompt_toolkit_cpr_warning
 

--- a/tests/cli/test_ctrl_enter_newline.py
+++ b/tests/cli/test_ctrl_enter_newline.py
@@ -22,6 +22,13 @@ def test_native_windows_preserves_newline():
         assert cli_mod._preserve_ctrl_enter_newline() is True
 
 
+def test_macos_preserves_ctrl_j_newline():
+    import cli as cli_mod
+    with patch.object(sys, "platform", "darwin"):
+        with patch.dict(os.environ, {}, clear=True):
+            assert cli_mod._preserve_ctrl_enter_newline() is True
+
+
 def test_ssh_session_preserves_newline_on_linux():
     import cli as cli_mod
     with patch.object(sys, "platform", "linux"):

--- a/tests/hermes_cli/test_tips.py
+++ b/tests/hermes_cli/test_tips.py
@@ -32,6 +32,10 @@ class TestTipsCorpus:
         for i, tip in enumerate(TIPS):
             assert tip == tip.strip(), f"Tip {i} has leading/trailing whitespace"
 
+    def test_multiline_tip_mentions_ctrl_j(self):
+        multiline_tips = [tip for tip in TIPS if "multi-line input" in tip]
+        assert any("Ctrl+J" in tip for tip in multiline_tips)
+
 
 class TestGetRandomTip:
     """Validate the get_random_tip() function."""


### PR DESCRIPTION
## Summary
- Preserves Ctrl+J as a multiline newline shortcut on macOS instead of binding it to prompt submit
- Updates the startup/tips copy to surface Ctrl+J first, while keeping Alt+Enter as a forwarded-terminal option
- Adds focused regression coverage for macOS keybinding behavior and the multiline tip

## Test plan
- `.venv/bin/python -m pytest -o addopts="-m 'not integration'" -q tests/cli/test_ctrl_enter_newline.py tests/cli/test_cli_init.py tests/hermes_cli/test_tips.py`
- direct keybinding assertion: `macos_ctrl_j_preserve_and_keybinding_assertion=PASS`
- `git diff --check`
