### PR TITLE
fix(gateway): check alternate platform user ids during auth

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5755,6 +5755,15 @@ class GatewayRunner:
         if "@" in user_id:
             check_ids.add(user_id.split("@")[0])
 
+        # Adapters with a stable secondary identity (Signal UUID alongside
+        # phone, DingTalk staff_id alongside sender_id, Feishu union_id, ...)
+        # carry it in source.user_id_alt. Honor it so operators can put either
+        # form in the platform allowlist.
+        if source.user_id_alt:
+            check_ids.add(source.user_id_alt)
+            if "@" in source.user_id_alt:
+                check_ids.add(source.user_id_alt.split("@")[0])
+
         # WhatsApp: resolve phone↔LID aliases from bridge session mapping files
         if source.platform == Platform.WHATSAPP:
             normalized_allowed_ids = set()

--- a/tests/gateway/test_unauthorized_dm_behavior.py
+++ b/tests/gateway/test_unauthorized_dm_behavior.py
@@ -646,3 +646,78 @@ def test_qqbot_with_allowlist_ignores_unauthorized_dm(monkeypatch):
 
     behavior = runner._get_unauthorized_dm_behavior(Platform.QQBOT)
     assert behavior == "ignore"
+
+
+def test_signal_user_id_alt_uuid_matches_allowlist(monkeypatch):
+    """Signal adapter carries the stable account UUID in source.user_id_alt
+    while source.user_id is the phone number. Operators allowlisting the UUID
+    must still be authorized — previously the auth check only inspected
+    source.user_id and silently rejected them.
+    """
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("SIGNAL_ALLOWED_USERS", "uuid:abc-123")
+
+    runner, _adapter = _make_runner(
+        Platform.SIGNAL,
+        GatewayConfig(platforms={Platform.SIGNAL: PlatformConfig(enabled=True)}),
+    )
+
+    source = SessionSource(
+        platform=Platform.SIGNAL,
+        user_id="+15550000001",
+        user_id_alt="uuid:abc-123",
+        chat_id="+15550000001",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+    assert runner._is_user_authorized(source) is True
+
+
+def test_dingtalk_user_id_alt_staff_id_matches_allowlist(monkeypatch):
+    """DingTalk adapter carries the staff_id (stable org identity) in
+    source.user_id_alt while source.user_id is the per-conversation sender_id.
+    Operators allowlisting the staff_id must still be authorized.
+    """
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("DINGTALK_ALLOWED_USERS", "staff_1234")
+
+    runner, _adapter = _make_runner(
+        Platform.DINGTALK,
+        GatewayConfig(platforms={Platform.DINGTALK: PlatformConfig(enabled=True)}),
+    )
+
+    source = SessionSource(
+        platform=Platform.DINGTALK,
+        user_id="sender1",
+        user_id_alt="staff_1234",
+        chat_id="cid-1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+    assert runner._is_user_authorized(source) is True
+
+
+def test_user_id_alt_not_in_allowlist_still_rejected(monkeypatch):
+    """The alt-ID path must not become a backdoor: when neither user_id nor
+    user_id_alt is in the allowlist, the user stays unauthorized.
+    """
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("SIGNAL_ALLOWED_USERS", "uuid:allowed-only")
+
+    runner, _adapter = _make_runner(
+        Platform.SIGNAL,
+        GatewayConfig(platforms={Platform.SIGNAL: PlatformConfig(enabled=True)}),
+    )
+
+    source = SessionSource(
+        platform=Platform.SIGNAL,
+        user_id="+15550000002",
+        user_id_alt="uuid:not-listed",
+        chat_id="+15550000002",
+        user_name="stranger",
+        chat_type="dm",
+    )
+
+    assert runner._is_user_authorized(source) is False


### PR DESCRIPTION
## Summary
- `_is_user_authorized()` in `gateway/run.py` only checked `source.user_id`
  against the platform allowlist, ignoring `source.user_id_alt`.
- Adapters that legitimately publish both identities (Signal `user_id=phone`
  + `user_id_alt=UUID`, DingTalk `user_id=sender_id` + `user_id_alt=staff_id`,
  Feishu union_id) silently failed auth when the operator allowlisted the
  alt-form ID — even though `SessionSource` documents `user_id_alt` as a
  "Platform-specific stable alt ID".
- Fix extends `check_ids` to include `source.user_id_alt` (and its bare
  local-part when it contains `@`). Additive — existing setups unchanged.

## Test plan
- [x] `pytest tests/gateway/test_unauthorized_dm_behavior.py` — 29/29 pass
  (3 new regression tests added: Signal UUID, DingTalk staff_id, negative
  no-backdoor case)
- [x] Wider auth suite: `test_discord_bot_auth_bypass`,
  `test_feishu_bot_auth_bypass`, `test_busy_session_auth_bypass`,
  `test_approve_deny_commands` — 69/69 pass


## Reproduction (without the fix)
1. `export SIGNAL_ALLOWED_USERS=uuid:abc-123`
2. Build a `SessionSource(platform=SIGNAL, user_id="+15550000001",
   user_id_alt="uuid:abc-123", ...)`
3. `runner._is_user_authorized(source)` → returns `False` (expected `True`)

Same shape repros for DingTalk with `DINGTALK_ALLOWED_USERS=staff_1234`,
`user_id="sender1"`, `user_id_alt="staff_1234"`.