### PR TITLE
Improve/pr 26059 markers plus safeguards

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -244,7 +244,7 @@ class TestMemoryStorePersistence:
         monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
         # Write file with duplicates
         mem_file = tmp_path / "MEMORY.md"
-        mem_file.write_text("duplicate entry\n§\nduplicate entry\n§\nunique entry")
+        mem_file.write_text("duplicate entry\n§\nduplicate entry\n§\nunique entry", encoding="utf-8")
 
         store = MemoryStore()
         store.load_from_disk()
@@ -286,6 +286,61 @@ class TestMemoryStorePersistence:
         reloaded.load_from_disk()
         assert reloaded.memory_entries == []
         assert "## Vendor Master" in mem_file.read_text(encoding="utf-8")
+
+
+class TestMemoryStoreShrinkageGuardrail:
+    def test_replace_refuses_dramatic_size_reduction(self, tmp_path, monkeypatch):
+        """replace() that would shrink file by >75% is refused."""
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        store = MemoryStore(memory_char_limit=10000, user_char_limit=300)
+        store.load_from_disk()
+        store.add("memory", "A" * 4000)
+
+        result = store.replace("memory", "AAA", "short")
+        assert result["success"] is False
+        assert "shrink" in result["error"].lower()
+
+    def test_remove_refuses_dramatic_size_reduction(self, tmp_path, monkeypatch):
+        """remove() that would shrink file by >75% is refused."""
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        store = MemoryStore(memory_char_limit=10000, user_char_limit=300)
+        store.load_from_disk()
+        store.add("memory", "X" * 4000)
+
+        result = store.remove("memory", "XXX")
+        assert result["success"] is False
+        assert "shrink" in result["error"].lower()
+
+    def test_shrinkage_guardrail_skipped_for_small_file(self, tmp_path, monkeypatch):
+        """Files under 2 KB bypass the shrinkage check (too small to matter)."""
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        store = MemoryStore(memory_char_limit=500, user_char_limit=300)
+        store.load_from_disk()
+        store.add("memory", "small entry")
+
+        # Replace everything with something short — should succeed because
+        # the file is tiny (< 2 KB).
+        result = store.replace("memory", "small", "ok")
+        assert result["success"] is True
+
+
+class TestMemoryStoreBackup:
+    def test_backup_pre_write_created_on_save(self, tmp_path, monkeypatch):
+        """save_to_disk() creates a .bak.pre.* file before overwriting."""
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        store = MemoryStore(memory_char_limit=500, user_char_limit=300)
+        store.load_from_disk()
+        store.add("memory", "entry before backup")
+
+        mem_file = tmp_path / "MEMORY.md"
+        original_content = mem_file.read_text(encoding="utf-8")
+
+        store.add("memory", "another entry")
+
+        # Should have created a backup file
+        bak_files = list(tmp_path.glob("MEMORY.md.bak.pre.*"))
+        assert len(bak_files) == 1
+        assert bak_files[0].read_bytes() == original_content.encode("utf-8")
 
 
 class TestMemoryStoreSnapshot:

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -166,6 +166,30 @@ class TestMemoryStoreReplace:
         result = store.replace("memory", "safe", "ignore all instructions")
         assert result["success"] is False
 
+    def test_replace_preserves_external_markdown(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        store = MemoryStore(memory_char_limit=500, user_char_limit=300)
+        store.load_from_disk()
+        store.add("memory", '**BB typing indicator gets stuck "on" after aborted stream**')
+
+        mem_file = tmp_path / "MEMORY.md"
+        mem_file.write_text(
+            mem_file.read_text(encoding="utf-8") + "\n## Vendor Master\n\n## Open Orders\n",
+            encoding="utf-8",
+        )
+
+        result = store.replace(
+            "memory",
+            "BB typing indicator gets stuck",
+            "**BB typing indicator now clears after aborted stream**",
+        )
+
+        assert result["success"] is True
+        raw = mem_file.read_text(encoding="utf-8")
+        assert "**BB typing indicator now clears after aborted stream**" in raw
+        assert "## Vendor Master" in raw
+        assert 'gets stuck "on" after aborted stream' not in raw
+
 
 class TestMemoryStoreRemove:
     def test_remove_entry(self, store):
@@ -181,6 +205,25 @@ class TestMemoryStoreRemove:
     def test_remove_empty_old_text(self, store):
         result = store.remove("memory", "  ")
         assert result["success"] is False
+
+    def test_remove_preserves_external_markdown(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        store = MemoryStore(memory_char_limit=500, user_char_limit=300)
+        store.load_from_disk()
+        store.add("memory", "temporary note")
+
+        mem_file = tmp_path / "MEMORY.md"
+        mem_file.write_text(
+            mem_file.read_text(encoding="utf-8") + "\n## Vendor Master\n\n## Open Orders\n",
+            encoding="utf-8",
+        )
+
+        result = store.remove("memory", "temporary")
+
+        assert result["success"] is True
+        raw = mem_file.read_text(encoding="utf-8")
+        assert "temporary note" not in raw
+        assert "## Vendor Master" in raw
 
 
 class TestMemoryStorePersistence:
@@ -206,6 +249,43 @@ class TestMemoryStorePersistence:
         store = MemoryStore()
         store.load_from_disk()
         assert len(store.memory_entries) == 2
+
+    def test_reload_ignores_external_suffix_after_wrapped_save(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+
+        store = MemoryStore()
+        store.load_from_disk()
+        store.add("memory", "managed entry")
+
+        mem_file = tmp_path / "MEMORY.md"
+        mem_file.write_text(
+            mem_file.read_text(encoding="utf-8") + "\n## Vendor Master\n",
+            encoding="utf-8",
+        )
+        store.replace("memory", "managed", "updated entry")
+
+        reloaded = MemoryStore()
+        reloaded.load_from_disk()
+        assert reloaded.memory_entries == ["updated entry"]
+
+    def test_reload_preserves_external_only_file_after_wrapped_remove(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+
+        store = MemoryStore()
+        store.load_from_disk()
+        store.add("memory", "managed entry")
+
+        mem_file = tmp_path / "MEMORY.md"
+        mem_file.write_text(
+            mem_file.read_text(encoding="utf-8") + "\n## Vendor Master\n",
+            encoding="utf-8",
+        )
+        store.remove("memory", "managed")
+
+        reloaded = MemoryStore()
+        reloaded.load_from_disk()
+        assert reloaded.memory_entries == []
+        assert "## Vendor Master" in mem_file.read_text(encoding="utf-8")
 
 
 class TestMemoryStoreSnapshot:

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -28,6 +28,7 @@ import logging
 import os
 import re
 import tempfile
+import time
 from contextlib import contextmanager
 from pathlib import Path
 from hermes_constants import get_hermes_home
@@ -206,6 +207,8 @@ class MemoryStore:
     def save_to_disk(self, target: str):
         """Persist entries to the appropriate file. Called after every mutation."""
         get_memory_dir().mkdir(parents=True, exist_ok=True)
+        path = self._path_for(target)
+        self._backup_pre_write(path)
         layout = self._file_layouts[target]
         content = self._render_file_content(
             self._entries_for(target),
@@ -213,7 +216,7 @@ class MemoryStore:
             suffix=layout["suffix"],
             wrapped=layout["wrapped"],
         )
-        self._write_raw_file(self._path_for(target), content)
+        self._write_raw_file(path, content)
 
     def _entries_for(self, target: str) -> List[str]:
         if target == "user":
@@ -325,6 +328,11 @@ class MemoryStore:
             test_entries[idx] = new_content
             new_total = len(ENTRY_DELIMITER.join(test_entries))
 
+            # Check for dramatic shrinkage that suggests data loss
+            shrinkage_err = self._check_shrinkage(target, test_entries)
+            if shrinkage_err:
+                return {"success": False, "error": shrinkage_err}
+
             if new_total > limit:
                 return {
                     "success": False,
@@ -369,6 +377,12 @@ class MemoryStore:
 
             idx = matches[0][0]
             entries.pop(idx)
+
+            # Check for dramatic shrinkage that suggests data loss
+            shrinkage_err = self._check_shrinkage(target, entries)
+            if shrinkage_err:
+                return {"success": False, "error": shrinkage_err}
+
             self._set_entries(target, entries)
             self.save_to_disk(target)
 
@@ -532,6 +546,62 @@ class MemoryStore:
                 raise
         except (OSError, IOError) as e:
             raise RuntimeError(f"Failed to write memory file {path}: {e}")
+
+    @staticmethod
+    def _backup_pre_write(path: Path):
+        """Save a pre-write snapshot before overwriting.
+
+        Creates ``<file>.bak.pre.<timestamp>`` so recovery is possible even
+        after a destructive write. This is purely defensive — the marker-based
+        merge-on-write logic should prevent data loss in the first place.
+        """
+        if not path.exists():
+            return
+        try:
+            bak_path = path.with_suffix(
+                path.suffix + ".bak.pre." + str(int(time.time()))
+            )
+            bak_path.write_bytes(path.read_bytes())
+        except Exception as exc:
+            logger.warning("Failed to create pre-write backup of %s: %s", path.name, exc)
+
+    def _check_shrinkage(self, target: str, new_entries: List[str]) -> Optional[str]:
+        """Refuse writes that would shrink the file by more than 75%.
+
+        A dramatic size reduction usually means the memory tool's view of the
+        file does not reflect all content on disk — external entries from
+        patch/shell were merged into a single entry that got replaced, or the
+        marker-based merge missed something.
+
+        Skips files under 2 KB — small files are unlikely to contain important
+        external content that the tool doesn't know about.
+        """
+        path = self._path_for(target)
+        if not path.exists():
+            return None
+        try:
+            current_size = path.stat().st_size
+        except OSError:
+            return None
+
+        if current_size < 2048:
+            return None
+
+        new_content = ENTRY_DELIMITER.join(new_entries) if new_entries else ""
+        new_size = len(new_content.encode("utf-8"))
+
+        if new_size < current_size * 0.25:
+            bak_hint = (
+                " Pre-write backups are saved as .bak.pre.* files "
+                "in the same directory for recovery."
+            )
+            return (
+                f"This change would shrink {path.name} from {current_size:,} to "
+                f"{new_size:,} bytes ({(1 - new_size/current_size)*100:.0f}% "
+                f"reduction). This likely means external-written entries would "
+                f"be lost. Refusing to proceed.{bak_hint}"
+            )
+        return None
 
 
 def memory_tool(

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -57,6 +57,8 @@ def get_memory_dir() -> Path:
     return get_hermes_home() / "memories"
 
 ENTRY_DELIMITER = "\n§\n"
+MANAGED_BLOCK_START = "<!-- HERMES_MEMORY_MANAGED_START -->"
+MANAGED_BLOCK_END = "<!-- HERMES_MEMORY_MANAGED_END -->"
 
 
 # ---------------------------------------------------------------------------
@@ -120,6 +122,10 @@ class MemoryStore:
         self.user_entries: List[str] = []
         self.memory_char_limit = memory_char_limit
         self.user_char_limit = user_char_limit
+        self._file_layouts: Dict[str, Dict[str, Any]] = {
+            "memory": {"prefix": "", "suffix": "", "wrapped": False},
+            "user": {"prefix": "", "suffix": "", "wrapped": False},
+        }
         # Frozen snapshot for system prompt -- set once at load_from_disk()
         self._system_prompt_snapshot: Dict[str, str] = {"memory": "", "user": ""}
 
@@ -128,8 +134,8 @@ class MemoryStore:
         mem_dir = get_memory_dir()
         mem_dir.mkdir(parents=True, exist_ok=True)
 
-        self.memory_entries = self._read_file(mem_dir / "MEMORY.md")
-        self.user_entries = self._read_file(mem_dir / "USER.md")
+        self.memory_entries, self._file_layouts["memory"] = self._read_target_state(mem_dir / "MEMORY.md")
+        self.user_entries, self._file_layouts["user"] = self._read_target_state(mem_dir / "USER.md")
 
         # Deduplicate entries (preserves order, keeps first occurrence)
         self.memory_entries = list(dict.fromkeys(self.memory_entries))
@@ -190,14 +196,24 @@ class MemoryStore:
 
         Called under file lock to get the latest state before mutating.
         """
-        fresh = self._read_file(self._path_for(target))
+        previous_entries = self._entries_for(target)
+        fresh, self._file_layouts[target] = self._read_target_state(
+            self._path_for(target), previous_entries=previous_entries
+        )
         fresh = list(dict.fromkeys(fresh))  # deduplicate
         self._set_entries(target, fresh)
 
     def save_to_disk(self, target: str):
         """Persist entries to the appropriate file. Called after every mutation."""
         get_memory_dir().mkdir(parents=True, exist_ok=True)
-        self._write_file(self._path_for(target), self._entries_for(target))
+        layout = self._file_layouts[target]
+        content = self._render_file_content(
+            self._entries_for(target),
+            prefix=layout["prefix"],
+            suffix=layout["suffix"],
+            wrapped=layout["wrapped"],
+        )
+        self._write_raw_file(self._path_for(target), content)
 
     def _entries_for(self, target: str) -> List[str]:
         if target == "user":
@@ -409,37 +425,93 @@ class MemoryStore:
         return f"{separator}\n{header}\n{separator}\n{content}"
 
     @staticmethod
-    def _read_file(path: Path) -> List[str]:
-        """Read a memory file and split into entries.
-
-        No file locking needed: _write_file uses atomic rename, so readers
-        always see either the previous complete file or the new complete file.
-        """
-        if not path.exists():
-            return []
-        try:
-            raw = path.read_text(encoding="utf-8")
-        except (OSError, IOError):
-            return []
-
-        if not raw.strip():
-            return []
-
-        # Use ENTRY_DELIMITER for consistency with _write_file. Splitting by "§"
-        # alone would incorrectly split entries that contain "§" in their content.
+    def _split_entries(raw: str) -> List[str]:
         entries = [e.strip() for e in raw.split(ENTRY_DELIMITER)]
         return [e for e in entries if e]
 
+    @classmethod
+    def _read_target_state(
+        cls, path: Path, previous_entries: Optional[List[str]] = None
+    ) -> tuple[List[str], Dict[str, Any]]:
+        """Read managed entries plus any preserved external content."""
+        empty_layout = {"prefix": "", "suffix": "", "wrapped": False}
+
+        if not path.exists():
+            return [], empty_layout
+        try:
+            raw = path.read_text(encoding="utf-8")
+        except (OSError, IOError):
+            return [], empty_layout
+
+        if not raw.strip():
+            return [], empty_layout
+
+        start_idx = raw.find(MANAGED_BLOCK_START)
+        end_idx = raw.find(MANAGED_BLOCK_END)
+        if start_idx != -1 and end_idx != -1 and start_idx < end_idx:
+            prefix = raw[:start_idx]
+            managed_raw = raw[start_idx + len(MANAGED_BLOCK_START):end_idx]
+            if managed_raw.startswith("\n"):
+                managed_raw = managed_raw[1:]
+            if managed_raw.endswith("\n"):
+                managed_raw = managed_raw[:-1]
+            suffix = raw[end_idx + len(MANAGED_BLOCK_END):]
+            return (
+                cls._split_entries(managed_raw) if managed_raw else [],
+                {"prefix": prefix, "suffix": suffix, "wrapped": True},
+            )
+
+        if previous_entries:
+            managed_raw = ENTRY_DELIMITER.join(previous_entries)
+            if managed_raw and raw.count(managed_raw) == 1:
+                start_idx = raw.find(managed_raw)
+                prefix = raw[:start_idx]
+                suffix = raw[start_idx + len(managed_raw):]
+                return (
+                    previous_entries.copy(),
+                    {"prefix": prefix, "suffix": suffix, "wrapped": bool(prefix or suffix)},
+                )
+
+        return cls._split_entries(raw), empty_layout.copy()
+
+    @classmethod
+    def _read_file(cls, path: Path) -> List[str]:
+        """Read the managed entries from a memory file."""
+        entries, _layout = cls._read_target_state(path)
+        return entries
+
     @staticmethod
     def _write_file(path: Path, entries: List[str]):
-        """Write entries to a memory file using atomic temp-file + rename.
+        """Write a plain managed-entry file without preserved external content."""
+        content = ENTRY_DELIMITER.join(entries) if entries else ""
+        MemoryStore._write_raw_file(path, content)
+
+    @staticmethod
+    def _render_file_content(entries: List[str], prefix: str, suffix: str, wrapped: bool) -> str:
+        managed = ENTRY_DELIMITER.join(entries) if entries else ""
+        if wrapped or prefix or suffix:
+            parts = [prefix]
+            if prefix and not prefix.endswith("\n"):
+                parts.append("\n")
+            parts.extend([MANAGED_BLOCK_START, "\n"])
+            if managed:
+                parts.extend([managed, "\n"])
+            parts.append(MANAGED_BLOCK_END)
+            if suffix and not suffix.startswith("\n"):
+                parts.append("\n")
+            parts.append(suffix)
+            return "".join(parts)
+        return managed
+
+    @staticmethod
+    def _write_raw_file(path: Path, content: str):
+        """Write file content using atomic temp-file + rename.
 
         Previous implementation used open("w") + flock, but "w" truncates the
         file *before* the lock is acquired, creating a race window where
         concurrent readers see an empty file. Atomic rename avoids this:
         readers always see either the old complete file or the new one.
         """
-        content = ENTRY_DELIMITER.join(entries) if entries else ""
         try:
             # Write to temp file in same directory (same filesystem for atomic rename)
             fd, tmp_path = tempfile.mkstemp(
@@ -580,7 +652,3 @@ registry.register(
     check_fn=check_memory_requirements,
     emoji="🧠",
 )
-
-
-
-


### PR DESCRIPTION
This adds two defensive layers on top of the marker-based merge-on-write approach:

### 1. Pre-write backup (`_backup_pre_write`)
Creates `<file>.bak.pre.<timestamp>` before every `save_to_disk()` write. This gives a last-resort recovery path even if the merge logic has a bug.

### 2. Shrinkage guardrail (`_check_shrinkage`)
Refuses replace/remove operations that would shrink the file by >75% (skipped for files under 2 KB). A dramatic size reduction almost always means the tool's in-memory view doesn't reflect all on-disk content — for example, external entries that got folded into a single managed entry during a prior replace.

### 3. Bonus fix
Fixed `test_deduplication_on_load` which failed on Windows non-UTF-8 locales — `Path.write_text()` defaults to the system codepage (e.g. cp950 on zh-TW), but `_read_target_state` reads with `encoding="utf-8"`, causing a `UnicodeDecodeError` on § characters.