### PR TITLE
fix(gateway): treat explicit empty allow_admin_from as active slash gating

### DIFF
--- a/gateway/slash_access.py
+++ b/gateway/slash_access.py
@@ -15,10 +15,18 @@ Two lists per platform scope (DM vs group, mirroring ``allow_from`` vs
 
 Backward compatibility:
 
-  If ``allow_admin_from`` is not set for a scope, slash command gating
-  is disabled entirely for that scope. Every allowed user can run every
-  slash command, exactly like before. This means existing installs are
-  unaffected until an operator opts in by listing at least one admin.
+  If ``allow_admin_from`` is not present in the platform extra for a
+  scope, slash command gating is disabled entirely for that scope.
+  Every allowed user can run every slash command, exactly like before.
+  This means existing installs are unaffected until an operator opts
+  in by adding the key.
+
+  Note the distinction between *unset* and *explicitly empty*. Setting
+  ``allow_admin_from: []`` is an explicit operator choice — gating
+  stays active for that scope, but no user is an admin. Non-admins are
+  then restricted to ``user_allowed_commands`` plus the always-allowed
+  floor (``/help``, ``/whoami``). Only omitting the key entirely turns
+  gating off.
 
 The gate is applied at the slash command dispatch site in
 ``gateway/run.py`` so it covers BOTH built-in and plugin-registered
@@ -170,6 +178,13 @@ def _keys_for_scope(scope: str) -> Tuple[str, str]:
 def policy_from_extra(extra: dict, scope: str) -> SlashAccessPolicy:
     """Build a policy from a platform's ``extra`` dict for one scope.
 
+    Gating is enabled when the scope's admin key is *present* in
+    ``extra``, regardless of whether the list is empty. An explicit
+    ``allow_admin_from: []`` is an operator choice to enforce gating
+    without naming an admin — it must not silently collapse back to
+    the unset (gating-off) behavior, since that would expose the full
+    slash command surface to non-admins.
+
     DM scope falls back to group scope keys ONLY for ``user_allowed_commands``
     when the DM scope didn't specify its own. This keeps the common case
     (operator wants the same command set DM and group) ergonomic without
@@ -185,7 +200,7 @@ def policy_from_extra(extra: dict, scope: str) -> SlashAccessPolicy:
         # so operators only need to list it once if it's the same.
         cmds = _coerce_command_list(extra.get("group_user_allowed_commands"))
 
-    enabled = bool(admin_ids)
+    enabled = admin_key in extra
     return SlashAccessPolicy(
         enabled=enabled,
         admin_user_ids=admin_ids,
@@ -199,7 +214,9 @@ def policy_for_source(gateway_config: Any, source: Any) -> SlashAccessPolicy:
     Returns a "disabled" policy (gating off, allow everything) when:
       - gateway_config is None
       - the platform has no PlatformConfig
-      - the platform's PlatformConfig has no admin list set for the scope
+      - the platform's PlatformConfig does not include the scope's
+        admin key at all (an *explicit* empty list keeps gating active —
+        see ``policy_from_extra``)
 
     Callers should treat the returned policy as authoritative for slash
     command gating only. It does not gate plain chat messages.

--- a/tests/gateway/test_slash_access.py
+++ b/tests/gateway/test_slash_access.py
@@ -140,6 +140,60 @@ class TestPolicyFromExtra:
         dm = policy_from_extra(extra, "dm")
         assert dm.user_allowed_commands == frozenset({"status", "model"})
 
+    def test_explicit_empty_admin_list_keeps_gating_active(self):
+        # Regression: an operator who writes ``allow_admin_from: []`` is
+        # explicitly opting into gating with no admins. The old behaviour
+        # used ``bool(admin_ids)`` to flip ``enabled``, which collapsed
+        # this case back to "no admin list configured" and silently
+        # exposed every slash command to non-admins. Presence of the key
+        # must take precedence over emptiness of the value.
+        p = policy_from_extra({"allow_admin_from": []}, "dm")
+        assert p.enabled is True
+        assert p.admin_user_ids == frozenset()
+        assert p.is_admin("anyone") is False
+        # No commands listed → non-admin is restricted to the always-allowed
+        # floor (/help and /whoami) and nothing else.
+        assert p.can_run("anyone", "help") is True
+        assert p.can_run("anyone", "whoami") is True
+        assert p.can_run("anyone", "stop") is False
+        assert p.can_run("anyone", "restart") is False
+        assert p.can_run("anyone", "model") is False
+
+    def test_explicit_empty_admin_list_honors_user_allowed_commands(self):
+        # The reproduction case from the bug report: operator wants
+        # "no admins, but allow non-admins to run /status only".
+        p = policy_from_extra(
+            {"allow_admin_from": [], "user_allowed_commands": ["status"]},
+            "dm",
+        )
+        assert p.enabled is True
+        assert p.is_admin("999") is False
+        assert p.can_run("999", "status") is True
+        assert p.can_run("999", "stop") is False
+        assert p.can_run("999", "restart") is False
+
+    def test_explicit_empty_group_admin_list_keeps_group_gating_active(self):
+        # Same fix must apply to the group scope's admin key.
+        extra = {"group_allow_admin_from": []}
+        gp = policy_from_extra(extra, "group")
+        assert gp.enabled is True
+        assert gp.is_admin("anyone") is False
+        assert gp.can_run("anyone", "stop") is False
+        # DM scope was not configured → still backward-compat (gating off).
+        dm = policy_from_extra(extra, "dm")
+        assert dm.enabled is False
+        assert dm.can_run("anyone", "stop") is True
+
+    def test_unset_vs_explicit_empty_admin_list_diverge(self):
+        # The two cases that used to behave identically must now diverge.
+        unset = policy_from_extra({}, "dm")
+        explicit_empty = policy_from_extra({"allow_admin_from": []}, "dm")
+        assert unset.enabled is False
+        assert explicit_empty.enabled is True
+        # Backward-compat fallback still treats the unset case as "admin".
+        assert unset.is_admin("anyone") is True
+        assert explicit_empty.is_admin("anyone") is False
+
     def test_dm_admin_does_not_imply_group_admin(self):
         # Admin lists are scope-specific. DM admin must not auto-promote in groups.
         extra = {"allow_admin_from": ["111"]}

--- a/tests/gateway/test_slash_access_dispatch.py
+++ b/tests/gateway/test_slash_access_dispatch.py
@@ -226,6 +226,72 @@ async def test_user_runs_listed_command():
 
 
 @pytest.mark.asyncio
+async def test_explicit_empty_admin_list_whoami_reports_user_tier():
+    """Regression: ``allow_admin_from: []`` is an explicit operator choice
+    to enable gating with no admins. The /whoami response for a non-admin
+    must report the user tier (not "unrestricted"), proving the gate is
+    actually engaged on this scope."""
+    runner = _make_runner(
+        platform_extra={
+            "allow_admin_from": [],
+            "user_allowed_commands": ["status"],
+        }
+    )
+    result = await runner._handle_message(
+        _make_event("/whoami", _make_source(user_id="999"))
+    )
+    assert "Tier: user" in result
+    assert "Tier: unrestricted" not in result
+    assert "/status" in result
+
+
+@pytest.mark.asyncio
+async def test_explicit_empty_admin_list_denies_admin_only_command():
+    """Regression: with ``allow_admin_from: []`` and a non-empty
+    ``user_allowed_commands``, a non-admin attempting a command not on
+    the list must be denied, not silently allowed.
+
+    Before the fix this returned None (gate disabled because the admin
+    list was empty), letting non-admins reach /stop, /restart, etc."""
+    runner = _make_runner(
+        platform_extra={
+            "allow_admin_from": [],
+            "user_allowed_commands": ["status"],
+        }
+    )
+    result = await runner._handle_message(
+        _make_event("/stop", _make_source(user_id="999"))
+    )
+    assert result is not None
+    assert "⛔" in result
+    assert "/stop is admin-only here" in result
+    # Denial preview should still surface what the user CAN run.
+    assert "/status" in result
+
+
+@pytest.mark.asyncio
+async def test_explicit_empty_admin_list_running_agent_fastpath_blocks_non_admin():
+    """The running-agent fast-path must honor the explicit-empty admin
+    list too — otherwise an in-flight agent would be a bypass for the
+    same bug on the hot path."""
+    runner = _make_runner(
+        platform_extra={
+            "allow_admin_from": [],
+            "user_allowed_commands": [],
+        }
+    )
+    src = _make_source(user_id="999")
+    sk = build_session_key(src)
+    runner._running_agents[sk] = MagicMock()
+    runner._running_agents_ts[sk] = 0
+
+    result = await runner._handle_message(_make_event("/restart", src))
+    assert result is not None
+    assert "⛔" in result
+    assert "/restart is admin-only here" in result
+
+
+@pytest.mark.asyncio
 async def test_backward_compat_no_admin_list_means_no_gate():
     runner = _make_runner(platform_extra={})  # nothing configured
     # Random non-listed user runs /whoami; should return unrestricted profile,


### PR DESCRIPTION
## Summary

`gateway/slash_access.py` used `enabled = bool(admin_ids)`, which collapsed
`allow_admin_from: []` (explicit empty) into the same code path as the key
being unset — silently turning slash-command gating **off** for that scope.

An operator config like:

```yaml
extra:
  allow_admin_from: []
  user_allowed_commands: [status]
```

was supposed to mean "no admins, non-admins can only run `/status`". In
practice non-admins could reach `/stop`, `/restart`, `/new`, and every
plugin-registered slash command, and `/whoami` falsely reported
`Tier: unrestricted`. The module docstring already promised the
unset-vs-explicit-empty distinction; the implementation didn't honor it.

## Fix

One-line behavior change — gate on **key presence** instead of list truthiness:

```python
# before
enabled = bool(admin_ids)
# after
enabled = admin_key in extra
```

Docstrings in `policy_from_extra`, `policy_for_source`, and the module
header updated so the unset-vs-explicit-empty contract is explicit.

## Backward compatibility

Configs that don't mention `allow_admin_from` at all keep the old
"gate disabled, allow everything" behavior — all 39 pre-existing tests
still pass without modification. Only the previously broken explicit-empty
case changes, and it changes to the documented, more secure interpretation.

## Files changed

- `gateway/slash_access.py` — 1-line behavior change + docstring updates
- `tests/gateway/test_slash_access.py` — 4 new pure-policy regression tests
- `tests/gateway/test_slash_access_dispatch.py` — 3 new dispatch regression
  tests (cold path, `/whoami` shape, running-agent fast-path)

## Test plan

- [x] `pytest tests/gateway/test_slash_access.py tests/gateway/test_slash_access_dispatch.py -n 4` → **46 passed** (39 existing + 7 new)
- [x] New tests cover: explicit empty admin list keeps gating active;
      `/whoami` reports `Tier: user`; `/stop` returns the ⛔ denial;
      running-agent fast-path denies non-admin `/restart`;
      `unset` vs `explicit empty` diverge as a regression guard.

## Platforms

Pure-Python logic, no platform-specific calls. Targeted suite run on Windows;
covered identically on Linux/macOS in CI.

## Risk

**Low.** Only behavior change affects configs that today silently expose the
full slash-command surface against the operator's stated intent. No
production code path outside `policy_from_extra` was touched.