### PR TITLE
feat(dashboard): expose embedded chat diagnostics

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -534,6 +534,45 @@ def _probe_gateway_health() -> tuple[bool, dict | None]:
     return False, None
 
 
+def _dashboard_chat_diagnostics() -> dict[str, Any]:
+    """Return lightweight diagnostics for the dashboard embedded Chat path.
+
+    The browser Chat tab runs a PTY-backed TUI, which in turn may spawn a
+    persistent ``tui_gateway.slash_worker`` helper.  If those helpers survive
+    their parent session, dashboard Chat can feel progressively heavier.  Keep
+    this status payload best-effort and read-only so /api/status remains cheap
+    and safe.
+    """
+
+    pids: list[int] = []
+    if sys.platform != "win32":
+        try:
+            output = subprocess.check_output(
+                ["ps", "-axo", "pid=,command="],
+                text=True,
+                stderr=subprocess.DEVNULL,
+                timeout=1,
+            )
+        except Exception:
+            output = ""
+        for line in output.splitlines():
+            if "tui_gateway.slash_worker" not in line:
+                continue
+            parts = line.strip().split(maxsplit=1)
+            if not parts:
+                continue
+            try:
+                pids.append(int(parts[0]))
+            except ValueError:
+                continue
+
+    return {
+        "embedded_chat_enabled": _DASHBOARD_EMBEDDED_CHAT_ENABLED,
+        "stale_slash_worker_count": len(pids),
+        "stale_slash_worker_pids": pids[:20],
+    }
+
+
 @app.get("/api/status")
 async def get_status():
     current_ver, latest_ver = check_config_version()
@@ -637,6 +676,7 @@ async def get_status():
         "gateway_exit_reason": gateway_exit_reason,
         "gateway_updated_at": gateway_updated_at,
         "active_sessions": active_sessions,
+        "dashboard_chat": _dashboard_chat_diagnostics(),
     }
 
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -125,6 +125,49 @@ class TestWebServerEndpoints:
         assert "hermes_home" in data
         assert "active_sessions" in data
 
+    def test_get_status_includes_dashboard_chat_diagnostics(self, monkeypatch):
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setattr(
+            web_server,
+            "_dashboard_chat_diagnostics",
+            lambda: {
+                "embedded_chat_enabled": True,
+                "stale_slash_worker_count": 2,
+                "stale_slash_worker_pids": [111, 222],
+            },
+        )
+
+        resp = self.client.get("/api/status")
+
+        assert resp.status_code == 200
+        assert resp.json()["dashboard_chat"] == {
+            "embedded_chat_enabled": True,
+            "stale_slash_worker_count": 2,
+            "stale_slash_worker_pids": [111, 222],
+        }
+
+    def test_dashboard_chat_diagnostics_counts_slash_worker_processes(self, monkeypatch):
+        import subprocess
+        import hermes_cli.web_server as web_server
+
+        ps_output = """
+          101 /usr/bin/python -m tui_gateway.slash_worker --session-key old-one
+          202 /usr/bin/python -m tui_gateway.entry
+          303 /usr/bin/python -m tui_gateway.slash_worker --session-key old-two
+        """
+        monkeypatch.setattr(
+            subprocess,
+            "check_output",
+            lambda *args, **kwargs: ps_output,
+        )
+
+        diagnostics = web_server._dashboard_chat_diagnostics()
+
+        assert diagnostics["embedded_chat_enabled"] is web_server._DASHBOARD_EMBEDDED_CHAT_ENABLED
+        assert diagnostics["stale_slash_worker_count"] == 2
+        assert diagnostics["stale_slash_worker_pids"] == [101, 303]
+
     def test_get_status_filters_unconfigured_gateway_platforms(self, monkeypatch):
         import gateway.config as gateway_config
         import hermes_cli.web_server as web_server


### PR DESCRIPTION
## Summary
- Add lightweight `/api/status` diagnostics for the dashboard embedded Chat path.
- Report whether embedded chat is enabled plus detected `tui_gateway.slash_worker` helper PIDs/counts.
- Add regression coverage for the status payload and process parsing.

## Test plan
- `python -m py_compile hermes_cli/web_server.py`
- `python -m pytest tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_dashboard_chat_diagnostics_counts_slash_worker_processes tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_get_status_includes_dashboard_chat_diagnostics tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_get_status -q -o 'addopts='`
