### PR TITLE
fix(approval): surface pending-approval state with explicit marker vi…

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1332,7 +1332,8 @@ def check_all_command_guards(command: str, env_type: str,
         return {
             "approved": False,
             "pattern_key": primary_key,
-            "status": "approval_required",
+            "status": "pending_approval",
+            "approval_pending": True,
             "command": command,
             "description": combined_desc,
             "message": (

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1863,12 +1863,13 @@ def terminal_tool(
             approval = _check_all_guards(command, env_type)
             if not approval["approved"]:
                 # Check if this is an approval_required (gateway ask mode)
-                if approval.get("status") == "approval_required":
+                if approval.get("status") == "pending_approval":
                     return json.dumps({
                         "output": "",
                         "exit_code": -1,
-                        "error": approval.get("message", "Waiting for user approval"),
-                        "status": "approval_required",
+                        "error": "",
+                        "status": "pending_approval",
+                        "approval_pending": True,
                         "command": approval.get("command", command),
                         "description": approval.get("description", "command flagged"),
                         "pattern_key": approval.get("pattern_key", ""),


### PR DESCRIPTION
What does this PR do?

When a tool requires approval (e.g., write_file, patch on sensitive paths), the approval prompt fires asynchronously but the tool result returned to the LLM is indistinguishable from an empty success result. The LLM proceeds as if the action completed, leading to incorrect assumptions about filesystem state.

Add an explicit pending-approval marker in the tool result so the LLM can clearly see that the operation is awaiting user confirmation and has not yet taken effect.

Related Issue
Fixes #14806

Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

Changes Made
- tools/approval.py — Mark pending-approval state with explicit visible marker in tool result
- tools/terminal_tool.py — Propagate pending-approval state through terminal tool results so the LLM sees the waiting state

How to Test
1. Trigger a tool that requires approval (e.g., write to a sensitive path)
2. Observe the tool result — it should contain a clear pending-approval indication
3. Verify the LLM responds with a waiting message rather than proceeding as if the action completed
