### PR TITLE
fix: guard Honcho durable memory writes

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -184,6 +184,41 @@ CONCLUDE_SCHEMA = {
 ALL_TOOL_SCHEMAS = [PROFILE_SCHEMA, SEARCH_SCHEMA, REASONING_SCHEMA, CONTEXT_SCHEMA, CONCLUDE_SCHEMA]
 
 
+# Durable-memory guardrail: Honcho conclusions are shared, long-lived memory.
+# Keep transient task state, credentials, raw logs, and implementation artifacts
+# out of the representation layer so multi-agent fleets do not inherit stale work.
+_HONCHO_BLOCKED_CONCLUSION_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"github\.com/login/device", re.I), "device-auth flow URL"),
+    (re.compile(r"\b[A-Z0-9]{4}-[A-Z0-9]{4}\b"), "device/auth code"),
+    (re.compile(r"\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{20,}\b"), "GitHub token material"),
+    (re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}\b", re.I), "GitHub token material"),
+    (re.compile(r"\bsk-[A-Za-z0-9_-]{20,}\b"), "API key material"),
+    (re.compile(r"\bxox[abprs]-[A-Za-z0-9-]{20,}\b", re.I), "Slack token material"),
+    (re.compile(r"\bAKIA[0-9A-Z]{16}\b"), "AWS access key material"),
+    (re.compile(r"\beyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{10,}\b"), "JWT/bearer token material"),
+    (re.compile(r"\b(?:ssh-rsa|ssh-ed25519|ecdsa-sha2-[A-Za-z0-9-]+)\s+\S+", re.I), "raw SSH public key"),
+    (re.compile(r"BEGIN [A-Z ]*PRIVATE KEY", re.I), "private key material"),
+    (re.compile(r"\b(currently working|working on|in progress|awaiting|waiting for|blocked on|next task is|next step is|todo)\b", re.I), "transient task state"),
+    (re.compile(r"\b(?:PR|pull request|issue)\s*#?\d+\b", re.I), "stale PR/issue artifact"),
+    (re.compile(r"\b(?:commit\s+)?[0-9a-f]{12,40}\b", re.I), "stale commit artifact"),
+    (re.compile(r"\bworkflow run\b", re.I), "stale workflow-run artifact"),
+    (re.compile(r"\b(?:Traceback \(most recent call last\)|Exception in thread|ERROR\s+\[[^\]]+\])", re.I), "raw log/stack trace"),
+]
+
+
+def _honcho_conclusion_guardrail(conclusion: str) -> Optional[str]:
+    """Return a block reason when a conclusion is unsafe for durable Honcho memory."""
+    text = (conclusion or "").strip()
+    if not text:
+        return "empty conclusion"
+    if len(text) > 1200:
+        return "too long for durable memory; summarize before saving"
+    for pattern, reason in _HONCHO_BLOCKED_CONCLUSION_PATTERNS:
+        if pattern.search(text):
+            return reason
+    return None
+
+
 # ---------------------------------------------------------------------------
 # MemoryProvider implementation
 # ---------------------------------------------------------------------------
@@ -1166,6 +1201,10 @@ class HonchoMemoryProvider(MemoryProvider):
         """
         if action != "add" or target != "user" or not content:
             return
+        blocked_reason = _honcho_conclusion_guardrail(content)
+        if blocked_reason:
+            logger.info("Honcho memory mirror blocked unsafe durable conclusion: %s", blocked_reason)
+            return
         if self._cron_skipped:
             return
         if not self._manager or not self._session_key:
@@ -1296,6 +1335,13 @@ class HonchoMemoryProvider(MemoryProvider):
                     if ok:
                         return json.dumps({"result": f"Conclusion {delete_id} deleted."})
                     return tool_error(f"Failed to delete conclusion {delete_id}.")
+                blocked_reason = _honcho_conclusion_guardrail(conclusion)
+                if blocked_reason:
+                    return tool_error(
+                        "Refusing to save unsafe durable Honcho conclusion: "
+                        f"{blocked_reason}. Store transient work in Mission Control/NATS, "
+                        "docs in Obsidian, and procedures in skills instead."
+                    )
                 ok = self._manager.create_conclusion(self._session_key, conclusion, peer=peer)
                 if ok:
                     return json.dumps({"result": f"Conclusion saved for {peer}: {conclusion}"})

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -4,6 +4,8 @@ from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
+
 from plugins.memory.honcho.session import (
     HonchoSession,
     HonchoSessionManager,
@@ -413,6 +415,79 @@ class TestConcludeToolDispatch:
             "telegram:123",
             "Assistant likes terse replies",
             peer="ai",
+        )
+
+    def test_honcho_conclude_blocks_unsafe_durable_task_state(self):
+        import json
+
+        provider = HonchoMemoryProvider()
+        provider._session_initialized = True
+        provider._session_key = "telegram:123"
+        provider._manager = MagicMock()
+
+        result = provider.handle_tool_call(
+            "honcho_conclude",
+            {"conclusion": "Assistant is currently working on PR #123 and awaiting CI."},
+        )
+
+        parsed = json.loads(result)
+        assert "Refusing to save unsafe durable Honcho conclusion" in parsed["error"]
+        assert "transient task state" in parsed["error"]
+        provider._manager.create_conclusion.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("conclusion", "reason"),
+        [
+            ("Use github.com/login/device with code ABCD-1234.", "device-auth flow URL"),
+            ("Temporary token " + "ghp_" + "a" * 26, "GitHub token material"),
+            ("OpenAI key " + "sk-" + "a" * 26, "API key material"),
+            ("AWS key " + "AKIA" + "A" * 16, "AWS access key material"),
+            ("Public key ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMockKey", "raw SSH public key"),
+            ("Next step is pull request 123 after CI", "transient task state"),
+            ("Deployment came from a1b2c3d4e5f67890", "stale commit artifact"),
+            ("Traceback (most recent call last): boom", "raw log/stack trace"),
+        ],
+    )
+    def test_honcho_conclude_blocks_auth_and_transient_artifacts(self, conclusion, reason):
+        import json
+
+        provider = HonchoMemoryProvider()
+        provider._session_initialized = True
+        provider._session_key = "telegram:123"
+        provider._manager = MagicMock()
+
+        result = provider.handle_tool_call(
+            "honcho_conclude",
+            {"conclusion": conclusion},
+        )
+
+        parsed = json.loads(result)
+        assert reason in parsed["error"]
+        provider._manager.create_conclusion.assert_not_called()
+
+    def test_builtin_memory_mirror_blocks_unsafe_conclusions(self):
+        provider = HonchoMemoryProvider()
+        provider._session_key = "telegram:123"
+        provider._manager = MagicMock()
+
+        provider.on_memory_write(
+            "add",
+            "user",
+            "User is blocked on workflow run 123456 and next task is PR #99.",
+        )
+
+        provider._manager.create_conclusion.assert_not_called()
+
+    def test_builtin_memory_mirror_allows_durable_preferences(self):
+        provider = HonchoMemoryProvider()
+        provider._session_key = "telegram:123"
+        provider._manager = MagicMock()
+
+        provider.on_memory_write("add", "user", "User prefers concise local-time status reports.")
+
+        provider._manager.create_conclusion.assert_called_once_with(
+            "telegram:123",
+            "User prefers concise local-time status reports.",
         )
 
     def test_honcho_profile_can_target_explicit_peer_id(self):


### PR DESCRIPTION
## Summary
- block unsafe Honcho conclusions before durable writes
- reject device/auth artifacts, raw key material, transient task state, PR/issue/workflow artifacts, commit refs, and oversized raw blobs
- apply the same guardrail to built-in memory mirror writes

## Test Plan
- /home/hermes/.hermes/hermes-agent/venv/bin/python -m pytest tests/honcho_plugin -q -o 'addopts='