### PR TITLE
feat(auxiliary): add enabled toggle for individual auxiliary tasks (#27877)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4427,6 +4427,11 @@ def call_llm(
     Raises:
         RuntimeError: If no provider is configured.
     """
+    # Early-exit when the task is disabled via auxiliary.<task>.enabled: false
+    if task and not _get_auxiliary_task_config(task).get("enabled", True):
+        logger.debug("Auxiliary task %s disabled via config — skipping", task)
+        return None
+
     resolved_provider, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _resolve_task_provider_model(
         task, provider, model, base_url, api_key)
     effective_extra_body = _get_task_extra_body(task)
@@ -4829,6 +4834,11 @@ async def async_call_llm(
 
     Same as call_llm() but async. See call_llm() for full documentation.
     """
+    # Early-exit when the task is disabled via auxiliary.<task>.enabled: false
+    if task and not _get_auxiliary_task_config(task).get("enabled", True):
+        logger.debug("Auxiliary task %s disabled via config — skipping", task)
+        return None
+
     resolved_provider, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _resolve_task_provider_model(
         task, provider, model, base_url, api_key)
     effective_extra_body = _get_task_extra_body(task)

--- a/tests/agent/test_auxiliary_enabled_toggle.py
+++ b/tests/agent/test_auxiliary_enabled_toggle.py
@@ -1,0 +1,93 @@
+"""Tests for auxiliary task enabled toggle (regression test for #27877)."""
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+class TestAuxiliaryEnabledToggle:
+    """call_llm / async_call_llm skip execution when enabled=false."""
+
+    def test_call_llm_returns_none_when_disabled(self):
+        """call_llm() returns None immediately when auxiliary.<task>.enabled is false."""
+        from agent.auxiliary_client import call_llm
+
+        disabled_config = {"enabled": False}
+        with patch("agent.auxiliary_client._get_auxiliary_task_config", return_value=disabled_config), \
+             patch("agent.auxiliary_client._resolve_task_provider_model") as mock_resolve:
+            result = call_llm(task="title_generation", messages=[{"role": "user", "content": "hi"}])
+        assert result is None
+        mock_resolve.assert_not_called()
+
+    def test_call_llm_resolves_when_enabled_true(self):
+        """call_llm() reaches _resolve_task_provider_model when enabled is True."""
+        from agent.auxiliary_client import call_llm
+
+        enabled_config = {"enabled": True}
+        with patch("agent.auxiliary_client._get_auxiliary_task_config", return_value=enabled_config), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("openai", "gpt-4o-mini", None, "sk-test", None)) as mock_resolve, \
+             patch("agent.auxiliary_client._get_task_extra_body", return_value={}), \
+             patch("agent.auxiliary_client.logger"):
+            try:
+                call_llm(task="title_generation", messages=[{"role": "user", "content": "hi"}])
+            except Exception:
+                pass  # We only care that resolve was called, not the full execution
+        mock_resolve.assert_called_once()
+
+    def test_call_llm_resolves_when_enabled_missing(self):
+        """call_llm() reaches _resolve when enabled key absent (default True)."""
+        from agent.auxiliary_client import call_llm
+
+        empty_config = {}
+        with patch("agent.auxiliary_client._get_auxiliary_task_config", return_value=empty_config), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("openai", "gpt-4o-mini", None, "sk-test", None)) as mock_resolve, \
+             patch("agent.auxiliary_client._get_task_extra_body", return_value={}), \
+             patch("agent.auxiliary_client.logger"):
+            try:
+                call_llm(task="title_generation", messages=[{"role": "user", "content": "hi"}])
+            except Exception:
+                pass
+        mock_resolve.assert_called_once()
+
+    def test_call_llm_no_task_always_resolves(self):
+        """call_llm() without a task always proceeds to resolve."""
+        from agent.auxiliary_client import call_llm
+
+        with patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("openai", "gpt-4o-mini", None, "sk-test", None)) as mock_resolve, \
+             patch("agent.auxiliary_client._get_task_extra_body", return_value={}), \
+             patch("agent.auxiliary_client.logger"):
+            try:
+                call_llm(task=None, messages=[{"role": "user", "content": "hi"}])
+            except Exception:
+                pass
+        mock_resolve.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_async_call_llm_returns_none_when_disabled(self):
+        """async_call_llm() returns None immediately when enabled is false."""
+        from agent.auxiliary_client import async_call_llm
+
+        disabled_config = {"enabled": False}
+        with patch("agent.auxiliary_client._get_auxiliary_task_config", return_value=disabled_config), \
+             patch("agent.auxiliary_client._resolve_task_provider_model") as mock_resolve:
+            result = await async_call_llm(task="compression", messages=[{"role": "user", "content": "hi"}])
+        assert result is None
+        mock_resolve.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_async_call_llm_resolves_when_enabled(self):
+        """async_call_llm() reaches _resolve when enabled is True."""
+        from agent.auxiliary_client import async_call_llm
+
+        enabled_config = {"enabled": True}
+        with patch("agent.auxiliary_client._get_auxiliary_task_config", return_value=enabled_config), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("openai", "gpt-4o-mini", None, "sk-test", None)) as mock_resolve, \
+             patch("agent.auxiliary_client._get_task_extra_body", return_value={}), \
+             patch("agent.auxiliary_client.logger"):
+            try:
+                await async_call_llm(task="compression", messages=[{"role": "user", "content": "hi"}])
+            except Exception:
+                pass
+        mock_resolve.assert_called_once()


### PR DESCRIPTION
## Summary

There is currently no way to disable individual auxiliary tasks (title_generation, compression, etc.) through `config.yaml`. When an auxiliary task fails (e.g. provider returns HTTP 502), Hermes emits a user-visible warning with no way to silence it.

## Changes

- Add `enabled` boolean check at the top of `call_llm()` and `async_call_llm()` in `agent/auxiliary_client.py`
- When `auxiliary.<task>.enabled: false` is set in config, the task is completely skipped — no LLM call, no warning, no error
- Default is `True` (backward compatible — existing configs unchanged)

## Usage

```yaml
auxiliary:
  title_generation:
    enabled: false
  compression:
    enabled: false
```

## Testing

- 6 new tests in `tests/agent/test_auxiliary_enabled_toggle.py`:
  - `call_llm` returns `None` when disabled (resolve never called)
  - `call_llm` proceeds when enabled=true
  - `call_llm` proceeds when enabled key absent (default true)
  - `call_llm` without task always proceeds
  - `async_call_llm` returns `None` when disabled
  - `async_call_llm` proceeds when enabled=true
- 172 existing `test_auxiliary_client.py` tests pass (zero regression)

Fixes #27877
