### PR TITLE
fix(send_message): add WeCom native MEDIA attachment delivery (#27947)

### DIFF
--- a/tests/tools/test_send_wecom_media.py
+++ b/tests/tools/test_send_wecom_media.py
@@ -1,0 +1,99 @@
+"""Tests for _send_wecom media support (regression test for #27947)."""
+import asyncio
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+class TestSendWecomMedia:
+    """_send_wecom routes media files through adapter._send_media_source."""
+
+    def _make_adapter(self, send_result=None, media_result=None):
+        """Build a mock WeComAdapter with configurable results."""
+        adapter = MagicMock()
+        adapter.connect = AsyncMock(return_value=True)
+        adapter.disconnect = AsyncMock(return_value=None)
+        adapter.fatal_error_message = None
+
+        if send_result is None:
+            send_result = SimpleNamespace(success=True, message_id="msg-123")
+        adapter.send = AsyncMock(return_value=send_result)
+
+        if media_result is None:
+            media_result = SimpleNamespace(success=True)
+        adapter._send_media_source = AsyncMock(return_value=media_result)
+        return adapter
+
+    def _run(self, *args, **kwargs):
+        from tools.send_message_tool import _send_wecom
+        return asyncio.run(_send_wecom(*args, **kwargs))
+
+    def test_text_only_sends_via_adapter_send(self):
+        adapter = self._make_adapter()
+        with patch("gateway.platforms.wecom.WeComAdapter", return_value=adapter), \
+             patch("gateway.platforms.wecom.check_wecom_requirements", return_value=True), \
+             patch.dict(os.environ, {"WECOM_BOT_ID": "bot1", "WECOM_BOT_SECRET": "sec1"}):
+            result = self._run({"url": "https://wecom.example"}, "chat1", "hello")
+        assert result["success"] is True
+        assert result["platform"] == "wecom"
+        adapter.send.assert_called_once_with("chat1", "hello")
+        adapter._send_media_source.assert_not_called()
+
+    def test_media_files_use_send_media_source(self):
+        adapter = self._make_adapter()
+        with patch("gateway.platforms.wecom.WeComAdapter", return_value=adapter), \
+             patch("gateway.platforms.wecom.check_wecom_requirements", return_value=True), \
+             patch.dict(os.environ, {"WECOM_BOT_ID": "bot1", "WECOM_BOT_SECRET": "sec1"}):
+            result = self._run(
+                {"url": "https://wecom.example"},
+                "chat1",
+                "Here is the file",
+                media_files=["/tmp/test.pdf"],
+            )
+        assert result["success"] is True
+        adapter._send_media_source.assert_called_once_with("chat1", "/tmp/test.pdf")
+        adapter.send.assert_called_once_with("chat1", "Here is the file")
+
+    def test_media_files_only_no_text(self):
+        adapter = self._make_adapter()
+        with patch("gateway.platforms.wecom.WeComAdapter", return_value=adapter), \
+             patch("gateway.platforms.wecom.check_wecom_requirements", return_value=True), \
+             patch.dict(os.environ, {"WECOM_BOT_ID": "bot1", "WECOM_BOT_SECRET": "sec1"}):
+            result = self._run(
+                {"url": "https://wecom.example"},
+                "chat1",
+                "   ",
+                media_files=["/tmp/doc.pdf"],
+            )
+        assert result["success"] is True
+        adapter._send_media_source.assert_called_once_with("chat1", "/tmp/doc.pdf")
+        adapter.send.assert_not_called()
+
+    def test_media_failure_returns_error(self):
+        media_fail = SimpleNamespace(success=False, error="upload timeout")
+        adapter = self._make_adapter(media_result=media_fail)
+        with patch("gateway.platforms.wecom.WeComAdapter", return_value=adapter), \
+             patch("gateway.platforms.wecom.check_wecom_requirements", return_value=True), \
+             patch.dict(os.environ, {"WECOM_BOT_ID": "bot1", "WECOM_BOT_SECRET": "sec1"}):
+            result = self._run(
+                {"url": "https://wecom.example"},
+                "chat1",
+                "text",
+                media_files=["/tmp/fail.pdf"],
+            )
+        assert "error" in result
+        assert "upload timeout" in result["error"]
+
+    def test_multiple_media_files_all_sent(self):
+        adapter = self._make_adapter()
+        with patch("gateway.platforms.wecom.WeComAdapter", return_value=adapter), \
+             patch("gateway.platforms.wecom.check_wecom_requirements", return_value=True), \
+             patch.dict(os.environ, {"WECOM_BOT_ID": "bot1", "WECOM_BOT_SECRET": "sec1"}):
+            result = self._run(
+                {"url": "https://wecom.example"},
+                "chat1",
+                "multiple files",
+                media_files=["/tmp/a.pdf", "/tmp/b.png"],
+            )
+        assert result["success"] is True
+        assert adapter._send_media_source.call_count == 2

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -613,6 +613,20 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if platform == Platform.WEIXIN:
         return await _send_weixin(pconfig, chat_id, message, media_files=media_files)
 
+    # --- WeCom: native media attachment support via adapter ---
+    if platform == Platform.WECOM and media_files:
+        last_result = None
+        for i, chunk in enumerate(chunks):
+            is_last = (i == len(chunks) - 1)
+            result = await _send_wecom(
+                pconfig.extra, chat_id, chunk,
+                media_files=media_files if is_last else None,
+            )
+            if isinstance(result, dict) and result.get("error"):
+                return result
+            last_result = result
+        return last_result
+
     # --- Discord: special handling for media attachments ---
     if platform == Platform.DISCORD:
         last_result = None
@@ -699,7 +713,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if media_files and not message.strip():
         return {
             "error": (
-                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao and feishu; "
+                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, wecom, signal, yuanbao and feishu; "
                 f"target {platform.value} had only media attachments"
             )
         }
@@ -707,7 +721,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if media_files:
         warning = (
             f"MEDIA attachments were omitted for {platform.value}; "
-            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao and feishu"
+            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, wecom, signal, yuanbao and feishu"
         )
 
     last_result = None
@@ -1638,8 +1652,12 @@ async def _send_dingtalk(extra, chat_id, message):
         return _error(f"DingTalk send failed: {e}")
 
 
-async def _send_wecom(extra, chat_id, message):
-    """Send via WeCom using the adapter's WebSocket send pipeline."""
+async def _send_wecom(extra, chat_id, message, media_files=None):
+    """Send via WeCom using the adapter's WebSocket send pipeline.
+
+    When *media_files* is provided, each file is uploaded via the adapter's
+    ``_send_media_source`` helper and delivered as a native WeCom attachment.
+    """
     try:
         from gateway.platforms.wecom import WeComAdapter, check_wecom_requirements
         if not check_wecom_requirements():
@@ -1655,6 +1673,23 @@ async def _send_wecom(extra, chat_id, message):
         if not connected:
             return _error(f"WeCom: failed to connect - {adapter.fatal_error_message or 'unknown error'}")
         try:
+            # Send media files as native attachments
+            if media_files:
+                for mf in media_files:
+                    file_path = mf if isinstance(mf, str) else getattr(mf, "name", str(mf))
+                    media_result = await adapter._send_media_source(
+                        chat_id, file_path,
+                    )
+                    if not media_result.success:
+                        return _error(f"WeCom media send failed: {media_result.error}")
+                # Send text after media
+                if message and message.strip():
+                    result = await adapter.send(chat_id, message)
+                    if not result.success:
+                        return _error(f"WeCom send failed: {result.error}")
+                    return {"success": True, "platform": "wecom", "chat_id": chat_id, "message_id": result.message_id}
+                return {"success": True, "platform": "wecom", "chat_id": chat_id}
+            # Text-only path
             result = await adapter.send(chat_id, message)
             if not result.success:
                 return _error(f"WeCom send failed: {result.error}")


### PR DESCRIPTION
## Summary

WeCom adapter already has `_send_media_source` / `_upload_media_bytes` / `_send_media_message` for outbound file delivery, but `send_message_tool.py` never routed MEDIA files through it — the tool fell through to the "non-media platform" path and silently dropped attachments with a warning.

## Changes

- Add WeCom to the media-platform routing block in `_send_to_platform()` (same pattern as Weixin/Feishu/Signal/Yuanbao)
- Extend `_send_wecom()` with `media_files` parameter that uploads each file via `adapter._send_media_source` before sending text caption
- Update platform list in error/warning messages to include `wecom`

## Testing

- 5 new test cases in `tests/tools/test_send_wecom_media.py` covering:
  - Text-only path unchanged
  - Media + text sends media then text
  - Media-only (no text) sends just media
  - Media upload failure returns error
  - Multiple media files all sent
- 134 existing `test_send_message_tool.py` tests pass (zero regression)

Fixes #27947
