### PR TITLE
fix(cron): chown jobs.json to match parent directory on save

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -147,6 +147,18 @@ def _secure_file(path: Path):
     except (OSError, NotImplementedError):
         pass
 
+    # If file owner doesn't match parent directory owner, fix it.
+    # This handles the case where cronjob tools run as a different
+    # user (e.g. docker exec default root) but the cron scheduler
+    # runs as a non-root user (hermes). Without the chown the
+    # scheduler gets IOError when it reloads jobs.json.
+    try:
+        parent_uid = path.parent.stat().st_uid
+        if path.stat().st_uid != parent_uid:
+            os.chown(path, parent_uid, -1)
+    except (OSError, NotImplementedError):
+        pass
+
 
 def ensure_dirs():
     """Ensure cron directories exist with secure permissions."""

--- a/tests/cron/test_file_permissions.py
+++ b/tests/cron/test_file_permissions.py
@@ -57,6 +57,38 @@ class TestCronFilePermissions(unittest.TestCase):
             file_mode = stat.S_IMODE(os.stat(jobs_file).st_mode)
             self.assertEqual(file_mode, 0o600)
 
+    def test_save_jobs_chowns_to_parent_owner(self):
+        """save_jobs should chown jobs.json to match its parent directory owner."""
+        cron_dir = Path(self.tmpdir) / "cron"
+        output_dir = cron_dir / "output"
+        jobs_file = cron_dir / "jobs.json"
+
+        # Make cron dir owned by our process UID (the "correct" owner)
+        cron_dir.mkdir(parents=True, exist_ok=True)
+        our_uid = os.getuid()
+        os.chown(cron_dir, our_uid, -1)
+
+        with patch("cron.jobs.CRON_DIR", cron_dir), \
+             patch("cron.jobs.OUTPUT_DIR", output_dir), \
+             patch("cron.jobs.JOBS_FILE", jobs_file):
+            from cron.jobs import save_jobs
+            save_jobs([{"id": "test", "prompt": "hello"}])
+
+            self.assertEqual(os.stat(jobs_file).st_uid, our_uid,
+                             "jobs.json should match parent dir owner after save")
+
+            # Now simulate the agent-running-as-root scenario: write as root (UID 0)
+            # while cron dir is owned by our_uid.
+            os.chown(jobs_file, 0, -1)  # simulate root ownership
+            self.assertEqual(os.stat(jobs_file).st_uid, 0,
+                             "test precondition: file should be root-owned")
+
+            # _secure_file is called by save_jobs internally. Verify it fixes ownership.
+            from cron.jobs import _secure_file
+            _secure_file(jobs_file)
+            self.assertEqual(os.stat(jobs_file).st_uid, our_uid,
+                             "_secure_file should chown back to parent dir owner")
+
     def test_save_job_output_sets_0600(self):
         output_dir = Path(self.tmpdir) / "output"
         with patch("cron.jobs.OUTPUT_DIR", output_dir), \


### PR DESCRIPTION
## Problem

When the `cronjob` built-in tool runs inside a container where the agent process UID differs from the cron directory owner (e.g. `docker exec` runs as root while the cron scheduler runs as a non-root user like `hermes`), `save_jobs()` writes `jobs.json` with the wrong owner via `tempfile.mkstemp` + `os.replace`. The cron scheduler then fails with `IOError` on its next tick when it tries to read the file.

## Fix

`_secure_file()` already handles `chmod 0600` on `jobs.json` after every save. This PR extends it to also detect when the file owner does not match the parent directory owner, and calls `os.chown()` to correct it. The chown is a no-op when ownership already matches (the common case).

## Testing

Added `test_save_jobs_chowns_to_parent_owner` which:
1. Creates a cron directory owned by the process UID
2. Writes a job (verify owner matches)
3. Simulates root ownership (chown to 0)
4. Calls `_secure_file()` and verifies it restores the correct owner

All 9 tests in `tests/cron/test_file_permissions.py` pass.