### PR TITLE
feat: WhatsApp group subject update endpoint

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -1059,6 +1059,23 @@ class WhatsAppAdapter(BasePlatformAdapter):
         
         return {"name": chat_id, "type": "dm"}
     
+    async def set_group_name(self, chat_id: str, name: str) -> bool:
+        """Change a WhatsApp group subject via the bridge."""
+        if not self._running or not self._http_session:
+            return False
+        if await self._check_managed_bridge_exit():
+            return False
+        try:
+            import aiohttp
+            async with self._http_session.post(
+                f"http://127.0.0.1:{self._bridge_port}/group/set-name",
+                json={"chatId": chat_id, "name": name},
+                timeout=aiohttp.ClientTimeout(total=15)
+            ) as resp:
+                return resp.status == 200
+        except Exception:
+            return False
+    
     async def _poll_messages(self) -> None:
         """Poll the bridge for incoming messages."""
         import aiohttp

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -12,6 +12,7 @@
  *   POST /send-media     - Send media natively { chatId, filePath, mediaType?, caption?, fileName? }
  *   POST /typing         - Send typing indicator { chatId }
  *   GET  /chat/:id       - Get chat info
+ *   POST /group/set-name - Change group subject { chatId, name }
  *   GET  /health         - Health check
  *
  * Usage:
@@ -675,6 +676,23 @@ app.get('/chat/:id', async (req, res) => {
     isGroup,
     participants: [],
   });
+});
+
+// Change group subject
+app.post('/group/set-name', async (req, res) => {
+  if (!sock || connectionState !== 'connected') {
+    return res.status(503).json({ error: 'Not connected to WhatsApp' });
+  }
+  const { chatId, name } = req.body;
+  if (!chatId || !name) {
+    return res.status(400).json({ error: 'chatId and name are required' });
+  }
+  try {
+    await sock.groupUpdateSubject(chatId, name);
+    res.json({ success: true });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
 });
 
 // Health check


### PR DESCRIPTION
## What
Adds a new `/group/set-name` HTTP endpoint to the WhatsApp Bridge and a corresponding `set_group_name()` adapter method in the Python WhatsApp platform adapter.

### Bridge (`scripts/whatsapp-bridge/bridge.js`)
- New `POST /group/set-name` endpoint that calls Baileys `sock.groupUpdateSubject(chatId, name)` to change a WhatsApp group's subject/name
- Updated endpoint comments at the top of the file to include the new route

### Adapter (`gateway/platforms/whatsapp.py`)
- New `set_group_name(chat_id, name) -> bool` async method on `WhatsAppAdapter`
- Posts to the bridge's `/group/set-name` endpoint with `chatId` and `name`
- Returns `True` on success, `False` on any error (including bridge not running)

## Why
Enables dynamic group name updates — useful for showing live info in the group name (e.g., active model, token usage) via gateway hooks or cron jobs.

## Changes
- **2 files changed, ~35 lines added**
- `scripts/whatsapp-bridge/bridge.js` — new endpoint
- `gateway/platforms/whatsapp.py` — new adapter method

## Testing
- Manual testing planned
- Bridge endpoint validated against the Baileys `groupUpdateSubject` API