### PR TITLE
fix(gateway): parse /footer subcommands from MessageEvent args

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11147,15 +11147,7 @@ class GatewayRunner:
         platform_key = _platform_config_key(event.source.platform)
 
         # --- parse argument -------------------------------------------------
-        arg = ""
-        try:
-            text = (getattr(event, "message", None) or "").strip()
-            if text.startswith("/"):
-                parts = text.split(None, 1)
-                if len(parts) > 1:
-                    arg = parts[1].strip().lower()
-        except Exception:
-            arg = ""
+        arg = (event.get_command_args() or "").strip().lower()
 
         # --- load config ----------------------------------------------------
         try:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -258,6 +258,7 @@ AUTHOR_MAP = {
     "274096618+hermes-agent-dhabibi@users.noreply.github.com": "dhabibi",
     "dejie.guo@gmail.com": "JayGwod",
     "133716830+0xKingBack@users.noreply.github.com": "0xKingBack",
+    "kronexoi13@gmail.com": "kronexoi",
     "daixin1204@gmail.com": "SimbaKingjoe",
     "maxence@groine.fr": "MaxyMoos",
     "61830395+leprincep35700@users.noreply.github.com": "leprincep35700",

--- a/tests/gateway/test_footer_command.py
+++ b/tests/gateway/test_footer_command.py
@@ -1,0 +1,124 @@
+"""Tests for the gateway /footer command."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import yaml
+
+import gateway.run as gateway_run
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+def _make_event(text="/footer", platform=Platform.TELEGRAM) -> MessageEvent:
+    source = SessionSource(
+        platform=platform,
+        user_id="12345",
+        chat_id="67890",
+        user_name="testuser",
+    )
+    return MessageEvent(text=text, source=source)
+
+
+def _make_runner():
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {}
+    runner._ephemeral_system_prompt = ""
+    runner._prefill_messages = []
+    runner._reasoning_config = None
+    runner._show_reasoning = False
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._running_agents = {}
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner.hooks.loaded_hooks = []
+    runner._session_db = None
+    runner._get_or_create_gateway_honcho = lambda session_key: (None, None)
+    return runner
+
+
+def _write_config(path, enabled):
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "display": {
+                    "runtime_footer": {
+                        "enabled": enabled,
+                        "fields": ["model", "context_pct", "cwd"],
+                    }
+                }
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+
+class TestFooterCommand:
+    @pytest.mark.asyncio
+    async def test_status_reports_current_state_without_toggling(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        _write_config(config_path, enabled=False)
+
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+        runner = _make_runner()
+        result = await runner._handle_footer_command(_make_event("/footer status"))
+
+        saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert saved["display"]["runtime_footer"]["enabled"] is False
+        assert "OFF" in result
+        assert "model, context_pct, cwd" in result
+        assert "telegram" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_off_does_not_flip_disabled_footer_back_on(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        _write_config(config_path, enabled=False)
+
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+        runner = _make_runner()
+        result = await runner._handle_footer_command(_make_event("/footer off"))
+
+        saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert saved["display"]["runtime_footer"]["enabled"] is False
+        assert "OFF" in result
+
+    @pytest.mark.asyncio
+    async def test_on_enables_footer_persistently(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        _write_config(config_path, enabled=False)
+
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+        runner = _make_runner()
+        result = await runner._handle_footer_command(_make_event("/footer on"))
+
+        saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert saved["display"]["runtime_footer"]["enabled"] is True
+        assert "ON" in result
+
+    @pytest.mark.asyncio
+    async def test_bare_footer_toggles_current_state(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        _write_config(config_path, enabled=True)
+
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+        runner = _make_runner()
+        result = await runner._handle_footer_command(_make_event("/footer"))
+
+        saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert saved["display"]["runtime_footer"]["enabled"] is False
+        assert "OFF" in result


### PR DESCRIPTION
## What does this PR do?

Fixes the gateway `/footer` command so `on`, `off`, and `status` are parsed from the real `MessageEvent` input instead of a missing `event.message` field.

Before this change, `/footer status` and `/footer off` could incorrectly fall through to the toggle path and persist the wrong config state. Using `event.get_command_args()` matches the rest of the gateway command handlers and fixes the bug with a minimal, low-risk change.

## Related Issue

Fixes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)


## Changes Made

- Updated `gateway/run.py` so `_handle_footer_command()` parses args via `event.get_command_args()`
- Added `tests/gateway/test_footer_command.py`
- Covered `/footer status`, `/footer on`, `/footer off`, and bare `/footer` toggle behavior

## How to Test

1. Run `pytest tests/gateway/test_footer_command.py -q`
2. Verify all 4 tests pass
3. Reproduce manually with `/footer status`, `/footer off`, and `/footer on` to confirm they no longer fall through to toggle behavior

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)


### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

-  `4 passed`