### PR TITLE
fix(vision): route images natively for custom_providers (private LLM gateways)

### DIFF
--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -96,6 +96,115 @@ def _lookup_supports_vision(provider: str, model: str) -> Optional[bool]:
     return bool(caps.supports_vision)
 
 
+# Model-name patterns that strongly indicate vision support across providers.
+# Used as a fallback when the active provider isn't in the models.dev catalogue
+# (e.g. ``custom:*`` providers like enterprise LLM gateways). Patterns are
+# matched case-insensitively against the bare model slug. Conservative on
+# purpose — text-only siblings of these families are rare; the cost of a
+# false positive is one HTTP 400 from the provider, the cost of a false
+# negative is the user's image silently dropped to a text description path.
+_VISION_CAPABLE_MODEL_PATTERNS = (
+    "claude-3",      # claude-3-opus / sonnet / haiku — all see images
+    "claude-sonnet", # claude-sonnet-4-* and beyond
+    "claude-opus",   # claude-opus-4-* and beyond
+    "claude-haiku",  # claude-haiku-4-* and beyond
+    "gpt-4o",        # gpt-4o, gpt-4o-mini
+    "gpt-4.1",       # gpt-4.1 family
+    "gpt-4-turbo",   # gpt-4-turbo with vision
+    "gpt-4-vision",  # explicit vision variant
+    "gpt-5",         # gpt-5 / gpt-5.x family — multimodal
+    "gemini-1.5",
+    "gemini-2",
+    "gemini-3",
+    "llama-3.2-vision",
+    "llama-4",       # Llama 4 family is multimodal
+    "qwen-vl",
+    "qwen2-vl",
+    "qwen2.5-vl",
+    "qwen3-vl",
+    "pixtral",
+    "molmo",
+    "internvl",
+)
+
+
+def _custom_provider_likely_supports_vision(
+    provider: str,
+    model: str,
+    cfg: Optional[Dict[str, Any]],
+) -> bool:
+    """Heuristic: does this ``custom:*`` provider's model likely accept images?
+
+    Used only when ``models.dev`` doesn't know the provider (the common case
+    for enterprise LLM gateways routed through ``custom_providers``). We check
+    two signals:
+      1. The provider must be declared in ``custom_providers`` with an
+         ``api_mode`` that supports image content blocks
+         (``anthropic_messages`` or ``chat_completions``).
+      2. The model slug must match a known vision-capable family pattern.
+
+    Both signals together avoid both false positives (text-only model on a
+    vision-capable protocol) and false negatives (vision model behind an
+    unfamiliar provider name).
+
+    Provider name handling: callers may pass either the full namespaced form
+    ``"custom:my-gateway"`` (as written in config.yaml) or the bare ``"custom"``
+    that AIAgent uses at runtime after the namespace is stripped. When given
+    ``"custom"``, we recover the full name from ``cfg["model"]["provider"]``
+    so the lookup against ``custom_providers`` still works.
+    """
+    if not model:
+        return False
+    if not isinstance(cfg, dict):
+        return False
+
+    p_lower = provider.strip().lower() if isinstance(provider, str) else ""
+
+    if p_lower.startswith("custom:"):
+        custom_name = p_lower.split(":", 1)[1].strip()
+    elif p_lower == "custom":
+        # Bare ``"custom"`` — AIAgent strips the ``:my-gateway`` namespace at
+        # runtime. Recover it from the config's model.provider string,
+        # which preserves the full form.
+        model_cfg = cfg.get("model")
+        if isinstance(model_cfg, dict):
+            cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
+            if cfg_provider.startswith("custom:"):
+                custom_name = cfg_provider.split(":", 1)[1].strip()
+            else:
+                return False
+        else:
+            return False
+    else:
+        return False
+
+    if not custom_name:
+        return False
+
+    custom_providers = cfg.get("custom_providers")
+    if not isinstance(custom_providers, list):
+        return False
+
+    matched = None
+    for entry in custom_providers:
+        if not isinstance(entry, dict):
+            continue
+        if str(entry.get("name", "")).strip().lower() == custom_name:
+            matched = entry
+            break
+    if matched is None:
+        return False
+
+    api_mode = str(matched.get("api_mode") or "").strip().lower()
+    # Both protocols can carry image parts. Other modes (e.g. plain
+    # text-completion APIs) cannot reliably forward images.
+    if api_mode not in {"anthropic_messages", "chat_completions"}:
+        return False
+
+    model_lower = model.lower()
+    return any(pat in model_lower for pat in _VISION_CAPABLE_MODEL_PATTERNS)
+
+
 def decide_image_input_mode(
     provider: str,
     model: str,
@@ -125,6 +234,11 @@ def decide_image_input_mode(
 
     supports = _lookup_supports_vision(provider, model)
     if supports is True:
+        return "native"
+    if supports is None and _custom_provider_likely_supports_vision(provider, model, cfg):
+        # Custom provider not in models.dev catalogue, but its declared
+        # api_mode + model name strongly suggest vision support. Trust it
+        # and fall back to text-pipeline only if the provider rejects.
         return "native"
     return "text"
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -9464,9 +9464,23 @@ class AIAgent:
             if not provider or not model:
                 return False
             caps = get_model_capabilities(provider, model)
-            if caps is None:
+            if caps is not None:
+                return bool(caps.supports_vision)
+            # Caps lookup returned None — provider isn't in the models.dev
+            # catalogue. For ``custom:*`` / bare ``custom`` providers
+            # (enterprise LLM gateways), fall back to the same heuristic
+            # used by image_routing: api_mode + model-name family check.
+            # This keeps the three vision-capability gates in sync —
+            # decide_image_input_mode (gateway-side image routing),
+            # _supports_media_in_tool_results (vision_analyze fast path),
+            # and _model_supports_vision (run_agent tool-result delivery).
+            try:
+                from agent.image_routing import _custom_provider_likely_supports_vision
+                from hermes_cli.config import load_config
+                cfg = load_config()
+                return _custom_provider_likely_supports_vision(provider, model, cfg)
+            except Exception:
                 return False
-            return bool(caps.supports_vision)
         except Exception:
             return False
 

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -124,6 +124,160 @@ class TestDecideImageInputMode:
         with patch("agent.models_dev.fetch_models_dev", return_value=registry):
             assert decide_image_input_mode("xiaomi", "mimo-v2.5-pro", {}) == "text"
 
+    # ── custom provider fallback (enterprise LLM gateways) ──────────────────
+    # Bug repro: ``custom:my-gateway`` running ``claude-opus-4-7`` over the
+    # ``anthropic_messages`` protocol used to fall through to ``"text"`` and
+    # then explode because no aux vision provider was configured.
+
+    def _my_gateway_cfg(self, api_mode="anthropic_messages"):
+        return {
+            "custom_providers": [
+                {
+                    "name": "my-gateway",
+                    "base_url": "https://my-gateway.example",
+                    "api_key": "sk-x",
+                    "api_mode": api_mode,
+                },
+            ],
+        }
+
+    def test_custom_provider_anthropic_protocol_claude_opus_is_native(self):
+        with patch("agent.image_routing._lookup_supports_vision", return_value=None):
+            assert (
+                decide_image_input_mode(
+                    "custom:my-gateway", "claude-opus-4-7", self._my_gateway_cfg()
+                )
+                == "native"
+            )
+
+    def test_custom_provider_anthropic_protocol_haiku_is_native(self):
+        with patch("agent.image_routing._lookup_supports_vision", return_value=None):
+            assert (
+                decide_image_input_mode(
+                    "custom:my-gateway",
+                    "claude-haiku-4-5-20251001",
+                    self._my_gateway_cfg(),
+                )
+                == "native"
+            )
+
+    def test_custom_provider_chat_completions_gpt5_is_native(self):
+        with patch("agent.image_routing._lookup_supports_vision", return_value=None):
+            assert (
+                decide_image_input_mode(
+                    "custom:my-gateway",
+                    "gpt-5.4",
+                    self._my_gateway_cfg(api_mode="chat_completions"),
+                )
+                == "native"
+            )
+
+    def test_custom_provider_text_only_model_falls_back_to_text(self):
+        """Text-only model behind a vision-capable protocol must NOT go native."""
+        with patch("agent.image_routing._lookup_supports_vision", return_value=None):
+            assert (
+                decide_image_input_mode(
+                    "custom:my-gateway",
+                    "deepseek-r1-text",
+                    self._my_gateway_cfg(),
+                )
+                == "text"
+            )
+
+    def test_custom_provider_unknown_api_mode_falls_back_to_text(self):
+        with patch("agent.image_routing._lookup_supports_vision", return_value=None):
+            assert (
+                decide_image_input_mode(
+                    "custom:my-gateway",
+                    "claude-opus-4-7",
+                    self._my_gateway_cfg(api_mode="responses"),
+                )
+                == "text"
+            )
+
+    def test_custom_provider_not_declared_in_config_falls_back_to_text(self):
+        """If user types custom:foo but never declared it, don't guess."""
+        with patch("agent.image_routing._lookup_supports_vision", return_value=None):
+            assert (
+                decide_image_input_mode("custom:foo", "claude-opus-4-7", {})
+                == "text"
+            )
+
+    def test_custom_provider_caps_known_takes_priority_over_fallback(self):
+        """If models.dev DOES know the provider, trust it (don't double-guess)."""
+        # models.dev says supports_vision=False for this model — fallback must
+        # not override. Even with a vision-capable name pattern.
+        with patch("agent.image_routing._lookup_supports_vision", return_value=False):
+            assert (
+                decide_image_input_mode(
+                    "custom:my-gateway",
+                    "claude-opus-4-7",
+                    self._my_gateway_cfg(),
+                )
+                == "text"
+            )
+
+    def test_custom_provider_aux_vision_override_still_wins(self):
+        """User explicitly configured aux vision → respect it, don't bypass."""
+        cfg: dict = self._my_gateway_cfg()
+        cfg["auxiliary"] = {
+            "vision": {"provider": "openrouter", "model": "google/gemini-2.5-flash"}
+        }
+        with patch("agent.image_routing._lookup_supports_vision", return_value=None):
+            assert (
+                decide_image_input_mode("custom:my-gateway", "claude-opus-4-7", cfg)
+                == "text"
+            )
+
+    # ── bare "custom" runtime form (AIAgent strips :namespace at init) ───────
+
+    def _my_gateway_cfg_with_model(self, api_mode="anthropic_messages"):
+        """Cfg as it actually appears at runtime: model.provider=custom:my-gateway."""
+        return {
+            "model": {
+                "default": "claude-opus-4-7",
+                "provider": "custom:my-gateway",
+            },
+            "custom_providers": [
+                {
+                    "name": "my-gateway",
+                    "base_url": "https://my-gateway.example",
+                    "api_key": "sk-x",
+                    "api_mode": api_mode,
+                },
+            ],
+        }
+
+    def test_bare_custom_recovers_namespace_from_model_config(self):
+        """AIAgent passes provider='custom' (no :my-gateway) at runtime — must still resolve."""
+        with patch("agent.image_routing._lookup_supports_vision", return_value=None):
+            assert (
+                decide_image_input_mode(
+                    "custom", "claude-opus-4-7", self._my_gateway_cfg_with_model()
+                )
+                == "native"
+            )
+
+    def test_bare_custom_without_model_config_falls_back_to_text(self):
+        """If model.provider isn't a custom:* form, can't recover → text."""
+        cfg = {
+            "custom_providers": [
+                {"name": "my-gateway", "api_mode": "anthropic_messages"},
+            ],
+            # No model.provider, or it's not custom:*
+        }
+        with patch("agent.image_routing._lookup_supports_vision", return_value=None):
+            assert decide_image_input_mode("custom", "claude-opus-4-7", cfg) == "text"
+
+    def test_bare_custom_text_only_model_falls_back(self):
+        with patch("agent.image_routing._lookup_supports_vision", return_value=None):
+            assert (
+                decide_image_input_mode(
+                    "custom", "deepseek-r1-text", self._my_gateway_cfg_with_model()
+                )
+                == "text"
+            )
+
 
 # ─── build_native_content_parts ──────────────────────────────────────────────
 

--- a/tests/run_agent/test_vision_aware_preprocessing.py
+++ b/tests/run_agent/test_vision_aware_preprocessing.py
@@ -168,3 +168,34 @@ class TestModelSupportsVision:
         agent = _make_agent()
         with patch("agent.models_dev.get_model_capabilities", side_effect=RuntimeError("boom")):
             assert agent._model_supports_vision() is False
+
+    def test_none_caps_with_custom_provider_falls_back_to_heuristic(self):
+        """When caps lookup returns None for a custom: provider, the helper
+        from agent.image_routing should resolve api_mode + model name."""
+        agent = _make_agent()
+        agent.provider = "custom"
+        agent.model = "claude-opus-4-7"
+        cfg = {
+            "model": {"provider": "custom:my-gateway"},
+            "custom_providers": [
+                {"name": "my-gateway", "api_mode": "anthropic_messages"},
+            ],
+        }
+        with patch("agent.models_dev.get_model_capabilities", return_value=None), \
+             patch("hermes_cli.config.load_config", return_value=cfg):
+            assert agent._model_supports_vision() is True
+
+    def test_none_caps_with_custom_provider_text_only_model_returns_false(self):
+        """Heuristic fallback must reject text-only models behind a vision protocol."""
+        agent = _make_agent()
+        agent.provider = "custom"
+        agent.model = "deepseek-r1-text"
+        cfg = {
+            "model": {"provider": "custom:my-gateway"},
+            "custom_providers": [
+                {"name": "my-gateway", "api_mode": "anthropic_messages"},
+            ],
+        }
+        with patch("agent.models_dev.get_model_capabilities", return_value=None), \
+             patch("hermes_cli.config.load_config", return_value=cfg):
+            assert agent._model_supports_vision() is False

--- a/tests/tools/test_vision_native_fast_path.py
+++ b/tests/tools/test_vision_native_fast_path.py
@@ -58,6 +58,51 @@ class TestSupportsMediaInToolResults:
     def test_unknown_provider_conservative_no(self):
         assert _supports_media_in_tool_results("brand-new-provider", "any-model") is False
 
+    # ── custom: provider fallback ────────────────────────────────────────────
+
+    def _my_gateway_cfg(self, api_mode="anthropic_messages"):
+        return {
+            "custom_providers": [
+                {"name": "my-gateway", "base_url": "https://x", "api_key": "k", "api_mode": api_mode},
+            ],
+        }
+
+    def test_custom_my_gateway_claude_opus_yes(self):
+        assert (
+            _supports_media_in_tool_results(
+                "custom:my-gateway", "claude-opus-4-7", self._my_gateway_cfg()
+            )
+            is True
+        )
+
+    def test_custom_my_gateway_haiku_yes(self):
+        assert (
+            _supports_media_in_tool_results(
+                "custom:my-gateway", "claude-haiku-4-5-20251001", self._my_gateway_cfg()
+            )
+            is True
+        )
+
+    def test_custom_my_gateway_gpt5_chat_completions_yes(self):
+        assert (
+            _supports_media_in_tool_results(
+                "custom:my-gateway", "gpt-5.4", self._my_gateway_cfg(api_mode="chat_completions")
+            )
+            is True
+        )
+
+    def test_custom_my_gateway_text_only_model_no(self):
+        assert (
+            _supports_media_in_tool_results(
+                "custom:my-gateway", "deepseek-r1-text", self._my_gateway_cfg()
+            )
+            is False
+        )
+
+    def test_custom_provider_no_cfg_no(self):
+        """No cfg means we can't verify api_mode → conservative no."""
+        assert _supports_media_in_tool_results("custom:my-gateway", "claude-opus-4-7") is False
+
     def test_empty_provider_no(self):
         assert _supports_media_in_tool_results("", "anything") is False
         assert _supports_media_in_tool_results(None, "anything") is False  # type: ignore[arg-type]

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -416,7 +416,11 @@ def _resize_image_for_vision(image_path: Path, mime_type: Optional[str] = None,
 # ---------------------------------------------------------------------------
 
 
-def _supports_media_in_tool_results(provider: str, model: str) -> bool:
+def _supports_media_in_tool_results(
+    provider: str,
+    model: str,
+    cfg: Optional[Dict[str, Any]] = None,
+) -> bool:
     """Whether the given provider+model combination accepts image content
     inside a tool-result message.
 
@@ -431,6 +435,11 @@ def _supports_media_in_tool_results(provider: str, model: str) -> bool:
         accepts an array of ``input_text``/``input_image`` items.
       * Gemini 3 (and proxied via aggregators): supports multimodal tool
         results. Older Gemini does NOT.
+      * ``custom:*`` providers (enterprise LLM gateways): supported when
+        the gateway's declared ``api_mode`` is ``anthropic_messages`` or
+        ``chat_completions`` AND the model name matches a vision-capable
+        family. Mirrors the ``decide_image_input_mode`` fallback so users
+        on private gateways aren't silently downgraded to the text path.
 
     For unknown / legacy providers we conservatively return False — the
     caller falls back to the legacy aux-LLM text path.
@@ -469,6 +478,19 @@ def _supports_media_in_tool_results(provider: str, model: str) -> bool:
         if "gemini-3" in m or "gemini-pro-3" in m or "gemini-flash-3" in m:
             return True
         return False
+
+    # Custom providers (enterprise LLM gateways, e.g. ``custom:my-gateway``).
+    # Reuse the same heuristic as image routing: trust the fast path when
+    # the user declared an ``api_mode`` that carries images and the model
+    # name matches a known vision-capable family. Accepts both the full
+    # ``custom:my-gateway`` form and the bare ``custom`` runtime form
+    # (AIAgent strips the namespace prefix when initializing self.provider).
+    if p.startswith("custom:") or p == "custom":
+        try:
+            from agent.image_routing import _custom_provider_likely_supports_vision
+        except Exception:  # pragma: no cover - defensive
+            return False
+        return _custom_provider_likely_supports_vision(p, model, cfg)
 
     # Other vision-capable provider stacks. Conservative default: False.
     # Add explicit entries here as we verify each provider's tool-result
@@ -1029,7 +1051,7 @@ def _handle_vision_analyze(args: Dict[str, Any], **kw: Any) -> Awaitable[str]:
         _model = _read_main_model()
         _cfg = load_config()
         _mode = decide_image_input_mode(_provider, _model, _cfg)
-        if _mode == "native" and _supports_media_in_tool_results(_provider, _model):
+        if _mode == "native" and _supports_media_in_tool_results(_provider, _model, _cfg):
             logger.info(
                 "vision_analyze: native fast path (provider=%s, model=%s)",
                 _provider, _model,


### PR DESCRIPTION
## Summary

Fixes a regression where `vision_analyze` (and the broader image-routing decision) errors out with `No LLM provider configured for task=vision` when the active main model is served via a `custom_providers` entry — common for OpenAI/Anthropic-compatible LLM gateways (Claude/GPT proxied through a private LiteLLM-style endpoint).

## Repro

```yaml
# ~/.hermes/config.yaml
model:
  default: claude-opus-4-7
  provider: custom:my-gateway
  context_length: 1000000

custom_providers:
- name: my-gateway
  base_url: https://my-gateway.example.com
  api_key: sk-...
  api_mode: anthropic_messages

auxiliary:
  vision:
    provider: auto    # default — not configured
```

Send any image to the agent → `vision_analyze` is called → fails with:

```
Error analyzing image: No LLM provider configured for task=vision provider=auto. Run: hermes setup
```

…even though `claude-opus-4-7` natively supports vision.

## Root cause

Three independent vision-capability gates inside hermes-agent each treat `models.dev` caps lookup returning `None` as "no vision":

1. **`agent.image_routing.decide_image_input_mode`** — gateway-side image routing decided `"text"` and tried to pre-describe the image via auxiliary vision. With no aux configured, it errored out.

2. **`tools.vision_tools._supports_media_in_tool_results`** — gates the native fast path that returns image bytes inside a tool-result envelope. With this returning `False`, the fast path was skipped and the broken aux pipeline ran.

3. **`run_agent.AIAgent._model_supports_vision`** — final gate inside the agent loop. Even after the first two were fixed, this stripped image content from successful multimodal envelopes, replacing them with text summaries before the model ever saw the pixels (logged as `"Tool ... returned image content for non-vision model ...; falling back to text summary"`). The model then hallucinated descriptions from the summary alone.

The catalogue (`PROVIDER_TO_MODELS_DEV` mapping) only knows canonical provider IDs (`anthropic`, `openrouter`, …) — it has no entry for `custom:*` providers, so all three gates silently downgraded.

## Fix

When caps lookup yields `None`, all three gates fall back to a shared heuristic helper `_custom_provider_likely_supports_vision()` (in `agent/image_routing.py`) that checks two signals on the `custom:*` provider:

1. The provider is declared in `custom_providers` with `api_mode` ∈ `{anthropic_messages, chat_completions}` (both protocols carry image content blocks).
2. The model slug matches a known vision-capable family pattern (`claude-{opus,sonnet,haiku,3}`, `gpt-{4o,4.1,4-turbo,5}`, `gemini-{1.5,2,3}`, `llama-{3.2-vision,4}`, `qwen*-vl`, `pixtral`, `molmo`, `internvl`).

Both signals required → avoids both false positives (text-only model on a vision-capable protocol) and false negatives (vision model behind an unfamiliar provider name).

### Provider name handling

Callers may pass either form:

- **Full namespaced** — `"custom:my-gateway"` as written in `config.yaml`.
- **Bare runtime form** — `"custom"`. AIAgent strips the `:my-gateway` namespace at init time, so `self.provider` becomes `"custom"` and any guard based on `provider.startswith("custom:")` would never match at runtime.

When given bare `"custom"`, the helper recovers the namespace from `cfg["model"]["provider"]` (which preserves the full form) and re-keys the `custom_providers` lookup. If `model.provider` is missing or not in `custom:*` form, it falls back to text — same conservatism as before.

## Conservative by design

- Explicit `auxiliary.vision.*` config still wins → user intent respected, no silent bypass.
- `_lookup_supports_vision` returning `False` (catalogue says no) still wins → catalogue knows best.
- Fallback only kicks in when caps are genuinely unknown.
- False-positive cost: one HTTP 400 from the provider on the first image. False-negative cost: every image silently downgraded to text description. Bias toward letting the provider reject.

## Test plan

- [x] `pytest tests/agent/test_image_routing.py` — all passing, +11 new
- [x] `pytest tests/tools/test_vision_native_fast_path.py` — all passing, +5 new
- [x] `pytest tests/run_agent/test_vision_aware_preprocessing.py` — all passing, +2 new
- [x] `pytest tests/gateway/test_native_image_buffer_isolation.py` — 0 regressions

New cases cover the full custom-provider matrix:

- `custom:my-gateway` + `claude-opus-4-7` over `anthropic_messages` → `native` ✓
- `custom:my-gateway` + `claude-haiku-4-5-*` over `anthropic_messages` → `native` ✓
- `custom:my-gateway` + `gpt-5.4` over `chat_completions` → `native` ✓
- `custom:my-gateway` + text-only model → `text` (fallback)
- `custom:my-gateway` + unknown `api_mode` (e.g. `responses`) → `text` (fallback)
- `custom:foo` not declared in `custom_providers` → `text` (don't guess)
- `_lookup_supports_vision` returning `False` → `text` (catalogue beats fallback)
- Explicit `auxiliary.vision` config → `text` (user intent wins)
- Bare `"custom"` runtime form recovers namespace from `cfg.model.provider` → resolves correctly
- Bare `"custom"` without recoverable model.provider → `text` (don't guess)
- `_supports_media_in_tool_results` mirror cases for the fast path
- `AIAgent._model_supports_vision` mirror cases for the delivery gate

## Verified end-to-end

After the fix, on a real `custom:my-gateway` config running Claude Opus:

```
decide_image_input_mode -> 'native'
_supports_media_in_tool_results -> True
AIAgent._model_supports_vision -> True
Fast path activates → image bytes attached natively → main model sees pixels ✓
```

## Changes

- `agent/image_routing.py` — new `_VISION_CAPABLE_MODEL_PATTERNS` + `_custom_provider_likely_supports_vision()` helper, called from `decide_image_input_mode()` when caps lookup returns `None`.
- `tools/vision_tools.py` — `_supports_media_in_tool_results()` now accepts optional `cfg` and reuses the same helper for `custom:*` providers; caller in `_handle_vision_analyze` passes `cfg`.
- `run_agent.py` — `AIAgent._model_supports_vision()` falls back to the same helper when caps lookup returns `None`.
- Tests as listed above.
