### PR TITLE
feat(dingtalk): use dws send-by-bot for cron delivery with native Markdown

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -583,7 +583,12 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
         # Prefer the live adapter when the gateway is running — this supports E2EE
         # rooms (e.g. Matrix) where the standalone HTTP path cannot encrypt.
-        runtime_adapter = (adapters or {}).get(platform)
+        # DingTalk is excluded: live adapter uses session_webhook which can't render
+        # GFM tables and has no Markdown fallback; standalone path uses dws send-by-bot.
+        if platform == Platform.DINGTALK:
+            runtime_adapter = None
+        else:
+            runtime_adapter = (adapters or {}).get(platform)
         delivered = False
         if runtime_adapter is not None and loop is not None and getattr(loop, "is_running", lambda: False)():
             send_metadata = {"thread_id": thread_id} if thread_id else None

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -10,6 +10,7 @@ import json
 import logging
 import os
 import re
+import shutil
 import ssl
 import time
 from email.utils import formatdate
@@ -1608,22 +1609,67 @@ async def _send_homeassistant(token, extra, chat_id, message):
 
 
 async def _send_dingtalk(extra, chat_id, message):
-    """Send via DingTalk robot webhook.
+    """Send via DingTalk robot using `dws chat message send-by-bot`, with webhook fallback.
 
-    Note: The gateway's DingTalk adapter uses per-session webhook URLs from
-    incoming messages (dingtalk-stream SDK).  For cross-platform send_message
-    delivery we use a static robot webhook URL instead, which must be
-    configured via ``DINGTALK_WEBHOOK_URL`` env var or ``webhook_url`` in the
-    platform's extra config.
+    Prefers the official DingTalk CLI (`dws`) which sends as the bot identity
+    with full Markdown rendering support.  Falls back to the legacy robot
+    webhook (plain text, no Markdown) if `dws` is not installed or fails.
+
+    The robot_code is resolved from config.extra.robot_code, then
+    DINGTALK_CLIENT_ID env var.
     """
+    import subprocess
+
+    robot_code = extra.get("robot_code") or os.getenv("DINGTALK_CLIENT_ID", "")
+    if not robot_code:
+        return {"error": "DingTalk not configured. Set DINGTALK_CLIENT_ID or robot_code in dingtalk platform extra config."}
+
+    # --- Try dws send-by-bot first (Markdown + bot identity) ---
+    dws = shutil.which("dws")
+    if dws:
+        title = "Hermes"
+        first_line = (message.split("\n")[0] or "").strip()
+        if first_line.startswith("#"):
+            title = first_line.lstrip("#").strip()
+
+        cmd = [
+            dws, "chat", "message", "send-by-bot",
+            "--robot-code", robot_code,
+            "--group", chat_id,
+            "--title", title,
+            "--text", message,
+            "--format", "json",
+        ]
+        try:
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=60,
+            )
+            if result.returncode == 0:
+                try:
+                    data = json.loads(result.stdout)
+                    if data.get("success"):
+                        return {"success": True, "platform": "dingtalk", "chat_id": chat_id}
+                except json.JSONDecodeError:
+                    pass
+            logger.warning(
+                "dws send-by-bot failed, falling back to webhook: %s",
+                result.stderr[:200] if result.stderr else result.stdout[:200],
+            )
+        except subprocess.TimeoutExpired:
+            logger.warning("dws send-by-bot timed out, falling back to webhook")
+        except Exception:
+            logger.debug("dws send-by-bot error, falling back to webhook", exc_info=True)
+
+    # --- Fallback: legacy robot webhook (plain text, no Markdown) ---
     try:
         import httpx
     except ImportError:
-        return {"error": "httpx not installed"}
+        return {"error": "dws CLI not found and httpx not installed"}
+
     try:
         webhook_url = extra.get("webhook_url") or os.getenv("DINGTALK_WEBHOOK_URL", "")
         if not webhook_url:
-            return {"error": "DingTalk not configured. Set DINGTALK_WEBHOOK_URL env var or webhook_url in dingtalk platform extra config."}
+            return {"error": "dws CLI not available and DingTalk webhook not configured"}
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.post(
                 webhook_url,


### PR DESCRIPTION
## Summary / 摘要

### EN
Replace DingTalk's `_send_dingtalk()` webhook sender with `dws chat message send-by-bot` CLI call. This enables:
- **Bot identity**: messages sent as the bot, not as a user
- **Native Markdown**: tables, headers, lists, blockquotes all render correctly
- **Webhook fallback**: if `dws` is not installed or fails, gracefully falls back to the legacy robot webhook (plain text)

### CN
将钉钉 `_send_dingtalk()` 从 webhook HTTP POST 改为 `dws chat message send-by-bot` CLI 调用，实现：
- **机器人身份**：消息以机器人身份发送，非用户身份
- **原生 Markdown**：表格、标题、列表、引用块均可正确渲染
- **webhook 降级**：当 `dws` 未安装或调用失败时，优雅降级到原有 webhook（纯文本）

## Changes / 改动

**tools/send_message_tool.py**:
- `_send_dingtalk()` tries `dws send-by-bot` first (Markdown + bot identity)
- If `dws` not found or fails → falls back to `DINGTALK_WEBHOOK_URL` (plain text)
- Added `import shutil` for `shutil.which()`

**gateway/platforms/dingtalk.py**:
- Removed `_convert_gfm_tables_to_html()` — Markdown tables preserved as-is

**cron/scheduler.py**:
- DingTalk cron delivery skips live adapter (which uses session_webhook with limited Markdown support) and goes directly to standalone path where `dws send-by-bot` renders full Markdown

## Why / 原因

The DingTalk session webhook only supports `text` and limited `markdown` types — GFM tables, lists, and other Markdown syntax don't render. Using `dws send-by-bot` via the DingTalk OpenAPI bypasses this limitation entirely.

## Test plan / 测试

- [ ] With `dws` installed: cron delivery to DingTalk renders Markdown tables correctly as bot identity
- [ ] Without `dws`: delivery still works via webhook fallback (plain text)
- [ ] `dws` returns error: gracefully falls back to webhook