### PR TITLE
P1.6 cleanup: SKILL.md guard, patch no-op, escape-drift, sessions schema

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -182,7 +182,7 @@ def _log_wal_fallback_once(db_label: str, exc: Exception) -> None:
         exc,
     )
 
-SCHEMA_SQL = """
+SCHEMA_TABLES_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
     version INTEGER NOT NULL
 );
@@ -243,12 +243,24 @@ CREATE TABLE IF NOT EXISTS state_meta (
     key TEXT PRIMARY KEY,
     value TEXT
 );
+"""
 
+# Indexes are split from tables so column reconciliation can run between them.
+# A legacy DB missing a column referenced by an index (e.g. parent_session_id)
+# would otherwise fail in executescript before _reconcile_columns had a chance
+# to ADD it.  See TestSchemaReconciliation in tests/test_hermes_state.py.
+SCHEMA_INDEXES_SQL = """
 CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source);
 CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_started ON sessions(started_at DESC);
 CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, timestamp);
 """
+
+# Back-compat alias: anything that imports SCHEMA_SQL (tests, downstream tools,
+# the schema-parsing reconciler) sees both halves concatenated, which is the
+# original behaviour.  Do NOT executescript() this; use the two halves with
+# _reconcile_columns() between them, as _init_schema does.
+SCHEMA_SQL = SCHEMA_TABLES_SQL + SCHEMA_INDEXES_SQL
 
 FTS_SQL = """
 CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
@@ -562,14 +574,16 @@ class SessionDB:
         """
         cursor = self._conn.cursor()
 
-        cursor.executescript(SCHEMA_SQL)
+        # 1. Create tables (no-op if they already exist).
+        cursor.executescript(SCHEMA_TABLES_SQL)
 
-        # ── Declarative column reconciliation ──────────────────────────
-        # Diff live tables against SCHEMA_SQL and ADD any missing columns.
-        # This is idempotent and self-healing: even if a version-gated
-        # migration was skipped (e.g. due to version renumbering), the
-        # column gets created here.
+        # 2. Reconcile columns BEFORE indexes — a legacy DB missing a column
+        #    that an index references (e.g. parent_session_id) would otherwise
+        #    fail the CREATE INDEX statement.
         self._reconcile_columns(cursor)
+
+        # 3. Now safe to create indexes against the reconciled tables.
+        cursor.executescript(SCHEMA_INDEXES_SQL)
 
         # ── Schema version bookkeeping ─────────────────────────────────
         # Bump to current so future data migrations (if any) can gate on

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2943,3 +2943,137 @@ class TestFTS5ToolCallMigration:
         finally:
             session_db.close()
 
+
+# =========================================================================
+# Schema reconciliation — declarative ADD COLUMN drift handling
+# =========================================================================
+
+
+class TestSchemaReconciliation:
+    """Older DBs missing later-added columns must self-heal on open.
+
+    The declarative reconciliation (_reconcile_columns) is the contract.
+    Without it, a SessionDB opened against a legacy file would either
+    UPDATE-fail on the missing column or silently SELECT it as NULL —
+    both manifest as bug reports like "sessions schema drift". Lock the
+    behaviour in so future column additions don't regress.
+    """
+
+    def test_legacy_sessions_table_missing_columns_is_reconciled(self, tmp_path):
+        """Open a hand-rolled legacy DB; reconciler adds every declared column."""
+        import sqlite3
+        from hermes_state import SCHEMA_SQL
+
+        db_path = tmp_path / "legacy_state.db"
+        conn = sqlite3.connect(str(db_path))
+        # Minimal legacy schema: only the columns that existed in early hermes.
+        conn.executescript("""
+            CREATE TABLE schema_version (version INTEGER NOT NULL);
+            INSERT INTO schema_version VALUES (1);
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                source TEXT NOT NULL,
+                started_at REAL NOT NULL
+            );
+            CREATE TABLE messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL REFERENCES sessions(id),
+                role TEXT NOT NULL,
+                content TEXT,
+                timestamp REAL NOT NULL
+            );
+        """)
+        conn.commit()
+        conn.close()
+
+        # Open via SessionDB — reconciliation must add the missing columns.
+        session_db = SessionDB(db_path=db_path)
+        try:
+            rows = session_db._conn.execute("PRAGMA table_info(sessions)").fetchall()
+            live = {row[1] if isinstance(row, tuple) else row["name"] for row in rows}
+            # A representative sampling of columns added across the history.
+            for required in (
+                "user_id", "model", "system_prompt", "parent_session_id",
+                "ended_at", "end_reason",
+                "message_count", "tool_call_count",
+                "input_tokens", "output_tokens",
+                "cache_read_tokens", "cache_write_tokens", "reasoning_tokens",
+                "billing_provider", "billing_base_url", "billing_mode",
+                "estimated_cost_usd", "actual_cost_usd",
+                "cost_status", "cost_source", "pricing_version",
+                "title", "api_call_count",
+                "handoff_state", "handoff_platform", "handoff_error",
+            ):
+                assert required in live, (
+                    f"reconcile_columns must ADD missing sessions.{required}"
+                )
+
+            # Same check for messages.
+            rows = session_db._conn.execute("PRAGMA table_info(messages)").fetchall()
+            live_msg = {row[1] if isinstance(row, tuple) else row["name"] for row in rows}
+            for required in (
+                "tool_call_id", "tool_calls", "tool_name",
+                "token_count", "finish_reason",
+                "reasoning", "reasoning_content", "reasoning_details",
+                "codex_reasoning_items", "codex_message_items",
+            ):
+                assert required in live_msg, (
+                    f"reconcile_columns must ADD missing messages.{required}"
+                )
+        finally:
+            session_db.close()
+
+    def test_reconcile_is_idempotent_on_current_schema(self, db):
+        """A second open with no schema gap is a no-op (no error, no churn)."""
+        # `db` fixture already opened once.  Open again on the same file.
+        from hermes_state import SessionDB
+        path = db.db_path
+        db.close()
+        for _ in range(3):
+            again = SessionDB(db_path=path)
+            try:
+                # Should be quietly fine; PRAGMA still returns the full column set.
+                rows = again._conn.execute("PRAGMA table_info(sessions)").fetchall()
+                assert len(rows) > 20  # full sessions schema
+            finally:
+                again.close()
+
+    def test_sessions_writes_use_all_columns_after_reconcile(self, tmp_path):
+        """End-to-end: a legacy DB → SessionDB.create_session uses every column."""
+        import sqlite3
+        db_path = tmp_path / "legacy_e2e.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.executescript("""
+            CREATE TABLE schema_version (version INTEGER NOT NULL);
+            INSERT INTO schema_version VALUES (1);
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                source TEXT NOT NULL,
+                started_at REAL NOT NULL
+            );
+            CREATE TABLE messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL REFERENCES sessions(id),
+                role TEXT NOT NULL,
+                content TEXT,
+                timestamp REAL NOT NULL
+            );
+        """)
+        conn.commit()
+        conn.close()
+
+        session_db = SessionDB(db_path=db_path)
+        try:
+            sid = "sess-legacy-e2e"
+            session_db.create_session(session_id=sid, source="cli", model="claude-opus-4-7")
+            row = session_db.get_session(sid)
+            # Field that didn't exist in legacy schema but is now writable.
+            assert row["model"] == "claude-opus-4-7"
+            session_db.update_token_counts(
+                sid, input_tokens=10, output_tokens=20, api_call_count=1,
+            )
+            row = session_db.get_session(sid)
+            assert row["input_tokens"] == 10
+            assert row["output_tokens"] == 20
+        finally:
+            session_db.close()

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -125,6 +125,20 @@ class TestPatchResult:
         assert d["success"] is False
         assert d["error"] == "File not found"
 
+    def test_to_dict_message_field(self):
+        """Message field is surfaced when set (used for no-op success)."""
+        r = PatchResult(success=True, message="no changes needed (old_string == new_string)")
+        d = r.to_dict()
+        assert d["success"] is True
+        assert d["message"] == "no changes needed (old_string == new_string)"
+        assert "diff" not in d
+        assert "files_modified" not in d
+
+    def test_to_dict_no_message_when_none(self):
+        r = PatchResult(success=True, diff="--- a\n+++ b", files_modified=["a.py"])
+        d = r.to_dict()
+        assert "message" not in d
+
 
 class TestSearchResult:
     def test_to_dict_with_matches(self):
@@ -579,3 +593,35 @@ class TestPatchReplacePostWriteVerification:
         result = ops.patch_replace("/tmp/test/a.py", "hello", "hi")
         assert result.error is not None
         assert "could not re-read" in result.error.lower()
+
+
+class TestPatchReplaceNoOp:
+    """`patch_replace` must succeed silently when old_string == new_string.
+
+    Retry-safe automation (idempotent skill steps, cron-driven repairs) often
+    re-applies the same edit; previously this raised "could not find match"
+    because the matcher reported the new_string in place and the path looked
+    indistinguishable from a stale-string failure.  The fast path now returns
+    success with an explanatory ``message`` field and an empty diff so callers
+    can distinguish "no edit needed" from a real change.
+    """
+
+    def test_noop_returns_success_with_message(self, file_ops, mock_env):
+        # No I/O should happen: the noop check returns before any _exec call.
+        result = file_ops.patch_replace("/tmp/test/whatever.py", "same", "same")
+        assert result.success is True
+        assert result.error is None
+        assert result.diff == ""
+        assert result.files_modified == []
+        assert result.message is not None
+        assert "no changes needed" in result.message
+        # Confirm we short-circuited before any shell call.
+        mock_env.execute.assert_not_called()
+
+    def test_noop_to_dict_shape(self, file_ops):
+        """Downstream consumers see the no-op outcome via to_dict()."""
+        result = file_ops.patch_replace("/tmp/test/whatever.py", "x", "x")
+        d = result.to_dict()
+        assert d["success"] is True
+        assert d.get("message", "").startswith("no changes needed")
+        assert "error" not in d

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -183,6 +183,26 @@ class TestValidateFilePath:
         assert "File must be under one of:" in err
         assert "'malicious.py'" in err
 
+    def test_skill_md_rejected_with_helpful_message(self):
+        """write_file is for supporting files; SKILL.md goes through edit/patch.
+
+        The validator must point the caller at the right action instead of
+        emitting the generic "must be under references/..." error, which
+        confuses agents trying to update the main skill body.
+        """
+        err = _validate_file_path("SKILL.md")
+        assert err is not None
+        assert "action='edit'" in err
+        assert "action='patch'" in err
+        assert "supporting files" in err
+
+    def test_skill_md_case_insensitive_rejected(self):
+        """Cover SKILL.MD / skill.md / Skill.md variants too."""
+        for variant in ("skill.md", "Skill.md", "SKILL.MD"):
+            err = _validate_file_path(variant)
+            assert err is not None
+            assert "action='edit'" in err, f"variant={variant!r} got: {err}"
+
 
 # ---------------------------------------------------------------------------
 # CRUD operations

--- a/tests/tools/test_skills_guard.py
+++ b/tests/tools/test_skills_guard.py
@@ -262,6 +262,40 @@ class TestScanFile:
         # Same pattern on same line should appear only once
         assert len(root_rm) == 1
 
+    def test_unicode_escape_chain_real_obfuscation_detected(self, tmp_path):
+        """Contiguous \\uXXXX chain that spells out a payload IS flagged."""
+        f = tmp_path / "evil.py"
+        # "Hello" as contiguous unicode escapes — classic obfuscation.
+        f.write_text('payload = "\\u0048\\u0065\\u006c\\u006c\\u006f"\n')
+        findings = scan_file(f, "evil.py")
+        assert any(fi.pattern_id == "unicode_escape_chain" for fi in findings), (
+            "Contiguous unicode escape chain must still be flagged"
+        )
+
+    def test_unicode_escape_chain_no_false_positive_in_prose(self, tmp_path):
+        """SKILL.md documenting multiple \\uXXXX codes with prose between
+        them used to trip the over-greedy `.* .* .*` pattern. The narrowed
+        pattern requires the escapes to be contiguous (whitespace/`+` only)
+        so explanatory text breaks the chain.
+        """
+        f = tmp_path / "doc.md"
+        f.write_text(
+            "Invisible characters include U+2068 (\\u2068, first strong isolate), "
+            "U+2069 (\\u2069, pop directional isolate), and U+200B (\\u200b, "
+            "zero-width space) — be careful when pasting unknown text.\n"
+        )
+        findings = scan_file(f, "doc.md")
+        assert not any(fi.pattern_id == "unicode_escape_chain" for fi in findings), (
+            f"prose with non-contiguous \\u escapes must NOT flag: got {findings!r}"
+        )
+
+    def test_unicode_escape_chain_no_false_positive_two_codes(self, tmp_path):
+        """Two escapes on a line should not trigger (need >= 3 contiguous)."""
+        f = tmp_path / "doc.md"
+        f.write_text('Example: "\\u0041\\u0042" decodes to "AB".\n')
+        findings = scan_file(f, "doc.md")
+        assert not any(fi.pattern_id == "unicode_escape_chain" for fi in findings)
+
 
 # ---------------------------------------------------------------------------
 # scan_skill — directory scanning

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -146,9 +146,13 @@ class PatchResult:
     # See :class:`WriteResult.lsp_diagnostics`.
     lsp_diagnostics: Optional[str] = None
     error: Optional[str] = None
-    
+    # Optional human-readable note (used e.g. for no-op success on
+    # ``patch_replace`` when ``old_string == new_string``).  Surfaced via
+    # ``to_dict`` so the caller can distinguish a no-op from a real edit.
+    message: Optional[str] = None
+
     def to_dict(self) -> dict:
-        result = {"success": self.success}
+        result: Dict[str, Any] = {"success": self.success}
         if self.diff:
             result["diff"] = self.diff
         if self.files_modified:
@@ -163,6 +167,8 @@ class PatchResult:
             result["lsp_diagnostics"] = self.lsp_diagnostics
         if self.error:
             result["error"] = self.error
+        if self.message:
+            result["message"] = self.message
         return result
 
 
@@ -1015,6 +1021,19 @@ class ShellFileOperations(FileOperations):
         """
         # Expand ~ and other shell paths
         path = self._expand_path(path)
+
+        # No-op fast path: if old_string == new_string, the caller asked for a
+        # no-change replacement.  This used to error ("could not find match"
+        # because we'd still attempt a match and the result was indistinguishable
+        # from a stale string) which broke retry-safe automation.  Treat it as
+        # a silent success — the file already contains what the caller wants.
+        if old_string == new_string:
+            return PatchResult(
+                success=True,
+                diff="",
+                files_modified=[],
+                message="no changes needed (old_string == new_string)",
+            )
 
         # Block writes to sensitive paths
         if _is_write_denied(path):

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -311,6 +311,17 @@ def _validate_file_path(file_path: str) -> Optional[str]:
     if has_traversal_component(file_path):
         return "Path traversal ('..') is not allowed."
 
+    # Detect the most common footgun: trying to write SKILL.md via write_file.
+    # write_file is for supporting files; the main skill body is owned by
+    # action='create' (new skill) or action='edit' / action='patch' (existing).
+    if len(normalized.parts) == 1 and normalized.parts[0].lower() == "skill.md":
+        return (
+            "SKILL.md cannot be written via action='write_file'. "
+            "Use action='edit' (full rewrite) or action='patch' (targeted change) "
+            "to modify the main skill body. write_file is for supporting files only "
+            f"(under {', '.join(sorted(ALLOWED_SUBDIRS))}/)."
+        )
+
     # Must be under an allowed subdirectory
     if not normalized.parts or normalized.parts[0] not in ALLOWED_SUBDIRS:
         allowed = ", ".join(sorted(ALLOWED_SUBDIRS))

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -322,9 +322,16 @@ THREAT_PATTERNS = [
     (r'chr\s*\(\s*\d+\s*\)\s*\+\s*chr\s*\(\s*\d+',
      "chr_building", "high", "obfuscation",
      "building string from chr() calls (obfuscation)"),
-    (r'\\u[0-9a-fA-F]{4}.*\\u[0-9a-fA-F]{4}.*\\u[0-9a-fA-F]{4}',
+    # Real obfuscation chains escapes back-to-back with at most whitespace
+    # between them (e.g. ``\u0048\u0065\u006c\u006c\u006f`` for "Hello").
+    # Documentation/log output mentioning multiple ``\uXXXX`` codes with
+    # explanatory prose between them is not obfuscation — narrow the
+    # pattern to require >= 3 contiguous escapes (optionally separated by
+    # whitespace or ``+`` for string concatenation) so we stop flagging
+    # legitimate SKILL.md examples and pasted log snippets.
+    (r'(?:\\u[0-9a-fA-F]{4}[\s+]*){3,}',
      "unicode_escape_chain", "medium", "obfuscation",
-     "chain of unicode escapes (possible obfuscation)"),
+     "contiguous chain of unicode escapes (possible obfuscation)"),
 
     # ── Process execution in scripts ──
     (r'subprocess\.(run|call|Popen|check_output)\s*\(',


### PR DESCRIPTION
P1.6 cleanup bundle — 4 small fixes called out in the parent epic. Total: 4 files (impl) + 4 files (tests), +296/-11 lines (under the 300-line cap).

## Commits

- `996b7ef29` fix(skills): reject SKILL.md in write_file with action-pointer message
- `e37182e1c` fix(patch): treat old_string == new_string as silent success
- `4242a3069` fix(skills-guard): narrow unicode_escape_chain to contiguous escapes
- `b1198bc2b` fix(hermes-state): reconcile columns before creating indexes

## Items

1. **skill_manage SKILL.md** — `_validate_file_path` now bounces `file_path='SKILL.md'` for `write_file` with a targeted error pointing at `action='edit'` / `action='patch'`.
2. **patch no-op success** — `patch_replace` short-circuits when `old_string == new_string` and returns `success=true` with a "no changes needed" message. Footgun for retry-safe automation removed.
3. **Escape-drift false positive** — `unicode_escape_chain` now requires ≥3 contiguous `\uXXXX` sequences (whitespace/`+` allowed between). Prose mentioning escape codes with words between them no longer trips.
4. **Sessions schema drift** — `_init_schema` reorders to tables → `_reconcile_columns` → indexes (was: `SCHEMA_SQL` all-at-once, which `CREATE INDEX`'d against pre-reconcile tables and failed on legacy DBs).
5. **personality warning** — already fixed on main; `_probe_config_health` (tui_gateway/server.py:1336) runs once at session init via `_session_info`. Covered by `tests/tui_gateway/test_make_agent_provider.py::test_probe_config_health_flags_null_personalities_with_active_personality`. No per-turn emitter exists (verified by rg across cli.py / gateway/run.py / run_agent.py). Deferred to existing landed work.

## Tests

602/603 pass on the targeted suite:

```
venv/bin/pytest tests/tools/test_skill_manager_tool.py tests/tools/test_skills_guard.py \
                tests/tools/test_file_operations.py tests/test_hermes_state.py \
                tests/tui_gateway/test_make_agent_provider.py tests/test_tui_gateway_server.py
```

One pre-existing fail (`test_browser_manage_connect_default_local_reports_launch_hint`) reproduces on `origin/main` — host has Chrome installed; unrelated to this cleanup.

Refs: t_34b03c82
