### PR TITLE
docs: clarify cronjob script path requirements

### DIFF
--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -647,6 +647,9 @@ the `cronjob` tool, the `hermes cron` CLI (`list`, `add`, `edit`,
   job), `context_from` (chain job A's output into job B), `workdir`
   (run in a specific dir with its `AGENTS.md` / `CLAUDE.md` loaded),
   multi-platform delivery.
+  For script-backed cron jobs created through the `cronjob` tool, place the
+  script under `~/.hermes/scripts/` and pass only the relative filename
+  (`script="name.py"`). Absolute or `~`-relative script paths are rejected.
 - **Invariants:** 3-minute hard interrupt per run, `.tick.lock` file
   prevents duplicate ticks across processes, cron sessions pass
   `skip_memory=True` by default, and cron deliveries are framed with a

--- a/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent.md
+++ b/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent.md
@@ -664,6 +664,9 @@ the `cronjob` tool, the `hermes cron` CLI (`list`, `add`, `edit`,
   job), `context_from` (chain job A's output into job B), `workdir`
   (run in a specific dir with its `AGENTS.md` / `CLAUDE.md` loaded),
   multi-platform delivery.
+  For script-backed cron jobs created through the `cronjob` tool, place the
+  script under `~/.hermes/scripts/` and pass only the relative filename
+  (`script="name.py"`). Absolute or `~`-relative script paths are rejected.
 - **Invariants:** 3-minute hard interrupt per run, `.tick.lock` file
   prevents duplicate ticks across processes, cron sessions pass
   `skip_memory=True` by default, and cron deliveries are framed with a
@@ -853,7 +856,7 @@ Common gateway problems:
 - **Windows-specific issues** (`Alt+Enter` newline, WinError 10106, UTF-8 BOM config, test suite, line endings): see the dedicated **Windows-Specific Quirks** section above.
 
 ### Auxiliary models not working
-If `auxiliary` tasks (vision, compression) fail silently, the `auto` provider can't find a backend. Either set `OPENROUTER_API_KEY` or `GOOGLE_API_KEY`, or explicitly configure each auxiliary task's provider:
+If `auxiliary` tasks (vision, compression, session_search) fail silently, the `auto` provider can't find a backend. Either set `OPENROUTER_API_KEY` or `GOOGLE_API_KEY`, or explicitly configure each auxiliary task's provider:
 ```bash
 hermes config set auxiliary.vision.provider <your_provider>
 hermes config set auxiliary.vision.model <model_name>


### PR DESCRIPTION
## Summary

- Documents that script-backed cron jobs created through the `cronjob` tool must store scripts under `~/.hermes/scripts/`.
- Clarifies that callers should pass a relative script filename such as `script="name.py"`.
- Notes that absolute and `~`-relative script paths are rejected.
- Syncs the generated Hermes Agent skill docs page, including an existing auxiliary-model wording drift from the source skill.

## Validation

- `git diff --check origin/main...HEAD`
- `python3 website/scripts/generate-skill-docs.py` plus clean diff check for `skills/autonomous-ai-agents/hermes-agent/SKILL.md` and `website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent.md`
- `PYTHONDONTWRITEBYTECODE=1 scripts/run_tests.sh tests/cron/test_cron_script.py::TestCronjobToolScriptValidation -q`
