### PR TITLE
fix(agent): switch stream stall watchdog to monotonic clock

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1247,10 +1247,10 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     request_client_holder = {"client": None, "diag": None}
     first_delta_fired = {"done": False}
     deltas_were_sent = {"yes": False}  # Track if any deltas were fired (for fallback)
-    # Wall-clock timestamp of the last real streaming chunk.  The outer
+    # Monotonic timestamp of the last real streaming chunk. The outer
     # poll loop uses this to detect stale connections that keep receiving
-    # SSE keep-alive pings but no actual data.
-    last_chunk_time = {"t": time.time()}
+    # SSE keep-alive pings but no actual data, even if wall clock time jumps.
+    last_chunk_time = {"t": time.monotonic()}
 
     def _fire_first_delta():
         if not first_delta_fired["done"] and on_first_delta:
@@ -1307,7 +1307,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         )
         # Reset stale-stream timer so the detector measures from this
         # attempt's start, not a previous attempt's last chunk.
-        last_chunk_time["t"] = time.time()
+        last_chunk_time["t"] = time.monotonic()
         agent._touch_activity("waiting for provider response (streaming)")
         # Initialize per-attempt stream diagnostics so the retry block can
         # reach for them after the stream dies.  Lives on
@@ -1343,7 +1343,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         reasoning_parts: list = []
         usage_obj = None
         for chunk in stream:
-            last_chunk_time["t"] = time.time()
+            last_chunk_time["t"] = time.monotonic()
             agent._touch_activity("receiving stream response")
 
             # Update per-attempt diagnostic counters.  Best-effort —
@@ -1556,7 +1556,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         has_tool_use = False
 
         # Reset stale-stream timer for this attempt
-        last_chunk_time["t"] = time.time()
+        last_chunk_time["t"] = time.monotonic()
         # Per-attempt diagnostic dict for the retry block to consume.
         _diag = agent._stream_diag_init()
         request_client_holder["diag"] = _diag
@@ -1579,7 +1579,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 # Opus streams after 180 s even when events are
                 # actively arriving (the chat_completions path
                 # already does this at the top of its chunk loop).
-                last_chunk_time["t"] = time.time()
+                last_chunk_time["t"] = time.monotonic()
                 agent._touch_activity("receiving stream response")
 
                 # Update per-attempt diagnostic counters (best-effort).
@@ -1914,7 +1914,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
 
     t = threading.Thread(target=_call, daemon=True)
     t.start()
-    _last_heartbeat = time.time()
+    _last_heartbeat = time.monotonic()
     _HEARTBEAT_INTERVAL = 30.0  # seconds between gateway activity touches
     while t.is_alive():
         t.join(timeout=0.3)
@@ -1927,7 +1927,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         # activity on each chunk, but the gap between API call start
         # and first chunk can exceed the gateway timeout — especially
         # when the stale-stream timeout is disabled (local providers).
-        _hb_now = time.time()
+        _hb_now = time.monotonic()
         if _hb_now - _last_heartbeat >= _HEARTBEAT_INTERVAL:
             _last_heartbeat = _hb_now
             _waiting_secs = int(_hb_now - last_chunk_time["t"])
@@ -1938,7 +1938,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         # Detect stale streams: connections kept alive by SSE pings
         # but delivering no real chunks.  Kill the client so the
         # inner retry loop can start a fresh connection.
-        _stale_elapsed = time.time() - last_chunk_time["t"]
+        _stale_elapsed = time.monotonic() - last_chunk_time["t"]
         if _stale_elapsed > _stream_stale_timeout:
             _est_ctx = sum(len(str(v)) for v in api_kwargs.get("messages", [])) // 4
             logger.warning(
@@ -1967,7 +1967,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 pass
             # Reset the timer so we don't kill repeatedly while
             # the inner thread processes the closure.
-            last_chunk_time["t"] = time.time()
+            last_chunk_time["t"] = time.monotonic()
             agent._touch_activity(
                 f"stale stream detected after {int(_stale_elapsed)}s, reconnecting"
             )

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -4,6 +4,7 @@ Tests the unified streaming API call, delta callbacks, tool-call
 suppression, provider fallback, and CLI streaming display.
 """
 import json
+import os
 import threading
 import uuid
 from types import SimpleNamespace
@@ -53,6 +54,27 @@ def _make_tool_call_delta(index=0, tc_id=None, name=None, arguments=None, extra_
 def _make_empty_chunk(model=None, usage=None):
     """Build a chunk with no choices (usage-only final chunk)."""
     return SimpleNamespace(choices=[], model=model, usage=usage)
+
+
+class _BlockingStream:
+    """Streaming iterator that blocks until interrupted or explicitly released."""
+
+    def __init__(self, agent, release_event=None, release_exc_factory=None):
+        self._agent = agent
+        self._release_event = release_event or threading.Event()
+        self._release_exc_factory = release_exc_factory or (
+            lambda: InterruptedError("stream released")
+        )
+        self.response = None
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        while not self._release_event.wait(0.01):
+            if self._agent._interrupt_requested:
+                raise InterruptedError("stream interrupted")
+        raise self._release_exc_factory()
 
 
 # ── Test: Streaming Accumulator ──────────────────────────────────────────
@@ -669,6 +691,131 @@ class TestStreamingFallback:
 
 
 # ── Test: Reasoning Streaming ────────────────────────────────────────────
+
+
+class TestStreamingMonotonicClocks:
+    """Verify stale-stream logic uses monotonic elapsed time."""
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_stale_stream_detection_uses_monotonic_when_wall_clock_moves_backward(
+        self, mock_close, mock_create
+    ):
+        """Backward wall-clock jumps must not suppress stale-stream recovery."""
+        from run_agent import AIAgent
+        import httpx
+        import agent.chat_completion_helpers as helpers
+
+        monotonic_values = iter([0.0, 0.2])
+        monotonic_counter = {"value": 0.2}
+        wall_clock_counter = {"value": 1000.0}
+
+        def _fake_monotonic():
+            try:
+                return next(monotonic_values)
+            except StopIteration:
+                monotonic_counter["value"] += 0.2
+                return monotonic_counter["value"]
+
+        def _fake_time():
+            wall_clock_counter["value"] -= 100.0
+            return wall_clock_counter["value"]
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        release_event = threading.Event()
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _BlockingStream(
+            agent,
+            release_event=release_event,
+            release_exc_factory=lambda: httpx.ConnectError("released after stale close"),
+        )
+        mock_create.return_value = mock_client
+
+        def _close_side_effect(_client, reason=None):
+            if reason == "stale_stream_kill":
+                release_event.set()
+
+        mock_close.side_effect = _close_side_effect
+
+        with (
+            patch.dict(
+                os.environ,
+                {"HERMES_STREAM_STALE_TIMEOUT": "0.35", "HERMES_STREAM_RETRIES": "0"},
+                clear=False,
+            ),
+            patch.object(helpers.time, "monotonic", side_effect=_fake_monotonic),
+            patch.object(helpers.time, "time", side_effect=_fake_time),
+        ):
+            with pytest.raises(httpx.ConnectError, match="released after stale close"):
+                agent._interruptible_streaming_api_call({})
+
+        close_reasons = [call.kwargs.get("reason") for call in mock_close.call_args_list]
+        assert "stale_stream_kill" in close_reasons
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_stale_stream_detection_ignores_forward_wall_clock_jumps(
+        self, mock_close, mock_create
+    ):
+        """Forward wall-clock jumps must not trigger false stale-stream reconnects."""
+        from run_agent import AIAgent
+        import agent.chat_completion_helpers as helpers
+
+        monotonic_counter = {"value": 0.0}
+        wall_clock_counter = {"value": 1000.0}
+
+        def _fake_monotonic():
+            monotonic_counter["value"] += 0.05
+            return monotonic_counter["value"]
+
+        def _fake_time():
+            wall_clock_counter["value"] += 1000.0
+            return wall_clock_counter["value"]
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _BlockingStream(agent)
+        mock_create.return_value = mock_client
+
+        interrupter = threading.Timer(0.35, lambda: setattr(agent, "_interrupt_requested", True))
+        interrupter.start()
+        try:
+            with (
+                patch.dict(
+                    os.environ,
+                    {"HERMES_STREAM_STALE_TIMEOUT": "0.35", "HERMES_STREAM_RETRIES": "0"},
+                    clear=False,
+                ),
+                patch.object(helpers.time, "monotonic", side_effect=_fake_monotonic),
+                patch.object(helpers.time, "time", side_effect=_fake_time),
+            ):
+                with pytest.raises(InterruptedError):
+                    agent._interruptible_streaming_api_call({})
+        finally:
+            interrupter.cancel()
+
+        close_reasons = [call.kwargs.get("reason") for call in mock_close.call_args_list]
+        assert "stale_stream_kill" not in close_reasons
 
 
 class TestReasoningStreaming:


### PR DESCRIPTION
## What does this PR do?

The stream stale-connection watchdog was using `time.time()` to measure elapsed time between chunks. Wall-clock is the wrong source here: it can jump backward (NTP correction, manual time change, VM resume) or forward (drift correction, container time skew), and both cases break the watchdog's behavior.

This PR switches the watchdog, heartbeat tracking, and chunk-activity timers to `time.monotonic()`, which is what should have been used from the start for any "how much time has elapsed" computation.

## Root cause

The stall detector compares the current time against a stored timestamp to decide whether the stream has gone quiet long enough to warrant a reconnect:

```python
last_chunk_time = time.time()
...
if time.time() - last_chunk_time > stale_timeout:
    # trigger reconnect
```

Because `time.time()` is wall-clock, this fails in two directions:

- **Backward jump** — `now - last_chunk_time` becomes negative or near-zero, so the watchdog never fires and a genuinely stalled stream is held open
- **Forward jump** — the same delta inflates past `stale_timeout` even though no real time has passed, triggering a false reconnect on a healthy stream

## Fix

Use `time.monotonic()` for all elapsed-time computations in the streaming path:

```python
last_chunk_time = time.monotonic()
...
if time.monotonic() - last_chunk_time > stale_timeout:
    # trigger reconnect
```

Touched call sites: the chunk-activity timer, the heartbeat clock, and the post-reconnect timer reset. Log timestamps that need real wall-clock semantics are left alone.

## Related Issue

Fixes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Security fix
- [ ] Documentation update
- [x] Tests
- [ ] Refactor
- [ ] New skill

## How to Test

```
uv run pytest tests/run_agent/test_streaming.py -k "stale_stream_detection or sse_connection_lost_retried_as_transient" -q
```

Expected: `3 passed`.

The two new tests monkey-patch `time.time()` to simulate wall-clock jumps while leaving `time.monotonic()` advancing normally, then assert:

- backward wall-clock jumps do **not** suppress stale-stream recovery
- forward wall-clock jumps do **not** trigger false stale reconnects

The third test (`test_sse_connection_lost_retried_as_transient`) is the existing regression for the surrounding retry path and confirms unchanged behavior under normal conditions.

## Checklist

- [x] Conventional Commits (`fix(agent): ...`)
- [x] Searched existing PRs for duplicates
- [x] PR contains only changes related to this fix (unrelated `uv.lock` drift excluded)
- [x] Targeted test suite passes locally (`3 passed`)
- [x] Added regression tests for both jump directions
- [x] No public API, config, or schema changes — documentation update N/A
- [x] No tool/skill behavior changes — schema update N/A

## Notes for reviewer

This is a semantics-preserving change under normal operation — `time.monotonic()` and `time.time()` advance at the same rate when the clock is stable, so retry timing, heartbeat cadence, and stall thresholds are unchanged. The fix only manifests when the wall-clock deviates from real elapsed time.