### PR TITLE
fix(matrix): implement thread_require_mention to prevent multi-agent reply loops

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -380,12 +380,7 @@ class MatrixAdapter(BasePlatformAdapter):
         self._require_mention: bool = os.getenv(
             "MATRIX_REQUIRE_MENTION", "true"
         ).lower() not in {"false", "0", "no"}
-        self._thread_require_mention: bool = (
-            config.extra.get("thread_require_mention")
-            if isinstance(config.extra.get("thread_require_mention"), bool)
-            else os.getenv("MATRIX_THREAD_REQUIRE_MENTION", "false").lower()
-                 in {"true", "1", "yes"}
-        )
+        self._thread_require_mention: bool = self._parse_thread_require_mention(config)
         free_rooms_raw = config.extra.get("free_response_rooms")
         if free_rooms_raw is None:
             free_rooms_raw = os.getenv("MATRIX_FREE_RESPONSE_ROOMS", "")
@@ -473,6 +468,27 @@ class MatrixAdapter(BasePlatformAdapter):
         self._processed_events.append(event_id)
         self._processed_events_set.add(event_id)
         return False
+
+    @staticmethod
+    def _parse_thread_require_mention(config) -> bool:
+        """Parse thread_require_mention from config.extra or env var.
+
+        Handles both YAML booleans and string values (``\"true\"``, ``\"false\"``,
+        ``\"yes\"``, ``\"no\"``, ``\"on\"``, ``\"off\"``, ``\"1\"``, ``\"0\"``).
+        Falls back to ``MATRIX_THREAD_REQUIRE_MENTION`` env var, default ``false``.
+        Mirrors Discord adapter's parsing pattern.
+        """
+        configured = config.extra.get("thread_require_mention")
+        if configured is not None:
+            if isinstance(configured, bool):
+                return configured
+            if isinstance(configured, str):
+                return configured.lower() not in {"false", "0", "no", "off"}
+            # int, float, etc. — truthiness fallback
+            return bool(configured)
+        return os.getenv(
+            "MATRIX_THREAD_REQUIRE_MENTION", "false"
+        ).lower() in {"true", "1", "yes", "on"}
 
     # ------------------------------------------------------------------
     # E2EE helpers
@@ -1711,7 +1727,8 @@ class MatrixAdapter(BasePlatformAdapter):
             # require @mention when thread_require_mention is enabled.
             # Prevents infinite reply loops in multi-agent shared rooms
             # where multiple bots all participate in the same thread.
-            elif self._thread_require_mention and in_bot_thread:
+            elif (self._thread_require_mention and in_bot_thread
+                  and not is_free_room):
                 if not is_mentioned:
                     logger.debug(
                         "Matrix: ignoring message %s in thread %s — "

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -380,6 +380,12 @@ class MatrixAdapter(BasePlatformAdapter):
         self._require_mention: bool = os.getenv(
             "MATRIX_REQUIRE_MENTION", "true"
         ).lower() not in {"false", "0", "no"}
+        self._thread_require_mention: bool = (
+            config.extra.get("thread_require_mention")
+            if isinstance(config.extra.get("thread_require_mention"), bool)
+            else os.getenv("MATRIX_THREAD_REQUIRE_MENTION", "false").lower()
+                 in {"true", "1", "yes"}
+        )
         free_rooms_raw = config.extra.get("free_response_rooms")
         if free_rooms_raw is None:
             free_rooms_raw = os.getenv("MATRIX_FREE_RESPONSE_ROOMS", "")
@@ -1698,6 +1704,20 @@ class MatrixAdapter(BasePlatformAdapter):
                         "(set MATRIX_REQUIRE_MENTION=false to disable)",
                         event_id,
                         room_id,
+                    )
+                    return None
+
+            # Thread-level @mention gating: even in a bot-participated thread,
+            # require @mention when thread_require_mention is enabled.
+            # Prevents infinite reply loops in multi-agent shared rooms
+            # where multiple bots all participate in the same thread.
+            elif self._thread_require_mention and in_bot_thread:
+                if not is_mentioned:
+                    logger.debug(
+                        "Matrix: ignoring message %s in thread %s — "
+                        "no @mention (thread_require_mention=true)",
+                        event_id,
+                        thread_id,
                     )
                     return None
 


### PR DESCRIPTION
## Summary

Implement `thread_require_mention` for the Matrix adapter to prevent infinite reply loops in multi-agent shared rooms. Mirrors the existing Discord adapter behavior.

## Problem

When multiple Hermes bots share a Matrix room with `MATRIX_AUTO_THREAD=true` (the default), the `in_bot_thread` bypass in `_resolve_message_context()` skips `@mention` gating for all threaded messages. This causes N-way positive feedback loops where hundreds of messages flood the room in minutes.

The existing `thread_require_mention` config field was already in config.yaml schemas but had **zero effect** on Matrix — it was implemented for Discord only.

### Root cause: `in_bot_thread` bypass + missing `thread_require_mention`

```python
# _resolve_message_context() line ~1692
in_bot_thread = bool(thread_id and thread_id in self._threads)
if self._require_mention and not is_free_room and not in_bot_thread:
    if not is_mentioned:
        return None  # only this path checks @mention
```

When multiple bots auto-thread the same message (via `MATRIX_AUTO_THREAD=true` + `_threads.mark()`), `in_bot_thread` is True for all of them, and the @mention gate is completely bypassed.

Additionally, `self._threads.mark(thread_id)` at line 1727 executes unconditionally after any successful message processing, so even bots with `MATRIX_AUTO_THREAD=false` get registered once @mentioned into a shared thread.

### Loop mechanism

```
1. Bot A (auto_thread=true) receives message M1 → creates thread from event_id
2. Bot A replies in thread (no @mention, per convention)
3. Bot B sees A’s reply → in_bot_thread=True → @mention bypassed → B replies
4. B’s reply also in same thread → C, D, E… repeat → N-way positive feedback loop
```

## Changes

Two additions to `gateway/platforms/matrix.py`, no existing behavior changed:

1. **Parse `thread_require_mention` config in `__init__()`** — reads from `config.yaml` (`matrix.thread_require_mention`) or env var `MATRIX_THREAD_REQUIRE_MENTION`. Defaults to `false` for backward compatibility with single-bot rooms.

2. **Add thread-level `@mention` check in `_resolve_message_context()`** — even when `in_bot_thread` is True, requires `@mention` unless `thread_require_mention` is disabled. An `elif` branch after the existing `_require_mention` check.

## Testing

- Verified on a 9-bot Matrix room that previously experienced loops: with `MATRIX_AUTO_THREAD=false` + `MATRIX_REQUIRE_MENTION=true`, bots respond to @mentions once and stop.
- Single-bot rooms unaffected (default `false` maintains existing behavior).
- Discord adapter behavior unchanged.

## Backward compatibility

Default is `false` — existing single-bot rooms continue to function identically. Multi-bot room operators opt in by setting `thread_require_mention: true` in config.yaml.

Fixes #27995