### PR TITLE
fix(tui): keep /goal verdict out of compact status row

### DIFF
--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -4,7 +4,7 @@ import { createGatewayEventHandler } from '../app/createGatewayEventHandler.js'
 import { getOverlayState, resetOverlayState } from '../app/overlayStore.js'
 import { turnController } from '../app/turnController.js'
 import { getTurnState, resetTurnState } from '../app/turnStore.js'
-import { patchUiState, resetUiState } from '../app/uiStore.js'
+import { getUiState, patchUiState, resetUiState } from '../app/uiStore.js'
 import { estimateTokensRough } from '../lib/text.js'
 import type { Msg } from '../types.js'
 
@@ -130,6 +130,46 @@ describe('createGatewayEventHandler', () => {
     } as any)
 
     expect(ctx.system.sys).toHaveBeenCalledWith('compressing 968 messages (~123,400 tok)…')
+  })
+
+  it('keeps goal verdict text in transcript but shows a brief idle status (#goal statusbar)', () => {
+    const appended: Msg[] = []
+    const ctx = buildCtx(appended)
+    const onEvent = createGatewayEventHandler(ctx)
+    const verdict = '✓ Goal achieved: long judge reason goes only in transcript, not merged with cwd label.'
+
+    vi.useFakeTimers()
+    try {
+      onEvent({
+        payload: { kind: 'goal', text: verdict },
+        type: 'status.update'
+      } as any)
+
+      expect(ctx.system.sys).toHaveBeenCalledWith(verdict)
+      expect(getUiState().status).toBe('✓ goal complete')
+
+      vi.advanceTimersByTime(6001)
+      expect(getUiState().status).toBe('ready')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('maps goal status.update prefixes to short status strings', () => {
+    const ctx = buildCtx([])
+    const onEvent = createGatewayEventHandler(ctx)
+
+    onEvent({
+      payload: { kind: 'goal', text: '↻ Continuing toward goal (1/10): reason' },
+      type: 'status.update'
+    } as any)
+    expect(getUiState().status).toBe('↻ goal continuing')
+
+    onEvent({
+      payload: { kind: 'goal', text: '⏸ Goal paused — budget exhausted.' },
+      type: 'status.update'
+    } as any)
+    expect(getUiState().status).toBe('⏸ goal paused')
   })
 
   it('surfaces self-improvement review summaries as a persistent system line', () => {

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -338,14 +338,23 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
           return
         }
 
-        setStatus(p.text)
-
-        if (p.kind === 'compressing') {
+        if (p.kind === 'goal') {
           sys(p.text)
+          const brief = p.text.startsWith('✓')
+            ? '✓ goal complete'
+            : p.text.startsWith('↻')
+              ? '↻ goal continuing'
+              : p.text.startsWith('⏸')
+                ? '⏸ goal paused'
+                : 'ready'
+          setStatus(brief)
+          restoreStatusAfter(6000)
           return
         }
 
-        if (p.kind === 'goal') {
+        setStatus(p.text)
+
+        if (p.kind === 'compressing') {
           sys(p.text)
           return
         }


### PR DESCRIPTION
## What does this PR do?

When `/goal` finished, the gateway sent `status.update` with `kind: "goal"` and the **full** judge verdict as `text`. The handler applied `setStatus(p.text)` for every payload before branching on kind, so the status bar rendered that long sentence on the same row as model, context usage, and cwd — making it look like the verdict had “merged” with the status chrome.

This change handles **`kind === "goal"` first**: the full verdict still goes to the transcript via `sys()`, but the Nanostores `status` becomes a short label (`✓ goal complete`, `↻ goal continuing`, `⏸ goal paused`, or `ready`) and restores to idle after `restoreStatusAfter(6000)`.

No server / Python changes — client-only.

## Related Issue

N/A (no filed issue attached).

Fixes #(n/a — report was in chat)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `ui-tui/src/app/createGatewayEventHandler.ts` — process `status.update` payloads with `kind: "goal"` before the generic `setStatus(p.text)` path; narrow idle status labels; reuse existing `restoreStatusAfter`.
- `ui-tui/src/__tests__/createGatewayEventHandler.test.ts` — Vitest assertions for transcript vs. brief UI status and prefix mapping.

## How to Test

1. Run `cd ui-tui && npm test -- --run src/__tests__/createGatewayEventHandler.test.ts`.
2. Manually: `hermes --tui`, set a `/goal …`, complete a turn; confirm the verdict appears as a system line while the bottom status row stays short (model / usage / path), without the long verdict string inline.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

_N/A._

## Screenshots / Logs

<img width="1580" height="318" alt="image" src="https://github.com/user-attachments/assets/0782c5ef-639c-42b8-ba79-f16e10cbb51a" />