### PR TITLE
fix(acp): inherit provider transport and MCP toolsets on fork

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -155,6 +155,34 @@ def _expand_acp_enabled_toolsets(
     return expanded
 
 
+def _refresh_agent_tool_surface(
+    agent: Any,
+    *,
+    enabled_toolsets: List[str] | None,
+    disabled_toolsets: List[str] | None,
+) -> None:
+    """Rebuild agent tool metadata after inheriting session-local toolsets."""
+    if not enabled_toolsets:
+        return
+
+    from model_tools import get_tool_definitions
+
+    tools = get_tool_definitions(
+        enabled_toolsets=enabled_toolsets,
+        disabled_toolsets=disabled_toolsets,
+        quiet_mode=True,
+    )
+    agent.tools = tools
+    agent.valid_tool_names = {
+        tool["function"]["name"]
+        for tool in tools or []
+        if isinstance(tool, dict) and isinstance(tool.get("function"), dict)
+    }
+    invalidate = getattr(agent, "_invalidate_system_prompt", None)
+    if callable(invalidate):
+        invalidate()
+
+
 def _clear_task_cwd(task_id: str) -> None:
     """Remove task-specific cwd overrides for an ACP session."""
     if not task_id:
@@ -260,11 +288,31 @@ class SessionManager:
             return None
 
         new_id = str(uuid.uuid4())
+        requested_provider = getattr(original.agent, "provider", None)
+        base_url = getattr(original.agent, "base_url", None)
+        api_mode = getattr(original.agent, "api_mode", None)
         agent = self._make_agent(
             session_id=new_id,
             cwd=cwd,
             model=original.model or None,
+            requested_provider=requested_provider,
+            base_url=base_url,
+            api_mode=api_mode,
         )
+        enabled_toolsets = copy.deepcopy(getattr(original.agent, "enabled_toolsets", None))
+        disabled_toolsets = copy.deepcopy(getattr(original.agent, "disabled_toolsets", None))
+        if enabled_toolsets is not None:
+            agent.enabled_toolsets = enabled_toolsets
+        if disabled_toolsets is not None:
+            agent.disabled_toolsets = disabled_toolsets
+        try:
+            _refresh_agent_tool_surface(
+                agent,
+                enabled_toolsets=enabled_toolsets,
+                disabled_toolsets=disabled_toolsets,
+            )
+        except Exception:
+            logger.debug("Failed to refresh ACP fork tool surface", exc_info=True)
         state = SessionState(
             session_id=new_id,
             agent=agent,

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -163,6 +163,106 @@ class TestForkSession:
     def test_fork_nonexistent_returns_none(self, manager):
         assert manager.fork_session("bogus-id") is None
 
+    def test_fork_session_preserves_runtime_transport(self, tmp_path, monkeypatch):
+        runtime_choice = {"provider": "anthropic"}
+
+        def fake_resolve_runtime_provider(requested=None, **kwargs):
+            provider = requested or runtime_choice["provider"]
+            return {
+                "provider": provider,
+                "api_mode": "anthropic_messages" if provider == "anthropic" else "chat_completions",
+                "base_url": f"https://{provider}.example/v1",
+                "api_key": f"{provider}-key",
+                "command": None,
+                "args": [],
+            }
+
+        def fake_agent(**kwargs):
+            return SimpleNamespace(
+                model=kwargs.get("model"),
+                provider=kwargs.get("provider"),
+                base_url=kwargs.get("base_url"),
+                api_mode=kwargs.get("api_mode"),
+                enabled_toolsets=kwargs.get("enabled_toolsets"),
+                disabled_toolsets=None,
+                tools=[],
+                valid_tool_names=set(),
+                _invalidate_system_prompt=MagicMock(),
+            )
+
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {
+            "model": {"provider": runtime_choice["provider"], "default": "test-model"}
+        })
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            fake_resolve_runtime_provider,
+        )
+        manager = SessionManager(db=SessionDB(tmp_path / "state.db"))
+
+        with patch("run_agent.AIAgent", side_effect=fake_agent):
+            original = manager.create_session(cwd="/work")
+            runtime_choice["provider"] = "openrouter"
+            forked = manager.fork_session(original.session_id, cwd="/fork")
+
+        assert forked is not None
+        assert forked.agent.provider == "anthropic"
+        assert forked.agent.base_url == "https://anthropic.example/v1"
+        assert forked.agent.api_mode == "anthropic_messages"
+
+    def test_fork_session_preserves_toolsets_and_refreshes_tools(self, tmp_path, monkeypatch):
+        def fake_resolve_runtime_provider(requested=None, **kwargs):
+            return {
+                "provider": requested or "openrouter",
+                "api_mode": "chat_completions",
+                "base_url": "https://openrouter.example/v1",
+                "api_key": "test-key",
+                "command": None,
+                "args": [],
+            }
+
+        def fake_agent(**kwargs):
+            return SimpleNamespace(
+                model=kwargs.get("model"),
+                provider=kwargs.get("provider"),
+                base_url=kwargs.get("base_url"),
+                api_mode=kwargs.get("api_mode"),
+                enabled_toolsets=kwargs.get("enabled_toolsets"),
+                disabled_toolsets=None,
+                tools=[],
+                valid_tool_names=set(),
+                _invalidate_system_prompt=MagicMock(),
+            )
+
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {
+            "model": {"provider": "openrouter", "default": "test-model"}
+        })
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            fake_resolve_runtime_provider,
+        )
+        manager = SessionManager(db=SessionDB(tmp_path / "state.db"))
+        fake_tools = [{"function": {"name": "mcp_demo_search"}}]
+
+        with patch("run_agent.AIAgent", side_effect=fake_agent):
+            original = manager.create_session(cwd="/work")
+            original.agent.enabled_toolsets = ["hermes-acp", "mcp-demo"]
+            original.agent.disabled_toolsets = ["legacy"]
+
+            with patch("model_tools.get_tool_definitions", return_value=fake_tools) as mock_defs:
+                forked = manager.fork_session(original.session_id, cwd="/fork")
+
+        assert forked is not None
+        mock_defs.assert_called_once_with(
+            enabled_toolsets=["hermes-acp", "mcp-demo"],
+            disabled_toolsets=["legacy"],
+            quiet_mode=True,
+        )
+        assert forked.agent.enabled_toolsets == ["hermes-acp", "mcp-demo"]
+        assert forked.agent.disabled_toolsets == ["legacy"]
+        assert forked.agent.tools == fake_tools
+        assert forked.agent.valid_tool_names == {"mcp_demo_search"}
+        forked.agent._invalidate_system_prompt.assert_called_once()
+
 
 # ---------------------------------------------------------------------------
 # list / cleanup / remove


### PR DESCRIPTION
## What does this PR do?

ACP session forks were silently losing parent context. `SessionManager.fork_session()` rebuilt the child agent from config defaults and only carried over the model name — anything else attached to the parent session at runtime was dropped.

In practice this meant a fork could end up:
- pointing at the wrong backend (custom `provider`, `base_url`, or `api_mode` lost)
- with a reduced tool surface (parent's enabled ACP MCP toolsets gone)

This PR makes fork actually preserve the parent's runtime, not just its transcript.

## Inheritance now covered on fork

| Field | Before | After |
|---|---|---|
| `model` | inherited | inherited |
| `provider` | dropped | inherited |
| `base_url` | dropped | inherited |
| `api_mode` | dropped | inherited |
| `enabled_toolsets` | reset to defaults | inherited |
| `disabled_toolsets` | reset to defaults | inherited |
| Tool definitions / `valid_tool_names` | rebuilt from defaults | rebuilt from inherited toolsets |

After inheriting toolsets, the forked agent refreshes its tool definitions so `tools` and `valid_tool_names` stay consistent with the parent.

## Related Issue

Fixes #

## Type of Change

- [x] Bug fix

- [x] Tests


## How to Test

1. Open an ACP session against a custom provider with one or more MCP toolsets enabled
2. Fork that session
3. Inspect the forked agent: `provider`, `base_url`, `api_mode`, `enabled_toolsets`, and tool definitions should all match the parent — not the global defaults

Automated coverage:

```
uv run --extra dev --extra acp pytest tests/acp/test_session.py -k "fork_session_preserves"
```

Result: `2 passed`.

Two new tests assert:
- runtime transport (`provider` / `base_url` / `api_mode`) survives the fork
- MCP toolsets and the refreshed tool surface survive the fork

A broader ACP session subset was also exercised to confirm no collateral damage:

```
pytest tests/acp/test_session.py -k "TestForkSession or test_restore_preserves_persisted_provider_snapshot"
```

Result: `6 passed`.

## Checklist

- [x] Conventional Commits (`fix(acp): ...`)
- [x] Searched existing PRs for duplicates
- [x] PR contains only changes related to this fix (unrelated `uv.lock` drift excluded)
- [x] Targeted tests pass; broader ACP session subset also passes (`6 passed`)
- [x] Regression tests added for both inherited dimensions (transport + toolsets)
- [x] No public API or schema surface changes — documentation update N/A
- [x] No config keys added or changed — example config update N/A

## Notes for reviewer

The fix is a parity change: CLI and gateway already construct child agents with full parent context, so this brings ACP fork in line with the rest of the codebase rather than introducing new semantics. Behavior under callers that explicitly pass overrides on fork is unchanged — inheritance only fills in fields the caller did not specify.