### PR TITLE
fix(discord): accept bot role mentions

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -4450,10 +4450,28 @@ class DiscordAdapter(BasePlatformAdapter):
             if snapshot_text_parts and not raw_content:
                 raw_content = "\n".join(snapshot_text_parts)
                 normalized_content = raw_content
-        if self._client.user and self._client.user in message.mentions:
+        client_user = self._client.user if self._client else None
+        self_role_mentioned = False
+        if client_user and getattr(message, "guild", None) and getattr(message, "role_mentions", None):
+            bot_member = getattr(message.guild, "me", None)
+            if bot_member is None and hasattr(message.guild, "get_member"):
+                bot_member = message.guild.get_member(client_user.id)
+            bot_role_ids = {
+                getattr(role, "id", None)
+                for role in getattr(bot_member, "roles", [])
+            }
+            self_role_mentioned = any(
+                getattr(role, "id", None) in bot_role_ids
+                for role in message.role_mentions
+            )
+
+        if client_user and (client_user in message.mentions or self_role_mentioned):
             mention_prefix = True
-            normalized_content = normalized_content.replace(f"<@{self._client.user.id}>", "").strip()
-            normalized_content = normalized_content.replace(f"<@!{self._client.user.id}>", "").strip()
+            normalized_content = normalized_content.replace(f"<@{client_user.id}>", "").strip()
+            normalized_content = normalized_content.replace(f"<@!{client_user.id}>", "").strip()
+            if self_role_mentioned:
+                for role in getattr(message, "role_mentions", []) or []:
+                    normalized_content = normalized_content.replace(f"<@&{role.id}>", "").strip()
             message.content = normalized_content
         if not isinstance(message.channel, discord.DMChannel):
             channel_ids = {str(message.channel.id)}

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -125,16 +125,18 @@ def adapter(monkeypatch):
     return adapter
 
 
-def make_message(*, channel, content: str, mentions=None, msg_type=None):
+def make_message(*, channel, content: str, mentions=None, role_mentions=None, guild=None, msg_type=None):
     author = SimpleNamespace(id=42, display_name="Jezza", name="Jezza")
     return SimpleNamespace(
         id=123,
         content=content,
         mentions=list(mentions or []),
+        role_mentions=list(role_mentions or []),
         attachments=[],
         reference=None,
         created_at=datetime.now(timezone.utc),
         channel=channel,
+        guild=guild,
         author=author,
         type=msg_type if msg_type is not None else discord_platform.discord.MessageType.default,
     )
@@ -345,6 +347,27 @@ async def test_discord_accepts_and_strips_bot_mentions_when_required(adapter, mo
     adapter.handle_message.assert_awaited_once()
     event = adapter.handle_message.await_args.args[0]
     assert event.text == "hello with mention"
+
+
+@pytest.mark.asyncio
+async def test_discord_accepts_bot_role_mentions_when_required(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+
+    bot_role = SimpleNamespace(id=888)
+    guild = SimpleNamespace(id=777, me=SimpleNamespace(roles=[bot_role]))
+    message = make_message(
+        channel=FakeTextChannel(channel_id=321),
+        content="<@&888> hello via role mention",
+        role_mentions=[bot_role],
+        guild=guild,
+    )
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "hello via role mention"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Treat mentions of roles held by the Discord bot as a valid bot mention
- Strip role mention tokens from the forwarded message text
- Add regression coverage for role mentions when `DISCORD_REQUIRE_MENTION=true`

## Why
Discord mobile can surface an app-managed bot role in the mention picker while hiding the bot user itself. In channels where Hermes requires mentions, selecting that role currently leaves the gateway silent even though the user appears to have mentioned the bot.

This keeps the behavior conservative: role mentions only count when the mentioned role belongs to the current bot member.

## Test Plan
- [x] `python -m pytest tests/gateway/test_discord_free_response.py -q`
