### PR TITLE
fix(agent): route rate-limit pool recovery helper

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2251,11 +2251,16 @@ def run_conversation(
                     # still recover.  See _pool_may_recover_from_rate_limit
                     # for the single-credential-pool and CloudCode-quota
                     # exceptions.  Fixes #11314 and #13636.
-                    pool_may_recover = _pool_may_recover_from_rate_limit(
-                        agent._credential_pool,
-                        provider=agent.provider,
-                        base_url=getattr(agent, "base_url", None),
+                    pool_may_recover = False
+                    _pool_recovery_check = getattr(
+                        _ra(), "_pool_may_recover_from_rate_limit", None
                     )
+                    if callable(_pool_recovery_check):
+                        pool_may_recover = _pool_recovery_check(
+                            agent._credential_pool,
+                            provider=agent.provider,
+                            base_url=getattr(agent, "base_url", None),
+                        )
                     if not pool_may_recover:
                         agent._emit_status("⚠️ Rate limited — switching to fallback provider...")
                         if agent._try_activate_fallback(reason=classified.reason):


### PR DESCRIPTION
Summary:
- Route the extracted conversation loop to the run_agent pool-recovery helper through the lazy bridge.
- Avoid direct helper references that can fail after loop extraction.

Test Plan:
- /Users/manus/.hermes/hermes-agent/venv/bin/python -m py_compile agent/conversation_loop.py run_agent.py
- /Users/manus/.hermes/hermes-agent/venv/bin/python -m pytest tests/run_agent/test_provider_fallback.py tests/run_agent/test_primary_runtime_restore.py -o 'addopts=' -q