### PR TITLE
fix: resolve fallback pool helper in conversation loop

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -82,6 +82,17 @@ def _ra():
     return run_agent
 
 
+def _pool_may_recover_from_rate_limit(*args, **kwargs):
+    """Delegate to ``run_agent``'s helper while preserving patchability.
+
+    ``run_conversation`` was extracted from ``run_agent.AIAgent`` but still
+    refers to this helper in the eager fallback path. Resolve lazily through
+    ``run_agent`` so gateway sessions do not hit a module-local NameError when
+    the primary provider rate-limits and a fallback model is configured.
+    """
+    return _ra()._pool_may_recover_from_rate_limit(*args, **kwargs)
+
+
 def _restore_or_build_system_prompt(agent, system_message, conversation_history):
     """Restore the cached system prompt from the session DB or build it fresh.
 

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -8,6 +8,7 @@ advancement through multiple providers.
 from unittest.mock import MagicMock, patch
 
 from run_agent import AIAgent, _pool_may_recover_from_rate_limit
+import agent.conversation_loop as conversation_loop
 
 
 def _make_agent(fallback_model=None):
@@ -195,6 +196,29 @@ def _pool(n_entries: int, has_available: bool = True):
 
 
 class TestPoolRotationRoom:
+    def test_conversation_loop_exposes_pool_recovery_helper(self):
+        """The extracted conversation loop must resolve the helper lazily.
+
+        Gateway sessions call ``agent.conversation_loop.run_conversation``
+        directly. The eager fallback branch used to reference this helper as a
+        module-local global even though it lived in ``run_agent``, raising
+        NameError instead of switching to the configured fallback provider.
+        """
+        pool = _pool(1)
+
+        with patch("run_agent._pool_may_recover_from_rate_limit", return_value=False) as helper:
+            assert conversation_loop._pool_may_recover_from_rate_limit(
+                pool,
+                provider="openai-codex",
+                base_url="https://chatgpt.com/backend-api/codex",
+            ) is False
+
+        helper.assert_called_once_with(
+            pool,
+            provider="openai-codex",
+            base_url="https://chatgpt.com/backend-api/codex",
+        )
+
     def test_none_pool_returns_false(self):
         assert _pool_may_recover_from_rate_limit(None) is False
 


### PR DESCRIPTION
## Summary
- add a lazy conversation_loop wrapper for run_agent._pool_may_recover_from_rate_limit
- preserve run_agent patchability after the run_conversation extraction
- cover the gateway/Discord fallback NameError path with a regression test

## Reference
Observed in local Discord gateway logs when Codex primary hit HTTP 429 and fallback_model was configured:

```
agent.conversation_loop: API call failed ... provider=openai-codex ... HTTP 429
File "agent/conversation_loop.py", line 2254, in run_conversation
    pool_may_recover = _pool_may_recover_from_rate_limit(...)
NameError: name '_pool_may_recover_from_rate_limit' is not defined
```

The helper lives in run_agent.py, but the extracted conversation loop referenced it as a module-local global. Gateway sessions call the extracted loop directly, so the eager fallback branch crashed before activating the configured fallback provider.

## Test Plan
- /usr/local/lib/hermes-agent/venv/bin/python -m pytest tests/run_agent/test_provider_fallback.py tests/agent/test_gemini_fast_fallback.py -q -o 'addopts='
- /usr/local/lib/hermes-agent/venv/bin/python -m py_compile agent/conversation_loop.py run_agent.py
- git diff --check