### PR TITLE
feat(codex-app-server): forward SOUL.md instructions

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -17,10 +17,11 @@ compatibility.
 from __future__ import annotations
 
 import logging
-import os
 import time
 from types import SimpleNamespace
 from typing import Any, Dict, List
+
+from agent.prompt_builder import load_soul_md
 
 logger = logging.getLogger(__name__)
 
@@ -253,6 +254,9 @@ def run_codex_app_server_turn(
         from agent.runtime_cwd import resolve_agent_cwd
 
         cwd = getattr(agent, "session_cwd", None) or str(resolve_agent_cwd())
+        base_instructions = None
+        if agent.load_soul_identity or not agent.skip_context_files:
+            base_instructions = load_soul_md()
         # Approval callback: defer to Hermes' standard prompt flow if a
         # CLI thread has installed one. Gateway / cron contexts get the
         # codex-side fail-closed default.
@@ -278,11 +282,14 @@ def run_codex_app_server_turn(
             except Exception:
                 logger.debug("codex tool-progress callback raised", exc_info=True)
 
-        agent._codex_session = CodexAppServerSession(
-            cwd=cwd,
-            approval_callback=approval_callback,
-            on_event=_on_codex_event,
-        )
+        session_kwargs = {
+            "cwd": cwd,
+            "approval_callback": approval_callback,
+            "on_event": _on_codex_event,
+        }
+        if base_instructions:
+            session_kwargs["base_instructions"] = base_instructions
+        agent._codex_session = CodexAppServerSession(**session_kwargs)
 
     # NOTE: the user message is ALREADY appended to messages by the
     # standard run_conversation() flow (line ~11823) before the early

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -204,6 +204,8 @@ class CodexAppServerSession:
         codex_bin: str = "codex",
         codex_home: Optional[str] = None,
         permission_profile: Optional[str] = None,
+        base_instructions: Optional[str] = None,
+        developer_instructions: Optional[str] = None,
         approval_callback: Optional[Callable[..., str]] = None,
         on_event: Optional[Callable[[dict], None]] = None,
         request_routing: Optional[_ServerRequestRouting] = None,
@@ -212,6 +214,8 @@ class CodexAppServerSession:
         self._cwd = cwd or os.getcwd()
         self._codex_bin = codex_bin
         self._codex_home = codex_home
+        self._base_instructions = base_instructions
+        self._developer_instructions = developer_instructions
         self._permission_profile = (
             permission_profile or _HERMES_TO_CODEX_PERMISSION_PROFILE.get(
                 os.environ.get("HERMES_TERMINAL_SECURITY_MODE", "auto"),
@@ -267,6 +271,10 @@ class CodexAppServerSession:
         # Users who want a write-capable profile configure it in their
         # ~/.codex/config.toml the same way they would for any codex usage.
         params: dict[str, Any] = {"cwd": self._cwd}
+        if self._base_instructions and self._base_instructions.strip():
+            params["baseInstructions"] = self._base_instructions
+        if self._developer_instructions and self._developer_instructions.strip():
+            params["developerInstructions"] = self._developer_instructions
         result = self._client.request("thread/start", params, timeout=15)
         # Cross-fill thread.id/sessionId — different codex versions have
         # serialized this under either key. Mirrors openclaw beta.8's
@@ -290,11 +298,11 @@ class CodexAppServerSession:
         self._thread_id = thread_id
         logger.info(
             "codex app-server thread started: id=%s profile=%s cwd=%s",
-            self._thread_id[:8],
+            thread_id[:8],
             self._permission_profile,
             self._cwd,
         )
-        return self._thread_id
+        return thread_id
 
     def close(self) -> None:
         if self._closed:

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -149,7 +149,7 @@ class TestLifecycle:
         method_calls = [m for (m, _) in client.requests if m == "thread/start"]
         assert len(method_calls) == 1
 
-    def test_thread_start_passes_cwd_only(self):
+    def test_thread_start_passes_cwd_without_optional_fields_by_default(self):
         """thread/start carries cwd. We intentionally do NOT pass `permissions`
         on this codex version (experimentalApi-gated + requires matching
         config.toml [permissions] table). Letting codex use its default
@@ -160,6 +160,34 @@ class TestLifecycle:
         method, params = next(r for r in client.requests if r[0] == "thread/start")
         assert params["cwd"] == "/tmp"
         assert "permissions" not in params  # see session.ensure_started() comment
+        assert "baseInstructions" not in params
+        assert "developerInstructions" not in params
+
+    def test_thread_start_passes_non_empty_instruction_params(self):
+        client = FakeClient()
+        s = make_session(
+            client,
+            base_instructions="SOUL identity",
+            developer_instructions="Hermes runtime guidance",
+        )
+        s.ensure_started()
+        method, params = next(r for r in client.requests if r[0] == "thread/start")
+        assert params == {
+            "cwd": "/tmp",
+            "baseInstructions": "SOUL identity",
+            "developerInstructions": "Hermes runtime guidance",
+        }
+
+    def test_thread_start_omits_empty_instruction_params(self):
+        client = FakeClient()
+        s = make_session(
+            client,
+            base_instructions="",
+            developer_instructions="   ",
+        )
+        s.ensure_started()
+        method, params = next(r for r in client.requests if r[0] == "thread/start")
+        assert params == {"cwd": "/tmp"}
 
     def test_close_idempotent(self):
         client = FakeClient()

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+import agent.codex_runtime as codex_runtime
 import run_agent
 from agent.transports.codex_app_server_session import CodexAppServerSession, TurnResult
 
@@ -62,6 +63,25 @@ def _make_codex_agent():
         skip_context_files=True,
         skip_memory=True,
     )
+
+
+def _capture_codex_session_kwargs(monkeypatch):
+    captured = {}
+
+    def fake_init(self, **kwargs):
+        captured.update(kwargs)
+
+    def fake_run_turn(self, user_input: str, **kwargs):
+        return TurnResult(
+            final_text=f"echo: {user_input}",
+            projected_messages=[{"role": "assistant", "content": f"echo: {user_input}"}],
+            turn_id="turn-stub-1",
+            thread_id="thread-stub-1",
+        )
+
+    monkeypatch.setattr(CodexAppServerSession, "__init__", fake_init)
+    monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+    return captured
 
 
 class TestApiModeAccepted:
@@ -326,6 +346,52 @@ class TestRunConversationCodexPath:
 
         assert captured["cwd"] == str(tmp_path)
 
+    def test_soul_md_is_forwarded_as_base_instructions_when_context_files_load(
+        self, monkeypatch
+    ):
+        captured = _capture_codex_session_kwargs(monkeypatch)
+        monkeypatch.setattr(codex_runtime, "load_soul_md", lambda: "SOUL IDENTITY")
+        agent = _make_codex_agent()
+        agent.skip_context_files = False
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("hi")
+
+        assert captured["base_instructions"] == "SOUL IDENTITY"
+
+    def test_soul_md_is_forwarded_when_load_soul_identity_overrides_skip(
+        self, monkeypatch
+    ):
+        captured = _capture_codex_session_kwargs(monkeypatch)
+        monkeypatch.setattr(codex_runtime, "load_soul_md", lambda: "SOUL IDENTITY")
+        agent = _make_codex_agent()
+        agent.load_soul_identity = True
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("hi")
+
+        assert captured["base_instructions"] == "SOUL IDENTITY"
+
+    def test_soul_md_is_not_forwarded_when_skipped_or_absent(self, monkeypatch):
+        captured = _capture_codex_session_kwargs(monkeypatch)
+        monkeypatch.setattr(codex_runtime, "load_soul_md", lambda: "SOUL IDENTITY")
+        agent = _make_codex_agent()
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("hi")
+
+        assert "base_instructions" not in captured
+
+        captured.clear()
+        monkeypatch.setattr(codex_runtime, "load_soul_md", lambda: None)
+        agent = _make_codex_agent()
+        agent.skip_context_files = False
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("hi")
+
+        assert "base_instructions" not in captured
+
 
 class TestReviewForkApiModeDowngrade:
     """When the parent agent runs on codex_app_server, the background
@@ -588,4 +654,3 @@ class TestCodexToolProgressBridge:
 
         assert "on_event" in captured_init and captured_init["on_event"] is not None
         assert ("tool.started", "exec_command", "pytest") in events
-


### PR DESCRIPTION
## What does this PR do?

Forward Hermes `SOUL.md` identity content into Codex app-server threads via the protocol-supported `baseInstructions` field. This keeps the Codex app-server runtime aligned with Hermes identity loading semantics without sending the full Hermes system prompt or agent-loop tool guidance.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add optional `base_instructions` and `developer_instructions` support to `CodexAppServerSession`, sent on `thread/start` as `baseInstructions` and `developerInstructions` when non-empty.
- Load `SOUL.md` for the `codex_app_server` runtime when `agent.load_soul_identity` is true or context files are enabled, matching Hermes system prompt identity semantics.
- Add unit and integration regression coverage for instruction params and SOUL.md runtime wiring.

## How to Test

1. `scripts/run_tests.sh tests/agent/transports/test_codex_app_server_session.py tests/run_agent/test_codex_app_server_integration.py -q`
2. Confirm `thread/start` receives `baseInstructions` only when SOUL.md content is loaded.
3. Confirm skipped or absent SOUL.md does not send empty instruction fields.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Targeted tests:

```
scripts/run_tests.sh tests/agent/transports/test_codex_app_server_session.py tests/run_agent/test_codex_app_server_integration.py -q
75 passed in 12.36s
```