### PR TITLE
fix: allow websocket clients on explicit insecure binds

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3184,13 +3184,28 @@ def _is_public_bind() -> bool:
     return getattr(app.state, "bound_host", "") in {"0.0.0.0", "::"}
 
 
+def _is_explicit_non_loopback_bind() -> bool:
+    """True when bound to a specific non-loopback interface.
+
+    ``start_server`` only permits this shape when the operator explicitly passed
+    ``--insecure``. Treat it like an intentional network exposure for the PTY
+    WebSocket gate too; otherwise the HTTP dashboard is reachable on a
+    Tailscale/LAN IP but the embedded chat fails after token auth. The token is
+    not robust remote-user authentication in insecure mode; network access must
+    still be restricted to trusted/private interfaces.
+    """
+    bound_host = str(getattr(app.state, "bound_host", "") or "").lower()
+    return bool(bound_host) and bound_host not in _LOOPBACK_HOSTS and not _is_public_bind()
+
+
 def _ws_client_is_allowed(ws: "WebSocket") -> bool:
     """Check if the WebSocket client IP is acceptable.
 
-    Allows loopback always; allows any IP when bound to all-interfaces
-    (--insecure mode, guarded by session token auth).
+    Allows loopback always. Allows any client when bound to a deliberate
+    non-loopback interface (specific IP or all-interfaces), guarded by the
+    session token auth that every dashboard PTY WebSocket requires.
     """
-    if _is_public_bind():
+    if _is_public_bind() or _is_explicit_non_loopback_bind():
         return True
     client_host = ws.client.host if ws.client else ""
     if not client_host:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2127,6 +2127,65 @@ class TestPtyWebSocket:
                 pass
         assert exc.value.code == 4401
 
+    def test_ws_client_gate_allows_explicit_non_loopback_bind(self, monkeypatch):
+        """Specific Tailscale/LAN binds are intentional non-local exposure.
+
+        `start_server` only allows this when the operator passes --insecure; the
+        PTY WebSocket gate should not force users to bind to 0.0.0.0 just to
+        make embedded chat work over a trusted tailnet.
+        """
+        from types import SimpleNamespace
+        from typing import Any, cast
+
+        monkeypatch.setattr(
+            self.ws_module.app.state, "bound_host", "100.64.12.34", raising=False
+        )
+        fake_ws = cast(Any, SimpleNamespace(client=SimpleNamespace(host="100.80.1.2")))
+
+        assert self.ws_module._ws_client_is_allowed(fake_ws)
+
+    def test_ws_client_gate_still_rejects_remote_client_on_loopback_bind(self, monkeypatch):
+        from types import SimpleNamespace
+        from typing import Any, cast
+
+        monkeypatch.setattr(
+            self.ws_module.app.state, "bound_host", "127.0.0.1", raising=False
+        )
+        fake_ws = cast(Any, SimpleNamespace(client=SimpleNamespace(host="100.80.1.2")))
+
+        assert not self.ws_module._ws_client_is_allowed(fake_ws)
+
+    def test_start_server_refuses_explicit_non_loopback_without_insecure(self):
+        with pytest.raises(SystemExit) as exc:
+            self.ws_module.start_server(
+                host="100.64.12.34",
+                port=9119,
+                open_browser=False,
+                allow_public=False,
+            )
+
+        assert "Refusing to bind to 100.64.12.34" in str(exc.value)
+
+    def test_start_server_accepts_explicit_non_loopback_with_insecure(self, monkeypatch):
+        captured = {}
+
+        def fake_uvicorn_run(app, host, port, **kwargs):
+            captured.update({"app": app, "host": host, "port": port, "kwargs": kwargs})
+
+        monkeypatch.setattr("uvicorn.run", fake_uvicorn_run)
+
+        self.ws_module.start_server(
+            host="100.64.12.34",
+            port=9119,
+            open_browser=False,
+            allow_public=True,
+        )
+
+        assert captured["host"] == "100.64.12.34"
+        assert captured["port"] == 9119
+        assert self.ws_module.app.state.bound_host == "100.64.12.34"
+        assert self.ws_module.app.state.bound_port == 9119
+
     def test_streams_child_stdout_to_client(self, monkeypatch):
         monkeypatch.setattr(
             self.ws_module,


### PR DESCRIPTION
## Summary
- Treat explicit non-loopback dashboard binds as intentional insecure exposure for PTY WebSocket gating
- Preserve remote-client rejection for loopback-only binds
- Add coverage for explicit Tailscale/LAN bind accept/refuse behavior

## Test Plan
- python -m pytest tests/hermes_cli/test_web_server.py -q