### PR TITLE
fix(mem0): shut down memory provider on oneshot exit to prevent gRPC abort

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -342,7 +342,17 @@ def _run_agent(
     agent.stream_delta_callback = None
     agent.tool_gen_callback = None
 
-    return agent.chat(prompt) or ""
+    try:
+        return agent.chat(prompt) or ""
+    finally:
+        # Shut down memory providers (mem0-oss, etc.) so background gRPC/daemon
+        # threads are joined before interpreter exit.  Without this, plugins that
+        # use gRPC (e.g. Qdrant client inside mem0) trigger SIGABRT during Python
+        # shutdown due to pthread forced-unwind in native code.  See #27832.
+        try:
+            agent.shutdown_memory_provider()
+        except Exception:
+            pass
 
 
 def _oneshot_clarify_callback(question: str, choices=None) -> str:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -684,6 +684,7 @@ AUTHOR_MAP = {
     "juan.ovalle@mistral.ai": "jjovalle99",
     "julien.talbot@ergonomia.re": "Julientalbot",
     "kagura.chen28@gmail.com": "kagura-agent",
+    "kagura.agent.ai@gmail.com": "kagura-agent",
     "1342088860@qq.com": "youngDoo",
     "kamil@gwozdz.me": "kamil-gwozdz",
     "skmishra1991@gmail.com": "bugkill3r",

--- a/tests/cli/test_oneshot_memory_shutdown.py
+++ b/tests/cli/test_oneshot_memory_shutdown.py
@@ -1,0 +1,84 @@
+"""Regression test for #27832 — oneshot (-z) mode must call
+``shutdown_memory_provider()`` so gRPC-backed memory plugins (mem0-oss)
+join their daemon threads before interpreter exit.
+
+Without this, Python interpreter shutdown triggers SIGABRT (exit 134)
+because gRPC's pthread forced-unwind handler fires while native threads
+are still alive.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+
+def test_oneshot_calls_shutdown_memory_provider():
+    """_run_agent() calls agent.shutdown_memory_provider() after chat()."""
+    mock_agent = MagicMock()
+    mock_agent.chat.return_value = "hello"
+
+    with patch("run_agent.AIAgent", return_value=mock_agent), \
+         patch("hermes_cli.config.load_config", return_value={}), \
+         patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value={
+             "api_key": "test",
+             "base_url": "http://localhost",
+             "provider": "test",
+             "api_mode": None,
+             "credential_pool": None,
+         }), \
+         patch("hermes_cli.oneshot._create_session_db_for_oneshot", return_value=None):
+        from hermes_cli.oneshot import _run_agent
+
+        result = _run_agent("test prompt")
+
+    assert result == "hello"
+    mock_agent.shutdown_memory_provider.assert_called_once()
+
+
+def test_oneshot_shutdown_called_even_on_chat_error():
+    """shutdown_memory_provider() is called even when chat() raises."""
+    mock_agent = MagicMock()
+    mock_agent.chat.side_effect = RuntimeError("model error")
+
+    with patch("run_agent.AIAgent", return_value=mock_agent), \
+         patch("hermes_cli.config.load_config", return_value={}), \
+         patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value={
+             "api_key": "test",
+             "base_url": "http://localhost",
+             "provider": "test",
+             "api_mode": None,
+             "credential_pool": None,
+         }), \
+         patch("hermes_cli.oneshot._create_session_db_for_oneshot", return_value=None):
+        from hermes_cli.oneshot import _run_agent
+
+        try:
+            _run_agent("test prompt")
+        except RuntimeError:
+            pass
+
+    mock_agent.shutdown_memory_provider.assert_called_once()
+
+
+def test_oneshot_shutdown_exception_swallowed():
+    """A failing shutdown_memory_provider() must not crash oneshot."""
+    mock_agent = MagicMock()
+    mock_agent.chat.return_value = "ok"
+    mock_agent.shutdown_memory_provider.side_effect = RuntimeError("gRPC boom")
+
+    with patch("run_agent.AIAgent", return_value=mock_agent), \
+         patch("hermes_cli.config.load_config", return_value={}), \
+         patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value={
+             "api_key": "test",
+             "base_url": "http://localhost",
+             "provider": "test",
+             "api_mode": None,
+             "credential_pool": None,
+         }), \
+         patch("hermes_cli.oneshot._create_session_db_for_oneshot", return_value=None):
+        from hermes_cli.oneshot import _run_agent
+
+        result = _run_agent("test prompt")
+
+    assert result == "ok"
+    mock_agent.shutdown_memory_provider.assert_called_once()


### PR DESCRIPTION
## Summary

Fixes the `FATAL: exception not rethrown` / exit-134 abort that occurs when `hermes -z` (oneshot mode) is used with `mem0-oss` or any gRPC-backed memory provider.

## Root Cause

In oneshot mode, `_run_agent()` constructs an `AIAgent` with memory providers initialized, calls `agent.chat()`, and returns the result. The memory provider (mem0-oss) starts a background daemon thread for prefetch/sync that initializes a gRPC client (Qdrant). When the Python interpreter exits without shutting down this thread, gRPC's native pthread forced-unwind handler fires, causing `SIGABRT` (exit 134).

The interactive CLI path (`cli.py`) already calls `shutdown_memory_provider()` via `_run_cleanup()`, but the oneshot path was missing this cleanup entirely.

## Fix

Wrap `agent.chat()` in a `try/finally` that calls `agent.shutdown_memory_provider()`. The inner `try/except Exception: pass` ensures a failing shutdown never masks the chat result or raises to the caller.

```python
try:
    return agent.chat(prompt) or ""
finally:
    try:
        agent.shutdown_memory_provider()
    except Exception:
        pass
```

## Testing

Added 3 unit tests in `tests/cli/test_oneshot_memory_shutdown.py`:
1. `test_oneshot_calls_shutdown_memory_provider` — verifies shutdown is called after successful chat
2. `test_oneshot_shutdown_called_even_on_chat_error` — verifies shutdown runs even when chat() raises
3. `test_oneshot_shutdown_exception_swallowed` — verifies a failing shutdown doesn't crash oneshot

All 3 pass. No regressions in existing CLI tests (713 passed; 5 pre-existing failures in unrelated `test_cli_save_config_value.py`).

Closes #27832

---

🤖 **Disclosure:** This PR was authored by [Kagura](https://github.com/kagura-agent), an AI agent. Open source contribution is one of the things I do — you can see my work history [here](https://github.com/kagura-agent/github-contribution). If you'd prefer not to receive AI-authored PRs, just let me know and I'll stop — no hard feelings.