### PR TITLE
feat(state): make trigram FTS5 index optional

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -269,6 +269,17 @@ BROWSER_INACTIVITY_TIMEOUT=120
 # Contains full conversation history in trajectory format for debugging/replay
 
 # =============================================================================
+# SESSION DATABASE (state.db)
+# =============================================================================
+# Set HERMES_DISABLE_FTS_TRIGRAM=1 to skip creating the trigram FTS5 index on
+# fresh databases. The trigram index is only useful for CJK substring search
+# (3+ characters); on instances that never run such queries it typically
+# accounts for ~50% of state.db size. With this flag set, search_messages()
+# falls back to LIKE for CJK queries. Existing databases can be reclaimed
+# with SessionDB.drop_fts_trigram() — see issue #22478.
+# HERMES_DISABLE_FTS_TRIGRAM=0
+
+# =============================================================================
 # VOICE TRANSCRIPTION & OPENAI TTS
 # =============================================================================
 # Required for voice message transcription (Whisper) and OpenAI TTS voices.

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -16,6 +16,7 @@ Key design decisions:
 
 import json
 import logging
+import os
 import random
 import re
 import sqlite3
@@ -28,6 +29,27 @@ from hermes_constants import get_hermes_home
 from typing import Any, Callable, Dict, List, Optional, TypeVar
 
 logger = logging.getLogger(__name__)
+
+
+def _env_flag(name: str) -> bool:
+    """Return True when env var *name* is set to a truthy value.
+
+    Recognizes ``1``, ``true``, ``yes``, ``on`` (case-insensitive). Any
+    other value — including the env var being unset — returns False.
+    """
+    val = os.environ.get(name)
+    if val is None:
+        return False
+    return val.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _fts_trigram_disabled() -> bool:
+    """The trigram FTS5 index doubles state.db size to support CJK substring
+    search. Pure-English deployments don't need it. Setting
+    ``HERMES_DISABLE_FTS_TRIGRAM=1`` skips creating the index and falls back
+    to ``LIKE`` for CJK queries. See issue #22478.
+    """
+    return _env_flag("HERMES_DISABLE_FTS_TRIGRAM")
 
 T = TypeVar("T")
 
@@ -332,6 +354,9 @@ class SessionDB:
 
         self._lock = threading.Lock()
         self._write_count = 0
+        # Cached probe for the trigram FTS5 table — populated lazily by
+        # ``_has_fts_trigram()`` and invalidated by ``drop_fts_trigram()``.
+        self._fts_trigram_available: Optional[bool] = None
         try:
             self._conn = sqlite3.connect(
                 str(self.db_path),
@@ -441,6 +466,72 @@ class SessionDB:
                     )
         except Exception:
             pass  # Best effort — never fatal.
+
+    def _has_fts_trigram(self) -> bool:
+        """Whether the trigram FTS5 table is present in this database.
+
+        Cached after first probe.  Invalidated by ``drop_fts_trigram()``.
+        ``search_messages`` uses this to route CJK queries to LIKE when
+        the index has been opted out via ``HERMES_DISABLE_FTS_TRIGRAM=1``.
+        """
+        if self._fts_trigram_available is not None:
+            return self._fts_trigram_available
+        try:
+            with self._lock:
+                self._conn.execute(
+                    "SELECT 1 FROM messages_fts_trigram LIMIT 0"
+                )
+            self._fts_trigram_available = True
+        except sqlite3.OperationalError:
+            self._fts_trigram_available = False
+        return self._fts_trigram_available
+
+    def drop_fts_trigram(self) -> None:
+        """Drop the trigram FTS5 index and its triggers, then VACUUM.
+
+        Reclaims the ~half-of-state.db that the trigram index occupies on
+        instances that never run CJK substring searches. After this call,
+        ``search_messages`` falls back to LIKE for CJK queries with 3+
+        characters, exactly as it does when ``HERMES_DISABLE_FTS_TRIGRAM=1``
+        was set before the database was first created. Safe to call on a
+        database that has already had the index dropped — no-op in that
+        case. See issue #22478.
+        """
+        def _drop(conn: sqlite3.Connection) -> None:
+            for trig in (
+                "messages_fts_trigram_insert",
+                "messages_fts_trigram_delete",
+                "messages_fts_trigram_update",
+            ):
+                try:
+                    conn.execute(f"DROP TRIGGER IF EXISTS {trig}")
+                except sqlite3.OperationalError:
+                    pass
+            try:
+                conn.execute("DROP TABLE IF EXISTS messages_fts_trigram")
+            except sqlite3.OperationalError:
+                pass
+
+        self._execute_write(_drop)
+        self._fts_trigram_available = False
+        # VACUUM cannot run inside a transaction. Run on the bare
+        # connection without our BEGIN IMMEDIATE wrapper.
+        try:
+            with self._lock:
+                self._conn.execute("VACUUM")
+        except sqlite3.OperationalError as exc:
+            logger.debug("VACUUM after drop_fts_trigram failed: %s", exc)
+
+    def vacuum(self) -> None:
+        """Run SQLite ``VACUUM`` to reclaim free pages and defragment the
+        database file. Useful after large session deletions or after
+        ``drop_fts_trigram()``. Cannot run inside a transaction.
+        """
+        try:
+            with self._lock:
+                self._conn.execute("VACUUM")
+        except sqlite3.OperationalError as exc:
+            logger.debug("VACUUM failed: %s", exc)
 
     def close(self):
         """Close the database connection.
@@ -584,11 +675,14 @@ class SessionDB:
             # backfills, index changes tied to a specific version step) stay
             # in a version-gated chain. Column additions are handled by
             # _reconcile_columns() above and no longer need entries here.
-            if current_version < 10:
+            if current_version < 10 and not _fts_trigram_disabled():
                 # v10: trigram FTS5 table for CJK/substring search. The
                 # virtual table + triggers are created unconditionally via
                 # FTS_TRIGRAM_SQL below, but existing rows need a one-time
                 # backfill into the FTS index.
+                #
+                # When ``HERMES_DISABLE_FTS_TRIGRAM=1`` we skip the migration
+                # entirely; ``search_messages`` falls back to LIKE for CJK.
                 try:
                     cursor.execute("SELECT * FROM messages_fts_trigram LIMIT 0")
                     _fts_trigram_exists = True
@@ -607,14 +701,16 @@ class SessionDB:
                 # overwrite, so we drop them explicitly and let the post-migration
                 # existence checks (below) recreate them from FTS_SQL /
                 # FTS_TRIGRAM_SQL, then backfill every message row. Fixes #16751.
-                for _trig in (
+                _trigram_off = _fts_trigram_disabled()
+                _triggers_to_drop = [
                     "messages_fts_insert",
                     "messages_fts_delete",
                     "messages_fts_update",
                     "messages_fts_trigram_insert",
                     "messages_fts_trigram_delete",
                     "messages_fts_trigram_update",
-                ):
+                ]
+                for _trig in _triggers_to_drop:
                     try:
                         cursor.execute(f"DROP TRIGGER IF EXISTS {_trig}")
                     except sqlite3.OperationalError:
@@ -627,7 +723,6 @@ class SessionDB:
                 # Recreate virtual tables + triggers with the new inline-mode
                 # schema that indexes content || tool_name || tool_calls.
                 cursor.executescript(FTS_SQL)
-                cursor.executescript(FTS_TRIGRAM_SQL)
                 # Backfill both indexes from every existing messages row.
                 cursor.execute(
                     "INSERT INTO messages_fts(rowid, content) "
@@ -637,14 +732,16 @@ class SessionDB:
                     "COALESCE(tool_calls, '') "
                     "FROM messages"
                 )
-                cursor.execute(
-                    "INSERT INTO messages_fts_trigram(rowid, content) "
-                    "SELECT id, "
-                    "COALESCE(content, '') || ' ' || "
-                    "COALESCE(tool_name, '') || ' ' || "
-                    "COALESCE(tool_calls, '') "
-                    "FROM messages"
-                )
+                if not _trigram_off:
+                    cursor.executescript(FTS_TRIGRAM_SQL)
+                    cursor.execute(
+                        "INSERT INTO messages_fts_trigram(rowid, content) "
+                        "SELECT id, "
+                        "COALESCE(content, '') || ' ' || "
+                        "COALESCE(tool_name, '') || ' ' || "
+                        "COALESCE(tool_calls, '') "
+                        "FROM messages"
+                    )
             if current_version < SCHEMA_VERSION:
                 cursor.execute(
                     "UPDATE schema_version SET version = ?",
@@ -666,11 +763,17 @@ class SessionDB:
         except sqlite3.OperationalError:
             cursor.executescript(FTS_SQL)
 
-        # Trigram FTS5 for CJK/substring search
-        try:
-            cursor.execute("SELECT * FROM messages_fts_trigram LIMIT 0")
-        except sqlite3.OperationalError:
-            cursor.executescript(FTS_TRIGRAM_SQL)
+        # Trigram FTS5 for CJK/substring search.
+        # Skipped when ``HERMES_DISABLE_FTS_TRIGRAM=1`` — the trigram index
+        # roughly doubles state.db size on top of the porter index and is
+        # only useful for CJK substring queries with ≥3 characters. See
+        # issue #22478. ``search_messages`` falls back to LIKE when the
+        # table is absent.
+        if not _fts_trigram_disabled():
+            try:
+                cursor.execute("SELECT * FROM messages_fts_trigram LIMIT 0")
+            except sqlite3.OperationalError:
+                cursor.executescript(FTS_TRIGRAM_SQL)
 
         self._conn.commit()
 
@@ -1950,9 +2053,13 @@ class SessionDB:
         # missing exact phrase matches.
         #
         # For queries with 3+ CJK characters, we use the trigram FTS5 table
-        # (indexed substring matching with ranking and snippets).  For shorter
-        # CJK queries (1-2 chars), trigram can't match (it needs ≥9 UTF-8
-        # bytes = 3 CJK chars), so we fall back to LIKE.
+        # (indexed substring matching with ranking and snippets) when it is
+        # available.  When it has been opted out via
+        # ``HERMES_DISABLE_FTS_TRIGRAM=1`` (issue #22478) or dropped via
+        # ``drop_fts_trigram()``, we fall back to the LIKE substring path
+        # used for short queries below.  For shorter CJK queries (1-2 chars),
+        # trigram can't match (it needs ≥9 UTF-8 bytes = 3 CJK chars), so we
+        # always use LIKE.
         is_cjk = self._contains_cjk(query)
         if is_cjk:
             raw_query = query.strip('"').strip()
@@ -1970,7 +2077,10 @@ class SessionDB:
                 self._count_cjk(t) < 3 for t in _tokens_for_check
             )
 
-            if cjk_count >= 3 and not _any_short_cjk:
+            # Also route to LIKE when the trigram FTS5 table is absent —
+            # opted out via ``HERMES_DISABLE_FTS_TRIGRAM=1`` (issue #22478)
+            # or removed via ``drop_fts_trigram()``.
+            if cjk_count >= 3 and not _any_short_cjk and self._has_fts_trigram():
                 # Trigram FTS5 path — quote each non-operator token to handle
                 # FTS5 special chars (%, *, etc.) while preserving boolean
                 # operators (AND, OR, NOT) for multi-term queries.
@@ -2021,8 +2131,11 @@ class SessionDB:
                     else:
                         matches = [dict(row) for row in tri_cursor.fetchall()]
             else:
-                # Short / mixed CJK query: trigram cannot match tokens with
-                # <3 CJK chars. Fall back to LIKE substring search.
+                # Short / mixed CJK query, or trigram FTS5 absent: trigram
+                # cannot match tokens with <3 CJK chars; trigram is also
+                # skipped when opted out via ``HERMES_DISABLE_FTS_TRIGRAM=1``
+                # / removed via ``drop_fts_trigram()`` (issue #22478). Fall
+                # back to LIKE substring search.
                 # For multi-token OR queries (e.g. "广西 OR 桂林 OR 漓江"),
                 # build one LIKE condition per non-operator token so each term
                 # is matched independently (#20494).

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -947,6 +947,7 @@ AUTHOR_MAP = {
     "zhicheng.han@mathematik.uni-goettingen.de": "hanzckernel",  # PR #20311 (api-server approval events)
     "agentsmithlaor@gmail.com": "oferlaor",  # PR #22356 salvage (cron origin sender identity)
     "jhin.lee@unity3d.com": "leehack",  # PR #22053 salvage (telegram DM topic reply fallback)
+    "cotrelllucia@gmail.com": "cotrelllucia",  # PR #22710 (optional FTS5 trigram index)
     # pander: empty email, salvaged via PR #19665 from #16126 by @ms-alan
     "ayman.a.kamal@hotmail.com": "A-kamal",  # PR #18678 (xAI image resolution fix)
 }

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1,5 +1,6 @@
 """Tests for hermes_state.py — SessionDB SQLite CRUD, FTS5 search, export."""
 
+import os
 import time
 import pytest
 from pathlib import Path
@@ -2942,4 +2943,139 @@ class TestFTS5ToolCallMigration:
             assert version == 11
         finally:
             session_db.close()
+
+
+# =========================================================================
+# Optional trigram FTS5 index — issue #22478
+# =========================================================================
+
+class TestFTS5TrigramOptional:
+    """Regression tests for ``HERMES_DISABLE_FTS_TRIGRAM`` and
+    ``drop_fts_trigram()`` (issue #22478).
+
+    The trigram FTS5 index roughly doubles state.db size and is only
+    useful for CJK substring search.  Pure-English deployments can opt
+    out via the env var or by dropping the existing index.
+    """
+
+    @pytest.fixture()
+    def disabled_db(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_DISABLE_FTS_TRIGRAM", "1")
+        db_path = tmp_path / "state_no_trigram.db"
+        session_db = SessionDB(db_path=db_path)
+        try:
+            yield session_db
+        finally:
+            session_db.close()
+
+    @staticmethod
+    def _trigram_table_exists(session_db: SessionDB) -> bool:
+        row = session_db._conn.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='table' AND name='messages_fts_trigram'"
+        ).fetchone()
+        return row is not None
+
+    def test_env_var_skips_trigram_table(self, disabled_db):
+        """``HERMES_DISABLE_FTS_TRIGRAM=1`` prevents the trigram virtual
+        table from being created on a fresh database."""
+        assert not self._trigram_table_exists(disabled_db)
+        assert disabled_db._has_fts_trigram() is False
+
+    def test_env_var_skips_trigram_triggers(self, disabled_db):
+        """No trigram triggers should exist when the index is opted out."""
+        rows = disabled_db._conn.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='trigger' AND name LIKE 'messages_fts_trigram_%'"
+        ).fetchall()
+        assert rows == []
+
+    def test_porter_fts_still_works_when_trigram_disabled(self, disabled_db):
+        """English FTS path is unaffected by disabling the trigram index."""
+        disabled_db.create_session(session_id="s1", source="cli")
+        disabled_db.append_message(
+            "s1", role="user", content="docker deployment notes"
+        )
+        results = disabled_db.search_messages("deployment")
+        assert len(results) == 1
+        assert results[0]["session_id"] == "s1"
+
+    def test_cjk_search_falls_back_to_like_when_trigram_disabled(
+        self, disabled_db
+    ):
+        """CJK queries with ≥3 characters should fall back to LIKE rather
+        than crash when the trigram index is opted out."""
+        disabled_db.create_session(session_id="s1", source="cli")
+        disabled_db.create_session(session_id="s2", source="cli")
+        disabled_db.append_message(
+            "s1", role="user", content="记忆系统已经设计完成"
+        )
+        disabled_db.append_message(
+            "s2", role="user", content="今天的天气真好"
+        )
+        results = disabled_db.search_messages("记忆系统")
+        assert len(results) == 1
+        assert results[0]["session_id"] == "s1"
+
+    def test_short_cjk_search_works_when_trigram_disabled(self, disabled_db):
+        """1-2 char CJK queries already use LIKE; that path must still work."""
+        disabled_db.create_session(session_id="s1", source="cli")
+        disabled_db.append_message("s1", role="user", content="昨晚讨论了记忆系统")
+        results = disabled_db.search_messages("昨晚")
+        assert len(results) == 1
+
+    def test_inserts_dont_write_to_missing_trigram_table(self, disabled_db):
+        """When the trigram triggers don't exist, INSERTs must not fail."""
+        disabled_db.create_session(session_id="s1", source="cli")
+        # Should not raise.
+        disabled_db.append_message("s1", role="user", content="hello world")
+        disabled_db.append_message(
+            "s1", role="assistant", content="", tool_name="web_search",
+        )
+        results = disabled_db.search_messages("hello")
+        assert len(results) == 1
+
+    def test_drop_fts_trigram_removes_table_and_triggers(self, db):
+        """``drop_fts_trigram()`` removes the trigram table and its triggers."""
+        # Sanity: the index exists by default.
+        assert self._trigram_table_exists(db)
+        db.drop_fts_trigram()
+        assert not self._trigram_table_exists(db)
+        rows = db._conn.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='trigger' AND name LIKE 'messages_fts_trigram_%'"
+        ).fetchall()
+        assert rows == []
+        assert db._has_fts_trigram() is False
+
+    def test_drop_fts_trigram_is_idempotent(self, disabled_db):
+        """Calling ``drop_fts_trigram()`` on a DB without the index is a no-op."""
+        # Should not raise even though the table never existed.
+        disabled_db.drop_fts_trigram()
+        assert not self._trigram_table_exists(disabled_db)
+
+    def test_search_after_drop_fts_trigram_routes_cjk_to_like(self, db):
+        """After dropping the trigram index, long CJK queries still return results
+        via the LIKE fallback."""
+        db.create_session(session_id="s1", source="cli")
+        db.append_message("s1", role="user", content="项目管理系统的设计文档")
+        # Verify the trigram path works first.
+        results = db.search_messages("项目管理")
+        assert len(results) == 1
+
+        db.drop_fts_trigram()
+
+        # After dropping, LIKE fallback handles the same CJK query.
+        results = db.search_messages("项目管理")
+        assert len(results) == 1
+        assert results[0]["session_id"] == "s1"
+
+    def test_vacuum_runs_without_error(self, db):
+        """``vacuum()`` should not raise on a small fresh database."""
+        db.create_session(session_id="s1", source="cli")
+        db.append_message("s1", role="user", content="hello")
+        db.vacuum()  # must not raise
+        # The DB should still be usable after VACUUM.
+        results = db.search_messages("hello")
+        assert len(results) == 1
 

--- a/website/docs/developer-guide/session-storage.md
+++ b/website/docs/developer-guide/session-storage.md
@@ -130,6 +130,27 @@ CREATE TRIGGER IF NOT EXISTS messages_fts_update AFTER UPDATE ON messages BEGIN
 END;
 ```
 
+### Disabling the trigram FTS5 index
+
+The `messages_fts_trigram` index is only used to serve CJK substring queries
+with three or more characters. On instances that never run such queries it
+typically accounts for **~50% of `state.db` size** because trigram tokens
+expand more aggressively for CJK text than porter stemming does for English.
+For deployments that don't need CJK substring search, the index can be
+opted out:
+
+- **Fresh databases** — set `HERMES_DISABLE_FTS_TRIGRAM=1` before creating
+  `state.db`. The trigram virtual table and its triggers are skipped, and
+  `search_messages()` automatically falls back to `LIKE` for CJK queries.
+- **Existing databases** — call `SessionDB.drop_fts_trigram()` to drop the
+  trigram table, its triggers, and run `VACUUM` to reclaim the freed pages.
+  After this, the database behaves as if it had been created with the env
+  var set. The operation is idempotent.
+
+Re-enabling the index later requires upgrading from a database that pre-dates
+v10; the v10 backfill path will recreate it. (Manually re-creating the
+trigram virtual table and re-indexing every message is also possible but
+not exposed as a public API.)
 
 ## Schema Version and Migrations
 


### PR DESCRIPTION
## What does this PR do?

Makes the `messages_fts_trigram` virtual table optional. The trigram FTS5 index is only used to serve CJK substring queries with three or more characters. On instances that never run such queries it typically accounts for **~50 % of `state.db` size** because trigram tokens expand more aggressively for CJK text than porter stemming does for English. Pure-English deployments paid the storage cost for a feature they did not use, and there was no clean way to disable or reclaim it.

This change adds an explicit opt-out path — without breaking the existing CJK search behavior for users who want it — and exposes the maintenance hooks needed to reclaim space on databases that have already been bloated by the index.

The approach is intentionally minimal:

- a single env var (`HERMES_DISABLE_FTS_TRIGRAM`) gates *creation* of the virtual table and triggers in both v10/v11 migration paths and the post-migration existence check;
- `SessionDB.drop_fts_trigram()` lets operators reclaim space on existing databases by dropping the table and triggers and running `VACUUM`;
- `search_messages()` already had a LIKE-fallback path for short (1–2 char) CJK queries, so the new behavior reuses it for longer CJK queries when the trigram table is absent — no new query path was introduced.

## Related Issue

Refs #22478

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_state.py`
  - Added module-level helpers `_env_flag()` and `_fts_trigram_disabled()` that read the new `HERMES_DISABLE_FTS_TRIGRAM` env var (`1`/`true`/`yes`/`on`).
  - In `_init_schema()`:
    - the v10 backfill block is gated on `_fts_trigram_disabled()`;
    - the v11 re-index block runs the porter-FTS recreation unconditionally and only recreates+backfills the trigram FTS when the flag is off;
    - the post-migration existence check creates the trigram virtual table only when the flag is off.
  - Added `SessionDB._fts_trigram_available` cache + `_has_fts_trigram()` runtime probe so `search_messages()` can route around a missing table without raising.
  - Added `SessionDB.drop_fts_trigram()` — drops the trigram triggers and table, then `VACUUM`s; idempotent on a database that already has the index dropped.
  - Added `SessionDB.vacuum()` — plain `VACUUM` for callers that want to defragment after large deletions.
  - In `search_messages()` the long-CJK branch now requires `_has_fts_trigram()`; otherwise it falls through to the existing LIKE substring path that was already used for 1–2 char CJK queries (no new query code path was introduced).
- `tests/test_hermes_state.py` — new `TestFTS5TrigramOptional` class with 10 regression tests covering: env-var skip on fresh DB (table + triggers), porter FTS still works, long CJK queries fall back to LIKE when disabled, short CJK queries unaffected, INSERTs don't fail when triggers are missing, `drop_fts_trigram()` removes table + triggers, `drop_fts_trigram()` is idempotent, `search_messages()` routes long CJK to LIKE after the index is dropped, `vacuum()` runs cleanly.
- `website/docs/developer-guide/session-storage.md` — new "Disabling the trigram FTS5 index" section explaining the env var, `drop_fts_trigram()`, and re-enable semantics.
- `.env.example` — documented the new env var under a new `SESSION DATABASE (state.db)` section.

## How to Test

```bash
# 1. Full hermes_state regression suite (220 tests, including 10 new ones)
scripts/run_tests.sh tests/test_hermes_state.py -q

# 2. Just the new tests
scripts/run_tests.sh tests/test_hermes_state.py::TestFTS5TrigramOptional -v

# 3. End-to-end on a fresh DB
HERMES_DISABLE_FTS_TRIGRAM=1 hermes -q "Test message"
sqlite3 ~/.hermes/state.db ".tables" | tr ' ' '\n' | grep fts
#   → only `messages_fts` is listed; `messages_fts_trigram` is absent.

# 4. Reclaim space on an existing bloated DB
python -c "from hermes_state import SessionDB; db = SessionDB(); db.drop_fts_trigram(); db.close()"
ls -la ~/.hermes/state.db
#   → file size drops by ~50 % on CJK-heavy English-only deployments.
```

CJK substring search still works after the env var is set (1–2 char and long queries both use the LIKE substring path) — see `test_cjk_search_falls_back_to_like_when_trigram_disabled` and `test_short_cjk_search_works_when_trigram_disabled`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(state): make trigram FTS5 index optional`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run `pytest tests/test_hermes_state.py -q` and all 220 tests pass
- [x] I've added tests for my changes (10 new regression tests in `TestFTS5TrigramOptional`)
- [x] I've tested on my platform: Ubuntu 24.04, Python 3.11.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/developer-guide/session-storage.md`, `.env.example`)
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (env var, not config key)
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — env var reads via `os.environ`, no platform-specific calls; `ruff check .` and `scripts/check-windows-footguns.py --all` both pass.
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/test_hermes_state.py::TestFTS5TrigramOptional -v
[gw0] PASSED tests/.../test_env_var_skips_trigram_table
[gw1] PASSED tests/.../test_porter_fts_still_works_when_trigram_disabled
[gw2] PASSED tests/.../test_short_cjk_search_works_when_trigram_disabled
[gw3] PASSED tests/.../test_drop_fts_trigram_removes_table_and_triggers
[gw0] PASSED tests/.../test_env_var_skips_trigram_triggers
[gw2] PASSED tests/.../test_inserts_dont_write_to_missing_trigram_table
[gw1] PASSED tests/.../test_cjk_search_falls_back_to_like_when_trigram_disabled
[gw3] PASSED tests/.../test_drop_fts_trigram_is_idempotent
[gw0] PASSED tests/.../test_search_after_drop_fts_trigram_routes_cjk_to_like
[gw2] PASSED tests/.../test_vacuum_runs_without_error

============================== 10 passed in 3.81s ==============================
```

```
$ scripts/run_tests.sh tests/test_hermes_state.py -q
220 passed in 2.69s
```
