### PR TITLE
feat(plugin): add xcodebuild test support to build-macos-apps

### DIFF
--- a/plugins/build-macos-apps/README.md
+++ b/plugins/build-macos-apps/README.md
@@ -2,11 +2,12 @@
 
 Bundled standalone Hermes plugin for local macOS app build workflows.
 
-Phase 1 scope:
+Current scope:
 
 - inspect a repo for `.xcworkspace` / `.xcodeproj`
 - list schemes through `xcodebuild -list -json`
 - run unsigned `xcodebuild build`
+- run `xcodebuild test`
 
 Included toolset:
 
@@ -17,10 +18,10 @@ Included tools:
 - `macos_inspect_project`
 - `macos_list_schemes`
 - `macos_build_project`
+- `macos_test_project`
 
-What this plugin does not do in Phase 1:
+What this plugin does not do yet:
 
-- run tests
 - launch or stop apps
 - collect logs or crash reports
 - sign or notarize builds
@@ -30,15 +31,16 @@ Availability gate:
 
 - only exposed when Hermes is running on macOS and `xcodebuild` is available in `PATH`
 
-Build behavior:
+Build/test behavior:
 
-- `macos_build_project` performs an unsigned build by passing:
+- `macos_build_project` and `macos_test_project` disable signing by passing:
   - `CODE_SIGNING_ALLOWED=NO`
   - `CODE_SIGNING_REQUIRED=NO`
   - `CODE_SIGN_IDENTITY=`
+- `macos_test_project` supports optional `test_plan`, `only_testing`, `skip_testing`, and `result_bundle_path`
 
 Recommended flow:
 
 1. `macos_inspect_project`
 2. `macos_list_schemes`
-3. `macos_build_project`
+3. `macos_build_project` or `macos_test_project`

--- a/plugins/build-macos-apps/README.md
+++ b/plugins/build-macos-apps/README.md
@@ -1,0 +1,44 @@
+# build-macos-apps
+
+Bundled standalone Hermes plugin for local macOS app build workflows.
+
+Phase 1 scope:
+
+- inspect a repo for `.xcworkspace` / `.xcodeproj`
+- list schemes through `xcodebuild -list -json`
+- run unsigned `xcodebuild build`
+
+Included toolset:
+
+- `macos-dev`
+
+Included tools:
+
+- `macos_inspect_project`
+- `macos_list_schemes`
+- `macos_build_project`
+
+What this plugin does not do in Phase 1:
+
+- run tests
+- launch or stop apps
+- collect logs or crash reports
+- sign or notarize builds
+- drive the UI or computer-use flows
+
+Availability gate:
+
+- only exposed when Hermes is running on macOS and `xcodebuild` is available in `PATH`
+
+Build behavior:
+
+- `macos_build_project` performs an unsigned build by passing:
+  - `CODE_SIGNING_ALLOWED=NO`
+  - `CODE_SIGNING_REQUIRED=NO`
+  - `CODE_SIGN_IDENTITY=`
+
+Recommended flow:
+
+1. `macos_inspect_project`
+2. `macos_list_schemes`
+3. `macos_build_project`

--- a/plugins/build-macos-apps/__init__.py
+++ b/plugins/build-macos-apps/__init__.py
@@ -4,12 +4,14 @@ from .schemas import (
     MACOS_BUILD_PROJECT_SCHEMA,
     MACOS_INSPECT_PROJECT_SCHEMA,
     MACOS_LIST_SCHEMES_SCHEMA,
+    MACOS_TEST_PROJECT_SCHEMA,
 )
 from .tools import (
     check_macos_dev_requirements,
     handle_macos_build_project,
     handle_macos_inspect_project,
     handle_macos_list_schemes,
+    handle_macos_test_project,
 )
 
 TOOLSET = "macos-dev"
@@ -42,4 +44,13 @@ def register(ctx):
         check_fn=check_macos_dev_requirements,
         description=MACOS_BUILD_PROJECT_SCHEMA["description"],
         emoji="🛠️",
+    )
+    ctx.register_tool(
+        name="macos_test_project",
+        toolset=TOOLSET,
+        schema=MACOS_TEST_PROJECT_SCHEMA,
+        handler=handle_macos_test_project,
+        check_fn=check_macos_dev_requirements,
+        description=MACOS_TEST_PROJECT_SCHEMA["description"],
+        emoji="🧪",
     )

--- a/plugins/build-macos-apps/__init__.py
+++ b/plugins/build-macos-apps/__init__.py
@@ -1,0 +1,45 @@
+"""Bundled build-macos-apps plugin."""
+
+from .schemas import (
+    MACOS_BUILD_PROJECT_SCHEMA,
+    MACOS_INSPECT_PROJECT_SCHEMA,
+    MACOS_LIST_SCHEMES_SCHEMA,
+)
+from .tools import (
+    check_macos_dev_requirements,
+    handle_macos_build_project,
+    handle_macos_inspect_project,
+    handle_macos_list_schemes,
+)
+
+TOOLSET = "macos-dev"
+
+
+def register(ctx):
+    ctx.register_tool(
+        name="macos_inspect_project",
+        toolset=TOOLSET,
+        schema=MACOS_INSPECT_PROJECT_SCHEMA,
+        handler=handle_macos_inspect_project,
+        check_fn=check_macos_dev_requirements,
+        description=MACOS_INSPECT_PROJECT_SCHEMA["description"],
+        emoji="🧭",
+    )
+    ctx.register_tool(
+        name="macos_list_schemes",
+        toolset=TOOLSET,
+        schema=MACOS_LIST_SCHEMES_SCHEMA,
+        handler=handle_macos_list_schemes,
+        check_fn=check_macos_dev_requirements,
+        description=MACOS_LIST_SCHEMES_SCHEMA["description"],
+        emoji="📋",
+    )
+    ctx.register_tool(
+        name="macos_build_project",
+        toolset=TOOLSET,
+        schema=MACOS_BUILD_PROJECT_SCHEMA,
+        handler=handle_macos_build_project,
+        check_fn=check_macos_dev_requirements,
+        description=MACOS_BUILD_PROJECT_SCHEMA["description"],
+        emoji="🛠️",
+    )

--- a/plugins/build-macos-apps/plugin.yaml
+++ b/plugins/build-macos-apps/plugin.yaml
@@ -1,0 +1,8 @@
+name: build-macos-apps
+version: 0.1.0
+description: "Inspect local macOS Xcode projects, list schemes, and run unsigned xcodebuild builds."
+kind: standalone
+provides_tools:
+  - macos_inspect_project
+  - macos_list_schemes
+  - macos_build_project

--- a/plugins/build-macos-apps/plugin.yaml
+++ b/plugins/build-macos-apps/plugin.yaml
@@ -1,8 +1,9 @@
 name: build-macos-apps
 version: 0.1.0
-description: "Inspect local macOS Xcode projects, list schemes, and run unsigned xcodebuild builds."
+description: "Inspect local macOS Xcode projects, list schemes, run tests, and run unsigned xcodebuild builds."
 kind: standalone
 provides_tools:
   - macos_inspect_project
   - macos_list_schemes
   - macos_build_project
+  - macos_test_project

--- a/plugins/build-macos-apps/schemas.py
+++ b/plugins/build-macos-apps/schemas.py
@@ -1,0 +1,90 @@
+"""Schemas for the build-macos-apps plugin."""
+
+MACOS_INSPECT_PROJECT_SCHEMA = {
+    "name": "macos_inspect_project",
+    "description": (
+        "Inspect a local macOS app repository for Xcode build containers. "
+        "Reports .xcworkspace/.xcodeproj files, Swift Package hints, and the "
+        "recommended container to use for scheme listing or builds."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "path": {
+                "type": "string",
+                "description": "Repository or project path to inspect.",
+            }
+        },
+        "required": ["path"],
+    },
+}
+
+MACOS_LIST_SCHEMES_SCHEMA = {
+    "name": "macos_list_schemes",
+    "description": (
+        "List Xcode schemes, targets, and configurations for a macOS project "
+        "or workspace using xcodebuild -list -json."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "path": {
+                "type": "string",
+                "description": "Repository or project path that contains the Xcode container.",
+            },
+            "container_path": {
+                "type": "string",
+                "description": "Optional explicit .xcworkspace or .xcodeproj path to use.",
+            },
+        },
+        "required": ["path"],
+    },
+}
+
+MACOS_BUILD_PROJECT_SCHEMA = {
+    "name": "macos_build_project",
+    "description": (
+        "Build a local macOS Xcode scheme with xcodebuild. This Phase 1 tool "
+        "performs an unsigned build only; it does not run tests, launch apps, "
+        "or handle notarization."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "path": {
+                "type": "string",
+                "description": "Repository or project path that contains the Xcode container.",
+            },
+            "scheme": {
+                "type": "string",
+                "description": "Xcode scheme to build.",
+            },
+            "container_path": {
+                "type": "string",
+                "description": "Optional explicit .xcworkspace or .xcodeproj path to use.",
+            },
+            "configuration": {
+                "type": "string",
+                "description": "Build configuration, usually Debug or Release.",
+                "default": "Debug",
+            },
+            "destination": {
+                "type": "string",
+                "description": "xcodebuild destination string.",
+                "default": "generic/platform=macOS",
+            },
+            "derived_data_path": {
+                "type": "string",
+                "description": "Optional DerivedData output path.",
+            },
+            "timeout_seconds": {
+                "type": "integer",
+                "description": "Maximum build time before Hermes aborts the command.",
+                "default": 1800,
+                "minimum": 30,
+                "maximum": 7200,
+            },
+        },
+        "required": ["path", "scheme"],
+    },
+}

--- a/plugins/build-macos-apps/schemas.py
+++ b/plugins/build-macos-apps/schemas.py
@@ -88,3 +88,69 @@ MACOS_BUILD_PROJECT_SCHEMA = {
         "required": ["path", "scheme"],
     },
 }
+
+MACOS_TEST_PROJECT_SCHEMA = {
+    "name": "macos_test_project",
+    "description": (
+        "Run xcodebuild test for a local macOS Xcode scheme. This Phase 2 "
+        "tool adds test execution support without expanding into app launch, "
+        "diagnostics, or signing workflows."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "path": {
+                "type": "string",
+                "description": "Repository or project path that contains the Xcode container.",
+            },
+            "scheme": {
+                "type": "string",
+                "description": "Xcode scheme to test.",
+            },
+            "container_path": {
+                "type": "string",
+                "description": "Optional explicit .xcworkspace or .xcodeproj path to use.",
+            },
+            "configuration": {
+                "type": "string",
+                "description": "Test configuration, usually Debug.",
+                "default": "Debug",
+            },
+            "destination": {
+                "type": "string",
+                "description": "xcodebuild destination string.",
+                "default": "platform=macOS",
+            },
+            "test_plan": {
+                "type": "string",
+                "description": "Optional Xcode test plan name.",
+            },
+            "only_testing": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional list of -only-testing identifiers.",
+            },
+            "skip_testing": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional list of -skip-testing identifiers.",
+            },
+            "derived_data_path": {
+                "type": "string",
+                "description": "Optional DerivedData output path.",
+            },
+            "result_bundle_path": {
+                "type": "string",
+                "description": "Optional path for the generated .xcresult bundle.",
+            },
+            "timeout_seconds": {
+                "type": "integer",
+                "description": "Maximum test time before Hermes aborts the command.",
+                "default": 1800,
+                "minimum": 30,
+                "maximum": 7200,
+            },
+        },
+        "required": ["path", "scheme"],
+    },
+}

--- a/plugins/build-macos-apps/tools.py
+++ b/plugins/build-macos-apps/tools.py
@@ -1,0 +1,316 @@
+"""Handlers for the build-macos-apps plugin."""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import re
+import shlex
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+from tools.registry import tool_error, tool_result
+
+_DISCOVERY_MAX_DEPTH = 3
+_XCODEBUILD_PATH = "xcodebuild"
+_SIGNING_DISABLED_FLAGS = [
+    "CODE_SIGNING_ALLOWED=NO",
+    "CODE_SIGNING_REQUIRED=NO",
+    "CODE_SIGN_IDENTITY=",
+]
+
+
+def check_macos_dev_requirements() -> bool:
+    """Return True when Hermes can expose the macOS build toolset."""
+    return sys_platform_is_darwin() and bool(shutil.which(_XCODEBUILD_PATH))
+
+
+def sys_platform_is_darwin() -> bool:
+    return platform.system().lower() == "darwin"
+
+
+def _normalize_path(raw: str | os.PathLike[str]) -> Path:
+    if raw is None:
+        raise ValueError("path is required")
+    path = Path(raw).expanduser()
+    try:
+        resolved = path.resolve()
+    except FileNotFoundError:
+        resolved = path.absolute()
+    return resolved
+
+
+def _coerce_timeout(raw: Any, default: int = 1800) -> int:
+    try:
+        timeout = int(raw)
+    except Exception:
+        timeout = default
+    return max(30, min(7200, timeout))
+
+
+def _iter_candidates(root: Path, suffix: str) -> Iterable[Path]:
+    if root.is_file():
+        if root.suffix == suffix:
+            yield root
+        return
+
+    seen: set[Path] = set()
+    for current_root, dirs, files in os.walk(root):
+        current = Path(current_root)
+        rel_parts = current.relative_to(root).parts if current != root else ()
+        if len(rel_parts) > _DISCOVERY_MAX_DEPTH:
+            dirs[:] = []
+            continue
+
+        if suffix == ".xcodeproj":
+            names = [name for name in dirs if name.endswith(suffix)]
+        else:
+            names = [name for name in dirs if name.endswith(suffix)]
+
+        for name in sorted(names):
+            candidate = current / name
+            if candidate not in seen:
+                seen.add(candidate)
+                yield candidate
+
+
+def _inspect_project(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(f"Path not found: {path}")
+
+    root = path if path.is_dir() else path.parent
+    workspaces = list(_iter_candidates(path, ".xcworkspace"))
+    projects = list(_iter_candidates(path, ".xcodeproj"))
+    package_swift = sorted(
+        p for p in root.rglob("Package.swift")
+        if len(p.relative_to(root).parts) <= _DISCOVERY_MAX_DEPTH + 1
+    ) if root.exists() else []
+
+    primary: Path | None = None
+    primary_type = "none"
+    if workspaces:
+        primary = workspaces[0]
+        primary_type = "workspace"
+    elif projects:
+        primary = projects[0]
+        primary_type = "project"
+
+    return {
+        "input_path": str(path),
+        "project_root": str(root),
+        "exists": True,
+        "xcode_workspaces": [str(p) for p in workspaces],
+        "xcode_projects": [str(p) for p in projects],
+        "swift_packages": [str(p) for p in package_swift],
+        "has_package_swift": bool(package_swift),
+        "recommended_container": str(primary) if primary else None,
+        "recommended_container_type": primary_type,
+        "supports_xcodebuild_flow": bool(primary),
+        "notes": _build_inspection_notes(workspaces, projects, package_swift),
+    }
+
+
+def _build_inspection_notes(
+    workspaces: List[Path], projects: List[Path], packages: List[Path]
+) -> List[str]:
+    notes: List[str] = []
+    if workspaces:
+        notes.append("Workspace detected; prefer the workspace for scheme listing and builds.")
+    elif projects:
+        notes.append("Project detected; scheme listing and builds can target the .xcodeproj directly.")
+    else:
+        notes.append("No .xcworkspace or .xcodeproj was found within the inspection depth.")
+
+    if packages and not (workspaces or projects):
+        notes.append("Swift Package manifest detected, but Phase 1 only exposes Xcode project/workspace flows.")
+    elif packages:
+        notes.append("Swift Package manifest detected alongside Xcode build metadata.")
+    return notes
+
+
+def _select_container(base_path: Path, container_path: str | None) -> Dict[str, str]:
+    explicit = None
+    if container_path:
+        candidate = Path(container_path).expanduser()
+        if not candidate.is_absolute():
+            base_dir = base_path if base_path.is_dir() else base_path.parent
+            candidate = (base_dir / candidate).resolve()
+        explicit = _normalize_path(candidate)
+    if explicit:
+        if not explicit.exists():
+            raise FileNotFoundError(f"Container not found: {explicit}")
+        if explicit.suffix not in {".xcworkspace", ".xcodeproj"}:
+            raise ValueError("container_path must point to a .xcworkspace or .xcodeproj")
+        return {"type": "workspace" if explicit.suffix == ".xcworkspace" else "project", "path": str(explicit)}
+
+    inspection = _inspect_project(base_path)
+    recommended = inspection.get("recommended_container")
+    if not recommended:
+        raise ValueError(
+            "No .xcworkspace or .xcodeproj found. Run macos_inspect_project first and point Hermes at an Xcode container."
+        )
+    return {
+        "type": inspection["recommended_container_type"],
+        "path": str(recommended),
+    }
+
+
+def _run_xcodebuild(
+    command: List[str],
+    *,
+    cwd: Path,
+    timeout_seconds: int,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        timeout=timeout_seconds,
+        check=False,
+    )
+
+
+def _shape_xcode_output(stdout: str, stderr: str, *, max_tail_lines: int = 40) -> Dict[str, Any]:
+    combined = "\n".join(part for part in [stdout.strip(), stderr.strip()] if part).strip()
+    if not combined:
+        return {"tail": [], "highlights": [], "line_count": 0}
+
+    lines = combined.splitlines()
+    highlights: List[str] = []
+    pattern = re.compile(r"(error:|warning:|\*\* BUILD (SUCCEEDED|FAILED) \*\*|Testing failed:)", re.IGNORECASE)
+    for line in lines:
+        if pattern.search(line):
+            highlights.append(line)
+        if len(highlights) >= 20:
+            break
+
+    tail = lines[-max_tail_lines:]
+    return {
+        "tail": tail,
+        "highlights": highlights,
+        "line_count": len(lines),
+    }
+
+
+def _json_loads_or_error(raw: str) -> Dict[str, Any]:
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"xcodebuild returned non-JSON output: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError("xcodebuild returned an unexpected JSON payload")
+    return data
+
+
+def handle_macos_inspect_project(args: dict, **kw) -> str:
+    try:
+        path = _normalize_path(args.get("path"))
+        inspection = _inspect_project(path)
+        return tool_result({"success": True, **inspection})
+    except Exception as exc:
+        return tool_error(str(exc), success=False)
+
+
+def handle_macos_list_schemes(args: dict, **kw) -> str:
+    try:
+        path = _normalize_path(args.get("path"))
+        container = _select_container(path, args.get("container_path"))
+        command = [_XCODEBUILD_PATH, "-list", "-json", f"-{container['type']}", container["path"]]
+        completed = _run_xcodebuild(command, cwd=path if path.is_dir() else path.parent, timeout_seconds=120)
+        if completed.returncode != 0:
+            shaped = _shape_xcode_output(completed.stdout, completed.stderr)
+            return tool_error(
+                "xcodebuild -list failed",
+                success=False,
+                exit_code=completed.returncode,
+                command=shlex.join(command),
+                container=container,
+                output=shaped,
+            )
+
+        payload = _json_loads_or_error(completed.stdout)
+        return tool_result(
+            {
+                "success": True,
+                "command": shlex.join(command),
+                "container": container,
+                "project": payload.get("project"),
+            }
+        )
+    except subprocess.TimeoutExpired:
+        return tool_error("xcodebuild -list timed out", success=False)
+    except Exception as exc:
+        return tool_error(str(exc), success=False)
+
+
+def handle_macos_build_project(args: dict, **kw) -> str:
+    try:
+        path = _normalize_path(args.get("path"))
+        scheme = str(args.get("scheme") or "").strip()
+        if not scheme:
+            return tool_error("scheme is required", success=False)
+
+        container = _select_container(path, args.get("container_path"))
+        configuration = str(args.get("configuration") or "Debug").strip() or "Debug"
+        destination = str(args.get("destination") or "generic/platform=macOS").strip() or "generic/platform=macOS"
+        timeout_seconds = _coerce_timeout(args.get("timeout_seconds"), default=1800)
+
+        command = [
+            _XCODEBUILD_PATH,
+            "build",
+            f"-{container['type']}",
+            container["path"],
+            "-scheme",
+            scheme,
+            "-configuration",
+            configuration,
+            "-destination",
+            destination,
+        ]
+        derived_data_path = args.get("derived_data_path")
+        if derived_data_path:
+            derived_path = Path(str(derived_data_path)).expanduser()
+            if not derived_path.is_absolute():
+                base_dir = path if path.is_dir() else path.parent
+                derived_path = (base_dir / derived_path).resolve()
+            command.extend(["-derivedDataPath", str(_normalize_path(derived_path))])
+        command.extend(_SIGNING_DISABLED_FLAGS)
+
+        started = time.time()
+        completed = _run_xcodebuild(
+            command,
+            cwd=path if path.is_dir() else path.parent,
+            timeout_seconds=timeout_seconds,
+        )
+        duration_seconds = round(time.time() - started, 2)
+        shaped = _shape_xcode_output(completed.stdout, completed.stderr)
+        success = completed.returncode == 0
+
+        result = {
+            "success": success,
+            "command": shlex.join(command),
+            "container": container,
+            "scheme": scheme,
+            "configuration": configuration,
+            "destination": destination,
+            "unsigned_build": True,
+            "duration_seconds": duration_seconds,
+            "exit_code": completed.returncode,
+            "output": shaped,
+        }
+        if success:
+            return tool_result(result)
+        return tool_error("xcodebuild build failed", **result)
+    except subprocess.TimeoutExpired as exc:
+        return tool_error(
+            "xcodebuild build timed out",
+            success=False,
+            timeout_seconds=exc.timeout,
+        )
+    except Exception as exc:
+        return tool_error(str(exc), success=False)

--- a/plugins/build-macos-apps/tools.py
+++ b/plugins/build-macos-apps/tools.py
@@ -52,6 +52,15 @@ def _coerce_timeout(raw: Any, default: int = 1800) -> int:
     return max(30, min(7200, timeout))
 
 
+def _coerce_string_list(raw: Any) -> List[str]:
+    if raw is None:
+        return []
+    if isinstance(raw, list):
+        return [str(item).strip() for item in raw if str(item).strip()]
+    item = str(raw).strip()
+    return [item] if item else []
+
+
 def _iter_candidates(root: Path, suffix: str) -> Iterable[Path]:
     if root.is_file():
         if root.suffix == suffix:
@@ -157,6 +166,16 @@ def _select_container(base_path: Path, container_path: str | None) -> Dict[str, 
         "type": inspection["recommended_container_type"],
         "path": str(recommended),
     }
+
+
+def _resolve_optional_path(base_path: Path, raw_path: Any) -> str | None:
+    if not raw_path:
+        return None
+    candidate = Path(str(raw_path)).expanduser()
+    if not candidate.is_absolute():
+        base_dir = base_path if base_path.is_dir() else base_path.parent
+        candidate = (base_dir / candidate).resolve()
+    return str(_normalize_path(candidate))
 
 
 def _run_xcodebuild(
@@ -272,13 +291,9 @@ def handle_macos_build_project(args: dict, **kw) -> str:
             "-destination",
             destination,
         ]
-        derived_data_path = args.get("derived_data_path")
+        derived_data_path = _resolve_optional_path(path, args.get("derived_data_path"))
         if derived_data_path:
-            derived_path = Path(str(derived_data_path)).expanduser()
-            if not derived_path.is_absolute():
-                base_dir = path if path.is_dir() else path.parent
-                derived_path = (base_dir / derived_path).resolve()
-            command.extend(["-derivedDataPath", str(_normalize_path(derived_path))])
+            command.extend(["-derivedDataPath", derived_data_path])
         command.extend(_SIGNING_DISABLED_FLAGS)
 
         started = time.time()
@@ -309,6 +324,89 @@ def handle_macos_build_project(args: dict, **kw) -> str:
     except subprocess.TimeoutExpired as exc:
         return tool_error(
             "xcodebuild build timed out",
+            success=False,
+            timeout_seconds=exc.timeout,
+        )
+    except Exception as exc:
+        return tool_error(str(exc), success=False)
+
+
+def handle_macos_test_project(args: dict, **kw) -> str:
+    try:
+        path = _normalize_path(args.get("path"))
+        scheme = str(args.get("scheme") or "").strip()
+        if not scheme:
+            return tool_error("scheme is required", success=False)
+
+        container = _select_container(path, args.get("container_path"))
+        configuration = str(args.get("configuration") or "Debug").strip() or "Debug"
+        destination = str(args.get("destination") or "platform=macOS").strip() or "platform=macOS"
+        test_plan = str(args.get("test_plan") or "").strip() or None
+        only_testing = _coerce_string_list(args.get("only_testing"))
+        skip_testing = _coerce_string_list(args.get("skip_testing"))
+        timeout_seconds = _coerce_timeout(args.get("timeout_seconds"), default=1800)
+
+        command = [
+            _XCODEBUILD_PATH,
+            "test",
+            f"-{container['type']}",
+            container["path"],
+            "-scheme",
+            scheme,
+            "-configuration",
+            configuration,
+            "-destination",
+            destination,
+        ]
+        if test_plan:
+            command.extend(["-testPlan", test_plan])
+        for identifier in only_testing:
+            command.extend(["-only-testing", identifier])
+        for identifier in skip_testing:
+            command.extend(["-skip-testing", identifier])
+
+        derived_data_path = _resolve_optional_path(path, args.get("derived_data_path"))
+        if derived_data_path:
+            command.extend(["-derivedDataPath", derived_data_path])
+
+        result_bundle_path = _resolve_optional_path(path, args.get("result_bundle_path"))
+        if result_bundle_path:
+            command.extend(["-resultBundlePath", result_bundle_path])
+
+        command.extend(_SIGNING_DISABLED_FLAGS)
+
+        started = time.time()
+        completed = _run_xcodebuild(
+            command,
+            cwd=path if path.is_dir() else path.parent,
+            timeout_seconds=timeout_seconds,
+        )
+        duration_seconds = round(time.time() - started, 2)
+        shaped = _shape_xcode_output(completed.stdout, completed.stderr)
+        success = completed.returncode == 0
+
+        result = {
+            "success": success,
+            "command": shlex.join(command),
+            "container": container,
+            "scheme": scheme,
+            "configuration": configuration,
+            "destination": destination,
+            "test_plan": test_plan,
+            "only_testing": only_testing,
+            "skip_testing": skip_testing,
+            "result_bundle_path": result_bundle_path,
+            "signing_disabled": True,
+            "duration_seconds": duration_seconds,
+            "exit_code": completed.returncode,
+            "output": shaped,
+        }
+        if success:
+            return tool_result(result)
+        return tool_error("xcodebuild test failed", **result)
+    except subprocess.TimeoutExpired as exc:
+        return tool_error(
+            "xcodebuild test timed out",
             success=False,
             timeout_seconds=exc.timeout,
         )

--- a/tests/plugins/test_build_macos_apps_plugin.py
+++ b/tests/plugins/test_build_macos_apps_plugin.py
@@ -1,0 +1,70 @@
+"""Bundled-plugin discovery tests for build-macos-apps."""
+
+import yaml
+
+
+class TestBundledBuildMacosAppsDiscovery:
+    def _write_enabled_config(self, hermes_home, names):
+        cfg_path = hermes_home / "config.yaml"
+        cfg_path.write_text(yaml.safe_dump({"plugins": {"enabled": list(names)}}))
+
+    def test_discovered_but_not_loaded_by_default(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        from hermes_cli import plugins as pmod
+
+        mgr = pmod.PluginManager()
+        mgr.discover_and_load()
+
+        assert "build-macos-apps" in mgr._plugins
+        loaded = mgr._plugins["build-macos-apps"]
+        assert loaded.manifest.source == "bundled"
+        assert loaded.manifest.kind == "standalone"
+        assert not loaded.enabled
+        assert loaded.error and "not enabled" in loaded.error
+
+    def test_loads_when_enabled_and_registers_tools(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        self._write_enabled_config(hermes_home, ["build-macos-apps"])
+
+        from hermes_cli import plugins as pmod
+
+        mgr = pmod.PluginManager()
+        mgr.discover_and_load()
+
+        loaded = mgr._plugins["build-macos-apps"]
+        assert loaded.enabled
+        assert sorted(loaded.tools_registered) == [
+            "macos_build_project",
+            "macos_inspect_project",
+            "macos_list_schemes",
+        ]
+
+    def test_toolset_is_visible_when_enabled(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        self._write_enabled_config(hermes_home, ["build-macos-apps"])
+
+        from hermes_cli import plugins as plugins_mod
+        from model_tools import get_tool_definitions
+
+        mgr = plugins_mod.PluginManager()
+        mgr.discover_and_load()
+        monkeypatch.setattr(plugins_mod, "_plugin_manager", mgr)
+        import sys
+
+        plugin_tools = sys.modules["hermes_plugins.build_macos_apps.tools"]
+        monkeypatch.setattr(plugin_tools, "check_macos_dev_requirements", lambda: True)
+
+        defs = get_tool_definitions(enabled_toolsets=["macos-dev"], quiet_mode=True)
+        tool_names = sorted(item["function"]["name"] for item in defs)
+        assert tool_names == [
+            "macos_build_project",
+            "macos_inspect_project",
+            "macos_list_schemes",
+        ]

--- a/tests/plugins/test_build_macos_apps_plugin.py
+++ b/tests/plugins/test_build_macos_apps_plugin.py
@@ -42,6 +42,7 @@ class TestBundledBuildMacosAppsDiscovery:
             "macos_build_project",
             "macos_inspect_project",
             "macos_list_schemes",
+            "macos_test_project",
         ]
 
     def test_toolset_is_visible_when_enabled(self, tmp_path, monkeypatch):
@@ -67,4 +68,5 @@ class TestBundledBuildMacosAppsDiscovery:
             "macos_build_project",
             "macos_inspect_project",
             "macos_list_schemes",
+            "macos_test_project",
         ]

--- a/tests/plugins/test_build_macos_apps_tools.py
+++ b/tests/plugins/test_build_macos_apps_tools.py
@@ -187,3 +187,75 @@ class TestBuildProject:
         result = json.loads(tools_mod.handle_macos_build_project({"path": str(repo)}))
         assert result["success"] is False
         assert result["error"] == "scheme is required"
+
+
+class TestTestProject:
+    def test_test_includes_filters_and_result_bundle(self, tools_mod, tmp_path, monkeypatch):
+        repo = tmp_path / "TestRepo"
+        project = repo / "App.xcodeproj"
+        project.mkdir(parents=True)
+        captured = {}
+
+        def fake_run(command, cwd, timeout_seconds):
+            captured["command"] = command
+            captured["cwd"] = cwd
+            captured["timeout_seconds"] = timeout_seconds
+            return CompletedProcess(command, 0, stdout="Test Suite 'All tests' passed\n", stderr="")
+
+        monkeypatch.setattr(tools_mod, "_run_xcodebuild", fake_run)
+
+        result = json.loads(
+            tools_mod.handle_macos_test_project(
+                {
+                    "path": str(repo),
+                    "scheme": "App",
+                    "test_plan": "CI",
+                    "only_testing": ["AppTests/FooTests"],
+                    "skip_testing": ["AppUITests"],
+                    "result_bundle_path": "artifacts/AppTests.xcresult",
+                }
+            )
+        )
+
+        assert result["success"] is True
+        assert result["test_plan"] == "CI"
+        assert result["only_testing"] == ["AppTests/FooTests"]
+        assert result["skip_testing"] == ["AppUITests"]
+        assert result["signing_disabled"] is True
+        assert "-testPlan" in captured["command"]
+        assert "-only-testing" in captured["command"]
+        assert "-skip-testing" in captured["command"]
+        assert "-resultBundlePath" in captured["command"]
+        assert "CODE_SIGNING_ALLOWED=NO" in captured["command"]
+
+    def test_test_failure_returns_shaped_output(self, tools_mod, tmp_path, monkeypatch):
+        repo = tmp_path / "TestFailRepo"
+        workspace = repo / "App.xcworkspace"
+        workspace.mkdir(parents=True)
+
+        monkeypatch.setattr(
+            tools_mod,
+            "_run_xcodebuild",
+            lambda command, cwd, timeout_seconds: CompletedProcess(
+                command,
+                65,
+                stdout="Test Case '-[AppTests FooTests testBar]' failed\n** TEST FAILED **\n",
+                stderr="FooTests.swift:12: error: XCTAssertTrue failed\n",
+            ),
+        )
+
+        result = json.loads(
+            tools_mod.handle_macos_test_project({"path": str(repo), "scheme": "App"})
+        )
+
+        assert result["success"] is False
+        assert result["exit_code"] == 65
+        assert result["output"]["highlights"]
+
+    def test_test_requires_scheme(self, tools_mod, tmp_path):
+        repo = tmp_path / "NoTestSchemeRepo"
+        (repo / "App.xcodeproj").mkdir(parents=True)
+
+        result = json.loads(tools_mod.handle_macos_test_project({"path": str(repo)}))
+        assert result["success"] is False
+        assert result["error"] == "scheme is required"

--- a/tests/plugins/test_build_macos_apps_tools.py
+++ b/tests/plugins/test_build_macos_apps_tools.py
@@ -1,0 +1,189 @@
+"""Tool tests for the build-macos-apps plugin."""
+
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+from subprocess import CompletedProcess
+
+import pytest
+
+
+def _load_tools_module():
+    repo_root = Path(__file__).resolve().parents[2]
+    plugin_dir = repo_root / "plugins" / "build-macos-apps"
+    spec = importlib.util.spec_from_file_location(
+        "hermes_plugins.build_macos_apps.tools",
+        plugin_dir / "tools.py",
+        submodule_search_locations=[str(plugin_dir)],
+    )
+    if "hermes_plugins" not in sys.modules:
+        ns = types.ModuleType("hermes_plugins")
+        ns.__path__ = []
+        sys.modules["hermes_plugins"] = ns
+    pkg = sys.modules.get("hermes_plugins.build_macos_apps")
+    if pkg is None:
+        pkg = types.ModuleType("hermes_plugins.build_macos_apps")
+        pkg.__path__ = [str(plugin_dir)]
+        sys.modules["hermes_plugins.build_macos_apps"] = pkg
+
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = "hermes_plugins.build_macos_apps"
+    sys.modules["hermes_plugins.build_macos_apps.tools"] = mod
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def tools_mod():
+    return _load_tools_module()
+
+
+class TestCheckFn:
+    def test_requires_macos_and_xcodebuild(self, tools_mod, monkeypatch):
+        monkeypatch.setattr(tools_mod.platform, "system", lambda: "Darwin")
+        monkeypatch.setattr(tools_mod.shutil, "which", lambda name: "/usr/bin/xcodebuild")
+        assert tools_mod.check_macos_dev_requirements() is True
+
+        monkeypatch.setattr(tools_mod.platform, "system", lambda: "Linux")
+        assert tools_mod.check_macos_dev_requirements() is False
+
+
+class TestInspect:
+    def test_detects_workspace_and_project(self, tools_mod, tmp_path):
+        repo = tmp_path / "MyApp"
+        (repo / "App.xcworkspace").mkdir(parents=True)
+        (repo / "App.xcodeproj").mkdir()
+        (repo / "Package.swift").write_text("// swift-tools-version: 5.9\n")
+
+        result = json.loads(tools_mod.handle_macos_inspect_project({"path": str(repo)}))
+
+        assert result["success"] is True
+        assert result["recommended_container_type"] == "workspace"
+        assert result["supports_xcodebuild_flow"] is True
+        assert len(result["xcode_workspaces"]) == 1
+        assert len(result["xcode_projects"]) == 1
+        assert result["has_package_swift"] is True
+
+    def test_errors_when_path_missing(self, tools_mod, tmp_path):
+        result = json.loads(
+            tools_mod.handle_macos_inspect_project({"path": str(tmp_path / "missing")})
+        )
+        assert result["success"] is False
+        assert "Path not found" in result["error"]
+
+
+class TestListSchemes:
+    def test_lists_schemes_from_workspace(self, tools_mod, tmp_path, monkeypatch):
+        repo = tmp_path / "WorkspaceRepo"
+        workspace = repo / "App.xcworkspace"
+        workspace.mkdir(parents=True)
+
+        monkeypatch.setattr(
+            tools_mod,
+            "_run_xcodebuild",
+            lambda command, cwd, timeout_seconds: CompletedProcess(
+                command,
+                0,
+                stdout=json.dumps(
+                    {
+                        "project": {
+                            "name": "App",
+                            "schemes": ["App"],
+                            "targets": ["App"],
+                            "configurations": ["Debug", "Release"],
+                        }
+                    }
+                ),
+                stderr="",
+            ),
+        )
+
+        result = json.loads(tools_mod.handle_macos_list_schemes({"path": str(repo)}))
+        assert result["success"] is True
+        assert result["container"]["type"] == "workspace"
+        assert result["project"]["schemes"] == ["App"]
+
+    def test_surfaces_xcodebuild_failure(self, tools_mod, tmp_path, monkeypatch):
+        repo = tmp_path / "ProjectRepo"
+        project = repo / "App.xcodeproj"
+        project.mkdir(parents=True)
+
+        monkeypatch.setattr(
+            tools_mod,
+            "_run_xcodebuild",
+            lambda command, cwd, timeout_seconds: CompletedProcess(
+                command,
+                65,
+                stdout="** BUILD FAILED **\n",
+                stderr="xcodebuild: error: scheme App not found\n",
+            ),
+        )
+
+        result = json.loads(tools_mod.handle_macos_list_schemes({"path": str(repo)}))
+        assert result["success"] is False
+        assert result["exit_code"] == 65
+        assert result["output"]["highlights"]
+
+
+class TestBuildProject:
+    def test_build_includes_unsigned_flags(self, tools_mod, tmp_path, monkeypatch):
+        repo = tmp_path / "BuildRepo"
+        project = repo / "App.xcodeproj"
+        project.mkdir(parents=True)
+        captured = {}
+
+        def fake_run(command, cwd, timeout_seconds):
+            captured["command"] = command
+            captured["cwd"] = cwd
+            captured["timeout_seconds"] = timeout_seconds
+            return CompletedProcess(command, 0, stdout="** BUILD SUCCEEDED **\n", stderr="")
+
+        monkeypatch.setattr(tools_mod, "_run_xcodebuild", fake_run)
+
+        result = json.loads(
+            tools_mod.handle_macos_build_project(
+                {"path": str(repo), "scheme": "App", "configuration": "Release"}
+            )
+        )
+
+        assert result["success"] is True
+        assert result["unsigned_build"] is True
+        assert "CODE_SIGNING_ALLOWED=NO" in captured["command"]
+        assert "CODE_SIGNING_REQUIRED=NO" in captured["command"]
+        assert "CODE_SIGN_IDENTITY=" in captured["command"]
+        assert result["configuration"] == "Release"
+
+    def test_build_failure_returns_shaped_output(self, tools_mod, tmp_path, monkeypatch):
+        repo = tmp_path / "BuildFailRepo"
+        workspace = repo / "App.xcworkspace"
+        workspace.mkdir(parents=True)
+
+        monkeypatch.setattr(
+            tools_mod,
+            "_run_xcodebuild",
+            lambda command, cwd, timeout_seconds: CompletedProcess(
+                command,
+                65,
+                stdout="CompileSwift normal arm64 Foo.swift\n** BUILD FAILED **\n",
+                stderr="Foo.swift:1:1: error: broken\n",
+            ),
+        )
+
+        result = json.loads(
+            tools_mod.handle_macos_build_project({"path": str(repo), "scheme": "App"})
+        )
+
+        assert result["success"] is False
+        assert result["exit_code"] == 65
+        assert result["output"]["highlights"]
+
+    def test_build_requires_scheme(self, tools_mod, tmp_path):
+        repo = tmp_path / "NoSchemeRepo"
+        (repo / "App.xcodeproj").mkdir(parents=True)
+
+        result = json.loads(tools_mod.handle_macos_build_project({"path": str(repo)}))
+        assert result["success"] is False
+        assert result["error"] == "scheme is required"

--- a/website/docs/user-guide/features/built-in-plugins.md
+++ b/website/docs/user-guide/features/built-in-plugins.md
@@ -59,6 +59,7 @@ The repo ships these bundled plugins under `plugins/`. All are opt-in — enable
 | `observability/langfuse` | hooks | Trace turns / LLM calls / tools to [Langfuse](https://langfuse.com) |
 | `spotify` | backend (7 tools) | Native Spotify playback, queue, search, playlists, albums, library |
 | `google_meet` | standalone | Join Meet calls, live-caption transcription, optional realtime duplex audio |
+| `build-macos-apps` | standalone | Inspect local Xcode projects, list schemes, and run unsigned macOS builds |
 | `image_gen/openai` | image backend | OpenAI `gpt-image-2` image generation backend (alternative to FAL) |
 | `image_gen/openai-codex` | image backend | OpenAI image generation via Codex OAuth |
 | `image_gen/xai` | image backend | xAI `grok-2-image` backend |
@@ -199,6 +200,34 @@ The agent kicks off the meeting join, streams the transcription back into its co
 **When to use it:** recurring standups where you want a bot to transcribe + summarize for async attendees; deposition-style interviews where you want structured notes; any case where you'd otherwise need Fireflies / Otter / Grain. When you'd rather not have an AI listening in — don't enable it.
 
 **Disabling:** `hermes plugins disable google_meet`. Any cached transcripts and recordings stay in `~/.hermes/cache/google_meet/` until you remove them.
+
+### build-macos-apps
+
+Bundled standalone plugin for local macOS app build workflows. Phase 1 combines read-only inspection with real unsigned build support.
+
+**Included toolset:** `macos-dev`
+
+**Included tools:**
+
+- `macos_inspect_project` — inspect a repo for `.xcworkspace`, `.xcodeproj`, and `Package.swift`
+- `macos_list_schemes` — run `xcodebuild -list -json` for a selected workspace or project
+- `macos_build_project` — run an unsigned `xcodebuild build` for a chosen scheme
+
+**Availability gate:** only exposed when Hermes is running on macOS and `xcodebuild` is available in `PATH`.
+
+**Phase 1 exclusions:**
+
+- no test execution
+- no app launch or stop flow
+- no logs or crash diagnostics
+- no signing or notarization
+- no GUI automation or computer-use
+
+**Build behavior:** `macos_build_project` disables signing with `CODE_SIGNING_ALLOWED=NO`, `CODE_SIGNING_REQUIRED=NO`, and `CODE_SIGN_IDENTITY=` so the PR stays focused on local unsigned builds.
+
+**Enabling:** `hermes plugins enable build-macos-apps`
+
+**Recommended flow:** inspect the repo, list schemes, then build the target scheme.
 
 ### hermes-achievements
 

--- a/website/docs/user-guide/features/built-in-plugins.md
+++ b/website/docs/user-guide/features/built-in-plugins.md
@@ -59,7 +59,7 @@ The repo ships these bundled plugins under `plugins/`. All are opt-in — enable
 | `observability/langfuse` | hooks | Trace turns / LLM calls / tools to [Langfuse](https://langfuse.com) |
 | `spotify` | backend (7 tools) | Native Spotify playback, queue, search, playlists, albums, library |
 | `google_meet` | standalone | Join Meet calls, live-caption transcription, optional realtime duplex audio |
-| `build-macos-apps` | standalone | Inspect local Xcode projects, list schemes, and run unsigned macOS builds |
+| `build-macos-apps` | standalone | Inspect local Xcode projects, list schemes, run tests, and run unsigned macOS builds |
 | `image_gen/openai` | image backend | OpenAI `gpt-image-2` image generation backend (alternative to FAL) |
 | `image_gen/openai-codex` | image backend | OpenAI image generation via Codex OAuth |
 | `image_gen/xai` | image backend | xAI `grok-2-image` backend |
@@ -203,7 +203,7 @@ The agent kicks off the meeting join, streams the transcription back into its co
 
 ### build-macos-apps
 
-Bundled standalone plugin for local macOS app build workflows. Phase 1 combines read-only inspection with real unsigned build support.
+Bundled standalone plugin for local macOS app build workflows. Phase 2 adds xcodebuild test support on top of the existing inspection and build flow.
 
 **Included toolset:** `macos-dev`
 
@@ -212,22 +212,22 @@ Bundled standalone plugin for local macOS app build workflows. Phase 1 combines 
 - `macos_inspect_project` — inspect a repo for `.xcworkspace`, `.xcodeproj`, and `Package.swift`
 - `macos_list_schemes` — run `xcodebuild -list -json` for a selected workspace or project
 - `macos_build_project` — run an unsigned `xcodebuild build` for a chosen scheme
+- `macos_test_project` — run `xcodebuild test` for a chosen scheme with optional test filtering
 
 **Availability gate:** only exposed when Hermes is running on macOS and `xcodebuild` is available in `PATH`.
 
-**Phase 1 exclusions:**
+**Current exclusions:**
 
-- no test execution
 - no app launch or stop flow
 - no logs or crash diagnostics
 - no signing or notarization
 - no GUI automation or computer-use
 
-**Build behavior:** `macos_build_project` disables signing with `CODE_SIGNING_ALLOWED=NO`, `CODE_SIGNING_REQUIRED=NO`, and `CODE_SIGN_IDENTITY=` so the PR stays focused on local unsigned builds.
+**Build/test behavior:** `macos_build_project` and `macos_test_project` disable signing with `CODE_SIGNING_ALLOWED=NO`, `CODE_SIGNING_REQUIRED=NO`, and `CODE_SIGN_IDENTITY=` so the plugin stays focused on local unsigned workflows. `macos_test_project` also supports optional `test_plan`, `only_testing`, `skip_testing`, and `result_bundle_path` arguments.
 
 **Enabling:** `hermes plugins enable build-macos-apps`
 
-**Recommended flow:** inspect the repo, list schemes, then build the target scheme.
+**Recommended flow:** inspect the repo, list schemes, then build or test the target scheme.
 
 ### hermes-achievements
 


### PR DESCRIPTION
## Summary

  This adds Phase 2 test support to the bundled `build-macos-apps` plugin.

  It introduces a new `macos_test_project` tool under the existing `macos-dev` toolset, extending the current inspect → scheme list → build flow with typed `xcodebuild test` support.

  This is additive to Phase 1. It does not expand into app launch, diagnostics, signing, or notarization workflows.

  ## What’s included

  - new `macos_test_project` tool
  - schema and registration wiring for the existing bundled plugin
  - `xcodebuild test` execution with the same macOS + `xcodebuild` availability gate
  - optional support for:
    - `test_plan`
    - `only_testing`
    - `skip_testing`
    - `result_bundle_path`
  - README update
  - built-in plugin docs update
  - targeted plugin/tool tests

  ## Scope

  Included:

  - local Xcode scheme test execution
  - optional test filtering
  - optional test plan selection
  - optional xcresult bundle output

  Excluded:

  - app launch / stop
  - logs / crash diagnostics
  - signing / notarization
  - GUI automation / computer-use
  - core plugin-system changes

  ## Behavior details

  - `macos_test_project` uses `xcodebuild test`
  - it reuses the same container selection flow as Phase 1 (`.xcworkspace` / `.xcodeproj`)
  - it stays under the same `macos-dev` toolset
  - it is exposed only when Hermes is running on macOS and `xcodebuild` is available in `PATH`
  - it keeps the unsigned local-workflow posture by passing:
    - `CODE_SIGNING_ALLOWED=NO`
    - `CODE_SIGNING_REQUIRED=NO`
    - `CODE_SIGN_IDENTITY=`

  ## Why this shape

  Phase 1 already covered the common inspection and build path. The next bounded step is test execution, without yet pulling in run-loop or diagnostics concerns.

  This keeps the plugin mergeable in small slices while making the existing Xcode-native workflow more complete:

  1. inspect project
  2. list schemes
  3. build scheme
  4. test scheme

  ## Testing

  Ran targeted tests:

  ```bash
  pytest -q -n0 tests/plugins/test_build_macos_apps_tools.py tests/plugins/test_build_macos_apps_plugin.py
  ```
  - 14 passed
