### PR TITLE
fix(memory): label recalled memory as informational, not authoritativ…

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -46,7 +46,7 @@ _INTERNAL_CONTEXT_RE = re.compile(
     re.IGNORECASE,
 )
 _INTERNAL_NOTE_RE = re.compile(
-    r'\[System note:\s*The following is recalled memory context,\s*NOT new user input\.\s*Treat as (?:informational background data|authoritative reference data[^\]]*)\.\]\s*',
+    r'\[System note:\s*The following is recalled memory context,\s*NOT new user input\.\s*Treat as (?:informational background data|authoritative reference data)[^\]]*\.\]\s*',
     re.IGNORECASE,
 )
 
@@ -180,8 +180,9 @@ def build_memory_context_block(raw_context: str) -> str:
     return (
         "<memory-context>\n"
         "[System note: The following is recalled memory context, "
-        "NOT new user input. Treat as authoritative reference data — "
-        "this is the agent's persistent memory and should inform all responses.]\n\n"
+        "NOT new user input. Treat as informational background data "
+        "(may be stale) — this is the agent's persistent memory and "
+        "should inform all responses.]\n\n"
         f"{clean}\n"
         "</memory-context>"
     )

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -579,3 +579,129 @@ class TestPatchReplacePostWriteVerification:
         result = ops.patch_replace("/tmp/test/a.py", "hello", "hi")
         assert result.error is not None
         assert "could not re-read" in result.error.lower()
+
+
+# =========================================================================
+# Git baseline check for write_file warning
+# =========================================================================
+
+class TestGitBaselineCheck:
+    """Regression tests for _check_git_baseline and warning in write_file result (#27856)."""
+
+    def _make_mock(self, side_effect_fn, cwd="/tmp/test"):
+        env = MagicMock()
+        env.cwd = cwd
+        env.execute.side_effect = side_effect_fn
+        ops = ShellFileOperations(env)
+        return ops
+
+    def test_git_not_available_returns_none(self):
+        """When git is not on PATH, _check_git_baseline returns None."""
+        def side_effect(command, stdin_data=None, **kwargs):
+            if "command -v git" in command:
+                return {"output": "", "returncode": 1}
+            return {"output": "", "returncode": 0}
+        ops = self._make_mock(side_effect)
+        assert ops._check_git_baseline("/some/file.py") is None
+
+    def test_not_in_git_repo_returns_none(self):
+        """When the path is not inside a git work tree, returns None."""
+        def side_effect(command, stdin_data=None, **kwargs):
+            if "command -v git" in command:
+                return {"output": "yes\n", "returncode": 0}
+            if "git rev-parse --is-inside-work-tree" in command:
+                return {"output": "false\n", "returncode": 128}
+            return {"output": "", "returncode": 0}
+        ops = self._make_mock(side_effect)
+        assert ops._check_git_baseline("/some/file.py") is None
+
+    def test_clean_repo_returns_none(self):
+        """When the git working tree is clean, returns None."""
+        def side_effect(command, stdin_data=None, **kwargs):
+            if "command -v git" in command:
+                return {"output": "yes\n", "returncode": 0}
+            if "git rev-parse --is-inside-work-tree" in command:
+                return {"output": "true\n", "returncode": 0}
+            if "git rev-parse --abbrev-ref HEAD" in command:
+                return {"output": "main\n", "returncode": 0}
+            if "git status --porcelain" in command:
+                return {"output": "", "returncode": 0}
+            return {"output": "", "returncode": 0}
+        ops = self._make_mock(side_effect)
+        assert ops._check_git_baseline("/some/file.py") is None
+
+    def test_dirty_repo_returns_warning(self):
+        """When the git working tree has uncommitted changes, returns a warning string."""
+        def side_effect(command, stdin_data=None, **kwargs):
+            if "command -v git" in command:
+                return {"output": "yes\n", "returncode": 0}
+            if "git rev-parse --is-inside-work-tree" in command:
+                return {"output": "true\n", "returncode": 0}
+            if "git rev-parse --abbrev-ref HEAD" in command:
+                return {"output": "feature-branch\n", "returncode": 0}
+            if "git status --porcelain" in command:
+                return {"output": " M file.py\n", "returncode": 0}
+            return {"output": "", "returncode": 0}
+        ops = self._make_mock(side_effect)
+        warning = ops._check_git_baseline("/repo/file.py")
+        assert warning is not None
+        assert "dirty" in warning.lower()
+        assert "feature-branch" in warning
+
+    def test_write_file_includes_git_warning_when_dirty(self):
+        """write_file result dict includes warning key when git tree is dirty."""
+        state = {"content": "initial\n"}
+
+        def side_effect(command, stdin_data=None, **kwargs):
+            if "command -v git" in command:
+                return {"output": "yes\n", "returncode": 0}
+            if "git rev-parse --is-inside-work-tree" in command:
+                return {"output": "true\n", "returncode": 0}
+            if "git rev-parse --abbrev-ref HEAD" in command:
+                return {"output": "main\n", "returncode": 0}
+            if "git status --porcelain" in command:
+                return {"output": " M test.txt\n", "returncode": 0}
+            if command.startswith("cat >"):  # write
+                if stdin_data is not None:
+                    state["content"] = stdin_data
+                return {"output": "", "returncode": 0}
+            if command.startswith("mkdir "):
+                return {"output": "", "returncode": 0}
+            if command.startswith("wc -c"):
+                return {"output": str(len(state["content"].encode())), "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        ops = self._make_mock(side_effect)
+        result = ops.write_file("/repo/test.txt", "new content\n")
+        d = result.to_dict()
+        assert "warning" in d
+        assert d["warning"] is not None
+        assert "dirty" in d["warning"].lower()
+
+    def test_write_file_omits_warning_when_clean(self):
+        """write_file result dict has no warning key when git tree is clean."""
+        state = {"content": "initial\n"}
+
+        def side_effect(command, stdin_data=None, **kwargs):
+            if "command -v git" in command:
+                return {"output": "yes\n", "returncode": 0}
+            if "git rev-parse --is-inside-work-tree" in command:
+                return {"output": "true\n", "returncode": 0}
+            if "git rev-parse --abbrev-ref HEAD" in command:
+                return {"output": "main\n", "returncode": 0}
+            if "git status --porcelain" in command:
+                return {"output": "", "returncode": 0}
+            if command.startswith("cat >"):  # write
+                if stdin_data is not None:
+                    state["content"] = stdin_data
+                return {"output": "", "returncode": 0}
+            if command.startswith("mkdir "):
+                return {"output": "", "returncode": 0}
+            if command.startswith("wc -c"):
+                return {"output": str(len(state["content"].encode())), "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        ops = self._make_mock(side_effect)
+        result = ops.write_file("/repo/test.txt", "new content\n")
+        d = result.to_dict()
+        assert "warning" not in d or d["warning"] is None

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -581,6 +581,42 @@ class ShellFileOperations(FileOperations):
             result = self._exec(f"command -v {cmd} >/dev/null 2>&1 && echo 'yes'")
             self._command_cache[cmd] = result.stdout.strip() == 'yes'
         return self._command_cache[cmd]
+
+    def _check_git_baseline(self, path: str) -> Optional[str]:
+        """Check git baseline status for the given path.
+
+        Returns a warning string if the file is inside a git repo with
+        uncommitted changes, or None if the tree is clean or not in a repo.
+        """
+        if not self._has_command("git"):
+            return None
+        dir_path = os.path.dirname(path) or "."
+        check_cmd = (
+            f"cd {self._escape_shell_arg(dir_path)} 2>/dev/null "
+            f"&& git rev-parse --is-inside-work-tree 2>/dev/null"
+        )
+        result = self._exec(check_cmd)
+        if result.exit_code != 0 or "true" not in result.stdout:
+            return None
+        branch_cmd = (
+            f"cd {self._escape_shell_arg(dir_path)} 2>/dev/null "
+            f"&& git rev-parse --abbrev-ref HEAD 2>/dev/null"
+        )
+        branch_result = self._exec(branch_cmd)
+        branch = branch_result.stdout.strip() if branch_result.exit_code == 0 else "unknown"
+        dirty_cmd = (
+            f"cd {self._escape_shell_arg(dir_path)} 2>/dev/null "
+            f"&& git status --porcelain 2>/dev/null"
+        )
+        dirty_result = self._exec(dirty_cmd)
+        has_uncommitted = dirty_result.exit_code == 0 and bool(dirty_result.stdout.strip())
+        if has_uncommitted:
+            return (
+                f"Git working tree is dirty on branch '{branch}'. "
+                "Uncommitted changes exist — verify the current codebase state "
+                "before assuming memory or session history is accurate."
+            )
+        return None
     
     def _is_likely_binary(self, path: str, content_sample: str = None) -> bool:
         """
@@ -944,6 +980,9 @@ class ShellFileOperations(FileOperations):
         # rather than an external IDE.
         self._snapshot_lsp_baseline(path)
 
+        # Check git baseline before writing — warn if working tree is dirty
+        git_warning = self._check_git_baseline(path)
+
         # Create parent directories
         parent = os.path.dirname(path)
         dirs_created = False
@@ -993,6 +1032,7 @@ class ShellFileOperations(FileOperations):
             dirs_created=dirs_created,
             lint=lint_result.to_dict() if lint_result else None,
             lsp_diagnostics=lsp_diagnostics,
+            warning=git_warning,
         )
     
     # =========================================================================


### PR DESCRIPTION
What does this PR do?

Two interacting problems caused the agent to report false project status and mutate files based on stale memory:
1. Memory context system note told the LLM to treat recalled memory as "authoritative reference data" — directly encouraging trust in potentially stale information. Changed to "informational background data (may be stale)" so the model treats memory as suggestive context, not ground truth.
2. No git baseline verification before file writes — the agent could write to files without checking whether the working tree was clean, making it impossible to detect when its memory was out of sync with actual project state. Added a _check_git_baseline() method that warns before write_file if uncommitted changes exist.

Related Issue
Fixes #17164

Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

Changes Made
- agent/memory_manager.py:
  - build_memory_context_block(): system note now says "informational background data (may be stale)" instead of "authoritative reference data"
  - _INTERNAL_NOTE_RE: updated regex to match both old and new phrasings
- tools/file_operations.py:
  - ShellFileOperations._check_git_baseline(): new method that detects dirty git working trees
  - ShellFileOperations.write_file(): calls git baseline check before writing, includes warning in result when tree is dirty

How to Test
1. Create a conversation where memory contains stale project status
2. Verify the LLM treats it as informational rather than authoritative (checks git status or asks for confirmation)
3. Make a file write in a dirty git repo — verify a "dirty working tree" warning appears in the result
4. Make a file write in a clean git repo — verify no warning appears