### PR TITLE
fix(agent): import _pool_may_recover_from_rate_limit in conversation_loop (#27719)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2251,6 +2251,7 @@ def run_conversation(
                     # still recover.  See _pool_may_recover_from_rate_limit
                     # for the single-credential-pool and CloudCode-quota
                     # exceptions.  Fixes #11314 and #13636.
+                    from run_agent import _pool_may_recover_from_rate_limit
                     pool_may_recover = _pool_may_recover_from_rate_limit(
                         agent._credential_pool,
                         provider=agent.provider,

--- a/tests/agent/test_fallback_pool_recover_import.py
+++ b/tests/agent/test_fallback_pool_recover_import.py
@@ -1,0 +1,44 @@
+"""Regression test for issue #27719.
+
+The eager rate-limit fallback path in ``agent.conversation_loop`` calls
+``_pool_may_recover_from_rate_limit``, which is defined in ``run_agent``.
+Prior to the fix, the helper was referenced but never imported inside
+``agent/conversation_loop.py`` -- triggering ``NameError`` whenever the
+primary provider returned a 429/quota error and a fallback chain was
+configured (e.g. DeepSeek exhausted, OpenRouter fallback).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import agent.conversation_loop as conversation_loop
+
+
+def _call_site_uses_lazy_import() -> bool:
+    src = Path(conversation_loop.__file__).read_text()
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == "run_agent":
+            for alias in node.names:
+                if alias.name == "_pool_may_recover_from_rate_limit":
+                    return True
+    return False
+
+
+def test_pool_recover_helper_is_importable_from_run_agent():
+    from run_agent import _pool_may_recover_from_rate_limit
+
+    assert callable(_pool_may_recover_from_rate_limit)
+    assert _pool_may_recover_from_rate_limit(None) is False
+
+
+def test_conversation_loop_imports_pool_recover_helper():
+    # Guards against #27719 regressing: the symbol must be referenced via
+    # an explicit `from run_agent import _pool_may_recover_from_rate_limit`
+    # so the eager-fallback codepath never raises NameError again.
+    assert _call_site_uses_lazy_import(), (
+        "agent/conversation_loop.py must import "
+        "_pool_may_recover_from_rate_limit from run_agent (issue #27719)."
+    )


### PR DESCRIPTION
## Summary

Fixes #27719 — `NameError: name '_pool_may_recover_from_rate_limit' is not defined` when the eager rate-limit fallback path fires.

## Root cause

`agent/conversation_loop.py` calls `_pool_may_recover_from_rate_limit(...)` at the rate-limit/billing fallback branch (~L2254), but the helper is defined in `run_agent.py` and was never imported into `agent/conversation_loop.py`.

So whenever a primary provider returned a 429/quota error and a fallback chain was configured (e.g. DeepSeek exhausted → OpenRouter fallback as in the issue), the code crashed with `NameError` instead of switching to the fallback provider.

`grep` confirms the missing reference:

```
agent/conversation_loop.py:2254:  pool_may_recover = _pool_may_recover_from_rate_limit(...)
run_agent.py:239: def _pool_may_recover_from_rate_limit(...)   ← defined here
```

## Fix

Use a **lazy local import** right above the call site:

```python
from run_agent import _pool_may_recover_from_rate_limit
pool_may_recover = _pool_may_recover_from_rate_limit(...)
```

Why lazy: `run_agent.py` already imports extensively from `agent/*` (including `agent.conversation_loop`), so a top-level `from run_agent import ...` would create a circular import. The lazy import runs only when the rate-limit fallback branch is hit, which is a cold path.

## Test

Added `tests/agent/test_fallback_pool_recover_import.py` with two checks:

1. `_pool_may_recover_from_rate_limit` is callable from `run_agent` and `None` short-circuits to `False`.
2. AST scan of `agent/conversation_loop.py` confirms an explicit `from run_agent import _pool_may_recover_from_rate_limit` exists — so the historical NameError cannot silently regress.

```
$ pytest tests/agent/test_fallback_pool_recover_import.py \
         tests/run_agent/test_provider_fallback.py \
         tests/agent/test_gemini_fast_fallback.py -q
30 passed in 12.59s
```

## Scope

- `agent/conversation_loop.py` — 1 line added (lazy import)
- `tests/agent/test_fallback_pool_recover_import.py` — new regression test
