### PR TITLE
Add SendIt remote MCP OAuth skill

### DIFF
--- a/optional-skills/mcp/sendit/SKILL.md
+++ b/optional-skills/mcp/sendit/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: sendit
 description: Use SendIt from Hermes Agent for social publishing, scheduling, platform connection, media upload, content validation, previews, and analytics through remote MCP OAuth.
-version: 0.2.0
+version: 0.2.1
 author: SendIt / Infinite Apps AI
 license: MIT
+licenseUrl: https://github.com/Shree-git/sendit-hermes-skills/blob/main/LICENSE
 platforms: [linux, macos]
 category: social-media
 tags: [sendit, social-media, mcp, oauth, publishing, scheduling, analytics]
@@ -30,29 +31,23 @@ metadata:
 
 # SendIt
 
-SendIt is an MCP server for AI-native social media publishing. Use this skill
-when the user wants Hermes to connect social accounts, publish or schedule
-posts, upload media, validate platform requirements, preview content, or review
-analytics through SendIt.
-
 ## When To Use
-
-Use SendIt for:
 
 - Publishing or scheduling social posts to connected platforms.
 - Listing or connecting LinkedIn, Instagram, TikTok, Threads, X, and other
   SendIt-supported accounts.
 - Validating text, media, captions, hashtags, and platform-specific limits.
-- Creating upload sessions for images, videos, or chat attachments.
+- Creating upload sessions for local images, videos, or chat attachments.
 - Checking previews and analytics before or after publishing.
-- Working in a team context after discovering teams with SendIt tools.
+- Working in a SendIt team context after discovering teams.
 
-Do not use SendIt when the user only wants local content drafting with no
-publishing, scheduling, account connection, upload, or analytics action.
+Do not use SendIt for local-only drafting.
 
-## MCP Configuration
+## Quick Reference
 
-Configure SendIt as a remote HTTP MCP server with OAuth:
+Use `https://sendit.infiniteappsai.com/api/mcp` as the remote MCP URL. Do not
+use `https://sendit.infiniteappsai.com/mcp`; that endpoint is reserved for the
+ChatGPT app profile and exposes a reduced catalog.
 
 ```yaml
 mcp_servers:
@@ -61,13 +56,7 @@ mcp_servers:
     auth: oauth
 ```
 
-Use `https://sendit.infiniteappsai.com/api/mcp`, not
-`https://sendit.infiniteappsai.com/mcp`. The `/mcp` endpoint is reserved for the
-ChatGPT app submission profile and exposes a reduced catalog. The `/api/mcp`
-endpoint exposes the standard SendIt catalog, including team tools.
-
-Hermes registers MCP tools with the `mcp_<server>_<tool>` naming pattern. With
-the server name `sendit`, expected tools include:
+Hermes exposes tools as `mcp_<server>_<tool>`. Default SendIt tools include:
 
 - `mcp_sendit_list_connected_accounts`
 - `mcp_sendit_list_teams`
@@ -75,85 +64,61 @@ the server name `sendit`, expected tools include:
 - `mcp_sendit_get_platform_requirements`
 - `mcp_sendit_validate_content`
 - `mcp_sendit_create_upload_session`
-- `mcp_sendit_get_upload_session`
 - `mcp_sendit_preview_content`
 - `mcp_sendit_publish_content`
 - `mcp_sendit_schedule_content`
 - `mcp_sendit_get_analytics`
 
-If the configured MCP server name is not `sendit`, replace the `mcp_sendit_`
-prefix with the configured name.
+- Remote VPS, Telegram, and OAuth callback replay: `references/remote-oauth.md`
+- Publishing and scheduling examples: `references/publishing-workflows.md`
+- File, network, and sensitive-data scope: `references/security.md`
 
-## Setup From A Remote VPS Or Telegram
+## Permissions
 
-Use this flow when Hermes runs on a VPS and the user opens OAuth links on a
-local phone or laptop.
+Helper scripts may copy this skill into `~/.hermes/skills/social-media/sendit`,
+read or update `~/.hermes/config.yaml` or `$HERMES_HOME/config.yaml`, run
+`hermes mcp login sendit`, and write `/tmp/sendit-hermes` PID/log files.
+Callback replay only accepts `localhost` or `127.0.0.1` `/callback` URLs and
+redacts sensitive query parameters.
 
-If this folder was uploaded through Telegram or another messaging gateway, read
-`TELEGRAM_SETUP.md` in this directory first. It contains the shorter operator
-playbook.
+## Core Workflows
 
-1. Install the skill and MCP config:
+### Configure Hermes
 
-   ```bash
-   node ${HERMES_SKILL_DIR}/scripts/install-sendit-hermes.mjs
-   ```
+Run the installer to set up SendIt or repair an older `/mcp` URL:
 
-   If Hermes has not substituted `${HERMES_SKILL_DIR}`, run the same command
-   from this skill directory as:
+```bash
+node ${HERMES_SKILL_DIR}/scripts/install-sendit-hermes.mjs
+```
 
-   ```bash
-   node scripts/install-sendit-hermes.mjs
-   ```
+### Complete Remote OAuth
 
-2. Start the OAuth login on the VPS:
+For a VPS, Telegram-only handoff, or browser-on-another-device setup, follow
+`references/remote-oauth.md`.
 
-   ```bash
-   node ${HERMES_SKILL_DIR}/scripts/start-oauth-login.mjs
-   ```
+Minimal sequence:
 
-3. Send the printed SendIt authorization URL to the user.
-4. Ask the user to open it, sign in, approve SendIt, and copy the final
-   localhost callback URL from their browser address bar.
-5. When the user pastes the callback URL, replay it on the VPS:
+```bash
+node ${HERMES_SKILL_DIR}/scripts/start-oauth-login.mjs
+node ${HERMES_SKILL_DIR}/scripts/complete-oauth-callback.mjs '<PASTED_CALLBACK_URL>'
+```
 
-   ```bash
-   node ${HERMES_SKILL_DIR}/scripts/complete-oauth-callback.mjs '<PASTED_CALLBACK_URL>'
-   ```
+Treat pasted callback URLs as sensitive because their `code` and `state` query
+parameters can complete OAuth.
 
-6. Ask the user to send `/reload-mcp`, or restart the Hermes gateway/session if
-   tools do not appear.
+### Publish Or Schedule
 
-The callback helper accepts only `http://127.0.0.1:<port>/callback?...` and
-`http://localhost:<port>/callback?...` URLs. Treat callback URLs as sensitive
-because their `code` and `state` query parameters can complete OAuth.
+List accounts, choose the team when relevant, validate content, and preview
+when possible. Publish immediately only on clear user request. Confirm date,
+time, and timezone before scheduling. See
+`references/publishing-workflows.md`.
 
-## Publishing Workflow
-
-1. Call `mcp_sendit_list_connected_accounts` before publishing or scheduling.
-2. If the user has teams, call `mcp_sendit_list_teams` and use the intended
-   `team_id` where relevant.
-3. Call `mcp_sendit_get_platform_requirements` when requirements are uncertain.
-4. If the user provides a local image, video, or chat attachment, create a
-   SendIt upload session and use the returned HTTPS URL. Do not pass arbitrary
-   local file paths to publish tools unless the tool description explicitly says
-   the target platform accepts them.
-5. Call `mcp_sendit_validate_content` before publish or schedule.
-6. Call `mcp_sendit_preview_content` before publishing when available.
-7. Use `mcp_sendit_publish_content` only when the user clearly asks for
-   immediate publishing.
-8. Use `mcp_sendit_schedule_content` for delayed posts. Confirm date, time, and
-   timezone before scheduling.
-9. Use `mcp_sendit_get_analytics` for performance reporting.
-
-## Platform Connection Workflow
+### Connect A Platform
 
 1. Call `mcp_sendit_list_connected_accounts`.
-2. For missing accounts, call `mcp_sendit_connect_platform` with the target
-   platform.
+2. For missing accounts, call `mcp_sendit_connect_platform`.
 3. Send the returned platform OAuth URL to the user.
-4. Ask the user to complete platform authorization in their browser.
-5. Re-run `mcp_sendit_list_connected_accounts` to verify the connection.
+4. Re-run `mcp_sendit_list_connected_accounts` after authorization.
 
 ## Safety Rules
 
@@ -163,25 +128,9 @@ because their `code` and `state` query parameters can complete OAuth.
 - Preview before publish when the preview tool is available.
 - Confirm destructive actions such as deleting published or scheduled posts.
 - Do not ask the user for a SendIt API key. This setup uses MCP OAuth.
-- Treat pasted OAuth callback URLs as sensitive. Never echo full `code` or
-  `state` values in chat, logs, or summaries.
+- Never echo full OAuth `code` or `state` values in chat, logs, or summaries.
 - Only replay callback URLs whose host is `127.0.0.1` or `localhost` and whose
   path is `/callback`.
-- If OAuth fails or times out, restart the background `hermes mcp login sendit`
-  flow and send the new authorization URL.
-
-## Troubleshooting
-
-- If Hermes mentions ChatGPT or team tools are missing, repair the MCP config by
-  running `node ${HERMES_SKILL_DIR}/scripts/install-sendit-hermes.mjs`. Older
-  installs may have used the reduced `/mcp` endpoint.
-- If the authorization URL is not printed, inspect
-  `/tmp/sendit-hermes/oauth.log` and verify `hermes mcp login sendit` is still
-  running.
-- If callback replay fails, ensure the OAuth login process is still waiting on
-  the VPS and rerun `node ${HERMES_SKILL_DIR}/scripts/start-oauth-login.mjs`.
-- If tools do not appear after OAuth succeeds, ask the user to send
-  `/reload-mcp` or restart the Hermes session.
 
 ## Verification
 

--- a/optional-skills/mcp/sendit/SKILL.md
+++ b/optional-skills/mcp/sendit/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: sendit
+description: Use SendIt from Hermes Agent for social publishing, scheduling, platform connection, media upload, content validation, previews, and analytics through remote MCP OAuth.
+version: 0.2.0
+author: SendIt / Infinite Apps AI
+license: MIT
+platforms: [linux, macos]
+category: social-media
+tags: [sendit, social-media, mcp, oauth, publishing, scheduling, analytics]
+repository: https://github.com/Shree-git/sendit-hermes-skills
+sourceUrl: https://github.com/Shree-git/sendit-hermes-skills/tree/main/skills/sendit
+summary: SendIt gives Hermes a remote OAuth MCP workflow for connecting social accounts, validating content, uploading media, publishing or scheduling posts, and reviewing analytics.
+icon: https://sendit.infiniteappsai.com/favicon.ico
+metadata:
+  hermes:
+    category: social-media
+    tags: [sendit, social-media, mcp, oauth, publishing, scheduling, analytics]
+    homepage: https://sendit.infiniteappsai.com
+    repository: https://github.com/Shree-git/sendit-hermes-skills
+    config:
+      - key: sendit.mcp_server_name
+        description: Hermes MCP server name for SendIt.
+        default: sendit
+        prompt: SendIt MCP server name
+      - key: sendit.mcp_url
+        description: SendIt remote MCP endpoint.
+        default: https://sendit.infiniteappsai.com/api/mcp
+        prompt: SendIt MCP endpoint
+---
+
+# SendIt
+
+SendIt is an MCP server for AI-native social media publishing. Use this skill
+when the user wants Hermes to connect social accounts, publish or schedule
+posts, upload media, validate platform requirements, preview content, or review
+analytics through SendIt.
+
+## When To Use
+
+Use SendIt for:
+
+- Publishing or scheduling social posts to connected platforms.
+- Listing or connecting LinkedIn, Instagram, TikTok, Threads, X, and other
+  SendIt-supported accounts.
+- Validating text, media, captions, hashtags, and platform-specific limits.
+- Creating upload sessions for images, videos, or chat attachments.
+- Checking previews and analytics before or after publishing.
+- Working in a team context after discovering teams with SendIt tools.
+
+Do not use SendIt when the user only wants local content drafting with no
+publishing, scheduling, account connection, upload, or analytics action.
+
+## MCP Configuration
+
+Configure SendIt as a remote HTTP MCP server with OAuth:
+
+```yaml
+mcp_servers:
+  sendit:
+    url: "https://sendit.infiniteappsai.com/api/mcp"
+    auth: oauth
+```
+
+Use `https://sendit.infiniteappsai.com/api/mcp`, not
+`https://sendit.infiniteappsai.com/mcp`. The `/mcp` endpoint is reserved for the
+ChatGPT app submission profile and exposes a reduced catalog. The `/api/mcp`
+endpoint exposes the standard SendIt catalog, including team tools.
+
+Hermes registers MCP tools with the `mcp_<server>_<tool>` naming pattern. With
+the server name `sendit`, expected tools include:
+
+- `mcp_sendit_list_connected_accounts`
+- `mcp_sendit_list_teams`
+- `mcp_sendit_connect_platform`
+- `mcp_sendit_get_platform_requirements`
+- `mcp_sendit_validate_content`
+- `mcp_sendit_create_upload_session`
+- `mcp_sendit_get_upload_session`
+- `mcp_sendit_preview_content`
+- `mcp_sendit_publish_content`
+- `mcp_sendit_schedule_content`
+- `mcp_sendit_get_analytics`
+
+If the configured MCP server name is not `sendit`, replace the `mcp_sendit_`
+prefix with the configured name.
+
+## Setup From A Remote VPS Or Telegram
+
+Use this flow when Hermes runs on a VPS and the user opens OAuth links on a
+local phone or laptop.
+
+If this folder was uploaded through Telegram or another messaging gateway, read
+`TELEGRAM_SETUP.md` in this directory first. It contains the shorter operator
+playbook.
+
+1. Install the skill and MCP config:
+
+   ```bash
+   node ${HERMES_SKILL_DIR}/scripts/install-sendit-hermes.mjs
+   ```
+
+   If Hermes has not substituted `${HERMES_SKILL_DIR}`, run the same command
+   from this skill directory as:
+
+   ```bash
+   node scripts/install-sendit-hermes.mjs
+   ```
+
+2. Start the OAuth login on the VPS:
+
+   ```bash
+   node ${HERMES_SKILL_DIR}/scripts/start-oauth-login.mjs
+   ```
+
+3. Send the printed SendIt authorization URL to the user.
+4. Ask the user to open it, sign in, approve SendIt, and copy the final
+   localhost callback URL from their browser address bar.
+5. When the user pastes the callback URL, replay it on the VPS:
+
+   ```bash
+   node ${HERMES_SKILL_DIR}/scripts/complete-oauth-callback.mjs '<PASTED_CALLBACK_URL>'
+   ```
+
+6. Ask the user to send `/reload-mcp`, or restart the Hermes gateway/session if
+   tools do not appear.
+
+The callback helper accepts only `http://127.0.0.1:<port>/callback?...` and
+`http://localhost:<port>/callback?...` URLs. Treat callback URLs as sensitive
+because their `code` and `state` query parameters can complete OAuth.
+
+## Publishing Workflow
+
+1. Call `mcp_sendit_list_connected_accounts` before publishing or scheduling.
+2. If the user has teams, call `mcp_sendit_list_teams` and use the intended
+   `team_id` where relevant.
+3. Call `mcp_sendit_get_platform_requirements` when requirements are uncertain.
+4. If the user provides a local image, video, or chat attachment, create a
+   SendIt upload session and use the returned HTTPS URL. Do not pass arbitrary
+   local file paths to publish tools unless the tool description explicitly says
+   the target platform accepts them.
+5. Call `mcp_sendit_validate_content` before publish or schedule.
+6. Call `mcp_sendit_preview_content` before publishing when available.
+7. Use `mcp_sendit_publish_content` only when the user clearly asks for
+   immediate publishing.
+8. Use `mcp_sendit_schedule_content` for delayed posts. Confirm date, time, and
+   timezone before scheduling.
+9. Use `mcp_sendit_get_analytics` for performance reporting.
+
+## Platform Connection Workflow
+
+1. Call `mcp_sendit_list_connected_accounts`.
+2. For missing accounts, call `mcp_sendit_connect_platform` with the target
+   platform.
+3. Send the returned platform OAuth URL to the user.
+4. Ask the user to complete platform authorization in their browser.
+5. Re-run `mcp_sendit_list_connected_accounts` to verify the connection.
+
+## Safety Rules
+
+- Do not publish, schedule, delete, reply, or trigger scheduled posts unless the
+  user clearly asks for that action.
+- Validate before publish or schedule.
+- Preview before publish when the preview tool is available.
+- Confirm destructive actions such as deleting published or scheduled posts.
+- Do not ask the user for a SendIt API key. This setup uses MCP OAuth.
+- Treat pasted OAuth callback URLs as sensitive. Never echo full `code` or
+  `state` values in chat, logs, or summaries.
+- Only replay callback URLs whose host is `127.0.0.1` or `localhost` and whose
+  path is `/callback`.
+- If OAuth fails or times out, restart the background `hermes mcp login sendit`
+  flow and send the new authorization URL.
+
+## Troubleshooting
+
+- If Hermes mentions ChatGPT or team tools are missing, repair the MCP config by
+  running `node ${HERMES_SKILL_DIR}/scripts/install-sendit-hermes.mjs`. Older
+  installs may have used the reduced `/mcp` endpoint.
+- If the authorization URL is not printed, inspect
+  `/tmp/sendit-hermes/oauth.log` and verify `hermes mcp login sendit` is still
+  running.
+- If callback replay fails, ensure the OAuth login process is still waiting on
+  the VPS and rerun `node ${HERMES_SKILL_DIR}/scripts/start-oauth-login.mjs`.
+- If tools do not appear after OAuth succeeds, ask the user to send
+  `/reload-mcp` or restart the Hermes session.
+
+## Verification
+
+After OAuth completes and MCP reloads, ask Hermes:
+
+```text
+Use the SendIt skill and list my connected social accounts.
+```
+
+Hermes should call `mcp_sendit_list_connected_accounts` or the equivalent
+SendIt MCP tool for the configured server name.

--- a/optional-skills/mcp/sendit/TELEGRAM_SETUP.md
+++ b/optional-skills/mcp/sendit/TELEGRAM_SETUP.md
@@ -1,0 +1,94 @@
+# SendIt Telegram-Only Setup For Hermes
+
+Use this playbook when the user sends this skill folder or archive to a Hermes
+Agent running on a remote VPS through Telegram or another messaging gateway.
+
+## Goal
+
+Configure SendIt in Hermes without asking the user to SSH into the VPS.
+
+Hermes should:
+
+1. Install the SendIt skill into `~/.hermes/skills/social-media/sendit`.
+2. Add the SendIt remote MCP server to `~/.hermes/config.yaml`.
+3. Start the OAuth login flow on the VPS.
+4. Send the user the authorization URL.
+5. Wait for the user to paste the failed localhost callback URL from their local
+   browser.
+6. Replay that callback URL against the VPS-local callback listener.
+7. Reload MCP and verify SendIt tools work.
+
+## Commands
+
+Run these commands from the directory that contains this file.
+
+### 1. Install skill and MCP config
+
+```bash
+node scripts/install-sendit-hermes.mjs
+```
+
+This also repairs older installs that used `https://sendit.infiniteappsai.com/mcp`.
+Hermes should use `https://sendit.infiniteappsai.com/api/mcp`; `/mcp` is the
+ChatGPT-specific app endpoint and has a reduced tool catalog.
+
+### 2. Start OAuth login
+
+```bash
+node scripts/start-oauth-login.mjs
+```
+
+Send the printed authorization URL to the user.
+
+### 3. Complete OAuth after the user pastes a callback URL
+
+When the user pastes a URL like:
+
+```text
+http://127.0.0.1:43879/callback?code=...&state=...
+```
+
+run:
+
+```bash
+node scripts/complete-oauth-callback.mjs '<PASTED_CALLBACK_URL>'
+```
+
+Do not echo the pasted URL back to the user. The helper validates the callback
+host and path, replays it to the VPS-local listener, and redacts sensitive query
+values from output.
+
+### 4. Reload and verify
+
+Ask the user to send:
+
+```text
+/reload-mcp
+```
+
+Then verify:
+
+```text
+Use the SendIt skill and list my connected social accounts.
+```
+
+## Telegram Prompt The User Can Send
+
+After uploading this folder or archive to Hermes, the user can say:
+
+```text
+Unpack this SendIt Hermes setup folder if needed. Read TELEGRAM_SETUP.md.
+Configure SendIt completely from Telegram. Install the skill, add the MCP server,
+start OAuth, send me the auth URL, wait for me to paste the localhost callback
+URL, then replay it on the VPS and verify SendIt tools are available.
+```
+
+## Notes
+
+- Do not ask the user for a SendIt API key. This setup uses MCP OAuth.
+- Use only `https://sendit.infiniteappsai.com/api/mcp` for the MCP server URL.
+- Do not echo full OAuth `code` or `state` values back to the user.
+- Only replay localhost callback URLs with host `127.0.0.1` or `localhost` and
+  path `/callback`.
+- If OAuth times out, rerun `node scripts/start-oauth-login.mjs` and send the
+  new authorization URL.

--- a/optional-skills/mcp/sendit/references/publishing-workflows.md
+++ b/optional-skills/mcp/sendit/references/publishing-workflows.md
@@ -1,0 +1,104 @@
+# Publishing Workflows
+
+Use this reference for tool order, media handling, scheduling, and analytics
+requests. Tool names assume the MCP server is named `sendit`; if the server name
+differs, replace the `mcp_sendit_` prefix.
+
+## Account And Team Discovery
+
+Call before publishing, scheduling, connecting, or reporting:
+
+```text
+mcp_sendit_list_connected_accounts
+```
+
+If the user works across teams, discover teams and carry the intended `team_id`
+into later tool calls when the tool schema supports it:
+
+```text
+mcp_sendit_list_teams
+```
+
+## Platform Requirements
+
+Use requirements when the user asks about limits, when content includes media,
+or when the target platform has platform-specific constraints:
+
+```text
+mcp_sendit_get_platform_requirements
+```
+
+Then validate the exact content before any publish or schedule call:
+
+```text
+mcp_sendit_validate_content
+```
+
+## Media Uploads
+
+For local images, videos, or chat attachments, create a SendIt upload session
+and use the returned HTTPS asset URL in later publish or schedule calls:
+
+```text
+mcp_sendit_create_upload_session
+mcp_sendit_get_upload_session
+```
+
+Do not pass arbitrary local file paths to publishing tools unless the tool
+description explicitly supports local paths.
+
+## Preview
+
+Preview whenever the tool is available, especially for multi-platform posts:
+
+```text
+mcp_sendit_preview_content
+```
+
+Ask the user to confirm material changes when previews reveal truncation,
+platform warnings, or media problems.
+
+## Publish Now
+
+Use immediate publishing only after the user clearly asks to publish now:
+
+```text
+mcp_sendit_publish_content
+```
+
+Good confirmations mention target platforms and account/team context, for
+example: "Publish this to the company LinkedIn page and Threads now."
+
+## Schedule
+
+Use scheduling for delayed posts:
+
+```text
+mcp_sendit_schedule_content
+```
+
+Confirm the exact date, time, and timezone before scheduling. If the user gives
+relative time such as "tomorrow morning", resolve it to a concrete timestamp
+before calling the tool.
+
+## Platform Connection
+
+For missing platforms:
+
+```text
+mcp_sendit_connect_platform
+```
+
+Send the returned OAuth URL to the user, ask them to complete authorization,
+then call `mcp_sendit_list_connected_accounts` again to verify.
+
+## Analytics
+
+Use analytics for performance summaries, post status, or platform comparison:
+
+```text
+mcp_sendit_get_analytics
+```
+
+Clarify date range, platform, account/team, and whether the user wants aggregate
+or post-level reporting when the request is ambiguous.

--- a/optional-skills/mcp/sendit/references/remote-oauth.md
+++ b/optional-skills/mcp/sendit/references/remote-oauth.md
@@ -1,0 +1,86 @@
+# Remote OAuth
+
+Use this reference when Hermes runs on a VPS, inside a remote shell, or behind a
+Telegram/file-transfer workflow where the user opens OAuth URLs on another
+device.
+
+## Canonical MCP URL
+
+Configure SendIt at:
+
+```text
+https://sendit.infiniteappsai.com/api/mcp
+```
+
+Do not configure:
+
+```text
+https://sendit.infiniteappsai.com/mcp
+```
+
+The `/mcp` endpoint is reserved for the ChatGPT app submission profile and has a
+reduced tool catalog. The `/api/mcp` endpoint exposes the standard SendIt MCP
+catalog, including team tools.
+
+## Setup Sequence
+
+If the skill arrived through Telegram or another archive handoff, `TELEGRAM_SETUP.md`
+contains the operator checklist. The full sequence is:
+
+1. Install the skill and repair/create Hermes MCP config:
+
+   ```bash
+   node ${HERMES_SKILL_DIR}/scripts/install-sendit-hermes.mjs
+   ```
+
+   If `${HERMES_SKILL_DIR}` was not substituted, run from the skill directory:
+
+   ```bash
+   node scripts/install-sendit-hermes.mjs
+   ```
+
+2. Start the OAuth listener on the VPS:
+
+   ```bash
+   node ${HERMES_SKILL_DIR}/scripts/start-oauth-login.mjs
+   ```
+
+3. Send the printed SendIt authorization URL to the user.
+4. Ask the user to open it, sign in, approve SendIt, and copy the final
+   localhost callback URL from the browser address bar.
+5. Replay the callback URL on the VPS:
+
+   ```bash
+   node ${HERMES_SKILL_DIR}/scripts/complete-oauth-callback.mjs '<PASTED_CALLBACK_URL>'
+   ```
+
+6. Ask the user to send `/reload-mcp`, or restart the Hermes gateway/session if
+   SendIt tools do not appear.
+
+## Callback Rules
+
+The replay helper accepts only callback URLs with:
+
+- protocol `http:`
+- host `127.0.0.1` or `localhost`
+- path `/callback`
+- a valid loopback port
+
+Reject remote hosts, malformed URLs, and non-callback paths. Treat callback URLs
+as sensitive because the `code` and `state` values can complete OAuth. The
+helper redacts those parameters in user-visible output.
+
+## Logs And Recovery
+
+OAuth helper state is stored under `/tmp/sendit-hermes`:
+
+- `/tmp/sendit-hermes/oauth.pid`
+- `/tmp/sendit-hermes/oauth.log`
+
+If the auth URL is not printed, inspect the log and confirm `hermes mcp login
+sendit` is still running. If callback replay fails because the listener timed
+out or exited, run `start-oauth-login.mjs` again and use the new authorization
+URL.
+
+If SendIt tools do not appear after successful OAuth, reload MCP in Hermes or
+restart the Hermes session.

--- a/optional-skills/mcp/sendit/references/security.md
+++ b/optional-skills/mcp/sendit/references/security.md
@@ -1,0 +1,55 @@
+# Security And Permissions
+
+This skill uses remote MCP OAuth. It does not require a SendIt API key, browser
+cookies, platform passwords, or local social account tokens.
+
+## Local Files
+
+The installer may read or write:
+
+- `$HERMES_HOME/config.yaml` when `HERMES_HOME` is set.
+- `~/.hermes/config.yaml` when `HERMES_HOME` is not set.
+- `~/.hermes/skills/social-media/sendit/` for the installed skill copy.
+
+Before changing an existing config, the installer preserves unrelated YAML and
+backs up the original file beside it with a timestamped `.bak` suffix. The
+repair path only targets the SendIt MCP entry and upgrades older
+`https://sendit.infiniteappsai.com/mcp` values to
+`https://sendit.infiniteappsai.com/api/mcp`.
+
+The OAuth starter writes temporary process state under `/tmp/sendit-hermes`:
+
+- `oauth.pid`
+- `oauth.log`
+
+These files are operational logs only and should not be committed.
+
+## Network And Commands
+
+The setup scripts may invoke:
+
+```bash
+hermes mcp login sendit
+```
+
+They configure SendIt as a remote OAuth MCP server at:
+
+```text
+https://sendit.infiniteappsai.com/api/mcp
+```
+
+No script reads browser profiles, password stores, SSH keys, shell history, or
+application source files.
+
+## OAuth Callback Handling
+
+`complete-oauth-callback.mjs` accepts only:
+
+- `http://127.0.0.1:<port>/callback?...`
+- `http://localhost:<port>/callback?...`
+
+It rejects remote hosts, malformed URLs, and non-`/callback` paths. In output,
+the helper redacts sensitive callback parameters such as `code` and `state`.
+
+Never paste full callback URLs into public logs or issue trackers. If a URL was
+exposed, restart the OAuth login flow so the old callback becomes unusable.

--- a/optional-skills/mcp/sendit/scripts/complete-oauth-callback.mjs
+++ b/optional-skills/mcp/sendit/scripts/complete-oauth-callback.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+
+const sensitiveKeys = new Set(['code', 'state']);
+const allowedHosts = new Set(['127.0.0.1', 'localhost']);
+
+function redactCallbackUrl(value) {
+  try {
+    const parsed = new URL(value);
+    for (const key of sensitiveKeys) {
+      if (parsed.searchParams.has(key)) {
+        parsed.searchParams.set(key, 'REDACTED');
+      }
+    }
+    return parsed.toString();
+  } catch {
+    return value
+      .replace(/([?&](?:code|state)=)[^"'&<\s]+/g, '$1REDACTED')
+      .replace(/((?:code|state)=)[^"'&<\s]+/g, '$1REDACTED');
+  }
+}
+
+function parseAndValidateCallback(rawUrl) {
+  let parsed;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new Error('Invalid URL.');
+  }
+
+  if (parsed.protocol !== 'http:' || !allowedHosts.has(parsed.hostname)) {
+    throw new Error('Refusing to replay callback: URL must be http://127.0.0.1 or http://localhost.');
+  }
+
+  if (parsed.pathname !== '/callback') {
+    throw new Error('Refusing to replay callback: path must be /callback.');
+  }
+
+  const port = Number(parsed.port);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error('Refusing to replay callback: URL must include a valid port.');
+  }
+
+  if (!parsed.searchParams.has('code') && !parsed.searchParams.has('error')) {
+    throw new Error('Refusing to replay callback: URL must include code or error.');
+  }
+
+  return parsed;
+}
+
+function assertSelfTest(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function runSelfTest() {
+  const valid = parseAndValidateCallback(
+    'http://127.0.0.1:43879/callback?code=secret-code&state=secret-state',
+  );
+  assertSelfTest(valid.port === '43879', 'Expected valid localhost callback to parse.');
+
+  const localhost = parseAndValidateCallback('http://localhost:1/callback?error=access_denied');
+  assertSelfTest(localhost.hostname === 'localhost', 'Expected localhost error callback to parse.');
+
+  for (const badUrl of [
+    'https://127.0.0.1:43879/callback?code=x',
+    'http://example.com:43879/callback?code=x',
+    'http://127.0.0.1:43879/not-callback?code=x',
+    'http://127.0.0.1/callback?code=x',
+    'not a url',
+  ]) {
+    let rejected = false;
+    try {
+      parseAndValidateCallback(badUrl);
+    } catch {
+      rejected = true;
+    }
+    assertSelfTest(rejected, `Expected rejection for ${badUrl}`);
+  }
+
+  const redacted = redactCallbackUrl(
+    'http://127.0.0.1:43879/callback?code=secret-code&state=secret-state&scope=ok',
+  );
+  assertSelfTest(!redacted.includes('secret-code'), 'Expected code redaction.');
+  assertSelfTest(!redacted.includes('secret-state'), 'Expected state redaction.');
+  assertSelfTest(redacted.includes('scope=ok'), 'Expected non-sensitive query values to remain.');
+
+  console.log('complete-oauth-callback self-test passed.');
+}
+
+if (process.argv.includes('--self-test')) {
+  runSelfTest();
+  process.exit(0);
+}
+
+let rawUrl = process.argv.slice(2).join(' ').trim();
+
+if (!rawUrl && !process.stdin.isTTY) {
+  const chunks = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk);
+  }
+  rawUrl = Buffer.concat(chunks).toString('utf8').trim();
+}
+
+if (!rawUrl) {
+  console.error('Usage: complete-oauth-callback.mjs <localhost-callback-url>');
+  process.exit(2);
+}
+
+let parsed;
+try {
+  parsed = parseAndValidateCallback(rawUrl);
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(2);
+}
+
+const replayUrl = new URL(parsed.toString());
+replayUrl.hostname = '127.0.0.1';
+
+const controller = new AbortController();
+const timeout = setTimeout(() => controller.abort(), 10000);
+
+try {
+  const response = await fetch(replayUrl, { signal: controller.signal });
+  const text = await response.text();
+  const status = `${response.status} ${response.statusText}`.trim();
+  console.log(`Callback replayed to VPS localhost: ${status}`);
+
+  const sanitized = redactCallbackUrl(text);
+  if (sanitized.trim()) {
+    console.log(sanitized.slice(0, 500));
+  }
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`Callback replay failed: ${message}`);
+  console.error('Make sure the Hermes OAuth login process is still waiting on the VPS.');
+  process.exit(1);
+} finally {
+  clearTimeout(timeout);
+}

--- a/optional-skills/mcp/sendit/scripts/install-sendit-hermes.mjs
+++ b/optional-skills/mcp/sendit/scripts/install-sendit-hermes.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+
+import { cpSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const skillSourceDir = resolve(scriptDir, '..');
+const hermesHome = process.env.HERMES_HOME || join(homedir(), '.hermes');
+const configPath = join(hermesHome, 'config.yaml');
+const skillTargetDir = join(hermesHome, 'skills', 'social-media', 'sendit');
+const standardMcpUrl = 'https://sendit.infiniteappsai.com/api/mcp';
+
+const senditBlock = [
+  '  sendit:',
+  `    url: "${standardMcpUrl}"`,
+  '    auth: oauth',
+].join('\n');
+
+function timestamp() {
+  return new Date().toISOString().replace(/[:.]/g, '-');
+}
+
+function backupConfig(original) {
+  writeFileSync(`${configPath}.bak-${timestamp()}`, original, 'utf8');
+}
+
+function installSkill() {
+  if (resolve(skillSourceDir) === resolve(skillTargetDir)) {
+    console.log(`SendIt skill already running from install target: ${skillTargetDir}`);
+    return;
+  }
+
+  mkdirSync(dirname(skillTargetDir), { recursive: true });
+  cpSync(skillSourceDir, skillTargetDir, {
+    recursive: true,
+    force: true,
+    filter: (src) => !src.includes('/.DS_Store'),
+  });
+  console.log(`Installed SendIt skill: ${skillTargetDir}`);
+}
+
+function findMcpSection(lines) {
+  const start = lines.findIndex((line) => /^mcp_servers:\s*(#.*)?$/.test(line));
+  if (start === -1) return null;
+
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (line.trim() === '' || line.trimStart().startsWith('#')) continue;
+    if (!/^[ \t]/.test(line)) {
+      end = i;
+      break;
+    }
+  }
+
+  return { start, end };
+}
+
+function findSendItBlock(lines, mcpSection) {
+  for (let i = mcpSection.start + 1; i < mcpSection.end; i += 1) {
+    if (/^[ \t]{2}sendit:\s*(#.*)?$/.test(lines[i])) {
+      let end = mcpSection.end;
+      for (let j = i + 1; j < mcpSection.end; j += 1) {
+        const line = lines[j];
+        if (line.trim() === '' || line.trimStart().startsWith('#')) continue;
+        if (/^[ \t]{2}\S/.test(line)) {
+          end = j;
+          break;
+        }
+      }
+      return { start: i, end };
+    }
+  }
+
+  return null;
+}
+
+function repairSendItServer(text) {
+  const lines = text.split(/\r?\n/);
+  const mcpSection = findMcpSection(lines);
+  if (!mcpSection) return null;
+
+  const senditSection = findSendItBlock(lines, mcpSection);
+  if (!senditSection) return null;
+
+  const existingBlock = lines.slice(senditSection.start, senditSection.end);
+  const urlIndex = existingBlock.findIndex((line) => /^[ \t]{4}url:\s*/.test(line));
+  const authIndex = existingBlock.findIndex((line) => /^[ \t]{4}auth:\s*/.test(line));
+  let changed = false;
+
+  if (urlIndex === -1) {
+    existingBlock.splice(1, 0, `    url: "${standardMcpUrl}"`);
+    changed = true;
+  } else if (!existingBlock[urlIndex].includes(standardMcpUrl)) {
+    existingBlock[urlIndex] = `    url: "${standardMcpUrl}"`;
+    changed = true;
+  }
+
+  if (authIndex === -1) {
+    existingBlock.push('    auth: oauth');
+    changed = true;
+  } else if (!/auth:\s*oauth\s*(#.*)?$/.test(existingBlock[authIndex])) {
+    existingBlock[authIndex] = '    auth: oauth';
+    changed = true;
+  }
+
+  if (!changed) return text;
+
+  lines.splice(senditSection.start, senditSection.end - senditSection.start, ...existingBlock);
+  return lines.join('\n').replace(/\s*$/, '\n');
+}
+
+function addMcpConfig() {
+  mkdirSync(hermesHome, { recursive: true });
+
+  if (!existsSync(configPath)) {
+    writeFileSync(configPath, `mcp_servers:\n${senditBlock}\n`, 'utf8');
+    console.log(`Created Hermes config with SendIt MCP server: ${configPath}`);
+    return;
+  }
+
+  const original = readFileSync(configPath, 'utf8');
+  const repaired = repairSendItServer(original);
+  if (repaired) {
+    if (repaired !== original) {
+      backupConfig(original);
+      writeFileSync(configPath, repaired, 'utf8');
+      console.log(`Updated existing SendIt MCP server to standard endpoint: ${standardMcpUrl}`);
+    } else {
+      console.log('SendIt MCP server already exists in config.yaml.');
+    }
+    return;
+  }
+
+  backupConfig(original);
+
+  const lines = original.split(/\r?\n/);
+  const mcpSection = findMcpSection(lines);
+
+  if (!mcpSection) {
+    const next = `${original.replace(/\s*$/, '')}\n\nmcp_servers:\n${senditBlock}\n`;
+    writeFileSync(configPath, next, 'utf8');
+    console.log('Added mcp_servers.sendit to config.yaml.');
+    return;
+  }
+
+  lines.splice(mcpSection.end, 0, ...senditBlock.split('\n'));
+  writeFileSync(configPath, lines.join('\n').replace(/\s*$/, '\n'), 'utf8');
+  console.log('Added mcp_servers.sendit to config.yaml.');
+}
+
+installSkill();
+addMcpConfig();
+
+console.log('');
+console.log('Next: run `node scripts/start-oauth-login.mjs` from this setup folder.');

--- a/optional-skills/mcp/sendit/scripts/start-oauth-login.mjs
+++ b/optional-skills/mcp/sendit/scripts/start-oauth-login.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, openSync, readFileSync, writeFileSync } from 'node:fs';
+import { spawn } from 'node:child_process';
+
+const serverName = process.env.SENDIT_HERMES_MCP_SERVER || 'sendit';
+const logDir = process.env.SENDIT_HERMES_LOG_DIR || '/tmp/sendit-hermes';
+const logPath = `${logDir}/oauth.log`;
+const pidPath = `${logDir}/oauth.pid`;
+const authUrlPattern = /https:\/\/sendit\.infiniteappsai\.com\/oauth\/authorize[^\s"'<>]+/;
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+mkdirSync(logDir, { recursive: true });
+
+const out = openSync(logPath, 'w');
+const child = spawn('hermes', ['mcp', 'login', serverName], {
+  detached: true,
+  stdio: ['ignore', out, out],
+});
+
+child.unref();
+writeFileSync(pidPath, `${child.pid}\n`, 'utf8');
+
+console.log(`Started Hermes SendIt OAuth login on VPS. PID: ${child.pid}`);
+console.log(`MCP server name: ${serverName}`);
+console.log(`Log: ${logPath}`);
+
+let authUrl = '';
+for (let i = 0; i < 60; i += 1) {
+  await sleep(500);
+  if (!existsSync(logPath)) continue;
+
+  const log = readFileSync(logPath, 'utf8');
+  const match = log.match(authUrlPattern);
+  if (match) {
+    authUrl = match[0];
+    break;
+  }
+}
+
+if (!authUrl) {
+  console.log('');
+  console.log('Authorization URL was not found yet. Ask Hermes to inspect:');
+  console.log(`  ${logPath}`);
+  console.log('If the process exited, rerun this script.');
+  process.exit(1);
+}
+
+console.log('');
+console.log('Send this authorization URL to the user:');
+console.log(authUrl);
+console.log('');
+console.log('After the user signs in, ask them to paste the full localhost callback URL.');
+console.log('Then run:');
+console.log("  node scripts/complete-oauth-callback.mjs '<PASTED_CALLBACK_URL>'");


### PR DESCRIPTION
## Summary
- Add a SendIt optional skill under optional-skills/mcp/sendit
- Document remote MCP OAuth setup against https://sendit.infiniteappsai.com/api/mcp
- Include VPS/Telegram-friendly OAuth callback replay helpers for remote Hermes deployments

## Validation
- Validated in SendIt source with npm run validate
- Built standalone Hermes tap and validated generated release
- Published standalone tap: https://github.com/Shree-git/sendit-hermes-skills
- LobeHub import queued as shree-git-sendit-hermes-skills-sendit

## Notes
Live OAuth and publish tests require user-owned SendIt and social platform credentials.