### PR TITLE
feat: add wake-word voice mode

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -876,6 +876,42 @@ stt:
   #   model: "voxtral-mini-latest"  # voxtral-mini-latest | voxtral-mini-2602
 
 # =============================================================================
+# Voice Mode
+# =============================================================================
+# Local CLI voice controls. Secrets still belong in .env; non-secret tuning
+# belongs here.
+voice:
+  record_key: "ctrl+b"
+  max_recording_seconds: 120
+  auto_tts: false
+  beep_enabled: true
+  silence_threshold: 200
+  silence_duration: 3.0
+  # 0 = derive the "still waiting for model" notice from model/API timeouts.
+  model_wait_notice_seconds: 0
+  wake:
+    provider: "openwakeword"
+    phrase: "Hermes"
+    # Leave empty to resolve/download a known openWakeWord model for the phrase.
+    model_path: ""
+    threshold: 0.5
+    patience_frames: 2
+    vad_threshold: 0.25
+    pre_roll_ms: 1200
+    dialog_timeout_seconds: 45.0
+    max_utterance_seconds: 30.0
+    silence_threshold: 200
+    silence_duration: 3.0
+    frame_samples: 1280
+    training:
+      positive_samples: 50
+      negative_samples: 30
+      ambient_seconds: 60
+      # Optional shell command for custom wake-word training. Hermes provides:
+      # HERMES_WAKE_PHRASE, HERMES_WAKE_DATASET_DIR, HERMES_WAKE_OUTPUT_PATH.
+      command: ""
+
+# =============================================================================
 # Response Pacing (Messaging Platforms)
 # =============================================================================
 # Add human-like delays between message chunks.

--- a/cli.py
+++ b/cli.py
@@ -2330,6 +2330,47 @@ def _prepend_note_to_message(message, note: str):
     return message
 
 
+def _resolve_cli_model_wait_notice_seconds(agent: Any) -> float:
+    """Return when the CLI should tell the user a model call is still pending."""
+    config_value = None
+    try:
+        from hermes_cli.config import load_config
+        config = load_config()
+        voice_config = config.get("voice", {}) if isinstance(config, dict) else {}
+        if isinstance(voice_config, dict):
+            config_value = voice_config.get("model_wait_notice_seconds")
+    except Exception:
+        config_value = None
+
+    if config_value is not None:
+        try:
+            parsed = float(config_value)
+            if parsed > 0:
+                return parsed
+        except (TypeError, ValueError):
+            logger.debug(
+                "Invalid voice.model_wait_notice_seconds=%r",
+                config_value,
+            )
+
+    timeout = 45.0
+    try:
+        compute_stream_timeout = getattr(agent, "_compute_stream_stale_timeout", None)
+        if callable(compute_stream_timeout):
+            resolved = float(compute_stream_timeout([]))
+        else:
+            resolve_stale_timeout = getattr(agent, "_resolved_api_call_stale_timeout_base", None)
+            if not callable(resolve_stale_timeout):
+                return timeout
+            resolved, _uses_default = resolve_stale_timeout()
+            resolved = float(resolved)
+        if resolved > 0 and resolved != float("inf"):
+            timeout = min(timeout, resolved)
+    except Exception:
+        pass
+    return max(5.0, timeout)
+
+
 # ---------------------------------------------------------------------------
 # File-drop / local attachment detection — extracted as pure helpers for tests.
 # ---------------------------------------------------------------------------
@@ -3582,6 +3623,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         self._voice_continuous = False
         self._voice_tts_done = threading.Event()
         self._voice_tts_done.set()
+        self._voice_wake_listener = None
+        self._voice_wake_enabled = False
+        self._voice_wake_state = "stopped"
+        self._voice_wake_last_score = 0.0
 
         # Status bar visibility (toggled via /statusbar)
         self._status_bar_visible = True
@@ -4158,6 +4203,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             return [("class:voice-status", f" 🎤 {label} ")]
         tts = " | TTS on" if self._voice_tts else ""
         cont = " | Continuous" if self._voice_continuous else ""
+        if getattr(self, "_voice_wake_enabled", False):
+            wake_state = getattr(self, "_voice_wake_state", "wake")
+            return [("class:voice-status", f" 🎤 Wake {wake_state}{tts}  —  {label} override ")]
         return [("class:voice-status", f" 🎤 Voice mode{tts}{cont}  —  {label} to record ")]
 
     def _build_status_bar_text(self, width: Optional[int] = None) -> str:
@@ -9029,6 +9077,22 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             )
             self._invalidate()
 
+        if not self._voice_mode:
+            return
+        if not function_name or function_name.startswith("_"):
+            return
+        if not self._voice_tool_beeps_enabled():
+            return
+        try:
+            from tools.voice_mode import play_beep
+            threading.Thread(
+                target=play_beep,
+                kwargs={"frequency": 1200, "duration": 0.06, "count": 1},
+                daemon=True,
+            ).start()
+        except Exception:
+            pass
+
     def _on_tool_start(self, tool_call_id: str, function_name: str, function_args: dict):
         """Capture local before-state for write-capable tools."""
         try:
@@ -9094,6 +9158,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 "Option 3: Set VOICE_TOOLS_OPENAI_KEY (paid)"
             )
 
+        self._pause_voice_wake_listener("manual")
+
         # Prevent double-start from concurrent threads (atomic check-and-set)
         with self._voice_lock:
             if self._voice_recording:
@@ -9143,14 +9209,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 self._app.invalidate()
             self._voice_stop_and_transcribe()
 
-        # Audio cue: single beep BEFORE starting stream (avoid CoreAudio conflict)
-        if self._voice_beeps_enabled():
-            try:
-                from tools.voice_mode import play_beep
-                play_beep(frequency=880, count=1)
-            except Exception:
-                pass
-
         try:
             self._voice_recorder.start(on_silence_stop=_on_silence)
         except Exception:
@@ -9197,14 +9255,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 return
 
             wav_path = self._voice_recorder.stop()
-
-            # Audio cue: double beep after stream stopped (no CoreAudio conflict)
-            if self._voice_beeps_enabled():
-                try:
-                    from tools.voice_mode import play_beep
-                    play_beep(frequency=660, count=2)
-                except Exception:
-                    pass
 
             if wav_path is None:
                 _cprint(f"{_DIM}No speech detected.{_RST}")
@@ -9267,9 +9317,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     self._voice_continuous = False
                     self._no_speech_count = 0
                     _cprint(f"{_DIM}No speech detected 3 times, continuous mode stopped.{_RST}")
+                    self._resume_voice_wake_listener()
                     return
             else:
                 self._no_speech_count = 0
+
+            if not submitted and not self._voice_continuous:
+                self._resume_voice_wake_listener()
 
             # If no transcript was submitted but continuous mode is active,
             # restart recording so the user can keep talking.
@@ -9300,6 +9354,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         """Speak the agent's response aloud using TTS (runs in background thread)."""
         if not self._voice_tts:
             return
+        self._pause_voice_wake_listener("tts")
         self._voice_tts_done.clear()
         try:
             from tools.tts_tool import text_to_speech_tool
@@ -9321,25 +9376,42 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             if not tts_text:
                 return
 
-            # Use MP3 output for CLI playback (afplay doesn't handle OGG well).
-            # The TTS tool may auto-convert MP3->OGG, but the original MP3 remains.
+            # Pick a container the configured provider can write/play locally, then
+            # honor the actual file path returned by the TTS tool.
             os.makedirs(os.path.join(tempfile.gettempdir(), "hermes_voice"), exist_ok=True)
-            mp3_path = os.path.join(
+            tts_provider = "edge"
+            try:
+                from tools.tts_tool import _get_provider, _load_tts_config
+
+                tts_provider = _get_provider(_load_tts_config())
+            except Exception:
+                pass
+            wav_providers = {"neutts", "kittentts", "gemini"}
+            ext = "wav" if tts_provider in wav_providers else "mp3"
+            audio_path = os.path.join(
                 tempfile.gettempdir(), "hermes_voice",
-                f"tts_{time.strftime('%Y%m%d_%H%M%S')}.mp3",
+                f"tts_{time.strftime('%Y%m%d_%H%M%S')}.{ext}",
             )
 
-            text_to_speech_tool(text=tts_text, output_path=mp3_path)
+            tts_result_raw = text_to_speech_tool(text=tts_text, output_path=audio_path)
+            play_path = audio_path
+            try:
+                tts_result = json.loads(tts_result_raw)
+                if tts_result.get("success") is False:
+                    logger.warning("Voice TTS generation failed: %s", tts_result.get("error"))
+                    return
+                if tts_result.get("file_path"):
+                    play_path = str(tts_result["file_path"])
+            except Exception:
+                pass
 
-            # Play the MP3 directly (the TTS tool returns OGG path but MP3 still exists)
-            if os.path.isfile(mp3_path) and os.path.getsize(mp3_path) > 0:
-                play_audio_file(mp3_path)
-                # Clean up
+            if os.path.isfile(play_path) and os.path.getsize(play_path) > 0:
+                play_audio_file(play_path)
                 try:
-                    os.unlink(mp3_path)
-                    ogg_path = mp3_path.rsplit(".", 1)[0] + ".ogg"
-                    if os.path.isfile(ogg_path):
-                        os.unlink(ogg_path)
+                    base = audio_path.rsplit(".", 1)[0]
+                    for candidate in {audio_path, play_path, f"{base}.ogg", f"{base}.mp3", f"{base}.wav"}:
+                        if os.path.isfile(candidate):
+                            os.unlink(candidate)
                 except OSError:
                     pass
         except Exception as e:
@@ -9347,7 +9419,271 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             _cprint(f"{_DIM}TTS playback failed: {e}{_RST}")
         finally:
             self._voice_tts_done.set()
+            if not getattr(self, "_agent_running", False):
+                self._resume_voice_wake_listener()
 
+    def _handle_voice_command(self, command: str):
+        """Handle /voice [on|off|tts|status|wake ...] command."""
+        parts = command.strip().split(maxsplit=1)
+        subcommand_raw = parts[1].strip() if len(parts) > 1 else ""
+        subcommand = subcommand_raw.lower().strip()
+
+        if subcommand == "on":
+            self._enable_voice_mode()
+        elif subcommand == "off":
+            self._disable_voice_mode()
+        elif subcommand == "tts" or subcommand.startswith("tts "):
+            self._handle_voice_tts_command(subcommand_raw)
+        elif subcommand == "status":
+            self._show_voice_status()
+        elif subcommand == "wake" or subcommand.startswith("wake "):
+            self._handle_voice_wake_command(subcommand_raw)
+        elif subcommand == "":
+            # Toggle
+            if self._voice_mode:
+                self._disable_voice_mode()
+            else:
+                self._enable_voice_mode()
+        else:
+            _cprint(f"Unknown voice subcommand: {subcommand}")
+            _cprint("Usage: /voice [on|off|tts [on|off|status]|status|wake on|off|status|train]")
+
+    def _handle_voice_tts_command(self, command: str):
+        """Handle /voice tts [on|off|status] commands."""
+        import shlex
+
+        try:
+            args = shlex.split(command)
+        except ValueError as exc:
+            _cprint(f"{_DIM}Invalid TTS command: {exc}{_RST}")
+            return
+
+        action = args[1].lower() if len(args) > 1 else "toggle"
+        if action == "toggle":
+            self._toggle_voice_tts()
+        elif action in {"on", "enable", "enabled"}:
+            self._set_voice_tts(True)
+        elif action in {"off", "disable", "disabled"}:
+            self._set_voice_tts(False)
+        elif action == "status":
+            _cprint(f"{_ACCENT}Voice TTS {'ON' if self._voice_tts else 'OFF'}.{_RST}")
+        else:
+            _cprint(f"Unknown voice TTS subcommand: {action}")
+            _cprint("Usage: /voice tts [on|off|status]")
+
+    def _handle_voice_wake_command(self, command: str):
+        """Handle /voice wake [on|off|status|train] commands."""
+        import shlex
+
+        try:
+            args = shlex.split(command)
+        except ValueError as exc:
+            _cprint(f"{_DIM}Invalid wake command: {exc}{_RST}")
+            return
+        action = args[1].lower() if len(args) > 1 else "status"
+
+        if action == "on":
+            if not self._voice_mode:
+                self._enable_voice_mode()
+            if self._voice_mode:
+                self._start_voice_wake_mode()
+        elif action == "off":
+            self._stop_voice_wake_mode()
+        elif action == "status":
+            self._show_voice_wake_status()
+        elif action == "train":
+            self._train_voice_wake_model(args[2:])
+        else:
+            _cprint(f"Unknown wake subcommand: {action}")
+            _cprint('Usage: /voice wake [on|off|status|train --phrase "Hermes"]')
+
+    def _start_voice_wake_mode(self):
+        """Start the continuous wake-word listener."""
+        if getattr(self, "_voice_wake_enabled", False):
+            _cprint(f"{_DIM}Wake-word mode is already enabled.{_RST}")
+            return
+
+        from tools.wake_word import WakeWordListener, check_wake_requirements, load_wake_config, wake_install_hint
+
+        cfg = load_wake_config()
+        reqs = check_wake_requirements(cfg, download_missing=True)
+        if not reqs["available"]:
+            _cprint(f"\n{_ACCENT}Wake-word mode requirements not met:{_RST}")
+            for line in reqs["details"].split("\n"):
+                _cprint(f"  {_DIM}{line}{_RST}")
+            if reqs.get("missing_packages"):
+                _cprint(f"\n  {_BOLD}Install: {wake_install_hint()}{_RST}")
+            return
+        if reqs.get("resolved_model_path"):
+            cfg.model_path = reqs["resolved_model_path"]
+
+        def _on_status(status: dict):
+            self._voice_wake_state = status.get("state", "unknown")
+            self._voice_wake_last_score = float(status.get("last_score", 0.0) or 0.0)
+            if hasattr(self, "_app") and self._app:
+                self._app.invalidate()
+
+        def _on_error(exc: Exception):
+            _cprint(f"\n{_DIM}Wake-word listener error: {exc}{_RST}")
+            self._stop_voice_wake_mode()
+
+        def _on_transcript(transcript: str):
+            transcript = transcript.strip()
+            if not transcript:
+                return
+            self._attached_images.clear()
+            self._pending_input.put(transcript)
+            self._pause_voice_wake_listener("agent")
+            if hasattr(self, "_app") and self._app:
+                self._app.invalidate()
+
+        listener = WakeWordListener(
+            cfg,
+            on_transcript=_on_transcript,
+            on_status=_on_status,
+            on_error=_on_error,
+        )
+        try:
+            listener.start()
+        except Exception as exc:
+            _cprint(f"\n{_DIM}Wake-word listener failed to start: {exc}{_RST}")
+            return
+
+        with self._voice_lock:
+            self._voice_wake_listener = listener
+            self._voice_wake_enabled = True
+            self._voice_wake_state = "passive"
+            self._voice_wake_last_score = 0.0
+
+        phrase = cfg.phrase or "configured phrase"
+        _cprint(f"\n{_ACCENT}Wake-word mode enabled{_RST}")
+        _cprint(f"  {_DIM}Listening for: {phrase}{_RST}")
+        _cprint(f"  {_DIM}TTS: {'ON' if self._voice_tts else 'OFF'}{_RST}")
+        _cprint(f"  {_DIM}/voice wake off  to stop wake listening{_RST}")
+        _cprint(f"  {_DIM}Ctrl+B remains available as manual override{_RST}")
+
+    def _stop_voice_wake_mode(self):
+        """Stop the wake-word listener and release the audio stream."""
+        listener = None
+        with self._voice_lock:
+            listener = getattr(self, "_voice_wake_listener", None)
+            self._voice_wake_listener = None
+            self._voice_wake_enabled = False
+            self._voice_wake_state = "stopped"
+            self._voice_wake_last_score = 0.0
+        if listener is not None:
+            try:
+                listener.stop()
+            except Exception:
+                logger.debug("Wake-word listener stop failed", exc_info=True)
+        _cprint(f"{_DIM}Wake-word mode disabled.{_RST}")
+
+    def _pause_voice_wake_listener(self, reason: str = ""):
+        """Pause wake listening while manual recording, agent output, or TTS is active."""
+        listener = getattr(self, "_voice_wake_listener", None)
+        if not getattr(self, "_voice_wake_enabled", False) or listener is None:
+            return
+        try:
+            listener.pause(reason)
+            self._voice_wake_state = "paused"
+        except Exception:
+            logger.debug("Wake-word listener pause failed", exc_info=True)
+
+    def _resume_voice_wake_listener(self):
+        """Resume wake listening after manual recording, agent output, or TTS."""
+        listener = getattr(self, "_voice_wake_listener", None)
+        if not getattr(self, "_voice_wake_enabled", False) or listener is None:
+            return
+        if getattr(self, "_voice_recording", False) or getattr(self, "_voice_processing", False):
+            return
+        try:
+            listener.resume()
+            self._voice_wake_state = listener.status().get("state", "passive")
+            self._voice_wake_last_score = float(listener.status().get("last_score", 0.0) or 0.0)
+        except Exception:
+            logger.debug("Wake-word listener resume failed", exc_info=True)
+
+    def _show_voice_wake_status(self):
+        """Show wake-word listener status and requirements."""
+        from tools.wake_word import check_wake_requirements, load_wake_config
+
+        cfg = load_wake_config()
+        reqs = check_wake_requirements(cfg)
+        state = getattr(self, "_voice_wake_state", "stopped")
+        score = getattr(self, "_voice_wake_last_score", 0.0)
+        _cprint(f"\n{_BOLD}Wake-Word Status{_RST}")
+        _cprint(f"  Mode:      {'ON' if getattr(self, '_voice_wake_enabled', False) else 'OFF'}")
+        _cprint(f"  State:     {state}")
+        _cprint(f"  Phrase:    {cfg.phrase}")
+        resolved_model = reqs.get("resolved_model_path") or cfg.model_path
+        if resolved_model and cfg.model_path and resolved_model != cfg.model_path:
+            model_display = f"{resolved_model} (resolved from {cfg.model_path})"
+        else:
+            model_display = resolved_model or "(not set)"
+        _cprint(f"  Model:     {model_display}")
+        _cprint(f"  Threshold: {cfg.threshold:.2f}")
+        _cprint(f"  Endpoint:  silence RMS <= {cfg.silence_threshold} for {cfg.silence_duration:.1f}s")
+        _cprint(f"  Max rec:   {cfg.max_utterance_seconds:.1f}s")
+        _cprint(f"  Last score:{score:.3f}")
+        _cprint(f"\n  {_BOLD}Requirements:{_RST}")
+        for line in reqs["details"].split("\n"):
+            _cprint(f"    {line}")
+
+    def _train_voice_wake_model(self, args: list[str]):
+        """Collect local wake-word samples and save the trained model path."""
+        from tools.wake_word import WakeWordTrainer, load_wake_config, wake_install_hint, write_existing_model_config
+
+        cfg = load_wake_config()
+        phrase = cfg.phrase
+        existing_model = ""
+        threshold = cfg.threshold
+        idx = 0
+        while idx < len(args):
+            token = args[idx]
+            if token == "--phrase" and idx + 1 < len(args):
+                phrase = args[idx + 1]
+                idx += 2
+            elif token == "--model" and idx + 1 < len(args):
+                existing_model = args[idx + 1]
+                idx += 2
+            elif token == "--threshold" and idx + 1 < len(args):
+                try:
+                    threshold = float(args[idx + 1])
+                except ValueError:
+                    _cprint(f"{_DIM}Invalid threshold: {args[idx + 1]}{_RST}")
+                    return
+                idx += 2
+            else:
+                _cprint(f"{_DIM}Unknown wake train option: {token}{_RST}")
+                _cprint('Usage: /voice wake train --phrase "Hermes" [--model /path/model.onnx] [--threshold 0.5]')
+                return
+
+        if existing_model:
+            updates = write_existing_model_config(existing_model, phrase, threshold)
+            if not os.path.isfile(os.path.expanduser(existing_model)):
+                _cprint(f"{_DIM}Wake model not found: {existing_model}{_RST}")
+                return
+            for key, value in updates.items():
+                save_config_value(key, value)
+            _cprint(f"{_ACCENT}Wake-word model configured: {existing_model}{_RST}")
+            return
+
+        cfg.phrase = phrase
+        cfg.threshold = threshold
+        _cprint(f"\n{_ACCENT}Wake-word training: {phrase}{_RST}")
+        _cprint(f"  {_DIM}Collecting local samples; this can take a few minutes.{_RST}")
+        try:
+            result = WakeWordTrainer(cfg).train()
+        except Exception as exc:
+            _cprint(f"\n{_DIM}Wake-word training failed: {exc}{_RST}")
+            _cprint(f"  {_DIM}Install hint: {wake_install_hint(training=True)}{_RST}")
+            return
+
+        for key, value in result.get("config_update", {}).items():
+            save_config_value(key, value)
+        _cprint(f"\n{_ACCENT}Wake-word model saved{_RST}")
+        _cprint(f"  {_DIM}{result['model_path']}{_RST}")
+        _cprint(f"  {_DIM}Run /voice wake on to start listening.{_RST}")
 
     def _voice_beeps_enabled(self) -> bool:
         """Return whether CLI voice mode should play record start/stop beeps."""
@@ -9355,10 +9691,23 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             from hermes_cli.config import load_config
             voice_cfg = load_config().get("voice", {})
             if isinstance(voice_cfg, dict):
-                return bool(voice_cfg.get("beep_enabled", True))
+                return bool(voice_cfg.get("beep_enabled", False))
         except Exception:
             pass
-        return True
+        return False
+
+    def _voice_tool_beeps_enabled(self) -> bool:
+        """Return whether CLI voice mode should play per-tool audio cues."""
+        try:
+            from hermes_cli.config import load_config
+            voice_cfg = load_config().get("voice", {})
+            if isinstance(voice_cfg, dict):
+                return bool(voice_cfg.get("beep_enabled", False)) and bool(
+                    voice_cfg.get("tool_beep_enabled", False)
+                )
+        except Exception:
+            pass
+        return False
 
     def _enable_voice_mode(self):
         """Enable voice mode after checking requirements."""
@@ -9422,6 +9771,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
     def _disable_voice_mode(self):
         """Disable voice mode, cancel any active recording, and stop TTS."""
+        if getattr(self, "_voice_wake_enabled", False):
+            self._stop_voice_wake_mode()
+
         recorder = None
         with self._voice_lock:
             if self._voice_recording and self._voice_recorder:
@@ -9458,16 +9810,28 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             _cprint(f"{_DIM}Enable voice mode first: /voice on{_RST}")
             return
 
-        with self._voice_lock:
-            self._voice_tts = not self._voice_tts
-        status = "enabled" if self._voice_tts else "disabled"
+        self._set_voice_tts(not self._voice_tts)
 
-        if self._voice_tts:
+    def _set_voice_tts(self, enabled: bool):
+        """Set TTS output for voice mode."""
+        if not self._voice_mode:
+            _cprint(f"{_DIM}Enable voice mode first: /voice on{_RST}")
+            return
+
+        with self._voice_lock:
+            changed = self._voice_tts != enabled
+            self._voice_tts = enabled
+        status = "enabled" if enabled else "disabled"
+
+        if enabled:
             from tools.tts_tool import check_tts_requirements
             if not check_tts_requirements():
                 _cprint(f"{_DIM}Warning: No TTS provider available. Install edge-tts or set API keys.{_RST}")
 
-        _cprint(f"{_ACCENT}Voice TTS {status}.{_RST}")
+        if changed:
+            _cprint(f"{_ACCENT}Voice TTS {status}.{_RST}")
+        else:
+            _cprint(f"{_DIM}Voice TTS already {status}.{_RST}")
 
     def _show_voice_status(self):
         """Show current voice mode status."""
@@ -9484,6 +9848,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         # #19835, same class as round-13). Reading live config here
         # would drift after a mid-session config edit.
         _cprint(f"  Record key: {self._voice_record_key_label()}")
+        _cprint(f"  Wake:      {'ON' if getattr(self, '_voice_wake_enabled', False) else 'OFF'}")
+        if getattr(self, "_voice_wake_enabled", False):
+            _cprint(f"  Wake state:{getattr(self, '_voice_wake_state', 'unknown')}")
+            _cprint(f"  Wake score:{getattr(self, '_voice_wake_last_score', 0.0):.3f}")
         _cprint(f"\n  {_BOLD}Requirements:{_RST}")
         for line in reqs["details"].split("\n"):
             _cprint(f"    {line}")
@@ -10114,8 +10482,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             self._reasoning_shown_this_turn = False
 
             # --- Streaming TTS setup ---
-            # When ElevenLabs is the TTS provider and sounddevice is available,
-            # we stream audio sentence-by-sentence as the agent generates tokens
+            # When the selected TTS provider supports CLI streaming, stream
+            # audio sentence-by-sentence as the agent generates tokens
             # instead of waiting for the full response.
             use_streaming_tts = False
             _streaming_box_opened = False
@@ -10128,14 +10496,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 try:
                     from tools.tts_tool import (
                         _load_tts_config as _load_tts_cfg,
-                        _get_provider as _get_prov,
+                        _get_provider as _get_tts_provider,
                         _import_elevenlabs,
                         _import_sounddevice,
                         stream_tts_to_speaker,
                     )
                     _tts_cfg = _load_tts_cfg()
-                    if _get_prov(_tts_cfg) == "elevenlabs":
-                        # Verify both ElevenLabs SDK and audio output are available
+                    if _get_tts_provider(_tts_cfg) == "elevenlabs":
                         _import_elevenlabs()
                         _import_sounddevice()
                         use_streaming_tts = True
@@ -10290,6 +10657,26 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             # by the Enter key binding (routed to the clarify response queue),
             # so we skip interrupt processing to avoid stealing that input.
             interrupt_msg = None
+            model_wait_notice_seconds = _resolve_cli_model_wait_notice_seconds(self.agent)
+            model_wait_notice_printed = False
+
+            def maybe_print_model_wait_notice():
+                nonlocal model_wait_notice_printed
+                if model_wait_notice_printed or self._prompt_start_time is None:
+                    return
+                elapsed = time.time() - self._prompt_start_time
+                if elapsed < model_wait_notice_seconds:
+                    return
+                model_wait_notice_printed = True
+                provider_label = getattr(self.agent, "provider", None) or "provider"
+                model_label = getattr(self.agent, "model", None) or "model"
+                _cprint(
+                    f"\n{_DIM}⚠ Still waiting for {provider_label}/{model_label} "
+                    f"after {int(elapsed)}s. If the provider is blocked or "
+                    f"rate-limited, Hermes will fail over once its timeout fires; "
+                    f"press Ctrl+C to interrupt now.{_RST}"
+                )
+
             while agent_thread.is_alive():
                 if hasattr(self, '_interrupt_queue'):
                     try:
@@ -10323,10 +10710,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         # StdoutProxy buffer only flushes on renderer passes
                         # triggered by input events — on macOS this causes
                         # the CLI to appear frozen until the user types. (#1624)
+                        maybe_print_model_wait_notice()
                         self._invalidate(min_interval=0.15)
                 else:
                     # Fallback for non-interactive mode (e.g., single-query)
                     agent_thread.join(0.1)
+                    maybe_print_model_wait_notice()
 
             # Wait for the agent thread to finish.  After an interrupt the
             # agent may take a few seconds to clean up (kill subprocess, persist
@@ -11119,6 +11508,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         self._voice_continuous = False  # Whether to auto-restart after agent responds
         self._voice_tts_done = threading.Event()  # Signals TTS playback finished
         self._voice_tts_done.set()  # Initially "done" (no TTS pending)
+        self._voice_wake_listener = None
+        self._voice_wake_enabled = False
+        self._voice_wake_state = "stopped"
+        self._voice_wake_last_score = 0.0
 
         if os.environ.get("HERMES_DEFER_AGENT_STARTUP") != "1":
             self._install_tool_callbacks()
@@ -11893,9 +12286,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 with cli_ref._voice_lock:
                     cli_ref._voice_continuous = True
 
-                # Dispatch to a daemon thread so play_beep(sd.wait),
-                # AudioRecorder.start(lock acquire), and config I/O
-                # never block the prompt_toolkit event loop.
+                # Dispatch to a daemon thread so AudioRecorder.start(lock acquire)
+                # and config I/O never block the prompt_toolkit event loop.
                 def _start_recording():
                     try:
                         cli_ref._voice_start_recording()
@@ -13025,6 +13417,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
                     # Regular chat - run agent
                     self._agent_running = True
+                    self._pause_voice_wake_listener("agent")
                     app.invalidate()  # Refresh status line
 
                     try:
@@ -13064,6 +13457,17 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                                 except Exception as e:
                                     _cprint(f"{_DIM}Voice auto-restart failed: {e}{_RST}")
                             threading.Thread(target=_restart_recording, daemon=True).start()
+                        elif getattr(self, "_voice_wake_enabled", False):
+                            def _resume_wake_listener():
+                                try:
+                                    if self._voice_tts:
+                                        self._voice_tts_done.wait(timeout=60)
+                                        time.sleep(0.3)
+                                    self._resume_voice_wake_listener()
+                                    app.invalidate()
+                                except Exception as e:
+                                    _cprint(f"{_DIM}Wake-word resume failed: {e}{_RST}")
+                            threading.Thread(target=_resume_wake_listener, daemon=True).start()
 
                         # Drain process notifications (completions + watch matches)
                         # that arrived while the agent was running.

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -155,7 +155,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
                cli_only=True, args_hint="[kaomoji|emoji|unicode|ascii]",
                subcommands=("kaomoji", "emoji", "unicode", "ascii")),
     CommandDef("voice", "Toggle voice mode", "Configuration",
-               args_hint="[on|off|tts|status]", subcommands=("on", "off", "tts", "status")),
+               args_hint="[on|off|tts|wake|status]", subcommands=("on", "off", "tts", "wake", "status")),
     CommandDef("busy", "Control what Enter does while Hermes is working", "Configuration",
                cli_only=True, args_hint="[queue|steer|interrupt|status]",
                subcommands=("queue", "steer", "interrupt", "status")),

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1695,6 +1695,27 @@ DEFAULT_CONFIG = {
         "beep_enabled": True,         # Play record start/stop beeps in CLI voice mode
         "silence_threshold": 200,     # RMS below this = silence (0-32767)
         "silence_duration": 3.0,      # Seconds of silence before auto-stop
+        "model_wait_notice_seconds": 0,  # 0 = derive from model/API stale-timeout settings
+        "wake": {
+            "provider": "openwakeword",
+            "phrase": "Hermes",
+            "model_path": "",
+            "threshold": 0.5,
+            "patience_frames": 2,
+            "vad_threshold": 0.25,
+            "pre_roll_ms": 1200,
+            "dialog_timeout_seconds": 45.0,
+            "max_utterance_seconds": 30.0,
+            "silence_threshold": 200,
+            "silence_duration": 3.0,
+            "frame_samples": 1280,
+            "training": {
+                "positive_samples": 50,
+                "negative_samples": 30,
+                "ambient_seconds": 60,
+                "command": "",
+            },
+        },
     },
     
     "human_delay": {

--- a/hermes_cli/voice.py
+++ b/hermes_cli/voice.py
@@ -245,16 +245,16 @@ def _debug(msg: str) -> None:
 
 
 def _beeps_enabled() -> bool:
-    """CLI parity: voice.beep_enabled in config.yaml (default True)."""
+    """CLI parity: voice.beep_enabled in config.yaml (default False)."""
     try:
         from hermes_cli.config import load_config
 
         voice_cfg = load_config().get("voice", {})
         if isinstance(voice_cfg, dict):
-            return bool(voice_cfg.get("beep_enabled", True))
+            return bool(voice_cfg.get("beep_enabled", False))
     except Exception:
         pass
-    return True
+    return False
 
 
 def _play_beep(frequency: int, count: int = 1) -> None:
@@ -741,9 +741,9 @@ def speak_text(text: str) -> None:
     """Synthesize ``text`` with the configured TTS provider and play it.
 
     Mirrors cli.py:_voice_speak_response exactly — same markdown strip
-    pipeline, same 4000-char cap, same explicit mp3 output path, same
-    MP3-over-OGG playback choice (afplay misbehaves on OGG), same cleanup
-    of both extensions. Keeping these in sync means a voice-mode TTS
+    pipeline, same 4000-char cap, same provider-aware local output path,
+    same returned-file playback, same cleanup of common generated extensions.
+    Keeping these in sync means a voice-mode TTS
     session in the TUI sounds identical to one in the classic CLI.
 
     While playback is in flight the module-level _tts_playing Event is
@@ -754,6 +754,7 @@ def speak_text(text: str) -> None:
     if not text or not text.strip():
         return
 
+    import json
     import re
     import tempfile
     import time
@@ -796,31 +797,49 @@ def speak_text(text: str) -> None:
         if not tts_text:
             return
 
-        # MP3 output path, pre-chosen so we can play the MP3 directly even
-        # when text_to_speech_tool auto-converts to OGG for messaging
-        # platforms.  afplay's OGG support is flaky, MP3 always works.
+        # Pick a local container the configured provider can write reliably,
+        # then honor the actual path returned by text_to_speech_tool.
         os.makedirs(os.path.join(tempfile.gettempdir(), "hermes_voice"), exist_ok=True)
-        mp3_path = os.path.join(
+        tts_provider = "edge"
+        try:
+            from tools.tts_tool import _get_provider, _load_tts_config
+
+            tts_provider = _get_provider(_load_tts_config())
+        except Exception:
+            pass
+        wav_providers = {"neutts", "kittentts", "gemini"}
+        ext = "wav" if tts_provider in wav_providers else "mp3"
+        audio_path = os.path.join(
             tempfile.gettempdir(),
             "hermes_voice",
-            f"tts_{time.strftime('%Y%m%d_%H%M%S')}.mp3",
+            f"tts_{time.strftime('%Y%m%d_%H%M%S')}.{ext}",
         )
 
-        _debug(f"speak_text: synthesizing {len(tts_text)} chars -> {mp3_path}")
-        text_to_speech_tool(text=tts_text, output_path=mp3_path)
+        _debug(f"speak_text: synthesizing {len(tts_text)} chars -> {audio_path}")
+        tts_result_raw = text_to_speech_tool(text=tts_text, output_path=audio_path)
+        play_path = audio_path
+        try:
+            tts_result = json.loads(tts_result_raw)
+            if tts_result.get("success") is False:
+                logger.warning("Voice TTS generation failed: %s", tts_result.get("error"))
+                return
+            if tts_result.get("file_path"):
+                play_path = str(tts_result["file_path"])
+        except Exception:
+            pass
 
-        if os.path.isfile(mp3_path) and os.path.getsize(mp3_path) > 0:
-            _debug(f"speak_text: playing {mp3_path} ({os.path.getsize(mp3_path)} bytes)")
-            play_audio_file(mp3_path)
+        if os.path.isfile(play_path) and os.path.getsize(play_path) > 0:
+            _debug(f"speak_text: playing {play_path} ({os.path.getsize(play_path)} bytes)")
+            play_audio_file(play_path)
             try:
-                os.unlink(mp3_path)
-                ogg_path = mp3_path.rsplit(".", 1)[0] + ".ogg"
-                if os.path.isfile(ogg_path):
-                    os.unlink(ogg_path)
+                base = audio_path.rsplit(".", 1)[0]
+                for candidate in {audio_path, play_path, f"{base}.ogg", f"{base}.mp3", f"{base}.wav"}:
+                    if os.path.isfile(candidate):
+                        os.unlink(candidate)
             except OSError:
                 pass
         else:
-            _debug(f"speak_text: TTS tool produced no audio at {mp3_path}")
+            _debug(f"speak_text: TTS tool produced no audio at {play_path}")
     except Exception as e:
         logger.warning("Voice TTS playback failed: %s", e)
         _debug(f"speak_text raised {type(e).__name__}: {e}")

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3597,6 +3597,17 @@ def test_commands_catalog_includes_tui_mouse_command():
     assert "/mouse" in tui_pairs
 
 
+def test_commands_catalog_includes_voice_wake_subcommand():
+    resp = server.handle_request(
+        {"id": "1", "method": "commands.catalog", "params": {}}
+    )
+
+    pairs = dict(resp["result"]["pairs"])
+
+    assert "/voice" in pairs
+    assert "/voice [on|off|tts|wake|status]" in pairs["/voice"]
+
+
 def test_commands_catalog_filters_gateway_only_commands_and_keeps_status_visible():
     resp = server.handle_request(
         {"id": "1", "method": "commands.catalog", "params": {}}

--- a/tests/tools/test_voice_cli_integration.py
+++ b/tests/tools/test_voice_cli_integration.py
@@ -29,6 +29,10 @@ def _make_voice_cli(**overrides):
     cli._voice_continuous = False
     cli._voice_tts_done = threading.Event()
     cli._voice_tts_done.set()
+    cli._voice_wake_listener = None
+    cli._voice_wake_enabled = False
+    cli._voice_wake_state = "stopped"
+    cli._voice_wake_last_score = 0.0
     cli._pending_input = queue.Queue()
     cli._app = None
     cli._attached_images = []
@@ -121,6 +125,36 @@ class TestMarkdownStripping:
         assert "Answer" in result
         assert "Good luck!" in result
         assert "docs" in result
+
+
+# ============================================================================
+# Model wait notice
+# ============================================================================
+
+class TestModelWaitNotice:
+    def test_uses_config_override(self, monkeypatch):
+        from cli import _resolve_cli_model_wait_notice_seconds
+        import hermes_cli.config as config
+
+        monkeypatch.setattr(
+            config,
+            "load_config",
+            lambda: {"voice": {"model_wait_notice_seconds": 7}},
+        )
+
+        assert _resolve_cli_model_wait_notice_seconds(object()) == 7.0
+
+    def test_uses_stream_stale_timeout_when_available(self, monkeypatch):
+        from cli import _resolve_cli_model_wait_notice_seconds
+        import hermes_cli.config as config
+
+        monkeypatch.setattr(config, "load_config", lambda: {"voice": {}})
+
+        class Agent:
+            def _compute_stream_stale_timeout(self, messages):
+                return 12.0
+
+        assert _resolve_cli_model_wait_notice_seconds(Agent()) == 12.0
 
 
 # ============================================================================
@@ -811,6 +845,7 @@ class TestHandleVoiceCommandReal:
         cli._disable_voice_mode = MagicMock()
         cli._toggle_voice_tts = MagicMock()
         cli._show_voice_status = MagicMock()
+        cli._handle_voice_wake_command = MagicMock()
         return cli
 
     @patch("cli._cprint")
@@ -838,6 +873,12 @@ class TestHandleVoiceCommandReal:
         cli._show_voice_status.assert_called_once()
 
     @patch("cli._cprint")
+    def test_wake_subcommands_call_wake_handler(self, _cp):
+        cli = self._cli()
+        cli._handle_voice_command('/voice wake train --phrase "Гермес"')
+        cli._handle_voice_wake_command.assert_called_once_with('wake train --phrase "Гермес"')
+
+    @patch("cli._cprint")
     def test_toggle_off_when_enabled(self, _cp):
         cli = self._cli()
         cli._voice_mode = True
@@ -860,6 +901,54 @@ class TestHandleVoiceCommandReal:
         # Should print usage via _cprint
         assert any("Unknown" in str(c) or "unknown" in str(c)
                     for c in mock_cp.call_args_list)
+
+
+class TestVoiceWakeCommandReal:
+    """Tests classic CLI wake-word command helpers."""
+
+    @patch("cli._cprint")
+    @patch("tools.wake_word.check_wake_requirements",
+           return_value={"available": False, "details": "Wake model: MISSING"})
+    def test_wake_on_requires_model(self, _req, _cp):
+        cli = _make_voice_cli(_voice_mode=True)
+        cli._start_voice_wake_mode()
+        assert cli._voice_wake_enabled is False
+
+    @patch("cli._cprint")
+    @patch("tools.wake_word.WakeWordListener")
+    @patch("tools.wake_word.check_wake_requirements",
+           return_value={"available": True, "details": "OK"})
+    @patch("tools.wake_word.load_wake_config")
+    def test_wake_on_starts_listener(self, mock_cfg, _req, mock_listener_cls, _cp):
+        mock_cfg.return_value = SimpleNamespace(phrase="Гермес", model_path="/tmp/hermes.onnx", threshold=0.5)
+        listener = MagicMock()
+        mock_listener_cls.return_value = listener
+        cli = _make_voice_cli(_voice_mode=True)
+
+        cli._start_voice_wake_mode()
+
+        listener.start.assert_called_once()
+        assert cli._voice_wake_enabled is True
+
+    @patch("cli._cprint")
+    def test_wake_off_stops_listener(self, _cp):
+        listener = MagicMock()
+        cli = _make_voice_cli(_voice_mode=True, _voice_wake_listener=listener, _voice_wake_enabled=True)
+        cli._stop_voice_wake_mode()
+        listener.stop.assert_called_once()
+        assert cli._voice_wake_enabled is False
+
+    def test_manual_recording_pauses_wake_listener(self):
+        listener = MagicMock()
+        cli = _make_voice_cli(_voice_wake_listener=listener, _voice_wake_enabled=True)
+        cli._pause_voice_wake_listener("manual")
+        listener.pause.assert_called_once_with("manual")
+
+    def test_manual_recording_resumes_wake_listener(self):
+        listener = MagicMock()
+        cli = _make_voice_cli(_voice_wake_listener=listener, _voice_wake_enabled=True)
+        cli._resume_voice_wake_listener()
+        listener.resume.assert_called_once()
 
 
 class TestEnableVoiceModeReal:
@@ -941,12 +1030,33 @@ class TestVoiceBeepConfigReal:
     @patch("hermes_cli.config.load_config", return_value={"voice": {}})
     def test_beeps_enabled_by_default(self, _cfg):
         cli = _make_voice_cli()
-        assert cli._voice_beeps_enabled() is True
+        assert cli._voice_beeps_enabled() is False
 
     @patch("hermes_cli.config.load_config", return_value={"voice": {"beep_enabled": False}})
     def test_beeps_can_be_disabled(self, _cfg):
         cli = _make_voice_cli()
         assert cli._voice_beeps_enabled() is False
+
+    @patch("hermes_cli.config.load_config", return_value={"voice": {}})
+    def test_tool_beeps_disabled_by_default(self, _cfg):
+        cli = _make_voice_cli()
+        assert cli._voice_tool_beeps_enabled() is False
+
+    @patch(
+        "hermes_cli.config.load_config",
+        return_value={"voice": {"beep_enabled": True, "tool_beep_enabled": True}},
+    )
+    def test_tool_beeps_can_be_enabled(self, _cfg):
+        cli = _make_voice_cli()
+        assert cli._voice_tool_beeps_enabled() is True
+
+    @patch(
+        "hermes_cli.config.load_config",
+        return_value={"voice": {"beep_enabled": False, "tool_beep_enabled": True}},
+    )
+    def test_tool_beeps_follow_global_beep_toggle(self, _cfg):
+        cli = _make_voice_cli()
+        assert cli._voice_tool_beeps_enabled() is False
 
     @patch("cli._cprint")
     @patch("cli.threading.Thread")
@@ -973,6 +1083,44 @@ class TestVoiceBeepConfigReal:
         },
     )
     def test_start_recording_skips_beep_when_disabled(
+        self, _cfg, _req, mock_create, mock_beep, mock_thread, _cp
+    ):
+        recorder = MagicMock()
+        recorder.supports_silence_autostop = True
+        mock_create.return_value = recorder
+        mock_thread.return_value = MagicMock(start=MagicMock())
+
+        cli = _make_voice_cli()
+        cli._voice_start_recording()
+
+        recorder.start.assert_called_once()
+        mock_beep.assert_not_called()
+
+    @patch("cli._cprint")
+    @patch("cli.threading.Thread")
+    @patch("tools.voice_mode.play_beep")
+    @patch("tools.voice_mode.create_audio_recorder")
+    @patch(
+        "tools.voice_mode.check_voice_requirements",
+        return_value={
+            "available": True,
+            "audio_available": True,
+            "stt_available": True,
+            "details": "OK",
+            "missing_packages": [],
+        },
+    )
+    @patch(
+        "hermes_cli.config.load_config",
+        return_value={
+            "voice": {
+                "beep_enabled": True,
+                "silence_threshold": 200,
+                "silence_duration": 3.0,
+            }
+        },
+    )
+    def test_start_recording_skips_beep_even_when_config_enabled(
         self, _cfg, _req, mock_create, mock_beep, mock_thread, _cp
     ):
         recorder = MagicMock()
@@ -1131,44 +1279,6 @@ class TestVoiceSpeakResponseReal:
         cli = _make_voice_cli(_voice_tts=True)
         cli._voice_speak_response("Hello world")
         mock_play.assert_called_once()
-
-
-class TestVoiceStopAndTranscribeReal:
-    """Tests _voice_stop_and_transcribe with real CLI instance."""
-
-    @patch("cli._cprint")
-    def test_guard_not_recording(self, _cp):
-        cli = _make_voice_cli(_voice_recording=False)
-        with patch("tools.voice_mode.transcribe_recording") as mock_tr:
-            cli._voice_stop_and_transcribe()
-            mock_tr.assert_not_called()
-
-    @patch("cli._cprint")
-    def test_no_recorder_returns_early(self, _cp):
-        cli = _make_voice_cli(_voice_recording=True, _voice_recorder=None)
-        with patch("tools.voice_mode.transcribe_recording") as mock_tr:
-            cli._voice_stop_and_transcribe()
-            mock_tr.assert_not_called()
-        assert cli._voice_recording is False
-
-    @patch("cli._cprint")
-    @patch("tools.voice_mode.play_beep")
-    def test_no_speech_detected(self, _beep, _cp):
-        recorder = MagicMock()
-        recorder.stop.return_value = None
-        cli = _make_voice_cli(_voice_recording=True, _voice_recorder=recorder)
-        cli._voice_stop_and_transcribe()
-        assert cli._pending_input.empty()
-
-    @patch("cli._cprint")
-    @patch("hermes_cli.config.load_config", return_value={"voice": {"beep_enabled": False}})
-    @patch("tools.voice_mode.play_beep")
-    def test_no_speech_detected_skips_beep_when_disabled(self, mock_beep, _cfg, _cp):
-        recorder = MagicMock()
-        recorder.stop.return_value = None
-        cli = _make_voice_cli(_voice_recording=True, _voice_recorder=recorder)
-        cli._voice_stop_and_transcribe()
-        mock_beep.assert_not_called()
 
     @patch("cli._cprint")
     @patch("cli.os.unlink")

--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -894,6 +894,7 @@ class TestPlayAudioFile:
             return mock_sd_obj, np
 
         monkeypatch.setattr("tools.voice_mode._import_audio", _fake_import)
+        monkeypatch.setattr("platform.system", lambda: "Linux")
 
         from tools.voice_mode import play_audio_file
 
@@ -902,6 +903,27 @@ class TestPlayAudioFile:
         assert result is True
         mock_sd_obj.play.assert_called_once()
         mock_sd_obj.stop.assert_called_once()
+
+    def test_play_wav_prefers_afplay_on_macos(self, monkeypatch, sample_wav):
+        def _fail_if_called():
+            raise AssertionError("macOS WAV playback should prefer afplay")
+
+        mock_proc = MagicMock()
+        mock_proc.wait.return_value = 0
+        mock_proc.returncode = 0
+        mock_popen = MagicMock(return_value=mock_proc)
+
+        monkeypatch.setattr("tools.voice_mode._import_audio", _fail_if_called)
+        monkeypatch.setattr("platform.system", lambda: "Darwin")
+        monkeypatch.setattr("shutil.which", lambda cmd: "/usr/bin/afplay" if cmd == "afplay" else None)
+        monkeypatch.setattr("subprocess.Popen", mock_popen)
+
+        from tools.voice_mode import play_audio_file
+
+        result = play_audio_file(sample_wav)
+
+        assert result is True
+        mock_popen.assert_called_once_with(["afplay", sample_wav])
 
     def test_returns_false_when_no_player(self, monkeypatch, sample_wav):
         def _fail_import():
@@ -1416,6 +1438,7 @@ class TestConfigurableSilenceParams:
 class TestSubprocessTimeoutKill:
     """Bug: proc.wait(timeout) raised TimeoutExpired but process was not killed."""
 
+    @pytest.mark.live_system_guard_bypass
     def test_timeout_kills_process(self):
         import subprocess
         proc = subprocess.Popen(["sleep", "600"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)

--- a/tests/tools/test_wake_word.py
+++ b/tests/tools/test_wake_word.py
@@ -1,0 +1,459 @@
+"""Wake-word voice mode tests."""
+
+import json
+import sys
+import types
+from pathlib import Path
+
+
+def _frame(value: int = 0, samples: int = 1280):
+    import numpy as np
+
+    return (np.ones((samples, 1), dtype=np.int16) * value)
+
+
+class _FakeOpenWakeWordModel:
+    def __init__(self, scores):
+        self._scores = list(scores)
+        self.calls = 0
+
+    def predict(self, frame, **kwargs):
+        self.calls += 1
+        score = self._scores.pop(0) if self._scores else 0.0
+        return {"hermes": score}
+
+
+def _install_fake_openwakeword(monkeypatch, tmp_path: Path, *, model_cls=None):
+    pkg_dir = tmp_path / "openwakeword"
+    pkg_dir.mkdir(exist_ok=True)
+    (pkg_dir / "__init__.py").write_text("", encoding="utf-8")
+
+    fake_openwakeword = types.SimpleNamespace(
+        __file__=str(pkg_dir / "__init__.py"),
+        MODELS={
+            "hey_jarvis": {
+                "model_path": str(pkg_dir / "resources" / "models" / "hey_jarvis_v0.1.tflite"),
+                "download_url": "https://example.test/hey_jarvis_v0.1.tflite",
+            }
+        },
+        FEATURE_MODELS={
+            "melspectrogram": {
+                "model_path": str(pkg_dir / "resources" / "models" / "melspectrogram.tflite"),
+                "download_url": "https://example.test/melspectrogram.tflite",
+            },
+            "embedding": {
+                "model_path": str(pkg_dir / "resources" / "models" / "embedding_model.tflite"),
+                "download_url": "https://example.test/embedding_model.tflite",
+            },
+        },
+    )
+    monkeypatch.setitem(sys.modules, "openwakeword", fake_openwakeword)
+    if model_cls is not None:
+        monkeypatch.setitem(sys.modules, "openwakeword.model", types.SimpleNamespace(Model=model_cls))
+    return fake_openwakeword
+
+
+def test_load_wake_config_defaults():
+    from tools.wake_word import FRAME_SAMPLES, WAKE_MIN_SILENCE_DURATION_SECONDS, load_wake_config
+
+    cfg = load_wake_config({"voice": {}})
+
+    assert cfg.provider == "openwakeword"
+    assert cfg.threshold == 0.5
+    assert cfg.patience_frames == 2
+    assert cfg.vad_threshold == 0.25
+    assert cfg.pre_roll_ms == 1200
+    assert cfg.dialog_timeout_seconds == 45.0
+    assert cfg.max_utterance_seconds == 30.0
+    assert cfg.silence_duration == WAKE_MIN_SILENCE_DURATION_SECONDS
+    assert cfg.frame_samples == FRAME_SAMPLES
+    assert cfg.training.positive_samples == 50
+    assert cfg.training.negative_samples == 30
+    assert cfg.training.ambient_seconds == 60
+    assert cfg.training.command == ""
+
+
+def test_load_wake_config_reads_training_command():
+    from tools.wake_word import load_wake_config
+
+    cfg = load_wake_config(
+        {
+            "voice": {
+                "wake": {
+                    "training": {
+                        "command": "python train_wake.py",
+                    },
+                },
+            },
+        }
+    )
+
+    assert cfg.training.command == "python train_wake.py"
+
+
+def test_load_wake_config_clamps_short_silence_duration():
+    from tools.wake_word import WAKE_MIN_SILENCE_DURATION_SECONDS, load_wake_config
+
+    cfg = load_wake_config({"voice": {"wake": {"silence_duration": 1.2}}})
+
+    assert cfg.silence_duration == WAKE_MIN_SILENCE_DURATION_SECONDS
+
+
+def test_load_wake_config_uses_voice_threshold_for_wake_recording():
+    from tools.wake_word import load_wake_config
+
+    cfg = load_wake_config(
+        {
+            "voice": {
+                "silence_threshold": 200,
+                "wake": {"silence_threshold": 700},
+            }
+        }
+    )
+
+    assert cfg.silence_threshold == 200
+
+
+def test_detector_triggers_only_after_patience_frames():
+    from tools.wake_word import OpenWakeWordDetector, load_wake_config
+
+    fake_model = _FakeOpenWakeWordModel([0.7, 0.8])
+    cfg = load_wake_config(
+        {
+            "voice": {
+                "wake": {
+                    "model_path": "/tmp/hermes.onnx",
+                    "threshold": 0.5,
+                    "patience_frames": 2,
+                }
+            }
+        }
+    )
+    detector = OpenWakeWordDetector(cfg, model_factory=lambda _cfg: fake_model)
+
+    assert detector.process_frame(_frame()) is False
+    assert detector.last_score == 0.7
+    assert detector.process_frame(_frame()) is True
+    assert detector.last_score == 0.8
+
+
+def test_default_model_factory_uses_sibling_onnx_assets(tmp_path: Path, monkeypatch):
+    from tools import wake_word
+
+    model_path = tmp_path / "hey_jarvis_v0.1.onnx"
+    melspec_path = tmp_path / "melspectrogram.onnx"
+    embedding_path = tmp_path / "embedding_model.onnx"
+    model_path.write_bytes(b"wake")
+    melspec_path.write_bytes(b"melspec")
+    embedding_path.write_bytes(b"embedding")
+
+    pkg_dir = tmp_path / "openwakeword"
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text("", encoding="utf-8")
+    fake_openwakeword = types.SimpleNamespace(__file__=str(pkg_dir / "__init__.py"))
+    captured: dict = {}
+
+    class FakeModel:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setitem(sys.modules, "openwakeword", fake_openwakeword)
+    monkeypatch.setitem(sys.modules, "openwakeword.model", types.SimpleNamespace(Model=FakeModel))
+
+    cfg = wake_word.load_wake_config(
+        {"voice": {"wake": {"model_path": str(model_path), "vad_threshold": 0.25}}}
+    )
+    wake_word._default_model_factory(cfg)
+
+    assert captured["wakeword_models"] == [str(model_path)]
+    assert captured["inference_framework"] == "onnx"
+    assert captured["melspec_model_path"] == str(melspec_path)
+    assert captured["embedding_model_path"] == str(embedding_path)
+    assert captured["vad_threshold"] == 0.0
+
+
+def test_resolve_wake_model_path_uses_cached_pretrained_for_stale_temp_path(tmp_path: Path, monkeypatch):
+    from tools import wake_word
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _install_fake_openwakeword(monkeypatch, tmp_path)
+    cache_dir = tmp_path / ".hermes" / "wake_words" / "openwakeword" / "v0.5.1" / "onnx"
+    cache_dir.mkdir(parents=True)
+    cached_model = cache_dir / "hey_jarvis_v0.1.onnx"
+    cached_model.write_bytes(b"wake")
+    (cache_dir / "melspectrogram.onnx").write_bytes(b"melspec")
+    (cache_dir / "embedding_model.onnx").write_bytes(b"embedding")
+
+    cfg = wake_word.load_wake_config(
+        {
+            "voice": {
+                "wake": {
+                    "phrase": "hey jarvis",
+                    "model_path": "/tmp/hermes_wake_models/hey_jarvis_v0.1.onnx",
+                }
+            }
+        }
+    )
+
+    assert wake_word.resolve_wake_model_path(cfg) == cached_model
+
+
+def test_check_wake_requirements_downloads_known_pretrained_model(tmp_path: Path, monkeypatch):
+    from tools import wake_word
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _install_fake_openwakeword(monkeypatch, tmp_path)
+    monkeypatch.setattr(wake_word, "_audio_available", lambda: True)
+    monkeypatch.setattr(wake_word, "_openwakeword_model_available", lambda: True)
+
+    downloaded: list[str] = []
+
+    def fake_download(url: str, target_path: Path) -> None:
+        downloaded.append(url)
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        target_path.write_bytes(b"asset")
+
+    monkeypatch.setattr(wake_word, "_download_file", fake_download)
+    cfg = wake_word.load_wake_config(
+        {
+            "voice": {
+                "wake": {
+                    "phrase": "hey jarvis",
+                    "model_path": "/tmp/hermes_wake_models/hey_jarvis_v0.1.onnx",
+                }
+            }
+        }
+    )
+
+    result = wake_word.check_wake_requirements(cfg, download_missing=True)
+
+    assert result["available"] is True
+    assert result["model_available"] is True
+    assert result["resolved_model_path"].endswith("/hey_jarvis_v0.1.onnx")
+    assert downloaded == [
+        "https://example.test/hey_jarvis_v0.1.onnx",
+        "https://example.test/melspectrogram.onnx",
+        "https://example.test/embedding_model.onnx",
+    ]
+
+
+def test_default_model_factory_uses_cached_feature_assets_for_custom_onnx(tmp_path: Path, monkeypatch):
+    from tools import wake_word
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    model_path = tmp_path / "custom.onnx"
+    model_path.write_bytes(b"wake")
+    cache_dir = tmp_path / ".hermes" / "wake_words" / "openwakeword" / "v0.5.1" / "onnx"
+    cache_dir.mkdir(parents=True)
+    melspec_path = cache_dir / "melspectrogram.onnx"
+    embedding_path = cache_dir / "embedding_model.onnx"
+    melspec_path.write_bytes(b"melspec")
+    embedding_path.write_bytes(b"embedding")
+
+    captured: dict = {}
+
+    class FakeModel:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    _install_fake_openwakeword(monkeypatch, tmp_path, model_cls=FakeModel)
+    cfg = wake_word.load_wake_config({"voice": {"wake": {"model_path": str(model_path)}}})
+
+    wake_word._default_model_factory(cfg)
+
+    assert captured["wakeword_models"] == [str(model_path)]
+    assert captured["inference_framework"] == "onnx"
+    assert captured["melspec_model_path"] == str(melspec_path)
+    assert captured["embedding_model_path"] == str(embedding_path)
+
+
+def test_listener_keeps_pre_roll_when_wake_detects():
+    from tools.wake_word import WakeWordListener, load_wake_config
+
+    fake_model = _FakeOpenWakeWordModel([0.0, 0.0, 0.9])
+    cfg = load_wake_config(
+        {
+            "voice": {
+                "wake": {
+                    "model_path": "/tmp/hermes.onnx",
+                    "threshold": 0.5,
+                    "patience_frames": 1,
+                    "pre_roll_ms": 240,
+                }
+            }
+        }
+    )
+    listener = WakeWordListener(
+        cfg,
+        on_transcript=lambda _text: None,
+        model_factory=lambda _cfg: fake_model,
+        async_transcribe=False,
+    )
+
+    listener.process_frame(_frame(10))
+    listener.process_frame(_frame(20))
+    listener.process_frame(_frame(300))
+
+    assert listener.state == "recording"
+    assert [int(frame[0][0]) for frame in listener.recording_frames] == [10, 20, 300]
+
+
+def test_listener_dialog_timeout_returns_to_passive():
+    from tools.wake_word import WakeWordListener, load_wake_config
+
+    now = [100.0]
+    cfg = load_wake_config(
+        {"voice": {"wake": {"model_path": "/tmp/hermes.onnx", "dialog_timeout_seconds": 45}}}
+    )
+    listener = WakeWordListener(
+        cfg,
+        on_transcript=lambda _text: None,
+        model_factory=lambda _cfg: _FakeOpenWakeWordModel([0.0]),
+        time_fn=lambda: now[0],
+    )
+
+    listener.enter_dialog()
+    assert listener.state == "dialog"
+    now[0] += 46.0
+    listener.process_frame(_frame())
+
+    assert listener.state == "passive"
+
+
+def test_listener_pause_prevents_detection_until_resume():
+    from tools.wake_word import WakeWordListener, load_wake_config
+
+    fake_model = _FakeOpenWakeWordModel([0.95])
+    cfg = load_wake_config(
+        {"voice": {"wake": {"model_path": "/tmp/hermes.onnx", "threshold": 0.5}}}
+    )
+    listener = WakeWordListener(
+        cfg,
+        on_transcript=lambda _text: None,
+        model_factory=lambda _cfg: fake_model,
+    )
+
+    listener.pause("tts")
+    listener.process_frame(_frame(400))
+    assert fake_model.calls == 0
+    assert listener.state == "paused"
+
+    listener.resume()
+    listener.process_frame(_frame(400))
+    assert fake_model.calls == 1
+
+
+def test_listener_keeps_recording_through_short_pause():
+    from tools.wake_word import WakeWordListener, load_wake_config
+
+    now = [100.0]
+    cfg = load_wake_config(
+        {
+            "voice": {
+                "wake": {
+                    "model_path": "/tmp/hermes.onnx",
+                    "silence_duration": 1.2,
+                    "silence_threshold": 100,
+                }
+            }
+        }
+    )
+    listener = WakeWordListener(
+        cfg,
+        on_transcript=lambda _text: None,
+        model_factory=lambda _cfg: _FakeOpenWakeWordModel([0.0]),
+        time_fn=lambda: now[0],
+    )
+
+    with listener._lock:
+        listener._recording_started_at = now[0]
+        listener._last_speech_at = now[0]
+        listener._has_speech = True
+
+    now[0] += 1.3
+    assert listener._finish_reason_locked() == ""
+
+    now[0] += 1.6
+    assert listener._finish_reason_locked() == ""
+
+    now[0] += 0.2
+    assert listener._finish_reason_locked() == "silence"
+
+
+def test_strip_wake_phrase_from_transcript():
+    from tools.wake_word import strip_wake_phrase
+
+    assert strip_wake_phrase("Гермес, сколько времени?", "Гермес") == "сколько времени?"
+    assert strip_wake_phrase("гермес сделай заметку", "Гермес") == "сделай заметку"
+    assert strip_wake_phrase("Без ключевого слова", "Гермес") == "Без ключевого слова"
+
+
+def test_trainer_writes_model_metadata_and_config_update(tmp_path: Path):
+    from tools.wake_word import WakeWordTrainer, load_wake_config
+
+    def collect_samples(config, dataset_dir):
+        positive = []
+        negative = []
+        ambient = []
+        for bucket, count, target in (
+            ("positive", config.training.positive_samples, positive),
+            ("negative", config.training.negative_samples, negative),
+            ("ambient", 1, ambient),
+        ):
+            bucket_dir = dataset_dir / bucket
+            bucket_dir.mkdir(parents=True, exist_ok=True)
+            for idx in range(count):
+                sample_path = bucket_dir / f"{idx}.wav"
+                sample_path.write_bytes(b"RIFFsample")
+                target.append(sample_path)
+        return {"positive": positive, "negative": negative, "ambient": ambient}
+
+    def train_backend(config, dataset_dir, output_path):
+        output_path.write_bytes(b"onnx-model")
+
+    cfg = load_wake_config(
+        {"voice": {"wake": {"phrase": "Гермес", "training": {"positive_samples": 2, "negative_samples": 1}}}}
+    )
+    trainer = WakeWordTrainer(
+        cfg,
+        output_root=tmp_path,
+        sample_collector=collect_samples,
+        training_backend=train_backend,
+    )
+
+    result = trainer.train()
+
+    model_path = Path(result["model_path"])
+    metadata_path = model_path.parent / "metadata.json"
+    assert model_path.exists()
+    assert json.loads(metadata_path.read_text())["phrase"] == "Гермес"
+    assert result["config_update"]["voice.wake.model_path"] == str(model_path)
+    assert result["counts"]["positive"] == 2
+    assert result["counts"]["negative"] == 1
+
+
+def test_trainer_command_backend_uses_configured_command(tmp_path: Path, monkeypatch):
+    from tools import wake_word
+
+    captured = {}
+
+    def fake_run(command, *, env, cwd, **kwargs):
+        captured.update({"command": command, "env": env, "cwd": cwd, "kwargs": kwargs})
+        Path(env["HERMES_WAKE_OUTPUT_PATH"]).write_bytes(b"onnx-model")
+        return types.SimpleNamespace(returncode=0, stderr="", stdout="")
+
+    monkeypatch.setattr(wake_word.subprocess, "run", fake_run)
+    cfg = wake_word.load_wake_config(
+        {"voice": {"wake": {"phrase": "Hermes", "training": {"command": "python train_wake.py"}}}}
+    )
+    dataset_dir = tmp_path / "dataset"
+    dataset_dir.mkdir()
+    output_path = tmp_path / "model.onnx"
+
+    wake_word.WakeWordTrainer(cfg)._run_training_command_backend(cfg, dataset_dir, output_path)
+
+    assert captured["command"] == "python train_wake.py"
+    assert captured["cwd"] == str(tmp_path)
+    assert captured["env"]["HERMES_WAKE_PHRASE"] == "Hermes"
+    assert captured["env"]["HERMES_WAKE_DATASET_DIR"] == str(dataset_dir)
+    assert captured["env"]["HERMES_WAKE_OUTPUT_PATH"] == str(output_path)

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -1059,6 +1059,28 @@ def play_audio_file(file_path: str) -> bool:
         logger.warning("Audio file not found: %s", file_path)
         return False
 
+    # On macOS, CoreAudio's afplay is more reliable for generated WAV files
+    # than PortAudio/sounddevice on some default output devices.
+    if file_path.endswith(".wav") and platform.system() == "Darwin" and shutil.which("afplay"):
+        try:
+            proc = subprocess.Popen(["afplay", file_path])
+            with _playback_lock:
+                _active_playback = proc
+            proc.wait(timeout=300)
+            with _playback_lock:
+                _active_playback = None
+            return proc.returncode == 0
+        except subprocess.TimeoutExpired:
+            logger.warning("System player afplay timed out, killing process")
+            proc.kill()
+            proc.wait()
+            with _playback_lock:
+                _active_playback = None
+        except Exception as e:
+            logger.debug("System player afplay failed: %s", e)
+            with _playback_lock:
+                _active_playback = None
+
     # Try sounddevice for WAV files
     if file_path.endswith(".wav"):
         try:
@@ -1163,10 +1185,19 @@ def check_voice_requirements() -> Dict[str, Any]:
         details_parts.append("STT provider: OK (Groq)")
     elif stt_provider == "openai":
         details_parts.append("STT provider: OK (OpenAI)")
+    elif stt_provider == "whisper_http":
+        details_parts.append("STT provider: OK (Whisper HTTP)")
+    elif stt_provider == "local_command":
+        details_parts.append("STT provider: OK (local command)")
+    elif stt_provider == "mistral":
+        details_parts.append("STT provider: OK (Mistral)")
+    elif stt_provider == "xai":
+        details_parts.append("STT provider: OK (xAI)")
     else:
         details_parts.append(
             "STT provider: MISSING (uv pip install faster-whisper — "
             "`pip install faster-whisper` also works if pip is on PATH, "
+            "set HERMES_LOCAL_STT_COMMAND, configure whisper_http, "
             "or set GROQ_API_KEY / VOICE_TOOLS_OPENAI_KEY)"
         )
 

--- a/tools/wake_word.py
+++ b/tools/wake_word.py
@@ -1,0 +1,1067 @@
+"""Wake-word runtime for Hermes CLI voice mode.
+
+This module intentionally stays thin around the existing voice pipeline:
+it only listens for a local wake-word model, records one WAV utterance with
+pre-roll, and delegates transcription to ``tools.voice_mode``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import urllib.request
+from collections import deque
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional
+
+from hermes_constants import get_hermes_home
+from tools.voice_mode import (
+    CHANNELS,
+    DTYPE,
+    SAMPLE_RATE,
+    SILENCE_DURATION_SECONDS,
+    SILENCE_RMS_THRESHOLD,
+    AudioRecorder,
+    _audio_available,
+    _import_audio,
+)
+
+logger = logging.getLogger(__name__)
+
+FRAME_SAMPLES = 1280
+FRAME_MS = int(FRAME_SAMPLES / SAMPLE_RATE * 1000)
+OPENWAKEWORD_RELEASE_TAG = "v0.5.1"
+OPENWAKEWORD_DEFAULT_FRAMEWORK = "onnx"
+WAKE_MIN_SILENCE_DURATION_SECONDS = 3.0
+
+
+@dataclass
+class WakeTrainingConfig:
+    positive_samples: int = 50
+    negative_samples: int = 30
+    ambient_seconds: int = 60
+    command: str = ""
+
+
+@dataclass
+class WakeWordConfig:
+    provider: str = "openwakeword"
+    phrase: str = "Hermes"
+    model_path: str = ""
+    threshold: float = 0.5
+    patience_frames: int = 2
+    vad_threshold: float = 0.25
+    pre_roll_ms: int = 1200
+    dialog_timeout_seconds: float = 45.0
+    max_utterance_seconds: float = 30.0
+    silence_threshold: int = SILENCE_RMS_THRESHOLD
+    silence_duration: float = SILENCE_DURATION_SECONDS
+    frame_samples: int = FRAME_SAMPLES
+    training: WakeTrainingConfig = field(default_factory=WakeTrainingConfig)
+
+    @property
+    def pre_roll_frames(self) -> int:
+        return max(1, math.ceil(self.pre_roll_ms / FRAME_MS))
+
+
+def _as_dict(value: Any) -> dict:
+    return value if isinstance(value, dict) else {}
+
+
+def _float_value(raw: dict, key: str, default: float) -> float:
+    try:
+        return float(raw.get(key, default))
+    except (TypeError, ValueError):
+        return default
+
+
+def _int_value(raw: dict, key: str, default: int) -> int:
+    try:
+        return int(raw.get(key, default))
+    except (TypeError, ValueError):
+        return default
+
+
+def load_wake_config(config: Optional[dict] = None) -> WakeWordConfig:
+    """Load ``voice.wake`` from the Hermes config with safe defaults."""
+    if config is None:
+        try:
+            from hermes_cli.config import load_config
+
+            config = load_config()
+        except Exception:
+            config = {}
+
+    voice_cfg = _as_dict(_as_dict(config).get("voice"))
+    wake_cfg = _as_dict(voice_cfg.get("wake"))
+    training_cfg = _as_dict(wake_cfg.get("training"))
+    voice_silence_duration = _float_value(voice_cfg, "silence_duration", SILENCE_DURATION_SECONDS)
+    wake_silence_duration = _float_value(wake_cfg, "silence_duration", voice_silence_duration)
+    voice_silence_threshold = max(
+        0,
+        _int_value(voice_cfg, "silence_threshold", SILENCE_RMS_THRESHOLD),
+    )
+    wake_silence_threshold = max(
+        0,
+        _int_value(wake_cfg, "silence_threshold", voice_silence_threshold),
+    )
+    # Dialog/wake recording is still normal voice capture after the wake event.
+    # A stale or overly high wake-specific threshold can make resumed dialog
+    # mode look ready while quiet speech never starts/extends recording.
+    effective_silence_threshold = min(wake_silence_threshold, voice_silence_threshold)
+
+    return WakeWordConfig(
+        provider=str(wake_cfg.get("provider", "openwakeword") or "openwakeword"),
+        phrase=str(wake_cfg.get("phrase", "Hermes") or "Hermes"),
+        model_path=str(wake_cfg.get("model_path", "") or ""),
+        threshold=_float_value(wake_cfg, "threshold", 0.5),
+        patience_frames=max(1, _int_value(wake_cfg, "patience_frames", 2)),
+        vad_threshold=_float_value(wake_cfg, "vad_threshold", 0.25),
+        pre_roll_ms=max(0, _int_value(wake_cfg, "pre_roll_ms", 1200)),
+        dialog_timeout_seconds=max(1.0, _float_value(wake_cfg, "dialog_timeout_seconds", 45.0)),
+        max_utterance_seconds=max(1.0, _float_value(wake_cfg, "max_utterance_seconds", 30.0)),
+        silence_threshold=effective_silence_threshold,
+        silence_duration=max(WAKE_MIN_SILENCE_DURATION_SECONDS, wake_silence_duration),
+        frame_samples=max(160, _int_value(wake_cfg, "frame_samples", FRAME_SAMPLES)),
+        training=WakeTrainingConfig(
+            positive_samples=max(1, _int_value(training_cfg, "positive_samples", 50)),
+            negative_samples=max(0, _int_value(training_cfg, "negative_samples", 30)),
+            ambient_seconds=max(0, _int_value(training_cfg, "ambient_seconds", 60)),
+            command=str(training_cfg.get("command", "") or "").strip(),
+        ),
+    )
+
+
+def _openwakeword_model_available() -> bool:
+    try:
+        from openwakeword.model import Model  # noqa: F401
+
+        return True
+    except Exception:
+        return False
+
+
+def _canonical_openwakeword_name(value: str) -> str:
+    value = str(value or "").strip()
+    if not value:
+        return ""
+    stem = Path(value).stem
+    stem = re.sub(r"_v\d+(?:\.\d+)*$", "", stem, flags=re.IGNORECASE)
+    return re.sub(r"[^a-z0-9]+", "_", stem.lower()).strip("_")
+
+
+def _preferred_openwakeword_framework(config: WakeWordConfig) -> str:
+    suffix = Path(config.model_path).suffix.lower().lstrip(".")
+    if suffix in {"onnx", "tflite"}:
+        return suffix
+    return OPENWAKEWORD_DEFAULT_FRAMEWORK
+
+
+def _openwakeword_model_specs() -> dict[str, dict]:
+    try:
+        import openwakeword
+
+        specs = getattr(openwakeword, "MODELS", {})
+        return specs if isinstance(specs, dict) else {}
+    except Exception:
+        return {}
+
+
+def _openwakeword_feature_specs() -> dict[str, dict]:
+    try:
+        import openwakeword
+
+        specs = getattr(openwakeword, "FEATURE_MODELS", {})
+        return specs if isinstance(specs, dict) else {}
+    except Exception:
+        return {}
+
+
+def _openwakeword_pretrained_model_name(config: WakeWordConfig) -> str:
+    specs = _openwakeword_model_specs()
+    if not specs:
+        return ""
+
+    candidates = [
+        _canonical_openwakeword_name(config.model_path),
+        _canonical_openwakeword_name(config.phrase),
+    ]
+    for candidate in candidates:
+        if candidate in specs:
+            return candidate
+    return ""
+
+
+def _existing_file(path: str | Path) -> Optional[Path]:
+    if not path:
+        return None
+    candidate = Path(path).expanduser()
+    try:
+        if candidate.is_file() and candidate.stat().st_size > 0:
+            return candidate
+    except OSError:
+        return None
+    return None
+
+
+def _openwakeword_cache_dir(framework: str = OPENWAKEWORD_DEFAULT_FRAMEWORK) -> Path:
+    return get_hermes_home() / "wake_words" / "openwakeword" / OPENWAKEWORD_RELEASE_TAG / framework
+
+
+def _framework_url(url: str, framework: str) -> str:
+    if framework == "onnx":
+        return re.sub(r"\.tflite$", ".onnx", url)
+    if framework == "tflite":
+        return re.sub(r"\.onnx$", ".tflite", url)
+    return url
+
+
+def _framework_filename(path_or_url: str, framework: str) -> str:
+    path = Path(str(path_or_url))
+    suffix = f".{framework}"
+    if path.suffix.lower() in {".onnx", ".tflite"}:
+        return path.with_suffix(suffix).name
+    return path.name
+
+
+def _download_file(url: str, target_path: Path) -> None:
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(dir=str(target_path.parent), delete=False) as tmp:
+        tmp_path = Path(tmp.name)
+        try:
+            with urllib.request.urlopen(url, timeout=60) as response:
+                shutil.copyfileobj(response, tmp)
+        except Exception:
+            try:
+                tmp_path.unlink()
+            except OSError:
+                pass
+            raise
+    if tmp_path.stat().st_size <= 0:
+        tmp_path.unlink(missing_ok=True)
+        raise RuntimeError(f"Downloaded empty wake-word asset from {url}")
+    tmp_path.replace(target_path)
+
+
+def _ensure_openwakeword_asset(url: str, filename: str, framework: str, *, download_missing: bool) -> Optional[Path]:
+    target_path = _openwakeword_cache_dir(framework) / filename
+    existing = _existing_file(target_path)
+    if existing is not None:
+        return existing
+    if not download_missing:
+        return None
+    _download_file(url, target_path)
+    return _existing_file(target_path)
+
+
+def resolve_openwakeword_feature_paths(
+    framework: str = OPENWAKEWORD_DEFAULT_FRAMEWORK,
+    *,
+    model_dir: Optional[Path] = None,
+    download_missing: bool = False,
+) -> dict[str, Path]:
+    """Resolve the openWakeWord audio feature models needed by ONNX/TFLite."""
+    names = {
+        "melspectrogram": f"melspectrogram.{framework}",
+        "embedding": f"embedding_model.{framework}",
+    }
+    resolved: dict[str, Path] = {}
+
+    if model_dir is not None:
+        for key, filename in names.items():
+            sibling = _existing_file(model_dir / filename)
+            if sibling is not None:
+                resolved[key] = sibling
+
+    missing = [key for key in names if key not in resolved]
+    if missing:
+        specs = _openwakeword_feature_specs()
+        for key in missing:
+            spec = specs.get(key)
+            if not isinstance(spec, dict):
+                continue
+            url = spec.get("download_url", "")
+            if not url:
+                continue
+            path = _ensure_openwakeword_asset(
+                _framework_url(str(url), framework),
+                names[key],
+                framework,
+                download_missing=download_missing,
+            )
+            if path is not None:
+                resolved[key] = path
+
+    return resolved
+
+
+def resolve_wake_model_path(
+    config: WakeWordConfig,
+    *,
+    download_missing: bool = False,
+) -> Optional[Path]:
+    """Resolve a configured or known openWakeWord model to a durable file path."""
+    existing = _existing_file(config.model_path)
+    if existing is not None:
+        return existing
+
+    model_name = _openwakeword_pretrained_model_name(config)
+    if not model_name:
+        return None
+
+    framework = _preferred_openwakeword_framework(config)
+    specs = _openwakeword_model_specs()
+    spec = specs.get(model_name, {})
+    if not isinstance(spec, dict):
+        return None
+
+    model_path = str(spec.get("model_path", ""))
+    download_url = str(spec.get("download_url", ""))
+    if not model_path or not download_url:
+        return None
+
+    filename = _framework_filename(model_path, framework)
+    resolved = _ensure_openwakeword_asset(
+        _framework_url(download_url, framework),
+        filename,
+        framework,
+        download_missing=download_missing,
+    )
+    if resolved is None:
+        return None
+
+    if framework in {"onnx", "tflite"}:
+        features = resolve_openwakeword_feature_paths(framework, download_missing=download_missing)
+        if not {"melspectrogram", "embedding"}.issubset(features):
+            return None
+
+    return resolved
+
+
+def check_wake_requirements(
+    config: Optional[WakeWordConfig] = None,
+    *,
+    download_missing: bool = False,
+) -> Dict[str, Any]:
+    """Check whether wake-word listening can start."""
+    cfg = config or load_wake_config()
+    missing: list[str] = []
+    details: list[str] = []
+
+    audio_ok = _audio_available()
+    if audio_ok:
+        details.append("Audio capture: OK")
+    else:
+        details.append("Audio capture: MISSING (pip install sounddevice numpy)")
+        missing.extend(["sounddevice", "numpy"])
+
+    provider_ok = cfg.provider == "openwakeword"
+    if provider_ok:
+        details.append("Wake provider: OK (openWakeWord)")
+    else:
+        details.append(f"Wake provider: MISSING (unsupported provider: {cfg.provider})")
+
+    runtime_ok = _openwakeword_model_available()
+    if runtime_ok:
+        details.append("Wake runtime: OK")
+    else:
+        details.append("Wake runtime: MISSING (pip install openwakeword onnxruntime)")
+        missing.append("openwakeword")
+
+    resolved_model_path = None
+    resolved_features: dict[str, Path] = {}
+    model_error = ""
+    if runtime_ok:
+        try:
+            resolved_model_path = resolve_wake_model_path(cfg, download_missing=download_missing)
+            if resolved_model_path is not None and resolved_model_path.suffix == ".onnx":
+                resolved_features = resolve_openwakeword_feature_paths(
+                    "onnx",
+                    model_dir=resolved_model_path.parent,
+                    download_missing=download_missing,
+                )
+        except Exception as exc:
+            model_error = str(exc)
+
+    feature_assets_ok = True
+    if resolved_model_path is not None and resolved_model_path.suffix == ".onnx":
+        feature_assets_ok = {"melspectrogram", "embedding"}.issubset(resolved_features)
+
+    model_ok = resolved_model_path is not None and feature_assets_ok
+    if model_ok:
+        configured = Path(cfg.model_path).expanduser() if cfg.model_path else None
+        if configured and configured != resolved_model_path:
+            details.append(f"Wake model: OK ({resolved_model_path}; resolved from {configured})")
+        else:
+            details.append(f"Wake model: OK ({resolved_model_path})")
+    else:
+        pretrained_name = _openwakeword_pretrained_model_name(cfg) if runtime_ok else ""
+        if model_error:
+            details.append(f"Wake model: MISSING (auto-download failed: {model_error})")
+        elif resolved_model_path is not None and not feature_assets_ok:
+            details.append(
+                "Wake model: MISSING (openWakeWord ONNX feature assets are not cached; "
+                "run /voice wake on with network access or set voice.wake.model_path to a model directory with "
+                "melspectrogram.onnx and embedding_model.onnx)"
+            )
+        elif pretrained_name:
+            details.append(
+                f"Wake model: MISSING (openWakeWord model '{pretrained_name}' is not cached; "
+                "run /voice wake on with network access, /voice wake train, or set voice.wake.model_path)"
+            )
+        else:
+            details.append("Wake model: MISSING (run /voice wake train --phrase \"Hermes\" or set voice.wake.model_path)")
+
+    return {
+        "available": bool(audio_ok and provider_ok and runtime_ok and model_ok),
+        "audio_available": audio_ok,
+        "runtime_available": runtime_ok,
+        "model_available": model_ok,
+        "resolved_model_path": str(resolved_model_path) if resolved_model_path else "",
+        "resolved_feature_paths": {key: str(path) for key, path in resolved_features.items()},
+        "missing_packages": missing,
+        "details": "\n".join(details),
+    }
+
+
+def _default_model_factory(config: WakeWordConfig):
+    import openwakeword
+    from openwakeword.model import Model
+
+    kwargs: dict[str, Any] = {"vad_threshold": config.vad_threshold}
+    model_path = resolve_wake_model_path(config, download_missing=True)
+    if model_path is not None:
+        kwargs["wakeword_models"] = [str(model_path)]
+        if model_path.suffix == ".onnx":
+            kwargs["inference_framework"] = "onnx"
+            features = resolve_openwakeword_feature_paths(
+                "onnx",
+                model_dir=model_path.parent,
+                download_missing=True,
+            )
+            if features.get("melspectrogram"):
+                kwargs["melspec_model_path"] = str(features["melspectrogram"])
+            if features.get("embedding"):
+                kwargs["embedding_model_path"] = str(features["embedding"])
+
+    if kwargs["vad_threshold"] > 0:
+        vad_path = (
+            Path(openwakeword.__file__).resolve().parent
+            / "resources"
+            / "models"
+            / "silero_vad.onnx"
+        )
+        if not vad_path.is_file():
+            kwargs["vad_threshold"] = 0.0
+    return Model(**kwargs)
+
+
+def _copy_frame(frame):
+    return frame.copy() if hasattr(frame, "copy") else frame
+
+
+def _flatten_frame(frame):
+    if hasattr(frame, "reshape"):
+        return frame.reshape(-1)
+    return frame
+
+
+def _rms(frame) -> int:
+    try:
+        _, np = _import_audio()
+        arr = frame.astype(np.float64) if hasattr(frame, "astype") else np.asarray(frame, dtype=np.float64)
+        if arr.size == 0:
+            return 0
+        return int(np.sqrt(np.mean(arr ** 2)))
+    except Exception:
+        try:
+            values = [float(v) for row in frame for v in (row if isinstance(row, (list, tuple)) else [row])]
+            if not values:
+                return 0
+            return int(math.sqrt(sum(v * v for v in values) / len(values)))
+        except Exception:
+            return 0
+
+
+class OpenWakeWordDetector:
+    """Small adapter around ``openwakeword.Model.predict``."""
+
+    def __init__(
+        self,
+        config: WakeWordConfig,
+        *,
+        model_factory: Optional[Callable[[WakeWordConfig], Any]] = None,
+    ) -> None:
+        self.config = config
+        self._model_factory = model_factory or _default_model_factory
+        self._model = None
+        self._consecutive = 0
+        self.last_score = 0.0
+        self.last_label = ""
+
+    @property
+    def model(self):
+        if self._model is None:
+            self._model = self._model_factory(self.config)
+        return self._model
+
+    def reset(self) -> None:
+        self._consecutive = 0
+        if self._model is not None and hasattr(self._model, "reset"):
+            try:
+                self._model.reset()
+            except Exception:
+                logger.debug("openWakeWord reset failed", exc_info=True)
+
+    def process_frame(self, frame) -> bool:
+        predictions = self._predict(frame)
+        score, label = self._extract_score(predictions)
+        self.last_score = score
+        self.last_label = label
+
+        if score >= self.config.threshold:
+            self._consecutive += 1
+        else:
+            self._consecutive = 0
+
+        if self._consecutive >= self.config.patience_frames:
+            self._consecutive = 0
+            return True
+        return False
+
+    def _predict(self, frame) -> dict:
+        return self.model.predict(_flatten_frame(frame))
+
+    @staticmethod
+    def _extract_score(predictions: Any) -> tuple[float, str]:
+        if not isinstance(predictions, dict):
+            try:
+                return float(predictions), ""
+            except (TypeError, ValueError):
+                return 0.0, ""
+
+        best_score = 0.0
+        best_label = ""
+        for label, value in predictions.items():
+            if isinstance(value, dict):
+                values = value.values()
+            else:
+                values = [value]
+            for candidate in values:
+                try:
+                    score = float(candidate)
+                except (TypeError, ValueError):
+                    continue
+                if score >= best_score:
+                    best_score = score
+                    best_label = str(label)
+        return best_score, best_label
+
+
+class WakeWordListener:
+    """Continuous wake-word listener with passive and dialog states."""
+
+    def __init__(
+        self,
+        config: WakeWordConfig,
+        *,
+        on_transcript: Callable[[str], None],
+        on_status: Optional[Callable[[dict], None]] = None,
+        on_error: Optional[Callable[[Exception], None]] = None,
+        transcribe_func: Optional[Callable[[str], dict]] = None,
+        model_factory: Optional[Callable[[WakeWordConfig], Any]] = None,
+        time_fn: Callable[[], float] = time.monotonic,
+        async_transcribe: bool = True,
+    ) -> None:
+        self.config = config
+        self.on_transcript = on_transcript
+        self.on_status = on_status
+        self.on_error = on_error
+        self.transcribe_func = transcribe_func
+        self.time_fn = time_fn
+        self.async_transcribe = async_transcribe
+        self.detector = OpenWakeWordDetector(config, model_factory=model_factory)
+        self.state = "passive"
+        self._lock = threading.RLock()
+        self._stream = None
+        self._running = False
+        self._paused = False
+        self._resume_state = "passive"
+        self._pre_roll = deque(maxlen=config.pre_roll_frames)
+        self._recording_frames: list[Any] = []
+        self._recording_started_at = 0.0
+        self._last_speech_at = 0.0
+        self._has_speech = False
+        self._dialog_deadline = 0.0
+        self._last_wav_path: Optional[str] = None
+        self._recording_finish_reason = ""
+
+    @property
+    def recording_frames(self) -> list[Any]:
+        with self._lock:
+            return list(self._recording_frames)
+
+    @property
+    def last_score(self) -> float:
+        return self.detector.last_score
+
+    def status(self) -> dict:
+        with self._lock:
+            return {
+                "state": self.state,
+                "phrase": self.config.phrase,
+                "model_path": self.config.model_path,
+                "threshold": self.config.threshold,
+                "last_score": self.detector.last_score,
+                "paused": self._paused,
+            }
+
+    def start(self) -> None:
+        with self._lock:
+            if self._running:
+                return
+            self._running = True
+            self._paused = False
+            self._set_state_locked("passive")
+
+        sd, _np = _import_audio()
+
+        def _callback(indata, frames, time_info, status):  # noqa: ARG001
+            if status:
+                logger.debug("wake-word sounddevice status: %s", status)
+            try:
+                self.process_frame(indata)
+            except Exception as exc:
+                self._handle_error(exc)
+
+        stream = None
+        try:
+            stream = sd.InputStream(
+                samplerate=SAMPLE_RATE,
+                channels=CHANNELS,
+                dtype=DTYPE,
+                blocksize=self.config.frame_samples,
+                callback=_callback,
+            )
+            stream.start()
+        except Exception:
+            with self._lock:
+                self._running = False
+                self._set_state_locked("stopped")
+            if stream is not None:
+                try:
+                    stream.close()
+                except Exception:
+                    pass
+            raise
+
+        with self._lock:
+            self._stream = stream
+
+    def stop(self) -> None:
+        with self._lock:
+            self._running = False
+            self._paused = False
+            stream = self._stream
+            self._stream = None
+            self._recording_frames = []
+            self._pre_roll.clear()
+            self._set_state_locked("stopped")
+
+        if stream is None:
+            return
+
+        def _close_stream() -> None:
+            try:
+                stream.stop()
+                stream.close()
+            except Exception:
+                logger.debug("wake-word stream close failed", exc_info=True)
+
+        closer = threading.Thread(target=_close_stream, daemon=True)
+        closer.start()
+        closer.join(timeout=3.0)
+        if closer.is_alive():
+            logger.warning("Wake-word audio stream close timed out")
+
+    def pause(self, reason: str = "") -> None:
+        del reason
+        with self._lock:
+            if self.state != "paused":
+                self._resume_state = self.state if self.state != "stopped" else "passive"
+            self._paused = True
+            self._set_state_locked("paused")
+
+    def resume(self) -> None:
+        with self._lock:
+            if not self._paused:
+                return
+            self._paused = False
+            target = self._resume_state or "passive"
+            if target == "dialog" and self._dialog_deadline and self.time_fn() >= self._dialog_deadline:
+                target = "passive"
+            self._set_state_locked(target)
+
+    def enter_dialog(self) -> None:
+        with self._lock:
+            self._dialog_deadline = self.time_fn() + self.config.dialog_timeout_seconds
+            self._set_state_locked("dialog")
+
+    def process_frame(self, frame) -> None:
+        frame_copy = _copy_frame(frame)
+        with self._lock:
+            if self.state == "stopped":
+                return
+            if self._paused:
+                self._set_state_locked("paused")
+                return
+
+            if self.state == "dialog" and self._dialog_deadline and self.time_fn() >= self._dialog_deadline:
+                self._set_state_locked("passive")
+
+            if self.state == "recording":
+                self._record_frame_locked(frame_copy)
+                finish_reason = self._finish_reason_locked()
+                if finish_reason:
+                    frames = self._finish_recording_locked(finish_reason)
+                else:
+                    frames = None
+            else:
+                frames = None
+                self._pre_roll.append(frame_copy)
+                if self.state == "dialog":
+                    if _rms(frame_copy) > self.config.silence_threshold:
+                        self._begin_recording_locked()
+                elif self.state == "passive" and self.detector.process_frame(frame_copy):
+                    self._begin_recording_locked()
+
+        if frames is not None:
+            self._transcribe_frames(frames)
+
+    def _begin_recording_locked(self) -> None:
+        self._recording_frames = [_copy_frame(frame) for frame in self._pre_roll]
+        now = self.time_fn()
+        self._recording_started_at = now
+        self._last_speech_at = now
+        self._has_speech = any(_rms(frame) > self.config.silence_threshold for frame in self._recording_frames)
+        if not self._has_speech:
+            self._last_speech_at = 0.0
+        self._set_state_locked("recording")
+        logger.info(
+            "Wake recording started (silence_threshold=%d, silence_duration=%.1fs, max_utterance=%.1fs)",
+            self.config.silence_threshold,
+            self.config.silence_duration,
+            self.config.max_utterance_seconds,
+        )
+
+    def _record_frame_locked(self, frame) -> None:
+        self._recording_frames.append(frame)
+        if _rms(frame) > self.config.silence_threshold:
+            self._has_speech = True
+            self._last_speech_at = self.time_fn()
+
+    def _finish_reason_locked(self) -> str:
+        now = self.time_fn()
+        if now - self._recording_started_at >= self.config.max_utterance_seconds:
+            return "max_utterance"
+        if self._has_speech and self._last_speech_at and now - self._last_speech_at >= self.config.silence_duration:
+            return "silence"
+        return ""
+
+    def _finish_recording_locked(self, reason: str) -> list[Any]:
+        frames = list(self._recording_frames)
+        self._recording_frames = []
+        self._pre_roll.clear()
+        elapsed = max(0.0, self.time_fn() - self._recording_started_at)
+        self._recording_finish_reason = reason
+        logger.info(
+            "Wake recording finished (reason=%s, elapsed=%.1fs, frames=%d)",
+            reason,
+            elapsed,
+            len(frames),
+        )
+        self._set_state_locked("transcribing")
+        return frames
+
+    def _transcribe_frames(self, frames: list[Any]) -> None:
+        if self.async_transcribe:
+            threading.Thread(target=self._transcribe_frames_sync, args=(frames,), daemon=True).start()
+        else:
+            self._transcribe_frames_sync(frames)
+
+    def _transcribe_frames_sync(self, frames: list[Any]) -> None:
+        wav_path = None
+        try:
+            if not frames:
+                self._return_to_passive()
+                return
+            _, np = _import_audio()
+            audio = np.concatenate(frames, axis=0)
+            wav_path = AudioRecorder._write_wav(audio)
+            self._last_wav_path = wav_path
+            transcribe = self.transcribe_func
+            if transcribe is None:
+                from tools.voice_mode import transcribe_recording
+
+                transcribe = transcribe_recording
+            result = transcribe(wav_path)
+            if result.get("success") and result.get("transcript", "").strip():
+                transcript = strip_wake_phrase(result["transcript"].strip(), self.config.phrase)
+                if transcript:
+                    self.enter_dialog()
+                    self.on_transcript(transcript)
+                else:
+                    self._return_to_passive()
+            else:
+                self._return_to_passive()
+        except Exception as exc:
+            self._handle_error(exc)
+            self._return_to_passive()
+        finally:
+            if wav_path:
+                try:
+                    os.unlink(wav_path)
+                except OSError:
+                    pass
+
+    def _return_to_passive(self) -> None:
+        with self._lock:
+            if self.state != "stopped":
+                self._set_state_locked("passive")
+
+    def _set_state_locked(self, state: str) -> None:
+        self.state = state
+        if self.on_status:
+            try:
+                self.on_status(self.status())
+            except Exception:
+                logger.debug("wake-word status callback failed", exc_info=True)
+
+    def _handle_error(self, exc: Exception) -> None:
+        if self.on_error:
+            try:
+                self.on_error(exc)
+            except Exception:
+                logger.debug("wake-word error callback failed", exc_info=True)
+        else:
+            logger.warning("Wake-word listener error: %s", exc, exc_info=True)
+
+
+def strip_wake_phrase(transcript: str, phrase: str) -> str:
+    """Remove the configured wake phrase from the beginning of a transcript."""
+    text = transcript.strip()
+    phrase = phrase.strip()
+    if not text or not phrase:
+        return text
+    pattern = rf"^\s*{re.escape(phrase)}[\s,;:!\-—]*"
+    cleaned = re.sub(pattern, "", text, count=1, flags=re.IGNORECASE).strip()
+    return cleaned or text
+
+
+def _slugify_phrase(phrase: str) -> str:
+    slug = re.sub(r"[^\w]+", "-", phrase.lower(), flags=re.UNICODE).strip("-")
+    return slug or "wake-word"
+
+
+class WakeWordTrainer:
+    """Collect wake samples and export a local wake-word model artifact.
+
+    The default trainer supports an external command hook because openWakeWord
+    custom training pipelines vary heavily by environment. Tests can inject a
+    pure-Python backend, and local setups can set ``voice.wake.training.command``.
+    """
+
+    def __init__(
+        self,
+        config: WakeWordConfig,
+        *,
+        output_root: Optional[Path] = None,
+        sample_collector: Optional[Callable[[WakeWordConfig, Path], dict]] = None,
+        training_backend: Optional[Callable[[WakeWordConfig, Path, Path], None]] = None,
+    ) -> None:
+        self.config = config
+        self.output_root = Path(output_root or (get_hermes_home() / "wake_words")).expanduser()
+        self.sample_collector = sample_collector or self._collect_samples_interactively
+        self.training_backend = training_backend or self._run_training_command_backend
+
+    def train(self) -> dict:
+        phrase_slug = _slugify_phrase(self.config.phrase)
+        model_dir = self.output_root / phrase_slug
+        dataset_dir = model_dir / "samples"
+        model_dir.mkdir(parents=True, exist_ok=True)
+        dataset_dir.mkdir(parents=True, exist_ok=True)
+
+        samples = self.sample_collector(self.config, dataset_dir)
+        model_path = model_dir / "model.onnx"
+        self.training_backend(self.config, dataset_dir, model_path)
+        if not model_path.is_file() or model_path.stat().st_size <= 0:
+            raise RuntimeError(f"Wake-word training did not create a model at {model_path}")
+
+        counts = {key: len(value or []) for key, value in samples.items()}
+        metadata = {
+            "phrase": self.config.phrase,
+            "provider": self.config.provider,
+            "model_path": str(model_path),
+            "threshold": self.config.threshold,
+            "patience_frames": self.config.patience_frames,
+            "counts": counts,
+            "created_at": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+        }
+        metadata_path = model_dir / "metadata.json"
+        metadata_path.write_text(json.dumps(metadata, ensure_ascii=False, indent=2), encoding="utf-8")
+
+        return {
+            "success": True,
+            "model_path": str(model_path),
+            "metadata_path": str(metadata_path),
+            "counts": counts,
+            "config_update": {
+                "voice.wake.provider": self.config.provider,
+                "voice.wake.phrase": self.config.phrase,
+                "voice.wake.model_path": str(model_path),
+                "voice.wake.threshold": self.config.threshold,
+                "voice.wake.patience_frames": self.config.patience_frames,
+            },
+        }
+
+    def _collect_samples_interactively(self, config: WakeWordConfig, dataset_dir: Path) -> dict:
+        positive = []
+        negative = []
+        ambient = []
+        positive_dir = dataset_dir / "positive"
+        negative_dir = dataset_dir / "negative"
+        ambient_dir = dataset_dir / "ambient"
+        positive_dir.mkdir(parents=True, exist_ok=True)
+        negative_dir.mkdir(parents=True, exist_ok=True)
+        ambient_dir.mkdir(parents=True, exist_ok=True)
+
+        print(f"Collecting {config.training.positive_samples} positive samples for: {config.phrase}")
+        for index in range(config.training.positive_samples):
+            positive.append(self._record_sample(positive_dir, f"positive_{index:03d}.wav", f"Say wake phrase #{index + 1}, then pause. Press Enter when ready."))
+
+        print(f"Collecting {config.training.negative_samples} negative voice samples.")
+        for index in range(config.training.negative_samples):
+            negative.append(self._record_sample(negative_dir, f"negative_{index:03d}.wav", f"Say any non-wake phrase #{index + 1}, then pause. Press Enter when ready."))
+
+        if config.training.ambient_seconds > 0:
+            ambient.append(self._record_fixed_sample(ambient_dir, "ambient_000.wav", config.training.ambient_seconds))
+
+        return {"positive": positive, "negative": negative, "ambient": ambient}
+
+    def _record_sample(self, target_dir: Path, filename: str, prompt: str) -> Path:
+        input(prompt)
+        from tools.voice_mode import create_audio_recorder
+
+        done = threading.Event()
+        recorder = create_audio_recorder()
+        try:
+            recorder.start(on_silence_stop=done.set)
+            done.wait(timeout=15.0)
+            wav_path = recorder.stop()
+        finally:
+            try:
+                recorder.shutdown()
+            except Exception:
+                pass
+        if not wav_path:
+            raise RuntimeError("No audio captured for wake-word training sample")
+        target_path = target_dir / filename
+        shutil.move(wav_path, target_path)
+        return target_path
+
+    def _record_fixed_sample(self, target_dir: Path, filename: str, seconds: int) -> Path:
+        print(f"Recording {seconds}s of ambient noise. Stay quiet and press Enter when ready.")
+        input()
+        from tools.voice_mode import create_audio_recorder
+
+        recorder = create_audio_recorder()
+        try:
+            recorder.start(on_silence_stop=None)
+            time.sleep(seconds)
+            wav_path = recorder.stop()
+        finally:
+            try:
+                recorder.shutdown()
+            except Exception:
+                pass
+        if not wav_path:
+            raise RuntimeError("No ambient audio captured for wake-word training")
+        target_path = target_dir / filename
+        shutil.move(wav_path, target_path)
+        return target_path
+
+    def _run_training_command_backend(self, config: WakeWordConfig, dataset_dir: Path, output_path: Path) -> None:
+        command = config.training.command.strip()
+        if not command:
+            raise RuntimeError(
+                "Wake-word samples were collected, but no training backend is configured. "
+                "Install wake training deps and set voice.wake.training.command to a command "
+                "that writes HERMES_WAKE_OUTPUT_PATH, or provide an existing ONNX model via "
+                "voice.wake.model_path."
+            )
+        env = os.environ.copy()
+        env.update(
+            {
+                "HERMES_WAKE_PHRASE": config.phrase,
+                "HERMES_WAKE_DATASET_DIR": str(dataset_dir),
+                "HERMES_WAKE_OUTPUT_PATH": str(output_path),
+            }
+        )
+        result = subprocess.run(
+            command,
+            shell=True,
+            cwd=str(dataset_dir.parent),
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=3600,
+            check=False,
+        )
+        if result.returncode != 0:
+            details = (result.stderr or result.stdout or "").strip()
+            raise RuntimeError(f"Wake-word training command failed: {details}")
+
+
+def wake_install_hint(training: bool = False) -> str:
+    packages = "openwakeword onnxruntime"
+    if training:
+        packages += " torch scipy tqdm torchmetrics torchinfo"
+    return f"{sys.executable} -m pip install {packages}"
+
+
+def write_existing_model_config(model_path: str, phrase: str, threshold: float = 0.5) -> dict:
+    """Return config key updates for a pre-trained openWakeWord model."""
+    return {
+        "voice.wake.provider": "openwakeword",
+        "voice.wake.phrase": phrase,
+        "voice.wake.model_path": str(Path(model_path).expanduser()),
+        "voice.wake.threshold": threshold,
+    }
+
+
+__all__ = [
+    "FRAME_SAMPLES",
+    "WAKE_MIN_SILENCE_DURATION_SECONDS",
+    "WakeTrainingConfig",
+    "WakeWordConfig",
+    "OpenWakeWordDetector",
+    "WakeWordListener",
+    "WakeWordTrainer",
+    "check_wake_requirements",
+    "load_wake_config",
+    "resolve_openwakeword_feature_paths",
+    "resolve_wake_model_path",
+    "strip_wake_phrase",
+    "wake_install_hint",
+    "write_existing_model_config",
+]

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -354,6 +354,23 @@ describe('createSlashHandler', () => {
     expect(ctx.voice.setVoiceRecordKey).not.toHaveBeenCalled()
   })
 
+  it('/voice wake delegates to the shared slash worker instead of voice.toggle', async () => {
+    const gw = { ...buildGateway().gw, request: vi.fn(() => Promise.resolve({ output: 'Wake-Word Status' })) }
+    const rpc = vi.fn(() => Promise.resolve({ enabled: false, tts: false }))
+    const ctx = buildCtx({ gateway: { ...buildGateway(), gw, rpc } })
+
+    expect(createSlashHandler(ctx)('/voice wake status')).toBe(true)
+
+    expect(rpc).not.toHaveBeenCalled()
+    expect(gw.request).toHaveBeenCalledWith('slash.exec', {
+      command: 'voice wake status',
+      session_id: null
+    })
+    await vi.waitFor(() => {
+      expect(ctx.transcript.sys).toHaveBeenCalledWith('Wake-Word Status')
+    })
+  })
+
   it('cycles details mode and persists it', async () => {
     const ctx = buildCtx()
 

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -8,6 +8,7 @@ import type {
   SessionBranchResponse,
   SessionCompressResponse,
   SessionUsageResponse,
+  SlashExecResponse,
   VoiceToggleResponse
 } from '../../../gatewayTypes.js'
 import { formatVoiceRecordKey, parseVoiceRecordKey } from '../../../lib/platform.js'
@@ -254,8 +255,25 @@ export const sessionCommands: SlashCommand[] = [
   {
     help: 'voice mode: [on|off|tts|status]',
     name: 'voice',
-    run: (arg, ctx) => {
+    run: (arg, ctx, cmd) => {
       const normalized = (arg ?? '').trim().toLowerCase()
+
+      if (normalized === 'wake' || normalized.startsWith('wake ')) {
+        ctx.gateway.gw
+          .request<SlashExecResponse>('slash.exec', { command: cmd.slice(1), session_id: ctx.sid })
+          .then(
+            ctx.guarded<SlashExecResponse>(r => {
+              const body = r?.output || '/voice wake: no output'
+              const text = r?.warning ? `warning: ${r.warning}\n${body}` : body
+              const long = text.length > 180 || text.split('\n').filter(Boolean).length > 2
+
+              long ? ctx.transcript.page(text, 'Voice') : ctx.transcript.sys(text)
+            })
+          )
+          .catch(ctx.guardedErr)
+
+        return
+      }
 
       const action =
         normalized === 'on' || normalized === 'off' || normalized === 'tts' || normalized === 'status'

--- a/website/docs/guides/use-voice-mode-with-hermes.md
+++ b/website/docs/guides/use-voice-mode-with-hermes.md
@@ -171,6 +171,12 @@ voice:
   beep_enabled: true
   silence_threshold: 200
   silence_duration: 3.0
+  model_wait_notice_seconds: 0
+  wake:
+    provider: "openwakeword"
+    phrase: "Hermes"
+    model_path: ""
+    threshold: 0.5
 
 stt:
   provider: "local"
@@ -233,6 +239,9 @@ Workflow:
 /voice on
 /voice off
 /voice tts
+/voice wake status
+/voice wake on
+/voice wake off
 /voice status
 ```
 
@@ -292,6 +301,34 @@ If `Ctrl+B` conflicts with your terminal or tmux habits:
 voice:
   record_key: "ctrl+space"
 ```
+
+### Wake phrase
+
+Wake-word mode listens locally until your configured phrase is detected, then
+submits the next utterance through the normal voice pipeline. The command is
+available in both the classic CLI and the TUI:
+
+```text
+/voice wake on
+/voice wake off
+/voice wake train --phrase "Hermes"
+```
+
+Tune it in `~/.hermes/config.yaml`:
+
+```yaml
+voice:
+  wake:
+    phrase: "Hermes"
+    threshold: 0.5
+    model_path: ""
+    training:
+      command: ""
+```
+
+Use `voice.wake.model_path` for an existing ONNX model. Use
+`voice.wake.training.command` only when you have a local training command that
+can write `HERMES_WAKE_OUTPUT_PATH`.
 
 ## Use case 2: voice replies in Telegram or Discord
 

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -126,6 +126,7 @@ Then use these commands inside the CLI:
 /voice on       Enable voice mode
 /voice off      Disable voice mode
 /voice tts      Toggle TTS output
+/voice wake     Manage wake-word listening
 /voice status   Show current state
 ```
 
@@ -145,6 +146,48 @@ This loop continues until you press **Ctrl+B** during recording (exits continuou
 :::tip
 The record key is configurable via `voice.record_key` in `~/.hermes/config.yaml` (default: `ctrl+b`).
 :::
+
+### Wake-Word Mode
+
+Wake-word mode keeps the local microphone listener passive until it hears your
+configured phrase, then records the next utterance and submits it through the
+same CLI voice pipeline. It is available from the shared `/voice` slash command
+surface in both the classic CLI and the TUI.
+
+```text
+/voice wake on
+/voice wake off
+/voice wake status
+/voice wake train --phrase "Hermes"
+/voice wake train --phrase "Hermes" --model /path/to/model.onnx
+```
+
+If the wake-word runtime is missing, install:
+
+```bash
+python -m pip install openwakeword onnxruntime
+```
+
+Wake-word settings live in `~/.hermes/config.yaml`:
+
+```yaml
+voice:
+  wake:
+    provider: "openwakeword"
+    phrase: "Hermes"
+    model_path: ""
+    threshold: 0.5
+    training:
+      positive_samples: 50
+      negative_samples: 30
+      ambient_seconds: 60
+      command: ""
+```
+
+Set `voice.wake.model_path` if you already have an ONNX model. For custom
+training, set `voice.wake.training.command` to a local command that writes the
+path from `HERMES_WAKE_OUTPUT_PATH`; Hermes also passes `HERMES_WAKE_PHRASE`
+and `HERMES_WAKE_DATASET_DIR` to that subprocess.
 
 ### Silence Detection
 


### PR DESCRIPTION
## Summary
- Add wake-word voice mode support with listener lifecycle, model resolution, status, training command hooks, and CLI integration.
- Add voice-mode CLI polish around wake listener pause/resume and tool-beep configuration.
- Excludes Yandex/HTTP provider-specific changes so this PR is reviewable independently.

## Tests
- `scripts/run_tests.sh tests/tools/test_wake_word.py tests/tools/test_voice_mode.py tests/tools/test_voice_cli_integration.py` — 167 passed

## Safety
- No real credentials or tokens are included; this PR does not add secret-bearing config.
