### PR TITLE
feat(discord): allow opt-in auto-threading for free-response channels

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -823,6 +823,13 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["require_mention"] = platform_cfg["require_mention"]
                 if "free_response_channels" in platform_cfg:
                     bridged["free_response_channels"] = platform_cfg["free_response_channels"]
+                if (
+                    plat == Platform.DISCORD
+                    and "auto_thread_free_response_channels" in platform_cfg
+                ):
+                    bridged["auto_thread_free_response_channels"] = platform_cfg[
+                        "auto_thread_free_response_channels"
+                    ]
                 if "mention_patterns" in platform_cfg:
                     bridged["mention_patterns"] = platform_cfg["mention_patterns"]
                 if "dm_policy" in platform_cfg:
@@ -919,6 +926,15 @@ def load_gateway_config() -> GatewayConfig:
                     if isinstance(frc, list):
                         frc = ",".join(str(v) for v in frc)
                     os.environ["DISCORD_FREE_RESPONSE_CHANNELS"] = str(frc)
+                atfrc = discord_cfg.get("auto_thread_free_response_channels")
+                if atfrc is not None and not os.getenv(
+                    "DISCORD_AUTO_THREAD_FREE_RESPONSE_CHANNELS"
+                ):
+                    if isinstance(atfrc, list):
+                        atfrc = ",".join(str(v) for v in atfrc)
+                    os.environ["DISCORD_AUTO_THREAD_FREE_RESPONSE_CHANNELS"] = str(
+                        atfrc
+                    )
                 if "auto_thread" in discord_cfg and not os.getenv("DISCORD_AUTO_THREAD"):
                     os.environ["DISCORD_AUTO_THREAD"] = str(discord_cfg["auto_thread"]).lower()
                 if "reactions" in discord_cfg and not os.getenv("DISCORD_REACTIONS"):

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -3601,28 +3601,48 @@ class DiscordAdapter(BasePlatformAdapter):
             return 32 * 1024 * 1024
         return max(0, value)
 
+    @staticmethod
+    def _parse_discord_channel_set(raw: Any) -> set:
+        """Parse Discord channel-id config from env/config scalar or sequence values."""
+        if raw is None or isinstance(raw, bool):
+            return set()
+        if isinstance(raw, str):
+            return {part.strip() for part in raw.split(",") if part.strip()}
+        if isinstance(raw, (list, tuple, set, frozenset)):
+            channel_ids = set()
+            for part in raw:
+                channel_ids.update(DiscordAdapter._parse_discord_channel_set(part))
+            return channel_ids
+        value = str(raw).strip()
+        return {value} if value else set()
+
+    def _discord_channel_set_from_env_or_config(self, env_var: str, config_key: str) -> set:
+        """Return a channel-id set with env vars taking precedence over config.extra."""
+        raw_env = os.getenv(env_var)
+        if raw_env is not None:
+            return self._parse_discord_channel_set(raw_env)
+        return self._parse_discord_channel_set(self.config.extra.get(config_key))
+
     def _discord_free_response_channels(self) -> set:
         """Return Discord channel IDs where no bot mention is required.
 
-        A single ``"*"`` entry (either from a list or a comma-separated
-        string) is preserved in the returned set so callers can short-circuit
-        on wildcard membership, consistent with ``allowed_channels``.
+        A single ``"*"`` entry (either from a list, scalar, or a
+        comma-separated string) is preserved in the returned set so callers can
+        short-circuit on wildcard membership, consistent with
+        ``allowed_channels``. ``DISCORD_FREE_RESPONSE_CHANNELS`` takes
+        precedence over ``discord.free_response_channels`` when set.
         """
-        raw = self.config.extra.get("free_response_channels")
-        if raw is None:
-            raw = os.getenv("DISCORD_FREE_RESPONSE_CHANNELS", "")
-        if isinstance(raw, list):
-            return {str(part).strip() for part in raw if str(part).strip()}
-        # Coerce non-list scalars (str/int/float) to str before splitting.
-        # YAML parses a bare numeric value such as
-        # `free_response_channels: 1491973769726791812` as int, which was
-        # previously falling through the isinstance(str) branch and silently
-        # returning an empty set.  str() here accepts whatever scalar the YAML
-        # loader hands us without changing existing string/CSV semantics.
-        s = str(raw).strip() if raw is not None else ""
-        if s:
-            return {part.strip() for part in s.split(",") if part.strip()}
-        return set()
+        return self._discord_channel_set_from_env_or_config(
+            "DISCORD_FREE_RESPONSE_CHANNELS",
+            "free_response_channels",
+        )
+
+    def _discord_auto_thread_free_response_channels(self) -> set:
+        """Return free-response parent channels that may still auto-thread."""
+        return self._discord_channel_set_from_env_or_config(
+            "DISCORD_AUTO_THREAD_FREE_RESPONSE_CHANNELS",
+            "auto_thread_free_response_channels",
+        )
 
     def _discord_thread_require_mention(self) -> bool:
         """Return whether thread participation requires @mention to follow up.
@@ -4424,6 +4444,7 @@ class DiscordAdapter(BasePlatformAdapter):
         #   discord.allowed_channels: If set, bot ONLY responds in these channels (whitelist)
         #   discord.no_thread_channels: Channel IDs where bot responds directly without creating thread
         #   discord.auto_thread: Auto-create thread on @mention in channels (default: true)
+        #   discord.auto_thread_free_response_channels: Free-response parent channels that still auto-thread
 
         thread_id = None
         parent_channel_id = None
@@ -4513,8 +4534,19 @@ class DiscordAdapter(BasePlatformAdapter):
         if not is_thread and not isinstance(message.channel, discord.DMChannel):
             no_thread_channels_raw = os.getenv("DISCORD_NO_THREAD_CHANNELS", "")
             no_thread_channels = {ch.strip() for ch in no_thread_channels_raw.split(",") if ch.strip()}
-            skip_thread = bool(channel_ids & no_thread_channels) or is_free_channel
-            auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in {"true", "1", "yes"}
+            auto_thread_free_response_channels = self._discord_auto_thread_free_response_channels()
+            free_response_auto_thread_enabled = (
+                is_free_channel
+                and not is_voice_linked_channel
+                and (
+                    "*" in auto_thread_free_response_channels
+                    or bool(channel_ids & auto_thread_free_response_channels)
+                )
+            )
+            skip_thread = bool(channel_ids & no_thread_channels) or (
+                is_free_channel and not free_response_auto_thread_enabled
+            )
+            auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in ("true", "1", "yes")
             is_reply_message = getattr(message, "type", None) == discord.MessageType.reply
             if auto_thread and not skip_thread and not is_voice_linked_channel and not is_reply_message:
                 thread = await self._auto_create_thread(message)

--- a/tests/gateway/test_discord_channel_controls.py
+++ b/tests/gateway/test_discord_channel_controls.py
@@ -245,6 +245,28 @@ async def test_normal_channel_still_auto_threads(adapter, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_free_response_channel_can_auto_thread_when_configured(adapter, monkeypatch):
+    """Free-response parent channels may auto-thread when explicitly configured."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "789")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD_FREE_RESPONSE_CHANNELS", "789")
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
+    monkeypatch.delenv("DISCORD_NO_THREAD_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+
+    fake_thread = FakeThread(channel_id=999, name="auto-thread")
+    adapter._auto_create_thread = AsyncMock(return_value=fake_thread)
+
+    message = make_message(channel=FakeTextChannel(channel_id=789), content="hello")
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_awaited_once()
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_type == "thread"
+
+
+@pytest.mark.asyncio
 async def test_no_thread_channels_csv_parsing(adapter, monkeypatch):
     """Multiple no_thread channel IDs parsed from CSV."""
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")


### PR DESCRIPTION
## Problem

`discord.free_response_channels` lets operators turn off the mention
requirement for designated channels so the bot responds inline. Today
free-response → inline-only is treated as doctrine
(#12728, `fix(discord): keep free-response channels inline`,
`fix(discord): free-response channels skip auto-threading`).

For some real deployments that's the wrong default. Consider a "lounge"
or "sandbox" channel where the bot is conversational without mention,
but each user turn benefits from being isolated in its own thread —
concurrent users don't talk over each other's tool calls, and per-thread
context stays clean. The current path to get that requires reverting to
`require_mention=true`, which defeats the point of free-response.

## Fix

Add an **opt-in** YAML key `discord.auto_thread_free_response_channels`
(+ matching `DISCORD_AUTO_THREAD_FREE_RESPONSE_CHANNELS` env var).
Defaults to empty / off → existing "free-response = inline" behavior is
preserved for every existing operator. When a parent channel is listed,
that channel still auto-threads on each user-initiated turn while
remaining free-response (no mention required).

Supports `*` wildcard, same convention as `allowed_channels`.

## Refactor (small, isolated)

Extracts Discord channel-id parsing into `_parse_discord_channel_set`
which accepts str / list / tuple / set / frozenset / scalar (including
YAML bare numerics like `1491973769726791812`). This is a strict
superset of the existing `_discord_free_response_channels` parser and
incidentally subsumes the recent bare-numeric coercion fix.

`_discord_channel_set_from_env_or_config(env_var, config_key)`
consolidates the env-takes-precedence-over-config pattern used by every
channel-id config.

## Test

`test_free_response_channel_can_auto_thread_when_configured` covers the
new behavior: with `DISCORD_FREE_RESPONSE_CHANNELS=789` and
`DISCORD_AUTO_THREAD_FREE_RESPONSE_CHANNELS=789`, a message arriving in
channel 789 auto-creates a thread before being handled.

## Scope

3 files. Default behavior unchanged for every existing operator. No
config schema change beyond one new opt-in key.