### PR TITLE
fix: harden lead-review reply semantics

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7128,6 +7128,25 @@ class GatewayRunner:
             reply_snippet = event.reply_to_text[:500]
             message_text = f'[Replying to: "{reply_snippet}"]\n\n{message_text}'
 
+            # Lead-review reports use reply-as-command semantics. When the user
+            # replies to a reviewer report, we want the model to treat
+            # DUYỆT/LOẠI/CHI TIẾT as operational instructions for the quoted
+            # report, not as a request for a polite acknowledgement. This keeps
+            # the live Telegram reply path aligned with the cron report contract
+            # and avoids the common "confirm but do nothing" failure mode.
+            reply_snippet_upper = reply_snippet.upper()
+            if (
+                "JOB:" in reply_snippet_upper
+                or "CRONJOB RESPONSE: LEAD SCOUT REVIEWER" in reply_snippet_upper
+                or "LEAD SCOUT REVIEWER" in reply_snippet_upper
+            ):
+                message_text = (
+                    "[This is a lead-review control reply. Treat DUYỆT / LOẠI / CHI TIẾT as state-changing commands for the quoted report. "
+                    "Do not respond with mere acknowledgement. If the user DUYỆTs items, take the next concrete action for those items now (within available tools), "
+                    "then report what is currently doing, what is done, and what is waiting on PR / external response.]\n\n"
+                    f"{message_text}"
+                )
+
         if "@" in message_text:
             try:
                 from agent.context_references import preprocess_context_references_async

--- a/tests/gateway/test_reply_to_injection.py
+++ b/tests/gateway/test_reply_to_injection.py
@@ -157,3 +157,31 @@ async def test_reply_snippet_truncated_to_500_chars():
     assert result is not None
     assert result.startswith('[Replying to: "' + "x" * 500 + '"]')
     assert "x" * 501 not in result
+
+
+@pytest.mark.asyncio
+async def test_lead_review_reply_gets_control_semantics_prefix():
+    runner = _make_runner()
+    source = _source()
+    event = MessageEvent(
+        text="DUYỆT 1,2,3,4,5,6,7,8",
+        source=source,
+        reply_to_message_id="99",
+        reply_to_text=(
+            "Cronjob Response: Lead scout reviewer (agent)\n"
+            "(job_id: df9c23638494)\n"
+            "-------------\n"
+            "[OK] Đã review payload 21 candidates, giữ lại 5 lead."
+        ),
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert result is not None
+    assert result.startswith("[This is a lead-review control reply.")
+    assert '[Replying to: "Cronjob Response: Lead scout reviewer (agent)' in result
+    assert result.endswith("DUYỆT 1,2,3,4,5,6,7,8")


### PR DESCRIPTION
## Summary\n- Treat replies to lead-review reports as control commands instead of polite acknowledgements\n- Add a regression test for the lead-review reply prefix\n\n## Verification\n- ./venv/bin/python -m pytest tests/gateway/test_reply_to_injection.py -q\n\n## Notes\nThis keeps DUYỆT/LOẠI/CHI TIẾT aligned with the reply-based report contract and reduces confirm-but-do-nothing behavior.