### PR TITLE
fix: flush missing streaming suffixes

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1045,7 +1045,10 @@ def run_conversation(
                     # Log response with provider info if available
                     resp_model = getattr(response, 'model', 'N/A') if response else 'N/A'
                     logging.debug(f"API Response received - Model: {resp_model}, Usage: {response.usage if hasattr(response, 'usage') else 'N/A'}")
-                
+
+                if agent._has_stream_consumers():
+                    agent._flush_stream_delivery_tails()
+
                 # Validate response shape before proceeding
                 response_invalid = False
                 error_details = []
@@ -3338,6 +3341,9 @@ def run_conversation(
                     assistant_message.content = "\n".join(parts)
                 else:
                     assistant_message.content = str(raw)
+
+            if not getattr(assistant_message, "tool_calls", None):
+                agent._emit_missing_stream_suffix(assistant_message.content or "")
 
             try:
                 from hermes_cli.plugins import (

--- a/run_agent.py
+++ b/run_agent.py
@@ -4016,8 +4016,8 @@ class AIAgent:
 
     # ── Unified streaming API call ─────────────────────────────────────────
 
-    def _reset_stream_delivery_tracking(self) -> None:
-        """Reset tracking for text delivered during the current model response."""
+    def _flush_stream_delivery_tails(self) -> None:
+        """Flush scrubber-held stream tails at a known response boundary."""
         # Flush any benign partial-tag tail held by the think scrubber
         # first (#17924): an innocent '<' at the end of the stream that
         # turned out not to be a tag prefix should reach the UI.  Then
@@ -4055,7 +4055,26 @@ class AIAgent:
                     except Exception:
                         pass
                 self._record_streamed_assistant_text(tail)
+
+    def _reset_stream_delivery_tracking(self) -> None:
+        """Reset tracking for text delivered during the current model response."""
+        self._flush_stream_delivery_tails()
         self._current_streamed_assistant_text = ""
+
+    def _emit_missing_stream_suffix(self, final_text: str) -> None:
+        """Deliver a final-response suffix that was not present in stream deltas."""
+        if not isinstance(final_text, str) or not final_text:
+            return
+        if not self._has_stream_consumers():
+            return
+        streamed = getattr(self, "_current_streamed_assistant_text", "") or ""
+        if not streamed or len(final_text) <= len(streamed):
+            return
+        if not final_text.startswith(streamed):
+            return
+        suffix = final_text[len(streamed):]
+        if suffix.strip():
+            self._fire_stream_delta(suffix)
 
     def _record_streamed_assistant_text(self, text: str) -> None:
         """Accumulate visible assistant text emitted through stream callbacks."""

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5795,6 +5795,29 @@ class TestStreamingApiCall:
         callback.assert_any_call("lo ")
         callback.assert_any_call("World")
 
+    def test_reset_flushes_scrubber_tail_before_clearing_stream_tracking(self, agent):
+        callback = MagicMock()
+        agent.stream_delta_callback = callback
+
+        agent._fire_stream_delta("Answer ends with <")
+        agent._reset_stream_delivery_tracking()
+
+        assert [args[0][0] for args in callback.call_args_list] == [
+            "Answer ends with ",
+            "<",
+        ]
+        assert agent._current_streamed_assistant_text == ""
+
+    def test_emit_missing_stream_suffix_only_delivers_final_text_tail(self, agent):
+        callback = MagicMock()
+        agent.stream_delta_callback = callback
+        agent._current_streamed_assistant_text = "The answer"
+
+        agent._emit_missing_stream_suffix("The answer is complete.")
+
+        callback.assert_called_once_with(" is complete.")
+        assert agent._current_streamed_assistant_text == "The answer is complete."
+
     def test_tool_call_accumulation(self, agent):
         # Per OpenAI streaming spec, function names are delivered atomically
         # in the first chunk; only `arguments` is fragmented across chunks.


### PR DESCRIPTION
## Summary
- Flush held streaming scrubber tails at response boundaries.
- Emit a final-response suffix when stream deltas missed the tail of the assistant text.

## Tests
- `scripts/run_tests.sh tests/run_agent/test_run_agent_codex_responses.py` — 63 passed

## Safety
- No real credentials or tokens are included; this PR changes runtime streaming code only.
