### PR TITLE
fix(conversation_loop): use _ra() prefix for _pool_may_recover_from_r…

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2317,7 +2317,7 @@ def run_conversation(
                     # still recover.  See _pool_may_recover_from_rate_limit
                     # for the single-credential-pool and CloudCode-quota
                     # exceptions.  Fixes #11314 and #13636.
-                    pool_may_recover = _pool_may_recover_from_rate_limit(
+                    pool_may_recover = _ra()._pool_may_recover_from_rate_limit(
                         agent._credential_pool,
                         provider=agent.provider,
                         base_url=getattr(agent, "base_url", None),


### PR DESCRIPTION
## What does this PR do?

`_pool_may_recover_from_rate_limit` is defined as a module-level function in `run_agent.py` but was called as a bare name in `agent/conversation_loop.py` after the conversation loop was extracted into its own module. When a rate-limit or billing error occurs **and** the agent has a fallback provider configured, Python raises a `NameError` at runtime because the name isn't defined or imported in that module.

The fix prefixes the call with `_ra().` — the same pattern already used throughout the file for `_set_interrupt`, `handle_function_call`, and `AIAgent._get_tool_call_name_static`. `_ra()` is a lazy module reference to `run_agent`, so existing patches in tests keep working without changes.

## Related Issue

No issue filed. Discovered during static analysis after the conversation-loop extraction refactor.

Fixes # N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/conversation_loop.py:2320` — changed `_pool_may_recover_from_rate_limit(...)` to `_ra()._pool_may_recover_from_rate_limit(...)`

## How to Test

1. Configure a fallback model (`fallback_model` in config.yaml)
2. Trigger a 429 (rate-limit) response from the primary provider
3. **Before fix:** `NameError: name '_pool_may_recover_from_rate_limit' is not defined`
4. **After fix:** agent correctly evaluates credential-pool rotation and falls back to the backup provider

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(conversation_loop):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes
- [ ] I've tested on my platform: <!-- macOS -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation — N/A (single-line bug fix)
- [ ] I've updated `cli-config.yaml.example` — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [ ] I've considered cross-platform impact — N/A (Python name resolution is platform-agnostic)
- [ ] I've updated tool descriptions/schemas — N/A
