### PR TITLE
feat(plugins): add goal lifecycle hooks

### DIFF
--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -464,6 +464,26 @@ def judge_goal(
 
 
 # ──────────────────────────────────────────────────────────────────────
+# Plugin hook helper — fire-and-forget, never raises
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _fire_goal_hook(hook_name: str, **kwargs: Any) -> None:
+    """Invoke a goal lifecycle hook on every registered plugin.
+
+    Wrapped in a broad try/except so a misbehaving plugin (or an absent
+    plugin manager during unit tests) can never wedge the goal mutation
+    that triggered the hook. Plugin return values are ignored — these
+    hooks are observers only.
+    """
+    try:
+        from hermes_cli.plugins import invoke_hook as _invoke_hook
+        _invoke_hook(hook_name, **kwargs)
+    except Exception:
+        logger.debug("goal hook %s: dispatch failed", hook_name, exc_info=True)
+
+
+# ──────────────────────────────────────────────────────────────────────
 # GoalManager — the orchestration surface CLI + gateway talk to
 # ──────────────────────────────────────────────────────────────────────
 
@@ -533,6 +553,12 @@ class GoalManager:
         )
         self._state = state
         save_goal(self.session_id, state)
+        _fire_goal_hook(
+            "on_goal_set",
+            session_id=self.session_id,
+            goal_text=state.goal,
+            max_turns=state.max_turns,
+        )
         return state
 
     def pause(self, reason: str = "user-paused") -> Optional[GoalState]:
@@ -541,6 +567,11 @@ class GoalManager:
         self._state.status = "paused"
         self._state.paused_reason = reason
         save_goal(self.session_id, self._state)
+        _fire_goal_hook(
+            "on_goal_pause",
+            session_id=self.session_id,
+            reason=reason,
+        )
         return self._state
 
     def resume(self, *, reset_budget: bool = True) -> Optional[GoalState]:
@@ -551,6 +582,11 @@ class GoalManager:
         if reset_budget:
             self._state.turns_used = 0
         save_goal(self.session_id, self._state)
+        _fire_goal_hook(
+            "on_goal_resume",
+            session_id=self.session_id,
+            reset_budget=bool(reset_budget),
+        )
         return self._state
 
     def clear(self) -> None:
@@ -567,6 +603,12 @@ class GoalManager:
         self._state.last_verdict = "done"
         self._state.last_reason = reason
         save_goal(self.session_id, self._state)
+        _fire_goal_hook(
+            "on_goal_complete",
+            session_id=self.session_id,
+            reason=reason,
+            turns_used=self._state.turns_used,
+        )
 
     # --- /subgoal user controls ---------------------------------------
 

--- a/hermes_cli/hooks.py
+++ b/hermes_cli/hooks.py
@@ -182,6 +182,24 @@ _DEFAULT_PAYLOADS = {
         "child_status": "completed",
         "duration_ms": 1234,
     },
+    "on_goal_set": {
+        "session_id": "test-session",
+        "goal_text": "ship the feature",
+        "max_turns": 20,
+    },
+    "on_goal_pause": {
+        "session_id": "test-session",
+        "reason": "user-paused",
+    },
+    "on_goal_resume": {
+        "session_id": "test-session",
+        "reset_budget": True,
+    },
+    "on_goal_complete": {
+        "session_id": "test-session",
+        "reason": "judge verdict: done",
+        "turns_used": 4,
+    },
 }
 
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -165,6 +165,20 @@ VALID_HOOKS: Set[str] = {
     #   choice: "once" | "session" | "always" | "deny" | "timeout"
     "pre_approval_request",
     "post_approval_response",
+    # Goal lifecycle hooks. Fired by hermes_cli/goals.py when the
+    # /goal state machine transitions. Observers only -- return values
+    # are ignored, and exceptions raised by plugin callbacks do not
+    # interrupt the goal mutation that fired the hook.
+    #
+    # Kwargs:
+    #   on_goal_set:      session_id, goal_text, max_turns
+    #   on_goal_pause:    session_id, reason
+    #   on_goal_resume:   session_id, reset_budget
+    #   on_goal_complete: session_id, reason, turns_used
+    "on_goal_set",
+    "on_goal_pause",
+    "on_goal_resume",
+    "on_goal_complete",
 }
 
 ENTRY_POINTS_GROUP = "hermes_agent.plugins"

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -738,3 +738,129 @@ class TestStatusLineSubgoalCount:
         mgr.add_subgoal("b")
         line = mgr.status_line()
         assert "2 subgoals" in line
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Goal lifecycle plugin hooks
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestGoalLifecycleHooks:
+    """Plugin hooks fired on goal state transitions.
+
+    Each hook is fire-and-forget: return values are ignored, and
+    exceptions raised inside a hook callback must never wedge the
+    goal mutation that triggered it.
+    """
+
+    def test_hooks_registered_as_valid(self):
+        from hermes_cli.plugins import VALID_HOOKS
+
+        for name in (
+            "on_goal_set",
+            "on_goal_pause",
+            "on_goal_resume",
+            "on_goal_complete",
+        ):
+            assert name in VALID_HOOKS
+
+    def test_on_goal_set_fires_with_payload(self, hermes_home):
+        from hermes_cli.goals import GoalManager
+
+        with patch("hermes_cli.plugins.invoke_hook") as mock_invoke:
+            mgr = GoalManager(session_id="hook-set")
+            mgr.set("ship it", max_turns=7)
+
+        names = [c.args[0] for c in mock_invoke.call_args_list]
+        assert "on_goal_set" in names
+
+        call = next(c for c in mock_invoke.call_args_list if c.args[0] == "on_goal_set")
+        assert call.kwargs == {
+            "session_id": "hook-set",
+            "goal_text": "ship it",
+            "max_turns": 7,
+        }
+
+    def test_on_goal_pause_fires_with_reason(self, hermes_home):
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="hook-pause")
+        mgr.set("ship it")
+
+        with patch("hermes_cli.plugins.invoke_hook") as mock_invoke:
+            mgr.pause(reason="judge-parse-failure")
+
+        call = next(c for c in mock_invoke.call_args_list if c.args[0] == "on_goal_pause")
+        assert call.kwargs == {
+            "session_id": "hook-pause",
+            "reason": "judge-parse-failure",
+        }
+
+    def test_on_goal_resume_fires_with_budget_flag(self, hermes_home):
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="hook-resume")
+        mgr.set("ship it")
+        mgr.pause()
+
+        with patch("hermes_cli.plugins.invoke_hook") as mock_invoke:
+            mgr.resume(reset_budget=False)
+
+        call = next(c for c in mock_invoke.call_args_list if c.args[0] == "on_goal_resume")
+        assert call.kwargs == {
+            "session_id": "hook-resume",
+            "reset_budget": False,
+        }
+
+    def test_on_goal_complete_fires_with_turns(self, hermes_home):
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="hook-complete")
+        state = mgr.set("ship it")
+        state.turns_used = 4
+
+        with patch("hermes_cli.plugins.invoke_hook") as mock_invoke:
+            mgr.mark_done("judge verdict: done")
+
+        call = next(c for c in mock_invoke.call_args_list if c.args[0] == "on_goal_complete")
+        assert call.kwargs == {
+            "session_id": "hook-complete",
+            "reason": "judge verdict: done",
+            "turns_used": 4,
+        }
+
+    def test_pause_without_active_goal_does_not_fire(self, hermes_home):
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="hook-empty")
+        with patch("hermes_cli.plugins.invoke_hook") as mock_invoke:
+            assert mgr.pause("user-paused") is None
+            assert mgr.resume() is None
+            mgr.mark_done("noop")
+
+        # No state means no transition -> no hook.
+        assert not any(
+            c.args[0].startswith("on_goal_") for c in mock_invoke.call_args_list
+        )
+
+    def test_hook_exception_does_not_break_goal_mutation(self, hermes_home):
+        """A misbehaving plugin must not wedge the state machine."""
+        from hermes_cli.goals import GoalManager
+
+        with patch(
+            "hermes_cli.plugins.invoke_hook",
+            side_effect=RuntimeError("plugin exploded"),
+        ):
+            mgr = GoalManager(session_id="hook-explode")
+            state = mgr.set("ship it")
+            assert state.status == "active"
+            assert state.goal == "ship it"
+
+            mgr.pause("explode-test")
+            assert mgr._state.status == "paused"
+
+            mgr.resume(reset_budget=True)
+            assert mgr._state.status == "active"
+
+            mgr.mark_done("explode-test-done")
+            assert mgr._state.status == "done"


### PR DESCRIPTION
## Summary

Add four new fire-and-forget plugin hooks fired by `GoalManager` when the `/goal` state machine transitions:

| Hook | Trigger | Payload |
|------|---------|---------|
| `on_goal_set` | New goal created | `session_id`, `goal_text`, `max_turns` |
| `on_goal_pause` | Goal paused (user/judge parse failure/etc.) | `session_id`, `reason` |
| `on_goal_resume` | Goal resumed | `session_id`, `reset_budget` |
| `on_goal_complete` | Goal marked done | `session_id`, `reason`, `turns_used` |

Plugin callbacks are observers — return values are ignored, and any exception raised inside a callback is swallowed (logged at DEBUG) so a misbehaving plugin cannot wedge the goal mutation that fired the hook. Consistent with the existing hook contract used by `pre_api_request` etc.

## Changes

- `hermes_cli/plugins.py` — add the four hook names to `VALID_HOOKS`
- `hermes_cli/hooks.py` — add synthetic `_DEFAULT_PAYLOADS` entries so `hermes plugins test on_goal_set` (and friends) work
- `hermes_cli/goals.py` — new `_fire_goal_hook()` helper invoked from `set()`, `pause()`, `resume()`, and `mark_done()`
- `tests/hermes_cli/test_goals.py` — new `TestGoalLifecycleHooks` class with 7 tests covering each hook payload, no-op on inactive state, and the error-isolation contract

## Tests

```
$ pytest tests/hermes_cli/test_goals.py tests/cli/test_session_boundary_hooks.py tests/hermes_cli/test_plugins.py -q
133 passed in 5.92s

$ ruff check hermes_cli/goals.py hermes_cli/plugins.py hermes_cli/hooks.py tests/hermes_cli/test_goals.py
All checks passed!
```

No existing tests had to be modified — this is a pure addition.

Closes #27777
