### PR TITLE
fix(doctor): attach codex cli hint to codex auth

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -799,6 +799,15 @@ def run_doctor(args):
             check_warn("OpenAI Codex auth", "(not logged in)")
             if codex_status.get("error"):
                 check_info(codex_status["error"])
+            if not _safe_which("codex"):
+                # Native OAuth uses Hermes' own device-code flow — the Codex
+                # CLI is only relevant if the user wants to import an
+                # existing ~/.codex/auth.json login. Keep the hint attached to
+                # the Codex auth check so it doesn't read like MiniMax advice.
+                check_info(
+                    "codex CLI not installed "
+                    "(optional — only required to import tokens from an existing Codex CLI login)"
+                )
 
         gemini_status = get_gemini_oauth_auth_status()
         if gemini_status.get("logged_in"):
@@ -839,15 +848,6 @@ def run_doctor(args):
 
     if _safe_which("codex"):
         check_ok("codex CLI")
-    else:
-        # Native OAuth uses Hermes' own device-code flow — the Codex CLI is
-        # only needed if you want to import existing tokens from
-        # ~/.codex/auth.json.  Downgrade to info so users running
-        # `hermes auth openai-codex` aren't told they're missing something.
-        check_info(
-            "codex CLI not installed "
-            "(optional — only required to import tokens from an existing Codex CLI login)"
-        )
 
     _section("Directory Structure")
     hermes_home = HERMES_HOME

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -94,6 +94,7 @@ AUTHOR_MAP = {
     "szymonclawd@mac.home": "szymonclawd",
     "257759490+szymonclawd@users.noreply.github.com": "szymonclawd",
     "101180447+worlldz@users.noreply.github.com": "worlldz",
+    "cryptoworlldz@gmail.com": "worlldz",
     "zhanganzhe@tenclass.com": "luoyuctl",
     "51604064+luoyuctl@users.noreply.github.com": "luoyuctl",
     "127238744+teknium1@users.noreply.github.com": "teknium1",

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -892,6 +892,52 @@ class TestGitHubTokenCheck:
         assert "GitHub authenticated via gh CLI" in out or "token configured" in out
 
 
+def test_run_doctor_attaches_codex_cli_hint_to_codex_auth_not_minimax(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+    project = tmp_path / "project"
+    project.mkdir(exist_ok=True)
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    from hermes_cli import auth as _auth_mod
+
+    monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {"logged_in": True})
+    monkeypatch.setattr(
+        _auth_mod,
+        "get_codex_auth_status",
+        lambda: {"logged_in": False, "error": "No Codex credentials stored. Run `hermes auth` to authenticate."},
+    )
+    monkeypatch.setattr(_auth_mod, "get_gemini_oauth_auth_status", lambda: {})
+    monkeypatch.setattr(_auth_mod, "get_minimax_oauth_auth_status", lambda: {})
+    monkeypatch.setattr(doctor_mod, "_safe_which", lambda cmd: None if cmd == "codex" else "/usr/bin/ok")
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    out = buf.getvalue()
+
+    codex_block = (
+        "⚠ OpenAI Codex auth (not logged in)\n"
+        "    → No Codex credentials stored. Run `hermes auth` to authenticate.\n"
+        "    → codex CLI not installed (optional — only required to import tokens from an existing Codex CLI login)"
+    )
+    assert codex_block in out
+
+    minimax_index = out.index("⚠ MiniMax OAuth (not logged in)")
+    codex_hint_index = out.index("codex CLI not installed")
+    assert codex_hint_index < minimax_index
+
+
 def _run_doctor_with_healthy_oauth_fallback(
     monkeypatch,
     tmp_path,


### PR DESCRIPTION
Fixes #27975

`hermes doctor` currently prints the optional `codex CLI not installed` import hint after the `MiniMax OAuth` line, which makes it read like MiniMax-related guidance.

This patch attaches that hint directly to the `OpenAI Codex auth` warning instead, which is the only place where it is actually relevant.

Validation:
`uv run --extra dev pytest tests/hermes_cli/test_doctor.py -q -k codex_cli_hint`

Result:
`1 passed in 11.88s`
