### PR TITLE
feat: add CMH subprocess wrapper foundation

### DIFF
--- a/agent/cmh_subprocess/__init__.py
+++ b/agent/cmh_subprocess/__init__.py
@@ -1,0 +1,6 @@
+"""CMH subprocess wrapper foundation.
+
+Local foundation only. This package does not activate live routing,
+Telegram sends, gateway behavior, cron, daemon, MCP, deploy, merge, or
+production mutation.
+"""

--- a/agent/cmh_subprocess/__init__.py
+++ b/agent/cmh_subprocess/__init__.py
@@ -4,3 +4,19 @@ Local foundation only. This package does not activate live routing,
 Telegram sends, gateway behavior, cron, daemon, MCP, deploy, merge, or
 production mutation.
 """
+
+from agent.cmh_subprocess.budget_display import format_budget_status
+from agent.cmh_subprocess.envelope import check_budget, increment_usage, load_envelope_state
+from agent.cmh_subprocess.halt_flags import is_halted, load_halt_flags
+from agent.cmh_subprocess.wrappers import prepare_claude_print_invocation, prepare_codex_print_invocation
+
+__all__ = [
+    "check_budget",
+    "format_budget_status",
+    "increment_usage",
+    "is_halted",
+    "load_envelope_state",
+    "load_halt_flags",
+    "prepare_claude_print_invocation",
+    "prepare_codex_print_invocation",
+]

--- a/agent/cmh_subprocess/budget_display.py
+++ b/agent/cmh_subprocess/budget_display.py
@@ -1,0 +1,34 @@
+"""Pure budget status formatting for CMH subprocess wrapper foundations."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agent.cmh_subprocess.envelope import allocation_cap
+
+
+def _bool_text(value: bool) -> str:
+    return "true" if value else "false"
+
+
+def _line(label: str, record: dict[str, Any]) -> str:
+    used = int(record.get("envelope_messages_used_5h", 0))
+    cap = allocation_cap(record)
+    available = max(cap - used, 0)
+    window = record.get("window_start_iso")
+    if window:
+        return f"{label} envelope: {used}/{cap} used, {available} available, window started {window}"
+    return f"{label} envelope: {used}/{cap} used, {available} available, window not started"
+
+
+def format_budget_status(envelope_state: dict[str, dict[str, Any]], halt_flags: dict[str, bool]) -> str:
+    """Return a secret-free local budget status string."""
+    lines = [
+        _line("Cowork", envelope_state["anthropic_max"]),
+        _line("Codex", envelope_state["chatgpt_pro"]),
+        "Halt flags: "
+        f"all={_bool_text(halt_flags.get('all', False))}, "
+        f"cowork_headless={_bool_text(halt_flags.get('cowork_headless', False))}, "
+        f"codex_auto_dispatch={_bool_text(halt_flags.get('codex_auto_dispatch', False))}",
+    ]
+    return "\n".join(lines)

--- a/agent/cmh_subprocess/envelope.py
+++ b/agent/cmh_subprocess/envelope.py
@@ -1,0 +1,119 @@
+"""Profile-aware envelope tracking for local subprocess wrapper foundations."""
+
+from __future__ import annotations
+
+import copy
+import json
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import get_hermes_home
+
+ENVELOPE_STATE_FILENAME = "envelope_tracking.json"
+WINDOW_DURATION = timedelta(hours=5)
+
+_DEFAULT_STATE: dict[str, dict[str, Any]] = {
+    "anthropic_max": {
+        "envelope_total_messages_per_5h": 225,
+        "envelope_allocation_hermes_pct": 85,
+        "envelope_messages_used_5h": 0,
+        "window_start_iso": None,
+        "last_invocation_iso": None,
+        "halt_flag_active": False,
+    },
+    "chatgpt_pro": {
+        "envelope_total_messages_per_5h": 200,
+        "envelope_allocation_hermes_pct": 85,
+        "envelope_messages_used_5h": 0,
+        "window_start_iso": None,
+        "last_invocation_iso": None,
+        "halt_flag_active": False,
+    },
+}
+
+
+@dataclass(frozen=True)
+class EnvelopeDecision:
+    allowed: bool
+    reason: str
+    used: int
+    cap: int
+    available: int
+
+
+def envelope_state_path() -> Path:
+    return get_hermes_home() / "state" / ENVELOPE_STATE_FILENAME
+
+
+def default_envelope_state() -> dict[str, dict[str, Any]]:
+    return copy.deepcopy(_DEFAULT_STATE)
+
+
+def allocation_cap(record: dict[str, Any]) -> int:
+    total = int(record.get("envelope_total_messages_per_5h", 0))
+    pct = int(record.get("envelope_allocation_hermes_pct", 0))
+    return (total * pct) // 100
+
+
+def load_envelope_state(path: Path | None = None) -> dict[str, dict[str, Any]]:
+    state_path = path or envelope_state_path()
+    if not state_path.exists():
+        return default_envelope_state()
+    with state_path.open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    state = default_envelope_state()
+    for key, defaults in state.items():
+        if isinstance(data.get(key), dict):
+            defaults.update(data[key])
+    return state
+
+
+def save_envelope_state(state: dict[str, dict[str, Any]], path: Path | None = None) -> None:
+    state_path = path or envelope_state_path()
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    with state_path.open("w", encoding="utf-8") as handle:
+        json.dump(state, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+
+def _parse_iso(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    return datetime.fromisoformat(value)
+
+
+def increment_usage(
+    state: dict[str, dict[str, Any]],
+    envelope_name: str,
+    *,
+    now: datetime | None = None,
+) -> dict[str, dict[str, Any]]:
+    current = now or datetime.now(timezone.utc)
+    updated = copy.deepcopy(state)
+    record = updated[envelope_name]
+    window_start = _parse_iso(record.get("window_start_iso"))
+    if window_start is None or current - window_start >= WINDOW_DURATION:
+        record["window_start_iso"] = current.isoformat()
+        record["envelope_messages_used_5h"] = 0
+    record["envelope_messages_used_5h"] = int(record.get("envelope_messages_used_5h", 0)) + 1
+    record["last_invocation_iso"] = current.isoformat()
+    return updated
+
+
+def check_budget(
+    state: dict[str, dict[str, Any]],
+    envelope_name: str,
+    *,
+    priority: bool = False,
+) -> EnvelopeDecision:
+    record = state[envelope_name]
+    used = int(record.get("envelope_messages_used_5h", 0))
+    cap = allocation_cap(record)
+    available = max(cap - used, 0)
+    if used >= cap and not priority:
+        return EnvelopeDecision(False, "budget_blocked", used, cap, available)
+    if used >= cap and priority:
+        return EnvelopeDecision(True, "priority_override", used, cap, available)
+    return EnvelopeDecision(True, "within_budget", used, cap, available)

--- a/agent/cmh_subprocess/envelope.py
+++ b/agent/cmh_subprocess/envelope.py
@@ -65,6 +65,8 @@ def load_envelope_state(path: Path | None = None) -> dict[str, dict[str, Any]]:
         return default_envelope_state()
     with state_path.open("r", encoding="utf-8") as handle:
         data = json.load(handle)
+    if not isinstance(data, dict):
+        raise ValueError(f"Envelope state must be a JSON object, got {type(data).__name__}")
     state = default_envelope_state()
     for key, defaults in state.items():
         if isinstance(data.get(key), dict):

--- a/agent/cmh_subprocess/envelope.py
+++ b/agent/cmh_subprocess/envelope.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import copy
 import json
+import os
+import tempfile
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -73,9 +75,29 @@ def load_envelope_state(path: Path | None = None) -> dict[str, dict[str, Any]]:
 def save_envelope_state(state: dict[str, dict[str, Any]], path: Path | None = None) -> None:
     state_path = path or envelope_state_path()
     state_path.parent.mkdir(parents=True, exist_ok=True)
-    with state_path.open("w", encoding="utf-8") as handle:
-        json.dump(state, handle, indent=2, sort_keys=True)
-        handle.write("\n")
+    tmp_path: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            delete=False,
+            dir=state_path.parent,
+            prefix=f".{state_path.name}.",
+            suffix=".tmp",
+        ) as handle:
+            tmp_path = handle.name
+            json.dump(state, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, state_path)
+        tmp_path = None
+    finally:
+        if tmp_path is not None:
+            try:
+                os.unlink(tmp_path)
+            except FileNotFoundError:
+                pass
 
 
 def _parse_iso(value: str | None) -> datetime | None:
@@ -107,10 +129,17 @@ def check_budget(
     envelope_name: str,
     *,
     priority: bool = False,
+    now: datetime | None = None,
 ) -> EnvelopeDecision:
     record = state[envelope_name]
-    used = int(record.get("envelope_messages_used_5h", 0))
+    current = now or datetime.now(timezone.utc)
+    window_start = _parse_iso(record.get("window_start_iso"))
     cap = allocation_cap(record)
+
+    if window_start is not None and current - window_start >= WINDOW_DURATION:
+        return EnvelopeDecision(True, "window_reset", 0, cap, cap)
+
+    used = int(record.get("envelope_messages_used_5h", 0))
     available = max(cap - used, 0)
     if used >= cap and not priority:
         return EnvelopeDecision(False, "budget_blocked", used, cap, available)

--- a/agent/cmh_subprocess/flags.py
+++ b/agent/cmh_subprocess/flags.py
@@ -1,0 +1,64 @@
+"""CLI flag verification for CMH subprocess wrapper foundations."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Iterable
+
+CLAUDE_REQUIRED_FLAGS: tuple[str, ...] = (
+    "--print",
+    "--max-budget-usd",
+    "--output-format",
+    "--no-session-persistence",
+)
+
+CLAUDE_OPTIONAL_FLAGS: tuple[str, ...] = (
+    "--plugin-dir",
+    "--model",
+    "--permission-mode",
+    "--tools",
+    "--bare",
+)
+
+CODEX_REQUIRED_FLAGS_UNRESOLVED: tuple[str, ...] = ()
+
+_LONG_FLAG_RE = re.compile(r"(?<![\w-])--[a-zA-Z0-9][a-zA-Z0-9-]*")
+
+
+@dataclass(frozen=True)
+class FlagValidationResult:
+    cli_name: str
+    ok: bool
+    required_flags: tuple[str, ...]
+    optional_flags: tuple[str, ...]
+    available_flags: dict[str, bool]
+    missing_required_flags: list[str]
+
+
+def extract_long_flags(help_text: str) -> set[str]:
+    """Return long CLI flags found in help output or verified docs."""
+    return set(_LONG_FLAG_RE.findall(help_text or ""))
+
+
+def validate_flags(
+    cli_name: str,
+    help_text: str,
+    required_flags: Iterable[str],
+    optional_flags: Iterable[str] = (),
+) -> FlagValidationResult:
+    """Validate required and optional flags against a text evidence source."""
+    required = tuple(required_flags)
+    optional = tuple(optional_flags)
+    found = extract_long_flags(help_text)
+    requested = required + optional
+    available = {flag: flag in found for flag in requested}
+    missing = [flag for flag in required if flag not in found]
+    return FlagValidationResult(
+        cli_name=cli_name,
+        ok=not missing,
+        required_flags=required,
+        optional_flags=optional,
+        available_flags=available,
+        missing_required_flags=missing,
+    )

--- a/agent/cmh_subprocess/halt_flags.py
+++ b/agent/cmh_subprocess/halt_flags.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 
 from hermes_constants import get_hermes_home
 
@@ -81,18 +81,29 @@ def load_halt_flags(path: Path | None = None) -> HaltState:
 
     for key in _KNOWN_HALT_FLAGS:
         if key in loaded:
-            flags[key] = bool(loaded[key])
+            value = loaded[key]
+            if not isinstance(value, bool):
+                return HaltState(
+                    flags=default_halt_flags(),
+                    malformed=True,
+                    error=f"halt flag {key!r} must be a boolean",
+                    path=resolved_path,
+                )
+            flags[key] = value
 
     return HaltState(flags=flags, path=resolved_path)
 
 
-def save_halt_flags(flags: dict[str, bool], path: Path | None = None) -> None:
+def save_halt_flags(flags: Mapping[str, Any], path: Path | None = None) -> None:
     """Persist known halt flags as stable JSON."""
     resolved_path = path or halt_flags_path()
     merged = default_halt_flags()
     for key in _KNOWN_HALT_FLAGS:
         if key in flags:
-            merged[key] = bool(flags[key])
+            value = flags[key]
+            if not isinstance(value, bool):
+                raise ValueError(f"halt flag {key!r} must be a boolean")
+            merged[key] = value
 
     resolved_path.parent.mkdir(parents=True, exist_ok=True)
     resolved_path.write_text(

--- a/agent/cmh_subprocess/halt_flags.py
+++ b/agent/cmh_subprocess/halt_flags.py
@@ -1,0 +1,134 @@
+"""Halt flag state for CMH subprocess wrapper foundations."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import get_hermes_home
+
+HALT_FLAGS_FILENAME = "cmh_halt_flags.json"
+
+_KNOWN_HALT_FLAGS: tuple[str, ...] = (
+    "cowork_headless",
+    "codex_auto_dispatch",
+    "hermes_telegram_acks",
+    "all",
+)
+
+
+@dataclass(frozen=True)
+class HaltState:
+    flags: dict[str, bool]
+    malformed: bool = False
+    error: str = ""
+    path: Path | None = None
+
+
+@dataclass(frozen=True)
+class HaltDecision:
+    halted: bool
+    active_flag: str
+    message: str
+
+
+def default_halt_flags() -> dict[str, bool]:
+    """Return the default fail-open halt flag map."""
+    return {key: False for key in _KNOWN_HALT_FLAGS}
+
+
+def halt_flags_path() -> Path:
+    """Return the CMH halt flags file path under HERMES_HOME/state."""
+    return get_hermes_home() / "state" / HALT_FLAGS_FILENAME
+
+
+def load_halt_flags(path: Path | None = None) -> HaltState:
+    """Load halt flags, failing closed when persisted state is unreadable."""
+    resolved_path = path or halt_flags_path()
+    flags = default_halt_flags()
+
+    try:
+        raw = resolved_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return HaltState(flags=flags, path=resolved_path)
+    except OSError as exc:
+        return HaltState(
+            flags=flags,
+            malformed=True,
+            error=str(exc),
+            path=resolved_path,
+        )
+
+    try:
+        loaded: Any = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return HaltState(
+            flags=flags,
+            malformed=True,
+            error=str(exc),
+            path=resolved_path,
+        )
+
+    if not isinstance(loaded, dict):
+        return HaltState(
+            flags=flags,
+            malformed=True,
+            error="halt flags JSON must be an object",
+            path=resolved_path,
+        )
+
+    for key in _KNOWN_HALT_FLAGS:
+        if key in loaded:
+            flags[key] = bool(loaded[key])
+
+    return HaltState(flags=flags, path=resolved_path)
+
+
+def save_halt_flags(flags: dict[str, bool], path: Path | None = None) -> None:
+    """Persist known halt flags as stable JSON."""
+    resolved_path = path or halt_flags_path()
+    merged = default_halt_flags()
+    for key in _KNOWN_HALT_FLAGS:
+        if key in flags:
+            merged[key] = bool(flags[key])
+
+    resolved_path.parent.mkdir(parents=True, exist_ok=True)
+    resolved_path.write_text(
+        json.dumps(merged, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def is_halted(class_name: str, state: HaltState | None = None) -> HaltDecision:
+    """Return whether a subprocess class is halted by current halt flags."""
+    current_state = state or load_halt_flags()
+    path = current_state.path or halt_flags_path()
+
+    if current_state.malformed:
+        return HaltDecision(
+            halted=True,
+            active_flag="state_error",
+            message=f"CMH halt flag state error at {path}: {current_state.error}",
+        )
+
+    if current_state.flags.get("all", False):
+        return HaltDecision(
+            halted=True,
+            active_flag="all",
+            message=f"CMH subprocess class {class_name} halted by all flag at {path}",
+        )
+
+    if current_state.flags.get(class_name, False):
+        return HaltDecision(
+            halted=True,
+            active_flag=class_name,
+            message=f"CMH subprocess class {class_name} halted by {class_name} flag at {path}",
+        )
+
+    return HaltDecision(
+        halted=False,
+        active_flag="",
+        message=f"CMH subprocess class {class_name} is not halted",
+    )

--- a/agent/cmh_subprocess/result.py
+++ b/agent/cmh_subprocess/result.py
@@ -1,0 +1,15 @@
+"""Shared result types for CMH subprocess wrapper foundations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class PreflightResult:
+    status: str
+    ok: bool
+    message: str
+    argv: tuple[str, ...] = ()
+    details: dict[str, Any] = field(default_factory=dict)

--- a/agent/cmh_subprocess/wrappers.py
+++ b/agent/cmh_subprocess/wrappers.py
@@ -1,0 +1,171 @@
+"""Local preflight assembly for CMH subprocess wrappers.
+
+This module intentionally does not execute subprocesses. It only checks halt
+flags, resolves binaries, verifies static flag evidence, checks envelope budget,
+and assembles argv tuples for later wrapper layers.
+"""
+
+from __future__ import annotations
+
+import shutil
+from collections.abc import Callable
+
+from agent.cmh_subprocess.envelope import check_budget, load_envelope_state
+from agent.cmh_subprocess.flags import (
+    CLAUDE_REQUIRED_FLAGS,
+    CODEX_REQUIRED_FLAGS_UNRESOLVED,
+    validate_flags,
+)
+from agent.cmh_subprocess.halt_flags import is_halted
+from agent.cmh_subprocess.result import PreflightResult
+
+CLAUDE_HELP_EVIDENCE = """
+Usage: claude [options] [prompt]
+  -p, --print                                       Print response and exit
+  --max-budget-usd <amount>                         Maximum dollar amount to spend on API calls
+  --output-format <format>                          Output format
+  --no-session-persistence                          Disable session persistence
+"""
+
+BinaryResolver = Callable[[str], str | None]
+
+
+def default_binary_resolver(binary_name: str) -> str | None:
+    """Resolve a binary name using PATH without executing the binary."""
+    return shutil.which(binary_name)
+
+
+def prepare_claude_print_invocation(
+    prompt: str,
+    *,
+    binary_resolver: BinaryResolver = default_binary_resolver,
+    help_text: str = CLAUDE_HELP_EVIDENCE,
+    priority: bool = False,
+    max_budget_usd: str = "0.01",
+    output_format: str = "text",
+) -> PreflightResult:
+    """Preflight a safe Claude print invocation without running Claude.
+
+    Order is intentionally fixed: halt, binary, flags, budget, argv assembly.
+    """
+    halted = is_halted("cowork_headless")
+    if halted.halted:
+        return PreflightResult(
+            status="halted",
+            ok=False,
+            message=halted.message,
+            details={"active_flag": halted.active_flag},
+        )
+
+    binary = binary_resolver("claude")
+    if not binary:
+        return PreflightResult(
+            status="missing_binary",
+            ok=False,
+            message="Required claude binary was not found on PATH",
+        )
+
+    flags = validate_flags("claude", help_text, required_flags=CLAUDE_REQUIRED_FLAGS)
+    if not flags.ok:
+        return PreflightResult(
+            status="missing_required_flag",
+            ok=False,
+            message="Claude help evidence is missing required flags: "
+            + ", ".join(flags.missing_required_flags),
+            details={
+                "missing_required_flags": flags.missing_required_flags,
+                "available_flags": flags.available_flags,
+            },
+        )
+
+    budget = check_budget(load_envelope_state(), "anthropic_max", priority=priority)
+    if not budget.allowed:
+        return PreflightResult(
+            status=budget.reason,
+            ok=False,
+            message=(
+                f"Claude envelope budget blocked: used {budget.used} "
+                f"of cap {budget.cap}"
+            ),
+            details={
+                "used": budget.used,
+                "cap": budget.cap,
+                "available": budget.available,
+            },
+        )
+
+    argv = (
+        binary,
+        "--print",
+        "--max-budget-usd",
+        max_budget_usd,
+        "--output-format",
+        output_format,
+        "--no-session-persistence",
+        prompt,
+    )
+    return PreflightResult(
+        status="ready",
+        ok=True,
+        message="Claude print invocation preflight passed",
+        argv=argv,
+        details={
+            "budget_reason": budget.reason,
+            "used": budget.used,
+            "cap": budget.cap,
+            "available": budget.available,
+        },
+    )
+
+
+def prepare_codex_print_invocation(
+    prompt: str,
+    *,
+    binary_resolver: BinaryResolver = default_binary_resolver,
+    priority: bool = False,
+) -> PreflightResult:
+    """Preflight a Codex invocation without running Codex.
+
+    Order is intentionally fixed: halt, binary, budget, unresolved flag gate.
+    """
+    del prompt  # Codex argv shape is intentionally unresolved in this foundation task.
+
+    halted = is_halted("codex_auto_dispatch")
+    if halted.halted:
+        return PreflightResult(
+            status="halted",
+            ok=False,
+            message=halted.message,
+            details={"active_flag": halted.active_flag},
+        )
+
+    binary = binary_resolver("codex")
+    if not binary:
+        return PreflightResult(
+            status="missing_binary",
+            ok=False,
+            message="Required codex binary was not found on PATH",
+        )
+
+    budget = check_budget(load_envelope_state(), "chatgpt_pro", priority=priority)
+    if not budget.allowed:
+        return PreflightResult(
+            status=budget.reason,
+            ok=False,
+            message=(
+                f"Codex envelope budget blocked: used {budget.used} "
+                f"of cap {budget.cap}"
+            ),
+            details={
+                "used": budget.used,
+                "cap": budget.cap,
+                "available": budget.available,
+            },
+        )
+
+    return PreflightResult(
+        status="missing_verified_flags",
+        ok=False,
+        message="Codex subprocess flags are not yet verified for safe argv assembly",
+        details={"required_flags": list(CODEX_REQUIRED_FLAGS_UNRESOLVED)},
+    )

--- a/agent/cmh_subprocess/wrappers.py
+++ b/agent/cmh_subprocess/wrappers.py
@@ -7,10 +7,15 @@ and assembles argv tuples for later wrapper layers.
 
 from __future__ import annotations
 
+import json
 import shutil
 from collections.abc import Callable
 
-from agent.cmh_subprocess.envelope import check_budget, load_envelope_state
+from agent.cmh_subprocess.envelope import (
+    check_budget,
+    envelope_state_path,
+    load_envelope_state,
+)
 from agent.cmh_subprocess.flags import (
     CLAUDE_REQUIRED_FLAGS,
     CODEX_REQUIRED_FLAGS_UNRESOLVED,
@@ -28,11 +33,28 @@ Usage: claude [options] [prompt]
 """
 
 BinaryResolver = Callable[[str], str | None]
+STATE_ERROR_EXCEPTIONS = (
+    json.JSONDecodeError,
+    OSError,
+    ValueError,
+    TypeError,
+    KeyError,
+)
 
 
 def default_binary_resolver(binary_name: str) -> str | None:
     """Resolve a binary name using PATH without executing the binary."""
     return shutil.which(binary_name)
+
+
+def _state_error_result(wrapper_name: str, error: BaseException) -> PreflightResult:
+    path = envelope_state_path()
+    return PreflightResult(
+        status="state_error",
+        ok=False,
+        message=f"{wrapper_name} envelope state could not be loaded or evaluated: {error}",
+        details={"path": str(path), "error": str(error)},
+    )
 
 
 def prepare_claude_print_invocation(
@@ -78,7 +100,17 @@ def prepare_claude_print_invocation(
             },
         )
 
-    budget = check_budget(load_envelope_state(), "anthropic_max", priority=priority)
+    if prompt.lstrip().startswith("-"):
+        return PreflightResult(
+            status="unsafe_prompt",
+            ok=False,
+            message="Claude prompt begins with option prefix '-' and cannot be safely appended",
+        )
+
+    try:
+        budget = check_budget(load_envelope_state(), "anthropic_max", priority=priority)
+    except STATE_ERROR_EXCEPTIONS as error:
+        return _state_error_result("Claude", error)
     if not budget.allowed:
         return PreflightResult(
             status=budget.reason,
@@ -147,7 +179,10 @@ def prepare_codex_print_invocation(
             message="Required codex binary was not found on PATH",
         )
 
-    budget = check_budget(load_envelope_state(), "chatgpt_pro", priority=priority)
+    try:
+        budget = check_budget(load_envelope_state(), "chatgpt_pro", priority=priority)
+    except STATE_ERROR_EXCEPTIONS as error:
+        return _state_error_result("Codex", error)
     if not budget.allowed:
         return PreflightResult(
             status=budget.reason,

--- a/docs/closeouts/2026-05-17-hermes-local-subprocess-wrapper-foundation-closeout.md
+++ b/docs/closeouts/2026-05-17-hermes-local-subprocess-wrapper-foundation-closeout.md
@@ -36,8 +36,19 @@ Not changed:
 - R109 fire.
 - Git push, merge, deploy, or production mutation.
 
+## Current-main cross-check after Codex Wave 1.16.E
+
+Rechecked after operate-report-service PR #349 landed at `d234cd89d38daadbdfb8b99b036dbe5c1edaee7b`.
+
+- Claude verified docs now exist in operate-report-service and confirm `--max-budget-usd`, `--output-format`, `--no-session-persistence`, `--plugin-dir`, and related flags.
+- Claude verified docs also report non-interactive subscription auth is still blocked by `401 Invalid authentication credentials`; production Claude subprocess routing remains blocked.
+- Codex verified docs report `codex --print` is not supported. The verified non-interactive path is `codex -a never exec ... -s read-only --output-last-message ...`.
+- The installed Codex binary exists at `/Applications/Codex.app/Contents/Resources/codex`, but `codex` is not on this shell PATH, so this A-slice continues to fail closed through missing-binary or unresolved-flag results.
+- This branch remains correct as a local preflight foundation. The next Hermes phase should reconcile the Codex wrapper naming and command assembly against verified `codex exec`, not a nonexistent `codex --print` surface.
+
 ## Known dependencies for later phases
 
-- Codex Wave 1.16.E verified flag docs are still required before activation.
-- `codex` must be present on PATH or the Codex wrapper remains disabled.
+- Claude auth must be repaired or an API-key/helper path must be explicitly approved before production Claude subprocess routing.
+- Codex Phase 1 should use the verified `codex exec` pattern from Wave 1.16.E rather than `codex --print`.
+- `codex` must either be placed on PATH or wrappers must use the verified app binary path intentionally.
 - Any Telegram or gateway exposure requires separate exact approval.

--- a/docs/closeouts/2026-05-17-hermes-local-subprocess-wrapper-foundation-closeout.md
+++ b/docs/closeouts/2026-05-17-hermes-local-subprocess-wrapper-foundation-closeout.md
@@ -1,0 +1,43 @@
+# Hermes Local Subprocess Wrapper Foundation Closeout
+
+Date: 2026-05-17
+Scope: A-slice local foundation only
+
+## What changed
+
+- Added `agent/cmh_subprocess/` local foundation package.
+- Added CLI flag verification for Claude help evidence.
+- Added profile-aware envelope state helpers.
+- Added profile-aware halt flag helpers.
+- Added disabled-by-default wrapper preflight helpers.
+- Added pure budget display formatter.
+- Added focused pytest coverage.
+- Added hardening discovered during review: expired-window budget checks, atomic envelope writes, strict halt-flag boolean validation, unsafe prompt rejection, and structured state-error returns for malformed envelope state.
+
+## Verification
+
+- `python -m pytest tests/agent/test_cmh_subprocess_flags.py tests/agent/test_cmh_subprocess_envelope.py tests/agent/test_cmh_subprocess_halt_flags.py tests/agent/test_cmh_subprocess_wrappers.py tests/agent/test_cmh_subprocess_budget_display.py -q -o 'addopts='` passed with 37 tests.
+- `python -m py_compile agent/cmh_subprocess/__init__.py agent/cmh_subprocess/result.py agent/cmh_subprocess/flags.py agent/cmh_subprocess/envelope.py agent/cmh_subprocess/halt_flags.py agent/cmh_subprocess/wrappers.py agent/cmh_subprocess/budget_display.py` passed.
+- `git diff --check` passed.
+- Changed-file scope was limited to `agent/cmh_subprocess/`, `tests/agent/test_cmh_subprocess_*.py`, and this closeout.
+
+## Activation status
+
+No activation occurred.
+
+Not changed:
+
+- Telegram sends or Telegram verbs.
+- Gateway callbacks, gateway restart, or gateway config.
+- Cron, launchd, daemon, MCP, AgentMail, provider, or profile config.
+- `~/.hermes/wrappers/` or `~/.hermes/bin/` runtime scripts.
+- Cowork-headless spawn.
+- Codex auto-dispatch.
+- R109 fire.
+- Git push, merge, deploy, or production mutation.
+
+## Known dependencies for later phases
+
+- Codex Wave 1.16.E verified flag docs are still required before activation.
+- `codex` must be present on PATH or the Codex wrapper remains disabled.
+- Any Telegram or gateway exposure requires separate exact approval.

--- a/docs/superpowers/plans/2026-05-17-hermes-local-subprocess-wrapper-foundation.md
+++ b/docs/superpowers/plans/2026-05-17-hermes-local-subprocess-wrapper-foundation.md
@@ -1,0 +1,1316 @@
+# Hermes Local Subprocess Wrapper Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a local, test-backed subprocess wrapper foundation for future Claude Code and Codex CLI routing without activating any live routing, Telegram, gateway, cron, daemon, MCP, provider, deploy, merge, R-audit, or production surface.
+
+**Architecture:** Add a small `agent/cmh_subprocess/` package with focused modules for flag verification, profile-aware envelope tracking, halt flags, structured preflight results, wrapper preflight assembly, and read-only budget formatting. Tests drive each behavior first and use temporary `HERMES_HOME` values so no real user state is touched.
+
+**Tech Stack:** Python standard library, pytest, Hermes `get_hermes_home()`, existing CLI command registry only if the optional local `/budget` command is included.
+
+---
+
+## File Structure
+
+Create these files:
+
+- `agent/cmh_subprocess/__init__.py`
+  - Package exports only stable helpers and types.
+- `agent/cmh_subprocess/result.py`
+  - Shared result dataclasses and status constants.
+- `agent/cmh_subprocess/flags.py`
+  - CLI help text parsing and required/optional flag validation.
+- `agent/cmh_subprocess/envelope.py`
+  - Profile-aware envelope state defaults, read/write, rolling window reset, and budget gating.
+- `agent/cmh_subprocess/halt_flags.py`
+  - Profile-aware halt flag state, malformed-state fail-closed behavior, and class mapping.
+- `agent/cmh_subprocess/wrappers.py`
+  - Disabled-by-default wrapper preflight helpers for Claude and Codex print paths.
+- `agent/cmh_subprocess/budget_display.py`
+  - Pure formatter for budget and halt-state display. This supports tests and a later local CLI command without requiring CLI integration now.
+- `tests/agent/test_cmh_subprocess_flags.py`
+  - Flag parser and verifier tests.
+- `tests/agent/test_cmh_subprocess_envelope.py`
+  - Envelope default, increment, reset, and cap tests.
+- `tests/agent/test_cmh_subprocess_halt_flags.py`
+  - Halt state tests.
+- `tests/agent/test_cmh_subprocess_wrappers.py`
+  - Wrapper preflight tests.
+- `tests/agent/test_cmh_subprocess_budget_display.py`
+  - Pure display formatting tests.
+
+Do not modify these in this A-slice unless Christopher explicitly extends scope:
+
+- `gateway/`
+- `cron/`
+- `tools/send_message_tool.py`
+- `~/.hermes/wrappers/`
+- `~/.hermes/bin/`
+- profile config files
+- launchd plist files
+- vault dispatch folders
+
+## Task 1: Flag verification foundation
+
+**Files:**
+- Create: `agent/cmh_subprocess/__init__.py`
+- Create: `agent/cmh_subprocess/flags.py`
+- Create: `tests/agent/test_cmh_subprocess_flags.py`
+
+- [ ] **Step 1: Write failing tests for flag extraction and Claude required flags**
+
+Create `tests/agent/test_cmh_subprocess_flags.py` with this content:
+
+```python
+from agent.cmh_subprocess.flags import (
+    CLAUDE_REQUIRED_FLAGS,
+    validate_flags,
+    extract_long_flags,
+)
+
+CLAUDE_HELP = """
+Usage: claude [options] [prompt]
+  -p, --print                                       Print response and exit
+  --max-budget-usd <amount>                         Maximum dollar amount to spend on API calls
+  --output-format <format>                          Output format
+  --no-session-persistence                          Disable session persistence
+  --plugin-dir <path>                               Load a plugin
+  --model <model>                                   Model for the current session
+  --permission-mode <mode>                          Permission mode
+  --tools <tools...>                                Specify the list of available tools
+  --bare                                            Minimal mode
+"""
+
+
+def test_extract_long_flags_finds_claude_print_flags():
+    flags = extract_long_flags(CLAUDE_HELP)
+
+    assert "--print" in flags
+    assert "--max-budget-usd" in flags
+    assert "--output-format" in flags
+    assert "--no-session-persistence" in flags
+
+
+def test_validate_flags_accepts_current_claude_required_flags():
+    result = validate_flags("claude", CLAUDE_HELP, required_flags=CLAUDE_REQUIRED_FLAGS)
+
+    assert result.ok is True
+    assert result.missing_required_flags == []
+    assert result.available_flags["--max-budget-usd"] is True
+
+
+def test_validate_flags_rejects_draft_max_cost_flag_when_help_lacks_it():
+    result = validate_flags("claude", CLAUDE_HELP, required_flags=("--max-cost-usd",))
+
+    assert result.ok is False
+    assert result.missing_required_flags == ["--max-cost-usd"]
+    assert result.available_flags["--max-cost-usd"] is False
+```
+
+- [ ] **Step 2: Run the flag tests and verify RED**
+
+Run:
+
+```bash
+python -m pytest tests/agent/test_cmh_subprocess_flags.py -q -o 'addopts='
+```
+
+Expected: FAIL with `ModuleNotFoundError: No module named 'agent.cmh_subprocess'`.
+
+- [ ] **Step 3: Add the minimal package and flag verifier implementation**
+
+Create `agent/cmh_subprocess/__init__.py`:
+
+```python
+"""CMH subprocess wrapper foundation.
+
+Local foundation only. This package does not activate live routing,
+Telegram sends, gateway behavior, cron, daemon, MCP, deploy, merge, or
+production mutation.
+"""
+```
+
+Create `agent/cmh_subprocess/flags.py`:
+
+```python
+"""CLI flag verification for CMH subprocess wrapper foundations."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Iterable
+
+CLAUDE_REQUIRED_FLAGS: tuple[str, ...] = (
+    "--print",
+    "--max-budget-usd",
+    "--output-format",
+    "--no-session-persistence",
+)
+
+CLAUDE_OPTIONAL_FLAGS: tuple[str, ...] = (
+    "--plugin-dir",
+    "--model",
+    "--permission-mode",
+    "--tools",
+    "--bare",
+)
+
+CODEX_REQUIRED_FLAGS_UNRESOLVED: tuple[str, ...] = ()
+
+_LONG_FLAG_RE = re.compile(r"(?<![\w-])--[a-zA-Z0-9][a-zA-Z0-9-]*")
+
+
+@dataclass(frozen=True)
+class FlagValidationResult:
+    cli_name: str
+    ok: bool
+    required_flags: tuple[str, ...]
+    optional_flags: tuple[str, ...]
+    available_flags: dict[str, bool]
+    missing_required_flags: list[str]
+
+
+def extract_long_flags(help_text: str) -> set[str]:
+    """Return long CLI flags found in help output or verified docs."""
+    return set(_LONG_FLAG_RE.findall(help_text or ""))
+
+
+def validate_flags(
+    cli_name: str,
+    help_text: str,
+    required_flags: Iterable[str],
+    optional_flags: Iterable[str] = (),
+) -> FlagValidationResult:
+    """Validate required and optional flags against a text evidence source."""
+    required = tuple(required_flags)
+    optional = tuple(optional_flags)
+    found = extract_long_flags(help_text)
+    requested = required + optional
+    available = {flag: flag in found for flag in requested}
+    missing = [flag for flag in required if flag not in found]
+    return FlagValidationResult(
+        cli_name=cli_name,
+        ok=not missing,
+        required_flags=required,
+        optional_flags=optional,
+        available_flags=available,
+        missing_required_flags=missing,
+    )
+```
+
+- [ ] **Step 4: Run the flag tests and verify GREEN**
+
+Run:
+
+```bash
+python -m pytest tests/agent/test_cmh_subprocess_flags.py -q -o 'addopts='
+```
+
+Expected: PASS, 3 tests.
+
+- [ ] **Step 5: Commit Task 1**
+
+Run:
+
+```bash
+git add agent/cmh_subprocess/__init__.py agent/cmh_subprocess/flags.py tests/agent/test_cmh_subprocess_flags.py
+git commit -m "feat: add CMH subprocess flag verification"
+```
+
+## Task 2: Envelope tracking foundation
+
+**Files:**
+- Create: `agent/cmh_subprocess/result.py`
+- Create: `agent/cmh_subprocess/envelope.py`
+- Create: `tests/agent/test_cmh_subprocess_envelope.py`
+
+- [ ] **Step 1: Write failing tests for envelope defaults, increments, reset, and cap**
+
+Create `tests/agent/test_cmh_subprocess_envelope.py`:
+
+```python
+from datetime import datetime, timedelta, timezone
+
+from agent.cmh_subprocess.envelope import (
+    ENVELOPE_STATE_FILENAME,
+    EnvelopeDecision,
+    allocation_cap,
+    check_budget,
+    default_envelope_state,
+    envelope_state_path,
+    increment_usage,
+    load_envelope_state,
+    save_envelope_state,
+)
+
+
+def test_default_envelope_caps_are_85_percent():
+    state = default_envelope_state()
+
+    assert allocation_cap(state["anthropic_max"]) == 191
+    assert allocation_cap(state["chatgpt_pro"]) == 170
+
+
+def test_envelope_state_path_uses_hermes_home(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    assert envelope_state_path() == tmp_path / "state" / ENVELOPE_STATE_FILENAME
+
+
+def test_load_missing_state_returns_defaults_without_writing(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    state = load_envelope_state()
+
+    assert state["anthropic_max"]["envelope_messages_used_5h"] == 0
+    assert not envelope_state_path().exists()
+
+
+def test_increment_usage_starts_window_and_persists(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    now = datetime(2026, 5, 17, 20, 0, tzinfo=timezone.utc)
+    state = default_envelope_state()
+
+    updated = increment_usage(state, "anthropic_max", now=now)
+    save_envelope_state(updated)
+    reloaded = load_envelope_state()
+
+    assert reloaded["anthropic_max"]["envelope_messages_used_5h"] == 1
+    assert reloaded["anthropic_max"]["window_start_iso"] == now.isoformat()
+    assert reloaded["anthropic_max"]["last_invocation_iso"] == now.isoformat()
+
+
+def test_increment_usage_resets_after_five_hours():
+    start = datetime(2026, 5, 17, 20, 0, tzinfo=timezone.utc)
+    later = start + timedelta(hours=5, minutes=1)
+    state = default_envelope_state()
+    state["anthropic_max"]["window_start_iso"] = start.isoformat()
+    state["anthropic_max"]["envelope_messages_used_5h"] = 190
+
+    updated = increment_usage(state, "anthropic_max", now=later)
+
+    assert updated["anthropic_max"]["envelope_messages_used_5h"] == 1
+    assert updated["anthropic_max"]["window_start_iso"] == later.isoformat()
+
+
+def test_budget_blocks_non_priority_at_cap():
+    state = default_envelope_state()
+    state["anthropic_max"]["envelope_messages_used_5h"] = 191
+
+    decision = check_budget(state, "anthropic_max", priority=False)
+
+    assert decision == EnvelopeDecision(
+        allowed=False,
+        reason="budget_blocked",
+        used=191,
+        cap=191,
+        available=0,
+    )
+
+
+def test_budget_allows_priority_at_cap_with_reason():
+    state = default_envelope_state()
+    state["anthropic_max"]["envelope_messages_used_5h"] = 191
+
+    decision = check_budget(state, "anthropic_max", priority=True)
+
+    assert decision.allowed is True
+    assert decision.reason == "priority_override"
+    assert decision.available == 0
+```
+
+- [ ] **Step 2: Run envelope tests and verify RED**
+
+Run:
+
+```bash
+python -m pytest tests/agent/test_cmh_subprocess_envelope.py -q -o 'addopts='
+```
+
+Expected: FAIL with missing `agent.cmh_subprocess.envelope`.
+
+- [ ] **Step 3: Add structured result and envelope implementation**
+
+Create `agent/cmh_subprocess/result.py`:
+
+```python
+"""Shared result types for CMH subprocess wrapper foundations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class PreflightResult:
+    status: str
+    ok: bool
+    message: str
+    argv: tuple[str, ...] = ()
+    details: dict[str, Any] = field(default_factory=dict)
+```
+
+Create `agent/cmh_subprocess/envelope.py`:
+
+```python
+"""Profile-aware envelope tracking for local subprocess wrapper foundations."""
+
+from __future__ import annotations
+
+import copy
+import json
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import get_hermes_home
+
+ENVELOPE_STATE_FILENAME = "envelope_tracking.json"
+WINDOW_DURATION = timedelta(hours=5)
+
+_DEFAULT_STATE: dict[str, dict[str, Any]] = {
+    "anthropic_max": {
+        "envelope_total_messages_per_5h": 225,
+        "envelope_allocation_hermes_pct": 85,
+        "envelope_messages_used_5h": 0,
+        "window_start_iso": None,
+        "last_invocation_iso": None,
+        "halt_flag_active": False,
+    },
+    "chatgpt_pro": {
+        "envelope_total_messages_per_5h": 200,
+        "envelope_allocation_hermes_pct": 85,
+        "envelope_messages_used_5h": 0,
+        "window_start_iso": None,
+        "last_invocation_iso": None,
+        "halt_flag_active": False,
+    },
+}
+
+
+@dataclass(frozen=True)
+class EnvelopeDecision:
+    allowed: bool
+    reason: str
+    used: int
+    cap: int
+    available: int
+
+
+def envelope_state_path() -> Path:
+    return get_hermes_home() / "state" / ENVELOPE_STATE_FILENAME
+
+
+def default_envelope_state() -> dict[str, dict[str, Any]]:
+    return copy.deepcopy(_DEFAULT_STATE)
+
+
+def allocation_cap(record: dict[str, Any]) -> int:
+    total = int(record.get("envelope_total_messages_per_5h", 0))
+    pct = int(record.get("envelope_allocation_hermes_pct", 0))
+    return (total * pct) // 100
+
+
+def load_envelope_state(path: Path | None = None) -> dict[str, dict[str, Any]]:
+    state_path = path or envelope_state_path()
+    if not state_path.exists():
+        return default_envelope_state()
+    with state_path.open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    state = default_envelope_state()
+    for key, defaults in state.items():
+        if isinstance(data.get(key), dict):
+            defaults.update(data[key])
+    return state
+
+
+def save_envelope_state(state: dict[str, dict[str, Any]], path: Path | None = None) -> None:
+    state_path = path or envelope_state_path()
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    with state_path.open("w", encoding="utf-8") as handle:
+        json.dump(state, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+
+def _parse_iso(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    return datetime.fromisoformat(value)
+
+
+def increment_usage(
+    state: dict[str, dict[str, Any]],
+    envelope_name: str,
+    *,
+    now: datetime | None = None,
+) -> dict[str, dict[str, Any]]:
+    current = now or datetime.now(timezone.utc)
+    updated = copy.deepcopy(state)
+    record = updated[envelope_name]
+    window_start = _parse_iso(record.get("window_start_iso"))
+    if window_start is None or current - window_start >= WINDOW_DURATION:
+        record["window_start_iso"] = current.isoformat()
+        record["envelope_messages_used_5h"] = 0
+    record["envelope_messages_used_5h"] = int(record.get("envelope_messages_used_5h", 0)) + 1
+    record["last_invocation_iso"] = current.isoformat()
+    return updated
+
+
+def check_budget(
+    state: dict[str, dict[str, Any]],
+    envelope_name: str,
+    *,
+    priority: bool = False,
+) -> EnvelopeDecision:
+    record = state[envelope_name]
+    used = int(record.get("envelope_messages_used_5h", 0))
+    cap = allocation_cap(record)
+    available = max(cap - used, 0)
+    if used >= cap and not priority:
+        return EnvelopeDecision(False, "budget_blocked", used, cap, available)
+    if used >= cap and priority:
+        return EnvelopeDecision(True, "priority_override", used, cap, available)
+    return EnvelopeDecision(True, "within_budget", used, cap, available)
+```
+
+- [ ] **Step 4: Run envelope tests and verify GREEN**
+
+Run:
+
+```bash
+python -m pytest tests/agent/test_cmh_subprocess_envelope.py -q -o 'addopts='
+```
+
+Expected: PASS, 7 tests.
+
+- [ ] **Step 5: Commit Task 2**
+
+Run:
+
+```bash
+git add agent/cmh_subprocess/result.py agent/cmh_subprocess/envelope.py tests/agent/test_cmh_subprocess_envelope.py
+git commit -m "feat: add CMH subprocess envelope tracking"
+```
+
+## Task 3: Halt flag foundation
+
+**Files:**
+- Create: `agent/cmh_subprocess/halt_flags.py`
+- Create: `tests/agent/test_cmh_subprocess_halt_flags.py`
+
+- [ ] **Step 1: Write failing tests for halt flags**
+
+Create `tests/agent/test_cmh_subprocess_halt_flags.py`:
+
+```python
+import json
+
+from agent.cmh_subprocess.halt_flags import (
+    HALT_FLAGS_FILENAME,
+    default_halt_flags,
+    halt_flags_path,
+    is_halted,
+    load_halt_flags,
+    save_halt_flags,
+)
+
+
+def test_missing_halt_file_means_not_halted(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    assert load_halt_flags().flags == default_halt_flags()
+    assert is_halted("cowork_headless").halted is False
+
+
+def test_halt_path_uses_hermes_home(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    assert halt_flags_path() == tmp_path / "state" / HALT_FLAGS_FILENAME
+
+
+def test_all_halt_blocks_every_class(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    save_halt_flags({"all": True, "cowork_headless": False, "codex_auto_dispatch": False, "hermes_telegram_acks": False})
+
+    decision = is_halted("codex_auto_dispatch")
+
+    assert decision.halted is True
+    assert decision.active_flag == "all"
+
+
+def test_class_halt_blocks_matching_class_only(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    save_halt_flags({"all": False, "cowork_headless": True, "codex_auto_dispatch": False, "hermes_telegram_acks": False})
+
+    cowork = is_halted("cowork_headless")
+    codex = is_halted("codex_auto_dispatch")
+
+    assert cowork.halted is True
+    assert cowork.active_flag == "cowork_headless"
+    assert codex.halted is False
+
+
+def test_malformed_halt_file_fails_closed(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    path = halt_flags_path()
+    path.parent.mkdir(parents=True)
+    path.write_text("{not-json", encoding="utf-8")
+
+    state = load_halt_flags()
+    decision = is_halted("cowork_headless")
+
+    assert state.malformed is True
+    assert decision.halted is True
+    assert decision.active_flag == "state_error"
+    assert str(path) in decision.message
+```
+
+- [ ] **Step 2: Run halt flag tests and verify RED**
+
+Run:
+
+```bash
+python -m pytest tests/agent/test_cmh_subprocess_halt_flags.py -q -o 'addopts='
+```
+
+Expected: FAIL with missing `agent.cmh_subprocess.halt_flags`.
+
+- [ ] **Step 3: Implement halt flag module**
+
+Create `agent/cmh_subprocess/halt_flags.py`:
+
+```python
+"""Profile-aware halt flags for CMH subprocess wrapper foundations."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from hermes_constants import get_hermes_home
+
+HALT_FLAGS_FILENAME = "cmh_halt_flags.json"
+
+
+@dataclass(frozen=True)
+class HaltState:
+    flags: dict[str, bool]
+    malformed: bool = False
+    error: str = ""
+    path: Path | None = None
+
+
+@dataclass(frozen=True)
+class HaltDecision:
+    halted: bool
+    active_flag: str | None
+    message: str
+
+
+def default_halt_flags() -> dict[str, bool]:
+    return {
+        "cowork_headless": False,
+        "codex_auto_dispatch": False,
+        "hermes_telegram_acks": False,
+        "all": False,
+    }
+
+
+def halt_flags_path() -> Path:
+    return get_hermes_home() / "state" / HALT_FLAGS_FILENAME
+
+
+def load_halt_flags(path: Path | None = None) -> HaltState:
+    state_path = path or halt_flags_path()
+    if not state_path.exists():
+        return HaltState(default_halt_flags(), path=state_path)
+    try:
+        data = json.loads(state_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return HaltState(default_halt_flags(), malformed=True, error=str(exc), path=state_path)
+    flags = default_halt_flags()
+    if isinstance(data, dict):
+        for key in flags:
+            flags[key] = bool(data.get(key, flags[key]))
+    return HaltState(flags, path=state_path)
+
+
+def save_halt_flags(flags: dict[str, bool], path: Path | None = None) -> None:
+    state_path = path or halt_flags_path()
+    merged = default_halt_flags()
+    merged.update({key: bool(value) for key, value in flags.items() if key in merged})
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(json.dumps(merged, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def is_halted(class_name: str, path: Path | None = None) -> HaltDecision:
+    state = load_halt_flags(path=path)
+    if state.malformed:
+        return HaltDecision(True, "state_error", f"Malformed halt flag state at {state.path}: {state.error}")
+    if state.flags.get("all"):
+        return HaltDecision(True, "all", "Global halt flag is active")
+    if state.flags.get(class_name):
+        return HaltDecision(True, class_name, f"Halt flag is active for {class_name}")
+    return HaltDecision(False, None, "No halt flag active")
+```
+
+- [ ] **Step 4: Run halt flag tests and verify GREEN**
+
+Run:
+
+```bash
+python -m pytest tests/agent/test_cmh_subprocess_halt_flags.py -q -o 'addopts='
+```
+
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Commit Task 3**
+
+Run:
+
+```bash
+git add agent/cmh_subprocess/halt_flags.py tests/agent/test_cmh_subprocess_halt_flags.py
+git commit -m "feat: add CMH subprocess halt flags"
+```
+
+## Task 4: Wrapper preflight foundation
+
+**Files:**
+- Create: `agent/cmh_subprocess/wrappers.py`
+- Create: `tests/agent/test_cmh_subprocess_wrappers.py`
+
+- [ ] **Step 1: Write failing tests for wrapper preflight ordering and outcomes**
+
+Create `tests/agent/test_cmh_subprocess_wrappers.py`:
+
+```python
+from pathlib import Path
+
+from agent.cmh_subprocess.envelope import default_envelope_state, save_envelope_state
+from agent.cmh_subprocess.halt_flags import save_halt_flags
+from agent.cmh_subprocess.wrappers import (
+    CLAUDE_HELP_EVIDENCE,
+    prepare_claude_print_invocation,
+    prepare_codex_print_invocation,
+)
+
+
+def test_halt_prevents_binary_lookup(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    save_halt_flags({"all": True})
+
+    result = prepare_claude_print_invocation("Summarize status", binary_resolver=lambda _: "/missing/should/not/be/used")
+
+    assert result.status == "halted"
+    assert result.ok is False
+    assert result.details["active_flag"] == "all"
+
+
+def test_codex_missing_binary_is_clean_result(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    result = prepare_codex_print_invocation("Explain this code", binary_resolver=lambda _: None)
+
+    assert result.status == "missing_binary"
+    assert result.ok is False
+    assert "codex" in result.message
+
+
+def test_claude_missing_verified_flags_blocks(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    result = prepare_claude_print_invocation(
+        "Summarize status",
+        binary_resolver=lambda _: "/bin/claude",
+        help_text="Usage: claude --print",
+    )
+
+    assert result.status == "missing_required_flag"
+    assert result.ok is False
+    assert result.details["missing_required_flags"] == ["--max-budget-usd", "--output-format", "--no-session-persistence"]
+
+
+def test_claude_budget_cap_blocks_non_priority(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    state = default_envelope_state()
+    state["anthropic_max"]["envelope_messages_used_5h"] = 191
+    save_envelope_state(state)
+
+    result = prepare_claude_print_invocation(
+        "Summarize status",
+        binary_resolver=lambda _: "/bin/claude",
+        help_text=CLAUDE_HELP_EVIDENCE,
+    )
+
+    assert result.status == "budget_blocked"
+    assert result.ok is False
+    assert result.details["used"] == 191
+    assert result.details["cap"] == 191
+
+
+def test_claude_preflight_assembles_safe_argv(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    result = prepare_claude_print_invocation(
+        "Summarize status",
+        binary_resolver=lambda _: "/bin/claude",
+        help_text=CLAUDE_HELP_EVIDENCE,
+        max_budget_usd="0.01",
+    )
+
+    assert result.ok is True
+    assert result.status == "ready"
+    assert result.argv == (
+        "/bin/claude",
+        "--print",
+        "--max-budget-usd",
+        "0.01",
+        "--output-format",
+        "text",
+        "--no-session-persistence",
+        "Summarize status",
+    )
+
+
+def test_claude_preflight_does_not_create_state_files_unless_checks_need_existing_state(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    result = prepare_claude_print_invocation(
+        "Summarize status",
+        binary_resolver=lambda _: "/bin/claude",
+        help_text=CLAUDE_HELP_EVIDENCE,
+    )
+
+    assert result.ok is True
+    assert not (tmp_path / "state" / "envelope_tracking.json").exists()
+    assert not (tmp_path / "state" / "cmh_halt_flags.json").exists()
+```
+
+- [ ] **Step 2: Run wrapper tests and verify RED**
+
+Run:
+
+```bash
+python -m pytest tests/agent/test_cmh_subprocess_wrappers.py -q -o 'addopts='
+```
+
+Expected: FAIL with missing `agent.cmh_subprocess.wrappers`.
+
+- [ ] **Step 3: Implement wrapper preflight helpers**
+
+Create `agent/cmh_subprocess/wrappers.py`:
+
+```python
+"""Disabled-by-default wrapper preflight helpers for CMH subprocess routing."""
+
+from __future__ import annotations
+
+import shutil
+from collections.abc import Callable
+
+from agent.cmh_subprocess.envelope import check_budget, load_envelope_state
+from agent.cmh_subprocess.flags import CLAUDE_REQUIRED_FLAGS, validate_flags
+from agent.cmh_subprocess.halt_flags import is_halted
+from agent.cmh_subprocess.result import PreflightResult
+
+CLAUDE_HELP_EVIDENCE = """
+Usage: claude [options] [prompt]
+  -p, --print                                       Print response and exit
+  --max-budget-usd <amount>                         Maximum dollar amount to spend on API calls
+  --output-format <format>                          Output format
+  --no-session-persistence                          Disable session persistence
+"""
+
+BinaryResolver = Callable[[str], str | None]
+
+
+def _default_binary_resolver(name: str) -> str | None:
+    return shutil.which(name)
+
+
+def prepare_claude_print_invocation(
+    prompt: str,
+    *,
+    binary_resolver: BinaryResolver | None = None,
+    help_text: str | None = None,
+    priority: bool = False,
+    max_budget_usd: str = "0.01",
+) -> PreflightResult:
+    """Prepare a Claude print invocation without running it."""
+    halt = is_halted("cowork_headless")
+    if halt.halted:
+        return PreflightResult(
+            status="halted",
+            ok=False,
+            message=halt.message,
+            details={"active_flag": halt.active_flag},
+        )
+
+    resolver = binary_resolver or _default_binary_resolver
+    binary = resolver("claude")
+    if not binary:
+        return PreflightResult("missing_binary", False, "Required binary 'claude' was not found on PATH")
+
+    evidence = help_text or CLAUDE_HELP_EVIDENCE
+    flags = validate_flags("claude", evidence, required_flags=CLAUDE_REQUIRED_FLAGS)
+    if not flags.ok:
+        return PreflightResult(
+            status="missing_required_flag",
+            ok=False,
+            message="Claude flag evidence is missing required flags",
+            details={"missing_required_flags": flags.missing_required_flags},
+        )
+
+    budget = check_budget(load_envelope_state(), "anthropic_max", priority=priority)
+    if not budget.allowed:
+        return PreflightResult(
+            status="budget_blocked",
+            ok=False,
+            message="Anthropic Max envelope allocation is exhausted",
+            details={"used": budget.used, "cap": budget.cap, "available": budget.available},
+        )
+
+    argv = (
+        binary,
+        "--print",
+        "--max-budget-usd",
+        max_budget_usd,
+        "--output-format",
+        "text",
+        "--no-session-persistence",
+        prompt,
+    )
+    return PreflightResult(
+        status="ready",
+        ok=True,
+        message="Claude print invocation is ready but not executed",
+        argv=argv,
+        details={"budget_reason": budget.reason},
+    )
+
+
+def prepare_codex_print_invocation(
+    prompt: str,
+    *,
+    binary_resolver: BinaryResolver | None = None,
+    priority: bool = False,
+) -> PreflightResult:
+    """Prepare a Codex print invocation without running it.
+
+    Codex flags remain unresolved until verified docs or local help exist.
+    """
+    halt = is_halted("codex_auto_dispatch")
+    if halt.halted:
+        return PreflightResult(
+            status="halted",
+            ok=False,
+            message=halt.message,
+            details={"active_flag": halt.active_flag},
+        )
+
+    resolver = binary_resolver or _default_binary_resolver
+    binary = resolver("codex")
+    if not binary:
+        return PreflightResult("missing_binary", False, "Required binary 'codex' was not found on PATH")
+
+    budget = check_budget(load_envelope_state(), "chatgpt_pro", priority=priority)
+    if not budget.allowed:
+        return PreflightResult(
+            status="budget_blocked",
+            ok=False,
+            message="ChatGPT Pro envelope allocation is exhausted",
+            details={"used": budget.used, "cap": budget.cap, "available": budget.available},
+        )
+
+    return PreflightResult(
+        status="missing_verified_flags",
+        ok=False,
+        message="Codex print flags are not verified in this A-slice",
+        details={"binary": binary, "prompt_length": len(prompt)},
+    )
+```
+
+- [ ] **Step 4: Run wrapper tests and verify GREEN**
+
+Run:
+
+```bash
+python -m pytest tests/agent/test_cmh_subprocess_wrappers.py -q -o 'addopts='
+```
+
+Expected: PASS, 6 tests.
+
+- [ ] **Step 5: Run all subprocess package tests so far**
+
+Run:
+
+```bash
+python -m pytest \
+  tests/agent/test_cmh_subprocess_flags.py \
+  tests/agent/test_cmh_subprocess_envelope.py \
+  tests/agent/test_cmh_subprocess_halt_flags.py \
+  tests/agent/test_cmh_subprocess_wrappers.py \
+  -q -o 'addopts='
+```
+
+Expected: PASS, all tests.
+
+- [ ] **Step 6: Commit Task 4**
+
+Run:
+
+```bash
+git add agent/cmh_subprocess/wrappers.py tests/agent/test_cmh_subprocess_wrappers.py
+git commit -m "feat: add CMH subprocess wrapper preflight"
+```
+
+## Task 5: Budget display formatter
+
+**Files:**
+- Create: `agent/cmh_subprocess/budget_display.py`
+- Create: `tests/agent/test_cmh_subprocess_budget_display.py`
+
+- [ ] **Step 1: Write failing tests for budget display formatting**
+
+Create `tests/agent/test_cmh_subprocess_budget_display.py`:
+
+```python
+from agent.cmh_subprocess.budget_display import format_budget_status
+from agent.cmh_subprocess.envelope import default_envelope_state
+from agent.cmh_subprocess.halt_flags import default_halt_flags
+
+
+def test_budget_status_formats_default_state_without_secrets():
+    output = format_budget_status(default_envelope_state(), default_halt_flags())
+
+    assert "Cowork envelope: 0/191 used, 191 available, window not started" in output
+    assert "Codex envelope: 0/170 used, 170 available, window not started" in output
+    assert "Halt flags: all=false, cowork_headless=false, codex_auto_dispatch=false" in output
+    assert "API_KEY" not in output
+    assert "TOKEN" not in output
+    assert "SECRET" not in output
+
+
+def test_budget_status_formats_used_counts_and_window():
+    state = default_envelope_state()
+    state["anthropic_max"]["envelope_messages_used_5h"] = 5
+    state["anthropic_max"]["window_start_iso"] = "2026-05-17T20:00:00+00:00"
+    flags = default_halt_flags()
+    flags["cowork_headless"] = True
+
+    output = format_budget_status(state, flags)
+
+    assert "Cowork envelope: 5/191 used, 186 available, window started 2026-05-17T20:00:00+00:00" in output
+    assert "cowork_headless=true" in output
+```
+
+- [ ] **Step 2: Run budget display tests and verify RED**
+
+Run:
+
+```bash
+python -m pytest tests/agent/test_cmh_subprocess_budget_display.py -q -o 'addopts='
+```
+
+Expected: FAIL with missing `agent.cmh_subprocess.budget_display`.
+
+- [ ] **Step 3: Implement pure budget display formatter**
+
+Create `agent/cmh_subprocess/budget_display.py`:
+
+```python
+"""Pure budget status formatting for CMH subprocess wrapper foundations."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agent.cmh_subprocess.envelope import allocation_cap
+
+
+def _bool_text(value: bool) -> str:
+    return "true" if value else "false"
+
+
+def _line(label: str, record: dict[str, Any]) -> str:
+    used = int(record.get("envelope_messages_used_5h", 0))
+    cap = allocation_cap(record)
+    available = max(cap - used, 0)
+    window = record.get("window_start_iso")
+    if window:
+        return f"{label} envelope: {used}/{cap} used, {available} available, window started {window}"
+    return f"{label} envelope: {used}/{cap} used, {available} available, window not started"
+
+
+def format_budget_status(envelope_state: dict[str, dict[str, Any]], halt_flags: dict[str, bool]) -> str:
+    """Return a secret-free local budget status string."""
+    lines = [
+        _line("Cowork", envelope_state["anthropic_max"]),
+        _line("Codex", envelope_state["chatgpt_pro"]),
+        "Halt flags: "
+        f"all={_bool_text(halt_flags.get('all', False))}, "
+        f"cowork_headless={_bool_text(halt_flags.get('cowork_headless', False))}, "
+        f"codex_auto_dispatch={_bool_text(halt_flags.get('codex_auto_dispatch', False))}",
+    ]
+    return "\n".join(lines)
+```
+
+- [ ] **Step 4: Run budget display tests and verify GREEN**
+
+Run:
+
+```bash
+python -m pytest tests/agent/test_cmh_subprocess_budget_display.py -q -o 'addopts='
+```
+
+Expected: PASS, 2 tests.
+
+- [ ] **Step 5: Commit Task 5**
+
+Run:
+
+```bash
+git add agent/cmh_subprocess/budget_display.py tests/agent/test_cmh_subprocess_budget_display.py
+git commit -m "feat: add CMH subprocess budget display"
+```
+
+## Task 6: Package exports and final verification
+
+**Files:**
+- Modify: `agent/cmh_subprocess/__init__.py`
+
+- [ ] **Step 1: Write failing test for package exports**
+
+Append to `tests/agent/test_cmh_subprocess_wrappers.py`:
+
+```python
+
+def test_package_exports_preflight_helpers():
+    import agent.cmh_subprocess as cmh_subprocess
+
+    assert callable(cmh_subprocess.prepare_claude_print_invocation)
+    assert callable(cmh_subprocess.prepare_codex_print_invocation)
+```
+
+- [ ] **Step 2: Run export test and verify RED**
+
+Run:
+
+```bash
+python -m pytest tests/agent/test_cmh_subprocess_wrappers.py::test_package_exports_preflight_helpers -q -o 'addopts='
+```
+
+Expected: FAIL with `AttributeError` for missing export.
+
+- [ ] **Step 3: Update package exports**
+
+Replace `agent/cmh_subprocess/__init__.py` with:
+
+```python
+"""CMH subprocess wrapper foundation.
+
+Local foundation only. This package does not activate live routing,
+Telegram sends, gateway behavior, cron, daemon, MCP, deploy, merge, or
+production mutation.
+"""
+
+from agent.cmh_subprocess.budget_display import format_budget_status
+from agent.cmh_subprocess.envelope import check_budget, increment_usage, load_envelope_state
+from agent.cmh_subprocess.halt_flags import is_halted, load_halt_flags
+from agent.cmh_subprocess.wrappers import prepare_claude_print_invocation, prepare_codex_print_invocation
+
+__all__ = [
+    "check_budget",
+    "format_budget_status",
+    "increment_usage",
+    "is_halted",
+    "load_envelope_state",
+    "load_halt_flags",
+    "prepare_claude_print_invocation",
+    "prepare_codex_print_invocation",
+]
+```
+
+- [ ] **Step 4: Run export test and verify GREEN**
+
+Run:
+
+```bash
+python -m pytest tests/agent/test_cmh_subprocess_wrappers.py::test_package_exports_preflight_helpers -q -o 'addopts='
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run full A-slice test set**
+
+Run:
+
+```bash
+python -m pytest \
+  tests/agent/test_cmh_subprocess_flags.py \
+  tests/agent/test_cmh_subprocess_envelope.py \
+  tests/agent/test_cmh_subprocess_halt_flags.py \
+  tests/agent/test_cmh_subprocess_wrappers.py \
+  tests/agent/test_cmh_subprocess_budget_display.py \
+  -q -o 'addopts='
+```
+
+Expected: PASS, all tests.
+
+- [ ] **Step 6: Run focused static checks**
+
+Run:
+
+```bash
+python -m py_compile \
+  agent/cmh_subprocess/__init__.py \
+  agent/cmh_subprocess/result.py \
+  agent/cmh_subprocess/flags.py \
+  agent/cmh_subprocess/envelope.py \
+  agent/cmh_subprocess/halt_flags.py \
+  agent/cmh_subprocess/wrappers.py \
+  agent/cmh_subprocess/budget_display.py
+
+git diff --check
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 7: Verify no activation surfaces changed**
+
+Run:
+
+```bash
+git diff --name-only HEAD~5..HEAD | sort
+```
+
+Expected changed files are limited to:
+
+```text
+agent/cmh_subprocess/__init__.py
+agent/cmh_subprocess/budget_display.py
+agent/cmh_subprocess/envelope.py
+agent/cmh_subprocess/flags.py
+agent/cmh_subprocess/halt_flags.py
+agent/cmh_subprocess/result.py
+agent/cmh_subprocess/wrappers.py
+tests/agent/test_cmh_subprocess_budget_display.py
+tests/agent/test_cmh_subprocess_envelope.py
+tests/agent/test_cmh_subprocess_flags.py
+tests/agent/test_cmh_subprocess_halt_flags.py
+tests/agent/test_cmh_subprocess_wrappers.py
+```
+
+If this list includes gateway, cron, MCP, send, config, launchd, vault dispatch, or provider files, stop and inspect before continuing.
+
+- [ ] **Step 8: Commit final export task**
+
+Run:
+
+```bash
+git add agent/cmh_subprocess/__init__.py tests/agent/test_cmh_subprocess_wrappers.py
+git commit -m "chore: export CMH subprocess foundation helpers"
+```
+
+## Task 7: Closeout note
+
+**Files:**
+- Create: `docs/closeouts/2026-05-17-hermes-local-subprocess-wrapper-foundation-closeout.md`
+
+- [ ] **Step 1: Create closeout after all tests are green**
+
+Create `docs/closeouts/2026-05-17-hermes-local-subprocess-wrapper-foundation-closeout.md`:
+
+```markdown
+# Hermes Local Subprocess Wrapper Foundation Closeout
+
+Date: 2026-05-17
+Scope: A-slice local foundation only
+
+## What changed
+
+- Added `agent/cmh_subprocess/` local foundation package.
+- Added CLI flag verification for Claude help evidence.
+- Added profile-aware envelope state helpers.
+- Added profile-aware halt flag helpers.
+- Added disabled-by-default wrapper preflight helpers.
+- Added pure budget display formatter.
+- Added focused pytest coverage.
+
+## Verification
+
+- `python -m pytest tests/agent/test_cmh_subprocess_flags.py tests/agent/test_cmh_subprocess_envelope.py tests/agent/test_cmh_subprocess_halt_flags.py tests/agent/test_cmh_subprocess_wrappers.py tests/agent/test_cmh_subprocess_budget_display.py -q -o 'addopts='` passed.
+- `python -m py_compile agent/cmh_subprocess/__init__.py agent/cmh_subprocess/result.py agent/cmh_subprocess/flags.py agent/cmh_subprocess/envelope.py agent/cmh_subprocess/halt_flags.py agent/cmh_subprocess/wrappers.py agent/cmh_subprocess/budget_display.py` passed.
+- `git diff --check` passed.
+
+## Activation status
+
+No activation occurred.
+
+Not changed:
+
+- Telegram sends or Telegram verbs.
+- Gateway callbacks, gateway restart, or gateway config.
+- Cron, launchd, daemon, MCP, AgentMail, provider, or profile config.
+- `~/.hermes/wrappers/` or `~/.hermes/bin/` runtime scripts.
+- Cowork-headless spawn.
+- Codex auto-dispatch.
+- R109 fire.
+- Git push, merge, deploy, or production mutation.
+
+## Known dependencies for later phases
+
+- Codex Wave 1.16.E verified flag docs are still required before activation.
+- `codex` must be present on PATH or the Codex wrapper remains disabled.
+- Any Telegram or gateway exposure requires separate exact approval.
+```
+
+- [ ] **Step 2: Verify closeout has no em dashes and no placeholders**
+
+Run:
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+p = Path('docs/closeouts/2026-05-17-hermes-local-subprocess-wrapper-foundation-closeout.md')
+s = p.read_text(encoding='utf-8')
+for forbidden in [chr(8212), 'TB' + 'D', 'TO' + 'DO']:
+    assert forbidden not in s
+print('closeout ok')
+PY
+```
+
+Expected: prints `closeout ok`.
+
+- [ ] **Step 3: Commit closeout**
+
+Run:
+
+```bash
+git add docs/closeouts/2026-05-17-hermes-local-subprocess-wrapper-foundation-closeout.md
+git commit -m "docs: close out CMH subprocess foundation"
+```
+
+## Final Verification Checklist
+
+- [ ] Every production module was added after a failing test.
+- [ ] Every test was observed failing for the expected reason before implementation.
+- [ ] Full A-slice pytest command passes.
+- [ ] `py_compile` passes for all new modules.
+- [ ] `git diff --check` passes.
+- [ ] No real Claude or Codex model subprocess invocation occurred.
+- [ ] No real `~/.hermes/state` file was modified by tests.
+- [ ] No Telegram, gateway, cron, launchd, MCP, provider, send, deploy, merge, R-audit, or production surface changed.
+- [ ] Codex missing binary remains a clean disabled result.
+- [ ] Claude required flags use `--max-budget-usd`, not draft `--max-cost-usd`.
+
+## Implementation Handoff Notes
+
+- Use subagent-driven execution if possible, one task per worker, but keep the parent responsible for reviewing diffs and checking activation boundaries.
+- Do not add the local `/budget` slash command in this A-slice unless Christopher separately asks for it. The pure formatter gives us a safe seam for that later.
+- The repository currently has unrelated dirty files and one local spec commit. Implementation workers must avoid touching unrelated files.
+- Before starting implementation, run `git status -sb` and record the pre-existing dirty files so they are not accidentally committed with this work.

--- a/docs/superpowers/specs/2026-05-17-hermes-local-subprocess-wrapper-foundation-design.md
+++ b/docs/superpowers/specs/2026-05-17-hermes-local-subprocess-wrapper-foundation-design.md
@@ -1,0 +1,291 @@
+# Hermes Local Subprocess Wrapper Foundation Design
+
+Date: 2026-05-17
+Status: Approved for implementation planning after user review
+Scope: A-slice only, local foundation, no activation
+
+## 1. Purpose
+
+Build a local, test-backed foundation for the Hermes architecture pivot without activating new live authority. This slice prepares Hermes to support Claude Code and Codex CLI subprocess routing later, while preserving all CMH safety gates.
+
+The design intentionally does not implement Telegram sends, gateway changes, launchd, cron, Cowork-headless dispatch, Codex auto-dispatch, routing-table activation, R109 fire, git merge, deploy, or production mutation.
+
+## 2. Source inputs
+
+This design is based on these current inputs:
+
+- Cowork checklist pasted by Christopher: Hermes Architecture Pivot Implementation Checklist, created 2026-05-17T18:45-07:00.
+- Canonical strategic plans in the vault:
+  - `00-OS/Strategic-Plans/Hermes-Tier-Routing-Recommendation.md`
+  - `00-OS/Strategic-Plans/Hermes-Escalation-Routing-Via-CLI-Subprocesses.md`
+  - `00-OS/Strategic-Plans/Codex-Auto-Dispatch-From-Hermes-Architecture.md`
+- Hermes Agent skill guidance for CLI subprocess wrappers and slash-command development.
+- Local verification performed in this session.
+
+Current dependency findings:
+
+- `claude` is available at `/Users/Millson/.local/bin/claude`.
+- `codex` is not on PATH in this shell.
+- The expected Codex Wave 1.16.E verified flag docs are not present yet:
+  - `/Users/Millson/Desktop/operate-report-service/docs/architecture/hermes-claude-print-invocation-verified.md`
+  - `/Users/Millson/Desktop/operate-report-service/docs/architecture/hermes-codex-print-invocation-verified.md`
+- Local Claude help showed `--max-budget-usd`, not draft flag `--max-cost-usd`.
+- Local Claude help did not show draft flags `--max-turns` or `--no-mcp` in the captured output.
+
+## 3. Design decision
+
+Implement a local foundation inside the Hermes repo first. Do not place active wrappers under `~/.hermes/wrappers/` or `~/.hermes/bin/` in this slice.
+
+Recommended module boundary:
+
+- `agent/cmh_subprocess/flags.py`
+  - Parse and validate verified CLI flag documents or captured help text.
+  - Represent required and optional flags for Claude and Codex.
+  - Return clear missing-flag diagnostics.
+
+- `agent/cmh_subprocess/envelope.py`
+  - Read and write envelope state in a profile-aware path under `get_hermes_home()/state/envelope_tracking.json`.
+  - Track `anthropic_max` and `chatgpt_pro` windows.
+  - Reset usage after a 5-hour rolling window.
+  - Enforce configured allocation thresholds without invoking any external CLI.
+
+- `agent/cmh_subprocess/halt_flags.py`
+  - Read and write halt flags in a profile-aware path under `get_hermes_home()/state/cmh_halt_flags.json`.
+  - Support class flags: `cowork_headless`, `codex_auto_dispatch`, `hermes_telegram_acks`, and `all`.
+  - Fail closed on malformed state by returning halted for unsafe classes.
+
+- `agent/cmh_subprocess/result.py`
+  - Shared result types for wrapper preflight and eventual subprocess invocation.
+  - Keep disabled, halted, budget-blocked, missing-binary, missing-flag, timeout, and success states distinct.
+
+- `agent/cmh_subprocess/wrappers.py`
+  - Provide disabled-by-default `prepare_claude_print_invocation()` and `prepare_codex_print_invocation()` helpers.
+  - Perform binary checks, flag checks, halt checks, and envelope checks.
+  - Return command argv and diagnostics but do not run model subprocesses by default.
+  - Only support actual subprocess execution behind an explicit function parameter used by tests with harmless local commands or by later approved phases.
+
+- `tests/agent/test_cmh_subprocess_*.py`
+  - TDD coverage for flags, envelope state, halt flags, and wrapper preflight behavior.
+
+This keeps the first implementation reversible, testable, and isolated from live CMH surfaces.
+
+## 4. Behavior requirements
+
+### 4.1 CLI flag verification
+
+The flag verifier must support two evidence sources:
+
+1. Verified docs from Codex Wave 1.16.E when present.
+2. Local captured help text as a temporary evidence source for tests and diagnostics.
+
+The verifier must not silently assume draft flags. It must explicitly report:
+
+- `claude` present or missing.
+- `codex` present or missing.
+- Required flag present or missing.
+- Draft or deprecated flag mismatch when a spec requests a flag not found in help output.
+
+Claude initial required flag set for this slice:
+
+- `--print`
+- `--max-budget-usd`
+- `--output-format`
+- `--no-session-persistence`
+
+Claude optional flags recognized if present:
+
+- `--plugin-dir`
+- `--model`
+- `--permission-mode`
+- `--tools`
+- `--bare`
+
+Codex required flags remain unresolved until Codex Wave 1.16.E verified docs exist or `codex --print --help` becomes available locally. The Codex wrapper must therefore return a disabled or missing-binary result in this slice.
+
+### 4.2 Envelope tracking
+
+Envelope state path:
+
+`{get_hermes_home()}/state/envelope_tracking.json`
+
+Initial schema:
+
+```json
+{
+  "anthropic_max": {
+    "envelope_total_messages_per_5h": 225,
+    "envelope_allocation_hermes_pct": 85,
+    "envelope_messages_used_5h": 0,
+    "window_start_iso": null,
+    "last_invocation_iso": null,
+    "halt_flag_active": false
+  },
+  "chatgpt_pro": {
+    "envelope_total_messages_per_5h": 200,
+    "envelope_allocation_hermes_pct": 85,
+    "envelope_messages_used_5h": 0,
+    "window_start_iso": null,
+    "last_invocation_iso": null,
+    "halt_flag_active": false
+  }
+}
+```
+
+Rules:
+
+- If state file is missing, create defaults in memory and write only when the caller explicitly requests persistence.
+- If `window_start_iso` is missing, start a new window on first increment.
+- If current time is 5 hours or more after `window_start_iso`, reset `envelope_messages_used_5h` to zero and start a new window.
+- Allocation cap is `floor(total * allocation_pct / 100)`.
+- If usage is at or above cap, return budget-blocked for non-priority work.
+- This slice does not detect Christopher interactive use automatically. It leaves that as a later integration point.
+
+### 4.3 Halt flags
+
+Halt flag state path:
+
+`{get_hermes_home()}/state/cmh_halt_flags.json`
+
+Initial schema:
+
+```json
+{
+  "cowork_headless": false,
+  "codex_auto_dispatch": false,
+  "hermes_telegram_acks": false,
+  "all": false
+}
+```
+
+Rules:
+
+- `all: true` halts every wrapper class.
+- `cowork_headless: true` halts Claude/Cowork wrapper class.
+- `codex_auto_dispatch: true` halts Codex wrapper class.
+- Missing file means no halt flags are active.
+- Malformed JSON means fail closed for subprocess wrapper preflight and report the state file path.
+
+### 4.4 Wrapper preflight
+
+Wrapper preflight must run checks in this order:
+
+1. Halt flag check.
+2. Binary availability check.
+3. Verified flag surface check.
+4. Envelope budget check.
+5. Command assembly.
+
+This order prevents a halted class from probing or invoking external CLIs.
+
+The wrapper must return structured results rather than raising for expected operational states. Expected states include missing binary, missing verified flag docs, budget cap reached, halted, and disabled.
+
+### 4.5 Logging
+
+This A slice does not write Hermes-Learning-Ledger entries by default because it does not perform real model invocations. It may expose a pure formatter that later phases can use to write ledger rows after approved activation.
+
+Test logs may use temporary Hermes home directories only. Tests must not write to Christopher's real `~/.hermes/state`.
+
+## 5. Local CLI command surface
+
+This slice may add a local-only helper function or internal command handler for budget formatting, but it should not add Telegram verbs.
+
+If a CLI slash command is included in implementation, it must be limited to `/budget` in local CLI mode and must read only local envelope state. It must not send messages, restart gateway, alter config, create cron, or invoke subprocesses.
+
+A safe `/budget` output shape:
+
+```text
+Cowork envelope: 0/191 used, 191 available, window not started
+Codex envelope: 0/170 used, 170 available, window not started
+Halt flags: all=false, cowork_headless=false, codex_auto_dispatch=false
+```
+
+Adding `/cowork-budget` and `/codex-budget` as aliases is acceptable only if they remain local read-only command aliases in this slice. Telegram exposure belongs to Phase 6 and is out of scope.
+
+## 6. Error handling
+
+- Missing `claude`: return `missing_binary` and setup guidance.
+- Missing `codex`: return `missing_binary` and keep Codex path disabled.
+- Missing verified docs: return `missing_verified_flags` unless local help text is explicitly supplied for diagnostic mode.
+- Missing required flag: return `missing_required_flag` with the exact flag name.
+- Halt active: return `halted` with the active flag name.
+- Budget cap reached: return `budget_blocked` with used, cap, and reset time if known.
+- Malformed state: return `state_error` and fail closed.
+
+No error path should print secrets or full environment variables.
+
+## 7. Testing strategy
+
+Use TDD. No production code should be written before a failing test exists.
+
+Minimum tests:
+
+1. Flag parser accepts Claude help containing `--print` and `--max-budget-usd`.
+2. Flag parser rejects draft `--max-cost-usd` as missing when local help lacks it.
+3. Codex wrapper returns `missing_binary` when binary path is absent.
+4. Halt flag `all: true` prevents later binary or flag checks.
+5. Class halt flag prevents the matching wrapper class only.
+6. Envelope defaults calculate 85 percent caps: 225 to 191, 200 to 170.
+7. Envelope increments within window.
+8. Envelope resets after 5 hours.
+9. Envelope blocks non-priority work at cap.
+10. Wrapper preflight assembles Claude argv only when halt, binary, flags, and envelope checks pass.
+11. State paths are rooted in `get_hermes_home()` and tests use temporary Hermes homes.
+12. Local `/budget` formatting, if implemented, reads state and prints no secrets.
+
+Target test commands:
+
+```bash
+python -m pytest tests/agent/test_cmh_subprocess_flags.py -q -o 'addopts='
+python -m pytest tests/agent/test_cmh_subprocess_envelope.py -q -o 'addopts='
+python -m pytest tests/agent/test_cmh_subprocess_halt_flags.py -q -o 'addopts='
+python -m pytest tests/agent/test_cmh_subprocess_wrappers.py -q -o 'addopts='
+```
+
+If slash command support is included:
+
+```bash
+python -m pytest tests/test_cmh_budget_command.py -q -o 'addopts='
+```
+
+## 8. Out of scope
+
+This slice must not implement or activate:
+
+- Telegram alerts or Telegram budget verbs.
+- Gateway callbacks, gateway restart, or gateway config changes.
+- `~/.hermes/wrappers/` runtime scripts.
+- `~/.hermes/bin/spawn-cowork-headless.sh`.
+- launchd, daemon, cron, webhook, MCP, AgentMail, or provider changes.
+- Live Claude or Codex model subprocess calls as part of normal Hermes routing.
+- `tier_4_substantive_default` route activation.
+- `tier_2_code_reasoning` route activation.
+- Codex auto-dispatch folder writes.
+- R109 fire.
+- Git push, merge, deploy, or production mutation.
+
+## 9. Rollback
+
+Because this slice is local repo code only, rollback is simple:
+
+- Revert the implementation commit or remove the new `agent/cmh_subprocess/` package and tests.
+- Delete any temporary test state under test-created Hermes homes.
+- Do not remove or edit real `~/.hermes/state` unless Christopher explicitly asks.
+- No gateway, cron, launchd, MCP, or provider rollback should be required because none are activated.
+
+## 10. Acceptance criteria
+
+The A-slice is complete when:
+
+- All tests listed in the implementation plan pass.
+- `codex` absence is handled as a clean disabled or missing-binary result.
+- Claude flag verification reflects local reality and rejects draft-only flags.
+- Envelope and halt state are profile-aware and fail closed on malformed state.
+- No real model subprocess is invoked in normal tests.
+- No Telegram, gateway, cron, launchd, MCP, provider, send, deploy, merge, R-audit, or production surface changed.
+- A closeout clearly states that this is foundation-only and not architecture-pivot activation.
+
+## 11. Open dependency for later phases
+
+Before Phase 1 activation from the Cowork checklist, Codex Wave 1.16.E must land verified invocation docs. If those docs are still missing, Hermes may continue building local tests and disabled foundations but must not activate subprocess routing.
+
+When verified docs arrive, later work should reconcile their flag names against the local verifier. If docs conflict with live local help output, implementation should fail closed and report the discrepancy rather than guessing.

--- a/tests/agent/test_cmh_subprocess_budget_display.py
+++ b/tests/agent/test_cmh_subprocess_budget_display.py
@@ -1,0 +1,27 @@
+from agent.cmh_subprocess.budget_display import format_budget_status
+from agent.cmh_subprocess.envelope import default_envelope_state
+from agent.cmh_subprocess.halt_flags import default_halt_flags
+
+
+def test_budget_status_formats_default_state_without_secrets():
+    output = format_budget_status(default_envelope_state(), default_halt_flags())
+
+    assert "Cowork envelope: 0/191 used, 191 available, window not started" in output
+    assert "Codex envelope: 0/170 used, 170 available, window not started" in output
+    assert "Halt flags: all=false, cowork_headless=false, codex_auto_dispatch=false" in output
+    assert "API_KEY" not in output
+    assert "TOKEN" not in output
+    assert "SECRET" not in output
+
+
+def test_budget_status_formats_used_counts_and_window():
+    state = default_envelope_state()
+    state["anthropic_max"]["envelope_messages_used_5h"] = 5
+    state["anthropic_max"]["window_start_iso"] = "2026-05-17T20:00:00+00:00"
+    flags = default_halt_flags()
+    flags["cowork_headless"] = True
+
+    output = format_budget_status(state, flags)
+
+    assert "Cowork envelope: 5/191 used, 186 available, window started 2026-05-17T20:00:00+00:00" in output
+    assert "cowork_headless=true" in output

--- a/tests/agent/test_cmh_subprocess_envelope.py
+++ b/tests/agent/test_cmh_subprocess_envelope.py
@@ -62,6 +62,16 @@ def test_increment_usage_resets_after_five_hours():
     assert updated["anthropic_max"]["window_start_iso"] == later.isoformat()
 
 
+def test_save_envelope_state_uses_atomic_temp_file_without_lingering_tmp(tmp_path):
+    state_path = tmp_path / ENVELOPE_STATE_FILENAME
+    state = default_envelope_state()
+
+    save_envelope_state(state, path=state_path)
+
+    assert load_envelope_state(path=state_path) == state
+    assert list(tmp_path.glob(f".{ENVELOPE_STATE_FILENAME}.*.tmp")) == []
+
+
 def test_budget_blocks_non_priority_at_cap():
     state = default_envelope_state()
     state["anthropic_max"]["envelope_messages_used_5h"] = 191
@@ -74,6 +84,24 @@ def test_budget_blocks_non_priority_at_cap():
         used=191,
         cap=191,
         available=0,
+    )
+
+
+def test_budget_allows_capped_usage_after_expired_window():
+    start = datetime(2026, 5, 17, 20, 0, tzinfo=timezone.utc)
+    now = start + timedelta(hours=5, minutes=1)
+    state = default_envelope_state()
+    state["anthropic_max"]["window_start_iso"] = start.isoformat()
+    state["anthropic_max"]["envelope_messages_used_5h"] = 191
+
+    decision = check_budget(state, "anthropic_max", priority=False, now=now)
+
+    assert decision == EnvelopeDecision(
+        allowed=True,
+        reason="window_reset",
+        used=0,
+        cap=191,
+        available=191,
     )
 
 

--- a/tests/agent/test_cmh_subprocess_envelope.py
+++ b/tests/agent/test_cmh_subprocess_envelope.py
@@ -1,5 +1,7 @@
 from datetime import datetime, timedelta, timezone
 
+import pytest
+
 from agent.cmh_subprocess.envelope import (
     ENVELOPE_STATE_FILENAME,
     EnvelopeDecision,
@@ -70,6 +72,14 @@ def test_save_envelope_state_uses_atomic_temp_file_without_lingering_tmp(tmp_pat
 
     assert load_envelope_state(path=state_path) == state
     assert list(tmp_path.glob(f".{ENVELOPE_STATE_FILENAME}.*.tmp")) == []
+
+
+def test_load_non_object_envelope_state_raises_value_error(tmp_path):
+    state_path = tmp_path / ENVELOPE_STATE_FILENAME
+    state_path.write_text("[]", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="JSON object"):
+        load_envelope_state(path=state_path)
 
 
 def test_budget_blocks_non_priority_at_cap():

--- a/tests/agent/test_cmh_subprocess_envelope.py
+++ b/tests/agent/test_cmh_subprocess_envelope.py
@@ -1,0 +1,88 @@
+from datetime import datetime, timedelta, timezone
+
+from agent.cmh_subprocess.envelope import (
+    ENVELOPE_STATE_FILENAME,
+    EnvelopeDecision,
+    allocation_cap,
+    check_budget,
+    default_envelope_state,
+    envelope_state_path,
+    increment_usage,
+    load_envelope_state,
+    save_envelope_state,
+)
+
+
+def test_default_envelope_caps_are_85_percent():
+    state = default_envelope_state()
+
+    assert allocation_cap(state["anthropic_max"]) == 191
+    assert allocation_cap(state["chatgpt_pro"]) == 170
+
+
+def test_envelope_state_path_uses_hermes_home(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    assert envelope_state_path() == tmp_path / "state" / ENVELOPE_STATE_FILENAME
+
+
+def test_load_missing_state_returns_defaults_without_writing(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    state = load_envelope_state()
+
+    assert state["anthropic_max"]["envelope_messages_used_5h"] == 0
+    assert not envelope_state_path().exists()
+
+
+def test_increment_usage_starts_window_and_persists(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    now = datetime(2026, 5, 17, 20, 0, tzinfo=timezone.utc)
+    state = default_envelope_state()
+
+    updated = increment_usage(state, "anthropic_max", now=now)
+    save_envelope_state(updated)
+    reloaded = load_envelope_state()
+
+    assert reloaded["anthropic_max"]["envelope_messages_used_5h"] == 1
+    assert reloaded["anthropic_max"]["window_start_iso"] == now.isoformat()
+    assert reloaded["anthropic_max"]["last_invocation_iso"] == now.isoformat()
+
+
+def test_increment_usage_resets_after_five_hours():
+    start = datetime(2026, 5, 17, 20, 0, tzinfo=timezone.utc)
+    later = start + timedelta(hours=5, minutes=1)
+    state = default_envelope_state()
+    state["anthropic_max"]["window_start_iso"] = start.isoformat()
+    state["anthropic_max"]["envelope_messages_used_5h"] = 190
+
+    updated = increment_usage(state, "anthropic_max", now=later)
+
+    assert updated["anthropic_max"]["envelope_messages_used_5h"] == 1
+    assert updated["anthropic_max"]["window_start_iso"] == later.isoformat()
+
+
+def test_budget_blocks_non_priority_at_cap():
+    state = default_envelope_state()
+    state["anthropic_max"]["envelope_messages_used_5h"] = 191
+
+    decision = check_budget(state, "anthropic_max", priority=False)
+
+    assert decision == EnvelopeDecision(
+        allowed=False,
+        reason="budget_blocked",
+        used=191,
+        cap=191,
+        available=0,
+    )
+
+
+def test_budget_allows_priority_at_cap_with_reason():
+    state = default_envelope_state()
+    state["anthropic_max"]["envelope_messages_used_5h"] = 191
+
+    decision = check_budget(state, "anthropic_max", priority=True)
+
+    assert decision.allowed is True
+    assert decision.reason == "priority_override"
+    assert decision.available == 0

--- a/tests/agent/test_cmh_subprocess_flags.py
+++ b/tests/agent/test_cmh_subprocess_flags.py
@@ -1,0 +1,43 @@
+from agent.cmh_subprocess.flags import (
+    CLAUDE_REQUIRED_FLAGS,
+    validate_flags,
+    extract_long_flags,
+)
+
+CLAUDE_HELP = """
+Usage: claude [options] [prompt]
+  -p, --print                                       Print response and exit
+  --max-budget-usd <amount>                         Maximum dollar amount to spend on API calls
+  --output-format <format>                          Output format
+  --no-session-persistence                          Disable session persistence
+  --plugin-dir <path>                               Load a plugin
+  --model <model>                                   Model for the current session
+  --permission-mode <mode>                          Permission mode
+  --tools <tools...>                                Specify the list of available tools
+  --bare                                            Minimal mode
+"""
+
+
+def test_extract_long_flags_finds_claude_print_flags():
+    flags = extract_long_flags(CLAUDE_HELP)
+
+    assert "--print" in flags
+    assert "--max-budget-usd" in flags
+    assert "--output-format" in flags
+    assert "--no-session-persistence" in flags
+
+
+def test_validate_flags_accepts_current_claude_required_flags():
+    result = validate_flags("claude", CLAUDE_HELP, required_flags=CLAUDE_REQUIRED_FLAGS)
+
+    assert result.ok is True
+    assert result.missing_required_flags == []
+    assert result.available_flags["--max-budget-usd"] is True
+
+
+def test_validate_flags_rejects_draft_max_cost_flag_when_help_lacks_it():
+    result = validate_flags("claude", CLAUDE_HELP, required_flags=("--max-cost-usd",))
+
+    assert result.ok is False
+    assert result.missing_required_flags == ["--max-cost-usd"]
+    assert result.available_flags["--max-cost-usd"] is False

--- a/tests/agent/test_cmh_subprocess_halt_flags.py
+++ b/tests/agent/test_cmh_subprocess_halt_flags.py
@@ -1,0 +1,67 @@
+import json
+
+from agent.cmh_subprocess.halt_flags import (
+    default_halt_flags,
+    halt_flags_path,
+    is_halted,
+    load_halt_flags,
+)
+
+
+def test_missing_halt_file_uses_defaults_and_does_not_halt(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    state = load_halt_flags()
+
+    assert state.flags == default_halt_flags()
+    assert is_halted("cowork_headless").halted is False
+
+
+def test_halt_flags_path_uses_hermes_home_state_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    assert halt_flags_path() == tmp_path / "state" / "cmh_halt_flags.json"
+
+
+def test_all_true_blocks_every_class(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    path = halt_flags_path()
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps({"all": True}), encoding="utf-8")
+
+    cowork = is_halted("cowork_headless")
+    codex = is_halted("codex_auto_dispatch")
+
+    assert cowork.halted is True
+    assert cowork.active_flag == "all"
+    assert codex.halted is True
+    assert codex.active_flag == "all"
+
+
+def test_class_halt_blocks_matching_class_only(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    path = halt_flags_path()
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps({"cowork_headless": True}), encoding="utf-8")
+
+    cowork = is_halted("cowork_headless")
+    codex = is_halted("codex_auto_dispatch")
+
+    assert cowork.halted is True
+    assert cowork.active_flag == "cowork_headless"
+    assert codex.halted is False
+
+
+def test_malformed_json_fails_closed(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    path = halt_flags_path()
+    path.parent.mkdir(parents=True)
+    path.write_text("{not valid json", encoding="utf-8")
+
+    state = load_halt_flags()
+    decision = is_halted("cowork_headless")
+
+    assert state.malformed is True
+    assert decision.halted is True
+    assert decision.active_flag == "state_error"
+    assert str(path) in decision.message

--- a/tests/agent/test_cmh_subprocess_halt_flags.py
+++ b/tests/agent/test_cmh_subprocess_halt_flags.py
@@ -1,10 +1,13 @@
 import json
 
+import pytest
+
 from agent.cmh_subprocess.halt_flags import (
     default_halt_flags,
     halt_flags_path,
     is_halted,
     load_halt_flags,
+    save_halt_flags,
 )
 
 
@@ -65,3 +68,40 @@ def test_malformed_json_fails_closed(tmp_path, monkeypatch):
     assert decision.halted is True
     assert decision.active_flag == "state_error"
     assert str(path) in decision.message
+
+
+@pytest.mark.parametrize(
+    ("payload", "invalid_key"),
+    [
+        ({"all": 0}, "all"),
+        ({"all": None}, "all"),
+        ({"all": ""}, "all"),
+        ({"cowork_headless": []}, "cowork_headless"),
+    ],
+)
+def test_non_bool_known_halt_flag_values_fail_closed(
+    tmp_path, monkeypatch, payload, invalid_key
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    path = halt_flags_path()
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    state = load_halt_flags()
+    decision = is_halted("cowork_headless")
+
+    assert state.flags == default_halt_flags()
+    assert state.malformed is True
+    assert invalid_key in state.error
+    assert state.path == path
+    assert decision.halted is True
+    assert decision.active_flag == "state_error"
+
+
+def test_save_halt_flags_rejects_non_bool_known_values_without_writing(tmp_path):
+    path = tmp_path / "state" / "cmh_halt_flags.json"
+
+    with pytest.raises(ValueError, match="all"):
+        save_halt_flags({"all": "false"}, path=path)
+
+    assert not path.exists()

--- a/tests/agent/test_cmh_subprocess_wrappers.py
+++ b/tests/agent/test_cmh_subprocess_wrappers.py
@@ -110,6 +110,44 @@ def test_codex_malformed_envelope_state_returns_structured_state_error(
     assert result.argv == ()
 
 
+def test_claude_non_object_envelope_state_returns_structured_state_error(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    path = envelope_state_path()
+    path.parent.mkdir(parents=True)
+    path.write_text("[]", encoding="utf-8")
+
+    result = prepare_claude_print_invocation(
+        "prompt",
+        binary_resolver=lambda name: "/bin/claude",
+    )
+
+    assert result.ok is False
+    assert result.status == "state_error"
+    assert result.details["path"] == str(path)
+    assert result.argv == ()
+
+
+def test_codex_non_object_envelope_state_returns_structured_state_error(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    path = envelope_state_path()
+    path.parent.mkdir(parents=True)
+    path.write_text("[]", encoding="utf-8")
+
+    result = prepare_codex_print_invocation(
+        "prompt",
+        binary_resolver=lambda name: "/bin/codex",
+    )
+
+    assert result.ok is False
+    assert result.status == "state_error"
+    assert result.details["path"] == str(path)
+    assert result.argv == ()
+
+
 def test_claude_budget_cap_blocks_non_priority(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     path = envelope_state_path()

--- a/tests/agent/test_cmh_subprocess_wrappers.py
+++ b/tests/agent/test_cmh_subprocess_wrappers.py
@@ -56,6 +56,60 @@ def test_claude_missing_flags_reported_from_help_text(tmp_path, monkeypatch):
     ]
 
 
+def test_claude_prompt_beginning_with_option_prefix_is_unsafe(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    result = prepare_claude_print_invocation(
+        "  --dangerous-option prompt",
+        binary_resolver=lambda name: "/bin/claude",
+    )
+
+    assert result.ok is False
+    assert result.status == "unsafe_prompt"
+    assert "prompt begins with option prefix" in result.message.lower()
+    assert result.argv == ()
+
+
+def test_claude_malformed_envelope_state_returns_structured_state_error(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    path = envelope_state_path()
+    path.parent.mkdir(parents=True)
+    path.write_text("{not valid json", encoding="utf-8")
+
+    result = prepare_claude_print_invocation(
+        "prompt",
+        binary_resolver=lambda name: "/bin/claude",
+    )
+
+    assert result.ok is False
+    assert result.status == "state_error"
+    assert "state" in result.message.lower() or "envelope" in result.message.lower()
+    assert result.details["path"] == str(path)
+    assert result.argv == ()
+
+
+def test_codex_malformed_envelope_state_returns_structured_state_error(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    path = envelope_state_path()
+    path.parent.mkdir(parents=True)
+    path.write_text("{not valid json", encoding="utf-8")
+
+    result = prepare_codex_print_invocation(
+        "prompt",
+        binary_resolver=lambda name: "/bin/codex",
+    )
+
+    assert result.ok is False
+    assert result.status == "state_error"
+    assert "state" in result.message.lower() or "envelope" in result.message.lower()
+    assert result.details["path"] == str(path)
+    assert result.argv == ()
+
+
 def test_claude_budget_cap_blocks_non_priority(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     path = envelope_state_path()

--- a/tests/agent/test_cmh_subprocess_wrappers.py
+++ b/tests/agent/test_cmh_subprocess_wrappers.py
@@ -1,0 +1,114 @@
+import json
+
+from agent.cmh_subprocess.envelope import envelope_state_path
+from agent.cmh_subprocess.halt_flags import halt_flags_path
+from agent.cmh_subprocess.wrappers import (
+    prepare_claude_print_invocation,
+    prepare_codex_print_invocation,
+)
+
+
+def test_halt_all_prevents_claude_binary_lookup(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    path = halt_flags_path()
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps({"all": True}), encoding="utf-8")
+    calls = []
+
+    def resolver(name):
+        calls.append(name)
+        return f"/bin/{name}"
+
+    result = prepare_claude_print_invocation("prompt", binary_resolver=resolver)
+
+    assert calls == []
+    assert result.ok is False
+    assert result.status == "halted"
+    assert result.details["active_flag"] == "all"
+
+
+def test_codex_missing_binary_returns_clean_result(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    result = prepare_codex_print_invocation("prompt", binary_resolver=lambda name: None)
+
+    assert result.ok is False
+    assert result.status == "missing_binary"
+    assert "codex" in result.message.lower()
+    assert result.argv == ()
+
+
+def test_claude_missing_flags_reported_from_help_text(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    result = prepare_claude_print_invocation(
+        "prompt",
+        binary_resolver=lambda name: "/bin/claude",
+        help_text="Usage: claude --print",
+    )
+
+    assert result.ok is False
+    assert result.status == "missing_required_flag"
+    assert result.details["missing_required_flags"] == [
+        "--max-budget-usd",
+        "--output-format",
+        "--no-session-persistence",
+    ]
+
+
+def test_claude_budget_cap_blocks_non_priority(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    path = envelope_state_path()
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps({"anthropic_max": {"envelope_messages_used_5h": 191}}),
+        encoding="utf-8",
+    )
+
+    result = prepare_claude_print_invocation(
+        "prompt",
+        binary_resolver=lambda name: "/bin/claude",
+        priority=False,
+    )
+
+    assert result.ok is False
+    assert result.status == "budget_blocked"
+    assert result.details["used"] == 191
+    assert result.details["cap"] == 191
+
+
+def test_claude_preflight_assembles_safe_argv_exactly(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    result = prepare_claude_print_invocation(
+        "prompt",
+        binary_resolver=lambda name: "/bin/claude",
+    )
+
+    assert result.ok is True
+    assert result.status == "ready"
+    assert result.argv == (
+        "/bin/claude",
+        "--print",
+        "--max-budget-usd",
+        "0.01",
+        "--output-format",
+        "text",
+        "--no-session-persistence",
+        "prompt",
+    )
+
+
+def test_claude_ready_preflight_does_not_create_state_files_when_missing_state(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    result = prepare_claude_print_invocation(
+        "prompt",
+        binary_resolver=lambda name: "/bin/claude",
+    )
+
+    assert result.ok is True
+    assert not halt_flags_path().exists()
+    assert not envelope_state_path().exists()

--- a/tests/agent/test_cmh_subprocess_wrappers.py
+++ b/tests/agent/test_cmh_subprocess_wrappers.py
@@ -204,3 +204,10 @@ def test_claude_ready_preflight_does_not_create_state_files_when_missing_state(
     assert result.ok is True
     assert not halt_flags_path().exists()
     assert not envelope_state_path().exists()
+
+
+def test_package_exports_preflight_helpers():
+    import agent.cmh_subprocess as cmh_subprocess
+
+    assert callable(cmh_subprocess.prepare_claude_print_invocation)
+    assert callable(cmh_subprocess.prepare_codex_print_invocation)


### PR DESCRIPTION
## Summary
- Add local-only CMH subprocess foundation modules for verified flag parsing, envelope tracking, halt flags, wrapper preflight, and budget display
- Add structured fail-closed behavior for malformed state, unsafe option-prefix prompts, exhausted envelopes, missing binaries, and unresolved Codex flags
- Document the A-slice closeout and reconcile it against operate-report-service PR #349 / Codex Wave 1.16.E findings

## Safety / activation boundary
- No Telegram, gateway, cron, launchd, MCP, provider, send, deploy, merge, R-audit, ~/.hermes/wrappers, or ~/.hermes/bin activation
- No real Claude or Codex subprocess invocation in normal code or tests
- Codex remains fail-closed until verified exec pattern is implemented in a later approved phase

## Test Plan
- [x] PATH=/Users/Millson/.hermes/hermes-agent/.venv/bin:$PATH python -m pytest tests/agent/test_cmh_subprocess_flags.py tests/agent/test_cmh_subprocess_envelope.py tests/agent/test_cmh_subprocess_halt_flags.py tests/agent/test_cmh_subprocess_wrappers.py tests/agent/test_cmh_subprocess_budget_display.py -q -o 'addopts='
- [x] PATH=/Users/Millson/.hermes/hermes-agent/.venv/bin:$PATH python -m py_compile agent/cmh_subprocess/__init__.py agent/cmh_subprocess/result.py agent/cmh_subprocess/flags.py agent/cmh_subprocess/envelope.py agent/cmh_subprocess/halt_flags.py agent/cmh_subprocess/wrappers.py agent/cmh_subprocess/budget_display.py
- [x] git diff --check