### PR TITLE
feat(feishu): render code blocks and tables as interactive card (OpenClaw-style)

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -607,6 +607,183 @@ def _build_markdown_post_rows(content: str) -> List[List[Dict[str, str]]]:
     return rows or [[{"tag": "md", "text": content}]]
 
 
+# ---------------------------------------------------------------------------
+# Interactive card helpers (mirrors OpenClaw @larksuite/openclaw-lark design)
+# ---------------------------------------------------------------------------
+
+# Feishu CardKit markdown elements cap at 3 markdown tables per card.
+# Exceeding this triggers API error 230099/11310.
+_FEISHU_CARD_TABLE_LIMIT = 3
+_FEISHU_CARD_TABLE_LIMIT_ERROR_RE = re.compile(
+    r"table number over limit", re.IGNORECASE
+)
+_FEISHU_CARD_RATE_LIMIT_CODE = 230020
+_FEISHU_CARD_CONTENT_FAILURE_CODE = 230099
+_FEISHU_CARD_ELEMENT_LIMIT_SUBCODE = 11310
+
+# Regex to find markdown tables (header + separator) outside fenced code blocks.
+_FEISHU_TABLE_RE = re.compile(
+    r"\|.+?\|[\r\n]+\|[-:| ]+\|[\s\S]*?(?=\n\n|\n(?!\|)|$)",
+    re.MULTILINE,
+)
+_FEISHU_CODE_FENCE_RE = re.compile(r"```[\s\S]*?```")
+
+
+def _find_tables_outside_code_blocks(text: str) -> list[dict]:
+    """Find markdown table matches outside fenced code blocks.
+
+    Returns list of dicts with 'index', 'length', 'raw' keys.
+    """
+    code_block_ranges: list[tuple[int, int]] = []
+    for m in _FEISHU_CODE_FENCE_RE.finditer(text):
+        code_block_ranges.append((m.start(), m.end()))
+
+    def _inside_code_block(idx: int) -> bool:
+        return any(start <= idx < end for start, end in code_block_ranges)
+
+    matches: list[dict] = []
+    for m in _FEISHU_TABLE_RE.finditer(text):
+        if not _inside_code_block(m.start()):
+            matches.append({
+                "index": m.start(),
+                "length": m.end() - m.start(),
+                "raw": m.group(0),
+            })
+    return matches
+
+
+def _should_use_interactive_card(text: str) -> bool:
+    """Detect if content benefits from being sent as an interactive card.
+
+    Returns True when the content has fenced code blocks or 1-3 markdown
+    tables outside code blocks.  Cards render these elements fully, while
+    Feishu post ``md`` elements do not.
+    """
+    table_matches = _find_tables_outside_code_blocks(text)
+    if len(table_matches) > _FEISHU_CARD_TABLE_LIMIT:
+        return False
+    if _FEISHU_CODE_FENCE_RE.search(text):
+        return True
+    if table_matches:
+        return True
+    return False
+
+
+def _optimize_feishu_markdown(text: str) -> str:
+    """Optimize markdown for Feishu display — heading downgrade + spacing.
+
+    Mirrors OpenClaw ``optimizeMarkdownStyle()``:
+
+    - H1 → H4, H2-H6 → H5 (Feishu post md / card markdown renders ATX
+      headings as plain text, so smaller headings are less visually jarring)
+    - Adds ``<br>`` spacing around tables and code blocks for readability
+    - Compresses 3+ consecutive blank lines to 2
+    - Code block contents are isolated before transforms so they are unaffected
+    """
+    # 1. Extract fenced code blocks, replace with placeholders
+    MARK = "\x00CB_"  # unlikely to appear in real content
+    code_blocks: list[str] = []
+    def _replace_code_block(m: re.Match) -> str:
+        idx = len(code_blocks)
+        code_blocks.append(m.group(0))
+        return f"{MARK}{idx}___{MARK}"
+    result = _FEISHU_CODE_FENCE_RE.sub(_replace_code_block, text)
+
+    # 2. Heading downgrade — only if the doc actually uses H1-H3
+    if re.search(r"^#{1,3} ", result, re.MULTILINE):
+        # H2-H6 → H5 first (order matters: H1→H4 later avoids double match)
+        result = re.sub(r"^#{2,6} (.+)$", r"##### \1", result, flags=re.MULTILINE)
+        result = re.sub(r"^# (.+)$", r"#### \1", result, flags=re.MULTILINE)
+
+    # 3. Table spacing: ensure <br> around tables
+    #   3a. Non-table line directly before a table → insert blank line
+    result = re.sub(r"^([^|\n].*)\n(\|.+\|)", r"\1\n\n\2", result, flags=re.MULTILINE)
+    #   3b. Table block: insert <br> before (on blank-line boundary)
+    result = re.sub(
+        r"\n\n((?:\|.+\|[^\S\n]*\n?)+)",
+        r"\n\n<br>\n\n\1",
+        result,
+    )
+    #   3c. Table block: append <br> after (skip if followed by heading/bold/end)
+    def _after_table(m: re.Match) -> str:
+        table_text = m.group(0)
+        after = result[m.end():].lstrip("\n")
+        if not after or re.match(r"^(---|#{4,5} |\*\*)", after):
+            return table_text
+        return table_text.rstrip("\n") + "\n<br>\n"
+    result = re.sub(
+        r"(?m)^(?:\|[^\n]+\|[^\S\n]*\n?)+(?=\n|$)",
+        _after_table,
+        result,
+    )
+
+    #   3d. Collapse "text\n\n<br>\n\n|" → "text\n<br>\n|" when text is not a heading/bold
+    result = re.sub(
+        r"^((?!#{4,5} )(?!\*\*).+)\n\n(<br>)\n\n(\|)",
+        r"\1\n\2\n\3",
+        result,
+        flags=re.MULTILINE,
+    )
+    #   3e. Bold line before table: "**text**\n\n<br>\n\n|" → "**text**\n<br>\n\n|"
+    result = re.sub(
+        r"^(\*\*.+)\n\n(<br>)\n\n(\|)",
+        r"\1\n\2\n\n\3",
+        result,
+        flags=re.MULTILINE,
+    )
+    #   3f. Table followed by normal text: collapse blank line
+    result = re.sub(
+        r"(\|[^\n]*\n)\n(<br>\n)((?!#{4,5} )(?!\*\*))",
+        r"\1\2\3",
+        result,
+    )
+
+    # 4. Restore code blocks with <br> padding
+    for i, block in enumerate(code_blocks):
+        result = result.replace(f"{MARK}{i}___{MARK}", f"\n<br>\n{block}\n<br>\n")
+
+    # 5. Compress 3+ blank lines → 2
+    result = re.sub(r"\n{3,}", "\n\n", result)
+
+    return result
+
+
+def _build_interactive_card_payload(text: str) -> str:
+    """Build a Feishu interactive card (v2) JSON payload with a markdown element.
+
+    Returns JSON string suitable for ``msg_type="interactive"``.
+    """
+    optimized = _optimize_feishu_markdown(text)
+    card = {
+        "schema": "2.0",
+        "config": {
+            "wide_screen_mode": True,
+        },
+        "body": {
+            "elements": [
+                {
+                    "tag": "markdown",
+                    "content": optimized,
+                }
+            ]
+        },
+    }
+    return json.dumps(card, ensure_ascii=False)
+
+
+def _is_card_table_limit_error(response_or_exc: Any) -> bool:
+    """Check if a response/exception indicates card table count exceeded."""
+    if response_or_exc is None:
+        return False
+    if isinstance(response_or_exc, Exception):
+        msg = str(response_or_exc)
+    elif isinstance(response_or_exc, dict):
+        msg = str(response_or_exc.get("msg", ""))
+    else:
+        msg = str(getattr(response_or_exc, "msg", "") or "")
+    return bool(_FEISHU_CARD_TABLE_LIMIT_ERROR_RE.search(msg))
+
+
 def parse_feishu_post_payload(
     payload: Any,
     *,
@@ -1781,20 +1958,61 @@ class FeishuAdapter(BasePlatformAdapter):
                         metadata=metadata,
                     )
                 except Exception as exc:
-                    if msg_type != "post" or not _POST_CONTENT_INVALID_RE.search(str(exc)):
+                    # Interactive card failure → fall back to post
+                    if msg_type == "interactive":
+                        logger.warning(
+                            "[Feishu] Interactive card send failed; falling back to post: %s",
+                            exc,
+                        )
+                        msg_type = "post"
+                        payload = _build_markdown_post_payload(chunk)
+                        response = await self._feishu_send_with_retry(
+                            chat_id=chat_id,
+                            msg_type=msg_type,
+                            payload=payload,
+                            reply_to=reply_to,
+                            metadata=metadata,
+                        )
+                    elif msg_type == "post" and _POST_CONTENT_INVALID_RE.search(str(exc)):
+                        logger.warning(
+                            "[Feishu] Invalid post payload rejected by API; falling back to plain text"
+                        )
+                        msg_type = "text"
+                        payload = json.dumps(
+                            {"text": _strip_markdown_to_plain_text(chunk)},
+                            ensure_ascii=False,
+                        )
+                        response = await self._feishu_send_with_retry(
+                            chat_id=chat_id,
+                            msg_type=msg_type,
+                            payload=payload,
+                            reply_to=reply_to,
+                            metadata=metadata,
+                        )
+                    else:
                         raise
-                    logger.warning("[Feishu] Invalid post payload rejected by API; falling back to plain text")
+                # Response-level fallback checks
+                if msg_type == "interactive" and not self._response_succeeded(response):
+                    logger.warning(
+                        "[Feishu] Interactive card send response indicated failure; "
+                        "falling back to post: code=%s",
+                        getattr(response, "code", "unknown"),
+                    )
+                    msg_type = "post"
+                    payload = _build_markdown_post_payload(chunk)
                     response = await self._feishu_send_with_retry(
                         chat_id=chat_id,
-                        msg_type="text",
-                        payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
+                        msg_type=msg_type,
+                        payload=payload,
                         reply_to=reply_to,
                         metadata=metadata,
                     )
                 if (
                     msg_type == "post"
                     and not self._response_succeeded(response)
-                    and _POST_CONTENT_INVALID_RE.search(str(getattr(response, "msg", "") or ""))
+                    and _POST_CONTENT_INVALID_RE.search(
+                        str(getattr(response, "msg", "") or "")
+                    )
                 ):
                     logger.warning("[Feishu] Post payload rejected by API response; falling back to plain text")
                     response = await self._feishu_send_with_retry(
@@ -1830,6 +2048,23 @@ class FeishuAdapter(BasePlatformAdapter):
             request = self._build_update_message_request(message_id=message_id, request_body=body)
             response = await asyncio.to_thread(self._client.im.v1.message.update, request)
             result = self._finalize_send_result(response, "update failed")
+            # Interactive card update failed → fall back to post
+            if not result.success and msg_type == "interactive":
+                logger.warning(
+                    "[Feishu] Interactive card update failed; falling back to post"
+                )
+                msg_type = "post"
+                payload = _build_markdown_post_payload(content)
+                fallback_body = self._build_update_message_body(
+                    msg_type=msg_type, content=payload
+                )
+                fallback_request = self._build_update_message_request(
+                    message_id=message_id, request_body=fallback_body
+                )
+                fallback_response = await asyncio.to_thread(
+                    self._client.im.v1.message.update, fallback_request
+                )
+                result = self._finalize_send_result(fallback_response, "update failed")
             if not result.success and msg_type == "post" and _POST_CONTENT_INVALID_RE.search(result.error or ""):
                 logger.warning("[Feishu] Invalid post update payload rejected by API; falling back to plain text")
                 fallback_body = self._build_update_message_body(
@@ -4222,14 +4457,15 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
-        # Feishu post-type 'md' elements do not render markdown tables; sending
-        # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
-        if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
-            return "text", json.dumps(text_payload, ensure_ascii=False)
+        # Interactive card: code blocks, 1-3 markdown tables → card v2
+        # (cards render these elements fully, post md does not)
+        if _should_use_interactive_card(content):
+            return "interactive", _build_interactive_card_payload(content)
+        # Post: standard markdown without tables/code blocks
         if _MARKDOWN_HINT_RE.search(content):
-            return "post", _build_markdown_post_payload(content)
+            return "post", _build_markdown_post_payload(
+                _optimize_feishu_markdown(content)
+            )
         text_payload = {"text": content}
         return "text", json.dumps(text_payload, ensure_ascii=False)
 

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2594,22 +2594,14 @@ class TestAdapterBehavior(unittest.TestCase):
             )
 
         self.assertTrue(result.success)
-        self.assertEqual(captured["request"].request_body.msg_type, "post")
-        payload = json.loads(captured["request"].request_body.content)
-        rows = payload["zh_cn"]["content"]
-        self.assertEqual(
-            rows,
-            [
-                [
-                    {
-                        "tag": "md",
-                        "text": "确认已入库 ✓\n文件路径：`/root/.hermes/profiles/agent_cto/cron/jobs.json`\n**解码后的内容：**",
-                    }
-                ],
-                [{"tag": "md", "text": "```json\n{\"cron\": \"list\"}\n```"}],
-                [{"tag": "md", "text": "后续说明仍应保留。"}],
-            ],
-        )
+        self.assertEqual(captured["request"].request_body.msg_type, "interactive")
+        card = json.loads(captured["request"].request_body.content)
+        self.assertEqual(card["schema"], "2.0")
+        self.assertTrue(card["config"]["wide_screen_mode"])
+        elements = card["body"]["elements"]
+        self.assertEqual(elements[0]["tag"], "markdown")
+        self.assertIn("确认已入库 ✓", elements[0]["content"])
+        self.assertIn("```json", elements[0]["content"])
 
     @patch.dict(os.environ, {}, clear=True)
     def test_build_post_payload_keeps_fence_like_code_lines_inside_code_block(self):
@@ -4823,3 +4815,324 @@ class TestFeishuMentionEndToEnd(unittest.TestCase):
         # Body: leading @Hermes stripped, Alice preserved, trailing text intact.
         self.assertIn("@Alice review the spec with Alice", event.text)
         self.assertNotIn("@Hermes @Alice", event.text)
+
+
+@unittest.skipIf(not _HAS_LARK_OAPI, "lark_oapi not installed")
+class TestFeishuInteractiveCardHelpers(unittest.TestCase):
+    """Tests for the interactive card helpers (OpenClaw-style)."""
+
+    def setUp(self):
+        from gateway.platforms.feishu import (
+            _FEISHU_CARD_TABLE_LIMIT,
+            _FEISHU_CODE_FENCE_RE,
+            _FEISHU_TABLE_RE,
+            _build_interactive_card_payload,
+            _find_tables_outside_code_blocks,
+            _optimize_feishu_markdown,
+            _should_use_interactive_card,
+        )
+        self._find_tables = _find_tables_outside_code_blocks
+        self._should_use_card = _should_use_interactive_card
+        self._optimize = _optimize_feishu_markdown
+        self._build_card = _build_interactive_card_payload
+        self._table_limit = _FEISHU_CARD_TABLE_LIMIT
+        self._code_fence_re = _FEISHU_CODE_FENCE_RE
+        self._table_re = _FEISHU_TABLE_RE
+
+    # -- _find_tables_outside_code_blocks ------------------------------------
+
+    def test_find_tables_plain(self):
+        """Detect a simple markdown table."""
+        text = "| A | B |\n|---|---|\n| 1 | 2 |"
+        matches = self._find_tables(text)
+        self.assertEqual(len(matches), 1)
+        self.assertIn("| A | B |", matches[0]["raw"])
+
+    def test_find_tables_inside_code_block(self):
+        """Tables inside ``` fences are excluded."""
+        text = (
+            "Some text\n"
+            "```\n"
+            "| A | B |\n"
+            "|---|---|\n"
+            "| 1 | 2 |\n"
+            "```\n"
+            "More text"
+        )
+        matches = self._find_tables(text)
+        self.assertEqual(len(matches), 0)
+
+    def test_find_tables_mixed(self):
+        """Table outside code blocks is found, inside is excluded."""
+        text = (
+            "| Real | Data |\n"
+            "|------|------|\n"
+            "| x    | y    |\n"
+            "\n"
+            "```\n"
+            "| Example | Only |\n"
+            "|---------|------|\n"
+            "| a       | b    |\n"
+            "```"
+        )
+        matches = self._find_tables(text)
+        self.assertEqual(len(matches), 1)
+        self.assertIn("Real", matches[0]["raw"])
+
+    # -- _should_use_interactive_card ----------------------------------------
+
+    def test_should_use_card_plain_text(self):
+        """Plain text → no card."""
+        self.assertFalse(self._should_use_card("Hello world"))
+
+    def test_should_use_card_simple_markdown(self):
+        """Bold/lists/links → no card (post handles these)."""
+        self.assertFalse(self._should_use_card("**bold** and *italic*"))
+
+    def test_should_use_card_code_block(self):
+        """Fenced code block → use card."""
+        self.assertTrue(self._should_use_card("Before\n```python\nprint(1)\n```\nAfter"))
+
+    def test_should_use_card_table_one(self):
+        """Single table → use card."""
+        self.assertTrue(self._should_use_card("| A | B |\n|---|---|\n| 1 | 2 |"))
+
+    def test_should_use_card_tables_at_limit(self):
+        """Tables within limit → use card."""
+        tables = "\n\n".join(
+            f"| H{i} |\n|---|\n| v{i} |" for i in range(self._table_limit)
+        )
+        self.assertTrue(self._should_use_card(tables))
+
+    def test_should_use_card_tables_exceed_limit(self):
+        """More tables than FEISHU_CARD_TABLE_LIMIT → no card."""
+        tables = "\n\n".join(
+            f"| H{i} |\n|---|\n| v{i} |" for i in range(self._table_limit + 1)
+        )
+        self.assertFalse(self._should_use_card(tables))
+
+    def test_should_use_card_table_in_code_block(self):
+        """Table inside code block is not counted → code block triggers card."""
+        text = "```\n| Fake |\n|------|\n| data |\n```"
+        # No real table, has code block → still use card
+        self.assertTrue(self._should_use_card(text))
+
+    # -- _optimize_feishu_markdown -------------------------------------------
+
+    def test_optimize_heading_downgrade(self):
+        """H1 → H4, H2-H6 → H5."""
+        result = self._optimize("# Title\n## Section\n### Sub\nPlain\n")
+        self.assertIn("#### Title", result)
+        self.assertIn("##### Section", result)
+        self.assertIn("##### Sub", result)
+
+    def test_optimize_preserves_code_block(self):
+        """Code block content is not affected by heading transforms."""
+        result = self._optimize("# Title\n```\n# Not a heading\n## Still not\n```\nEnd")
+        self.assertIn("#### Title", result)
+        self.assertIn("```\n# Not a heading\n## Still not\n```", result)
+
+    def test_optimize_table_spacing(self):
+        """Tables get <br> spacing before and after."""
+        result = self._optimize("text\n\n| A | B |\n|---|---|\n| 1 | 2 |\n\nmore text")
+        self.assertIn("<br>", result)
+        # Table content preserved
+        self.assertIn("| A | B |", result)
+        self.assertIn("| 1 | 2 |", result)
+
+    def test_optimize_collapses_excess_blank_lines(self):
+        """3+ blank lines → 2."""
+        result = self._optimize("a\n\n\n\n\nb")
+        self.assertNotIn("\n\n\n", result)
+
+    def test_optimize_no_h1_no_change(self):
+        """No H1-H3 in text → no heading downgrade."""
+        text = "#### Already H4\nPlain\n##### Already H5"
+        result = self._optimize(text)
+        self.assertIn("#### Already H4", result)
+        self.assertIn("##### Already H5", result)
+
+    # -- _build_interactive_card_payload -------------------------------------
+
+    def test_build_card_structure(self):
+        """Card JSON has correct schema v2 structure."""
+        payload = self._build_card("Hello **world**")
+        card = json.loads(payload)
+        self.assertEqual(card["schema"], "2.0")
+        self.assertTrue(card["config"]["wide_screen_mode"])
+        self.assertEqual(len(card["body"]["elements"]), 1)
+        self.assertEqual(card["body"]["elements"][0]["tag"], "markdown")
+
+    def test_build_card_preserves_content(self):
+        """Card markdown element contains the input text."""
+        text = "Hello **bold** and `code`"
+        payload = self._build_card(text)
+        card = json.loads(payload)
+        content = card["body"]["elements"][0]["content"]
+        self.assertIn("Hello", content)
+        self.assertIn("**bold**", content)
+
+    def test_build_card_optimizes_markdown(self):
+        """Card content is run through optimizeMarkdownStyle first."""
+        payload = self._build_card("# Title\nplain")
+        card = json.loads(payload)
+        content = card["body"]["elements"][0]["content"]
+        self.assertIn("#### Title", content)  # H1 → H4
+
+
+@unittest.skipIf(not _HAS_LARK_OAPI, "lark_oapi not installed")
+class TestFeishuOutboundPayloadRouting(unittest.TestCase):
+    """Tests for _build_outbound_payload routing logic."""
+
+    def setUp(self):
+        from gateway.platforms.feishu import FeishuAdapter
+
+        self.adapter = FeishuAdapter.__new__(FeishuAdapter)
+
+    def _build(self, content: str) -> tuple:
+        return self.adapter._build_outbound_payload(content)
+
+    def test_plain_text_routes_to_text(self):
+        """Plain text → 'text' type."""
+        msg_type, payload = self._build("hello world")
+        self.assertEqual(msg_type, "text")
+        data = json.loads(payload)
+        self.assertEqual(data["text"], "hello world")
+
+    def test_bold_text_routes_to_post(self):
+        """Bold/inline markdown → 'post' type."""
+        msg_type, _ = self._build("**bold** text")
+        self.assertEqual(msg_type, "post")
+
+    def test_code_block_routes_to_interactive(self):
+        """Fenced code block → 'interactive' card."""
+        msg_type, _ = self._build("```python\nx = 1\n```")
+        self.assertEqual(msg_type, "interactive")
+
+    def test_table_routes_to_interactive(self):
+        """Markdown table → 'interactive' card."""
+        msg_type, _ = self._build("| A | B |\n|---|---|\n| 1 | 2 |")
+        self.assertEqual(msg_type, "interactive")
+
+    def test_link_routes_to_post(self):
+        """Link → 'post' type."""
+        msg_type, _ = self._build("[click](https://example.com)")
+        self.assertEqual(msg_type, "post")
+
+    def test_list_routes_to_post(self):
+        """Unordered list → 'post' type."""
+        msg_type, _ = self._build("- item\n- another")
+        self.assertEqual(msg_type, "post")
+
+
+@unittest.skipIf(not _HAS_LARK_OAPI, "lark_oapi not installed")
+class TestFeishuCardSendFallback(unittest.TestCase):
+    """Tests for send() interactive card → post → text fallback chain."""
+
+    def setUp(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        self.adapter = FeishuAdapter(PlatformConfig())
+
+    def _mock_client(self, create_func):
+        class _MessageAPI:
+            def create(inner_self, request):
+                return create_func(request)
+
+        self.adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+    def test_send_code_block_sends_interactive_card(self):
+        """Code block content is sent as interactive card on success."""
+        captured = {}
+        content = "```python\nx = 1\n```"
+
+        def _create(request):
+            captured["msg_type"] = request.request_body.msg_type
+            return SimpleNamespace(
+                success=lambda: True,
+                data=SimpleNamespace(message_id="om_card_test"),
+            )
+
+        self._mock_client(_create)
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                self.adapter.send(chat_id="oc_test", content=content)
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["msg_type"], "interactive")
+
+    def test_send_interactive_fallback_on_exception(self):
+        """When interactive card throws, fall back to post."""
+        attempts = []
+
+        def _create(request):
+            attempts.append(request.request_body.msg_type)
+            if request.request_body.msg_type == "interactive":
+                raise Exception("CardKit API error")
+            return SimpleNamespace(
+                success=lambda: True,
+                data=SimpleNamespace(message_id="om_fallback"),
+            )
+
+        self._mock_client(_create)
+        content = "```code\nfallback test\n```"
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                self.adapter.send(chat_id="oc_test", content=content)
+            )
+
+        self.assertTrue(result.success)
+        # _feishu_send_with_retry retries 3x before propagating
+        self.assertEqual(
+            attempts,
+            ["interactive", "interactive", "interactive", "post"],
+        )
+
+    def test_send_interactive_fallback_on_response_failure(self):
+        """When interactive card response fails, fall back to post."""
+        attempts = []
+        interactive_call = [True]
+
+        def _create(request):
+            attempts.append(request.request_body.msg_type)
+            if interactive_call[0]:
+                interactive_call[0] = False
+                return SimpleNamespace(
+                    success=lambda: False,
+                    code=230099,
+                    msg="card failed",
+                )
+            return SimpleNamespace(
+                success=lambda: True,
+                data=SimpleNamespace(message_id="om_fallback2"),
+            )
+
+        self._mock_client(_create)
+        content = "```code\nfallback response test\n```"
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                self.adapter.send(chat_id="oc_test", content=content)
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(attempts, ["interactive", "post"])


### PR DESCRIPTION
Closing in favor of PR #27922 — @neilwong89's minimal fix (+3/-10 lines) is the correct approach. Verified that Feishu post type now natively supports markdown tables. The interactive card approach (CardKit v2) returns code 230099 for tables and is not viable.

The heading downgrade optimization could be a separate follow-up PR if the community wants it.