### PR TITLE
feat(tui_gateway): expose real-time session status files

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -387,6 +387,8 @@ def _emit(event: str, sid: str, payload: dict | None = None):
     if payload is not None:
         params["payload"] = payload
     write_json({"jsonrpc": "2.0", "method": "event", "params": params})
+    if event in _STATUS_EVENTS:
+        _write_session_status(event, sid, payload)
 
 
 def _status_update(sid: str, kind: str, text: str | None = None):
@@ -398,6 +400,81 @@ def _status_update(sid: str, kind: str, text: str | None = None):
         sid,
         {"kind": kind if text is not None else "status", "text": body},
     )
+
+
+# ── Session status file for external consumers (Keryx, etc.) ──────────
+# Best-effort write of /tmp/hermes-status/<sid>.json on every relevant
+# event so external tools can read agent status in real-time.
+
+_STATUS_DIR = Path("/tmp/hermes-status")
+_STATUS_EVENTS = frozenset({
+    "message.start",
+    "message.complete",
+    "thinking.delta",
+    "reasoning.delta",
+    "tool.generating",
+    "tool.progress",
+    "tool.complete",
+    "status.update",
+    "error",
+})
+
+_EVENT_TO_STATUS = {
+    "message.start": "thinking",
+    "thinking.delta": "thinking",
+    "reasoning.delta": "thinking",
+    "tool.generating": "tool",
+    "tool.progress": "tool",
+    "tool.complete": "tool",
+    "message.complete": "idle",
+    "error": "failed",
+}
+
+
+def _resolve_status(event: str, payload: dict | None) -> str:
+    """Derive a short status string from the event type and payload."""
+    if event == "status.update":
+        kind = (payload or {}).get("kind", "")
+        if kind == "ready":
+            return "idle"
+        return "busy"
+    return _EVENT_TO_STATUS.get(event, "idle")
+
+
+def _resolve_session_title(session: dict) -> str:
+    """Best-effort title lookup — never raises."""
+    try:
+        db = _get_db()
+        if db:
+            key = session.get("session_key")
+            if key:
+                title = db.get_session_title(key)
+                if title:
+                    return title
+        return session.get("pending_title") or ""
+    except Exception:
+        return ""
+
+
+def _write_session_status(event: str, sid: str, payload: dict | None = None):
+    """Write a small JSON file to /tmp/hermes-status/<sid>.json."""
+    try:
+        session = _sessions.get(sid)
+        if session is None:
+            return
+        status = _resolve_status(event, payload)
+        title = _resolve_session_title(session)
+        _STATUS_DIR.mkdir(parents=True, exist_ok=True)
+        data = {
+            "session_id": sid,
+            "title": title,
+            "status": status,
+            "event": event,
+            "timestamp": time.time(),
+        }
+        (_STATUS_DIR / f"{sid}.json").write_text(json.dumps(data))
+    except Exception:
+        pass  # best-effort — never crash the gateway
 
 
 def _estimate_image_tokens(width: int, height: int) -> int:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -470,6 +470,7 @@ def _write_session_status(event: str, sid: str, payload: dict | None = None):
             "title": title,
             "status": status,
             "event": event,
+            "pid": os.getpid(),
             "timestamp": time.time(),
         }
         (_STATUS_DIR / f"{sid}.json").write_text(json.dumps(data))

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -464,6 +464,17 @@ def _resolve_session_title(session: dict) -> str:
         return ""
 
 
+def _get_tty_name() -> str:
+    """Best-effort TTY name from /proc/self/stat."""
+    try:
+        tty_nr = int(open("/proc/self/stat").read().split()[6])
+        if tty_nr > 0 and os.major(tty_nr) == 136:
+            return f"pts/{os.minor(tty_nr)}"
+    except Exception:
+        pass
+    return ""
+
+
 def _write_session_status(event: str, sid: str, payload: dict | None = None):
     """Write a small JSON file to /tmp/hermes-status/<sid>.json."""
     try:
@@ -479,6 +490,7 @@ def _write_session_status(event: str, sid: str, payload: dict | None = None):
             "status": status,
             "event": event,
             "pid": os.getpid(),
+            "tty": _get_tty_name(),
             "timestamp": time.time(),
         }
         (_STATUS_DIR / f"{sid}.json").write_text(json.dumps(data))

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -287,6 +287,14 @@ def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> No
     if not session or session.get("_finalized"):
         return
     session["_finalized"] = True
+    # Clean up session status file
+    try:
+        for _sid, _s in _sessions.items():
+            if _s is session:
+                (_STATUS_DIR / f"{_sid}.json").unlink(missing_ok=True)
+                break
+    except Exception:
+        pass
     stop_event = session.get("_notif_stop")
     if stop_event is not None:
         stop_event.set()


### PR DESCRIPTION
## Summary

Write lightweight JSON status files to `/tmp/hermes-status/<session_id>.json` on every relevant TUI event, enabling external tools (Zellij plugins, dashboards, status bars) to read agent status in real-time without polling the API.

## What it does

On every relevant `_emit()` call, a small JSON file is written to `/tmp/hermes-status/`:

```json
{
  "session_id": "0454c18d",
  "title": "Keryx plugin dev",
  "status": "thinking",
  "event": "thinking.delta",
  "timestamp": 1716012345.678
}
```

### Status mapping

| Event | Status |
|---|---|
| `message.start`, `thinking.delta`, `reasoning.delta` | `thinking` |
| `tool.generating`, `tool.progress`, `tool.complete` | `tool` |
| `message.complete` | `idle` |
| `status.update` kind=`ready` | `idle`, else `busy` |
| `error` | `failed` |

## Implementation

- Added `_write_session_status()` hook inside `_emit()` — fires only for events in `_STATUS_EVENTS` set
- `_resolve_session_title()` — best-effort title lookup from SessionDB, falls back to `pending_title` or empty string
- All writes are best-effort with blanket `except Exception: pass` — never crashes the gateway
- Zero config, zero dependencies — just a directory write

## Use case

[Keryx](https://github.com/lelabdev/keryx) — a Zellij WASM plugin that relays Hermes agent status to tab names in real-time.

## Testing

Manual testing on a TUI session — status files update in real-time during thinking, tool calls, and idle states.

## Notes

- Title resolution is best-effort (never blocks or adds latency)
- Files are per-session — multiple concurrent TUI sessions each get their own file
- `/tmp/` is used intentionally — ephemeral, no cleanup needed on reboot