### PR TITLE
chore(release): map Jack Yang contributor email

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -579,6 +579,7 @@ AUTHOR_MAP = {
     "kopjop926@gmail.com": "cesareth",
     "fuleinist@gmail.com": "fuleinist",
     "jack.47@gmail.com": "JackTheGit",
+    "jack@jackyang.com": "0xjackyang",
     "dalvidjr2022@gmail.com": "Jr-kenny",
     "m@statecraft.systems": "mbierling",
     "balyan.sid@gmail.com": "alt-glitch",


### PR DESCRIPTION
Adds the contributor email mapping for Jack Yang (@0xjackyang) so future release-note generation attributes commits correctly. Companion to the existing entries in `scripts/release.py`.