### PR TITLE
feat: add local HTTP voice providers

### DIFF
--- a/tests/tools/test_http_voice_providers.py
+++ b/tests/tools/test_http_voice_providers.py
@@ -1,0 +1,461 @@
+"""Tests for OpenClaw-compatible HTTP STT/TTS voice providers."""
+
+import json
+import threading
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from unittest.mock import patch
+
+import pytest
+
+
+class _FakeVoiceHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self._handle()
+
+    def do_POST(self):
+        self._handle()
+
+    def _handle(self):
+        length = int(self.headers.get("content-length", "0") or 0)
+        body = self.rfile.read(length) if length else b""
+        route = self.server.routes.get((self.command, self.path))
+        if route is None:
+            self.send_response(404)
+            self.end_headers()
+            self.wfile.write(b"not found")
+            return
+
+        if callable(route):
+            status, headers, response_body = route(self, body)
+        else:
+            status, headers, response_body = route
+
+        self.send_response(status)
+        for key, value in headers.items():
+            self.send_header(key, value)
+        self.end_headers()
+        self.wfile.write(response_body)
+
+    def log_message(self, _format, *args):
+        return
+
+
+@contextmanager
+def _fake_voice_server(routes):
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _FakeVoiceHandler)
+    server.routes = routes
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        thread.join(timeout=2)
+        server.server_close()
+
+
+def _json_response(payload, status=200):
+    return (
+        status,
+        {"Content-Type": "application/json"},
+        json.dumps(payload).encode("utf-8"),
+    )
+
+
+def _text_response(text, status=200):
+    return (
+        status,
+        {"Content-Type": "text/plain; charset=utf-8"},
+        text.encode("utf-8"),
+    )
+
+
+def _audio_response(data=b"RIFF\x10\x00\x00\x00WAVEfmt fake"):
+    return 200, {"Content-Type": "audio/wav"}, data
+
+
+def test_get_provider_honors_explicit_whisper_http():
+    from tools.transcription_tools import _get_provider
+
+    assert _get_provider({"provider": "whisper_http"}) == "whisper_http"
+
+
+def test_transcribe_audio_dispatches_to_whisper_http(tmp_path):
+    audio_file = tmp_path / "test.wav"
+    audio_file.write_bytes(b"fake audio")
+
+    with patch(
+        "tools.transcription_tools._load_stt_config",
+        return_value={"provider": "whisper_http", "whisper_http": {"model": "whisper-1"}},
+    ), patch(
+        "tools.transcription_tools._get_provider",
+        return_value="whisper_http",
+    ), patch(
+        "tools.transcription_tools._transcribe_whisper_http",
+        return_value={"success": True, "transcript": "hi", "provider": "whisper_http"},
+    ) as mock_whisper_http:
+        from tools.transcription_tools import transcribe_audio
+
+        result = transcribe_audio(str(audio_file))
+
+    assert result["success"] is True
+    mock_whisper_http.assert_called_once_with(str(audio_file), "whisper-1")
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        (" plain text ", "plain text"),
+        ({"text": "json text"}, "json text"),
+        ({"transcript": "json transcript"}, "json transcript"),
+        ({"segments": [{"text": "first"}, {"text": "second"}]}, "first second"),
+    ],
+)
+def test_whisper_http_extracts_common_response_shapes(payload, expected):
+    from tools.transcription_tools import _extract_whisper_http_transcript
+
+    assert _extract_whisper_http_transcript(payload) == expected
+
+
+def test_whisper_http_openai_compatible_plain_text(tmp_path):
+    audio_file = tmp_path / "test.wav"
+    audio_file.write_bytes(b"fake audio")
+
+    routes = {
+        ("POST", "/v1/audio/transcriptions"): _text_response("привет из http"),
+    }
+    with _fake_voice_server(routes) as base_url, patch(
+        "tools.transcription_tools._load_stt_config",
+        return_value={
+            "provider": "whisper_http",
+            "whisper_http": {
+                "base_url": base_url,
+                "path": "/v1/audio/transcriptions",
+                "model": "whisper-podlodka-turbo",
+                "timeout": 5,
+            },
+        },
+    ):
+        from tools.transcription_tools import transcribe_audio
+
+        result = transcribe_audio(str(audio_file))
+
+    assert result == {
+        "success": True,
+        "transcript": "привет из http",
+        "provider": "whisper_http",
+    }
+
+
+def test_whisper_http_openclaw_inference_segments(tmp_path):
+    audio_file = tmp_path / "test.wav"
+    audio_file.write_bytes(b"fake audio")
+
+    routes = {
+        ("POST", "/inference"): _json_response(
+            {"segments": [{"text": "проверка"}, {"text": "связи"}]}
+        ),
+    }
+    with _fake_voice_server(routes) as base_url, patch(
+        "tools.transcription_tools._load_stt_config",
+        return_value={
+            "provider": "whisper_http",
+            "whisper_http": {
+                "base_url": base_url,
+                "path": "/inference",
+                "model": "whisper-podlodka-turbo",
+                "language": "ru",
+                "timeout": 5,
+            },
+        },
+    ):
+        from tools.transcription_tools import transcribe_audio
+
+        result = transcribe_audio(str(audio_file))
+
+    assert result["success"] is True
+    assert result["transcript"] == "проверка связи"
+    assert result["provider"] == "whisper_http"
+
+
+@pytest.mark.parametrize(
+    ("route", "error_part"),
+    [
+        (_json_response({"text": ""}), "empty transcript"),
+        (_text_response("upstream failed", status=503), "HTTP 503"),
+    ],
+)
+def test_whisper_http_surfaces_empty_and_non_200_errors(tmp_path, route, error_part):
+    audio_file = tmp_path / "test.wav"
+    audio_file.write_bytes(b"fake audio")
+
+    with _fake_voice_server({("POST", "/v1/audio/transcriptions"): route}) as base_url, patch(
+        "tools.transcription_tools._load_stt_config",
+        return_value={
+            "provider": "whisper_http",
+            "whisper_http": {
+                "base_url": base_url,
+                "path": "/v1/audio/transcriptions",
+                "timeout": 5,
+            },
+        },
+    ):
+        from tools.transcription_tools import transcribe_audio
+
+        result = transcribe_audio(str(audio_file))
+
+    assert result["success"] is False
+    assert error_part in result["error"]
+
+
+def test_whisper_http_connection_error_is_helpful(tmp_path):
+    import requests
+
+    audio_file = tmp_path / "test.wav"
+    audio_file.write_bytes(b"fake audio")
+
+    with patch(
+        "tools.transcription_tools._load_stt_config",
+        return_value={
+            "provider": "whisper_http",
+            "whisper_http": {"base_url": "http://127.0.0.1:1", "timeout": 5},
+        },
+    ), patch(
+        "requests.post",
+        side_effect=requests.exceptions.ConnectionError("connection refused"),
+    ):
+        from tools.transcription_tools import transcribe_audio
+
+        result = transcribe_audio(str(audio_file))
+
+    assert result["success"] is False
+    assert "connection error" in result["error"].lower()
+
+
+@pytest.mark.parametrize("provider", ["silero_http", "piper_http"])
+def test_http_tts_providers_create_audio_file(tmp_path, provider, monkeypatch):
+    output_path = tmp_path / f"{provider}.wav"
+    config = {
+        "provider": provider,
+        provider: {
+            "base_url": "",
+            "path": "/tts",
+            "timeout": 5,
+        },
+    }
+    if provider == "silero_http":
+        config[provider]["speaker"] = "eugene"
+    else:
+        config[provider]["voice_id"] = "ru_RU-test"
+
+    with _fake_voice_server({("POST", "/tts"): _audio_response()}) as base_url:
+        config[provider]["base_url"] = base_url
+        monkeypatch.setattr("tools.tts_tool._load_tts_config", lambda: config)
+        monkeypatch.setattr("tools.tts_tool._convert_to_opus", lambda _path: None)
+
+        from tools.tts_tool import text_to_speech_tool
+
+        result = json.loads(text_to_speech_tool("hello", output_path=str(output_path)))
+
+    assert result["success"] is True
+    assert result["provider"] == provider
+    assert output_path.exists()
+    assert output_path.stat().st_size > 0
+
+
+def test_piper_http_passes_edge_compatible_voice_and_speed(tmp_path, monkeypatch):
+    output_path = tmp_path / "piper.wav"
+    captured = {}
+
+    def handle_tts(_handler, body):
+        captured["payload"] = json.loads(body.decode("utf-8"))
+        return _audio_response()
+
+    with _fake_voice_server({("POST", "/tts"): handle_tts}) as base_url:
+        monkeypatch.setattr(
+            "tools.tts_tool._load_tts_config",
+            lambda: {
+                "provider": "piper_http",
+                "piper_http": {
+                    "base_url": base_url,
+                    "path": "/tts",
+                    "voice_id": "en-US-AndrewMultilingualNeural",
+                    "speed": 1.7,
+                    "output_format": "wav",
+                    "timeout": 5,
+                },
+            },
+        )
+        monkeypatch.setattr("tools.tts_tool._convert_to_opus", lambda _path: None)
+
+        from tools.tts_tool import text_to_speech_tool
+
+        result = json.loads(text_to_speech_tool("hello", output_path=str(output_path)))
+
+    assert result["success"] is True
+    assert captured["payload"]["voice_id"] == "en-US-AndrewMultilingualNeural"
+    assert captured["payload"]["speed"] == 1.7
+    assert captured["payload"]["output_format"] == "wav"
+
+
+@pytest.mark.parametrize("output_format", ["mp3", "ogg"])
+def test_piper_http_default_output_path_matches_output_format(
+    tmp_path, monkeypatch, output_format
+):
+    captured = {}
+
+    def handle_tts(_handler, body):
+        captured["payload"] = json.loads(body.decode("utf-8"))
+        return _audio_response()
+
+    with _fake_voice_server({("POST", "/tts"): handle_tts}) as base_url:
+        monkeypatch.setattr(
+            "tools.tts_tool._load_tts_config",
+            lambda: {
+                "provider": "piper_http",
+                "piper_http": {
+                    "base_url": base_url,
+                    "path": "/tts",
+                    "output_format": output_format,
+                    "timeout": 5,
+                },
+            },
+        )
+        monkeypatch.setattr("tools.tts_tool.DEFAULT_OUTPUT_DIR", str(tmp_path))
+        monkeypatch.setattr("tools.tts_tool._convert_to_opus", lambda _path: None)
+
+        from tools.tts_tool import text_to_speech_tool
+
+        result = json.loads(text_to_speech_tool("hello"))
+
+    assert result["success"] is True
+    assert result["file_path"].endswith(f".{output_format}")
+    assert result["media_tag"].endswith(f".{output_format}")
+    assert captured["payload"]["output_format"] == output_format
+
+
+def test_piper_http_explicit_output_path_suffix_matches_output_format(
+    tmp_path, monkeypatch
+):
+    requested_output = tmp_path / "piper.wav"
+    expected_output = tmp_path / "piper.ogg"
+
+    with _fake_voice_server({("POST", "/tts"): _audio_response()}) as base_url:
+        monkeypatch.setattr(
+            "tools.tts_tool._load_tts_config",
+            lambda: {
+                "provider": "piper_http",
+                "piper_http": {
+                    "base_url": base_url,
+                    "path": "/tts",
+                    "output_format": "ogg",
+                    "timeout": 5,
+                },
+            },
+        )
+        monkeypatch.setattr("tools.tts_tool._convert_to_opus", lambda _path: None)
+
+        from tools.tts_tool import text_to_speech_tool
+
+        result = json.loads(
+            text_to_speech_tool("hello", output_path=str(requested_output))
+        )
+
+    assert result["success"] is True
+    assert result["file_path"] == str(expected_output)
+    assert expected_output.exists()
+    assert not requested_output.exists()
+
+
+def test_piper_http_rejects_unknown_output_format(tmp_path, monkeypatch):
+    with _fake_voice_server({("POST", "/tts"): _audio_response()}) as base_url:
+        monkeypatch.setattr(
+            "tools.tts_tool._load_tts_config",
+            lambda: {
+                "provider": "piper_http",
+                "piper_http": {
+                    "base_url": base_url,
+                    "path": "/tts",
+                    "output_format": "flac",
+                    "timeout": 5,
+                },
+            },
+        )
+
+        from tools.tts_tool import text_to_speech_tool
+
+        result = json.loads(
+            text_to_speech_tool("hello", output_path=str(tmp_path / "piper.wav"))
+        )
+
+    assert result["success"] is False
+    assert "output_format" in result["error"]
+
+
+def test_http_tts_keeps_wav_for_non_telegram_playback(tmp_path, monkeypatch):
+    output_path = tmp_path / "silero.wav"
+    with _fake_voice_server({("POST", "/tts"): _audio_response()}) as base_url:
+        monkeypatch.setattr(
+            "tools.tts_tool._load_tts_config",
+            lambda: {
+                "provider": "silero_http",
+                "silero_http": {"base_url": base_url, "path": "/tts", "timeout": 5},
+            },
+        )
+
+        def fail_if_called(_path):
+            raise AssertionError("CLI/local playback should not be converted to Opus")
+
+        monkeypatch.setattr("tools.tts_tool._convert_to_opus", fail_if_called)
+
+        from tools.tts_tool import text_to_speech_tool
+
+        result = json.loads(text_to_speech_tool("hello", output_path=str(output_path)))
+
+    assert result["success"] is True
+    assert result["file_path"] == str(output_path)
+    assert result["voice_compatible"] is False
+    assert result["media_tag"] == f"MEDIA:{output_path}"
+
+
+def test_http_tts_empty_audio_is_error(tmp_path, monkeypatch):
+    with _fake_voice_server({("POST", "/tts"): _audio_response(b"")}) as base_url:
+        monkeypatch.setattr(
+            "tools.tts_tool._load_tts_config",
+            lambda: {
+                "provider": "silero_http",
+                "silero_http": {"base_url": base_url, "path": "/tts", "timeout": 5},
+            },
+        )
+
+        from tools.tts_tool import text_to_speech_tool
+
+        result = json.loads(text_to_speech_tool("hello", output_path=str(tmp_path / "out.wav")))
+
+    assert result["success"] is False
+    assert "empty audio" in result["error"]
+
+
+def test_check_tts_requirements_accepts_http_provider_with_base_url(monkeypatch):
+    for key in ("MINIMAX_API_KEY", "XAI_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY", "MISTRAL_API_KEY"):
+        monkeypatch.delenv(key, raising=False)
+
+    with patch("tools.tts_tool._import_edge_tts", side_effect=ImportError), patch(
+        "tools.tts_tool._import_elevenlabs", side_effect=ImportError
+    ), patch("tools.tts_tool._import_openai_client", side_effect=ImportError), patch(
+        "tools.tts_tool._import_mistral_client", side_effect=ImportError
+    ), patch(
+        "tools.tts_tool._check_neutts_available", return_value=False
+    ), patch(
+        "tools.tts_tool._check_kittentts_available", return_value=False
+    ), patch(
+        "tools.tts_tool._load_tts_config",
+        return_value={
+            "provider": "silero_http",
+            "silero_http": {"base_url": "http://127.0.0.1:9000"},
+        },
+    ):
+        from tools.tts_tool import check_tts_requirements
+
+        assert check_tts_requirements() is True

--- a/tests/tools/test_tts_max_text_length.py
+++ b/tests/tools/test_tts_max_text_length.py
@@ -111,7 +111,8 @@ class TestResolveMaxTextLength:
 
     def test_all_documented_providers_have_defaults(self):
         expected = {"edge", "openai", "xai", "minimax", "mistral",
-                    "gemini", "elevenlabs", "neutts", "kittentts"}
+                    "gemini", "elevenlabs", "neutts", "kittentts",
+                    "silero_http", "piper_http"}
         assert expected.issubset(PROVIDER_MAX_TEXT_LENGTH.keys())
 
 

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -12,6 +12,7 @@ Provides speech-to-text transcription with six providers:
   - **xai** — xAI Grok STT API, requires ``XAI_API_KEY``. High accuracy,
     Inverse Text Normalization, diarization, 21 languages.
   - **elevenlabs** — ElevenLabs Scribe API, requires ``ELEVENLABS_API_KEY``.
+  - **whisper_http** — OpenAI-compatible or OpenClaw-style HTTP Whisper services.
 
 Used by the messaging gateway to automatically transcribe voice messages
 sent by users on Telegram, Discord, WhatsApp, Slack, and Signal.
@@ -90,6 +91,9 @@ DEFAULT_STT_MODEL = os.getenv("STT_OPENAI_MODEL", "whisper-1")
 DEFAULT_GROQ_STT_MODEL = os.getenv("STT_GROQ_MODEL", "whisper-large-v3-turbo")
 DEFAULT_MISTRAL_STT_MODEL = os.getenv("STT_MISTRAL_MODEL", "voxtral-mini-latest")
 DEFAULT_ELEVENLABS_STT_MODEL = os.getenv("STT_ELEVENLABS_MODEL", "scribe_v2")
+DEFAULT_WHISPER_HTTP_BASE_URL = os.getenv("STT_WHISPER_HTTP_BASE_URL", "http://127.0.0.1:8000")
+DEFAULT_WHISPER_HTTP_PATH = os.getenv("STT_WHISPER_HTTP_PATH", "/v1/audio/transcriptions")
+DEFAULT_WHISPER_HTTP_TIMEOUT = 30
 LOCAL_STT_COMMAND_ENV = "HERMES_LOCAL_STT_COMMAND"
 LOCAL_STT_LANGUAGE_ENV = "HERMES_LOCAL_STT_LANGUAGE"
 COMMON_LOCAL_BIN_DIRS = ("/opt/homebrew/bin", "/usr/local/bin")
@@ -826,6 +830,9 @@ def _get_provider(stt_config: dict) -> str:
             )
             return "none"
 
+        if provider == "whisper_http":
+            return "whisper_http"
+
         return provider  # Unknown — let it fail downstream
 
     # --- Auto-detect (no explicit provider): local > groq > openai > xai > elevenlabs -
@@ -1379,6 +1386,222 @@ def _transcribe_openai(file_path: str, model_name: str) -> Dict[str, Any]:
         return {"success": False, "transcript": "", "error": f"Transcription failed: {e}"}
 
 # ---------------------------------------------------------------------------
+# Provider: whisper_http (OpenAI-compatible or OpenClaw-style HTTP STT)
+# ---------------------------------------------------------------------------
+
+
+def _join_http_endpoint(base_url: str, path: str) -> str:
+    """Join a configured base URL and endpoint path without dropping path prefixes."""
+    return urljoin(f"{base_url.rstrip('/')}/", path.lstrip("/"))
+
+
+def _extract_whisper_http_transcript(payload: Any) -> str:
+    """Normalize common Whisper HTTP response shapes to plain transcript text."""
+    if isinstance(payload, str):
+        return payload.strip()
+
+    if isinstance(payload, dict):
+        for key in ("text", "transcript", "transcription", "result"):
+            value = payload.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+
+        segments = payload.get("segments")
+        if isinstance(segments, list):
+            parts = []
+            for segment in segments:
+                if isinstance(segment, dict):
+                    text = segment.get("text")
+                    if isinstance(text, str) and text.strip():
+                        parts.append(text.strip())
+                elif isinstance(segment, str) and segment.strip():
+                    parts.append(segment.strip())
+            return " ".join(parts).strip()
+
+        return ""
+
+    return str(payload).strip() if payload is not None else ""
+
+
+def _parse_whisper_http_response(response: Any) -> str:
+    content_type = str(response.headers.get("content-type", "")).lower()
+    text = str(response.text or "").strip()
+    if "json" in content_type or text.startswith("{") or text.startswith("["):
+        try:
+            return _extract_whisper_http_transcript(response.json())
+        except Exception:
+            logger.debug("Whisper HTTP response advertised JSON but could not be parsed")
+    return _extract_whisper_http_transcript(text)
+
+
+def _transcribe_whisper_http(file_path: str, model_name: str) -> Dict[str, Any]:
+    """Transcribe with a local/remote Whisper HTTP service.
+
+    Supported shapes:
+      - OpenAI-compatible ``POST /v1/audio/transcriptions``
+      - OpenClaw-style ``POST /inference``
+
+    Both are multipart uploads. ``/inference`` services vary on the file field
+    name, so Hermes tries the likely field first and falls back once on common
+    validation failures unless ``stt.whisper_http.file_field`` is explicit.
+    """
+    import requests
+
+    stt_config = _load_stt_config()
+    http_config = stt_config.get("whisper_http", {})
+    base_url = str(
+        http_config.get("base_url")
+        or os.getenv("WHISPER_HTTP_BASE_URL")
+        or DEFAULT_WHISPER_HTTP_BASE_URL
+    ).strip().rstrip("/")
+    path = str(
+        http_config.get("path")
+        or http_config.get("transcribe_path")
+        or DEFAULT_WHISPER_HTTP_PATH
+    ).strip() or DEFAULT_WHISPER_HTTP_PATH
+    language = str(
+        http_config.get("language")
+        or os.getenv(LOCAL_STT_LANGUAGE_ENV)
+        or ""
+    ).strip()
+    api_key = str(
+        http_config.get("api_key")
+        or os.getenv("WHISPER_HTTP_API_KEY")
+        or ""
+    ).strip()
+    try:
+        timeout = float(http_config.get("timeout", DEFAULT_WHISPER_HTTP_TIMEOUT))
+    except (TypeError, ValueError):
+        timeout = DEFAULT_WHISPER_HTTP_TIMEOUT
+
+    if not base_url:
+        return {
+            "success": False,
+            "transcript": "",
+            "provider": "whisper_http",
+            "error": "stt.whisper_http.base_url is required for whisper_http",
+        }
+
+    endpoint = _join_http_endpoint(base_url, path)
+    headers: Dict[str, str] = {}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    data: Dict[str, str] = {}
+    if model_name:
+        data["model"] = model_name
+    if language:
+        data["language"] = language
+    response_format = http_config.get("response_format")
+    if response_format:
+        data["response_format"] = str(response_format)
+
+    configured_field = (
+        http_config.get("file_field")
+        or http_config.get("fileField")
+    )
+    if configured_field:
+        file_fields = [str(configured_field)]
+    elif path.rstrip("/").endswith("/inference"):
+        file_fields = ["audio_file", "file"]
+    else:
+        file_fields = ["file", "audio_file"]
+
+    last_error = ""
+    for index, file_field in enumerate(file_fields):
+        try:
+            with open(file_path, "rb") as audio_file:
+                files = {
+                    file_field: (
+                        Path(file_path).name,
+                        audio_file,
+                        "application/octet-stream",
+                    )
+                }
+                response = requests.post(
+                    endpoint,
+                    headers=headers,
+                    data=data,
+                    files=files,
+                    timeout=timeout,
+                )
+
+            if (
+                not configured_field
+                and response.status_code in {400, 404, 422}
+                and index + 1 < len(file_fields)
+            ):
+                last_error = response.text.strip()[:300]
+                continue
+
+            if response.status_code >= 400:
+                detail = response.text.strip()[:300] or response.reason
+                return {
+                    "success": False,
+                    "transcript": "",
+                    "provider": "whisper_http",
+                    "error": f"Whisper HTTP error (HTTP {response.status_code}): {detail}",
+                }
+
+            transcript_text = _parse_whisper_http_response(response)
+            if not transcript_text:
+                return {
+                    "success": False,
+                    "transcript": "",
+                    "provider": "whisper_http",
+                    "error": "Whisper HTTP returned empty transcript",
+                }
+
+            logger.info(
+                "Transcribed %s via Whisper HTTP (%s, %d chars)",
+                Path(file_path).name,
+                endpoint,
+                len(transcript_text),
+            )
+            return {
+                "success": True,
+                "transcript": transcript_text,
+                "provider": "whisper_http",
+            }
+
+        except PermissionError:
+            return {
+                "success": False,
+                "transcript": "",
+                "provider": "whisper_http",
+                "error": f"Permission denied: {file_path}",
+            }
+        except requests.exceptions.Timeout:
+            return {
+                "success": False,
+                "transcript": "",
+                "provider": "whisper_http",
+                "error": f"Whisper HTTP request timed out after {timeout:g}s",
+            }
+        except requests.exceptions.ConnectionError as e:
+            return {
+                "success": False,
+                "transcript": "",
+                "provider": "whisper_http",
+                "error": f"Whisper HTTP connection error: {e}",
+            }
+        except Exception as e:
+            logger.error("Whisper HTTP transcription failed: %s", e, exc_info=True)
+            return {
+                "success": False,
+                "transcript": "",
+                "provider": "whisper_http",
+                "error": f"Whisper HTTP transcription failed: {e}",
+            }
+
+    return {
+        "success": False,
+        "transcript": "",
+        "provider": "whisper_http",
+        "error": f"Whisper HTTP request failed: {last_error or 'unknown error'}",
+    }
+
+# ---------------------------------------------------------------------------
 # Provider: mistral (Voxtral Transcribe API)
 # ---------------------------------------------------------------------------
 
@@ -1677,6 +1900,11 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
         openai_cfg = stt_config.get("openai", {})
         model_name = model or openai_cfg.get("model", DEFAULT_STT_MODEL)
         return _transcribe_openai(file_path, model_name)
+
+    if provider == "whisper_http":
+        whisper_http_cfg = stt_config.get("whisper_http", {})
+        model_name = model or whisper_http_cfg.get("model", DEFAULT_STT_MODEL)
+        return _transcribe_whisper_http(file_path, model_name)
 
     if provider == "mistral":
         mistral_cfg = stt_config.get("mistral", {})

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -13,6 +13,8 @@ Built-in TTS providers:
 - NeuTTS (local, free, no API key): On-device TTS via neutts
 - KittenTTS (local, free, no API key): On-device 25MB model
 - Piper (local, free, no API key): OHF-Voice/piper1-gpl neural VITS, 44 languages
+- Silero HTTP (local HTTP): OpenClaw-compatible local Silero service
+- Piper HTTP (local HTTP): OpenClaw-compatible local Piper service
 
 Custom command providers:
 - Users can declare any number of named providers with ``type: command``
@@ -192,6 +194,10 @@ DEFAULT_GEMINI_TTS_VOICE = "Kore"
 DEFAULT_GEMINI_TTS_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
 DEFAULT_GEMINI_AUDIO_TAGS = False
 GEMINI_AUDIO_TAG_REWRITE_TASK = "tts_audio_tags"
+DEFAULT_SILERO_HTTP_BASE_URL = "http://127.0.0.1:9000"
+DEFAULT_SILERO_HTTP_SPEAKER = "eugene"
+DEFAULT_PIPER_HTTP_BASE_URL = "http://127.0.0.1:8088"
+PIPER_HTTP_OUTPUT_FORMATS = {"wav", "mp3", "ogg"}
 # PCM output specs for Gemini TTS (fixed by the API)
 GEMINI_TTS_SAMPLE_RATE = 24000
 GEMINI_TTS_CHANNELS = 1
@@ -221,6 +227,8 @@ PROVIDER_MAX_TEXT_LENGTH: Dict[str, int] = {
     "neutts": 2000,       # local model, quality falls off on long text
     "kittentts": 2000,    # local 25MB model
     "piper": 5000,        # local VITS model, phoneme-based; practical cap
+    "silero_http": 4000,  # local HTTP services vary; keep requests modest
+    "piper_http": 4000,
 }
 
 # ElevenLabs caps vary by model_id. https://elevenlabs.io/docs/overview/models
@@ -384,6 +392,8 @@ BUILTIN_TTS_PROVIDERS = frozenset({
     "neutts",
     "kittentts",
     "piper",
+    "silero_http",
+    "piper_http",
 })
 
 DEFAULT_COMMAND_TTS_TIMEOUT_SECONDS = 120
@@ -798,6 +808,23 @@ def _configured_command_tts_output_path(path: Path, config: Dict[str, Any]) -> P
     return path.with_suffix(f".{fmt}")
 
 
+def _get_piper_http_output_format(tts_config: Dict[str, Any]) -> str:
+    """Return the configured Piper HTTP audio format."""
+    piper_config = tts_config.get("piper_http", {})
+    fmt = str(piper_config.get("output_format") or "wav").strip().lower().lstrip(".")
+    if fmt not in PIPER_HTTP_OUTPUT_FORMATS:
+        allowed = ", ".join(sorted(PIPER_HTTP_OUTPUT_FORMATS))
+        raise ValueError(
+            f"tts.piper_http.output_format must be one of: {allowed}"
+        )
+    return fmt
+
+
+def _configured_piper_http_output_path(path: Path, tts_config: Dict[str, Any]) -> Path:
+    """Return an output path whose extension matches piper_http.output_format."""
+    return path.with_suffix(f".{_get_piper_http_output_format(tts_config)}")
+
+
 def _generate_command_tts(
     text: str,
     output_path: str,
@@ -1180,6 +1207,122 @@ def _generate_xai_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -
         f.write(response.content)
 
     return output_path
+
+
+# ===========================================================================
+# Providers: Silero/Piper HTTP TTS
+# ===========================================================================
+def _http_tts_endpoint(base_url: str, path: str) -> str:
+    return urljoin(f"{base_url.rstrip('/')}/", path.lstrip("/"))
+
+
+def _http_tts_headers(api_key: str = "") -> Dict[str, str]:
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    return headers
+
+
+def _write_http_tts_response(response: Any, output_path: str, provider: str) -> str:
+    if response.status_code >= 400:
+        detail = response.text.strip()[:300] or response.reason
+        raise RuntimeError(f"{provider} HTTP error (HTTP {response.status_code}): {detail}")
+    if not response.content:
+        raise RuntimeError(f"{provider} returned empty audio")
+
+    with open(output_path, "wb") as f:
+        f.write(response.content)
+    return output_path
+
+
+def _generate_silero_http_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """Generate speech using an OpenClaw-compatible Silero HTTP service."""
+    import requests
+
+    silero_config = tts_config.get("silero_http", {})
+    base_url = str(
+        silero_config.get("base_url")
+        or os.getenv("SILERO_TTS_BASE_URL")
+        or DEFAULT_SILERO_HTTP_BASE_URL
+    ).strip()
+    path = str(silero_config.get("path") or "/tts").strip() or "/tts"
+    speaker = str(
+        silero_config.get("speaker")
+        or DEFAULT_SILERO_HTTP_SPEAKER
+    ).strip()
+    api_key = str(
+        silero_config.get("api_key")
+        or os.getenv("SILERO_TTS_API_KEY")
+        or ""
+    ).strip()
+    timeout = float(silero_config.get("timeout", 60))
+
+    payload: Dict[str, Any] = {"text": text}
+    if speaker:
+        payload["speaker"] = speaker
+    if "auto_ssml" in silero_config:
+        payload["auto_ssml"] = silero_config["auto_ssml"]
+    if "ssml_options" in silero_config:
+        payload["ssml_options"] = silero_config["ssml_options"]
+
+    response = requests.post(
+        _http_tts_endpoint(base_url, path),
+        headers=_http_tts_headers(api_key),
+        json=payload,
+        timeout=timeout,
+    )
+    return _write_http_tts_response(response, output_path, "silero_http")
+
+
+def _generate_piper_http_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """Generate speech using an OpenClaw-compatible Piper HTTP service."""
+    import requests
+
+    piper_config = tts_config.get("piper_http", {})
+    base_url = str(
+        piper_config.get("base_url")
+        or os.getenv("PIPER_TTS_BASE_URL")
+        or DEFAULT_PIPER_HTTP_BASE_URL
+    ).strip()
+    path = str(piper_config.get("path") or "/tts").strip() or "/tts"
+    voice_id = str(piper_config.get("voice_id") or "").strip()
+    speed = piper_config.get("speed", tts_config.get("speed"))
+    rate = str(piper_config.get("rate") or "").strip()
+    volume = str(piper_config.get("volume") or "").strip()
+    pitch = str(piper_config.get("pitch") or "").strip()
+    requested_output_format = str(piper_config.get("output_format") or "").strip()
+    output_format = _get_piper_http_output_format(tts_config)
+    api_key = str(
+        piper_config.get("api_key")
+        or os.getenv("PIPER_TTS_API_KEY")
+        or ""
+    ).strip()
+    timeout = float(piper_config.get("timeout", 60))
+
+    payload: Dict[str, Any] = {"text": text}
+    if voice_id:
+        payload["voice_id"] = voice_id
+    if speed is not None:
+        try:
+            payload["speed"] = float(speed)
+        except (TypeError, ValueError):
+            pass
+    if rate:
+        payload["rate"] = rate
+    if volume:
+        payload["volume"] = volume
+    if pitch:
+        payload["pitch"] = pitch
+    if requested_output_format:
+        payload["output_format"] = output_format
+
+    response = requests.post(
+        _http_tts_endpoint(base_url, path),
+        headers=_http_tts_headers(api_key),
+        json=payload,
+        timeout=timeout,
+    )
+    return _write_http_tts_response(response, output_path, "piper_http")
 
 
 # ===========================================================================
@@ -2094,6 +2237,14 @@ def text_to_speech_tool(
             file_path = _configured_command_tts_output_path(
                 file_path, command_provider_config
             )
+        elif provider == "piper_http":
+            try:
+                file_path = _configured_piper_http_output_path(file_path, tts_config)
+            except ValueError as e:
+                return tool_error(
+                    f"TTS configuration error ({provider}): {e}",
+                    success=False,
+                )
     else:
         timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
         out_dir = Path(DEFAULT_OUTPUT_DIR)
@@ -2105,6 +2256,17 @@ def text_to_speech_tool(
         # otherwise fall back to .mp3 (Edge TTS will attempt ffmpeg conversion later).
         elif want_opus and provider in {"openai", "elevenlabs", "mistral", "gemini"}:
             file_path = out_dir / f"tts_{timestamp}.ogg"
+        elif provider == "silero_http":
+            file_path = out_dir / f"tts_{timestamp}.wav"
+        elif provider == "piper_http":
+            try:
+                fmt = _get_piper_http_output_format(tts_config)
+            except ValueError as e:
+                return tool_error(
+                    f"TTS configuration error ({provider}): {e}",
+                    success=False,
+                )
+            file_path = out_dir / f"tts_{timestamp}.{fmt}"
         else:
             file_path = out_dir / f"tts_{timestamp}.mp3"
 
@@ -2158,6 +2320,14 @@ def text_to_speech_tool(
                 }, ensure_ascii=False)
             logger.info("Generating speech with OpenAI TTS...")
             _generate_openai_tts(text, file_str, tts_config)
+
+        elif provider == "silero_http":
+            logger.info("Generating speech with Silero HTTP TTS...")
+            _generate_silero_http_tts(text, file_str, tts_config)
+
+        elif provider == "piper_http":
+            logger.info("Generating speech with Piper HTTP TTS...")
+            _generate_piper_http_tts(text, file_str, tts_config)
 
         elif provider == "minimax":
             logger.info("Generating speech with MiniMax TTS...")
@@ -2291,6 +2461,12 @@ def text_to_speech_tool(
             if opus_path:
                 file_str = opus_path
                 voice_compatible = True
+        elif provider in {"silero_http", "piper_http"}:
+            if want_opus and not file_str.endswith(".ogg"):
+                opus_path = _convert_to_opus(file_str)
+                if opus_path:
+                    file_str = opus_path
+            voice_compatible = file_str.endswith(".ogg")
         elif provider in {"elevenlabs", "openai", "mistral", "gemini"}:
             voice_compatible = want_opus and file_str.endswith(".ogg")
 
@@ -2330,6 +2506,31 @@ def text_to_speech_tool(
 # ===========================================================================
 # Requirements check
 # ===========================================================================
+def _configured_http_tts_base_url(provider: str, tts_config: Dict[str, Any]) -> str:
+    """Return the effective base URL when an HTTP provider is explicitly usable."""
+    provider_config = tts_config.get(provider)
+    selected_provider = _get_provider(tts_config)
+
+    cfg = provider_config if isinstance(provider_config, dict) else {}
+    if provider == "silero_http":
+        if selected_provider != provider:
+            return str(os.getenv("SILERO_TTS_BASE_URL") or "").strip()
+        return str(
+            cfg.get("base_url")
+            or os.getenv("SILERO_TTS_BASE_URL")
+            or DEFAULT_SILERO_HTTP_BASE_URL
+        ).strip()
+    if provider == "piper_http":
+        if selected_provider != provider:
+            return str(os.getenv("PIPER_TTS_BASE_URL") or "").strip()
+        return str(
+            cfg.get("base_url")
+            or os.getenv("PIPER_TTS_BASE_URL")
+            or DEFAULT_PIPER_HTTP_BASE_URL
+        ).strip()
+    return ""
+
+
 def check_tts_requirements() -> bool:
     """
     Check if at least one TTS provider is available.
@@ -2341,8 +2542,10 @@ def check_tts_requirements() -> bool:
     Returns:
         bool: True if at least one provider can work.
     """
+    tts_config = _load_tts_config()
+
     # Any configured command provider counts as available.
-    if _has_any_command_tts_provider():
+    if _has_any_command_tts_provider(tts_config):
         return True
     try:
         _import_edge_tts()
@@ -2381,6 +2584,10 @@ def check_tts_requirements() -> bool:
     if _check_neutts_available():
         return True
     if _check_kittentts_available():
+        return True
+    if _configured_http_tts_base_url("silero_http", tts_config):
+        return True
+    if _configured_http_tts_base_url("piper_http", tts_config):
         return True
     if _check_piper_available():
         return True

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -14,7 +14,7 @@ If you have a paid [Nous Portal](https://portal.nousresearch.com) subscription, 
 
 ## Text-to-Speech
 
-Convert text to speech with ten providers:
+Convert text to speech with built-in cloud, local, and local-HTTP providers:
 
 | Provider | Quality | Cost | API Key |
 |----------|---------|------|---------|
@@ -28,6 +28,8 @@ Convert text to speech with ten providers:
 | **NeuTTS** | Good | Free (local) | None needed |
 | **KittenTTS** | Good | Free (local) | None needed |
 | **Piper** | Good | Free (local) | None needed |
+| **Silero HTTP** | Good | Free (local service) | Optional bearer token |
+| **Piper HTTP** | Good | Free (local service) | Optional bearer token |
 
 ### Platform Delivery
 
@@ -43,7 +45,7 @@ Convert text to speech with ten providers:
 ```yaml
 # In ~/.hermes/config.yaml
 tts:
-  provider: "edge"              # "edge" | "elevenlabs" | "openai" | "minimax" | "mistral" | "gemini" | "xai" | "neutts" | "kittentts" | "piper"
+  provider: "edge"              # "edge" | "elevenlabs" | "openai" | "minimax" | "mistral" | "gemini" | "xai" | "neutts" | "kittentts" | "piper" | "silero_http" | "piper_http"
   speed: 1.0                    # Global speed multiplier (provider-specific settings override this)
   edge:
     voice: "en-US-AriaNeural"   # 322 voices, 74 languages
@@ -95,6 +97,17 @@ tts:
     # noise_w_scale: 0.8
     # volume: 1.0                               # 0.5 = half as loud
     # normalize_audio: true
+  silero_http:
+    base_url: "http://127.0.0.1:9000"
+    path: "/tts"
+    speaker: "eugene"
+    # api_key: ""                               # Optional bearer token
+  piper_http:
+    base_url: "http://127.0.0.1:8088"
+    path: "/tts"
+    voice_id: "en_US-lessac-medium"
+    output_format: "wav"                        # "wav" | "mp3" | "ogg"
+    # api_key: ""                               # Optional bearer token
 ```
 
 **Speed control**: The global `tts.speed` value applies to all providers by default. Each provider can override it with its own `speed` setting (e.g., `tts.openai.speed: 1.5`). Provider-specific speed takes precedence over the global value. Default is `1.0` (normal speed).
@@ -177,6 +190,8 @@ Telegram voice bubbles require Opus/OGG audio format:
 - **NeuTTS** outputs WAV and also needs **ffmpeg** to convert for Telegram voice bubbles
 - **KittenTTS** outputs WAV and also needs **ffmpeg** to convert for Telegram voice bubbles
 - **Piper** outputs WAV and also needs **ffmpeg** to convert for Telegram voice bubbles
+- **Silero HTTP** usually outputs WAV and needs **ffmpeg** to convert for Telegram voice bubbles
+- **Piper HTTP** can output WAV/MP3/OGG; set `tts.piper_http.output_format: ogg` if your server returns Opus-compatible audio
 
 ```bash
 # Ubuntu/Debian
@@ -236,6 +251,20 @@ tts:
 ```
 
 **Advanced knobs** (`tts.piper.length_scale` / `noise_scale` / `noise_w_scale` / `volume` / `normalize_audio`, `use_cuda`) correspond 1:1 to Piper's `SynthesisConfig`. They're ignored on older `piper-tts` versions.
+
+### Local HTTP providers
+
+Use `silero_http`, `piper_http`, and `whisper_http` when you already run a local voice service that speaks the OpenClaw/OpenAI-compatible HTTP contract. These built-ins exist for common local voice servers with stable request/response shapes: they use normal `config.yaml` keys, produce regular `MEDIA:` responses for gateways, and do not require shell commands or plugin boilerplate.
+
+Pick a different surface when the backend does not match that HTTP shape:
+
+| Backend shape | Recommended surface |
+|---|---|
+| OpenClaw/OpenAI-compatible local HTTP service | Built-in `silero_http`, `piper_http`, or `whisper_http` |
+| A CLI that reads text/audio and writes a file | Command provider |
+| A Python SDK, OAuth flow, dynamic voice list, or custom streaming behavior | Plugin provider |
+
+`piper_http.output_format` accepts `wav`, `mp3`, or `ogg`. Hermes writes the output file with the matching suffix for both default paths and caller-supplied paths, so gateways and local playback can infer the codec from the file name.
 
 ### Custom command providers
 
@@ -416,6 +445,7 @@ Voice messages sent on Telegram, Discord, WhatsApp, Slack, or Signal are automat
 | **Local Whisper** (default) | Good | Free | None needed |
 | **Groq Whisper API** | Good–Best | Free tier | `GROQ_API_KEY` |
 | **OpenAI Whisper API** | Good–Best | Paid | `VOICE_TOOLS_OPENAI_KEY` or `OPENAI_API_KEY` |
+| **Whisper HTTP** | Depends on local service | Free (local service) | Optional bearer token |
 
 :::info Zero Config
 Local transcription works out of the box when `faster-whisper` is installed. If that's unavailable, Hermes can also use a local `whisper` CLI from common install locations (like `/opt/homebrew/bin`) or a custom command via `HERMES_LOCAL_STT_COMMAND`.
@@ -426,7 +456,7 @@ Local transcription works out of the box when `faster-whisper` is installed. If 
 ```yaml
 # In ~/.hermes/config.yaml
 stt:
-  provider: "local"           # "local" | "groq" | "openai" | "mistral" | "xai"
+  provider: "local"           # "local" | "groq" | "openai" | "mistral" | "xai" | "elevenlabs" | "whisper_http"
   local:
     model: "base"             # tiny, base, small, medium, large-v3
   openai:
@@ -435,6 +465,11 @@ stt:
     model: "voxtral-mini-latest"  # voxtral-mini-latest, voxtral-mini-2602
   xai:
     model: "grok-stt"         # xAI Grok STT
+  whisper_http:
+    base_url: "http://127.0.0.1:8000"
+    path: "/v1/audio/transcriptions"
+    model: "whisper-1"
+    language: "en"
 ```
 
 ### Provider Details
@@ -456,6 +491,8 @@ stt:
 **Mistral API (Voxtral Transcribe)** — Requires `MISTRAL_API_KEY`. Uses Mistral's [Voxtral Transcribe](https://docs.mistral.ai/capabilities/audio/speech_to_text/) models. Supports 13 languages, speaker diarization, and word-level timestamps. Install with `pip install hermes-agent[mistral]`.
 
 **xAI Grok STT** — Requires `XAI_API_KEY`. Posts to `https://api.x.ai/v1/stt` as multipart/form-data. Good choice if you're already using xAI for chat or TTS and want one API key for everything. Auto-detection order puts it after Groq — explicitly set `stt.provider: xai` to force it.
+
+**Whisper HTTP** — Posts multipart audio to a local OpenAI-compatible or OpenClaw-style Whisper endpoint. Use it for services such as a local `whisper.cpp`, faster-whisper, or OpenClaw transcription server that is already exposed over HTTP. Use an STT command provider instead when the backend is only a CLI, and a plugin when the backend needs SDK-level auth or richer lifecycle hooks.
 
 **Custom local CLI fallback** — Set `HERMES_LOCAL_STT_COMMAND` if you want Hermes to call a local transcription command directly. The command template supports `{input_path}`, `{output_dir}`, `{language}`, and `{model}` placeholders. Your command must write a `.txt` transcript somewhere under `{output_dir}`.
 
@@ -564,7 +601,7 @@ The shell command runs under the same user as Hermes with full filesystem access
 
 ### Python plugin providers (STT)
 
-For STT engines that aren't built-in AND can't be expressed as a shell command (need a Python SDK, OAuth-refreshing auth, streaming chunks, etc.), register a Python plugin via `ctx.register_transcription_provider()`. The plugin **coexists with** the 6 built-in providers (`local`, `local_command`, `groq`, `openai`, `mistral`, `xai`) and the `stt.providers.<name>: type: command` registry — built-ins keep their native implementations and always win on name collision; command providers win over plugins of the same name (config is more local than plugin install).
+For STT engines that aren't built-in AND can't be expressed as a shell command (need a Python SDK, OAuth-refreshing auth, streaming chunks, etc.), register a Python plugin via `ctx.register_transcription_provider()`. The plugin **coexists with** the built-in providers and the `stt.providers.<name>: type: command` registry — built-ins keep their native implementations and always win on name collision; command providers win over plugins of the same name (config is more local than plugin install).
 
 #### When to pick which (STT)
 


### PR DESCRIPTION
## Summary
- Add local HTTP voice providers: `whisper_http` STT plus `silero_http` and `piper_http` TTS.
- Supports OpenAI-compatible and OpenClaw-style HTTP endpoints.
- Keeps non-Telegram local playback as WAV; Opus conversion remains Telegram-specific.

## Tests
- `scripts/run_tests.sh tests/tools/test_http_voice_providers.py tests/tools/test_tts_max_text_length.py` — 44 passed

## Safety
- No real credentials or tokens are included; this PR only references env variable names for optional HTTP provider API keys.
