### PR TITLE
feat: add proactive compression pressure estimate

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1080,6 +1080,18 @@ def init_agent(
     compression_enabled = str(_compression_cfg.get("enabled", True)).lower() in {"true", "1", "yes"}
     compression_target_ratio = float(_compression_cfg.get("target_ratio", 0.20))
     compression_protect_last = int(_compression_cfg.get("protect_last_n", 20))
+    _proactive_cfg = _compression_cfg.get("proactive", {})
+    if not isinstance(_proactive_cfg, dict):
+        _proactive_cfg = {}
+    agent._proactive_compression_enabled = str(
+        _proactive_cfg.get("enabled", False)
+    ).lower() in {"true", "1", "yes"}
+    try:
+        agent._proactive_compression_next_turn_reserve_ratio = float(
+            _proactive_cfg.get("next_turn_reserve_ratio", 0.20)
+        )
+    except (TypeError, ValueError):
+        agent._proactive_compression_next_turn_reserve_ratio = 0.20
     # protect_first_n is the number of non-system messages to protect at
     # the head, in addition to the system prompt (which is always
     # implicitly protected by the compressor).  Floor at 0 — a value of

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -34,11 +34,72 @@ import tempfile
 import uuid
 from datetime import datetime
 from pathlib import Path
-from typing import Any, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from agent.model_metadata import estimate_request_tokens_rough
 
 logger = logging.getLogger(__name__)
+
+
+def _clamp_ratio(value: Any, *, default: float = 0.20) -> float:
+    """Parse a config ratio and clamp it to a conservative safe range."""
+    try:
+        ratio = float(value)
+    except (TypeError, ValueError):
+        ratio = default
+    return max(0.0, min(ratio, 0.50))
+
+
+def estimate_proactive_compression_pressure(
+    agent: Any,
+    messages: List[Dict[str, Any]],
+    *,
+    system_prompt: str = "",
+) -> Dict[str, Any]:
+    """Estimate whether a completed turn should be proactively compressed.
+
+    This is the common trigger math for post-turn / idle compression.  The
+    reserve is expressed as a percentage of the model's full context window,
+    not an absolute token count, so it scales with model choice:
+
+        projected = current_request_tokens + context_length * reserve_ratio
+
+    If the projection crosses the normal hard compression threshold, callers
+    may compress while the session is idle.  The existing preflight check still
+    remains the authoritative safety net for unusually large next prompts.
+    """
+    compressor = getattr(agent, "context_compressor", None)
+    context_length = int(getattr(compressor, "context_length", 0) or 0)
+    threshold_tokens = int(getattr(compressor, "threshold_tokens", 0) or 0)
+    reserve_ratio = _clamp_ratio(
+        getattr(agent, "_proactive_compression_next_turn_reserve_ratio", 0.20)
+    )
+    reserve_tokens = int(context_length * reserve_ratio) if context_length else 0
+    current_tokens = estimate_request_tokens_rough(
+        messages or [],
+        system_prompt=system_prompt or "",
+        tools=getattr(agent, "tools", None) or None,
+    )
+    projected_tokens = current_tokens + reserve_tokens
+    enabled = bool(getattr(agent, "compression_enabled", True)) and bool(
+        getattr(agent, "_proactive_compression_enabled", False)
+    )
+    should_compress = bool(
+        enabled
+        and threshold_tokens > 0
+        and projected_tokens >= threshold_tokens
+    )
+
+    return {
+        "enabled": enabled,
+        "current_tokens": current_tokens,
+        "context_length": context_length,
+        "threshold_tokens": threshold_tokens,
+        "reserve_ratio": reserve_ratio,
+        "reserve_tokens": reserve_tokens,
+        "projected_tokens": projected_tokens,
+        "should_compress": should_compress,
+    }
 
 
 def check_compression_model_feasibility(agent: Any) -> None:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3914,6 +3914,15 @@ def run_conversation(
             last_reasoning = msg["reasoning"]
             break
 
+    try:
+        _proactive_pressure = agent._estimate_proactive_compression_pressure(
+            messages,
+            system_prompt=agent._cached_system_prompt or "",
+        )
+    except Exception as _proactive_err:
+        logger.debug("proactive compression pressure estimate failed: %s", _proactive_err)
+        _proactive_pressure = {"enabled": False, "should_compress": False}
+
     # Build result with interrupt info if applicable
     result = {
         "final_response": final_response,
@@ -3940,6 +3949,7 @@ def run_conversation(
         "estimated_cost_usd": agent.session_estimated_cost_usd,
         "cost_status": agent.session_cost_status,
         "cost_source": agent.session_cost_source,
+        "proactive_compression": _proactive_pressure,
     }
     if agent._tool_guardrail_halt_decision is not None:
         result["guardrail"] = agent._tool_guardrail_halt_decision.to_metadata()

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -359,6 +359,16 @@ compression:
   # Range: 0.10 - 0.80
   target_ratio: 0.20
 
+  # Optional post-turn compression pressure check (default: disabled).
+  # When enabled, Hermes estimates current context usage after a reply is delivered,
+  # reserves this fraction of the model's total context for likely next-turn growth,
+  # and schedules idle compression if projected usage crosses threshold.
+  # With threshold 0.75 and next_turn_reserve_ratio 0.20, proactive compression
+  # can run around 55% context usage, leaving the normal preflight check as fallback.
+  proactive:
+    enabled: false
+    next_turn_reserve_ratio: 0.20
+
   # Number of most-recent messages to always preserve (default: 20 ≈ 10 full turns)
   # Higher values keep more recent conversation intact at the cost of more aggressive
   # compression of older turns.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2960,6 +2960,126 @@ class GatewayRunner:
                 pass
             self._cleanup_agent_resources(agent)
 
+    def _register_proactive_compression_callback(
+        self,
+        *,
+        adapter: Any,
+        session_key: str,
+        run_generation: Optional[int],
+        session_entry: Any,
+        agent_result: Dict[str, Any],
+    ) -> bool:
+        """Run opt-in context compression after the user-visible reply is delivered.
+
+        The core agent only reports pressure; the gateway owns response delivery
+        and can safely do the expensive compression work after the final message
+        has been sent.  The callback fires before the adapter releases the
+        per-session guard, so a queued follow-up waits for the compressed session
+        instead of racing it.
+        """
+        if not adapter or not session_key or session_entry is None:
+            return False
+        pressure = agent_result.get("proactive_compression") or {}
+        if not isinstance(pressure, dict) or not pressure.get("should_compress"):
+            return False
+        if agent_result.get("failed") or agent_result.get("compression_exhausted"):
+            return False
+        messages = agent_result.get("messages") or []
+        if not messages:
+            return False
+
+        approx_tokens = pressure.get("current_tokens") or pressure.get("projected_tokens")
+        original_session_id = agent_result.get("session_id") or getattr(session_entry, "session_id", None)
+
+        async def _compress_after_delivery() -> None:
+            if run_generation is not None and not self._is_session_run_current(session_key, run_generation):
+                logger.debug(
+                    "Skipping proactive compression for stale session run %s generation %s",
+                    session_key,
+                    run_generation,
+                )
+                return
+
+            def _compress_sync() -> Optional[Dict[str, Any]]:
+                agent = self._running_agents.get(session_key)
+                if agent is None or agent is _AGENT_PENDING_SENTINEL:
+                    return None
+                if not getattr(agent, "compression_enabled", False):
+                    return None
+                if not getattr(agent, "_proactive_compression_enabled", False):
+                    return None
+
+                old_status_callback = getattr(agent, "status_callback", None)
+                try:
+                    # Keep post-turn compression silent. The user already got
+                    # their answer; emitting a second status bubble defeats the
+                    # point of hiding this latency off the critical path.
+                    agent.status_callback = None
+                    compressed_messages, _new_system_prompt = agent._compress_context(
+                        list(messages),
+                        None,
+                        approx_tokens=approx_tokens,
+                        task_id=original_session_id or session_key,
+                        focus_topic="next turn reserve",
+                    )
+                    agent._persist_session(compressed_messages, None)
+                    return {
+                        "old_session_id": original_session_id,
+                        "new_session_id": getattr(agent, "session_id", None),
+                        "message_count": len(compressed_messages),
+                    }
+                finally:
+                    agent.status_callback = old_status_callback
+
+            try:
+                result = await self._run_in_executor_with_context(_compress_sync)
+            except Exception as exc:
+                logger.warning("Proactive context compression failed for %s: %s", session_key, exc)
+                return
+            if not result:
+                return
+
+            new_session_id = result.get("new_session_id")
+            if new_session_id and new_session_id != getattr(session_entry, "session_id", None):
+                logger.info(
+                    "Proactive session split detected: %s → %s (post-delivery compression)",
+                    getattr(session_entry, "session_id", None),
+                    new_session_id,
+                )
+                session_entry.session_id = new_session_id
+                try:
+                    self.session_store._save()
+                except Exception as exc:
+                    logger.debug("session_store save after proactive compression failed: %s", exc)
+            try:
+                self.session_store.update_session(
+                    session_key,
+                    last_prompt_tokens=pressure.get("current_tokens", 0) or 0,
+                )
+            except Exception:
+                pass
+
+        try:
+            if getattr(type(adapter), "register_post_delivery_callback", None) is not None:
+                adapter.register_post_delivery_callback(
+                    session_key,
+                    _compress_after_delivery,
+                    generation=run_generation,
+                )
+            else:
+                adapter._post_delivery_callbacks[session_key] = _compress_after_delivery
+            logger.info(
+                "Scheduled proactive context compression for %s: current=~%s projected=~%s threshold=%s",
+                session_key,
+                pressure.get("current_tokens"),
+                pressure.get("projected_tokens"),
+                pressure.get("threshold_tokens"),
+            )
+            return True
+        except Exception as exc:
+            logger.debug("Could not register proactive compression callback for %s: %s", session_key, exc)
+            return False
+
     def _cleanup_agent_resources(self, agent: Any) -> None:
         """Best-effort cleanup for temporary or cached agent instances."""
         if agent is None:
@@ -8114,6 +8234,18 @@ class GatewayRunner:
             self.session_store.update_session(
                 session_entry.session_key,
                 last_prompt_tokens=agent_result.get("last_prompt_tokens", 0),
+            )
+
+            # Optional post-delivery compression.  Register the callback after
+            # the current turn is safely persisted but before returning the
+            # response to the adapter, so base.py can fire it after the visible
+            # reply has been sent and before the next queued message runs.
+            self._register_proactive_compression_callback(
+                adapter=self.adapters.get(source.platform),
+                session_key=session_key,
+                run_generation=run_generation,
+                session_entry=session_entry,
+                agent_result=agent_result,
             )
 
             # Auto voice reply: send TTS audio before the text response
@@ -15894,6 +16026,7 @@ class GatewayRunner:
                     "output_tokens": _output_toks,
                     "model": _resolved_model,
                     "context_length": _context_length,
+                    "proactive_compression": result.get("proactive_compression", {}),
                 }
             
             # Scan tool results for MEDIA:<path> tags that need to be delivered
@@ -16015,6 +16148,7 @@ class GatewayRunner:
                 "context_length": _context_length,
                 "session_id": effective_session_id,
                 "response_previewed": result.get("response_previewed", False),
+                "proactive_compression": result.get("proactive_compression", {}),
             }
         
         # Start progress message sender if enabled

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -764,6 +764,10 @@ DEFAULT_CONFIG = {
         "target_ratio": 0.20,         # fraction of threshold to preserve as recent tail
         "protect_last_n": 20,         # minimum recent messages to keep uncompressed
         "hygiene_hard_message_limit": 400,  # gateway session-hygiene force-compress threshold by message count
+        "proactive": {
+            "enabled": False,         # opt-in: recommend idle/post-turn compression before preflight blocks
+            "next_turn_reserve_ratio": 0.20,  # reserve this fraction of total context for likely next-turn growth
+        },
         "protect_first_n": 3,         # non-system head messages always preserved
                                       # verbatim, in ADDITION to the system prompt
                                       # (which is always implicitly protected). Set to

--- a/run_agent.py
+++ b/run_agent.py
@@ -821,6 +821,13 @@ class AIAgent:
         from agent.conversation_compression import replay_compression_warning
         replay_compression_warning(self)
 
+    def _estimate_proactive_compression_pressure(self, messages: list, *, system_prompt: str = "") -> dict:
+        """Forwarder — see ``agent.conversation_compression.estimate_proactive_compression_pressure``."""
+        from agent.conversation_compression import estimate_proactive_compression_pressure
+        return estimate_proactive_compression_pressure(
+            self, messages, system_prompt=system_prompt,
+        )
+
     def _is_direct_openai_url(self, base_url: str = None) -> bool:
         """Return True when a base URL targets OpenAI's native API."""
         if base_url is not None:

--- a/tests/gateway/test_proactive_compression_callback.py
+++ b/tests/gateway/test_proactive_compression_callback.py
@@ -1,0 +1,153 @@
+"""Gateway post-delivery proactive compression tests."""
+
+import asyncio
+from types import SimpleNamespace
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+
+
+class CallbackAdapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="***"), Platform.TELEGRAM)
+        self.sent = []
+
+    async def connect(self) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def get_chat_info(self, chat_id: str):
+        return {"id": chat_id}
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self.sent.append({"chat_id": chat_id, "content": content, "metadata": metadata})
+        return SendResult(success=True, message_id="m1")
+
+
+class FakeSessionStore:
+    def __init__(self):
+        self.saved = 0
+        self.updated = []
+
+    def _save(self):
+        self.saved += 1
+
+    def update_session(self, session_key, **kwargs):
+        self.updated.append((session_key, kwargs))
+
+
+class FakeAgent:
+    compression_enabled = True
+    _proactive_compression_enabled = True
+
+    def __init__(self):
+        self.session_id = "sess-old"
+        self.status_callback = lambda *_args, **_kwargs: None
+        self.compressed = []
+        self.persisted = []
+
+    def _compress_context(self, messages, system_message, *, approx_tokens=None, task_id="default", focus_topic=None):
+        assert self.status_callback is None
+        self.compressed.append(
+            {
+                "messages": messages,
+                "system_message": system_message,
+                "approx_tokens": approx_tokens,
+                "task_id": task_id,
+                "focus_topic": focus_topic,
+            }
+        )
+        self.session_id = "sess-new"
+        return [{"role": "assistant", "content": "summary"}], "new system"
+
+    def _persist_session(self, messages, conversation_history=None):
+        self.persisted.append((messages, conversation_history))
+
+
+def _make_runner(agent):
+    import gateway.run as gateway_run
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._running_agents = {"session-key": agent}
+    runner.session_store = FakeSessionStore()
+    runner._is_session_run_current = lambda session_key, generation: True
+
+    async def _run_in_executor_with_context(fn, *args, **kwargs):
+        return fn(*args, **kwargs)
+
+    runner._run_in_executor_with_context = _run_in_executor_with_context
+    return runner
+
+
+def test_registers_post_delivery_compression_and_updates_session_entry():
+    async def run():
+        adapter = CallbackAdapter()
+        agent = FakeAgent()
+        runner = _make_runner(agent)
+        session_entry = SimpleNamespace(session_id="sess-old")
+        agent_result = {
+            "session_id": "sess-old",
+            "messages": [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "world"},
+            ],
+            "proactive_compression": {
+                "enabled": True,
+                "should_compress": True,
+                "current_tokens": 560,
+                "projected_tokens": 760,
+                "threshold_tokens": 750,
+            },
+        }
+
+        registered = runner._register_proactive_compression_callback(
+            adapter=adapter,
+            session_key="session-key",
+            run_generation=3,
+            session_entry=session_entry,
+            agent_result=agent_result,
+        )
+
+        assert registered is True
+        callback = adapter.pop_post_delivery_callback("session-key", generation=3)
+        assert callable(callback)
+
+        await callback()
+
+        assert agent.compressed == [
+            {
+                "messages": agent_result["messages"],
+                "system_message": None,
+                "approx_tokens": 560,
+                "task_id": "sess-old",
+                "focus_topic": "next turn reserve",
+            }
+        ]
+        assert agent.persisted == [([{"role": "assistant", "content": "summary"}], None)]
+        assert session_entry.session_id == "sess-new"
+        assert runner.session_store.saved == 1
+        assert runner.session_store.updated == [("session-key", {"last_prompt_tokens": 560})]
+
+    asyncio.run(run())
+
+
+def test_does_not_register_when_pressure_says_no_compression():
+    adapter = CallbackAdapter()
+    runner = _make_runner(FakeAgent())
+    session_entry = SimpleNamespace(session_id="sess-old")
+
+    registered = runner._register_proactive_compression_callback(
+        adapter=adapter,
+        session_key="session-key",
+        run_generation=1,
+        session_entry=session_entry,
+        agent_result={
+            "messages": [{"role": "user", "content": "hello"}],
+            "proactive_compression": {"enabled": True, "should_compress": False},
+        },
+    )
+
+    assert registered is False
+    assert adapter.pop_post_delivery_callback("session-key", generation=1) is None

--- a/tests/test_proactive_compression.py
+++ b/tests/test_proactive_compression.py
@@ -1,0 +1,62 @@
+from types import SimpleNamespace
+
+from agent.model_metadata import estimate_request_tokens_rough
+
+
+def _agent(*, context_length=100_000, threshold_tokens=75_000, enabled=True, ratio=0.20):
+    compressor = SimpleNamespace(
+        context_length=context_length,
+        threshold_tokens=threshold_tokens,
+    )
+    return SimpleNamespace(
+        compression_enabled=enabled,
+        context_compressor=compressor,
+        tools=[{"type": "function", "function": {"name": "noop", "description": "x" * 40}}],
+        _proactive_compression_enabled=True,
+        _proactive_compression_next_turn_reserve_ratio=ratio,
+    )
+
+
+def test_proactive_compression_pressure_uses_context_window_ratio():
+    from agent.conversation_compression import estimate_proactive_compression_pressure
+
+    messages = [{"role": "user", "content": "x" * 55_000 * 4}]
+    system_prompt = "system"
+    agent = _agent(context_length=100_000, threshold_tokens=75_000, ratio=0.20)
+
+    pressure = estimate_proactive_compression_pressure(
+        agent, messages, system_prompt=system_prompt
+    )
+
+    current = estimate_request_tokens_rough(
+        messages, system_prompt=system_prompt, tools=agent.tools
+    )
+    assert pressure["current_tokens"] == current
+    assert pressure["reserve_tokens"] == 20_000
+    assert pressure["projected_tokens"] == current + 20_000
+    assert pressure["threshold_tokens"] == 75_000
+    assert pressure["should_compress"] is True
+
+
+def test_proactive_compression_pressure_respects_disabled_setting():
+    from agent.conversation_compression import estimate_proactive_compression_pressure
+
+    messages = [{"role": "user", "content": "x" * 70_000 * 4}]
+    agent = _agent(enabled=False, ratio=0.20)
+
+    pressure = estimate_proactive_compression_pressure(agent, messages)
+
+    assert pressure["enabled"] is False
+    assert pressure["should_compress"] is False
+
+
+def test_proactive_reserve_ratio_is_clamped():
+    from agent.conversation_compression import estimate_proactive_compression_pressure
+
+    messages = [{"role": "user", "content": "x"}]
+    agent = _agent(context_length=100_000, threshold_tokens=75_000, ratio=2.0)
+
+    pressure = estimate_proactive_compression_pressure(agent, messages)
+
+    assert pressure["reserve_ratio"] == 0.5
+    assert pressure["reserve_tokens"] == 50_000


### PR DESCRIPTION
## Summary
- Adds opt-in proactive context compression with a configurable next-turn reserve ratio.
- Documents the new config keys in `cli-config.yaml.example`.
- Uses the existing rough token estimate plus a percentage of the model context window to decide whether the next turn is likely to cross the compression threshold.
- Wires the signal into the messaging gateway so compression runs **after the visible reply is delivered**, not at the start of the next user turn.
- Keeps existing preflight compression as the conservative fallback.

## How it works
The existing preflight compression path still acts as the final safety check immediately before a model request. This PR adds an earlier post-turn pressure estimate: after a response is generated, Hermes estimates the current request size using the same rough heuristic already used by preflight compression, then adds a configurable next-turn reserve expressed as a ratio of the model's total context window.

If the current context plus that reserve would cross the existing compression threshold, `run_conversation()` returns a `proactive_compression` payload with the detailed math:

- `current_tokens`
- `reserve_ratio`
- `reserve_tokens`
- `projected_tokens`
- `threshold_tokens`
- `should_compress`

The gateway consumes that payload after persisting the turn and registers a one-shot post-delivery callback. The callback fires after the adapter sends the final reply, silently compresses the session in the executor, persists the compressed continuation session, and updates the gateway session entry if compression rotated the `session_id`. A queued follow-up message waits behind the same per-session guard, so it sees the compressed session instead of racing the background work.

If the estimate is too optimistic, proactive compression is disabled, or the post-delivery task does not run, the existing preflight compression remains in place as the safety net.

## Config
Default behavior remains unchanged and the feature is opt-in:

```yaml
compression:
  proactive:
    enabled: false
    next_turn_reserve_ratio: 0.20
```

Example enablement:

```yaml
compression:
  enabled: true
  threshold: 0.75
  target_ratio: 0.30
  protect_last_n: 5
  protect_first_n: 2
  proactive:
    enabled: true
    next_turn_reserve_ratio: 0.20
```

With `threshold: 0.75` and `next_turn_reserve_ratio: 0.20`, Hermes schedules proactive compression once the current context is roughly `55%` full, because it reserves another `20%` of the total context window for the next turn before comparing against the `75%` threshold.

The reserve ratio is clamped conservatively to `0.50`.

## Test Plan
- `python -m compileall -q gateway/run.py tests/gateway/test_proactive_compression_callback.py`
- `python - <<'PY' ... yaml.safe_load(Path("cli-config.yaml.example").read_text()) ... PY`
- `git diff --check`
- `python scripts/check-windows-footguns.py --diff origin/main`
- `PYTHONPATH=. PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -u -m pytest -o addopts= tests/test_proactive_compression.py tests/gateway/test_proactive_compression_callback.py tests/gateway/test_post_delivery_callback_chaining.py -q`
- `PYTHONPATH=. python -u -m pytest -o addopts= tests/test_proactive_compression.py tests/test_ctx_halving_fix.py tests/gateway/test_proactive_compression_callback.py tests/gateway/test_post_delivery_callback_chaining.py tests/gateway/test_run_cleanup_progress.py -q`

Related: #27579

