### PR TITLE
feat(hooks): invoke post_tool_call at human_ops gate sites

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2589,7 +2589,31 @@ def block_task(
     reason: Optional[str] = None,
     expected_run_id: Optional[int] = None,
 ) -> bool:
-    """Transition ``running -> blocked``."""
+    """Transition ``running -> blocked``.
+
+    Fires ``post_tool_call`` with ``event_type='human_ops_gate'`` around
+    the transition so plugins (e.g. cost-event-wrapper) can observe when
+    a task enters the human-ops gate:
+
+    * ``phase='before'``  — gate entered (block requested)
+    * ``phase='after'`` / ``outcome='approved'``  — transition succeeded
+    * ``phase='after'`` / ``outcome='denied'``    — transition failed
+      (task not in running/ready, or run_id mismatch)
+    """
+    # Plugin hook: human_ops_gate — before phase
+    try:
+        from hermes_cli.plugins import invoke_hook as _invoke_hook
+        _invoke_hook(
+            "post_tool_call",
+            event_type="human_ops_gate",
+            card_id=task_id,
+            tool="kanban_block",
+            phase="before",
+            gate_reason="r3_human_ops_required",
+        )
+    except Exception:
+        pass
+
     with write_txn(conn):
         if expected_run_id is None:
             cur = conn.execute(
@@ -2619,6 +2643,20 @@ def block_task(
                 (task_id, int(expected_run_id)),
             )
         if cur.rowcount != 1:
+            # Plugin hook: human_ops_gate — after/denied
+            try:
+                from hermes_cli.plugins import invoke_hook as _invoke_hook
+                _invoke_hook(
+                    "post_tool_call",
+                    event_type="human_ops_gate",
+                    card_id=task_id,
+                    tool="kanban_block",
+                    phase="after",
+                    gate_reason="r3_human_ops_required",
+                    outcome="denied",
+                )
+            except Exception:
+                pass
             return False
         run_id = _end_run(
             conn, task_id,
@@ -2634,7 +2672,23 @@ def block_task(
                 summary=reason,
             )
         _append_event(conn, task_id, "blocked", {"reason": reason}, run_id=run_id)
-        return True
+
+    # Plugin hook: human_ops_gate — after/approved (outside write_txn so
+    # the committed state is visible to plugins that read the DB).
+    try:
+        from hermes_cli.plugins import invoke_hook as _invoke_hook
+        _invoke_hook(
+            "post_tool_call",
+            event_type="human_ops_gate",
+            card_id=task_id,
+            tool="kanban_block",
+            phase="after",
+            gate_reason="r3_human_ops_required",
+            outcome="approved",
+        )
+    except Exception:
+        pass
+    return True
 
 
 def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1530,3 +1530,154 @@ def test_task_dict_survives_corrupt_created_at(tmp_path, monkeypatch):
         conn.close()
     age = kb.task_age(task)
     assert age["created_age_seconds"] is None
+
+
+# ---------------------------------------------------------------------------
+# T1-T4: post_tool_call hook at human_ops gate sites (PR-3)
+# ---------------------------------------------------------------------------
+
+class TestHumanOpsGateHook:
+    """Tests for post_tool_call invocation at R3 human_ops gate sites.
+
+    T1 — gate hit fires phase='before'
+    T2 — gate approved fires phase='after', outcome='approved'
+    T3 — gate denied fires phase='after', outcome='denied'
+    T4 — existing plugin (mock) that ignores new event_type does not crash
+    """
+
+    def _collected_calls(self, monkeypatch):
+        """Return a list that collects every invoke_hook call payload."""
+        calls: list[dict] = []
+
+        def _fake_invoke(hook_name: str, **kwargs) -> list:
+            calls.append({"hook_name": hook_name, **kwargs})
+            return []
+
+        monkeypatch.setattr(
+            "hermes_cli.kanban_db.invoke_hook", _fake_invoke, raising=False
+        )
+        # Also patch at the plugins import site used inside block_task
+        import hermes_cli.kanban_db as _kdb
+        monkeypatch.setattr(_kdb, "_HAS_PLUGINS_PATCHED", True, raising=False)
+        return calls
+
+    def _patch_invoke(self, monkeypatch):
+        """Monkey-patch the inline import inside block_task/unblock_task."""
+        calls: list[dict] = []
+
+        original_import = __builtins__.__import__ if hasattr(__builtins__, "__import__") else None
+
+        import hermes_cli.plugins as _plugins_mod
+
+        def _mock_invoke(hook_name: str, **kwargs) -> list:
+            calls.append({"hook_name": hook_name, **kwargs})
+            return []
+
+        monkeypatch.setattr(_plugins_mod, "invoke_hook", _mock_invoke)
+        return calls
+
+    def test_t1_gate_hit_before_fires(self, kanban_home, monkeypatch):
+        """T1: block_task fires post_tool_call with phase='before' before state change."""
+        calls = self._patch_invoke(monkeypatch)
+
+        with kb.connect() as conn:
+            tid = kb.create_task(conn, title="gate-test", assignee="ops")
+            kb.claim_task(conn, tid)
+            kb.block_task(conn, tid, reason="need human input")
+
+        before_calls = [
+            c for c in calls
+            if c.get("event_type") == "human_ops_gate" and c.get("phase") == "before"
+        ]
+        assert len(before_calls) >= 1, "expected at least one before-phase call"
+        first = before_calls[0]
+        assert first["card_id"] == tid
+        assert first["tool"] == "kanban_block"
+        assert first["gate_reason"] == "r3_human_ops_required"
+        assert first["hook_name"] == "post_tool_call"
+
+    def test_t2_gate_approved_after_fires(self, kanban_home, monkeypatch):
+        """T2: successful block_task fires phase='after', outcome='approved'."""
+        calls = self._patch_invoke(monkeypatch)
+
+        with kb.connect() as conn:
+            tid = kb.create_task(conn, title="gate-approve", assignee="ops")
+            kb.claim_task(conn, tid)
+            result = kb.block_task(conn, tid, reason="approved path")
+
+        assert result is True
+        after_approved = [
+            c for c in calls
+            if c.get("event_type") == "human_ops_gate"
+            and c.get("phase") == "after"
+            and c.get("outcome") == "approved"
+        ]
+        assert len(after_approved) >= 1, "expected after/approved call"
+        first = after_approved[0]
+        assert first["card_id"] == tid
+        assert first["hook_name"] == "post_tool_call"
+
+    def test_t3_gate_denied_after_fires(self, kanban_home, monkeypatch):
+        """T3: failed block_task (task not in running/ready) fires phase='after', outcome='denied'."""
+        calls = self._patch_invoke(monkeypatch)
+
+        with kb.connect() as conn:
+            tid = kb.create_task(conn, title="gate-deny", assignee="ops")
+            # Task is 'ready' but not claimed — block on a done task to force deny
+            kb.claim_task(conn, tid)
+            kb.complete_task(conn, tid, result="done")
+            # Now task is 'done', block_task should fail → denied
+            result = kb.block_task(conn, tid, reason="should be denied")
+
+        assert result is False
+        after_denied = [
+            c for c in calls
+            if c.get("event_type") == "human_ops_gate"
+            and c.get("phase") == "after"
+            and c.get("outcome") == "denied"
+        ]
+        assert len(after_denied) >= 1, "expected after/denied call"
+        first = after_denied[0]
+        assert first["card_id"] == tid
+        assert first["hook_name"] == "post_tool_call"
+
+    def test_t4_existing_plugin_ignores_new_event_type(self, kanban_home):
+        """T4: a plugin that ignores unknown event_type kwargs does not crash.
+
+        Simulates cost-event-wrapper style plugin that uses **kwargs to absorb
+        unknown keyword arguments.  When block_task fires the human_ops_gate
+        event, the plugin must receive the call without raising.
+        """
+        from hermes_cli.plugins import PluginContext, PluginManifest, PluginManager
+
+        manifest = PluginManifest(
+            name="mock-cost-wrapper", source="test", key="mock-cost-wrapper"
+        )
+        manager = PluginManager()
+        ctx = PluginContext(manifest, manager)
+
+        observed: list[dict] = []
+
+        def mock_post_tool_call(tool_name: str = "", args: dict = None,
+                                result: str = "", task_id: str = "",
+                                duration_ms: int = 0, **kwargs) -> None:
+            """Existing plugin — only reads normal post_tool_call kwargs.
+            New event_type kwarg is captured silently in **kwargs."""
+            observed.append({"tool_name": tool_name, "extra": kwargs})
+
+        ctx.register_hook("post_tool_call", mock_post_tool_call)
+
+        # Fire the human_ops_gate event the same way block_task does.
+        manager.invoke_hook(
+            "post_tool_call",
+            event_type="human_ops_gate",
+            card_id="t_test123",
+            tool="kanban_block",
+            phase="before",
+            gate_reason="r3_human_ops_required",
+        )
+
+        # Plugin received the call without crashing and absorbed event_type in **kwargs.
+        assert len(observed) == 1
+        assert observed[0]["extra"].get("event_type") == "human_ops_gate"
+        assert observed[0]["tool_name"] == ""  # not set in gate events

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -499,6 +499,39 @@ def register(ctx):
     ctx.register_hook("post_tool_call", track_metrics)
 ```
 
+#### Extended event type: `human_ops_gate`
+
+`post_tool_call` is also fired at Kanban R3 human-ops gate sites (inside
+`kanban_db.block_task`). These calls carry an `event_type` kwarg that
+distinguishes them from normal tool-dispatch events.
+
+**When it fires:** `kanban_db.block_task()` is called — once before the
+state transition (`phase='before'`) and once after (`phase='after'`).
+
+**Additional kwargs for `event_type='human_ops_gate'`:**
+
+| Kwarg | Type | Description |
+|-------|------|-------------|
+| `event_type` | `str` | Always `"human_ops_gate"` |
+| `card_id` | `str` | Kanban task ID that entered the gate |
+| `tool` | `str` | Always `"kanban_block"` |
+| `phase` | `str` | `"before"` (gate entry) or `"after"` (gate outcome) |
+| `gate_reason` | `str` | Always `"r3_human_ops_required"` |
+| `outcome` | `str \| None` | `"approved"` (block succeeded) or `"denied"` (block failed — task not in running/ready). Only present when `phase="after"`. |
+
+**Compatibility:** Existing `post_tool_call` plugins that do not read
+`event_type` receive these calls as extra kwargs captured by `**kwargs`
+and are unaffected. To handle only tool-dispatch events, filter on
+`event_type` being absent or `None`:
+
+```python
+def on_tool(tool_name="", event_type=None, **kwargs):
+    if event_type == "human_ops_gate":
+        # observe human-ops gate: kwargs has card_id, phase, outcome …
+        return
+    # normal tool-dispatch path …
+```
+
 ---
 
 ### `pre_llm_call`


### PR DESCRIPTION
## Why

The Kanban dispatcher's R3 human-ops gate (`kanban_db.block_task`) had no
`post_tool_call` hook invocation.  Plugins such as `cost-event-wrapper` that
listen to `post_tool_call` had no way to observe when a task entered human-ops
review — they could not measure ops-intervention wait time, count human-review
requests per session, or fire alerts when a task gets blocked.

Related: ADR-013 (R3 gate), ADR-004 (cost-event-wrapper observation points),
P2.4 Phase A.

## What

Added two `post_tool_call` invocations inside `kanban_db.block_task`:

| Call | When |
|------|------|
| `phase='before'` | Immediately before the SQL state transition |
| `phase='after'`, `outcome='approved'` | After a successful `running → blocked` transition |
| `phase='after'`, `outcome='denied'` | After a failed transition (task not in running/ready, or run_id mismatch) |

All calls carry `event_type='human_ops_gate'` so plugins can distinguish gate
events from normal tool-dispatch `post_tool_call` events.

### Changed files

| File | Change |
|------|--------|
| `hermes_cli/kanban_db.py` | `block_task`: added `before` / `after` hook invocations (~55 lines) |
| `tests/hermes_cli/test_kanban_db.py` | 4 new tests (T1–T4, class `TestHumanOpsGateHook`) |
| `website/docs/user-guide/features/hooks.md` | New subsection "Extended event type: human_ops_gate" under `post_tool_call` |

## Tests

| ID | Description | Result |
|----|-------------|--------|
| T1 | `block_task` fires `phase='before'` with correct `card_id`, `tool`, `gate_reason` | PASS |
| T2 | Successful `block_task` fires `phase='after'`, `outcome='approved'` | PASS |
| T3 | Failed `block_task` (task not in running/ready) fires `phase='after'`, `outcome='denied'` | PASS |
| T4 | Existing plugin mock with `**kwargs` absorbs `event_type` kwarg without crashing | PASS |

Existing kanban regression: `pytest tests/hermes_cli/test_kanban_db.py` → **86 passed**
(82 pre-existing + 4 new).

## Compatibility

- **No breaking changes.** The new hook calls are on `post_tool_call`, which
  already fires in many places.  Existing plugin callbacks that use `**kwargs`
  (the documented idiom — see `disk-cleanup`, `langfuse`) receive the new
  kwargs silently.
- Plugins that do not register a `post_tool_call` handler are unaffected.
- The `event_type='human_ops_gate'` kwarg is absent from all existing call
  sites, so plugins that filter on its presence or value are cleanly separated.
- `block_task` return value and behaviour are unchanged; hook errors are caught
  and suppressed so a broken plugin cannot block the gate transition.
- This PR adds only the invocation sites.  Consuming the new event in a plugin
  (e.g. recording intervention latency in `cost-event-wrapper`) is a follow-up
  PR.
