### PR TITLE
fix(agent): scope DeepSeek and MiMo reasoning echo to host, not model name

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3628,12 +3628,16 @@ class AIAgent:
         DeepSeek V4 thinking mode requires ``reasoning_content`` on every
         assistant tool-call turn; omitting it causes HTTP 400 when the
         message is replayed in a subsequent API request (#15250).
+
+        Detection is host-driven, not model-name-driven: aggregators like
+        OpenRouter that re-export DeepSeek models speak their own protocol
+        and reject ``reasoning_content`` echoes. We only enable the
+        deepseek-reasoning replay when the request actually targets the
+        official DeepSeek endpoint or the dedicated deepseek provider.
         """
         provider = (self.provider or "").lower()
-        model = (self.model or "").lower()
         return (
             provider == "deepseek"
-            or "deepseek" in model
             or base_url_host_matches(self.base_url, "api.deepseek.com")
         )
 
@@ -3643,12 +3647,16 @@ class AIAgent:
         MiMo thinking mode requires ``reasoning_content`` on every assistant
         tool-call message when replaying history; omitting it causes HTTP 400.
         Refs: https://platform.xiaomimimo.com/docs/zh-CN/usage-guide/passing-back-reasoning_content
+
+        Detection is host-driven, not model-name-driven: aggregators that
+        re-export MiMo models speak their own protocol and reject
+        ``reasoning_content`` echoes. We only enable the replay when the
+        request actually targets an official MiMo endpoint or the dedicated
+        xiaomi provider.
         """
         provider = (self.provider or "").lower()
-        model = (self.model or "").lower()
         return (
             provider == "xiaomi"
-            or "mimo" in model
             or base_url_host_matches(self.base_url, "api.xiaomimimo.com")
             or base_url_host_matches(self.base_url, "xiaomimimo.com")
         )

--- a/tests/run_agent/test_deepseek_reasoning_content_echo.py
+++ b/tests/run_agent/test_deepseek_reasoning_content_echo.py
@@ -14,9 +14,12 @@ Fix covers three paths:
    persisted poisoned.
 2. ``_copy_reasoning_content_for_api`` — already-poisoned history replays
    with ``reasoning_content=" "`` injected defensively.
-3. Detection covers three signals: ``provider == "deepseek"``,
-   ``"deepseek" in model``, and ``api.deepseek.com`` host match. The third
-   catches custom-provider setups pointing at DeepSeek.
+3. Detection is host-driven, not model-name-driven: two signals suffice —
+   ``provider == "deepseek"`` and ``api.deepseek.com`` host match. The host
+   match catches custom-provider setups pointing at the official DeepSeek
+   endpoint. Aggregators like OpenRouter that re-export DeepSeek models are
+   intentionally excluded — they speak their own protocol and reject
+   ``reasoning_content`` echoes.
 
 The placeholder is a single space (not empty string) because DeepSeek V4 Pro
 tightened validation and rejects empty-string reasoning_content with a
@@ -78,10 +81,15 @@ class TestNeedsDeepSeekToolReasoning:
         agent = _make_agent(provider="deepseek", model="deepseek-v4-flash")
         assert agent._needs_deepseek_tool_reasoning() is True
 
-    def test_model_substring(self) -> None:
-        # Custom provider pointing at DeepSeek with provider='custom'
-        agent = _make_agent(provider="custom", model="deepseek-v4-pro")
-        assert agent._needs_deepseek_tool_reasoning() is True
+    def test_openrouter_deepseek_model_not_detected(self) -> None:
+        # OpenRouter re-exports deepseek models but speaks its own protocol —
+        # must NOT trigger reasoning_content echo or it causes HTTP 400.
+        agent = _make_agent(
+            provider="openrouter",
+            model="deepseek/deepseek-v3",
+            base_url="https://openrouter.ai/api/v1",
+        )
+        assert agent._needs_deepseek_tool_reasoning() is False
 
     def test_base_url_host(self) -> None:
         agent = _make_agent(


### PR DESCRIPTION
## Problem

`_needs_deepseek_tool_reasoning` triggered on `"deepseek" in model` and `_needs_mimo_tool_reasoning` triggered on `"mimo" in model`. Both substring checks fire for any re-exported model whose name contains the substring — including OpenRouter routes like `deepseek/deepseek-v3` or `xiaomi/mimo-v2.5-pro`.

When triggered, Hermes injects `reasoning_content` into every assistant message before sending it to the API. OpenRouter (and other aggregators) do not understand this field and reject the request:

```
HTTP 400 — The reasoning_content in the thinking mode must be passed back to the API.
```

This breaks **every tool-call turn** for users running DeepSeek or MiMo models through OpenRouter or any other aggregator.

## Root Cause

```python
# BEFORE — substring fires for OpenRouter re-exports
def _needs_deepseek_tool_reasoning(self) -> bool:
    model = (self.model or "").lower()
    return (
        provider == "deepseek"
        or "deepseek" in model          # ← false positive on openrouter
        or base_url_host_matches(...)
    )
```

## Fix

Remove the model-name substring checks. Provider identity and base-URL host matching already cover all official API paths:

```python
# AFTER — host-driven only
def _needs_deepseek_tool_reasoning(self) -> bool:
    return (
        provider == "deepseek"
        or base_url_host_matches(self.base_url, "api.deepseek.com")
    )
```

Same fix applied to `_needs_mimo_tool_reasoning`.

## Parity

Commit `532b209f0` applied the identical correction to `_needs_kimi_tool_reasoning` with the explicit note:

> "Detection is host-driven, not model-name-driven: aggregators like OpenRouter that re-export Kimi/Moonshot models speak their own protocol and reject `reasoning_content` echoes."

DeepSeek and MiMo were left behind. This PR brings them to the same standard.

## Tests

- `test_model_substring` replaced with `test_openrouter_deepseek_model_not_detected` — asserts the bug case now returns `False`
- All existing 35 tests continue to pass (`36/36`)

## Checklist

- [x] Root cause identified and fixed (2 functions)
- [x] Parity with `_needs_kimi_tool_reasoning` (commit `532b209f0`)
- [x] No new dependencies
- [x] Stale test updated to match correct behavior
- [x] Full test suite passes (`36/36`)