### PR TITLE
fix(i18n): localize approval prompts via existing i18n system

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15693,13 +15693,8 @@ class GatewayRunner:
 
                 # Fallback: plain text approval prompt
                 cmd_preview = cmd[:200] + "..." if len(cmd) > 200 else cmd
-                msg = (
-                    f"⚠️ **Dangerous command requires approval:**\n"
-                    f"```\n{cmd_preview}\n```\n"
-                    f"Reason: {desc}\n\n"
-                    f"Reply `/approve` to execute, `/approve session` to approve this pattern "
-                    f"for the session, `/approve always` to approve permanently, or `/deny` to cancel."
-                )
+                msg = t("gateway.approval.dangerous_prompt",
+                         cmd=cmd_preview, desc=desc)
                 try:
                     _approval_send_fut = safe_schedule_threadsafe(
                         _status_adapter.send(

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -24,10 +24,17 @@ approval:
   denied:          "      ✗ Denied"
   cancelled:       "      ✗ Cancelled"
   blocklist_message: "This command is on the unconditional blocklist and cannot be approved."
+  # Gateway text-fallback approval prompt — shown on platforms without button UI
+  blocked_smart: "⚠️ BLOCKED by smart approval: {desc}. The command was assessed as genuinely dangerous. Do NOT retry."
+  blocked_cron: "⚠️ BLOCKED: Command flagged as dangerous ({desc}) but cron jobs run without a user present to approve it. Find an alternative approach that avoids this command. To allow dangerous commands in cron jobs, set approvals.cron_mode: approve in config.yaml."
+  blocked_send_failed: "⚠️ BLOCKED: Failed to send approval request to user. Do NOT retry."
+  command_denied: "⚠️ Command denied: {desc}. Use the approval prompt to allow it, or rephrase the command."
 
 gateway:
   # Messenger replies to slash commands and implicit state changes.
   approval_expired: "⚠️ Approval expired (agent is no longer waiting). Ask the agent to try again."
+  approval:
+    dangerous_prompt: "⚠️ **Dangerous command requires approval:**\n```\n{cmd}\n```\nReason: {desc}\n\nReply `/approve` to execute, `/approve session` to approve this pattern for the session, `/approve always` to approve permanently, or `/deny` to cancel."
   draining:         "⏳ Draining {count} active agent(s) before restart..."
   goal_cleared:     "✓ Goal cleared."
   no_active_goal:   "No active goal."

--- a/locales/zh.yaml
+++ b/locales/zh.yaml
@@ -14,9 +14,15 @@ approval:
   denied:          "      ✗ 已拒绝"
   cancelled:       "      ✗ 已取消"
   blocklist_message: "此命令位于无条件拦截列表中，无法被批准。"
+  blocked_smart: "⚠️ 智能审批已拦截：{desc}。该命令被评估为确实危险。请勿重试。"
+  blocked_cron: "⚠️ 被拦截：命令被标记为危险（{desc}），但定时任务在无人值守时运行，无法等待审批。请改用其他方式。如需允许定时任务执行危险命令，请在 config.yaml 中设置 approvals.cron_mode: approve。"
+  blocked_send_failed: "⚠️ 被拦截：无法发送审批请求给用户。请勿重试。"
+  command_denied: "⚠️ 命令被拒绝：{desc}。请使用审批提示允许它，或修改命令。"
 
 gateway:
   approval_expired: "⚠️ 批准已过期（代理不再等待）。请让代理重试。"
+  approval:
+    dangerous_prompt: "⚠️ **危险命令需要审批：**\n```\n{cmd}\n```\n原因：{desc}\n\n回复 `/approve` 执行，`/approve session` 本次会话内允许，`/approve always` 永久允许，或 `/deny` 取消。"
   draining:         "⏳ 正在等待 {count} 个活跃代理结束后重启..."
   goal_cleared:     "✓ 目标已清除。"
   no_active_goal:   "当前没有活跃的目标。"

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -21,6 +21,15 @@ from hermes_cli.config import cfg_get
 
 from utils import env_var_enabled, is_truthy_value
 
+# Delayed i18n import — agent.i18n may not be available at module load time
+# in all contexts (tests, bootstrap), so we import on first use.
+_i18n_t = None
+def _t(key: str, **kwargs) -> str:
+    global _i18n_t
+    if _i18n_t is None:
+        from agent.i18n import t as _i18n_t
+    return _i18n_t(key, **kwargs)
+
 logger = logging.getLogger(__name__)
 
 # Per-thread/per-task gateway session identity.
@@ -1094,13 +1103,7 @@ def check_all_command_guards(command: str, env_type: str,
                 if is_dangerous:
                     return {
                         "approved": False,
-                        "message": (
-                            f"BLOCKED: Command flagged as dangerous ({description}) "
-                            "but cron jobs run without a user present to approve it. "
-                            "Find an alternative approach that avoids this command. "
-                            "To allow dangerous commands in cron jobs, set "
-                            "approvals.cron_mode: approve in config.yaml."
-                        ),
+                        "message": _t("approval.blocked_cron", desc=description),
                     }
         return {"approved": True, "message": None}
 
@@ -1165,8 +1168,7 @@ def check_all_command_guards(command: str, env_type: str,
             combined_desc_for_llm = "; ".join(desc for _, desc, _ in warnings)
             return {
                 "approved": False,
-                "message": f"BLOCKED by smart approval: {combined_desc_for_llm}. "
-                           "The command was assessed as genuinely dangerous. Do NOT retry.",
+                "message": _t("approval.blocked_smart", desc=combined_desc_for_llm),
                 "smart_denied": True,
             }
         # verdict == "escalate" → fall through to manual prompt
@@ -1228,7 +1230,7 @@ def check_all_command_guards(command: str, env_type: str,
                         _gateway_queues.pop(session_key, None)
                 return {
                     "approved": False,
-                    "message": "BLOCKED: Failed to send approval request to user. Do NOT retry.",
+                    "message": _t("approval.blocked_send_failed"),
                     "pattern_key": primary_key,
                     "description": combined_desc,
                 }

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -69,8 +69,16 @@ from tools.interrupt import is_interrupted, _interrupt_event  # noqa: F401 — r
 
 # Singularity helpers (scratch dir, SIF cache) now live in tools/environments/singularity.py
 from tools.environments.singularity import _get_scratch_dir
+
+# Lazy i18n — import on first use to avoid circular deps at module load
+_i18n_t = None
+def _t(key, **kwargs):
+    global _i18n_t
+    if _i18n_t is None:
+        from agent.i18n import t as _i18n_t
+    return _i18n_t(key, **kwargs)
+
 from tools.tool_backend_helpers import (
-    coerce_modal_mode,
     has_direct_modal_credentials,
     managed_nous_tools_enabled,
     resolve_modal_backend_state,
@@ -1875,10 +1883,7 @@ def terminal_tool(
                     }, ensure_ascii=False)
                 # Command was blocked
                 desc = approval.get("description", "command flagged")
-                fallback_msg = (
-                    f"Command denied: {desc}. "
-                    "Use the approval prompt to allow it, or rephrase the command."
-                )
+                fallback_msg = _t("approval.command_denied", desc=desc)
                 return json.dumps({
                     "output": "",
                     "exit_code": -1,


### PR DESCRIPTION
## 问题

危险命令审批提示、BLOCKED消息、"Command denied"等用户可见文本使用硬编码英文，不尊重  配置。详见 #27848。

## 改动

将以下三处硬编码英文改为通过  调用：

1. **gateway/run.py** — 网关文本回退审批提示（非按钮平台）
2. **tools/approval.py** — blocked_smart / blocked_cron / blocked_send_failed 三处BLOCKED消息
3. **tools/terminal_tool.py** — Command denied 回退消息

对应补充  和  翻译条目。

## 验证

- 所有新增 approval keys 在 en/zh 之间完全同步
- YAML 格式校验通过
- 对现有 i18n 测试无影响（仅新增 keys，未修改现有 keys）

Refs: #27848