### PR TITLE
fix: auto-restore pairing data from pre-update snapshot after `hermes update`

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8234,6 +8234,65 @@ def _cmd_update_impl(args, gateway_mode: bool):
         print()
         print("✓ Update complete!")
 
+        # Restore pairing data from pre-update snapshot.
+        # Issue #15733: the snapshot backs up pairing JSONs but git pull + pip
+        # install can leave `~/.hermes/pairing/` stale (e.g. the new gateway
+        # code reads a different path or the files were removed during a
+        # virtualenv rebuild).  Auto-restore so users don't lose authorization
+        # on messaging platforms after an update.
+        try:
+            from hermes_cli.backup import (
+                restore_quick_snapshot,
+                list_quick_snapshots,
+                _quick_snapshot_root,
+            )
+            from hermes_constants import get_hermes_home
+
+            snaps = list_quick_snapshots(limit=1)
+            pre_snap = next(
+                (s for s in snaps if s.get("label") == "pre-update"), None
+            )
+            if pre_snap:
+                sid = pre_snap["id"]
+                try:
+                    hermes_home = get_hermes_home()
+                    snap_dir = _quick_snapshot_root(hermes_home) / sid
+                    _PAIRING_PATHS = [
+                        "pairing",
+                        "platforms/pairing",
+                        "feishu_comment_pairing.json",
+                    ]
+                    restored = 0
+                    for rel in _PAIRING_PATHS:
+                        src = snap_dir / rel
+                        if src.exists():
+                            if src.is_dir():
+                                for f in src.rglob("*"):
+                                    if not f.is_file():
+                                        continue
+                                    sub_rel = f.relative_to(snap_dir)
+                                    dst = hermes_home / sub_rel
+                                    dst.parent.mkdir(
+                                        parents=True, exist_ok=True
+                                    )
+                                    shutil.copy2(f, dst)
+                                    restored += 1
+                            else:
+                                dst = hermes_home / rel
+                                dst.parent.mkdir(
+                                    parents=True, exist_ok=True
+                                )
+                                shutil.copy2(src, dst)
+                                restored += 1
+                    if restored:
+                        print(
+                            f"  ✓ Restored {restored} pairing/auth file(s)"
+                        )
+                except Exception:
+                    pass
+        except Exception as exc:
+            logger.debug("Pairing auto-restore: %s", exc)
+
         # Curator first-run heads-up. Only prints when curator is enabled AND
         # has never run — i.e. the window where the ticker would otherwise
         # have fired against a fresh skill library. Kept silent on steady


### PR DESCRIPTION
## Problem

After `hermes update`, the gateway restart clears platform pairing authorization (Issue #15733). All paired messaging users become "Unauthorized" until the operator manually runs `/snapshot restore`.

The pre-update quick snapshot already backs up the pairing JSONs (`pairing/`, `platforms/pairing/`, `feishu_comment_pairing.json`), but the update flow (`_cmd_update_impl`) never restores them before the gateway restarts.

## Fix

Insert an auto-restore step after `✓ Update complete!` (post git pull + pip install) and before the gateway restart / curator notices. It:

1. Finds the most recent `pre-update` quick snapshot
2. Copies pairing JSON files back to their live `~/.hermes/` locations
3. Reports how many files were restored

The restore is defense-in-depth: even if the JSONs survive the git pull + venv rebuild, this ensures they are always in the expected state when the newly started gateway validates authorization.

## Testing

- Verified: pairing data is present in pre-update snapshots
- Verified: `_QUICK_STATE_FILES` includes `"pairing"`, `"platforms/pairing"` and `"feishu_comment_pairing.json"`
- Syntax-checked with `ast.parse`
- Applied and tested on a local instance (user confirmed fix resolved the issue)

Closes #15733