### PR TITLE
fix(gateway): unbreak /platform pause and resume parsing

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8935,7 +8935,11 @@ class GatewayRunner:
             ``/platform pause whatsapp`` — stop the reconnect watcher hammering whatsapp
             ``/platform resume whatsapp`` — re-queue a paused platform for retry
         """
-        text = (getattr(event, "content", "") or "").strip()
+        text = (
+            getattr(event, "text", None)
+            or getattr(event, "content", "")
+            or ""
+        ).strip()
         # Strip the leading "/platform" (or "/PLATFORM") token if present
         parts = text.split(maxsplit=2)
         if parts and parts[0].lower().lstrip("/").startswith("platform"):

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -201,6 +201,7 @@ AUTHOR_MAP = {
     "JamesX88@users.noreply.github.com": "JamesX88",
     "novax635@gmail.com": "novax635",
     "krionex1@gmail.com": "Krionex",
+    "kronexoi13@gmail.com": "kronexoi",
     "rxdxxxx@users.noreply.github.com": "rxdxxxx",
     "ma.haohao2@xydigit.com": "MaHaoHao-ch",
     "29756950+revaraver@users.noreply.github.com": "revaraver",

--- a/tests/gateway/test_platform_reconnect.py
+++ b/tests/gateway/test_platform_reconnect.py
@@ -640,9 +640,7 @@ class TestPlatformSlashCommand:
     """Test the /platform list|pause|resume slash command handler."""
 
     def _make_event(self, content: str):
-        ev = MagicMock()
-        ev.content = content
-        return ev
+        return MessageEvent(text=content)
 
     @pytest.mark.asyncio
     async def test_list_shows_connected_and_paused(self):


### PR DESCRIPTION
## What does this PR do?

Fixes `/platform` command parsing in the gateway so `pause` and `resume` work with real `MessageEvent` inputs. The handler was reading `event.content`, while gateway events use `event.text`, causing `/platform pause <name>` and `/platform resume <name>` to fall back to the default `list` behavior. The tests now use real `MessageEvent` objects so this regression is not masked.

## Related Issue

Fixes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Read `/platform` command text from `event.text` with `event.content` as fallback in `gateway/run.py`
- Updated gateway slash-command tests to construct real `MessageEvent(text=...)` instances in `tests/gateway/test_platform_reconnect.py`

## How to Test

1. Run `pytest tests/gateway/test_platform_reconnect.py -k platform -q`
2. Verify all platform command tests pass
3. Manually confirm `/platform pause whatsapp` and `/platform resume whatsapp` parse correctly in the gateway path

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)


### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `29 passed in 7.67s`