### PR TITLE
feat: add tag-based memory filtering

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -946,6 +946,7 @@ def init_agent(
                 agent._memory_store = MemoryStore(
                     memory_char_limit=mem_config.get("memory_char_limit", 2200),
                     user_char_limit=mem_config.get("user_char_limit", 1375),
+                    tag_filter=mem_config.get("active_tag", ""),
                 )
                 agent._memory_store.load_from_disk()
         except Exception:

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -115,11 +115,12 @@ class MemoryStore:
         Tool responses always reflect this live state.
     """
 
-    def __init__(self, memory_char_limit: int = 2200, user_char_limit: int = 1375):
+    def __init__(self, memory_char_limit: int = 2200, user_char_limit: int = 1375, tag_filter: str = ""):
         self.memory_entries: List[str] = []
         self.user_entries: List[str] = []
         self.memory_char_limit = memory_char_limit
         self.user_char_limit = user_char_limit
+        self.tag_filter = tag_filter.strip()
         # Frozen snapshot for system prompt -- set once at load_from_disk()
         self._system_prompt_snapshot: Dict[str, str] = {"memory": "", "user": ""}
 
@@ -134,6 +135,14 @@ class MemoryStore:
         # Deduplicate entries (preserves order, keeps first occurrence)
         self.memory_entries = list(dict.fromkeys(self.memory_entries))
         self.user_entries = list(dict.fromkeys(self.user_entries))
+
+        # Tag filtering: only keep tagged entries matching the filter + untagged entries
+        if self.tag_filter:
+            prefix = f"[{self.tag_filter}]"
+            self.memory_entries = [
+                e for e in self.memory_entries
+                if e.startswith(prefix) or not e.startswith("[")
+            ]
 
         # Capture frozen snapshot for system prompt injection
         self._system_prompt_snapshot = {


### PR DESCRIPTION
## Summary

Adds optional tag-based filtering to the built-in MemoryStore. When configured,
only memory entries matching the specified tag (plus untagged entries) are injected
into the system prompt, reducing context window waste on irrelevant entries.

## Changes

- **`tools/memory_tool.py`**: `MemoryStore.__init__()` accepts a new `tag_filter`
  parameter. `load_from_disk()` filters `memory_entries` to keep only lines
  starting with `[tag]` plus any untagged lines.
- **`run_agent.py`**: reads `memory.active_tag` from config and passes it to
  MemoryStore.

## Configuration

```yaml
memory:
  active_tag: ""       # empty = all entries (backward compatible, default)
  active_tag: "创作"    # only [创作] + untagged entries