### PR TITLE
fix(goals): pause loop when judge errors and response is terminal (#27585)

### DIFF
--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -67,6 +67,32 @@ _JUDGE_RESPONSE_SNIPPET_CHARS = 4000
 # `judge reply was not JSON`.
 DEFAULT_MAX_CONSECUTIVE_PARSE_FAILURES = 3
 
+# Reason prefix produced by ``judge_goal`` on an auxiliary API/transport
+# error. Used by ``evaluate_after_turn`` to distinguish a real ``"continue"``
+# verdict from a fail-open continue caused by an unreachable judge.
+_JUDGE_ERROR_REASON_PREFIX = "judge error:"
+
+# When the judge fails-open to ``continue`` AND the assistant's latest
+# response matches one of these phrases, pause the loop instead of queueing
+# another continuation prompt. Without this guard, a transient judge outage
+# causes /goal to spam the gateway channel with the same terminal message
+# every few seconds until the turn budget exhausts (#27585).
+_TERMINAL_RESPONSE_RE = re.compile(
+    r"\b(?:"
+    r"goal\s+is\s+(?:already\s+|now\s+)?(?:complete|done|achieved|finished|satisfied)"
+    r"|requested\s+goal\s+is\s+complete"
+    r"|i(?:'m|\s+am)\s+stopping(?:\s+here)?"
+    r"|nothing\s+(?:left|more)\s+to\s+do"
+    r")\b",
+    re.IGNORECASE,
+)
+
+
+def _response_looks_terminal(last_response: str) -> bool:
+    """True when the assistant's message indicates it has stopped/completed."""
+    return bool(last_response and last_response.strip()
+                and _TERMINAL_RESPONSE_RE.search(last_response))
+
 
 CONTINUATION_PROMPT_TEMPLATE = (
     "[Continuing toward your standing goal]\n"
@@ -450,7 +476,7 @@ def judge_goal(
         )
     except Exception as exc:
         logger.info("goal judge: API call failed (%s) — falling through to continue", exc)
-        return "continue", f"judge error: {type(exc).__name__}", False
+        return "continue", f"{_JUDGE_ERROR_REASON_PREFIX} {type(exc).__name__}", False
 
     try:
         raw = resp.choices[0].message.content or ""
@@ -665,6 +691,37 @@ class GoalManager:
             state.consecutive_parse_failures += 1
         else:
             state.consecutive_parse_failures = 0
+
+        # Safe-stop fallback: judge failed-open to "continue" because of an
+        # API/transport error AND the assistant's response indicates it has
+        # finished or is explicitly stopping. Pause instead of queueing
+        # another continuation prompt — otherwise /goal spams the gateway
+        # channel with repeated terminal messages until the turn budget runs
+        # out (#27585). Parse-failure auto-pause already guards the
+        # bad-judge-output case; this guards the unreachable-judge case.
+        if (
+            verdict == "continue"
+            and reason.startswith(_JUDGE_ERROR_REASON_PREFIX)
+            and _response_looks_terminal(last_response)
+        ):
+            state.status = "paused"
+            state.paused_reason = (
+                "goal judge unreachable; assistant response appears terminal — "
+                "pausing to avoid spam"
+            )
+            save_goal(self.session_id, state)
+            return {
+                "status": "paused",
+                "should_continue": False,
+                "continuation_prompt": None,
+                "verdict": "continue",
+                "reason": reason,
+                "message": (
+                    "⏸ Goal paused — judge couldn't be reached and the "
+                    "assistant appears to have stopped. Use /goal resume "
+                    "to keep going, or /goal clear to stop."
+                ),
+            }
 
         if verdict == "done":
             state.status = "done"

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -720,6 +720,145 @@ class TestJudgeGoalWithSubgoals:
         assert "ship it" in user_msg
 
 
+# ──────────────────────────────────────────────────────────────────────
+# Safe-stop when judge unreachable + assistant response is terminal (#27585)
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestResponseLooksTerminal:
+    """Unit tests for the terminal-phrase detector used by the
+    judge-error safe-stop fallback."""
+
+    @pytest.mark.parametrize("response", [
+        "Goal is complete.\n\nI'm stopping here because the requested goal is complete.",
+        "The goal is now done — the artifact is at /tmp/out.md.",
+        "I am stopping here. Nothing more to do.",
+        "Goal is already complete from the previous run.",
+        "Goal is achieved.",
+    ])
+    def test_terminal_phrases_match(self, response):
+        from hermes_cli.goals import _response_looks_terminal
+        assert _response_looks_terminal(response) is True
+
+    @pytest.mark.parametrize("response", [
+        "Working on the next step now.",
+        "I tried but ran into an error retrieving the file.",
+        "Let me continue the analysis.",
+        "",
+        "   ",
+        "Progress: 30% complete with this subtask.",
+    ])
+    def test_non_terminal_phrases_do_not_match(self, response):
+        from hermes_cli.goals import _response_looks_terminal
+        assert _response_looks_terminal(response) is False
+
+
+class TestJudgeErrorSafeStop:
+    """Regression: when the goal judge fails open to ``continue`` because of
+    an API/transport error AND the assistant's response is terminal, the
+    loop must pause instead of queueing another continuation prompt.
+
+    Without this guard, /goal spams the gateway channel with repeated
+    terminal messages (#27585)."""
+
+    def test_judge_api_error_with_terminal_response_auto_pauses(self, hermes_home):
+        from hermes_cli import goals
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="judge-err-term-1", default_max_turns=20)
+        mgr.set("generate the artifact")
+
+        # Mimic the fail-open return that ``judge_goal`` produces on a
+        # transient API error (e.g. BadRequestError, ConnectionError).
+        with patch.object(
+            goals,
+            "judge_goal",
+            return_value=("continue", "judge error: BadRequestError", False),
+        ):
+            decision = mgr.evaluate_after_turn(
+                "Goal is complete.\n\nThe requested artifact is already done "
+                "and saved at /tmp/out.md.\n\nI'm stopping here because the "
+                "requested goal is complete."
+            )
+
+        assert decision["should_continue"] is False
+        assert decision["status"] == "paused"
+        assert decision["continuation_prompt"] is None
+        assert mgr.state.status == "paused"
+        assert "unreachable" in (mgr.state.paused_reason or "").lower()
+        assert mgr.state.turns_used == 1
+
+    def test_judge_api_error_with_non_terminal_response_still_continues(self, hermes_home):
+        """Fail-open behavior is preserved when the response is non-terminal —
+        a flaky judge must not wedge progress on an in-flight goal."""
+        from hermes_cli import goals
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="judge-err-cont-1", default_max_turns=20)
+        mgr.set("write the report")
+
+        with patch.object(
+            goals,
+            "judge_goal",
+            return_value=("continue", "judge error: ConnectionError", False),
+        ):
+            decision = mgr.evaluate_after_turn(
+                "Drafting section 2 now — about halfway through the data review."
+            )
+
+        assert decision["should_continue"] is True
+        assert decision["status"] == "active"
+        assert decision["continuation_prompt"] is not None
+        assert mgr.state.status == "active"
+        assert mgr.state.turns_used == 1
+
+    def test_judge_ok_continue_with_terminal_phrasing_still_continues(self, hermes_home):
+        """The safe-stop only fires when the judge call itself errored — a
+        successful judge that returns ``continue`` retains authority over
+        the loop even if the assistant happens to use a terminal phrase."""
+        from hermes_cli import goals
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="judge-ok-term-1", default_max_turns=20)
+        mgr.set("complete the migration")
+
+        with patch.object(
+            goals,
+            "judge_goal",
+            return_value=("continue", "step 1 of 3 done", False),
+        ):
+            decision = mgr.evaluate_after_turn(
+                "Goal is complete for step 1. Moving on."
+            )
+
+        assert decision["should_continue"] is True
+        assert decision["status"] == "active"
+        assert mgr.state.status == "active"
+
+    def test_judge_done_overrides_safe_stop(self, hermes_home):
+        """If the judge does return ``done`` (successful judge call), the
+        safe-stop branch must not fire — status should be ``done`` not
+        ``paused``."""
+        from hermes_cli import goals
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="judge-done-term-1", default_max_turns=20)
+        mgr.set("ship the change")
+
+        with patch.object(
+            goals,
+            "judge_goal",
+            return_value=("done", "all acceptance criteria met", False),
+        ):
+            decision = mgr.evaluate_after_turn(
+                "Goal is complete. I'm stopping here."
+            )
+
+        assert decision["status"] == "done"
+        assert decision["should_continue"] is False
+        assert mgr.state.status == "done"
+
+
 class TestStatusLineSubgoalCount:
     def test_status_line_no_subgoals(self, hermes_home):
         from hermes_cli.goals import GoalManager


### PR DESCRIPTION
## What does this PR do?

When the goal judge raises an API/transport error (e.g. `BadRequestError`, `ConnectionError`, 4xx), `judge_goal` deliberately fails OPEN to `("continue", "judge error: ...", False)` so a broken judge doesn't wedge progress. That assumption breaks when the assistant has already emitted a terminal response on the same turn — `evaluate_after_turn` re-queues a continuation prompt, the agent re-emits a near-identical terminal message, the judge keeps erroring, and the gateway channel (Discord/Telegram/etc.) gets spammed with the same completion message every few seconds until the turn budget runs out (16 of 20 turns in the reporter's case). This PR adds a safe-stop fallback: when the verdict is `continue` AND the reason starts with `_JUDGE_ERROR_REASON_PREFIX` ("judge error:") AND the assistant's response matches a small set of terminal-phrasing patterns ("goal is complete", "i'm/i am stopping", "nothing left to do"), pause the loop instead of queueing another turn. Fail-open is preserved for in-flight goals (non-terminal response → still continue), so a transient judge outage mid-task does not wedge legitimate progress.

## Related Issue

Fixes #27585

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/goals.py` — `judge_goal`'s error path now emits the `_JUDGE_ERROR_REASON_PREFIX` shared constant so the producer/consumer contract is explicit. `GoalManager.evaluate_after_turn` adds the safe-stop fallback: terminal-phrase regex match + judge-error prefix → pause with `paused_reason="goal judge unreachable; assistant response appears terminal — pausing to avoid spam"`.
- `tests/hermes_cli/test_goals.py` — new `TestJudgeErrorSafeStop` class (judge API error + terminal response → paused; judge API error + non-terminal → still continues; judge OK + terminal phrasing → still continues; judge done + terminal phrasing → status=done) and `TestResponseLooksTerminal` parametrized helper coverage.

## How to Test

1. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/hermes_cli/test_goals.py -v` — 65 passed.
2. Regression guard: with the production change stashed, `test_judge_api_error_with_terminal_response_auto_pauses` fails with `assert True is False` on the `should_continue` assertion — exactly matching the issue's reproduction. With the fix applied, it passes alongside the existing 61 tests.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Sibling Audit

> The parse-failure auto-pause already guards the bad-judge-output case (weak models emitting non-JSON for N turns). This PR is the orthogonal guard for the unreachable-judge case — different failure mode, complementary backstop. Audited siblings: no other call sites consume the judge-error prefix. No widening needed.

## Related

- Different failure mode from #21576 (auto-pause on consecutive parse failures); this guards the unreachable-judge case where the judge call itself errors out.
- Different failure mode from #18421 (judge false positive — claims done when not); this guards the inverse where the judge cannot evaluate and the assistant has explicitly stopped.
