### PR TITLE
perf: RTK output compaction + DeepSeek prefix-cache optimizations

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1162,27 +1162,10 @@ def build_skills_system_prompt(
     if not skills_by_category:
         result = ""
     else:
-        index_lines = []
-        for category in sorted(skills_by_category.keys()):
-            cat_desc = category_descriptions.get(category, "")
-            if cat_desc:
-                index_lines.append(f"  {category}: {cat_desc}")
-            else:
-                index_lines.append(f"  {category}:")
-            # Deduplicate and sort skills within each category
-            seen = set()
-            for name, desc in sorted(skills_by_category[category], key=lambda x: x[0]):
-                if name in seen:
-                    continue
-                seen.add(name)
-                if desc:
-                    index_lines.append(f"    - {name}: {desc}")
-                else:
-                    index_lines.append(f"    - {name}")
-
         result = (
             "## Skills (mandatory)\n"
-            "Before replying, scan the skills below. If a skill matches or is even partially relevant "
+            "Before replying, call skill_list to see available skills. "
+            "If a skill matches or is even partially relevant "
             "to your task, you MUST load it with skill_view(name) and follow its instructions. "
             "Err on the side of loading — it is always better to have context you don't need "
             "than to miss critical steps, pitfalls, or established workflows. "
@@ -1201,10 +1184,6 @@ def build_skills_system_prompt(
             "After difficult/iterative tasks, offer to save as a skill. "
             "If a skill you loaded was missing steps, had wrong commands, or needed "
             "pitfalls you discovered, update it before finishing.\n"
-            "\n"
-            "<available_skills>\n"
-            + "\n".join(index_lines) + "\n"
-            "</available_skills>\n"
             "\n"
             "Only proceed without loading a skill if genuinely none are relevant to the task."
         )

--- a/run_agent.py
+++ b/run_agent.py
@@ -1985,6 +1985,9 @@ class AIAgent:
         
         # Cached system prompt -- built once per session, only rebuilt on compression
         self._cached_system_prompt: Optional[str] = None
+        # Cached memory blocks (injected as separate system messages to
+        # keep the main prefix cacheable across memory updates).
+        self._cached_memory_messages: str = ""
         
         # Filesystem checkpoint manager (transparent — not a tool)
         from tools.checkpoint_manager import CheckpointManager
@@ -2819,6 +2822,7 @@ class AIAgent:
 
         # ── Invalidate cached system prompt so it rebuilds next turn ──
         self._cached_system_prompt = None
+        self._cached_memory_messages = ""
 
         # ── Update _primary_runtime so the change persists across turns ──
         _cc = self.context_compressor if hasattr(self, "context_compressor") and self.context_compressor else None
@@ -4440,6 +4444,7 @@ class AIAgent:
                     # measured impact (~26% end-to-end cost reduction on
                     # Sonnet 4.5).
                     review_agent._cached_system_prompt = self._cached_system_prompt
+                    review_agent._cached_memory_messages = self._cached_memory_messages
                     # Defensive: pin session_start + session_id to the
                     # parent's so any code path that re-renders parts of
                     # the system prompt (compression, plugin hooks) still
@@ -6054,14 +6059,16 @@ class AIAgent:
     def _build_system_prompt_parts(self, system_message: str = None) -> Dict[str, str]:
         """Assemble the system prompt as three ordered parts.
 
-        Returns a dict with three keys:
+        Returns a dict with four keys:
           * ``stable``   — identity, tool guidance, skills prompt,
             environment hints, platform hints, model-family operational
             guidance.
           * ``context``  — context files (AGENTS.md, .cursorrules, etc.)
             and caller-supplied system_message.
-          * ``volatile`` — memory snapshot, user profile, external
-            memory provider block, timestamp line.
+          * ``volatile`` — external memory provider block, timestamp line.
+          * ``memory``   — built-in memory and user profile blocks
+            (injected as separate system messages to keep the main prefix
+            cacheable across memory updates).
 
         Joined into a single string by ``_build_system_prompt`` and
         cached on ``_cached_system_prompt`` for the lifetime of the
@@ -6222,16 +6229,21 @@ class AIAgent:
         # ── Volatile tier (changes per session/turn — never cached) ───
         volatile_parts: List[str] = []
 
+        # ── Memory tier (injected as separate system messages after the
+        # main prefix so built-in memory updates don't invalidate the
+        # DeepSeek prefix cache) ──
+        memory_parts: List[str] = []
+
         if self._memory_store:
             if self._memory_enabled:
                 mem_block = self._memory_store.format_for_system_prompt("memory")
                 if mem_block:
-                    volatile_parts.append(mem_block)
+                    memory_parts.append(mem_block)
             # USER.md is always included when enabled.
             if self._user_profile_enabled:
                 user_block = self._memory_store.format_for_system_prompt("user")
                 if user_block:
-                    volatile_parts.append(user_block)
+                    memory_parts.append(user_block)
 
         # External memory provider system prompt block (additive to built-in)
         if self._memory_manager:
@@ -6257,6 +6269,7 @@ class AIAgent:
             "stable":   "\n\n".join(p.strip() for p in stable_parts   if p and p.strip()),
             "context":  "\n\n".join(p.strip() for p in context_parts  if p and p.strip()),
             "volatile": "\n\n".join(p.strip() for p in volatile_parts if p and p.strip()),
+            "memory":   "\n\n".join(p.strip() for p in memory_parts  if p and p.strip()),
         }
 
     def _build_system_prompt(self, system_message: str = None) -> str:
@@ -6269,13 +6282,19 @@ class AIAgent:
 
         Layers are ordered cache-friendly: stable identity/guidance first,
         then session-stable context files, then per-call volatile content
-        (memory, USER profile, timestamp).  The whole string is treated as
-        one cached block — Hermes never rebuilds or reinjects parts of it
-        mid-session, which is the only way to keep upstream prompt caches
-        warm across turns.
+        (timestamp).  The whole string is treated as one cached block — Hermes
+        never rebuilds or reinjects parts of it mid-session, which is the only
+        way to keep upstream prompt caches warm across turns.
+
+        Memory and user profile blocks are intentionally EXCLUDED from this
+        cached string and injected as separate system messages at API-call
+        time.  This keeps the main prefix stable across memory updates and
+        session restarts — only the memory messages change, not the cache key.
         """
         parts = self._build_system_prompt_parts(system_message=system_message)
         joined = "\n\n".join(p for p in (parts["stable"], parts["context"], parts["volatile"]) if p)
+        # Store memory blocks separately for injection at message construction time
+        self._cached_memory_messages = parts.get("memory", "")
         return joined
 
     # =========================================================================
@@ -6647,6 +6666,7 @@ class AIAgent:
         so the rebuilt prompt captures any writes from this session.
         """
         self._cached_system_prompt = None
+        self._cached_memory_messages = ""
         if self._memory_store:
             self._memory_store.load_from_disk()
 
@@ -11958,6 +11978,8 @@ class AIAgent:
                 effective_system = (effective_system + "\n\n" + self.ephemeral_system_prompt).strip()
             if effective_system:
                 api_messages = [{"role": "system", "content": effective_system}] + api_messages
+                if self._cached_memory_messages:
+                    api_messages.insert(1, {"role": "system", "content": self._cached_memory_messages})
             if self.prefill_messages:
                 sys_offset = 1 if effective_system else 0
                 for idx, pfm in enumerate(self.prefill_messages):
@@ -12800,6 +12822,13 @@ class AIAgent:
                 effective_system = (effective_system + "\n\n" + self.ephemeral_system_prompt).strip()
             if effective_system:
                 api_messages = [{"role": "system", "content": effective_system}] + api_messages
+                # Inject memory blocks as a separate system message right after
+                # the main prefix.  This keeps the immutable prefix cacheable
+                # across memory updates — only the memory message changes, not
+                # the cache key.  DeepSeek supports multiple system messages
+                # and treats them as concatenated.
+                if self._cached_memory_messages:
+                    api_messages.insert(1, {"role": "system", "content": self._cached_memory_messages})
 
             # Inject ephemeral prefill messages right after the system prompt
             # but before conversation history. Same API-call-time-only pattern.

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -405,6 +405,61 @@ class LocalEnvironment(BaseEnvironment):
     CWD persists via file-based read after each command.
     """
 
+    # Commands that RTK can compact (from rtk gain list).
+    # When rtk is on PATH, these are transparently rewritten
+    # to their ``rtk <cmd>`` equivalents for token savings.
+    _RTK_WHITELIST: frozenset[str] = frozenset({
+        "ps", "ls", "grep", "find", "git", "gh", "curl",
+        "cargo", "npm", "npx", "go", "pip", "docker", "kubectl",
+        "pnpm", "jest", "vitest", "tsc", "eslint", "prettier",
+        "pytest", "ruff", "uv",
+    })
+
+    @staticmethod
+    def _rtk_available() -> bool:
+        return shutil.which("rtk") is not None
+
+    @classmethod
+    def _try_rtk_rewrite(cls, command: str) -> str:
+        """Rewrite *command* to use ``rtk <subcmd>`` when the leading binary
+        is in the whitelist and ``rtk`` is on PATH.  Returns the original
+        command unchanged when rtk is absent or the command is unknown."""
+        if not cls._rtk_available():
+            return command
+        stripped = command.lstrip()
+        if not stripped:
+            return command
+        # Extract the first token (the binary name)
+        first_token = stripped.split(maxsplit=1)[0]
+        # Strip common path prefixes and `sudo`
+        binary = first_token.rsplit("/", maxsplit=1)[-1]
+        if binary == "sudo":
+            # ``sudo foo bar`` → ``sudo rtk foo bar``
+            rest = stripped.split(maxsplit=1)[1].lstrip() if " " in stripped else ""
+            if not rest:
+                return command
+            inner = cls._try_rtk_rewrite(rest)
+            if inner is not rest:
+                return f"sudo {inner}"
+            return command
+        if binary not in cls._RTK_WHITELIST:
+            return command
+        rest = stripped[len(first_token):]
+        return f"rtk {binary}{rest}"
+
+    def execute(
+        self,
+        command: str,
+        cwd: str = "",
+        *,
+        timeout: int | None = None,
+        stdin_data: str | None = None,
+    ) -> dict:
+        # Transparent RTK rewrites for token savings (~14% avg).
+        # Safe: unknown commands pass through unchanged.
+        command = self._try_rtk_rewrite(command)
+        return super().execute(command, cwd=cwd, timeout=timeout, stdin_data=stdin_data)
+
     def __init__(self, cwd: str = "", timeout: int = 60, env: dict = None):
         if cwd:
             cwd = os.path.expanduser(cwd)


### PR DESCRIPTION
## Summary

Three token-saving optimizations for DeepSeek users:

### 1. RTK output compaction (transparent)
When `rtk` is on PATH, whitelisted terminal commands are transparently rewritten to `rtk <cmd>` equivalents (`ps` → 88% savings, `ls` → 74%).

### 2. Skills list removed from system prompt
The `<available_skills>` block (~2K chars) was redundant with tool schemas. Now tells the model to call `skill_list()` instead of embedding the full list — reducing immutable prefix size.

### 3. Memory blocks as separate system messages
Built-in memory and user profile moved from the system prompt's VOLATILE tier to a separate system message. The main prefix (identity + guidance) stays byte-stable across memory updates — only memory messages change, preserving DeepSeek's 90% cache-hit discount.

Inspired by [Reasonix](https://github.com/esengine/DeepSeek-Reasonix)'s Pillar 1 (Cache-First Loop).