### PR TITLE
fix(gateway): premark active sessions before drain

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5098,6 +5098,56 @@ class GatewayRunner:
                 except Exception as _e:
                     logger.debug("cleanup_all_browsers (%s) error: %s", phase, _e)
 
+            def _mark_active_sessions_resume_pending_before_drain(reason: str) -> set[str]:
+                """Durably mark currently running sessions before waiting.
+
+                On service restarts systemd can terminate the gateway while it
+                is still inside the drain wait.  If we only set
+                ``resume_pending`` after that wait times out, long-running
+                sessions whose ``updated_at`` is older than the startup
+                fallback window are lost.  Mark first, then clear the marks if
+                the drain completes gracefully.
+                """
+                marked: set[str] = set()
+                snapshot_running_agents = getattr(self, "_snapshot_running_agents", None)
+                if callable(snapshot_running_agents):
+                    active = snapshot_running_agents()
+                else:
+                    active = {
+                        session_key: agent
+                        for session_key, agent in getattr(self, "_running_agents", {}).items()
+                        if agent is not _AGENT_PENDING_SENTINEL
+                    }
+                if not active or getattr(self, "session_store", None) is None:
+                    return marked
+                try:
+                    with self.session_store._lock:  # noqa: SLF001 - durable shutdown bookkeeping
+                        self.session_store._ensure_loaded_locked()  # noqa: SLF001
+                        changed = False
+                        now = datetime.now()
+                        for session_key in active:
+                            entry = self.session_store._entries.get(session_key)  # noqa: SLF001
+                            if entry is None or entry.suspended or entry.resume_pending:
+                                continue
+                            entry.resume_pending = True
+                            entry.resume_reason = reason
+                            entry.last_resume_marked_at = now
+                            marked.add(session_key)
+                            changed = True
+                        if changed:
+                            self.session_store._save()  # noqa: SLF001
+                except Exception as _e:
+                    logger.debug(
+                        "Failed to pre-mark active sessions as resume_pending: %s",
+                        _e,
+                    )
+                if marked:
+                    logger.info(
+                        "Pre-marked %d active session(s) as resumable before gateway drain",
+                        len(marked),
+                    )
+                return marked
+
             logger.info(
                 "Stopping gateway%s...",
                 " for restart" if self._restart_requested else "",
@@ -5109,6 +5159,13 @@ class GatewayRunner:
 
             self._running = False
             self._draining = True
+
+            _resume_reason = (
+                "restart_timeout" if self._restart_requested else "shutdown_timeout"
+            )
+            _pre_drain_resume_marks = _mark_active_sessions_resume_pending_before_drain(
+                _resume_reason
+            )
 
             # Notify all chats with active agents BEFORE draining.
             # Adapters are still connected here, so messages can be sent.
@@ -5136,30 +5193,17 @@ class GatewayRunner:
                     timeout,
                     self._running_agent_count(),
                 )
-                # Mark forcibly-interrupted sessions as resume_pending BEFORE
-                # interrupting the agents.  This preserves each session's
-                # session_id + transcript so the next message on the same
-                # session_key auto-resumes from the existing conversation
-                # instead of getting routed through suspend_recently_active()
-                # and converted into a fresh session.  Terminal escalation
-                # for genuinely stuck sessions still flows through the
-                # existing ``.restart_failure_counts`` stuck-loop counter
-                # (incremented below, threshold 3), which sets
-                # ``suspended=True`` and overrides resume_pending.
+                # Active sessions were already marked resume_pending before
+                # the drain wait, so the marker survives even if systemd kills
+                # us right at the timeout boundary.  Refresh the marker for
+                # sessions that are still running now; sessions that completed
+                # during drain will have their early marker cleared below on
+                # the graceful path.
                 #
-                # Iterate self._running_agents (current) rather than the
-                # drain-start ``active_agents`` snapshot — the snapshot
-                # may include sessions that finished gracefully during
-                # the drain window, and marking those falsely would give
-                # them a stray restart-interruption system note on their
-                # next turn even though their previous turn completed
-                # cleanly.  Skip pending sentinels for the same reason
-                # _interrupt_running_agents() does: their agent hasn't
-                # started yet, there's nothing to interrupt, and the
-                # session shouldn't carry a misleading resume flag.
-                _resume_reason = (
-                    "restart_timeout" if self._restart_requested else "shutdown_timeout"
-                )
+                # Terminal escalation for genuinely stuck sessions still flows
+                # through the existing ``.restart_failure_counts`` stuck-loop
+                # counter (incremented below, threshold 3), which sets
+                # ``suspended=True`` and overrides resume_pending.
                 for _sk, _agent in list(self._running_agents.items()):
                     if _agent is _AGENT_PENDING_SENTINEL:
                         continue
@@ -5191,6 +5235,27 @@ class GatewayRunner:
                     "Shutdown phase: post-interrupt tool kill done at +%.2fs",
                     _phase_elapsed(),
                 )
+            elif _pre_drain_resume_marks:
+                # Drain completed cleanly: the active turns finished and the
+                # early crash-safety resume markers would be misleading on the
+                # next message.  Clear only the markers this stop() call added;
+                # pre-existing resume_pending entries were intentionally left
+                # untouched by the pre-mark helper.
+                cleared = 0
+                for _sk in _pre_drain_resume_marks:
+                    try:
+                        if self.session_store.clear_resume_pending(_sk):
+                            cleared += 1
+                    except Exception as _e:
+                        logger.debug(
+                            "clear pre-drain resume_pending failed for %s: %s",
+                            _sk, _e,
+                        )
+                if cleared:
+                    logger.info(
+                        "Cleared %d pre-drain resume marker(s) after graceful drain",
+                        cleared,
+                    )
 
             if self._restart_requested and self._restart_detached:
                 try:

--- a/tests/gateway/test_clean_shutdown_marker.py
+++ b/tests/gateway/test_clean_shutdown_marker.py
@@ -226,3 +226,77 @@ class TestCleanShutdownMarker:
             asyncio.get_event_loop().run_until_complete(runner.stop(restart=True))
 
         assert marker.exists(), ".clean_shutdown marker should exist after restart-stop too"
+
+    def test_active_sessions_are_resume_marked_before_drain(self, tmp_path, monkeypatch):
+        """Active sessions must be durable before the drain window starts.
+
+        systemd can kill the gateway while stop() is still waiting for the
+        drain timeout.  If resume_pending is only written after the timeout,
+        long-running sessions whose updated_at is older than the startup
+        fallback window are lost/stopped after restart.
+        """
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        marker = tmp_path / ".clean_shutdown"
+
+        from gateway.run import GatewayRunner
+        runner = object.__new__(GatewayRunner)
+        runner._restart_requested = False
+        runner._restart_detached = False
+        runner._restart_via_service = False
+        runner._restart_task_started = False
+        runner._running = True
+        runner._draining = False
+        runner._stop_task = None
+        runner._pending_messages = {}
+        runner._pending_approvals = {}
+        runner._background_tasks = set()
+        runner._shutdown_event = MagicMock()
+        runner._restart_drain_timeout = 5
+        runner._exit_code = None
+        runner._exit_reason = None
+        runner.adapters = {}
+        runner.config = GatewayConfig()
+        runner._running_agents_ts = {}
+
+        store = _make_store(tmp_path)
+        source = _make_source(chat_id="273403055", user_id="273403055")
+        entry = store.get_or_create_session(source)
+        # Make the startup suspend_recently_active(updated_at cutoff) fallback
+        # intentionally unable to catch this session; only early durable marking
+        # can preserve it if the process dies during drain.
+        with store._lock:
+            entry.updated_at = datetime.now() - timedelta(minutes=10)
+            store._save()
+        runner.session_store = store
+        running_agent = object()
+        runner._running_agents = {entry.session_key: running_agent}
+
+        async def assert_marked_before_drain(_runner, timeout):
+            with store._lock:
+                store._ensure_loaded_locked()
+                refreshed = store._entries[entry.session_key]
+                assert refreshed.resume_pending is True
+                assert refreshed.resume_reason == "restart_timeout"
+            return ({entry.session_key: running_agent}, False)
+
+        with patch("gateway.run.GatewayRunner._drain_active_agents", new=assert_marked_before_drain), \
+             patch("gateway.run.GatewayRunner._finalize_shutdown_agents"), \
+             patch("gateway.run.GatewayRunner._update_runtime_status"), \
+             patch("gateway.status.remove_pid_file"), \
+             patch("gateway.status.release_gateway_runtime_lock"), \
+             patch("tools.process_registry.process_registry") as mock_proc_reg, \
+             patch("tools.terminal_tool.cleanup_all_environments"), \
+             patch("tools.browser_tool.cleanup_all_browsers"):
+            mock_proc_reg.kill_all = MagicMock()
+
+            import asyncio
+            asyncio.get_event_loop().run_until_complete(runner.stop(restart=True))
+
+        # Because the mocked drain completed gracefully, stop() should clean up
+        # the early marker and still write the clean-shutdown marker.
+        with store._lock:
+            store._ensure_loaded_locked()
+            refreshed = store._entries[entry.session_key]
+            assert refreshed.resume_pending is False
+            assert refreshed.resume_reason is None
+        assert marker.exists(), ".clean_shutdown marker should exist after graceful restart-stop"


### PR DESCRIPTION
## Summary

Marks currently running gateway sessions as `resume_pending` **before** the restart/shutdown drain wait begins, then clears those early markers if the drain finishes cleanly.

This protects active messaging sessions when the service manager kills the gateway while it is still inside the drain window. In that case the existing post-timeout `mark_resume_pending()` path never runs, so long-running sessions can be lost/stopped after restart.

## Why

The current flow only writes `resume_pending` after `_drain_active_agents(timeout)` returns `timed_out=True`.

On systemd/launchd restarts the process can be terminated while still awaiting that drain, before control returns to the timeout branch. If the session's `updated_at` is outside the startup fallback window, the next boot has no durable marker to resume it.

This keeps the conservative `resume_pending` model from #12301, but moves the first durable marker earlier than the vulnerable wait.

## Behavior

- Active sessions are pre-marked with `restart_timeout` / `shutdown_timeout` before drain.
- If drain completes gracefully, only markers created by this stop call are cleared.
- If drain times out, the existing post-timeout refresh and interrupt path still runs.
- Existing `suspended=True` sessions are not overridden.
- Existing `resume_pending` sessions are left alone and are not cleared by this cleanup.
- The shutdown helper also tolerates lightweight test/fake gateway objects that expose `_running_agents` without the newer `_snapshot_running_agents()` helper.

## Related

Fixes #27856.

- Same failure mode family as #9128, but avoids writing `.clean_shutdown` at the start of stop.
- Builds on the `resume_pending` recovery model from #12301 / #11852.

## Test plan

RED:
- Applied the new regression test alone on `upstream/main`.
- Confirmed `tests/gateway/test_clean_shutdown_marker.py::TestCleanShutdownMarker::test_active_sessions_are_resume_marked_before_drain` failed because `resume_pending` was still `False` inside the drain call.

GREEN:
- `python -m pytest tests/gateway/test_clean_shutdown_marker.py::TestCleanShutdownMarker::test_active_sessions_are_resume_marked_before_drain tests/gateway/test_shutdown_cache_cleanup.py -q -o 'addopts='`
- `python -m pytest tests/gateway/test_clean_shutdown_marker.py tests/gateway/test_restart_resume_pending.py tests/gateway/test_shutdown_cache_cleanup.py -q -o 'addopts='`
- `python -m py_compile gateway/run.py tests/gateway/test_clean_shutdown_marker.py tests/gateway/test_shutdown_cache_cleanup.py`
- `ruff check gateway/run.py tests/gateway/test_clean_shutdown_marker.py tests/gateway/test_shutdown_cache_cleanup.py`
- `git diff --check`

Baseline note:
- `python -m pytest tests/hermes_cli/test_aux_config.py -q -o 'addopts='` currently fails the same way on `upstream/main` at `41f1eddee` because `DEFAULT_CONFIG["auxiliary"]` is missing `session_search`. This is unrelated to this PR's gateway shutdown diff.

## AI Disclosure

This fix was prepared with AI assistance.
