### PR TITLE
fix: guard fcntl.flock(LOCK_UN) with try/except in 5 files

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1823,7 +1823,10 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
         return sum(_results)
     finally:
         if fcntl:
-            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            try:
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            except (OSError, IOError):
+                pass
         elif msvcrt:
             try:
                 msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -954,7 +954,10 @@ def _file_lock(
         finally:
             holder.depth = 0
             if fcntl:
-                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+                try:
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+                except (OSError, IOError):
+                    pass
             elif msvcrt:
                 try:
                     lock_file.seek(0)

--- a/tools/environments/file_sync.py
+++ b/tools/environments/file_sync.py
@@ -289,7 +289,10 @@ class FileSyncManager:
             fcntl.flock(lock_fd, fcntl.LOCK_EX)
             self._sync_back_impl()
         finally:
-            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            try:
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            except (OSError, IOError):
+                pass
             lock_fd.close()
 
     def _sync_back_impl(self) -> None:

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -166,7 +166,10 @@ class MemoryStore:
             yield
         finally:
             if fcntl:
-                fcntl.flock(fd, fcntl.LOCK_UN)
+                try:
+                    fcntl.flock(fd, fcntl.LOCK_UN)
+                except (OSError, IOError):
+                    pass
             elif msvcrt:
                 try:
                     fd.seek(0)

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -86,7 +86,10 @@ def _usage_file_lock():
         yield
     finally:
         if fcntl:
-            fcntl.flock(fd, fcntl.LOCK_UN)
+            try:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            except (OSError, IOError):
+                pass
         elif msvcrt:
             try:
                 fd.seek(0)


### PR DESCRIPTION
## Problem

On POSIX systems, `fcntl.flock(LOCK_UN)` can raise `OSError` (e.g. `EBADF` if the fd was already closed, or `EINTR` on signal delivery). When this happens inside a `finally` block, the subsequent `fd.close()` is skipped — leaking the file descriptor and potentially holding the lock indefinitely.

The `msvcrt` (Windows) path in all these files already wraps the unlock in `try/except`, but the `fcntl` path did not. This inconsistency means the bug only manifests on Linux/macOS.

## Fix

Wrap `fcntl.flock(lock_fd, fcntl.LOCK_UN)` in `try: ... except (OSError, IOError): pass` to match the existing msvcrt pattern. Zero behavioral change on the happy path; prevents fd leaks and exception masking on the error path.

## Files Changed

| File | Context |
|------|---------|
| `tools/environments/file_sync.py` | sync_back file lock |
| `tools/memory_tool.py` | memory write lock |
| `tools/skill_usage.py` | skill usage tracking lock |
| `cron/scheduler.py` | tick lock |
| `hermes_cli/auth.py` | credential pool lock |

## Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| `flock(LOCK_UN)` raises `OSError` | `fd.close()` skipped -> fd leak + lock held forever | Exception caught, `fd.close()` runs normally |
| `flock(LOCK_UN)` succeeds | Works normally | Works normally (no change) |

## Tests

Existing tests cover the happy path. The error path is hard to trigger deterministically (requires fd invalidation or signal delivery during unlock), but the fix is defensive and follows the same pattern already used for the msvcrt branch in each file.