### PR TITLE
fix(cli): prevent Py_FinalizeEx deadlock via os._exit(0) in _run_cleanup (#27563)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -692,6 +692,11 @@ from tools.browser_tool import _emergency_cleanup_all_sessions as _cleanup_all_b
 _cleanup_done = False
 # Weak reference to the active AIAgent for memory provider shutdown at exit
 _active_agent_ref = None
+# Set to False in tests to prevent os._exit(0) from killing the test process.
+# Production (CLI) runs expect immediate exit after cleanup to avoid the
+# Py_FinalizeEx worker-thread deadlock; tests call _run_cleanup() directly
+# and need it to return normally.
+_enable_force_exit = True
 
 def _run_cleanup():
     """Run resource cleanup exactly once."""
@@ -743,6 +748,15 @@ def _run_cleanup():
                 _active_agent_ref.shutdown_memory_provider()
     except Exception:
         pass
+    # Force immediate exit after cleanup to prevent Py_FinalizeEx deadlock
+    # with non-daemon threads (httpx pools, prompt_toolkit workers) that
+    # don't check exit flags during interpreter shutdown.  All critical
+    # resources (terminals, browsers, MCP, voice, session, memory provider)
+    # have been released above — bypassing normal shutdown is safe here.
+    # Guarded by _enable_force_exit so tests that call _run_cleanup() directly
+    # are not killed mid-process.  See #27563.
+    if _enable_force_exit:
+        os._exit(0)
 
 
 # =============================================================================

--- a/tests/cli/test_cli_shutdown_memory_messages.py
+++ b/tests/cli/test_cli_shutdown_memory_messages.py
@@ -35,11 +35,13 @@ def test_cleanup_forwards_session_messages(mock_invoke_hook):
 
     cli_mod._active_agent_ref = agent
     cli_mod._cleanup_done = False
+    cli_mod._enable_force_exit = False
     try:
         cli_mod._run_cleanup()
     finally:
         cli_mod._active_agent_ref = None
         cli_mod._cleanup_done = False
+        cli_mod._enable_force_exit = True
 
     agent.shutdown_memory_provider.assert_called_once_with(transcript)
 
@@ -57,11 +59,13 @@ def test_cleanup_empty_list_still_forwarded(mock_invoke_hook):
 
     cli_mod._active_agent_ref = agent
     cli_mod._cleanup_done = False
+    cli_mod._enable_force_exit = False
     try:
         cli_mod._run_cleanup()
     finally:
         cli_mod._active_agent_ref = None
         cli_mod._cleanup_done = False
+        cli_mod._enable_force_exit = True
 
     agent.shutdown_memory_provider.assert_called_once_with([])
 
@@ -81,11 +85,13 @@ def test_cleanup_non_list_attribute_falls_back_to_no_arg(mock_invoke_hook):
 
     cli_mod._active_agent_ref = agent
     cli_mod._cleanup_done = False
+    cli_mod._enable_force_exit = False
     try:
         cli_mod._run_cleanup()
     finally:
         cli_mod._active_agent_ref = None
         cli_mod._cleanup_done = False
+        cli_mod._enable_force_exit = True
 
     agent.shutdown_memory_provider.assert_called_once_with()
 
@@ -102,10 +108,12 @@ def test_cleanup_provider_exception_is_swallowed(mock_invoke_hook):
 
     cli_mod._active_agent_ref = agent
     cli_mod._cleanup_done = False
+    cli_mod._enable_force_exit = False
     try:
         cli_mod._run_cleanup()  # must not raise
     finally:
         cli_mod._active_agent_ref = None
         cli_mod._cleanup_done = False
+        cli_mod._enable_force_exit = True
 
     agent.shutdown_memory_provider.assert_called_once()

--- a/tests/cli/test_session_boundary_hooks.py
+++ b/tests/cli/test_session_boundary_hooks.py
@@ -42,6 +42,7 @@ def test_session_finalize_on_cleanup(mock_invoke_hook):
     mock_agent.session_id = "cleanup-session-id"
     cli_mod._active_agent_ref = mock_agent
     cli_mod._cleanup_done = False
+    cli_mod._enable_force_exit = False
 
     cli_mod._run_cleanup()
 


### PR DESCRIPTION
## Problem

After certain operations (Ctrl+C or internal errors), the Hermes CLI process hangs indefinitely — terminal becomes unresponsive but the process stays alive consuming CPU. The process requires `kill -9` to terminate.

## Root Cause

Python interpreter exit deadlock: `Py_FinalizeEx` → `wait_for_thread_shutdown` blocks forever waiting for non-daemon threads (httpx connection pools, prompt_toolkit workers) that don't check exit flags and continue executing bytecode.

## Fix

Add `os._exit(0)` as the final step in `_run_cleanup()`, guarded by a module-level `_enable_force_exit` flag. Since all critical resources (terminals, browsers, MCP servers, voice, session, memory provider) are already released before this point, bypassing normal interpreter exit is safe and prevents the process from hanging.

The guard flag is set to `False` in tests that directly call `_run_cleanup()` to avoid killing the test process.

## Changes

- **cli.py**: +14 lines — `_enable_force_exit` guard variable + `os._exit(0)` at end of `_run_cleanup()`
- **tests/cli/test_cli_shutdown_memory_messages.py**: +8 lines — set `_enable_force_exit = False` in 4 tests
- **tests/cli/test_session_boundary_hooks.py**: +1 line — set `_enable_force_exit = False` in 1 test

## Testing

- 8/8 affected tests pass
- Syntax check passed via `ast.parse`
- Security scan: 0 new findings

Closes #27563