### PR TITLE
feat(web): add Ollama Cloud web search + extract provider (#27876)

### DIFF
--- a/agent/web_search_registry.py
+++ b/agent/web_search_registry.py
@@ -124,6 +124,7 @@ _LEGACY_PREFERENCE = (
     "parallel",
     "tavily",
     "exa",
+    "ollama",
     "searxng",
     "brave-free",
     "ddgs",

--- a/plugins/web/ollama/__init__.py
+++ b/plugins/web/ollama/__init__.py
@@ -1,0 +1,15 @@
+"""Ollama Cloud web search + extract plugin — bundled, auto-loaded.
+
+Backed by Ollama Cloud API (requires ``OLLAMA_API_KEY`` from
+https://ollama.com/settings/keys). Search and content extraction in
+one provider.
+"""
+
+from __future__ import annotations
+
+from plugins.web.ollama.provider import OllamaWebSearchProvider
+
+
+def register(ctx) -> None:
+    """Register the Ollama provider with the plugin context."""
+    ctx.register_web_search_provider(OllamaWebSearchProvider())

--- a/plugins/web/ollama/plugin.yaml
+++ b/plugins/web/ollama/plugin.yaml
@@ -1,0 +1,7 @@
+name: web-ollama
+version: 1.0.0
+description: "Ollama Cloud web search + content extraction. Free tier available, paid upgrade for higher rate limits."
+author: blackdeathdrow
+kind: backend
+provides_web_providers:
+  - ollama

--- a/plugins/web/ollama/provider.py
+++ b/plugins/web/ollama/provider.py
@@ -1,0 +1,211 @@
+"""Ollama Cloud web search + content extraction — plugin form.
+
+Subclasses :class:`agent.web_search_provider.WebSearchProvider`. Two
+capabilities advertised:
+
+- ``supports_search()``  -> True (Ollama ``/api/web_search``)
+- ``supports_extract()`` -> True (Ollama ``/api/web_fetch``)
+- ``supports_crawl()``   -> False
+
+Config keys this provider responds to::
+
+    web:
+      search_backend: "ollama"      # explicit per-capability
+      extract_backend: "ollama"     # explicit per-capability
+      backend: "ollama"             # shared fallback for all three
+
+Env vars::
+
+    OLLAMA_API_KEY=...           # https://ollama.com/settings/keys (required)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, List
+
+from agent.web_search_provider import WebSearchProvider
+
+logger = logging.getLogger(__name__)
+
+_OLLAMA_API = "https://ollama.com"
+
+
+class OllamaWebSearchProvider(WebSearchProvider):
+    """Ollama Cloud search + extract provider."""
+
+    @property
+    def name(self) -> str:
+        return "ollama"
+
+    @property
+    def display_name(self) -> str:
+        return "Ollama Cloud"
+
+    def is_available(self) -> bool:
+        """Return True when ``OLLAMA_API_KEY`` is set to a non-empty value."""
+        return bool(os.getenv("OLLAMA_API_KEY", "").strip())
+
+    def supports_search(self) -> bool:
+        return True
+
+    def supports_extract(self) -> bool:
+        return True
+
+    def supports_crawl(self) -> bool:
+        return False
+
+    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+        """Execute an Ollama web search."""
+        import httpx
+
+        api_key = os.getenv("OLLAMA_API_KEY", "").strip()
+        if not api_key:
+            return {"success": False, "error": "OLLAMA_API_KEY is not set"}
+
+        count = max(1, min(int(limit), 10))
+
+        try:
+            from tools.interrupt import is_interrupted
+
+            if is_interrupted():
+                return {"success": False, "error": "Interrupted"}
+
+            logger.info("Ollama web search: '%s' (limit=%d)", query, count)
+            resp = httpx.post(
+                f"{_OLLAMA_API}/api/web_search",
+                json={"query": query, "max_results": count},
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "Content-Type": "application/json",
+                },
+                timeout=60,
+            )
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            logger.warning("Ollama web search HTTP error: %s", exc)
+            return {
+                "success": False,
+                "error": f"Ollama web search returned HTTP {exc.response.status_code}",
+            }
+        except httpx.RequestError as exc:
+            logger.warning("Ollama web search request error: %s", exc)
+            return {"success": False, "error": f"Could not reach Ollama web search: {exc}"}
+
+        try:
+            data = resp.json()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Ollama web search response parse error: %s", exc)
+            return {
+                "success": False,
+                "error": "Could not parse Ollama web search response as JSON",
+            }
+
+        raw_results = data.get("results", [])
+
+        web_results = [
+            {
+                "title": str(r.get("title", "")),
+                "url": str(r.get("url", "")),
+                "description": str(r.get("content", "")),
+                "position": i + 1,
+            }
+            for i, r in enumerate(raw_results[:limit])
+        ]
+
+        logger.info(
+            "Ollama web search '%s': %d results (from %d raw, limit %d)",
+            query,
+            len(web_results),
+            len(raw_results),
+            limit,
+        )
+
+        return {"success": True, "data": {"web": web_results}}
+
+    def extract(self, urls: List[str], **kwargs: Any) -> List[Dict[str, Any]]:
+        """Extract content from one or more URLs via Ollama web_fetch.
+
+        Sync — the underlying call is httpx.post(...). Returns the legacy
+        list-of-results shape; per-URL failures become items with ``error``.
+        """
+        import httpx
+
+        api_key = os.getenv("OLLAMA_API_KEY", "").strip()
+        if not api_key:
+            return [{"url": u, "title": "", "content": "", "error": "OLLAMA_API_KEY is not set"} for u in urls]
+
+        try:
+            from tools.interrupt import is_interrupted
+
+            if is_interrupted():
+                return [{"url": u, "title": "", "content": "", "error": "Interrupted"} for u in urls]
+
+            logger.info("Ollama web fetch: %d URL(s)", len(urls))
+        except Exception:  # noqa: BLE001
+            pass
+
+        documents: List[Dict[str, Any]] = []
+        for url in urls:
+            try:
+                resp = httpx.post(
+                    f"{_OLLAMA_API}/api/web_fetch",
+                    json={"url": url},
+                    headers={
+                        "Authorization": f"Bearer {api_key}",
+                        "Content-Type": "application/json",
+                    },
+                    timeout=60,
+                )
+                resp.raise_for_status()
+                data = resp.json()
+            except httpx.HTTPStatusError as exc:
+                logger.warning("Ollama web fetch HTTP error for %s: %s", url, exc)
+                documents.append({
+                    "url": url,
+                    "title": "",
+                    "content": "",
+                    "error": f"Ollama web fetch returned HTTP {exc.response.status_code}",
+                })
+            except httpx.RequestError as exc:
+                logger.warning("Ollama web fetch request error for %s: %s", url, exc)
+                documents.append({
+                    "url": url,
+                    "title": "",
+                    "content": "",
+                    "error": f"Could not reach Ollama web fetch: {exc}",
+                })
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Ollama web fetch error for %s: %s", url, exc)
+                documents.append({
+                    "url": url,
+                    "title": "",
+                    "content": "",
+                    "error": f"Ollama web fetch failed: {exc}",
+                })
+            else:
+                raw_content = data.get("content", "")
+                documents.append({
+                    "url": url,
+                    "title": data.get("title", ""),
+                    "content": raw_content,
+                    "raw_content": raw_content,
+                    "metadata": {"sourceURL": url},
+                })
+
+        return documents
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Ollama Cloud",
+            "badge": "free tier · paid upgrade",
+            "tag": "Search + extract via Ollama Cloud API. Generous free tier available.",
+            "env_vars": [
+                {
+                    "key": "OLLAMA_API_KEY",
+                    "prompt": "Ollama API key",
+                    "url": "https://ollama.com/settings/keys",
+                },
+            ],
+        }

--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -45,6 +45,7 @@ def _clear_web_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "TOOL_GATEWAY_DOMAIN",
         "TOOL_GATEWAY_USER_TOKEN",
         "XAI_API_KEY",
+        "OLLAMA_API_KEY",
     ):
         monkeypatch.delenv(k, raising=False)
 
@@ -68,9 +69,9 @@ def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 class TestBundledPluginsRegister:
-    """All eight bundled web plugins discover and register correctly."""
+    """All nine bundled web plugins discover and register correctly."""
 
-    def test_all_seven_plugins_present_in_registry(self) -> None:
+    def test_all_nine_plugins_present_in_registry(self) -> None:
         _ensure_plugins_loaded()
         from agent.web_search_registry import list_providers
 
@@ -80,6 +81,7 @@ class TestBundledPluginsRegister:
             "ddgs",
             "exa",
             "firecrawl",
+            "ollama",
             "parallel",
             "searxng",
             "tavily",
@@ -98,6 +100,7 @@ class TestBundledPluginsRegister:
             ("firecrawl", True, True),
             # xai: search-only via Grok's agentic web_search tool.
             ("xai", True, False),
+            ("ollama", True, True),
         ],
     )
     def test_capability_flags_match_spec(
@@ -116,7 +119,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
+        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai", "ollama"],
     )
     def test_each_plugin_has_name_and_display_name(self, plugin_name: str) -> None:
         _ensure_plugins_loaded()
@@ -129,7 +132,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
+        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai", "ollama"],
     )
     def test_each_plugin_has_setup_schema(self, plugin_name: str) -> None:
         """``get_setup_schema()`` returns a dict the picker can consume."""
@@ -244,6 +247,16 @@ class TestIsAvailable:
         assert p is not None
         assert p.is_available() is False  # no XAI_API_KEY, no auth.json
         monkeypatch.setenv("XAI_API_KEY", "real")
+        assert p.is_available() is True
+
+    def test_ollama_requires_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("ollama")
+        assert p is not None
+        assert p.is_available() is False  # no OLLAMA_API_KEY
+        monkeypatch.setenv("OLLAMA_API_KEY", "real")
         assert p.is_available() is True
 
 
@@ -496,3 +509,26 @@ class TestErrorResponseShapes:
         assert isinstance(result, dict)
         assert result.get("success") is False
         assert "error" in result
+
+    def test_ollama_returns_error_dict_when_unconfigured(self) -> None:
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("ollama")
+        assert p is not None
+        result = p.search("test", limit=5)
+        assert isinstance(result, dict)
+        assert result.get("success") is False
+        assert "error" in result
+
+    def test_ollama_extract_returns_per_url_errors_when_unconfigured(self) -> None:
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("ollama")
+        assert p is not None
+        result = p.extract(["https://example.com"])
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert "error" in result[0]
+        assert result[0]["url"] == "https://example.com"

--- a/tests/tools/test_web_providers_ollama.py
+++ b/tests/tools/test_web_providers_ollama.py
@@ -1,0 +1,257 @@
+"""Tests for the Ollama Cloud web search + extract provider.
+
+Covers:
+- OllamaWebSearchProvider.is_available() — reflects OLLAMA_API_KEY presence
+- OllamaWebSearchProvider.search() — happy path, missing key, HTTP errors
+- OllamaWebSearchProvider.extract() — happy path, per-URL failure handling
+- Result normalization (title, url, description/content, position)
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import httpx
+
+# ---------------------------------------------------------------------------
+# OllamaWebSearchProvider unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestOllamaProviderIsConfigured:
+    def test_configured_when_api_key_set(self, monkeypatch):
+        from plugins.web.ollama.provider import OllamaWebSearchProvider
+
+        monkeypatch.setenv("OLLAMA_API_KEY", "ol-test-key")
+        assert OllamaWebSearchProvider().is_available() is True
+
+    def test_not_configured_when_key_missing(self, monkeypatch):
+        from plugins.web.ollama.provider import OllamaWebSearchProvider
+
+        monkeypatch.delenv("OLLAMA_API_KEY", raising=False)
+        assert OllamaWebSearchProvider().is_available() is False
+
+    def test_not_configured_when_key_empty(self, monkeypatch):
+        from plugins.web.ollama.provider import OllamaWebSearchProvider
+
+        monkeypatch.setenv("OLLAMA_API_KEY", "")
+        assert OllamaWebSearchProvider().is_available() is False
+
+    def test_provider_name(self):
+        from plugins.web.ollama.provider import OllamaWebSearchProvider
+
+        assert OllamaWebSearchProvider().name == "ollama"
+
+    def test_implements_web_search_provider(self):
+        from agent.web_search_provider import WebSearchProvider
+        from plugins.web.ollama.provider import OllamaWebSearchProvider
+
+        assert issubclass(OllamaWebSearchProvider, WebSearchProvider)
+
+
+class TestOllamaProviderSearch:
+    def test_happy_path_normalizes_results(self, monkeypatch):
+        from plugins.web.ollama.provider import OllamaWebSearchProvider
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "results": [
+                {"title": "A", "url": "https://a.example.com", "content": "desc A"},
+                {"title": "B", "url": "https://b.example.com", "content": "desc B"},
+            ]
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        def fake_post(*args, **kwargs):
+            return mock_response
+
+        monkeypatch.setenv("OLLAMA_API_KEY", "ol-key")
+        monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False, raising=False)
+        monkeypatch.setattr("httpx.post", fake_post)
+
+        result = OllamaWebSearchProvider().search("q", limit=5)
+
+        assert result["success"] is True
+        web = result["data"]["web"]
+        assert len(web) == 2
+        assert web[0] == {"title": "A", "url": "https://a.example.com", "description": "desc A", "position": 1}
+        assert web[1]["position"] == 2
+
+    def test_limit_is_respected(self, monkeypatch):
+        from plugins.web.ollama.provider import OllamaWebSearchProvider
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "results": [{"title": f"R{i}", "url": f"https://r{i}.example.com", "content": f"desc {i}"}
+                        for i in range(10)]
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        def fake_post(*args, **kwargs):
+            return mock_response
+
+        monkeypatch.setenv("OLLAMA_API_KEY", "ol-key")
+        monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False, raising=False)
+        monkeypatch.setattr("httpx.post", fake_post)
+
+        result = OllamaWebSearchProvider().search("q", limit=3)
+
+        assert result["success"] is True
+        assert len(result["data"]["web"]) == 3
+
+    def test_missing_key_returns_failure(self, monkeypatch):
+        from plugins.web.ollama.provider import OllamaWebSearchProvider
+
+        monkeypatch.delenv("OLLAMA_API_KEY", raising=False)
+        result = OllamaWebSearchProvider().search("q", limit=5)
+        assert result["success"] is False
+        assert "OLLAMA_API_KEY" in result["error"]
+
+    def test_http_error_returns_failure(self, monkeypatch):
+        from plugins.web.ollama.provider import OllamaWebSearchProvider
+
+        mock_response = MagicMock()
+        mock_response.status_code = 429
+        exc = httpx.HTTPStatusError("too many requests", request=MagicMock(), response=mock_response)
+
+        def fake_post(*args, **kwargs):
+            raise exc
+
+        monkeypatch.setenv("OLLAMA_API_KEY", "ol-key")
+        monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False, raising=False)
+        monkeypatch.setattr("httpx.post", fake_post)
+
+        result = OllamaWebSearchProvider().search("q", limit=5)
+        assert result["success"] is False
+        assert "HTTP" in result["error"]
+
+    def test_request_error_returns_failure(self, monkeypatch):
+        from plugins.web.ollama.provider import OllamaWebSearchProvider
+
+        def fake_post(*args, **kwargs):
+            raise httpx.ConnectError("connection refused")
+
+        monkeypatch.setenv("OLLAMA_API_KEY", "ol-key")
+        monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False, raising=False)
+        monkeypatch.setattr("httpx.post", fake_post)
+
+        result = OllamaWebSearchProvider().search("q", limit=5)
+        assert result["success"] is False
+        assert "Could not reach" in result["error"]
+
+    def test_json_parse_error_returns_failure(self, monkeypatch):
+        from plugins.web.ollama.provider import OllamaWebSearchProvider
+
+        mock_response = MagicMock()
+        mock_response.json.side_effect = ValueError("invalid json")
+
+        def fake_post(*args, **kwargs):
+            return mock_response
+
+        monkeypatch.setenv("OLLAMA_API_KEY", "ol-key")
+        monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False, raising=False)
+        monkeypatch.setattr("httpx.post", fake_post)
+
+        result = OllamaWebSearchProvider().search("q", limit=5)
+        assert result["success"] is False
+        assert "parse" in result["error"].lower()
+
+    def test_empty_results(self, monkeypatch):
+        from plugins.web.ollama.provider import OllamaWebSearchProvider
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"results": []}
+        mock_response.raise_for_status = MagicMock()
+
+        def fake_post(*args, **kwargs):
+            return mock_response
+
+        monkeypatch.setenv("OLLAMA_API_KEY", "ol-key")
+        monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False, raising=False)
+        monkeypatch.setattr("httpx.post", fake_post)
+
+        result = OllamaWebSearchProvider().search("nothing", limit=5)
+        assert result["success"] is True
+        assert result["data"]["web"] == []
+
+
+class TestOllamaProviderExtract:
+    def test_happy_path(self, monkeypatch):
+        from plugins.web.ollama.provider import OllamaWebSearchProvider
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "title": "Example",
+            "content": "page content here",
+            "links": [],
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        def fake_post(*args, **kwargs):
+            return mock_response
+
+        monkeypatch.setenv("OLLAMA_API_KEY", "ol-key")
+        monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False, raising=False)
+        monkeypatch.setattr("httpx.post", fake_post)
+
+        result = OllamaWebSearchProvider().extract(["https://example.com"])
+
+        assert len(result) == 1
+        doc = result[0]
+        assert doc["url"] == "https://example.com"
+        assert doc["title"] == "Example"
+        assert doc["content"] == "page content here"
+        assert "error" not in doc
+
+    def test_per_url_failure(self, monkeypatch):
+        from plugins.web.ollama.provider import OllamaWebSearchProvider
+
+        call_count = [0]
+
+        def fake_post(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                mock = MagicMock()
+                mock.json.return_value = {"title": "OK", "content": "ok", "links": []}
+                mock.raise_for_status = MagicMock()
+                return mock
+            else:
+                mock_resp = MagicMock()
+                mock_resp.status_code = 500
+                raise httpx.HTTPStatusError("error", request=MagicMock(), response=mock_resp)
+
+        monkeypatch.setenv("OLLAMA_API_KEY", "ol-key")
+        monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False, raising=False)
+        monkeypatch.setattr("httpx.post", fake_post)
+
+        result = OllamaWebSearchProvider().extract([
+            "https://ok.example.com",
+            "https://fail.example.com",
+        ])
+
+        assert len(result) == 2
+        assert "error" not in result[0]
+        assert "error" in result[1]
+
+
+class TestOllamaProviderCapabilities:
+    def test_supports_search(self):
+        from plugins.web.ollama.provider import OllamaWebSearchProvider
+        assert OllamaWebSearchProvider().supports_search() is True
+
+    def test_supports_extract(self):
+        from plugins.web.ollama.provider import OllamaWebSearchProvider
+        assert OllamaWebSearchProvider().supports_extract() is True
+
+    def test_supports_crawl(self):
+        from plugins.web.ollama.provider import OllamaWebSearchProvider
+        assert OllamaWebSearchProvider().supports_crawl() is False
+
+    def test_setup_schema(self):
+        from plugins.web.ollama.provider import OllamaWebSearchProvider
+
+        schema = OllamaWebSearchProvider().get_setup_schema()
+        assert "name" in schema
+        assert "env_vars" in schema
+        assert len(schema["env_vars"]) == 1
+        assert schema["env_vars"][0]["key"] == "OLLAMA_API_KEY"


### PR DESCRIPTION

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

Add a new web search + content extraction backend using the Ollama Cloud API (https://ollama.com). Users who have an OLLAMA_API_KEY can now choose ollama as their web.search_backend or web.extract_backend, replacing the need for separate providers for search and extract. The provider implements search() (POST /api/web_search) and extract() (POST /api/web_fetch), following the existing WebSearchProvider plugin ABC.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- plugins/web/ollama/provider.py — new OllamaWebSearchProvider with search() and extract() methods
- plugins/web/ollama/__init__.py — plugin registration via ctx.register_web_search_provider()
- plugins/web/ollama/plugin.yaml — kind: backend manifest listing "ollama" provider
- tests/tools/test_web_providers_ollama.py — 18 unit tests covering is_available, search, extract, capabilities, setup schema
- agent/web_search_registry.py — added "ollama" to _LEGACY_PREFERENCE tuple (after tavily, before searxng)

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Set OLLAMA_API_KEY env var (from https://ollama.com/settings/keys)
2. Run python -c "from plugins.web.ollama.provider import OllamaWebSearchProvider; print(OllamaWebSearchProvider().is_available())" — should print True
3. Run scripts/run_tests.sh tests/tools/test_web_providers_ollama.py -q — all 18 tests should pass
4. Optionally run scripts/run_tests.sh tests/tools/test_web_providers.py tests/tools/test_web_tools_config.py -q — all 63 tests should pass

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

