### PR TITLE
fix(feishu): render markdown tables via post+md instead of force-text

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -545,6 +545,12 @@ def _coerce_required_int(value: Any, default: int, min_value: int = 0) -> int:
 # Post payload builders and parsers
 # ---------------------------------------------------------------------------
 
+# Pattern to identify markdown table blocks: header line + separator + optional data rows
+_TABLE_BLOCK_RE = re.compile(
+    r'(^\|.*\|\n\|[-|: ]+\|(?:\n\|.*\|)*)',
+    re.MULTILINE,
+)
+
 
 def _build_markdown_post_payload(content: str) -> str:
     rows = _build_markdown_post_rows(content)
@@ -561,9 +567,9 @@ def _build_markdown_post_payload(content: str) -> str:
 def _build_markdown_post_rows(content: str) -> List[List[Dict[str, str]]]:
     """Build Feishu post rows while isolating fenced code blocks.
 
-    Feishu's `md` renderer can swallow trailing content when a fenced code block
-    appears inside one large markdown element. Split the reply at real fence
-    lines so prose before/after the code block remains visible while code stays
+    Feishu's ``md`` tag supports full GFM markdown (tables, bold, italic,
+    code blocks, lists, links, etc.). Split at fenced code-block boundaries
+    so prose before/after the code block remains visible while code stays
     in a dedicated row.
     """
     if not content:
@@ -4222,13 +4228,9 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
-        # Feishu post-type 'md' elements do not render markdown tables; sending
-        # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
-        if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
-            return "text", json.dumps(text_payload, ensure_ascii=False)
-        if _MARKDOWN_HINT_RE.search(content):
+        # Feishu post-type 'md' elements support tables natively (GFM).
+        # Route tables and markdown content through post for full rendering.
+        if _MARKDOWN_HINT_RE.search(content) or _TABLE_BLOCK_RE.search(content):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}
         return "text", json.dumps(text_payload, ensure_ascii=False)


### PR DESCRIPTION
Feishu post-type messages with tag:md support full GFM markdown including tables. The _MARKDOWN_TABLE_RE force-text fallback in _build_outbound_payload was downgrading any message containing a table to plain text, stripping ALL markdown formatting.
Fix:
- Add _TABLE_BLOCK_RE to detect markdown table blocks
- Route table content through post (tag:md) instead of text
- Update docstring to reflect md tag GFM support
Related: #27529, #26658
## What does this PR do?
Fixes Feishu/Lark message rendering for content containing markdown tables. 
In v0.14.0, `_build_outbound_payload` uses `_MARKDOWN_TABLE_RE` to detect tables and forces the entire message to plain `text` type. While this prevented blank rendering (the original concern), it strips ALL markdown formatting — bold, italic, code blocks, links — making complex AI responses unreadable.
This PR routes table-containing content through `post` with `tag:md` elements, which natively support GFM tables. Tested on Feishu 7.x client.
## Related Issue
Fixes #27529
## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
## Changes Made
- `gateway/platforms/feishu.py`: Add `_TABLE_BLOCK_RE` regex for table detection
- `gateway/platforms/feishu.py`: Modify `_build_outbound_payload` to route table content through `post` instead of `text`
- `gateway/platforms/feishu.py`: Update `_build_markdown_post_rows` docstring
## How to Test
1. Start Hermes gateway with Feishu platform
2. Send a message that generates a markdown table response
3. Verify tables render correctly with bold/italic/code blocks preserved
## Checklist
### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04, Feishu 7.x
### Documentation & Housekeeping
- [x] I've updated relevant documentation — N/A (docstring only)
- [x] I've updated cli-config.yaml.example — N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md — N/A
- [x] I've considered cross-platform impact — N/A (Feishu-only)
- [x] I've updated tool descriptions/schemas — N/A