### PR TITLE
fix(minimax-oauth): quarantine dead tokens on terminal refresh failure

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -6614,7 +6614,28 @@ def resolve_minimax_oauth_runtime_credentials(
             "MiniMax (OAuth).",
             provider="minimax-oauth", code="not_logged_in", relogin_required=True,
         )
-    state = _refresh_minimax_oauth_state(state)
+    try:
+        state = _refresh_minimax_oauth_state(state)
+    except AuthError as exc:
+        if exc.relogin_required and state.get("refresh_token"):
+            # Terminal refresh failure — clear dead tokens from auth.json so
+            # subsequent calls fail fast without a network retry, mirroring
+            # the Nous / xAI-OAuth / Codex-OAuth quarantine pattern.
+            for _k in ("access_token", "refresh_token", "expires_at", "expires_in", "obtained_at"):
+                state.pop(_k, None)
+            state["last_auth_error"] = {
+                "provider": "minimax-oauth",
+                "code": exc.code or "refresh_failed",
+                "message": str(exc),
+                "reason": "runtime_refresh_failure",
+                "relogin_required": True,
+                "at": datetime.now(timezone.utc).isoformat(),
+            }
+            try:
+                _minimax_save_auth_state(state)
+            except Exception as _save_exc:
+                logger.debug("MiniMax OAuth: failed to persist quarantined state: %s", _save_exc)
+        raise
     return {
         "provider": "minimax-oauth",
         "api_key": state["access_token"],


### PR DESCRIPTION
## Summary

- `resolve_minimax_oauth_runtime_credentials` called `_refresh_minimax_oauth_state` without catching its `AuthError`. On a terminal failure (`invalid_grant`, `refresh_token_reused`, `invalid_refresh_token`), the error propagated but the dead `refresh_token` remained in `auth.json` — so every subsequent API call retried the same token via a network round-trip, failing identically each time.
- Fix: wrap the refresh call; when `exc.relogin_required` is `True` and a `refresh_token` is still present, clear the dead OAuth fields (`access_token`, `refresh_token`, `expires_*`) and write a `last_auth_error` quarantine marker to `auth.json` before re-raising. The next call sees no `access_token` and fails fast with `"not_logged_in"` — no network retry.
- Mirrors the established quarantine pattern for Nous (`_quarantine_nous_oauth_state`), xAI-OAuth (PR #27898), and Codex-OAuth (PR #27911). Persist failure is best-effort (logged at DEBUG; original error still re-raised).

## Test plan

- [ ] Unit: mock `_refresh_minimax_oauth_state` to raise `AuthError(relogin_required=True, code="refresh_failed")`; assert `auth.json` loses `refresh_token` and gains `last_auth_error.relogin_required = True`.
- [ ] Unit: mock non-terminal `AuthError(relogin_required=False)`; assert `auth.json` is unchanged.
- [ ] Integration: after simulated terminal failure, second call to `resolve_minimax_oauth_runtime_credentials` raises `"not_logged_in"` without a network request.