### PR TITLE
feat: add config option to disable eager rate-limit fallback

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1303,6 +1303,13 @@ def init_agent(
         _api_retries = 3
     agent._api_max_retries = _api_retries
 
+    # Whether a 429 rate-limit triggers immediate fallback to the next provider
+    # instead of retrying the primary model.  Default True preserves existing
+    # behavior; set False to retry api_max_retries times first.  Billing (402)
+    # always fails over eagerly regardless of this flag -- see
+    # _should_eager_fallback in agent/conversation_loop.py.
+    agent._eager_rate_limit_fallback = _agent_section.get("eager_rate_limit_fallback", True)
+
     # Initialize context compressor for automatic context management
     # Compresses conversation when approaching model's context limit
     # Configuration via config.yaml (compression section)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -153,6 +153,32 @@ def _ra():
     return run_agent
 
 
+def _should_eager_fallback(reason: "FailoverReason", eager_rate_limit_fallback: bool) -> bool:
+    """Whether a failover ``reason`` should trigger an immediate ("eager")
+    switch to the next fallback provider, before the normal retry/backoff loop.
+
+    Two reasons reach the eager-fallback gate:
+
+    * ``FailoverReason.billing`` (HTTP 402) — **always** eager, regardless of
+      the user setting.  A confirmed billing error is permanent: retrying burns
+      paid requests against an exhausted balance (#31273), and skipping fallback
+      would only drop it into the ``is_client_error`` abort path without ever
+      trying a backup provider.
+    * ``FailoverReason.rate_limit`` (HTTP 429) — eager by default, but honored
+      as configurable via ``agent.eager_rate_limit_fallback``.  Transient limits
+      (e.g. DashScope burst quotas, peak-hour throttling) often clear within the
+      retry window, so users can opt into retrying the primary first by setting
+      the flag to ``False``.
+
+    Any other reason is not handled by this gate and returns ``False``.
+    """
+    if reason == FailoverReason.billing:
+        return True
+    if reason == FailoverReason.rate_limit:
+        return bool(eager_rate_limit_fallback)
+    return False
+
+
 def _nous_entitlement_message(capability: str) -> str:
     try:
         from hermes_cli.nous_account import (
@@ -2791,15 +2817,25 @@ def run_conversation(
                     # Fall through to normal error handling if compression
                     # is exhausted or didn't help.
 
-                # Eager fallback for rate-limit errors (429 or quota exhaustion).
+                # Eager fallback for rate-limit (429) and billing (402) errors.
                 # When a fallback model is configured, switch immediately instead
                 # of burning through retries with exponential backoff -- the
                 # primary provider won't recover within the retry window.
+                #
+                # Billing always fails over eagerly (402 is permanent); rate-
+                # limit honors agent.eager_rate_limit_fallback (default True), so
+                # users on bursty-but-recovering primaries can set it False to
+                # retry the primary api_max_retries times before falling back.
+                # See _should_eager_fallback for the full rationale.
                 is_rate_limited = classified.reason in {
                     FailoverReason.rate_limit,
                     FailoverReason.billing,
                 }
-                if is_rate_limited and agent._fallback_index < len(agent._fallback_chain):
+                should_eager_fallback = _should_eager_fallback(
+                    classified.reason,
+                    getattr(agent, "_eager_rate_limit_fallback", True),
+                )
+                if should_eager_fallback and agent._fallback_index < len(agent._fallback_chain):
                     # Don't eagerly fallback if credential pool rotation may
                     # still recover.  See _pool_may_recover_from_rate_limit
                     # for the single-credential-pool and CloudCode-quota

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -927,6 +927,13 @@ DEFAULT_CONFIG = {
         # on flaky primaries; raise it if you prefer to tolerate longer
         # provider hiccups on a single provider.
         "api_max_retries": 3,
+        # When True (default), a 429 rate-limit triggers an immediate fallback
+        # to a backup provider instead of retrying the primary model.  Set to
+        # False to let the normal retry loop with exponential backoff run first
+        # — the primary is retried api_max_retries times before falling back.
+        # Confirmed billing errors (402) always fail over eagerly regardless of
+        # this setting, since retrying a permanent error is pointless.
+        "eager_rate_limit_fallback": True,
         "service_tier": "",
         # Tool-use enforcement: injects system prompt guidance that tells the
         # model to actually call tools instead of describing intended actions.

--- a/tests/agent/test_eager_rate_limit_fallback.py
+++ b/tests/agent/test_eager_rate_limit_fallback.py
@@ -1,0 +1,138 @@
+"""Tests for ``agent.eager_rate_limit_fallback``.
+
+This config knob decides what happens when a provider returns a 429 rate-limit
+error: fail over to the next provider immediately (eager, the default) or run
+the normal retry/backoff loop against the primary first.
+
+Coverage:
+  * ``_should_eager_fallback`` — the decision helper, including the invariant
+    that billing (HTTP 402) ALWAYS fails over eagerly regardless of the flag.
+    402 is permanent; retrying it burns paid requests against an exhausted
+    balance, and suppressing its fallback would only drop it into the
+    ``is_client_error`` abort path without ever trying a backup provider
+    (see #31273 and ``tests/run_agent/test_31273_402_not_retried.py``).
+  * Config propagation + default — ``agent.eager_rate_limit_fallback`` reaches
+    the agent object and defaults to ``True`` when unset (mirrors
+    ``tests/run_agent/test_api_max_retries_config.py``).
+  * A source-introspection guard that the production gate in
+    ``run_conversation`` actually delegates to the helper (mirrors
+    ``tests/agent/test_gemini_fast_fallback.py``).
+"""
+import inspect
+from unittest.mock import patch
+
+from agent import conversation_loop
+from agent.conversation_loop import _should_eager_fallback
+from agent.error_classifier import FailoverReason
+from hermes_cli.config import DEFAULT_CONFIG
+from run_agent import AIAgent
+
+
+# --------------------------------------------------------------------------- #
+# Decision helper: _should_eager_fallback(reason, eager_rate_limit_fallback)
+# --------------------------------------------------------------------------- #
+
+def test_rate_limit_eager_by_default_falls_back_immediately():
+    """eager=True (the default) + 429 → switch to the next provider now."""
+    assert _should_eager_fallback(FailoverReason.rate_limit, True) is True
+
+
+def test_rate_limit_eager_disabled_defers_to_retry_loop():
+    """eager=False + 429 → do NOT fall back at this gate; let the normal
+    retry/backoff loop run ``api_max_retries`` times against the primary
+    before fallback engages."""
+    assert _should_eager_fallback(FailoverReason.rate_limit, False) is False
+
+
+def test_billing_always_falls_back_regardless_of_setting():
+    """402 is permanent, so it fails over eagerly whether the flag is True or
+    False.  Honoring the flag for billing would only drop a 402 into the
+    ``is_client_error`` abort path without ever trying a backup provider
+    (#31273)."""
+    assert _should_eager_fallback(FailoverReason.billing, True) is True
+    assert _should_eager_fallback(FailoverReason.billing, False) is True
+
+
+def test_unrelated_reasons_are_not_handled_by_this_gate():
+    """Only rate_limit and billing reach the eager-fallback gate.  Every other
+    reason is handled by its own branch and must return False here regardless
+    of the flag (so flipping the knob can never change their routing)."""
+    for reason in (
+        FailoverReason.overloaded,
+        FailoverReason.context_overflow,
+        FailoverReason.unknown,
+    ):
+        assert _should_eager_fallback(reason, True) is False
+        assert _should_eager_fallback(reason, False) is False
+
+
+# --------------------------------------------------------------------------- #
+# Config propagation: agent.eager_rate_limit_fallback → the agent object.
+# Mirrors tests/run_agent/test_api_max_retries_config.py — the sibling knob
+# read one line above this one in agent/agent_init.py.
+# --------------------------------------------------------------------------- #
+
+def _make_agent(eager_rate_limit_fallback=None):
+    """Build an AIAgent with a mocked ``config.load_config`` that returns a
+    config tree containing the given ``agent.eager_rate_limit_fallback`` (or
+    omits the key entirely to exercise the default)."""
+    cfg = {"agent": {}}
+    if eager_rate_limit_fallback is not None:
+        cfg["agent"]["eager_rate_limit_fallback"] = eager_rate_limit_fallback
+
+    with patch("run_agent.OpenAI"), \
+         patch("hermes_cli.config.load_config", return_value=cfg):
+        return AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+
+def test_default_eager_rate_limit_fallback_is_true():
+    """No config override → eager fallback stays on (preserves the prior,
+    always-eager behavior)."""
+    agent = _make_agent()
+    assert agent._eager_rate_limit_fallback is True
+
+
+def test_eager_rate_limit_fallback_honors_config_false():
+    """``agent.eager_rate_limit_fallback: false`` propagates to the agent."""
+    agent = _make_agent(eager_rate_limit_fallback=False)
+    assert agent._eager_rate_limit_fallback is False
+
+
+def test_eager_rate_limit_fallback_honors_config_true():
+    """Explicit ``true`` propagates too (and matches the documented default)."""
+    agent = _make_agent(eager_rate_limit_fallback=True)
+    assert agent._eager_rate_limit_fallback is True
+
+
+def test_default_config_ships_true_default():
+    """DEFAULT_CONFIG carries the documented default so the knob is discoverable
+    (e.g. via ``hermes config``) even when the user never set it."""
+    assert DEFAULT_CONFIG["agent"]["eager_rate_limit_fallback"] is True
+
+
+# --------------------------------------------------------------------------- #
+# Belt-and-suspenders: the production gate must route through the helper, so
+# the billing-always-eager / rate-limit-configurable policy actually applies
+# inside run_conversation — not just in the unit-tested helper.  Mirrors the
+# source guards in test_gemini_fast_fallback.py and test_31273_402_not_retried.py.
+# --------------------------------------------------------------------------- #
+
+def test_conversation_loop_gates_eager_fallback_through_helper():
+    src = inspect.getsource(conversation_loop.run_conversation)
+    assert "should_eager_fallback = _should_eager_fallback(" in src, (
+        "run_conversation must compute the eager-fallback decision via "
+        "_should_eager_fallback — otherwise the billing/rate-limit policy is "
+        "not actually enforced in production."
+    )
+    assert "if should_eager_fallback and agent._fallback_index" in src, (
+        "the eager-fallback gate must branch on the helper's decision, not on "
+        "the old combined `is_rate_limited and getattr(...flag...)` shape that "
+        "let eager=False wrongly suppress billing (402) fallback."
+    )

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -842,6 +842,21 @@ When the iteration budget is fully exhausted, the CLI shows a notification to th
 
 `agent.api_max_retries` controls how many times Hermes retries a provider API call on transient errors (rate limits, connection drops, 5xx) **before** fallback-provider switching engages. The default is `3` — four attempts total. If you have [fallback providers](/user-guide/features/fallback-providers) configured and want to fail over faster, drop this to `0` so the first transient error on your primary immediately hands off to the fallback instead of churning retries against the flaky endpoint.
 
+### Eager Rate-Limit Fallback
+
+`agent.eager_rate_limit_fallback` (default: `true`) controls what happens when a provider returns a 429 rate-limit error:
+
+- **`true` (default)**: Immediately switch to the next [fallback provider](/user-guide/features/fallback-providers) without retrying the rate-limited one. This is the safest default — you get a response from the backup provider instead of waiting through retries that may all fail.
+- **`false`**: Retry the rate-limited provider up to `api_max_retries` times with exponential backoff before falling back. Useful when your primary provider's rate limits are transient (e.g., DashScope burst quotas, Anthropic peak-hour throttling) — the primary often recovers within a few seconds.
+
+**Note**: Confirmed billing errors (402 — insufficient credits, subscription expired) always trigger immediate fallback regardless of this setting. Retrying a permanent billing error only burns paid requests against an exhausted balance ([#31273](https://github.com/NousResearch/hermes-agent/issues/31273)), so billing never honors the retry path.
+
+```yaml
+agent:
+  api_max_retries: 3                    # Retries per provider
+  eager_rate_limit_fallback: false      # Retry before fallback (default: true)
+```
+
 ### API Timeouts
 
 Hermes has separate timeout layers for streaming, plus a stale detector for non-streaming calls. The stale detectors auto-adjust for local providers only when you leave them at their implicit defaults.


### PR DESCRIPTION
## What does this PR do?

Add `agent.eager_rate_limit_fallback` (default: `true`) to control what happens on a **429 rate-limit** error: fail over to the next provider immediately (the existing behavior), or run the normal retry loop with exponential backoff against the primary first.

When set to `false`, rate-limit errors respect `api_max_retries` — the primary model is retried N times before falling back. Useful when the primary hits **transient** burst limits (e.g. DashScope quota bursting, peak-hour throttling) that usually clear within the retry window.

**Confirmed billing errors (402) always fail over eagerly, regardless of this setting.** A 402 is permanent — retrying it burns paid requests against an exhausted balance ([#31273](https://github.com/NousResearch/hermes-agent/issues/31273)), and suppressing its fallback would only drop it into the `is_client_error` abort path without ever trying a backup provider.

## Related Issue

Fixes #31273

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/config.py` — add `eager_rate_limit_fallback: true` to `DEFAULT_CONFIG`, next to `api_max_retries`
- `agent/agent_init.py` — read the config onto `agent._eager_rate_limit_fallback` (default `True`)
- `agent/conversation_loop.py` — gate eager fallback via a new pure helper `_should_eager_fallback(reason, flag)` (mirrors `_pool_may_recover_from_rate_limit`): billing → always eager, rate-limit → honors the flag
- `tests/agent/test_eager_rate_limit_fallback.py` — new: helper decisions (incl. billing-always-eager), config propagation + default, and a source guard that the production gate routes through the helper
- `website/docs/user-guide/configuration.md` — document the knob next to `api_max_retries`

### Usage
```yaml
agent:
  api_max_retries: 3                 # retries per provider
  eager_rate_limit_fallback: false   # retry the primary before falling back (default: true)
```
```bash
hermes config set agent.eager_rate_limit_fallback false
```

### Changes since sweeper review
- [x] **Separated rate_limit (configurable) from billing (always eager)** — the flag now gates only `FailoverReason.rate_limit`. `FailoverReason.billing` always fails over eagerly: 402 is permanent, so retrying is pointless, and (with no fallback configured) it correctly aborts via the `is_client_error` path rather than burning retries (#31273). The decision is extracted into `_should_eager_fallback` for clarity and unit-testability.
- [x] **Added test coverage** in `tests/agent/test_eager_rate_limit_fallback.py` — default eager rate-limit fallback, disabled-eager rate-limit deferring to the retry loop, billing-always-eager (both flag values), config propagation, and the `true` default. The directly-related failover/retry tests still pass.
- [x] **Added docs** in `website/docs/user-guide/configuration.md`, next to `api_max_retries`.
- [x] **Dropped the NameError fix** — `_ra()._pool_may_recover_from_rate_limit` is already on `main` via `25e0f4d46`, so rebasing onto current `main` drops it cleanly (no conflict).

Rebased onto current `main`. Supersedes #21678.

## How to Test

1. Configure a primary provider and at least one fallback provider
2. Set `agent.eager_rate_limit_fallback: false` and `agent.api_max_retries: 3`
3. Trigger a 429 rate-limit error on the primary provider
4. Verify Hermes retries the primary 3 times before falling back
5. Set `agent.eager_rate_limit_fallback: true` (default)
6. Trigger a 429 rate-limit error on the primary provider
7. Verify Hermes immediately falls back without retrying
8. Trigger a 402 billing error on the primary provider
9. Verify Hermes immediately falls back regardless of the flag setting

Automated: Tests cover helper decisions (billing-always-eager, rate-limit honors flag), config propagation, default value, and source guard ensuring production code routes through the helper. All directly-related failover/retry tests still pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
