### PR TITLE
fix(agent): share fallback pool recovery helper

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -32,6 +32,7 @@ from agent.auxiliary_client import set_runtime_main
 from agent.codex_responses_adapter import _summarize_user_message_for_log
 from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
+from agent.fallback_utils import pool_may_recover_from_rate_limit
 from agent.iteration_budget import IterationBudget
 from agent.memory_manager import build_memory_context_block
 from agent.message_sanitization import (
@@ -2248,10 +2249,10 @@ def run_conversation(
                 }
                 if is_rate_limited and agent._fallback_index < len(agent._fallback_chain):
                     # Don't eagerly fallback if credential pool rotation may
-                    # still recover.  See _pool_may_recover_from_rate_limit
+                    # still recover.  See pool_may_recover_from_rate_limit
                     # for the single-credential-pool and CloudCode-quota
                     # exceptions.  Fixes #11314 and #13636.
-                    pool_may_recover = _pool_may_recover_from_rate_limit(
+                    pool_may_recover = pool_may_recover_from_rate_limit(
                         agent._credential_pool,
                         provider=agent.provider,
                         base_url=getattr(agent, "base_url", None),

--- a/agent/fallback_utils.py
+++ b/agent/fallback_utils.py
@@ -1,0 +1,22 @@
+"""Shared fallback decision helpers."""
+
+from __future__ import annotations
+
+
+def pool_may_recover_from_rate_limit(
+    pool, *, provider: str | None = None, base_url: str | None = None
+) -> bool:
+    """Decide whether credential-pool rotation can recover a rate limit.
+
+    Rotation is only useful when the pool exists, has an available credential,
+    and contains more than one entry. Single-entry pools retry the same
+    exhausted credential. CloudCode/Gemini CLI quotas are account-wide, so
+    rotating entries does not escape the same throttle window.
+    """
+    if pool is None:
+        return False
+    if not pool.has_available():
+        return False
+    if provider == "google-gemini-cli" or str(base_url or "").startswith("cloudcode-pa://"):
+        return False
+    return len(pool.entries()) > 1

--- a/run_agent.py
+++ b/run_agent.py
@@ -124,6 +124,7 @@ from agent.memory_manager import StreamingContextScrubber, build_memory_context_
 from agent.think_scrubber import StreamingThinkScrubber
 from agent.retry_utils import jittered_backoff
 from agent.error_classifier import classify_api_error, FailoverReason
+from agent.fallback_utils import pool_may_recover_from_rate_limit
 from agent.prompt_builder import (
     DEFAULT_AGENT_IDENTITY, PLATFORM_HINTS,
     MEMORY_GUIDANCE, SESSION_SEARCH_GUIDANCE, SKILLS_GUIDANCE,
@@ -236,39 +237,7 @@ def _routermint_headers() -> dict:
     }
 
 
-def _pool_may_recover_from_rate_limit(
-    pool, *, provider: str | None = None, base_url: str | None = None
-) -> bool:
-    """Decide whether to wait for credential-pool rotation instead of falling back.
-
-    The existing pool-rotation path requires the pool to (1) exist and (2) have
-    at least one entry not currently in exhaustion cooldown.  But rotation is
-    only meaningful when the pool has more than one entry.
-
-    With a single-credential pool (common for Gemini OAuth, Vertex service
-    accounts, and any "one personal key" configuration), the primary entry
-    just 429'd and there is nothing to rotate to.  Waiting for the pool
-    cooldown to expire means retrying against the same exhausted quota — the
-    daily-quota 429 will recur immediately, and the retry budget is burned.
-
-    Additionally, Google CloudCode / Gemini CLI rate limits are ACCOUNT-level
-    throttles — even a multi-entry pool shares the same quota window, so
-    rotation won't recover.  Skip straight to the fallback for those (#13636).
-
-    In those cases we must fall back to the configured ``fallback_model``
-    instead.  Returns True only when rotation has somewhere to go.
-
-    See issues #11314 and #13636.
-    """
-    if pool is None:
-        return False
-    if not pool.has_available():
-        return False
-    # CloudCode / Gemini CLI quotas are account-wide — all pool entries share
-    # the same throttle window, so rotation can't recover.  Prefer fallback.
-    if provider == "google-gemini-cli" or str(base_url or "").startswith("cloudcode-pa://"):
-        return False
-    return len(pool.entries()) > 1
+_pool_may_recover_from_rate_limit = pool_may_recover_from_rate_limit
 
 
 def _qwen_portal_headers() -> dict:

--- a/tests/agent/test_gemini_fast_fallback.py
+++ b/tests/agent/test_gemini_fast_fallback.py
@@ -7,7 +7,13 @@ rotation is pointless — prefer fallback immediately.
 """
 from unittest.mock import MagicMock
 
+from agent.conversation_loop import pool_may_recover_from_rate_limit
 from run_agent import _pool_may_recover_from_rate_limit
+
+
+def test_run_agent_compat_alias_matches_conversation_loop_helper():
+    """The extracted conversation loop must not rely on a run_agent local name."""
+    assert _pool_may_recover_from_rate_limit is pool_may_recover_from_rate_limit
 
 
 def _pool(entries: int = 2):
@@ -18,7 +24,7 @@ def _pool(entries: int = 2):
 
 
 def test_cloudcode_provider_skips_pool_rotation():
-    assert _pool_may_recover_from_rate_limit(
+    assert pool_may_recover_from_rate_limit(
         _pool(entries=3),
         provider="google-gemini-cli",
         base_url="cloudcode-pa://google",
@@ -28,7 +34,7 @@ def test_cloudcode_provider_skips_pool_rotation():
 def test_cloudcode_base_url_skips_pool_rotation_even_on_alias_provider():
     # Even if the provider label is something else, a cloudcode-pa:// URL
     # signals the account-wide quota regime.
-    assert _pool_may_recover_from_rate_limit(
+    assert pool_may_recover_from_rate_limit(
         _pool(entries=3),
         provider="custom-provider",
         base_url="cloudcode-pa://google",
@@ -36,7 +42,7 @@ def test_cloudcode_base_url_skips_pool_rotation_even_on_alias_provider():
 
 
 def test_non_cloudcode_multi_entry_pool_still_recovers():
-    assert _pool_may_recover_from_rate_limit(
+    assert pool_may_recover_from_rate_limit(
         _pool(entries=3),
         provider="openrouter",
         base_url="https://openrouter.ai/api/v1",
@@ -45,7 +51,7 @@ def test_non_cloudcode_multi_entry_pool_still_recovers():
 
 def test_single_entry_pool_skips_rotation_regardless_of_provider():
     # Pre-existing single-entry-pool exception (#11314) still holds.
-    assert _pool_may_recover_from_rate_limit(
+    assert pool_may_recover_from_rate_limit(
         _pool(entries=1),
         provider="openrouter",
         base_url="https://openrouter.ai/api/v1",
@@ -55,8 +61,8 @@ def test_single_entry_pool_skips_rotation_regardless_of_provider():
 def test_exhausted_pool_skips_rotation():
     p = MagicMock()
     p.has_available.return_value = False
-    assert _pool_may_recover_from_rate_limit(p) is False
+    assert pool_may_recover_from_rate_limit(p) is False
 
 
 def test_no_pool_skips_rotation():
-    assert _pool_may_recover_from_rate_limit(None) is False
+    assert pool_may_recover_from_rate_limit(None) is False


### PR DESCRIPTION
## What does this PR do?

This PR fixes a post-refactor fallback crash in the extracted agent conversation
loop.

`agent/conversation_loop.py` now owns the main `run_conversation()` body, but the
rate-limit fallback path still referenced `_pool_may_recover_from_rate_limit()`
as if it were local to that module. The helper was still defined in
`run_agent.py`, so quota/rate-limit fallback could raise `NameError` before the
configured fallback provider was attempted.

The fix moves the helper into a small shared module and imports it from the
conversation loop. `run_agent._pool_may_recover_from_rate_limit` remains as a
compatibility alias for existing tests and external patch/import sites.

## Related Issue

Related to #27719 and #27370.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `agent/fallback_utils.py` with `pool_may_recover_from_rate_limit()`.
- Updated `agent/conversation_loop.py` to import and call the shared helper
  directly in the rate-limit fallback path.
- Kept `run_agent._pool_may_recover_from_rate_limit` as a compatibility alias.
- Updated the Gemini/CloudCode fallback regression test to verify the
  conversation loop imports the shared helper and the old `run_agent` alias
  still points to the same function.

## How to Test

1. Run the focused fallback tests:

   ```bash
   pytest -q tests/agent/test_gemini_fast_fallback.py tests/run_agent/test_provider_fallback.py -k "pool or cloudcode or fallback"
   ```

2. Run ruff on the touched files:

   ```bash
   python -m ruff check agent/fallback_utils.py agent/conversation_loop.py run_agent.py tests/agent/test_gemini_fast_fallback.py
   ```

3. Local results:

   ```text
   29 passed in 70.91s
   All checks passed!
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL/Linux checkout

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
$ pytest -q tests/agent/test_gemini_fast_fallback.py tests/run_agent/test_provider_fallback.py -k "pool or cloudcode or fallback"
.............................                                            [100%]
29 passed in 70.91s (0:01:10)

$ python -m ruff check agent/fallback_utils.py agent/conversation_loop.py run_agent.py tests/agent/test_gemini_fast_fallback.py
All checks passed!
```
