### PR TITLE
fix(bluebubbles): avoid stale duplicate webhook events

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -275,7 +275,10 @@ class BlueBubblesAdapter(BasePlatformAdapter):
 
         payload = {
             "url": webhook_url,
-            "events": ["new-message", "updated-message"],
+            # Subscribe only to new messages. "updated-message" can fire for the
+            # same inbound SMS/iMessage after metadata changes, causing duplicate
+            # Hermes replies unless every downstream handler dedupes perfectly.
+            "events": ["new-message"],
         }
 
         try:

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -55,6 +55,7 @@ _TAPBACK_REMOVED = {
 
 # Webhook event types that carry user messages
 _MESSAGE_EVENTS = {"new-message", "message", "updated-message"}
+_DESIRED_WEBHOOK_EVENTS = ["new-message"]
 
 # Log redaction patterns
 _PHONE_RE = re.compile(r"\+?\d{7,15}")
@@ -265,20 +266,27 @@ class BlueBubblesAdapter(BasePlatformAdapter):
 
         webhook_url = self._webhook_register_url
 
-        # Crash resilience — reuse an existing registration if present
+        # Crash resilience — reuse an existing registration only if it already
+        # has exactly the desired event set. Older Hermes builds registered
+        # ``updated-message`` too, which can double-deliver the same inbound SMS
+        # after BlueBubbles metadata changes; clean those stale registrations up
+        # before creating a fresh new-message-only registration.
         existing = await self._find_registered_webhooks(webhook_url)
         if existing:
-            logger.info(
-                "[bluebubbles] webhook already registered: %s", webhook_url
-            )
-            return True
+            stale = [wh for wh in existing if wh.get("events") != _DESIRED_WEBHOOK_EVENTS]
+            if not stale and len(existing) == 1:
+                logger.info(
+                    "[bluebubbles] webhook already registered: %s", webhook_url
+                )
+                return True
+            await self._unregister_webhook()
 
         payload = {
             "url": webhook_url,
             # Subscribe only to new messages. "updated-message" can fire for the
             # same inbound SMS/iMessage after metadata changes, causing duplicate
             # Hermes replies unless every downstream handler dedupes perfectly.
-            "events": ["new-message"],
+            "events": list(_DESIRED_WEBHOOK_EVENTS),
         }
 
         try:

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -549,17 +549,27 @@ class TestBlueBubblesWebhookRegistration:
     # -- _register_webhook --
 
     def test_register_fresh(self, monkeypatch):
-        """No existing webhook → POST creates one."""
+        """No existing webhook → POST creates a new-message-only registration."""
         import asyncio
         adapter = _make_adapter(monkeypatch)
         adapter.client = self._mock_client(
             get_response={"status": 200, "data": []},
             post_response={"status": 200, "data": {"id": 42}},
         )
+        captured_payload = None
+        orig_api_post = adapter._api_post
+
+        async def tracking_post(path, payload):
+            nonlocal captured_payload
+            captured_payload = payload
+            return await orig_api_post(path, payload)
+
+        adapter._api_post = tracking_post
         ok = asyncio.get_event_loop().run_until_complete(
             adapter._register_webhook()
         )
         assert ok is True
+        assert captured_payload["events"] == ["new-message"]
 
     def test_register_accepts_201(self, monkeypatch):
         """BB might return 201 Created — must still succeed."""

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -584,6 +584,47 @@ class TestBlueBubblesWebhookRegistration:
         )
         assert ok is True
 
+    def test_register_replaces_stale_event_registration(self, monkeypatch):
+        """Existing matching URL with updated-message is removed and recreated cleanly."""
+        import asyncio
+        adapter = _make_adapter(monkeypatch)
+        url = adapter._webhook_register_url
+        deleted = []
+        captured_payload = None
+
+        adapter.client = self._mock_client(
+            get_response={"status": 200, "data": [
+                {"id": 7, "url": url, "events": ["new-message", "updated-message"]},
+            ]},
+            post_response={"status": 200, "data": {"id": 8}},
+        )
+
+        async def tracking_delete(*args, **kwargs):
+            deleted.append(args[0] if args else "")
+            class R:
+                status_code = 200
+                def raise_for_status(self):
+                    pass
+            return R()
+
+        orig_api_post = adapter._api_post
+        async def tracking_post(path, payload):
+            nonlocal captured_payload
+            captured_payload = payload
+            return await orig_api_post(path, payload)
+
+        adapter.client.delete = tracking_delete
+        adapter._api_post = tracking_post
+
+        ok = asyncio.get_event_loop().run_until_complete(
+            adapter._register_webhook()
+        )
+
+        assert ok is True
+        assert len(deleted) == 1
+        assert "/api/v1/webhook/7" in deleted[0]
+        assert captured_payload["events"] == ["new-message"]
+
     def test_register_reuses_existing(self, monkeypatch):
         """Crash resilience — existing registration is reused, no POST needed."""
         import asyncio


### PR DESCRIPTION
## Summary

BlueBubbles webhook registration now subscribes only to `new-message` events and replaces existing registrations for the same URL when their event set is stale. This avoids duplicate inbound handling from `updated-message` registrations while still reusing an already-correct webhook after restart.

## Diff scope

- `gateway/platforms/bluebubbles.py` — register with `new-message` only; compare existing webhook events; delete/recreate stale registrations.
- `tests/gateway/test_bluebubbles.py` — regression coverage for fresh registration, stale-event replacement, existing correct registration reuse, and duplicate cleanup.

## Verification

```text
$ HOME=/Users/watson scripts/run_tests.sh tests/gateway/test_bluebubbles.py
▶ running pytest with 4 workers, hermetic env, in /tmp/hermes-bluebubbles-v014
  (TZ=UTC LANG=C.UTF-8 PYTHONHASHSEED=0; all credential env vars unset)
============================= test session starts ==============================
platform darwin -- Python 3.11.14, pytest-9.0.2, pluggy-1.6.0
rootdir: /private/tmp/hermes-bluebubbles-v014
configfile: pyproject.toml
plugins: xdist-3.8.0, split-0.11.0, asyncio-1.3.0, anyio-4.13.0
created: 4/4 workers
4 workers [50 items]

..................................................                       [100%]
============================== 50 passed in 1.00s ==============================
```

```text
$ /Users/watson/.hermes/hermes-agent/venv/bin/python -m ruff check gateway/platforms/bluebubbles.py tests/gateway/test_bluebubbles.py
All checks passed!
```

```text
$ git diff --check origin/main...HEAD
# no output
```

## Real-behavior proof

- **Behavior addressed:** BlueBubbles webhook setup could subscribe to both `new-message` and `updated-message`, and an old same-URL webhook with stale events could be reused instead of corrected.
- **Real environment tested:** Local Hermes Agent checkout on macOS, Python 3.11.14, pytest 9.0.2; mocked BlueBubbles client in `tests/gateway/test_bluebubbles.py`.
- **Exact command:** `HOME=/Users/watson scripts/run_tests.sh tests/gateway/test_bluebubbles.py`
- **Evidence after fix:** full targeted suite above: `50 passed in 1.00s`.
- **Observed result:** Fresh registration posts `events == ["new-message"]`; stale same-URL registrations containing `updated-message` are deleted and recreated; already-correct same-URL `new-message` registrations are reused.
- **What was NOT tested:** A live BlueBubbles server/device was not contacted; this PR validates the adapter behavior with mocked API responses.

### Regression check against pre-fix base

I copied the updated BlueBubbles test file onto `origin/main` in a detached worktree and ran the two behavior tests that cover this change:

```text
$ HOME=/Users/watson scripts/run_tests.sh \
  tests/gateway/test_bluebubbles.py::TestBlueBubblesWebhookRegistration::test_register_fresh \
  tests/gateway/test_bluebubbles.py::TestBlueBubblesWebhookRegistration::test_register_replaces_stale_event_registration
created: 4/4 workers
4 workers [2 items]

FF                                                                       [100%]
FAILED tests/gateway/test_bluebubbles.py::TestBlueBubblesWebhookRegistration::test_register_replaces_stale_event_registration
E       assert 0 == 1
E        +  where 0 = len([])
FAILED tests/gateway/test_bluebubbles.py::TestBlueBubblesWebhookRegistration::test_register_fresh
E       AssertionError: assert ['new-message...ated-message'] == ['new-message']
============================== 2 failed in 0.88s ===============================
```

## Test plan

- [x] Targeted BlueBubbles gateway tests pass.
- [x] Ruff passes on changed files.
- [x] Diff whitespace check passes.
- [x] Regression check fails on `origin/main` with the updated behavior tests.

## Commits

1. `3a0c51194 fix(bluebubbles): register new-message webhooks only`
2. `64fb41983 fix(bluebubbles): replace stale webhook event registrations`
