### PR TITLE
fix(tools): wire Telegram proxy to Bot in send_message so media uploads stop timing out

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -794,7 +794,33 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                 formatted = message
             send_parse_mode = ParseMode.MARKDOWN_V2
 
-        bot = Bot(token=token)
+        # Resolve proxy — same chain as the gateway adapter (telegram.py).
+        # Without this, environments that require a proxy to reach
+        # api.telegram.org will timeout on every media upload.
+        _proxy_url = None
+        try:
+            from gateway.platforms.base import resolve_proxy_url
+            _proxy_url = resolve_proxy_url("TELEGRAM_PROXY",
+                                           target_hosts=["api.telegram.org"])
+        except Exception:
+            pass
+
+        bot_kwargs: dict = {}
+        if _proxy_url:
+            try:
+                from telegram.request import HTTPXRequest as _HTTPXReq
+                _req = _HTTPXReq(
+                    proxy=_proxy_url,
+                    connect_timeout=10.0,
+                    read_timeout=20.0,
+                    write_timeout=20.0,
+                )
+                bot_kwargs["request"] = _req
+            except Exception:
+                # Fallback: some PTB versions accept proxy= directly
+                bot_kwargs["proxy"] = _proxy_url
+
+        bot = Bot(token=token, **bot_kwargs)
         int_chat_id = int(chat_id)
         media_files = media_files or []
         thread_kwargs = {}


### PR DESCRIPTION
## Summary

In environments that require a proxy to reach `api.telegram.org`, the `send_message` tool fails to deliver **any** media files (photos, videos, audio, documents) because the `Bot` instance it creates has no proxy configured — unlike the gateway adapter which correctly uses one.

## Problem

The gateway adapter (`gateway/platforms/telegram.py`) resolves the proxy via `resolve_proxy_url("TELEGRAM_PROXY")` and passes it to `HTTPXRequest`, so all gateway replies work fine behind a proxy.

However, the `send_message` tool (`tools/send_message_tool.py`) creates its own separate `Bot` instance without any proxy:

```python
# send_message_tool.py — _send_telegram()
bot = Bot(token=token)  # direct connection to api.telegram.org — no proxy
```

This `bot` is used for both text and media sends. In proxy-dependent environments, the TCP connection to `api.telegram.org` cannot be established directly, causing every `send_message` call to timeout. The gateway itself is unaffected because it uses a different, properly proxied `Bot` instance.

## Fix

Reuse the same proxy resolution chain as the gateway adapter:

```python
_proxy_url = resolve_proxy_url("TELEGRAM_PROXY", target_hosts=["api.telegram.org"])
if _proxy_url:
    _req = HTTPXRequest(proxy=_proxy_url, connect_timeout=10.0, read_timeout=20.0, write_timeout=20.0)
    bot = Bot(token=token, request=_req)
else:
    bot = Bot(token=token)  # no proxy needed
```

Timeout values match the gateway adapter (`telegram.py` lines 1219–1221). When no proxy is configured, behavior is unchanged.

## Testing

Verified locally with `TELEGRAM_PROXY`:

| Scenario | Before | After |
|----------|--------|-------|
| `send_message` with `.ogg` audio | timeout | ✅ delivered |
| `send_message` with `.html` file | timeout | ✅ delivered |
| `send_message` with `.md` file | timeout | ✅ delivered |
| Gateway auto-reply (text + media) | already worked | unchanged |

## Related

- #9291 — Telegram media delivery failures
- #21757 — `HERMES_TELEGRAM_HTTP_MEDIA_WRITE_TIMEOUT` not wired to PTB