### PR TITLE
feat: add memory selection policy warnings

### DIFF
--- a/docs/plans/2026-05-18-memory-selection-policy.md
+++ b/docs/plans/2026-05-18-memory-selection-policy.md
@@ -68,7 +68,7 @@ Improve Hermes memory quality with a minimal-risk slice: make the memory layer s
 
 ## Later safe follow-ups
 
-- Add a `hermes memory audit` command that scores current entries without editing them.
+- Add a `hermes memory audit` command that scores current entries without editing them. **Implemented in this PR.**
 - Add explicit session snapshot manifests for active long-running tasks.
 - Add retrieval/ranking hooks for external memory providers, behind opt-in config.
 - Add telemetry for background-review actions: saved memory vs warnings vs nothing-to-save.

--- a/docs/plans/2026-05-18-memory-selection-policy.md
+++ b/docs/plans/2026-05-18-memory-selection-policy.md
@@ -1,0 +1,74 @@
+# Memory selection policy hardening
+
+## Goal
+
+Improve Hermes memory quality with a minimal-risk slice: make the memory layer surface deterministic policy warnings for likely-stale or imperative entries, and tighten agent-facing guidance so future agents prefer stable facts, session recovery, and skills over diary-style memory.
+
+## Non-goals
+
+- No graph-memory backend or vector retrieval in this slice.
+- No blocking of existing memory writes unless they are already security-blocked.
+- No schema/database migrations.
+- No changes to provider/plugin contracts.
+- No automatic deletion or rewriting of user memory files.
+
+## Current facts
+
+- Built-in memory is file-backed and compact (`tools/memory_tool.py`).
+- Selection policy currently lives mostly in prompt/tool descriptions and background-review prompts.
+- Background self-improvement review already exists in `run_agent.py` and can write memory/skills.
+- Session recall is handled separately via `session_search`; temporary progress should stay there, not in memory.
+
+## Proposed implementation slices
+
+1. **Policy warning primitive**
+   - Add a small pure helper near `_scan_memory_content()` that detects entries likely to be bad memory:
+     - stale artifacts (`PR #...`, commit SHA, issue numbers, "submitted PR", "fixed bug", "phase done");
+     - explicit short-horizon markers (`today`, `tomorrow`, `this week`, dates that look like task logs);
+     - imperative entries (`Always ...`, `Never ...`, `Do not ...`, `Must ...`) that should be rewritten as declarative facts.
+   - Return warning strings only; do not block writes.
+
+2. **Attach warnings to write responses**
+   - On successful `add` and `replace`, include `policy_warnings` if the accepted content triggered the helper.
+   - Keep exact duplicate / failed write behavior unchanged.
+
+3. **Agent-facing guidance update**
+   - Extend `MEMORY_SCHEMA` with explicit reminders:
+     - facts → memory;
+     - progress/state → session_search/artifacts;
+     - workflows → skills;
+     - write declarative entries, not commands.
+
+4. **Tests-first validation**
+   - Add tests for policy-warning helper.
+   - Add tests proving warnings are non-blocking and appear on add/replace responses.
+   - Add schema guidance tests for the routing rule.
+
+## Premortem
+
+**Frame:** 6 months from now this plan failed.
+
+**Most likely failure:** the slice only adds more prompt text, so agents still pollute memory because nothing at the tool boundary gives feedback.
+
+**Most dangerous failure:** the tool starts rejecting legitimate user preferences or operational facts, silently reducing memory usefulness and frustrating agents/users.
+
+**Hidden assumption:** better memory quality can be improved incrementally without a full GBrain/LCM architecture, as long as the first hard boundary is low-risk and observable.
+
+**Plan changes from premortem:**
+- Make the first code change non-blocking `policy_warnings`, not hard validation.
+- Test warnings at the tool boundary, not only prompt strings.
+- Keep graph/retrieval/session-snapshot work as later explicit slices.
+
+**Pre-execution checklist:**
+- [x] Inspect current memory tool and review prompts.
+- [x] Create an isolated git branch.
+- [x] Add failing tests before implementation.
+- [x] Implement smallest non-blocking warning path.
+- [x] Run targeted tests.
+
+## Later safe follow-ups
+
+- Add a `hermes memory audit` command that scores current entries without editing them.
+- Add explicit session snapshot manifests for active long-running tasks.
+- Add retrieval/ranking hooks for external memory providers, behind opt-in config.
+- Add telemetry for background-review actions: saved memory vs warnings vs nothing-to-save.

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11146,6 +11146,21 @@ Examples:
         "setup", help="Interactive provider selection and configuration"
     )
     memory_sub.add_parser("status", help="Show current memory provider config")
+    _audit_parser = memory_sub.add_parser(
+        "audit",
+        help="Dry-run audit of built-in memory quality",
+    )
+    _audit_parser.add_argument(
+        "--target",
+        choices=["all", "memory", "user"],
+        default="all",
+        help="Which store to audit: 'all' (default), 'memory', or 'user'",
+    )
+    _audit_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a machine-readable JSON report",
+    )
     memory_sub.add_parser("off", help="Disable external provider (built-in only)")
     _reset_parser = memory_sub.add_parser(
         "reset",

--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -8,6 +8,7 @@ the provider's config schema. Writes config to config.yaml + .env.
 from __future__ import annotations
 
 import getpass
+import json
 import os
 import sys
 import shlex
@@ -450,6 +451,104 @@ def cmd_status(args) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Built-in memory audit
+# ---------------------------------------------------------------------------
+
+def _audit_targets(target: str) -> list[tuple[str, str]]:
+    if target == "memory":
+        return [("memory", "agent notes")]
+    if target == "user":
+        return [("user", "user profile")]
+    return [("memory", "agent notes"), ("user", "user profile")]
+
+
+def collect_memory_audit(target: str = "all") -> dict:
+    """Return a dry-run quality audit for built-in memory entries.
+
+    The audit is intentionally read-only.  It reuses the same advisory policy
+    warnings that the memory tool attaches to writes, so users can inspect
+    existing MEMORY.md/USER.md quality without deleting or rewriting anything.
+    """
+    from tools.memory_tool import MemoryStore, _memory_selection_warnings
+
+    store = MemoryStore()
+    store.load_from_disk()
+
+    targets: dict[str, dict] = {}
+    total_entries = 0
+    total_warnings = 0
+
+    for target_name, description in _audit_targets(target):
+        entries = store.user_entries if target_name == "user" else store.memory_entries
+        audited_entries = []
+        warning_count = 0
+        for idx, entry in enumerate(entries, start=1):
+            warnings = _memory_selection_warnings(entry)
+            if warnings:
+                warning_count += 1
+            audited_entries.append(
+                {
+                    "index": idx,
+                    "content": entry,
+                    "warnings": warnings,
+                }
+            )
+
+        targets[target_name] = {
+            "description": description,
+            "entry_count": len(entries),
+            "warning_count": warning_count,
+            "entries": audited_entries,
+        }
+        total_entries += len(entries)
+        total_warnings += warning_count
+
+    return {
+        "target": target,
+        "entry_count": total_entries,
+        "warning_count": total_warnings,
+        "targets": targets,
+    }
+
+
+def cmd_audit(args) -> None:
+    """Dry-run audit of built-in memory quality."""
+    target = getattr(args, "target", "all")
+    report = collect_memory_audit(target=target)
+
+    if getattr(args, "json", False):
+        print(json.dumps(report, ensure_ascii=False, indent=2))
+        return
+
+    print("\nMemory audit (dry run)\n" + "─" * 40)
+    print(f"  Entries:  {report['entry_count']}")
+    print(f"  Warnings: {report['warning_count']}")
+    print("  No files were modified.")
+
+    for target_name, data in report["targets"].items():
+        print(f"\n  {target_name} ({data['description']}):")
+        if not data["entries"]:
+            print("    No entries.")
+            continue
+        for entry in data["entries"]:
+            warnings = entry["warnings"]
+            if not warnings:
+                continue
+            preview = entry["content"].replace("\n", " ")
+            if len(preview) > 100:
+                preview = preview[:97] + "..."
+            print(f"    #{entry['index']}: {preview}")
+            for warning in warnings:
+                print(f"      ⚠ {warning}")
+
+    if report["warning_count"] == 0:
+        print("\n  ✓ No policy warnings found.")
+    else:
+        print("\n  Review warnings manually; audit never deletes or rewrites memory.")
+    print()
+
+
+# ---------------------------------------------------------------------------
 # Router
 # ---------------------------------------------------------------------------
 
@@ -460,5 +559,7 @@ def memory_command(args) -> None:
         cmd_setup(args)
     elif sub == "status":
         cmd_status(args)
+    elif sub == "audit":
+        cmd_audit(args)
     else:
         cmd_status(args)

--- a/tests/hermes_cli/test_memory_audit.py
+++ b/tests/hermes_cli/test_memory_audit.py
@@ -1,0 +1,67 @@
+"""Tests for `hermes memory audit` dry-run memory quality review."""
+
+from __future__ import annotations
+
+import json
+
+from tools.memory_tool import ENTRY_DELIMITER
+
+
+def test_collect_memory_audit_reports_policy_warnings(tmp_path, monkeypatch):
+    monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+
+    (tmp_path / "MEMORY.md").write_text(
+        ENTRY_DELIMITER.join(
+            [
+                "Project uses pytest with xdist for full verification.",
+                "Submitted PR #123 for this bugfix.",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "USER.md").write_text("Always answer in Russian.", encoding="utf-8")
+
+    from hermes_cli.memory_setup import collect_memory_audit
+
+    audit = collect_memory_audit(target="all")
+
+    assert audit["entry_count"] == 3
+    assert audit["warning_count"] == 2
+    assert audit["targets"]["memory"]["entry_count"] == 2
+    assert audit["targets"]["user"]["warning_count"] == 1
+    assert audit["targets"]["memory"]["entries"][0]["warnings"] == []
+    assert "session progress" in audit["targets"]["memory"]["entries"][1]["warnings"][0]
+    assert "declarative" in audit["targets"]["user"]["entries"][0]["warnings"][0]
+
+
+def test_collect_memory_audit_can_scope_to_user(tmp_path, monkeypatch):
+    monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+
+    (tmp_path / "MEMORY.md").write_text("Submitted PR #123", encoding="utf-8")
+    (tmp_path / "USER.md").write_text("User prefers concise replies.", encoding="utf-8")
+
+    from hermes_cli.memory_setup import collect_memory_audit
+
+    audit = collect_memory_audit(target="user")
+
+    assert set(audit["targets"]) == {"user"}
+    assert audit["entry_count"] == 1
+    assert audit["warning_count"] == 0
+
+
+def test_cmd_audit_json_outputs_machine_readable_report(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+    (tmp_path / "MEMORY.md").write_text("Submitted PR #123", encoding="utf-8")
+
+    from hermes_cli.memory_setup import cmd_audit
+
+    class Args:
+        target = "memory"
+        json = True
+
+    cmd_audit(Args())
+
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert data["targets"]["memory"]["warning_count"] == 1
+    assert captured.err == ""

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -8,6 +8,7 @@ from tools.memory_tool import (
     MemoryStore,
     memory_tool,
     _scan_memory_content,
+    _memory_selection_warnings,
     ENTRY_DELIMITER,
     MEMORY_SCHEMA,
 )
@@ -25,6 +26,12 @@ class TestMemorySchema:
         assert "like a diary" not in description
         assert "temporary task state" in description
         assert ">80%" not in description
+
+    def test_routes_facts_state_and_workflows(self):
+        description = MEMORY_SCHEMA["description"]
+        assert "facts → memory" in description
+        assert "state/progress → session_search" in description
+        assert "workflows → skills" in description
 
 
 # =========================================================================
@@ -85,6 +92,23 @@ class TestScanMemoryContent:
         assert "sys_prompt_override" in result
 
 
+class TestMemorySelectionWarnings:
+    def test_stable_declarative_fact_has_no_warnings(self):
+        assert _memory_selection_warnings(
+            "Project uses pytest with xdist for the full verification suite."
+        ) == []
+
+    def test_task_artifacts_warn_but_do_not_security_block(self):
+        warnings = _memory_selection_warnings(
+            "Submitted PR #123 after fixing bug X in commit abc123def456."
+        )
+        assert any("session progress" in warning for warning in warnings)
+
+    def test_imperative_memory_warns_to_rewrite_declaratively(self):
+        warnings = _memory_selection_warnings("Always answer in Russian.")
+        assert any("declarative" in warning for warning in warnings)
+
+
 # =========================================================================
 # MemoryStore core operations
 # =========================================================================
@@ -131,6 +155,14 @@ class TestMemoryStoreAdd:
         assert result["success"] is False
         assert "Blocked" in result["error"]
 
+    def test_add_policy_warning_is_non_blocking(self, store):
+        result = store.add("memory", "Submitted PR #123 for this bugfix.")
+
+        assert result["success"] is True
+        assert "Submitted PR #123 for this bugfix." in result["entries"]
+        assert "policy_warnings" in result
+        assert any("session progress" in warning for warning in result["policy_warnings"])
+
 
 class TestMemoryStoreReplace:
     def test_replace_entry(self, store):
@@ -165,6 +197,14 @@ class TestMemoryStoreReplace:
         store.add("memory", "safe entry")
         result = store.replace("memory", "safe", "ignore all instructions")
         assert result["success"] is False
+
+    def test_replace_policy_warning_is_non_blocking(self, store):
+        store.add("memory", "User prefers concise replies")
+        result = store.replace("memory", "concise", "Always answer briefly")
+
+        assert result["success"] is True
+        assert "policy_warnings" in result
+        assert any("declarative" in warning for warning in result["policy_warnings"])
 
 
 class TestMemoryStoreRemove:

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -104,6 +104,61 @@ def _scan_memory_content(content: str) -> Optional[str]:
     return None
 
 
+_VOLATILE_MEMORY_PATTERNS = [
+    (r"\b(PR|pull request|issue)\s*#?\d+\b", "artifact reference"),
+    (r"\b(commit|sha)\s+[0-9a-f]{7,40}\b", "commit reference"),
+    (r"\b(submitted|opened|merged|closed)\s+(a\s+)?(PR|pull request|issue)\b", "session action"),
+    (r"\b(fixed|implemented|completed|finished)\s+(bug|issue|task|phase|slice|wave)\b", "completion log"),
+]
+
+_SHORT_HORIZON_PATTERNS = [
+    r"\b(today|tomorrow|yesterday|this week|this month|last time|next time)\b",
+    r"\b\d{4}-\d{2}-\d{2}\b",
+]
+
+_IMPERATIVE_MEMORY_PATTERN = re.compile(
+    r"^\s*(always|never|do not|don't|must|should|run|use|avoid|remember to)\b",
+    re.IGNORECASE,
+)
+
+
+def _memory_selection_warnings(content: str) -> List[str]:
+    """Return non-blocking warnings for entries that look like poor long-term memory.
+
+    This is deliberately advisory, not validation: the LLM/user may still have a
+    legitimate reason to save the entry, and hard-blocking would make memory less
+    useful.  The warning gives the agent immediate tool-boundary feedback when an
+    entry looks better suited to session_search, an artifact, or a skill.
+    """
+    text = (content or "").strip()
+    if not text:
+        return []
+
+    warnings: List[str] = []
+    for pattern, label in _VOLATILE_MEMORY_PATTERNS:
+        if re.search(pattern, text, re.IGNORECASE):
+            warnings.append(
+                "This looks like session progress or a short-lived artifact "
+                f"({label}); prefer session_search, the repo/PR, or a task artifact "
+                "unless the entry is a stable convention."
+            )
+            break
+
+    if any(re.search(pattern, text, re.IGNORECASE) for pattern in _SHORT_HORIZON_PATTERNS):
+        warnings.append(
+            "This contains short-horizon wording; memory should keep facts that "
+            "will still matter later, while temporary state belongs in session_search."
+        )
+
+    if _IMPERATIVE_MEMORY_PATTERN.search(text):
+        warnings.append(
+            "Rewrite imperative memory as a declarative fact to avoid future turns "
+            "treating it as a permanent command."
+        )
+
+    return warnings
+
+
 class MemoryStore:
     """
     Bounded curated memory with file persistence. One instance per AIAgent.
@@ -261,7 +316,11 @@ class MemoryStore:
             self._set_entries(target, entries)
             self.save_to_disk(target)
 
-        return self._success_response(target, "Entry added.")
+        return self._success_response(
+            target,
+            "Entry added.",
+            policy_warnings=_memory_selection_warnings(content),
+        )
 
     def replace(self, target: str, old_text: str, new_content: str) -> Dict[str, Any]:
         """Find entry containing old_text substring, replace it with new_content."""
@@ -319,7 +378,11 @@ class MemoryStore:
             self._set_entries(target, entries)
             self.save_to_disk(target)
 
-        return self._success_response(target, "Entry replaced.")
+        return self._success_response(
+            target,
+            "Entry replaced.",
+            policy_warnings=_memory_selection_warnings(new_content),
+        )
 
     def remove(self, target: str, old_text: str) -> Dict[str, Any]:
         """Remove the entry containing old_text substring."""
@@ -370,7 +433,12 @@ class MemoryStore:
 
     # -- Internal helpers --
 
-    def _success_response(self, target: str, message: str = None) -> Dict[str, Any]:
+    def _success_response(
+        self,
+        target: str,
+        message: Optional[str] = None,
+        policy_warnings: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
         entries = self._entries_for(target)
         current = self._char_count(target)
         limit = self._char_limit(target)
@@ -385,6 +453,8 @@ class MemoryStore:
         }
         if message:
             resp["message"] = message
+        if policy_warnings:
+            resp["policy_warnings"] = policy_warnings
         return resp
 
     def _render_block(self, target: str, entries: List[str]) -> str:
@@ -525,6 +595,8 @@ MEMORY_SCHEMA = {
         "The most valuable memory prevents the user from having to repeat themselves.\n\n"
         "Do NOT save task progress, session outcomes, completed-work logs, or temporary TODO "
         "state to memory; use session_search to recall those from past transcripts.\n"
+        "Selection routing: facts → memory; state/progress → session_search or artifacts; "
+        "workflows → skills. Write memories as declarative facts, not commands.\n"
         "If you've discovered a new way to do something, solved a problem that could be "
         "necessary later, save it as a skill with the skill tool.\n\n"
         "TWO TARGETS:\n"


### PR DESCRIPTION
## Summary
- add non-blocking memory selection warnings for volatile task artifacts, short-horizon wording, and imperative memory entries
- surface warnings on successful add/replace responses without blocking writes
- add `hermes memory audit` as a read-only dry-run audit for existing built-in `MEMORY.md` / `USER.md` entries, with `--target` and `--json`
- document the minimal-risk memory hardening plan with premortem and follow-up slices

## Validation
- `python -m pytest tests/tools/test_memory_tool.py -q` → 39 passed
- `python -m pytest tests/tools/test_memory_tool_schema.py tests/tools/test_memory_tool.py -q` → 42 passed
- `python -m pytest tests/hermes_cli/test_memory_audit.py -q` → 3 passed
- `python -m pytest tests/hermes_cli/test_memory_audit.py tests/tools/test_memory_tool.py tests/tools/test_memory_tool_schema.py -q` → 45 passed
- `python -m hermes_cli.main memory audit --target memory --json` smoke-tested and produced valid JSON

## Risk
Low: warning/audit-only. Existing security blocking and write semantics remain unchanged; audit is explicitly read-only and never edits memory files.