### PR TITLE
fix(auxiliary_client): resolve provider=auto + fall back to auxiliary.default when main differs

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3993,6 +3993,15 @@ def _resolve_task_provider_model(
         if cfg_provider and cfg_provider != "auto":
             return cfg_provider, resolved_model, cfg_base_url, cfg_api_key, resolved_api_mode
 
+        # provider is "auto" (or unset) but config specified an explicit model
+        # (e.g. auxiliary.default.model = us.anthropic.claude-haiku-...).
+        # _resolve_auto ignores the model hint and always uses the main model,
+        # so we must resolve the provider explicitly here to honour cfg_model.
+        if resolved_model:
+            explicit_provider = _read_main_provider() or "auto"
+            if explicit_provider and explicit_provider != "auto":
+                return explicit_provider, resolved_model, None, None, resolved_api_mode
+
         return "auto", resolved_model, None, None, resolved_api_mode
 
     return "auto", resolved_model, None, None, resolved_api_mode
@@ -4002,7 +4011,11 @@ _DEFAULT_AUX_TIMEOUT = 30.0
 
 
 def _get_auxiliary_task_config(task: str) -> Dict[str, Any]:
-    """Return the config dict for auxiliary.<task>, or {} when unavailable."""
+    """Return the config dict for auxiliary.<task>, or {} when unavailable.
+
+    Falls back to auxiliary.default when no task-specific config exists.
+    Task-specific keys win over default keys ({**default_config, **task_config}).
+    """
     if not task:
         return {}
     try:
@@ -4011,8 +4024,13 @@ def _get_auxiliary_task_config(task: str) -> Dict[str, Any]:
     except ImportError:
         return {}
     aux = config.get("auxiliary", {}) if isinstance(config, dict) else {}
+    if not isinstance(aux, dict):
+        return {}
+    default_config = aux.get("default", {})
+    default_config = default_config if isinstance(default_config, dict) else {}
     task_config = aux.get(task, {}) if isinstance(aux, dict) else {}
-    return task_config if isinstance(task_config, dict) else {}
+    task_config = task_config if isinstance(task_config, dict) else {}
+    return {**default_config, **task_config}
 
 
 def _get_task_timeout(task: str, default: float = _DEFAULT_AUX_TIMEOUT) -> float:


### PR DESCRIPTION
## What

Two related fixes in `agent/auxiliary_client.py` that together make the
auxiliary-client routing actually honour `auxiliary.default.*` config:

1. `_get_auxiliary_task_config` now falls back to `auxiliary.default` and
   merges (`{**default_config, **task_config}`) instead of returning `{}`
   when no task-specific key exists.
2. `_resolve_task_provider_model` now resolves `provider="auto"` to the
   main configured provider when an explicit `cfg_model` was supplied —
   `_resolve_auto` always picks the main *model* and ignores the
   `cfg_model` hint, which silently routed compression/mem0 tasks to the
   main model.

## Why

The breakage surfaces whenever the main provider's default model differs
from `auxiliary.default.model`. Concrete repro:

```yaml
model:
  provider: bedrock
  default: us.amazon.nova-pro-v1:0

auxiliary:
  default:
    model: us.anthropic.claude-haiku-4-5-20251001-v1:0
    # provider unset → "auto"
```

Expected: context-compression uses Claude Haiku (an Anthropic model
on Bedrock).

Actual (before this patch):

1. `_get_auxiliary_task_config("context_compression")` returns `{}`
   (no `auxiliary.context_compression` key exists) — so the
   `auxiliary.default.model` is dropped entirely.
2. Even when the user adds an explicit `auxiliary.context_compression`
   block with `model: <haiku>` and `provider: auto`, `_resolve_auto`
   picks Nova Pro (the main model) and routes through
   `AnthropicAuxiliaryClient` — which 400s, because Nova Pro is not
   an Anthropic model.

The user-facing symptom is "context compression broken" with an opaque
Anthropic SDK error. Hard to diagnose because the config looks right.

## The fix

The first change closes the silent fallthrough: an `auxiliary.default`
block with a `model:` key is now actually applied to every auxiliary
task. The second change closes the wrong-provider routing: when the
config gave us an explicit model but left provider as `auto`, we look
up the main provider directly and route there with the configured
model, rather than letting `_resolve_auto` override the model.

Both changes are conservative — they only kick in on paths that
previously returned `{}` or selected `"auto"` with the wrong model.
Setups that already worked are unaffected.

## Context

Carried in [Fox in the Box](https://github.com/fox-in-the-box-ai/fox-in-the-box)
as a runtime monkey-patch since our v0.5.x line; the bug surfaces in
production any time a user with a Bedrock + non-Claude main model wires
up `auxiliary.default.model` for Claude. We'd love to retire the patch
and let users get the fix natively.

Happy to write a unit test if you'd like one — point me at the test
file convention you'd prefer. The natural home in the existing layout
looks like `tests/agent/test_auxiliary_client_resolution.py`, covering
both the `_get_auxiliary_task_config` merge behaviour and the
`provider=auto + explicit model` resolution path.
