### PR TITLE
fix(tui): exit slash worker on stdin EOF

### DIFF
--- a/tests/test_tui_slash_worker.py
+++ b/tests/test_tui_slash_worker.py
@@ -1,0 +1,72 @@
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+def test_slash_worker_exits_on_stdin_eof_even_with_live_non_daemon_threads(tmp_path):
+    """The dashboard/TUI slash worker must not survive its parent session.
+
+    A real HermesCLI can leave helper threads alive.  When the TUI gateway or
+    browser-backed PTY disappears, stdin reaches EOF; the worker should still
+    terminate instead of lingering as an orphaned ``tui_gateway.slash_worker``
+    process.
+    """
+    fake_cli = tmp_path / "cli.py"
+    fake_cli.write_text(
+        textwrap.dedent(
+            """
+            import threading
+            import time
+
+            class HermesCLI:
+                def __init__(self, *args, **kwargs):
+                    def spin():
+                        while True:
+                            time.sleep(60)
+                    threading.Thread(target=spin, daemon=False).start()
+                    self.console = None
+
+                def process_command(self, command):
+                    return None
+            """
+        )
+    )
+
+    repo_root = Path(__file__).resolve().parents[1]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = f"{tmp_path}{os.pathsep}{repo_root}{os.pathsep}{env.get('PYTHONPATH', '')}"
+    env["HERMES_SLASH_WORKER_SHUTDOWN_GRACE_S"] = "0.1"
+
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "tui_gateway.slash_worker",
+            "--session-key",
+            "test-session",
+            "--model",
+            "test-model",
+        ],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        cwd=tmp_path,
+        env=env,
+    )
+    assert proc.stdin is not None
+    proc.stdin.close()
+    proc.stdin = None
+
+    try:
+        proc.wait(timeout=2)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        stdout, stderr = proc.communicate(timeout=2)
+        raise AssertionError(
+            f"slash_worker stayed alive after stdin EOF; stdout={stdout!r} stderr={stderr!r}"
+        )
+
+    assert proc.returncode == 0

--- a/tui_gateway/slash_worker.py
+++ b/tui_gateway/slash_worker.py
@@ -9,10 +9,42 @@ import io
 import json
 import os
 import sys
+import threading
 
 import cli as cli_mod
 from cli import HermesCLI
 from rich.console import Console
+
+
+_DEFAULT_SHUTDOWN_GRACE_S = 1.0
+
+
+def _shutdown_grace_seconds() -> float:
+    raw = (os.environ.get("HERMES_SLASH_WORKER_SHUTDOWN_GRACE_S") or "").strip()
+    if not raw:
+        return _DEFAULT_SHUTDOWN_GRACE_S
+    try:
+        value = float(raw)
+    except ValueError:
+        return _DEFAULT_SHUTDOWN_GRACE_S
+    return value if value > 0 else _DEFAULT_SHUTDOWN_GRACE_S
+
+
+def _exit_after_stdin_eof() -> None:
+    """Exit even when HermesCLI left non-daemon helper threads running.
+
+    The TUI gateway owns this worker via stdin/stdout pipes. When the gateway
+    process or browser-backed PTY disappears, stdin reaches EOF and there is no
+    useful work left to do. A normal ``return``/``sys.exit`` can still hang if
+    CLI setup left non-daemon helper threads alive, producing orphaned
+    ``tui_gateway.slash_worker`` processes. Give ordinary cleanup a short
+    chance, then force-exit the worker.
+    """
+
+    timer = threading.Timer(_shutdown_grace_seconds(), lambda: os._exit(0))
+    timer.daemon = True
+    timer.start()
+    sys.exit(0)
 
 
 def _run(cli: HermesCLI, command: str) -> str:
@@ -70,6 +102,8 @@ def main():
         except Exception as e:
             sys.stdout.write(json.dumps({"id": rid, "ok": False, "error": str(e)}) + "\n")
             sys.stdout.flush()
+
+    _exit_after_stdin_eof()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Make `tui_gateway.slash_worker` terminate when its stdin pipe reaches EOF, even if CLI initialization left non-daemon helper threads alive.
- Add a shutdown grace timer with a force-exit fallback so browser/dashboard/TUI disconnects do not leave orphaned slash-worker processes.
- Add a regression test that simulates a HermesCLI with a live non-daemon thread and verifies the worker exits on stdin EOF.

## Test plan
- `python -m py_compile tui_gateway/slash_worker.py`
- `python -m pytest tests/test_tui_slash_worker.py::test_slash_worker_exits_on_stdin_eof_even_with_live_non_daemon_threads -q -o 'addopts='`
