### PR TITLE
fix(doctor): attach codex CLI hint to OpenAI Codex auth warning for #27975

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -799,6 +799,16 @@ def run_doctor(args):
             check_warn("OpenAI Codex auth", "(not logged in)")
             if codex_status.get("error"):
                 check_info(codex_status["error"])
+            # Native OAuth uses Hermes' own device-code flow — the Codex CLI is
+            # only needed to import existing tokens from ~/.codex/auth.json.
+            # Attach the hint to the Codex auth row so it doesn't read as
+            # remediation for whichever provider happens to print next (#27975).
+            if not _safe_which("codex"):
+                check_info(
+                    "codex CLI not installed "
+                    "(optional — only required to import tokens "
+                    "from an existing Codex CLI login)"
+                )
 
         gemini_status = get_gemini_oauth_auth_status()
         if gemini_status.get("logged_in"):
@@ -836,18 +846,6 @@ def run_doctor(args):
                 check_info(xai_oauth_status["error"])
     except Exception:
         pass
-
-    if _safe_which("codex"):
-        check_ok("codex CLI")
-    else:
-        # Native OAuth uses Hermes' own device-code flow — the Codex CLI is
-        # only needed if you want to import existing tokens from
-        # ~/.codex/auth.json.  Downgrade to info so users running
-        # `hermes auth openai-codex` aren't told they're missing something.
-        check_info(
-            "codex CLI not installed "
-            "(optional — only required to import tokens from an existing Codex CLI login)"
-        )
 
     _section("Directory Structure")
     hermes_home = HERMES_HOME

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1288,6 +1288,17 @@ class TestDoctorCodexCliHintPlacement:
         # Hint must sit between Codex auth and the next provider row (#27975).
         assert codex_idx < hint_idx < minimax_idx
 
+    def test_hint_suppressed_when_codex_cli_present(self, monkeypatch, tmp_path):
+        out = self._run(monkeypatch, tmp_path, codex_logged_in=False, codex_cli_present=True)
+        assert "OpenAI Codex auth" in out
+        assert self._hint_line() not in out
+
+    def test_hint_suppressed_when_codex_logged_in(self, monkeypatch, tmp_path):
+        out = self._run(monkeypatch, tmp_path, codex_logged_in=True, codex_cli_present=False)
+        assert "OpenAI Codex auth" in out
+        assert "(logged in)" in out
+        assert self._hint_line() not in out
+
     def test_hint_never_attaches_to_minimax_row(self, monkeypatch, tmp_path):
         out = self._run(monkeypatch, tmp_path, codex_logged_in=False, codex_cli_present=False)
         # The MiniMax OAuth row and the hint must not be adjacent — the hint

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1223,3 +1223,76 @@ class TestDoctorXaiOAuthStatus:
         # None → {} → logged_in falsy → shows not-logged-in warn
         assert "xAI OAuth" in out
         assert "(not logged in)" in out
+
+
+# ---------------------------------------------------------------------------
+# ◆ Auth Providers — codex CLI import hint placement (issue #27975)
+# ---------------------------------------------------------------------------
+
+
+class TestDoctorCodexCliHintPlacement:
+    """The `codex CLI not installed` hint belongs under OpenAI Codex auth.
+
+    Regression for #27975: the hint used to be emitted as a standalone block
+    after all auth-provider rows, so it visually attached to whichever
+    provider happened to print last (MiniMax OAuth in the reported repro),
+    reading as remediation for an unrelated provider.
+    """
+
+    def _run(self, monkeypatch, tmp_path, *, codex_logged_in: bool, codex_cli_present: bool) -> str:
+        home = tmp_path / ".hermes"
+        home.mkdir(parents=True, exist_ok=True)
+        (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+        project = tmp_path / "project"
+        project.mkdir(exist_ok=True)
+
+        monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+        monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+        monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+
+        fake_model_tools = types.SimpleNamespace(
+            check_tool_availability=lambda *a, **kw: ([], []),
+            TOOLSET_REQUIREMENTS={},
+        )
+        monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {"logged_in": False})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {"logged_in": codex_logged_in})
+        monkeypatch.setattr(_auth_mod, "get_gemini_oauth_auth_status", lambda: {"logged_in": False})
+        monkeypatch.setattr(_auth_mod, "get_minimax_oauth_auth_status", lambda: {"logged_in": False})
+        monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {"logged_in": False})
+
+        real_which = doctor_mod.shutil.which
+        monkeypatch.setattr(
+            doctor_mod.shutil,
+            "which",
+            lambda cmd: ("/usr/local/bin/codex" if codex_cli_present else None) if cmd == "codex" else real_which(cmd),
+        )
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            doctor_mod.run_doctor(Namespace(fix=False))
+        return buf.getvalue()
+
+    @staticmethod
+    def _hint_line() -> str:
+        return "codex CLI not installed"
+
+    def test_hint_appears_under_codex_auth_when_missing(self, monkeypatch, tmp_path):
+        out = self._run(monkeypatch, tmp_path, codex_logged_in=False, codex_cli_present=False)
+        lines = out.splitlines()
+        codex_idx = next(i for i, l in enumerate(lines) if "OpenAI Codex auth" in l)
+        hint_idx = next(i for i, l in enumerate(lines) if self._hint_line() in l)
+        minimax_idx = next(i for i, l in enumerate(lines) if "MiniMax OAuth" in l)
+        # Hint must sit between Codex auth and the next provider row (#27975).
+        assert codex_idx < hint_idx < minimax_idx
+
+    def test_hint_never_attaches_to_minimax_row(self, monkeypatch, tmp_path):
+        out = self._run(monkeypatch, tmp_path, codex_logged_in=False, codex_cli_present=False)
+        # The MiniMax OAuth row and the hint must not be adjacent — the hint
+        # belongs to the Codex auth row directly above it.
+        lines = [l for l in out.splitlines() if l.strip()]
+        minimax_idx = next(i for i, l in enumerate(lines) if "MiniMax OAuth" in l)
+        assert self._hint_line() not in lines[minimax_idx - 1]
+        assert minimax_idx + 1 >= len(lines) or self._hint_line() not in lines[minimax_idx + 1]


### PR DESCRIPTION
## What does this PR do?

Fixes the misattached `codex CLI not installed` import hint in `hermes doctor`'s **Auth Providers** section.

The hint used to be emitted as a standalone block *after* every auth-provider row, so it visually attached to whichever provider happened to print last — `MiniMax OAuth` in the reported repro:

```
⚠ OpenAI Codex auth (not logged in)
  → No Codex credentials stored. Run `hermes auth` to authenticate.
⚠ Google Gemini OAuth (logged in, ...)
⚠ MiniMax OAuth (not logged in)
  → codex CLI not installed (optional — only required to import tokens from an existing Codex CLI login)
```

Reading that output, the import hint looks like remediation for `MiniMax OAuth`, even though it only applies to importing existing tokens from a Codex CLI login.

This PR inlines the hint under the OpenAI Codex auth warning where it belongs, and drops the standalone block. The hint stays silent when either signal flips (Codex auth already logged in, or `codex` binary already on PATH).

## Related Issue

Fixes #27975

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/doctor.py` (-12 / +10):
  - Emit the `codex CLI not installed` hint as an indented `check_info` line under the `OpenAI Codex auth (not logged in)` warning, gated on both `not codex_status.get("logged_in")` and `not _safe_which("codex")`.
  - Drop the standalone `if _safe_which("codex"): ... else: ...` block that used to live between the Auth Providers section and Directory Structure. The previous "✓ codex CLI" success row was redundant — the CLI's only purpose here is the optional token import, which is meaningless when Codex auth is already healthy.

- `tests/hermes_cli/test_doctor.py` (+84): added `TestDoctorCodexCliHintPlacement` with 4 cases:
  - `test_hint_appears_under_codex_auth_when_missing` — pins line ordering: `OpenAI Codex auth` → hint → `MiniMax OAuth`.
  - `test_hint_suppressed_when_codex_cli_present` — silent when `codex` is on PATH.
  - `test_hint_suppressed_when_codex_logged_in` — silent when Codex auth already succeeded.
  - `test_hint_never_attaches_to_minimax_row` — hint cannot be adjacent to the `MiniMax OAuth` row (the row that absorbed it before the fix).

Commits (3, all conventional, scoped to `doctor`):
- `fix(doctor): attach codex CLI hint to OpenAI Codex auth warning for #27975`
- `test(doctor): pin codex CLI hint placement under Codex auth row for #27975`
- `test(doctor): cover codex CLI hint suppression cases for #27975`

## How to Test

1. Check out this branch and activate the venv:
   ```
   source .venv/bin/activate
   ```
2. Run the new tests on their own:
   ```
   scripts/run_tests.sh tests/hermes_cli/test_doctor.py -v -k CodexCliHint
   ```
   Expected: **4 passed**.
3. Run the full doctor suite to confirm no cross-test regressions:
   ```
   scripts/run_tests.sh tests/hermes_cli/test_doctor.py
   ```
   Expected: **61 passed** (57 pre-existing + 4 new).
4. Optional manual repro of the original bug — with Codex auth not logged in and `codex` not on PATH:
   ```
   hermes doctor
   ```
   After: the hint now reads as remediation for the Codex auth row directly above it.
   ```
   ⚠ OpenAI Codex auth (not logged in)
     → codex CLI not installed (optional — only required to import tokens from an existing Codex CLI login)
   ⚠ Google Gemini OAuth (not logged in)
   ⚠ MiniMax OAuth (not logged in)
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(doctor): ...`, `test(doctor): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/hermes_cli/test_doctor.py` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.x (Darwin 24.6.0), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (no behavior change outside doctor output ordering)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — tests stub `shutil.which` and all auth helpers; no real filesystem or platform-specific calls
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/hermes_cli/test_doctor.py -v -k CodexCliHint
4 workers [4 items]
tests/hermes_cli/test_doctor.py::TestDoctorCodexCliHintPlacement::test_hint_appears_under_codex_auth_when_missing PASSED
tests/hermes_cli/test_doctor.py::TestDoctorCodexCliHintPlacement::test_hint_suppressed_when_codex_cli_present  PASSED
tests/hermes_cli/test_doctor.py::TestDoctorCodexCliHintPlacement::test_hint_suppressed_when_codex_logged_in    PASSED
tests/hermes_cli/test_doctor.py::TestDoctorCodexCliHintPlacement::test_hint_never_attaches_to_minimax_row      PASSED
======================== 4 passed in 3.38s =========================

$ scripts/run_tests.sh tests/hermes_cli/test_doctor.py
4 workers [61 items]
.............................................................        [100%]
======================== 61 passed in 2.80s ========================
```
