### PR TITLE
fix(gateway): return JSON 404 for unmatched /api/* instead of SPA shell

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3550,6 +3550,14 @@ def mount_spa(application: FastAPI):
     if not WEB_DIST.exists():
         @application.get("/{full_path:path}")
         async def no_frontend(full_path: str):
+            # Unmatched /api/* must not be swallowed by the SPA fallback —
+            # they should surface as JSON 404s so missing-route bugs are
+            # visible instead of masked as "working" HTML responses.
+            if full_path.startswith("api/"):
+                return JSONResponse(
+                    {"error": f"no such api route: /{full_path}"},
+                    status_code=404,
+                )
             return JSONResponse(
                 {"error": "Frontend not built. Run: cd web && npm run build"},
                 status_code=404,
@@ -3613,6 +3621,16 @@ def mount_spa(application: FastAPI):
 
     @application.get("/{full_path:path}")
     async def serve_spa(full_path: str, request: Request):
+        # Unmatched /api/* must NOT be swallowed by the SPA fallback —
+        # they should surface as JSON 404s so missing-route bugs are
+        # visible instead of masked as "working" HTML responses. (Real
+        # /api/* routes are mounted before mount_spa(); reaching here
+        # means none of them matched.)
+        if full_path.startswith("api/"):
+            return JSONResponse(
+                {"error": f"no such api route: /{full_path}"},
+                status_code=404,
+            )
         prefix = _normalise_prefix(request.headers.get("x-forwarded-prefix"))
         file_path = WEB_DIST / full_path
         # Prevent path traversal via url-encoded sequences (%2e%2e/)
@@ -4388,6 +4406,58 @@ def _mount_plugin_api_routes():
 
 # Mount plugin API routes before the SPA catch-all.
 _mount_plugin_api_routes()
+
+
+def _install_api_404_fallback(application) -> None:
+    """Register a JSON 404 fallback for unmatched ``/api/*`` paths.
+
+    Without this, the SPA catch-all (``mount_spa``) would serve ``index.html``
+    with HTTP 200 + ``text/html`` for any unknown API path — silently masking
+    missing/unmounted plugin routes as success and breaking every downstream
+    consumer that does ``res.json()`` after a 2xx check.
+
+    For ``/api/plugins/<name>/...`` we additionally distinguish between
+    "known plugin, no such route" and "unknown plugin" so frontend code can
+    tell a misconfiguration from a typo.
+    """
+
+    @application.get("/api/plugins/{plugin_name}/{rest:path}")
+    @application.post("/api/plugins/{plugin_name}/{rest:path}")
+    @application.put("/api/plugins/{plugin_name}/{rest:path}")
+    @application.delete("/api/plugins/{plugin_name}/{rest:path}")
+    @application.patch("/api/plugins/{plugin_name}/{rest:path}")
+    async def _plugin_api_404(plugin_name: str, rest: str):
+        known = {str(p["name"]) for p in _get_dashboard_plugins()}
+        if plugin_name in known:
+            return JSONResponse(
+                {
+                    "error": "no such plugin route",
+                    "plugin": plugin_name,
+                    "path": rest,
+                },
+                status_code=404,
+            )
+        return JSONResponse(
+            {
+                "error": "unknown plugin",
+                "plugin": plugin_name,
+            },
+            status_code=404,
+        )
+
+    @application.get("/api/{full_api_path:path}")
+    @application.post("/api/{full_api_path:path}")
+    @application.put("/api/{full_api_path:path}")
+    @application.delete("/api/{full_api_path:path}")
+    @application.patch("/api/{full_api_path:path}")
+    async def _api_404(full_api_path: str):
+        return JSONResponse(
+            {"error": "no such api route", "path": full_api_path},
+            status_code=404,
+        )
+
+
+_install_api_404_fallback(app)
 
 mount_spa(app)
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2324,3 +2324,96 @@ class TestPtyWebSocket:
             ):
                 pass
         assert exc.value.code == 4400
+
+
+# ---------------------------------------------------------------------------
+# SPA catch-all must not swallow unmatched /api/* paths
+# ---------------------------------------------------------------------------
+
+
+class TestSpaCatchAllExcludesApi:
+    """Regression for hermes-ui board t_201cd739.
+
+    The SPA fallback (``serve_spa``) used to match ``/{full_path:path}``
+    for *every* unrouted request, which meant typos and missing-route
+    mounts under ``/api/*`` returned the SPA ``index.html`` shell with
+    HTTP 200 + ``text/html`` instead of a JSON 404. That masked real
+    routing bugs as "working" responses and produced at least one
+    false-positive bug report against a plugin that was, in fact, fine.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _setup_clients(self, monkeypatch, _isolate_hermes_home):
+        try:
+            from starlette.testclient import TestClient
+        except ImportError:
+            pytest.skip("fastapi/starlette not installed")
+
+        import hermes_state
+        from hermes_constants import get_hermes_home
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+        monkeypatch.setattr(
+            hermes_state, "DEFAULT_DB_PATH", get_hermes_home() / "state.db"
+        )
+
+        self.auth_client = TestClient(app)
+        self.auth_client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+
+    def test_unknown_plugin_returns_json_404(self):
+        """A completely fake plugin name must 404 JSON, not 200 HTML."""
+        resp = self.auth_client.get(
+            "/api/plugins/_definitely_not_a_plugin_/anything"
+        )
+        assert resp.status_code == 404
+        assert resp.headers["content-type"].startswith("application/json")
+        assert "<!doctype" not in resp.text.lower()
+        assert "<html" not in resp.text.lower()
+
+    def test_known_plugin_unknown_endpoint_returns_json_404(self):
+        """Real plugin + bogus endpoint must 404 JSON, not 200 HTML.
+
+        This is the headline trap: the plugin's router is mounted, so the
+        prefix exists, but the specific path is bogus. The auth middleware
+        passes the request through (token is valid), the plugin's router
+        returns 404, and the SPA catch-all used to swallow that and return
+        the index.html shell with 200. After the fix it must surface as a
+        JSON 404.
+        """
+        # Use hermes-achievements — a plugin loaded by default whose
+        # router has a stable set of endpoints. Any bogus suffix should
+        # 404 without being eaten by the SPA fallback.
+        resp = self.auth_client.get(
+            "/api/plugins/hermes-achievements/does-not-exist"
+        )
+        assert resp.status_code == 404
+        assert resp.headers["content-type"].startswith("application/json")
+        assert "<!doctype" not in resp.text.lower()
+
+    def test_unknown_top_level_api_returns_json_404(self):
+        """``/api/<bogus>`` (no plugin namespace) must also 404 JSON."""
+        resp = self.auth_client.get("/api/no-such-endpoint")
+        assert resp.status_code == 404
+        assert resp.headers["content-type"].startswith("application/json")
+
+    def test_real_api_route_still_works(self):
+        """Regression check: the catch-all must not break real /api routes."""
+        resp = self.auth_client.get("/api/status")
+        assert resp.status_code == 200
+        # /api/status returns JSON
+        assert resp.headers["content-type"].startswith("application/json")
+
+    def test_spa_route_still_falls_back_to_index(self):
+        """Non-/api/ client-side routes still hit the SPA index.html.
+
+        Skipped when the SPA bundle isn't built — the no_frontend branch
+        returns JSON 404 instead in that case (also a regression we test
+        below as a side effect, but the index-html assertion is moot).
+        """
+        from hermes_cli import web_server as ws_mod
+
+        if not ws_mod.WEB_DIST.exists():
+            pytest.skip("SPA bundle not built; /any/spa/route would JSON 404")
+        resp = self.auth_client.get("/any/client/side/route")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/html")

--- a/tests/test_gateway_plugin_routes.py
+++ b/tests/test_gateway_plugin_routes.py
@@ -1,0 +1,179 @@
+"""Gateway: ``/api/*`` must return JSON 404, NOT SPA index.html shell.
+
+Regression test for t_af4699af. Before the fix, the SPA catch-all
+(``mount_spa``) served ``index.html`` with HTTP 200 + ``text/html`` for any
+unmatched path including unknown ``/api/plugins/<name>/...`` routes. That
+silently masked missing/unmounted plugin routes as success and broke every
+downstream consumer that did ``res.json()`` after a 2xx check.
+
+The contract this file enforces:
+
+1. ``/api/plugins/<known>/<unmounted>`` -> 404 application/json with
+   ``{"error": "no such plugin route"}``.
+2. ``/api/plugins/<unknown>/...``        -> 404 application/json with
+   ``{"error": "unknown plugin"}``.
+3. ``/api/<anything-else-unmatched>``    -> 404 application/json with
+   ``{"error": "no such api route"}``.
+4. The SPA catch-all still serves the frontend for non-``/api`` paths
+   (regression guard: the fix must not break the SPA).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def client(monkeypatch, tmp_path):
+    """Authenticated TestClient against the live FastAPI app."""
+    try:
+        from starlette.testclient import TestClient
+    except ImportError:  # pragma: no cover
+        pytest.skip("fastapi/starlette not installed")
+
+    # Isolate hermes_home so test runs don't poison the user's real state.db.
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from hermes_cli.web_server import (
+        _SESSION_HEADER_NAME,
+        _SESSION_TOKEN,
+        app,
+    )
+
+    c = TestClient(app)
+    c.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+    return c
+
+
+@pytest.fixture
+def known_plugin_name(monkeypatch):
+    """Force ``_get_dashboard_plugins`` to return at least one known plugin
+    so tests don't depend on which plugins are installed on the dev box.
+    """
+    from hermes_cli import web_server
+
+    fake = [
+        {"name": "test-known-plugin", "_dir": "/tmp/fake", "_api_file": None},
+    ]
+    monkeypatch.setattr(web_server, "_get_dashboard_plugins", lambda *a, **k: fake)
+    return "test-known-plugin"
+
+
+# ---------------------------------------------------------------------------
+# AC 1: known plugin, no mounted route -> 404 JSON with "no such plugin route"
+# ---------------------------------------------------------------------------
+
+
+def test_known_plugin_unmounted_route_returns_404_json(client, known_plugin_name):
+    resp = client.get(f"/api/plugins/{known_plugin_name}/definitely-not-a-real-route")
+    assert resp.status_code == 404, (
+        f"Expected 404 for known plugin + unmounted route, got "
+        f"{resp.status_code} with body {resp.text[:200]!r}. "
+        f"If this is HTTP 200 with HTML, the SPA catch-all is masking /api/* again."
+    )
+    assert resp.headers["content-type"].startswith("application/json"), (
+        f"Expected application/json, got {resp.headers.get('content-type')!r}. "
+        f"HTML response means the SPA catch-all served index.html instead of 404."
+    )
+    body = resp.json()
+    assert body.get("error") == "no such plugin route", body
+    assert body.get("plugin") == known_plugin_name, body
+
+
+def test_known_plugin_unmounted_nested_path_returns_404_json(client, known_plugin_name):
+    resp = client.get(f"/api/plugins/{known_plugin_name}/nested/deep/path")
+    assert resp.status_code == 404
+    assert resp.headers["content-type"].startswith("application/json")
+    body = resp.json()
+    assert body["error"] == "no such plugin route"
+    assert body["path"] == "nested/deep/path"
+
+
+# ---------------------------------------------------------------------------
+# AC 2: unknown plugin -> 404 JSON with "unknown plugin"
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_plugin_returns_404_json(client, known_plugin_name):
+    # known_plugin_name fixture pins the known-plugin set so this name is unknown.
+    resp = client.get("/api/plugins/totally-bogus-plugin-name/list")
+    assert resp.status_code == 404
+    assert resp.headers["content-type"].startswith("application/json")
+    body = resp.json()
+    assert body["error"] == "unknown plugin"
+    assert body["plugin"] == "totally-bogus-plugin-name"
+
+
+# ---------------------------------------------------------------------------
+# AC 3: SPA catch-all match LAST — generic /api/* unmatched -> 404 JSON
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_api_route_returns_404_json(client):
+    resp = client.get("/api/this-is-not-a-real-endpoint")
+    assert resp.status_code == 404
+    assert resp.headers["content-type"].startswith("application/json")
+    body = resp.json()
+    assert body["error"] == "no such api route"
+
+
+def test_unknown_nested_api_route_returns_404_json(client):
+    resp = client.get("/api/foo/bar/baz")
+    assert resp.status_code == 404
+    assert resp.headers["content-type"].startswith("application/json")
+    body = resp.json()
+    assert body["error"] == "no such api route"
+    assert body["path"] == "foo/bar/baz"
+
+
+# ---------------------------------------------------------------------------
+# Regression guard for AC 3: SPA still works for non-/api paths.
+# ---------------------------------------------------------------------------
+
+
+def test_spa_catchall_still_serves_frontend_for_non_api_paths(client):
+    """The SPA catch-all must still match non-``/api`` paths.
+
+    If WEB_DIST doesn't exist in the test env (frontend not built), the
+    mount registers a ``no_frontend`` handler that returns JSON 404 instead.
+    Either outcome proves the catch-all hasn't been swallowed by the /api
+    fallback; only a route-not-found error from FastAPI would be a real
+    regression.
+    """
+    resp = client.get("/some-spa-route")
+    # Acceptable outcomes:
+    #   - 200 text/html (frontend built, SPA serving index.html)
+    #   - 404 application/json with "Frontend not built" (frontend not built)
+    # NOT acceptable: 404 with FastAPI's default "Not Found" JSON shape (would
+    # mean the SPA catch-all was clobbered).
+    assert resp.status_code in (200, 404), resp.status_code
+    if resp.status_code == 200:
+        assert "html" in resp.headers["content-type"].lower()
+    else:
+        # Should be the no_frontend handler, not FastAPI's default 404.
+        body = resp.json()
+        assert "Frontend not built" in body.get("error", ""), body
+
+
+# ---------------------------------------------------------------------------
+# Method coverage: POST/PUT/DELETE/PATCH on unmounted plugin routes also 404 JSON
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("method", ["post", "put", "delete", "patch"])
+def test_unmounted_plugin_route_non_get_returns_404_json(client, known_plugin_name, method):
+    resp = getattr(client, method)(f"/api/plugins/{known_plugin_name}/nope")
+    assert resp.status_code == 404, (
+        f"{method.upper()} on unmounted plugin route returned {resp.status_code}; "
+        "should be 404 JSON."
+    )
+    assert resp.headers["content-type"].startswith("application/json")
+    assert resp.json()["error"] == "no such plugin route"
+
+
+@pytest.mark.parametrize("method", ["post", "put", "delete", "patch"])
+def test_unknown_api_route_non_get_returns_404_json(client, method):
+    resp = getattr(client, method)("/api/no-such-thing")
+    assert resp.status_code == 404
+    assert resp.headers["content-type"].startswith("application/json")
+    assert resp.json()["error"] == "no such api route"


### PR DESCRIPTION
## Problem

The SPA catch-all (`@app.get("/{full_path:path}")` in `mount_spa()`, hermes_cli/web_server.py:3614) matches **every** unrouted request, including unknown paths under `/api/*`. That means a typo or missing plugin route returns the `index.html` shell with HTTP 200 + `text/html` instead of a JSON 404 — silently masking real routing bugs as "working" and breaking every downstream consumer that does `res.json()` after a 2xx check.

### Reproduced live (2026-05-18):
```
$ TOK=$(curl -s http://127.0.0.1:9119/ | grep -oE 'window.__HERMES_SESSION_TOKEN__="[^"]+"' | sed 's/.*="//; s/"$//')
$ curl -s -H "Authorization: Bearer $TOK" -o /tmp/r -w 'HTTP %{http_code} ct=%{content_type}\n' \
    'http://127.0.0.1:9119/api/plugins/quick-glance/list'
HTTP 200 ct=text/html; charset=utf-8     # ← bug
```

Same response for known-plugin-bogus-route and unknown-plugin alike. Already produced one false-positive bug report on the `hermes-ui` board (t_f5d825ac) — investigator thought the quick-glance plugin was broken because `res.json()` failed; in fact the plugin doesn't fetch that endpoint at all and the route just doesn't exist.

## Fix

Install a JSON 404 fallback for `/api/*` between `_mount_plugin_api_routes()` and `mount_spa()`. Order of route registration matters in FastAPI: real plugin routes mount first, the 404 fallback mounts after, the SPA catch-all mounts last.

Behavior matrix:

| Request | Before | After |
|---|---|---|
| `/api/plugins/<known>/<unmounted>` | 200 text/html (SPA shell) | 404 `{"error":"no such plugin route"}` |
| `/api/plugins/<unknown>/...` | 200 text/html (SPA shell) | 404 `{"error":"unknown plugin"}` |
| `/api/<other unmatched>` | 200 text/html (SPA shell) | 404 `{"error":"no such api route"}` |
| `/some-spa-route` | 200 text/html | 200 text/html (unchanged) |
| `/api/status` (real route) | 200 JSON | 200 JSON (unchanged) |

GET/POST/PUT/DELETE/PATCH all covered.

## Tests

- **NEW** `tests/test_gateway_plugin_routes.py` — 14 tests covering the three acceptance criteria + non-GET method coverage + SPA regression guard.
- **NEW** `tests/hermes_cli/test_web_server.py::TestSpaCatchAllExcludesApi` — 5 tests including a positive regression check that `/api/status` still works and a SPA-fallback check (an in-tree WIP class from a prior workshop on this same bug; validated against this fix).

```
============================== 19 passed in ~5s ===============================
```

Also confirmed no regressions in the broader `tests/hermes_cli/` + `tests/plugins/` slice (5372 pass; the 18 failures on this branch all reproduce on `origin/main` and are unrelated areas — systemd gateway service, openclaw migration, setup wizard, etc.).

## Refs

- t_af4699af on `hermes` board (this fix)
- t_f5d825ac on `hermes-ui` board (the false-positive bug report that exposed this)
- t_201cd739 on `hermes-ui` board (separately filed work-in-progress test class for the same issue, found uncommitted on disk in this checkout; rolled into this PR with both test files passing)