### PR TITLE
fix(runtime): remediate drift gate blockers

### DIFF
--- a/agent/skill_preprocessing.py
+++ b/agent/skill_preprocessing.py
@@ -1,7 +1,9 @@
 """Shared SKILL.md preprocessing helpers."""
 
 import logging
+import os
 import re
+import signal
 import subprocess
 from pathlib import Path
 
@@ -66,17 +68,46 @@ def run_inline_shell(command: str, cwd: Path | None, timeout: int) -> str:
     Failures return a short ``[inline-shell error: ...]`` marker instead of
     raising, so one bad snippet can't wreck the whole skill message.
     """
+    effective_timeout = max(1, int(timeout))
+    popen_kwargs = {
+        "cwd": str(cwd) if cwd else None,
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+        "text": True,
+    }
+    if os.name == "posix":
+        # Put the shell and its children in their own process group. Python's
+        # subprocess.run(timeout=...) only kills the immediate shell process;
+        # a sleeping/grandchild process that still owns stdout/stderr can keep
+        # communicate() blocked until it exits, which hides timeout markers in
+        # skill slash-command rendering under the test live-system guard.
+        popen_kwargs["start_new_session"] = True
+
     try:
-        completed = subprocess.run(
-            ["bash", "-c", command],
-            cwd=str(cwd) if cwd else None,
-            capture_output=True,
-            text=True,
-            timeout=max(1, int(timeout)),
-            check=False,
-        )
+        proc = subprocess.Popen(["bash", "-c", command], **popen_kwargs)
+        try:
+            stdout, stderr = proc.communicate(timeout=effective_timeout)
+        except subprocess.TimeoutExpired:
+            if os.name == "posix":
+                try:
+                    os.killpg(proc.pid, signal.SIGKILL)
+                except Exception:
+                    try:
+                        proc.kill()
+                    except Exception:
+                        pass
+            else:
+                try:
+                    proc.kill()
+                except Exception:
+                    pass
+            try:
+                proc.communicate(timeout=1)
+            except Exception:
+                pass
+            return f"[inline-shell timeout after {effective_timeout}s: {command}]"
     except subprocess.TimeoutExpired:
-        return f"[inline-shell timeout after {timeout}s: {command}]"
+        return f"[inline-shell timeout after {effective_timeout}s: {command}]"
     except FileNotFoundError:
         return "[inline-shell error: bash not found]"
     except RuntimeError as exc:
@@ -90,9 +121,9 @@ def run_inline_shell(command: str, cwd: Path | None, timeout: int) -> str:
     except Exception as exc:
         return f"[inline-shell error: {exc}]"
 
-    output = (completed.stdout or "").rstrip("\n")
-    if not output and completed.stderr:
-        output = completed.stderr.rstrip("\n")
+    output = (stdout or "").rstrip("\n")
+    if not output and stderr:
+        output = stderr.rstrip("\n")
     if len(output) > _INLINE_SHELL_MAX_OUTPUT:
         output = output[:_INLINE_SHELL_MAX_OUTPUT] + "...[truncated]"
     return output

--- a/tests/acp/test_approval_isolation.py
+++ b/tests/acp/test_approval_isolation.py
@@ -210,6 +210,7 @@ class TestAcpExecAskGate:
         monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
         monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
         monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
 
         from tools.approval import check_all_command_guards
 
@@ -219,9 +220,14 @@ class TestAcpExecAskGate:
             called_with.append((command, description))
             return "once"
 
-        # Without HERMES_INTERACTIVE: takes auto-approve path, callback NOT called
+        approvable_dangerous_command = "chmod 777 /tmp/test-exec-ask"
+
+        # Without HERMES_INTERACTIVE: takes auto-approve path, callback NOT called.
+        # Use a dangerous-but-not-hardline command so this remains a focused ACP
+        # callback-routing regression test even after Tirith/hardline guards learned
+        # to block destructive rm fixtures before any approval prompt can run.
         result = check_all_command_guards(
-            "rm -rf /tmp/test-exec-ask", "local", approval_callback=fake_cb,
+            approvable_dangerous_command, "local", approval_callback=fake_cb,
         )
         assert result["approved"] is True
         assert called_with == [], (
@@ -233,7 +239,7 @@ class TestAcpExecAskGate:
         monkeypatch.setenv("HERMES_INTERACTIVE", "1")
         called_with.clear()
         result = check_all_command_guards(
-            "rm -rf /tmp/test-exec-ask", "local", approval_callback=fake_cb,
+            approvable_dangerous_command, "local", approval_callback=fake_cb,
         )
         assert called_with, (
             "with HERMES_INTERACTIVE the approval path should consult the "
@@ -241,3 +247,14 @@ class TestAcpExecAskGate:
             "GHSA-96vc-wcxf-jjff"
         )
         assert result["approved"] is True
+
+        # Hardline commands must remain unconditionally blocked before the ACP
+        # direct callback path. This proves the fixture change above did not
+        # weaken the Tirith/hardline safety floor.
+        called_with.clear()
+        result = check_all_command_guards(
+            "rm -rf /", "local", approval_callback=fake_cb,
+        )
+        assert result["approved"] is False
+        assert result.get("hardline") is True
+        assert called_with == []

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -366,7 +366,17 @@ def test_workspace_resolution_failure_also_counts(kanban_home, all_assignees_spa
 # Worker aliveness / crash detection
 # ---------------------------------------------------------------------------
 
-def test_pid_alive_helper():
+def test_pid_alive_helper(monkeypatch):
+    import gateway.status as gateway_status
+
+    real_pid_exists = gateway_status._pid_exists
+
+    def fake_pid_exists(pid: int) -> bool:
+        if pid == 2 ** 30:
+            return False
+        return real_pid_exists(pid)
+
+    monkeypatch.setattr(gateway_status, "_pid_exists", fake_pid_exists)
     # Our own pid is alive.
     assert kb._pid_alive(os.getpid())
     # PID 0 / None / negative.
@@ -2435,6 +2445,7 @@ def test_build_worker_context_role_history_bounded_to_5(kanban_home):
 
 @pytest.mark.skipif("linux" not in __import__("sys").platform,
                     reason="zombie detection is Linux-specific")
+@pytest.mark.live_system_guard_bypass
 def test_pid_alive_detects_zombie(kanban_home):
     """_pid_alive must return False for a zombie process.
 
@@ -4321,8 +4332,9 @@ def test_repeated_timeouts_trip_the_circuit_breaker(kanban_home, monkeypatch):
         conn.close()
 
 
-def test_detect_crashed_workers_increments_counter(kanban_home):
+def test_detect_crashed_workers_increments_counter(kanban_home, monkeypatch):
     """A single crash increments the consecutive_failures counter."""
+    monkeypatch.setattr(kb, "_pid_alive", lambda pid: False)
     conn = kb.connect()
     try:
         tid = kb.create_task(conn, title="crashy", assignee="worker")


### PR DESCRIPTION
Remediates the three Hermes origin/main drift gate blockers found during SoLoVision live fast-forward review.\n\nChanges:\n- Use a non-hardline dangerous command in the ACP approval isolation test and assert hardline commands still bypass callbacks and block unconditionally.\n- Make inline skill shell timeout handling kill the process group and return the timeout marker without dropping the rest of the skill message.\n- Make Kanban PID/liveness tests hermetic under the live-system guard, with a narrow bypass only for the real child zombie signal test.\n\nVerification:\n- python -m pytest tests/acp/test_approval_isolation.py::TestAcpExecAskGate::test_interactive_env_var_routes_to_callback tests/agent/test_skill_commands.py::TestInlineShellExpansion::test_inline_shell_timeout_does_not_break_message tests/hermes_cli/test_kanban_core_functionality.py::test_pid_alive_helper tests/hermes_cli/test_kanban_core_functionality.py::test_pid_alive_detects_zombie tests/hermes_cli/test_kanban_core_functionality.py::test_detect_crashed_workers_increments_counter -q -o 'addopts=' → 5 passed in 2.90s\n- python -m pytest tests/acp/test_approval_isolation.py tests/agent/test_skill_commands.py tests/hermes_cli/test_kanban_core_functionality.py -q -o 'addopts=' → 201 passed in 6.09s