### PR TITLE
fix(dashboard): gate update action via config

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1078,6 +1078,7 @@ DEFAULT_CONFIG = {
         # Set this to True to re-enable the surfaces with the understanding
         # that the numbers are a local lower-bound estimate, not billing.
         "show_token_analytics": False,
+        "enable_update_action": True,  # Allow the dashboard to trigger `hermes update`
     },
 
     # Privacy settings

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -663,6 +663,27 @@ _ACTION_LOG_FILES: Dict[str, str] = {
 _ACTION_PROCS: Dict[str, subprocess.Popen] = {}
 
 
+def _dashboard_update_action_enabled() -> bool:
+    """Return whether the dashboard may start ``hermes update``.
+
+    The dashboard session token proves the request came from this browser
+    session, but some deployments still want source updates to go through an
+    explicit operator workflow. Default to the historical behavior unless the
+    profile opts out with ``dashboard.enable_update_action: false``.
+    """
+    try:
+        dashboard_cfg = load_config().get("dashboard", {})
+    except Exception:
+        return True
+
+    raw = dashboard_cfg.get("enable_update_action", True) if isinstance(dashboard_cfg, dict) else True
+    if isinstance(raw, bool):
+        return raw
+    if raw is None:
+        return True
+    return str(raw).strip().lower() not in {"0", "false", "no", "off", "disabled"}
+
+
 def _spawn_hermes_action(subcommand: List[str], name: str) -> subprocess.Popen:
     """Spawn ``hermes <subcommand>`` detached and record the Popen handle.
 
@@ -731,6 +752,11 @@ async def restart_gateway():
 @app.post("/api/hermes/update")
 async def update_hermes():
     """Kick off ``hermes update`` in the background."""
+    if not _dashboard_update_action_enabled():
+        raise HTTPException(
+            status_code=403,
+            detail="Dashboard-triggered Hermes updates are disabled for this profile.",
+        )
     try:
         proc = _spawn_hermes_action(["update"], "hermes-update")
     except Exception as exc:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -328,6 +328,46 @@ class TestWebServerEndpoints:
         resp = unauth_client.get("/api/status")
         assert resp.status_code == 200
 
+    def test_dashboard_update_disabled_by_config(self, monkeypatch):
+        """POST /api/hermes/update should honor the profile-level safety gate."""
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setattr(
+            web_server,
+            "load_config",
+            lambda: {"dashboard": {"enable_update_action": False}},
+        )
+
+        def _fail_spawn(*args, **kwargs):
+            raise AssertionError("update action should not spawn")
+
+        monkeypatch.setattr(web_server, "_spawn_hermes_action", _fail_spawn)
+
+        resp = self.client.post("/api/hermes/update")
+        assert resp.status_code == 403
+        assert "disabled" in resp.json()["detail"].lower()
+
+    def test_dashboard_update_enabled_by_default(self, monkeypatch):
+        """Existing profiles keep the dashboard update behavior unless they opt out."""
+        import hermes_cli.web_server as web_server
+
+        class _Proc:
+            pid = 4242
+
+        calls = []
+
+        monkeypatch.setattr(web_server, "load_config", lambda: {})
+        monkeypatch.setattr(
+            web_server,
+            "_spawn_hermes_action",
+            lambda subcommand, name: calls.append((subcommand, name)) or _Proc(),
+        )
+
+        resp = self.client.post("/api/hermes/update")
+        assert resp.status_code == 200
+        assert resp.json()["pid"] == 4242
+        assert calls == [(["update"], "hermes-update")]
+
     def test_path_traversal_blocked(self):
         """Verify URL-encoded path traversal is blocked."""
         # %2e%2e = ..


### PR DESCRIPTION
## Problem

The web dashboard exposes an Update action that triggers hermes update. For
operators running hermes-agent as a pinned long-running service (systemd unit
on a tag-pinned venv), an unguarded dashboard button can blow the pinned
version out from under the running process — a real foot-gun in 24/7 deploys.

## Fix

Add a new config key dashboard.enable_update_action (defaults to True
so existing behavior is preserved). When set to False, the dashboard
endpoint returns 403 and the action is hidden from the UI surface in
web_server.

## Test

tests/hermes_cli/test_web_server.py adds coverage for both flag states.

## Scope

3 files, +67 lines. No new dependency. Default-True preserves prior behavior;
operators who pin opt out explicitly.