### PR TITLE
feat(kanban): auto-unblock blocked tasks when non-self comment lands (kanban t_0abf738d)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -868,6 +868,21 @@ CREATE TABLE IF NOT EXISTS kanban_notify_subs (
     PRIMARY KEY (task_id, platform, chat_id, thread_id)
 );
 
+-- Worker-block auto-subscribe (card t_0abf738d). When a worker calls
+-- ``kanban_block`` from inside a dispatcher-spawned run, the tool layer
+-- writes one row here so the dispatcher tick knows to promote
+-- ``blocked -> ready`` as soon as a non-self ``commented`` event arrives.
+-- ``block_event_id`` is the baseline cursor: only comments with
+-- ``task_events.id > block_event_id`` count, which keeps pre-block context
+-- comments from causing a spurious wake. The row is removed atomically
+-- when the unblock fires so the next block-cycle starts fresh.
+CREATE TABLE IF NOT EXISTS kanban_auto_unblock_subs (
+    task_id           TEXT NOT NULL PRIMARY KEY,
+    notifier_profile  TEXT NOT NULL,
+    block_event_id    INTEGER NOT NULL,
+    created_at        INTEGER NOT NULL
+);
+
 CREATE INDEX IF NOT EXISTS idx_tasks_assignee_status ON tasks(assignee, status);
 CREATE INDEX IF NOT EXISTS idx_tasks_status          ON tasks(status);
 CREATE INDEX IF NOT EXISTS idx_tasks_tenant          ON tasks(tenant);
@@ -3092,6 +3107,10 @@ class DispatchResult:
     """Task ids auto-blocked by the spawn-failure circuit breaker."""
     timed_out: list[str] = field(default_factory=list)
     """Task ids whose workers exceeded ``max_runtime_seconds``."""
+    auto_unblocked: list[str] = field(default_factory=list)
+    """Task ids promoted ``blocked -> ready/todo`` by the worker-block
+    auto-subscribe loop (card t_0abf738d). The corresponding
+    ``unblocked_by_comment`` task_event is the audit record."""
 
 
 # Bounded registry of recently-reaped worker child exits, populated by the
@@ -3920,6 +3939,12 @@ def dispatch_once(
     if _crash_auto_blocked:
         result.auto_blocked.extend(_crash_auto_blocked)
     result.timed_out = enforce_max_runtime(conn)
+    # Worker-block auto-subscribe (card t_0abf738d): promote any subscribed
+    # ``blocked`` task that has accumulated a non-self ``commented`` event
+    # since the block. Must run BEFORE ``recompute_ready`` so a promotion
+    # that lands in 'todo' (parent re-gating) still gets picked up in the
+    # same tick when its parent is done.
+    result.auto_unblocked = auto_unblock_on_comment(conn)
     result.promoted = recompute_ready(conn)
 
     # Count tasks already running so max_spawn enforces concurrency rather
@@ -4592,6 +4617,195 @@ def remove_notify_sub(
             (task_id, platform, chat_id, thread_id or ""),
         )
     return cur.rowcount > 0
+
+
+# ---------------------------------------------------------------------------
+# Worker-block auto-subscribe (card t_0abf738d)
+# ---------------------------------------------------------------------------
+#
+# These helpers back the "worker self-blocks → user comments → worker
+# auto-wakes" loop. The subscription is opt-in: only the ``kanban_block``
+# tool layer writes rows (when running under a dispatcher-spawned worker),
+# so operator-driven blocks via ``hermes kanban block`` keep their explicit
+# unblock semantics. ``auto_unblock_on_comment`` is invoked as part of
+# :func:`dispatch_once` so the next dispatcher tick after a comment lands
+# both promotes ``blocked -> ready`` and claims/spawns the worker.
+#
+# Loop guard: the subscription stores the worker's profile name; a
+# ``commented`` event whose payload.author equals that profile does NOT
+# auto-unblock — workers must not unblock themselves with their own notes.
+
+
+def add_auto_unblock_sub(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    notifier_profile: str,
+) -> None:
+    """Subscribe a worker profile to comment-driven auto-unblock of a task.
+
+    Idempotent on ``task_id`` (PRIMARY KEY): a second call for the same
+    task is a no-op and the original ``block_event_id`` baseline is
+    preserved so the cursor doesn't slide forward across stale subscribe
+    attempts.
+
+    The ``block_event_id`` baseline is the highest ``blocked`` event id
+    on the task at subscribe time. Only ``commented`` events with
+    ``task_events.id > block_event_id`` count for the auto-unblock pass —
+    pre-block context comments are ignored.
+    """
+    if not task_id or not str(task_id).strip():
+        raise ValueError("task_id is required")
+    if not notifier_profile or not str(notifier_profile).strip():
+        raise ValueError("notifier_profile is required")
+    now = int(time.time())
+    with write_txn(conn):
+        baseline_row = conn.execute(
+            "SELECT id FROM task_events "
+            "WHERE task_id = ? AND kind = 'blocked' "
+            "ORDER BY id DESC LIMIT 1",
+            (task_id,),
+        ).fetchone()
+        baseline = int(baseline_row["id"]) if baseline_row else 0
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO kanban_auto_unblock_subs
+                (task_id, notifier_profile, block_event_id, created_at)
+            VALUES (?, ?, ?, ?)
+            """,
+            (task_id, notifier_profile.strip(), baseline, now),
+        )
+
+
+def list_auto_unblock_subs(
+    conn: sqlite3.Connection,
+    task_id: Optional[str] = None,
+) -> list[dict]:
+    if task_id is not None:
+        rows = conn.execute(
+            "SELECT * FROM kanban_auto_unblock_subs WHERE task_id = ?",
+            (task_id,),
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            "SELECT * FROM kanban_auto_unblock_subs"
+        ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def remove_auto_unblock_sub(
+    conn: sqlite3.Connection, task_id: str
+) -> bool:
+    with write_txn(conn):
+        cur = conn.execute(
+            "DELETE FROM kanban_auto_unblock_subs WHERE task_id = ?",
+            (task_id,),
+        )
+    return cur.rowcount > 0
+
+
+def auto_unblock_on_comment(conn: sqlite3.Connection) -> list[str]:
+    """Promote ``blocked -> ready`` for every subscribed task that has
+    accumulated a non-self ``commented`` event since the block.
+
+    Returns the list of task ids promoted (empty list when nothing fired).
+
+    Behaviour:
+      - Only tasks currently in ``status='blocked'`` are considered. If a
+        task was already moved out of blocked (operator unblock, archive),
+        the stale subscription is dropped without effect.
+      - Comments are filtered by ``task_events.id > block_event_id`` so
+        pre-block context never triggers a wake.
+      - Comments whose payload.author equals the subscription's
+        ``notifier_profile`` are ignored (loop guard — a worker's own
+        comment must not unblock its own task).
+      - Multiple matching comments coalesce to a single ``blocked -> ready``
+        transition and a single ``unblocked_by_comment`` event.
+      - The subscription row is removed atomically with the promotion so
+        the next block-cycle starts fresh.
+    """
+    promoted: list[str] = []
+    with write_txn(conn):
+        subs = conn.execute(
+            "SELECT task_id, notifier_profile, block_event_id "
+            "FROM kanban_auto_unblock_subs"
+        ).fetchall()
+        for sub in subs:
+            tid = sub["task_id"]
+            profile = sub["notifier_profile"]
+            baseline = int(sub["block_event_id"])
+
+            trow = conn.execute(
+                "SELECT status FROM tasks WHERE id = ?", (tid,),
+            ).fetchone()
+            if trow is None:
+                # Task gone (archived/purged); drop the orphan sub.
+                conn.execute(
+                    "DELETE FROM kanban_auto_unblock_subs WHERE task_id = ?",
+                    (tid,),
+                )
+                continue
+            if trow["status"] != "blocked":
+                # Operator already unblocked / archived it. Subscription is
+                # stale; drop it so the next block-cycle re-subscribes.
+                conn.execute(
+                    "DELETE FROM kanban_auto_unblock_subs WHERE task_id = ?",
+                    (tid,),
+                )
+                continue
+
+            # Find the first non-self commented event after the baseline.
+            rows = conn.execute(
+                "SELECT id, payload FROM task_events "
+                "WHERE task_id = ? AND kind = 'commented' AND id > ? "
+                "ORDER BY id ASC",
+                (tid, baseline),
+            ).fetchall()
+            triggered = False
+            for r in rows:
+                author = None
+                if r["payload"]:
+                    try:
+                        author = (json.loads(r["payload"]) or {}).get("author")
+                    except Exception:
+                        author = None
+                if author and author == profile:
+                    continue
+                triggered = True
+                break
+            if not triggered:
+                continue
+
+            # State transition + audit event + subscription cleanup.
+            # Mirror the invariant guard from unblock_task: re-gate on
+            # parent completion. If parents aren't done land in 'todo'.
+            undone = conn.execute(
+                "SELECT 1 FROM task_links l "
+                "JOIN tasks p ON p.id = l.parent_id "
+                "WHERE l.child_id = ? AND p.status NOT IN ('done', 'archived') "
+                "LIMIT 1",
+                (tid,),
+            ).fetchone()
+            new_status = "todo" if undone else "ready"
+            cur = conn.execute(
+                "UPDATE tasks SET status = ?, current_run_id = NULL "
+                "WHERE id = ? AND status = 'blocked'",
+                (new_status, tid),
+            )
+            if cur.rowcount != 1:
+                # Lost a race; leave the subscription in place for the
+                # next tick to retry.
+                continue
+            _append_event(
+                conn, tid, "unblocked_by_comment",
+                {"status": new_status, "notifier_profile": profile},
+            )
+            conn.execute(
+                "DELETE FROM kanban_auto_unblock_subs WHERE task_id = ?",
+                (tid,),
+            )
+            promoted.append(tid)
+    return promoted
 
 
 def unseen_events_for_sub(

--- a/tests/hermes_cli/test_kanban_auto_unblock.py
+++ b/tests/hermes_cli/test_kanban_auto_unblock.py
@@ -1,0 +1,331 @@
+"""Tests for worker-block auto-subscribe → comment auto-unblock.
+
+Card: t_0abf738d. Closes affected-flow #1 from t_02048c56: worker self-blocks
+pending user input → user comments → worker (or replacement) wakes within
+one dispatcher tick rather than sitting dead until manual `kanban unblock`.
+
+Surface under test:
+- :func:`hermes_cli.kanban_db.add_auto_unblock_sub` / ``list_auto_unblock_subs``
+  / ``remove_auto_unblock_sub`` (new DB-layer helpers backing the auto-wake
+  loop).
+- :func:`hermes_cli.kanban_db.auto_unblock_on_comment` invoked from inside
+  :func:`hermes_cli.kanban_db.dispatch_once` (new dispatcher tick rule).
+- :func:`tools.kanban_tools._handle_block` writes a subscription row keyed
+  on the worker profile when running under ``HERMES_KANBAN_TASK`` /
+  ``HERMES_PROFILE``.
+
+The contract is intentionally permissive: an unblock from this path is
+indistinguishable from an explicit ``hermes kanban unblock`` for downstream
+consumers (it lands in the same ``ready`` state and the same
+parent-completion gating applies). The differentiator is the
+``unblocked_by_comment`` event kind, which exists purely for audit.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with an empty kanban DB.
+
+    Mirrors the fixture used across ``tests/hermes_cli/test_kanban_*.py``
+    so tests in this file can be lifted/dropped without conftest gymnastics.
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    # Tool-level tests below also need HERMES_KANBAN_TASK to be undefined
+    # by default (the per-test monkeypatch.setenv flips it on as needed).
+    # Same goes for HERMES_KANBAN_RUN_ID / HERMES_PROFILE which leak from
+    # any kanban-worker process that runs the test suite (a self-hosted
+    # worker writing this very test file, for instance) — without scrubbing
+    # them, _handle_block calls block_task with the parent worker's run id
+    # and gets rejected against the test task's actual current_run_id.
+    for _leaky in (
+        "HERMES_KANBAN_TASK",
+        "HERMES_KANBAN_RUN_ID",
+        "HERMES_KANBAN_CLAIM_LOCK",
+        "HERMES_PROFILE",
+    ):
+        monkeypatch.delenv(_leaky, raising=False)
+    return home
+
+
+# ---------------------------------------------------------------------------
+# DB-layer helpers
+# ---------------------------------------------------------------------------
+
+
+def test_add_auto_unblock_sub_is_idempotent_per_task_profile(kanban_home):
+    """Calling add_auto_unblock_sub twice for the same (task, profile)
+    leaves a single row — the auto-wake loop must not double-fire."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="default")
+        kb.claim_task(conn, t)
+        kb.block_task(conn, t, reason="need input")
+
+        kb.add_auto_unblock_sub(conn, task_id=t, notifier_profile="default")
+        kb.add_auto_unblock_sub(conn, task_id=t, notifier_profile="default")
+
+        subs = kb.list_auto_unblock_subs(conn, task_id=t)
+        assert len(subs) == 1
+        assert subs[0]["notifier_profile"] == "default"
+        assert subs[0]["task_id"] == t
+
+
+def test_add_auto_unblock_sub_records_block_event_baseline(kanban_home):
+    """The subscription must capture the latest ``blocked`` event id so the
+    dispatcher only counts comments that arrive AFTER the block — comments
+    that predate the block must not auto-unblock."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="default")
+        kb.add_comment(conn, t, author="alex", body="early comment")
+        kb.claim_task(conn, t)
+        kb.block_task(conn, t, reason="need input")
+
+        kb.add_auto_unblock_sub(conn, task_id=t, notifier_profile="default")
+
+        sub = kb.list_auto_unblock_subs(conn, task_id=t)[0]
+        # Find the blocked event id
+        rows = conn.execute(
+            "SELECT id FROM task_events WHERE task_id=? AND kind='blocked' "
+            "ORDER BY id DESC LIMIT 1",
+            (t,),
+        ).fetchall()
+        latest_block_event_id = int(rows[0]["id"])
+        assert int(sub["block_event_id"]) == latest_block_event_id
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher tick rule
+# ---------------------------------------------------------------------------
+
+
+def test_auto_unblock_on_comment_promotes_blocked_to_ready(kanban_home):
+    """Happy path: subscribed task gets a non-self comment → ready."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="default")
+        kb.claim_task(conn, t)
+        kb.block_task(conn, t, reason="need input")
+        kb.add_auto_unblock_sub(conn, task_id=t, notifier_profile="default")
+
+        kb.add_comment(conn, t, author="alex", body="here's your answer")
+
+        promoted = kb.auto_unblock_on_comment(conn)
+        assert promoted == [t]
+        assert kb.get_task(conn, t).status == "ready"
+
+
+def test_auto_unblock_on_comment_emits_audit_event(kanban_home):
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="default")
+        kb.claim_task(conn, t)
+        kb.block_task(conn, t, reason="need input")
+        kb.add_auto_unblock_sub(conn, task_id=t, notifier_profile="default")
+        kb.add_comment(conn, t, author="alex", body="answer")
+        kb.auto_unblock_on_comment(conn)
+
+        kinds = [
+            r["kind"]
+            for r in conn.execute(
+                "SELECT kind FROM task_events WHERE task_id=? ORDER BY id ASC",
+                (t,),
+            ).fetchall()
+        ]
+    assert "unblocked_by_comment" in kinds
+
+
+def test_auto_unblock_on_comment_ignores_self_authored_comment(kanban_home):
+    """Loop guard: a worker that comments on its own blocked task while
+    its replacement hasn't booted yet must NOT auto-unblock itself. The
+    author of the unblocking comment must differ from the subscription's
+    ``notifier_profile``."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="default")
+        kb.claim_task(conn, t)
+        kb.block_task(conn, t, reason="need input")
+        kb.add_auto_unblock_sub(conn, task_id=t, notifier_profile="default")
+
+        kb.add_comment(conn, t, author="default", body="my own note")
+
+        promoted = kb.auto_unblock_on_comment(conn)
+        assert promoted == []
+        assert kb.get_task(conn, t).status == "blocked"
+
+
+def test_auto_unblock_on_comment_skips_comments_before_block(kanban_home):
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="default")
+        kb.add_comment(conn, t, author="alex", body="pre-block context")
+        kb.claim_task(conn, t)
+        kb.block_task(conn, t, reason="need input")
+        kb.add_auto_unblock_sub(conn, task_id=t, notifier_profile="default")
+        # No new comment after the block.
+
+        promoted = kb.auto_unblock_on_comment(conn)
+        assert promoted == []
+        assert kb.get_task(conn, t).status == "blocked"
+
+
+def test_auto_unblock_on_comment_coalesces_multiple_comments(kanban_home):
+    """Two comments must yield one unblock, not two state transitions."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="default")
+        kb.claim_task(conn, t)
+        kb.block_task(conn, t, reason="need input")
+        kb.add_auto_unblock_sub(conn, task_id=t, notifier_profile="default")
+        kb.add_comment(conn, t, author="alex", body="answer A")
+        kb.add_comment(conn, t, author="alex", body="and also B")
+
+        promoted = kb.auto_unblock_on_comment(conn)
+        assert promoted == [t]
+        unblock_events = conn.execute(
+            "SELECT COUNT(*) AS n FROM task_events "
+            "WHERE task_id=? AND kind='unblocked_by_comment'",
+            (t,),
+        ).fetchone()
+        assert int(unblock_events["n"]) == 1
+
+
+def test_auto_unblock_on_comment_removes_subscription_after_promote(kanban_home):
+    """After a successful auto-unblock the row is removed so the next
+    block-cycle starts fresh and the dispatcher doesn't keep re-checking
+    a stale ``blocked → ready`` transition that already happened."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="default")
+        kb.claim_task(conn, t)
+        kb.block_task(conn, t, reason="need input")
+        kb.add_auto_unblock_sub(conn, task_id=t, notifier_profile="default")
+        kb.add_comment(conn, t, author="alex", body="answer")
+        kb.auto_unblock_on_comment(conn)
+
+        assert kb.list_auto_unblock_subs(conn, task_id=t) == []
+
+
+def test_auto_unblock_on_comment_no_subscription_is_noop(kanban_home):
+    """A blocked task without a subscription must NOT be auto-unblocked.
+    Subscription is the explicit opt-in — operator-blocked tasks (no worker
+    intent) stay blocked even when somebody comments."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="default")
+        kb.claim_task(conn, t)
+        kb.block_task(conn, t, reason="operator hold")
+        kb.add_comment(conn, t, author="alex", body="any update?")
+
+        promoted = kb.auto_unblock_on_comment(conn)
+        assert promoted == []
+        assert kb.get_task(conn, t).status == "blocked"
+
+
+def test_dispatch_once_runs_auto_unblock(kanban_home):
+    """The dispatcher tick must include the auto-unblock pass and the
+    resulting ready task must be claimable in the same tick."""
+    spawned: list[tuple[str, str, str]] = []
+
+    def _spawn(task, workspace_path, board):
+        spawned.append((task.id, task.assignee, str(workspace_path)))
+        return 12345  # fake pid
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="default")
+        kb.claim_task(conn, t)
+        kb.block_task(conn, t, reason="need input")
+        kb.add_auto_unblock_sub(conn, task_id=t, notifier_profile="default")
+        kb.add_comment(conn, t, author="alex", body="answer")
+
+        result = kb.dispatch_once(conn, spawn_fn=_spawn)
+
+    assert any(s[0] == t for s in spawned), (
+        "auto-unblocked task must spawn in the same tick"
+    )
+    # The DispatchResult.spawned list mirrors the spawn callback.
+    assert any(entry[0] == t for entry in result.spawned)
+
+
+# ---------------------------------------------------------------------------
+# Tool-handler integration
+# ---------------------------------------------------------------------------
+
+
+def test_kanban_block_tool_writes_auto_unblock_sub(monkeypatch, kanban_home):
+    """When a worker calls ``kanban_block`` from inside a dispatcher-spawned
+    run (HERMES_KANBAN_TASK + HERMES_PROFILE set), a subscription row is
+    written transparently. Workers don't have to author it themselves —
+    that's the whole point of this card."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="default")
+        kb.claim_task(conn, t)
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", t)
+    monkeypatch.setenv("HERMES_PROFILE", "default")
+
+    from tools import kanban_tools as kt
+    out = kt._handle_block({"reason": "need input on routing"})
+    payload = json.loads(out)
+    assert payload.get("ok") is True, payload
+
+    with kb.connect() as conn:
+        subs = kb.list_auto_unblock_subs(conn, task_id=t)
+    assert len(subs) == 1
+    assert subs[0]["notifier_profile"] == "default"
+
+
+def test_kanban_block_tool_skips_sub_for_review_required_reason(
+    monkeypatch, kanban_home
+):
+    """``review-required`` block reasons must NOT auto-subscribe. Those
+    tasks need a human-authored unblock (or an LGTM comment, deferred to
+    a follow-up card per the task body). Auto-unblocking on any comment
+    would let a chatty reviewer accidentally promote a task that still
+    needs explicit sign-off."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="default")
+        kb.claim_task(conn, t)
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", t)
+    monkeypatch.setenv("HERMES_PROFILE", "default")
+
+    from tools import kanban_tools as kt
+    out = kt._handle_block(
+        {"reason": "review-required: 4/4 ACs verified, needs sign-off"}
+    )
+    payload = json.loads(out)
+    assert payload.get("ok") is True, payload
+
+    with kb.connect() as conn:
+        subs = kb.list_auto_unblock_subs(conn, task_id=t)
+    assert subs == []
+
+
+def test_kanban_block_tool_outside_worker_does_not_write_sub(
+    monkeypatch, kanban_home
+):
+    """Operator-driven block (CLI / dashboard, no HERMES_KANBAN_TASK) must
+    not insert a subscription — auto-unblock is a worker-intent loop, not
+    a global behaviour."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="default")
+        kb.claim_task(conn, t)
+
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.delenv("HERMES_PROFILE", raising=False)
+
+    # Call the DB layer directly (mirrors what the CLI does for an
+    # operator-driven block — no worker tool involved).
+    with kb.connect() as conn:
+        assert kb.block_task(conn, t, reason="operator hold")
+        subs = kb.list_auto_unblock_subs(conn, task_id=t)
+    assert subs == []
+
+

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -461,6 +461,41 @@ def _handle_block(args: dict, **kw) -> str:
                     f"could not block {tid} (unknown id or not in "
                     f"running/ready)"
                 )
+            # Worker-block auto-subscribe (card t_0abf738d). When this
+            # tool is invoked from inside a dispatcher-spawned worker
+            # (HERMES_KANBAN_TASK pinned to the target tid + HERMES_PROFILE
+            # populated by the dispatcher), register a subscription so a
+            # subsequent non-self comment from the user/operator wakes the
+            # task without manual `hermes kanban unblock`. Skipped when:
+            #   - tool was called outside a worker (no HERMES_KANBAN_TASK
+            #     or it points at a different tid — operator-driven block);
+            #   - HERMES_PROFILE missing (can't loop-guard a worker we
+            #     can't identify);
+            #   - reason is prefixed "review-required" — those need an
+            #     explicit human sign-off, not any random comment, per
+            #     the card's pitfalls section.
+            env_tid = os.environ.get("HERMES_KANBAN_TASK")
+            worker_profile = os.environ.get("HERMES_PROFILE")
+            reason_str = str(reason).strip().lower()
+            review_required = reason_str.startswith("review-required")
+            if (
+                env_tid == tid
+                and worker_profile
+                and not review_required
+            ):
+                try:
+                    kb.add_auto_unblock_sub(
+                        conn, task_id=tid,
+                        notifier_profile=worker_profile,
+                    )
+                except Exception:
+                    # The block already succeeded; failing to insert the
+                    # auto-unblock sub must NOT fail the tool call (the
+                    # caller can still be woken by `hermes kanban unblock`).
+                    logger.exception(
+                        "kanban_block: add_auto_unblock_sub failed for %s",
+                        tid,
+                    )
             run = kb.latest_run(conn, tid)
             return _ok(task_id=tid, run_id=run.id if run else None)
         finally:


### PR DESCRIPTION
Closes affected-flow #1 from parent card t_02048c56: worker self-blocks pending user input → user comments → worker (or replacement) wakes within one dispatcher tick instead of sitting dead until manual `hermes kanban unblock`.

## What

- **hermes_cli/kanban_db.py**: new `kanban_auto_unblock_subs` table + `add_auto_unblock_sub` / `list_auto_unblock_subs` / `remove_auto_unblock_sub` / `auto_unblock_on_comment` helpers. `DispatchResult` gains `auto_unblocked` field. `dispatch_once` runs the auto-unblock pass after `enforce_max_runtime`; promoted tasks land in `todo` if parents pending, `ready` otherwise (mirrors `unblock_task`'s parent-completion gate). Audit event kind: `unblocked_by_comment`.
- **tools/kanban_tools.py**: `_handle_block` inserts a subscription row keyed on `(task_id, HERMES_PROFILE)` when invoked from inside a worker run (`HERMES_KANBAN_TASK` + `HERMES_PROFILE` both set). Reasons prefixed with `review-required` skip the subscribe so they still require explicit human sign-off.

## Design notes

- Dedicated table rather than overloading `kanban_notify_subs` — different shape (PK on `task_id`, baseline event id), different consumer (dispatcher tick vs gateway delivery).
- Hook insert at the tool layer, not in `block_task` — operator-driven CLI blocks keep their explicit-unblock semantics; DB layer stays profile-agnostic.
- **Loop guard**: a `commented` event whose `payload.author` equals the subscription's `notifier_profile` does NOT trigger auto-unblock.
- **Coalescing**: subscription row is deleted atomically with the promotion in the same `write_txn`; multiple comments inside one tick window produce exactly one promotion.
- `baseline = highest blocked event id at subscribe time`, so pre-block context comments don't trigger a spurious wake.

## Tests

`tests/hermes_cli/test_kanban_auto_unblock.py` — 13 new tests:

- idempotent subscribe, baseline event tracking
- blocked→ready promotion, audit event
- self-author loop guard
- pre-block comment filtering
- multi-comment coalescing
- subscription cleanup on promote
- no-sub noop, `dispatch_once` integration
- `_handle_block` insert path, review-required skip, outside-worker no-op

```
13/13 new tests pass.
258 passed, 1 skipped in the broader kanban suite
(test_kanban_db + test_kanban_core_functionality + test_kanban_notify + this file).
```

## Cards

Card t_0abf738d (parent t_02048c56). Reviewer directive from Alex in card thread (2026-05-17): accept the shipped path per verification numbers, mark complete.