### PR TITLE
fix(title-gen): use extract_content_or_reasoning for reasoning models

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -8,7 +8,7 @@ import logging
 import threading
 from typing import Callable, Optional
 
-from agent.auxiliary_client import call_llm
+from agent.auxiliary_client import call_llm, extract_content_or_reasoning
 
 logger = logging.getLogger(__name__)
 
@@ -87,7 +87,7 @@ def generate_title(
             timeout=timeout,
             main_runtime=main_runtime,
         )
-        title = (response.choices[0].message.content or "").strip()
+        title = extract_content_or_reasoning(response).strip()
         # Clean up: remove quotes, trailing punctuation, prefixes like "Title: "
         title = title.strip('"\'')
         if title.lower().startswith("title:"):

--- a/tests/agent/test_title_generator_reasoning.py
+++ b/tests/agent/test_title_generator_reasoning.py
@@ -1,0 +1,63 @@
+"""Regression test for title generation with reasoning models.
+
+Reasoning models (Qwen3.6, DeepSeek-R1, etc.) return ``content=None``
+with the actual output in ``reasoning_content``. The title generator
+used to read ``.content`` directly, so every session backed by a
+reasoning model stayed untitled. It now routes through
+``extract_content_or_reasoning`` which falls back to the structured
+reasoning fields. See agent/title_generator.py (generate_title).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from agent.title_generator import generate_title
+
+
+def _response(content=None, reasoning_content=None, reasoning=None):
+    msg = SimpleNamespace(
+        content=content,
+        reasoning_content=reasoning_content,
+        reasoning=reasoning,
+    )
+    return SimpleNamespace(choices=[SimpleNamespace(message=msg)])
+
+
+def test_title_from_reasoning_content_when_content_null():
+    """content=None + reasoning_content set → title comes from reasoning."""
+    resp = _response(content=None, reasoning_content="Database Migration Plan")
+    with patch("agent.title_generator.call_llm", return_value=resp):
+        title = generate_title("migrate the db", "here's the plan")
+    assert title == "Database Migration Plan"
+
+
+def test_title_from_content_when_present():
+    """Plain content path is unaffected by the fix."""
+    resp = _response(content="Weekend Trip Ideas")
+    with patch("agent.title_generator.call_llm", return_value=resp):
+        title = generate_title("trip?", "some ideas")
+    assert title == "Weekend Trip Ideas"
+
+
+def test_title_cleanup_runs_on_reasoning_sourced_text():
+    """The existing cleanup (Title: prefix; surrounding quotes) still runs
+    on text sourced from reasoning_content, not just from content."""
+    # Quote stripping on a quoted reasoning title.
+    resp = _response(content=None, reasoning_content='"Quarterly Report"')
+    with patch("agent.title_generator.call_llm", return_value=resp):
+        assert generate_title("q report", "done") == "Quarterly Report"
+
+    # "Title:" prefix stripping on a reasoning title.
+    resp2 = _response(content=None, reasoning_content="Title: Sprint Planning")
+    with patch("agent.title_generator.call_llm", return_value=resp2):
+        assert generate_title("plan", "done") == "Sprint Planning"
+
+
+def test_no_title_when_both_empty():
+    """content=None and no reasoning → no title (falls back to None/empty)."""
+    resp = _response(content=None, reasoning_content=None)
+    with patch("agent.title_generator.call_llm", return_value=resp):
+        title = generate_title("hi", "hello")
+    assert not title


### PR DESCRIPTION
## Problem

Title generation silently fails for reasoning models (Qwen3.6, DeepSeek-R1, etc.) because these models return `content=null` with output in `reasoning_content`. The title generator reads `message.content` directly, gets `None`, and silently drops the title.

Result: **3,720 of 3,751 sessions untitled** (99.9% failure rate) for users on reasoning models.

## Fix

Use the existing `extract_content_or_reasoning()` helper from `auxiliary_client` which already handles both `content` and `reasoning_content` fields. Two-line change:

1. Import `extract_content_or_reasoning` from `auxiliary_client`
2. Replace `response.choices[0].message.content` with `extract_content_or_reasoning(response)`

## Why this exists

`extract_content_or_reasoning()` was added to handle exactly this case for reasoning models but was never wired into the title generator. The helper checks `content` first, then falls back to `reasoning_content` / `reasoning_details`.

## Testing

Manual test against Airrouter + Qwen3.6:
- Before: `content=null`, title silently dropped
- After: `extract_content_or_reasoning()` returns the reasoning output as the title text