### PR TITLE
fix: align Midnight Modern dashboard theme

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3633,13 +3633,14 @@ def mount_spa(application: FastAPI):
 # Built-in dashboard themes — label + description only.  The actual color
 # definitions live in the frontend (web/src/themes/presets.ts).
 _BUILTIN_DASHBOARD_THEMES = [
-    {"name": "default",       "label": "Hermes Teal",         "description": "Classic dark teal — the canonical Hermes look"},
-    {"name": "default-large", "label": "Hermes Teal (Large)", "description": "Hermes Teal with bigger fonts and roomier spacing"},
-    {"name": "midnight",      "label": "Midnight",            "description": "Deep blue-violet with cool accents"},
-    {"name": "ember",     "label": "Ember",          "description": "Warm crimson and bronze — forge vibes"},
-    {"name": "mono",      "label": "Mono",           "description": "Clean grayscale — minimal and focused"},
-    {"name": "cyberpunk", "label": "Cyberpunk",      "description": "Neon green on black — matrix terminal"},
-    {"name": "rose",      "label": "Rosé",           "description": "Soft pink and warm ivory — easy on the eyes"},
+    {"name": "default",           "label": "Hermes Teal",         "description": "Classic dark teal — the canonical Hermes look"},
+    {"name": "default-large",     "label": "Hermes Teal (Large)", "description": "Hermes Teal with bigger fonts and roomier spacing"},
+    {"name": "midnight",          "label": "Midnight",            "description": "Deep blue-violet with cool accents"},
+    {"name": "midnight-modern",   "label": "Midnight Modern",     "description": "Midnight colors with original sizing, Geist typography, and no background image"},
+    {"name": "ember",             "label": "Ember",               "description": "Warm crimson and bronze — forge vibes"},
+    {"name": "mono",              "label": "Mono",                "description": "Clean grayscale — minimal and focused"},
+    {"name": "cyberpunk",         "label": "Cyberpunk",           "description": "Neon green on black — matrix terminal"},
+    {"name": "rose",              "label": "Rosé",                "description": "Soft pink and warm ivory — easy on the eyes"},
 ]
 
 

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -108,6 +108,9 @@ code, kbd, pre, samp, .font-mono, .font-mono-ui {
    all proportionally in Tailwind v4. */
 @theme inline {
   --spacing: calc(0.25rem * var(--theme-spacing-mul, 1));
+  --font-sans: var(--theme-font-sans);
+  --font-mono: var(--theme-font-mono);
+  --font-display: var(--theme-font-display);
 }
 
 #root {

--- a/web/src/themes/presets.ts
+++ b/web/src/themes/presets.ts
@@ -78,6 +78,36 @@ export const midnightTheme: DashboardTheme = {
   },
 };
 
+/**
+ * Midnight's deep blue-violet palette with contemporary Geist typography while
+ * preserving the original Midnight sizing/spacing. The explicit `bg: "none"`
+ * suppresses the default filler artwork so this variant stays image-free.
+ */
+export const midnightModernTheme: DashboardTheme = {
+  name: "midnight-modern",
+  label: "Midnight Modern",
+  description: "Midnight colors with original sizing, Geist typography, and no background image",
+  palette: midnightTheme.palette,
+  typography: {
+    ...DEFAULT_TYPOGRAPHY,
+    fontSans: `"Geist", ${SYSTEM_SANS}`,
+    fontMono: `"Geist Mono", ${SYSTEM_MONO}`,
+    fontDisplay: `"Geist", ${SYSTEM_SANS}`,
+    fontUrl:
+      "https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500;600&display=swap",
+    letterSpacing: "-0.01em",
+  },
+  layout: midnightTheme.layout,
+  assets: {
+    bg: "none",
+  },
+  customCSS: `
+#root .font-mondwest {
+  font-family: var(--theme-font-sans) !important;
+}
+`,
+};
+
 export const emberTheme: DashboardTheme = {
   name: "ember",
   label: "Ember",
@@ -208,6 +238,7 @@ export const BUILTIN_THEMES: Record<string, DashboardTheme> = {
   default: defaultTheme,
   "default-large": defaultLargeTheme,
   midnight: midnightTheme,
+  "midnight-modern": midnightModernTheme,
   ember: emberTheme,
   mono: monoTheme,
   cyberpunk: cyberpunkTheme,

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -341,6 +341,7 @@ Built-in themes:
 | **Hermes Teal** (`default`) | Dark teal + cream, system fonts, comfortable spacing |
 | **Hermes Teal (Large)** (`default-large`) | Same as default with 18px text and roomier spacing |
 | **Midnight** (`midnight`) | Deep blue-violet, Inter + JetBrains Mono |
+| **Midnight Modern** (`midnight-modern`) | Midnight colors, original Midnight sizing/spacing, Geist + Geist Mono, no background image |
 | **Ember** (`ember`) | Warm crimson + bronze, Spectral serif + IBM Plex Mono |
 | **Mono** (`mono`) | Grayscale, IBM Plex, compact |
 | **Cyberpunk** (`cyberpunk`) | Neon green on black, Share Tech Mono |


### PR DESCRIPTION
## Summary
- adds the `midnight-modern` built-in dashboard theme to the client/server theme lists
- keeps Midnight Modern on the original Midnight sizing/spacing while using Geist/Geist Mono typography
- maps Tailwind font utilities to theme font variables and makes the active Midnight Modern theme override legacy Mondwest font usage
- suppresses the default background filler image for Midnight Modern with an explicit `bg: "none"`

## Verification
- `npm run build` (web) passes
- `git diff --check -- web/src/index.css web/src/themes/presets.ts hermes_cli/web_server.py website/docs/user-guide/features/web-dashboard.md` passes
- `npm run lint` (web) was attempted, but fails on pre-existing unrelated lint issues in OAuthProvidersCard, Toast, i18n, AnalyticsPage, ChatPage, ConfigPage, EnvPage, LogsPage, ModelsPage, PluginsPage, SessionsPage, SkillsPage, PluginPage, and themes/context.tsx

## Notes
- Left unrelated local working-tree changes in `agent/title_generator.py`, `hermes_cli/config.py`, and `tests/agent/test_title_generator.py` unstaged and out of this PR.
