### PR TITLE
feat(providers): add Requesty AI gateway

### DIFF
--- a/plugins/model-providers/requesty/__init__.py
+++ b/plugins/model-providers/requesty/__init__.py
@@ -7,7 +7,7 @@ from providers.base import ProviderProfile
 
 
 class RequestyProfile(ProviderProfile):
-    """Requesty — attribution headers + reasoning config passthrough."""
+    """Requesty — reasoning config passthrough."""
 
     def build_api_kwargs_extras(
         self,
@@ -33,10 +33,6 @@ requesty = RequestyProfile(
     signup_url="https://app.requesty.ai/api-keys",
     base_url="https://router.requesty.ai/v1",
     models_url="https://router.requesty.ai/v1/models",
-    default_headers={
-        "HTTP-Referer": "https://hermes-agent.nousresearch.com",
-        "X-Title": "Hermes Agent",
-    },
     default_aux_model="anthropic/claude-sonnet-4-6",
     fallback_models=(
         "anthropic/claude-sonnet-4-6",

--- a/plugins/model-providers/requesty/__init__.py
+++ b/plugins/model-providers/requesty/__init__.py
@@ -1,0 +1,49 @@
+"""Requesty AI gateway provider profile."""
+
+from typing import Any
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+class RequestyProfile(ProviderProfile):
+    """Requesty — attribution headers + reasoning config passthrough."""
+
+    def build_api_kwargs_extras(
+        self,
+        *,
+        reasoning_config: dict | None = None,
+        supports_reasoning: bool = True,
+        **ctx: Any,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        extra_body: dict[str, Any] = {}
+        if supports_reasoning and reasoning_config is not None:
+            extra_body["reasoning"] = dict(reasoning_config)
+        elif supports_reasoning:
+            extra_body["reasoning"] = {"enabled": True, "effort": "medium"}
+        return extra_body, {}
+
+
+requesty = RequestyProfile(
+    name="requesty",
+    aliases=("rq",),
+    env_vars=("REQUESTY_API_KEY",),
+    display_name="Requesty",
+    description="Requesty — unified AI gateway for 300+ models",
+    signup_url="https://app.requesty.ai/api-keys",
+    base_url="https://router.requesty.ai/v1",
+    models_url="https://router.requesty.ai/v1/models",
+    default_headers={
+        "HTTP-Referer": "https://hermes-agent.nousresearch.com",
+        "X-Title": "Hermes Agent",
+    },
+    default_aux_model="anthropic/claude-sonnet-4-6",
+    fallback_models=(
+        "anthropic/claude-sonnet-4-6",
+        "anthropic/claude-opus-4-7",
+        "openai/gpt-5.5",
+        "vertex/gemini-3.1-pro-preview:flex",
+    ),
+)
+
+register_provider(requesty)

--- a/plugins/model-providers/requesty/plugin.yaml
+++ b/plugins/model-providers/requesty/plugin.yaml
@@ -1,0 +1,5 @@
+name: requesty-provider
+kind: model-provider
+version: 1.0.0
+description: Requesty AI gateway
+author: Requesty

--- a/tests/providers/test_plugin_discovery.py
+++ b/tests/providers/test_plugin_discovery.py
@@ -68,7 +68,7 @@ def test_all_profiles_register():
     # Spot-check representative providers from different categories
     for required in (
         "openrouter", "anthropic", "custom", "bedrock", "openai-codex",
-        "minimax-oauth", "gmi", "xiaomi", "alibaba-coding-plan",
+        "minimax-oauth", "gmi", "xiaomi", "alibaba-coding-plan", "requesty",
     ):
         assert required in names, f"Missing profile: {required}"
 

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -46,6 +46,22 @@ class TestNvidiaProfile:
         assert p.default_headers == {}
 
 
+class TestRequestyProfile:
+    def test_discovery_and_name(self):
+        p = get_provider_profile("requesty")
+        assert p is not None
+        assert p.name == "requesty"
+
+    def test_alias_resolves(self):
+        assert get_provider_profile("rq").name == "requesty"
+
+    def test_no_attribution_headers(self):
+        # Attribution headers (HTTP-Referer / X-Title) must not be sent by
+        # default — see openrouter, which sets none. Regression guard.
+        p = get_provider_profile("requesty")
+        assert p.default_headers == {}
+
+
 class TestKimiProfile:
     def test_temperature_omit(self):
         p = get_provider_profile("kimi")

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -20,6 +20,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **GitHub Copilot ACP** | `hermes model` (spawns local `copilot --acp --stdio`) |
 | **Anthropic** | `hermes model` (Claude Max + extra usage credits via OAuth; also supports Anthropic API key or manual setup-token — see note below) |
 | **OpenRouter** | `OPENROUTER_API_KEY` in `~/.hermes/.env` |
+| **Requesty** | `REQUESTY_API_KEY` in `~/.hermes/.env` (provider: `requesty`, alias: `rq`, 300+ models, fallback routing, auto-caching) |
 | **NovitaAI** | `NOVITA_API_KEY` in `~/.hermes/.env` (provider: `novita`, 200+ models, Model API, Agent Sandbox, GPU Cloud) |
 | **z.ai / GLM** | `GLM_API_KEY` in `~/.hermes/.env` (provider: `zai`) |
 | **Kimi / Moonshot** | `KIMI_API_KEY` in `~/.hermes/.env` (provider: `kimi-coding`) |
@@ -1522,7 +1523,7 @@ fallback_model:
 
 When activated, the fallback swaps the model and provider mid-session without losing your conversation. The chain is tried entry-by-entry; activation is one-shot per session.
 
-Supported providers: `openrouter`, `nous`, `novita`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `gemini`, `google-gemini-cli`, `qwen-oauth`, `huggingface`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `minimax-oauth`, `deepseek`, `nvidia`, `xai`, `xai-oauth`, `ollama-cloud`, `bedrock`, `azure-foundry`, `opencode-zen`, `opencode-go`, `kilocode`, `xiaomi`, `arcee`, `gmi`, `stepfun`, `lmstudio`, `alibaba`, `alibaba-coding-plan`, `tencent-tokenhub`, `custom`.
+Supported providers: `openrouter`, `requesty`, `nous`, `novita`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `gemini`, `google-gemini-cli`, `qwen-oauth`, `huggingface`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `minimax-oauth`, `deepseek`, `nvidia`, `xai`, `xai-oauth`, `ollama-cloud`, `bedrock`, `azure-foundry`, `opencode-zen`, `opencode-go`, `kilocode`, `xiaomi`, `arcee`, `gmi`, `stepfun`, `lmstudio`, `alibaba`, `alibaba-coding-plan`, `tencent-tokenhub`, `custom`.
 
 :::tip
 Fallback is configured exclusively through `config.yaml` — or interactively via `hermes fallback`. For full details on when it triggers, how the chain advances, and how it interacts with auxiliary tasks and delegation, see [Fallback Providers](/user-guide/features/fallback-providers).


### PR DESCRIPTION
## What does this PR do?

Adds [Requesty](https://requesty.ai) as a first-class model provider. Requesty is an OpenAI-compatible AI gateway supporting 300+ models with automatic fallback routing, load balancing, and response caching.

This follows the "fast path" plugin pattern, just two files, no changes to core agent code. The profile auto-wires into the CLI picker, `hermes setup`, `hermes doctor`, runtime resolution, and auxiliary model routing.

## Related Issue

N/A, new provider integration.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/model-providers/requesty/__init__.py`: Provider profile subclass with attribution headers (`X-Title`, `HTTP-Referer`) for Requesty analytics, reasoning config passthrough (`build_api_kwargs_extras`) for reasoning-capable models, and curated fallback model list
- `plugins/model-providers/requesty/plugin.yaml`: Plugin manifest
- `website/docs/integrations/providers.md`: Added Requesty to the provider table and supported providers list

## How to Test

1. Set `REQUESTY_API_KEY` in your environment (get one at https://app.requesty.ai/api-keys)
2. Verify plugin loads:
   ```bash
   python -c "from providers import get_provider_profile; p = get_provider_profile('requesty'); print(p.name, p.base_url, p.default_headers)"
   ```
3. Verify alias resolution:
   ```bash
   python -c "from providers import get_provider_profile; p = get_provider_profile('rq'); print(p.name)"
   ```
4. Run a chat:
   ```bash
   hermes -z "hello" --provider requesty -m anthropic/claude-sonnet-4-6
   ```
5. Existing tests pass:
   ```bash
   python -m pytest tests/hermes_cli/test_runtime_provider_resolution.py tests/run_agent/test_provider_attribution_headers.py -q
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 14.3 (Darwin 23.3.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings)
- [x] No new config keys added so `cli-config.yaml.example` unchanged
- [x] No architecture or workflow changes so `CONTRIBUTING.md`/`AGENTS.md` unchanged
- [x] Pure Python, no platform-specific code, cross-platform safe
- [x] No tool behavior changes

## Screenshots / Logs

```
$ python -c "from providers import get_provider_profile; p = get_provider_profile('requesty'); print(p.name, p.base_url, p.default_headers)"
requesty https://router.requesty.ai/v1 {'HTTP-Referer': 'https://hermes-agent.nousresearch.com', 'X-Title': 'Hermes Agent'}

$ python -m pytest tests/hermes_cli/test_runtime_provider_resolution.py -q
110 passed in 6.94s

$ python -m pytest tests/run_agent/test_provider_attribution_headers.py -q
10 passed in 7.50s
```
