### PR TITLE
chore: update lark-oapi to 1.6.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -249,7 +249,7 @@ termux-all = [
   "hermes-agent[web]",
 ]
 dingtalk = ["dingtalk-stream==0.24.3", "alibabacloud-dingtalk==2.2.42", "qrcode==7.4.2"]
-feishu = ["lark-oapi==1.5.3", "qrcode==7.4.2"]
+feishu = ["lark-oapi==1.6.8", "qrcode==7.4.2"]
 google = [
   # Required by the google-workspace skill (Gmail, Calendar, Drive, Contacts,
   # Sheets, Docs).  Declared here so packagers (Nix, Homebrew) ship them with

--- a/uv.lock
+++ b/uv.lock
@@ -1794,7 +1794,7 @@ requires-dist = [
     { name = "honcho-ai", marker = "extra == 'honcho'", specifier = "==2.0.1" },
     { name = "httpx", extras = ["socks"], specifier = "==0.28.1" },
     { name = "jinja2", specifier = "==3.1.6" },
-    { name = "lark-oapi", marker = "extra == 'feishu'", specifier = "==1.5.3" },
+    { name = "lark-oapi", marker = "extra == 'feishu'", specifier = "==1.6.8" },
     { name = "markdown", specifier = "==3.10.2" },
     { name = "mautrix", extras = ["encryption"], marker = "extra == 'matrix'", specifier = "==0.21.0" },
     { name = "mcp", marker = "extra == 'computer-use'", specifier = "==1.26.0" },
@@ -2184,7 +2184,7 @@ wheels = [
 
 [[package]]
 name = "lark-oapi"
-version = "1.5.3"
+version = "1.6.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -2194,7 +2194,7 @@ dependencies = [
     { name = "websockets" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/ff/2ece5d735ebfa2af600a53176f2636ae47af2bf934e08effab64f0d1e047/lark_oapi-1.5.3-py3-none-any.whl", hash = "sha256:fda6b32bb38d21b6bdaae94979c600b94c7c521e985adade63a54e4b3e20cc36", size = 6993016, upload-time = "2026-01-27T08:21:49.307Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/ad/1ab04db5d549ad1a7a2cd33682b1c38dee1d65019cb24fd7a23270e6337d/lark_oapi-1.6.8-py3-none-any.whl", hash = "sha256:9b443a5d47a7d204dd42dc40896c8b75087cc35788e45c48c140806d7df7e5e8", size = 7798300, upload-time = "2026-06-02T07:40:05.492Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What does this PR do?

Updates the Feishu/Lark SDK dependency used by the optional `feishu` extra from `lark-oapi==1.5.3` to `lark-oapi==1.6.8`.

This keeps Hermes aligned with the current PyPI release of the Feishu SDK while preserving the existing optional dependency structure.

## Related Issue

N/A — dependency maintenance update.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)
- [x] Dependency update

## Changes Made

- Updated `pyproject.toml` so the `feishu` optional dependency pins `lark-oapi==1.6.8`.
- Refreshed `uv.lock` for the new `lark-oapi` wheel, hash, and version metadata.

## How to Test

1. `uv lock`
2. `UV_PROJECT_ENVIRONMENT=/tmp/hermes-pr-27738/.venv uv run --extra feishu python - <<'PY'`
   ```python
   import importlib.metadata as md
   print('lark-oapi', md.version('lark-oapi'))
   ```
3. Confirm both `pyproject.toml` and `uv.lock` resolve `lark-oapi` to `1.6.8`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — N/A, dependency-only update
- [x] I've tested on my platform: Ubuntu/Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
$ uv lock
Using CPython 3.11.15
Resolved 225 packages in 2ms

$ UV_PROJECT_ENVIRONMENT=/tmp/hermes-pr-27738/.venv uv run --extra feishu python - <<'PY'
import importlib.metadata as md
print('lark-oapi', md.version('lark-oapi'))
PY
Using CPython 3.11.15
Creating virtual environment at: .venv
Installed 65 packages in 2.26s
lark-oapi 1.6.8

Verified:
- pyproject.toml pins lark-oapi==1.6.8
- uv.lock resolves lark-oapi to version 1.6.8
```
