### PR TITLE
fix(skills): protect pinned external skills from mutation

### DIFF
--- a/agent/skill_mutation_policy.py
+++ b/agent/skill_mutation_policy.py
@@ -1,0 +1,96 @@
+"""Skill mutation policy helpers.
+
+This module is intentionally lightweight so both ``skill_manage`` and Curator
+telemetry/archive paths can consult the same mutation-boundary policy without
+importing the tool registry or agent runtime.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+
+READONLY_EXTERNAL_SKILL_ERROR = (
+    "Skill '{name}' is a pinned/read-only external skill at {path}; "
+    "refusing {operation}. External Atlas/shared skills must be unpinned or "
+    "explicitly opted into mutability before mutation."
+)
+
+
+def is_under(path: Path, root: Path) -> bool:
+    """Return True if *path* resolves under *root*."""
+    try:
+        path.resolve().relative_to(root.resolve())
+        return True
+    except (OSError, ValueError):
+        return False
+
+
+def is_external_skill_path(skill_dir: Path) -> bool:
+    """Return True if *skill_dir* lives under a configured external skill root."""
+    try:
+        from agent.skill_utils import get_external_skills_dirs
+    except Exception:
+        return False
+
+    for root in get_external_skills_dirs():
+        if is_under(skill_dir, root):
+            return True
+    return False
+
+
+def readonly_external_skill_error(
+    name: str,
+    skill_dir: Path,
+    operation: str,
+) -> Optional[str]:
+    """Return a fail-closed message for pinned external skills, else None.
+
+    The current policy is deliberately narrow: local pinned skills keep their
+    existing behavior, while skills resolved under configured external dirs are
+    treated as read-only when pinned in the usage sidecar.
+    """
+    if not is_external_skill_path(skill_dir):
+        return None
+    try:
+        from tools import skill_usage
+        rec = skill_usage.get_record(name)
+    except Exception:
+        return None
+    if not rec.get("pinned"):
+        return None
+    return READONLY_EXTERNAL_SKILL_ERROR.format(
+        name=name,
+        path=skill_dir,
+        operation=operation,
+    )
+
+
+def find_skill_dir_across_roots(skill_name: str) -> Optional[Path]:
+    """Locate a skill directory by directory name or frontmatter name.
+
+    Searches local skills first, then configured external skill dirs, mirroring
+    normal skill resolution order.
+    """
+    try:
+        from agent.skill_utils import EXCLUDED_SKILL_DIRS, get_all_skills_dirs
+        from agent.skill_utils import parse_frontmatter
+    except Exception:
+        return None
+
+    for root in get_all_skills_dirs():
+        if not root.exists():
+            continue
+        for skill_md in root.rglob("SKILL.md"):
+            if any(part in EXCLUDED_SKILL_DIRS for part in skill_md.parts):
+                continue
+            if skill_md.parent.name == skill_name:
+                return skill_md.parent
+            try:
+                frontmatter, _body = parse_frontmatter(skill_md.read_text(encoding="utf-8"))
+            except OSError:
+                continue
+            if str(frontmatter.get("name", "")).strip() == skill_name:
+                return skill_md.parent
+    return None

--- a/tests/test_skill_external_readonly_policy.py
+++ b/tests/test_skill_external_readonly_policy.py
@@ -1,0 +1,181 @@
+"""Pinned external skills are read-only at the mutation boundary."""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+import pytest
+
+
+SKILL_MD = """---
+name: atlas-load-bearing
+description: Load-bearing Atlas skill fixture
+---
+
+# Atlas Load Bearing
+
+Original guidance.
+"""
+
+EDITED_SKILL_MD = """---
+name: atlas-load-bearing
+description: Load-bearing Atlas skill fixture
+---
+
+# Atlas Load Bearing
+
+Edited guidance.
+"""
+
+
+@pytest.fixture()
+def external_skill_env(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    local_skills = hermes_home / "skills"
+    external_root = tmp_path / "atlas" / "shared" / "skills"
+    skill_dir = external_root / "atlas-load-bearing"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(SKILL_MD, encoding="utf-8")
+    (skill_dir / "references").mkdir()
+    (skill_dir / "references" / "note.md").write_text("original note\n", encoding="utf-8")
+
+    local_skills.mkdir(parents=True)
+    (hermes_home / "config.yaml").write_text(
+        f"skills:\n  external_dirs:\n    - {external_root}\n",
+        encoding="utf-8",
+    )
+    (local_skills / ".usage.json").write_text(
+        json.dumps({
+            "atlas-load-bearing": {
+                "created_by": "agent",
+                "pinned": True,
+                "state": "active",
+            }
+        }),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    import agent.skill_utils as skill_utils
+    skill_utils._external_dirs_cache_clear()
+
+    import tools.skill_usage as skill_usage
+    import tools.skill_manager_tool as skill_manager_tool
+    skill_usage = importlib.reload(skill_usage)
+    skill_manager_tool = importlib.reload(skill_manager_tool)
+    monkeypatch.setattr(skill_manager_tool, "HERMES_HOME", hermes_home)
+    monkeypatch.setattr(skill_manager_tool, "SKILLS_DIR", local_skills)
+
+    return {
+        "skill_manager_tool": skill_manager_tool,
+        "skill_usage": skill_usage,
+        "skill_dir": skill_dir,
+    }
+
+
+def _manage(tool, **kwargs):
+    return json.loads(tool.skill_manage(**kwargs))
+
+
+@pytest.mark.parametrize(
+    "kwargs, expected_file, expected_content",
+    [
+        (
+            {
+                "action": "patch",
+                "name": "atlas-load-bearing",
+                "old_string": "Original guidance.",
+                "new_string": "Patched guidance.",
+            },
+            "SKILL.md",
+            SKILL_MD,
+        ),
+        (
+            {
+                "action": "edit",
+                "name": "atlas-load-bearing",
+                "content": EDITED_SKILL_MD,
+            },
+            "SKILL.md",
+            SKILL_MD,
+        ),
+        (
+            {
+                "action": "write_file",
+                "name": "atlas-load-bearing",
+                "file_path": "references/new.md",
+                "file_content": "new note\n",
+            },
+            "references/new.md",
+            None,
+        ),
+        (
+            {
+                "action": "remove_file",
+                "name": "atlas-load-bearing",
+                "file_path": "references/note.md",
+            },
+            "references/note.md",
+            "original note\n",
+        ),
+        (
+            {
+                "action": "delete",
+                "name": "atlas-load-bearing",
+                "absorbed_into": "",
+            },
+            "SKILL.md",
+            SKILL_MD,
+        ),
+    ],
+)
+def test_pinned_external_skill_manage_mutations_fail_closed(
+    external_skill_env, kwargs, expected_file, expected_content
+):
+    tool = external_skill_env["skill_manager_tool"]
+    skill_dir = external_skill_env["skill_dir"]
+
+    result = _manage(tool, **kwargs)
+
+    assert result["success"] is False
+    assert "pinned/read-only external skill" in result["error"]
+    target = skill_dir / expected_file
+    if expected_content is None:
+        assert not target.exists()
+    else:
+        assert target.read_text(encoding="utf-8") == expected_content
+
+
+def test_unpinned_external_skill_can_still_be_patched(external_skill_env):
+    tool = external_skill_env["skill_manager_tool"]
+    skill_usage = external_skill_env["skill_usage"]
+    skill_dir = external_skill_env["skill_dir"]
+    usage = skill_usage.load_usage()
+    usage["atlas-load-bearing"]["pinned"] = False
+    skill_usage.save_usage(usage)
+
+    result = _manage(
+        tool,
+        action="patch",
+        name="atlas-load-bearing",
+        old_string="Original guidance.",
+        new_string="Patched guidance.",
+    )
+
+    assert result["success"] is True
+    assert "Patched guidance." in (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+
+
+def test_archive_skill_refuses_pinned_external_skill(external_skill_env):
+    skill_usage = external_skill_env["skill_usage"]
+    skill_dir = external_skill_env["skill_dir"]
+
+    ok, message = skill_usage.archive_skill("atlas-load-bearing")
+
+    assert ok is False
+    assert "pinned/read-only external skill" in message
+    assert skill_dir.exists()
+    assert (skill_dir / "SKILL.md").read_text(encoding="utf-8") == SKILL_MD

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -44,6 +44,7 @@ from typing import Dict, Any, Optional, Tuple
 
 from utils import atomic_replace, is_truthy_value
 from hermes_cli.config import cfg_get
+from agent.skill_mutation_policy import readonly_external_skill_error
 
 logger = logging.getLogger(__name__)
 
@@ -441,6 +442,10 @@ def _edit_skill(name: str, content: str) -> Dict[str, Any]:
     if not existing:
         return {"success": False, "error": f"Skill '{name}' not found. Use skills_list() to see available skills."}
 
+    readonly_err = readonly_external_skill_error(name, existing["path"], "edit")
+    if readonly_err:
+        return {"success": False, "error": readonly_err}
+
     skill_md = existing["path"] / "SKILL.md"
     # Back up original content for rollback
     original_content = skill_md.read_text(encoding="utf-8") if skill_md.exists() else None
@@ -482,6 +487,10 @@ def _patch_skill(
         return {"success": False, "error": f"Skill '{name}' not found."}
 
     skill_dir = existing["path"]
+
+    readonly_err = readonly_external_skill_error(name, skill_dir, "patch")
+    if readonly_err:
+        return {"success": False, "error": readonly_err}
 
     if file_path:
         # Patching a supporting file
@@ -570,6 +579,10 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
     if not existing:
         return {"success": False, "error": f"Skill '{name}' not found."}
 
+    readonly_err = readonly_external_skill_error(name, existing["path"], "delete")
+    if readonly_err:
+        return {"success": False, "error": readonly_err}
+
     pinned_err = _pinned_guard(name)
     if pinned_err:
         return {"success": False, "error": pinned_err}
@@ -639,6 +652,10 @@ def _write_file(name: str, file_path: str, file_content: str) -> Dict[str, Any]:
     if not existing:
         return {"success": False, "error": f"Skill '{name}' not found. Create it first with action='create'."}
 
+    readonly_err = readonly_external_skill_error(name, existing["path"], "write_file")
+    if readonly_err:
+        return {"success": False, "error": readonly_err}
+
     target, err = _resolve_skill_target(existing["path"], file_path)
     if err:
         return {"success": False, "error": err}
@@ -674,6 +691,10 @@ def _remove_file(name: str, file_path: str) -> Dict[str, Any]:
         return {"success": False, "error": f"Skill '{name}' not found."}
 
     skill_dir = existing["path"]
+
+    readonly_err = readonly_external_skill_error(name, skill_dir, "remove_file")
+    if readonly_err:
+        return {"success": False, "error": readonly_err}
 
     target, err = _resolve_skill_target(skill_dir, file_path)
     if err:
@@ -821,10 +842,11 @@ SKILL_MANAGE_SCHEMA = {
         "Skip for simple one-offs. Confirm with user before creating/deleting.\n\n"
         "Good skills: trigger conditions, numbered steps with exact commands, "
         "pitfalls section, verification steps. Use skill_view() to see format examples.\n\n"
-        "Pinned skills are protected from deletion only — skill_manage(action='delete') "
-        "will refuse with a message pointing the user to `hermes curator unpin <name>`. "
-        "Patches and edits go through on pinned skills so you can still improve them as "
-        "pitfalls come up; pin only guards against irrecoverable loss."
+        "Pinned local skills are protected from deletion only — skill_manage(action='delete') "
+        "will refuse and point to `hermes curator unpin`. Pinned skills resolved "
+        "from configured external skill dirs are treated as read-only: patch, edit, "
+        "write_file, remove_file, delete, and Curator archive/relocate-style "
+        "mutations are refused until explicitly unpinned or opted into mutability."
     ),
     "parameters": {
         "type": "object",

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -34,6 +34,10 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 from hermes_constants import get_hermes_home
+from agent.skill_mutation_policy import (
+    find_skill_dir_across_roots,
+    readonly_external_skill_error,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -487,7 +491,20 @@ def archive_skill(skill_name: str) -> Tuple[bool, str]:
 
     skill_dir = _find_skill_dir(skill_name)
     if skill_dir is None:
+        external_skill_dir = find_skill_dir_across_roots(skill_name)
+        if external_skill_dir is not None:
+            readonly_err = readonly_external_skill_error(
+                skill_name,
+                external_skill_dir,
+                "archive",
+            )
+            if readonly_err:
+                return False, readonly_err
         return False, f"skill '{skill_name}' not found"
+
+    readonly_err = readonly_external_skill_error(skill_name, skill_dir, "archive")
+    if readonly_err:
+        return False, readonly_err
 
     archive_root = _archive_dir()
     try:


### PR DESCRIPTION
## Summary

Pinned skills that live in configured external skill directories are now treated as read-only at the mutation boundary. This prevents `skill_manage` and curator archive flows from editing, deleting, or writing support files into shared/pinned external skills while preserving existing behavior for unpinned external skills.

## Diff scope

- `agent/skill_mutation_policy.py` — central policy helper for detecting pinned external skills and returning a consistent refusal message.
- `tools/skill_manager_tool.py` — applies the policy before patch/edit/delete/write/remove mutations.
- `tools/skill_usage.py` — applies the policy before curator archive moves.
- `tests/test_skill_external_readonly_policy.py` — regression tests for pinned external fail-closed behavior and unpinned external mutation compatibility.

## Verification

```text
$ HOME=/Users/watson scripts/run_tests.sh tests/test_skill_external_readonly_policy.py tests/tools/test_skill_manager_tool.py
▶ running pytest with 4 workers, hermetic env, in /tmp/hermes-pinned-skills-v014
  (TZ=UTC LANG=C.UTF-8 PYTHONHASHSEED=0; all credential env vars unset)
============================= test session starts ==============================
platform darwin -- Python 3.11.14, pytest-9.0.2, pluggy-1.6.0
rootdir: /private/tmp/hermes-pinned-skills-v014
configfile: pyproject.toml
plugins: xdist-3.8.0, split-0.11.0, asyncio-1.3.0, anyio-4.13.0
created: 4/4 workers
4 workers [93 items]

........................................................................ [ 77%]
.....................                                                    [100%]
============================== 93 passed in 1.52s ==============================
```

```text
$ /Users/watson/.hermes/hermes-agent/venv/bin/python -m ruff check agent/skill_mutation_policy.py tools/skill_manager_tool.py tools/skill_usage.py tests/test_skill_external_readonly_policy.py tests/tools/test_skill_manager_tool.py
All checks passed!
```

```text
$ git diff --check origin/main...HEAD
# no output
```

## Real-behavior proof

- **Behavior addressed:** A pinned skill in an external skill directory could still be patched, edited, support-file-mutated, or archived because existing pinned-skill protection only blocked deletion in one path.
- **Real environment tested:** Local Hermes Agent checkout on macOS, Python 3.11.14, pytest 9.0.2; tests create a temporary Hermes home with an external skill directory configured in `config.yaml` and `.usage.json` marking the skill pinned.
- **Exact command:** `HOME=/Users/watson scripts/run_tests.sh tests/test_skill_external_readonly_policy.py tests/tools/test_skill_manager_tool.py`
- **Evidence after fix:** targeted suite above: `93 passed in 1.52s`.
- **Observed result:** pinned external skills refuse `patch`, `edit`, `write_file`, `remove_file`, `delete`, and curator archive mutations with the pinned/read-only external skill message; unpinned external skills can still be patched.
- **What was NOT tested:** I did not run the full repository suite. The verification is focused on the skill manager and curator/archive mutation surfaces changed by this PR.

### Regression check against pre-fix base

I copied the new external-readonly policy test onto `origin/main` in a detached worktree and ran it against the unmodified base:

```text
$ HOME=/Users/watson scripts/run_tests.sh tests/test_skill_external_readonly_policy.py
created: 4/4 workers
4 workers [7 items]

FFFFF.F                                                                  [100%]
FAILED tests/test_skill_external_readonly_policy.py::test_pinned_external_skill_manage_mutations_fail_closed[...]
E       assert True is False
FAILED tests/test_skill_external_readonly_policy.py::test_archive_skill_refuses_pinned_external_skill
E       assert 'pinned/read-only external skill' in "skill 'atlas-load-bearing' not found"
========================= 6 failed, 1 passed in 1.05s ==========================
```

## Test plan

- [x] Pinned external skill mutation tests pass.
- [x] Existing skill manager tests pass.
- [x] Ruff passes on changed files.
- [x] Diff whitespace check passes.
- [x] Regression test fails on `origin/main` before the fix.

## Commits

1. `88fccba83 fix(skills): protect pinned external skills from mutation`
