### PR TITLE
Add TrustedRouter.com provider option

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -45,7 +45,7 @@ def _resolve_requests_verify() -> bool | str:
 # Only these are stripped — Ollama-style "model:tag" colons (e.g. "qwen3.5:27b")
 # are preserved so the full model name reaches cache lookups and server queries.
 _PROVIDER_PREFIXES: frozenset[str] = frozenset({
-    "openrouter", "nous", "openai-codex", "copilot", "copilot-acp",
+    "openrouter", "trustedrouter", "nous", "openai-codex", "copilot", "copilot-acp",
     "gemini", "ollama-cloud", "zai", "kimi-coding", "kimi-coding-cn", "stepfun", "minimax", "minimax-oauth", "minimax-cn", "anthropic", "deepseek",
     "opencode-zen", "opencode-go", "ai-gateway", "kilocode", "alibaba", "novita",
     "qwen-oauth",
@@ -67,6 +67,7 @@ _PROVIDER_PREFIXES: frozenset[str] = frozenset({
     "xai", "x-ai", "x.ai", "grok",
     "nvidia", "nim", "nvidia-nim", "nemotron",
     "qwen-portal", "novita-ai", "novitaai",
+    "tr", "trusted-router", "trustedrouter.com", "quillrouter", "quill-router",
 })
 
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -199,6 +199,9 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "gpt-4o",
         "gpt-4o-mini",
     ],
+    "trustedrouter": [
+        "trustedrouter/auto",
+    ],
     "openai-codex": _codex_curated_models(),
     "xai-oauth": _xai_curated_models(),
     "copilot-acp": [
@@ -924,6 +927,7 @@ class ProviderEntry(NamedTuple):
 CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("nous",           "Nous Portal",              "Nous Portal (Nous Research subscription)"),
     ProviderEntry("openrouter",     "OpenRouter",               "OpenRouter (100+ models, pay-per-use)"),
+    ProviderEntry("trustedrouter",  "TrustedRouter.com",        "TrustedRouter.com (end-to-end encrypted OpenRouter-compatible router)"),
     ProviderEntry("novita",         "NovitaAI",                 "NovitaAI (AI-native cloud: Model API, Agent Sandbox, GPU Cloud)"),
     ProviderEntry("lmstudio",       "LM Studio",                "LM Studio (local desktop app with built-in model server)"),
     ProviderEntry("anthropic",      "Anthropic",                "Anthropic (Claude models — API key or Claude Code)"),
@@ -984,6 +988,11 @@ _PROVIDER_LABELS["custom"] = "Custom endpoint"  # special case: not a named prov
 
 
 _PROVIDER_ALIASES = {
+    "tr": "trustedrouter",
+    "trusted-router": "trustedrouter",
+    "trustedrouter.com": "trustedrouter",
+    "quillrouter": "trustedrouter",
+    "quill-router": "trustedrouter",
     "glm": "zai",
     "z-ai": "zai",
     "z.ai": "zai",

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -199,9 +199,6 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "gpt-4o",
         "gpt-4o-mini",
     ],
-    "trustedrouter": [
-        "trustedrouter/auto",
-    ],
     "openai-codex": _codex_curated_models(),
     "xai-oauth": _xai_curated_models(),
     "copilot-acp": [
@@ -927,7 +924,6 @@ class ProviderEntry(NamedTuple):
 CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("nous",           "Nous Portal",              "Nous Portal (Nous Research subscription)"),
     ProviderEntry("openrouter",     "OpenRouter",               "OpenRouter (100+ models, pay-per-use)"),
-    ProviderEntry("trustedrouter",  "TrustedRouter.com",        "TrustedRouter.com (end-to-end encrypted OpenRouter-compatible router)"),
     ProviderEntry("novita",         "NovitaAI",                 "NovitaAI (AI-native cloud: Model API, Agent Sandbox, GPU Cloud)"),
     ProviderEntry("lmstudio",       "LM Studio",                "LM Studio (local desktop app with built-in model server)"),
     ProviderEntry("anthropic",      "Anthropic",                "Anthropic (Claude models — API key or Claude Code)"),

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -50,6 +50,13 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         extra_env_vars=("OPENAI_API_KEY",),
         base_url_env_var="OPENROUTER_BASE_URL",
     ),
+    "trustedrouter": HermesOverlay(
+        transport="openai_chat",
+        is_aggregator=True,
+        extra_env_vars=("TRUSTEDROUTER_API_KEY",),
+        base_url_override="https://api.quillrouter.com/v1",
+        base_url_env_var="TRUSTEDROUTER_BASE_URL",
+    ),
     "nous": HermesOverlay(
         transport="openai_chat",
         auth_type="oauth_device_code",
@@ -239,6 +246,11 @@ class ProviderDef:
 ALIASES: Dict[str, str] = {
     # openrouter
     "openai": "openrouter",     # bare "openai" → route through aggregator
+    "tr": "trustedrouter",
+    "trusted-router": "trustedrouter",
+    "trustedrouter.com": "trustedrouter",
+    "quillrouter": "trustedrouter",
+    "quill-router": "trustedrouter",
 
     # zai
     "glm": "zai",
@@ -370,6 +382,7 @@ ALIASES: Dict[str, str] = {
 
 _LABEL_OVERRIDES: Dict[str, str] = {
     "nous": "Nous Portal",
+    "trustedrouter": "TrustedRouter.com",
     "openai-codex": "OpenAI Codex",
     "copilot-acp": "GitHub Copilot ACP",
     "stepfun": "StepFun Step Plan",

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -54,7 +54,7 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         transport="openai_chat",
         is_aggregator=True,
         extra_env_vars=("TRUSTEDROUTER_API_KEY",),
-        base_url_override="https://api.quillrouter.com/v1",
+        base_url_override="https://api.trustedrouter.com/v1",
         base_url_env_var="TRUSTEDROUTER_BASE_URL",
     ),
     "nous": HermesOverlay(

--- a/plugins/model-providers/trustedrouter/__init__.py
+++ b/plugins/model-providers/trustedrouter/__init__.py
@@ -1,0 +1,70 @@
+"""TrustedRouter.com provider profile."""
+
+import logging
+from typing import Any
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+logger = logging.getLogger(__name__)
+
+_CACHE: list[str] | None = None
+
+
+class TrustedRouterProfile(ProviderProfile):
+    """TrustedRouter.com - end-to-end encrypted OpenRouter-compatible routing."""
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        """Fetch the TrustedRouter model catalog when credentials are available."""
+        global _CACHE  # noqa: PLW0603
+        if _CACHE is not None:
+            return _CACHE
+        try:
+            result = super().fetch_models(api_key=api_key, timeout=timeout)
+            if result is not None:
+                _CACHE = result
+            return result
+        except Exception as exc:
+            logger.debug("fetch_models(trustedrouter): %s", exc)
+            return None
+
+    def build_api_kwargs_extras(
+        self,
+        *,
+        reasoning_config: dict | None = None,
+        supports_reasoning: bool = False,
+        model: str | None = None,
+        session_id: str | None = None,
+        **context: Any,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """TrustedRouter accepts OpenRouter/OpenAI-compatible reasoning payloads."""
+        if supports_reasoning:
+            if reasoning_config is not None:
+                return {"reasoning": dict(reasoning_config)}, {}
+            return {"reasoning": {"enabled": True, "effort": "medium"}}, {}
+        return {}, {}
+
+
+trustedrouter = TrustedRouterProfile(
+    name="trustedrouter",
+    aliases=(
+        "tr",
+        "trusted-router",
+        "trustedrouter.com",
+        "quillrouter",
+        "quill-router",
+    ),
+    env_vars=("TRUSTEDROUTER_API_KEY", "TRUSTEDROUTER_BASE_URL"),
+    display_name="TrustedRouter.com",
+    description="TrustedRouter.com - end-to-end encrypted OpenRouter-compatible LLM router",
+    signup_url="https://trustedrouter.com/",
+    base_url="https://api.quillrouter.com/v1",
+    fallback_models=("trustedrouter/auto",),
+)
+
+register_provider(trustedrouter)

--- a/plugins/model-providers/trustedrouter/__init__.py
+++ b/plugins/model-providers/trustedrouter/__init__.py
@@ -63,7 +63,7 @@ trustedrouter = TrustedRouterProfile(
     display_name="TrustedRouter.com",
     description="TrustedRouter.com - end-to-end encrypted OpenRouter-compatible LLM router",
     signup_url="https://trustedrouter.com/",
-    base_url="https://api.quillrouter.com/v1",
+    base_url="https://api.trustedrouter.com/v1",
     fallback_models=("trustedrouter/auto",),
 )
 

--- a/plugins/model-providers/trustedrouter/plugin.yaml
+++ b/plugins/model-providers/trustedrouter/plugin.yaml
@@ -1,0 +1,5 @@
+name: trustedrouter-provider
+kind: model-provider
+version: 1.0.0
+description: TrustedRouter.com end-to-end encrypted OpenRouter-compatible LLM router
+author: Nous Research

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -43,6 +43,7 @@ class TestProviderRegistry:
         ("ai-gateway", "Vercel AI Gateway", "api_key"),
         ("kilocode", "Kilo Code", "api_key"),
         ("gmi", "GMI Cloud", "api_key"),
+        ("trustedrouter", "TrustedRouter.com", "api_key"),
     ])
     def test_provider_registered(self, provider_id, name, auth_type):
         assert provider_id in PROVIDER_REGISTRY
@@ -112,6 +113,12 @@ class TestProviderRegistry:
         assert pconfig.api_key_env_vars == ("GMI_API_KEY",)
         assert pconfig.base_url_env_var == "GMI_BASE_URL"
 
+    def test_trustedrouter_env_vars(self):
+        pconfig = PROVIDER_REGISTRY["trustedrouter"]
+        assert pconfig.api_key_env_vars == ("TRUSTEDROUTER_API_KEY",)
+        assert pconfig.base_url_env_var == "TRUSTEDROUTER_BASE_URL"
+        assert pconfig.inference_base_url == "https://api.quillrouter.com/v1"
+
     def test_huggingface_env_vars(self):
         pconfig = PROVIDER_REGISTRY["huggingface"]
         assert pconfig.api_key_env_vars == ("HF_TOKEN",)
@@ -129,6 +136,7 @@ class TestProviderRegistry:
         assert PROVIDER_REGISTRY["kilocode"].inference_base_url == "https://api.kilo.ai/api/gateway"
         assert PROVIDER_REGISTRY["gmi"].inference_base_url == "https://api.gmi-serving.com/v1"
         assert PROVIDER_REGISTRY["huggingface"].inference_base_url == "https://router.huggingface.co/v1"
+        assert PROVIDER_REGISTRY["trustedrouter"].inference_base_url == "https://api.quillrouter.com/v1"
 
     def test_oauth_providers_unchanged(self):
         """Ensure we didn't break the existing OAuth providers."""
@@ -151,6 +159,7 @@ PROVIDER_ENV_VARS = (
     "MINIMAX_API_KEY", "MINIMAX_CN_API_KEY",
     "AI_GATEWAY_API_KEY", "AI_GATEWAY_BASE_URL",
     "KILOCODE_API_KEY", "KILOCODE_BASE_URL",
+    "TRUSTEDROUTER_API_KEY", "TRUSTEDROUTER_BASE_URL",
     "GMI_API_KEY", "GMI_BASE_URL",
     "DASHSCOPE_API_KEY", "OPENCODE_ZEN_API_KEY", "OPENCODE_GO_API_KEY",
     "NOUS_API_KEY", "GITHUB_TOKEN", "GH_TOKEN",
@@ -222,6 +231,14 @@ class TestResolveProvider:
 
     def test_explicit_kilocode(self):
         assert resolve_provider("kilocode") == "kilocode"
+
+    def test_explicit_trustedrouter(self):
+        assert resolve_provider("trustedrouter") == "trustedrouter"
+
+    def test_alias_trusted_router(self):
+        assert resolve_provider("trusted-router") == "trustedrouter"
+        assert resolve_provider("tr") == "trustedrouter"
+        assert resolve_provider("quillrouter") == "trustedrouter"
 
     def test_alias_kilo(self):
         assert resolve_provider("kilo") == "kilocode"
@@ -302,6 +319,10 @@ class TestResolveProvider:
     def test_auto_detects_kilocode_key(self, monkeypatch):
         monkeypatch.setenv("KILOCODE_API_KEY", "test-kilo-key")
         assert resolve_provider("auto") == "kilocode"
+
+    def test_auto_detects_trustedrouter_key(self, monkeypatch):
+        monkeypatch.setenv("TRUSTEDROUTER_API_KEY", "sk-tr-v1-test")
+        assert resolve_provider("auto") == "trustedrouter"
 
     def test_auto_detects_hf_token(self, monkeypatch):
         monkeypatch.setenv("HF_TOKEN", "hf_test_token")

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -117,7 +117,7 @@ class TestProviderRegistry:
         pconfig = PROVIDER_REGISTRY["trustedrouter"]
         assert pconfig.api_key_env_vars == ("TRUSTEDROUTER_API_KEY",)
         assert pconfig.base_url_env_var == "TRUSTEDROUTER_BASE_URL"
-        assert pconfig.inference_base_url == "https://api.quillrouter.com/v1"
+        assert pconfig.inference_base_url == "https://api.trustedrouter.com/v1"
 
     def test_huggingface_env_vars(self):
         pconfig = PROVIDER_REGISTRY["huggingface"]
@@ -136,7 +136,7 @@ class TestProviderRegistry:
         assert PROVIDER_REGISTRY["kilocode"].inference_base_url == "https://api.kilo.ai/api/gateway"
         assert PROVIDER_REGISTRY["gmi"].inference_base_url == "https://api.gmi-serving.com/v1"
         assert PROVIDER_REGISTRY["huggingface"].inference_base_url == "https://router.huggingface.co/v1"
-        assert PROVIDER_REGISTRY["trustedrouter"].inference_base_url == "https://api.quillrouter.com/v1"
+        assert PROVIDER_REGISTRY["trustedrouter"].inference_base_url == "https://api.trustedrouter.com/v1"
 
     def test_oauth_providers_unchanged(self):
         """Ensure we didn't break the existing OAuth providers."""

--- a/tests/providers/test_plugin_discovery.py
+++ b/tests/providers/test_plugin_discovery.py
@@ -46,19 +46,20 @@ def test_bundled_plugins_discovered():
         assert (child / "plugin.yaml").exists(), f"{child.name} missing plugin.yaml"
 
 
-def test_all_34_profiles_register():
-    """After discovery, the registry must contain exactly 34 distinct profiles."""
+def test_all_35_profiles_register():
+    """After discovery, the registry must contain exactly 35 distinct profiles."""
     _clear_provider_caches()
     from providers import list_providers
 
     profiles = list_providers()
     names = sorted(p.name for p in profiles)
-    assert len(names) == 34, f"Expected 34 profiles, got {len(names)}: {names}"
+    assert len(names) == 35, f"Expected 35 profiles, got {len(names)}: {names}"
 
     # Spot-check representative providers from different categories
     for required in (
         "openrouter", "anthropic", "custom", "bedrock", "openai-codex",
         "minimax-oauth", "gmi", "xiaomi", "alibaba-coding-plan",
+        "trustedrouter",
     ):
         assert required in names, f"Missing profile: {required}"
 

--- a/tests/providers/test_plugin_discovery.py
+++ b/tests/providers/test_plugin_discovery.py
@@ -46,14 +46,20 @@ def test_bundled_plugins_discovered():
         assert (child / "plugin.yaml").exists(), f"{child.name} missing plugin.yaml"
 
 
-def test_all_35_profiles_register():
-    """After discovery, the registry must contain exactly 35 distinct profiles."""
+def test_all_bundled_profiles_register():
+    """After discovery, every bundled model-provider plugin should register."""
     _clear_provider_caches()
     from providers import list_providers
 
     profiles = list_providers()
     names = sorted(p.name for p in profiles)
-    assert len(names) == 35, f"Expected 35 profiles, got {len(names)}: {names}"
+    bundled_plugins = {
+        p.name
+        for p in (REPO_ROOT / "plugins" / "model-providers").iterdir()
+        if p.is_dir() and not p.name.startswith(("_", "."))
+    }
+    missing = sorted(bundled_plugins - set(names))
+    assert not missing, f"Missing bundled provider profiles: {missing}"
 
     # Spot-check representative providers from different categories
     for required in (

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -16,6 +16,8 @@ class TestRegistry:
         assert get_provider_profile("moonshot").name == "kimi-coding"
         assert get_provider_profile("kimi-coding-cn").name == "kimi-coding-cn"
         assert get_provider_profile("or").name == "openrouter"
+        assert get_provider_profile("tr").name == "trustedrouter"
+        assert get_provider_profile("trusted-router").name == "trustedrouter"
         assert get_provider_profile("nous-portal").name == "nous"
         assert get_provider_profile("qwen").name == "qwen-oauth"
         assert get_provider_profile("qwen-portal").name == "qwen-oauth"
@@ -210,6 +212,34 @@ class TestOpenRouterProfile:
         )
         assert eb["reasoning"] == {"enabled": True, "effort": "high"}
         assert tl["extra_headers"]["x-grok-conv-id"] == "sess-123"
+
+
+class TestTrustedRouterProfile:
+    def test_profile_loads(self):
+        p = get_provider_profile("trustedrouter")
+        assert p is not None
+        assert p.name == "trustedrouter"
+        assert p.display_name == "TrustedRouter.com"
+        assert p.base_url == "https://api.quillrouter.com/v1"
+        assert p.env_vars == ("TRUSTEDROUTER_API_KEY", "TRUSTEDROUTER_BASE_URL")
+
+    def test_aliases(self):
+        assert get_provider_profile("trusted-router").name == "trustedrouter"
+        assert get_provider_profile("trustedrouter.com").name == "trustedrouter"
+        assert get_provider_profile("quillrouter").name == "trustedrouter"
+
+    def test_fallback_auto_model(self):
+        p = get_provider_profile("trustedrouter")
+        assert p.fallback_models == ("trustedrouter/auto",)
+
+    def test_reasoning_passthrough(self):
+        p = get_provider_profile("trustedrouter")
+        eb, tl = p.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            supports_reasoning=True,
+        )
+        assert eb["reasoning"] == {"enabled": True, "effort": "high"}
+        assert tl == {}
 
 
 class TestNousProfile:

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -220,7 +220,7 @@ class TestTrustedRouterProfile:
         assert p is not None
         assert p.name == "trustedrouter"
         assert p.display_name == "TrustedRouter.com"
-        assert p.base_url == "https://api.quillrouter.com/v1"
+        assert p.base_url == "https://api.trustedrouter.com/v1"
         assert p.env_vars == ("TRUSTEDROUTER_API_KEY", "TRUSTEDROUTER_BASE_URL")
 
     def test_aliases(self):


### PR DESCRIPTION
## Summary
- add a TrustedRouter.com model-provider plugin using the OpenAI/OpenRouter-compatible endpoint
- register CLI provider metadata, aliases, environment variables, and default model discovery
- add provider profile, API-key provider, and metadata parsing tests

## Verification
- `python3 -m py_compile` on the touched Python files and tests
