### PR TITLE
Improve Telegram chunking and add configurable web search fallbacks

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -556,27 +556,68 @@ class TestSendToPlatformChunking:
         sent_text = send.await_args.args[2]
         assert "<https://en.wikipedia.org/wiki/Foo_(bar)|Foo>" in sent_text
 
-    def test_telegram_media_attaches_to_last_chunk(self):
+    def test_telegram_markdown_expansion_is_chunked_before_send(self, monkeypatch):
+        """Telegram chunking must account for MarkdownV2 escaping expansion."""
+        from gateway.platforms.base import utf16_len
 
-        sent_calls = []
+        send_lengths = []
 
-        async def fake_send(token, chat_id, message, media_files=None, thread_id=None, disable_link_previews=False, force_document=False):
-            sent_calls.append(media_files or [])
-            return {"success": True, "platform": "telegram", "chat_id": chat_id, "message_id": str(len(sent_calls))}
+        async def fake_send_message(**kwargs):
+            text = kwargs["text"]
+            send_lengths.append(utf16_len(text))
+            if utf16_len(text) > 4096:
+                raise Exception("Message is too long")
+            return SimpleNamespace(message_id=len(send_lengths))
 
-        long_msg = "word " * 2000  # ~10000 chars, well over 4096
-        media = [("/tmp/photo.png", False)]
-        with patch("tools.send_message_tool._send_telegram", fake_send):
-            asyncio.run(
-                _send_to_platform(
-                    Platform.TELEGRAM,
-                    SimpleNamespace(enabled=True, token="tok", extra={}),
-                    "123", long_msg, media_files=media,
-                )
+        bot = MagicMock()
+        bot.send_message = AsyncMock(side_effect=fake_send_message)
+        bot.send_photo = AsyncMock()
+        bot.send_video = AsyncMock()
+        bot.send_voice = AsyncMock()
+        bot.send_audio = AsyncMock()
+        bot.send_document = AsyncMock()
+        _install_telegram_mock(monkeypatch, bot)
+
+        result = asyncio.run(
+            _send_to_platform(
+                Platform.TELEGRAM,
+                SimpleNamespace(enabled=True, token="tok", extra={}),
+                "123",
+                "!" * 4096,
             )
-        assert len(sent_calls) >= 3
-        assert all(call == [] for call in sent_calls[:-1])
-        assert sent_calls[-1] == media
+        )
+
+        assert result["success"] is True
+        assert bot.send_message.await_count >= 2
+        assert max(send_lengths) <= 4096
+
+    def test_telegram_media_attaches_after_long_text_chunks(self, tmp_path, monkeypatch):
+        image_path = tmp_path / "photo.png"
+        image_path.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 32)
+
+        bot = MagicMock()
+        bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=1))
+        bot.send_photo = AsyncMock(return_value=SimpleNamespace(message_id=2))
+        bot.send_video = AsyncMock()
+        bot.send_voice = AsyncMock()
+        bot.send_audio = AsyncMock()
+        bot.send_document = AsyncMock()
+        _install_telegram_mock(monkeypatch, bot)
+
+        long_msg = "word " * 2000  # ~10000 chars, well over Telegram's 4096 limit
+        result = asyncio.run(
+            _send_to_platform(
+                Platform.TELEGRAM,
+                SimpleNamespace(enabled=True, token="tok", extra={}),
+                "123",
+                long_msg,
+                media_files=[(str(image_path), False)],
+            )
+        )
+
+        assert result["success"] is True
+        assert bot.send_message.await_count >= 3
+        bot.send_photo.assert_awaited_once()
 
     def test_matrix_media_uses_native_adapter_helper(self, tmp_path):
         doc_path = tmp_path / "test-send-message-matrix.pdf"

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -384,9 +384,10 @@ class TestBackendSelection:
             assert _get_backend() == "firecrawl"
 
     def test_fallback_no_keys_defaults_to_firecrawl(self):
-        """No keys, no config → 'firecrawl' (will fail at client init)."""
+        """No keys, no config → 'firecrawl' when no optional free backend is installed."""
         from tools.web_tools import _get_backend
-        with patch("tools.web_tools._load_web_config", return_value={}):
+        with patch("tools.web_tools._load_web_config", return_value={}), \
+             patch("tools.web_tools._ddgs_package_importable", return_value=False):
             assert _get_backend() == "firecrawl"
 
     def test_invalid_config_falls_through_to_fallback(self):
@@ -508,6 +509,90 @@ class TestWebSearchSchema:
         assert result == {"success": True, "data": {"web": []}}
         fake_search.assert_called_once_with("docs", 100)
 
+    def test_get_search_fallback_backends_normalizes_list_and_dedupes(self):
+        import tools.web_tools
+
+        with patch("tools.web_tools._load_web_config", return_value={
+            "search_fallbacks": ["ddgs", "tavily", "ddgs", "bad-backend", "  brave-free  "]
+        }):
+            result = tools.web_tools._get_search_fallback_backends("ddgs")
+
+        assert result == ["tavily", "brave-free"]
+
+    def test_web_search_uses_configured_fallback_when_primary_returns_failure(self):
+        import tools.web_tools
+
+        primary_provider = MagicMock(name="DDGSWebSearchProvider")
+        primary_provider.name = "ddgs"
+        primary_provider.supports_search.return_value = True
+        primary_provider.search.return_value = {"success": False, "error": "rate limited"}
+
+        fallback_provider = MagicMock(name="TavilyWebSearchProvider")
+        fallback_provider.name = "tavily"
+        fallback_provider.supports_search.return_value = True
+        fallback_provider.search.return_value = {
+            "success": True,
+            "data": {"web": [{"title": "OpenAI", "url": "https://openai.com", "description": "", "position": 1}]},
+        }
+
+        providers = {"ddgs": primary_provider, "tavily": fallback_provider}
+
+        with patch("tools.web_tools._get_search_backend", return_value="ddgs"), \
+             patch("tools.web_tools._get_search_fallback_backends", return_value=["tavily"]), \
+             patch("agent.web_search_registry.get_provider", side_effect=lambda name: providers.get(name)), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch.object(tools.web_tools._debug, "log_call"), \
+             patch.object(tools.web_tools._debug, "save"):
+            result = json.loads(tools.web_tools.web_search_tool("docs", limit=5))
+
+        assert result["success"] is True
+        assert result["data"]["web"][0]["url"] == "https://openai.com"
+        primary_provider.search.assert_called_once_with("docs", 5)
+        fallback_provider.search.assert_called_once_with("docs", 5)
+
+    def test_web_search_uses_brave_free_as_explicit_fallback_after_ddgs_failure(self):
+        import tools.web_tools
+
+        primary_provider = MagicMock(name="DDGSWebSearchProvider")
+        primary_provider.name = "ddgs"
+        primary_provider.supports_search.return_value = True
+        primary_provider.search.return_value = {
+            "success": False,
+            "error": "forced ddgs failure for brave fallback",
+        }
+
+        fallback_provider = MagicMock(name="BraveFreeWebSearchProvider")
+        fallback_provider.name = "brave-free"
+        fallback_provider.supports_search.return_value = True
+        fallback_provider.search.return_value = {
+            "success": True,
+            "data": {
+                "web": [
+                    {
+                        "title": "OpenAI | Research & Deployment",
+                        "url": "https://openai.com/",
+                        "description": "",
+                        "position": 1,
+                    }
+                ]
+            },
+        }
+
+        providers = {"ddgs": primary_provider, "brave-free": fallback_provider}
+
+        with patch("tools.web_tools._get_search_backend", return_value="ddgs"), \
+             patch("tools.web_tools._get_search_fallback_backends", return_value=["brave-free", "tavily"]), \
+             patch("agent.web_search_registry.get_provider", side_effect=lambda name: providers.get(name)), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch.object(tools.web_tools._debug, "log_call"), \
+             patch.object(tools.web_tools._debug, "save"):
+            result = json.loads(tools.web_tools.web_search_tool("OpenAI official website", limit=3))
+
+        assert result["success"] is True
+        assert result["data"]["web"][0]["url"] == "https://openai.com/"
+        primary_provider.search.assert_called_once_with("OpenAI official website", 3)
+        fallback_provider.search.assert_called_once_with("OpenAI official website", 3)
+
 
 class TestWebSearchErrorHandling:
     """Test suite for web_search_tool() error responses."""
@@ -602,8 +687,9 @@ class TestCheckWebApiKey:
             assert check_web_api_key() is True
 
     def test_no_keys_returns_false(self):
-        from tools.web_tools import check_web_api_key
-        assert check_web_api_key() is False
+        with patch("tools.web_tools._ddgs_package_importable", return_value=False):
+            from tools.web_tools import check_web_api_key
+            assert check_web_api_key() is False
 
     def test_both_keys_returns_true(self):
         with patch.dict(os.environ, {

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -533,16 +533,9 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     (preserves code-block boundaries, adds part indicators).
     """
     from gateway.config import Platform
-    from gateway.platforms.base import BasePlatformAdapter, utf16_len
+    from gateway.platforms.base import BasePlatformAdapter
     from gateway.platforms.discord import DiscordAdapter
     from gateway.platforms.slack import SlackAdapter
-
-    # Telegram adapter import is optional (requires python-telegram-bot)
-    try:
-        from gateway.platforms.telegram import TelegramAdapter
-        _telegram_available = True
-    except ImportError:
-        _telegram_available = False
 
     # Feishu adapter import is optional (requires lark-oapi)
     try:
@@ -553,6 +546,18 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
 
     media_files = media_files or []
 
+    if platform == Platform.TELEGRAM:
+        disable_link_previews = bool(getattr(pconfig, "extra", {}) and pconfig.extra.get("disable_link_previews"))
+        return await _send_telegram(
+            pconfig.token,
+            chat_id,
+            message,
+            media_files=media_files,
+            thread_id=thread_id,
+            disable_link_previews=disable_link_previews,
+            force_document=force_document,
+        )
+
     if platform == Platform.SLACK and message:
         try:
             slack_adapter = SlackAdapter.__new__(SlackAdapter)
@@ -562,7 +567,6 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
 
     # Platform message length limits (from adapter class attributes)
     _MAX_LENGTHS = {
-        Platform.TELEGRAM: TelegramAdapter.MAX_MESSAGE_LENGTH if _telegram_available else 4096,
         Platform.DISCORD: DiscordAdapter.MAX_MESSAGE_LENGTH,
         Platform.SLACK: SlackAdapter.MAX_MESSAGE_LENGTH,
     }
@@ -581,33 +585,11 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
 
     # Smart-chunk the message to fit within platform limits.
     # For short messages or platforms without a known limit this is a no-op.
-    # Telegram measures length in UTF-16 code units, not Unicode codepoints.
     max_len = _MAX_LENGTHS.get(platform)
     if max_len:
-        _len_fn = utf16_len if platform == Platform.TELEGRAM else None
-        chunks = BasePlatformAdapter.truncate_message(message, max_len, len_fn=_len_fn)
+        chunks = BasePlatformAdapter.truncate_message(message, max_len)
     else:
         chunks = [message]
-
-    # --- Telegram: special handling for media attachments ---
-    if platform == Platform.TELEGRAM:
-        last_result = None
-        disable_link_previews = bool(getattr(pconfig, "extra", {}) and pconfig.extra.get("disable_link_previews"))
-        for i, chunk in enumerate(chunks):
-            is_last = (i == len(chunks) - 1)
-            result = await _send_telegram(
-                pconfig.token,
-                chat_id,
-                chunk,
-                media_files=media_files if is_last else [],
-                thread_id=thread_id,
-                disable_link_previews=disable_link_previews,
-                force_document=force_document,
-            )
-            if isinstance(result, dict) and result.get("error"):
-                return result
-            last_result = result
-        return last_result
 
     # --- Weixin: use the native one-shot adapter helper for text + media ---
     if platform == Platform.WEIXIN:
@@ -827,35 +809,48 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
         warnings = []
 
         if formatted.strip():
-            try:
-                last_msg = await _send_telegram_message_with_retry(
-                    bot,
-                    chat_id=int_chat_id, text=formatted,
-                    parse_mode=send_parse_mode, **thread_kwargs
-                )
-            except Exception as md_error:
-                # Parse failed, fall back to plain text
-                if "parse" in str(md_error).lower() or "markdown" in str(md_error).lower() or "html" in str(md_error).lower():
-                    logger.warning(
-                        "Parse mode %s failed in _send_telegram, falling back to plain text: %s",
-                        send_parse_mode,
-                        _sanitize_error_text(md_error),
-                    )
-                    if not _has_html:
-                        try:
-                            from gateway.platforms.telegram import _strip_mdv2
-                            plain = _strip_mdv2(formatted)
-                        except Exception:
-                            plain = message
-                    else:
-                        plain = message
+            from gateway.platforms.base import BasePlatformAdapter, utf16_len
+
+            text_chunks = BasePlatformAdapter.truncate_message(
+                formatted,
+                4096,
+                len_fn=utf16_len,
+            )
+
+            for chunk in text_chunks:
+                try:
                     last_msg = await _send_telegram_message_with_retry(
                         bot,
-                        chat_id=int_chat_id, text=plain,
-                        parse_mode=None, **thread_kwargs
+                        chat_id=int_chat_id,
+                        text=chunk,
+                        parse_mode=send_parse_mode,
+                        **thread_kwargs,
                     )
-                else:
-                    raise
+                except Exception as md_error:
+                    # Parse failed, fall back to plain text per chunk.
+                    if "parse" in str(md_error).lower() or "markdown" in str(md_error).lower() or "html" in str(md_error).lower():
+                        logger.warning(
+                            "Parse mode %s failed in _send_telegram, falling back to plain text: %s",
+                            send_parse_mode,
+                            _sanitize_error_text(md_error),
+                        )
+                        if not _has_html:
+                            try:
+                                from gateway.platforms.telegram import _strip_mdv2
+                                plain = _strip_mdv2(chunk)
+                            except Exception:
+                                plain = chunk
+                        else:
+                            plain = chunk
+                        last_msg = await _send_telegram_message_with_retry(
+                            bot,
+                            chat_id=int_chat_id,
+                            text=plain,
+                            parse_mode=None,
+                            **thread_kwargs,
+                        )
+                    else:
+                        raise
 
         for media_path, is_voice in media_files:
             if not os.path.exists(media_path):

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -118,6 +118,17 @@ import sys
 logger = logging.getLogger(__name__)
 
 
+_VALID_WEB_BACKENDS = {
+    "parallel",
+    "firecrawl",
+    "tavily",
+    "exa",
+    "searxng",
+    "brave-free",
+    "ddgs",
+}
+
+
 # ─── Backend Selection ────────────────────────────────────────────────────────
 
 def _has_env(name: str) -> bool:
@@ -140,7 +151,7 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs"}:
+    if configured in _VALID_WEB_BACKENDS:
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -176,6 +187,32 @@ def _get_search_backend() -> str:
     (e.g. SearXNG for search + Firecrawl for extract).
     """
     return _get_capability_backend("search")
+
+
+def _get_search_fallback_backends(primary_backend: str) -> List[str]:
+    """Return configured fallback backends for ``web_search``.
+
+    Accepts either a YAML list or a comma-separated string in
+    ``web.search_fallbacks``. Returns normalized, de-duplicated backend names
+    and excludes the active primary backend.
+    """
+    cfg = _load_web_config()
+    raw = cfg.get("search_fallbacks", [])
+    if isinstance(raw, str):
+        candidates = [part.strip().lower() for part in raw.split(",")]
+    elif isinstance(raw, list):
+        candidates = [str(part).strip().lower() for part in raw]
+    else:
+        return []
+
+    backends: List[str] = []
+    seen = {primary_backend}
+    for backend in candidates:
+        if not backend or backend in seen or backend not in _VALID_WEB_BACKENDS:
+            continue
+        seen.add(backend)
+        backends.append(backend)
+    return backends
 
 
 def _get_extract_backend() -> str:
@@ -805,8 +842,28 @@ def web_search_tool(query: str, limit: int = 5) -> str:
             # configured backend isn't a registered search provider (typo,
             # uninstalled plugin, or capability mismatch).
             provider = get_active_search_provider()
+            backend = provider.name if provider is not None else backend
 
-        if provider is None:
+        fallback_backends = _get_search_fallback_backends(backend)
+        candidates: List[tuple[str, Any]] = []
+        seen_candidate_names = set()
+
+        if provider is not None and provider.supports_search():
+            candidates.append((backend or provider.name, provider))
+            seen_candidate_names.add(provider.name)
+
+        for fallback_backend in fallback_backends:
+            fallback_provider = _wsp_get_provider(fallback_backend)
+            if (
+                fallback_provider is None
+                or not fallback_provider.supports_search()
+                or fallback_provider.name in seen_candidate_names
+            ):
+                continue
+            candidates.append((fallback_backend, fallback_provider))
+            seen_candidate_names.add(fallback_provider.name)
+
+        if not candidates:
             response_data = {
                 "success": False,
                 "error": (
@@ -815,11 +872,50 @@ def web_search_tool(query: str, limit: int = 5) -> str:
                 ),
             }
         else:
-            logger.info(
-                "Web search via %s: '%s' (limit: %d)",
-                provider.name, query, limit,
-            )
-            response_data = provider.search(query, limit)
+            backend_errors: List[str] = []
+            response_data = None
+            for index, (_candidate_backend, candidate_provider) in enumerate(candidates):
+                logger.info(
+                    "Web search via %s: '%s' (limit: %d)",
+                    candidate_provider.name, query, limit,
+                )
+                try:
+                    candidate_response = candidate_provider.search(query, limit)
+                except Exception as exc:
+                    if len(candidates) == 1:
+                        raise
+                    error_text = f"{candidate_provider.name}: {exc}"
+                    backend_errors.append(error_text)
+                    logger.warning("web_search backend failed: %s", error_text)
+                    continue
+
+                if candidate_response.get("success") is True:
+                    response_data = candidate_response
+                    if index > 0:
+                        logger.info(
+                            "Web search fallback succeeded via %s (primary=%s)",
+                            candidate_provider.name,
+                            candidates[0][1].name,
+                        )
+                    break
+
+                if len(candidates) == 1:
+                    response_data = candidate_response
+                    break
+
+                error_text = str(candidate_response.get("error") or "search failed")
+                backend_errors.append(f"{candidate_provider.name}: {error_text}")
+                logger.warning(
+                    "web_search backend failed: %s: %s",
+                    candidate_provider.name,
+                    error_text,
+                )
+
+            if response_data is None:
+                response_data = {
+                    "success": False,
+                    "error": "Web search failed across backends: " + "; ".join(backend_errors[:3]),
+                }
 
         debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
         result_json = json.dumps(response_data, indent=2, ensure_ascii=False)


### PR DESCRIPTION
## Summary
- fix Telegram formatted-message chunking so long Markdown/HTML messages are split after formatting and still attach media correctly
- add configurable `web.search_fallbacks` handling for `web_search`
- add/extend tests covering `ddgs -> brave-free` fallback behavior and related fallback selection rules

## Changes
### Telegram send path
- route Telegram through the dedicated `_send_telegram()` path from `_send_to_platform()`
- chunk formatted Telegram text with UTF-16 length accounting before send
- preserve long-text + media behavior by sending text chunks first, then media
- fall back per chunk to plain text if Markdown/HTML parsing fails

### Web search fallback routing
- add `_VALID_WEB_BACKENDS`
- add `_get_search_fallback_backends(primary_backend)`
- support YAML-list or comma-separated `web.search_fallbacks`
- normalize, de-duplicate, and skip the active primary backend
- try fallback search providers in order when the primary provider fails
- return aggregated backend error context when all candidates fail

## Test Plan
- `scripts/run_tests.sh tests/tools/test_send_message_tool.py -q`
- `python -m pytest -o addopts='' tests/tools/test_web_tools_config.py -q -k 'fallback_backends or configured_fallback or brave_free or no_keys_defaults_to_firecrawl or no_keys_returns_false'`

## Notes
This branch keeps the web test-first history intact:
- `test(web): cover ddgs to brave-free fallback`
- `feat(web): add configured search fallback backends`

and separates the Telegram send-path fix into its own commit:
- `fix(telegram): chunk formatted messages before media send`
