### PR TITLE
feat(cron): surface failure diagnostics — rolling history + structured FAILED output

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -622,6 +622,7 @@ def create_job(
         "last_status": None,
         "last_error": None,
         "last_delivery_error": None,
+        "failure_history": [],  # Rolling last-5 failures: [{at, error}]
         # Delivery configuration
         "deliver": deliver,
         "origin": origin,  # Tracks where job was created for "origin" delivery
@@ -831,7 +832,17 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                 job["last_error"] = error if not success else None
                 # Track delivery failures separately — cleared on successful delivery
                 job["last_delivery_error"] = delivery_error
-                
+
+                # Maintain rolling failure history (last 5 entries).
+                # On success, clear it so the consecutive-failure counter resets.
+                if not success:
+                    _entry = {"at": now, "error": (error or "unknown")[:200]}
+                    _hist = list(job.get("failure_history") or [])
+                    _hist.append(_entry)
+                    job["failure_history"] = _hist[-5:]
+                else:
+                    job["failure_history"] = []
+
                 # Increment completed count
                 if job.get("repeat"):
                     job["repeat"]["completed"] = job["repeat"].get("completed", 0) + 1

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -17,6 +17,7 @@ import os
 import shutil
 import subprocess
 import sys
+import traceback
 
 # fcntl is Unix-only; on Windows use msvcrt for file locking
 try:
@@ -1605,22 +1606,54 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     except Exception as e:
         error_msg = f"{type(e).__name__}: {str(e)}"
         logger.exception("Job '%s' failed: %s", job_name, error_msg)
-        
+
+        # Collect agent activity diagnostics if available so the FAILED
+        # doc shows iteration count, last activity, and stuck-tool info
+        # without forcing the operator to open the session log.
+        _diag_lines: list[str] = []
+        if agent is not None:
+            try:
+                _act = agent.get_activity_summary() if hasattr(agent, "get_activity_summary") else {}
+                _api_calls = _act.get("api_call_count", "?")
+                _max_iter = _act.get("max_iterations", "?")
+                _last_act = _act.get("last_activity_desc", "unknown")
+                _idle = _act.get("seconds_since_activity", 0)
+                _diag_lines.append(f"**Iterations:** {_api_calls}/{_max_iter}")
+                _diag_lines.append(f"**Last activity:** {_last_act} ({int(_idle)}s ago)")
+                if _act.get("current_tool"):
+                    _diag_lines.append(f"**Stuck on tool:** `{_act['current_tool']}`")
+            except Exception:
+                pass
+
+        _tb = traceback.format_exc()
+        _diag_block = ("\n".join(_diag_lines) + "\n\n") if _diag_lines else ""
+
         output = f"""# Cron Job: {job_name} (FAILED)
 
 **Job ID:** {job_id}
+**Session:** `{_cron_session_id}`
 **Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}
 **Schedule:** {job.get('schedule_display', 'N/A')}
-
-## Prompt
-
-{prompt}
 
 ## Error
 
 ```
 {error_msg}
 ```
+
+## Agent Diagnostics
+
+{_diag_block}**Session log:** `~/.hermes/sessions/session_{_cron_session_id}.json`
+
+## Traceback
+
+```
+{_tb}
+```
+
+## Prompt
+
+{prompt}
 """
         return False, output, "", error_msg
 
@@ -1752,7 +1785,31 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
                 # Deliver the final response to the origin/target chat.
                 # If the agent responded with [SILENT], skip delivery (but
                 # output is already saved above).  Failed jobs always deliver.
-                deliver_content = final_response if success else f"⚠️ Cron job '{job.get('name', job['id'])}' failed:\n{error}"
+                if success:
+                    deliver_content = final_response
+                else:
+                    # Build a structured failure notification with enough
+                    # context to diagnose without opening logs manually.
+                    _fail_lines = [
+                        f"❌ **Cron job failed:** `{job.get('name', job['id'])}`",
+                        f"**Error:** {error}",
+                    ]
+                    # Surface consecutive failure count if available
+                    _history = job.get("failure_history") or []
+                    if len(_history) > 1:
+                        _fail_lines.append(
+                            f"**Consecutive failures:** {len(_history)} "
+                            f"(first: {_history[0].get('at', '?')[:16]})"
+                        )
+                    # Include session log path for easy debugging
+                    _session_files = sorted(
+                        (f for f in (_get_hermes_home() / "sessions").glob(f"session_cron_{job['id']}_*.json") if f.is_file()),
+                        key=lambda p: p.stat().st_mtime,
+                        reverse=True,
+                    )
+                    if _session_files:
+                        _fail_lines.append(f"**Session log:** `{_session_files[0]}`")
+                    deliver_content = "\n".join(_fail_lines)
                 should_deliver = bool(deliver_content)
                 if should_deliver and success and SILENT_MARKER in deliver_content.strip().upper():
                     logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -273,6 +273,14 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         "paused_at": job.get("paused_at"),
         "paused_reason": job.get("paused_reason"),
     }
+    # Surface failure history and last error only when there are failures —
+    # keeps the list output clean for healthy jobs.
+    if job.get("last_status") == "error" or job.get("failure_history"):
+        result["last_error"] = job.get("last_error")
+        _hist = job.get("failure_history") or []
+        if _hist:
+            result["failure_history"] = _hist
+            result["consecutive_failures"] = len(_hist)
     if job.get("script"):
         result["script"] = job["script"]
     if job.get("no_agent"):


### PR DESCRIPTION
## What

Surfaces cron-job failure diagnostics directly in the FAILED output and
in the delivery notification, instead of forcing the operator to open
the session log. Three files touched:

- `cron/jobs.py`: adds a rolling-5 `failure_history` field on the job,
  maintained by `mark_job_run` (cleared on the next successful run).
- `cron/scheduler.py`: enriches `run_job`'s FAILED output document with
  the session ID, an Agent Diagnostics section (iteration count, last
  activity, stuck-tool detection), and the traceback. The `tick`
  delivery notification becomes a structured multi-line block with the
  error, consecutive-failure count, and the session-log path.
- `tools/cronjob_tools.py`: the `cronjob` list output surfaces
  `last_error`, `failure_history`, and `consecutive_failures` — but only
  when the job has actually failed, keeping the output clean for
  healthy jobs.

## Why

Today, when a cron job fails, the operator gets `⚠️ Cron job 'X'
failed: <one-line error>` delivered to chat and nothing else surfaces
without manually finding and reading the session JSON. That's painful
when:

- the failure is intermittent — there's no way to see "is this the
  first failure or the fifth in a row?" without reading state files;
- the agent ran for 40 iterations and timed out — the operator has no
  signal about what the agent was doing when it died;
- the operator is on mobile and just needs to know whether to act now
  or wait for the next run.

This patch puts that information where the operator already is — the
delivery channel (Telegram / Slack / etc.) and the saved job output
document — without changing the storage shape of jobs (only one new
field: `failure_history`).

## Behavior changes

- **Healthy jobs**: no behavior change. `failure_history` stays `[]`,
  `_format_job` output is unchanged, delivery output is unchanged.
- **First failure**: delivery shows the structured block with error +
  session-log path. The FAILED doc gains the diagnostics + traceback
  sections.
- **Repeated failure**: delivery additionally shows
  "Consecutive failures: N (first: <timestamp>)" so the operator can
  triage at a glance.
- **Recovery**: `failure_history` clears on the next successful run.

## On the design

I went with one combined PR because the three changes share state
(`failure_history`) — splitting them would force a temporal coupling
between merges. Happy to split into prep (jobs.py field +
mark_job_run) and surface (scheduler/cronjob_tools) PRs if that's
preferred. Also happy to:

- swap the emoji prefixes in the delivery notification for plain
  `[FAILED]` if you'd rather avoid them in tool output;
- gate the `## Traceback` section behind a config flag if you'd
  rather keep the FAILED doc minimal by default;
- shorten the failure_history retention (currently 5).

## Context

Carried in [Fox in the Box](https://github.com/fox-in-the-box-ai/fox-in-the-box)
since our v0.5.x line as a runtime monkey-patch — we use it daily to
triage cron failures from chat without opening logs. Groundwork for an
autorecovery flow we're prototyping, but the diagnostics value stands
on its own.

Happy to write tests if you'd like — the natural homes look like
`tests/cron/test_failure_history.py` (mark_job_run rolling buffer)
and `tests/cron/test_run_job_failure_output.py` (FAILED doc shape).
