### PR TITLE
fix: use atomic writes for persistent JSON state files

### DIFF
--- a/gateway/sticker_cache.py
+++ b/gateway/sticker_cache.py
@@ -13,6 +13,7 @@ import time
 from typing import Optional
 
 from hermes_cli.config import get_hermes_home
+from utils import atomic_json_write
 
 
 CACHE_PATH = get_hermes_home() / "sticker_cache.json"
@@ -36,11 +37,7 @@ def _load_cache() -> dict:
 
 def _save_cache(cache: dict) -> None:
     """Save the sticker cache to disk."""
-    CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
-    CACHE_PATH.write_text(
-        json.dumps(cache, indent=2, ensure_ascii=False),
-        encoding="utf-8",
-    )
+    atomic_json_write(CACHE_PATH, cache)
 
 
 def get_cached_description(file_unique_id: str) -> Optional[dict]:

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -18,6 +18,7 @@ import time
 import uuid
 from abc import ABC, abstractmethod
 from pathlib import Path
+from utils import atomic_json_write
 from typing import IO, Callable, Protocol
 
 from hermes_constants import get_hermes_home
@@ -166,8 +167,7 @@ def _load_json_store(path: Path) -> dict:
 
 def _save_json_store(path: Path, data: dict) -> None:
     """Write *data* as pretty-printed JSON to *path*."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    atomic_json_write(path, data)
 
 
 def _file_mtime_key(host_path: str) -> tuple[float, int] | None:

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -26,6 +26,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from hermes_constants import get_hermes_home
+from utils import atomic_json_write
 from typing import Any, Dict, List, Optional, Tuple, Union
 from urllib.parse import urljoin, urlparse, urlunparse
 
@@ -2594,8 +2595,7 @@ class HubLockFile:
             return {"version": 1, "installed": {}}
 
     def save(self, data: dict) -> None:
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        self.path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n")
+        atomic_json_write(self.path, data)
 
     def record_install(
         self,
@@ -2661,8 +2661,7 @@ class TapsManager:
             return []
 
     def save(self, taps: List[dict]) -> None:
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        self.path.write_text(json.dumps({"taps": taps}, indent=2) + "\n")
+        atomic_json_write(self.path, {"taps": taps})
 
     def add(self, repo: str, path: str = "skills/") -> bool:
         """Add a tap. Returns False if already exists."""


### PR DESCRIPTION
## Problem

Several files write persistent JSON state (installed skills registry, taps config, sticker cache, environment store) using `write_text()` directly. If the process crashes or loses power mid-write, the file is left in a partially-written state — corrupted JSON that causes `JSONDecodeError` on next read.

## Fix

Replace `write_text()` with the existing `atomic_json_write()` helper from `utils.py`, which uses:
1. `tempfile.mkstemp()` — write to a temp file
2. `f.flush()` + `os.fsync()` — ensure data hits disk
3. `os.replace()` — atomically swap temp file into place

This is the same pattern already used by `gateway/status.py`, `gateway/pairing.py`, and `cron/jobs.py`.

## Files Changed

| File | What was at risk |
|------|------------------|
| `tools/skills_hub.py` | `SkillLockFile.save()` — installed skills registry |
| `tools/skills_hub.py` | `TapsFile.save()` — skill taps configuration |
| `gateway/sticker_cache.py` | `_save_cache()` — sticker description cache |
| `tools/environments/base.py` | `_save_json_store()` — generic env backend store |

## Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| Crash mid-write | Corrupted JSON, `JSONDecodeError` on next read | Previous version intact, no data loss |
| Normal write | Works | Works (temp + atomic replace) |

## Tests

Existing tests cover the happy path. Atomic write correctness is already validated by the `atomic_json_write()` implementation and its existing test coverage in `tests/test_utils.py`.