### PR TITLE
fix(aux): remove stale session_search model menu entry

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2127,7 +2127,6 @@ _AUX_TASKS: list[tuple[str, str, str]] = [
     ("vision", "Vision", "image/screenshot analysis"),
     ("compression", "Compression", "context summarization"),
     ("web_extract", "Web extract", "web page summarization"),
-    ("session_search", "Session search", "past-conversation recall"),
     ("approval", "Approval", "smart command approval"),
     ("mcp", "MCP", "MCP tool reasoning"),
     ("title_generation", "Title generation", "session titles"),

--- a/tests/hermes_cli/test_aux_config.py
+++ b/tests/hermes_cli/test_aux_config.py
@@ -42,12 +42,10 @@ def test_title_generation_present_in_default_config():
     assert tg["extra_body"] == {}
 
 
-def test_session_search_defaults_include_extra_body_and_concurrency():
-    ss = DEFAULT_CONFIG["auxiliary"]["session_search"]
-    assert ss["provider"] == "auto"
-    assert ss["model"] == ""
-    assert ss["extra_body"] == {}
-    assert ss["max_concurrency"] == 3
+def test_session_search_no_longer_appears_in_auxiliary_model_config():
+    """session_search is a direct DB-backed tool, not an auxiliary LLM task."""
+    assert "session_search" not in DEFAULT_CONFIG["auxiliary"]
+    assert "session_search" not in {key for key, _name, _desc in _AUX_TASKS}
 
 
 def test_aux_tasks_keys_all_exist_in_default_config():


### PR DESCRIPTION
## Summary

Fixes the auxiliary-model menu/config drift for `session_search`.

`session_search` became a direct DB-backed/session-store tool and no longer uses an auxiliary LLM. `DEFAULT_CONFIG["auxiliary"]` already documents and reflects that by omitting `session_search`, but `_AUX_TASKS` still exposed `session_search` in the `hermes model` auxiliary task menu.

This caused the auxiliary-config tests on current `main` to fail because the menu referenced a task that no longer exists in the default auxiliary config schema.

Fixes #27925

## Changes

- Remove `session_search` from `_AUX_TASKS` in `hermes_cli/main.py`.
- Update the stale regression test to assert the intended post-#27590 behavior:
  - `session_search` is absent from `DEFAULT_CONFIG["auxiliary"]`.
  - `session_search` is absent from `_AUX_TASKS`.

## Test Plan

```bash
python -m py_compile hermes_cli/main.py tests/hermes_cli/test_aux_config.py
scripts/run_tests.sh tests/hermes_cli/test_aux_config.py -q
```

Result:

```text
21 passed
```

## Privacy / Generality

This fix is fully repo-local and reproducible from current `main`. It does not include any private paths, hostnames, IP addresses, account names, credentials, or user-specific environment details.