### PR TITLE
docs(unsloth): fix duplicated words in llms-full reference

### DIFF
--- a/optional-skills/mlops/training/unsloth/references/llms-full.md
+++ b/optional-skills/mlops/training/unsloth/references/llms-full.md
@@ -4128,7 +4128,7 @@ With Unsloth's new RL improvements, you NEVER have to worry about tuning or sett
 
 ## :interrobang:Why does RL use so much memory?
 
-GRPO (and many RL variants) rely heavily on generation which is primarily powered by vLLM. But this comes comes with a steep cost since it requires constant **GPU memory for weights, activations, and the KV Cache**.
+GRPO (and many RL variants) rely heavily on generation which is primarily powered by vLLM. But this comes with a steep cost since it requires constant **GPU memory for weights, activations, and the KV Cache**.
 
 {% columns %}
 {% column width="41.66666666666667%" %}
@@ -5100,7 +5100,7 @@ training_args = GRPOConfig(
 
 Overall, Unsloth now with VLM vLLM fast inference enables for both 90% reduced memory usage but also 1.5-2x faster speed with GRPO and GSPO!
 
-If you'd like to read more about reinforcement learning, check out out RL guide:
+If you'd like to read more about reinforcement learning, check out our RL guide:
 
 [reinforcement-learning-rl-guide](https://docs.unsloth.ai/get-started/reinforcement-learning-rl-guide "mention")
 


### PR DESCRIPTION
## What does this PR do?

Fixes two duplicated-word typos in the Unsloth `llms-full` reference docs.

## Related Issue

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Replaced `comes comes` with `comes`
- Replaced `check out out` with `check out our`
- File: `optional-skills/mlops/training/unsloth/references/llms-full.md`

## How to Test

1. Open `optional-skills/mlops/training/unsloth/references/llms-full.md`
2. Verify the GRPO sentence reads `But this comes with a steep cost`
3. Verify the RL guide sentence reads `check out our RL guide`

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping
- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

`grep -n "comes with a steep cost\|check out our RL guide" optional-skills/mlops/training/unsloth/references/llms-full.md`
