### PR TITLE
fix(auxiliary): propagate resolved_model from fallback_chain + fix explicit kwarg names

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2693,17 +2693,18 @@ def _try_configured_fallback_chain(
         label = f"fallback_chain[{i}]({fb_provider})"
 
         try:
-            fb_client = _resolve_single_provider(
+            fb_client, fb_resolved_model = _resolve_single_provider(
                 fb_provider, fb_model, fb_base_url, fb_api_key)
         except Exception:
-            fb_client = None
+            fb_client, fb_resolved_model = None, None
 
         if fb_client is not None:
+            effective_model = fb_model or fb_resolved_model
             logger.info(
                 "Auxiliary %s: %s on %s — configured fallback to %s (%s)",
-                task, reason, failed_provider, label, fb_model or "default",
+                task, reason, failed_provider, label, effective_model or "default",
             )
-            return fb_client, fb_model, label
+            return fb_client, effective_model, label
         tried.append(label)
 
     if tried:
@@ -2719,19 +2720,23 @@ def _resolve_single_provider(
     model: Optional[str] = None,
     base_url: Optional[str] = None,
     api_key: Optional[str] = None,
-) -> Optional[Any]:
+) -> Tuple[Optional[Any], Optional[str]]:
     """Resolve a single provider entry from fallback_chain to an OpenAI client.
 
     Uses the existing provider resolution infrastructure where possible.
+    Returns (client, resolved_model) so callers can fall back to the
+    provider's default model when the chain entry omits ``model``.
     """
-    # Reuse resolve_provider_client which handles provider→client mapping
+    # Reuse resolve_provider_client which handles provider→client mapping.
+    # Use explicit_base_url / explicit_api_key — the public resolve_provider_client
+    # API does not accept positional base_url / api_key kwargs.
     client, resolved_model = resolve_provider_client(
         provider=provider,
         model=model,
-        base_url=base_url,
-        api_key=api_key,
+        explicit_base_url=base_url,
+        explicit_api_key=api_key,
     )
-    return client
+    return client, resolved_model
 
 def _resolve_auto(main_runtime: Optional[Dict[str, Any]] = None) -> Tuple[Optional[OpenAI], Optional[str]]:
     """Full auto-detection chain.

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2991,3 +2991,128 @@ class TestAuxUnhealthyCache:
             )
             # After the 402, OpenRouter is in the unhealthy cache.
             assert _is_provider_unhealthy("openrouter") is True
+
+
+class TestResolveSingleProvider:
+    """_resolve_single_provider passes explicit_base_url/explicit_api_key and
+    returns (client, resolved_model) so that callers can use the provider's
+    default model when the fallback_chain entry omits ``model``."""
+
+    def test_passes_explicit_kwargs_to_resolve_provider_client(self):
+        from agent.auxiliary_client import _resolve_single_provider
+
+        fake_client = MagicMock()
+        with patch("agent.auxiliary_client.resolve_provider_client",
+                   return_value=(fake_client, "resolved-model")) as resolver:
+            client, model = _resolve_single_provider(
+                "custom",
+                model="explicit-model",
+                base_url="https://fb.example/v1",
+                api_key="fb-key",
+            )
+
+        resolver.assert_called_once_with(
+            provider="custom",
+            model="explicit-model",
+            explicit_base_url="https://fb.example/v1",
+            explicit_api_key="fb-key",
+        )
+        assert client is fake_client
+        assert model == "resolved-model"
+
+    def test_returns_resolved_model_when_entry_omits_model(self):
+        """Chain entry with no model should use the provider's resolved default."""
+        from agent.auxiliary_client import _resolve_single_provider
+
+        fake_client = MagicMock()
+        with patch("agent.auxiliary_client.resolve_provider_client",
+                   return_value=(fake_client, "provider-default-model")):
+            client, model = _resolve_single_provider("openrouter")
+
+        assert client is fake_client
+        assert model == "provider-default-model"
+
+    def test_returns_none_client_and_none_model_when_unavailable(self):
+        from agent.auxiliary_client import _resolve_single_provider
+
+        with patch("agent.auxiliary_client.resolve_provider_client",
+                   return_value=(None, None)):
+            client, model = _resolve_single_provider("openrouter")
+
+        assert client is None
+        assert model is None
+
+
+class TestConfiguredFallbackChain:
+    """_try_configured_fallback_chain uses the provider's resolved model when
+    the chain entry omits ``model``, and passes explicit_base_url/api_key."""
+
+    def test_uses_resolved_model_when_entry_has_no_model(self, monkeypatch):
+        from agent.auxiliary_client import _try_configured_fallback_chain
+
+        fake_client = MagicMock()
+        task_cfg = {"fallback_chain": [{"provider": "openrouter"}]}
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            lambda task: task_cfg,
+        )
+        with patch("agent.auxiliary_client.resolve_provider_client",
+                   return_value=(fake_client, "or-default-model")):
+            client, model, label = _try_configured_fallback_chain(
+                "compression", "primary-provider"
+            )
+
+        assert client is fake_client
+        assert model == "or-default-model"
+        assert label == "fallback_chain[0](openrouter)"
+
+    def test_explicit_model_takes_precedence_over_resolved(self, monkeypatch):
+        from agent.auxiliary_client import _try_configured_fallback_chain
+
+        fake_client = MagicMock()
+        task_cfg = {
+            "fallback_chain": [
+                {"provider": "openrouter", "model": "openai/gpt-4o-mini"}
+            ]
+        }
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            lambda task: task_cfg,
+        )
+        with patch("agent.auxiliary_client.resolve_provider_client",
+                   return_value=(fake_client, "or-default-model")):
+            client, model, label = _try_configured_fallback_chain(
+                "compression", "primary-provider"
+            )
+
+        assert client is fake_client
+        assert model == "openai/gpt-4o-mini"
+
+    def test_passes_explicit_base_url_and_api_key(self, monkeypatch):
+        from agent.auxiliary_client import _try_configured_fallback_chain
+
+        fake_client = MagicMock()
+        task_cfg = {
+            "fallback_chain": [
+                {
+                    "provider": "custom",
+                    "model": "my-model",
+                    "base_url": "https://fb.example/v1",
+                    "api_key": "fb-key",
+                }
+            ]
+        }
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            lambda task: task_cfg,
+        )
+        with patch("agent.auxiliary_client.resolve_provider_client",
+                   return_value=(fake_client, "my-model")) as resolver:
+            _try_configured_fallback_chain("vision", "gemini")
+
+        resolver.assert_called_once_with(
+            provider="custom",
+            model="my-model",
+            explicit_base_url="https://fb.example/v1",
+            explicit_api_key="fb-key",
+        )


### PR DESCRIPTION
## Summary

`_resolve_single_provider` had two bugs that together caused `_try_configured_fallback_chain` to silently fail for every chain entry:

**Bug 1 — wrong kwarg names (addresses #27555)**
`resolve_provider_client` expects `explicit_base_url` / `explicit_api_key`, but the call site passed `base_url` / `api_key`. Python raised `TypeError` on every call, which `_try_configured_fallback_chain` caught and silently converted to `fb_client = None`, so no chain entry ever fired.

**Bug 2 — resolved_model silently dropped**
`_resolve_single_provider` computed `client, resolved_model = resolve_provider_client(...)` and returned only `client`. When a chain entry omits the optional `model:` field (documented as valid), `fb_model` is `None` and the caller passed `model=None` to `_build_call_kwargs`, producing an API call that providers reject. This is a parity gap with `_try_main_agent_model_fallback`, which correctly returns `resolved_model or main_model`.

## Changes

- `_resolve_single_provider`: fix kwarg names to `explicit_base_url` / `explicit_api_key`; change return type from `Optional[Any]` to `Tuple[Optional[Any], Optional[str]]` and return `(client, resolved_model)`
- `_try_configured_fallback_chain`: unpack the tuple; use `fb_model or fb_resolved_model` so entries without an explicit `model:` field get the provider's default — symmetric with `_try_main_agent_model_fallback`

## Test plan

- [x] `TestResolveSingleProvider::test_passes_explicit_kwargs_to_resolve_provider_client` — verifies `explicit_base_url` / `explicit_api_key` are forwarded correctly
- [x] `TestResolveSingleProvider::test_returns_resolved_model_when_entry_omits_model` — verifies provider default model is returned when caller passes `model=None`
- [x] `TestResolveSingleProvider::test_returns_none_client_and_none_model_when_unavailable` — verifies `(None, None)` on unavailable provider
- [x] `TestConfiguredFallbackChain::test_uses_resolved_model_when_entry_has_no_model` — chain entry without `model:` uses provider's resolved default
- [x] `TestConfiguredFallbackChain::test_explicit_model_takes_precedence_over_resolved` — explicit `model:` in config wins over provider default
- [x] `TestConfiguredFallbackChain::test_passes_explicit_base_url_and_api_key` — `base_url` / `api_key` from chain entry reach `resolve_provider_client` via correct kwarg names