### PR TITLE
fix(codex-runtime): preserve full-access permissions across re-migration (#27616)

### DIFF
--- a/hermes_cli/codex_runtime_plugin_migration.py
+++ b/hermes_cli/codex_runtime_plugin_migration.py
@@ -68,6 +68,7 @@ class MigrationReport:
     errors: list[str] = field(default_factory=list)
     written: bool = False
     dry_run: bool = False
+    preserved_permissions: Optional[dict[str, str]] = None
 
     def summary(self) -> str:
         lines = []
@@ -97,6 +98,11 @@ class MigrationReport:
             lines.append(
                 f"Wrote default_permissions = "
                 f"{self.wrote_permissions_default!r}"
+            )
+        if self.preserved_permissions:
+            lines.append(
+                f"Preserved existing full-access permissions: "
+                f"{self.preserved_permissions}"
             )
         for err in self.errors:
             lines.append(f"⚠ {err}")
@@ -447,6 +453,36 @@ def _strip_existing_managed_block(toml_text: str) -> str:
     return "".join(out)
 
 
+def _extract_existing_permissions(toml_text: str) -> dict[str, str]:
+    """Extract top-level permission keys from existing Codex config.
+
+    Scans for ``default_permissions``, ``sandbox_mode``, and
+    ``approval_policy`` keys that appear at the top level (before any
+    ``[table]`` header). Returns a dict of found keys and their values
+    (strings, with surrounding quotes stripped).
+
+    This is used by :func:`migrate_codex_runtime` to preserve a user's
+    full-access settings across re-migration instead of overwriting them
+    with the default ``:workspace`` profile.  See #27616.
+    """
+    result: dict[str, str] = {}
+    permission_keys = {"default_permissions", "sandbox_mode", "approval_policy"}
+    for line in toml_text.splitlines():
+        stripped = line.lstrip()
+        # Stop at first table header — keys after that belong to a table.
+        if _looks_like_table_header(stripped):
+            break
+        if "=" not in stripped:
+            continue
+        key, _, value = stripped.partition("=")
+        key = key.strip()
+        if key in permission_keys:
+            # Strip surrounding quotes and whitespace.
+            value = value.strip().strip('"').strip("'")
+            result[key] = value
+    return result
+
+
 def _query_codex_plugins(
     codex_home: Optional[Path] = None,
     timeout: float = 8.0,
@@ -682,11 +718,6 @@ def migrate(
         for p in plugins:
             report.migrated_plugins.append(f"{p['name']}@{p['marketplace']}")
 
-    # Track whether we wrote a default permission profile so the report
-    # surfaces it to the user.
-    if default_permission_profile:
-        report.wrote_permissions_default = default_permission_profile
-
     # Inject Hermes' own tool surface as an MCP server so the spawned
     # codex subprocess can call back into Hermes for the tools codex
     # doesn't ship with — web_search, browser_*, delegate_task, vision,
@@ -698,7 +729,41 @@ def migrate(
         if "hermes-tools" not in report.migrated:
             report.migrated.append("hermes-tools")
 
-    # Build the new managed block
+    # Build the new managed block.
+    #
+    # Before generating it, check whether the user has already set
+    # full-access permissions in their existing Codex config.  If so,
+    # preserve those instead of overwriting with the default
+    # ``:workspace`` profile.  This prevents the footgun described in
+    # #27616 where a re-migration silently downgrades Codex from
+    # full-access to workspace-write.
+    existing_text: Optional[str] = None
+    if target.exists():
+        try:
+            existing_text = target.read_text(encoding="utf-8")
+        except Exception as exc:
+            report.errors.append(f"could not read {target}: {exc}")
+            return report
+
+    if existing_text is not None:
+        existing_perms = _extract_existing_permissions(existing_text)
+        # Preserve an explicit full-access or no-sandbox setting.
+        _full_access_values = {
+            ":danger-no-sandbox",
+            "danger-full-access",
+            ":full-access",
+        }
+        dp = existing_perms.get("default_permissions", "")
+        if dp in _full_access_values:
+            default_permission_profile = dp
+            report.preserved_permissions = existing_perms
+
+    # Track whether we wrote a default permission profile so the report
+    # surfaces it to the user.  Must come after the preservation check
+    # above so the value reflects the actual (possibly preserved) profile.
+    if default_permission_profile:
+        report.wrote_permissions_default = default_permission_profile
+
     managed_block = render_codex_toml_section(
         translated, plugins=plugins,
         default_permission_profile=default_permission_profile,
@@ -706,13 +771,8 @@ def migrate(
 
     # Read existing codex config if any, strip the prior managed block,
     # append the new one.
-    if target.exists():
-        try:
-            existing = target.read_text(encoding="utf-8")
-        except Exception as exc:
-            report.errors.append(f"could not read {target}: {exc}")
-            return report
-        without_managed = _strip_existing_managed_block(existing)
+    if existing_text is not None:
+        without_managed = _strip_existing_managed_block(existing_text)
         # Bug B: when plugin/list ran authoritatively, codex's own
         # [plugins."<name>@<marketplace>"] tables outside our managed block
         # would survive _strip_existing_managed_block and then collide with

--- a/tests/hermes_cli/test_codex_runtime_plugin_migration.py
+++ b/tests/hermes_cli/test_codex_runtime_plugin_migration.py
@@ -308,6 +308,37 @@ class TestStripExistingManagedBlock:
         assert 'foo = "bar"' in out
 
 
+class TestExtractExistingPermissions:
+    """Unit tests for _extract_existing_permissions (#27616)."""
+
+    def test_extracts_top_level_permissions(self):
+        from hermes_cli.codex_runtime_plugin_migration import _extract_existing_permissions
+        text = 'default_permissions = ":danger-no-sandbox"\nsandbox_mode = "danger-full-access"\n'
+        result = _extract_existing_permissions(text)
+        assert result == {"default_permissions": ":danger-no-sandbox", "sandbox_mode": "danger-full-access"}
+
+    def test_stops_at_table_header(self):
+        from hermes_cli.codex_runtime_plugin_migration import _extract_existing_permissions
+        text = 'default_permissions = ":workspace"\n[features]\ndefault_permissions = ":danger-no-sandbox"\n'
+        result = _extract_existing_permissions(text)
+        assert result == {"default_permissions": ":workspace"}
+
+    def test_empty_config(self):
+        from hermes_cli.codex_runtime_plugin_migration import _extract_existing_permissions
+        assert _extract_existing_permissions("") == {}
+
+    def test_single_quoted_values(self):
+        from hermes_cli.codex_runtime_plugin_migration import _extract_existing_permissions
+        text = "default_permissions = ':danger-no-sandbox'\n"
+        result = _extract_existing_permissions(text)
+        assert result == {"default_permissions": ":danger-no-sandbox"}
+
+    def test_ignores_non_permission_keys(self):
+        from hermes_cli.codex_runtime_plugin_migration import _extract_existing_permissions
+        text = 'some_key = "value"\nother = 42\n'
+        assert _extract_existing_permissions(text) == {}
+
+
 # ---- end-to-end migrate(, expose_hermes_tools=False) ----
 
 class TestMigrate:
@@ -660,6 +691,56 @@ class TestMigrate:
         assert "Migrated 2 MCP server(s)" in summary
         assert "- a" in summary
         assert "- b" in summary
+
+    def test_preserves_existing_full_access_permissions(self, tmp_path):
+        """Regression test for #27616: re-migration should preserve an
+        existing ``default_permissions = ":danger-no-sandbox"`` instead of
+        overwriting it with the default ``:workspace``."""
+        # First migration with full-access
+        migrate({}, codex_home=tmp_path, discover_plugins=False,
+                default_permission_profile=":danger-no-sandbox",
+                expose_hermes_tools=False)
+        text = (tmp_path / "config.toml").read_text()
+        assert 'default_permissions = ":danger-no-sandbox"' in text
+
+        # Re-migration with default :workspace — should preserve full-access
+        report = migrate({}, codex_home=tmp_path, discover_plugins=False,
+                         default_permission_profile=":workspace",
+                         expose_hermes_tools=False)
+        text = (tmp_path / "config.toml").read_text()
+        assert 'default_permissions = ":danger-no-sandbox"' in text
+        assert report.preserved_permissions is not None
+        assert report.preserved_permissions.get("default_permissions") == ":danger-no-sandbox"
+        assert report.wrote_permissions_default == ":danger-no-sandbox"
+
+    def test_does_not_preserve_workspace_permissions(self, tmp_path):
+        """Only full-access values are preserved; workspace stays workspace."""
+        migrate({}, codex_home=tmp_path, discover_plugins=False,
+                default_permission_profile=":workspace",
+                expose_hermes_tools=False)
+
+        # Re-migration with default — nothing to preserve, stays :workspace
+        report = migrate({}, codex_home=tmp_path, discover_plugins=False,
+                         default_permission_profile=":workspace",
+                         expose_hermes_tools=False)
+        text = (tmp_path / "config.toml").read_text()
+        assert 'default_permissions = ":workspace"' in text
+        assert report.preserved_permissions is None
+
+    def test_full_access_preserved_even_when_caller_passes_read_only(self, tmp_path):
+        """Full-access permissions are always preserved, even if the caller
+        passes a different profile. Safety-first: we never downgrade."""
+        migrate({}, codex_home=tmp_path, discover_plugins=False,
+                default_permission_profile=":danger-no-sandbox",
+                expose_hermes_tools=False)
+
+        # Caller passes :read-only, but existing full-access is preserved
+        report = migrate({}, codex_home=tmp_path, discover_plugins=False,
+                         default_permission_profile=":read-only",
+                         expose_hermes_tools=False)
+        text = (tmp_path / "config.toml").read_text()
+        assert 'default_permissions = ":danger-no-sandbox"' in text
+        assert report.preserved_permissions is not None
 
 
 # ---- Bug B: duplicate [plugins.X] tables ----


### PR DESCRIPTION
## Summary

Fixes #27616 — codex-runtime re-migration silently downgrades user's full-access Codex permissions back to `:workspace`.

### Root Cause

`migrate_codex_runtime()` strips the entire old managed block (including the user's `default_permissions`) via `_strip_existing_managed_block()`, then rebuilds with the hardcoded default `:workspace` profile. Users who set `:danger-no-sandbox` / `danger-full-access` lose their setting on every migration pass.

### Fix

1. **`_extract_existing_permissions()`** — new function that reads top-level permission keys from existing config before stripping
2. **Preservation logic** — before building the new managed block, check for full-access values and preserve them
3. **`MigrationReport.preserved_permissions`** — new field surfaces preservation in summary output

### Testing

75/75 tests pass, including 5 new unit tests + 3 new integration tests for permission preservation behavior.