### PR TITLE
fix(dashboard): allow public app registry reads

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -119,7 +119,20 @@ _PUBLIC_API_PATHS: frozenset = frozenset({
     "/api/dashboard/themes",
     "/api/dashboard/plugins",
     "/api/dashboard/plugins/rescan",
+    # App registry read endpoints back the private Homebase /apps page.
+    # Keep public exemptions method-aware so POST/PUT/DELETE on an exact
+    # allowlisted path still hit the core dashboard session-token gate.
+    "/api/plugins/app-registry/schema",
+    "/api/plugins/app-registry/registry",
+    "/api/plugins/app-registry/stats",
 })
+# OPTIONS supports unauthenticated CORS/preflight probes.
+_PUBLIC_API_METHODS: frozenset = frozenset({"GET", "HEAD", "OPTIONS"})
+
+
+def _is_public_api_request(method: str, path: str) -> bool:
+    """True when an /api/ request is intentionally public and read-only."""
+    return method.upper() in _PUBLIC_API_METHODS and path in _PUBLIC_API_PATHS
 
 
 def _has_valid_session_token(request: Request) -> bool:
@@ -235,9 +248,9 @@ async def host_header_middleware(request: Request, call_next):
 
 @app.middleware("http")
 async def auth_middleware(request: Request, call_next):
-    """Require the session token on all /api/ routes except the public list."""
+    """Require the session token on all /api/ routes except public read endpoints."""
     path = request.url.path
-    if path.startswith("/api/") and path not in _PUBLIC_API_PATHS:
+    if path.startswith("/api/") and not _is_public_api_request(request.method, path):
         if not _has_valid_session_token(request):
             return JSONResponse(
                 status_code=401,

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -324,9 +324,51 @@ class TestWebServerEndpoints:
         assert resp.status_code == 401
         resp = unauth_client.get("/api/config")
         assert resp.status_code == 401
-        # Public endpoints should still work
+        # Public read endpoints should still work.
         resp = unauth_client.get("/api/status")
         assert resp.status_code == 200
+        # Public exemptions are method-aware: non-read methods still need auth,
+        # even when the path itself is on the public allowlist.
+        resp = unauth_client.post("/api/status")
+        assert resp.status_code == 401
+
+    def test_public_api_allowlist_is_method_aware(self):
+        """Only read methods bypass the dashboard session-token gate."""
+        from hermes_cli.web_server import _is_public_api_request
+
+        assert _is_public_api_request("GET", "/api/plugins/app-registry/schema")
+        assert _is_public_api_request("get", "/api/plugins/app-registry/schema")
+        assert _is_public_api_request("HEAD", "/api/plugins/app-registry/registry")
+        assert _is_public_api_request("OPTIONS", "/api/plugins/app-registry/stats")
+        assert not _is_public_api_request("POST", "/api/plugins/app-registry/registry")
+        assert not _is_public_api_request("PUT", "/api/plugins/app-registry/registry")
+        assert not _is_public_api_request("DELETE", "/api/plugins/app-registry/stats")
+        assert not _is_public_api_request("GET", "/api/plugins/app-registry/discover")
+
+    def test_app_registry_public_paths_are_read_only_through_middleware(self):
+        """The app-registry public paths bypass auth only for safe methods."""
+        from starlette.testclient import TestClient
+        from hermes_cli.web_server import app
+
+        unauth_client = TestClient(app)
+        app_registry_paths = [
+            "/api/plugins/app-registry/schema",
+            "/api/plugins/app-registry/registry",
+            "/api/plugins/app-registry/stats",
+        ]
+        for path in app_registry_paths:
+            # The plugin route may not be installed in an isolated test home, so
+            # 200/404/405 are all acceptable route-layer outcomes. 401 is not:
+            # read-style requests should pass the dashboard auth middleware.
+            assert unauth_client.get(path).status_code != 401
+            assert unauth_client.head(path).status_code != 401
+            assert unauth_client.options(path).status_code != 401
+
+            # Write-style requests to the same allowlisted paths must still be
+            # stopped by auth before any route handler can see them.
+            assert unauth_client.post(path).status_code == 401
+            assert unauth_client.put(path).status_code == 401
+            assert unauth_client.delete(path).status_code == 401
 
     def test_path_traversal_blocked(self):
         """Verify URL-encoded path traversal is blocked."""


### PR DESCRIPTION
## Summary
- allow the app-registry dashboard plugin's schema, registry, and stats endpoints to be read without a dashboard session token
- keep the exemption method-aware so POST/PUT/DELETE on those exact paths still require auth
- add regression coverage for both the helper and middleware behavior

## Test plan
- `python -m pytest tests/hermes_cli/test_web_server.py -q`
  - `146 passed`
- `/home/albert/.hermes/scripts/hermes_post_update_smoke.py`
  - core PR-relevant checks OK: version, git, gateway, cron, session_search, skill load
  - current overall smoke is `DEGRADED` only because unrelated recent `errors.log` entries include transient auxiliary/session-search and other active-agent warnings

## Branch state
- branch is current against `origin/main`
- local/fork commit: `707308f00 fix(dashboard): allow public app registry reads`

## Notes
This supports the Homebase `/apps` dashboard while keeping public API exemptions exact-path and read-method-only.
