### PR TITLE
feat(update): write restart handover status for post-restart notification

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13257,6 +13257,20 @@ class GatewayRunner:
                     msg = "✅ Hermes update finished successfully."
                 else:
                     msg = "❌ Hermes update failed. Check the gateway logs or run `hermes update` manually for details."
+
+                # Append restart handover status if present - written by
+                # hermes_cli.main._cmd_update_impl before gateway restart.
+                try:
+                    _status_path = _hermes_home / "cache" / "restart_status.json"
+                    if _status_path.exists():
+                        _status_data = json.loads(_status_path.read_text())
+                        _reason = _status_data.get("reason", "")
+                        if _reason:
+                            msg += f"\n\n📋 Update: {_reason}"
+                        _status_path.unlink(missing_ok=True)
+                except Exception:
+                    pass
+
                 await adapter.send(chat_id, msg, metadata=metadata)
                 logger.info(
                     "Sent post-update notification to %s:%s (exit=%s)",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8234,6 +8234,36 @@ def _cmd_update_impl(args, gateway_mode: bool):
         print()
         print("✓ Update complete!")
 
+        # Write restart handover status so the new gateway process can report
+        # what this update was about and what to follow up on.
+        try:
+            from hermes_cli.config import get_hermes_home
+            import json as _json
+
+            _status_file = get_hermes_home() / "cache" / "restart_status.json"
+            _status_file.parent.mkdir(parents=True, exist_ok=True)
+
+            # Detect version from git tags
+            _update_reason = "Hermes Agent update"
+            try:
+                _describe = subprocess.run(
+                    ["git", "describe", "--tags", "--abbrev=0"],
+                    cwd=PROJECT_ROOT,
+                    capture_output=True, text=True, timeout=5,
+                )
+                if _describe.returncode == 0 and _describe.stdout.strip():
+                    _update_reason = f"Hermes updated to {_describe.stdout.strip()}"
+            except Exception:
+                pass
+
+            _status = {
+                "reason": _update_reason,
+                "timestamp": datetime.now().isoformat(),
+            }
+            _status_file.write_text(_json.dumps(_status, ensure_ascii=False, indent=2))
+        except Exception as _exc:
+            logger.debug("Could not write restart status: %s", _exc)
+
         # Curator first-run heads-up. Only prints when curator is enabled AND
         # has never run — i.e. the window where the ticker would otherwise
         # have fired against a fresh skill library. Kept silent on steady


### PR DESCRIPTION
## Summary

After `hermes update` succeeds, write a small JSON file (`~/.hermes/cache/restart_status.json`) with the new version tag and timestamp. The gateway reads this file on startup and appends it to the post-update notification sent to the user.

This prevents the "restarted but forgot what happened" problem where the user receives no feedback after a gateway restart triggered by an update.

## Changes

- **hermes_cli/main.py**: After printing "Update complete!", write status JSON with `git describe --tags` version to `~/.hermes/cache/restart_status.json`
- **gateway/run.py**: In `_send_update_notification()`, read and append the status to the message, then delete the file

## Files changed

```
hermes_cli/main.py | 30 +++++++++++++++++++++++++++
gateway/run.py     | 14 +++++++++++++
```