### PR TITLE
fix(goals): add consecutive API error auto-pause to prevent goal spam (#27585)

### DIFF
--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -60,12 +60,19 @@ DEFAULT_JUDGE_MAX_TOKENS = 4096
 _JUDGE_RESPONSE_SNIPPET_CHARS = 4000
 # After this many consecutive judge *parse* failures (empty output / non-JSON),
 # the loop auto-pauses and points the user at the goal_judge config. API /
-# transport errors do NOT count toward this — those are transient. This guards
-# against small models (e.g. deepseek-v4-flash) that cannot follow the strict
-# JSON reply contract; without it the loop runs until the turn budget is
-# exhausted with every reply shaped like `judge returned empty response` or
-# `judge reply was not JSON`.
+# transport errors do NOT count toward this — those are tracked separately via
+# consecutive_api_errors. This guards against small models (e.g.
+# deepseek-v4-flash) that cannot follow the strict JSON reply contract; without
+# it the loop runs until the turn budget is exhausted with every reply shaped
+# like `judge returned empty response` or `judge reply was not JSON`.
 DEFAULT_MAX_CONSECUTIVE_PARSE_FAILURES = 3
+
+# After this many consecutive judge *API/transport* errors (network timeouts,
+# 429 rate limits, provider outages), the loop auto-pauses so the user is
+# alerted instead of silently cycling until the turn budget is exhausted. This
+# prevents the spam described in #27585 where the agent has already produced a
+# terminal response but the broken judge keeps returning ``continue``.
+DEFAULT_MAX_CONSECUTIVE_API_ERRORS = 5
 
 
 CONTINUATION_PROMPT_TEMPLATE = (
@@ -153,6 +160,7 @@ class GoalState:
     last_reason: Optional[str] = None
     paused_reason: Optional[str] = None       # why we auto-paused (budget, etc.)
     consecutive_parse_failures: int = 0       # judge-output parse failures in a row
+    consecutive_api_errors: int = 0          # judge API/transport errors in a row
     # User-added criteria appended mid-loop via the /subgoal command.
     # When non-empty the judge prompt and continuation prompt both
     # include them so the agent works toward them and the judge factors
@@ -181,6 +189,7 @@ class GoalState:
             last_reason=data.get("last_reason"),
             paused_reason=data.get("paused_reason"),
             consecutive_parse_failures=int(data.get("consecutive_parse_failures", 0) or 0),
+            consecutive_api_errors=int(data.get("consecutive_api_errors", 0) or 0),
             subgoals=subgoals,
         )
 
@@ -374,47 +383,50 @@ def judge_goal(
     *,
     timeout: float = DEFAULT_JUDGE_TIMEOUT,
     subgoals: Optional[List[str]] = None,
-) -> Tuple[str, str, bool]:
+) -> Tuple[str, str, bool, bool]:
     """Ask the auxiliary model whether the goal is satisfied.
 
-    Returns ``(verdict, reason, parse_failed)`` where verdict is ``"done"``,
-    ``"continue"``, or ``"skipped"`` (when the judge couldn't be reached).
+    Returns ``(verdict, reason, parse_failed, api_error)`` where verdict is
+    ``"done"``, ``"continue"``, or ``"skipped"`` (when the judge couldn't be
+    reached).
 
     ``parse_failed`` is True only when the judge call succeeded but its output
-    was unusable (empty or non-JSON). API/transport errors return False — they
-    are transient and should fail-open silently. Callers use this flag to
-    auto-pause after N consecutive parse failures (see
-    ``DEFAULT_MAX_CONSECUTIVE_PARSE_FAILURES``).
+    was unusable (empty or non-JSON). API/transport errors return False.
+
+    ``api_error`` is True when the judge call itself failed (network timeout,
+    429, provider outage, etc.). Callers use this flag to auto-pause after N
+    consecutive API errors (see ``DEFAULT_MAX_CONSECUTIVE_API_ERRORS``).
 
     ``subgoals`` is an optional list of user-added criteria (from
     ``/subgoal``) that the judge must also factor into its DONE/CONTINUE
     decision. When non-empty the prompt switches to the with-subgoals
     template; otherwise behavior is identical to the original judge.
 
-    This is deliberately fail-open: any error returns ``("continue", "...", False)``
-    so a broken judge doesn't wedge progress — the turn budget and the
-    consecutive-parse-failures auto-pause are the backstops.
+    This is deliberately fail-open: any error returns
+    ``("continue", "...", False, True)`` so a broken judge doesn't wedge
+    progress — the turn budget, consecutive-parse-failures, and
+    consecutive-api-errors auto-pauses are the backstops.
     """
     if not goal.strip():
-        return "skipped", "empty goal", False
+        return "skipped", "empty goal", False, False
     if not last_response.strip():
         # No substantive reply this turn — almost certainly not done yet.
-        return "continue", "empty response (nothing to evaluate)", False
+        return "continue", "empty response (nothing to evaluate)", False, False
 
     try:
         from agent.auxiliary_client import get_auxiliary_extra_body, get_text_auxiliary_client
     except Exception as exc:
         logger.debug("goal judge: auxiliary client import failed: %s", exc)
-        return "continue", "auxiliary client unavailable", False
+        return "continue", "auxiliary client unavailable", False, True
 
     try:
         client, model = get_text_auxiliary_client("goal_judge")
     except Exception as exc:
         logger.debug("goal judge: get_text_auxiliary_client failed: %s", exc)
-        return "continue", "auxiliary client unavailable", False
+        return "continue", "auxiliary client unavailable", False, True
 
     if client is None or not model:
-        return "continue", "no auxiliary client configured", False
+        return "continue", "no auxiliary client configured", False, True
 
     # Build the prompt — pick the with-subgoals variant when applicable.
     clean_subgoals = [s.strip() for s in (subgoals or []) if s and s.strip()]
@@ -450,7 +462,7 @@ def judge_goal(
         )
     except Exception as exc:
         logger.info("goal judge: API call failed (%s) — falling through to continue", exc)
-        return "continue", f"judge error: {type(exc).__name__}", False
+        return "continue", f"judge error: {type(exc).__name__}", False, True
 
     try:
         raw = resp.choices[0].message.content or ""
@@ -460,7 +472,7 @@ def judge_goal(
     done, reason, parse_failed = _parse_judge_response(raw)
     verdict = "done" if done else "continue"
     logger.info("goal judge: verdict=%s reason=%s", verdict, _truncate(reason, 120))
-    return verdict, reason, parse_failed
+    return verdict, reason, parse_failed, False
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -652,7 +664,7 @@ class GoalManager:
         state.turns_used += 1
         state.last_turn_at = time.time()
 
-        verdict, reason, parse_failed = judge_goal(
+        verdict, reason, parse_failed, api_error = judge_goal(
             state.goal, last_response, subgoals=state.subgoals or None
         )
         state.last_verdict = verdict
@@ -665,6 +677,15 @@ class GoalManager:
             state.consecutive_parse_failures += 1
         else:
             state.consecutive_parse_failures = 0
+
+        # Track consecutive judge API/transport errors. Reset when the judge
+        # call succeeds (api_error=False). This prevents the spam described
+        # in #27585 where a broken judge keeps returning "continue" on every
+        # API error, causing the agent to repeat its terminal response.
+        if api_error:
+            state.consecutive_api_errors += 1
+        else:
+            state.consecutive_api_errors = 0
 
         if verdict == "done":
             state.status = "done"
@@ -705,6 +726,30 @@ class GoalManager:
                     "      provider: openrouter\n"
                     "      model: google/gemini-3-flash-preview\n"
                     "Then /goal resume to continue."
+                ),
+            }
+
+        # Auto-pause when the judge API is unreachable N turns in a row.
+        # This prevents the spam loop described in #27585: the agent has
+        # already produced a terminal response but the judge API keeps
+        # failing, so the loop keeps queuing continuation prompts.
+        if state.consecutive_api_errors >= DEFAULT_MAX_CONSECUTIVE_API_ERRORS:
+            state.status = "paused"
+            state.paused_reason = (
+                f"judge API unreachable {state.consecutive_api_errors} turns in a row"
+            )
+            save_goal(self.session_id, state)
+            return {
+                "status": "paused",
+                "should_continue": False,
+                "continuation_prompt": None,
+                "verdict": "continue",
+                "reason": reason,
+                "message": (
+                    f"⏸ Goal paused — the judge API has been unreachable for "
+                    f"{state.consecutive_api_errors} turns ({reason}). "
+                    "Check your auxiliary goal_judge config in ~/.hermes/config.yaml "
+                    "and run /goal resume when the provider is back."
                 ),
             }
 

--- a/tests/cli/test_cli_goal_interrupt.py
+++ b/tests/cli/test_cli_goal_interrupt.py
@@ -170,7 +170,7 @@ class TestHealthyTurnStillRuns:
         # Force the judge to say "continue" without touching the network.
         with patch(
             "hermes_cli.goals.judge_goal",
-            return_value=("continue", "needs more steps", False),
+            return_value=("continue", "needs more steps", False, False),
         ):
             cli._maybe_continue_goal_after_turn()
 
@@ -190,7 +190,7 @@ class TestHealthyTurnStillRuns:
 
         with patch(
             "hermes_cli.goals.judge_goal",
-            return_value=("done", "goal satisfied", False),
+            return_value=("done", "goal satisfied", False, False),
         ):
             cli._maybe_continue_goal_after_turn()
 

--- a/tests/gateway/test_goal_verdict_send.py
+++ b/tests/gateway/test_goal_verdict_send.py
@@ -107,7 +107,7 @@ async def test_goal_verdict_done_sent_via_adapter_send(hermes_home):
     mgr = GoalManager(session_entry.session_id)
     mgr.set("ship the feature")
 
-    with patch("hermes_cli.goals.judge_goal", return_value=("done", "the feature shipped", False)):
+    with patch("hermes_cli.goals.judge_goal", return_value=("done", "the feature shipped", False, False)):
         await runner._post_turn_goal_continuation(
             session_entry=session_entry,
             source=src,
@@ -136,7 +136,7 @@ async def test_goal_verdict_continue_enqueues_continuation(hermes_home):
     mgr = GoalManager(session_entry.session_id)
     mgr.set("polish the docs")
 
-    with patch("hermes_cli.goals.judge_goal", return_value=("continue", "still needs work", False)):
+    with patch("hermes_cli.goals.judge_goal", return_value=("continue", "still needs work", False, False)):
         await runner._post_turn_goal_continuation(
             session_entry=session_entry,
             source=src,
@@ -164,7 +164,7 @@ async def test_goal_verdict_budget_exhausted_sends_pause(hermes_home):
     state.turns_used = 2
     save_goal(session_entry.session_id, state)
 
-    with patch("hermes_cli.goals.judge_goal", return_value=("continue", "keep going", False)):
+    with patch("hermes_cli.goals.judge_goal", return_value=("continue", "keep going", False, False)):
         await runner._post_turn_goal_continuation(
             session_entry=session_entry,
             source=src,
@@ -211,7 +211,7 @@ async def test_goal_verdict_survives_adapter_without_send(hermes_home):
 
     runner.adapters[Platform.TELEGRAM] = _NoSendAdapter()
 
-    with patch("hermes_cli.goals.judge_goal", return_value=("done", "ok", False)):
+    with patch("hermes_cli.goals.judge_goal", return_value=("done", "ok", False, False)):
         # must not raise
         await runner._post_turn_goal_continuation(
             session_entry=session_entry,

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -103,13 +103,13 @@ class TestJudgeGoal:
     def test_empty_goal_skipped(self):
         from hermes_cli.goals import judge_goal
 
-        verdict, _, _ = judge_goal("", "some response")
+        verdict, _, _, _ = judge_goal("", "some response")
         assert verdict == "skipped"
 
     def test_empty_response_continues(self):
         from hermes_cli.goals import judge_goal
 
-        verdict, _, _ = judge_goal("ship the thing", "")
+        verdict, _, _, _ = judge_goal("ship the thing", "")
         assert verdict == "continue"
 
     def test_no_aux_client_continues(self):
@@ -120,7 +120,7 @@ class TestJudgeGoal:
             "agent.auxiliary_client.get_text_auxiliary_client",
             return_value=(None, None),
         ):
-            verdict, _, _ = goals.judge_goal("my goal", "my response")
+            verdict, _, _, _ = goals.judge_goal("my goal", "my response")
         assert verdict == "continue"
 
     def test_api_error_continues(self):
@@ -133,9 +133,10 @@ class TestJudgeGoal:
             "agent.auxiliary_client.get_text_auxiliary_client",
             return_value=(fake_client, "judge-model"),
         ):
-            verdict, reason, _ = goals.judge_goal("goal", "response")
+            verdict, reason, _, api_error = goals.judge_goal("goal", "response")
         assert verdict == "continue"
         assert "judge error" in reason.lower()
+        assert api_error is True
 
     def test_judge_says_done(self):
         from hermes_cli import goals
@@ -152,9 +153,10 @@ class TestJudgeGoal:
             "agent.auxiliary_client.get_text_auxiliary_client",
             return_value=(fake_client, "judge-model"),
         ):
-            verdict, reason, _ = goals.judge_goal("goal", "agent response")
+            verdict, reason, _, api_error = goals.judge_goal("goal", "agent response")
         assert verdict == "done"
         assert reason == "achieved"
+        assert api_error is False
 
     def test_judge_says_continue(self):
         from hermes_cli import goals
@@ -171,7 +173,7 @@ class TestJudgeGoal:
             "agent.auxiliary_client.get_text_auxiliary_client",
             return_value=(fake_client, "judge-model"),
         ):
-            verdict, reason, _ = goals.judge_goal("goal", "agent response")
+            verdict, reason, _, _ = goals.judge_goal("goal", "agent response")
         assert verdict == "continue"
         assert reason == "not yet"
 
@@ -260,7 +262,7 @@ class TestGoalManager:
         mgr = GoalManager(session_id="eval-sid-1")
         mgr.set("ship it")
 
-        with patch.object(goals, "judge_goal", return_value=("done", "shipped", False)):
+        with patch.object(goals, "judge_goal", return_value=("done", "shipped", False, False)):
             decision = mgr.evaluate_after_turn("I shipped the feature.")
 
         assert decision["verdict"] == "done"
@@ -276,7 +278,7 @@ class TestGoalManager:
         mgr = GoalManager(session_id="eval-sid-2", default_max_turns=5)
         mgr.set("a long goal")
 
-        with patch.object(goals, "judge_goal", return_value=("continue", "more work", False)):
+        with patch.object(goals, "judge_goal", return_value=("continue", "more work", False, False)):
             decision = mgr.evaluate_after_turn("made some progress")
 
         assert decision["verdict"] == "continue"
@@ -294,7 +296,7 @@ class TestGoalManager:
         mgr = GoalManager(session_id="eval-sid-3", default_max_turns=2)
         mgr.set("hard goal")
 
-        with patch.object(goals, "judge_goal", return_value=("continue", "not yet", False)):
+        with patch.object(goals, "judge_goal", return_value=("continue", "not yet", False, False)):
             d1 = mgr.evaluate_after_turn("step 1")
             assert d1["should_continue"] is True
             assert mgr.state.turns_used == 1
@@ -405,9 +407,10 @@ class TestJudgeParseFailureAutoPause:
             "agent.auxiliary_client.get_text_auxiliary_client",
             return_value=(fake_client, "judge-model"),
         ):
-            verdict, _, parse_failed = goals.judge_goal("goal", "response")
+            verdict, _, parse_failed, api_error = goals.judge_goal("goal", "response")
         assert verdict == "continue"
         assert parse_failed is False
+        assert api_error is True
 
     def test_empty_judge_reply_flagged_as_parse_failure(self):
         """End-to-end: judge returns empty content → parse_failed=True."""
@@ -421,9 +424,10 @@ class TestJudgeParseFailureAutoPause:
             "agent.auxiliary_client.get_text_auxiliary_client",
             return_value=(fake_client, "judge-model"),
         ):
-            verdict, _, parse_failed = goals.judge_goal("goal", "response")
+            verdict, _, parse_failed, api_error = goals.judge_goal("goal", "response")
         assert verdict == "continue"
         assert parse_failed is True
+        assert api_error is False
 
     def test_auto_pause_after_three_consecutive_parse_failures(self, hermes_home):
         """N=3 consecutive parse failures → auto-pause with config pointer."""
@@ -435,7 +439,7 @@ class TestJudgeParseFailureAutoPause:
         mgr.set("do a thing")
 
         with patch.object(
-            goals, "judge_goal", return_value=("continue", "judge returned empty response", True)
+            goals, "judge_goal", return_value=("continue", "judge returned empty response", True, False)
         ):
             d1 = mgr.evaluate_after_turn("step 1")
             assert d1["should_continue"] is True
@@ -464,7 +468,7 @@ class TestJudgeParseFailureAutoPause:
 
         # Two parse failures…
         with patch.object(
-            goals, "judge_goal", return_value=("continue", "not json", True)
+            goals, "judge_goal", return_value=("continue", "not json", True, False)
         ):
             mgr.evaluate_after_turn("step 1")
             mgr.evaluate_after_turn("step 2")
@@ -472,27 +476,34 @@ class TestJudgeParseFailureAutoPause:
 
         # …then one clean reply resets the counter.
         with patch.object(
-            goals, "judge_goal", return_value=("continue", "making progress", False)
+            goals, "judge_goal", return_value=("continue", "making progress", False, False)
         ):
             d = mgr.evaluate_after_turn("step 3")
             assert d["should_continue"] is True
             assert mgr.state.consecutive_parse_failures == 0
 
     def test_parse_failure_counter_not_incremented_by_api_errors(self, hermes_home):
-        """API/transport errors must NOT count toward the auto-pause threshold."""
+        """API/transport errors must NOT count toward the parse-failure auto-pause
+        threshold — they have their own counter (consecutive_api_errors)."""
         from hermes_cli import goals
-        from hermes_cli.goals import GoalManager
+        from hermes_cli.goals import GoalManager, DEFAULT_MAX_CONSECUTIVE_API_ERRORS
 
         mgr = GoalManager(session_id="parse-fail-sid-3", default_max_turns=20)
         mgr.set("goal")
 
+        # Use fewer turns than DEFAULT_MAX_CONSECUTIVE_API_ERRORS so the
+        # new API error auto-pause doesn't kick in during this test.
+        turns = DEFAULT_MAX_CONSECUTIVE_API_ERRORS - 1
         with patch.object(
-            goals, "judge_goal", return_value=("continue", "judge error: RuntimeError", False)
+            goals, "judge_goal", return_value=("continue", "judge error: RuntimeError", False, True)
         ):
-            for _ in range(5):
+            for _ in range(turns):
                 d = mgr.evaluate_after_turn("still going")
                 assert d["should_continue"] is True
+            # Parse failure counter stays at 0 (API errors don't count).
             assert mgr.state.consecutive_parse_failures == 0
+            # But the API error counter does increment.
+            assert mgr.state.consecutive_api_errors == turns
             assert mgr.state.status == "active"
 
     def test_consecutive_parse_failures_persists_across_goalmanager_reloads(
@@ -506,7 +517,7 @@ class TestJudgeParseFailureAutoPause:
         mgr.set("persistent goal")
 
         with patch.object(
-            goals, "judge_goal", return_value=("continue", "empty", True)
+            goals, "judge_goal", return_value=("continue", "empty", True, False)
         ):
             mgr.evaluate_after_turn("r")
             mgr.evaluate_after_turn("r")
@@ -514,6 +525,85 @@ class TestJudgeParseFailureAutoPause:
         reloaded = load_goal("parse-fail-sid-4")
         assert reloaded is not None
         assert reloaded.consecutive_parse_failures == 2
+
+    def test_auto_pause_after_consecutive_api_errors(self, hermes_home):
+        """N consecutive judge API errors → auto-pause (fixes #27585 spam)."""
+        from hermes_cli import goals
+        from hermes_cli.goals import GoalManager, DEFAULT_MAX_CONSECUTIVE_API_ERRORS
+
+        assert DEFAULT_MAX_CONSECUTIVE_API_ERRORS == 5
+        mgr = GoalManager(session_id="api-error-sid-1", default_max_turns=20)
+        mgr.set("ship the feature")
+
+        # Simulate 5 consecutive API errors (e.g. provider outage).
+        with patch.object(
+            goals, "judge_goal",
+            return_value=("continue", "judge error: ConnectionError", False, True),
+        ):
+            for i in range(DEFAULT_MAX_CONSECUTIVE_API_ERRORS - 1):
+                d = mgr.evaluate_after_turn(f"step {i + 1}")
+                assert d["should_continue"] is True, f"turn {i + 1} should continue"
+                assert mgr.state.consecutive_api_errors == i + 1
+
+            # The N-th error triggers auto-pause.
+            d_final = mgr.evaluate_after_turn("step 5")
+            assert d_final["should_continue"] is False
+            assert d_final["status"] == "paused"
+            assert mgr.state.consecutive_api_errors == DEFAULT_MAX_CONSECUTIVE_API_ERRORS
+            assert "unreachable" in d_final["message"].lower()
+
+    def test_api_error_counter_resets_on_good_reply(self, hermes_home):
+        """A single successful judge call resets the API error counter."""
+        from hermes_cli import goals
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="api-error-sid-2", default_max_turns=20)
+        mgr.set("build the thing")
+
+        # 3 API errors…
+        with patch.object(
+            goals, "judge_goal",
+            return_value=("continue", "judge error: TimeoutError", False, True),
+        ):
+            for _ in range(3):
+                mgr.evaluate_after_turn("step")
+            assert mgr.state.consecutive_api_errors == 3
+
+        # …then one clean reply resets the counter.
+        with patch.object(
+            goals, "judge_goal",
+            return_value=("continue", "making progress", False, False),
+        ):
+            d = mgr.evaluate_after_turn("step 4")
+            assert d["should_continue"] is True
+            assert mgr.state.consecutive_api_errors == 0
+
+    def test_api_error_counter_independent_of_parse_failure_counter(self, hermes_home):
+        """API errors and parse failures track independently."""
+        from hermes_cli import goals
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="api-error-sid-3", default_max_turns=20)
+        mgr.set("mixed errors")
+
+        # 1 parse failure + 1 API error — neither counter should reset the other.
+        with patch.object(
+            goals, "judge_goal",
+            return_value=("continue", "bad json", True, False),
+        ):
+            mgr.evaluate_after_turn("step 1")
+            assert mgr.state.consecutive_parse_failures == 1
+            assert mgr.state.consecutive_api_errors == 0
+
+        with patch.object(
+            goals, "judge_goal",
+            return_value=("continue", "connection lost", False, True),
+        ):
+            mgr.evaluate_after_turn("step 2")
+            # Parse failure counter resets (parse_failed=False), but that's
+            # expected — it tracks parse failures only.
+            assert mgr.state.consecutive_parse_failures == 0
+            assert mgr.state.consecutive_api_errors == 1
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -674,7 +764,7 @@ class TestJudgeGoalWithSubgoals:
                    return_value=(_FakeClient, "fake-model")), \
              patch("agent.auxiliary_client.get_auxiliary_extra_body",
                    return_value=None):
-            verdict, reason, parse_failed = goals.judge_goal(
+            verdict, reason, parse_failed, _ = goals.judge_goal(
                 "ship the feature",
                 "ok shipped",
                 subgoals=["write tests", "update docs"],


### PR DESCRIPTION
## Summary

Fixes #27585 — the `/goal` loop can spam repeated completion messages when the goal judge API is unreachable.

### Root Cause

`judge_goal()` returns `("continue", ..., parse_failed=False)` on API/transport errors. `evaluate_after_turn()` only tracked consecutive **parse** failures for auto-pause — API errors reset the parse counter to 0, so a persistent outage caused infinite continuation loops.

### Fix

Mirror the existing `consecutive_parse_failures` pattern for API errors:

1. **`judge_goal()` returns 4-tuple** — new `api_error` flag distinguishes API failures from parse failures
2. **`GoalState.consecutive_api_errors`** — persisted counter (backward-compatible via `from_json` default)
3. **`DEFAULT_MAX_CONSECUTIVE_API_ERRORS = 5`** — auto-pause threshold, same structure as parse failure guard
4. **Auto-pause message** — directs user to check auxiliary `goal_judge` config

### Testing

53/53 tests pass, including 3 new tests covering API error auto-pause, counter reset, and independence from parse failure counter.

### Relationship to PR #27752

PR #27752 (briandevans) takes a different approach: detecting terminal response content in the agent output. This PR addresses the general case — **any** consecutive API error triggers auto-pause regardless of response content. The approaches are complementary.