### PR TITLE
fix(process-registry): detach stdin from background subprocesses to p…

### DIFF
--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -555,7 +555,7 @@ class ProcessRegistry:
             errors="replace",
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
-            stdin=subprocess.PIPE,
+            stdin=subprocess.DEVNULL,
             preexec_fn=None if _IS_WINDOWS else os.setsid,
             creationflags=subprocess.CREATE_NO_WINDOW if _IS_WINDOWS else 0,
         )


### PR DESCRIPTION
What does this PR do?
Background process non-PTY path used stdin=subprocess.PIPE unconditionally, creating an orphan pipe that was never written to and never closed. Child processes that read stdin would block indefinitely, competing with the parent's prompt_toolkit event loop for terminal ownership and causing complete keyboard lockout.

Change to stdin=subprocess.DEVNULL so children get immediate EOF on stdin reads instead of blocking forever. For interactive stdin, the PTY path (which has its own independent PTY via ptyprocess.PtyProcess.spawn) should be used instead.
Related Issue

Fixes #17959

Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

Changes Made
- tools/process_registry.py — Use subprocess.DEVNULL for background subprocess stdin instead of subprocess.PIPE to prevent orphan pipe blocking

How to Test
1. Run a background terminal command that reads stdin (e.g., bash -c 'read -t 1 line; echo got: "$line"' with background=True)
2. Verify keyboard input (typing, Ctrl+C) remains responsive during the background process
3. Verify the background process exits cleanly without blocking on stdin