### PR TITLE
feat(web): add local sxng-search provider plugin

### DIFF
--- a/plugins/web/sxng/__init__.py
+++ b/plugins/web/sxng/__init__.py
@@ -1,0 +1,9 @@
+"""Bundled local sxng-search web provider plugin."""
+from __future__ import annotations
+
+from plugins.web.sxng.provider import SxngWebSearchProvider
+
+
+def register(ctx) -> None:
+    """Register the sxng provider with the plugin context."""
+    ctx.register_web_search_provider(SxngWebSearchProvider())

--- a/plugins/web/sxng/plugin.yaml
+++ b/plugins/web/sxng/plugin.yaml
@@ -1,0 +1,7 @@
+name: web-sxng
+version: 1.0.0
+description: "Local sxng-search command wrapper — free, local, search-only web provider."
+author: Kuan-Chieh Huang
+kind: backend
+provides_web_providers:
+  - sxng

--- a/plugins/web/sxng/provider.py
+++ b/plugins/web/sxng/provider.py
@@ -1,0 +1,206 @@
+"""Local ``sxng-search`` command wrapper — bundled web provider plugin.
+
+The provider is intentionally search-only. Configure the executable and timeout
+in ``config.yaml``::
+
+    web:
+      search_backend: sxng
+      sxng:
+        command: sxng-search
+        timeout: 45
+
+No credential or behavioral setting is stored in ``.env``.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from typing import Any, Dict, List
+
+from agent.web_search_provider import WebSearchProvider
+
+_DEFAULT_COMMAND = "sxng-search"
+_DEFAULT_TIMEOUT = 45
+_MAX_TIMEOUT = 300
+
+
+def _sxng_config() -> Dict[str, Any]:
+    """Return the ``web.sxng`` mapping from the merged Hermes config."""
+    try:
+        from hermes_cli.config import load_config
+
+        config = load_config() or {}
+    except Exception:  # noqa: BLE001 — config remains optional for plugin import
+        config = {}
+    web = config.get("web", {}) if isinstance(config, dict) else {}
+    if not isinstance(web, dict):
+        return {}
+    sxng = web.get("sxng", {})
+    return sxng if isinstance(sxng, dict) else {}
+
+
+def _command_name() -> str:
+    value = _sxng_config().get("command", _DEFAULT_COMMAND)
+    command = str(value or "").strip()
+    return command or _DEFAULT_COMMAND
+
+
+def _resolve_command() -> str:
+    """Resolve the configured executable without invoking a shell."""
+    return shutil.which(_command_name()) or ""
+
+
+def _timeout_seconds() -> int:
+    raw = _sxng_config().get("timeout", _DEFAULT_TIMEOUT)
+    if raw is None:
+        return _DEFAULT_TIMEOUT
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        value = _DEFAULT_TIMEOUT
+    return min(max(value, 1), _MAX_TIMEOUT)
+
+
+def _candidate_results(payload: Any) -> List[Any]:
+    if isinstance(payload, list):
+        return payload
+    if not isinstance(payload, dict):
+        return []
+    if isinstance(payload.get("results"), list):
+        return payload["results"]
+    data = payload.get("data")
+    if isinstance(data, dict) and isinstance(data.get("web"), list):
+        return data["web"]
+    if isinstance(payload.get("web"), list):
+        return payload["web"]
+    return []
+
+
+def _normalize_results(payload: Any, limit: int) -> List[Dict[str, Any]]:
+    web_results: List[Dict[str, Any]] = []
+    for item in _candidate_results(payload):
+        if not isinstance(item, dict):
+            continue
+        title = str(item.get("title") or item.get("name") or "").strip()
+        url = str(item.get("url") or item.get("link") or "").strip()
+        if not title and not url:
+            continue
+        description = str(
+            item.get("description")
+            or item.get("content")
+            or item.get("snippet")
+            or item.get("summary")
+            or ""
+        ).strip()
+        web_results.append(
+            {
+                "title": title,
+                "url": url,
+                "description": description,
+                "position": len(web_results) + 1,
+            }
+        )
+        if len(web_results) >= limit:
+            break
+    return web_results
+
+
+def _redact_error(text: str) -> str:
+    detail = str(text or "").strip() or "sxng-search failed"
+    try:
+        from agent.redact import redact_sensitive_text
+
+        detail = redact_sensitive_text(detail, force=True)
+    except Exception:  # noqa: BLE001 — never echo unredacted subprocess output
+        return "sxng-search failed"
+    return detail[:1000]
+
+
+class SxngWebSearchProvider(WebSearchProvider):
+    """Search provider backed by a local ``sxng-search`` executable."""
+
+    @property
+    def name(self) -> str:
+        return "sxng"
+
+    @property
+    def display_name(self) -> str:
+        return "Local sxng-search wrapper"
+
+    def is_available(self) -> bool:
+        return bool(_resolve_command())
+
+    def supports_search(self) -> bool:
+        return True
+
+    def supports_extract(self) -> bool:
+        return False
+
+    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+        command = _resolve_command()
+        if not command:
+            return {
+                "success": False,
+                "error": (
+                    "sxng-search command not found. Install it on PATH or set "
+                    "web.sxng.command in config.yaml."
+                ),
+            }
+
+        try:
+            result_limit = min(max(int(limit), 1), 100)
+        except (TypeError, ValueError):
+            result_limit = 5
+        timeout = _timeout_seconds()
+        args = [command, str(query or ""), "--limit", str(result_limit), "--json"]
+
+        try:
+            completed = subprocess.run(
+                args,
+                text=True,
+                capture_output=True,
+                timeout=timeout,
+                check=False,
+                shell=False,
+            )
+        except subprocess.TimeoutExpired:
+            return {
+                "success": False,
+                "error": f"sxng-search timed out after {timeout} seconds",
+            }
+        except OSError:
+            return {
+                "success": False,
+                "error": "sxng-search failed to start",
+            }
+
+        if completed.returncode != 0:
+            return {
+                "success": False,
+                "error": _redact_error(completed.stderr or completed.stdout),
+            }
+
+        try:
+            payload = json.loads(completed.stdout or "{}")
+        except (TypeError, json.JSONDecodeError):
+            return {
+                "success": False,
+                "error": "Could not parse sxng-search output as JSON",
+            }
+
+        return {
+            "success": True,
+            "data": {"web": _normalize_results(payload, result_limit)},
+        }
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": self.display_name,
+            "badge": "free · local",
+            "tag": (
+                "Search only via an installed sxng-search command; configure "
+                "advanced command/timeout settings under web.sxng."
+            ),
+            "env_vars": [],
+        }

--- a/plugins/web/sxng/provider.py
+++ b/plugins/web/sxng/provider.py
@@ -106,17 +106,6 @@ def _normalize_results(payload: Any, limit: int) -> List[Dict[str, Any]]:
     return web_results
 
 
-def _redact_error(text: str) -> str:
-    detail = str(text or "").strip() or "sxng-search failed"
-    try:
-        from agent.redact import redact_sensitive_text
-
-        detail = redact_sensitive_text(detail, force=True)
-    except Exception:  # noqa: BLE001 — never echo unredacted subprocess output
-        return "sxng-search failed"
-    return detail[:1000]
-
-
 class SxngWebSearchProvider(WebSearchProvider):
     """Search provider backed by a local ``sxng-search`` executable."""
 
@@ -153,7 +142,17 @@ class SxngWebSearchProvider(WebSearchProvider):
         except (TypeError, ValueError):
             result_limit = 5
         timeout = _timeout_seconds()
-        args = [command, str(query or ""), "--limit", str(result_limit), "--json"]
+        # Put fixed options first and terminate option parsing before the query.
+        # Without ``--``, a query such as ``--help`` is interpreted by argparse
+        # as a command option rather than search text.
+        args = [
+            command,
+            "--limit",
+            str(result_limit),
+            "--json",
+            "--",
+            str(query or ""),
+        ]
 
         try:
             completed = subprocess.run(
@@ -178,7 +177,9 @@ class SxngWebSearchProvider(WebSearchProvider):
         if completed.returncode != 0:
             return {
                 "success": False,
-                "error": _redact_error(completed.stderr or completed.stdout),
+                # Do not expose subprocess output to the model: it may contain
+                # private paths, local endpoints, usernames, or credentials.
+                "error": f"sxng-search failed with exit code {completed.returncode}",
             }
 
         try:

--- a/tests/plugins/web/test_sxng_provider_plugin.py
+++ b/tests/plugins/web/test_sxng_provider_plugin.py
@@ -141,10 +141,11 @@ class TestSxngSearch:
         }
         assert run.call_args.args[0] == [
             "/usr/bin/custom-sxng",
-            "test query",
             "--limit",
             "5",
             "--json",
+            "--",
+            "test query",
         ]
         assert run.call_args.kwargs["timeout"] == 17
         assert run.call_args.kwargs["shell"] is False
@@ -197,7 +198,57 @@ class TestSxngSearch:
         with patch("subprocess.run", return_value=completed):
             result = SxngWebSearchProvider().search("q")
 
-        assert result == {"success": False, "error": "backend unavailable"}
+        assert result == {
+            "success": False,
+            "error": "sxng-search failed with exit code 2",
+        }
+
+    def test_nonzero_exit_does_not_echo_private_path(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from plugins.web.sxng.provider import SxngWebSearchProvider
+
+        _set_config(monkeypatch)
+        monkeypatch.setattr("shutil.which", lambda command: "/usr/bin/sxng-search")
+        private_path = "/" + "home/example/.config/sxng/private.yml"
+        completed = MagicMock(
+            returncode=2,
+            stdout="",
+            stderr=f"{private_path}: backend unavailable",
+        )
+
+        with patch("subprocess.run", return_value=completed):
+            result = SxngWebSearchProvider().search("q")
+
+        assert result == {
+            "success": False,
+            "error": "sxng-search failed with exit code 2",
+        }
+        assert private_path not in result["error"]
+
+    def test_leading_dash_query_is_after_option_terminator(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from plugins.web.sxng.provider import SxngWebSearchProvider
+
+        _set_config(monkeypatch)
+        monkeypatch.setattr("shutil.which", lambda command: "/usr/bin/sxng-search")
+        completed = MagicMock(returncode=0, stdout='{"results": []}', stderr="")
+
+        with patch("subprocess.run", return_value=completed) as run:
+            result = SxngWebSearchProvider().search("--help", limit=3)
+
+        assert result["success"] is True
+        assert run.call_args.args[0] == [
+            "/usr/bin/sxng-search",
+            "--limit",
+            "3",
+            "--json",
+            "--",
+            "--help",
+        ]
 
     def test_nonzero_exit_redacts_secret_like_stderr(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from plugins.web.sxng.provider import SxngWebSearchProvider

--- a/tests/plugins/web/test_sxng_provider_plugin.py
+++ b/tests/plugins/web/test_sxng_provider_plugin.py
@@ -1,0 +1,300 @@
+"""Contract tests for the bundled local sxng-search web provider plugin."""
+from __future__ import annotations
+
+import json
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _set_config(monkeypatch: pytest.MonkeyPatch, *, command: str = "sxng-search", timeout=45) -> None:
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"web": {"sxng": {"command": command, "timeout": timeout}}},
+    )
+
+
+class TestSxngPluginContract:
+    def test_provider_implements_current_abc(self) -> None:
+        from agent.web_search_provider import WebSearchProvider
+        from plugins.web.sxng.provider import SxngWebSearchProvider
+
+        provider = SxngWebSearchProvider()
+        assert isinstance(provider, WebSearchProvider)
+        assert provider.name == "sxng"
+        assert provider.display_name == "Local sxng-search wrapper"
+        assert provider.supports_search() is True
+        assert provider.supports_extract() is False
+
+    def test_register_uses_web_provider_hook(self) -> None:
+        from plugins.web.sxng import register
+
+        ctx = MagicMock()
+        register(ctx)
+
+        ctx.register_web_search_provider.assert_called_once()
+        assert ctx.register_web_search_provider.call_args.args[0].name == "sxng"
+
+    def test_setup_schema_has_no_nonsecret_env_fields(self) -> None:
+        from plugins.web.sxng.provider import SxngWebSearchProvider
+
+        schema = SxngWebSearchProvider().get_setup_schema()
+
+        assert schema["name"] == "Local sxng-search wrapper"
+        assert schema["env_vars"] == []
+        assert "search only" in schema["tag"].lower()
+
+    def test_picker_row_is_generated_from_plugin_schema(self) -> None:
+        from hermes_cli.tools_config import _plugin_web_search_providers
+
+        rows = _plugin_web_search_providers()
+        sxng = next(row for row in rows if row.get("web_backend") == "sxng")
+
+        assert sxng["name"] == "Local sxng-search wrapper"
+        assert sxng["web_search_plugin_name"] == "sxng"
+        assert sxng["env_vars"] == []
+
+
+class TestSxngAvailabilityAndConfig:
+    def test_available_when_configured_command_is_on_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from plugins.web.sxng.provider import SxngWebSearchProvider
+
+        _set_config(monkeypatch, command="custom-sxng")
+        monkeypatch.setattr("shutil.which", lambda command: "/usr/bin/custom-sxng" if command == "custom-sxng" else None)
+
+        assert SxngWebSearchProvider().is_available() is True
+
+    def test_unavailable_when_command_cannot_be_resolved(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from plugins.web.sxng.provider import SxngWebSearchProvider
+
+        _set_config(monkeypatch)
+        monkeypatch.setattr("shutil.which", lambda command: None)
+
+        assert SxngWebSearchProvider().is_available() is False
+
+    @pytest.mark.parametrize(
+        "configured,expected",
+        [(None, 45), ("bad", 45), (0, 1), (-2, 1), (12, 12), (999, 300)],
+    )
+    def test_timeout_is_config_only_and_bounded(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        configured,
+        expected: int,
+    ) -> None:
+        from plugins.web.sxng.provider import _timeout_seconds
+
+        _set_config(monkeypatch, timeout=configured)
+
+        assert _timeout_seconds() == expected
+
+
+class TestSxngSearch:
+    def test_happy_path_normalizes_wrapper_results(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from plugins.web.sxng.provider import SxngWebSearchProvider
+
+        _set_config(monkeypatch, command="custom-sxng", timeout=17)
+        monkeypatch.setattr("shutil.which", lambda command: "/usr/bin/custom-sxng")
+        completed = MagicMock(
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "results": [
+                        {
+                            "title": "A",
+                            "url": "https://a.example",
+                            "content": "desc A",
+                        },
+                        {
+                            "title": "B",
+                            "url": "https://b.example",
+                            "description": "desc B",
+                        },
+                    ]
+                }
+            ),
+            stderr="",
+        )
+
+        with patch("subprocess.run", return_value=completed) as run:
+            result = SxngWebSearchProvider().search("test query", limit=5)
+
+        assert result == {
+            "success": True,
+            "data": {
+                "web": [
+                    {
+                        "title": "A",
+                        "url": "https://a.example",
+                        "description": "desc A",
+                        "position": 1,
+                    },
+                    {
+                        "title": "B",
+                        "url": "https://b.example",
+                        "description": "desc B",
+                        "position": 2,
+                    },
+                ]
+            },
+        }
+        assert run.call_args.args[0] == [
+            "/usr/bin/custom-sxng",
+            "test query",
+            "--limit",
+            "5",
+            "--json",
+        ]
+        assert run.call_args.kwargs["timeout"] == 17
+        assert run.call_args.kwargs["shell"] is False
+
+    def test_accepts_data_web_shape_and_caps_limit(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from plugins.web.sxng.provider import SxngWebSearchProvider
+
+        _set_config(monkeypatch)
+        monkeypatch.setattr("shutil.which", lambda command: "/usr/bin/sxng-search")
+        completed = MagicMock(
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "data": {
+                        "web": [
+                            {"title": "A", "url": "https://a.example", "snippet": "A"},
+                            {"title": "B", "url": "https://b.example", "snippet": "B"},
+                        ]
+                    }
+                }
+            ),
+            stderr="",
+        )
+
+        with patch("subprocess.run", return_value=completed):
+            result = SxngWebSearchProvider().search("q", limit=1)
+
+        assert result["success"] is True
+        assert len(result["data"]["web"]) == 1
+        assert result["data"]["web"][0]["position"] == 1
+
+    def test_missing_command_returns_typed_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from plugins.web.sxng.provider import SxngWebSearchProvider
+
+        _set_config(monkeypatch)
+        monkeypatch.setattr("shutil.which", lambda command: None)
+
+        result = SxngWebSearchProvider().search("q")
+
+        assert result["success"] is False
+        assert "web.sxng.command" in result["error"]
+
+    def test_nonzero_exit_returns_bounded_stderr(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from plugins.web.sxng.provider import SxngWebSearchProvider
+
+        _set_config(monkeypatch)
+        monkeypatch.setattr("shutil.which", lambda command: "/usr/bin/sxng-search")
+        completed = MagicMock(returncode=2, stdout="", stderr="backend unavailable")
+
+        with patch("subprocess.run", return_value=completed):
+            result = SxngWebSearchProvider().search("q")
+
+        assert result == {"success": False, "error": "backend unavailable"}
+
+    def test_nonzero_exit_redacts_secret_like_stderr(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from plugins.web.sxng.provider import SxngWebSearchProvider
+
+        _set_config(monkeypatch)
+        monkeypatch.setattr("shutil.which", lambda command: "/usr/bin/sxng-search")
+        fake_secret = "sk-" + "a" * 24
+        completed = MagicMock(
+            returncode=2,
+            stdout="",
+            stderr=f"backend unavailable: {fake_secret}",
+        )
+
+        with patch("subprocess.run", return_value=completed):
+            result = SxngWebSearchProvider().search("q")
+
+        assert result["success"] is False
+        assert fake_secret not in result["error"]
+
+    def test_os_error_does_not_echo_private_command_path(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from plugins.web.sxng.provider import SxngWebSearchProvider
+
+        private_path = "/private/example/sxng-search"
+        _set_config(monkeypatch, command=private_path)
+        monkeypatch.setattr("shutil.which", lambda command: private_path)
+
+        with patch("subprocess.run", side_effect=OSError(private_path)):
+            result = SxngWebSearchProvider().search("q")
+
+        assert result == {"success": False, "error": "sxng-search failed to start"}
+        assert private_path not in result["error"]
+
+    def test_bad_json_returns_typed_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from plugins.web.sxng.provider import SxngWebSearchProvider
+
+        _set_config(monkeypatch)
+        monkeypatch.setattr("shutil.which", lambda command: "/usr/bin/sxng-search")
+        completed = MagicMock(returncode=0, stdout="not-json", stderr="")
+
+        with patch("subprocess.run", return_value=completed):
+            result = SxngWebSearchProvider().search("q")
+
+        assert result["success"] is False
+        assert "json" in result["error"].lower()
+
+    def test_timeout_returns_typed_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from plugins.web.sxng.provider import SxngWebSearchProvider
+
+        _set_config(monkeypatch, timeout=9)
+        monkeypatch.setattr("shutil.which", lambda command: "/usr/bin/sxng-search")
+
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("sxng-search", 9)):
+            result = SxngWebSearchProvider().search("q")
+
+        assert result == {"success": False, "error": "sxng-search timed out after 9 seconds"}
+
+
+class TestSxngRegistryIntegration:
+    def test_real_registry_dispatches_web_search(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path,
+    ) -> None:
+        from agent.web_search_registry import _reset_for_tests, register_provider
+        from plugins.web.sxng.provider import SxngWebSearchProvider
+        from tools import web_tools
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        _set_config(monkeypatch)
+        monkeypatch.setattr("shutil.which", lambda command: "/usr/bin/sxng-search")
+        monkeypatch.setattr(web_tools, "_ensure_web_plugins_loaded", lambda: None)
+        monkeypatch.setattr(web_tools, "_get_search_backend", lambda: "sxng")
+        completed = MagicMock(
+            returncode=0,
+            stdout=json.dumps(
+                {"results": [{"title": "Result", "url": "https://example.com"}]}
+            ),
+            stderr="",
+        )
+
+        _reset_for_tests()
+        register_provider(SxngWebSearchProvider())
+        try:
+            with patch("subprocess.run", return_value=completed):
+                result = json.loads(web_tools.web_search_tool("integration", limit=1))
+        finally:
+            _reset_for_tests()
+
+        assert result["success"] is True
+        assert result["data"]["web"] == [
+            {
+                "title": "Result",
+                "url": "https://example.com",
+                "description": "",
+                "position": 1,
+            }
+        ]

--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -2,7 +2,7 @@
 
 Covers:
 
-- All eight bundled plugins (brave-free, ddgs, searxng, exa, parallel,
+- All nine bundled plugins (brave-free, ddgs, searxng, sxng, exa, parallel,
   tavily, firecrawl, xai) instantiate and self-report the expected
   capabilities + ABC-derived defaults.
 - Each plugin's ``is_available()`` correctly reflects env-var presence.
@@ -68,9 +68,9 @@ def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 class TestBundledPluginsRegister:
-    """All eight bundled web plugins discover and register correctly."""
+    """All nine bundled web plugins discover and register correctly."""
 
-    def test_all_seven_plugins_present_in_registry(self) -> None:
+    def test_all_bundled_plugins_present_in_registry(self) -> None:
         _ensure_plugins_loaded()
         from agent.web_search_registry import list_providers
 
@@ -82,6 +82,7 @@ class TestBundledPluginsRegister:
             "firecrawl",
             "parallel",
             "searxng",
+            "sxng",
             "tavily",
             "xai",
         ]
@@ -92,6 +93,7 @@ class TestBundledPluginsRegister:
             ("brave-free", True, False),
             ("ddgs", True, False),
             ("searxng", True, False),
+            ("sxng", True, False),
             ("exa", True, True),
             ("parallel", True, True),
             ("tavily", True, True),
@@ -116,7 +118,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
+        ["brave-free", "ddgs", "searxng", "sxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
     )
     def test_each_plugin_has_name_and_display_name(self, plugin_name: str) -> None:
         _ensure_plugins_loaded()
@@ -129,7 +131,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
+        ["brave-free", "ddgs", "searxng", "sxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
     )
     def test_each_plugin_has_setup_schema(self, plugin_name: str) -> None:
         """``get_setup_schema()`` returns a dict the picker can consume."""

--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -312,23 +312,44 @@ class TestRegistryResolution:
         assert result.supports_extract() is True
         assert result.is_available() is True
 
-    def test_no_config_no_credentials_returns_none(
+    def test_no_config_uses_only_an_available_provider(
         self,
     ) -> None:
-        """No backend configured AND no available providers → typically None.
+        """No backend config may still resolve a credential-free provider.
 
-        ``ddgs`` is the no-credential fallback; if its ``ddgs`` Python
-        package is installed in the test env, ddgs will be picked.
-        Otherwise the resolver returns None. Either outcome is correct.
+        DDGS can be available through its Python package and sxng through a
+        local executable. Otherwise the resolver returns None.
         """
         _ensure_plugins_loaded()
         from agent.web_search_registry import _resolve
 
         result = _resolve(None, capability="search")
         if result is not None:
-            # The only no-credential provider is ddgs; anything else
-            # means an env var leaked in.
             assert result.is_available() is True
+
+    def test_installed_sxng_is_auto_selected_when_sole_available_provider(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import _resolve, get_provider
+
+        sxng = get_provider("sxng")
+        ddgs = get_provider("ddgs")
+        assert sxng is not None
+        assert ddgs is not None
+
+        monkeypatch.setattr(
+            "shutil.which",
+            lambda command: "/usr/bin/sxng-search" if command == "sxng-search" else None,
+        )
+        monkeypatch.setattr(ddgs, "is_available", lambda: False)
+
+        result = _resolve(None, capability="search")
+
+        assert result is not None
+        assert result is sxng
+        assert result.is_available() is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_web_providers.py
+++ b/tests/tools/test_web_providers.py
@@ -290,6 +290,9 @@ class TestUnconfiguredErrorEnvelopeParity:
             "TOOL_GATEWAY_DOMAIN",
         ):
             monkeypatch.delenv(k, raising=False)
+        # Local, credential-free providers must also be made unavailable for
+        # this test's explicit "no provider configured" invariant.
+        monkeypatch.setattr("shutil.which", lambda _command: None)
 
     def test_unconfigured_search_emits_top_level_error(self, monkeypatch):
         """``web_search_tool`` with no creds returns ``{"error": "Error searching web: ..."}``

--- a/website/docs/developer-guide/web-search-provider-plugin.md
+++ b/website/docs/developer-guide/web-search-provider-plugin.md
@@ -6,7 +6,7 @@ description: "How to build a web-search/extract/crawl backend plugin for Hermes 
 
 # Building a Web Search Provider Plugin
 
-Web-search provider plugins register a backend that services `web_search`, `web_extract`, and (optionally) deep-crawl tool calls. Built-in providers — Firecrawl, SearXNG, Tavily, Exa, Parallel, Brave Search (free tier), xAI, and DDGS — all ship as plugins under `plugins/web/<name>/`. You can add a new one, or override a bundled one, by dropping a directory next to them.
+Web-search provider plugins register a backend that services `web_search`, `web_extract`, and (optionally) deep-crawl tool calls. Built-in providers — Firecrawl, SearXNG, Local sxng-search, Tavily, Exa, Parallel, Brave Search (free tier), xAI, and DDGS — all ship as plugins under `plugins/web/<name>/`. You can add a new one, or override a bundled one, by dropping a directory next to them.
 
 :::tip
 Web search is one of several **backend plugins** Hermes supports. The others (with their own ABCs) are [Image Generation Provider Plugins](/developer-guide/image-gen-provider-plugin), [Video Generation Provider Plugins](/developer-guide/video-gen-provider-plugin), [Memory Provider Plugins](/developer-guide/memory-provider-plugin), [Context Engine Plugins](/developer-guide/context-engine-plugin), and [Model Provider Plugins](/developer-guide/model-provider-plugin). General tool/hook/CLI plugins live in [Build a Hermes Plugin](/developer-guide/plugins).

--- a/website/docs/developer-guide/web-search-provider-plugin.md
+++ b/website/docs/developer-guide/web-search-provider-plugin.md
@@ -28,7 +28,7 @@ Each plugin's `register(ctx)` function calls `ctx.register_web_search_provider(.
 | `web_extract` | `web.extract_backend` | `web.backend` |
 | Deep crawl modes inside `web_extract` | `web.extract_backend` | `web.backend` |
 
-When neither key is set, Hermes auto-detects the backend from whichever API key/URL is present in the environment. `hermes tools` walks users through selection.
+When neither key is set, Hermes resolves an available provider. Availability may come from an API key/URL or from a credential-free local dependency such as DDGS or `sxng-search`. `hermes tools` walks users through explicit selection.
 
 ## Directory structure
 
@@ -39,7 +39,7 @@ plugins/web/my-backend/
 └── plugin.yaml     # Manifest with kind: backend and provides_web_providers
 ```
 
-`brave_free/` and `ddgs/` are the smallest in-tree references — `brave_free` for an API-key-gated search-only provider, `ddgs` for a no-key provider that lazy-installs its SDK.
+`brave_free/`, `ddgs/`, and `sxng/` are the smallest in-tree references — respectively an API-key-gated search-only provider, a no-key provider that lazy-installs its SDK, and a no-key local-command provider.
 
 ## The WebSearchProvider ABC
 

--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -271,7 +271,7 @@ web:
 Hermes invokes the configured executable without a shell as:
 
 ```text
-sxng-search <query> --limit <N> --json
+sxng-search --limit <N> --json -- <query>
 ```
 
 The command must be on `PATH` unless `web.sxng.command` is an executable path. Command and timeout are behavioral settings in `config.yaml`; they are not stored in `.env`.
@@ -387,16 +387,16 @@ web:
   extract_backend: "firecrawl"  # used by web_extract
 ```
 
-When per-capability keys are empty, both fall through to `web.backend`. When `web.backend` is also empty, the backend is auto-detected from whichever API key/URL is present.
+When per-capability keys are empty, both fall through to `web.backend`. When `web.backend` is also empty, Hermes resolves an available provider from configured credentials/URLs or credential-free local providers.
 
 **Priority order (per capability):**
 1. `web.search_backend` / `web.extract_backend` (explicit per-capability)
 2. `web.backend` (shared fallback)
-3. Auto-detect from environment variables
+3. Auto-detect from provider availability
 
 ### Auto-detection
 
-If no backend is explicitly configured, Hermes picks the first available one based on which credentials are set:
+If no backend is explicitly configured, Hermes picks an available provider. Most providers advertise availability through credentials or a configured URL:
 
 | Credential present | Auto-selected backend |
 |--------------------|-----------------------|
@@ -405,6 +405,9 @@ If no backend is explicitly configured, Hermes picks the first available one bas
 | `TAVILY_API_KEY` | tavily |
 | `EXA_API_KEY` | exa |
 | `SEARXNG_URL` | searxng |
+| `sxng-search` executable on `PATH` | sxng, when it is the sole available search provider |
+
+The local sxng wrapper is not added to the legacy multi-provider preference order. If another credential-free provider such as DDGS is also available, select sxng explicitly with `web.search_backend: "sxng"`.
 
 xAI Web Search is **not** in the auto-detection chain — having `XAI_API_KEY` set (or being signed in via xAI Grok OAuth) does not automatically route web traffic through xAI, since those credentials are also used for inference / TTS / image gen and the user may want a different backend for web. Opt in explicitly with `web.backend: "xai"`.
 

--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -20,6 +20,7 @@ Both are configured through a single backend selection. Providers are chosen via
 |----------|---------|--------|---------|-----------|
 | **Firecrawl** (default) | `FIRECRAWL_API_KEY` | ✔ | ✔ | 500 credits/mo |
 | **SearXNG** | `SEARXNG_URL` | ✔ | — | ✔ Free (self-hosted) |
+| **Local sxng-search wrapper** | — (local command) | ✔ | — | ✔ Free |
 | **Brave Search (free tier)** | `BRAVE_SEARCH_API_KEY` | ✔ | — | 2 000 queries/mo |
 | **DDGS (DuckDuckGo)** | — (no key) | ✔ | — | ✔ Free |
 | **Tavily** | `TAVILY_API_KEY` | ✔ | ✔ | 1 000 searches/mo |
@@ -27,7 +28,7 @@ Both are configured through a single backend selection. Providers are chosen via
 | **Parallel** | `PARALLEL_API_KEY` | ✔ | ✔ | Paid |
 | **xAI (Grok)** | `XAI_API_KEY` or `hermes auth login xai-oauth` | ✔ | — | Paid (SuperGrok or per-token) |
 
-Brave Search, DDGS, and xAI are **search-only** — pair any of them with Firecrawl/Tavily/Exa/Parallel when you also need `web_extract`. DDGS uses the [`ddgs` Python package](https://pypi.org/project/ddgs/) under the hood; if it isn't already installed, run `pip install ddgs` (or let Hermes lazy-install it on first use). xAI runs Grok's server-side `web_search` tool on the Responses API — results are LLM-generated rather than index-backed, so titles, descriptions, and URL choice are all model output (see the [trust-model caveat](#xai-grok) below).
+Brave Search, DDGS, Local sxng-search, and xAI are **search-only** — pair any of them with Firecrawl/Tavily/Exa/Parallel when you also need `web_extract`. The sxng provider executes an already-installed local `sxng-search` command; it does not require an API key. DDGS uses the [`ddgs` Python package](https://pypi.org/project/ddgs/) under the hood; if it isn't already installed, run `pip install ddgs` (or let Hermes lazy-install it on first use). xAI runs Grok's server-side `web_search` tool on the Responses API — results are LLM-generated rather than index-backed, so titles, descriptions, and URL choice are all model output (see the [trust-model caveat](#xai-grok) below).
 
 **Per-capability split:** you can use different providers for search and extract independently — for example SearXNG (free) for search and Firecrawl for extract. See [Per-capability configuration](#per-capability-configuration) below.
 
@@ -251,6 +252,32 @@ With this config, Hermes uses SearXNG for all search queries and Firecrawl for U
 
 ---
 
+### Local sxng-search wrapper
+
+Use this backend when an `sxng-search` command is already installed locally and returns JSON results. It is search-only and requires no API key.
+
+Select **Local sxng-search wrapper** in `hermes tools`, or configure it directly:
+
+```yaml
+# ~/.hermes/config.yaml
+web:
+  search_backend: "sxng"
+  extract_backend: "firecrawl"  # optional; sxng itself cannot extract URLs
+  sxng:
+    command: "sxng-search"   # executable name or absolute path; no shell arguments
+    timeout: 45               # seconds; values are clamped to 1-300
+```
+
+Hermes invokes the configured executable without a shell as:
+
+```text
+sxng-search <query> --limit <N> --json
+```
+
+The command must be on `PATH` unless `web.sxng.command` is an executable path. Command and timeout are behavioral settings in `config.yaml`; they are not stored in `.env`.
+
+---
+
 ### Tavily
 
 AI-optimised search and extract with a generous free tier.
@@ -346,7 +373,7 @@ Set one provider for all web capabilities:
 ```yaml
 # ~/.hermes/config.yaml
 web:
-  backend: "searxng"   # firecrawl | searxng | brave-free | ddgs | tavily | exa | parallel | xai
+  backend: "searxng"   # firecrawl | searxng | sxng | brave-free | ddgs | tavily | exa | parallel | xai
 ```
 
 ### Per-capability configuration


### PR DESCRIPTION
## Summary

This updates the original local `sxng-search` integration for Hermes' current web-provider plugin architecture.

- adds a bundled search-only provider under `plugins/web/sxng/`
- registers a `WebSearchProvider` through `register(ctx)` and `plugin.yaml`
- surfaces the provider in `hermes tools` through `get_setup_schema()`
- uses the existing registry/dispatcher capability path; no special cases in `tools/web_tools.py` or `hermes_cli/tools_config.py`
- reads the executable and timeout from `web.sxng` in `config.yaml` rather than adding non-secret `.env` variables
- invokes the local command with `shell=False` and normalizes supported JSON response shapes
- suppresses subprocess stdout/stderr on failures and does not echo configured executable paths
- documents the search-only behavior and pairing with an extract provider

## Configuration

```yaml
web:
  search_backend: sxng
  extract_backend: firecrawl  # optional; sxng itself is search-only
  sxng:
    command: sxng-search      # executable name or absolute path; no shell arguments
    timeout: 45               # seconds; clamped to 1-300
```

The executable contract is:

```text
sxng-search --limit <N> --json -- <query>
```

## Architecture migration

The original PR targeted the legacy `tools.web_providers` API. Current Hermes routes web backends through plugin discovery and `agent.web_search_provider.WebSearchProvider`. This revision moves the integration entirely onto that contract:

- `plugins/web/sxng/plugin.yaml`
- `plugins/web/sxng/__init__.py::register(ctx)`
- `plugins/web/sxng/provider.py::SxngWebSearchProvider`
- dynamic picker metadata from `get_setup_schema()`
- `supports_search() == True`
- `supports_extract() == False`

## Verification

```text
Relevant web/plugin/config matrix: 421 passed, 0 failed
Ruff: PASS
py_compile: PASS
git diff --check: PASS
Live local-command smoke: normal and leading-dash queries both success=true;
failure smoke: private-path stderr suppressed, fixed exit-code error returned
```

The test coverage includes:

- plugin discovery and registration
- current ABC/capability contract
- generated `hermes tools` picker row
- PATH and `web.sxng.command` resolution
- config-only bounded timeout
- real registry → `web_search_tool` dispatch
- JSON normalization and result limiting
- missing command, nonzero exit, invalid JSON, timeout, and OS errors
- subprocess stdout/stderr suppression, including secret-like text and private paths
- `--` option terminator protection for leading-dash queries
- local-command auto-detection when sxng is the sole available provider
- isolation of existing no-provider error-envelope tests when a local command is installed

## Security and privacy

- no API keys or credentials are required or added
- no private endpoints, account identifiers, local user paths, or captured provider payloads are included
- command and timeout are behavioral settings in `config.yaml`, not `.env`
- subprocess execution is an argv list with `shell=False`
- nonzero subprocess output is never returned to the model; only the numeric exit code is exposed
- added-lines secret/private-identifier scan: 0 findings

## Reviewer request addressed

- [x] port to `plugins/web/sxng/`
- [x] add `plugin.yaml`
- [x] subclass the current `WebSearchProvider`
- [x] register through `register(ctx)`
- [x] use `get_setup_schema()` for picker integration
- [x] keep search-only capability handling in the generic registry path
- [x] move timeout and command behavior to `web.sxng` config
- [x] remove legacy provider/picker/dispatcher special cases
- [x] terminate option parsing before untrusted query text
- [x] suppress subprocess output that may contain private paths/endpoints/credentials
