### PR TITLE
feat: add Yandex SpeechKit TTS provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -319,6 +319,16 @@ BROWSER_INACTIVITY_TIMEOUT=120
 # VOICE_TOOLS_OPENAI_KEY=
 
 # =============================================================================
+# YANDEX SPEECHKIT TTS
+# =============================================================================
+# Optional provider for high-quality Russian speech synthesis in CLI voice mode.
+# Install: python -m pip install 'hermes-agent[voice,tts-yandex]'
+# Configure tts.provider: yandex in ~/.hermes/config.yaml.
+# YANDEX_FOLDER_ID=
+# YANDEX_API_KEY=
+# YANDEX_IAM_TOKEN=
+
+# =============================================================================
 # SLACK INTEGRATION
 # =============================================================================
 # Slack Bot Token - From Slack App settings (OAuth & Permissions)

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -849,14 +849,33 @@ platform_toolsets:
 # Gemini TTS supports persona/director prompt files, and Gemini 3.1 Flash TTS
 # can use a hidden auxiliary rewrite pass to insert expressive square-bracket
 # audio tags into the TTS script without showing tags in chat.
+# Providers: edge (free) | openai | elevenlabs | mistral | xai | minimax |
+# gemini | yandex | neutts | kittentts | piper
 #
 # tts:
-#   provider: "gemini"
+#   provider: "edge"
+#   edge:
+#     voice: "en-US-AriaNeural"
 #   gemini:
 #     model: "gemini-3.1-flash-tts-preview"
 #     voice: "Kore"
 #     audio_tags: false
 #     persona_prompt_file: ""  # e.g. ~/.hermes/tts/radio-host.md
+#   # Yandex SpeechKit gRPC streaming TTS for CLI voice mode.
+#   # Install: python -m pip install 'hermes-agent[voice,tts-yandex]'
+#   # Credentials: set YANDEX_FOLDER_ID and YANDEX_API_KEY,
+#   #              or set YANDEX_IAM_TOKEN.
+#   # Yandex lists all SpeechKit voices as Realtime-compatible; kirill is a ru-RU male v3 voice.
+#   yandex:
+#     folder_id: "${YANDEX_FOLDER_ID}"
+#     api_key: "${YANDEX_API_KEY}"
+#     iam_token: "${YANDEX_IAM_TOKEN}"
+#     voice: "kirill"
+#     role: "neutral"
+#     speed: 1.5
+#     audio_format: "PCM16(24000)"
+#     timeout: 60
+#     stream_timeout: 600
 
 # =============================================================================
 # Voice Transcription (Speech-to-Text)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,6 +144,7 @@ matrix = ["mautrix[encryption]==0.21.0", "aiosqlite==0.22.1", "asyncpg==0.31.0",
 wecom = ["defusedxml==0.7.1"]
 cli = ["simple-term-menu==1.6.6"]
 tts-premium = ["elevenlabs==1.59.0"]
+tts-yandex = ["yandex-ai-studio-sdk==0.20.1"]
 voice = [
   # Local STT pulls in wheel-only transitive deps (ctranslate2, onnxruntime),
   # so keep it out of the base install for source-build packagers like Homebrew.

--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -103,6 +103,9 @@ class TestAllowlist:
     def test_feature_install_command_unknown(self):
         assert ld.feature_install_command("not.real") is None
 
+    def test_yandex_tts_lazy_dep_is_allowlisted(self):
+        assert ld.LAZY_DEPS["tts.yandex"] == ("yandex-ai-studio-sdk==0.20.1",)
+
 
 # ---------------------------------------------------------------------------
 # allow_lazy_installs gating

--- a/tests/tools/test_tts_max_text_length.py
+++ b/tests/tools/test_tts_max_text_length.py
@@ -111,7 +111,7 @@ class TestResolveMaxTextLength:
 
     def test_all_documented_providers_have_defaults(self):
         expected = {"edge", "openai", "xai", "minimax", "mistral",
-                    "gemini", "elevenlabs", "neutts", "kittentts"}
+                    "gemini", "yandex", "elevenlabs", "neutts", "kittentts"}
         assert expected.issubset(PROVIDER_MAX_TEXT_LENGTH.keys())
 
 

--- a/tests/tools/test_yandex_tts.py
+++ b/tests/tools/test_yandex_tts.py
@@ -1,0 +1,477 @@
+"""Tests for Yandex SpeechKit TTS provider."""
+
+import json
+import queue
+import sys
+import threading
+from types import ModuleType
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clean_yandex_env(monkeypatch):
+    for key in (
+        "YANDEX_FOLDER_ID",
+        "YANDEX_API_KEY",
+        "YANDEX_IAM_TOKEN",
+        "HERMES_SESSION_PLATFORM",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def _yandex_config(**overrides):
+    config = {
+        "provider": "yandex",
+        "yandex": {
+            "folder_id": "folder-1",
+            "api_key": "api-key-1",
+            "iam_token": "iam-token-1",
+            "voice": "kirill",
+            "role": "neutral",
+            "speed": 1.5,
+            "audio_format": "PCM16(24000)",
+            "timeout": 12,
+            "stream_timeout": 34,
+        },
+    }
+    config["yandex"].update(overrides)
+    return config
+
+
+def test_get_provider_accepts_yandex():
+    from tools.tts_tool import _get_provider
+
+    assert _get_provider({"provider": "yandex"}) == "yandex"
+
+
+def test_yandex_import_uses_lazy_deps(monkeypatch):
+    calls = []
+    fake_sdk = ModuleType("yandex_ai_studio_sdk")
+
+    class FakeAIStudio:
+        pass
+
+    fake_sdk.AIStudio = FakeAIStudio
+    monkeypatch.setitem(sys.modules, "yandex_ai_studio_sdk", fake_sdk)
+
+    def fake_ensure(feature, *, prompt=True):
+        calls.append((feature, prompt))
+
+    monkeypatch.setattr("tools.lazy_deps.ensure", fake_ensure)
+
+    from tools.tts_tool import _import_yandex_ai_studio
+
+    assert _import_yandex_ai_studio() is FakeAIStudio
+    assert calls == [("tts.yandex", False)]
+
+
+def test_yandex_auth_prefers_api_key_and_ignores_placeholders(monkeypatch):
+    monkeypatch.setenv("YANDEX_FOLDER_ID", "env-folder")
+    monkeypatch.setenv("YANDEX_API_KEY", "env-api-key")
+    monkeypatch.setenv("YANDEX_IAM_TOKEN", "env-iam-token")
+
+    from tools.tts_tool import _resolve_yandex_tts_config
+
+    resolved = _resolve_yandex_tts_config(
+        {
+            "yandex": {
+                "folder_id": "${YANDEX_FOLDER_ID}",
+                "api_key": "",
+                "iam_token": "",
+            }
+        }
+    )
+
+    assert resolved["folder_id"] == "env-folder"
+    assert resolved["auth"] == "env-api-key"
+    assert resolved["auth_type"] == "api_key"
+
+
+def test_yandex_auth_error_does_not_leak_secret():
+    from tools.tts_tool import _resolve_yandex_tts_config
+
+    with pytest.raises(ValueError) as exc:
+        _resolve_yandex_tts_config({"yandex": {"api_key": "super-secret"}})
+
+    assert "super-secret" not in str(exc.value)
+
+
+def test_yandex_file_fallback_writes_wav_and_passes_config(tmp_path, monkeypatch):
+    output_path = tmp_path / "yandex.wav"
+    captured = {}
+
+    class FakeResult:
+        data = b"\x01\x00\x02\x00"
+
+    class FakeTTS:
+        def run(self, text, timeout):
+            captured["run"] = {"text": text, "timeout": timeout}
+            return FakeResult()
+
+    class FakeSpeechKit:
+        def tts(self, **kwargs):
+            captured["tts_kwargs"] = kwargs
+            return FakeTTS()
+
+    class FakeAIStudio:
+        def __init__(self, folder_id, auth):
+            captured["sdk"] = {"folder_id": folder_id, "auth": auth}
+            self.speechkit = FakeSpeechKit()
+
+    monkeypatch.setattr("tools.tts_tool._import_yandex_ai_studio", lambda: FakeAIStudio)
+    monkeypatch.setattr("tools.tts_tool._load_tts_config", lambda: _yandex_config())
+
+    from tools.tts_tool import text_to_speech_tool
+
+    result = json.loads(text_to_speech_tool("Привет", output_path=str(output_path)))
+
+    assert result["success"] is True
+    assert result["provider"] == "yandex"
+    assert output_path.read_bytes().startswith(b"RIFF")
+    assert captured["sdk"] == {"folder_id": "folder-1", "auth": "api-key-1"}
+    assert captured["tts_kwargs"] == {
+        "voice": "kirill",
+        "role": "neutral",
+        "speed": 1.5,
+        "audio_format": "PCM16(24000)",
+    }
+    assert captured["run"] == {"text": "Привет", "timeout": 12.0}
+
+
+def test_check_tts_requirements_requires_yandex_sdk_and_credentials(monkeypatch):
+    monkeypatch.setattr("tools.tts_tool._load_tts_config", lambda: _yandex_config())
+
+    with patch("tools.tts_tool._import_yandex_ai_studio", return_value=object):
+        from tools.tts_tool import check_tts_requirements
+
+        assert check_tts_requirements() is True
+
+    monkeypatch.setattr(
+        "tools.tts_tool._load_tts_config",
+        lambda: {"provider": "yandex", "yandex": {"folder_id": "folder-1"}},
+    )
+    with patch("tools.tts_tool._import_yandex_ai_studio", return_value=object):
+        assert check_tts_requirements() is False
+
+
+def test_check_streaming_tts_available_accepts_yandex(monkeypatch):
+    monkeypatch.setattr("tools.tts_tool._import_yandex_ai_studio", lambda: object)
+    monkeypatch.setattr("tools.tts_tool._import_sounddevice", lambda: object())
+
+    from tools.tts_tool import check_streaming_tts_available
+
+    assert check_streaming_tts_available(_yandex_config()) is True
+
+
+def test_yandex_streaming_writes_clean_sentences_and_audio(monkeypatch):
+    text_queue = queue.Queue()
+    text_queue.put("**Привет** [дом](https://example.com).")
+    text_queue.put(None)
+    stop_event = threading.Event()
+    done_event = threading.Event()
+    displayed = []
+
+    class FakeChunk:
+        data = b"\x01\x00\x02\x00"
+
+    class FakeStream:
+        def __init__(self):
+            self.writes = []
+            self.flushes = 0
+            self.done = False
+            self.responses = queue.Queue()
+
+        def write(self, text):
+            self.writes.append(text)
+            self.responses.put(FakeChunk())
+
+        def flush(self):
+            self.flushes += 1
+
+        def done_writing(self):
+            self.done = True
+            self.responses.put(None)
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            item = self.responses.get(timeout=1)
+            if item is None:
+                raise StopIteration
+            return item
+
+    fake_stream = FakeStream()
+
+    class FakeTTS:
+        def create_bistream(self, timeout):
+            assert timeout == 34.0
+            return fake_stream
+
+    class FakeOutputStream:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.writes = []
+            self.started = False
+            self.closed = False
+
+        def start(self):
+            self.started = True
+
+        def write(self, data):
+            self.writes.append(data)
+
+        def stop(self):
+            pass
+
+        def close(self):
+            self.closed = True
+
+    fake_output = FakeOutputStream
+    output_instances = []
+
+    class FakeSoundDevice:
+        def RawOutputStream(self, **kwargs):
+            stream = fake_output(**kwargs)
+            output_instances.append(stream)
+            return stream
+
+    monkeypatch.setattr("tools.tts_tool._create_yandex_tts_client", lambda _cfg: (FakeTTS(), _cfg["yandex"]))
+    monkeypatch.setattr("tools.tts_tool._import_sounddevice", lambda: FakeSoundDevice())
+
+    from tools.tts_tool import _stream_yandex_tts_to_speaker
+
+    monkeypatch.setattr("tools.tts_tool.time.sleep", lambda _seconds: None)
+
+    _stream_yandex_tts_to_speaker(
+        text_queue,
+        stop_event,
+        done_event,
+        display_callback=displayed.append,
+        tts_config=_yandex_config(),
+    )
+
+    assert done_event.is_set()
+    assert fake_stream.writes == ["Привет дом."]
+    assert fake_stream.flushes == 1
+    assert fake_stream.done is True
+    assert displayed == ["**Привет** [дом](https://example.com)."]
+    assert output_instances[0].kwargs == {"samplerate": 24000, "channels": 1, "dtype": "int16"}
+    assert output_instances[0].writes[0] == b"\x01\x00\x02\x00"
+    assert output_instances[0].writes[1].strip(b"\x00") == b""
+    assert len(output_instances[0].writes[1]) > 0
+    assert output_instances[0].writes[2].strip(b"\x00") == b""
+    assert len(output_instances[0].writes[2]) > len(output_instances[0].writes[1])
+    assert output_instances[0].closed is True
+
+
+def test_yandex_streaming_does_not_open_audio_before_text(monkeypatch):
+    text_queue = queue.Queue()
+    text_queue.put(None)
+    done_event = threading.Event()
+
+    def fail_create_client(_cfg):
+        raise AssertionError("Yandex runtime should be lazy until there is text to speak")
+
+    monkeypatch.setattr("tools.tts_tool._create_yandex_tts_client", fail_create_client)
+
+    from tools.tts_tool import _stream_yandex_tts_to_speaker
+
+    _stream_yandex_tts_to_speaker(
+        text_queue,
+        threading.Event(),
+        done_event,
+        tts_config=_yandex_config(),
+    )
+
+    assert done_event.is_set()
+
+
+def test_yandex_streaming_reuses_audio_stream_between_sentences(monkeypatch):
+    text_queue = queue.Queue()
+    text_queue.put("Первое предложение готово. Второе предложение тоже готово.")
+    text_queue.put(None)
+    done_event = threading.Event()
+
+    class FakeChunk:
+        data = b"\x01\x00"
+
+    class FakeStream:
+        def __init__(self):
+            self.responses = queue.Queue()
+
+        def write(self, text):
+            self.responses.put(FakeChunk())
+
+        def flush(self):
+            pass
+
+        def done_writing(self):
+            self.responses.put(None)
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            item = self.responses.get(timeout=1)
+            if item is None:
+                raise StopIteration
+            return item
+
+    class FakeTTS:
+        def create_bistream(self, timeout):
+            return FakeStream()
+
+    output_instances = []
+
+    class FakeOutputStream:
+        def __init__(self, **kwargs):
+            self.writes = []
+            self.closed = False
+
+        def start(self):
+            pass
+
+        def write(self, data):
+            self.writes.append(data)
+
+        def stop(self):
+            pass
+
+        def close(self):
+            self.closed = True
+
+    class FakeSoundDevice:
+        def RawOutputStream(self, **kwargs):
+            stream = FakeOutputStream(**kwargs)
+            output_instances.append(stream)
+            return stream
+
+    monkeypatch.setattr("tools.tts_tool._create_yandex_tts_client", lambda _cfg: (FakeTTS(), _cfg["yandex"]))
+    monkeypatch.setattr("tools.tts_tool._import_sounddevice", lambda: FakeSoundDevice())
+
+    from tools.tts_tool import _stream_yandex_tts_to_speaker
+
+    monkeypatch.setattr("tools.tts_tool.time.sleep", lambda _seconds: None)
+
+    _stream_yandex_tts_to_speaker(
+        text_queue,
+        threading.Event(),
+        done_event,
+        tts_config=_yandex_config(),
+    )
+
+    assert done_event.is_set()
+    assert len(output_instances) == 1
+    assert output_instances[0].closed is True
+    assert output_instances[0].writes[0] == b"\x01\x00"
+    assert output_instances[0].writes[1].strip(b"\x00") == b""
+    assert output_instances[0].writes[2] == b"\x01\x00"
+    assert output_instances[0].writes[3].strip(b"\x00") == b""
+    assert output_instances[0].writes[4].strip(b"\x00") == b""
+    assert len(output_instances[0].writes[4]) > len(output_instances[0].writes[3])
+
+
+def test_yandex_streaming_waits_for_reader_before_closing_output(monkeypatch):
+    text_queue = queue.Queue()
+    text_queue.put("Длинный ответ должен дождаться аудио целиком.")
+    text_queue.put(None)
+    stop_event = threading.Event()
+    done_event = threading.Event()
+    join_timeouts = []
+
+    class FakeThread:
+        def __init__(self, target, daemon=False):
+            self.target = target
+            self.daemon = daemon
+
+        def start(self):
+            pass
+
+        def join(self, timeout=None):
+            join_timeouts.append(timeout)
+
+        def is_alive(self):
+            return False
+
+    class FakeStream:
+        def __init__(self):
+            self.writes = []
+            self.done = False
+
+        def write(self, text):
+            self.writes.append(text)
+
+        def flush(self):
+            pass
+
+        def done_writing(self):
+            self.done = True
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            raise StopIteration
+
+    fake_stream = FakeStream()
+
+    class FakeTTS:
+        def create_bistream(self, timeout):
+            return fake_stream
+
+    class FakeOutputStream:
+        def start(self):
+            pass
+
+        def stop(self):
+            pass
+
+        def close(self):
+            pass
+
+    class FakeSoundDevice:
+        def RawOutputStream(self, **kwargs):
+            return FakeOutputStream()
+
+    monkeypatch.setattr("tools.tts_tool.threading.Thread", FakeThread)
+    monkeypatch.setattr("tools.tts_tool._create_yandex_tts_client", lambda _cfg: (FakeTTS(), _cfg["yandex"]))
+    monkeypatch.setattr("tools.tts_tool._import_sounddevice", lambda: FakeSoundDevice())
+
+    from tools.tts_tool import _stream_yandex_tts_to_speaker
+
+    _stream_yandex_tts_to_speaker(
+        text_queue,
+        stop_event,
+        done_event,
+        tts_config=_yandex_config(stream_timeout=34),
+    )
+
+    assert done_event.is_set()
+    assert fake_stream.done is True
+    assert join_timeouts == [34.0]
+
+
+def test_yandex_streaming_sets_done_on_error(monkeypatch):
+    text_queue = queue.Queue()
+    text_queue.put("Привет.")
+    text_queue.put(None)
+    done_event = threading.Event()
+
+    monkeypatch.setattr(
+        "tools.tts_tool._create_yandex_tts_client",
+        lambda _cfg: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    from tools.tts_tool import _stream_yandex_tts_to_speaker
+
+    _stream_yandex_tts_to_speaker(
+        text_queue,
+        threading.Event(),
+        done_event,
+        tts_config=_yandex_config(),
+    )
+
+    assert done_event.is_set()

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -104,6 +104,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     "tts.mistral": ("mistralai==2.4.8",),
     "tts.edge": ("edge-tts==7.2.7",),
     "tts.elevenlabs": ("elevenlabs==1.59.0",),
+    "tts.yandex": ("yandex-ai-studio-sdk==0.20.1",),
 
     # ─── Speech-to-text providers ──────────────────────────────────────────
     "stt.mistral": ("mistralai==2.4.8",),

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -46,8 +46,10 @@ import shlex
 import shutil
 import subprocess
 import tempfile
+import time
 import threading
 import uuid
+import wave
 from pathlib import Path
 from typing import Callable, Dict, Any, Optional
 from urllib.parse import urljoin
@@ -144,6 +146,23 @@ def _import_sounddevice():
     return sd
 
 
+def _import_yandex_ai_studio():
+    """Lazy import Yandex AI Studio SDK. Returns AIStudio or raises ImportError.
+
+    Calls :func:`tools.lazy_deps.ensure` first so the SDK gets installed on
+    demand if the user enabled Yandex TTS directly in config.yaml.
+    """
+    try:
+        from tools.lazy_deps import ensure
+        ensure("tts.yandex", prompt=False)
+    except ImportError:
+        pass
+    except Exception as e:  # FeatureUnavailable or any unexpected error
+        raise ImportError(str(e))
+    from yandex_ai_studio_sdk import AIStudio
+    return AIStudio
+
+
 def _import_kittentts():
     """Lazy import KittenTTS. Returns the class or raises ImportError."""
     from kittentts import KittenTTS
@@ -192,6 +211,12 @@ DEFAULT_GEMINI_TTS_VOICE = "Kore"
 DEFAULT_GEMINI_TTS_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
 DEFAULT_GEMINI_AUDIO_TAGS = False
 GEMINI_AUDIO_TAG_REWRITE_TASK = "tts_audio_tags"
+DEFAULT_YANDEX_TTS_VOICE = "kirill"
+DEFAULT_YANDEX_TTS_ROLE = "neutral"
+DEFAULT_YANDEX_TTS_SPEED = 1.7
+DEFAULT_YANDEX_TTS_AUDIO_FORMAT = "PCM16(24000)"
+DEFAULT_YANDEX_TTS_TIMEOUT = 60
+DEFAULT_YANDEX_TTS_STREAM_TIMEOUT = 600
 # PCM output specs for Gemini TTS (fixed by the API)
 GEMINI_TTS_SAMPLE_RATE = 24000
 GEMINI_TTS_CHANNELS = 1
@@ -217,6 +242,7 @@ PROVIDER_MAX_TEXT_LENGTH: Dict[str, int] = {
     "minimax": 10000,     # https://platform.minimax.io/docs/api-reference/speech-t2a-http (sync)
     "mistral": 4000,      # conservative; no published per-request cap
     "gemini": 32000,      # Gemini TTS has a 32k-token context window; char cap is conservative
+    "yandex": 5000,       # SpeechKit API v3 can stream chunks; keep per request modest
     "elevenlabs": 10000,  # fallback when model-aware lookup can't resolve (multilingual_v2)
     "neutts": 2000,       # local model, quality falls off on long text
     "kittentts": 2000,    # local 25MB model
@@ -342,6 +368,106 @@ def _get_provider(tts_config: Dict[str, Any]) -> str:
     return (tts_config.get("provider") or DEFAULT_PROVIDER).lower().strip()
 
 
+def _clean_config_value(value: Any) -> str:
+    """Return a stripped config/env value, ignoring unresolved ${ENV} placeholders."""
+    text = str(value or "").strip()
+    if text.startswith("${") and text.endswith("}"):
+        return ""
+    return text
+
+
+def _config_or_env(config_value: Any, env_name: str) -> str:
+    """Resolve a config value, falling back to env when config is empty/placeholder."""
+    return _clean_config_value(config_value) or _clean_config_value(os.getenv(env_name))
+
+
+def _resolve_yandex_tts_config(tts_config: Dict[str, Any]) -> Dict[str, Any]:
+    """Resolve Yandex SpeechKit TTS settings and credentials."""
+    yandex_config = tts_config.get("yandex", {})
+    if not isinstance(yandex_config, dict):
+        yandex_config = {}
+
+    folder_id = _config_or_env(yandex_config.get("folder_id"), "YANDEX_FOLDER_ID")
+    api_key = _config_or_env(yandex_config.get("api_key"), "YANDEX_API_KEY")
+    iam_token = _config_or_env(yandex_config.get("iam_token"), "YANDEX_IAM_TOKEN")
+
+    if not folder_id:
+        raise ValueError("Yandex SpeechKit folder_id is not set (tts.yandex.folder_id or YANDEX_FOLDER_ID).")
+    if not api_key and not iam_token:
+        raise ValueError(
+            "Yandex SpeechKit credentials are not set "
+            "(tts.yandex.api_key / YANDEX_API_KEY or tts.yandex.iam_token / YANDEX_IAM_TOKEN)."
+        )
+
+    auth = api_key or iam_token
+    auth_type = "api_key" if api_key else "iam_token"
+    speed = yandex_config.get("speed", tts_config.get("speed", DEFAULT_YANDEX_TTS_SPEED))
+
+    return {
+        "folder_id": folder_id,
+        "auth": auth,
+        "auth_type": auth_type,
+        "voice": _clean_config_value(yandex_config.get("voice")) or DEFAULT_YANDEX_TTS_VOICE,
+        "role": _clean_config_value(yandex_config.get("role")) or DEFAULT_YANDEX_TTS_ROLE,
+        "speed": float(speed),
+        "audio_format": _clean_config_value(yandex_config.get("audio_format")) or DEFAULT_YANDEX_TTS_AUDIO_FORMAT,
+        "timeout": float(yandex_config.get("timeout", DEFAULT_YANDEX_TTS_TIMEOUT)),
+        "stream_timeout": float(yandex_config.get("stream_timeout", DEFAULT_YANDEX_TTS_STREAM_TIMEOUT)),
+        "volume": yandex_config.get("volume"),
+        "pitch_shift": yandex_config.get("pitch_shift"),
+    }
+
+
+def _create_yandex_tts_client(tts_config: Dict[str, Any]):
+    """Create and configure a Yandex SpeechKit TTS object via yandex-ai-studio-sdk."""
+    resolved = _resolve_yandex_tts_config(tts_config)
+    AIStudio = _import_yandex_ai_studio()
+    sdk = AIStudio(folder_id=resolved["folder_id"], auth=resolved["auth"])
+    speechkit = sdk.speechkit
+    tts_factory = getattr(speechkit, "tts", None) or getattr(speechkit, "text_to_speech")
+
+    kwargs: Dict[str, Any] = {
+        "voice": resolved["voice"],
+        "role": resolved["role"],
+        "speed": resolved["speed"],
+        "audio_format": resolved["audio_format"],
+    }
+    if resolved["volume"] is not None:
+        kwargs["volume"] = float(resolved["volume"])
+    if resolved["pitch_shift"] is not None:
+        kwargs["pitch_shift"] = float(resolved["pitch_shift"])
+
+    return tts_factory(**kwargs), resolved
+
+
+def _yandex_pcm_sample_rate(audio_format: str) -> int:
+    """Extract sample rate from PCM16(N) audio_format; default to 24000 Hz."""
+    match = re.search(r"PCM16\((\d+)\)", str(audio_format or ""), flags=re.IGNORECASE)
+    if match:
+        return int(match.group(1))
+    return 24000
+
+
+def _yandex_output_extension(tts_config: Dict[str, Any]) -> str:
+    """Return the preferred file extension for the configured Yandex audio format."""
+    yandex_config = tts_config.get("yandex", {})
+    audio_format = str((yandex_config or {}).get("audio_format") or DEFAULT_YANDEX_TTS_AUDIO_FORMAT).lower()
+    if "mp3" in audio_format:
+        return "mp3"
+    if "ogg" in audio_format:
+        return "ogg"
+    return "wav"
+
+
+def _write_pcm16_wav(pcm_data: bytes, output_path: str, sample_rate: int) -> None:
+    """Wrap raw mono PCM16 bytes in a WAV container."""
+    with wave.open(output_path, "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(sample_rate)
+        wav_file.writeframes(pcm_data)
+
+
 # ===========================================================================
 # Custom command providers (type: command under tts.providers.<name>)
 # ===========================================================================
@@ -381,6 +507,7 @@ BUILTIN_TTS_PROVIDERS = frozenset({
     "xai",
     "mistral",
     "gemini",
+    "yandex",
     "neutts",
     "kittentts",
     "piper",
@@ -1703,6 +1830,26 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
 
 
 # ===========================================================================
+# Provider: Yandex SpeechKit TTS
+# ===========================================================================
+def _generate_yandex_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """Generate audio using Yandex SpeechKit via yandex-ai-studio-sdk."""
+    tts, resolved = _create_yandex_tts_client(tts_config)
+    result = tts.run(text, timeout=resolved["timeout"])
+    audio_bytes = getattr(result, "data", b"")
+    if not audio_bytes:
+        raise RuntimeError("Yandex SpeechKit returned empty audio data")
+
+    audio_format = str(resolved["audio_format"]).lower()
+    if audio_format.startswith("pcm16"):
+        _write_pcm16_wav(audio_bytes, output_path, _yandex_pcm_sample_rate(resolved["audio_format"]))
+    else:
+        with open(output_path, "wb") as f:
+            f.write(audio_bytes)
+    return output_path
+
+
+# ===========================================================================
 # NeuTTS (local, on-device TTS via neutts_cli)
 # ===========================================================================
 
@@ -2105,6 +2252,8 @@ def text_to_speech_tool(
         # otherwise fall back to .mp3 (Edge TTS will attempt ffmpeg conversion later).
         elif want_opus and provider in {"openai", "elevenlabs", "mistral", "gemini"}:
             file_path = out_dir / f"tts_{timestamp}.ogg"
+        elif provider == "yandex":
+            file_path = out_dir / f"tts_{timestamp}.{_yandex_output_extension(tts_config)}"
         else:
             file_path = out_dir / f"tts_{timestamp}.mp3"
 
@@ -2182,6 +2331,18 @@ def text_to_speech_tool(
         elif provider == "gemini":
             logger.info("Generating speech with Google Gemini TTS...")
             _generate_gemini_tts(text, file_str, tts_config)
+
+        elif provider == "yandex":
+            try:
+                _import_yandex_ai_studio()
+            except ImportError:
+                return json.dumps({
+                    "success": False,
+                    "error": "Yandex SpeechKit provider selected but 'yandex-ai-studio-sdk' is not installed. "
+                             "Run: pip install 'hermes-agent[tts-yandex]'"
+                }, ensure_ascii=False)
+            logger.info("Generating speech with Yandex SpeechKit TTS...")
+            _generate_yandex_tts(text, file_str, tts_config)
 
         elif provider == "neutts":
             if not _check_neutts_available():
@@ -2284,7 +2445,7 @@ def text_to_speech_tool(
                 voice_compatible = file_str.endswith(".ogg")
         elif (
             want_opus
-            and provider in {"edge", "neutts", "minimax", "xai", "kittentts", "piper"}
+            and provider in {"edge", "neutts", "minimax", "xai", "kittentts", "piper", "yandex"}
             and not file_str.endswith(".ogg")
         ):
             opus_path = _convert_to_opus(file_str)
@@ -2330,6 +2491,36 @@ def text_to_speech_tool(
 # ===========================================================================
 # Requirements check
 # ===========================================================================
+def _check_yandex_available(tts_config: Dict[str, Any]) -> bool:
+    """Return True when the Yandex SDK and credentials are available."""
+    try:
+        _import_yandex_ai_studio()
+        _resolve_yandex_tts_config(tts_config)
+        return True
+    except (ImportError, ValueError):
+        return False
+
+
+def check_streaming_tts_available(tts_config: Optional[Dict[str, Any]] = None) -> bool:
+    """Return True when the selected TTS provider can stream to the CLI speaker."""
+    config = tts_config if tts_config is not None else _load_tts_config()
+    provider = _get_provider(config)
+
+    try:
+        if provider == "elevenlabs":
+            _import_elevenlabs()
+            _import_sounddevice()
+            return True
+        if provider == "yandex":
+            _import_yandex_ai_studio()
+            _import_sounddevice()
+            _resolve_yandex_tts_config(config)
+            return True
+    except (ImportError, OSError, ValueError):
+        return False
+    return False
+
+
 def check_tts_requirements() -> bool:
     """
     Check if at least one TTS provider is available.
@@ -2341,9 +2532,14 @@ def check_tts_requirements() -> bool:
     Returns:
         bool: True if at least one provider can work.
     """
+    tts_config = _load_tts_config()
+
     # Any configured command provider counts as available.
-    if _has_any_command_tts_provider():
+    if _has_any_command_tts_provider(tts_config):
         return True
+
+    if _get_provider(tts_config) == "yandex":
+        return _check_yandex_available(tts_config)
     try:
         _import_edge_tts()
         return True
@@ -2453,6 +2649,202 @@ def _strip_markdown_for_tts(text: str) -> str:
     return text.strip()
 
 
+def _stream_yandex_tts_to_speaker(
+    text_queue: queue.Queue,
+    stop_event: threading.Event,
+    tts_done_event: threading.Event,
+    display_callback: Optional[Callable[[str], None]] = None,
+    tts_config: Optional[Dict[str, Any]] = None,
+):
+    """Consume text deltas and stream them through Yandex SpeechKit gRPC TTS."""
+    tts_done_event.clear()
+    output_stream = None
+
+    try:
+        config = tts_config if tts_config is not None else _load_tts_config()
+        tts = None
+        resolved: Optional[Dict[str, Any]] = None
+        sample_rate = _yandex_pcm_sample_rate(DEFAULT_YANDEX_TTS_AUDIO_FORMAT)
+        reader_join_timeout = 120.0
+        sd = None
+        audio_stream_had_audio = False
+        sentence_silence_tail_seconds = 0.08
+        final_silence_tail_seconds = 0.32
+        final_stream_drain_seconds = 0.08
+
+        def _ensure_runtime() -> None:
+            nonlocal tts, resolved, sample_rate, reader_join_timeout, sd
+            if tts is not None and resolved is not None and sd is not None:
+                return
+            tts, resolved = _create_yandex_tts_client(config)
+            sample_rate = _yandex_pcm_sample_rate(resolved["audio_format"])
+            try:
+                reader_join_timeout = min(max(float(resolved["stream_timeout"]), 30.0), 120.0)
+            except (TypeError, ValueError):
+                reader_join_timeout = 120.0
+            sd = _import_sounddevice()
+
+        def _ensure_output_stream():
+            nonlocal output_stream
+            _ensure_runtime()
+            if sd is None:
+                return None
+            if output_stream is None:
+                output_stream = sd.RawOutputStream(
+                    samplerate=sample_rate,
+                    channels=1,
+                    dtype="int16",
+                )
+                output_stream.start()
+            return output_stream
+
+        def _write_silence_tail(seconds: float) -> None:
+            if output_stream is None or stop_event.is_set():
+                return
+            silence_samples = max(1, int(sample_rate * seconds))
+            output_stream.write(b"\x00\x00" * silence_samples)
+
+        def _write_sentence_silence_tail() -> None:
+            _write_silence_tail(sentence_silence_tail_seconds)
+
+        def _write_final_silence_tail() -> None:
+            if not audio_stream_had_audio or output_stream is None or stop_event.is_set():
+                return
+            _write_silence_tail(final_silence_tail_seconds)
+            time.sleep(final_stream_drain_seconds)
+
+        def _play_sentence_audio(cleaned: str) -> None:
+            nonlocal audio_stream_had_audio
+            _ensure_runtime()
+            if tts is None or resolved is None or sd is None:
+                return
+
+            yandex_stream = None
+            reader_thread = None
+            done_writing_sent = False
+            reader_errors: list[Exception] = []
+            audio_written = False
+
+            try:
+                playback_stream = _ensure_output_stream()
+                if playback_stream is None:
+                    return
+
+                yandex_stream = tts.create_bistream(timeout=resolved["stream_timeout"])
+
+                def _read_audio() -> None:
+                    nonlocal audio_written, audio_stream_had_audio
+                    try:
+                        for chunk in yandex_stream:
+                            if stop_event.is_set():
+                                break
+                            audio = getattr(chunk, "data", b"") or b""
+                            if audio:
+                                playback_stream.write(audio)
+                                audio_written = True
+                                audio_stream_had_audio = True
+                    except Exception as exc:
+                        reader_errors.append(exc)
+                        logger.warning("Yandex streaming TTS reader failed: %s", exc)
+
+                reader_thread = threading.Thread(target=_read_audio, daemon=True)
+                reader_thread.start()
+
+                yandex_stream.write(cleaned)
+                yandex_stream.flush()
+                yandex_stream.done_writing()
+                done_writing_sent = True
+
+                reader_thread.join(timeout=reader_join_timeout)
+                if reader_thread.is_alive():
+                    logger.warning(
+                        "Yandex streaming TTS reader still active after %.0fs; skipping inter-sentence silence tail",
+                        reader_join_timeout,
+                    )
+                elif audio_written:
+                    _write_sentence_silence_tail()
+                if reader_errors:
+                    logger.debug("Yandex streaming TTS completed with reader errors: %s", reader_errors)
+            finally:
+                if yandex_stream is not None and not done_writing_sent:
+                    try:
+                        yandex_stream.done_writing()
+                    except Exception:
+                        pass
+
+        sentence_buf = ""
+        min_sentence_len = 20
+        long_flush_len = 100
+        queue_timeout = 0.5
+        spoken_sentences: list[str] = []
+        think_block_re = re.compile(r'<think[\s>].*?</think>', flags=re.DOTALL)
+
+        def _send_sentence(sentence: str) -> None:
+            if stop_event.is_set():
+                return
+            cleaned = _strip_markdown_for_tts(sentence).strip()
+            if not cleaned:
+                return
+            cleaned_lower = cleaned.lower().rstrip(".!,")
+            for prev in spoken_sentences:
+                if prev.lower().rstrip(".!,") == cleaned_lower:
+                    return
+            spoken_sentences.append(cleaned)
+            if display_callback is not None:
+                display_callback(sentence)
+            _play_sentence_audio(cleaned)
+
+        while not stop_event.is_set():
+            try:
+                delta = text_queue.get(timeout=queue_timeout)
+            except queue.Empty:
+                if len(sentence_buf) > long_flush_len:
+                    _send_sentence(sentence_buf)
+                    sentence_buf = ""
+                continue
+
+            if delta is None:
+                sentence_buf = think_block_re.sub('', sentence_buf)
+                if sentence_buf.strip():
+                    _send_sentence(sentence_buf)
+                break
+
+            sentence_buf += delta
+            sentence_buf = think_block_re.sub('', sentence_buf)
+            if '<think' in sentence_buf and '</think>' not in sentence_buf:
+                continue
+
+            while True:
+                match = _SENTENCE_BOUNDARY_RE.search(sentence_buf)
+                if match is None:
+                    break
+                end_pos = match.end()
+                sentence = sentence_buf[:end_pos]
+                sentence_buf = sentence_buf[end_pos:]
+                if len(sentence.strip()) < min_sentence_len:
+                    sentence_buf = sentence + sentence_buf
+                    break
+                _send_sentence(sentence)
+
+    except Exception as exc:
+        logger.warning("Yandex streaming TTS pipeline error: %s", exc)
+    finally:
+        if output_stream is not None:
+            try:
+                _write_final_silence_tail()
+            except Exception:
+                logger.debug("Yandex streaming TTS failed to write final silence tail", exc_info=True)
+            try:
+                output_stream.stop()
+            except Exception:
+                pass
+            try:
+                output_stream.close()
+            except Exception:
+                pass
+        tts_done_event.set()
+
+
 def stream_tts_to_speaker(
     text_queue: queue.Queue,
     stop_event: threading.Event,
@@ -2471,6 +2863,16 @@ def stream_tts_to_speaker(
           waiting on it (continuous voice mode) know playback is finished.
     """
     tts_done_event.clear()
+    tts_config = _load_tts_config()
+    if _get_provider(tts_config) == "yandex":
+        _stream_yandex_tts_to_speaker(
+            text_queue,
+            stop_event,
+            tts_done_event,
+            display_callback=display_callback,
+            tts_config=tts_config,
+        )
+        return
 
     try:
         # --- TTS client setup (optional -- display_callback works without it) ---
@@ -2479,7 +2881,6 @@ def stream_tts_to_speaker(
         voice_id = DEFAULT_ELEVENLABS_VOICE_ID
         model_id = DEFAULT_ELEVENLABS_STREAMING_MODEL_ID
 
-        tts_config = _load_tts_config()
         el_config = tts_config.get("elevenlabs", {})
         voice_id = el_config.get("voice_id", voice_id)
         model_id = el_config.get("streaming_model_id",

--- a/uv.lock
+++ b/uv.lock
@@ -1271,6 +1271,15 @@ wheels = [
 ]
 
 [[package]]
+name = "get-annotations"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/6e/265083c3bc64f17b7bc52e8c3720739841772e81b44272b8ba12d46a01ce/get-annotations-0.1.2.tar.gz", hash = "sha256:da7b69b8043237cc7f7ce5919e9cc59bd18fc4e2704b43eb34e3ba4fa9374bab", size = 4506, upload-time = "2021-12-27T06:42:40.22Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/42/9515026b884c7d5877c610082d35bcbad4f8ff4dfbf31aff0fe914f7ff3d/get_annotations-0.1.2-py3-none-any.whl", hash = "sha256:788ba8aa2434ee34ffb985c4aea2f9e575204c884c0e0dd0f969be846470e527", size = 4482, upload-time = "2021-12-27T06:42:41.79Z" },
+]
+
+[[package]]
 name = "google-api-core"
 version = "2.30.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1351,6 +1360,90 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/99/96/a0205167fa0154f4a542fd6925bdc63d039d88dab3588b875078107e6f06/googleapis_common_protos-1.73.0.tar.gz", hash = "sha256:778d07cd4fbeff84c6f7c72102f0daf98fa2bfd3fa8bea426edc545588da0b5a", size = 147323, upload-time = "2026-03-06T21:53:09.727Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/69/28/23eea8acd65972bbfe295ce3666b28ac510dfcb115fac089d3edb0feb00a/googleapis_common_protos-1.73.0-py3-none-any.whl", hash = "sha256:dfdaaa2e860f242046be561e6d6cb5c5f1541ae02cfbcb034371aadb2942b4e8", size = 297578, upload-time = "2026-03-06T21:52:33.933Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.81.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b0/b5/1ff353970a87eda4c98251e34d2dfd214abd4982dc89119c9252a2a482d2/grpcio-1.81.1.tar.gz", hash = "sha256:6fa10a767143a5e82e8eaab53918af0cd8909a57a27f8cb2288b80a613ac671b", size = 13026582, upload-time = "2026-06-11T12:46:51.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/ea/1c2fa386b718ff493225e61cfc052ef400b4d6ffc54cbe261026432624b5/grpcio-1.81.1-cp311-cp311-linux_armv7l.whl", hash = "sha256:d71d30f2d92f67d944631c523713934fee37292469e182ebcd2c1dd8a64ce53f", size = 6093112, upload-time = "2026-06-11T12:44:52.131Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/18/acf45fa8bd1bc5d7b0c2fd3dc4c209379fbd5bb396b440b68a83342226b7/grpcio-1.81.1-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:b137f4bf3ada9dc44d411478decc6ff09a79ed30b306cd2abaa98408c3588137", size = 12074277, upload-time = "2026-06-11T12:44:55.354Z" },
+    { url = "https://files.pythonhosted.org/packages/48/d7/ee86a60699b7db039f772a2c4a7e4facc7138984ff42c0130933a0063884/grpcio-1.81.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a3acb384427816dd5d470f47e62137b87f74da694faa8a50147012cf40df276a", size = 6640348, upload-time = "2026-06-11T12:44:59.223Z" },
+    { url = "https://files.pythonhosted.org/packages/26/ee/d2de5e47378ffc207d476c230fea3be4d2601edbce9995f4fe45535d4896/grpcio-1.81.1-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:f9a0ebbe45c29b5e5866593c12b78bd9035f0f0f0d4bc8361680cd580d99db49", size = 7331842, upload-time = "2026-06-11T12:45:02.001Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d6/abeda5c2b896a0b341584fe5ac411bbf72e197a9a374c355fb90965e08d2/grpcio-1.81.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0a37165cc80b1a368384b383e63a4c38116a10467ae44c904d2d7468c4470ec2", size = 6842229, upload-time = "2026-06-11T12:45:04.76Z" },
+    { url = "https://files.pythonhosted.org/packages/10/1c/1f0da7d590b4aeee006826ba568d0e419ca14b23e18f901a3da3e9fba613/grpcio-1.81.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6282caffb41ec326d4cb67ca9cf53b739d1b2f975a2acb498c7418e9f7d9a416", size = 7446096, upload-time = "2026-06-11T12:45:07.499Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/81/5c505d508f7c887aa7982d21443a4126597c80d34b0bcf40f9cec576d7f3/grpcio-1.81.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:a35009284d0d3d5c2c9601c164a911b8b4331608d98a9a66d47d97bb2f522b70", size = 8445238, upload-time = "2026-06-11T12:45:10.243Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/b2/524847365122ee509ca17bcc4e092198b700e94af7bfd5bb5e6dd9f3ee66/grpcio-1.81.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1b22c80559854b789a01fd89e8929b3798a156c0829b5282a8939f33ad4115ad", size = 7873989, upload-time = "2026-06-11T12:45:13.102Z" },
+    { url = "https://files.pythonhosted.org/packages/18/fa/07c037c50b006909d1d13a5848774f8aa7b242f70dc03a035c64eea0e6db/grpcio-1.81.1-cp311-cp311-win32.whl", hash = "sha256:428bec0161b48d8cf583c068591bc0016d0d9cfff52462b72b3884861ea768c5", size = 4202223, upload-time = "2026-06-11T12:45:16.166Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ed/6bff15376920942fac6b95b9802752b837437172c9e8fc2d3170546b89cc/grpcio-1.81.1-cp311-cp311-win_amd64.whl", hash = "sha256:30e825f6848d9f18bba350ed6c75c1b02a0b5184474a31db9a32b1fa66fd8c79", size = 4941303, upload-time = "2026-06-11T12:45:18.724Z" },
+    { url = "https://files.pythonhosted.org/packages/85/07/9a979c81738863a738dc23d65177056e71fbb2db817740ed870b33434e7a/grpcio-1.81.1-cp312-cp312-linux_armv7l.whl", hash = "sha256:8b39472beafc0bdcafc4c8c73ad082ebfdb449d566897a61e7acb4fa88089115", size = 6053264, upload-time = "2026-06-11T12:45:21.017Z" },
+    { url = "https://files.pythonhosted.org/packages/75/95/539706ca0d3bd40dbad583dc56fd883da941f37556b629132da5762781b9/grpcio-1.81.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:12b7524c88d4026d3dcb7b0ebe16b6714f3b4af402ddd0f0639ab064a00c87c3", size = 12052560, upload-time = "2026-06-11T12:45:23.652Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/44/f257b7e0bd69c93b06c6cb8ac8d1b901ccb42bedabd83c1a4c77a71f8810/grpcio-1.81.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1e123f9b37edb8375fd74130d1f69c944bbf0a7b06761ae7211154b8759e94d2", size = 6595983, upload-time = "2026-06-11T12:45:26.963Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/f3/19782aa04c960968bef8c5539329d8e3bbc3364e2e46d19eb5e5cc5e43b7/grpcio-1.81.1-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:2c2e2ae6867c2966b8daccc836d54a13218e0007e9a490aeb81dd05be64d22d7", size = 7303455, upload-time = "2026-06-11T12:45:29.707Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/8c/dea020b6d91508cd84463917a63149ec196ee7db505d032ae43fcb3303b9/grpcio-1.81.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:766bc7c9a9c340342f4c864ccbda8e78111e4751f13b895812b9c148fb79e9d0", size = 6809167, upload-time = "2026-06-11T12:45:32.52Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/c7/3030dd940408083bd32cd95d634777a71605ade4887154d93e8a89244946/grpcio-1.81.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b259a04a737cb3496be0901328eb8b7552ed8df4865d8c8f1cf1bffcfc0776a3", size = 7412536, upload-time = "2026-06-11T12:45:35.403Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/dd/1172a9e42b168edcafefad6115346ef619a3fc02158bb170e66ced24bcdd/grpcio-1.81.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:85b10a45b8993d195c4f3ff57025b8d1e11834909ee475c403bfa60cb4caefaf", size = 8408276, upload-time = "2026-06-11T12:45:37.78Z" },
+    { url = "https://files.pythonhosted.org/packages/25/7a/71437c7f3596e5246155c515852795a85a1a8d228190212432b13b97a95d/grpcio-1.81.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8ea1936c26b99999b27479853039a7f34713f56c49375ad52b38535ec93a796c", size = 7849660, upload-time = "2026-06-11T12:45:40.627Z" },
+    { url = "https://files.pythonhosted.org/packages/65/40/7debc0da45d2efebafb82da75644be347497fe4ee250514b8cd3b86ae8bf/grpcio-1.81.1-cp312-cp312-win32.whl", hash = "sha256:a185a04039df6cae8648bc8ab6d6fde7bf94f7188ecf7828e76ac52eef1e41d6", size = 4185819, upload-time = "2026-06-11T12:45:43.027Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b9/8fe3ba5ed462067774ebc1f9c7f26aa7ebcc280ddd476be107153de1339e/grpcio-1.81.1-cp312-cp312-win_amd64.whl", hash = "sha256:3ad74f8bb1a18963914c5452d289422830b39459e8776ebbcd207be1fbfb1d94", size = 4930461, upload-time = "2026-06-11T12:45:45.775Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/42/dcc2e4b600538ef18327c0839d56b7d3c3812337c5d710df5877dbb39b1e/grpcio-1.81.1-cp313-cp313-linux_armv7l.whl", hash = "sha256:b10e1ff4756ed27d5a29d7fc79cfce7ef1ff56ad20025b89bac7cf79e09abbbe", size = 6054466, upload-time = "2026-06-11T12:45:48.43Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/4a/a36e03210183a8a7d4c80c3936acee679f4bd77d5861f369db47b2cc5f05/grpcio-1.81.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:819edbdcb42ab8598b494bcf0222684bbb7a3c772bd1b1f0be7e029a6063c28e", size = 12048795, upload-time = "2026-06-11T12:45:54.011Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/d5/d68e30b29098f63beab6fe501100fe82674ff142b32c672532da86a99b3a/grpcio-1.81.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c5bf2dc311127d91230cc79b92188c082634a06cf66c5234db49a43b910183b0", size = 6599094, upload-time = "2026-06-11T12:45:57.799Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/b3/e837954d279754f638a11cca5dcf6b24a005efb398984cefaf7735945a54/grpcio-1.81.1-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:e8ca6a1fcdb2943c9cbc1804a1baf3acb6071d72a471591678ded84218006e14", size = 7307182, upload-time = "2026-06-11T12:46:00.568Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/1e/b47957057e729adc6cdf519a47f8be2562b7140e280f1418443eb4022192/grpcio-1.81.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e64dd101d380a115cc5a0c7856788adb535f1a4e21fc543775602f8be95180ae", size = 6810962, upload-time = "2026-06-11T12:46:03.312Z" },
+    { url = "https://files.pythonhosted.org/packages/40/26/569868e364e05b19ec8f969da53d230bcd89c962cd198f7c29943155c4d3/grpcio-1.81.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:98a07f9bf591e3a8919797bee1c53f026ba4acd587e5a4404c8e57c9ec36b2a5", size = 7415698, upload-time = "2026-06-11T12:46:06.005Z" },
+    { url = "https://files.pythonhosted.org/packages/36/0c/5440a0582cb5653fc42a6e262eeb22700943313f8076f9dc927491b20a59/grpcio-1.81.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:c261d74b1a945cf895a9d6eccd1685a8e837531beaab782da4d630a8d12deffb", size = 8407779, upload-time = "2026-06-11T12:46:08.84Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/aa/66fe9f39871d766987d869a03ee0842a026f499c7b1e62decb9e78a8088e/grpcio-1.81.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:58ad1131c300d3c9b933802b3cc4dc69d380822935ba50b28703156ea826fbf7", size = 7844521, upload-time = "2026-06-11T12:46:12.171Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/9e/69bb7194861bcd28fb3193261d4f9c3831b4446993f002cf59068943e7ab/grpcio-1.81.1-cp313-cp313-win32.whl", hash = "sha256:78e29211f26da2fdd0e9c6d2b79f489476140cf7029b6a64808ade7ca4156a42", size = 4182786, upload-time = "2026-06-11T12:46:15.192Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/20/3da8bb0d637feccdc3e1e419bb511ce93651ce7d54164f95de22cc0b8b34/grpcio-1.81.1-cp313-cp313-win_amd64.whl", hash = "sha256:edb59506291b647a30884b1d51a599d605f40b20af4a7dc3d33786a47a31de60", size = 4928648, upload-time = "2026-06-11T12:46:17.823Z" },
+]
+
+[[package]]
+name = "grpcio-tools"
+version = "1.81.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "grpcio" },
+    { name = "protobuf" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/b3/1c5951352d6777fd7f99a0ccee04617fdfd8a5dbf2918a1f58c8b2b280b8/grpcio_tools-1.81.1.tar.gz", hash = "sha256:a22a3870180927fdd84e2b27d079ef5b7f5f8c6110181b6736afc17a463481f1", size = 6236155, upload-time = "2026-06-11T12:51:21.235Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/76/14ff87090199a36f914388299a1148d0734a20cea1b0ca8480bae1f373f1/grpcio_tools-1.81.1-cp311-cp311-linux_armv7l.whl", hash = "sha256:8161f398f957a376cae7385ea7c8684f439d460ef702b528912da3bcb31fc515", size = 2586251, upload-time = "2026-06-11T12:49:43.514Z" },
+    { url = "https://files.pythonhosted.org/packages/87/a8/d5aa99de9d8b2dd2a8192c1779796eda8b0d0f1dd915422e0a8a61b80391/grpcio_tools-1.81.1-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:53ef76cc3b0493ff734a5e8c39d5b519e1822236fcccdfe7677c5e1efd767761", size = 5818063, upload-time = "2026-06-11T12:49:45.975Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/cb/2e9a6dbc6a514dd3cd264fb3bf9217937453a4d45dbc3ca6ca4ee34ba1a7/grpcio_tools-1.81.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:690e6dcaa8b8a7886ce206ba344e2127211597e1a1ddab73df9f3d80c8f6707e", size = 2634061, upload-time = "2026-06-11T12:49:48.13Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/2b/2ccd1a929e6c8ad84a0aa8d66ad9f615b4a8e79d9927373d86aa36b4ba2e/grpcio_tools-1.81.1-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:ad7a997c07bd345e84842e60561e7e2cc090ce6c4e1d2f0407e31b85b40fc49a", size = 2958029, upload-time = "2026-06-11T12:49:50.466Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/67/2da8cd312edc348f44f26f82096b25cdb7d2905cd786acc6bf777b169502/grpcio_tools-1.81.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b6bd163ece4535726e5292b845ed80ae9b2cae73ba091c7d6c66033c430e3857", size = 2698031, upload-time = "2026-06-11T12:49:52.292Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/ba/ad1680fbdf9317c4f1e54c37c96d1f422370df66ac9adbd175c7cb3531d7/grpcio_tools-1.81.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2baa7e735f35b2a648144c03348a126097b13e101d3c242d5edb6ac91437ccbe", size = 3147541, upload-time = "2026-06-11T12:49:54.43Z" },
+    { url = "https://files.pythonhosted.org/packages/57/c1/57cd08eef293d713cb8935295e4f08d8f0013480b2ba3aad1af0271eb7ba/grpcio_tools-1.81.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:1d602b410b2b2addc434cace9ce4fe2035974a3078228f98ffa049a5c90acc2f", size = 3708524, upload-time = "2026-06-11T12:49:56.544Z" },
+    { url = "https://files.pythonhosted.org/packages/52/31/01ea8ca9c82fe2c79b5b594c3ae427d56699bc106b2d91caca129add8b10/grpcio_tools-1.81.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f8cb64f87c45ccca8234fa47e6b21f09e43801ff11b556deecb461b3b3e9f292", size = 3367022, upload-time = "2026-06-11T12:49:59.608Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/35/8140cd175602df3d17215cfb28a7ea55b7a67e2b872be76e1ee4af5c4df9/grpcio_tools-1.81.1-cp311-cp311-win32.whl", hash = "sha256:87b25ca0e27373a4a32a629a4ba976f5764b9887dd50d6fe017d38009a0363e8", size = 1008980, upload-time = "2026-06-11T12:50:01.422Z" },
+    { url = "https://files.pythonhosted.org/packages/be/86/1bd29ab3c52457702b96536f1f208ab27695322d855f95c9666dfb713019/grpcio_tools-1.81.1-cp311-cp311-win_amd64.whl", hash = "sha256:204de03b539a4b08772c6553b92bcc112cbc965e0ac22f909f6d133b8ac33a8c", size = 1174840, upload-time = "2026-06-11T12:50:03.408Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/8a/824a9ca20bcdce8a568bb8c9f98bfeb7fad62129235e6d2ae7576fd1250a/grpcio_tools-1.81.1-cp312-cp312-linux_armv7l.whl", hash = "sha256:353b1fafcc739c31ed42271052709595b340d34f27c459beeb78a32938305bb5", size = 2585927, upload-time = "2026-06-11T12:50:05.671Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/35/e5f9f671378b1b89a896150d3e4fa2c6ec61a5e1e9e5107ce4c140ccc931/grpcio_tools-1.81.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:768f584c2423cbeb6cb6867817a39365b987ff16b8259a3adbc6546b9e303a4e", size = 5815665, upload-time = "2026-06-11T12:50:08.178Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/02/631b628e4072e988c669bd8f1b2406ef3c9a4cfcb2625bbf2a308a07b71d/grpcio_tools-1.81.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1680b35a84f4694401819ac4acac42dda6dbc7bb8fc74112fd1a60425a07adf4", size = 2635518, upload-time = "2026-06-11T12:50:10.391Z" },
+    { url = "https://files.pythonhosted.org/packages/de/7c/2e3537e3ea3d1c0ddd6766cf6a7c62b487d89fb005713df2781d5f21483a/grpcio_tools-1.81.1-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:f64e665c8ec639278ecf009beb92cbdcc5994f617c1af3d58036e1f70b1423ec", size = 2958252, upload-time = "2026-06-11T12:50:12.677Z" },
+    { url = "https://files.pythonhosted.org/packages/35/68/14013cb2942bdac354746b643b4c37dd91906da8dce00f41c616e88bf33d/grpcio_tools-1.81.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ba8f1ae82ad199f43448995715445cc623fb20d3882382e4be61f0da8ccb3f0e", size = 2698439, upload-time = "2026-06-11T12:50:15.017Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/45/000c14c0338a7ad36054b9f17ea41842deb7841c05c067dd36cc831bc0f4/grpcio_tools-1.81.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b7b6d1e986d5923751bfe2b5cca9c4cb3d5653446e4fa4aacd438033e2dc360a", size = 3152160, upload-time = "2026-06-11T12:50:17.3Z" },
+    { url = "https://files.pythonhosted.org/packages/41/97/881930ca3967d2c8a95649bea8ebc991a7cf2331bc96679fd3600450dccc/grpcio_tools-1.81.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:7f208c207aca639dcb34648d3826c38d7cf3485118fb2065117e9fc4827406b3", size = 3710468, upload-time = "2026-06-11T12:50:19.479Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/b5/67baeba7366162652cdc1dbd962289accde07241bc8f42f6f02b305efcc6/grpcio_tools-1.81.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:724ecb69af63d2f6d4ccea3e6fa0ca110ed9c5824d48c2f887c631bbb03c1c3c", size = 3370797, upload-time = "2026-06-11T12:50:21.501Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/5d/34f2dce2125ccb107e32b57f5a9c1257edcc0793b0d2fef1e8b13a6bac3c/grpcio_tools-1.81.1-cp312-cp312-win32.whl", hash = "sha256:895a6782cec86beac71ccebb4b9848259c6f04a3028b8e42fa8d40cfe5146593", size = 1008453, upload-time = "2026-06-11T12:50:23.358Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/be/09da8256ec8d2a5ce8a1acc51cbbc4ca52a462d78ed3412778440a56502e/grpcio_tools-1.81.1-cp312-cp312-win_amd64.whl", hash = "sha256:0265fd1386b7458302f79542558345880d484f8fa92ae196c0c0268242c5f23a", size = 1174857, upload-time = "2026-06-11T12:50:25.685Z" },
+    { url = "https://files.pythonhosted.org/packages/76/90/5faa8b26e03495e5117f93bef8293cbada4af136362745dad7d1813ef0b0/grpcio_tools-1.81.1-cp313-cp313-linux_armv7l.whl", hash = "sha256:3d604b4fd114b79ebb9f865bf3e04fd3ae93c704e1fad96f7fd03b0865c263b7", size = 2586071, upload-time = "2026-06-11T12:50:28.4Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/9a/85dc589fa6ae2439451eaa81a1578de31e29c676980d38bef7549b8a1f45/grpcio_tools-1.81.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:3389e705460efa3f3758141ba5520e6743b131c9576197c944fb9cbe49048126", size = 5813299, upload-time = "2026-06-11T12:50:31.295Z" },
+    { url = "https://files.pythonhosted.org/packages/77/fd/c53994e58a837e6eefe48f53eb3492afc04f2b8af255df4adb37d14378f8/grpcio_tools-1.81.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8a17d8ceeb6a855fadf39f5171c80a382d97c4db98d5943eca553497fdebf84b", size = 2634668, upload-time = "2026-06-11T12:50:33.938Z" },
+    { url = "https://files.pythonhosted.org/packages/34/32/de988e86688686a2117e7ce6ce9eff4f638c929bb55b0afe60d6fbd2e45c/grpcio_tools-1.81.1-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:43baf71dc60fd653062da2e95e95c73b35dd130be8f9fa3d544c3af3f808a290", size = 2957930, upload-time = "2026-06-11T12:50:36.726Z" },
+    { url = "https://files.pythonhosted.org/packages/72/97/3f18a0ea32b5f809d21961dbd0bc382b589a4c3d501e3d67c345d5456ed3/grpcio_tools-1.81.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:136e90906af0df51ad929713244ba812d0dbb1844b4f467d5d86bdb054698f90", size = 2697760, upload-time = "2026-06-11T12:50:39.108Z" },
+    { url = "https://files.pythonhosted.org/packages/49/c0/dbf5cbc877290ff7504a59959a8af4fdcfdaa1e84237948405ccf1aa82a6/grpcio_tools-1.81.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bd6c3bf3ea6a61eb58c54368d72ada591f2a270f3a31a32e8536e773337e76d9", size = 3151456, upload-time = "2026-06-11T12:50:41.983Z" },
+    { url = "https://files.pythonhosted.org/packages/de/ea/16fe2dc83140a59e5c0a0b9dc2693dd36bfaa6bd835724b4ec66a68eab7b/grpcio_tools-1.81.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2c306c307f8f74cddc4056fdbb6f1da55de087a21120efbd02bd915daa5a52fd", size = 3710469, upload-time = "2026-06-11T12:50:44.596Z" },
+    { url = "https://files.pythonhosted.org/packages/22/7d/df987d7d81e7ad2f7516d9e9d56ff29c54dbc6d8587e425688dca9a28e49/grpcio_tools-1.81.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bdbdc927be2e0ea13c32564a72ee31d712a716fb6f8c0d53d37a77d8277c272c", size = 3370488, upload-time = "2026-06-11T12:50:47.199Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/c5/5a63444d694ea47bf670138208f71830cc1759c402c8818092b28ab2dc5f/grpcio_tools-1.81.1-cp313-cp313-win32.whl", hash = "sha256:9d383724bcd67244b6def9e9164c640ee9380c0b7534ee7545a6fb0022a59afe", size = 1008229, upload-time = "2026-06-11T12:50:49.527Z" },
+    { url = "https://files.pythonhosted.org/packages/00/75/3945e26d5c94ae6ed9be5caef73d4d66c47dc8cfdd7b4995efaf942754e0/grpcio_tools-1.81.1-cp313-cp313-win_amd64.whl", hash = "sha256:f3eb15849979ca7bb864ce81a74d68b0f225a7f111ed3fe212bfc08cf9812b10", size = 1174523, upload-time = "2026-06-11T12:50:51.755Z" },
 ]
 
 [[package]]
@@ -1565,6 +1658,9 @@ termux-all = [
 tts-premium = [
     { name = "elevenlabs" },
 ]
+tts-yandex = [
+    { name = "yandex-ai-studio-sdk" },
+]
 voice = [
     { name = "faster-whisper" },
     { name = "numpy" },
@@ -1691,9 +1787,10 @@ requires-dist = [
     { name = "urllib3", specifier = ">=2.7.0,<3" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.24.0,<1" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'web'", specifier = "==0.41.0" },
+    { name = "yandex-ai-studio-sdk", marker = "extra == 'tts-yandex'", specifier = "==0.20.1" },
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = "==1.2.4" },
 ]
-provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "pty", "honcho", "vision", "mcp", "nemo-relay", "homeassistant", "sms", "computer-use", "acp", "mistral", "bedrock", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
+provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "tts-yandex", "voice", "pty", "honcho", "vision", "mcp", "nemo-relay", "homeassistant", "sms", "computer-use", "acp", "mistral", "bedrock", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
 
 [[package]]
 name = "hf-xet"
@@ -4139,6 +4236,46 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/57/54/35a84d0a4d23ea675994104e667ceff49227ce473ba6a59ba2c84f250b74/wrapt-1.17.3-cp313-cp313-win_amd64.whl", hash = "sha256:1f0b2f40cf341ee8cc1a97d51ff50dddb9fcc73241b9143ec74b30fc4f44f6cb", size = 38885, upload-time = "2025-08-12T05:53:08.695Z" },
     { url = "https://files.pythonhosted.org/packages/01/77/66e54407c59d7b02a3c4e0af3783168fff8e5d61def52cda8728439d86bc/wrapt-1.17.3-cp313-cp313-win_arm64.whl", hash = "sha256:7425ac3c54430f5fc5e7b6f41d41e704db073309acfc09305816bc6a0b26bb16", size = 36896, upload-time = "2025-08-12T05:52:55.34Z" },
     { url = "https://files.pythonhosted.org/packages/1f/f6/a933bd70f98e9cf3e08167fc5cd7aaaca49147e48411c0bd5ae701bb2194/wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22", size = 23591, upload-time = "2025-08-12T05:53:20.674Z" },
+]
+
+[[package]]
+name = "yandex-ai-studio-sdk"
+version = "0.20.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiofiles" },
+    { name = "click" },
+    { name = "get-annotations" },
+    { name = "grpcio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "packaging" },
+    { name = "typing-extensions" },
+    { name = "yandexcloud" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/43/8bc69ecdab7a23d2b143e4144ec848cbb4f426975ce0ce5591c266837765/yandex_ai_studio_sdk-0.20.1.tar.gz", hash = "sha256:d65397779366a37e9cd761a192d286ed2e59076909683e4edaad2fb25533abd0", size = 215999, upload-time = "2026-04-03T15:23:01.869Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/64/81d33eb7c0afe393acab46465a56b33372944a5751224123d2bfc63d8628/yandex_ai_studio_sdk-0.20.1-py3-none-any.whl", hash = "sha256:3949768eadcfe41209a90001c700e8e4255ea5fde61bb3c19818d116b7b8a95b", size = 331711, upload-time = "2026-04-03T15:22:59.197Z" },
+]
+
+[[package]]
+name = "yandexcloud"
+version = "0.394.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "deprecated" },
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "grpcio-tools" },
+    { name = "protobuf" },
+    { name = "pyjwt" },
+    { name = "requests" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/39/ba6a2dfbbed4c346f15957a6a3fd7c2f891ad5683b9bef3ddb2904437676/yandexcloud-0.394.0.tar.gz", hash = "sha256:db624ce1b58f079afafbd0f02060486cbca12687b64e2ce21113a8166d03a248", size = 3922796, upload-time = "2026-06-08T16:27:12.021Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/fe/1d0a8dcb2169e3c0223dfdba8a427baa6afd5dc62c1e248fd9f9748126a6/yandexcloud-0.394.0-py3-none-any.whl", hash = "sha256:bd96167ee86659187e355af3a42082c42a5c8b3ec58f810140ebc5d8310ab24e", size = 5991802, upload-time = "2026-06-08T16:27:09.536Z" },
 ]
 
 [[package]]

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -25,6 +25,7 @@ Convert text to speech with ten providers:
 | **Mistral (Voxtral TTS)** | Excellent | Paid | `MISTRAL_API_KEY` |
 | **Google Gemini TTS** | Excellent | Free tier | `GEMINI_API_KEY` |
 | **xAI TTS** | Excellent | Paid | `XAI_API_KEY` |
+| **Yandex SpeechKit** | Excellent | Paid | `YANDEX_API_KEY` or `YANDEX_IAM_TOKEN` |
 | **NeuTTS** | Good | Free (local) | None needed |
 | **KittenTTS** | Good | Free (local) | None needed |
 | **Piper** | Good | Free (local) | None needed |
@@ -43,7 +44,7 @@ Convert text to speech with ten providers:
 ```yaml
 # In ~/.hermes/config.yaml
 tts:
-  provider: "edge"              # "edge" | "elevenlabs" | "openai" | "minimax" | "mistral" | "gemini" | "xai" | "neutts" | "kittentts" | "piper"
+  provider: "edge"              # "edge" | "elevenlabs" | "openai" | "minimax" | "mistral" | "gemini" | "xai" | "yandex" | "neutts" | "kittentts" | "piper"
   speed: 1.0                    # Global speed multiplier (provider-specific settings override this)
   edge:
     voice: "en-US-AriaNeural"   # 322 voices, 74 languages
@@ -76,6 +77,14 @@ tts:
     sample_rate: 24000          # 22050 / 24000 (default) / 44100 / 48000
     bit_rate: 128000            # MP3 bitrate; only applies when codec=mp3
     # base_url: "https://api.x.ai/v1"   # Override via XAI_BASE_URL env var
+  yandex:
+    folder_id: "${YANDEX_FOLDER_ID}"
+    api_key: "${YANDEX_API_KEY}"         # or iam_token: "${YANDEX_IAM_TOKEN}"
+    voice: "kirill"
+    role: "neutral"
+    speed: 1.5
+    audio_format: "PCM16(24000)"
+    stream_timeout: 600
   neutts:
     ref_audio: ''
     ref_text: ''
@@ -140,6 +149,7 @@ Each provider has a documented per-request input-character cap. Hermes truncates
 | MiniMax | 10000 |
 | Mistral | 4000 |
 | Google Gemini | 32000 |
+| Yandex SpeechKit | 5000 |
 | ElevenLabs | Model-aware (see below) |
 | NeuTTS | 2000 |
 | KittenTTS | 2000 |
@@ -174,6 +184,7 @@ Telegram voice bubbles require Opus/OGG audio format:
 - **MiniMax TTS** outputs MP3 and needs **ffmpeg** to convert for Telegram voice bubbles
 - **Google Gemini TTS** outputs raw PCM and uses **ffmpeg** to encode Opus directly for Telegram voice bubbles
 - **xAI TTS** outputs MP3 and needs **ffmpeg** to convert for Telegram voice bubbles
+- **Yandex SpeechKit** outputs PCM/WAV by default and needs **ffmpeg** to convert for Telegram voice bubbles
 - **NeuTTS** outputs WAV and also needs **ffmpeg** to convert for Telegram voice bubbles
 - **KittenTTS** outputs WAV and also needs **ffmpeg** to convert for Telegram voice bubbles
 - **Piper** outputs WAV and also needs **ffmpeg** to convert for Telegram voice bubbles
@@ -207,6 +218,30 @@ tts:
 ```
 
 See the [xAI Custom Voices docs](https://docs.x.ai/developers/model-capabilities/audio/custom-voices) for details on recording, supported formats, and limits.
+
+### Yandex SpeechKit
+
+Yandex SpeechKit uses `yandex-ai-studio-sdk` and is installed lazily when `tts.provider: yandex` is selected, or explicitly with:
+
+```bash
+python -m pip install 'hermes-agent[tts-yandex]'
+```
+
+Set `YANDEX_FOLDER_ID` plus either `YANDEX_API_KEY` or `YANDEX_IAM_TOKEN`, or put the same values under `tts.yandex` in `config.yaml`:
+
+```yaml
+tts:
+  provider: yandex
+  yandex:
+    folder_id: "${YANDEX_FOLDER_ID}"
+    api_key: "${YANDEX_API_KEY}"
+    voice: "kirill"
+    role: "neutral"
+    speed: 1.5
+    audio_format: "PCM16(24000)"
+```
+
+Use `stream_timeout` for long CLI voice-mode playback; file-mode TTS uses `timeout`.
 
 ### Piper (local, 44 languages)
 


### PR DESCRIPTION
## What does this PR do?

Adds Yandex SpeechKit as an optional TTS provider for Hermes. The provider uses `yandex-ai-studio-sdk` lazily, so users who do not select Yandex do not import or install the SDK. The implementation supports file-mode TTS and streaming CLI voice playback with PCM16/WAV handling.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `tts.provider: yandex` support in `tools/tts_tool.py` with SpeechKit config, credentials, file output, and streaming playback.
- Added `tts-yandex` optional extra and `tools.lazy_deps` allowlist entry for `yandex-ai-studio-sdk==0.20.1`.
- Regenerated `uv.lock` from current `main`.
- Added Yandex TTS tests and lazy-dependency regression coverage.
- Updated `.env.example`, `cli-config.yaml.example`, and `website/docs/user-guide/features/tts.md`.

## How to Test

1. `scripts/run_tests.sh tests/tools/test_yandex_tts.py tests/tools/test_lazy_deps.py tests/tools/test_tts_max_text_length.py`
2. `uv lock --check`
3. `git diff --check upstream/main..HEAD`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, targeted test suite

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted tests passed locally:

```text
3 files, 101 tests passed, 0 failed
```