### PR TITLE
fix(cron): fail loud when prompt-required tools are hidden

### DIFF
--- a/contributors/emails/lgndscntn@googlemail.com
+++ b/contributors/emails/lgndscntn@googlemail.com
@@ -1,0 +1,2 @@
+Fewmanism
+# googlemail form of Fewmanism identity (PR #27948)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -153,6 +153,149 @@ class CronPromptInjectionBlocked(Exception):
     """
 
 
+_EXPLICIT_TOOL_CODE_RE = re.compile(r"`([A-Za-z_][A-Za-z0-9_]*)`")
+_EXPLICIT_TOOL_POSITIVE_RE = re.compile(
+    r"\b(must|require(?:d|s)?|use|call|invoke|run|execute|search with|via)\b"
+    r"|必ず|必須|使(?:う|用)|呼び出|実行|検索",
+    re.IGNORECASE,
+)
+_EXPLICIT_TOOL_NEGATIVE_RE = re.compile(
+    r"\b(do not|don't|never|avoid|without|not\s+(?:use|call|invoke|run|execute))\b"
+    r"|禁止|使わない|使用しない|呼び出さない|実行しない",
+    re.IGNORECASE,
+)
+
+
+def _line_looks_like_positive_tool_requirement(line: str) -> bool:
+    """Heuristic: distinguish required tool mentions from prohibitions/docs."""
+    if _EXPLICIT_TOOL_NEGATIVE_RE.search(line):
+        return False
+    return bool(_EXPLICIT_TOOL_POSITIVE_RE.search(line))
+
+
+def _resolve_tool_names_for_toolsets(toolsets: list[str] | None) -> set[str] | None:
+    """Return requested tool names for *toolsets*, or None for full defaults."""
+    if toolsets is None:
+        return None
+    requested: set[str] = set()
+    try:
+        from model_tools import _LEGACY_TOOLSET_MAP
+        from toolsets import resolve_toolset, validate_toolset
+    except Exception:
+        return requested
+
+    for toolset_name in toolsets:
+        if validate_toolset(toolset_name):
+            requested.update(resolve_toolset(toolset_name))
+        elif toolset_name in _LEGACY_TOOLSET_MAP:
+            requested.update(_LEGACY_TOOLSET_MAP[toolset_name])
+    return requested
+
+
+def _cron_instruction_text_for_required_tool_preflight(job: dict) -> str:
+    """Return instruction-bearing text for required-tool preflight.
+
+    Only the job's stored prompt is treated as an instruction source. Runtime-
+    collected data — pre-run script stdout and ``context_from`` upstream-job
+    output — is intentionally excluded: those sections are untrusted/data
+    sources that may quote tool-shaped phrases (for example
+    ``Must use `terminal```) without requiring those tools on the job.
+    """
+    return str(job.get("prompt") or "")
+
+
+def _explicit_prompt_tool_availability_error(
+    instruction_prompt: str,
+    *,
+    enabled_toolsets: list[str] | None,
+    disabled_toolsets: list[str] | None,
+) -> str | None:
+    """Return a cron preflight error when instruction-required tools are hidden.
+
+    Cron jobs are unattended and auto-delivered. If the job's instruction
+    prompt says things like ``必ず `x_search` ツール`` but the effective cron
+    toolsets do not expose that tool (or the tool's check_fn filters it out),
+    running the LLM is wasteful and often produces a misleading "success".
+
+    Callers must pass *instruction* text only (see
+    :func:`_cron_instruction_text_for_required_tool_preflight`). Injected
+    script/upstream data must never be scanned here.
+
+    We only inspect exact markdown-code references to known Hermes tool names
+    to avoid flagging prose, commands, paths, or skill names.
+    """
+    if not instruction_prompt:
+        return None
+
+    try:
+        import model_tools
+        from model_tools import get_tool_definitions
+        from tools.registry import registry
+    except Exception as exc:
+        logger.warning("Cron explicit-tool preflight skipped: %s", exc)
+        return None
+
+    known_tool_names = set(registry.get_all_tool_names())
+    explicit: set[str] = set()
+    for line in instruction_prompt.splitlines():
+        for segment in re.split(r"(?<=[。.!?])\s+|[。.!?]", line):
+            if not _line_looks_like_positive_tool_requirement(segment):
+                continue
+            explicit.update(
+                match.group(1)
+                for match in _EXPLICIT_TOOL_CODE_RE.finditer(segment)
+                if match.group(1) in known_tool_names
+            )
+    explicit_tool_names = sorted(explicit)
+    if not explicit_tool_names:
+        return None
+
+    # skip_tool_search_assembly=True: when tool-search progressive disclosure
+    # is active, MCP/plugin tools are deferred behind tool_search/tool_call and
+    # vanish from the top-level schema. Preflight still needs the raw catalog
+    # to decide whether a required tool is *reachable* under the job's
+    # toolset filters (not whether it is listed in the collapsed schema).
+    available_tool_names = {
+        tool.get("function", {}).get("name")
+        for tool in get_tool_definitions(  # type: ignore[arg-type]
+            enabled_toolsets=enabled_toolsets,
+            disabled_toolsets=disabled_toolsets,
+            quiet_mode=True,
+            skip_tool_search_assembly=True,
+        )
+    }
+    missing = [name for name in explicit_tool_names if name not in available_tool_names]
+    if not missing:
+        return None
+
+    requested_names = _resolve_tool_names_for_toolsets(enabled_toolsets)
+    disabled_names = _resolve_tool_names_for_toolsets(disabled_toolsets) or set()
+    enabled_display = ", ".join(enabled_toolsets) if enabled_toolsets is not None else "<default/full>"
+    disabled_display = ", ".join(disabled_toolsets or []) or "<none>"
+
+    detail_lines: list[str] = []
+    for tool_name in missing:
+        toolset = model_tools.get_toolset_for_tool(tool_name) or "unknown"
+        if tool_name in disabled_names:
+            reason = f"toolset '{toolset}' is disabled"
+        elif requested_names is not None and tool_name not in requested_names:
+            reason = f"toolset '{toolset}' is not included in enabled_toolsets"
+        else:
+            reason = "tool requirements/check_fn failed (credential or runtime dependency unavailable)"
+        detail_lines.append(f"- `{tool_name}` (toolset `{toolset}`): {reason}")
+
+    return (
+        "Cron job instruction explicitly requires tool(s) that are not exposed "
+        "to this job. Refusing to run the unattended LLM tick.\n\n"
+        f"enabled_toolsets: {enabled_display}\n"
+        f"disabled_toolsets: {disabled_display}\n\n"
+        + "\n".join(detail_lines)
+        + "\n\nFix: add the missing toolset(s) to this cron job's `enabled_toolsets`, "
+        "enable the required credentials/dependencies, or remove the explicit "
+        "tool requirement from the job prompt."
+    )
+
+
 def _resolve_cron_disabled_toolsets(cfg: dict) -> list[str]:
     """Toolsets a cron-spawned agent must never receive.
 
@@ -3421,6 +3564,9 @@ def run_job(
         # ticks short-circuit on already-connected servers inside
         # register_mcp_servers(). Non-fatal on failure: a broken MCP server
         # shouldn't kill an otherwise-working cron job. See #4219.
+        #
+        # Discovery MUST run before required-tool preflight so dynamically
+        # registered MCP tools are known and resolvable.
         try:
             from tools.mcp_tool import discover_mcp_tools
             _mcp_tools = discover_mcp_tools()
@@ -3434,6 +3580,26 @@ def run_job(
                 "Job '%s': MCP initialization failed (non-fatal): %s",
                 job_id, _mcp_exc,
             )
+
+        cron_enabled_toolsets = _resolve_cron_enabled_toolsets(
+            job,
+            _cfg if isinstance(_cfg, dict) else {},
+        )
+        cron_disabled_toolsets = _resolve_cron_disabled_toolsets(
+            _cfg if isinstance(_cfg, dict) else {},
+        )
+
+        # Fail loud when the job *instruction* requires tools that this cron
+        # tick will not expose. Scan only instruction-bearing text (job
+        # prompt) — never injected script/upstream data. See
+        # _cron_instruction_text_for_required_tool_preflight.
+        tool_preflight_error = _explicit_prompt_tool_availability_error(
+            _cron_instruction_text_for_required_tool_preflight(job),
+            enabled_toolsets=cron_enabled_toolsets,
+            disabled_toolsets=cron_disabled_toolsets,
+        )
+        if tool_preflight_error:
+            raise RuntimeError(tool_preflight_error)
 
         agent = AIAgent(
             model=model,
@@ -3454,8 +3620,8 @@ def run_job(
             providers_order=pr.get("order"),
             provider_sort=pr.get("sort"),
             openrouter_min_coding_score=(_cfg.get("openrouter") or {}).get("min_coding_score"),
-            enabled_toolsets=_resolve_cron_enabled_toolsets(job, _cfg),
-            disabled_toolsets=_resolve_cron_disabled_toolsets(_cfg),
+            enabled_toolsets=cron_enabled_toolsets,
+            disabled_toolsets=cron_disabled_toolsets,
             quiet_mode=True,
             # Cron jobs should always inherit the user's SOUL.md identity from
             # HERMES_HOME. When a workdir is configured, also inject project

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1619,6 +1619,269 @@ class TestRunJobSessionPersistence:
             "cronjob", "messaging", "clarify", "terminal", "file",
         }
 
+    def test_run_job_instruction_required_tool_hidden_fails_preflight(self, tmp_path):
+        """Instruction-level ``Must use `terminal``` fails when terminal is disabled."""
+        (tmp_path / "config.yaml").write_text(
+            "agent:\n"
+            "  disabled_toolsets:\n"
+            "    - terminal\n",
+            encoding="utf-8",
+        )
+        job = {
+            "id": "req-tool-job",
+            "name": "required-tool",
+            "prompt": "Must use `terminal` to inspect the local process state.",
+            "enabled_toolsets": ["terminal", "file"],
+        }
+        with self._run_job_patches(tmp_path) as (_fake_db, mock_agent_cls):
+            success, _output, _final, error = run_job(job)
+
+        assert success is False
+        assert error is not None
+        assert "terminal" in error
+        mock_agent_cls.assert_not_called()
+
+    def test_run_job_injected_script_data_does_not_trigger_required_tool_preflight(
+        self, tmp_path, monkeypatch
+    ):
+        """Quoted tool requirements in script stdout must not fail the job.
+
+        Pre-run script output is data, not instruction. A feed that pastes
+        ``Must use `terminal``` must not block a job that intentionally leaves
+        terminal disabled.
+        """
+        from cron import scheduler
+
+        (tmp_path / "config.yaml").write_text(
+            "agent:\n"
+            "  disabled_toolsets:\n"
+            "    - terminal\n",
+            encoding="utf-8",
+        )
+        job = {
+            "id": "data-injection-job",
+            "name": "data-injection",
+            "prompt": "Summarize the script output for the operator.",
+            "script": "collect_data.py",
+            "enabled_toolsets": ["file", "web"],
+        }
+
+        def fake_run_script(script_path, workdir=None):
+            return (
+                True,
+                "Incident note: Must use `terminal` to inspect the local process state.",
+            )
+
+        monkeypatch.setattr(scheduler, "_run_job_script", fake_run_script)
+        monkeypatch.setattr(
+            scheduler,
+            "_run_job_script_with_claim_heartbeat",
+            lambda job, script_path, workdir=None: fake_run_script(script_path, workdir),
+        )
+
+        with self._run_job_patches(tmp_path) as (_fake_db, mock_agent_cls):
+            success, _output, final_response, error = run_job(job)
+
+        assert success is True, error
+        assert error is None
+        assert final_response == "ok"
+        mock_agent_cls.assert_called_once()
+        kwargs = mock_agent_cls.call_args.kwargs
+        assert "terminal" in set(kwargs["disabled_toolsets"] or [])
+
+    def test_run_job_injected_context_from_data_does_not_trigger_required_tool_preflight(
+        self, tmp_path
+    ):
+        """Quoted tool requirements in context_from upstream output must not fail.
+
+        Upstream job output is data, not instruction. A preceding job that pastes
+        ``Must use `terminal``` must not block a job that intentionally leaves
+        terminal disabled. Exercises the real context_from prompt-assembly path.
+        """
+        from cron.jobs import get_cron_output_dir
+
+        (tmp_path / "config.yaml").write_text(
+            "agent:\n"
+            "  disabled_toolsets:\n"
+            "    - terminal\n",
+            encoding="utf-8",
+        )
+        # Valid job IDs are 12-char hex (path component under cron/output).
+        upstream_id = "abcdef123456"
+        upstream_phrase = "Must use `terminal` to inspect the local process state."
+        out_dir = get_cron_output_dir() / upstream_id
+        out_dir.mkdir(parents=True, exist_ok=True)
+        (out_dir / "2026-07-27_12-00-00.md").write_text(
+            f"Incident note: {upstream_phrase}",
+            encoding="utf-8",
+        )
+
+        job = {
+            "id": "context-from-injection-job",
+            "name": "context-from-injection",
+            "prompt": "Summarize the upstream report for the operator.",
+            "context_from": [upstream_id],
+            "enabled_toolsets": ["file", "web"],
+        }
+
+        with self._run_job_patches(tmp_path) as (_fake_db, mock_agent_cls):
+            success, _output, final_response, error = run_job(job)
+
+        assert success is True, error
+        assert error is None
+        assert final_response == "ok"
+        mock_agent_cls.assert_called_once()
+        kwargs = mock_agent_cls.call_args.kwargs
+        assert "terminal" in set(kwargs["disabled_toolsets"] or [])
+        # Prove the real context_from assembly path injected upstream data into
+        # the prompt that reached the agent (data, not instruction preflight).
+        agent = mock_agent_cls.return_value
+        assert agent.run_conversation.called
+        assembled_prompt = agent.run_conversation.call_args[0][0]
+        assert upstream_phrase in assembled_prompt
+        assert f"Output from job '{upstream_id}'" in assembled_prompt
+
+    def test_run_job_real_preflight_recognizes_discovered_mcp_tool(
+        self, tmp_path, monkeypatch
+    ):
+        """MCP discovery must register tools before the real preflight runs.
+
+        Unlike a pure ordering mock, this exercises
+        ``_explicit_prompt_tool_availability_error`` against a dynamically
+        registered MCP tool and proves the tool is available after discovery
+        when its server alias is in enabled_toolsets.
+        """
+        from tools.registry import registry
+
+        tool_name = "mcp_preflightfake_fetch"
+        toolset_name = "mcp-preflightfake"
+        server_alias = "preflightfake"
+        registered = {"done": False}
+
+        def fake_discover_mcp_tools():
+            # Mirror register_mcp_servers: dynamic tool + server-name alias.
+            registry.register(
+                name=tool_name,
+                toolset=toolset_name,
+                schema={
+                    "name": tool_name,
+                    "description": "Fake MCP tool for cron preflight coverage",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+                handler=lambda args, **kw: "{}",
+            )
+            registry.register_toolset_alias(server_alias, toolset_name)
+            registered["done"] = True
+            return [tool_name]
+
+        job = {
+            "id": "mcp-real-preflight-job",
+            "name": "mcp-real-preflight",
+            "prompt": f"Must use `{tool_name}` to fetch the external data.",
+            # Name the MCP server alias so get_tool_definitions exposes it.
+            "enabled_toolsets": ["file", server_alias],
+        }
+
+        try:
+            with self._run_job_patches(
+                tmp_path,
+                extra=(
+                    patch(
+                        "tools.mcp_tool.discover_mcp_tools",
+                        side_effect=fake_discover_mcp_tools,
+                    ),
+                ),
+            ) as (_fake_db, mock_agent_cls):
+                success, _output, final_response, error = run_job(job)
+
+            assert registered["done"] is True
+            assert success is True, error
+            assert error is None
+            assert final_response == "ok"
+            mock_agent_cls.assert_called_once()
+            # Preflight ran with real availability and did not reject the MCP tool.
+            kwargs = mock_agent_cls.call_args.kwargs
+            assert server_alias in (kwargs["enabled_toolsets"] or [])
+        finally:
+            try:
+                registry.deregister(tool_name)
+            except Exception:
+                pass
+            # No global registry pollution (tool + alias both gone).
+            assert tool_name not in registry.get_all_tool_names()
+            assert server_alias not in registry.get_registered_toolset_aliases()
+
+    def test_run_job_discovered_mcp_tool_hidden_by_enabled_toolsets_fails_preflight(
+        self, tmp_path, monkeypatch
+    ):
+        """Discovered MCP tools still fail loud when their alias is not enabled.
+
+        Locks two invariants the positive-only path cannot:
+        1. Discovery-before-preflight — if preflight ran first, the unregistered
+           tool name would be skipped (unknown names are ignored) and the job
+           would wrongly succeed.
+        2. Real availability check — once the tool is known, omitting its
+           alias/toolset from enabled_toolsets must fail preflight and must not
+           construct AIAgent.
+        """
+        from tools.registry import registry
+
+        tool_name = "mcp_preflightneg_fetch"
+        toolset_name = "mcp-preflightneg"
+        server_alias = "preflightneg"
+        registered = {"done": False}
+
+        def fake_discover_mcp_tools():
+            registry.register(
+                name=tool_name,
+                toolset=toolset_name,
+                schema={
+                    "name": tool_name,
+                    "description": "Fake MCP tool for negative preflight coverage",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+                handler=lambda args, **kw: "{}",
+            )
+            registry.register_toolset_alias(server_alias, toolset_name)
+            registered["done"] = True
+            return [tool_name]
+
+        job = {
+            "id": "mcp-neg-preflight-job",
+            "name": "mcp-neg-preflight",
+            "prompt": f"Must use `{tool_name}` to fetch the external data.",
+            # Alias deliberately omitted: tool is discovered/known but hidden.
+            "enabled_toolsets": ["file"],
+        }
+
+        try:
+            with self._run_job_patches(
+                tmp_path,
+                extra=(
+                    patch(
+                        "tools.mcp_tool.discover_mcp_tools",
+                        side_effect=fake_discover_mcp_tools,
+                    ),
+                ),
+            ) as (_fake_db, mock_agent_cls):
+                success, _output, _final, error = run_job(job)
+
+            assert registered["done"] is True, (
+                "discovery must run before preflight; otherwise unknown tool "
+                "names are skipped and this negative path cannot fail loud"
+            )
+            assert success is False
+            assert error is not None
+            assert tool_name in error
+            mock_agent_cls.assert_not_called()
+        finally:
+            try:
+                registry.deregister(tool_name)
+            except Exception:
+                pass
+            assert tool_name not in registry.get_all_tool_names()
+            assert server_alias not in registry.get_registered_toolset_aliases()
+
     def test_run_job_enabled_toolsets_resolves_from_platform_config_when_not_set(self, tmp_path):
         """When a job has no explicit enabled_toolsets, the scheduler now
         resolves them from ``hermes tools`` platform config for ``cron``

--- a/tests/cron/test_scheduler_required_tools.py
+++ b/tests/cron/test_scheduler_required_tools.py
@@ -1,0 +1,130 @@
+"""Regression tests for cron tool preflight failures.
+
+Cron jobs are unattended. If the job *instruction* (stored prompt) explicitly
+requires a tool (for example ``必ず `x_search` ツール``) but the job's exposed
+toolsets do not include that tool, the scheduler should fail before spending
+an LLM run and surface a clear configuration error.
+
+Injected pre-run script stdout and ``context_from`` upstream-job output are
+data sources, not instructions — required-tool extraction must not scan them.
+"""
+
+from __future__ import annotations
+
+
+def test_explicit_prompt_tool_missing_from_enabled_toolsets_fails_loud():
+    from cron import scheduler
+
+    error = scheduler._explicit_prompt_tool_availability_error(
+        "必ず `x_search` ツールでX投稿を検索する。通常Web検索は禁止。",
+        enabled_toolsets=["web", "file", "terminal"],
+        disabled_toolsets=["cronjob", "messaging", "clarify"],
+    )
+
+    assert error is not None
+    assert "x_search" in error
+    assert "enabled_toolsets" in error
+    assert "web, file, terminal" in error
+
+
+def test_negative_prompt_tool_reference_is_not_treated_as_requirement():
+    from cron import scheduler
+
+    error = scheduler._explicit_prompt_tool_availability_error(
+        "Do not call `send_message`, create cron jobs, or publish externally.",
+        enabled_toolsets=["file", "terminal", "skills"],
+        disabled_toolsets=["cronjob", "messaging", "clarify"],
+    )
+
+    assert error is None
+
+
+def test_explicit_prompt_tool_available_when_toolset_exposed(monkeypatch):
+    from cron import scheduler
+    import model_tools
+
+    def fake_tool_definitions(
+        enabled_toolsets=None,
+        disabled_toolsets=None,
+        quiet_mode=False,
+        skip_tool_search_assembly=False,
+    ):
+        assert enabled_toolsets == ["x_search", "file"]
+        assert skip_tool_search_assembly is True
+        return [{"type": "function", "function": {"name": "x_search"}}]
+
+    monkeypatch.setattr(model_tools, "get_tool_definitions", fake_tool_definitions)
+
+    error = scheduler._explicit_prompt_tool_availability_error(
+        "必ず `x_search` ツールでX投稿を検索する。",
+        enabled_toolsets=["x_search", "file"],
+        disabled_toolsets=["cronjob", "messaging", "clarify"],
+    )
+
+    assert error is None
+
+
+def test_explicit_prompt_tool_hidden_by_agent_disabled_toolsets_fails_loud():
+    from cron import scheduler
+
+    disabled = scheduler._resolve_cron_disabled_toolsets(
+        {"agent": {"disabled_toolsets": ["terminal"]}}
+    )
+    error = scheduler._explicit_prompt_tool_availability_error(
+        "Must use `terminal` to inspect the local process state.",
+        enabled_toolsets=["terminal", "file"],
+        disabled_toolsets=disabled,
+    )
+
+    assert error is not None
+    assert "terminal" in error
+    assert "toolset 'terminal' is disabled" in error
+    assert "cronjob, messaging, clarify, terminal" in error
+
+
+def test_instruction_text_is_job_prompt_only():
+    from cron import scheduler
+
+    job = {
+        "prompt": "Summarize the upstream report.",
+        "script": "collect.py",
+        "context_from": ["aaaaaaaaaaaa"],
+    }
+    assert (
+        scheduler._cron_instruction_text_for_required_tool_preflight(job)
+        == "Summarize the upstream report."
+    )
+
+
+def test_injected_data_phrases_do_not_count_as_instruction_requirements():
+    """Quoted tool requirements inside data-shaped text must not fail preflight."""
+    from cron import scheduler
+
+    # Full assembled prompt would include this data; preflight must not scan it.
+    data_blob = (
+        "## Script Output\n"
+        "Must use `terminal` to inspect the local process state.\n"
+        "```\nMust use `terminal` now\n```\n"
+    )
+    instruction = "Summarize the script output for the operator."
+
+    disabled = scheduler._resolve_cron_disabled_toolsets(
+        {"agent": {"disabled_toolsets": ["terminal"]}}
+    )
+    # Scanning instruction alone: no terminal requirement.
+    assert (
+        scheduler._explicit_prompt_tool_availability_error(
+            instruction,
+            enabled_toolsets=["file", "web"],
+            disabled_toolsets=disabled,
+        )
+        is None
+    )
+    # Scanning data alone would false-positive — prove the boundary matters.
+    data_error = scheduler._explicit_prompt_tool_availability_error(
+        data_blob,
+        enabled_toolsets=["file", "web"],
+        disabled_toolsets=disabled,
+    )
+    assert data_error is not None
+    assert "terminal" in data_error


### PR DESCRIPTION
## Summary
- Add cron preflight validation for explicitly required tools referenced in the job instruction prompt
- Fail unattended cron ticks before the LLM run when a required tool is hidden by `enabled_toolsets`, `agent.disabled_toolsets`, or runtime requirements
- Preserve prompt-source boundaries: pre-run script stdout and `context_from` upstream-job output are treated as data and excluded from required-tool extraction
- Run the real preflight after MCP discovery so dynamically registered MCP tools are evaluated against their effective toolsets
- Avoid false positives for negative/prohibition references such as `Do not call \`send_message\``

## Test Plan
- `HERMES_PYTHON=/Users/tet/.hermes/hermes-agent/.venv/bin/python scripts/run_tests.sh tests/cron/test_scheduler_required_tools.py tests/cron/test_scheduler.py tests/scripts/test_contributor_map.py -q --tb=line`
- Result: `263 passed, 0 failed`
- `python -m py_compile cron/scheduler.py tests/cron/test_scheduler_required_tools.py tests/cron/test_scheduler.py scripts/release.py`
- `git diff --check origin/main...HEAD`
