### PR TITLE
feat(security): add Linux Security Guardian skill

### DIFF
--- a/optional-skills/devops/api-failure-investigation/SKILL.md
+++ b/optional-skills/devops/api-failure-investigation/SKILL.md
@@ -1,0 +1,285 @@
+---
+name: api-failure-investigation
+description: |-
+  Systematic API connectivity troubleshooting — a 5-phase methodology for diagnosing
+  API failures when an AI agent or developer encounters connection errors, timeouts,
+  or unexpected responses. Covers environment checks, test matrix, minimal GET discovery,
+  targeted POST verification, and pattern analysis with clear stop/retry rules.
+version: 1.0.0
+author: ligl0325
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [api, debugging, connectivity, troubleshooting, rest, grpc, network]
+    category: devops
+    requires_toolsets: [terminal, web]
+---
+
+# 🔌 API Failure Investigation
+
+> **One-liner**: When an API call fails and you — or your AI agent — don't know why,
+> follow this 5-phase script. It minimizes token waste, avoids infinite retry loops,
+> and always ends with a clear verdict: *what broke and what to do next.*
+
+**Target audience**: AI agents debugging API calls, and the developers who guide them
+**Time per run**: 2-5 minutes
+**Output**: Verdict (one of 7 types) + next step
+
+---
+
+## ⚠️ Anti-Hallucination Guardrails
+
+1. **Show the raw response.** Never summarize a 4xx/5xx error without quoting the exact
+   response body and HTTP status code. "The API returned an error" is not a diagnosis.
+2. **One hypothesis at a time.** If Phase 4 finds multiple anomalies, investigate the
+   MOST LIKELY cause first before branching. Parallel guessing wastes tokens.
+3. **Stop after 3 failed attempts.** If 3 different fix attempts all fail, escalate — do
+   not try a 4th. The issue needs human inspection of upstream docs or source.
+4. **Token budget: cap each phase at 5 tool calls.** If Phase 2's test matrix exceeds 5
+   curl commands, stop and ask the user which endpoints to prioritize.
+5. **Never retry a 401/403 without updated credentials.** Replaying an auth failure is
+   guaranteed to fail. Ask the user for new credentials first.
+
+---
+
+## Phase 1: Environment Check (1-2 tool calls)
+
+Goal: Rule out the obvious — wrong URL, wrong port, network issue, missing tool.
+
+```bash
+# 1a. Is curl installed and functional?
+curl --version 2>/dev/null || echo "missing-curl"
+
+# 1b. Is the target reachable at all? (connectivity)
+curl -s -o /dev/null -w "%{http_code}" --connect-timeout 5 "https://api.example.com" 2>&1
+
+# 1c. DNS resolution
+nslookup api.example.com 2>/dev/null || host api.example.com 2>/dev/null
+```
+
+**Decision tree after Phase 1:**
+
+| Observation | Verdict | Next Step |
+|-------------|---------|-----------|
+| curl not installed | `TOOL_MISSING` | `apt/brew install curl`, then retry |
+| Connection refused | `NETWORK_UNREACHABLE` | Check if service is up; verify URL |
+| DNS fails | `DNS_FAILURE` | Check `/etc/hosts` and DNS config |
+| HTTP response (any code) | — | Proceed to Phase 2 |
+
+---
+
+## Phase 2: Test Matrix (1-3 tool calls)
+
+Goal: Map the failure boundaries — does it fail on ALL methods, or only specific ones?
+Run a minimal 3×1 matrix (method × endpoint):
+
+```bash
+# GET the root/health endpoint — the most permissive test
+curl -sv https://api.example.com/health 2>&1 | head -30
+
+# GET the failing endpoint
+curl -sv https://api.example.com/v1/resource 2>&1 | head -30
+
+# OPTIONS (reveals allowed methods, CORS policy)
+curl -sv -X OPTIONS https://api.example.com/v1/resource 2>&1 | head -30
+```
+
+**Record for each call:**
+- HTTP status code
+- Response body (first 200 chars)
+- Response time (from `-w %{time_total}`)
+- Any TLS/certificate warnings
+
+**Decision tree after Phase 2:**
+
+| Matrix Pattern | Likely Cause | Proceed To |
+|----------------|--------------|------------|
+| All calls fail (connection error) | Phase 1 missed something | Re-check Phase 1 |
+| GET /health OK, GET /resource fails | Endpoint-specific issue | Phase 3 |
+| OPTIONS returns 405 | Method restriction | Check API docs |
+| All return 200 but wrong data | Schema mismatch | Phase 4 |
+
+---
+
+## Phase 3: Minimal GET Discovery (1-2 tool calls)
+
+Goal: Find a **known-good** GET endpoint to establish a baseline.
+
+```bash
+# Try common discovery/health endpoints
+for path in / /health /ping /status /api/v1/status /v1/health; do
+  code=$(curl -s -o /dev/null -w "%{http_code}" "https://api.example.com$path" --connect-timeout 5 2>/dev/null)
+  echo "$path → $code"
+done
+```
+
+If any returns 200, use that response structure as a reference:
+- Compare headers (Content-Type, API-Version, RateLimit-Remaining)
+- Compare response body structure (JSON fields)
+
+Document the working contract as: *"Baseline: GET <path> returns <status> with <shape>."*
+
+---
+
+## Phase 4: Targeted POST/PUT/Verification (1-2 tool calls)
+
+Goal: Reproduce the failure with MINIMAL payload, then diagnose the exact error.
+
+```bash
+# 4a. Reproduce with minimal valid payload
+curl -sv -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"test": true}' \
+  "https://api.example.com/v1/resource" \
+  --connect-timeout 10 2>&1
+
+# 4b. If auth-related: verify credentials (NEVER log the full token)
+# Show only: token present? token format? (header: 'Bearer ***...***')
+```
+
+**Record:**
+- Exact request sent (headers + body, with secrets redacted)
+- Full response headers
+- Full response body
+- Timing
+
+**Pattern analysis — map to one of these verdicts:**
+
+| Response Pattern | Verdict | Description |
+|-----------------|---------|-------------|
+| `4xx` with `{"error":"..."}` | `API_ERROR` | API returned a specific application error |
+| `401` / `403` | `AUTH_FAILURE` | Credentials missing, expired, or insufficient scope |
+| `404` | `ENDPOINT_NOT_FOUND` | URL path or method is wrong |
+| `405` | `METHOD_NOT_ALLOWED` | Wrong HTTP method for this endpoint |
+| `429` / Rate-limit headers | `RATE_LIMITED` | Exceeded quota; check Retry-After header |
+| `5xx` | `SERVER_ERROR` | Service-side failure; check status page |
+| Timeout (>30s) | `TIMEOUT` | Request exceeded deadline |
+| Connection reset mid-stream | `CONNECTION_DROPPED` | Proxy/LB closed the connection |
+| 200 OK but unexpected body | `SCHEMA_MISMATCH` | API changed; response doesn't match docs |
+
+---
+
+## Phase 5: Verdict & Next Step
+
+Output a single structured verdict. Example:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  🔌 API Failure Investigation — Verdict
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Verdict:       AUTH_FAILURE
+Endpoint:      POST https://api.example.com/v1/resource
+Status:        401 Unauthorized
+Response:      {"error":"invalid_token","message":"Token has expired"}
+
+Evidence:
+  - GET /health → 200 OK (API is reachable)
+  - OPTIONS /v1/resource → 204 No Content (CORS configured)
+  - POST /v1/resource → 401 (only this fails)
+
+Next Step:
+  🔑 Refresh the API token and retry.
+  ⚠️ If the new token also fails, check that the token has the
+     required scope: `resource:write`.
+
+Token spent: 4 curl calls / 3 phases
+```
+
+### Verdict Types (7)
+
+| Verdict | Means | Next Step |
+|---------|-------|-----------|
+| `TOOL_MISSING` | curl isn't installed | Install curl |
+| `NETWORK_UNREACHABLE` | Can't connect at all | Check URL, port, VPN, firewall |
+| `DNS_FAILURE` | Hostname won't resolve | Check DNS config |
+| `AUTH_FAILURE` | 401/403 | Rotate credentials, check scope |
+| `CLIENT_ERROR` | 4xx (non-auth) | Fix request per error message |
+| `SERVER_ERROR` | 5xx | Check service status, retry later |
+| `SCHEMA_MISMATCH` | 200 but wrong shape | Update client to match new schema |
+
+### When to Escalate
+
+- 3 consecutive failures with different approaches → document what was tried and ask for help
+- Any 500 error the user can't fix → file a support ticket with the raw response
+- Schema mismatch on a documented API → report a bug to the API provider
+
+---
+
+## Verification
+
+After applying the suggested fix:
+
+1. Re-run the **exact same request** from Phase 4 (same URL, method, headers).
+2. Confirm the HTTP status is now `2xx`.
+3. Confirm the response body matches the expected schema.
+4. Report: *"Fixed. <verdict> → 200 OK. <N> attempts."*
+
+If the fix didn't work:
+- Check if the fix was applied correctly (e.g., did the env var actually get exported?)
+- Try the next most likely cause from Phase 4's pattern analysis
+- After 3 total attempts, escalate
+
+---
+
+## Pitfalls
+
+- **Token leakage in logs**: Never paste a full `Authorization` header value into chat.
+  Show only the first 4 and last 4 characters: `Bearer "sk-****...****"`.
+- **CORS vs. server errors**: A browser CORS error does NOT mean the server is down.
+  Test with `curl -v` (bypasses CORS entirely) before blaming the backend.
+- **Rate-limit false positives**: A `429` response may include a useful `Retry-After`
+  header. Parse it and report the wait time rather than assuming "try again now."
+- **Redirect chains**: A `301`/`302` followed by a `404` on the new location looks like
+  a missing page. Always use `-L` (follow redirects) or report the full redirect chain.
+- **Proxy interference**: If behind a corporate proxy, `curl`'s connection to `127.0.0.1:7897`
+  (Clash, mitmproxy) may succeed while the actual target is unreachable. Run
+  `curl -v --noproxy '*' <url>` to bypass.
+- **Clash/mitmproxy intercepting localhost calls**: Tools like Clash, mitmproxy, or
+  Charles Proxy often set `http_proxy`/`https_proxy` env vars that redirect *all*
+  traffic — including connections to `127.0.0.1` and `localhost`. A `curl http://127.0.0.1:8080`
+  call meant for a local service may silently route through the proxy, hitting a different
+  process or failing with an unexpected response. **Diagnosis**: Compare `curl -v` output
+  (look for `Connected to 127.0.0.1:7897` instead of the expected address) and check
+  `echo $http_proxy $https_proxy`. **Fix**: Use `--noproxy '*'` to bypass the proxy.
+- **`--noproxy '*'` limitations**: The `--noproxy` flag works by matching the target
+  hostname against a comma-separated list of patterns. `--noproxy '*'` should bypass all
+  proxies, but some proxy configurations (notably mitmproxy in transparent mode, or
+  Docker-level `iptables` redirects) intercept traffic at a lower OSI layer that curl
+  cannot opt out of. **Diagnosis**: If `--noproxy '*'` still shows the proxy IP in
+  `Connected to ...`, try `unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY` in the
+  same shell, or use `curl --proxy "" <url>` to explicitly clear the proxy.
+- **Connection timeout vs. connection refused**: These two errors point to very different
+  root causes and must not be confused.
+
+  | Error | `curl` Signal | Meaning | Likely Cause |
+  |-------|--------------|---------|-------------|
+  | **Connection timeout** | `curl: (28) Connection timed out` | The OS sent a TCP SYN, waited N seconds, and never received a SYN-ACK. | Firewall dropping outbound packets; wrong IP/port; service not listening on that address; network routing issue. |
+  | **Connection refused** | `curl: (7) Failed to connect to ... Connection refused` | The TCP handshake reached the host, but the host sent back a RST (reset) because no process is listening on that port. | Service is down; port mismatch; service listening on different interface (e.g., `127.0.0.1` only but you're hitting the external IP). |
+
+  **How to diagnose each**:
+  - **Timeout**: Run `curl -v --connect-timeout 5 <url>` and watch for the stall. Use
+    `ping <host>` to check basic reachability. Use `mtr <host>` or `traceroute` to find
+    where packets are dropped. A timeout on the first hop usually points to a local
+    firewall (iptables, Windows Defender, VPN kill-switch).
+  - **Refused**: Run `curl -v <url>` — you'll see `TCP_NODELAY set` and then immediately
+    `Connection refused`, no delay. On the server, verify `ss -tlnp | grep <port>` or
+    `netstat -tlnp | grep <port>` shows the expected PID. A common pitfall: the service
+    binds to `127.0.0.1` only, but `curl` resolves the hostname to `::1` (IPv6 localhost)
+    or a public IP — use `curl -v http://127.0.0.1:<port>` to test explicitly.
+- **Example — bypass proxy for localhost diagnostics**:
+  ```bash
+  # Without bypass — may hit the proxy instead of local service
+  curl -v http://127.0.0.1:9090/api/health
+  
+  # With noproxy bypass — forces direct connection
+  curl -v --noproxy '*' http://127.0.0.1:9090/api/health
+  
+  # If noproxy still doesn't work, unset all proxy vars
+  unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY all_proxy ALL_PROXY
+  curl -v http://127.0.0.1:9090/api/health
+  
+  # Verify what proxy curl would use
+  echo "http_proxy=$http_proxy https_proxy=$https_proxy no_proxy=$no_proxy"
+  ```

--- a/optional-skills/security/linux-security-guardian/SKILL.md
+++ b/optional-skills/security/linux-security-guardian/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: linux-security-guardian
+description: |-
+  Linux server security health check — 5-dimension assessment covering SSH hardening,
+  firewall & network, system hardening, user privileges, and operational security.
+  Outputs a scored report with prioritized fix commands. Like a health checkup for your server.
+platforms: [linux]
+category: security
+triggers:
+  - "security check"
+  - "security health check"
+  - "server security audit"
+  - "hardening check"
+  - "Linux security scan"
+  - "检查服务器安全"
+  - "安全体检"
+  - "服务器安全加固"
+toolsets:
+  - terminal
+  - file
+---
+
+# 🛡️ Linux Security Guardian
+
+> **One-liner**: A lightweight security health check for Linux servers — like running a system
+> diagnostic, but for security. Covers SSH, firewall, system hardening, user privileges, and
+> operational security. Outputs a scored report with prioritized fix commands.
+
+**Target users**: Developers, small-team ops, self-hosters who manage Linux servers
+**Time**: First run ~5 min (to understand results), subsequent runs ~30 sec
+**Output**: Scored report (0-100) + prioritized fix list
+
+---
+
+## When to Use
+
+| Scenario | When | Frequency |
+|----------|------|-----------|
+| 🆕 New server | Just provisioned a VPS or bare metal | Once |
+| 📅 Routine | Weekly/monthly maintenance | Weekly |
+| 🔔 Incident | After suspicious log entries or alerts | On-demand |
+| 🏗️ Pre-deploy | Before launching a new service | Per deploy |
+| 🔄 Post-change | After kernel upgrade or major software install | Per change |
+
+## Quick Start
+
+Just say:
+
+> "Run a security health check on this server"
+
+The agent will automatically:
+1. Check SSH configuration (port, auth methods, root login, keys)
+2. Audit network/firewall state (ufw status, open ports)
+3. Scan system hardening (updates, file permissions, npm)
+4. Review user privileges (empty passwords, sudo users, failed logins)
+5. Verify operational security (fail2ban, auto-updates, logging)
+6. Calculate a composite score
+7. Output a prioritized fix list
+
+## Security Scoring
+
+| Score | Grade | Label | Meaning |
+|-------|-------|-------|---------|
+| 90-100 | A | 🛡️ Excellent | Baseline security in place |
+| 70-89 | B | ⚠️ Good | Minor optimizations available |
+| 50-69 | C | 🔶 Fair | Notable risks — recommend fixes |
+| 0-49 | D | 🔴 Poor | Critical gaps — fix immediately |
+
+**Weights**: SSH 25% / Network 25% / System 20% / User 20% / Ops 10%
+
+## Check Details
+
+### ① SSH Security (25%)
+
+| Check | Pass | Fail | Fix |
+|-------|------|------|-----|
+| Non-default port | Port ≠ 22 | Using port 22 | Edit `/etc/ssh/sshd_config` |
+| Password auth disabled | `PasswordAuthentication no` | Password login allowed | `sed -i 's/yes$/no/'` on config |
+| Root login disabled | `PermitRootLogin no` | Root can SSH directly | Same file, change to `no` |
+| Key auth configured | `~/.ssh/authorized_keys` exists | No keys | `ssh-keygen` then copy pubkey |
+| Protocol version | Protocol 2 only | v1 enabled | Default modern SSH |
+
+### ② Network & Firewall (25%)
+
+| Check | Pass | Fail | Fix |
+|-------|------|------|-----|
+| Firewall active | `ufw active` or iptables rules | No firewall | `ufw enable` |
+| Minimal open ports | Only necessary ports open | Unexpected listeners | `ufw deny <port>` |
+| Services bound locally | DB/cache on 127.0.0.1 | Services on 0.0.0.0 | Config bind address |
+
+### ③ System Hardening (20%)
+
+| Check | Pass | Fail | Fix |
+|-------|------|------|-----|
+| System updates | `apt list --upgradable` empty | Pending updates | `apt update && apt upgrade` |
+| Shadow permissions | `/etc/shadow` 600/640 | Too permissive | `chmod 640 /etc/shadow` |
+| /tmp sticky bit | Sticky bit set | Missing | `chmod +t /tmp` |
+| npm global packages | No known malicious packages | Blocklisted package found | `npm uninstall -g <pkg>` |
+
+### ④ User Privileges (20%)
+
+| Check | Pass | Fail | Fix |
+|-------|------|------|-----|
+| No empty passwords | All users have passwords | Empty password found | `passwd -l <user>` |
+| Sudo group minimal | Expected users only | Unexpected sudoer | `gpasswd -d <user> sudo` |
+| Failed logins | No recent spikes | Many recent failures | Check `/var/log/auth.log` |
+
+### ⑤ Operational Security (10%)
+
+| Check | Pass | Fail | Fix |
+|-------|------|------|-----|
+| fail2ban running | `systemctl is-active fail2ban` = active | Not running | `systemctl enable --now fail2ban` |
+| Auto-updates | `unattended-upgrades` configured | Not configured | `apt install unattended-upgrades` |
+| Logging active | rsyslog/journald running | Logging stopped | `systemctl start rsyslog` |
+
+## Example Output
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  🛡️ Linux Security Guardian
+  Server: 203.0.113.42
+  Time: 2026-05-18 22:30 UTC
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+📊 Score: 72/100 (B — Good)
+
+① SSH Security:      75/100  ⚠️
+  ✅ Port changed (non-22)
+  ✅ Root login disabled
+  ❌ Password login still allowed
+  ✅ SSH keys configured
+
+② Network & Firewall: 80/100  ⚠️
+  ✅ ufw active
+  ⚠️ Port 3000 exposed (close if unused)
+
+③ System Hardening:  60/100  🔶
+  ❌ 12 pending security updates
+  ✅ /etc/shadow permissions OK
+  ✅ npm packages clean
+
+④ User Privileges:   80/100  ⚠️
+  ✅ No empty-password users
+  ✅ Sudo group looks correct
+
+⑤ Ops Security:      60/100  🔶
+  ✅ fail2ban running
+  ❌ Auto-updates not configured
+
+📋 Fix Priority:
+  [HIGH]   Disable SSH password login
+  [HIGH]   Install security updates
+  [MEDIUM] Configure unattended-upgrades
+```
+
+## Verification
+
+After applying fixes, re-run the check to confirm the score improved.
+For SSH changes, test login in a separate session before closing the active one.
+
+## Pitfalls
+
+- **SSH lockout risk**: When disabling password auth, ensure key auth works FIRST.
+  Keep the active SSH session open while testing a new one.
+- **ufw reset warning**: If a cloud provider's metadata service uses a specific port,
+  `ufw enable` may block it. Whitelist cloud metadata IPs (e.g. 169.254.169.254).
+- **fail2ban false bans**: If you SSH from variable IPs, set `ignoreip` in jail.local.
+- **npm global packages**: Some packages legitimately use postinstall scripts.
+  Always review the script content before flagging as malicious.

--- a/optional-skills/security/linux-security-guardian/SKILL.md
+++ b/optional-skills/security/linux-security-guardian/SKILL.md
@@ -58,7 +58,16 @@ Before running any checks, collect the environment baseline:
 uname -a
 cat /etc/os-release
 
-# Uptime & load — spikes may indicate compromise
+# Package manager detection (Debian/Ubuntu -> apt, RHEL/CentOS -> dnf/yum)
+apt --version >/dev/null 2>&1 && echo "package_manager=apt"
+dpkg --version >/dev/null 2>&1 && echo "dpkg=available"
+
+# Firewall detection
+ufw status >/dev/null 2>&1 && echo "firewall=ufw"
+firewall-cmd --state 2>/dev/null && echo "firewall=firewalld"
+sudo -n iptables -L -n 2>/dev/null | head -3 >/dev/null && echo "firewall=iptables"
+
+# Uptime & load
 uptime
 
 # Who is logged in
@@ -69,10 +78,12 @@ sudo -n true 2>/dev/null && echo "has_sudo" || echo "no_sudo"
 ```
 
 From the output:
-- Note the distro/version (check against Debian/Ubuntu assumption)
-- Record `has_sudo` or `no_sudo` — this gates which Phase 2 checks are possible
+- Record `package_manager` and `firewall` — these select the audit command variants below
+- **Debian/Ubuntu (apt + ufw)**: Use the default commands shown in each section
+- **RHEL/CentOS (dnf/yum + firewalld)**: Swap `apt` -> `dnf`, `ufw` -> `firewall-cmd`; see "Alternatives" at the end of Phase 2
+- Record `has_sudo` or `no_sudo` — gates which checks are possible
 
-Report the environment to the user before proceeding.
+Report the detected package manager and firewall type to the user before proceeding.
 
 ---
 
@@ -125,7 +136,9 @@ Pass conditions:
 ```bash
 # C6: Firewall active (9 pts)
 ufw status 2>/dev/null || echo "not-installed"
-# Also check iptables if ufw absent:
+# RHEL/CentOS alternative:
+firewall-cmd --state 2>/dev/null || echo "firewalld-not-running"
+# Fallback if neither:
 sudo -n iptables -L -n 2>/dev/null | head -5 || echo "no-iptables-access"
 
 # C7: Minimal open ports (9 pts)
@@ -153,6 +166,8 @@ If the user marks any as unexpected, record a fail.
 ```bash
 # C9: Security updates (5 pts)
 apt list --upgradable 2>/dev/null | grep -i security | wc -l
+# RHEL/CentOS alternative:
+dnf updateinfo list security 2>/dev/null | grep -c "security" || echo "0"
 
 # C10: Shadow permissions (5 pts)
 stat -c '%a' /etc/shadow 2>/dev/null
@@ -200,6 +215,8 @@ systemctl is-active fail2ban 2>/dev/null
 
 # C17: Auto-updates (3 pts)
 dpkg -l unattended-upgrades 2>/dev/null | grep -c '^ii'
+# RHEL/CentOS alternative:
+rpm -q --quiet dnf-automatic 2>/dev/null && echo "1" || echo "0"
 
 # C18: Logging (3 pts)
 systemctl is-active rsyslog 2>/dev/null || journalctl -n 1 2>/dev/null | wc -l
@@ -211,6 +228,17 @@ Pass conditions:
 | C16 fail2ban | Output is `active` |
 | C17 Auto-updates | ≥ 1 (package installed) |
 | C18 Logging | Service active OR journalctl has output |
+
+### 2.6 Alternatives for Non-Debian/Ubuntu
+
+| Check | Debian/Ubuntu (default) | RHEL/CentOS |
+|-------|------------------------|-------------|
+| C6 Firewall | `ufw status` | `firewall-cmd --state` |
+| C7 Open ports | `ss -tlnp` | `ss -tlnp` (same) |
+| C9 Updates | `apt list --upgradable \| grep security` | `dnf updateinfo list security` |
+| C17 Auto-updates | `dpkg -l unattended-upgrades` | `rpm -q dnf-automatic` |
+
+When the user's distro is **not** Debian/Ubuntu, map to the RHEL/CentOS column. For other distros (Arch, Fedora, etc.), use the equivalent native tool (e.g. `pacman -Qe` for Arch).
 
 ---
 

--- a/optional-skills/security/linux-security-guardian/SKILL.md
+++ b/optional-skills/security/linux-security-guardian/SKILL.md
@@ -244,6 +244,65 @@ When the user's distro is **not** Debian/Ubuntu, map to the RHEL/CentOS column. 
 
 ## Phase 3: Score & Report
 
+### Deterministic Scoring Rubric
+
+Each check has an exact, machine-verifiable pass/fail condition. For subjective
+checks (C7, C14, C15), the agent must prompt the user for judgment and record
+the answer as part of the JSON state. This ensures repeated runs on the same
+state produce identical results.
+
+| Check | Weight | Pass condition (exact) | Fail condition |
+|-------|--------|----------------------|----------------|
+| C1 Port | 5 pts | `grep -E '^Port\s+' /etc/ssh/sshd_config` returns a number ≠ 22 | No Port line or Port 22 |
+| C2 PasswordAuth | 5 pts | `grep -E '^PasswordAuthentication\s+'` returns `no` | Returns `yes` or line absent with `yes` override |
+| C3 RootLogin | 5 pts | `grep -E '^PermitRootLogin\s+'` returns `no` | Returns `yes` or `prohibit-password` or absent |
+| C4 Keys | 5 pts | `authorized_keys` exists AND has ≥ 1 line | File missing or empty |
+| C5 Protocol | 5 pts | `grep -E '^Protocol\s+1'` returns no match | Protocol 1 present |
+| C6 Firewall | 9 pts | `ufw status` → `active` OR `firewall-cmd --state` → running OR iptables rules exist | No firewall detected |
+| C7 Open ports | 9 pts | User confirms all exposed ports are expected | Any unexpected port marked by user |
+| C8 Local bind | 7 pts | No WARN for 6379/5432/3306/27017/11211 on 0.0.0.0 | Any WARN |
+| C9 Security updates | 5 pts | Count of pending security updates = 0 | Count > 0 |
+| C10 Shadow | 5 pts | `stat -c '%a' /etc/shadow` = 600 or 640 | Any other value or permission error |
+| C11 Sticky bit | 5 pts | `stat -c '%a' /tmp` starts with `1` | Doesn't start with `1` |
+| C12 npm | 5 pts | Global package count ≤ 10 | Count > 10 |
+| C13 Empty pwd | 7 pts | No output from `/etc/shadow` scan | Any user with empty password (skip if no sudo) |
+| C14 Sudo group | 7 pts | User confirms all sudo members are authorized | Any unauthorized user flagged by user |
+| C15 Failed logins | 6 pts | `lastb` count < 10 | Count ≥ 10 |
+| C16 fail2ban | 4 pts | `systemctl is-active fail2ban` → `active` | Any other status or service not found |
+| C17 Auto-updates | 3 pts | `unattended-upgrades` installed (Debian) or `dnf-automatic` (RHEL) | Neither installed |
+| C18 Logging | 3 pts | `rsyslog` active OR `journalctl -n 1` returns output | Neither works |
+
+**Total possible: 100 pts**
+
+The scoring algorithm:
+```python
+DIMENSIONS = {
+    "SSH Security":       {"weight": 25, "checks": [5, 5, 5, 5, 5]},
+    "Network & Firewall": {"weight": 25, "checks": [9, 9, 7]},
+    "System Hardening":   {"weight": 20, "checks": [5, 5, 5, 5]},
+    "User Privileges":    {"weight": 20, "checks": [7, 7, 6]},
+    "Operational Security":{"weight": 10, "checks": [4, 3, 3]},
+}
+
+composite = 0
+for dim_name, dim in DIMENSIONS.items():
+    raw_score = sum(pts for pts, r in zip(dim["checks"], dim_results[dim_name]) if r == "pass")
+    max_possible = sum(dim["checks"])
+    dim_pct = round(raw_score / max_possible * 100)
+    weighted = dim_pct * dim["weight"] / 100
+    composite += weighted
+composite = round(composite)
+```
+
+For **subjective checks** (C7, C14, C15):
+- The agent must prompt the user with the data
+- Record user's response as the pass/fail value
+- Include the prompt and response in the report for reproducibility
+
+For **unrunnable checks** (C13 without sudo):
+- Record as `unable` — award 0 pts, note in coverage
+- `max_possible` stays unchanged to honestly reflect incomplete coverage
+
 Calculate the composite score:
 
 ```python

--- a/optional-skills/security/linux-security-guardian/SKILL.md
+++ b/optional-skills/security/linux-security-guardian/SKILL.md
@@ -4,7 +4,8 @@ description: |-
   Linux server security health check — 5-dimension assessment covering SSH hardening,
   firewall & network, system hardening, user privileges, and operational security.
   Outputs a scored report with prioritized fix commands. Like a health checkup for your server.
-platforms: [linux]
+  The agent runs all checks automatically, then offers to apply high-priority fixes interactively.
+platforms: [debian, ubuntu]
 category: security
 triggers:
   - "security check"
@@ -22,148 +23,341 @@ toolsets:
 
 # 🛡️ Linux Security Guardian
 
-> **One-liner**: A lightweight security health check for Linux servers — like running a system
-> diagnostic, but for security. Covers SSH, firewall, system hardening, user privileges, and
-> operational security. Outputs a scored report with prioritized fix commands.
+> **One-liner**: A lightweight, agent-driven security health check for Debian/Ubuntu servers.
+> The agent automatically audits SSH, firewall, system hardening, user privileges, and
+> operational security, produces a scored report, and interactively applies high-priority fixes.
 
-**Target users**: Developers, small-team ops, self-hosters who manage Linux servers
-**Time**: First run ~5 min (to understand results), subsequent runs ~30 sec
-**Output**: Scored report (0-100) + prioritized fix list
+**Target distribution**: Debian / Ubuntu (uses `apt` and `ufw`)
+**Target users**: Developers, small-team ops, self-hosters
+**Time**: Automated audit ~30s; with interactive fixes ~2-3 min
 
 ---
 
-## When to Use
+## ⚠️ Safety Guardrails
 
-| Scenario | When | Frequency |
-|----------|------|-----------|
-| 🆕 New server | Just provisioned a VPS or bare metal | Once |
-| 📅 Routine | Weekly/monthly maintenance | Weekly |
-| 🔔 Incident | After suspicious log entries or alerts | On-demand |
-| 🏗️ Pre-deploy | Before launching a new service | Per deploy |
-| 🔄 Post-change | After kernel upgrade or major software install | Per change |
+These are **hard rules**. Violating them invalidates the check and may lock you out of the server.
 
-## Quick Start
+1. **Never modify SSH config without user confirmation.** Before any `sed` or file edit
+   on `/etc/ssh/sshd_config`, show the exact change to the user and ask: *"Apply this change? (y/N)"*
+2. **Test SSH access before closing the session.** After any SSH config change, ask the user to
+   open a SECOND terminal and verify login BEFORE the current session is closed.
+3. **Root-only checks must detect privilege first.** Run `sudo -n true 2>/dev/null` before any
+   `sudo` command. If it fails, skip the check and note it in the report.
+4. **Never blindly run `apt upgrade`.** Show the pending package list and ask for confirmation.
+5. **Fix, then verify.** After applying any fix, re-run the relevant check(s) and confirm the
+   score improved. Report the before/after delta.
 
-Just say:
+---
 
-> "Run a security health check on this server"
+## Phase 1: Discover Environment
 
-The agent will automatically:
-1. Check SSH configuration (port, auth methods, root login, keys)
-2. Audit network/firewall state (ufw status, open ports)
-3. Scan system hardening (updates, file permissions, npm)
-4. Review user privileges (empty passwords, sudo users, failed logins)
-5. Verify operational security (fail2ban, auto-updates, logging)
-6. Calculate a composite score
-7. Output a prioritized fix list
+Before running any checks, collect the environment baseline:
 
-## Security Scoring
+```bash
+# Kernel & distro
+uname -a
+cat /etc/os-release
 
-| Score | Grade | Label | Meaning |
-|-------|-------|-------|---------|
-| 90-100 | A | 🛡️ Excellent | Baseline security in place |
-| 70-89 | B | ⚠️ Good | Minor optimizations available |
-| 50-69 | C | 🔶 Fair | Notable risks — recommend fixes |
-| 0-49 | D | 🔴 Poor | Critical gaps — fix immediately |
+# Uptime & load — spikes may indicate compromise
+uptime
 
-**Weights**: SSH 25% / Network 25% / System 20% / User 20% / Ops 10%
+# Who is logged in
+who
 
-## Check Details
+# sudo capability
+sudo -n true 2>/dev/null && echo "has_sudo" || echo "no_sudo"
+```
 
-### ① SSH Security (25%)
+From the output:
+- Note the distro/version (check against Debian/Ubuntu assumption)
+- Record `has_sudo` or `no_sudo` — this gates which Phase 2 checks are possible
 
-| Check | Pass | Fail | Fix |
-|-------|------|------|-----|
-| Non-default port | Port ≠ 22 | Using port 22 | Edit `/etc/ssh/sshd_config` |
-| Password auth disabled | `PasswordAuthentication no` | Password login allowed | `sed -i 's/yes$/no/'` on config |
-| Root login disabled | `PermitRootLogin no` | Root can SSH directly | Same file, change to `no` |
-| Key auth configured | `~/.ssh/authorized_keys` exists | No keys | `ssh-keygen` then copy pubkey |
-| Protocol version | Protocol 2 only | v1 enabled | Default modern SSH |
+Report the environment to the user before proceeding.
 
-### ② Network & Firewall (25%)
+---
 
-| Check | Pass | Fail | Fix |
-|-------|------|------|-----|
-| Firewall active | `ufw active` or iptables rules | No firewall | `ufw enable` |
-| Minimal open ports | Only necessary ports open | Unexpected listeners | `ufw deny <port>` |
-| Services bound locally | DB/cache on 127.0.0.1 | Services on 0.0.0.0 | Config bind address |
+## Phase 2: Run Audit (5 Dimensions)
 
-### ③ System Hardening (20%)
+Execute each check group in order. For every check:
 
-| Check | Pass | Fail | Fix |
-|-------|------|------|-----|
-| System updates | `apt list --upgradable` empty | Pending updates | `apt update && apt upgrade` |
-| Shadow permissions | `/etc/shadow` 600/640 | Too permissive | `chmod 640 /etc/shadow` |
-| /tmp sticky bit | Sticky bit set | Missing | `chmod +t /tmp` |
-| npm global packages | No known malicious packages | Blocklisted package found | `npm uninstall -g <pkg>` |
+1. Run the **audit command**.
+2. Compare output against the **pass condition**.
+3. Record **pass** or **fail** for the check.
+4. If **fail**: record the **fix command** (do NOT execute yet).
+5. Accumulate the raw score.
 
-### ④ User Privileges (20%)
+Format the result as a flat JSON structure for scoring in Phase 3.
 
-| Check | Pass | Fail | Fix |
-|-------|------|------|-----|
-| No empty passwords | All users have passwords | Empty password found | `passwd -l <user>` |
-| Sudo group minimal | Expected users only | Unexpected sudoer | `gpasswd -d <user> sudo` |
-| Failed logins | No recent spikes | Many recent failures | Check `/var/log/auth.log` |
+### 2.1 SSH Security (25%)
 
-### ⑤ Operational Security (10%)
+Audit all 5 checks:
 
-| Check | Pass | Fail | Fix |
-|-------|------|------|-----|
-| fail2ban running | `systemctl is-active fail2ban` = active | Not running | `systemctl enable --now fail2ban` |
-| Auto-updates | `unattended-upgrades` configured | Not configured | `apt install unattended-upgrades` |
-| Logging active | rsyslog/journald running | Logging stopped | `systemctl start rsyslog` |
+```bash
+# C1: Non-default port (5 pts)
+# If output is empty (line commented or absent), Port 22 is the default → fail
+# If output shows Port ≠ 22 → pass
+grep -E '^Port\s+' /etc/ssh/sshd_config
 
-## Example Output
+# C2: Password auth disabled (5 pts)
+grep -E '^PasswordAuthentication\s+' /etc/ssh/sshd_config
+
+# C3: Root login disabled (5 pts)
+grep -E '^PermitRootLogin\s+' /etc/ssh/sshd_config
+
+# C4: Key auth configured (5 pts)
+ls ~/.ssh/authorized_keys 2>/dev/null && wc -l < ~/.ssh/authorized_keys
+
+# C5: Protocol version (5 pts) — modern SSH defaults to v2; Protocol 1 is the fail
+grep -E '^Protocol\s+1' /etc/ssh/sshd_config
+```
+
+Pass conditions:
+| Check | Pass if |
+|-------|---------|
+| C1 Port | Output contains a `Port` line with a number ≠ 22 |
+| C2 PasswordAuth | Output is `PasswordAuthentication no` (or line absent AND no `yes` override) |
+| C3 RootLogin | Output is `PermitRootLogin no` |
+| C4 Keys | File exists and has ≥ 1 line |
+| C5 Protocol | No line matching `Protocol 1` |
+
+### 2.2 Network & Firewall (25%)
+
+```bash
+# C6: Firewall active (9 pts)
+ufw status 2>/dev/null || echo "not-installed"
+# Also check iptables if ufw absent:
+sudo -n iptables -L -n 2>/dev/null | head -5 || echo "no-iptables-access"
+
+# C7: Minimal open ports (9 pts)
+# List all public listeners (non-127.0.0.1)
+ss -tlnp | awk 'NR>1{print $4}' | grep -v 127.0.0.1 | sed 's/.*://'
+
+# C8: Services bound locally (7 pts) — check common DB/cache ports
+for port in 6379 5432 3306 27017 11211; do
+  ss -tlnp | grep -q "0.0.0.0:$port" && echo "WARN: port $port on 0.0.0.0"
+done
+```
+
+Pass conditions:
+| Check | Pass if |
+|-------|---------|
+| C6 Firewall | `ufw status` shows `active`, OR iptables has rules |
+| C7 Open ports | Only expected service ports (SSH, HTTP/S, etc.) are public |
+| C8 Local bind | No WARN lines (DB/cache bound to 0.0.0.0) |
+
+For C7, prompt the user: *"These ports are exposed. Are any unexpected? (y/N)"*
+If the user marks any as unexpected, record a fail.
+
+### 2.3 System Hardening (20%)
+
+```bash
+# C9: Security updates (5 pts)
+apt list --upgradable 2>/dev/null | grep -i security | wc -l
+
+# C10: Shadow permissions (5 pts)
+stat -c '%a' /etc/shadow 2>/dev/null
+
+# C11: /tmp sticky bit (5 pts)
+stat -c '%a' /tmp 2>/dev/null | grep -q '^1' && echo "sticky" || echo "no-sticky"
+
+# C12: npm global packages (5 pts)
+npm ls -g --depth=0 2>/dev/null | tail -n +2 | wc -l
+```
+
+Pass conditions:
+| Check | Pass if |
+|-------|---------|
+| C9 Security updates | Output is `0` (no security upgrades pending) |
+| C10 Shadow | Output is `600` or `640` |
+| C11 Sticky bit | Output is `sticky` |
+| C12 npm | ≤ 10 global packages (alert user if more) |
+
+### 2.4 User Privileges (20%)
+
+```bash
+# C13: Empty passwords (7 pts)
+sudo -n awk -F: '($2 == "" || $2 == "!") {print $1}' /etc/shadow 2>/dev/null
+
+# C14: Sudo group (7 pts)
+getent group sudo 2>/dev/null | cut -d: -f4
+
+# C15: Failed logins (6 pts)
+lastb 2>/dev/null | wc -l
+```
+
+Pass conditions:
+| Check | Pass if |
+|-------|---------|
+| C13 Empty passwords | No output (or only system accounts) — **requires sudo** |
+| C14 Sudo group | Output shows only expected system administrators |
+| C15 Failed logins | < 10 recent entries (subjective; flag to user if high) |
+
+### 2.5 Operational Security (10%)
+
+```bash
+# C16: fail2ban (4 pts)
+systemctl is-active fail2ban 2>/dev/null
+
+# C17: Auto-updates (3 pts)
+dpkg -l unattended-upgrades 2>/dev/null | grep -c '^ii'
+
+# C18: Logging (3 pts)
+systemctl is-active rsyslog 2>/dev/null || journalctl -n 1 2>/dev/null | wc -l
+```
+
+Pass conditions:
+| Check | Pass if |
+|-------|---------|
+| C16 fail2ban | Output is `active` |
+| C17 Auto-updates | ≥ 1 (package installed) |
+| C18 Logging | Service active OR journalctl has output |
+
+---
+
+## Phase 3: Score & Report
+
+Calculate the composite score:
+
+```python
+DIMENSIONS = {
+    "SSH Security":       {"weight": 25, "checks": [5, 5, 5, 5, 5]},       # 5 checks
+    "Network & Firewall": {"weight": 25, "checks": [9, 9, 7]},            # 3 checks
+    "System Hardening":   {"weight": 20, "checks": [5, 5, 5, 5]},         # 4 checks
+    "User Privileges":    {"weight": 20, "checks": [7, 7, 6]},            # 3 checks
+    "Operational Security":{"weight": 10, "checks": [4, 3, 3]},           # 3 checks
+}
+
+WHEN_UNABLE_TO_CHECK = "skip"  # skip skips the check (0 pts awarded); "exclude" removes it from the dimension
+
+for dim_name, dim in DIMENSIONS.items():
+    passes = [result for result in dim_results[dim_name] if result == "pass"]
+    raw_score = sum(pts for pts, r in zip(dim["checks"], dim_results[dim_name]) if r == "pass")
+    max_possible = sum(dim["checks"])
+    dim_pct = round(raw_score / max_possible * 100)
+    weighted = dim_pct * dim["weight"] / 100
+    composite += weighted
+
+composite = round(composite)
+
+GRADES = [
+    (90, "A", "🛡️ Excellent", "Baseline security in place"),
+    (70, "B", "⚠️ Good", "Minor optimizations available"),
+    (50, "C", "🔶 Fair", "Notable risks — recommend fixes"),
+    (0,  "D", "🔴 Poor", "Critical gaps — fix immediately"),
+]
+```
+
+**When a check cannot be run** (e.g. C13 needs sudo and user declined to provide it):
+- Skip the check (mark as `unable`), award 0 pts for it.
+- Note it in the report: `"C13 Empty passwords — skipped (requires sudo access)"`.
+- The max_possible DOES NOT change — the report honestly reflects incomplete coverage.
+
+### Report Format
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   🛡️ Linux Security Guardian
-  Server: 203.0.113.42
-  Time: 2026-05-18 22:30 UTC
+  Server: <hostname>
+  Time: <ISO-8601 timestamp>
+  Coverage: 14/18 checks (4 skipped — needs sudo)
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-📊 Score: 72/100 (B — Good)
+📊 Score: <N>/100 (<Grade> — <Label>)
 
-① SSH Security:      75/100  ⚠️
-  ✅ Port changed (non-22)
-  ✅ Root login disabled
-  ❌ Password login still allowed
-  ✅ SSH keys configured
+① SSH Security:      <N>/100 <emoji>
+  ✅ <passing check>
+  ❌ <failing check>     ← fix: <fix command>
 
-② Network & Firewall: 80/100  ⚠️
-  ✅ ufw active
-  ⚠️ Port 3000 exposed (close if unused)
+② Network & Firewall: <N>/100 <emoji>
+  ...
 
-③ System Hardening:  60/100  🔶
-  ❌ 12 pending security updates
-  ✅ /etc/shadow permissions OK
-  ✅ npm packages clean
+③ System Hardening:   ...
 
-④ User Privileges:   80/100  ⚠️
-  ✅ No empty-password users
-  ✅ Sudo group looks correct
+④ User Privileges:    ...
 
-⑤ Ops Security:      60/100  🔶
-  ✅ fail2ban running
-  ❌ Auto-updates not configured
+⑤ Ops Security:      ...
 
 📋 Fix Priority:
-  [HIGH]   Disable SSH password login
-  [HIGH]   Install security updates
-  [MEDIUM] Configure unattended-upgrades
+  [HIGH]   <critical fix 1>
+  [HIGH]   <critical fix 2>
+  [MEDIUM] <medium fix>
+  [LOW]    <nice-to-have fix>
 ```
+
+---
+
+## Phase 4: Interactive Fix
+
+After presenting the report, DO NOT apply fixes automatically. Instead:
+
+1. **Ask**: *"Would you like me to apply the HIGH-priority fixes? (y/N)"*
+2. If yes, apply fixes **one at a time**, with confirmation before each:
+   - Show the fix command and what it changes
+   - Ask: *"Apply this fix? (y/N)"*
+   - If yes, execute; if no, skip and explain the risk
+3. After each fix, re-run the affected check(s) to confirm.
+4. For **SSH config changes**: remind the user to open a second SSH session and verify
+   login BEFORE closing the current one.
+5. **Never** modify `sshd_config` and then close the session in the same turn.
+
+### Fix Commands Reference
+
+| Check | Fix Command |
+|-------|-------------|
+| C1 Port | Suggest changing port in `/etc/ssh/sshd_config` |
+| C2 PasswordAuth | `sed -i 's/^PasswordAuthentication yes$/PasswordAuthentication no/' /etc/ssh/sshd_config && sshd -t` |
+| C3 RootLogin | Edit `PermitRootLogin no` in `/etc/ssh/sshd_config` |
+| C4 Keys | `ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519 -N "" && cat ~/.ssh/id_ed25519.pub >> ~/.ssh/authorized_keys` |
+| C6 Firewall | `ufw allow <ssh-port> && ufw enable` |
+| C7 Exposed | `ufw deny <port>` |
+| C8 Local bind | Show config file paths for each exposed service |
+| C9 Updates | Show `apt list --upgradable \| grep security` output, ask before `apt upgrade` |
+| C13 Empty pwd | `passwd -l <user>` |
+| C14 Sudo | `gpasswd -d <user> sudo` |
+| C16 fail2ban | `apt install -y fail2ban && systemctl enable --now fail2ban` |
+| C17 Auto-updates | `apt install -y unattended-upgrades && dpkg-reconfigure -plow unattended-upgrades` |
+
+---
 
 ## Verification
 
-After applying fixes, re-run the check to confirm the score improved.
-For SSH changes, test login in a separate session before closing the active one.
+After applying any fix:
+
+1. Re-run the affected check(s):
+   ```bash
+   <audit command from Phase 2>
+   ```
+2. Confirm the check now passes.
+3. Recalculate the composite score and show the before/after delta.
+4. Report: *"Score improved from <before> to <after>. <N> fixes applied."*
+
+For SSH config changes specifically:
+- Run `sshd -t` to validate syntax BEFORE restarting sshd.
+- Tell the user: *"Please open a NEW terminal and SSH in to verify. Keep this session open as a fallback."*
+- Do NOT restart sshd or close the session for the user — they must do this manually for safety.
+
+## Testing the Skill
+
+```bash
+# Quick test — just check SSH checks are accessible
+grep -E '^Port\s+|^PasswordAuthentication\s+|^PermitRootLogin\s+' /etc/ssh/sshd_config
+
+# Full test — run all audit commands (as root or with sudo)
+bash -c "$(grep -E '^\s*# C[0-9]+' SKILL.md | sed 's/.*# C[0-9]\+: //' | tr '\n' ';')"
+```
 
 ## Pitfalls
 
-- **SSH lockout risk**: When disabling password auth, ensure key auth works FIRST.
-  Keep the active SSH session open while testing a new one.
-- **ufw reset warning**: If a cloud provider's metadata service uses a specific port,
-  `ufw enable` may block it. Whitelist cloud metadata IPs (e.g. 169.254.169.254).
-- **fail2ban false bans**: If you SSH from variable IPs, set `ignoreip` in jail.local.
-- **npm global packages**: Some packages legitimately use postinstall scripts.
-  Always review the script content before flagging as malicious.
+- **SSH lockout risk**: The #1 danger. Never modify `sshd_config` without (a) syntax validation
+  via `sshd -t`, (b) user confirmation, and (c) instructing the user to test in a separate session.
+  If the new session fails, the old session is still alive for recovery.
+- **`ufw enable` blocks cloud metadata**: Cloud providers serve metadata at 169.254.169.254.
+  Run `ufw allow from 169.254.169.254` BEFORE `ufw enable`.
+- **fail2ban whitelist**: If the user's SSH client has a dynamic IP (VPN, roaming), set
+  `ignoreip` in `/etc/fail2ban/jail.local` before enabling.
+- **`apt upgrade` without review**: Always show the pending package list. A kernel upgrade
+  triggers a reboot requirement that the user may not be ready for.
+- **npm false positives**: Some packages legitimately use postinstall scripts. Never
+  auto-uninstall; flag for user review with the script content.
+- **Permission gaps**: The report honestly reflects which checks could and could not run.
+  Telling the user *"4 checks need root — run with sudo for full coverage"* is honest.

--- a/optional-skills/security/linux-security-guardian/SKILL.md
+++ b/optional-skills/security/linux-security-guardian/SKILL.md
@@ -296,9 +296,13 @@ After presenting the report, DO NOT apply fixes automatically. Instead:
    - Ask: *"Apply this fix? (y/N)"*
    - If yes, execute; if no, skip and explain the risk
 3. After each fix, re-run the affected check(s) to confirm.
-4. For **SSH config changes**: remind the user to open a second SSH session and verify
+4. For **SSH config changes**: After editing `sshd_config`, run `sshd -t` to validate
+   the config syntax BEFORE restarting sshd. Only proceed if `sshd -t` returns exit
+   code 0. If it fails, display the error output to the user and abort the fix — do not
+   restart sshd or continue applying this change.
+5. For **SSH config changes**: remind the user to open a second SSH session and verify
    login BEFORE closing the current one.
-5. **Never** modify `sshd_config` and then close the session in the same turn.
+6. **Never** modify `sshd_config` and then close the session in the same turn.
 
 ### Fix Commands Reference
 

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -178,6 +178,7 @@ hermes skills uninstall <skill-name>
 | Skill | Description |
 |-------|-------------|
 | [**1password**](/docs/user-guide/skills/optional/security/security-1password) | Set up and use 1Password CLI (op). Use when installing the CLI, enabling desktop app integration, signing in, and reading/injecting secrets for commands. |
+| [**linux-security-guardian**](/docs/user-guide/skills/optional/security/security-linux-security-guardian) | Automated Debian/Ubuntu server security health check covering SSH, firewall, system hardening, user privileges, and ops security. Produces a scored report with interactive fix workflow. |
 | [**oss-forensics**](/docs/user-guide/skills/optional/security/security-oss-forensics) | Supply chain investigation, evidence recovery, and forensic analysis for GitHub repositories. Covers deleted commit recovery, force-push detection, IOC extraction, multi-source evidence collection, hypothesis formation/validation, and st... |
 | [**sherlock**](/docs/user-guide/skills/optional/security/security-sherlock) | OSINT username search across 400+ social networks. Hunt down social media accounts by username. |
 


### PR DESCRIPTION
# 🛡️ Linux Security Guardian — Server Security Health Check

Adds a new optional skill for Linux server security auditing.

## What it does

A lightweight security health check covering 5 dimensions:
1. **SSH Security** (25%) — port, password auth, root login, key auth
2. **Network & Firewall** (25%) — ufw status, open ports, service binding
3. **System Hardening** (20%) — updates, file permissions, npm audit
4. **User Privileges** (20%) — empty passwords, sudo users, failed logins
5. **Operational Security** (10%) — fail2ban, auto-updates, logging

Outputs a scored report (0-100) with prioritized fix commands.

## Why

Most Linux security tools are either too heavy (Wazuh, OSSEC) or too manual.
This fills the gap — a 30-second automated check any Hermes user can run on their servers.

## Files
- `optional-skills/security/linux-security-guardian/SKILL.md`

## Testing
1. Place in `~/.hermes/skills/security/linux-security-guardian/`
2. Run: "Run a security health check on this server"
