### PR TITLE
feat(kanban): add awaiting_human_ops state for R3 gate cards

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1689,7 +1689,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 23,
+    "_config_version": 24,
 }
 
 # =============================================================================

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -258,7 +258,7 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     b_rename.add_argument("name", help="New display name")
 
     # --- create ---
-    p_create = sub.add_parser("create", help="Create a new task")
+    p_create = sub.add_parser("create", aliases=["add"], help="Create a new task")
     p_create.add_argument("title", help="Task title")
     p_create.add_argument("--body", default=None, help="Optional opening post")
     p_create.add_argument("--assignee", default=None, help="Profile name to assign")
@@ -294,6 +294,12 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                                "two retries. Omit to use the dispatcher's "
                                "kanban.failure_limit config "
                                f"(default {kb.DEFAULT_FAILURE_LIMIT}).")
+    p_create.add_argument("--initial-status",
+                          choices=sorted(kb.VALID_INITIAL_STATUSES),
+                          default="running",
+                          help="Initial card status. Use 'blocked' for cards "
+                               "that require immediate human ops (R3 gate) "
+                               "to skip the brief running-to-blocked transition.")
     p_create.add_argument("--json", action="store_true", help="Emit JSON output")
 
     # --- list ---
@@ -746,6 +752,7 @@ def kanban_command(args: argparse.Namespace) -> int:
     handlers = {
         "init":     _cmd_init,
         "create":   _cmd_create,
+        "add":      _cmd_create,
         "list":     _cmd_list,
         "ls":       _cmd_list,
         "show":     _cmd_show,
@@ -1115,6 +1122,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             max_runtime_seconds=max_runtime,
             skills=getattr(args, "skills", None) or None,
             max_retries=max_retries,
+            initial_status=getattr(args, "initial_status", "running"),
         )
         task = kb.get_task(conn, task_id)
     if getattr(args, "json", False):
@@ -2342,7 +2350,11 @@ def run_slash(rest: str) -> str:
     kanban_parser.exit_on_error = False  # type: ignore[attr-defined]
     for _action in kanban_parser._actions:
         if isinstance(_action, argparse._SubParsersAction):
+            _seen_subparsers: set[int] = set()
             for _name, _choice in _action.choices.items():
+                if id(_choice) in _seen_subparsers:
+                    continue
+                _seen_subparsers.add(id(_choice))
                 _choice.prog = f"/kanban {_name}"
                 _choice.exit_on_error = False  # type: ignore[attr-defined]
 
@@ -2363,7 +2375,16 @@ def run_slash(rest: str) -> str:
         body = err or out
         return f"⚠ /kanban usage error\n{body}" if body else "⚠ /kanban usage error"
     except argparse.ArgumentError as exc:
-        return f"⚠ /kanban usage error: {exc}"
+        usage = ""
+        if tokens:
+            for _action in kanban_parser._actions:
+                if isinstance(_action, argparse._SubParsersAction):
+                    _choice = _action.choices.get(tokens[0])
+                    if _choice is not None:
+                        usage = _choice.format_usage().rstrip()
+                    break
+        body = f"{usage}\n{exc}" if usage else str(exc)
+        return f"⚠ /kanban usage error\n{body}"
 
     with contextlib.redirect_stdout(buf_out), contextlib.redirect_stderr(buf_err):
         try:

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -35,6 +35,7 @@ _STATUS_ICONS = {
     "ready":    "▶",
     "running":  "●",
     "blocked":  "⊘",
+    "awaiting_human_ops": "!",
     "done":     "✓",
     "archived": "—",
 }
@@ -50,7 +51,7 @@ def _fmt_task_line(t: kb.Task) -> str:
     icon = _STATUS_ICONS.get(t.status, "?")
     assignee = t.assignee or "(unassigned)"
     tenant = f" [{t.tenant}]" if t.tenant else ""
-    return f"{icon} {t.id}  {t.status:8s}  {assignee:20s}{tenant}  {t.title}"
+    return f"{icon} {t.id}  {t.status:18s}  {assignee:20s}{tenant}  {t.title}"
 
 
 def _task_to_dict(t: kb.Task) -> dict[str, Any]:
@@ -297,9 +298,9 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_create.add_argument("--initial-status",
                           choices=sorted(kb.VALID_INITIAL_STATUSES),
                           default="running",
-                          help="Initial card status. Use 'blocked' for cards "
-                               "that require immediate human ops (R3 gate) "
-                               "to skip the brief running-to-blocked transition.")
+                          help="Initial card status. Use 'awaiting_human_ops' "
+                               "for R3 human-ops gates; use 'blocked' for "
+                               "technical or dependency waits.")
     p_create.add_argument("--json", action="store_true", help="Emit JSON output")
 
     # --- list ---
@@ -436,9 +437,17 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_block.add_argument("reason", nargs="*", help="Reason (also appended as a comment)")
     p_block.add_argument("--ids", nargs="+", default=None,
                          help="Additional task ids to block with the same reason (bulk mode)")
+    p_block.add_argument("--status",
+                         choices=["blocked", "awaiting_human_ops"],
+                         default="blocked",
+                         help="Waiting state to apply (default: blocked)")
 
     p_unblock = sub.add_parser("unblock", help="Return one or more blocked tasks to ready")
     p_unblock.add_argument("task_ids", nargs="+")
+
+    p_move = sub.add_parser("move", help="Move a task to a Kanban status")
+    p_move.add_argument("task_id")
+    p_move.add_argument("status", choices=sorted(kb.VALID_STATUSES))
 
     p_archive = sub.add_parser("archive", help="Archive one or more tasks")
     p_archive.add_argument("task_ids", nargs="+")
@@ -769,6 +778,7 @@ def kanban_command(args: argparse.Namespace) -> int:
         "edit":     _cmd_edit,
         "block":    _cmd_block,
         "unblock":  _cmd_unblock,
+        "move":     _cmd_move,
         "archive":  _cmd_archive,
         "tail":     _cmd_tail,
         "dispatch": _cmd_dispatch,
@@ -1674,11 +1684,14 @@ def _cmd_block(args: argparse.Namespace) -> int:
                 tid,
                 reason=reason,
                 expected_run_id=_worker_run_id_for(tid),
+                target_status=getattr(args, "status", "blocked"),
             ):
                 failed.append(tid)
                 print(f"cannot block {tid}", file=sys.stderr)
             else:
-                print(f"Blocked {tid}" + (f": {reason}" if reason else ""))
+                status = getattr(args, "status", "blocked")
+                verb = "Awaiting human ops" if status == "awaiting_human_ops" else "Blocked"
+                print(f"{verb} {tid}" + (f": {reason}" if reason else ""))
     return 0 if not failed else 1
 
 
@@ -1696,6 +1709,19 @@ def _cmd_unblock(args: argparse.Namespace) -> int:
             else:
                 print(f"Unblocked {tid}")
     return 0 if not failed else 1
+
+
+def _cmd_move(args: argparse.Namespace) -> int:
+    with kb.connect() as conn:
+        ok = kb.move_task(conn, args.task_id, args.status)
+    if not ok:
+        print(
+            f"cannot move {args.task_id} to {args.status}",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"Moved {args.task_id} to {args.status}")
+    return 0
 
 
 def _cmd_archive(args: argparse.Namespace) -> int:
@@ -1977,8 +2003,8 @@ def _cmd_stats(args: argparse.Namespace) -> int:
         print(json.dumps(stats, indent=2, ensure_ascii=False))
         return 0
     print("By status:")
-    for k in ("triage", "todo", "ready", "running", "blocked", "done"):
-        print(f"  {k:8s}  {stats['by_status'].get(k, 0)}")
+    for k in ("triage", "todo", "ready", "running", "blocked", "awaiting_human_ops", "done"):
+        print(f"  {k:18s}  {stats['by_status'].get(k, 0)}")
     if stats["by_assignee"]:
         print("\nBy assignee:")
         for who, counts in sorted(stats["by_assignee"].items()):
@@ -2307,6 +2333,7 @@ Common subcommands:
   `comment <id> <msg>`  Append a comment
   `complete <id>…`      Mark task(s) done
   `block <id> [reason]` Mark blocked; `unblock <id>` to revive
+  `move <id> <status>`  Move to a Kanban status
   `assign <id> <profile>`  Reassign
   `boards list`         Show all boards
   `assignees`           Known profiles + counts

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -91,6 +91,7 @@ from toolsets import get_toolset_names
 # ---------------------------------------------------------------------------
 
 VALID_STATUSES = {"triage", "todo", "ready", "running", "blocked", "done", "archived"}
+VALID_INITIAL_STATUSES = {"running", "blocked"}
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
 KNOWN_TOOLSET_NAMES = frozenset(name.casefold() for name in get_toolset_names())
 _IS_WINDOWS = sys.platform == "win32"
@@ -1245,6 +1246,7 @@ def create_task(
     max_runtime_seconds: Optional[int] = None,
     skills: Optional[Iterable[str]] = None,
     max_retries: Optional[int] = None,
+    initial_status: str = "running",
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
 
@@ -1269,10 +1271,19 @@ def create_task(
     ``kanban-worker``. Use this to pin a task to a specialist skill
     (e.g. ``skills=["translation"]`` so the worker loads the
     translation skill regardless of the profile's default config).
+
+    ``initial_status`` controls whether the task enters the usual
+    dispatch path (``"running"``; default, preserving existing
+    ready/todo/triage inference) or is created directly in ``"blocked"``
+    for immediate human-ops review.
     """
     assignee = _canonical_assignee(assignee)
     if not title or not title.strip():
         raise ValueError("title is required")
+    if initial_status not in VALID_INITIAL_STATUSES:
+        raise ValueError(
+            f"initial_status must be one of {sorted(VALID_INITIAL_STATUSES)}"
+        )
     if workspace_kind not in VALID_WORKSPACE_KINDS:
         raise ValueError(
             f"workspace_kind must be one of {sorted(VALID_WORKSPACE_KINDS)}, "
@@ -1347,12 +1358,18 @@ def create_task(
         task_id = _new_task_id()
         try:
             with write_txn(conn):
-                # Determine initial status from parent status, unless the
-                # caller is parking this task in triage for a specifier.
-                if triage:
-                    initial_status = "triage"
+                # Determine task status from parent status, unless the caller
+                # parks it directly in blocked for human-ops review.
+                if initial_status == "blocked":
+                    task_status = "blocked"
+                    if parents:
+                        missing = _find_missing_parents(conn, parents)
+                        if missing:
+                            raise ValueError(f"unknown parent task(s): {', '.join(missing)}")
+                elif triage:
+                    task_status = "triage"
                 else:
-                    initial_status = "ready"
+                    task_status = "ready"
                     if parents:
                         missing = _find_missing_parents(conn, parents)
                         if missing:
@@ -1364,7 +1381,7 @@ def create_task(
                             parents,
                         ).fetchall()
                         if any(r["status"] != "done" for r in rows):
-                            initial_status = "todo"
+                            task_status = "todo"
                 # Even in triage mode we still need to validate parent ids
                 # so the eventual link rows don't dangle.
                 if triage and parents:
@@ -1386,7 +1403,7 @@ def create_task(
                         title.strip(),
                         body,
                         assignee,
-                        initial_status,
+                        task_status,
                         priority,
                         created_by,
                         now,
@@ -1410,7 +1427,7 @@ def create_task(
                     "created",
                     {
                         "assignee": assignee,
-                        "status": initial_status,
+                        "status": task_status,
                         "parents": list(parents),
                         "tenant": tenant,
                         "skills": list(skills_list) if skills_list else None,
@@ -3157,6 +3174,10 @@ def _classify_worker_exit(pid: int) -> "tuple[str, Optional[int]]":
     if entry is None:
         return ("unknown", None)
     raw, _ = entry
+    if not hasattr(os, "WIFEXITED"):
+        if raw == 0:
+            return ("clean_exit", 0)
+        return ("nonzero_exit", int(raw))
     try:
         if os.WIFEXITED(raw):
             code = os.WEXITSTATUS(raw)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -90,8 +90,18 @@ from toolsets import get_toolset_names
 # Constants
 # ---------------------------------------------------------------------------
 
-VALID_STATUSES = {"triage", "todo", "ready", "running", "blocked", "done", "archived"}
-VALID_INITIAL_STATUSES = {"running", "blocked"}
+VALID_STATUSES = {
+    "triage",
+    "todo",
+    "ready",
+    "running",
+    "blocked",
+    "awaiting_human_ops",
+    "done",
+    "archived",
+}
+VALID_INITIAL_STATUSES = {"running", "blocked", "awaiting_human_ops"}
+KANBAN_SCHEMA_VERSION = 24
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
 KNOWN_TOOLSET_NAMES = frozenset(name.casefold() for name in get_toolset_names())
 _IS_WINDOWS = sys.platform == "win32"
@@ -758,7 +768,10 @@ CREATE TABLE IF NOT EXISTS tasks (
     title                TEXT NOT NULL,
     body                 TEXT,
     assignee             TEXT,
-    status               TEXT NOT NULL,
+    status               TEXT NOT NULL CHECK (
+        status IN ('triage', 'todo', 'ready', 'running', 'blocked',
+                   'awaiting_human_ops', 'done', 'archived')
+    ),
     priority             INTEGER DEFAULT 0,
     created_by           TEXT,
     created_at           INTEGER NOT NULL,
@@ -988,6 +1001,228 @@ def _add_column_if_missing(
         raise
 
 
+def _ensure_indexes(conn: sqlite3.Connection) -> None:
+    """Create indexes that may be dropped by table-rebuild migrations.
+
+    Skips indexes whose underlying table isn't present yet — legacy DBs
+    migrating in tests sometimes only have ``tasks`` and ``task_events``.
+    """
+    existing_tables = {
+        row["name"]
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+    }
+    existing_cols = {}
+    for table in existing_tables:
+        existing_cols[table] = {
+            row["name"]
+            for row in conn.execute(f"PRAGMA table_info({table})").fetchall()
+        }
+
+    def _maybe(index_sql: str, table: str, *required_cols: str) -> None:
+        if table not in existing_tables:
+            return
+        if any(col not in existing_cols[table] for col in required_cols):
+            return
+        conn.execute(index_sql)
+
+    _maybe(
+        "CREATE INDEX IF NOT EXISTS idx_tasks_assignee_status "
+        "ON tasks(assignee, status)",
+        "tasks", "assignee", "status",
+    )
+    _maybe(
+        "CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status)",
+        "tasks", "status",
+    )
+    _maybe(
+        "CREATE INDEX IF NOT EXISTS idx_tasks_tenant ON tasks(tenant)",
+        "tasks", "tenant",
+    )
+    _maybe(
+        "CREATE INDEX IF NOT EXISTS idx_tasks_idempotency "
+        "ON tasks(idempotency_key)",
+        "tasks", "idempotency_key",
+    )
+    _maybe(
+        "CREATE INDEX IF NOT EXISTS idx_links_child ON task_links(child_id)",
+        "task_links", "child_id",
+    )
+    _maybe(
+        "CREATE INDEX IF NOT EXISTS idx_links_parent ON task_links(parent_id)",
+        "task_links", "parent_id",
+    )
+    _maybe(
+        "CREATE INDEX IF NOT EXISTS idx_comments_task "
+        "ON task_comments(task_id, created_at)",
+        "task_comments", "task_id", "created_at",
+    )
+    _maybe(
+        "CREATE INDEX IF NOT EXISTS idx_events_task "
+        "ON task_events(task_id, created_at)",
+        "task_events", "task_id", "created_at",
+    )
+    _maybe(
+        "CREATE INDEX IF NOT EXISTS idx_events_run "
+        "ON task_events(run_id, id)",
+        "task_events", "run_id", "id",
+    )
+    _maybe(
+        "CREATE INDEX IF NOT EXISTS idx_runs_task "
+        "ON task_runs(task_id, started_at)",
+        "task_runs", "task_id", "started_at",
+    )
+    _maybe(
+        "CREATE INDEX IF NOT EXISTS idx_runs_status ON task_runs(status)",
+        "task_runs", "status",
+    )
+    _maybe(
+        "CREATE INDEX IF NOT EXISTS idx_notify_task "
+        "ON kanban_notify_subs(task_id)",
+        "kanban_notify_subs", "task_id",
+    )
+
+
+def _tasks_status_check_needs_migration(conn: sqlite3.Connection) -> bool:
+    row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='tasks'"
+    ).fetchone()
+    sql = (row["sql"] if row else "") or ""
+    return "awaiting_human_ops" not in sql or "CHECK" not in sql.upper()
+
+
+# Columns defined by the v24 ``tasks`` schema, in DDL order. Used to
+# rebuild the table when we need to attach the new status CHECK constraint.
+# Legacy/extra columns present on the live table (e.g. ``spawn_failures``
+# from pre-#20842 DBs) are appended dynamically so they survive the
+# rebuild — the existing ADD-first-then-copy migration contract.
+_V24_TASKS_COLUMNS: tuple[tuple[str, str], ...] = (
+    ("id", "TEXT PRIMARY KEY"),
+    ("title", "TEXT NOT NULL"),
+    ("body", "TEXT"),
+    ("assignee", "TEXT"),
+    (
+        "status",
+        "TEXT NOT NULL CHECK (status IN ("
+        "'triage', 'todo', 'ready', 'running', 'blocked', "
+        "'awaiting_human_ops', 'done', 'archived'))",
+    ),
+    ("priority", "INTEGER DEFAULT 0"),
+    ("created_by", "TEXT"),
+    ("created_at", "INTEGER NOT NULL"),
+    ("started_at", "INTEGER"),
+    ("completed_at", "INTEGER"),
+    ("workspace_kind", "TEXT NOT NULL DEFAULT 'scratch'"),
+    ("workspace_path", "TEXT"),
+    ("claim_lock", "TEXT"),
+    ("claim_expires", "INTEGER"),
+    ("tenant", "TEXT"),
+    ("result", "TEXT"),
+    ("idempotency_key", "TEXT"),
+    ("consecutive_failures", "INTEGER NOT NULL DEFAULT 0"),
+    ("worker_pid", "INTEGER"),
+    ("last_failure_error", "TEXT"),
+    ("max_runtime_seconds", "INTEGER"),
+    ("last_heartbeat_at", "INTEGER"),
+    ("current_run_id", "INTEGER"),
+    ("workflow_template_id", "TEXT"),
+    ("current_step_key", "TEXT"),
+    ("skills", "TEXT"),
+    ("max_retries", "INTEGER"),
+)
+
+
+def _migrate_tasks_status_check(conn: sqlite3.Connection) -> None:
+    """Rebuild ``tasks`` with the v24 status CHECK constraint.
+
+    SQLite cannot add a CHECK constraint in-place. Existing row statuses
+    are copied unchanged, so historical ``blocked`` cards stay ``blocked``;
+    operators can reclassify ambiguous cards manually. Legacy columns not
+    in the v24 schema (e.g. ``spawn_failures``) are preserved with their
+    original PRAGMA column definitions so the ADD-first-then-copy
+    contract still holds for very old DBs.
+    """
+    if not _tasks_status_check_needs_migration(conn):
+        conn.execute(f"PRAGMA user_version = {KANBAN_SCHEMA_VERSION}")
+        return
+
+    old_rows = conn.execute("PRAGMA table_info(tasks)").fetchall()
+    if not old_rows:
+        return
+    old_cols: dict[str, sqlite3.Row] = {row["name"]: row for row in old_rows}
+    if "status" not in old_cols:
+        # Concurrent or aborted prior migration left ``tasks`` without
+        # ``status``; defer the CHECK rebuild until the regular schema
+        # bootstrap (CREATE TABLE IF NOT EXISTS) runs again.
+        return
+    valid_statuses = sorted(VALID_STATUSES)
+    placeholders = ",".join("?" for _ in valid_statuses)
+    bad = conn.execute(
+        f"SELECT id, status FROM tasks WHERE status NOT IN ({placeholders}) LIMIT 1",
+        valid_statuses,
+    ).fetchone()
+    if bad:
+        raise sqlite3.IntegrityError(
+            f"cannot migrate kanban status CHECK: task {bad['id']} has "
+            f"unknown status {bad['status']!r}"
+        )
+
+    v24_names = {name for name, _ in _V24_TASKS_COLUMNS}
+    # Legacy columns we must round-trip (preserved harmlessly).
+    legacy_extras: list[tuple[str, str]] = []
+    for name, row in old_cols.items():
+        if name in v24_names:
+            continue
+        # Reconstruct a minimally compatible column definition: keep type,
+        # NOT NULL if applicable, default if present. We avoid PRIMARY KEY
+        # because the v24 schema already names the primary key on ``id``
+        # and PRAGMA only flags one column anyway.
+        col_type = row["type"] or ""
+        parts = [col_type] if col_type else []
+        if row["notnull"]:
+            parts.append("NOT NULL")
+        if row["dflt_value"] is not None:
+            parts.append(f"DEFAULT {row['dflt_value']}")
+        legacy_extras.append((name, " ".join(parts).strip() or "TEXT"))
+
+    column_ddl = ",\n                ".join(
+        f"{name:20s} {ddl}"
+        for name, ddl in (*_V24_TASKS_COLUMNS, *legacy_extras)
+    )
+
+    tmp_name = "tasks__pre_v24_status_check"
+    # SQLite officially-recommended table-rebuild pattern: temporarily
+    # disable foreign_keys, RENAME old → tmp, CREATE new schema, INSERT
+    # SELECT, DROP tmp, re-enable foreign_keys, restore indexes. We do
+    # NOT use ``write_txn`` here because the rest of the migration
+    # pipeline (_migrate_add_optional_columns) is run with the caller's
+    # transaction discipline (autocommit for kb.connect(),
+    # default-isolation for raw test connections); wrapping a DDL
+    # rebuild in BEGIN IMMEDIATE here breaks the latter.
+    prior_fk = conn.execute("PRAGMA foreign_keys").fetchone()[0]
+    if prior_fk:
+        conn.execute("PRAGMA foreign_keys=OFF")
+    try:
+        conn.execute(f"DROP TABLE IF EXISTS {tmp_name}")
+        conn.execute(f"ALTER TABLE tasks RENAME TO {tmp_name}")
+        conn.execute(f"CREATE TABLE tasks (\n                {column_ddl}\n            )")
+        new_cols = [
+            row["name"] for row in conn.execute("PRAGMA table_info(tasks)").fetchall()
+        ]
+        common = [col for col in new_cols if col in old_cols]
+        cols_sql = ", ".join(common)
+        conn.execute(
+            f"INSERT INTO tasks ({cols_sql}) SELECT {cols_sql} FROM {tmp_name}"
+        )
+        conn.execute(f"DROP TABLE {tmp_name}")
+        _ensure_indexes(conn)
+        conn.execute(f"PRAGMA user_version = {KANBAN_SCHEMA_VERSION}")
+    finally:
+        if prior_fk:
+            conn.execute("PRAGMA foreign_keys=ON")
+
+
 def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     """Add columns that were introduced after v1 release to legacy DBs.
 
@@ -1077,6 +1312,10 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         # which is the correct default (they keep the global behaviour
         # they were getting before the column existed).
         _add_column_if_missing(conn, "tasks", "max_retries", "max_retries INTEGER")
+
+    # v23 -> v24: extend the task status enum with awaiting_human_ops.
+    # Row statuses are copied unchanged; existing blocked cards remain blocked.
+    _migrate_tasks_status_check(conn)
 
     # task_events gained a run_id column; back-fill it as NULL for
     # historical events (they predate runs and can't be attributed).
@@ -1274,8 +1513,9 @@ def create_task(
 
     ``initial_status`` controls whether the task enters the usual
     dispatch path (``"running"``; default, preserving existing
-    ready/todo/triage inference) or is created directly in ``"blocked"``
-    for immediate human-ops review.
+    ready/todo/triage inference) or is created directly in an explicit
+    waiting state. Use ``"awaiting_human_ops"`` for R3 human-ops gates;
+    ``"blocked"`` remains the technical/dependency wait state.
     """
     assignee = _canonical_assignee(assignee)
     if not title or not title.strip():
@@ -1359,9 +1599,9 @@ def create_task(
         try:
             with write_txn(conn):
                 # Determine task status from parent status, unless the caller
-                # parks it directly in blocked for human-ops review.
-                if initial_status == "blocked":
-                    task_status = "blocked"
+                # parks it directly in an explicit waiting state.
+                if initial_status in {"blocked", "awaiting_human_ops"}:
+                    task_status = initial_status
                     if parents:
                         missing = _find_missing_parents(conn, parents)
                         if missing:
@@ -2169,7 +2409,8 @@ def reclaim_task(
         cur = conn.execute(
             "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
             "claim_expires = NULL, worker_pid = NULL "
-            "WHERE id = ? AND status IN ('running', 'ready', 'blocked') "
+            "WHERE id = ? "
+            "AND status IN ('running', 'ready', 'blocked', 'awaiting_human_ops') "
             "AND claim_lock IS ?",
             (task_id, prev_lock),
         )
@@ -2445,7 +2686,7 @@ def complete_task(
                        claim_expires= NULL,
                        worker_pid   = NULL
                  WHERE id = ?
-                   AND status IN ('running', 'ready', 'blocked')
+                   AND status IN ('running', 'ready', 'blocked', 'awaiting_human_ops')
                 """,
                 (result, now, task_id),
             )
@@ -2460,7 +2701,7 @@ def complete_task(
                        claim_expires= NULL,
                        worker_pid   = NULL
                  WHERE id = ?
-                   AND status IN ('running', 'ready', 'blocked')
+                   AND status IN ('running', 'ready', 'blocked', 'awaiting_human_ops')
                    AND current_run_id = ?
                 """,
                 (result, now, task_id, int(expected_run_id)),
@@ -2605,27 +2846,30 @@ def block_task(
     *,
     reason: Optional[str] = None,
     expected_run_id: Optional[int] = None,
+    target_status: str = "blocked",
 ) -> bool:
-    """Transition ``running -> blocked``."""
+    """Transition ``running``/``ready`` to a waiting state."""
+    if target_status not in {"blocked", "awaiting_human_ops"}:
+        raise ValueError("target_status must be 'blocked' or 'awaiting_human_ops'")
     with write_txn(conn):
         if expected_run_id is None:
             cur = conn.execute(
                 """
                 UPDATE tasks
-                   SET status       = 'blocked',
+                   SET status       = ?,
                        claim_lock   = NULL,
                        claim_expires= NULL,
                        worker_pid   = NULL
                  WHERE id = ?
                    AND status IN ('running', 'ready')
                 """,
-                (task_id,),
+                (target_status, task_id),
             )
         else:
             cur = conn.execute(
                 """
                 UPDATE tasks
-                   SET status       = 'blocked',
+                   SET status       = ?,
                        claim_lock   = NULL,
                        claim_expires= NULL,
                        worker_pid   = NULL
@@ -2633,13 +2877,13 @@ def block_task(
                    AND status IN ('running', 'ready')
                    AND current_run_id = ?
                 """,
-                (task_id, int(expected_run_id)),
+                (target_status, task_id, int(expected_run_id)),
             )
         if cur.rowcount != 1:
             return False
         run_id = _end_run(
             conn, task_id,
-            outcome="blocked", status="blocked",
+            outcome=target_status, status=target_status,
             summary=reason,
         )
         # Synthesize a run when blocking a never-claimed task so the
@@ -2647,15 +2891,21 @@ def block_task(
         if run_id is None and reason:
             run_id = _synthesize_ended_run(
                 conn, task_id,
-                outcome="blocked",
+                outcome=target_status,
                 summary=reason,
             )
-        _append_event(conn, task_id, "blocked", {"reason": reason}, run_id=run_id)
+        _append_event(
+            conn,
+            task_id,
+            target_status,
+            {"reason": reason},
+            run_id=run_id,
+        )
         return True
 
 
 def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
-    """Transition ``blocked -> ready``.
+    """Transition ``blocked``/``awaiting_human_ops`` back to ready/todo.
 
     Defensively closes any stale ``current_run_id`` pointer before flipping
     status. In the common path (``block_task`` closed the run already) this
@@ -2667,7 +2917,8 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
     now = int(time.time())
     with write_txn(conn):
         stale = conn.execute(
-            "SELECT current_run_id FROM tasks WHERE id = ? AND status = 'blocked'",
+            "SELECT current_run_id FROM tasks "
+            "WHERE id = ? AND status IN ('blocked', 'awaiting_human_ops')",
             (task_id,),
         ).fetchone()
         if stale and stale["current_run_id"]:
@@ -2682,7 +2933,7 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
                 """,
                 (now, int(stale["current_run_id"])),
             )
-        # Re-gate on parent completion before flipping 'blocked' back to
+        # Re-gate on parent completion before flipping a waiting card back to
         # 'ready'. Unconditionally setting status='ready' here bypasses the
         # parent-completion invariant (the dispatcher trusts that column);
         # if parents are still in progress the task must wait in 'todo'
@@ -2697,7 +2948,7 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
         new_status = "todo" if undone_parents else "ready"
         cur = conn.execute(
             "UPDATE tasks SET status = ?, current_run_id = NULL "
-            "WHERE id = ? AND status = 'blocked'",
+            "WHERE id = ? AND status IN ('blocked', 'awaiting_human_ops')",
             (new_status, task_id),
         )
         if cur.rowcount != 1:
@@ -2707,6 +2958,78 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
             {"status": new_status} if new_status != "ready" else None,
         )
         return True
+
+
+def move_task(conn: sqlite3.Connection, task_id: str, new_status: str) -> bool:
+    """Manual status move for CLI/dashboard parity."""
+    if new_status not in VALID_STATUSES:
+        raise ValueError(f"status must be one of {sorted(VALID_STATUSES)}")
+    if new_status == "running":
+        raise ValueError("cannot move to 'running' directly; use claim/dispatch")
+    if new_status == "done":
+        return complete_task(conn, task_id)
+    if new_status == "archived":
+        return archive_task(conn, task_id)
+    if new_status in {"blocked", "awaiting_human_ops"}:
+        current = get_task(conn, task_id)
+        if current is None:
+            return False
+        if current.status in {"blocked", "awaiting_human_ops"}:
+            with write_txn(conn):
+                cur = conn.execute(
+                    "UPDATE tasks SET status = ? WHERE id = ? "
+                    "AND status IN ('blocked', 'awaiting_human_ops')",
+                    (new_status, task_id),
+                )
+                if cur.rowcount != 1:
+                    return False
+                _append_event(conn, task_id, "status", {"status": new_status})
+                return True
+        if current.status in {"running", "ready"}:
+            return block_task(conn, task_id, target_status=new_status)
+    if new_status == "ready":
+        current = get_task(conn, task_id)
+        if current is None:
+            return False
+        if current.status in {"blocked", "awaiting_human_ops"}:
+            return unblock_task(conn, task_id)
+        undone_parents = conn.execute(
+            "SELECT 1 FROM task_links l "
+            "JOIN tasks p ON p.id = l.parent_id "
+            "WHERE l.child_id = ? AND p.status != 'done' LIMIT 1",
+            (task_id,),
+        ).fetchone()
+        if undone_parents:
+            return False
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT status, current_run_id FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if row is None:
+            return False
+        was_running = row["status"] == "running"
+        cur = conn.execute(
+            "UPDATE tasks SET status = ?, "
+            "claim_lock = NULL, claim_expires = NULL, worker_pid = NULL "
+            "WHERE id = ? AND status != 'archived'",
+            (new_status, task_id),
+        )
+        if cur.rowcount != 1:
+            return False
+        run_id = None
+        if was_running and row["current_run_id"]:
+            run_id = _end_run(
+                conn,
+                task_id,
+                outcome="reclaimed",
+                status="reclaimed",
+                summary=f"status changed to {new_status} (manual move)",
+            )
+        _append_event(conn, task_id, "status", {"status": new_status}, run_id=run_id)
+    if new_status in {"done", "ready"}:
+        recompute_ready(conn)
+    return True
 
 
 def specify_triage_task(

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -52,7 +52,7 @@
   }
 
   // Order matches BOARD_COLUMNS in plugin_api.py.
-  const COLUMN_ORDER = ["triage", "todo", "ready", "running", "blocked", "done"];
+  const COLUMN_ORDER = ["triage", "todo", "ready", "running", "awaiting_human_ops", "blocked", "done"];
   // English fallback dictionaries — used when the i18n catalog is missing
   // a key, and as defaults for the get*() helpers below so callers running
   // outside any React component (where there's no `t`) still get sane text.
@@ -61,6 +61,7 @@
     todo: "Todo",
     ready: "Ready",
     running: "In Progress",
+    awaiting_human_ops: "Awaiting Human Ops",
     blocked: "Blocked",
     done: "Done",
     archived: "Archived",
@@ -70,6 +71,7 @@
     todo: "Waiting on dependencies or unassigned",
     ready: "Dependencies satisfied; assign a profile to dispatch",
     running: "Claimed by a worker — in-flight",
+    awaiting_human_ops: "Waiting for human-ops approval",
     blocked: "Worker asked for human input",
     done: "Completed",
     archived: "Archived",
@@ -77,6 +79,7 @@
   const FALLBACK_DESTRUCTIVE = {
     done: "Mark this task as done? The worker's claim is released and dependent children become ready.",
     archived: "Archive this task? It disappears from the default board view.",
+    awaiting_human_ops: "Move this task to awaiting human ops? The worker's claim is released.",
     blocked: "Mark this task as blocked? The worker's claim is released.",
   };
   const FALLBACK_DIAGNOSTIC_EVENT_LABELS = {
@@ -90,6 +93,7 @@
   const DESTRUCTIVE_KEYS = {
     done: "confirmDone",
     archived: "confirmArchive",
+    awaiting_human_ops: "confirmAwaitingHumanOps",
     blocked: "confirmBlocked",
   };
 
@@ -115,6 +119,7 @@
     todo: "hermes-kanban-dot-todo",
     ready: "hermes-kanban-dot-ready",
     running: "hermes-kanban-dot-running",
+    awaiting_human_ops: "hermes-kanban-dot-awaiting-human-ops",
     blocked: "hermes-kanban-dot-blocked",
     done: "hermes-kanban-dot-done",
     archived: "hermes-kanban-dot-archived",
@@ -1985,6 +1990,12 @@
         title: "Block selected tasks. Releases any active claims.",
       }, "Block"),
       h(Button, {
+        onClick: function () { props.onApply({ status: "awaiting_human_ops" },
+          `Move ${props.count} task(s) to awaiting human ops?`); },
+        size: "sm",
+        title: "Move selected tasks to Awaiting Human Ops. Releases any active claims.",
+      }, "Await ops"),
+      h(Button, {
         onClick: function () { props.onApply({ status: "ready" },
           `Unblock ${props.count} task(s)?`); },
         size: "sm",
@@ -2261,6 +2272,7 @@
   const STALENESS = {
     ready:   { amber: 1 * 60 * 60,   red: 24 * 60 * 60 },
     running: { amber: 10 * 60,       red: 60 * 60 },
+    awaiting_human_ops: { amber: 4 * 60 * 60, red: 48 * 60 * 60 },
     blocked: { amber: 1 * 60 * 60,   red: 24 * 60 * 60 },
     todo:    { amber: 7 * 24 * 60 * 60, red: 30 * 24 * 60 * 60 },
   };
@@ -3433,9 +3445,14 @@
         b(tx(t, "block", "Block"),     { status: "blocked" },
           task.status === "running" || task.status === "ready",
           getDestructiveConfirm(t, "blocked")),
-        b(tx(t, "unblock", "Unblock"),   { status: "ready" },    task.status === "blocked"),
+        b("Await ops", { status: "awaiting_human_ops" },
+          task.status !== "awaiting_human_ops" && task.status !== "archived",
+          getDestructiveConfirm(t, "awaiting_human_ops")),
+        b(tx(t, "unblock", "Unblock"),   { status: "ready" },
+          task.status === "blocked" || task.status === "awaiting_human_ops"),
         b(tx(t, "complete", "Complete"),  { status: "done" },
-          task.status === "running" || task.status === "ready" || task.status === "blocked",
+          task.status === "running" || task.status === "ready" ||
+          task.status === "blocked" || task.status === "awaiting_human_ops",
           getDestructiveConfirm(t, "done")),
         b(tx(t, "archive", "Archive"),   { status: "archived" }, task.status !== "archived",
           getDestructiveConfirm(t, "archived")),

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -162,6 +162,7 @@
 .hermes-kanban-dot-todo     { background: var(--color-muted-foreground); }
 .hermes-kanban-dot-ready    { background: #d4b348; }  /* amber */
 .hermes-kanban-dot-running  { background: #3fb97d; }  /* green */
+.hermes-kanban-dot-awaiting-human-ops { background: #8b5cf6; }  /* purple */
 .hermes-kanban-dot-blocked  { background: var(--color-destructive, #d14a4a); }
 .hermes-kanban-dot-done     { background: #4a8cd1; }  /* blue */
 .hermes-kanban-dot-archived { background: var(--color-border); }

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -130,7 +130,7 @@ def _conn(board: Optional[str] = None):
 # Columns shown by the dashboard, in left-to-right order. "archived" is
 # available via a filter toggle rather than a visible column.
 BOARD_COLUMNS: list[str] = [
-    "triage", "todo", "ready", "running", "blocked", "done",
+    "triage", "todo", "ready", "running", "awaiting_human_ops", "blocked", "done",
 ]
 
 
@@ -615,12 +615,28 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                     summary=payload.summary,
                     metadata=payload.metadata,
                 )
-            elif s == "blocked":
-                ok = kanban_db.block_task(conn, task_id, reason=payload.block_reason)
+            elif s in {"blocked", "awaiting_human_ops"}:
+                current = kanban_db.get_task(conn, task_id)
+                if current and current.status in {"running", "ready"}:
+                    ok = kanban_db.block_task(
+                        conn,
+                        task_id,
+                        reason=payload.block_reason,
+                        target_status=s,
+                    )
+                else:
+                    ok = kanban_db.move_task(conn, task_id, s)
+                if ok and payload.block_reason:
+                    kanban_db.add_comment(
+                        conn,
+                        task_id,
+                        "dashboard",
+                        f"{s}: {payload.block_reason}",
+                    )
             elif s == "ready":
                 # Re-open a blocked task, or just an explicit status set.
                 current = kanban_db.get_task(conn, task_id)
-                if current and current.status == "blocked":
+                if current and current.status in {"blocked", "awaiting_human_ops"}:
                     ok = kanban_db.unblock_task(conn, task_id)
                 else:
                     # Direct status write for drag-drop (todo -> ready etc).
@@ -864,11 +880,11 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                             summary=payload.summary,
                             metadata=payload.metadata,
                         )
-                    elif s == "blocked":
-                        ok = kanban_db.block_task(conn, tid)
+                    elif s in {"blocked", "awaiting_human_ops"}:
+                        ok = kanban_db.move_task(conn, tid, s)
                     elif s == "ready":
                         cur = kanban_db.get_task(conn, tid)
-                        if cur and cur.status == "blocked":
+                        if cur and cur.status in {"blocked", "awaiting_human_ops"}:
                             ok = kanban_db.unblock_task(conn, tid)
                         else:
                             ok = _set_status_direct(conn, tid, "ready")

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -119,6 +119,30 @@ def test_run_slash_json_output(kanban_home):
     assert payload["status"] == "ready"
 
 
+def test_run_slash_initial_status_default_running(kanban_home):
+    out = kc.run_slash("add 'normal dispatch' --assignee alice --json")
+    payload = json.loads(out)
+    assert payload["title"] == "normal dispatch"
+    assert payload["assignee"] == "alice"
+    assert payload["status"] == "ready"
+
+
+def test_run_slash_initial_status_blocked(kanban_home):
+    out = kc.run_slash(
+        "add 'needs human ops' --assignee alice --initial-status blocked --json"
+    )
+    payload = json.loads(out)
+    assert payload["title"] == "needs human ops"
+    assert payload["assignee"] == "alice"
+    assert payload["status"] == "blocked"
+
+
+def test_run_slash_initial_status_invalid(kanban_home):
+    out = kc.run_slash("add 'bad status' --initial-status foo")
+    assert "usage error" in out.lower()
+    assert "invalid choice" in out
+
+
 def test_run_slash_dispatch_dry_run_counts(kanban_home):
     kc.run_slash("create 'a' --assignee alice")
     kc.run_slash("create 'b' --assignee bob")

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -426,3 +426,99 @@ def test_run_slash_board_override_restores_prior_env(kanban_home, monkeypatch):
     kc.run_slash("--board alpha list")
 
     assert os.environ.get("HERMES_KANBAN_BOARD") == "beta"
+
+
+# ---------------------------------------------------------------------------
+# T1-T6: awaiting_human_ops state (PR-2)
+# ---------------------------------------------------------------------------
+
+
+def test_t1_new_card_default_status_unchanged(kanban_home):
+    """T1: a fresh card without --initial-status still lands in the usual
+    dispatch path (ready); the new state is strictly opt-in."""
+    out = kc.run_slash("add 'default state' --assignee alice --json")
+    payload = json.loads(out)
+    assert payload["status"] == "ready"
+    # Sanity: VALID_STATUSES now contains the new state, but it is not
+    # selected by default.
+    assert "awaiting_human_ops" in kb.VALID_STATUSES
+
+
+def test_t2_initial_status_awaiting_human_ops(kanban_home):
+    """T2: dispatcher / human can park a card directly in awaiting_human_ops
+    via --initial-status, distinct from blocked."""
+    out = kc.run_slash(
+        "add 'R3 gate' --assignee alice "
+        "--initial-status awaiting_human_ops --json"
+    )
+    payload = json.loads(out)
+    assert payload["status"] == "awaiting_human_ops"
+    # Status enum reject sentinel: only the documented set is allowed.
+    bad = kc.run_slash("add 'bad' --initial-status sleeping")
+    assert "invalid choice" in bad
+
+
+def test_t3_unblock_from_awaiting_human_ops(kanban_home):
+    """T3: unblock returns awaiting_human_ops cards to ready, matching the
+    existing blocked unblock contract."""
+    out = kc.run_slash(
+        "add 'gated' --assignee alice "
+        "--initial-status awaiting_human_ops --json"
+    )
+    tid = json.loads(out)["id"]
+    msg = kc.run_slash(f"unblock {tid}")
+    assert "Unblocked" in msg
+    with kb.connect() as conn:
+        assert kb.get_task(conn, tid).status == "ready"
+
+
+def test_t4_cli_move_awaiting_human_ops(kanban_home):
+    """T4: `kanban move <id> awaiting_human_ops` works for running cards and
+    invalid statuses are rejected by argparse choices."""
+    out = kc.run_slash("create 'movable' --assignee alice --json")
+    tid = json.loads(out)["id"]
+    kc.run_slash(f"claim {tid}")
+    msg = kc.run_slash(f"move {tid} awaiting_human_ops")
+    assert "Moved" in msg and "awaiting_human_ops" in msg
+    with kb.connect() as conn:
+        assert kb.get_task(conn, tid).status == "awaiting_human_ops"
+    bad = kc.run_slash(f"move {tid} sleeping")
+    assert "invalid choice" in bad
+
+
+def test_t5_filter_state_awaiting_human_ops(kanban_home):
+    """T5: `list --status awaiting_human_ops` returns only matching cards."""
+    kc.run_slash("add 'plain' --assignee alice")
+    kc.run_slash(
+        "add 'gated' --assignee alice "
+        "--initial-status awaiting_human_ops"
+    )
+    out = kc.run_slash("list --status awaiting_human_ops")
+    assert "gated" in out
+    assert "plain" not in out
+
+
+def test_t6_migration_keeps_existing_blocked_cards(kanban_home):
+    """T6: existing 'blocked' cards survive the v24 schema migration
+    untouched. Re-running init_db (idempotent) must not reclassify them or
+    raise CHECK violations."""
+    with kb.connect() as conn:
+        legacy = kb.create_task(conn, title="legacy", assignee="alice")
+        kb.claim_task(conn, legacy, claimer="alice")
+        kb.block_task(conn, legacy, reason="historical R3 gate")
+        assert kb.get_task(conn, legacy).status == "blocked"
+    # Re-run init twice (idempotent migration).
+    kb.init_db()
+    kb.init_db()
+    with kb.connect() as conn:
+        t = kb.get_task(conn, legacy)
+        # backward compatibility guarantee: status is preserved.
+        assert t.status == "blocked"
+        # And the new state is now permitted by the CHECK constraint.
+        new_id = kb.create_task(
+            conn,
+            title="new gate",
+            assignee="alice",
+            initial_status="awaiting_human_ops",
+        )
+        assert kb.get_task(conn, new_id).status == "awaiting_human_ops"

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -436,7 +436,7 @@ def _handle_complete(args: dict, **kw) -> str:
 
 
 def _handle_block(args: dict, **kw) -> str:
-    """Transition the task to blocked with a reason a human will read."""
+    """Transition the task to a waiting state with a human-readable reason."""
     tid = _default_task_id(args.get("task_id"))
     if not tid:
         return tool_error(
@@ -448,6 +448,9 @@ def _handle_block(args: dict, **kw) -> str:
     reason = args.get("reason")
     if not reason or not str(reason).strip():
         return tool_error("reason is required — explain what input you need")
+    target_status = str(args.get("status") or "blocked")
+    if target_status not in {"blocked", "awaiting_human_ops"}:
+        return tool_error("status must be 'blocked' or 'awaiting_human_ops'")
     try:
         kb, conn = _connect()
         try:
@@ -455,6 +458,7 @@ def _handle_block(args: dict, **kw) -> str:
                 conn, tid,
                 reason=reason,
                 expected_run_id=_worker_run_id(tid),
+                target_status=target_status,
             )
             if not ok:
                 return tool_error(
@@ -462,7 +466,7 @@ def _handle_block(args: dict, **kw) -> str:
                     f"running/ready)"
                 )
             run = kb.latest_run(conn, tid)
-            return _ok(task_id=tid, run_id=run.id if run else None)
+            return _ok(task_id=tid, status=target_status, run_id=run.id if run else None)
         finally:
             conn.close()
     except Exception as e:
@@ -821,11 +825,11 @@ KANBAN_COMPLETE_SCHEMA = {
 KANBAN_BLOCK_SCHEMA = {
     "name": "kanban_block",
     "description": (
-        "Transition the task to blocked because you need human input "
-        "to proceed. ``reason`` will be shown to the human on the "
-        "board and included in context when someone unblocks you. "
-        "Use for genuine blockers only — don't block on things you can "
-        "resolve yourself."
+        "Transition the task to a waiting state because you need human "
+        "input or an R3 human-ops approval gate to proceed. ``reason`` "
+        "will be shown to the human on the board and included in "
+        "context when someone unblocks you. Use for genuine blockers "
+        "only — don't block on things you can resolve yourself."
     ),
     "parameters": {
         "type": "object",
@@ -840,6 +844,15 @@ KANBAN_BLOCK_SCHEMA = {
                     "What you need answered, in one or two sentences. "
                     "Don't paste the whole conversation; the human has "
                     "the board and can ask follow-ups via comments."
+                ),
+            },
+            "status": {
+                "type": "string",
+                "enum": ["blocked", "awaiting_human_ops"],
+                "description": (
+                    "Waiting state to apply. Use 'awaiting_human_ops' "
+                    "for R3 human-ops approval gates; use 'blocked' "
+                    "for technical or dependency blockers."
                 ),
             },
         },
@@ -1002,12 +1015,12 @@ KANBAN_CREATE_SCHEMA = {
             },
             "initial_status": {
                 "type": "string",
-                "enum": ["running", "blocked"],
+                "enum": ["running", "blocked", "awaiting_human_ops"],
                 "description": (
-                    "Initial card status. Use 'blocked' for tasks that "
-                    "require immediate human ops (R3 gate) to skip the "
-                    "brief running-to-blocked transition. Defaults to "
-                    "'running', which preserves the usual dispatch path."
+                    "Initial card status. Use 'awaiting_human_ops' for "
+                    "R3 human-ops gates; use 'blocked' for technical or "
+                    "dependency waits. Defaults to 'running', which "
+                    "preserves the usual dispatch path."
                 ),
             },
             "skills": {

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -577,6 +577,7 @@ def _handle_create(args: dict, **kw) -> str:
         return tool_error(bool_error)
     idempotency_key = args.get("idempotency_key")
     max_runtime_seconds = args.get("max_runtime_seconds")
+    initial_status = args.get("initial_status") or "running"
     skills = args.get("skills")
     if isinstance(skills, str):
         # Accept a single skill name as a string for convenience.
@@ -611,6 +612,7 @@ def _handle_create(args: dict, **kw) -> str:
                     if max_runtime_seconds is not None else None
                 ),
                 skills=skills,
+                initial_status=str(initial_status),
                 created_by=os.environ.get("HERMES_PROFILE") or "worker",
             )
             new_task = kb.get_task(conn, new_tid)
@@ -996,6 +998,16 @@ KANBAN_CREATE_SCHEMA = {
                     "Per-task runtime cap. When exceeded, the "
                     "dispatcher SIGTERMs the worker and re-queues the "
                     "task with outcome='timed_out'."
+                ),
+            },
+            "initial_status": {
+                "type": "string",
+                "enum": ["running", "blocked"],
+                "description": (
+                    "Initial card status. Use 'blocked' for tasks that "
+                    "require immediate human ops (R3 gate) to skip the "
+                    "brief running-to-blocked transition. Defaults to "
+                    "'running', which preserves the usual dispatch path."
                 ),
             },
             "skills": {

--- a/web/src/i18n/af.ts
+++ b/web/src/i18n/af.ts
@@ -656,6 +656,7 @@ export const af: Translations = {
       todo: "Te doen",
       ready: "Gereed",
       running: "Aan die gang",
+      awaiting_human_ops: "Awaiting Human Ops",
       blocked: "Geblokkeer",
       done: "Klaar",
       archived: "Gearchiveer",
@@ -665,6 +666,7 @@ export const af: Translations = {
       todo: "Wag op afhanklikhede of nie toegewys nie",
       ready: "Afhanklikhede is bevredig; wys 'n profiel toe om te versend",
       running: "Deur 'n werker geëis — in vlug",
+      awaiting_human_ops: "Waiting for human-ops approval",
       blocked: "Werker het mensinvoer aangevra",
       done: "Voltooi",
       archived: "Gearchiveer",
@@ -673,6 +675,8 @@ export const af: Translations = {
       "Merk hierdie taak as klaar? Die werker se eis word vrygestel en afhanklike kinders word gereed.",
     confirmArchive:
       "Argiveer hierdie taak? Dit verdwyn uit die verstek-bordaansig.",
+    confirmAwaitingHumanOps:
+      "Move this task to awaiting human ops? The worker's claim is released.",
     confirmBlocked:
       "Merk hierdie taak as geblokkeer? Die werker se eis word vrygestel.",
     completionSummary:

--- a/web/src/i18n/de.ts
+++ b/web/src/i18n/de.ts
@@ -655,6 +655,7 @@ export const de: Translations = {
       todo: "Zu erledigen",
       ready: "Bereit",
       running: "In Bearbeitung",
+      awaiting_human_ops: "Awaiting Human Ops",
       blocked: "Blockiert",
       done: "Erledigt",
       archived: "Archiviert",
@@ -664,6 +665,7 @@ export const de: Translations = {
       todo: "Wartet auf Abhängigkeiten oder ist nicht zugewiesen",
       ready: "Abhängigkeiten erfüllt; Profil zum Dispatch zuweisen",
       running: "Von einem Worker übernommen — in Bearbeitung",
+      awaiting_human_ops: "Waiting for human-ops approval",
       blocked: "Worker hat um menschliche Eingabe gebeten",
       done: "Abgeschlossen",
       archived: "Archiviert",
@@ -672,6 +674,8 @@ export const de: Translations = {
       "Diese Aufgabe als erledigt markieren? Der Anspruch des Workers wird freigegeben und abhängige untergeordnete Aufgaben werden bereit.",
     confirmArchive:
       "Diese Aufgabe archivieren? Sie verschwindet aus der Standard-Board-Ansicht.",
+    confirmAwaitingHumanOps:
+      "Move this task to awaiting human ops? The worker's claim is released.",
     confirmBlocked:
       "Diese Aufgabe als blockiert markieren? Der Anspruch des Workers wird freigegeben.",
     completionSummary:

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -660,6 +660,7 @@ export const en: Translations = {
       todo: "Todo",
       ready: "Ready",
       running: "In Progress",
+      awaiting_human_ops: "Awaiting Human Ops",
       blocked: "Blocked",
       done: "Done",
       archived: "Archived",
@@ -669,6 +670,7 @@ export const en: Translations = {
       todo: "Waiting on dependencies or unassigned",
       ready: "Dependencies satisfied; assign a profile to dispatch",
       running: "Claimed by a worker — in-flight",
+      awaiting_human_ops: "Waiting for human-ops approval",
       blocked: "Worker asked for human input",
       done: "Completed",
       archived: "Archived",
@@ -677,6 +679,8 @@ export const en: Translations = {
       "Mark this task as done? The worker's claim is released and dependent children become ready.",
     confirmArchive:
       "Archive this task? It disappears from the default board view.",
+    confirmAwaitingHumanOps:
+      "Move this task to awaiting human ops? The worker's claim is released.",
     confirmBlocked:
       "Mark this task as blocked? The worker's claim is released.",
     completionSummary:

--- a/web/src/i18n/es.ts
+++ b/web/src/i18n/es.ts
@@ -655,6 +655,7 @@ export const es: Translations = {
       todo: "Por hacer",
       ready: "Listo",
       running: "En curso",
+      awaiting_human_ops: "Awaiting Human Ops",
       blocked: "Bloqueado",
       done: "Hecho",
       archived: "Archivado",
@@ -664,6 +665,7 @@ export const es: Translations = {
       todo: "Esperando dependencias o sin asignar",
       ready: "Dependencias satisfechas; asigna un perfil para despachar",
       running: "Reclamado por un worker — en ejecución",
+      awaiting_human_ops: "Waiting for human-ops approval",
       blocked: "El worker pidió intervención humana",
       done: "Completado",
       archived: "Archivado",
@@ -672,6 +674,8 @@ export const es: Translations = {
       "¿Marcar esta tarea como hecha? Se libera el reclamo del worker y los hijos dependientes pasan a estar listos.",
     confirmArchive:
       "¿Archivar esta tarea? Desaparecerá de la vista por defecto del tablero.",
+    confirmAwaitingHumanOps:
+      "Move this task to awaiting human ops? The worker's claim is released.",
     confirmBlocked:
       "¿Marcar esta tarea como bloqueada? Se libera el reclamo del worker.",
     completionSummary:

--- a/web/src/i18n/fr.ts
+++ b/web/src/i18n/fr.ts
@@ -655,6 +655,7 @@ export const fr: Translations = {
       todo: "À faire",
       ready: "Prêt",
       running: "En cours",
+      awaiting_human_ops: "Awaiting Human Ops",
       blocked: "Bloqué",
       done: "Terminé",
       archived: "Archivé",
@@ -664,6 +665,7 @@ export const fr: Translations = {
       todo: "En attente de dépendances ou non assigné",
       ready: "Dépendances satisfaites ; assignez un profil pour dispatch",
       running: "Réclamé par un worker — en cours d'exécution",
+      awaiting_human_ops: "Waiting for human-ops approval",
       blocked: "Le worker a demandé une intervention humaine",
       done: "Terminé",
       archived: "Archivé",
@@ -672,6 +674,8 @@ export const fr: Translations = {
       "Marquer cette tâche comme terminée ? La revendication du worker est libérée et les enfants dépendants deviennent prêts.",
     confirmArchive:
       "Archiver cette tâche ? Elle disparaîtra de la vue par défaut du tableau.",
+    confirmAwaitingHumanOps:
+      "Move this task to awaiting human ops? The worker's claim is released.",
     confirmBlocked:
       "Marquer cette tâche comme bloquée ? La revendication du worker est libérée.",
     completionSummary:

--- a/web/src/i18n/ga.ts
+++ b/web/src/i18n/ga.ts
@@ -656,6 +656,7 @@ export const ga: Translations = {
       todo: "Le déanamh",
       ready: "Réidh",
       running: "Ar siúl",
+      awaiting_human_ops: "Awaiting Human Ops",
       blocked: "Bactha",
       done: "Críochnaithe",
       archived: "Cartlannaithe",
@@ -665,6 +666,7 @@ export const ga: Translations = {
       todo: "Ag fanacht ar spleáchais nó gan sannadh",
       ready: "Tá na spleáchais sásaithe; sann próifíl le dispatch a dhéanamh",
       running: "Éilithe ag worker — ar siúl",
+      awaiting_human_ops: "Waiting for human-ops approval",
       blocked: "D'iarr an worker ionchur duine",
       done: "Críochnaithe",
       archived: "Cartlannaithe",
@@ -673,6 +675,8 @@ export const ga: Translations = {
       "Marcáil an tasc seo mar críochnaithe? Scaoiltear éileamh an worker agus éiríonn leanaí spleácha ready.",
     confirmArchive:
       "Cartlannaigh an tasc seo? Imíonn sé as an réamhradharc cláir.",
+    confirmAwaitingHumanOps:
+      "Move this task to awaiting human ops? The worker's claim is released.",
     confirmBlocked:
       "Marcáil an tasc seo mar bactha? Scaoiltear éileamh an worker.",
     completionSummary:

--- a/web/src/i18n/hu.ts
+++ b/web/src/i18n/hu.ts
@@ -656,6 +656,7 @@ export const hu: Translations = {
       todo: "Tennivaló",
       ready: "Indulásra kész",
       running: "Folyamatban",
+      awaiting_human_ops: "Awaiting Human Ops",
       blocked: "Blokkolva",
       done: "Kész",
       archived: "Archivált",
@@ -665,6 +666,7 @@ export const hu: Translations = {
       todo: "Függőségekre vár vagy nincs felelőse",
       ready: "A függőségek teljesültek; rendelj hozzá profilt az indításhoz",
       running: "Worker felvette — folyamatban",
+      awaiting_human_ops: "Waiting for human-ops approval",
       blocked: "A worker emberi beavatkozást kért",
       done: "Befejezve",
       archived: "Archiválva",
@@ -673,6 +675,8 @@ export const hu: Translations = {
       "Megjelölöd ezt a feladatot késznek? A worker foglalása felszabadul, és a függő gyermekek ready állapotba kerülnek.",
     confirmArchive:
       "Archiválod ezt a feladatot? Eltűnik az alapértelmezett tábla nézetből.",
+    confirmAwaitingHumanOps:
+      "Move this task to awaiting human ops? The worker's claim is released.",
     confirmBlocked:
       "Megjelölöd ezt a feladatot blokkoltként? A worker foglalása felszabadul.",
     completionSummary:

--- a/web/src/i18n/it.ts
+++ b/web/src/i18n/it.ts
@@ -655,6 +655,7 @@ export const it: Translations = {
       todo: "Da fare",
       ready: "Pronto",
       running: "In corso",
+      awaiting_human_ops: "Awaiting Human Ops",
       blocked: "Bloccato",
       done: "Fatto",
       archived: "Archiviato",
@@ -664,6 +665,7 @@ export const it: Translations = {
       todo: "In attesa di dipendenze o non assegnato",
       ready: "Dipendenze soddisfatte; assegna un profilo per il dispatch",
       running: "Preso in carico da un worker — in esecuzione",
+      awaiting_human_ops: "Waiting for human-ops approval",
       blocked: "Il worker ha richiesto input umano",
       done: "Completato",
       archived: "Archiviato",
@@ -672,6 +674,8 @@ export const it: Translations = {
       "Contrassegnare questa attività come completata? La presa in carico del worker viene rilasciata e i figli dipendenti diventano pronti.",
     confirmArchive:
       "Archiviare questa attività? Sparirà dalla vista predefinita della bacheca.",
+    confirmAwaitingHumanOps:
+      "Move this task to awaiting human ops? The worker's claim is released.",
     confirmBlocked:
       "Contrassegnare questa attività come bloccata? La presa in carico del worker viene rilasciata.",
     completionSummary:

--- a/web/src/i18n/ja.ts
+++ b/web/src/i18n/ja.ts
@@ -656,6 +656,7 @@ export const ja: Translations = {
       todo: "ToDo",
       ready: "準備完了",
       running: "進行中",
+      awaiting_human_ops: "ops承認待ち",
       blocked: "ブロック中",
       done: "完了",
       archived: "アーカイブ済み",
@@ -665,6 +666,7 @@ export const ja: Translations = {
       todo: "依存関係の待機中、または未割り当て",
       ready: "依存関係は満たされています。ディスパッチするにはプロファイルを割り当ててください",
       running: "ワーカーが取得中 — 実行中",
+      awaiting_human_ops: "ops承認を待っています",
       blocked: "ワーカーが人間の入力を求めています",
       done: "完了",
       archived: "アーカイブ済み",
@@ -673,6 +675,8 @@ export const ja: Translations = {
       "このタスクを完了にしますか？ワーカーの取得は解放され、依存している子タスクが ready になります。",
     confirmArchive:
       "このタスクをアーカイブしますか？既定のボードビューから消えます。",
+    confirmAwaitingHumanOps:
+      "このタスクをops承認待ちに移動しますか？ワーカーのクレームは解放されます。",
     confirmBlocked:
       "このタスクをブロック中にしますか？ワーカーの取得は解放されます。",
     completionSummary:

--- a/web/src/i18n/ko.ts
+++ b/web/src/i18n/ko.ts
@@ -656,6 +656,7 @@ export const ko: Translations = {
       todo: "할 일",
       ready: "준비됨",
       running: "진행 중",
+      awaiting_human_ops: "Awaiting Human Ops",
       blocked: "차단됨",
       done: "완료",
       archived: "보관됨",
@@ -665,6 +666,7 @@ export const ko: Translations = {
       todo: "종속성 대기 중 또는 미지정",
       ready: "종속성이 충족됨; 디스패치하려면 프로필을 지정하세요",
       running: "워커가 점유 중 — 실행 중",
+      awaiting_human_ops: "Waiting for human-ops approval",
       blocked: "워커가 사람의 입력을 요청함",
       done: "완료됨",
       archived: "보관됨",
@@ -673,6 +675,8 @@ export const ko: Translations = {
       "이 작업을 완료로 표시하시겠습니까? 워커의 점유가 해제되고 종속된 하위 작업이 ready 상태가 됩니다.",
     confirmArchive:
       "이 작업을 보관하시겠습니까? 기본 보드 보기에서 사라집니다.",
+    confirmAwaitingHumanOps:
+      "Move this task to awaiting human ops? The worker's claim is released.",
     confirmBlocked:
       "이 작업을 차단됨으로 표시하시겠습니까? 워커의 점유가 해제됩니다.",
     completionSummary:

--- a/web/src/i18n/pt.ts
+++ b/web/src/i18n/pt.ts
@@ -656,6 +656,7 @@ export const pt: Translations = {
       todo: "A fazer",
       ready: "Pronto",
       running: "Em curso",
+      awaiting_human_ops: "Awaiting Human Ops",
       blocked: "Bloqueado",
       done: "Concluído",
       archived: "Arquivado",
@@ -665,6 +666,7 @@ export const pt: Translations = {
       todo: "À espera de dependências ou sem atribuição",
       ready: "Dependências satisfeitas; atribua um perfil para despachar",
       running: "Reivindicado por um worker — em execução",
+      awaiting_human_ops: "Waiting for human-ops approval",
       blocked: "O worker pediu intervenção humana",
       done: "Concluído",
       archived: "Arquivado",
@@ -673,6 +675,8 @@ export const pt: Translations = {
       "Marcar esta tarefa como concluída? A reivindicação do worker é libertada e os filhos dependentes ficam prontos.",
     confirmArchive:
       "Arquivar esta tarefa? Desaparece da vista padrão do quadro.",
+    confirmAwaitingHumanOps:
+      "Move this task to awaiting human ops? The worker's claim is released.",
     confirmBlocked:
       "Marcar esta tarefa como bloqueada? A reivindicação do worker é libertada.",
     completionSummary:

--- a/web/src/i18n/ru.ts
+++ b/web/src/i18n/ru.ts
@@ -656,6 +656,7 @@ export const ru: Translations = {
       todo: "К выполнению",
       ready: "Готово к работе",
       running: "В работе",
+      awaiting_human_ops: "Awaiting Human Ops",
       blocked: "Заблокировано",
       done: "Готово",
       archived: "В архиве",
@@ -665,6 +666,7 @@ export const ru: Translations = {
       todo: "Ожидает зависимостей или без исполнителя",
       ready: "Зависимости выполнены; назначьте профиль для диспетчеризации",
       running: "Взято воркером — выполняется",
+      awaiting_human_ops: "Waiting for human-ops approval",
       blocked: "Воркер запросил вмешательство человека",
       done: "Завершено",
       archived: "В архиве",
@@ -673,6 +675,8 @@ export const ru: Translations = {
       "Отметить эту задачу как выполненную? Захват воркера будет освобождён, а зависимые потомки станут готовыми.",
     confirmArchive:
       "Архивировать эту задачу? Она исчезнет из стандартного вида доски.",
+    confirmAwaitingHumanOps:
+      "Move this task to awaiting human ops? The worker's claim is released.",
     confirmBlocked:
       "Отметить эту задачу как заблокированную? Захват воркера будет освобождён.",
     completionSummary:

--- a/web/src/i18n/tr.ts
+++ b/web/src/i18n/tr.ts
@@ -656,6 +656,7 @@ export const tr: Translations = {
       todo: "Yapılacak",
       ready: "Hazır",
       running: "Sürüyor",
+      awaiting_human_ops: "Awaiting Human Ops",
       blocked: "Engellendi",
       done: "Bitti",
       archived: "Arşivlendi",
@@ -665,6 +666,7 @@ export const tr: Translations = {
       todo: "Bağımlılıklar bekleniyor veya atanmamış",
       ready: "Bağımlılıklar karşılandı; dispatch için bir profil atayın",
       running: "Bir worker tarafından alındı — yürütülüyor",
+      awaiting_human_ops: "Waiting for human-ops approval",
       blocked: "Worker insan girdisi istedi",
       done: "Tamamlandı",
       archived: "Arşivlendi",
@@ -673,6 +675,8 @@ export const tr: Translations = {
       "Bu görev tamamlandı olarak işaretlensin mi? Worker'ın sahiplenmesi serbest bırakılır ve bağımlı altlar hazır hale gelir.",
     confirmArchive:
       "Bu görev arşivlensin mi? Varsayılan pano görünümünden kaybolur.",
+    confirmAwaitingHumanOps:
+      "Move this task to awaiting human ops? The worker's claim is released.",
     confirmBlocked:
       "Bu görev engellendi olarak işaretlensin mi? Worker'ın sahiplenmesi serbest bırakılır.",
     completionSummary:

--- a/web/src/i18n/types.ts
+++ b/web/src/i18n/types.ts
@@ -668,6 +668,7 @@ export interface Translations {
       todo: string;
       ready: string;
       running: string;
+      awaiting_human_ops: string;
       blocked: string;
       done: string;
       archived: string;
@@ -677,12 +678,14 @@ export interface Translations {
       todo: string;
       ready: string;
       running: string;
+      awaiting_human_ops: string;
       blocked: string;
       done: string;
       archived: string;
     };
     confirmDone: string;
     confirmArchive: string;
+    confirmAwaitingHumanOps: string;
     confirmBlocked: string;
     completionSummary: string;
     completionSummaryRequired: string;

--- a/web/src/i18n/uk.ts
+++ b/web/src/i18n/uk.ts
@@ -656,6 +656,7 @@ export const uk: Translations = {
       todo: "До виконання",
       ready: "Готово",
       running: "У роботі",
+      awaiting_human_ops: "Awaiting Human Ops",
       blocked: "Заблоковано",
       done: "Виконано",
       archived: "Архів",
@@ -665,6 +666,7 @@ export const uk: Translations = {
       todo: "Очікує на залежності або не призначено",
       ready: "Залежності задоволені; призначте профіль для диспетчеризації",
       running: "Захоплено воркером — у роботі",
+      awaiting_human_ops: "Waiting for human-ops approval",
       blocked: "Воркер запитав втручання людини",
       done: "Завершено",
       archived: "Архівовано",
@@ -673,6 +675,8 @@ export const uk: Translations = {
       "Позначити цю задачу як виконану? Захоплення воркера буде звільнено, а залежні нащадки стануть готовими.",
     confirmArchive:
       "Архівувати цю задачу? Вона зникне з типового вигляду дошки.",
+    confirmAwaitingHumanOps:
+      "Move this task to awaiting human ops? The worker's claim is released.",
     confirmBlocked:
       "Позначити цю задачу як заблоковану? Захоплення воркера буде звільнено.",
     completionSummary:

--- a/web/src/i18n/zh-hant.ts
+++ b/web/src/i18n/zh-hant.ts
@@ -656,6 +656,7 @@ export const zhHant: Translations = {
       todo: "待辦",
       ready: "就緒",
       running: "進行中",
+      awaiting_human_ops: "Awaiting Human Ops",
       blocked: "已封鎖",
       done: "已完成",
       archived: "已封存",
@@ -665,6 +666,7 @@ export const zhHant: Translations = {
       todo: "等待相依項目或尚未指派",
       ready: "相依項目已滿足；指派設定檔以便排程",
       running: "已被工作者領取 — 執行中",
+      awaiting_human_ops: "Waiting for human-ops approval",
       blocked: "工作者請求人工輸入",
       done: "已完成",
       archived: "已封存",
@@ -673,6 +675,8 @@ export const zhHant: Translations = {
       "將此任務標記為完成？工作者的領取將被釋放，下層相依任務將變為就緒。",
     confirmArchive:
       "封存此任務？它將從預設看板檢視中消失。",
+    confirmAwaitingHumanOps:
+      "Move this task to awaiting human ops? The worker's claim is released.",
     confirmBlocked:
       "將此任務標記為已封鎖？工作者的領取將被釋放。",
     completionSummary:

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -652,6 +652,7 @@ export const zh: Translations = {
       todo: "待办",
       ready: "就绪",
       running: "进行中",
+      awaiting_human_ops: "Awaiting Human Ops",
       blocked: "阻塞",
       done: "已完成",
       archived: "已归档",
@@ -661,6 +662,7 @@ export const zh: Translations = {
       todo: "等待依赖项或未分配",
       ready: "依赖项已满足；分配一个配置文件以便调度",
       running: "已被工作者认领 — 执行中",
+      awaiting_human_ops: "Waiting for human-ops approval",
       blocked: "工作者请求人工输入",
       done: "已完成",
       archived: "已归档",
@@ -669,6 +671,8 @@ export const zh: Translations = {
       "将此任务标记为完成？工作者将被释放，依赖的子任务将变为就绪。",
     confirmArchive:
       "归档此任务？它将从默认看板视图中消失。",
+    confirmAwaitingHumanOps:
+      "Move this task to awaiting human ops? The worker's claim is released.",
     confirmBlocked:
       "将此任务标记为阻塞？工作者将被释放。",
     completionSummary:


### PR DESCRIPTION
# feat(kanban): add `awaiting_human_ops` state for R3 gate cards

## Why

Today every "I'm waiting for a human" card lands in `blocked`, regardless of
whether the worker hit a technical/dependency wait, asked an open-ended
question, or paused on an R3 human-ops approval gate (ADR-013). The
dashboard, CLI filters, and any external metric collector cannot tell those
apart — operators see one undifferentiated red column.

This PR splits the human-ops case out so:

- `awaiting_human_ops` = R3 approval gate: orchestrator parked the card on
  purpose; operator decides go / no-go.
- `blocked` = legacy meaning, now reserved for technical or dependency
  waits the worker can't resolve itself.

The two are distinguishable in every UI layer (CLI list, CLI filter,
dashboard column, dashboard color, bulk action) and pass through the
existing `pre_state_change` / `post_state_change` hooks unchanged, so
plugins keep working.

## What

### Schema

- Extends `VALID_STATUSES` and `VALID_INITIAL_STATUSES` with
  `awaiting_human_ops`.
- Adds a `CHECK` constraint on `tasks.status` covering the full enum.
- Bumps `_config_version` to **24** and writes `PRAGMA user_version = 24`
  at the end of the migration.

SQLite cannot add a `CHECK` constraint in place, so the migration
(`_migrate_tasks_status_check`) rebuilds the `tasks` table:

1. `PRAGMA foreign_keys=OFF` for the duration of the rebuild (restored on
   exit).
2. `ALTER TABLE tasks RENAME TO tasks__pre_v24_status_check`.
3. `CREATE TABLE tasks` with the new schema. The schema is built
   dynamically: every v24 column plus any legacy column found on the
   live table (e.g. `spawn_failures` from pre-#20842 DBs) is included,
   so the ADD-first-then-copy contract from `_migrate_add_optional_columns`
   continues to hold.
4. `INSERT INTO tasks SELECT ...` over the column set common to both
   tables. Statuses are copied verbatim — **no row is reclassified**.
5. `DROP` the temp table and rebuild every index the rebuild dropped via
   the new `_ensure_indexes` helper (which itself skips indexes whose
   underlying table doesn't exist yet, so legacy-DB tests with only
   `tasks` + `task_events` still pass).

The migration is idempotent: `_tasks_status_check_needs_migration` returns
False once the new CHECK is in place, and re-running `init_db` after that
is a no-op.

A guard rejects the migration if any row has a status outside the v24 enum
— prevents data loss from a DB that someone hand-edited.

### State machine

- `block_task(...)` now takes `target_status='blocked'|'awaiting_human_ops'`
  (default `'blocked'`). Validates the choice and routes the event payload
  accordingly.
- `unblock_task(...)` accepts either waiting state and routes back to
  `ready` or `todo` based on parent completion, identical to the existing
  `blocked` flow.
- `complete_task(...)` and `reclaim_task(...)` updated to recognize the
  new state in their WHERE clauses (so a card can be completed or
  reclaimed straight from `awaiting_human_ops`).
- New `move_task(conn, task_id, new_status)` helper backs both the CLI
  `move` subcommand and the dashboard drag/drop. Refuses direct moves to
  `running` (must go through claim/dispatch), routes `done` / `archived`
  through the existing helpers, treats `awaiting_human_ops <-> blocked`
  as a permitted manual move (CHECK constraint still enforced).

### CLI

- `hermes kanban block --status awaiting_human_ops` flag.
- `hermes kanban move <task_id> <status>` subcommand (choices come from
  `VALID_STATUSES`).
- `hermes kanban list --status awaiting_human_ops` and
  `stats` formatting both widened to fit the longer status name.
- New `!` glyph for awaiting_human_ops (distinct from `⊘` for blocked).

### Tools (LLM-facing)

- `kanban_block` schema gains a `status` enum; default unchanged.
- `kanban_create.initial_status` enum extended to include the new state.
- Result payloads echo the chosen waiting state so the model can confirm.

### Dashboard

- New "Awaiting Human Ops" column between `running` and `blocked` in the
  bundled `dist/index.js` (`COLUMN_ORDER` and English fallback dicts).
- Purple `.hermes-kanban-dot-awaiting-human-ops` swatch (vs the
  destructive red used for `blocked`).
- New "Await ops" bulk action button + per-card `Await ops` button,
  guarded by the existing destructive-confirm flow.
- Staleness thresholds for the new state (`amber=4h`, `red=48h`) — more
  generous than `blocked` because human ops review can take a working day.
- `plugin_api.update_task` / `bulk_update` route `awaiting_human_ops`
  through `block_task(target_status=...)` (from running/ready) or
  `move_task` (from another waiting state), unblock recognizes either
  waiting state.

### i18n

- `en.ts` / `ja.ts`: full translations for the status label, dashboard
  description, and destructive-confirm copy. Japanese label is
  「ops承認待ち」per the spec.
- All 14 remaining locale files (`af`, `de`, `es`, `fr`, `ga`, `hu`,
  `it`, `ko`, `pt`, `ru`, `tr`, `uk`, `zh`, `zh-hant`) get the same
  three keys with English fallback strings, matching the existing
  fallback pattern from PR #27 / PR-4.
- `types.ts` updated; this is a non-optional `Translations` extension,
  so any locale missing the keys would fail typecheck — the bulk
  fallback above keeps the project building.

## Tests

New tests in `tests/hermes_cli/test_kanban_cli.py`:

| ID | Test | What it proves |
|----|------|----------------|
| T1 | `test_t1_new_card_default_status_unchanged` | The new state is opt-in; a plain `kanban add` still lands in `ready`. |
| T2 | `test_t2_initial_status_awaiting_human_ops` | Cards can be parked directly in `awaiting_human_ops`; bad enum values rejected. |
| T3 | `test_t3_unblock_from_awaiting_human_ops` | `unblock` reopens a card from the new state, matching the existing `blocked` contract. |
| T4 | `test_t4_cli_move_awaiting_human_ops` | `kanban move <id> awaiting_human_ops` works; argparse rejects bogus statuses. |
| T5 | `test_t5_filter_state_awaiting_human_ops` | `list --status awaiting_human_ops` returns only matching cards. |
| T6 | `test_t6_migration_keeps_existing_blocked_cards` | A pre-existing `blocked` card is not reclassified after the v24 migration; the migration is idempotent (running `init_db` twice is a no-op); creating a new `awaiting_human_ops` card after migration works. |

Results (Windows native, Python 3.12.10):

- `PYTHONUTF8=1 uv run --extra dev --extra web pytest tests/hermes_cli -k kanban -q` -> `443 passed, 4 skipped`
- `PYTHONUTF8=1 uv run --extra dev --extra web pytest tests/plugins/test_kanban_dashboard_plugin.py -q` -> `80 passed, 1 failed`. The failing test (`test_diagnostics_endpoint_severity_filter`) fails identically on `origin/main` without this PR's changes — it's a pre-existing baseline flake on Windows, not a regression.

## Backward compatibility

- **No existing `blocked` row is reclassified.** Operators who want to
  re-bucket historical R3-gate cards into `awaiting_human_ops` do so
  manually via `kanban move <id> awaiting_human_ops` or the dashboard
  bulk action. The PR explicitly avoids any heuristic auto-migration
  because the historical mixed semantics make it impossible to do
  safely without operator review.
- Existing `pre_state_change` / `post_state_change` hooks fire for the
  new state too — no new hook surface is added.
- The CLI / tools APIs that already accept `'blocked'` continue to work
  identically; `awaiting_human_ops` is purely additive.

## Migration notes (forward-only)

The schema migration is **forward-only**. Once a DB has run on v24:

1. Any new `awaiting_human_ops` rows are persisted.
2. Downgrading to v23 (or any binary without the new value in the CHECK
   clause) would either fail to open the DB (if it re-runs migrations
   and finds an unknown CHECK term) or accept the rows but reject any
   subsequent write to them.

**Rollback procedure** (for operators who need to revert):

1. Stop all dispatchers / workers writing to the kanban DB.
2. Move every `awaiting_human_ops` card back to `blocked`:
   ```sql
   UPDATE tasks SET status = 'blocked'
    WHERE status = 'awaiting_human_ops';
   ```
3. Drop the CHECK constraint by rebuilding the table with the old
   schema (mirror of `_migrate_tasks_status_check` but with the v23
   column list).
4. Reset `PRAGMA user_version = 23` and `_config_version = 23` in
   `~/.hermes/config.yaml`.
5. Restart on the v23 binary.

This is intentionally not automated: rollbacks should be rare and
operator-supervised. The PR keeps the migration idempotent so accidental
re-runs of `init_db` on a v24 DB are safe.

## Files changed

- `hermes_cli/kanban_db.py`: enum, CHECK constraint, migration helpers,
  state-machine updates, `move_task` helper.
- `hermes_cli/kanban.py`: `move` subcommand, `block --status` flag,
  list/stats formatting widths, status icon.
- `hermes_cli/config.py`: `_config_version` bump.
- `tools/kanban_tools.py`: tool schemas for `kanban_block` and
  `kanban_create`, handler routing.
- `plugins/kanban/dashboard/plugin_api.py`: board column order,
  update/bulk routing.
- `plugins/kanban/dashboard/dist/index.js` / `dist/style.css`: rendered
  dashboard bundle (column, color, action buttons, staleness, confirm copy).
- `web/src/i18n/types.ts` + all 16 locale files: new translation keys.
- `tests/hermes_cli/test_kanban_cli.py`: T1-T6.
