### PR TITLE
fix(gateway): wire launchd_restart to drain-aware SIGUSR1 path (#27745)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3056,8 +3056,19 @@ def launchd_restart():
 
     try:
         pid = get_running_pid()
-        if pid is not None and _request_gateway_self_restart(pid):
-            print("✓ Service restart requested")
+        if pid is not None and _graceful_restart_via_sigusr1(pid, drain_timeout + 5):
+            # SIGUSR1 drain succeeded: the gateway exited with code 75.
+            # KeepAlive (SuccessfulExit=false) will eventually respawn it,
+            # but only after launchd's throttle interval — kickstart fires
+            # the replacement immediately so the operator-requested restart
+            # is responsive, mirroring systemd_restart's reset-failed +
+            # restart shortcut.
+            subprocess.run(
+                ["launchctl", "kickstart", target],
+                check=False,
+                timeout=30,
+            )
+            print("✓ Service restarted (drained)")
             return
         if pid is not None:
             try:

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -554,12 +554,15 @@ class TestLaunchdServiceRecovery:
             ["launchctl", "kickstart", target],
         ]
 
-    def test_launchd_restart_drains_running_gateway_before_kickstart(self, monkeypatch):
+    def test_launchd_restart_falls_back_to_sigterm_when_drain_fails(self, monkeypatch):
         calls = []
         target = f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"
 
         monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
-        monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
+        monkeypatch.setattr(
+            gateway_cli, "_graceful_restart_via_sigusr1",
+            lambda pid, drain: False,
+        )
         monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", lambda timeout, force_after=None: True)
         monkeypatch.setattr(gateway_cli, "terminate_pid", lambda pid, force=False: calls.append(("term", pid, force)))
         monkeypatch.setattr(
@@ -580,28 +583,46 @@ class TestLaunchdServiceRecovery:
             ["launchctl", "kickstart", "-k", target],
         ]
 
-    def test_launchd_restart_self_requests_graceful_restart_without_kickstart(self, monkeypatch, capsys):
+    def test_launchd_restart_drains_then_kickstarts_without_force(self, monkeypatch, capsys):
+        # Regression guard for #27745: launchd_restart invoked from a fresh
+        # shell (non-ancestor PID) must still take the drain-aware SIGUSR1
+        # path and then kickstart (without -k) to respawn immediately.  The
+        # pre-fix call to _request_gateway_self_restart returned False for
+        # non-ancestor PIDs, falling straight through to SIGTERM and skipping
+        # the drain handler entirely.
         calls = []
+        target = f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"
 
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
+        monkeypatch.setattr(
+            gateway_cli, "_graceful_restart_via_sigusr1",
+            lambda pid, drain: calls.append(("sigusr1", pid, drain)) or True,
+        )
+        monkeypatch.setattr(
+            gateway_cli, "terminate_pid",
+            lambda pid, force=False: pytest.fail("SIGTERM fallback must not run when drain succeeds"),
+        )
         monkeypatch.setattr(
             "gateway.status.get_running_pid",
             lambda: 321,
         )
-        monkeypatch.setattr(
-            gateway_cli,
-            "_request_gateway_self_restart",
-            lambda pid: calls.append(("self", pid)) or True,
-        )
-        monkeypatch.setattr(
-            gateway_cli.subprocess,
-            "run",
-            lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("launchctl should not run")),
-        )
+
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
 
         gateway_cli.launchd_restart()
 
-        assert calls == [("self", 321)]
-        assert "restart requested" in capsys.readouterr().out.lower()
+        # Drain succeeded → unforced kickstart, NOT kickstart -k.  -k would
+        # SIGKILL the in-flight runs the drain handler just spent up to
+        # drain_timeout seconds protecting.
+        assert calls == [
+            ("sigusr1", 321, 17.0),  # drain_timeout + 5
+            ["launchctl", "kickstart", target],
+        ]
+        assert "drained" in capsys.readouterr().out.lower()
 
     def test_launchd_stop_uses_bootout_not_kill(self, monkeypatch):
         """launchd_stop must bootout the service so KeepAlive doesn't respawn it."""


### PR DESCRIPTION
## What does this PR do?

`hermes gateway restart` on macOS (launchd) bypassed its own SIGUSR1 drain handler when invoked from a fresh shell — operator-requested restarts went straight to SIGTERM and killed in-flight agent runs. `launchd_restart` (`hermes_cli/gateway.py:3021`) gated its only SIGUSR1 call on `_request_gateway_self_restart`, which is itself guarded by `_is_pid_ancestor_of_current_process`. That ancestor guard is correct for the in-process self-restart case (`gateway/run.py` handlers asking their own gateway ancestor to restart) but returns False whenever the calling CLI process is a sibling under launchd — which is exactly the fresh-shell case. The fallback was `terminate_pid(pid, force=False)` (SIGTERM, no drain wait). This PR switches `launchd_restart` to the unconditional drain-aware helper `_graceful_restart_via_sigusr1(...)`, matching what `systemd_restart` (line 2585) and the macOS `hermes update` flow already use. On successful drain, runs `launchctl kickstart` (without `-k`) to bypass launchd's throttle while preserving the drained in-flight runs.

## Related Issue

Fixes #27745

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/gateway.py` — `launchd_restart` now calls `_graceful_restart_via_sigusr1(pid, drain_timeout + 5)` unconditionally (same budget as `systemd_restart`). On success, `launchctl kickstart` without `-k` bypasses throttle but preserves drained runs. On failure, the original SIGTERM + `kickstart -k` fallback is kept intact.
- `tests/hermes_cli/test_gateway_service.py` — new `test_launchd_restart_drains_then_kickstarts_without_force` (mocks a non-ancestor PID, verifies SIGUSR1 fires and unforced `launchctl kickstart` follows), and rewrote `test_launchd_restart_falls_back_to_sigterm_when_drain_fails` to mock the drain failing and verify the SIGTERM + `kickstart -k` path is preserved.

## How to Test

1. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/hermes_cli/test_gateway_service.py -v -k launchd` — 13 passed.
2. Regression guard: before the fix, `_request_gateway_self_restart` was mocked to False in the drain test, proving the SIGTERM path. After the fix that mock is unreachable; the new test exercises the SIGUSR1 path explicitly and asserts no SIGTERM call.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x (launchd is the affected platform)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Sibling Audit

> Sibling cleanup: the legacy `_request_gateway_self_restart` helper is now unused outside its own definition. Happy to drop it (and the underlying `_is_pid_ancestor_of_current_process`) in this PR or a follow-up if preferred.

## Related

- Complements #11932 / PR #24993 (in-process SIGUSR1 self-restart path, post-SIGUSR1 kickstart). #27745 is the upstream gap — the SIGUSR1 path never fired today for fresh-shell invocations.
- Same shape as #25966 (drain timeout race on the SIGTERM fallback path).
