### PR TITLE
fix: add pre_start() to _IncomingHandler for dingtalk SDK compatibility

### DIFF
--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -1395,6 +1395,16 @@ class _IncomingHandler(
         self._adapter = adapter
         self._loop = loop
 
+    def pre_start(self) -> None:
+        """No-op pre-start hook required by dingtalk-stream SDK.
+
+        The SDK calls ``pre_start()`` on every registered handler before
+        opening the WebSocket connection.  Without this method, the SDK
+        raises ``AttributeError: '_IncomingHandler' object has no
+        attribute 'pre_start'`` and kills the stream connection.
+        """
+        return
+
     async def process(self, message: "CallbackMessage"):
         """Called by dingtalk-stream (>=0.20) when a message arrives.
 


### PR DESCRIPTION
## Problem

The `dingtalk-stream` SDK calls `pre_start()` on every registered handler before opening the WebSocket connection.

The custom `_IncomingHandler` in `gateway/platforms/dingtalk.py` was missing this method, causing:

```
WARNING: [Dingtalk] Stream client error: _IncomingHandler has no attribute pre_start
```

This error kills the stream connection immediately, making DingTalk unable to connect via Stream Mode.

## Fix

Added the `pre_start()` no-op method to `_IncomingHandler`, matching the pattern used by the SDKs built-in handlers (`CallbackHandler`, `EventHandler`, `SystemHandler`).

## Verification

After applying this fix locally, the DingTalk gateway connects successfully and the stream remains stable without the AttributeError.