### PR TITLE
fix(kanban-dashboard): wire onValueChange on OrchestrationPanel Selects

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -1548,14 +1548,12 @@
           h("div", { className: "flex flex-col gap-1" },
             h(Label, { className: "text-xs text-muted-foreground" },
               "Orchestrator profile"),
-            h(Select, {
+            h(Select, Object.assign({
               value: settings.orchestrator_profile || "",
               className: "h-8",
-              onChange: function (e) {
-                const v = (e && e.target ? e.target.value : e) || "";
-                saveSettings({ orchestrator_profile: v });
-              },
-            },
+            }, selectChangeHandler(function (v) {
+              saveSettings({ orchestrator_profile: v });
+            })),
               h(SelectOption, { value: "" },
                 "(default: " + (settings.active_profile || "default") + ")"),
               profileOptions,
@@ -1566,14 +1564,12 @@
           h("div", { className: "flex flex-col gap-1" },
             h(Label, { className: "text-xs text-muted-foreground" },
               "Default assignee"),
-            h(Select, {
+            h(Select, Object.assign({
               value: settings.default_assignee || "",
               className: "h-8",
-              onChange: function (e) {
-                const v = (e && e.target ? e.target.value : e) || "";
-                saveSettings({ default_assignee: v });
-              },
-            },
+            }, selectChangeHandler(function (v) {
+              saveSettings({ default_assignee: v });
+            })),
               h(SelectOption, { value: "" },
                 "(default: " + (settings.active_profile || "default") + ")"),
               profileOptions,


### PR DESCRIPTION
## Summary
The orchestrator profile and default assignee dropdowns in the kanban dashboard Orchestration panel did nothing on change — popup opened, user picked an option, popup closed, nothing saved. This fixes both.

## Root cause
The dashboard SDK's `<Select>` is a shadcn-style popup that fires `onValueChange(value)`, not native `onChange({target:{value}})`. `plugins/kanban/dashboard/dist/index.js` has a `selectChangeHandler()` helper at L213 with this comment:

> "Older plugin code calls `onChange({target:{value}})` which silently never fires."

#24547 already fixed three regressions onto the broken pattern (bulk-reassign / workspace-kind / new-task parent). The two OrchestrationPanel selects introduced later in #27572 regressed onto the same pattern and were missed.

## Changes
`plugins/kanban/dashboard/dist/index.js` (2 sites, 8+/12-):
- OrchestrationPanel `orchestrator_profile` picker
- OrchestrationPanel `default_assignee` picker

Both rewired through the existing `selectChangeHandler` helper for consistency with the other working Selects in the same file.

## Validation
`node --check` passes. Backend `PUT /orchestration` was already correct — it just wasn't being called.

| | Before | After |
|---|---|---|
| Pick orchestrator profile | popup closes, nothing saved | `PUT /orchestration` fires, config.yaml updated, resolved label re-renders |
| Pick default assignee | same as above | saves |

Reported by Exaario on Discord.