### PR TITLE
fix(auxiliary): resolve fallback_chain explicit overrides

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2724,12 +2724,16 @@ def _resolve_single_provider(
 
     Uses the existing provider resolution infrastructure where possible.
     """
-    # Reuse resolve_provider_client which handles provider→client mapping
+    # Reuse resolve_provider_client which handles provider→client mapping.
+    # NOTE: resolve_provider_client names these explicit_base_url /
+    # explicit_api_key. Passing base_url / api_key raises TypeError, which is
+    # swallowed by _try_configured_fallback_chain and makes configured
+    # auxiliary fallback_chain entries silently no-op.
     client, resolved_model = resolve_provider_client(
         provider=provider,
         model=model,
-        base_url=base_url,
-        api_key=api_key,
+        explicit_base_url=base_url,
+        explicit_api_key=api_key,
     )
     return client
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2725,11 +2725,9 @@ def _resolve_single_provider(
     Uses the existing provider resolution infrastructure where possible.
     """
     # Reuse resolve_provider_client which handles provider→client mapping.
-    # NOTE: resolve_provider_client names these explicit_base_url /
-    # explicit_api_key. Passing base_url / api_key raises TypeError, which is
-    # swallowed by _try_configured_fallback_chain and makes configured
-    # auxiliary fallback_chain entries silently no-op.
-    client, resolved_model = resolve_provider_client(
+    # NOTE: resolve_provider_client names these endpoint overrides explicit_*;
+    # using the public fallback_chain field names here regresses #27555.
+    client, _resolved_model = resolve_provider_client(
         provider=provider,
         model=model,
         explicit_base_url=base_url,

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1160,6 +1160,29 @@ class TestAuxiliaryFallbackLayering:
         exc.status_code = 402
         return exc
 
+
+    def test_resolve_single_provider_passes_explicit_overrides(self):
+        """fallback_chain entries with base_url/api_key resolve via explicit_* kwargs."""
+        from agent.auxiliary_client import _resolve_single_provider
+
+        fake_client = MagicMock()
+        with patch("agent.auxiliary_client.resolve_provider_client",
+                   return_value=(fake_client, "fallback-model")) as resolver:
+            client = _resolve_single_provider(
+                "custom",
+                model="fallback-model",
+                base_url="https://fallback.example/v1",
+                api_key="fallback-key",
+            )
+
+        assert client is fake_client
+        resolver.assert_called_once_with(
+            provider="custom",
+            model="fallback-model",
+            explicit_base_url="https://fallback.example/v1",
+            explicit_api_key="fallback-key",
+        )
+
     def test_explicit_provider_uses_configured_chain_first(self, monkeypatch, caplog):
         """When a user has fallback_chain configured, it's tried BEFORE the main agent model."""
         monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1183,6 +1183,45 @@ class TestAuxiliaryFallbackLayering:
             explicit_api_key="fallback-key",
         )
 
+
+    def test_configured_fallback_chain_uses_base_url_api_key_entry(self, monkeypatch):
+        """A fallback_chain entry with endpoint overrides resolves and is returned."""
+        from agent.auxiliary_client import _try_configured_fallback_chain
+
+        fake_client = MagicMock()
+        task_config = {
+            "fallback_chain": [
+                {
+                    "provider": "custom",
+                    "model": "fallback-model",
+                    "base_url": "https://fallback.example/v1",
+                    "api_key": "fallback-key",
+                }
+            ]
+        }
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            lambda task: task_config,
+        )
+
+        with patch("agent.auxiliary_client.resolve_provider_client",
+                   return_value=(fake_client, "fallback-model")) as resolver:
+            client, model, label = _try_configured_fallback_chain(
+                "vision",
+                failed_provider="primary-provider",
+                reason="rate limit",
+            )
+
+        assert client is fake_client
+        assert model == "fallback-model"
+        assert label == "fallback_chain[0](custom)"
+        resolver.assert_called_once_with(
+            provider="custom",
+            model="fallback-model",
+            explicit_base_url="https://fallback.example/v1",
+            explicit_api_key="fallback-key",
+        )
+
     def test_explicit_provider_uses_configured_chain_first(self, monkeypatch, caplog):
         """When a user has fallback_chain configured, it's tried BEFORE the main agent model."""
         monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")


### PR DESCRIPTION
## Summary

Fix `_resolve_single_provider()` so auxiliary `fallback_chain` entries pass explicit endpoint overrides using the parameter names accepted by `resolve_provider_client()`.

Previously it passed `base_url=` and `api_key=`, but `resolve_provider_client()` expects `explicit_base_url=` and `explicit_api_key=`. That raises a `TypeError`; `_try_configured_fallback_chain()` catches exceptions while resolving entries, so configured fallback chains can silently no-op and fall through to the main-agent fallback instead.

Closes #27555.

## Test plan

- `python -m compileall -q agent/auxiliary_client.py tests/agent/test_auxiliary_client.py`
- Manual unit check with `unittest.mock.patch` verifying `_resolve_single_provider()` calls `resolve_provider_client(provider=..., model=..., explicit_base_url=..., explicit_api_key=...)`

`pytest` is not installed in this checkout's current interpreter, so I could not run the pytest target locally.
