### PR TITLE
fix(docker): add libolm-dev so matrix lazy-install can build python-olm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/opt/hermes/.playwright
 # that would otherwise accumulate when hermes runs as PID 1. See #15012.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    build-essential curl nodejs npm python3 ripgrep ffmpeg gcc python3-dev libffi-dev procps git openssh-client docker-cli tini && \
+    build-essential curl nodejs npm python3 ripgrep ffmpeg gcc python3-dev libffi-dev libolm-dev procps git openssh-client docker-cli tini && \
     rm -rf /var/lib/apt/lists/*
 
 # Non-root user for runtime; UID can be overridden via HERMES_UID at runtime

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,7 +187,9 @@ all = [
   # no native build path on Windows or modern macOS. With matrix in
   # [all], `uv sync --locked` on Windows tried to build it from sdist
   # and failed on `make`. Lazy-install routes that build to first use,
-  # where the user is expected to have a toolchain available.
+  # where the user is expected to have a toolchain available. The Docker
+  # image ships `libolm-dev` so the lazy-install can build python-olm
+  # from source in the container.
   "hermes-agent[cron]",
   "hermes-agent[cli]",
   "hermes-agent[dev]",


### PR DESCRIPTION
## What does this PR do?

Add `libolm-dev` to the Docker image's `apt-get install` layer so that `python-olm` (a transitive dependency of `mautrix[encryption]`) can build from source during the Matrix gateway's first-boot lazy-install.

Since #24515 (2026-05-12), the `matrix` extra was dropped from the `[all]` Docker build extra and replaced with a first-boot lazy-install via `tools/lazy_deps.py`. The lazy-install runs as the non-root `hermes` user after root privileges are dropped, so no system package can be installed at that point. Without `libolm-dev` already in the base image, `python-olm` (sdist-only, requires libolm headers to compile) fails silently, causing the `✗ matrix error: Invalid event type` / `No adapter available for matrix` errors reported in #25495.

A comment in `pyproject.toml` is also updated to document that the Docker image ships `libolm-dev` to support this build path.

## Related Issue

Fixes #25495

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `Dockerfile`: add `libolm-dev` to the `apt-get install` layer so `python-olm` can compile during lazy-install
- `pyproject.toml`: update `[all]` policy comment to note that Docker ships `libolm-dev` for Matrix lazy-install builds

## How to Test

1. Build the updated image: `docker build -t hermes-test .`
2. Run the gateway: `docker run --rm -e MATRIX_HOMESERVER=... -e MATRIX_ACCESS_TOKEN=... hermes-test gateway run`
3. Confirm the log shows `Lazy install complete for feature 'platform.matrix'` followed by `Connecting to matrix...` without the `✗ matrix error: Invalid event type` error.
4. Alternatively: `docker run --rm hermes-test /bin/bash -c "/opt/hermes/.venv/bin/python -c 'import olm; print(olm.__version__)'"` — should print a version string instead of an ImportError.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes — N/A (Dockerfile change, no unit tests applicable)
- [x] I've tested on my platform: Linux (Debian trixie / docker build context)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (Docker image is Linux-only)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

The only failing CI check (`uv lock --check`) is a systemic issue on `main` unrelated to this PR's changes, as confirmed by [BoardJames-Bot's analysis](https://github.com/NousResearch/hermes-agent/pull/27795#issuecomment-4475411585) — being addressed separately in #27837.

<!-- autocontrib:worker-id=pr-comment-bb69bf76 kind=pr-description-update -->