### PR TITLE
fix: close /proc/cmdline file handles in PID scan loop

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -409,7 +409,8 @@ def _scan_gateway_pids(exclude_pids: set[int], all_profiles: bool = False) -> li
                         if pid == my_pid or pid in exclude_pids:
                             continue
                         try:
-                            cmdline = open(f"/proc/{pid}/cmdline", "rb").read().decode("utf-8", errors="replace")
+                            with open(f"/proc/{pid}/cmdline", "rb") as fh:
+                                cmdline = fh.read().decode("utf-8", errors="replace")
                             cmdline = cmdline.replace("\x00", " ")
                             if any(p in cmdline for p in patterns) and (
                                 all_profiles or _matches_current_profile(cmdline)


### PR DESCRIPTION
## Problem

`_find_hermes_pids()` in `hermes_cli/gateway.py` scans `/proc/` to find running Hermes processes. For each PID, it opens `/proc/{pid}/cmdline` but never closes the file handle:

```python
cmdline = open(f"/proc/{pid}/cmdline", "rb").read().decode("utf-8", errors="replace")
```

On a system with hundreds of processes, this leaks hundreds of file descriptors in a single call.

## Fix

Use a `with` statement (context manager) to ensure each handle is closed immediately after reading:

```python
with open(f"/proc/{pid}/cmdline", "rb") as fh:
    cmdline = fh.read().decode("utf-8", errors="replace")
```

## Impact

- Eliminates fd leak in a hot loop (called on every gateway startup and status check)
- No behavioral change on the happy path