### PR TITLE
fix: let HERMES_DEV bypass container detection

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -368,8 +368,11 @@ def _is_container() -> bool:
     When Hermes runs in a container with volume-mounted config files, forcing
     0o600 permissions breaks multi-process setups where the gateway and
     dashboard run as different UIDs or the volume mount requires broader
-    permissions.
+    permissions.  ``HERMES_DEV=1`` bypasses marker/cgroup detection so local
+    development checkouts can keep normal host file-permission behavior.
     """
+    if os.environ.get("HERMES_DEV") == "1":
+        return False
     # Explicit opt-out
     if os.environ.get("HERMES_CONTAINER") or os.environ.get("HERMES_SKIP_CHMOD"):
         return True

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -248,9 +248,13 @@ def is_container() -> bool:
 
     Checks ``/.dockerenv`` (Docker), ``/run/.containerenv`` (Podman),
     and ``/proc/1/cgroup`` for container runtime markers.  Result is
-    cached for the process lifetime.  Import-safe — no heavy deps.
+    cached for the process lifetime.  ``HERMES_DEV=1`` bypasses detection
+    so local development checkouts can run directly even when marker files
+    are present.  Import-safe — no heavy deps.
     """
     global _container_detected
+    if os.environ.get("HERMES_DEV") == "1":
+        return False
     if _container_detected is not None:
         return _container_detected
     if os.path.exists("/.dockerenv"):

--- a/tests/hermes_cli/test_container_aware_cli.py
+++ b/tests/hermes_cli/test_container_aware_cli.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from hermes_cli.config import (
+    _is_container,
     get_container_exec_info,
 )
 
@@ -91,6 +92,14 @@ def test_get_container_exec_info_not_skipped_when_hermes_dev_zero(container_env,
         info = get_container_exec_info()
 
     assert info is not None
+
+
+def test_is_container_skipped_when_hermes_dev(monkeypatch):
+    """HERMES_DEV=1 bypasses local container marker detection."""
+    monkeypatch.setenv("HERMES_DEV", "1")
+    monkeypatch.setattr(os.path, "exists", lambda p: p == "/.dockerenv")
+
+    assert _is_container() is False
 
 
 def test_get_container_exec_info_defaults():

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -118,6 +118,14 @@ class TestIsContainer:
         monkeypatch.setattr(os.path, "exists", lambda p: False)
         assert is_container() is True
 
+    def test_hermes_dev_bypasses_container_detection_and_cache(self, monkeypatch):
+        """HERMES_DEV=1 forces local-dev mode even if container detection was cached."""
+        monkeypatch.setenv("HERMES_DEV", "1")
+        monkeypatch.setattr(hermes_constants, "_container_detected", True)
+        monkeypatch.setattr(os.path, "exists", lambda p: p == "/.dockerenv")
+
+        assert is_container() is False
+
 
 class TestParseReasoningEffort:
     """Tests for parse_reasoning_effort() — string → reasoning config dict."""


### PR DESCRIPTION
## Summary
- make shared container detection return false when HERMES_DEV=1
- apply the same bypass to CLI config permission-skip container detection
- add regression coverage for marker-file detection and cached container state

## Tests
- python -m pytest tests/test_hermes_constants.py tests/hermes_cli/test_container_aware_cli.py -o 'addopts=' -q