### PR TITLE
fix: bound compression summary input

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -815,6 +815,7 @@ class ContextCompressor(ContextEngine):
     _CONTENT_TAIL = 1500      # chars kept from the end
     _TOOL_ARGS_MAX = 1500     # tool call argument chars
     _TOOL_ARGS_HEAD = 1200    # kept from the start of tool args
+    _SUMMARY_INPUT_MAX_CHARS = 160_000  # total serialized turns sent to aux summarizer
 
     def _serialize_for_summary(self, turns: List[Dict[str, Any]]) -> str:
         """Serialize conversation turns into labeled text for the summarizer.
@@ -871,6 +872,39 @@ class ContextCompressor(ContextEngine):
 
         return "\n\n".join(parts)
 
+    @classmethod
+    def _bound_summary_input(cls, content: str) -> str:
+        """Cap total summarizer input while preserving beginning and recent tail.
+
+        Per-message truncation alone is not enough for very long sessions: a
+        compression window with hundreds of messages can still produce a huge
+        single prompt that slow auxiliary backends time out on. Keep both edges
+        because the beginning often has task setup and the tail has the most
+        recent state; explicitly mark the omitted middle so the summarizer knows
+        context was intentionally compressed before it saw the prompt.
+        """
+        if len(content) <= cls._SUMMARY_INPUT_MAX_CHARS:
+            return content
+
+        marker_template = (
+            "\n\n...[summary input truncated: omitted "
+            "{omitted:,} chars from the middle to keep compression prompt bounded]...\n\n"
+        )
+        # Estimate once, then rebuild with the exact omitted span after the
+        # head/tail split is known. The second marker can differ by a few chars
+        # if the comma-formatted number changes width, so recompute once.
+        marker = marker_template.format(omitted=len(content))
+        remaining = max(cls._SUMMARY_INPUT_MAX_CHARS - len(marker), 0)
+        head_chars = int(remaining * 0.45)
+        tail_chars = remaining - head_chars
+        omitted = max(len(content) - head_chars - tail_chars, 0)
+        marker = marker_template.format(omitted=omitted)
+        remaining = max(cls._SUMMARY_INPUT_MAX_CHARS - len(marker), 0)
+        head_chars = int(remaining * 0.45)
+        tail_chars = remaining - head_chars
+        tail = content[-tail_chars:].lstrip() if tail_chars else ""
+        return content[:head_chars].rstrip() + marker + tail
+
     def _fallback_to_main_for_compression(self, e: Exception, reason: str) -> None:
         """Switch from a separate ``summary_model`` back to the main model.
 
@@ -925,7 +959,9 @@ class ContextCompressor(ContextEngine):
             return None
 
         summary_budget = self._compute_summary_budget(turns_to_summarize)
-        content_to_summarize = self._serialize_for_summary(turns_to_summarize)
+        content_to_summarize = self._bound_summary_input(
+            self._serialize_for_summary(turns_to_summarize)
+        )
 
         # Preamble shared by both first-compaction and iterative-update prompts.
         # Keep the wording deliberately plain: Azure/OpenAI-compatible content

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -1849,3 +1849,30 @@ class TestTruncateToolCallArgsJson:
         parsed = _json.loads(shrunk)
         assert parsed["path"] == "~/.hermes/skills/shopping/browser-setup-notes.md"
         assert parsed["content"].endswith("...[truncated]")
+
+
+class TestSummaryPromptBounding:
+    def test_oversized_summary_prompt_is_bounded_and_preserves_edges(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "bounded summary"
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=272000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+
+        messages = [
+            {"role": "user", "content": f"turn-{i}-" + ("x" * 6000)}
+            for i in range(80)
+        ]
+        messages[0]["content"] = "FIRST_SENTINEL " + messages[0]["content"]
+        messages[-1]["content"] = "LAST_SENTINEL " + messages[-1]["content"]
+
+        with patch("agent.context_compressor.call_llm", return_value=mock_response) as mock_call:
+            summary = c._generate_summary(messages)
+
+        prompt = mock_call.call_args.kwargs["messages"][0]["content"]
+        assert summary.startswith(SUMMARY_PREFIX)
+        assert len(prompt) < 180_000
+        assert "summary input truncated" in prompt
+        assert "FIRST_SENTINEL" in prompt
+        assert "LAST_SENTINEL" in prompt


### PR DESCRIPTION
## Summary
- cap the total serialized input sent to the compression summarizer
- preserve the beginning and recent tail of the compaction window when truncating
- add a regression test covering oversized summary prompts and edge preservation

## Why
Long sessions can create very large compression-summary prompts even though individual messages are truncated. Slow auxiliary backends, especially Codex Responses fallback paths, can exceed the auxiliary timeout and force fallback context markers instead of useful summaries.

## Test plan
- `venv/bin/python -m pytest tests/agent/test_context_compressor.py::TestSummaryPromptBounding::test_oversized_summary_prompt_is_bounded_and_preserves_edges -q`
- `venv/bin/python -m pytest tests/agent/test_context_compressor.py tests/agent/test_auxiliary_client.py -q`
- `venv/bin/python -m py_compile agent/context_compressor.py`