### PR TITLE
fix(conversation_loop): NameError on rate-limit fallback path

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2317,7 +2317,7 @@ def run_conversation(
                     # still recover.  See _pool_may_recover_from_rate_limit
                     # for the single-credential-pool and CloudCode-quota
                     # exceptions.  Fixes #11314 and #13636.
-                    pool_may_recover = _pool_may_recover_from_rate_limit(
+                    pool_may_recover = _ra()._pool_may_recover_from_rate_limit(
                         agent._credential_pool,
                         provider=agent.provider,
                         base_url=getattr(agent, "base_url", None),


### PR DESCRIPTION
## Summary

The eager-fallback path for 429 errors calls `_pool_may_recover_from_rate_limit()` as a bare name, but the function is defined in `run_agent.py` and is never imported into `agent/conversation_loop.py`. When this code path executes, it crashes with `NameError` instead of evaluating the pool-recovery check — which means the fallback chain never fires for single-credential providers that cannot rotate.

## The Bug

```python
# agent/conversation_loop.py:2320 — before fix
pool_may_recover = _pool_may_recover_from_rate_limit(
    agent._credential_pool,
    provider=agent.provider,
    base_url=getattr(agent, "base_url", None),
)
```

`_pool_may_recover_from_rate_limit` is a module-level function in `run_agent.py` (introduced in `1fc77f995`). `conversation_loop.py` does not `from run_agent import` it, nor is it defined locally. Every other cross-module call in this file uses the `_ra()` lazy accessor pattern (e.g. `_ra()._set_interrupt`, `_ra().handle_function_call`).

## The Fix

One-line change: `_pool_may_recover_from_rate_limit(` → `_ra()._pool_may_recover_from_rate_limit(`

## Why It Wasn't Caught

The code path only executes when **both** conditions are true:
1. A 429/rate-limit error occurs
2. The fallback chain has available entries (`_fallback_index < len(_fallback_chain)`)

With few fallback entries or rare rate limits, the buggy line is never reached. In production, observed as cron jobs dying silently on 429 instead of falling through to the configured `fallback_providers`.

## Test Plan

- [x] All 28 existing tests in `tests/run_agent/test_provider_fallback.py` and `tests/agent/test_gemini_fast_fallback.py` pass
- [x] Verified the function is accessible via `_ra()._pool_may_recover_from_rate_limit` at runtime
- [ ] Manual: trigger a 429 against a single-credential provider with a fallback configured — confirm fallback activates instead of NameError

Introduced in `1fc77f995` (fix(agent): fall back on rate limit when pool has no rotation room).