### PR TITLE
fix(gateway): align kanban artifact _IMAGE_EXTS with response dispatch

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4680,7 +4680,7 @@ class GatewayRunner:
         if not candidates:
             return
 
-        _IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".tiff", ".svg"}
+        _IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".gif", ".webp"}
         _VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".webm", ".3gp"}
 
         from urllib.parse import quote as _quote


### PR DESCRIPTION
## Summary

- `_deliver_kanban_artifacts` used `_IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".tiff", ".svg"}` — three extensions wider than the equivalent set in `_deliver_media_from_response` (`{'.jpg', '.jpeg', '.png', '.webp', '.gif'}`).
- `.svg` (XML text), `.bmp`, and `.tiff` routed through `send_multiple_images` (photo API), which rejects non-raster formats on most platforms (Telegram, Discord, Slack). The resulting exception is caught and logged as a warning, so the artifact is silently dropped.
- The regular agent-response dispatch (`_deliver_media_from_response`, line 10661) intentionally uses the narrower set for exactly this reason (see comment near line 10522: *"Telegram sendPhoto recompresses"*).
- Fix: align `_deliver_kanban_artifacts` `_IMAGE_EXTS` with the established narrow set so `.svg`/`.bmp`/`.tiff` fall through to `send_document`, symmetric with regular responses.

No behaviour change for `.png`/`.jpg`/`.jpeg`/`.gif`/`.webp`.

## Test plan

- [ ] Existing `test_notifier_uploads_artifacts_on_completion` and `test_notifier_artifact_delivery_skips_missing_files` still pass — they use `.png` and `.pdf` which are unaffected.
- [ ] Manually confirm: kanban worker producing `/tmp/chart.svg` → artifact routed to `send_document`, not `send_multiple_images`.