### PR TITLE
feat(feishu): render markdown tables as Feishu interactive card table elements

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -607,6 +607,171 @@ def _build_markdown_post_rows(content: str) -> List[List[Dict[str, str]]]:
     return rows or [[{"tag": "md", "text": content}]]
 
 
+# ---------------------------------------------------------------------------
+# Markdown table → Feishu interactive card helpers
+# ---------------------------------------------------------------------------
+
+_MARKDOWN_TABLE_LINE_RE = re.compile(r"^\|.*\|$")
+_FEISHU_CARD_MAX_SIZE = 30000  # bytes — Feishu interactive card content limit
+
+
+def _is_table_separator_row(line: str) -> bool:
+    """Check whether a line is a markdown table separator (e.g. |---|:---:|---|)."""
+    stripped = line.strip()
+    if stripped.startswith("|"):
+        stripped = stripped[1:]
+    if stripped.endswith("|"):
+        stripped = stripped[:-1]
+    cells = [c.strip() for c in stripped.split("|")]
+    return all(re.match(r"^:?-{3,}:?$", c) for c in cells if c)
+
+
+def _parse_table_row(line: str) -> list[str]:
+    """Split a single table row into cells, stripping leading/trailing pipes."""
+    line = line.strip()
+    if line.startswith("|"):
+        line = line[1:]
+    if line.endswith("|"):
+        line = line[:-1]
+    return [cell.strip() for cell in line.split("|")]
+
+
+def _pad_row(cells: list[str], target_len: int) -> list[str]:
+    """Pad a row to the given number of columns."""
+    return cells + [""] * (target_len - len(cells))
+
+
+def _parse_markdown_table(lines: list[str]) -> tuple[list[str], list[list[str]]] | None:
+    """Parse a markdown table from a list of lines.
+
+    Returns ``(headers, rows)`` or ``None`` if the input is not a valid table.
+    """
+    if len(lines) < 2:
+        return None
+    headers = _parse_table_row(lines[0])
+    if not headers:
+        return None
+    # Verify separator row
+    sep_cells = _parse_table_row(lines[1])
+    if not sep_cells:
+        return None
+    if not all(re.match(r"^:?-{3,}:?$", c) for c in sep_cells):
+        return None
+    data_rows = [_parse_table_row(line) for line in lines[2:]]
+    data_rows = [r for r in data_rows if r]
+    # Determine column count from the widest row
+    max_cols = max(
+        len(headers),
+        max((len(r) for r in data_rows), default=0),
+    )
+    headers = _pad_row(headers, max_cols)
+    rows = [_pad_row(r, max_cols) for r in data_rows]
+    return headers, rows
+
+
+def _split_content_by_tables(content: str) -> list[dict]:
+    """Split markdown content into alternating text and table segments.
+
+    Returns a list of dicts, each with ``"type"`` (``"text"`` or ``"table"``).
+    Text segments have ``"content"`` keys; table segments have ``"headers"``
+    and ``"rows"`` keys.
+    """
+    lines = content.split("\n")
+    segments: list[dict] = []
+    current_text_lines: list[str] = []
+    table_buffer: list[str] = []
+    i = 0
+    while i < len(lines):
+        stripped = lines[i].strip()
+        # Detect table start: line is a pipe row, followed by a separator row
+        if (
+            _MARKDOWN_TABLE_LINE_RE.match(stripped)
+            and i + 1 < len(lines)
+            and _is_table_separator_row(lines[i + 1])
+        ):
+            # Flush accumulated text
+            if current_text_lines:
+                segments.append(
+                    {"type": "text", "content": "\n".join(current_text_lines)}
+                )
+                current_text_lines = []
+            # Collect table lines
+            table_buffer.append(stripped)       # header
+            table_buffer.append(lines[i + 1].strip())  # separator
+            i += 2
+            while i < len(lines) and _MARKDOWN_TABLE_LINE_RE.match(lines[i].strip()):
+                table_buffer.append(lines[i].strip())
+                i += 1
+            # Parse table
+            parsed = _parse_markdown_table(table_buffer)
+            if parsed:
+                segments.append(
+                    {"type": "table", "headers": parsed[0], "rows": parsed[1]}
+                )
+            else:
+                # Not a valid table — treat as plain text
+                current_text_lines.extend(table_buffer)
+            table_buffer = []
+            continue
+        current_text_lines.append(lines[i])
+        i += 1
+    # Flush trailing text
+    if current_text_lines:
+        segments.append({"type": "text", "content": "\n".join(current_text_lines)})
+    return segments
+
+
+def _build_table_card_element(
+    headers: list[str], rows: list[list[str]]
+) -> dict:
+    """Build a Feishu card ``table`` element from parsed markdown table data.
+
+    Uses ``lark_md`` data type so inline markdown in cells is rendered.
+    """
+    _MAX_PAGE_SIZE = 50
+    _MIN_PAGE_SIZE = 10
+    return {
+        "tag": "table",
+        "columns": [
+            {"name": h, "data_type": "lark_md", "width": "auto"}
+            for h in headers
+        ],
+        "rows": [
+            [{"tag": "lark_md", "text": cell} for cell in row]
+            for row in rows
+        ],
+        "page_size": max(_MIN_PAGE_SIZE, min(_MAX_PAGE_SIZE, len(rows))),
+        "row_height": "low",
+    }
+
+
+def _build_interactive_table_card(content: str) -> str | None:
+    """Build a Feishu interactive card with native table rendering.
+
+    Returns the card JSON string, or ``None`` if the content has no markdown
+    tables or the resulting card exceeds Feishu size limits.
+    """
+    segments = _split_content_by_tables(content)
+    has_table = any(s["type"] == "table" for s in segments)
+    if not has_table:
+        return None
+    elements: list[dict] = []
+    for seg in segments:
+        if seg["type"] == "text":
+            text = seg["content"].strip()
+            if text:
+                elements.append({"tag": "markdown", "content": text})
+        elif seg["type"] == "table":
+            elements.append(
+                _build_table_card_element(seg["headers"], seg["rows"])
+            )
+    card = {"config": {"wide_screen_mode": True}, "elements": elements}
+    card_json = json.dumps(card, ensure_ascii=False)
+    if len(card_json.encode("utf-8")) > _FEISHU_CARD_MAX_SIZE:
+        return None
+    return card_json
+
+
 def parse_feishu_post_payload(
     payload: Any,
     *,
@@ -1781,9 +1946,32 @@ class FeishuAdapter(BasePlatformAdapter):
                         metadata=metadata,
                     )
                 except Exception as exc:
-                    if msg_type != "post" or not _POST_CONTENT_INVALID_RE.search(str(exc)):
+                    if msg_type == "post" and _POST_CONTENT_INVALID_RE.search(str(exc)):
+                        logger.warning("[Feishu] Invalid post payload rejected by API; falling back to plain text")
+                        response = await self._feishu_send_with_retry(
+                            chat_id=chat_id,
+                            msg_type="text",
+                            payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
+                            reply_to=reply_to,
+                            metadata=metadata,
+                        )
+                    elif msg_type == "interactive":
+                        logger.warning("[Feishu] Interactive card rejected; falling back to plain text")
+                        response = await self._feishu_send_with_retry(
+                            chat_id=chat_id,
+                            msg_type="text",
+                            payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
+                            reply_to=reply_to,
+                            metadata=metadata,
+                        )
+                    else:
                         raise
-                    logger.warning("[Feishu] Invalid post payload rejected by API; falling back to plain text")
+                if (
+                    msg_type == "post"
+                    and not self._response_succeeded(response)
+                    and _POST_CONTENT_INVALID_RE.search(str(getattr(response, "msg", "") or ""))
+                ):
+                    logger.warning("[Feishu] Post payload rejected by API response; falling back to plain text")
                     response = await self._feishu_send_with_retry(
                         chat_id=chat_id,
                         msg_type="text",
@@ -1791,12 +1979,11 @@ class FeishuAdapter(BasePlatformAdapter):
                         reply_to=reply_to,
                         metadata=metadata,
                     )
-                if (
-                    msg_type == "post"
+                elif (
+                    msg_type == "interactive"
                     and not self._response_succeeded(response)
-                    and _POST_CONTENT_INVALID_RE.search(str(getattr(response, "msg", "") or ""))
                 ):
-                    logger.warning("[Feishu] Post payload rejected by API response; falling back to plain text")
+                    logger.warning("[Feishu] Interactive card rejected by API response; falling back to plain text")
                     response = await self._feishu_send_with_retry(
                         chat_id=chat_id,
                         msg_type="text",
@@ -1830,8 +2017,12 @@ class FeishuAdapter(BasePlatformAdapter):
             request = self._build_update_message_request(message_id=message_id, request_body=body)
             response = await asyncio.to_thread(self._client.im.v1.message.update, request)
             result = self._finalize_send_result(response, "update failed")
-            if not result.success and msg_type == "post" and _POST_CONTENT_INVALID_RE.search(result.error or ""):
-                logger.warning("[Feishu] Invalid post update payload rejected by API; falling back to plain text")
+            if not result.success and (
+                (msg_type == "post" and _POST_CONTENT_INVALID_RE.search(result.error or ""))
+                or msg_type == "interactive"
+            ):
+                logger.warning("[Feishu] %s update payload rejected by API; falling back to plain text",
+                               msg_type)
                 fallback_body = self._build_update_message_body(
                     msg_type="text",
                     content=json.dumps({"text": _strip_markdown_to_plain_text(content)}, ensure_ascii=False),
@@ -4222,10 +4413,15 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
-        # Feishu post-type 'md' elements do not render markdown tables; sending
-        # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
+        # Feishu post-type 'md' elements do not render markdown tables;
+        # sending table content as post causes the message to appear blank
+        # on the client.  Convert markdown tables to Feishu interactive-card
+        # JSON 2.0 native ``table`` elements; fall back to plain text when the
+        # card exceeds API size limits or table parsing fails.
         if _MARKDOWN_TABLE_RE.search(content):
+            card_json = _build_interactive_table_card(content)
+            if card_json is not None:
+                return "interactive", card_json
             text_payload = {"text": content}
             return "text", json.dumps(text_payload, ensure_ascii=False)
         if _MARKDOWN_HINT_RE.search(content):

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2811,6 +2811,339 @@ class TestAdapterBehavior(unittest.TestCase):
         )
 
 
+class TestFeishuMarkdownTableCard(unittest.TestCase):
+    """Markdown table → Feishu interactive card conversion."""
+
+    def test_is_table_separator_row(self):
+        from gateway.platforms.feishu import _is_table_separator_row
+
+        self.assertTrue(_is_table_separator_row("|---|---|"))
+        self.assertTrue(_is_table_separator_row("|:---|:---:|---:|"))
+        self.assertTrue(_is_table_separator_row("| --- | --- |"))
+        self.assertFalse(_is_table_separator_row("| a | b |"))
+        self.assertFalse(_is_table_separator_row("hello"))
+
+    def test_parse_table_row(self):
+        from gateway.platforms.feishu import _parse_table_row
+
+        self.assertEqual(_parse_table_row("| a | b |"), ["a", "b"])
+        self.assertEqual(_parse_table_row("a | b"), ["a", "b"])
+        self.assertEqual(_parse_table_row("| a |"), ["a"])
+        self.assertEqual(_parse_table_row(""), [""])
+
+    def test_parse_markdown_table_basic(self):
+        from gateway.platforms.feishu import _parse_markdown_table
+
+        result = _parse_markdown_table([
+            "| Name | Age |",
+            "|------|-----|",
+            "| Alice | 30 |",
+            "| Bob   | 25 |",
+        ])
+        self.assertIsNotNone(result)
+        headers, rows = result  # type: ignore[misc]
+        self.assertEqual(headers, ["Name", "Age"])
+        self.assertEqual(rows, [["Alice", "30"], ["Bob", "25"]])
+
+    def test_parse_markdown_table_no_data_rows(self):
+        from gateway.platforms.feishu import _parse_markdown_table
+
+        result = _parse_markdown_table([
+            "| Col1 | Col2 |",
+            "|------|------|",
+        ])
+        self.assertIsNotNone(result)
+        headers, rows = result  # type: ignore[misc]
+        self.assertEqual(headers, ["Col1", "Col2"])
+        self.assertEqual(rows, [])
+
+    def test_parse_markdown_table_not_a_table(self):
+        from gateway.platforms.feishu import _parse_markdown_table
+
+        self.assertIsNone(_parse_markdown_table(["just a line"]))
+        self.assertIsNone(_parse_markdown_table([
+            "| a | b |",
+            "not a separator",
+        ]))
+
+    def test_split_content_by_tables_text_only(self):
+        from gateway.platforms.feishu import _split_content_by_tables
+
+        segments = _split_content_by_tables("Hello world")
+        self.assertEqual(len(segments), 1)
+        self.assertEqual(segments[0]["type"], "text")
+        self.assertEqual(segments[0]["content"], "Hello world")
+
+    def test_split_content_by_tables_table_only(self):
+        from gateway.platforms.feishu import _split_content_by_tables
+
+        segments = _split_content_by_tables(
+            "| A | B |\n|---|---|\n| 1 | 2 |"
+        )
+        self.assertEqual(len(segments), 1)
+        self.assertEqual(segments[0]["type"], "table")
+        self.assertEqual(segments[0]["headers"], ["A", "B"])
+        self.assertEqual(segments[0]["rows"], [["1", "2"]])
+
+    def test_split_content_by_tables_text_before_and_after(self):
+        from gateway.platforms.feishu import _split_content_by_tables
+
+        segments = _split_content_by_tables(
+            "Some text before.\n\n| A | B |\n|---|---|\n| 1 | 2 |\n\nAfter the table."
+        )
+        self.assertEqual(len(segments), 3)
+        self.assertEqual(segments[0]["type"], "text")
+        self.assertIn("Some text before", segments[0]["content"])
+        self.assertEqual(segments[1]["type"], "table")
+        self.assertEqual(segments[2]["type"], "text")
+        self.assertIn("After the table", segments[2]["content"])
+
+    def test_split_content_multiple_tables(self):
+        from gateway.platforms.feishu import _split_content_by_tables
+
+        segments = _split_content_by_tables(
+            "| A | B |\n|---|---|\n| 1 | 2 |\n\n| C | D |\n|---|---|\n| 3 | 4 |"
+        )
+        self.assertEqual(len(segments), 3)
+        self.assertEqual(segments[0]["type"], "table")
+        self.assertEqual(segments[1]["type"], "text")  # blank line between
+        self.assertEqual(segments[2]["type"], "table")
+
+    def test_build_interactive_table_card(self):
+        from gateway.platforms.feishu import _build_interactive_table_card
+
+        card_json = _build_interactive_table_card(
+            "| Name | Role |\n|------|------|\n| Alice | Admin |"
+        )
+        self.assertIsNotNone(card_json)
+        card = json.loads(card_json)  # type: ignore[arg-type]
+        self.assertEqual(card["config"]["wide_screen_mode"], True)
+        self.assertEqual(len(card["elements"]), 1)
+        table_el = card["elements"][0]
+        self.assertEqual(table_el["tag"], "table")
+        self.assertEqual(table_el["columns"][0]["name"], "Name")
+        self.assertEqual(table_el["columns"][1]["name"], "Role")
+        self.assertEqual(table_el["rows"][0][0]["text"], "Alice")
+        self.assertEqual(table_el["rows"][0][1]["text"], "Admin")
+
+    def test_build_interactive_table_card_no_table(self):
+        from gateway.platforms.feishu import _build_interactive_table_card
+
+        self.assertIsNone(_build_interactive_table_card("Just text, no table."))
+
+    def test_build_interactive_table_card_with_surrounding_text(self):
+        from gateway.platforms.feishu import _build_interactive_table_card
+
+        card_json = _build_interactive_table_card(
+            "Here is a summary:\n\n| Item | Qty |\n|------|-----|\n| Apple | 5 |\n\nEnd of summary."
+        )
+        self.assertIsNotNone(card_json)
+        card = json.loads(card_json)  # type: ignore[arg-type]
+        self.assertEqual(len(card["elements"]), 3)
+        self.assertEqual(card["elements"][0]["tag"], "markdown")
+        self.assertEqual(card["elements"][1]["tag"], "table")
+        self.assertEqual(card["elements"][2]["tag"], "markdown")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_build_outbound_payload_returns_interactive_for_table(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        msg_type, payload = adapter._build_outbound_payload(
+            "| A | B |\n|---|---|\n| 1 | 2 |"
+        )
+        self.assertEqual(msg_type, "interactive")
+        card = json.loads(payload)
+        self.assertIn("elements", card)
+        table_el = card["elements"][0]
+        self.assertEqual(table_el["tag"], "table")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_build_outbound_payload_still_uses_post_for_no_table(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        msg_type, _ = adapter._build_outbound_payload("**bold** and *italic*")
+        self.assertEqual(msg_type, "post")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_uses_interactive_for_markdown_table(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _MessageAPI:
+            def create(self, request):
+                captured["request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_table_card"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.send(
+                    chat_id="oc_chat",
+                    content="| Name | Score |\n|------|-------|\n| Jeff | 100 |",
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["request"].request_body.msg_type, "interactive")
+        card = json.loads(captured["request"].request_body.content)
+        table_el = card["elements"][0]
+        self.assertEqual(table_el["tag"], "table")
+        self.assertEqual(table_el["columns"][0]["name"], "Name")
+        self.assertEqual(table_el["columns"][1]["name"], "Score")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_interactive_fallback_to_text_on_api_error(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {"calls": []}
+
+        class _MessageAPI:
+            def create(self, request):
+                captured["calls"].append(request)
+                # Fail for interactive calls (before fallback to text)
+                if request.request_body.msg_type == "interactive":
+                    raise RuntimeError("interactive card rejected")
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_fallback"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.send(
+                    chat_id="oc_chat",
+                    content="| A | B |\n|---|---|\n| 1 | 2 |",
+                )
+            )
+
+        self.assertTrue(result.success)
+        # First call should be interactive; last call should be text after retry+
+        # fallback (retries happen inside _feishu_send_with_retry)
+        self.assertEqual(captured["calls"][0].request_body.msg_type, "interactive")
+        self.assertEqual(captured["calls"][-1].request_body.msg_type, "text")
+        text_content = json.loads(captured["calls"][-1].request_body.content)
+        self.assertIn("A", text_content["text"])
+        self.assertIn("B", text_content["text"])
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_interactive_fallback_to_text_on_api_failure_response(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {"calls": []}
+
+        class _MessageAPI:
+            def create(self, request):
+                captured["calls"].append(request)
+                if len(captured["calls"]) == 1:
+                    return SimpleNamespace(
+                        success=lambda: False,
+                        code=230001,
+                        msg="card content invalid",
+                    )
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_fallback_response"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.send(
+                    chat_id="oc_chat",
+                    content="| A | B |\n|---|---|\n| 1 | 2 |",
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["calls"][0].request_body.msg_type, "interactive")
+        self.assertEqual(captured["calls"][1].request_body.msg_type, "text")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_edit_message_uses_interactive_for_table(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _MessageAPI:
+            def update(self, request):
+                captured["request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.edit_message(
+                    chat_id="oc_chat",
+                    message_id="om_orig",
+                    content="| A | B |\n|---|---|\n| 1 | 2 |",
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["request"].request_body.msg_type, "interactive")
+        card = json.loads(captured["request"].request_body.content)
+        self.assertEqual(card["elements"][0]["tag"], "table")
+
+
 @unittest.skipUnless(_HAS_LARK_OAPI, "lark-oapi not installed")
 class TestHydrateBotIdentity(unittest.TestCase):
     """Hydration of bot identity via ``/open-apis/bot/v3/info``.


### PR DESCRIPTION
## Summary

Convert markdown tables in outbound Feishu messages to **interactive-card JSON 2.0 native `table` elements** instead of falling back to plain text.

## Problem

Feishu post-type `md` elements cannot render markdown tables — sending table content as post causes the message to appear **blank** on the client. The workaround was to force plain text for anything that looked like a markdown table (`_MARKDOWN_TABLE_RE`). This makes tables barely readable.

## Solution

When `_build_outbound_payload` detects a markdown table, it now:
1. Splits the content into alternating text/table segments
2. Parses each table into headers + data rows
3. Builds a Feishu interactive card with:
   - `markdown` elements for surrounding prose
   - `table` elements (with `lark_md` data type) for each detected table
4. Falls back to plain text if the card exceeds Feishu 30KB size limits

The card uses `wide_screen_mode: true` and `row_height: "low"` for compact rendering.

## Changes

### `gateway/platforms/feishu.py` (+207 / -11)
- **New functions** (lines 608–770): `_is_table_separator_row`, `_parse_table_row`, `_pad_row`, `_parse_markdown_table`, `_split_content_by_tables`, `_build_table_card_element`, `_build_interactive_table_card`
- **Modified** `_build_outbound_payload`: table detection now returns `("interactive", card_json)` instead of `("text", ...)`
- **Modified** `send()`: added interactive-card failure fallback (exception + response check)
- **Modified** `edit_message()`: added interactive-card failure fallback

### `tests/gateway/test_feishu.py` (+333)
- **18 new tests** in `TestFeishuMarkdownTableCard` covering:
  - Row/separator/table parsing
  - Content splitting (text-only, table-only, mixed, multiple tables)
  - Card JSON generation (single table, table + surrounding text, no table)
  - `_build_outbound_payload` integration (returns interactive for table, post for non-table)
  - Full `send()` integration (interactive card sends, API error fallback, response failure fallback)
  - `edit_message()` integration

## Verification

- ✅ All 216 tests pass (198 existing + 18 new)
- ✅ Zero regressions
- ✅ Backward compatible: no-table messages still use post/text routing

## Screenshots

Before: plain text table → barely readable
After: native Feishu card table with proper column alignment, inline markdown rendering