### PR TITLE
kanban: dispatch-time guard refuses to spawn workers for vanished tasks

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -72,6 +72,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import logging
 import os
 import re
 import secrets
@@ -84,6 +85,9 @@ from pathlib import Path
 from typing import Any, Iterable, Optional
 
 from toolsets import get_toolset_names
+
+
+_log = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -3092,6 +3096,23 @@ class DispatchResult:
     """Task ids auto-blocked by the spawn-failure circuit breaker."""
     timed_out: list[str] = field(default_factory=list)
     """Task ids whose workers exceeded ``max_runtime_seconds``."""
+    reclaimed_at_spawn: list[str] = field(default_factory=list)
+    """Task ids that were successfully claimed by ``claim_task`` but
+    whose ``tasks`` row vanished before we could fork the worker (i.e.
+    between the CAS that flipped ``ready -> running`` and the
+    just-before-spawn re-check). For each id we close the just-created
+    ``task_runs`` row with ``status='released' / outcome='reclaimed'``
+    and emit a ``task_events`` row of ``kind='reclaimed'`` with
+    ``payload={"reason": "task-row-missing-at-spawn"}``.
+
+    The Hermes codebase never DELETEs from ``tasks`` (only sets
+    ``status='archived'``), so a non-empty list here means a foreign
+    process touched the SQLite file directly. The dispatch-time guard
+    exists so that race burns ~zero LiteLLM tokens instead of spinning
+    up a full worker that finds nothing to do. See kanban card
+    ``t_398ca944`` for the forensic background (sibling ``t_44c9eb37``
+    handles the periodic reaper for orphan runs that slip through this
+    guard)."""
 
 
 # Bounded registry of recently-reaped worker child exits, populated by the
@@ -3854,10 +3875,15 @@ def dispatch_once(
       1. Reclaim stale running tasks (TTL expired).
       2. Reclaim crashed running tasks (host-local PID no longer alive).
       3. Promote todo -> ready where all parents are done.
-      4. For each ready task with an assignee, atomically claim and call
-         ``spawn_fn(task, workspace_path, board) -> Optional[int]``. The
-         return value (if any) is recorded as ``worker_pid`` so subsequent
-         ticks can detect crashes before the TTL expires.
+      4. For each ready task with an assignee, atomically claim, then
+         re-check the ``tasks`` row still exists (defense in depth
+         against foreign ``DELETE FROM tasks`` mid-dispatch — see card
+         ``t_398ca944``; on row-vanished we close the just-created
+         ``task_runs`` row as ``released/reclaimed`` and skip the
+         spawn instead of burning a worker boot), then call
+         ``spawn_fn(task, workspace_path, board) -> Optional[int]``.
+         The return value (if any) is recorded as ``worker_pid`` so
+         subsequent ticks can detect crashes before the TTL expires.
 
     Spawn failures are counted per-task. After ``failure_limit`` consecutive
     failures the task is auto-blocked with the last error as its reason —
@@ -3977,6 +4003,73 @@ def dispatch_once(
             continue
         claimed = claim_task(conn, row["id"], ttl_seconds=ttl_seconds)
         if claimed is None:
+            continue
+        # Defense in depth (card t_398ca944): re-check the tasks row
+        # exists right before we fork a worker subprocess. claim_task
+        # already proved the row existed during the CAS, but in the
+        # window between that commit and this read someone could
+        # ``DELETE FROM tasks WHERE id=?`` directly via sqlite3 — the
+        # codebase itself never does this (only ``UPDATE status=
+        # 'archived'``), but on 2026-05-18 a foreign process nuked 28
+        # rows mid-dispatch and the previous tick spawned 28 workers
+        # that burned ~4 minutes of LiteLLM tokens each before their
+        # ``kanban_show`` failed. Catch the race here so the cost of a
+        # vanished task is one extra SELECT, not a full agent boot.
+        still_exists = conn.execute(
+            "SELECT 1 FROM tasks WHERE id = ?", (claimed.id,),
+        ).fetchone()
+        if not still_exists:
+            now = int(time.time())
+            run_id = claimed.current_run_id
+            with write_txn(conn):
+                if run_id is not None:
+                    conn.execute(
+                        """
+                        UPDATE task_runs
+                           SET status        = 'released',
+                               outcome       = 'reclaimed',
+                               summary       = 'task row missing at spawn time',
+                               ended_at      = ?,
+                               claim_lock    = NULL,
+                               claim_expires = NULL,
+                               worker_pid    = NULL
+                         WHERE id = ?
+                           AND ended_at IS NULL
+                        """,
+                        (now, int(run_id)),
+                    )
+                # Emit a task_events row for audit. The owning tasks
+                # row is gone, so this is a soft orphan event (no FK
+                # is declared on task_events.task_id, so the INSERT
+                # succeeds). The sibling orphan-runs reaper
+                # (t_44c9eb37) explicitly does NOT emit events for
+                # this case because the row would be orphaned; at
+                # dispatch time we still emit one so an operator
+                # tailing ``task_events`` can correlate the SIGTERM
+                # window without grepping the dispatcher log.
+                payload = json.dumps(
+                    {
+                        "reason": "task-row-missing-at-spawn",
+                        "run_id": run_id,
+                        "assignee": claimed.assignee,
+                    },
+                    ensure_ascii=False,
+                )
+                conn.execute(
+                    "INSERT INTO task_events (task_id, run_id, kind, payload, created_at) "
+                    "VALUES (?, ?, ?, ?, ?)",
+                    (claimed.id, run_id, "reclaimed", payload, now),
+                )
+            result.reclaimed_at_spawn.append(claimed.id)
+            # WARNING so it lands in ~/.hermes/logs/errors.log via
+            # the standard handler chain (hermes_logging.setup_logging
+            # routes WARNING+ to errors.log).
+            _log.warning(
+                "kanban dispatcher: refusing to spawn worker for %s — "
+                "tasks row vanished between claim and spawn (run_id=%s); "
+                "closed run as reclaimed. Foreign DELETE FROM tasks suspected.",
+                claimed.id, run_id,
+            )
             continue
         try:
             workspace = resolve_workspace(claimed, board=board)

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import concurrent.futures
+import json
 import os
 import time
 from pathlib import Path
@@ -746,6 +747,123 @@ def test_dispatch_reclaims_stale_before_spawning(kanban_home):
         )
         res = kb.dispatch_once(conn, dry_run=True)
     assert res.reclaimed == 1
+
+
+def test_dispatch_refuses_to_spawn_when_task_row_vanishes_mid_tick(
+    kanban_home, all_assignees_spawnable, monkeypatch
+):
+    """Dispatch-time orphan guard (kanban card t_398ca944).
+
+    Foreign process DELETEs the ``tasks`` row in the window between
+    ``claim_task`` (which CAS-flipped ``ready -> running``) and the
+    just-before-spawn re-check. The dispatcher must:
+
+      1. NOT call spawn_fn for the vanished task.
+      2. Close the just-created ``task_runs`` row as
+         ``status='released' / outcome='reclaimed'`` with the
+         documented summary.
+      3. Emit a ``task_events`` row of ``kind='reclaimed'`` with
+         ``payload.reason == 'task-row-missing-at-spawn'``.
+      4. Surface the id in ``DispatchResult.reclaimed_at_spawn``.
+
+    Sibling ``test_dispatch_spawn_failure_releases_claim`` covers the
+    OTHER race (spawn_fn raises). This case is distinct: the row is
+    gone before we ever ask the spawner, so we never fork at all.
+    """
+    spawns: list[str] = []
+    real_claim = kb.claim_task
+
+    def claim_then_delete(conn, task_id, **kwargs):
+        # Real claim flips status + writes task_runs row. Then we
+        # simulate the foreign DELETE before the dispatch loop's
+        # re-check runs.
+        task = real_claim(conn, task_id, **kwargs)
+        if task is not None:
+            conn.execute("DELETE FROM tasks WHERE id = ?", (task_id,))
+            conn.commit()
+        return task
+
+    monkeypatch.setattr(kb, "claim_task", claim_then_delete)
+
+    def fake_spawn(task, workspace):
+        spawns.append(task.id)
+        return 4242
+
+    with kb.connect() as conn:
+        good = kb.create_task(conn, title="survives", assignee="alice")
+        doomed = kb.create_task(conn, title="vanishes", assignee="bob")
+        res = kb.dispatch_once(conn, spawn_fn=fake_spawn)
+
+    # Spawn loop iterates ready tasks in priority/created order. Both
+    # were monkeypatched, so BOTH get DELETEd between claim and the
+    # re-check. We assert on the structural shape, not the count: every
+    # claimed-then-vanished task must be reclaimed_at_spawn, none must
+    # be spawned.
+    assert spawns == [], (
+        f"spawn_fn was called for at least one vanished task: {spawns!r}"
+    )
+    assert set(res.reclaimed_at_spawn) == {good, doomed}, (
+        f"reclaimed_at_spawn={res.reclaimed_at_spawn!r}"
+    )
+    assert res.spawned == []
+
+    with kb.connect() as conn:
+        # task_runs row(s) must be closed with the documented values.
+        runs = conn.execute(
+            "SELECT task_id, status, outcome, summary, ended_at, "
+            "claim_lock, claim_expires, worker_pid "
+            "FROM task_runs ORDER BY id"
+        ).fetchall()
+        assert len(runs) == 2
+        for row in runs:
+            assert row["status"] == "released"
+            assert row["outcome"] == "reclaimed"
+            assert row["summary"] == "task row missing at spawn time"
+            assert row["ended_at"] is not None
+            assert row["claim_lock"] is None
+            assert row["claim_expires"] is None
+            assert row["worker_pid"] is None
+
+        # And a task_events 'reclaimed' row was written per task with
+        # the documented payload reason.
+        events = conn.execute(
+            "SELECT task_id, kind, payload FROM task_events "
+            "WHERE kind = 'reclaimed' ORDER BY id"
+        ).fetchall()
+        assert len(events) == 2
+        seen_task_ids = set()
+        for ev in events:
+            payload = json.loads(ev["payload"])
+            assert payload["reason"] == "task-row-missing-at-spawn"
+            assert payload["run_id"] is not None
+            seen_task_ids.add(ev["task_id"])
+        assert seen_task_ids == {good, doomed}
+
+
+def test_dispatch_normal_path_does_not_trigger_orphan_guard(
+    kanban_home, all_assignees_spawnable
+):
+    """Sanity check: when the tasks row stays put, reclaimed_at_spawn
+    is empty and the worker is spawned exactly once.
+
+    Guards against a regression where the spawn-time re-check
+    accidentally trips on healthy tasks (e.g. wrong column name, SQL
+    typo, missing commit visibility).
+    """
+    spawns: list[str] = []
+
+    def fake_spawn(task, workspace):
+        spawns.append(task.id)
+        return 9999
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="happy path", assignee="alice")
+        res = kb.dispatch_once(conn, spawn_fn=fake_spawn)
+
+    assert spawns == [t]
+    assert res.reclaimed_at_spawn == []
+    assert len(res.spawned) == 1
+    assert res.spawned[0][0] == t
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Defense in depth against foreign \`DELETE FROM tasks\` racing the dispatcher mid-tick.

## Context
On 2026-05-18 one dispatcher tick claimed and spawned 28 workers whose \`tasks\` rows had been hard-deleted between claim and worker boot (~3s window). Each worker burned ~4 minutes of LiteLLM tokens before its own \`kanban_show\` returned not-found.

Hermes never DELETEs from \`tasks\` itself (only \`UPDATE status=archived\`), so the row-vanished case is always a foreign sqlite3/dashboard/script write. The fix is purely defensive at the dispatcher.

## Change
After \`claim_task\` succeeds in \`dispatch_once\`, re-check \`SELECT 1 FROM tasks WHERE id=?\` before calling \`spawn_fn\`. On row-vanished:
- close the just-created \`task_runs\` row as \`status=released\` / \`outcome=reclaimed\` / \`summary='task row missing at spawn time'\`
- INSERT a \`task_events\` row of \`kind=reclaimed\` with \`payload.reason=task-row-missing-at-spawn\`
- log WARNING (lands in errors.log via setup_logging)
- skip spawn entirely, surface the id in new \`DispatchResult.reclaimed_at_spawn\` field

\`claim_task\` itself was verified orphan-safe already (CAS UPDATE WHERE id=? AND status='ready' returns rowcount=0 on missing row).

## Tests
- \`test_dispatch_refuses_to_spawn_when_task_row_vanishes_mid_tick\` — regression
- \`test_dispatch_normal_path_does_not_trigger_orphan_guard\` — sanity

236/237 tests pass in \`test_kanban_db.py\` + \`test_kanban_core_functionality.py\` (1 pre-existing skip).

## Files
- \`hermes_cli/kanban_db.py\` (+97 / -4)
- \`tests/hermes_cli/test_kanban_db.py\` (+118 / -0)

Kanban: t_398ca944