### PR TITLE
[codex] Fix GPT-5.5 Codex context window

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -152,7 +152,7 @@ DEFAULT_CONTEXT_LENGTHS = {
     # OpenAI — GPT-5 family (most have 400k; specific overrides first)
     # Source: https://developers.openai.com/api/docs/models
     # GPT-5.5 (launched Apr 23 2026) is 1.05M on the direct OpenAI API and
-    # ChatGPT Codex OAuth caps it at 272K; both paths resolve via their own
+    # ChatGPT Codex OAuth is pinned to 1M; both paths resolve via their own
     # provider-aware branches (_resolve_codex_oauth_context_length + models.dev).
     # This hardcoded value is only reached when every probe misses.
     "gpt-5.5": 1050000,
@@ -1239,8 +1239,8 @@ def _query_anthropic_context_length(model: str, base_url: str, api_key: str) -> 
 # Known ChatGPT Codex OAuth context windows (observed via live
 # chatgpt.com/backend-api/codex/models probe, Apr 2026). These are the
 # `context_window` values, which are what Codex actually enforces — the
-# direct OpenAI API has larger limits for the same slugs, but Codex OAuth
-# caps lower (e.g. gpt-5.5 is 1.05M on the API, 272K on Codex).
+# direct OpenAI API has larger limits for some slugs, while Codex OAuth
+# caps most GPT-5.x models lower. GPT-5.5 is a 1M Codex exception.
 #
 # Used as a fallback when the live probe fails (no token, network error).
 # Longest keys first so substring match picks the most specific entry.
@@ -1256,7 +1256,7 @@ _CODEX_OAUTH_CONTEXT_FALLBACK: Dict[str, int] = {
     "gpt-5.3-codex-spark": 128_000,
     "gpt-5.2-codex": 272_000,
     "gpt-5.4-mini": 272_000,
-    "gpt-5.5": 272_000,
+    "gpt-5.5": 1_000_000,
     "gpt-5.4": 272_000,
     "gpt-5.2": 272_000,
     "gpt-5": 272_000,
@@ -1330,6 +1330,11 @@ def _resolve_codex_oauth_context_length(
     model_bare = _strip_provider_prefix(model).strip()
     if not model_bare:
         return None
+
+    # GPT-5.5's Codex OAuth window is intentionally pinned. Older live
+    # metadata and persistent cache entries may still report 272K/1.05M.
+    if model_bare.lower() == "gpt-5.5":
+        return _CODEX_OAUTH_CONTEXT_FALLBACK["gpt-5.5"]
 
     if access_token:
         live = _fetch_codex_oauth_context_lengths(access_token)
@@ -1491,15 +1496,20 @@ def get_model_context_length(
     if base_url and provider != "lmstudio":
         cached = get_cached_context_length(model, base_url)
         if cached is not None:
-            # Invalidate stale Codex OAuth cache entries: pre-PR #14935 builds
-            # resolved gpt-5.x to the direct-API value (e.g. 1.05M) via
-            # models.dev and persisted it. Codex OAuth caps at 272K for every
-            # slug, so any cached Codex entry at or above 400K is a leftover
-            # from the old resolution path. Drop it and fall through to the
-            # live /models probe in step 5 below.
-            if provider == "openai-codex" and cached >= 400_000:
+            # Invalidate stale Codex OAuth cache entries. Pre-PR #14935 builds
+            # resolved gpt-5.x to direct-API values (e.g. 1.05M) via models.dev.
+            # GPT-5.5 is now pinned to 1M on Codex, so any cached GPT-5.5 value
+            # other than 1M must be normalized. Other Codex GPT-5.x slugs still
+            # treat values >= 400K as stale direct-API leakage.
+            if (
+                provider == "openai-codex"
+                and (
+                    (model.lower() == "gpt-5.5" and cached != 1_000_000)
+                    or (model.lower() != "gpt-5.5" and cached >= 400_000)
+                )
+            ):
                 logger.info(
-                    "Dropping stale Codex cache entry %s@%s -> %s (pre-fix value); "
+                    "Dropping stale Codex cache entry %s@%s -> %s; "
                     "re-resolving via live /models probe",
                     model, base_url, f"{cached:,}",
                 )
@@ -1638,9 +1648,9 @@ def get_model_context_length(
                 save_context_length(model, base_url, ctx)
             return ctx
     if effective_provider == "openai-codex":
-        # Codex OAuth enforces lower context limits than the direct OpenAI
-        # API for the same slug (e.g. gpt-5.5 is 1.05M on the API but 272K
-        # on Codex). Authoritative source is Codex's own /models endpoint.
+        # Codex OAuth can enforce different context limits than the direct
+        # OpenAI API for the same slug. Authoritative source is Codex's own
+        # /models endpoint, with pinned exceptions in the resolver.
         codex_ctx = _resolve_codex_oauth_context_length(model, access_token=api_key or "")
         if codex_ctx:
             if base_url:

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -262,9 +262,8 @@ class TestDefaultContextLengths:
 class TestCodexOAuthContextLength:
     """ChatGPT Codex OAuth imposes lower context limits than the direct
     OpenAI API for the same slugs. Verified Apr 2026 via live probe of
-    chatgpt.com/backend-api/codex/models: most models return 272k, while
-    models.dev reports 1.05M for gpt-5.5/gpt-5.4 and 400k for the rest.
-    (Known exception: gpt-5.3-codex-spark is 128k.)
+    chatgpt.com/backend-api/codex/models: most models return 272k, GPT-5.5
+    is pinned to 1M, and gpt-5.3-codex-spark is 128k.
     """
 
     def setup_method(self):
@@ -274,12 +273,12 @@ class TestCodexOAuthContextLength:
 
     def test_fallback_table_used_without_token(self):
         """With no access token, the hardcoded Codex fallback table wins
-        over models.dev (which reports 1.05M for gpt-5.5 but Codex is 272k).
+        over models.dev and preserves Codex-specific windows.
         """
         from agent.model_metadata import get_model_context_length
 
         expected = {
-            "gpt-5.5": 272_000,
+            "gpt-5.5": 1_000_000,
             "gpt-5.4": 272_000,
             "gpt-5.4-mini": 272_000,
             "gpt-5.3-codex": 272_000,
@@ -303,16 +302,16 @@ class TestCodexOAuthContextLength:
                     "(models.dev leakage?)"
                 )
 
-    def test_live_probe_overrides_fallback(self):
+    def test_live_probe_overrides_fallback_except_pinned_gpt55(self):
         """When a token is provided, the live /models probe is preferred
-        and its context_window drives the result."""
+        and its context_window drives the result, except pinned GPT-5.5."""
         from agent.model_metadata import get_model_context_length
 
         fake_response = MagicMock()
         fake_response.status_code = 200
         fake_response.json.return_value = {
             "models": [
-                {"slug": "gpt-5.5", "context_window": 300_000},
+                {"slug": "gpt-5.5", "context_window": 272_000},
                 {"slug": "gpt-5.4", "context_window": 400_000},
             ]
         }
@@ -332,12 +331,12 @@ class TestCodexOAuthContextLength:
                 api_key="fake-token",
                 provider="openai-codex",
             )
-        assert ctx_55 == 300_000
+        assert ctx_55 == 1_000_000
         assert ctx_54 == 400_000
 
     def test_probe_failure_falls_back_to_hardcoded(self):
         """If the probe fails (non-200 / network error), we still return
-        the hardcoded 272k rather than leaking through to models.dev 1.05M."""
+        the hardcoded GPT-5.5 pin rather than leaking through to models.dev."""
         from agent.model_metadata import get_model_context_length
 
         fake_response = MagicMock()
@@ -353,7 +352,7 @@ class TestCodexOAuthContextLength:
                 api_key="expired-token",
                 provider="openai-codex",
             )
-        assert ctx == 272_000
+        assert ctx == 1_000_000
 
     def test_non_codex_providers_unaffected(self):
         """Resolving gpt-5.5 on non-Codex providers must NOT use the Codex
@@ -380,12 +379,10 @@ class TestCodexOAuthContextLength:
             "leaked outside openai-codex provider"
         )
 
-    def test_stale_codex_cache_over_400k_is_invalidated(self, tmp_path, monkeypatch):
-        """Pre-PR #14935 builds cached gpt-5.5 at 1.05M (from models.dev)
-        before the Codex-aware branch existed. Upgrading users keep that
-        stale entry on disk and the cache-first lookup returns it forever.
-        Codex OAuth caps at 272k for every slug, so any cached Codex
-        entry >= 400k must be dropped and re-resolved via the live probe.
+    def test_stale_gpt55_codex_cache_over_400k_is_normalized(self, tmp_path, monkeypatch):
+        """Older builds cached gpt-5.5 at 1.05M (from models.dev) before the
+        Codex-aware branch existed. The GPT-5.5 Codex value is now pinned to
+        1M, so stale disk values must be dropped and replaced.
         """
         from agent import model_metadata as mm
 
@@ -398,7 +395,7 @@ class TestCodexOAuthContextLength:
         other_key = "other-model@https://api.openai.com/v1/"
         import yaml as _yaml
         cache_file.write_text(_yaml.dump({"context_lengths": {
-            stale_key: 1_050_000,   # stale pre-fix value
+            stale_key: 1_050_000,   # stale direct-API value
             other_key: 128_000,     # unrelated, must survive
         }}))
 
@@ -417,17 +414,17 @@ class TestCodexOAuthContextLength:
                 provider="openai-codex",
             )
 
-        assert ctx == 272_000, f"Stale entry should have been re-resolved to 272k, got {ctx}"
-        # Live save was called with the fresh value
-        mock_save.assert_called_with("gpt-5.5", base_url, 272_000)
+        assert ctx == 1_000_000, f"Stale entry should have normalized to 1M, got {ctx}"
+        # Fresh pinned value was saved
+        mock_save.assert_called_with("gpt-5.5", base_url, 1_000_000)
         # The stale entry was removed from disk; unrelated entries survived
         remaining = _yaml.safe_load(cache_file.read_text()).get("context_lengths", {})
         assert stale_key not in remaining, "Stale entry was not invalidated from the cache file"
         assert remaining.get(other_key) == 128_000, "Unrelated cache entries must not be touched"
 
-    def test_fresh_codex_cache_under_400k_is_respected(self, tmp_path, monkeypatch):
-        """Codex entries at the correct 272k must NOT be invalidated —
-        only stale pre-fix values (>= 400k) get dropped."""
+    def test_stale_gpt55_codex_cache_under_400k_is_normalized(self, tmp_path, monkeypatch):
+        """GPT-5.5 cache entries from the old 272k Codex cap must be
+        invalidated even though they are below the generic stale threshold."""
         from agent import model_metadata as mm
 
         cache_file = tmp_path / "context_length_cache.yaml"
@@ -439,10 +436,34 @@ class TestCodexOAuthContextLength:
             f"gpt-5.5@{base_url}": 272_000,
         }}))
 
-        # If the invalidation incorrectly fired, this would be called; assert it isn't.
-        with patch("agent.model_metadata.requests.get") as mock_get:
+        with patch("agent.model_metadata.requests.get") as mock_get, \
+             patch("agent.model_metadata.save_context_length") as mock_save:
             ctx = mm.get_model_context_length(
                 model="gpt-5.5",
+                base_url=base_url,
+                api_key="fake-token",
+                provider="openai-codex",
+            )
+        assert ctx == 1_000_000
+        mock_get.assert_not_called()
+        mock_save.assert_called_with("gpt-5.5", base_url, 1_000_000)
+
+    def test_fresh_non_gpt55_codex_cache_under_400k_is_respected(self, tmp_path, monkeypatch):
+        """Non-GPT-5.5 Codex entries at 272k must NOT be invalidated."""
+        from agent import model_metadata as mm
+
+        cache_file = tmp_path / "context_length_cache.yaml"
+        monkeypatch.setattr(mm, "_get_context_cache_path", lambda: cache_file)
+
+        base_url = "https://chatgpt.com/backend-api/codex/"
+        import yaml as _yaml
+        cache_file.write_text(_yaml.dump({"context_lengths": {
+            f"gpt-5.4@{base_url}": 272_000,
+        }}))
+
+        with patch("agent.model_metadata.requests.get") as mock_get:
+            ctx = mm.get_model_context_length(
+                model="gpt-5.4",
                 base_url=base_url,
                 api_key="fake-token",
                 provider="openai-codex",


### PR DESCRIPTION
## Summary

- pin `openai-codex` `gpt-5.5` context resolution to `1_000_000`
- normalize stale GPT-5.5 Codex cache entries that still contain `272_000` or direct-API values
- add regression coverage for fallback, live probe, probe failure, cache normalization, and non-Codex behavior

Fixes #27918

## Tests

- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run --extra dev python -m pytest tests/agent/test_model_metadata.py -q`
