### PR TITLE
fix: guard json.loads() against invalid TTS and skill_view responses

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -958,7 +958,12 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
     parts = []
     skipped: list[str] = []
     for skill_name in skill_names:
-        loaded = json.loads(skill_view(skill_name))
+        try:
+            loaded = json.loads(skill_view(skill_name))
+        except (json.JSONDecodeError, TypeError):
+            logger.warning("Cron job '%s': skill '%s' returned invalid JSON, skipping", job.get("name", job.get("id")), skill_name)
+            skipped.append(skill_name)
+            continue
         if not loaded.get("success"):
             error = loaded.get("error") or f"Failed to load skill '{skill_name}'"
             logger.warning("Cron job '%s': skill not found, skipping — %s", job.get("name", job.get("id")), error)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10590,7 +10590,11 @@ class GatewayRunner:
             result_json = await asyncio.to_thread(
                 text_to_speech_tool, text=tts_text, output_path=audio_path
             )
-            result = json.loads(result_json)
+            try:
+                result = json.loads(result_json)
+            except (json.JSONDecodeError, TypeError):
+                logger.warning("Auto voice reply TTS returned invalid JSON: %s", result_json[:200] if result_json else result_json)
+                return
 
             # Use the actual file path from result (may differ after opus conversion)
             actual_path = result.get("file_path", audio_path)


### PR DESCRIPTION
## Problem

Two code paths call `json.loads()` on output from external tools without catching `JSONDecodeError`. If the tool returns a non-JSON string (error message, empty string, or `None`), the entire call path crashes.

### 1. Voice reply crash (`gateway/run.py`)

When auto voice reply is enabled, `text_to_speech_tool()` is called and its result is parsed with `json.loads()`. If TTS fails and returns an error string instead of JSON, the voice reply handler crashes — killing the message response entirely.

**Impact:** Any TTS failure (API timeout, invalid voice config, audio encoding error) crashes the gateway's message handler instead of gracefully falling back to text.

### 2. Cron tick crash (`cron/scheduler.py`)

When a cron job specifies `skills: [...]`, each skill is loaded via `skill_view()` and parsed with `json.loads()`. If a skill file is corrupted, missing, or returns an error string, the entire cron tick crashes — preventing ALL jobs from executing that cycle.

**Impact:** One corrupted skill file blocks all scheduled jobs until the skill is fixed or removed.

## Fix

Both fixes catch `(json.JSONDecodeError, TypeError)`, log a warning, and gracefully skip the failed operation instead of crashing.

| File | Before | After |
|------|--------|-------|
| `gateway/run.py` | Crashes on invalid TTS JSON | Logs warning, returns (text reply sent instead) |
| `cron/scheduler.py` | Crashes on invalid skill JSON | Logs warning, skips skill, continues with remaining |

## Tests

Existing tests cover the happy path. The error paths are triggered when external tools return unexpected output — defensive guard that prevents cascading failures.