### PR TITLE
feat(gateway): summarize long TTS responses

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2015,11 +2015,12 @@ class BasePlatformAdapter(ABC):
         return await self.send(chat_id=chat_id, content=text, reply_to=reply_to, metadata=metadata)
 
     def prepare_tts_text(self, text: str) -> str:
-        """Prepare text for TTS. Override to filter tool output, code, etc.
-
-        Default strips markdown formatting and truncates to 4000 chars.
+        """Prepare text for TTS. Delegates to gateway.tts_summary for
+        summarization when ``voice.tts_summary_enabled`` is set, otherwise
+        falls back to the previous strip-and-truncate behavior.
         """
-        return re.sub(r'[*_`#\[\]()]', '', text)[:4000].strip()
+        from gateway.tts_summary import prepare_tts_text as _helper
+        return _helper(text)
 
     async def play_tts(
         self,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10427,9 +10427,10 @@ class GatewayRunner:
         audio_path = None
         actual_path = None
         try:
-            from tools.tts_tool import text_to_speech_tool, _strip_markdown_for_tts
+            from gateway.tts_summary import prepare_tts_text as _prepare_tts_text
+            from tools.tts_tool import text_to_speech_tool
 
-            tts_text = _strip_markdown_for_tts(text[:4000])
+            tts_text = await asyncio.to_thread(_prepare_tts_text, text)
             if not tts_text:
                 return
 

--- a/gateway/tts_summary.py
+++ b/gateway/tts_summary.py
@@ -1,0 +1,163 @@
+"""Prepare assistant responses for text-to-speech.
+
+By default this preserves Hermes' historical behavior: strip markdown and cap
+input at 4000 chars. When ``voice.tts_summary_enabled`` is true, it asks the
+auxiliary LLM router for a concise spoken summary while the full text response
+still goes to the chat.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from tools.tts_tool import _strip_markdown_for_tts
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_MAX_CHARS = 700
+_DEFAULT_MAX_TOKENS = 180
+_FALLBACK_INPUT_CHARS = 4000
+_SUMMARY_INPUT_CHARS = 8000
+
+
+def _fallback_tts_text(original: str) -> str:
+    """Previous behavior: markdown-stripped original capped before TTS."""
+    return _strip_markdown_for_tts((original or "")[:_FALLBACK_INPUT_CHARS])
+
+
+def _bounded_int(value: Any, default: int, *, minimum: int, maximum: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        parsed = default
+    return max(minimum, min(maximum, parsed))
+
+
+def _settings() -> tuple[bool, int, int]:
+    """Return (enabled, max_chars, max_tokens) from config with safe defaults."""
+    try:
+        from hermes_cli.config import load_config
+
+        voice_cfg = (load_config() or {}).get("voice", {}) or {}
+    except Exception as exc:
+        logger.debug("Could not load TTS summary settings: %s", exc)
+        voice_cfg = {}
+
+    enabled = bool(voice_cfg.get("tts_summary_enabled", False))
+    max_chars = _bounded_int(
+        voice_cfg.get("tts_summary_max_chars", _DEFAULT_MAX_CHARS),
+        _DEFAULT_MAX_CHARS,
+        minimum=120,
+        maximum=4000,
+    )
+    max_tokens = _bounded_int(
+        voice_cfg.get("tts_summary_max_tokens", _DEFAULT_MAX_TOKENS),
+        _DEFAULT_MAX_TOKENS,
+        minimum=32,
+        maximum=1000,
+    )
+    return enabled, max_chars, max_tokens
+
+
+def _extract_content(response: Any) -> str:
+    """Extract text from common LLM response shapes."""
+    if response is None:
+        return ""
+    if isinstance(response, str):
+        return response.strip()
+    if isinstance(response, dict):
+        for key in ("content", "text"):
+            value = response.get(key)
+            if isinstance(value, str):
+                return value.strip()
+        message = response.get("message")
+        if isinstance(message, dict) and isinstance(message.get("content"), str):
+            return message["content"].strip()
+        if isinstance(message, str):
+            return message.strip()
+
+    try:
+        choices = getattr(response, "choices", None)
+        if choices:
+            message = getattr(choices[0], "message", None)
+            content = getattr(message, "content", None)
+            if isinstance(content, str):
+                return content.strip()
+    except Exception:
+        pass
+
+    content = getattr(response, "content", None)
+    if isinstance(content, str):
+        return content.strip()
+    text = getattr(response, "text", None)
+    if isinstance(text, str):
+        return text.strip()
+    return ""
+
+
+def _clamp_for_speech(text: str, max_chars: int) -> str:
+    """Clamp text to max_chars, preferring natural-ish punctuation boundaries."""
+    cleaned = " ".join((text or "").split()).strip()
+    if len(cleaned) <= max_chars:
+        return cleaned
+
+    candidate = cleaned[:max_chars].rstrip()
+    boundary_floor = max(80, int(max_chars * 0.55))
+    for marker in (". ", "! ", "? ", "; ", ": ", ", "):
+        idx = candidate.rfind(marker)
+        if idx >= boundary_floor:
+            return candidate[: idx + 1].rstrip()
+    return candidate.rstrip(" ,;:-") + "…"
+
+
+def prepare_tts_text(original: str) -> str:
+    """Return TTS-ready text.
+
+    Disabled/default mode preserves the old behavior exactly. Summary mode is
+    best-effort and always falls back to the old behavior on errors or empty
+    output, so text delivery is never blocked by summarization.
+    """
+    if not original or not original.strip():
+        return ""
+
+    fallback = _fallback_tts_text(original)
+    enabled, max_chars, max_tokens = _settings()
+    if not enabled:
+        return fallback
+
+    try:
+        from agent.auxiliary_client import call_llm
+
+        response = call_llm(
+            task="tts_summary",
+            messages=[
+                {
+                    "role": "system",
+                    "content": (
+                        "Convert assistant replies into concise spoken Telegram voice notes. "
+                        "Preserve the key answer, decisions, blockers, and next actions. "
+                        "Omit code blocks, raw logs, long paths, URLs, tables, markdown, "
+                        "and implementation detail unless critical. Use natural speech. "
+                        "No intro, no sign-off."
+                    ),
+                },
+                {
+                    "role": "user",
+                    "content": (
+                        f"Summarize this assistant response for speech in at most {max_chars} characters.\n\n"
+                        f"Assistant response:\n{original[:_SUMMARY_INPUT_CHARS]}"
+                    ),
+                },
+            ],
+            temperature=0.2,
+            max_tokens=max_tokens,
+        )
+        summary = _strip_markdown_for_tts(_extract_content(response))
+        if summary and summary.strip():
+            return _clamp_for_speech(summary, max_chars)
+        logger.warning("TTS summary was empty; using fallback text")
+    except Exception as exc:
+        logger.warning("TTS summary failed; using fallback text: %s", exc)
+
+    return fallback

--- a/tests/gateway/test_tts_summary.py
+++ b/tests/gateway/test_tts_summary.py
@@ -1,0 +1,61 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from gateway.tts_summary import prepare_tts_text
+
+
+def _cfg(enabled=False, max_chars=700, max_tokens=180):
+    return {
+        "voice": {
+            "tts_summary_enabled": enabled,
+            "tts_summary_max_chars": max_chars,
+            "tts_summary_max_tokens": max_tokens,
+        }
+    }
+
+
+def test_prepare_tts_text_disabled_uses_stripped_original():
+    with patch("hermes_cli.config.load_config", return_value=_cfg(enabled=False)), \
+         patch("gateway.tts_summary._strip_markdown_for_tts", side_effect=lambda t: t.replace("**", "")) as strip, \
+         patch("agent.auxiliary_client.call_llm") as call_llm:
+        result = prepare_tts_text("**Full** text")
+
+    assert result == "Full text"
+    strip.assert_called_once_with("**Full** text")
+    call_llm.assert_not_called()
+
+
+def test_prepare_tts_text_enabled_uses_auxiliary_summary():
+    response = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="Short spoken summary."))]
+    )
+    with patch("hermes_cli.config.load_config", return_value=_cfg(enabled=True, max_chars=80)), \
+         patch("agent.auxiliary_client.call_llm", return_value=response) as call_llm, \
+         patch("gateway.tts_summary._strip_markdown_for_tts", side_effect=lambda t: t):
+        result = prepare_tts_text("Long detailed response with code and logs.")
+
+    assert result == "Short spoken summary."
+    call_llm.assert_called_once()
+    kwargs = call_llm.call_args.kwargs
+    assert kwargs["task"] == "tts_summary"
+    assert kwargs["max_tokens"] == 180
+
+
+def test_prepare_tts_text_summary_failure_falls_back_to_original():
+    with patch("hermes_cli.config.load_config", return_value=_cfg(enabled=True)), \
+         patch("agent.auxiliary_client.call_llm", side_effect=RuntimeError("boom")), \
+         patch("gateway.tts_summary._strip_markdown_for_tts", return_value="fallback text"):
+        result = prepare_tts_text("Long detailed response")
+
+    assert result == "fallback text"
+
+
+def test_prepare_tts_text_clamps_summary():
+    long_summary = "This is the first useful sentence. " + ("extra " * 80)
+    with patch("hermes_cli.config.load_config", return_value=_cfg(enabled=True, max_chars=120)), \
+         patch("agent.auxiliary_client.call_llm", return_value={"content": long_summary}), \
+         patch("gateway.tts_summary._strip_markdown_for_tts", side_effect=lambda t: t):
+        result = prepare_tts_text("Long detailed response")
+
+    assert len(result) <= 121  # allow ellipsis if no boundary is available
+    assert result.startswith("This is the first useful sentence.")


### PR DESCRIPTION
Summary:
- Add long-response summarization before TTS delivery.
- Keep full text behavior intact while avoiding oversized voice replies.

Test Plan:
- /Users/manus/.hermes/hermes-agent/venv/bin/python -m py_compile gateway/run.py gateway/platforms/base.py gateway/tts_summary.py
- /Users/manus/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_voice_command.py::TestSendVoiceReply tests/gateway/test_tts_summary.py -o 'addopts=' -q