### PR TITLE
fix(packaging): include hermes_cli subpackages in wheel (#27664)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,7 +214,7 @@ hermes_cli = ["web_dist/**/*"]
 gateway = ["assets/**/*"]
 
 [tool.setuptools.packages.find]
-include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*"]
+include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "hermes_cli.*", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -20,3 +20,21 @@ def test_manifest_includes_bundled_skills():
 
     assert "graft skills" in manifest
     assert "graft optional-skills" in manifest
+
+
+def test_hermes_cli_subpackages_bundled_in_wheel():
+    # Regression for #27664: `hermes proxy` subcommands crashed with
+    # `ModuleNotFoundError: No module named 'hermes_cli.proxy'` on Homebrew
+    # installs because packages.find listed only `hermes_cli`, not
+    # `hermes_cli.*`, so subpackages with on-disk Python code were dropped
+    # from the built wheel.
+    from setuptools import find_packages
+
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    include = data["tool"]["setuptools"]["packages"]["find"]["include"]
+
+    found = set(find_packages(where=str(REPO_ROOT), include=include))
+
+    assert "hermes_cli" in found
+    assert "hermes_cli.proxy" in found
+    assert "hermes_cli.proxy.adapters" in found


### PR DESCRIPTION
## Summary

`tool.setuptools.packages.find.include` listed `hermes_cli` without the `hermes_cli.*` glob, so the `hermes_cli.proxy` subpackage was dropped from the built wheel. Homebrew installs (and any other `find`-based packaging) advertised `hermes proxy` in the CLI dispatch but every subcommand crashed immediately.

## The bug

From #27664 on Homebrew v0.14.0:

\`\`\`
\$ hermes proxy providers
Traceback (most recent call last):
  ...
  File ".../hermes_cli/main.py", line 1480, in cmd_proxy
    from hermes_cli.proxy.cli import cmd_proxy as _cmd_proxy
ModuleNotFoundError: No module named 'hermes_cli.proxy'
\`\`\`

\`hermes_cli/proxy/\` (and its \`adapters/\` subpackage) lives in-tree but never makes it into the built distribution.

## The fix

Add \`hermes_cli.*\` alongside the existing \`hermes_cli\` entry in the \`packages.find\` include list. Every other top-level package that has Python subpackages — \`agent\`, \`tools\`, \`gateway\`, \`tui_gateway\`, \`plugins\`, \`providers\` — already uses the \`<pkg>, <pkg>.*\` pair, so this just restores symmetry.

\`\`\`diff
 [tool.setuptools.packages.find]
-include = [..., \"hermes_cli\", \"gateway\", ...]
+include = [..., \"hermes_cli\", \"hermes_cli.*\", \"gateway\", ...]
\`\`\`

## Test plan

- [x] Focused regression test \`test_hermes_cli_subpackages_bundled_in_wheel\` parses pyproject.toml, runs setuptools' \`find_packages\` against the include list, and asserts \`hermes_cli\`, \`hermes_cli.proxy\`, and \`hermes_cli.proxy.adapters\` all resolve.
- [x] Adjacent: full \`tests/test_packaging_metadata.py\` passes (3 passed in 37s with \`uv run --with pytest --with pytest-xdist --with pytest-asyncio --with setuptools\`).
- [x] Regression guard: with the pyproject change stashed, the new test fails with \`AssertionError: assert 'hermes_cli.proxy' in {'acp_adapter', 'agent', ...}\` — the same shape as the user-visible \`ModuleNotFoundError\`. With the fix applied it passes.

> Sibling code paths that may need the same fix: \`acp_adapter\` is listed without an \`acp_adapter.*\` glob and already has an \`acp_adapter/bootstrap/\` subpackage; \`cron\` is listed bare too. Both are defensive — only \`hermes_cli.proxy\` is referenced from main today — but the same root-cause class will bite again if either grows a subpackage with importable code. Intentionally left out of this PR's scope to keep the diff narrow — happy to widen if preferred.

## Related

- Fixes #27664
- Same packaging class as alt-glitch's notes on the issue: #24360 (skills dir missing), #24544 (ui-tui not included), #13581 (agent.transports missing).