### PR TITLE
fix(send_message): resolve Slack user IDs to DM channel IDs

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -27,7 +27,7 @@ _FEISHU_TARGET_RE = re.compile(r"^\s*((?:oc|ou|on|chat|open)_[-A-Za-z0-9]+)(?::(
 # because the API requires a conversation ID. To DM a user you must first call
 # conversations.open to obtain a D... ID. Without this gate, Slack IDs fall
 # through to channel-name resolution, which only matches by name and fails.
-_SLACK_TARGET_RE = re.compile(r"^\s*([CGD][A-Z0-9]{8,})\s*$")
+_SLACK_TARGET_RE = re.compile(r"^\s*([CGDU][A-Z0-9]{8,})\s*$")
 # Session-derived Slack thread targets use "<conversation_id>:<thread_ts>".
 _SLACK_THREAD_TARGET_RE = re.compile(r"^\s*([CGD][A-Z0-9]{8,}):([^\s:]+)\s*$")
 _WEIXIN_TARGET_RE = re.compile(r"^\s*((?:wxid|gh|v\d+|wm|wb)_[A-Za-z0-9_-]+|[A-Za-z0-9._-]+@chatroom|filehelper)\s*$")
@@ -274,6 +274,28 @@ def _handle_send(args):
     duplicate_skip = _maybe_skip_cron_duplicate_send(platform_name, chat_id, thread_id)
     if duplicate_skip:
         return json.dumps(duplicate_skip)
+
+    # Slack: resolve user IDs (U...) to DM channel IDs via conversations.open
+    if platform_name == "slack" and chat_id and chat_id.startswith("U"):
+        try:
+            import aiohttp
+            async def _open_slack_dm(token, user_id):
+                url = "https://slack.com/api/conversations.open"
+                headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+                async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10)) as session:
+                    async with session.post(url, headers=headers, json={"users": [user_id]}) as resp:
+                        data = await resp.json()
+                        if data.get("ok"):
+                            return data["channel"]["id"]
+                        return None
+            from model_tools import _run_async
+            dm_channel = _run_async(_open_slack_dm(pconfig.token, chat_id))
+            if dm_channel:
+                chat_id = dm_channel
+            else:
+                return json.dumps({"error": f"Could not open DM with Slack user {chat_id}. Check bot permissions (im:write)."})
+        except Exception as e:
+            return json.dumps({"error": f"Failed to open Slack DM: {e}"})
 
     try:
         from model_tools import _run_async


### PR DESCRIPTION
## Summary

`send_message` cannot deliver Slack DMs to users referenced by their Slack user ID (e.g. `U0VAK55U1`). Two bugs:

1. **`_SLACK_TARGET_RE` regex excludes `U` IDs** — only matches `[CGD]` (channels, groups, direct messages). User IDs start with `U` and fall through to channel-name resolution, which fails.
2. **No `conversations.open` fallback** — even if the regex matched, `chat.postMessage` requires a conversation ID (`D...`), not a user ID. There's no code to open a DM first.

**Symptom:** `Could not resolve 'U0VAK55U1' on slack. Use send_message(action='list') to see available targets.`

## Changes

- **`_SLACK_TARGET_RE`**: Expand character class from `[CGD]` to `[CGDU]` to accept user IDs
- **`_handle_send`**: Add `conversations.open` call when `chat_id` starts with `U`, converting user ID to DM channel ID before sending

## Test plan

- [ ] `send_message(target='slack:U...', message='test')` resolves user ID to DM channel and delivers
- [ ] `send_message(target='slack:C...', message='test')` still works for channels
- [ ] `send_message(target='slack:D...', message='test')` still works for existing DM channels
- [ ] Invalid user ID returns clear error message