### PR TITLE
feat(web): add TinyFish backend provider

### DIFF
--- a/plugins/web/tinyfish/__init__.py
+++ b/plugins/web/tinyfish/__init__.py
@@ -1,0 +1,10 @@
+"""TinyFish web search + extract plugin — bundled, auto-loaded."""
+
+from __future__ import annotations
+
+from plugins.web.tinyfish.provider import TinyfishWebSearchProvider
+
+
+def register(ctx) -> None:
+    """Register the TinyFish provider with the plugin context."""
+    ctx.register_web_search_provider(TinyfishWebSearchProvider())

--- a/plugins/web/tinyfish/plugin.yaml
+++ b/plugins/web/tinyfish/plugin.yaml
@@ -1,0 +1,7 @@
+name: web-tinyfish
+version: 1.0.0
+description: "TinyFish web search + content extraction provider. Requires TINYFISH_API_KEY; optional TINYFISH_LOCATION and TINYFISH_LANGUAGE."
+author: Hermes Agent
+kind: backend
+provides_web_providers:
+  - tinyfish

--- a/plugins/web/tinyfish/provider.py
+++ b/plugins/web/tinyfish/provider.py
@@ -1,0 +1,221 @@
+"""TinyFish web search + content extraction — plugin form.
+
+Subclasses :class:`agent.web_search_provider.WebSearchProvider`. Two
+capabilities advertised:
+
+- ``supports_search()``  -> True (TinyFish ``/search``)
+- ``supports_extract()`` -> True (TinyFish ``/extract``)
+
+TinyFish uses:
+- GET  https://api.search.tinyfish.ai with ``X-API-Key`` header for search
+- POST https://api.fetch.tinyfish.ai with ``X-API-Key`` header for extract
+
+Config keys this provider responds to::
+
+    web:
+      search_backend: "tinyfish"     # explicit per-capability
+      extract_backend: "tinyfish"   # explicit per-capability
+      backend: "tinyfish"           # shared fallback for all
+
+Env vars::
+
+    TINYFISH_API_KEY=...     # required
+    TINYFISH_LOCATION=...    # optional (e.g. "us", "eu")
+    TINYFISH_LANGUAGE=...    # optional (e.g. "en", "de")
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, List
+
+import httpx
+
+from agent.web_search_provider import WebSearchProvider
+
+logger = logging.getLogger(__name__)
+
+SEARCH_URL = "https://api.search.tinyfish.ai"
+EXTRACT_URL = "https://api.fetch.tinyfish.ai"
+
+
+def _tinyfish_request(
+    method: str, url: str, params: Dict[str, Any] | None = None, json: Dict[str, Any] | None = None
+) -> Dict[str, Any]:
+    """Make an authenticated request to the TinyFish API.
+
+    Raises ``ValueError`` when ``TINYFISH_API_KEY`` is unset; the caller
+    catches and surfaces as a typed error response.
+    """
+    api_key = os.getenv("TINYFISH_API_KEY")
+    if not api_key:
+        raise ValueError(
+            "TINYFISH_API_KEY environment variable not set. "
+            "Set TINYFISH_API_KEY to use TinyFish."
+        )
+
+    headers = {"X-API-Key": api_key}
+    logger.info("TinyFish %s request to %s", method, url)
+
+    with httpx.Client(timeout=60) as client:
+        if method.upper() == "GET":
+            response = client.get(url, headers=headers, params=params)
+        else:
+            response = client.post(url, headers=headers, json=json)
+    response.raise_for_status()
+    return response.json()
+
+
+def _normalize_tinyfish_search_results(response: Dict[str, Any]) -> Dict[str, Any]:
+    """Map TinyFish search response to ``{success, data: {web: [...]}}``."""
+    web_results = []
+    for i, result in enumerate(response.get("results", [])):
+        web_results.append(
+            {
+                "title": result.get("title", ""),
+                "url": result.get("url", ""),
+                "description": result.get("snippet", "") or result.get("description", ""),
+                "position": i + 1,
+            }
+        )
+    return {"success": True, "data": {"web": web_results}}
+
+
+def _normalize_tinyfish_documents(
+    response: Dict[str, Any], fallback_url: str = ""
+) -> List[Dict[str, Any]]:
+    """Map TinyFish ``/extract`` response to standard documents.
+
+    Documents follow the legacy LLM post-processing shape::
+
+        {"url", "title", "content", "raw_content", "metadata"}
+
+    Failures become result entries with an ``error`` field rather than raising.
+    """
+    documents: List[Dict[str, Any]] = []
+    for result in response.get("results", []):
+        url = result.get("url", fallback_url)
+        raw = result.get("raw_content", "") or result.get("content", "")
+        documents.append(
+            {
+                "url": url,
+                "title": result.get("title", ""),
+                "content": raw,
+                "raw_content": raw,
+                "metadata": {"sourceURL": url, "title": result.get("title", "")},
+            }
+        )
+    for fail in response.get("failed_results", []):
+        documents.append(
+            {
+                "url": fail.get("url", fallback_url),
+                "title": "",
+                "content": "",
+                "raw_content": "",
+                "error": fail.get("error", "extraction failed"),
+                "metadata": {"sourceURL": fail.get("url", fallback_url)},
+            }
+        )
+    return documents
+
+
+class TinyfishWebSearchProvider(WebSearchProvider):
+    """TinyFish search + extract provider."""
+
+    @property
+    def name(self) -> str:
+        return "tinyfish"
+
+    @property
+    def display_name(self) -> str:
+        return "TinyFish"
+
+    def is_available(self) -> bool:
+        """Return True when ``TINYFISH_API_KEY`` is set to a non-empty value."""
+        return bool(os.getenv("TINYFISH_API_KEY", "").strip())
+
+    def supports_search(self) -> bool:
+        return True
+
+    def supports_extract(self) -> bool:
+        return True
+
+    def supports_crawl(self) -> bool:
+        return False
+
+    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+        """Execute a TinyFish search."""
+        try:
+            from tools.interrupt import is_interrupted
+
+            if is_interrupted():
+                return {"success": False, "error": "Interrupted"}
+
+            logger.info("TinyFish search: '%s' (limit=%d)", query, limit)
+
+            params: Dict[str, Any] = {"query": query}
+            location = os.getenv("TINYFISH_LOCATION", "").strip()
+            if location:
+                params["location"] = location
+            language = os.getenv("TINYFISH_LANGUAGE", "").strip()
+            if language:
+                params["language"] = language
+
+            raw = _tinyfish_request("GET", SEARCH_URL, params=params)
+            if limit:
+                raw = dict(raw)
+                raw["results"] = list(raw.get("results", []))[: min(limit, 100)]
+            return _normalize_tinyfish_search_results(raw)
+        except ValueError as exc:
+            return {"success": False, "error": str(exc)}
+        except Exception as exc:  # noqa: BLE001 — including httpx errors
+            logger.warning("TinyFish search error: %s", exc)
+            return {"success": False, "error": f"TinyFish search failed: {exc}"}
+
+    def extract(self, urls: List[str], **kwargs: Any) -> List[Dict[str, Any]]:
+        """Extract content from one or more URLs via TinyFish.
+
+        Returns the legacy list-of-results shape; per-URL failures become
+        items with ``error``.
+        """
+        try:
+            from tools.interrupt import is_interrupted
+
+            if is_interrupted():
+                return [
+                    {"url": u, "error": "Interrupted", "title": ""} for u in urls
+                ]
+
+            logger.info("TinyFish extract: %d URL(s)", len(urls))
+
+            payload: Dict[str, Any] = {
+                "urls": urls,
+            }
+
+            raw = _tinyfish_request("POST", EXTRACT_URL, json=payload)
+            return _normalize_tinyfish_documents(
+                raw, fallback_url=urls[0] if urls else ""
+            )
+        except ValueError as exc:
+            return [{"url": u, "title": "", "content": "", "error": str(exc)} for u in urls]
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("TinyFish extract error: %s", exc)
+            return [
+                {"url": u, "title": "", "content": "", "error": f"TinyFish extract failed: {exc}"}
+                for u in urls
+            ]
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "TinyFish",
+            "badge": "paid",
+            "tag": "Web search + content extraction.",
+            "env_vars": [
+                {
+                    "key": "TINYFISH_API_KEY",
+                    "prompt": "TinyFish API key",
+                    "url": "https://tinyfish.ai",
+                },
+            ],
+        }

--- a/tests/tools/test_web_tools_tinyfish.py
+++ b/tests/tools/test_web_tools_tinyfish.py
@@ -1,0 +1,286 @@
+"""Tests for TinyFish web backend integration.
+
+Coverage:
+  _tinyfish_request() — API key handling, URL construction, error propagation.
+  _normalize_tinyfish_search_results() — search response normalization.
+  _normalize_tinyfish_documents() — extract response normalization, failed_results.
+  TinyfishWebSearchProvider — availability, capabilities, search, extract.
+"""
+
+import json
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+# ─── _tinyfish_request ─────────────────────────────────────────────────────────
+
+class TestTinyfishRequest:
+    """Test suite for the _tinyfish_request helper."""
+
+    def test_raises_without_api_key(self):
+        """No TINYFISH_API_KEY → ValueError with guidance."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("TINYFISH_API_KEY", None)
+            from plugins.web.tinyfish.provider import _tinyfish_request
+            with pytest.raises(ValueError, match="TINYFISH_API_KEY"):
+                _tinyfish_request("GET", "https://api.search.tinyfish.ai", params={"q": "test"})
+
+    def test_get_includes_api_key_header(self):
+        """X-API-Key header is sent on GET requests."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"results": []}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.dict(os.environ, {"TINYFISH_API_KEY": "tf-test-key"}):
+            with patch("plugins.web.tinyfish.provider.httpx.Client") as mock_client_cls:
+                mock_client = MagicMock()
+                mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
+                mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+                mock_client.get.return_value = mock_response
+
+                from plugins.web.tinyfish.provider import _tinyfish_request
+                _tinyfish_request("GET", "https://api.search.tinyfish.ai", params={"q": "hello"})
+
+                mock_client.get.assert_called_once()
+                call_kwargs = mock_client.get.call_args
+                assert call_kwargs.kwargs["headers"]["X-API-Key"] == "tf-test-key"
+
+    def test_post_includes_api_key_header(self):
+        """X-API-Key header is sent on POST requests."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"results": []}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.dict(os.environ, {"TINYFISH_API_KEY": "tf-test-key"}):
+            with patch("plugins.web.tinyfish.provider.httpx.Client") as mock_client_cls:
+                mock_client = MagicMock()
+                mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
+                mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+                mock_client.post.return_value = mock_response
+
+                from plugins.web.tinyfish.provider import _tinyfish_request
+                _tinyfish_request("POST", "https://api.fetch.tinyfish.ai", json={"urls": ["https://example.com"]})
+
+                mock_client.post.assert_called_once()
+                call_kwargs = mock_client.post.call_args
+                assert call_kwargs.kwargs["headers"]["X-API-Key"] == "tf-test-key"
+
+    def test_raises_on_http_error(self):
+        """Non-2xx responses propagate as httpx.HTTPStatusError."""
+        import httpx as _httpx
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = _httpx.HTTPStatusError(
+            "401 Unauthorized", request=MagicMock(), response=mock_response
+        )
+
+        with patch.dict(os.environ, {"TINYFISH_API_KEY": "tf-bad-key"}):
+            with patch("plugins.web.tinyfish.provider.httpx.Client") as mock_client_cls:
+                mock_client = MagicMock()
+                mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
+                mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+                mock_client.get.return_value = mock_response
+
+                from plugins.web.tinyfish.provider import _tinyfish_request
+                with pytest.raises(_httpx.HTTPStatusError):
+                    _tinyfish_request("GET", "https://api.search.tinyfish.ai", params={"q": "test"})
+
+
+# ─── _normalize_tinyfish_search_results ─────────────────────────────────────────
+
+class TestNormalizeTinyfishSearchResults:
+    """Test search result normalization."""
+
+    def test_basic_normalization(self):
+        from plugins.web.tinyfish.provider import _normalize_tinyfish_search_results
+        raw = {
+            "results": [
+                {"title": "Python Docs", "url": "https://docs.python.org", "snippet": "Official docs", "score": 0.9},
+                {"title": "Tutorial", "url": "https://example.com", "snippet": "A tutorial", "score": 0.8},
+            ]
+        }
+        result = _normalize_tinyfish_search_results(raw)
+        assert result["success"] is True
+        web = result["data"]["web"]
+        assert len(web) == 2
+        assert web[0]["title"] == "Python Docs"
+        assert web[0]["url"] == "https://docs.python.org"
+        assert web[0]["description"] == "Official docs"
+        assert web[0]["position"] == 1
+        assert web[1]["position"] == 2
+
+    def test_empty_results(self):
+        from plugins.web.tinyfish.provider import _normalize_tinyfish_search_results
+        result = _normalize_tinyfish_search_results({"results": []})
+        assert result["success"] is True
+        assert result["data"]["web"] == []
+
+    def test_missing_fields(self):
+        from plugins.web.tinyfish.provider import _normalize_tinyfish_search_results
+        result = _normalize_tinyfish_search_results({"results": [{}]})
+        web = result["data"]["web"]
+        assert web[0]["title"] == ""
+        assert web[0]["url"] == ""
+        assert web[0]["description"] == ""
+
+    def test_description_falls_back_to_description_field(self):
+        """When 'snippet' is absent, 'description' is used."""
+        from plugins.web.tinyfish.provider import _normalize_tinyfish_search_results
+        raw = {"results": [{"title": "T", "url": "https://x.com", "description": "from desc field"}]}
+        result = _normalize_tinyfish_search_results(raw)
+        assert result["data"]["web"][0]["description"] == "from desc field"
+
+
+# ─── _normalize_tinyfish_documents ──────────────────────────────────────────────
+
+class TestNormalizeTinyfishDocuments:
+    """Test extract document normalization."""
+
+    def test_basic_document(self):
+        from plugins.web.tinyfish.provider import _normalize_tinyfish_documents
+        raw = {
+            "results": [{
+                "url": "https://example.com",
+                "title": "Example",
+                "raw_content": "Full page content here",
+            }]
+        }
+        docs = _normalize_tinyfish_documents(raw)
+        assert len(docs) == 1
+        assert docs[0]["url"] == "https://example.com"
+        assert docs[0]["title"] == "Example"
+        assert docs[0]["content"] == "Full page content here"
+        assert docs[0]["raw_content"] == "Full page content here"
+        assert docs[0]["metadata"]["sourceURL"] == "https://example.com"
+
+    def test_falls_back_to_content_when_no_raw_content(self):
+        from plugins.web.tinyfish.provider import _normalize_tinyfish_documents
+        raw = {"results": [{"url": "https://example.com", "content": "Snippet"}]}
+        docs = _normalize_tinyfish_documents(raw)
+        assert docs[0]["content"] == "Snippet"
+
+    def test_failed_results_included(self):
+        from plugins.web.tinyfish.provider import _normalize_tinyfish_documents
+        raw = {
+            "results": [],
+            "failed_results": [
+                {"url": "https://fail.com", "error": "timeout"},
+            ],
+        }
+        docs = _normalize_tinyfish_documents(raw)
+        assert len(docs) == 1
+        assert docs[0]["url"] == "https://fail.com"
+        assert docs[0]["error"] == "timeout"
+        assert docs[0]["content"] == ""
+
+    def test_fallback_url(self):
+        from plugins.web.tinyfish.provider import _normalize_tinyfish_documents
+        raw = {"results": [{"content": "data"}]}
+        docs = _normalize_tinyfish_documents(raw, fallback_url="https://fallback.com")
+        assert docs[0]["url"] == "https://fallback.com"
+
+
+# ─── TinyfishWebSearchProvider ─────────────────────────────────────────────────
+
+class TestTinyfishProvider:
+    """Test the Tinyfish provider class."""
+
+    def test_name(self):
+        from plugins.web.tinyfish.provider import TinyfishWebSearchProvider
+        assert TinyfishWebSearchProvider().name == "tinyfish"
+
+    def test_display_name(self):
+        from plugins.web.tinyfish.provider import TinyfishWebSearchProvider
+        assert TinyfishWebSearchProvider().display_name == "TinyFish"
+
+    def test_supports_search(self):
+        from plugins.web.tinyfish.provider import TinyfishWebSearchProvider
+        assert TinyfishWebSearchProvider().supports_search() is True
+
+    def test_supports_extract(self):
+        from plugins.web.tinyfish.provider import TinyfishWebSearchProvider
+        assert TinyfishWebSearchProvider().supports_extract() is True
+
+    def test_supports_crawl(self):
+        from plugins.web.tinyfish.provider import TinyfishWebSearchProvider
+        assert TinyfishWebSearchProvider().supports_crawl() is False
+
+    def test_is_available_requires_api_key(self):
+        from plugins.web.tinyfish.provider import TinyfishWebSearchProvider
+        p = TinyfishWebSearchProvider()
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("TINYFISH_API_KEY", None)
+            assert p.is_available() is False
+        with patch.dict(os.environ, {"TINYFISH_API_KEY": "real"}):
+            assert p.is_available() is True
+
+    def test_search_returns_error_without_api_key(self):
+        from plugins.web.tinyfish.provider import TinyfishWebSearchProvider
+        p = TinyfishWebSearchProvider()
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("TINYFISH_API_KEY", None)
+            result = p.search("test")
+            assert result["success"] is False
+            assert "TINYFISH_API_KEY" in result["error"]
+
+    def test_search_returns_error_on_network_failure(self):
+        from plugins.web.tinyfish.provider import TinyfishWebSearchProvider
+        p = TinyfishWebSearchProvider()
+        with patch.dict(os.environ, {"TINYFISH_API_KEY": "tf-test"}):
+            with patch("plugins.web.tinyfish.provider.httpx.Client") as mock_client_cls:
+                mock_client = MagicMock()
+                mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
+                mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+                mock_client.get.side_effect = Exception("network error")
+
+                result = p.search("test")
+                assert result["success"] is False
+                assert "TinyFish search failed" in result["error"]
+
+    def test_search_returns_error_when_interrupted(self):
+        from plugins.web.tinyfish.provider import TinyfishWebSearchProvider
+        p = TinyfishWebSearchProvider()
+        with patch("tools.interrupt.is_interrupted", return_value=True):
+            result = p.search("test")
+            assert result["success"] is False
+            assert result["error"] == "Interrupted"
+
+    def test_extract_returns_error_without_api_key(self):
+        from plugins.web.tinyfish.provider import TinyfishWebSearchProvider
+        p = TinyfishWebSearchProvider()
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("TINYFISH_API_KEY", None)
+            result = p.extract(["https://example.com"])
+            assert len(result) == 1
+            assert "TINYFISH_API_KEY" in result[0]["error"]
+
+    def test_extract_returns_per_url_errors_on_network_failure(self):
+        from plugins.web.tinyfish.provider import TinyfishWebSearchProvider
+        p = TinyfishWebSearchProvider()
+        with patch.dict(os.environ, {"TINYFISH_API_KEY": "tf-test"}):
+            with patch("plugins.web.tinyfish.provider.httpx.Client") as mock_client_cls:
+                mock_client = MagicMock()
+                mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
+                mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+                mock_client.post.side_effect = Exception("network error")
+
+                result = p.extract(["https://example.com"])
+                assert len(result) == 1
+                assert "TinyFish extract failed" in result[0]["error"]
+
+    def test_extract_returns_per_url_errors_when_interrupted(self):
+        from plugins.web.tinyfish.provider import TinyfishWebSearchProvider
+        p = TinyfishWebSearchProvider()
+        with patch("tools.interrupt.is_interrupted", return_value=True):
+            result = p.extract(["https://a.com", "https://b.com"])
+            assert len(result) == 2
+            assert result[0]["error"] == "Interrupted"
+            assert result[1]["error"] == "Interrupted"
+
+    def test_setup_schema(self):
+        from plugins.web.tinyfish.provider import TinyfishWebSearchProvider
+        schema = TinyfishWebSearchProvider().get_setup_schema()
+        assert schema["name"] == "TinyFish"
+        assert schema["badge"] == "paid"
+        env_keys = [e["key"] for e in schema["env_vars"]]
+        assert "TINYFISH_API_KEY" in env_keys

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -140,7 +140,7 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs"}:
+    if configured in {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "tinyfish"}:
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -149,6 +149,7 @@ def _get_backend() -> str:
     # Free-tier backends (searxng / brave-free / ddgs) trail the paid ones so
     # existing paid setups are unaffected.
     backend_candidates = (
+        ("tinyfish", _has_env("TINYFISH_API_KEY")),
         ("firecrawl", _has_env("FIRECRAWL_API_KEY") or _has_env("FIRECRAWL_API_URL") or _is_tool_gateway_ready()),
         ("parallel", _has_env("PARALLEL_API_KEY")),
         ("tavily", _has_env("TAVILY_API_KEY")),
@@ -218,6 +219,8 @@ def _is_backend_available(backend: str) -> bool:
         return _has_env("BRAVE_SEARCH_API_KEY")
     if backend == "ddgs":
         return _ddgs_package_importable()
+    if backend == "tinyfish":
+        return _has_env("TINYFISH_API_KEY")
     return False
 
 
@@ -267,6 +270,9 @@ def _web_requires_env() -> list[str]:
         "TOOL_GATEWAY_DOMAIN",
         "TOOL_GATEWAY_SCHEME",
         "TOOL_GATEWAY_USER_TOKEN",
+        "TINYFISH_API_KEY",
+        "TINYFISH_LOCATION",
+        "TINYFISH_LANGUAGE",
     ]
 
 
@@ -1357,11 +1363,11 @@ async def web_crawl_tool(
 def check_web_api_key() -> bool:
     """Check whether the configured web backend is available."""
     configured = _load_web_config().get("backend", "").lower().strip()
-    if configured in {"exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs"}:
+    if configured in {"exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "tinyfish"}:
         return _is_backend_available(configured)
     return any(
         _is_backend_available(backend)
-        for backend in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs")
+        for backend in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "tinyfish")
     )
 
 


### PR DESCRIPTION
Summary:
- Add a TinyFish web backend plugin/provider.
- Wire TinyFish into web_tools backend selection.
- Add provider tests covering search/extract behavior.

Test Plan:
- /Users/manus/.hermes/hermes-agent/venv/bin/python -m py_compile tools/web_tools.py plugins/web/tinyfish/provider.py
- /Users/manus/.hermes/hermes-agent/venv/bin/python -m pytest tests/tools/test_web_tools_tinyfish.py -o 'addopts=' -q