### PR TITLE
fix(slack): scope assistant typing status by channel and thread

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -341,8 +341,9 @@ class SlackAdapter(BasePlatformAdapter):
         # Track message IDs that should get reaction lifecycle (DMs / @mentions).
         self._reacting_message_ids: set = set()
         # Track active assistant thread status indicators so stop_typing can
-        # clear them (chat_id → thread_ts).
-        self._active_status_threads: Dict[str, str] = {}
+        # clear them without cross-thread collisions in the same channel.
+        # Keyed by (chat_id, thread_ts).
+        self._active_status_threads: Dict[Tuple[str, str], str] = {}
         # Slash-command contexts: stash response_url + user_id so send()
         # can route the first reply ephemerally.  Keyed by
         # (channel_id, user_id) to avoid cross-user collisions.
@@ -807,7 +808,7 @@ class SlackAdapter(BasePlatformAdapter):
 
             # Clear Slack Assistant status as soon as the final message is posted.
             if thread_ts:
-                await self.stop_typing(chat_id)
+                await self.stop_typing(chat_id, metadata={"thread_ts": thread_ts})
 
             # Track the sent message ts so we can auto-respond to thread
             # replies without requiring @mention.
@@ -899,6 +900,41 @@ class SlackAdapter(BasePlatformAdapter):
             )
             return SendResult(success=False, error=str(e))
 
+    def _status_thread_ts_from_metadata(self, metadata: Optional[Dict[str, Any]]) -> Optional[str]:
+        """Return the Slack thread ts from adapter metadata."""
+        if not metadata:
+            return None
+        thread_ts = metadata.get("thread_id") or metadata.get("thread_ts")
+        if thread_ts is None:
+            return None
+        return str(thread_ts)
+
+    def _pop_active_status_thread(
+        self,
+        chat_id: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[str]:
+        """Pop the tracked status thread for a chat.
+
+        Prefer an exact (chat_id, thread_ts) match when metadata identifies the
+        thread. If metadata is absent, fall back to the sole tracked thread in
+        that chat so old call sites keep working.
+        """
+        thread_ts = self._status_thread_ts_from_metadata(metadata)
+        if thread_ts:
+            key = (chat_id, thread_ts)
+            if key in self._active_status_threads:
+                self._active_status_threads.pop(key, None)
+                return thread_ts
+            return None
+
+        matches = [key for key in self._active_status_threads if key[0] == chat_id]
+        if len(matches) != 1:
+            return None
+        _, only_thread_ts = matches[0]
+        self._active_status_threads.pop(matches[0], None)
+        return only_thread_ts
+
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """Show a typing/status indicator using assistant.threads.setStatus.
 
@@ -909,14 +945,11 @@ class SlackAdapter(BasePlatformAdapter):
         if not self._app:
             return
 
-        thread_ts = None
-        if metadata:
-            thread_ts = metadata.get("thread_id") or metadata.get("thread_ts")
-
+        thread_ts = self._status_thread_ts_from_metadata(metadata)
         if not thread_ts:
             return  # Can only set status in a thread context
 
-        self._active_status_threads[chat_id] = thread_ts
+        self._active_status_threads[(chat_id, thread_ts)] = thread_ts
         try:
             await self._get_client(chat_id).assistant_threads_setStatus(
                 channel_id=chat_id,
@@ -932,7 +965,7 @@ class SlackAdapter(BasePlatformAdapter):
         """Clear the assistant thread status indicator."""
         if not self._app:
             return
-        thread_ts = self._active_status_threads.pop(chat_id, None)
+        thread_ts = self._pop_active_status_thread(chat_id, metadata=metadata)
         if not thread_ts:
             return
         try:

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1302,7 +1302,23 @@ class TestSendTyping:
             thread_ts="parent_ts",
             status="",
         )
-        assert "C123" not in adapter._active_status_threads
+        assert ("C123", "parent_ts") not in adapter._active_status_threads
+
+    @pytest.mark.asyncio
+    async def test_stop_typing_clears_only_matching_thread_in_same_channel(self, adapter):
+        adapter._app.client.assistant_threads_setStatus = AsyncMock()
+        await adapter.send_typing("C123", metadata={"thread_id": "thread_a"})
+        await adapter.send_typing("C123", metadata={"thread_id": "thread_b"})
+
+        await adapter.stop_typing("C123", metadata={"thread_id": "thread_a"})
+
+        assert adapter._app.client.assistant_threads_setStatus.call_args_list[-1] == call(
+            channel_id="C123",
+            thread_ts="thread_a",
+            status="",
+        )
+        assert ("C123", "thread_a") not in adapter._active_status_threads
+        assert ("C123", "thread_b") in adapter._active_status_threads
 
     @pytest.mark.asyncio
     async def test_stop_typing_noop_without_tracked_thread(self, adapter):
@@ -1314,7 +1330,7 @@ class TestSendTyping:
 
     @pytest.mark.asyncio
     async def test_stop_typing_handles_api_error_gracefully(self, adapter):
-        adapter._active_status_threads["C123"] = "parent_ts"
+        adapter._active_status_threads[("C123", "parent_ts")] = "parent_ts"
         adapter._app.client.assistant_threads_setStatus = AsyncMock(
             side_effect=Exception("missing_scope")
         )
@@ -1326,13 +1342,14 @@ class TestSendTyping:
             thread_ts="parent_ts",
             status="",
         )
-        assert "C123" not in adapter._active_status_threads
+        assert ("C123", "parent_ts") not in adapter._active_status_threads
 
     @pytest.mark.asyncio
     async def test_send_clears_status_after_final_post(self, adapter):
         adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "reply_ts"})
         adapter._app.client.assistant_threads_setStatus = AsyncMock()
-        adapter._active_status_threads["C123"] = "parent_ts"
+        adapter._active_status_threads[("C123", "parent_ts")] = "parent_ts"
+        adapter._active_status_threads[("C123", "sibling_ts")] = "sibling_ts"
 
         result = await adapter.send("C123", "done", metadata={"thread_id": "parent_ts"})
 
@@ -1343,13 +1360,14 @@ class TestSendTyping:
             thread_ts="parent_ts",
             status="",
         )
-        assert "C123" not in adapter._active_status_threads
+        assert ("C123", "parent_ts") not in adapter._active_status_threads
+        assert ("C123", "sibling_ts") in adapter._active_status_threads
 
     @pytest.mark.asyncio
     async def test_streaming_final_edit_clears_status(self, adapter):
         adapter._app.client.chat_update = AsyncMock()
         adapter._app.client.assistant_threads_setStatus = AsyncMock()
-        adapter._active_status_threads["C123"] = "parent_ts"
+        adapter._active_status_threads[("C123", "parent_ts")] = "parent_ts"
 
         result = await adapter.edit_message(
             "C123",
@@ -1369,13 +1387,13 @@ class TestSendTyping:
             thread_ts="parent_ts",
             status="",
         )
-        assert "C123" not in adapter._active_status_threads
+        assert ("C123", "parent_ts") not in adapter._active_status_threads
 
     @pytest.mark.asyncio
     async def test_streaming_intermediate_edit_keeps_status(self, adapter):
         adapter._app.client.chat_update = AsyncMock()
         adapter._app.client.assistant_threads_setStatus = AsyncMock()
-        adapter._active_status_threads["C123"] = "parent_ts"
+        adapter._active_status_threads[("C123", "parent_ts")] = "parent_ts"
 
         result = await adapter.edit_message(
             "C123",
@@ -1386,7 +1404,7 @@ class TestSendTyping:
 
         assert result.success
         adapter._app.client.assistant_threads_setStatus.assert_not_called()
-        assert adapter._active_status_threads["C123"] == "parent_ts"
+        assert adapter._active_status_threads[("C123", "parent_ts")] == "parent_ts"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fix Slack assistant typing/status tracking so concurrent threads in the same channel do not overwrite or clear each other's status state.

## Problem

Slack typing status was tracked by `chat_id` only. When two threads in the same channel were active at the same time, the later thread overwrote the earlier one. Cleanup paths like `stop_typing()` and final-send status clearing could then clear the wrong thread or leave a stale `"is thinking..."` status behind.

## Fix

- Track active Slack assistant status by `(chat_id, thread_ts)` instead of `chat_id`
- Prefer exact thread cleanup when metadata identifies the target thread
- Keep a safe fallback for legacy call paths that do not pass thread metadata
- Clear the exact thread status after final threaded sends

## Tests

- Updated existing Slack typing-status tests for the new state shape
- Added coverage for two concurrent threads in the same channel to verify that clearing one thread does not affect the other

## Verification

- `pytest tests\gateway\test_slack.py -k "TestSendTyping" -q`
- Result: `11 passed`