### PR TITLE
fix(gateway): avoid ghost session creation for read-only history commands

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9690,7 +9690,9 @@ class GatewayRunner:
     async def _handle_retry_command(self, event: MessageEvent) -> str:
         """Handle /retry command - re-send the last user message."""
         source = event.source
-        session_entry = self.session_store.get_or_create_session(source)
+        session_entry = self.session_store.get_existing_session(source)
+        if session_entry is None:
+            return t("gateway.retry.no_previous")
         history = self.session_store.load_transcript(session_entry.session_id)
         
         # Find the last user message
@@ -9747,27 +9749,37 @@ class GatewayRunner:
         except Exception:
             return 20
 
-    def _get_goal_manager_for_event(self, event: "MessageEvent"):
+    def _get_goal_manager_for_event(
+        self,
+        event: "MessageEvent",
+        *,
+        create_if_missing: bool = True,
+    ):
         """Return a GoalManager bound to the session for this gateway event.
 
-        Returns ``(manager, session_entry)`` or ``(None, None)`` if the
-        goals module can't be loaded.
+        Returns ``(manager, session_entry, state)`` where ``state`` is one of:
+        ``"ok"``, ``"no_session"``, or ``"unavailable"``.
         """
         try:
             from hermes_cli.goals import GoalManager
         except Exception as exc:
             logger.debug("goal manager unavailable: %s", exc)
-            return None, None
+            return None, None, "unavailable"
         try:
-            session_entry = self.session_store.get_or_create_session(event.source)
+            if create_if_missing:
+                session_entry = self.session_store.get_or_create_session(event.source)
+            else:
+                session_entry = self.session_store.get_existing_session(event.source)
         except Exception as exc:
             logger.debug("goal manager: session lookup failed: %s", exc)
-            return None, None
+            return None, None, "unavailable"
+        if session_entry is None:
+            return None, None, "no_session"
         sid = getattr(session_entry, "session_id", None) or ""
         if not sid:
-            return None, None
+            return None, None, "no_session"
         max_turns = self._goal_max_turns_from_config()
-        return GoalManager(session_id=sid, default_max_turns=max_turns), session_entry
+        return GoalManager(session_id=sid, default_max_turns=max_turns), session_entry, "ok"
 
     async def _handle_goal_command(self, event: "MessageEvent") -> str:
         """Handle /goal for gateway platforms.
@@ -9783,8 +9795,21 @@ class GatewayRunner:
         args = (event.get_command_args() or "").strip()
         lower = args.lower()
 
-        mgr, session_entry = self._get_goal_manager_for_event(event)
+        read_only = not args or lower in {"status", "pause", "resume", "clear", "stop", "done"}
+        mgr, session_entry, goal_state = self._get_goal_manager_for_event(
+            event,
+            create_if_missing=not read_only,
+        )
         if mgr is None:
+            if goal_state == "no_session":
+                if not args or lower == "status":
+                    return "No active goal. Set one with /goal <text>."
+                if lower == "pause":
+                    return t("gateway.goal.no_goal_set")
+                if lower == "resume":
+                    return t("gateway.goal.no_resume")
+                if lower in {"clear", "stop", "done"}:
+                    return t("gateway.no_active_goal")
             return t("gateway.goal.unavailable")
 
         if not args or lower == "status":
@@ -9854,8 +9879,13 @@ class GatewayRunner:
         to invoke while the agent is running.
         """
         args = (event.get_command_args() or "").strip()
-        mgr, _session_entry = self._get_goal_manager_for_event(event)
+        mgr, _session_entry, goal_state = self._get_goal_manager_for_event(
+            event,
+            create_if_missing=False,
+        )
         if mgr is None:
+            if goal_state == "no_session":
+                return "No active goal. Set one with /goal <text>."
             return t("gateway.goal.unavailable")
         if not mgr.has_goal():
             return "No active goal. Set one with /goal <text>."
@@ -10031,7 +10061,9 @@ class GatewayRunner:
     async def _handle_undo_command(self, event: MessageEvent) -> str:
         """Handle /undo command - remove the last user/assistant exchange."""
         source = event.source
-        session_entry = self.session_store.get_or_create_session(source)
+        session_entry = self.session_store.get_existing_session(source)
+        if session_entry is None:
+            return t("gateway.undo.nothing")
         history = self.session_store.load_transcript(session_entry.session_id)
         
         # Find the last user message and remove everything from it onward
@@ -11201,7 +11233,9 @@ class GatewayRunner:
         more aggressive about discarding everything else.
         """
         source = event.source
-        session_entry = self.session_store.get_or_create_session(source)
+        session_entry = self.session_store.get_existing_session(source)
+        if session_entry is None:
+            return t("gateway.compress.not_enough")
         history = self.session_store.load_transcript(session_entry.session_id)
 
         if not history or len(history) < 4:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -853,6 +853,33 @@ class SessionStore:
             self._ensure_loaded_locked()
             return len(self._entries) > 1
 
+    def get_existing_session(self, source: SessionSource) -> Optional[SessionEntry]:
+        """Return the current session entry without creating a new one.
+
+        Read-only slash commands use this to inspect the current conversation
+        lane without leaving behind an empty SessionEntry when no conversation
+        exists yet.
+
+        Reset-policy semantics still apply: if the existing entry would be
+        auto-reset on the next real message, treat it as absent here too.
+        This preserves the old command behavior ("nothing to retry/undo") while
+        avoiding ghost session creation.
+        """
+        session_key = self._generate_session_key(source)
+
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            if entry is None:
+                return None
+            if entry.suspended:
+                return None
+            if entry.resume_pending:
+                return entry
+            if self._should_reset(entry, source):
+                return None
+            return entry
+
     def get_or_create_session(
         self,
         source: SessionSource,

--- a/tests/gateway/test_readonly_session_creation.py
+++ b/tests/gateway/test_readonly_session_creation.py
@@ -1,0 +1,93 @@
+"""Regression tests for read-only slash commands creating ghost sessions."""
+
+from unittest.mock import patch
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource, SessionStore
+
+
+def _make_store(tmp_path):
+    config = GatewayConfig()
+    with patch("hermes_state.SessionDB", side_effect=RuntimeError("disabled for test")):
+        store = SessionStore(sessions_dir=tmp_path, config=config)
+    store._db = None
+    store._loaded = True
+    return store, config
+
+
+def _make_runner(store, config):
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = config
+    runner.session_store = store
+    runner.adapters = {}
+    return runner
+
+
+def _make_source():
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        user_id="user-1",
+        user_name="alice",
+    )
+
+
+@pytest.mark.asyncio
+async def test_retry_no_previous_message_does_not_create_session(tmp_path):
+    store, config = _make_store(tmp_path)
+    runner = _make_runner(store, config)
+
+    result = await runner._handle_retry_command(
+        MessageEvent(text="/retry", message_type=MessageType.TEXT, source=_make_source())
+    )
+
+    assert result == "No previous message to retry."
+    assert store._entries == {}
+    assert not (tmp_path / "sessions.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_undo_no_history_does_not_create_session(tmp_path):
+    store, config = _make_store(tmp_path)
+    runner = _make_runner(store, config)
+
+    result = await runner._handle_undo_command(
+        MessageEvent(text="/undo", message_type=MessageType.TEXT, source=_make_source())
+    )
+
+    assert result == "Nothing to undo."
+    assert store._entries == {}
+    assert not (tmp_path / "sessions.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_compress_no_history_does_not_create_session(tmp_path):
+    store, config = _make_store(tmp_path)
+    runner = _make_runner(store, config)
+
+    result = await runner._handle_compress_command(
+        MessageEvent(text="/compress", message_type=MessageType.TEXT, source=_make_source())
+    )
+
+    assert result == "Not enough conversation to compress (need at least 4 messages)."
+    assert store._entries == {}
+    assert not (tmp_path / "sessions.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_goal_status_no_session_does_not_create_session(tmp_path):
+    store, config = _make_store(tmp_path)
+    runner = _make_runner(store, config)
+
+    result = await runner._handle_goal_command(
+        MessageEvent(text="/goal status", message_type=MessageType.TEXT, source=_make_source())
+    )
+
+    assert result == "No active goal. Set one with /goal <text>."
+    assert store._entries == {}
+    assert not (tmp_path / "sessions.json").exists()

--- a/tests/gateway/test_retry_replacement.py
+++ b/tests/gateway/test_retry_replacement.py
@@ -35,6 +35,7 @@ async def test_gateway_retry_replaces_last_user_turn_in_transcript(tmp_path):
     session_entry = MagicMock(session_id=session_id)
     session_entry.last_prompt_tokens = 111
     gw.session_store.get_or_create_session = MagicMock(return_value=session_entry)
+    gw.session_store.get_existing_session = MagicMock(return_value=session_entry)
 
     async def fake_handle_message(event):
         assert event.text == "retry me"
@@ -76,6 +77,7 @@ async def test_gateway_retry_replays_original_text_not_retry_command(tmp_path):
     session_entry = MagicMock(session_id="test-session")
     session_entry.last_prompt_tokens = 55
     gw.session_store.get_or_create_session.return_value = session_entry
+    gw.session_store.get_existing_session.return_value = session_entry
     gw.session_store.load_transcript.return_value = [
         {"role": "user", "content": "real message"},
         {"role": "assistant", "content": "answer"},


### PR DESCRIPTION
## Summary

Stops several read-only gateway slash commands from creating empty session entries when no conversation exists yet.

This adds a non-creating `SessionStore.get_existing_session()` lookup and switches the relevant handlers to use it when they only need to inspect existing state.

## What changed

- Added `SessionStore.get_existing_session()` in `gateway/session.py`
- Updated gateway handlers to avoid lazy session creation for empty/no-op paths:
  - `/retry`
  - `/undo`
  - `/compress`
  - read-only `/goal` flows (`status`, `pause`, `resume`, `clear`/`stop`/`done`)
  - `/subgoal` when no active goal/session exists
- Preserved existing reset-policy semantics by treating entries that would auto-reset on the next real message as absent for read-only checks
- Added regression coverage for ghost-session creation
- Updated existing retry tests to mock the new read-only session lookup

## Why

Before this change, some inspection/no-op slash commands called `get_or_create_session()` even when the user had not started a conversation yet. That left behind empty session entries and `sessions.json` state despite there being nothing to resume, retry, undo, or compress.

This PR keeps those commands read-only in the “no existing session” case and returns the same user-facing responses as before.

## Tests

Passed:

- `pytest tests/gateway/test_readonly_session_creation.py tests/gateway/test_retry_replacement.py tests/gateway/test_retry_response.py -q`
- `pytest tests/gateway/test_session.py -q`

