### PR TITLE
fix(update): key update-check cache by git HEAD

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -192,6 +192,11 @@ def _check_via_rev(local_rev: str) -> Optional[int]:
     return 0 if upstream_rev == local_rev else UPDATE_AVAILABLE_NO_COUNT
 
 
+def _local_git_head(repo_dir: Path) -> Optional[str]:
+    """Return the current checkout HEAD for cache invalidation."""
+    return _git_stdout(["rev-parse", "HEAD"], cwd=repo_dir)
+
+
 def _check_via_local_git(repo_dir: Path) -> Optional[int]:
     """Count commits behind origin/main in a local checkout."""
     origin_url = _git_stdout(["remote", "get-url", "origin"], cwd=repo_dir)
@@ -297,19 +302,42 @@ def check_for_updates() -> Optional[int]:
     except Exception:
         pass
 
-    # Read cache — invalidate if the embedded rev OR installed version has
-    # changed since the last check. The version guard matters for pip installs:
-    # `check_via_pypi()` compares against VERSION, so a `pip install --upgrade`
-    # changes VERSION but leaves rev unchanged (both None), and without this
-    # the stale "behind" count would survive the upgrade for up to 6h. See #34491.
+    repo_dir: Optional[Path] = None
+    repo_head: Optional[str] = None
+    if not embedded_rev:
+        # Prefer the running code's location over the profile-scoped path.
+        # $HERMES_HOME/hermes-agent/ may be a stale copy from --clone-all;
+        # Path(__file__) always resolves to the actual installed checkout.
+        candidate_repo_dir = Path(__file__).parent.parent.resolve()
+        if not (candidate_repo_dir / ".git").exists():
+            candidate_repo_dir = hermes_home / "hermes-agent"
+        if (candidate_repo_dir / ".git").exists():
+            repo_dir = candidate_repo_dir
+            repo_head = _local_git_head(repo_dir)
+
+    # Read cache — invalidate if the embedded rev, installed version, or local
+    # checkout HEAD has changed since the last check. The version guard matters
+    # for pip installs: `check_via_pypi()` compares against VERSION, so a
+    # `pip install --upgrade` changes VERSION but leaves rev unchanged (both
+    # None), and without this the stale "behind" count would survive the
+    # upgrade for up to 6h. See #34491.
     now = time.time()
     try:
         if cache_file.exists():
             cached = json.loads(cache_file.read_text())
+            cache_fingerprint_matches = (
+                cached.get("rev") == embedded_rev
+                and cached.get("ver") == VERSION
+            )
+            if repo_dir is not None:
+                cache_fingerprint_matches = (
+                    cache_fingerprint_matches
+                    and repo_head is not None
+                    and cached.get("repo_head") == repo_head
+                )
             if (
                 now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS
-                and cached.get("rev") == embedded_rev
-                and cached.get("ver") == VERSION
+                and cache_fingerprint_matches
             ):
                 return cached.get("behind")
     except Exception:
@@ -317,22 +345,16 @@ def check_for_updates() -> Optional[int]:
 
     if embedded_rev:
         behind = _check_via_rev(embedded_rev)
+    elif repo_dir is None:
+        behind = check_via_pypi()
     else:
-        # Prefer the running code's location over the profile-scoped path.
-        # $HERMES_HOME/hermes-agent/ may be a stale copy from --clone-all;
-        # Path(__file__) always resolves to the actual installed checkout.
-        repo_dir = Path(__file__).parent.parent.resolve()
-        if not (repo_dir / ".git").exists():
-            repo_dir = hermes_home / "hermes-agent"
-        if not (repo_dir / ".git").exists():
-            behind = check_via_pypi()
-        else:
-            behind = _check_via_local_git(repo_dir)
+        behind = _check_via_local_git(repo_dir)
 
     try:
-        cache_file.write_text(
-            json.dumps({"ts": now, "behind": behind, "rev": embedded_rev, "ver": VERSION})
-        )
+        payload = {"ts": now, "behind": behind, "rev": embedded_rev, "ver": VERSION}
+        if repo_head is not None:
+            payload["repo_head"] = repo_head
+        cache_file.write_text(json.dumps(payload))
     except Exception:
         pass
 

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -17,24 +17,77 @@ def test_version_string_no_v_prefix():
 
 
 def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
-    """When cache is fresh, check_for_updates should return cached value without calling git."""
-    from hermes_cli.banner import check_for_updates
-    from hermes_cli import __version__
+    """When cache is fresh and HEAD matches, check_for_updates should return cached value without fetching."""
+    import hermes_cli.banner as banner
 
-    # Create a fake git repo and fresh cache
-    repo_dir = tmp_path / "hermes-agent"
-    repo_dir.mkdir()
-    (repo_dir / ".git").mkdir()
+    project_root = tmp_path / "checkout"
+    project_root.mkdir()
+    (project_root / ".git").mkdir()
+    fake_banner = project_root / "hermes_cli" / "banner.py"
+    fake_banner.parent.mkdir(parents=True)
+    fake_banner.touch()
 
     cache_file = tmp_path / ".update_check"
-    cache_file.write_text(json.dumps({"ts": time.time(), "behind": 3, "ver": __version__}))
+    cache_file.write_text(
+        json.dumps({"ts": time.time(), "behind": 3, "rev": None, "ver": banner.VERSION, "repo_head": "same-head"})
+    )
 
+    monkeypatch.setattr(banner, "__file__", str(fake_banner))
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    with patch("hermes_cli.banner.subprocess.run") as mock_run:
-        result = check_for_updates()
+    monkeypatch.delenv("HERMES_REVISION", raising=False)
+    with patch("hermes_cli.banner.subprocess.run", return_value=MagicMock(returncode=0, stdout="same-head\n")) as mock_run:
+        result = banner.check_for_updates()
 
     assert result == 3
-    mock_run.assert_not_called()
+    mock_run.assert_called_once_with(
+        ["git", "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+        timeout=5,
+        cwd=str(project_root),
+    )
+
+
+def test_check_for_updates_invalidates_cache_when_git_head_changes(tmp_path, monkeypatch):
+    """Fresh local-git cache from an older HEAD must not report stale behind counts."""
+    import hermes_cli.banner as banner
+
+    project_root = tmp_path / "checkout"
+    project_root.mkdir()
+    (project_root / ".git").mkdir()
+    fake_banner = project_root / "hermes_cli" / "banner.py"
+    fake_banner.parent.mkdir(parents=True)
+    fake_banner.touch()
+
+    cache_file = tmp_path / ".update_check"
+    cache_file.write_text(
+        json.dumps({"ts": time.time(), "behind": 203, "rev": None, "ver": banner.VERSION, "repo_head": "old-head"})
+    )
+
+    monkeypatch.setattr(banner, "__file__", str(fake_banner))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_REVISION", raising=False)
+
+    def fake_run(cmd, **kwargs):
+        if cmd == ["git", "rev-parse", "HEAD"]:
+            return MagicMock(returncode=0, stdout="new-head\n")
+        if cmd == ["git", "remote", "get-url", "origin"]:
+            return MagicMock(returncode=0, stdout="https://github.com/NousResearch/hermes-agent.git\n")
+        if cmd == ["git", "fetch", "origin", "--quiet"]:
+            return MagicMock(returncode=0, stdout="")
+        if cmd == ["git", "rev-list", "--count", "HEAD..origin/main"]:
+            return MagicMock(returncode=0, stdout="0\n")
+        raise AssertionError(f"unexpected command: {cmd!r}")
+
+    with patch("hermes_cli.banner.subprocess.run", side_effect=fake_run) as mock_run:
+        result = banner.check_for_updates()
+
+    assert result == 0
+    assert mock_run.call_count == 4
+    cached = json.loads(cache_file.read_text())
+    assert cached["behind"] == 0
+    assert cached["ver"] == banner.VERSION
+    assert cached["repo_head"] == "new-head"
 
 
 def test_check_for_updates_invalidates_on_version_change(tmp_path, monkeypatch):
@@ -76,24 +129,38 @@ def test_check_for_updates_invalidates_on_version_change(tmp_path, monkeypatch):
 
 def test_check_for_updates_expired_cache(tmp_path, monkeypatch):
     """When cache is expired, check_for_updates should call git fetch."""
-    from hermes_cli.banner import check_for_updates
+    import hermes_cli.banner as banner
 
-    repo_dir = tmp_path / "hermes-agent"
-    repo_dir.mkdir()
-    (repo_dir / ".git").mkdir()
+    project_root = tmp_path / "checkout"
+    project_root.mkdir()
+    (project_root / ".git").mkdir()
+    fake_banner = project_root / "hermes_cli" / "banner.py"
+    fake_banner.parent.mkdir(parents=True)
+    fake_banner.touch()
 
     # Write an expired cache (timestamp far in the past)
     cache_file = tmp_path / ".update_check"
-    cache_file.write_text(json.dumps({"ts": 0, "behind": 1}))
+    cache_file.write_text(json.dumps({"ts": 0, "behind": 1, "rev": None, "ver": banner.VERSION, "repo_head": "same-head"}))
 
-    mock_result = MagicMock(returncode=0, stdout="5\n")
+    def fake_run(cmd, **kwargs):
+        if cmd == ["git", "rev-parse", "HEAD"]:
+            return MagicMock(returncode=0, stdout="same-head\n")
+        if cmd == ["git", "remote", "get-url", "origin"]:
+            return MagicMock(returncode=0, stdout="https://github.com/NousResearch/hermes-agent.git\n")
+        if cmd == ["git", "fetch", "origin", "--quiet"]:
+            return MagicMock(returncode=0, stdout="")
+        if cmd == ["git", "rev-list", "--count", "HEAD..origin/main"]:
+            return MagicMock(returncode=0, stdout="5\n")
+        raise AssertionError(f"unexpected command: {cmd!r}")
 
+    monkeypatch.setattr(banner, "__file__", str(fake_banner))
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    with patch("hermes_cli.banner.subprocess.run", return_value=mock_result) as mock_run:
-        result = check_for_updates()
+    monkeypatch.delenv("HERMES_REVISION", raising=False)
+    with patch("hermes_cli.banner.subprocess.run", side_effect=fake_run) as mock_run:
+        result = banner.check_for_updates()
 
     assert result == 5
-    assert mock_run.call_count == 3  # origin probe + git fetch + git rev-list
+    assert mock_run.call_count == 4  # HEAD fingerprint + origin probe + fetch + rev-list
 
 
 def test_check_for_updates_official_ssh_origin_uses_https_probe(tmp_path):


### PR DESCRIPTION
## Summary
- key local-git update-check cache entries by the active checkout `HEAD`
- treat old/mismatched cache entries as stale so `hermes --version` does not report an old commits-behind count after a pull
- update cache tests to cover matching HEAD, changed HEAD, and expired-cache paths

Closes #27841

## Test Plan
- `python -m py_compile hermes_cli/banner.py hermes_cli/main.py`
- `python -m pytest tests/hermes_cli/test_update_check.py tests/hermes_cli/test_cmd_update.py -q` — 19 passed

## Notes
This preserves the existing six-hour TTL, but only reuses it when the cache fingerprint matches the install mode:
- Nix/embedded revision builds still key by `HERMES_REVISION`
- Local git installs now key by `git rev-parse HEAD`
