### PR TITLE
feat(kanban): phantom-task cascade — orphan-run reaper + spawn-time guard + FK cascade + WARNING log

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3707,6 +3707,20 @@ def detect_orphan_runs(
             )
             if cur.rowcount == 1:
                 closed.append(int(row["id"]))
+                # Card t_4c0bbdae acceptance (D): WARNING-level log so
+                # operators can correlate phantom-task reaping with
+                # external activity. Routes to ~/.hermes/logs/errors.log
+                # via hermes_logging.setup_logging (WARNING+).
+                _log.warning(
+                    "kanban dispatcher: phantom-task-reap closed "
+                    "run_id=%s task_id=%s (tasks row missing); "
+                    "worker_pid=%s claim_lock=%s — "
+                    "foreign DELETE FROM tasks suspected.",
+                    int(row["id"]),
+                    row["task_id"],
+                    row["worker_pid"],
+                    row["claim_lock"],
+                )
     return closed
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -807,7 +807,9 @@ CREATE TABLE IF NOT EXISTS tasks (
 CREATE TABLE IF NOT EXISTS task_links (
     parent_id  TEXT NOT NULL,
     child_id   TEXT NOT NULL,
-    PRIMARY KEY (parent_id, child_id)
+    PRIMARY KEY (parent_id, child_id),
+    FOREIGN KEY (parent_id) REFERENCES tasks(id) ON DELETE CASCADE,
+    FOREIGN KEY (child_id)  REFERENCES tasks(id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS task_comments (
@@ -815,7 +817,8 @@ CREATE TABLE IF NOT EXISTS task_comments (
     task_id    TEXT NOT NULL,
     author     TEXT NOT NULL,
     body       TEXT NOT NULL,
-    created_at INTEGER NOT NULL
+    created_at INTEGER NOT NULL,
+    FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS task_events (
@@ -824,7 +827,8 @@ CREATE TABLE IF NOT EXISTS task_events (
     run_id     INTEGER,
     kind       TEXT NOT NULL,
     payload    TEXT,
-    created_at INTEGER NOT NULL
+    created_at INTEGER NOT NULL,
+    FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE
 );
 
 -- Historical attempt record. Each time the dispatcher claims a task, a
@@ -853,7 +857,8 @@ CREATE TABLE IF NOT EXISTS task_runs (
     --          gave_up | reclaimed | (null while still running)
     summary             TEXT,
     metadata            TEXT,
-    error               TEXT
+    error               TEXT,
+    FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE
 );
 
 -- Subscription from a gateway source (platform + chat + thread) to a
@@ -1173,6 +1178,18 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             (new, old),
         )
 
+    # Card t_4c0bbdae acceptance (C): add ON DELETE CASCADE FKs on
+    # task_id child tables for legacy DBs created before the constraint
+    # was declared in SCHEMA_SQL. Without this, a manual
+    # ``DELETE FROM tasks WHERE id=…`` strands rows in task_runs /
+    # task_events / task_comments / task_links — the exact phantom-run
+    # incident that motivated this card. New DBs already have the
+    # constraint baked into SCHEMA_SQL; this brings old ones up to par
+    # so future hard-deletes (which we cannot prevent — they happen
+    # outside this codebase) cascade cleanly instead of leaving
+    # bookkeeping debris for the dispatcher to reap.
+    _migrate_add_task_fk_cascades(conn)
+
 
 @contextlib.contextmanager
 def write_txn(conn: sqlite3.Connection):
@@ -1190,6 +1207,217 @@ def write_txn(conn: sqlite3.Connection):
         raise
     else:
         conn.execute("COMMIT")
+
+
+def _tables_missing_task_fk(conn: sqlite3.Connection) -> set[str]:
+    """Return the subset of (task_links, task_comments, task_events,
+    task_runs) that do NOT yet have a cascade FK on the task_id
+    column(s) referencing ``tasks(id)``.
+
+    A table counts as "has the FK" only if ``PRAGMA foreign_key_list``
+    returns at least one row with ``table='tasks'`` and ``on_delete``
+    set to ``CASCADE``. Anything weaker (NO ACTION, RESTRICT) doesn't
+    protect against the phantom-run failure mode this migration
+    targets, so we'd still upgrade it.
+    """
+    candidates = {
+        # table_name -> tuple of column names that should FK to tasks(id)
+        "task_links":    ("parent_id", "child_id"),
+        "task_comments": ("task_id",),
+        "task_events":   ("task_id",),
+        "task_runs":     ("task_id",),
+    }
+    existing = {
+        row["name"]
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        )
+    }
+    out: set[str] = set()
+    for table, required_cols in candidates.items():
+        if table not in existing:
+            continue
+        fks = conn.execute(f"PRAGMA foreign_key_list({table})").fetchall()
+        # PRAGMA foreign_key_list columns:
+        #   id | seq | table | from | to | on_update | on_delete | match
+        have = {
+            fk["from"]
+            for fk in fks
+            if fk["table"] == "tasks"
+            and (fk["to"] in ("id", None))
+            and (fk["on_delete"] or "").upper() == "CASCADE"
+        }
+        if not all(col in have for col in required_cols):
+            out.add(table)
+    return out
+
+
+def _migrate_add_task_fk_cascades(conn: sqlite3.Connection) -> None:
+    """Add ``FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE``
+    to the four child tables on legacy DBs that pre-date the constraint.
+
+    SQLite does not support ``ALTER TABLE ... ADD CONSTRAINT``, so the
+    only way to install a foreign key on an existing table is the
+    copy-rename dance documented at
+    https://www.sqlite.org/lang_altertable.html#otheralter (steps 1-12):
+
+    1. ``CREATE TABLE <new>`` with the new schema.
+    2. ``INSERT INTO <new> SELECT ... FROM <old>``.
+    3. ``DROP TABLE <old>``.
+    4. ``ALTER TABLE <new> RENAME TO <old>``.
+
+    We wrap the whole pass in ``PRAGMA foreign_keys=OFF`` (per SQLite
+    docs — required while restructuring a table involved in FK
+    constraints; otherwise the DROP step would refuse) and re-enable at
+    the end with a ``PRAGMA foreign_key_check`` sanity pass.
+
+    Idempotent: each table is inspected via ``PRAGMA foreign_key_list``
+    and skipped if the cascade FK is already present. Safe to re-run on
+    every connect — the inspect-and-skip path is O(table count) and
+    runs in microseconds when nothing needs to change.
+
+    Called once from :func:`_migrate_add_optional_columns` so opening a
+    legacy kanban DB transparently upgrades it.
+    """
+    needed = _tables_missing_task_fk(conn)
+    if not needed:
+        return
+
+    _log.warning(
+        "kanban: migrating legacy DB to add ON DELETE CASCADE FKs on "
+        "child tables (%s); this is a one-shot copy-rename and may "
+        "take a few seconds on large boards.",
+        ", ".join(sorted(needed)),
+    )
+
+    # PRAGMA foreign_keys=OFF must run OUTSIDE a transaction. The
+    # caller (``init_db`` / ``connect``) opens this on an autocommit
+    # connection (``isolation_level=None``), so we're fine to run the
+    # pragma here directly.
+    #
+    # NOTE: we deliberately do NOT wrap the per-table migrations in
+    # ``write_txn``. ``executescript`` issues an implicit COMMIT at the
+    # start and runs OUTSIDE the calling transaction (per SQLite docs),
+    # which would leave ``write_txn``'s closing COMMIT trying to commit
+    # a non-existent transaction (``cannot commit - no transaction is
+    # active``). Each ``executescript`` block below is therefore its
+    # own implicit transaction; on a failure the partial state stays
+    # but ``foreign_keys=ON`` at the end won't re-enable until the
+    # process recycles its connection, which is the safest possible
+    # failure mode (no partial drops leave child tables missing).
+    conn.execute("PRAGMA foreign_keys=OFF")
+    try:
+        if "task_links" in needed:
+            conn.executescript(
+                """
+                CREATE TABLE task_links__new (
+                    parent_id  TEXT NOT NULL,
+                    child_id   TEXT NOT NULL,
+                    PRIMARY KEY (parent_id, child_id),
+                    FOREIGN KEY (parent_id) REFERENCES tasks(id) ON DELETE CASCADE,
+                    FOREIGN KEY (child_id)  REFERENCES tasks(id) ON DELETE CASCADE
+                );
+                INSERT INTO task_links__new (parent_id, child_id)
+                    SELECT parent_id, child_id FROM task_links;
+                DROP TABLE task_links;
+                ALTER TABLE task_links__new RENAME TO task_links;
+                """
+            )
+        if "task_comments" in needed:
+            conn.executescript(
+                """
+                CREATE TABLE task_comments__new (
+                    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                    task_id    TEXT NOT NULL,
+                    author     TEXT NOT NULL,
+                    body       TEXT NOT NULL,
+                    created_at INTEGER NOT NULL,
+                    FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE
+                );
+                INSERT INTO task_comments__new (id, task_id, author, body, created_at)
+                    SELECT id, task_id, author, body, created_at FROM task_comments;
+                DROP TABLE task_comments;
+                ALTER TABLE task_comments__new RENAME TO task_comments;
+                """
+            )
+        if "task_events" in needed:
+            conn.executescript(
+                """
+                CREATE TABLE task_events__new (
+                    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                    task_id    TEXT NOT NULL,
+                    run_id     INTEGER,
+                    kind       TEXT NOT NULL,
+                    payload    TEXT,
+                    created_at INTEGER NOT NULL,
+                    FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE
+                );
+                INSERT INTO task_events__new (id, task_id, run_id, kind, payload, created_at)
+                    SELECT id, task_id, run_id, kind, payload, created_at FROM task_events;
+                DROP TABLE task_events;
+                ALTER TABLE task_events__new RENAME TO task_events;
+                """
+            )
+        if "task_runs" in needed:
+            conn.executescript(
+                """
+                CREATE TABLE task_runs__new (
+                    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+                    task_id             TEXT NOT NULL,
+                    profile             TEXT,
+                    step_key            TEXT,
+                    status              TEXT NOT NULL,
+                    claim_lock          TEXT,
+                    claim_expires       INTEGER,
+                    worker_pid          INTEGER,
+                    max_runtime_seconds INTEGER,
+                    last_heartbeat_at   INTEGER,
+                    started_at          INTEGER NOT NULL,
+                    ended_at            INTEGER,
+                    outcome             TEXT,
+                    summary             TEXT,
+                    metadata            TEXT,
+                    error               TEXT,
+                    FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE
+                );
+                INSERT INTO task_runs__new (
+                    id, task_id, profile, step_key, status,
+                    claim_lock, claim_expires, worker_pid,
+                    max_runtime_seconds, last_heartbeat_at,
+                    started_at, ended_at, outcome,
+                    summary, metadata, error
+                )
+                SELECT
+                    id, task_id, profile, step_key, status,
+                    claim_lock, claim_expires, worker_pid,
+                    max_runtime_seconds, last_heartbeat_at,
+                    started_at, ended_at, outcome,
+                    summary, metadata, error
+                FROM task_runs;
+                DROP TABLE task_runs;
+                ALTER TABLE task_runs__new RENAME TO task_runs;
+                """
+            )
+        # SQLite docs recommend a foreign_key_check after restructuring
+        # tables involved in FKs. Log violations as WARNING but don't
+        # raise — better to keep the DB usable and surface the bad
+        # rows for operator cleanup than to refuse to open it.  In
+        # practice the only way this fires is if a child row already
+        # points at a missing parent (i.e. the very phantom-run debris
+        # this migration is trying to make safe going forward); the
+        # sibling reaper / dispatch-time guard will clean those rows
+        # up on the next tick.
+        violations = conn.execute("PRAGMA foreign_key_check").fetchall()
+        if violations:
+            for v in violations:
+                _log.warning(
+                    "kanban: FK violation after cascade migration: "
+                    "table=%s rowid=%s parent=%s fkid=%s "
+                    "(orphan child row; will be reaped on next dispatcher tick)",
+                    v[0], v[1], v[2], v[3],
+                )
+    finally:
+        conn.execute("PRAGMA foreign_keys=ON")
 
 
 # ---------------------------------------------------------------------------
@@ -4160,14 +4388,18 @@ def dispatch_once(
                         (now, int(run_id)),
                     )
                 # Emit a task_events row for audit. The owning tasks
-                # row is gone, so this is a soft orphan event (no FK
-                # is declared on task_events.task_id, so the INSERT
-                # succeeds). The sibling orphan-runs reaper
-                # (t_44c9eb37) explicitly does NOT emit events for
-                # this case because the row would be orphaned; at
-                # dispatch time we still emit one so an operator
-                # tailing ``task_events`` can correlate the SIGTERM
-                # window without grepping the dispatcher log.
+                # row is gone, so this is a soft orphan event. The
+                # sibling orphan-runs reaper (t_44c9eb37) explicitly
+                # does NOT emit events for this case because the row
+                # would be orphaned; at dispatch time we still TRY to
+                # emit one so an operator tailing ``task_events`` can
+                # correlate the SIGTERM window without grepping the
+                # dispatcher log — but with the new ON DELETE CASCADE
+                # FK on ``task_events.task_id`` (card t_4c0bbdae
+                # acceptance C) the INSERT raises IntegrityError when
+                # the parent row is gone. Catch + swallow: the
+                # WARNING log below is the durable audit signal, the
+                # task_events entry is best-effort.
                 payload = json.dumps(
                     {
                         "reason": "task-row-missing-at-spawn",
@@ -4176,11 +4408,17 @@ def dispatch_once(
                     },
                     ensure_ascii=False,
                 )
-                conn.execute(
-                    "INSERT INTO task_events (task_id, run_id, kind, payload, created_at) "
-                    "VALUES (?, ?, ?, ?, ?)",
-                    (claimed.id, run_id, "reclaimed", payload, now),
-                )
+                try:
+                    conn.execute(
+                        "INSERT INTO task_events (task_id, run_id, kind, payload, created_at) "
+                        "VALUES (?, ?, ?, ?, ?)",
+                        (claimed.id, run_id, "reclaimed", payload, now),
+                    )
+                except sqlite3.IntegrityError:
+                    # Cascade FK rejected the orphan event row; that's
+                    # fine — the WARNING log line below carries the
+                    # same information for operator triage.
+                    pass
             result.reclaimed_at_spawn.append(claimed.id)
             # WARNING so it lands in ~/.hermes/logs/errors.log via
             # the standard handler chain (hermes_logging.setup_logging

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -72,6 +72,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import logging
 import os
 import re
 import secrets
@@ -84,6 +85,9 @@ from pathlib import Path
 from typing import Any, Iterable, Optional
 
 from toolsets import get_toolset_names
+
+
+_log = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -3101,6 +3105,23 @@ class DispatchResult:
     someone touched the SQLite file directly. Defense in depth: if
     a manual ``DELETE FROM tasks`` happens, the orphaned run no
     longer wedges the dispatcher's bookkeeping forever."""
+    reclaimed_at_spawn: list[str] = field(default_factory=list)
+    """Task ids that were successfully claimed by ``claim_task`` but
+    whose ``tasks`` row vanished before we could fork the worker (i.e.
+    between the CAS that flipped ``ready -> running`` and the
+    just-before-spawn re-check). For each id we close the just-created
+    ``task_runs`` row with ``status='released' / outcome='reclaimed'``
+    and emit a ``task_events`` row of ``kind='reclaimed'`` with
+    ``payload={"reason": "task-row-missing-at-spawn"}``.
+
+    The Hermes codebase never DELETEs from ``tasks`` (only sets
+    ``status='archived'``), so a non-empty list here means a foreign
+    process touched the SQLite file directly. The dispatch-time guard
+    exists so that race burns ~zero LiteLLM tokens instead of spinning
+    up a full worker that finds nothing to do. See kanban card
+    ``t_398ca944`` for the forensic background (sibling ``t_44c9eb37``
+    handles the periodic reaper for orphan runs that slip through this
+    guard)."""
 
 
 # Bounded registry of recently-reaped worker child exits, populated by the
@@ -3955,10 +3976,15 @@ def dispatch_once(
          gone (defense in depth against manual ``DELETE FROM tasks`` —
          see :func:`detect_orphan_runs`).
       4. Promote todo -> ready where all parents are done.
-      5. For each ready task with an assignee, atomically claim and call
-         ``spawn_fn(task, workspace_path, board) -> Optional[int]``. The
-         return value (if any) is recorded as ``worker_pid`` so subsequent
-         ticks can detect crashes before the TTL expires.
+      5. For each ready task with an assignee, atomically claim, then
+         re-check the ``tasks`` row still exists (defense in depth
+         against foreign ``DELETE FROM tasks`` mid-dispatch — see card
+         ``t_398ca944``; on row-vanished we close the just-created
+         ``task_runs`` row as ``released/reclaimed`` and skip the
+         spawn instead of burning a worker boot), then call
+         ``spawn_fn(task, workspace_path, board) -> Optional[int]``.
+         The return value (if any) is recorded as ``worker_pid`` so
+         subsequent ticks can detect crashes before the TTL expires.
 
     Spawn failures are counted per-task. After ``failure_limit`` consecutive
     failures the task is auto-blocked with the last error as its reason —
@@ -4084,6 +4110,73 @@ def dispatch_once(
             continue
         claimed = claim_task(conn, row["id"], ttl_seconds=ttl_seconds)
         if claimed is None:
+            continue
+        # Defense in depth (card t_398ca944): re-check the tasks row
+        # exists right before we fork a worker subprocess. claim_task
+        # already proved the row existed during the CAS, but in the
+        # window between that commit and this read someone could
+        # ``DELETE FROM tasks WHERE id=?`` directly via sqlite3 — the
+        # codebase itself never does this (only ``UPDATE status=
+        # 'archived'``), but on 2026-05-18 a foreign process nuked 28
+        # rows mid-dispatch and the previous tick spawned 28 workers
+        # that burned ~4 minutes of LiteLLM tokens each before their
+        # ``kanban_show`` failed. Catch the race here so the cost of a
+        # vanished task is one extra SELECT, not a full agent boot.
+        still_exists = conn.execute(
+            "SELECT 1 FROM tasks WHERE id = ?", (claimed.id,),
+        ).fetchone()
+        if not still_exists:
+            now = int(time.time())
+            run_id = claimed.current_run_id
+            with write_txn(conn):
+                if run_id is not None:
+                    conn.execute(
+                        """
+                        UPDATE task_runs
+                           SET status        = 'released',
+                               outcome       = 'reclaimed',
+                               summary       = 'task row missing at spawn time',
+                               ended_at      = ?,
+                               claim_lock    = NULL,
+                               claim_expires = NULL,
+                               worker_pid    = NULL
+                         WHERE id = ?
+                           AND ended_at IS NULL
+                        """,
+                        (now, int(run_id)),
+                    )
+                # Emit a task_events row for audit. The owning tasks
+                # row is gone, so this is a soft orphan event (no FK
+                # is declared on task_events.task_id, so the INSERT
+                # succeeds). The sibling orphan-runs reaper
+                # (t_44c9eb37) explicitly does NOT emit events for
+                # this case because the row would be orphaned; at
+                # dispatch time we still emit one so an operator
+                # tailing ``task_events`` can correlate the SIGTERM
+                # window without grepping the dispatcher log.
+                payload = json.dumps(
+                    {
+                        "reason": "task-row-missing-at-spawn",
+                        "run_id": run_id,
+                        "assignee": claimed.assignee,
+                    },
+                    ensure_ascii=False,
+                )
+                conn.execute(
+                    "INSERT INTO task_events (task_id, run_id, kind, payload, created_at) "
+                    "VALUES (?, ?, ?, ?, ?)",
+                    (claimed.id, run_id, "reclaimed", payload, now),
+                )
+            result.reclaimed_at_spawn.append(claimed.id)
+            # WARNING so it lands in ~/.hermes/logs/errors.log via
+            # the standard handler chain (hermes_logging.setup_logging
+            # routes WARNING+ to errors.log).
+            _log.warning(
+                "kanban dispatcher: refusing to spawn worker for %s — "
+                "tasks row vanished between claim and spawn (run_id=%s); "
+                "closed run as reclaimed. Foreign DELETE FROM tasks suspected.",
+                claimed.id, run_id,
+            )
             continue
         try:
             workspace = resolve_workspace(claimed, board=board)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3092,6 +3092,15 @@ class DispatchResult:
     """Task ids auto-blocked by the spawn-failure circuit breaker."""
     timed_out: list[str] = field(default_factory=list)
     """Task ids whose workers exceeded ``max_runtime_seconds``."""
+    orphan_runs: list[int] = field(default_factory=list)
+    """task_runs.id values for orphan runs reaped by
+    ``detect_orphan_runs`` — runs marked ``status='running'`` whose
+    parent ``tasks`` row has been hard-deleted out from under them.
+    The Hermes codebase never DELETEs from ``tasks`` (it sets
+    ``status='archived'`` instead), so a non-empty list here means
+    someone touched the SQLite file directly. Defense in depth: if
+    a manual ``DELETE FROM tasks`` happens, the orphaned run no
+    longer wedges the dispatcher's bookkeeping forever."""
 
 
 # Bounded registry of recently-reaped worker child exits, populated by the
@@ -3591,6 +3600,95 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     return crashed
 
 
+def detect_orphan_runs(
+    conn: sqlite3.Connection,
+    *,
+    signal_fn=None,
+) -> list[int]:
+    """Reap ``task_runs`` rows whose owning ``tasks`` row has vanished.
+
+    Defense in depth for a class of bug seen 2026-05-17 (kanban card
+    ``t_44c9eb37``): a worker was spawned for ``t_0281fae4``, but the
+    ``tasks`` row had been hard-deleted between the dispatcher's claim
+    and worker boot (~3s window). The worker's ``kanban_show`` returned
+    "task not found", so it could neither complete nor block — and
+    nothing else in the dispatcher would ever notice, because every
+    other reclaim path (``release_stale_claims`` /
+    ``detect_crashed_workers``) joins through ``tasks`` and skips runs
+    whose task row is gone.
+
+    The Hermes codebase itself never ``DELETE``s from ``tasks`` — it
+    sets ``status='archived'`` instead (see :func:`archive_task`). So a
+    non-empty result here means *someone touched the SQLite file
+    directly* (manual ``sqlite3`` session, errant migration, foreign
+    process). The fix is twofold:
+
+    1. Document/socialise "never DELETE from ``tasks``" — handled via
+       the kanban-worker skill and operator memory.
+    2. This function: scan for orphan runs, SIGTERM the worker pid when
+       host-local + alive, close the ``task_runs`` row with
+       ``status='reclaimed'`` + ``outcome='reclaimed'`` +
+       ``error='orphan: task row gone'``. Synthetic ``task_events`` are
+       NOT emitted because the event row would be orphaned too
+       (``task_events.task_id`` references the missing task).
+
+    Returns the list of ``task_runs.id`` values closed by this call.
+    Idempotent: subsequent calls return ``[]`` once the rows are
+    closed (the ``status='running'`` filter excludes already-reaped
+    runs).
+    """
+    closed: list[int] = []
+    now = int(time.time())
+    with write_txn(conn):
+        rows = conn.execute(
+            "SELECT id, task_id, worker_pid, claim_lock "
+            "FROM task_runs "
+            "WHERE status = 'running' "
+            "  AND ended_at IS NULL "
+            "  AND task_id NOT IN (SELECT id FROM tasks)"
+        ).fetchall()
+        for row in rows:
+            # Best-effort SIGTERM the worker (host-local only) before
+            # closing the run row, mirroring the contract used by
+            # ``release_stale_claims`` and ``reclaim_task``.
+            termination = _terminate_reclaimed_worker(
+                row["worker_pid"],
+                row["claim_lock"],
+                signal_fn=signal_fn,
+            )
+            metadata = {
+                "reason": "orphan_task_row",
+                "prev_task_id": row["task_id"],
+                "prev_lock": row["claim_lock"],
+            }
+            metadata.update(termination)
+            cur = conn.execute(
+                """
+                UPDATE task_runs
+                   SET status        = 'reclaimed',
+                       outcome       = 'reclaimed',
+                       error         = ?,
+                       metadata      = ?,
+                       ended_at      = ?,
+                       claim_lock    = NULL,
+                       claim_expires = NULL,
+                       worker_pid    = NULL
+                 WHERE id = ?
+                   AND status = 'running'
+                   AND ended_at IS NULL
+                """,
+                (
+                    f"orphan: task row {row['task_id']} missing",
+                    json.dumps(metadata, ensure_ascii=False),
+                    now,
+                    int(row["id"]),
+                ),
+            )
+            if cur.rowcount == 1:
+                closed.append(int(row["id"]))
+    return closed
+
+
 def _record_task_failure(
     conn: sqlite3.Connection,
     task_id: str,
@@ -3853,8 +3951,11 @@ def dispatch_once(
     Steps:
       1. Reclaim stale running tasks (TTL expired).
       2. Reclaim crashed running tasks (host-local PID no longer alive).
-      3. Promote todo -> ready where all parents are done.
-      4. For each ready task with an assignee, atomically claim and call
+      3. Reap orphan ``task_runs`` rows whose owning ``tasks`` row is
+         gone (defense in depth against manual ``DELETE FROM tasks`` —
+         see :func:`detect_orphan_runs`).
+      4. Promote todo -> ready where all parents are done.
+      5. For each ready task with an assignee, atomically claim and call
          ``spawn_fn(task, workspace_path, board) -> Optional[int]``. The
          return value (if any) is recorded as ``worker_pid`` so subsequent
          ticks can detect crashes before the TTL expires.
@@ -3920,6 +4021,12 @@ def dispatch_once(
     if _crash_auto_blocked:
         result.auto_blocked.extend(_crash_auto_blocked)
     result.timed_out = enforce_max_runtime(conn)
+    # Defense in depth (card t_44c9eb37): if the ``tasks`` row got
+    # hard-deleted out from under a running worker, the existing
+    # crashed/stale paths would never notice (they JOIN through tasks
+    # and so skip orphaned task_runs rows). Reap them here so the
+    # bookkeeping doesn't strand a "running" run row forever.
+    result.orphan_runs = detect_orphan_runs(conn)
     result.promoted = recompute_ready(conn)
 
     # Count tasks already running so max_spawn enforces concurrency rather

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -776,11 +776,16 @@ def test_dispatch_refuses_to_spawn_when_task_row_vanishes_mid_tick(
     def claim_then_delete(conn, task_id, **kwargs):
         # Real claim flips status + writes task_runs row. Then we
         # simulate the foreign DELETE before the dispatch loop's
-        # re-check runs.
+        # re-check runs. PRAGMA foreign_keys=OFF mirrors the
+        # external-sqlite3-session path that motivated this card;
+        # with cascades enabled the DELETE would nuke task_runs too
+        # and the dispatcher would see no row to guard.
         task = real_claim(conn, task_id, **kwargs)
         if task is not None:
+            conn.execute("PRAGMA foreign_keys=OFF")
             conn.execute("DELETE FROM tasks WHERE id = ?", (task_id,))
             conn.commit()
+            conn.execute("PRAGMA foreign_keys=ON")
         return task
 
     monkeypatch.setattr(kb, "claim_task", claim_then_delete)
@@ -824,20 +829,19 @@ def test_dispatch_refuses_to_spawn_when_task_row_vanishes_mid_tick(
             assert row["claim_expires"] is None
             assert row["worker_pid"] is None
 
-        # And a task_events 'reclaimed' row was written per task with
-        # the documented payload reason.
+        # task_events emit is best-effort: with the cascade FK on
+        # ``task_events.task_id`` (card t_4c0bbdae acceptance C), the
+        # INSERT raises IntegrityError when the parent ``tasks`` row
+        # is already gone — which is exactly the case this guard
+        # exists for. The dispatcher catches the IntegrityError and
+        # relies on the WARNING log line for operator triage. So we
+        # assert that NO orphan event row got persisted, and that the
+        # WARNING covers the audit trail instead.
         events = conn.execute(
             "SELECT task_id, kind, payload FROM task_events "
             "WHERE kind = 'reclaimed' ORDER BY id"
         ).fetchall()
-        assert len(events) == 2
-        seen_task_ids = set()
-        for ev in events:
-            payload = json.loads(ev["payload"])
-            assert payload["reason"] == "task-row-missing-at-spawn"
-            assert payload["run_id"] is not None
-            seen_task_ids.add(ev["task_id"])
-        assert seen_task_ids == {good, doomed}
+        assert len(events) == 0
 
 
 def test_dispatch_normal_path_does_not_trigger_orphan_guard(
@@ -892,8 +896,13 @@ def test_detect_orphan_runs_closes_run_when_task_row_missing(kanban_home):
 
         # Simulate the bug: someone hard-DELETEs the tasks row. The
         # task_runs row keeps its status='running' / ended_at=NULL.
+        # PRAGMA foreign_keys=OFF mirrors the external-sqlite3-session
+        # path that motivated this card; with FKs on, the cascade would
+        # nuke the run row too and there'd be no orphan to reap.
+        conn.execute("PRAGMA foreign_keys=OFF")
         conn.execute("DELETE FROM tasks WHERE id = ?", (t,))
         conn.commit()
+        conn.execute("PRAGMA foreign_keys=ON")
 
         killed: list[int] = []
         closed = kb.detect_orphan_runs(
@@ -930,8 +939,11 @@ def test_detect_orphan_runs_is_idempotent(kanban_home):
         host = _kb._claimer_id().split(":", 1)[0]
         kb.claim_task(conn, t, claimer=f"{host}:worker")
         kb._set_worker_pid(conn, t, 12345)
+        # Skip the cascade so the run row survives — see other orphan tests.
+        conn.execute("PRAGMA foreign_keys=OFF")
         conn.execute("DELETE FROM tasks WHERE id = ?", (t,))
         conn.commit()
+        conn.execute("PRAGMA foreign_keys=ON")
 
         first = kb.detect_orphan_runs(
             conn, signal_fn=lambda _p, _s: None,
@@ -974,8 +986,11 @@ def test_dispatch_once_reaps_orphan_runs(kanban_home, monkeypatch):
             "SELECT current_run_id FROM tasks WHERE id = ?", (t,),
         ).fetchone()["current_run_id"]
 
+        # Skip the cascade so the run row survives — see other orphan tests.
+        conn.execute("PRAGMA foreign_keys=OFF")
         conn.execute("DELETE FROM tasks WHERE id = ?", (t,))
         conn.commit()
+        conn.execute("PRAGMA foreign_keys=ON")
 
         res = kb.dispatch_once(
             conn,
@@ -1768,3 +1783,202 @@ def test_task_dict_survives_corrupt_created_at(tmp_path, monkeypatch):
         conn.close()
     age = kb.task_age(task)
     assert age["created_age_seconds"] is None
+
+
+# ---------------------------------------------------------------------------
+# Card t_4c0bbdae acceptance (C+D): cascade FK migration on legacy DBs
+# and WARNING logs on phantom-task reaping.
+#
+# Legacy DBs (pre-2026-05-18) created task_links / task_comments /
+# task_events / task_runs without FOREIGN KEY declarations. The migration
+# in ``_migrate_add_optional_columns`` brings them up to par by copy-
+# rename so a future ``DELETE FROM tasks`` cascades to the child rows
+# instead of stranding them as phantom-run debris.
+# ---------------------------------------------------------------------------
+
+def _drop_fks(conn):
+    """Recreate the four FK-bearing child tables WITHOUT their FKs to
+    simulate a legacy DB. Preserves row data + autoincrement state."""
+    import sqlite3 as _sq
+    conn.execute("PRAGMA foreign_keys=OFF")
+    # task_links
+    conn.executescript(
+        """
+        CREATE TABLE task_links__legacy (
+            parent_id  TEXT NOT NULL,
+            child_id   TEXT NOT NULL,
+            PRIMARY KEY (parent_id, child_id)
+        );
+        INSERT INTO task_links__legacy SELECT parent_id, child_id FROM task_links;
+        DROP TABLE task_links;
+        ALTER TABLE task_links__legacy RENAME TO task_links;
+
+        CREATE TABLE task_comments__legacy (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            task_id TEXT NOT NULL, author TEXT NOT NULL,
+            body TEXT NOT NULL, created_at INTEGER NOT NULL
+        );
+        INSERT INTO task_comments__legacy(id,task_id,author,body,created_at)
+            SELECT id,task_id,author,body,created_at FROM task_comments;
+        DROP TABLE task_comments;
+        ALTER TABLE task_comments__legacy RENAME TO task_comments;
+
+        CREATE TABLE task_events__legacy (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            task_id TEXT NOT NULL, run_id INTEGER,
+            kind TEXT NOT NULL, payload TEXT, created_at INTEGER NOT NULL
+        );
+        INSERT INTO task_events__legacy(id,task_id,run_id,kind,payload,created_at)
+            SELECT id,task_id,run_id,kind,payload,created_at FROM task_events;
+        DROP TABLE task_events;
+        ALTER TABLE task_events__legacy RENAME TO task_events;
+
+        CREATE TABLE task_runs__legacy (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            task_id TEXT NOT NULL, profile TEXT, step_key TEXT,
+            status TEXT NOT NULL,
+            claim_lock TEXT, claim_expires INTEGER, worker_pid INTEGER,
+            max_runtime_seconds INTEGER, last_heartbeat_at INTEGER,
+            started_at INTEGER NOT NULL, ended_at INTEGER, outcome TEXT,
+            summary TEXT, metadata TEXT, error TEXT
+        );
+        INSERT INTO task_runs__legacy
+            SELECT id,task_id,profile,step_key,status,
+                   claim_lock,claim_expires,worker_pid,
+                   max_runtime_seconds,last_heartbeat_at,
+                   started_at,ended_at,outcome,summary,metadata,error
+              FROM task_runs;
+        DROP TABLE task_runs;
+        ALTER TABLE task_runs__legacy RENAME TO task_runs;
+        """
+    )
+    conn.execute("PRAGMA foreign_keys=ON")
+
+
+def test_tables_missing_task_fk_detects_legacy_schema(kanban_home):
+    with kb.connect() as conn:
+        assert kb._tables_missing_task_fk(conn) == set()  # fresh DB has FKs
+
+        _drop_fks(conn)
+        missing = kb._tables_missing_task_fk(conn)
+    assert missing == {"task_links", "task_comments", "task_events", "task_runs"}
+
+
+def test_migrate_add_task_fk_cascades_is_idempotent(kanban_home):
+    """Running the migration on a fresh DB is a no-op (FKs are
+    already declared in SCHEMA_SQL) and preserves all rows."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="alive", assignee="alice")
+        kb.add_comment(conn, t, "alex", "hello")
+        before_tasks = conn.execute("SELECT count(*) FROM tasks").fetchone()[0]
+        before_comments = conn.execute("SELECT count(*) FROM task_comments").fetchone()[0]
+        before_events = conn.execute("SELECT count(*) FROM task_events").fetchone()[0]
+
+        kb._migrate_add_task_fk_cascades(conn)  # should be no-op
+
+        after_tasks = conn.execute("SELECT count(*) FROM tasks").fetchone()[0]
+        after_comments = conn.execute("SELECT count(*) FROM task_comments").fetchone()[0]
+        after_events = conn.execute("SELECT count(*) FROM task_events").fetchone()[0]
+    assert (before_tasks, before_comments, before_events) == (
+        after_tasks, after_comments, after_events,
+    )
+
+
+def test_migrate_add_task_fk_cascades_upgrades_legacy_db(kanban_home):
+    """End-to-end: legacy DB without FKs gets the cascade, and a
+    subsequent DELETE FROM tasks then nukes child rows instead of
+    stranding them as phantom debris."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="will-be-deleted", assignee="alice")
+        kb.add_comment(conn, t, "alex", "comment 1")
+        kb.claim_task(conn, t)
+        # Snapshot pre-migration state
+        run_count_before = conn.execute(
+            "SELECT count(*) FROM task_runs WHERE task_id = ?", (t,)
+        ).fetchone()[0]
+        event_count_before = conn.execute(
+            "SELECT count(*) FROM task_events WHERE task_id = ?", (t,)
+        ).fetchone()[0]
+        comment_count_before = conn.execute(
+            "SELECT count(*) FROM task_comments WHERE task_id = ?", (t,)
+        ).fetchone()[0]
+        assert run_count_before >= 1
+        assert event_count_before >= 1
+        assert comment_count_before == 1
+
+        # Strip FKs to simulate a legacy DB.
+        _drop_fks(conn)
+        assert kb._tables_missing_task_fk(conn) == {
+            "task_links", "task_comments", "task_events", "task_runs",
+        }
+
+        # Run the migration.
+        kb._migrate_add_task_fk_cascades(conn)
+
+        # Post-migration: FKs are in place again, row counts preserved.
+        assert kb._tables_missing_task_fk(conn) == set()
+        assert conn.execute(
+            "SELECT count(*) FROM task_runs WHERE task_id = ?", (t,)
+        ).fetchone()[0] == run_count_before
+        assert conn.execute(
+            "SELECT count(*) FROM task_comments WHERE task_id = ?", (t,)
+        ).fetchone()[0] == comment_count_before
+
+        # Now DELETE FROM tasks: cascades should nuke child rows.
+        conn.execute("DELETE FROM tasks WHERE id = ?", (t,))
+        conn.commit()
+
+        assert conn.execute(
+            "SELECT count(*) FROM task_runs WHERE task_id = ?", (t,)
+        ).fetchone()[0] == 0
+        assert conn.execute(
+            "SELECT count(*) FROM task_comments WHERE task_id = ?", (t,)
+        ).fetchone()[0] == 0
+        assert conn.execute(
+            "SELECT count(*) FROM task_events WHERE task_id = ?", (t,)
+        ).fetchone()[0] == 0
+
+
+def test_migrate_runs_via_init_db_on_legacy_open(kanban_home, tmp_path):
+    """Opening a legacy DB via the public ``init_db`` entry point
+    transparently upgrades it — no operator action required."""
+    # Build a legacy DB at an explicit path.
+    db_path = tmp_path / "legacy.db"
+    with kb.connect(db_path=db_path) as conn:
+        kb.create_task(conn, title="x", assignee="alice")
+        _drop_fks(conn)
+        assert kb._tables_missing_task_fk(conn) == {
+            "task_links", "task_comments", "task_events", "task_runs",
+        }
+
+    # Force re-migration via init_db (which always re-runs the pass).
+    kb.init_db(db_path=db_path)
+
+    with kb.connect(db_path=db_path) as conn:
+        assert kb._tables_missing_task_fk(conn) == set()
+
+
+def test_detect_orphan_runs_emits_warning_log(kanban_home, caplog):
+    """Acceptance (D): WARNING log when the orphan reaper closes a
+    phantom run. Operator-facing source-detection signal."""
+    import hermes_cli.kanban_db as _kb
+    import logging as _logging
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="orphan-me", assignee="alice")
+        host = _kb._claimer_id().split(":", 1)[0]
+        kb.claim_task(conn, t, claimer=f"{host}:worker")
+        kb._set_worker_pid(conn, t, 99999)
+
+        # Skip the cascade so the run row survives — see other orphan tests.
+        conn.execute("PRAGMA foreign_keys=OFF")
+        conn.execute("DELETE FROM tasks WHERE id = ?", (t,))
+        conn.commit()
+        conn.execute("PRAGMA foreign_keys=ON")
+
+        caplog.set_level(_logging.WARNING, logger="hermes_cli.kanban_db")
+        kb.detect_orphan_runs(conn, signal_fn=lambda _p, _s: None)
+
+    msgs = [r.getMessage() for r in caplog.records if "phantom-task-reap" in r.getMessage()]
+    assert msgs, f"expected phantom-task-reap WARNING; got {[r.getMessage() for r in caplog.records]}"
+    assert t in msgs[0]

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import concurrent.futures
+import json
 import os
 import time
 from pathlib import Path
@@ -746,6 +747,123 @@ def test_dispatch_reclaims_stale_before_spawning(kanban_home):
         )
         res = kb.dispatch_once(conn, dry_run=True)
     assert res.reclaimed == 1
+
+
+def test_dispatch_refuses_to_spawn_when_task_row_vanishes_mid_tick(
+    kanban_home, all_assignees_spawnable, monkeypatch
+):
+    """Dispatch-time orphan guard (kanban card t_398ca944).
+
+    Foreign process DELETEs the ``tasks`` row in the window between
+    ``claim_task`` (which CAS-flipped ``ready -> running``) and the
+    just-before-spawn re-check. The dispatcher must:
+
+      1. NOT call spawn_fn for the vanished task.
+      2. Close the just-created ``task_runs`` row as
+         ``status='released' / outcome='reclaimed'`` with the
+         documented summary.
+      3. Emit a ``task_events`` row of ``kind='reclaimed'`` with
+         ``payload.reason == 'task-row-missing-at-spawn'``.
+      4. Surface the id in ``DispatchResult.reclaimed_at_spawn``.
+
+    Sibling ``test_dispatch_spawn_failure_releases_claim`` covers the
+    OTHER race (spawn_fn raises). This case is distinct: the row is
+    gone before we ever ask the spawner, so we never fork at all.
+    """
+    spawns: list[str] = []
+    real_claim = kb.claim_task
+
+    def claim_then_delete(conn, task_id, **kwargs):
+        # Real claim flips status + writes task_runs row. Then we
+        # simulate the foreign DELETE before the dispatch loop's
+        # re-check runs.
+        task = real_claim(conn, task_id, **kwargs)
+        if task is not None:
+            conn.execute("DELETE FROM tasks WHERE id = ?", (task_id,))
+            conn.commit()
+        return task
+
+    monkeypatch.setattr(kb, "claim_task", claim_then_delete)
+
+    def fake_spawn(task, workspace):
+        spawns.append(task.id)
+        return 4242
+
+    with kb.connect() as conn:
+        good = kb.create_task(conn, title="survives", assignee="alice")
+        doomed = kb.create_task(conn, title="vanishes", assignee="bob")
+        res = kb.dispatch_once(conn, spawn_fn=fake_spawn)
+
+    # Spawn loop iterates ready tasks in priority/created order. Both
+    # were monkeypatched, so BOTH get DELETEd between claim and the
+    # re-check. We assert on the structural shape, not the count: every
+    # claimed-then-vanished task must be reclaimed_at_spawn, none must
+    # be spawned.
+    assert spawns == [], (
+        f"spawn_fn was called for at least one vanished task: {spawns!r}"
+    )
+    assert set(res.reclaimed_at_spawn) == {good, doomed}, (
+        f"reclaimed_at_spawn={res.reclaimed_at_spawn!r}"
+    )
+    assert res.spawned == []
+
+    with kb.connect() as conn:
+        # task_runs row(s) must be closed with the documented values.
+        runs = conn.execute(
+            "SELECT task_id, status, outcome, summary, ended_at, "
+            "claim_lock, claim_expires, worker_pid "
+            "FROM task_runs ORDER BY id"
+        ).fetchall()
+        assert len(runs) == 2
+        for row in runs:
+            assert row["status"] == "released"
+            assert row["outcome"] == "reclaimed"
+            assert row["summary"] == "task row missing at spawn time"
+            assert row["ended_at"] is not None
+            assert row["claim_lock"] is None
+            assert row["claim_expires"] is None
+            assert row["worker_pid"] is None
+
+        # And a task_events 'reclaimed' row was written per task with
+        # the documented payload reason.
+        events = conn.execute(
+            "SELECT task_id, kind, payload FROM task_events "
+            "WHERE kind = 'reclaimed' ORDER BY id"
+        ).fetchall()
+        assert len(events) == 2
+        seen_task_ids = set()
+        for ev in events:
+            payload = json.loads(ev["payload"])
+            assert payload["reason"] == "task-row-missing-at-spawn"
+            assert payload["run_id"] is not None
+            seen_task_ids.add(ev["task_id"])
+        assert seen_task_ids == {good, doomed}
+
+
+def test_dispatch_normal_path_does_not_trigger_orphan_guard(
+    kanban_home, all_assignees_spawnable
+):
+    """Sanity check: when the tasks row stays put, reclaimed_at_spawn
+    is empty and the worker is spawned exactly once.
+
+    Guards against a regression where the spawn-time re-check
+    accidentally trips on healthy tasks (e.g. wrong column name, SQL
+    typo, missing commit visibility).
+    """
+    spawns: list[str] = []
+
+    def fake_spawn(task, workspace):
+        spawns.append(task.id)
+        return 9999
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="happy path", assignee="alice")
+        res = kb.dispatch_once(conn, spawn_fn=fake_spawn)
+
+    assert spawns == [t]
+    assert res.reclaimed_at_spawn == []
+    assert len(res.spawned) == 1
+    assert res.spawned[0][0] == t
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -749,6 +749,126 @@ def test_dispatch_reclaims_stale_before_spawning(kanban_home):
 
 
 # ---------------------------------------------------------------------------
+# Orphan run reaping (card t_44c9eb37)
+#
+# Defends against the case where the ``tasks`` row gets hard-DELETEd out
+# from under a still-running ``task_runs`` row (manual sqlite poking, or
+# any future code path that bypasses :func:`archive_task`). Without
+# ``detect_orphan_runs`` the run row sits ``status='running'`` forever
+# because every other reclaim path joins through ``tasks``.
+# ---------------------------------------------------------------------------
+
+def test_detect_orphan_runs_closes_run_when_task_row_missing(kanban_home):
+    import hermes_cli.kanban_db as _kb
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="will-be-deleted", assignee="alice")
+        host = _kb._claimer_id().split(":", 1)[0]
+        kb.claim_task(conn, t, claimer=f"{host}:worker")
+        kb._set_worker_pid(conn, t, 12345)
+
+        run_id = conn.execute(
+            "SELECT current_run_id FROM tasks WHERE id = ?", (t,),
+        ).fetchone()["current_run_id"]
+        assert run_id is not None
+
+        # Simulate the bug: someone hard-DELETEs the tasks row. The
+        # task_runs row keeps its status='running' / ended_at=NULL.
+        conn.execute("DELETE FROM tasks WHERE id = ?", (t,))
+        conn.commit()
+
+        killed: list[int] = []
+        closed = kb.detect_orphan_runs(
+            conn, signal_fn=lambda _p, sig: killed.append(sig),
+        )
+
+        run_row = conn.execute(
+            "SELECT status, outcome, error, metadata, ended_at, "
+            "       worker_pid, claim_lock "
+            "  FROM task_runs WHERE id = ?",
+            (run_id,),
+        ).fetchone()
+
+    assert closed == [int(run_id)]
+    assert run_row["status"] == "reclaimed"
+    assert run_row["outcome"] == "reclaimed"
+    assert run_row["ended_at"] is not None
+    assert run_row["worker_pid"] is None
+    assert run_row["claim_lock"] is None
+    assert "orphan" in (run_row["error"] or "")
+    # Host-local pid 12345 should have been SIGTERMed (via injected
+    # signal_fn — we don't actually kill processes in tests).
+    import signal as _signal
+    assert killed == [_signal.SIGTERM]
+
+
+def test_detect_orphan_runs_is_idempotent(kanban_home):
+    """Second call returns [] because the orphan rows are no longer
+    ``status='running'`` once closed."""
+    import hermes_cli.kanban_db as _kb
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="alice")
+        host = _kb._claimer_id().split(":", 1)[0]
+        kb.claim_task(conn, t, claimer=f"{host}:worker")
+        kb._set_worker_pid(conn, t, 12345)
+        conn.execute("DELETE FROM tasks WHERE id = ?", (t,))
+        conn.commit()
+
+        first = kb.detect_orphan_runs(
+            conn, signal_fn=lambda _p, _s: None,
+        )
+        second = kb.detect_orphan_runs(
+            conn, signal_fn=lambda _p, _s: None,
+        )
+
+    assert len(first) == 1
+    assert second == []
+
+
+def test_detect_orphan_runs_ignores_runs_whose_task_still_exists(kanban_home):
+    """Sanity: a healthy running task is never touched."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="healthy", assignee="alice")
+        kb.claim_task(conn, t)
+        # tasks row still present — must be ignored.
+        closed = kb.detect_orphan_runs(conn)
+        assert closed == []
+        assert kb.get_task(conn, t).status == "running"
+
+
+def test_dispatch_once_reaps_orphan_runs(kanban_home, monkeypatch):
+    """End-to-end: ``dispatch_once`` should populate
+    ``DispatchResult.orphan_runs`` and close the underlying run row."""
+    import hermes_cli.kanban_db as _kb
+
+    # Skip the per-tick reap loop / spawn — we just want the orphan
+    # detector to fire. Patch _pid_alive so the SIGTERM wait loop in
+    # _terminate_reclaimed_worker doesn't sleep.
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="orphan-me", assignee="alice")
+        host = _kb._claimer_id().split(":", 1)[0]
+        kb.claim_task(conn, t, claimer=f"{host}:worker")
+        kb._set_worker_pid(conn, t, 12345)
+        run_id = conn.execute(
+            "SELECT current_run_id FROM tasks WHERE id = ?", (t,),
+        ).fetchone()["current_run_id"]
+
+        conn.execute("DELETE FROM tasks WHERE id = ?", (t,))
+        conn.commit()
+
+        res = kb.dispatch_once(
+            conn,
+            spawn_fn=lambda *a, **kw: None,
+            dry_run=False,
+        )
+
+    assert int(run_id) in res.orphan_runs
+
+
+# ---------------------------------------------------------------------------
 # Workspace resolution
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes the t_4c0bbdae acceptance bundle (which decomposes from t_be44930b
and covers child cards t_7d8b2961, t_398ca944, plus the schema/log work
the audit pulled in).

## Scope

Five commits stacked on main, each independently reviewable:

1. **9d8510b3c** Reap orphan task_runs whose tasks row was hard-deleted
2. **1120c6b81** Dispatch-time guard refuses to spawn workers for vanished tasks (t_398ca944)
3. **23955b55a** WARNING log on phantom-task-reap for source detection
4. **e61909c2a** ON DELETE CASCADE FK on task_id child tables
5. **29ba54e60** Cover cascade FK migration + adapt orphan tests

## Why

Forensic cohort 2026-05-18 00:51:57: 28 runs (ids 105–132) on \`hermes\`
board spawned with no tasks row. Workers booted, called \`kanban_show\`,
got \`task not found\`, and could not call \`kanban_complete\` /
\`kanban_block\` (every kanban_* tool requires the row). Runs would have
wedged forever.

Root cause: external sqlite poking (\`DELETE FROM tasks\`) bypassed
\`archive_task()\` and left run rows orphaned. The Hermes codebase itself
never DELETEs from \`tasks\` — only archive_task() sets status='archived'.
Companion KANBAN_GUIDANCE / kanban-worker skill change (separate commit
on the curator-side) documents the policy so workers stop reaching for
raw sqlite.

## What changes

- **detect_orphan_runs()** (kanban_db.py): scans for
  \`status='running' AND tasks.id IS NULL\`, SIGTERMs host-local worker
  pid via existing \`_terminate_reclaimed_worker\`, closes the run row
  (status='reclaimed', outcome='reclaimed', structured metadata).
  Idempotent. Skips task_events INSERT because task_events.task_id
  would itself be orphaned — operators see the closed run row + the
  DispatchResult.orphan_runs field instead.
- Wired into \`dispatch_once\` alongside \`release_stale_claims\` /
  \`detect_crashed_workers\` (no new cadence).
- Dispatch-time guard refuses to spawn when the parent row vanished
  between claim and fork (race window).
- WARNING log on every phantom reap names run_id + task_id for source
  forensics.
- ON DELETE CASCADE FKs on \`task_runs\`, \`task_events\`,
  \`task_comments\` so future DELETEs (manual or otherwise) auto-clean.
  Idempotent migration with \`_tables_missing_task_fk\` detector.

## Tests

\`tests/hermes_cli/test_kanban_db.py\` — 10 relevant tests all pass:
- closes-when-task-missing / idempotent / ignores-healthy / dispatch_once end-to-end
- migration: no-op on fresh schema, upgrades legacy DB, end-to-end DELETE
  cascades cleanly, idempotent
- WARNING log assertion for source detection

\`\`\`
============================== 10 passed in 1.57s ==============================
\`\`\`

Refs: t_4c0bbdae t_7d8b2961 t_398ca944 t_44c9eb37 t_be44930b