### PR TITLE
fix: resolve NameError in fallback provider logic (_pool_may_recover_from_rate_limit)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2317,7 +2317,7 @@ def run_conversation(
                     # still recover.  See _pool_may_recover_from_rate_limit
                     # for the single-credential-pool and CloudCode-quota
                     # exceptions.  Fixes #11314 and #13636.
-                    pool_may_recover = _pool_may_recover_from_rate_limit(
+                    pool_may_recover = _ra()._pool_may_recover_from_rate_limit(
                         agent._credential_pool,
                         provider=agent.provider,
                         base_url=getattr(agent, "base_url", None),


### PR DESCRIPTION
## Bug

When a primary provider (e.g. OpenAI Codex / GPT-5.5, Google Gemini) hits HTTP 429 or usage limit, and the user has `fallback_providers` configured, Hermes crashes with:

```
Error: name '_pool_may_recover_from_rate_limit' is not defined
```

The error occurs at the eager-fallback check in `conversation_loop.py` before `_try_activate_fallback` is ever called, so the fallback chain never runs.

## Root Cause

The function `_pool_may_recover_from_rate_limit` is defined in `run_agent.py` (line 239) but called from `agent/conversation_loop.py`. Due to circular import constraints, code in `conversation_loop.py` uses a `_ra()` lazy-import helper to access symbols from `run_agent.py`. However this call site at line ~2320 used the bare name instead of `_ra()._pool_may_recover_from_rate_limit(...)`.

## Fix

Changed the bare name call to use the `_ra()` helper, consistent with every other cross-module reference in this file.

```diff
-                    pool_may_recover = _pool_may_recover_from_rate_limit(
+                    pool_may_recover = _ra()._pool_may_recover_from_rate_limit(
```

## Testing

All 28 related tests pass:
- `tests/run_agent/test_provider_fallback.py`
- `tests/agent/test_gemini_fast_fallback.py`

Fixes model fallback not triggering on HTTP 429 / rate limit for any user with `fallback_providers` configured.