### PR TITLE
fix(telegram): resume typing indicator after inline approval click (#27853)

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2702,6 +2702,15 @@ class TelegramAdapter(BasePlatformAdapter):
                     )
                 except Exception as exc:
                     logger.error("Failed to resolve gateway approval from Telegram button: %s", exc)
+                    count = 0
+
+                # Resume the typing indicator — paused when the approval was
+                # sent (gateway/run.py).  The text /approve and /deny paths
+                # call resume_typing_for_chat here too; without it, typing
+                # stays paused for the rest of the turn after an inline
+                # button click.
+                if count and query_chat_id is not None:
+                    self.resume_typing_for_chat(str(query_chat_id))
             return
 
         # --- Slash-confirm callbacks (sc:choice:confirm_id) ---

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -272,6 +272,67 @@ class TestTelegramApprovalCallback:
         assert 1 not in adapter._approval_state
 
     @pytest.mark.asyncio
+    async def test_resume_typing_after_inline_approval(self):
+        """Clicking an inline approval button must un-pause the chat's typing.
+
+        Regression for #27853: the text /approve path resumed typing, but the
+        ea: callback path did not, so the typing indicator stayed gone for the
+        rest of a long-running turn after a button click.
+        """
+        adapter = _make_adapter()
+        adapter._approval_state[5] = "agent:main:telegram:group:12345:99"
+        adapter.pause_typing_for_chat("12345")
+        assert "12345" in adapter._typing_paused
+
+        query = AsyncMock()
+        query.data = "ea:once:5"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.from_user = MagicMock()
+        query.from_user.first_name = "Norbert"
+        query.from_user.id = "12345"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            with patch("tools.approval.resolve_gateway_approval", return_value=1):
+                await adapter._handle_callback_query(update, context)
+
+        assert "12345" not in adapter._typing_paused
+
+    @pytest.mark.asyncio
+    async def test_typing_stays_paused_when_resolve_returns_zero(self):
+        """If resolve_gateway_approval reports 0 resolves, the agent thread
+        was never unblocked, so typing should NOT be force-resumed."""
+        adapter = _make_adapter()
+        adapter._approval_state[6] = "agent:main:telegram:group:12345:99"
+        adapter.pause_typing_for_chat("12345")
+
+        query = AsyncMock()
+        query.data = "ea:once:6"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.from_user = MagicMock()
+        query.from_user.first_name = "Norbert"
+        query.from_user.id = "12345"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            with patch("tools.approval.resolve_gateway_approval", return_value=0):
+                await adapter._handle_callback_query(update, context)
+
+        assert "12345" in adapter._typing_paused
+
+    @pytest.mark.asyncio
     async def test_approval_callback_escapes_dynamic_user_name(self):
         adapter = _make_adapter()
         adapter._approval_state[3] = "agent:main:telegram:group:12345:99"


### PR DESCRIPTION
## What does this PR do?

Clicking a Telegram inline approval/deny button (`ea:*` callback) left the typing indicator paused for the rest of a long-running turn. Text `/approve` and `/deny` already resumed typing after `resolve_gateway_approval()` returned; the inline-button path called `resolve_gateway_approval(...)` but never `resume_typing_for_chat(...)`, so the chat stayed in `_typing_paused` forever after a button click. Confirmed in the issue's live-run log: the approval resolved, `npx tsc --noEmit` continued running, but Telegram typing stayed gone. This PR symmetry-matches the text path by calling `self.resume_typing_for_chat(str(query_chat_id))` after a successful resolve, guarded by `count > 0` so the indicator stays paused if nothing was actually resolved (expired session, etc.).

## Related Issue

Fixes #27853

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/telegram.py` — in the `ea:` branch of `_handle_callback_query`, after a successful `resolve_gateway_approval` returning `count > 0`, call `self.resume_typing_for_chat(str(query_chat_id))`. Guarded by `count > 0` to match the text path's `if not count: return` short-circuit. The exception handler above sets `count = 0` so an upstream `resolve_gateway_approval` failure does not force-resume either.
- `tests/gateway/test_telegram_approval_buttons.py` — new `test_resume_typing_after_inline_approval` (pauses the chat, clicks `ea:once:5` with `resolve_gateway_approval` mocked to return 1, asserts the chat is removed from `_typing_paused`) + negative `test_typing_stays_paused_when_resolve_returns_zero`.

## How to Test

1. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/gateway/test_telegram_approval_buttons.py -v` — 20/20 passed.
2. Regression guard: removed the production change via `git stash`, reran the new test, observed `AssertionError: assert '12345' not in {'12345'}`. Restored the fix → both tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Sibling Audit

> Sibling code paths that may need the same fix: `gateway/platforms/slack.py::_handle_action` (calls `resolve_gateway_approval` at line 2567), `gateway/platforms/feishu.py::_resolve_approval` (line 2628), `gateway/platforms/matrix.py` (line 2180), and the Discord approval button view (`gateway/platforms/discord.py:5016`). Each has the same gap — `resolve_gateway_approval` is called but `resume_typing_for_chat` is not. Intentionally left out of this PR's scope to keep the regression test honest for the issue's reported platform — happy to widen if preferred.
