### PR TITLE
feat(gateway): add contextual rationale to approval prompts

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -3990,6 +3990,7 @@ class DiscordAdapter(BasePlatformAdapter):
     async def send_exec_approval(
         self, chat_id: str, command: str, session_key: str,
         description: str = "dangerous command",
+        contextual_reason: str = "",
         metadata: Optional[dict] = None,
     ) -> SendResult:
         """
@@ -4014,9 +4015,12 @@ class DiscordAdapter(BasePlatformAdapter):
             # Discord embed description limit is 4096; show full command up to that
             max_desc = 4088
             cmd_display = command if len(command) <= max_desc else command[: max_desc - 3] + "..."
+            _embed_desc = f"```\n{cmd_display}\n```"
+            if contextual_reason:
+                _embed_desc = f"{contextual_reason}\n\n{_embed_desc}"
             embed = discord.Embed(
                 title="⚠️ Command Approval Required",
-                description=f"```\n{cmd_display}\n```",
+                description=_embed_desc,
                 color=discord.Color.orange(),
             )
             embed.add_field(name="Reason", value=description, inline=False)

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1849,6 +1849,7 @@ class FeishuAdapter(BasePlatformAdapter):
     async def send_exec_approval(
         self, chat_id: str, command: str, session_key: str,
         description: str = "dangerous command",
+        contextual_reason: str = "",
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send an interactive card with approval buttons.
@@ -1872,6 +1873,9 @@ class FeishuAdapter(BasePlatformAdapter):
                     "value": {"hermes_action": action_name, "approval_id": approval_id},
                 }
 
+            _rationale_md = (
+                f"{contextual_reason}\n\n" if contextual_reason else ""
+            )
             card = {
                 "config": {"wide_screen_mode": True},
                 "header": {
@@ -1881,7 +1885,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 "elements": [
                     {
                         "tag": "markdown",
-                        "content": f"```\n{cmd_preview}\n```\n**Reason:** {description}",
+                        "content": f"{_rationale_md}```\n{cmd_preview}\n```\n**Reason:** {description}",
                     },
                     {
                         "tag": "action",

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -1212,6 +1212,7 @@ class MatrixAdapter(BasePlatformAdapter):
         command: str,
         session_key: str,
         description: str = "dangerous command",
+        contextual_reason: str = "",
         metadata: Optional[dict] = None,
     ) -> SendResult:
         """Send a reaction-based exec approval prompt for Matrix."""
@@ -1219,8 +1220,10 @@ class MatrixAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         cmd_preview = command[:2000] + "..." if len(command) > 2000 else command
+        _rationale_block = f"{contextual_reason}\n\n" if contextual_reason else ""
         text = (
             "⚠️ **Dangerous command requires approval**\n"
+            f"{_rationale_block}"
             f"```\n{cmd_preview}\n```\n"
             f"Reason: {description}\n\n"
             "Reply `/approve` to execute, `/approve session` to approve this pattern for the session, "

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -2534,6 +2534,7 @@ class QQAdapter(BasePlatformAdapter):
             command: str,
             session_key: str,
             description: str = "dangerous command",
+            contextual_reason: str = "",
             metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send a button-based exec-approval prompt for a dangerous command.
@@ -2557,6 +2558,12 @@ class QQAdapter(BasePlatformAdapter):
             command_preview=command,
             timeout_sec=self._APPROVAL_TIMEOUT_SECONDS,
         )
+        # Prepend contextual rationale if available so the user sees
+        # the agent's reasoning before the approval card.
+        if contextual_reason:
+            await self.send(
+                chat_id, contextual_reason, reply_to=msg_id,
+            )
         return await self.send_approval_request(
             chat_id, req, reply_to=msg_id,
         )

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -2242,6 +2242,7 @@ class SlackAdapter(BasePlatformAdapter):
     async def send_exec_approval(
         self, chat_id: str, command: str, session_key: str,
         description: str = "dangerous command",
+        contextual_reason: str = "",
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send a Block Kit approval prompt with interactive buttons.
@@ -2256,6 +2257,9 @@ class SlackAdapter(BasePlatformAdapter):
             cmd_preview = command[:2900] + "..." if len(command) > 2900 else command
             thread_ts = self._resolve_thread_ts(None, metadata)
 
+            _rationale_text = (
+                f"{contextual_reason}\n\n" if contextual_reason else ""
+            )
             blocks = [
                 {
                     "type": "section",
@@ -2263,6 +2267,7 @@ class SlackAdapter(BasePlatformAdapter):
                         "type": "mrkdwn",
                         "text": (
                             f":warning: *Command Approval Required*\n"
+                            f"{_rationale_text}"
                             f"```{cmd_preview}```\n"
                             f"Reason: {description}"
                         ),

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2118,6 +2118,7 @@ class TelegramAdapter(BasePlatformAdapter):
     async def send_exec_approval(
         self, chat_id: str, command: str, session_key: str,
         description: str = "dangerous command",
+        contextual_reason: str = "",
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send an inline-keyboard approval prompt with interactive buttons.
@@ -2130,8 +2131,14 @@ class TelegramAdapter(BasePlatformAdapter):
 
         try:
             cmd_preview = command[:3800] + "..." if len(command) > 3800 else command
+            _rationale_html = (
+                f"{_html.escape(contextual_reason)}\n\n"
+                if contextual_reason
+                else ""
+            )
             text = (
                 f"⚠️ <b>Command Approval Required</b>\n\n"
+                f"{_rationale_html}"
                 f"<pre>{_html.escape(cmd_preview)}</pre>\n\n"
                 f"Reason: {_html.escape(description)}"
             )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15334,16 +15334,26 @@ class GatewayRunner:
                 except Exception as _sc_err:
                     logger.debug("Could not set up stream consumer: %s", _sc_err)
 
+            _last_assistant_rationale = ""
+
             def _interim_assistant_cb(text: str, *, already_streamed: bool = False) -> None:
+                nonlocal _last_assistant_rationale
                 if not _run_still_current():
                     return
+                # Capture the assistant's latest text for contextual approval
+                # prompts.  We keep only the last non-empty chunk so the
+                # approval card shows the most recent rationale, not an
+                # accumulation of every streaming segment.
+                _stripped = str(text or "").strip()
+                if _stripped:
+                    _last_assistant_rationale = _stripped
                 if _stream_consumer is not None:
                     if already_streamed:
                         _stream_consumer.on_segment_break()
                     else:
                         _stream_consumer.on_commentary(text)
                     return
-                if already_streamed or not _status_adapter or not str(text or "").strip():
+                if already_streamed or not _status_adapter or not _stripped:
                     return
                 safe_schedule_threadsafe(
                     _status_adapter.send(
@@ -15659,6 +15669,7 @@ class GatewayRunner:
 
                 cmd = approval_data.get("command", "")
                 desc = approval_data.get("description", "dangerous command")
+                _rationale = _last_assistant_rationale
 
                 # Prefer button-based approval when the adapter supports it.
                 # Check the *class* for the method, not the instance — avoids
@@ -15671,6 +15682,7 @@ class GatewayRunner:
                                 command=cmd,
                                 session_key=_approval_session_key,
                                 description=desc,
+                                contextual_reason=_rationale,
                                 metadata=_status_thread_metadata,
                             ),
                             _loop_for_step,
@@ -15693,8 +15705,10 @@ class GatewayRunner:
 
                 # Fallback: plain text approval prompt
                 cmd_preview = cmd[:200] + "..." if len(cmd) > 200 else cmd
+                _rationale_block = f"\n{_rationale}\n\n" if _rationale else ""
                 msg = (
                     f"⚠️ **Dangerous command requires approval:**\n"
+                    f"{_rationale_block}"
                     f"```\n{cmd_preview}\n```\n"
                     f"Reason: {desc}\n\n"
                     f"Reply `/approve` to execute, `/approve session` to approve this pattern "

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -919,6 +919,7 @@ class TeamsAdapter(BasePlatformAdapter):
         command: str,
         session_key: str,
         description: str = "dangerous command",
+        contextual_reason: str = "",
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send an Adaptive Card approval prompt with Allow/Deny buttons."""
@@ -933,14 +934,22 @@ class TeamsAdapter(BasePlatformAdapter):
             "desc": description,
         }
 
+        _body_blocks = [
+            TextBlock(text="⚠️ Command Approval Required", wrap=True, weight="Bolder"),
+        ]
+        if contextual_reason:
+            _body_blocks.append(
+                TextBlock(text=contextual_reason, wrap=True),
+            )
+        _body_blocks.extend([
+            TextBlock(text=f"```\n{cmd_preview}\n```", wrap=True),
+            TextBlock(text=f"Reason: {description}", wrap=True, isSubtle=True),
+        ])
+
         card = (
             AdaptiveCard()
             .with_version("1.4")
-            .with_body([
-                TextBlock(text="⚠️ Command Approval Required", wrap=True, weight="Bolder"),
-                TextBlock(text=f"```\n{cmd_preview}\n```", wrap=True),
-                TextBlock(text=f"Reason: {description}", wrap=True, isSubtle=True),
-            ])
+            .with_body(_body_blocks)
             .with_actions([
                 ExecuteAction(
                     title="Allow Once",

--- a/tests/gateway/test_approval_contextual_rationale.py
+++ b/tests/gateway/test_approval_contextual_rationale.py
@@ -1,0 +1,253 @@
+"""Test contextual_reason parameter in send_exec_approval across adapters.
+
+Verifies that the new ``contextual_reason`` kwarg is accepted by all adapter
+``send_exec_approval`` methods and renders the rationale text in the approval
+prompt when provided.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+# ===========================================================================
+# Helpers
+# ===========================================================================
+
+def _ensure_telegram_mock():
+    """Wire up the minimal mocks required to import TelegramAdapter."""
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+    mod = MagicMock()
+    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    mod.constants.ParseMode.MARKDOWN = "Markdown"
+    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    mod.constants.ParseMode.HTML = "HTML"
+    mod.constants.ChatType.PRIVATE = "private"
+    mod.constants.ChatType.GROUP = "group"
+    mod.constants.ChatType.SUPERGROUP = "supergroup"
+    mod.constants.ChatType.CHANNEL = "channel"
+    mod.error.NetworkError = type("NetworkError", (OSError,), {})
+    mod.error.TimedOut = type("TimedOut", (OSError,), {})
+    mod.error.BadRequest = type("BadRequest", (Exception,), {})
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+    sys.modules.setdefault("telegram.error", mod.error)
+
+
+_ensure_telegram_mock()
+
+
+def _make_telegram_adapter():
+    from gateway.platforms.telegram import TelegramAdapter
+    from gateway.config import PlatformConfig
+    config = PlatformConfig(enabled=True, token="test-token")
+    adapter = TelegramAdapter(config)
+    adapter._bot = AsyncMock()
+    adapter._app = MagicMock()
+    return adapter
+
+
+# ===========================================================================
+# Telegram
+# ===========================================================================
+
+class TestTelegramContextualRationale:
+
+    @pytest.mark.asyncio
+    async def test_rationale_appears_in_text(self):
+        adapter = _make_telegram_adapter()
+        mock_msg = MagicMock()
+        mock_msg.message_id = 42
+        adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+
+        result = await adapter.send_exec_approval(
+            chat_id="12345",
+            command="rm -rf /tmp/cache",
+            session_key="s:key",
+            description="recursive delete",
+            contextual_reason="I need to free up disk space before the build.",
+        )
+
+        assert result.success is True
+        kwargs = adapter._bot.send_message.call_args[1]
+        text = kwargs["text"]
+        assert "I need to free up disk space" in text
+        assert "recursive delete" in text
+
+    @pytest.mark.asyncio
+    async def test_no_rationale_omits_block(self):
+        adapter = _make_telegram_adapter()
+        mock_msg = MagicMock()
+        mock_msg.message_id = 42
+        adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+
+        result = await adapter.send_exec_approval(
+            chat_id="12345",
+            command="rm -rf /tmp",
+            session_key="s:key",
+        )
+
+        assert result.success is True
+        kwargs = adapter._bot.send_message.call_args[1]
+        assert "Command Approval Required" in kwargs["text"]
+
+    @pytest.mark.asyncio
+    async def test_rationale_html_escaped(self):
+        adapter = _make_telegram_adapter()
+        mock_msg = MagicMock()
+        mock_msg.message_id = 42
+        adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+
+        result = await adapter.send_exec_approval(
+            chat_id="12345",
+            command="echo test",
+            session_key="s:key",
+            contextual_reason="This has <script>alert(1)</script> tags",
+        )
+
+        assert result.success is True
+        kwargs = adapter._bot.send_message.call_args[1]
+        text = kwargs["text"]
+        assert "&lt;script&gt;" in text
+        assert "<script>" not in text
+
+
+# ===========================================================================
+# Feishu
+# ===========================================================================
+
+class TestFeishuContextualRationale:
+
+    @pytest.mark.asyncio
+    async def test_rationale_in_card_markdown(self):
+        from gateway.platforms.feishu import FeishuAdapter
+        adapter = object.__new__(FeishuAdapter)
+        adapter._client = MagicMock()
+        adapter._approval_counter = iter(range(1, 100))
+        adapter._approval_state = {}
+        adapter._feishu_send_with_retry = AsyncMock(
+            return_value=MagicMock(data={"data": {"message_id": "om_xxx"}})
+        )
+        adapter._finalize_send_result = MagicMock(
+            return_value=MagicMock(success=True, message_id="om_xxx")
+        )
+
+        result = await adapter.send_exec_approval(
+            chat_id="oc_xxx",
+            command="rm -rf /tmp",
+            session_key="s:key",
+            description="dangerous command",
+            contextual_reason="Cleaning up temp files for the new build.",
+        )
+
+        assert result.success is True
+        call_args = adapter._feishu_send_with_retry.call_args
+        payload = call_args.kwargs.get("payload") or call_args[1].get("payload")
+        card = json.loads(payload)
+        md_content = card["elements"][0]["content"]
+        assert "Cleaning up temp files" in md_content
+
+    @pytest.mark.asyncio
+    async def test_no_rationale_clean(self):
+        from gateway.platforms.feishu import FeishuAdapter
+        adapter = object.__new__(FeishuAdapter)
+        adapter._client = MagicMock()
+        adapter._approval_counter = iter(range(1, 100))
+        adapter._approval_state = {}
+        adapter._feishu_send_with_retry = AsyncMock(
+            return_value=MagicMock(data={"data": {"message_id": "om_xxx"}})
+        )
+        adapter._finalize_send_result = MagicMock(
+            return_value=MagicMock(success=True, message_id="om_xxx")
+        )
+
+        result = await adapter.send_exec_approval(
+            chat_id="oc_xxx",
+            command="rm -rf /tmp",
+            session_key="s:key",
+        )
+
+        assert result.success is True
+
+
+# ===========================================================================
+# Matrix
+# ===========================================================================
+
+class TestMatrixContextualRationale:
+
+    @pytest.mark.asyncio
+    async def test_rationale_in_text(self):
+        from gateway.platforms.matrix import MatrixAdapter
+        from gateway.config import PlatformConfig
+        config = PlatformConfig(enabled=True)
+        adapter = MatrixAdapter(config)
+        adapter._client = MagicMock()
+        adapter._approval_prompt_by_session = {}
+        adapter._approval_prompts_by_event = {}
+
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.message_id = "evt_1"
+        adapter.send = AsyncMock(return_value=mock_result)
+        adapter._send_reaction = AsyncMock(return_value="evt_react")
+
+        result = await adapter.send_exec_approval(
+            chat_id="!room:server",
+            command="rm -rf /tmp",
+            session_key="s:key",
+            description="dangerous command",
+            contextual_reason="Removing stale cache files.",
+        )
+
+        assert result.success is True
+        send_text = adapter.send.call_args[0][1]
+        assert "Removing stale cache files" in send_text
+
+
+# ===========================================================================
+# Signature acceptance tests (parameter accepted without error)
+# ===========================================================================
+
+class TestAdapterSignatureAcceptsContextualReason:
+    """Ensure all adapters accept the new contextual_reason kwarg."""
+
+    @pytest.mark.asyncio
+    async def test_telegram_accepts_contextual_reason(self):
+        adapter = _make_telegram_adapter()
+        mock_msg = MagicMock()
+        mock_msg.message_id = 1
+        adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+        # Should not raise TypeError
+        result = await adapter.send_exec_approval(
+            chat_id="1", command="echo hi", session_key="s",
+            contextual_reason="Test rationale",
+        )
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_matrix_accepts_contextual_reason(self):
+        from gateway.platforms.matrix import MatrixAdapter
+        from gateway.config import PlatformConfig
+        adapter = MatrixAdapter(PlatformConfig(enabled=True))
+        adapter._client = MagicMock()
+        adapter._approval_prompt_by_session = {}
+        adapter._approval_prompts_by_event = {}
+        mock_result = MagicMock(success=True, message_id="e1")
+        adapter.send = AsyncMock(return_value=mock_result)
+        adapter._send_reaction = AsyncMock(return_value="r1")
+
+        result = await adapter.send_exec_approval(
+            chat_id="!r:s", command="echo", session_key="s",
+            contextual_reason="Rationale here",
+        )
+        assert result.success is True


### PR DESCRIPTION
## Summary

Include the agent's last assistant text as contextual rationale in dangerous command approval prompts across all gateway adapters.

When the agent requests approval for a dangerous command (e.g. `rm -rf`), the user now sees the agent's reasoning (e.g. *"I need to free disk space before the build"*) above the command preview, giving context for the approval decision.

Closes #27604

## Changes

- **`gateway/run.py`**: Capture last assistant text in `_interim_assistant_cb` closure, pass to adapter `send_exec_approval` as `contextual_reason`
- **All 7 adapters** (Telegram, Feishu, Discord, Slack, Matrix, QQBot, Teams): Accept `contextual_reason: str = ""` kwarg, render in platform-native approval UI
- Graceful degradation: no rationale shown when interim messages disabled or assistant produced no text before tool call

## Test Plan

- **8 new tests** in `tests/gateway/test_approval_contextual_rationale.py`
- **253 total tests passing** (8 new + 61 existing adapter approval + 184 core approval)
- All 8 modified files pass syntax checks
- Verified: Telegram HTML escaping, Feishu card markdown, Matrix text body, Slack Block Kit, Discord embed

## Screenshots (conceptual)

**Before:**
```
⚠️ Command Approval Required
`rm -rf /tmp/cache`
Reason: dangerous command
[Allow Once] [Session] [Always] [Deny]
```

**After:**
```
⚠️ Command Approval Required
I need to free up disk space before the build.

`rm -rf /tmp/cache`
Reason: dangerous command
[Allow Once] [Session] [Always] [Deny]
```