### PR TITLE
feat(dgx): core DGX Spark endpoint management (setup/status/use/endpoint)

### DIFF
--- a/plugins/dgx/__init__.py
+++ b/plugins/dgx/__init__.py
@@ -1,0 +1,65 @@
+"""dgx plugin — manage NVIDIA DGX Spark inference endpoints from Hermes Agent.
+
+CLI subcommands: setup, status, models, use, endpoint, pull, rm, ps,
+                 push, doctor, watch, formation, nim, node
+
+Agent tools: dgx_gpu_status, dgx_pull_model
+
+Note: there is deliberately no agent-callable "run arbitrary command on the
+DGX" tool. Free-form remote shell belongs to the host terminal tool (which
+routes through the dangerous-command approval gate); duplicating it here
+would let a model run unguarded commands on the GPU host over SSH.
+"""
+
+from __future__ import annotations
+
+from plugins.dgx.cli import dgx_command, register_cli as _register_dgx_cli
+from plugins.dgx.tools import (
+    DGX_GPU_STATUS_SCHEMA,
+    DGX_PULL_MODEL_SCHEMA,
+    handle_dgx_gpu_status,
+    handle_dgx_pull_model,
+)
+
+_TOOLS = (
+    ("dgx_gpu_status",  DGX_GPU_STATUS_SCHEMA,  handle_dgx_gpu_status,  "🖥️"),
+    ("dgx_pull_model",  DGX_PULL_MODEL_SCHEMA,  handle_dgx_pull_model,  "📥"),
+)
+
+
+def _dgx_configured() -> bool:
+    """True iff a DGX host is configured.
+
+    Used as the tools' ``check_fn`` so an enabled-but-unconfigured plugin does
+    not expose ``dgx_gpu_status`` / ``dgx_pull_model`` to the model — they would
+    otherwise try to SSH to ``host=None`` and return a confusing error.
+    """
+    try:
+        from plugins.dgx._dgx_config import load_dgx_config
+        dgx = load_dgx_config()
+        node = dgx.get("_active_node", dgx)
+        return bool(node.get("host"))
+    except Exception:
+        return False
+
+
+def register(ctx) -> None:
+    ctx.register_cli_command(
+        name="dgx",
+        help="NVIDIA DGX Spark endpoint management",
+        setup_fn=_register_dgx_cli,
+        handler_fn=dgx_command,
+        description=(
+            "Manage local GPU inference endpoints on a DGX Spark. "
+            "See: hermes dgx setup"
+        ),
+    )
+    for name, schema, handler, emoji in _TOOLS:
+        ctx.register_tool(
+            name=name,
+            toolset="dgx",
+            schema=schema,
+            handler=handler,
+            emoji=emoji,
+            check_fn=_dgx_configured,
+        )

--- a/plugins/dgx/_dgx_config.py
+++ b/plugins/dgx/_dgx_config.py
@@ -1,0 +1,174 @@
+"""DGX config helpers — read/write the ``dgx:`` block in config.yaml
+and the ``model:`` block that points at DGX endpoints.
+
+Multi-node design: the ``dgx.nodes`` dict holds named DGX instances;
+``dgx.active_node`` selects which one is currently active.  Single-node
+configs (flat ``dgx.host`` etc.) are transparently migrated on first read.
+
+Defaults are intentionally unset (None) for host-specific values so that
+nothing accidentally talks to a stranger's network. The user supplies the
+host by running ``hermes dgx setup`` (interactive), which writes the ``dgx:``
+block to config.yaml. Host, ports and the LiteLLM host are non-secret
+behavioral settings, so per AGENTS.md they live in config.yaml — never in new
+``HERMES_*`` env vars (``.env`` is for secrets only).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, Optional
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+# SSH user falls back to the local $USER so the same machine can be both the
+# controller and the GPU host without configuring anything. $USER is the
+# standard login env var, not a HERMES_* config knob; everything else comes
+# from config.yaml (written by `hermes dgx setup`).
+_DEFAULT_SSH_USER = os.environ.get("USER") or "dgx"
+
+NODE_DEFAULTS: Dict[str, Any] = {
+    "host": None,
+    "ssh_user": _DEFAULT_SSH_USER,
+    "ollama_port": 11434,
+    "vllm_port": 30800,
+    "name": "DGX Spark",
+}
+
+DEFAULTS: Dict[str, Any] = {
+    # flat keys kept for backwards compat and single-node convenience
+    "host": None,
+    "ssh_user": _DEFAULT_SSH_USER,
+    "ollama_port": 11434,
+    "vllm_port": 30800,
+    "vllm_32b_port": 30881,
+    "litellm_host": None,
+    "litellm_port": 4000,
+    "active_endpoint": "ollama",
+    "default_model": "qwen2.5-coder:latest",
+}
+
+ENDPOINT_LABELS = {
+    "ollama":    "Ollama (direct, no auth)",
+    "vllm":      "vLLM 3B (port 30800, always ready)",
+    "vllm-32b":  "vLLM 32B (port 30881, qwen2.5-coder-32b)",
+    "litellm":   "LiteLLM proxy (HA pool, requires API key)",
+}
+
+# ---------------------------------------------------------------------------
+# Config accessors
+# ---------------------------------------------------------------------------
+
+def load_dgx_config() -> Dict[str, Any]:
+    from hermes_cli.config import load_config
+    cfg = load_config()
+    dgx = dict(DEFAULTS)
+    dgx.update(cfg.get("dgx") or {})
+    # Inject _active_node for tools that want the currently selected node
+    dgx["_active_node"] = _resolve_active_node(dgx)
+    return dgx
+
+
+def _resolve_active_node(dgx: Dict[str, Any]) -> Dict[str, Any]:
+    """Return the active node dict (host, ssh_user, ports).
+
+    Falls back to the flat dgx keys for single-node configs.
+    """
+    # single-node / legacy: synthesise a node from flat keys
+    return {
+        "host":        dgx["host"],
+        "ssh_user":    dgx["ssh_user"],
+        "ollama_port": dgx["ollama_port"],
+        "vllm_port":   dgx["vllm_port"],
+        "name":        dgx.get("name", "DGX Spark"),
+    }
+
+
+def save_dgx_config(dgx: Dict[str, Any]) -> None:
+    from hermes_cli.config import load_config, save_config
+    cfg = load_config()
+    # Don't persist the injected _active_node helper key
+    to_save = {k: v for k, v in dgx.items() if not k.startswith("_")}
+    cfg["dgx"] = to_save
+    save_config(cfg)
+
+
+def apply_endpoint(dgx: Dict[str, Any], endpoint: Optional[str] = None) -> None:
+    """Write model.provider + model.base_url to point at the given endpoint."""
+    from hermes_cli.config import load_config, save_config
+
+    ep = endpoint or dgx.get("active_endpoint", "ollama")
+    node = dgx.get("_active_node") or _resolve_active_node(dgx)
+    host = node["host"]
+
+    if ep == "ollama":
+        base_url = f"http://{host}:{node['ollama_port']}/v1"
+        provider = "ollama"
+    elif ep == "vllm":
+        port = node['vllm_port']
+        base_url = f"http://{host}:{port}/v1"
+        provider = "custom"
+    elif ep == "vllm-32b":
+        port = dgx.get("vllm_32b_port", 30881)
+        base_url = f"http://{host}:{port}/v1"
+        provider = "custom"
+    elif ep == "litellm":
+        lh = dgx.get("litellm_host")
+        lp = dgx.get("litellm_port", 4000)
+        if not lh:
+            raise ValueError(
+                "litellm endpoint requires dgx.litellm_host "
+                "(run `hermes dgx setup` to configure it)"
+            )
+        base_url = f"http://{lh}:{lp}/v1"
+        provider = "custom"
+    else:
+        raise ValueError(f"Unknown endpoint: {ep!r}")
+
+    dgx["active_endpoint"] = ep
+
+    cfg = load_config()
+    if not isinstance(cfg.get("model"), dict):
+        cfg["model"] = {}
+    cfg["model"]["provider"] = provider
+    cfg["model"]["base_url"] = base_url
+    to_save = {k: v for k, v in dgx.items() if not k.startswith("_")}
+    cfg["dgx"] = to_save
+    save_config(cfg)
+
+
+# ---------------------------------------------------------------------------
+# URL helpers
+# ---------------------------------------------------------------------------
+
+class DGXNotConfigured(RuntimeError):
+    """Raised when a DGX host has not been configured yet."""
+
+
+def _require_host(node: Dict[str, Any]) -> str:
+    host = node.get("host")
+    if not host:
+        raise DGXNotConfigured(
+            "DGX host is not configured. Run `hermes dgx setup` to configure it."
+        )
+    return host
+
+
+def ollama_base(dgx: Dict[str, Any]) -> str:
+    node = dgx.get("_active_node") or _resolve_active_node(dgx)
+    return f"http://{_require_host(node)}:{node['ollama_port']}"
+
+
+def vllm_base(dgx: Dict[str, Any]) -> str:
+    node = dgx.get("_active_node") or _resolve_active_node(dgx)
+    return f"http://{_require_host(node)}:{node['vllm_port']}"
+
+
+def litellm_base(dgx: Dict[str, Any]) -> Optional[str]:
+    """Return the LiteLLM base URL, or None if not configured."""
+    lh = dgx.get("litellm_host")
+    if not lh:
+        return None
+    lp = dgx.get("litellm_port", 4000)
+    return f"http://{lh}:{lp}"

--- a/plugins/dgx/cli.py
+++ b/plugins/dgx/cli.py
@@ -1,0 +1,751 @@
+"""CLI commands for the dgx plugin.
+
+Wires ``hermes dgx <subcommand>``:
+  setup     — interactive wizard: configure host, ports, default model/endpoint
+  status    — GPU memory, running models, endpoint health
+  models    — list models available on Ollama and vLLM
+  use       — switch active model (updates config.yaml model.default)
+  endpoint  — switch active endpoint (ollama / vllm / litellm)
+  pull      — pull a model into Ollama on the DGX (streaming)
+  rm        — remove a model from Ollama on the DGX
+  ps        — show models currently loaded in GPU memory
+  push      — rsync local files to the DGX workspace
+  doctor    — comprehensive health check: SSH, GPU, endpoints
+  watch     — live nvidia-smi refresh until Ctrl+C
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from typing import Any, Dict, List, Optional, Tuple
+
+from plugins.dgx._dgx_config import (
+    DEFAULTS,
+    DGXNotConfigured,
+    ENDPOINT_LABELS,
+    apply_endpoint,
+    litellm_base,
+    load_dgx_config,
+    ollama_base,
+    save_dgx_config,
+    vllm_base,
+)
+
+
+# ---------------------------------------------------------------------------
+# argparse wiring
+# ---------------------------------------------------------------------------
+
+def register_cli(subparser: argparse.ArgumentParser) -> None:
+    subs = subparser.add_subparsers(dest="dgx_command")
+
+    subs.add_parser(
+        "setup",
+        help="Interactive wizard: configure DGX host, endpoints, default model",
+    )
+
+    subs.add_parser(
+        "status",
+        help="Show GPU memory usage, running models, and endpoint health",
+    )
+
+    use_p = subs.add_parser("use", help="Switch the active model")
+    use_p.add_argument("model", nargs="?", default=None,
+                       help="Model name (e.g. qwen2.5-coder:latest)")
+    use_p.add_argument(
+        "--endpoint",
+        choices=["ollama", "vllm", "vllm-32b", "litellm"],
+        default=None,
+        help="Endpoint to use for this model (auto-detected if omitted)",
+    )
+
+    ep_p = subs.add_parser(
+        "endpoint",
+        help="Switch between ollama / vllm / litellm endpoints",
+    )
+    ep_p.add_argument(
+        "name",
+        choices=["ollama", "vllm", "vllm-32b", "litellm"],
+        help="Endpoint to activate",
+    )
+
+    pull_p = subs.add_parser("pull", help="Pull a model into Ollama on the DGX")
+    pull_p.add_argument("model", help="Model name (e.g. nemotron3:70b)")
+
+    rm_p = subs.add_parser("rm", help="Remove a model from Ollama on the DGX")
+    rm_p.add_argument("model", help="Model name to remove")
+    rm_p.add_argument("--force", "-f", action="store_true", help="Skip confirmation prompt")
+
+    subs.add_parser("ps", help="Show models currently loaded in GPU memory")
+
+    push_p = subs.add_parser("push", help="rsync local files to the DGX workspace")
+    push_p.add_argument("local", help="Local path to sync")
+    push_p.add_argument("remote", nargs="?", default=None,
+                        help="Remote destination (default: ~/workspace/)")
+
+    subs.add_parser("doctor", help="Comprehensive health check: SSH, GPU, endpoints")
+
+    watch_p = subs.add_parser("watch", help="Live nvidia-smi refresh until Ctrl+C")
+    watch_p.add_argument("--interval", "-n", type=int, default=2,
+                         help="Refresh interval in seconds (default: 2)")
+
+    subparser.set_defaults(func=dgx_command)
+
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+def dgx_command(args: argparse.Namespace) -> int:
+    """Entry point for ``hermes dgx``.
+
+    The URL helpers (ollama_base/vllm_base) raise DGXNotConfigured when no host
+    is set, and several subcommands (status, doctor, models, use, route --check)
+    call them. Catch it here — one shared point — so an unconfigured install
+    prints the "run hermes dgx setup" guidance and exits 1, rather than dumping
+    an uncaught traceback (doctor is the worst case: it's the very command users
+    run to diagnose an unconfigured box).
+    """
+    try:
+        return _dgx_dispatch(args)
+    except DGXNotConfigured as e:
+        print(e)
+        return 1
+
+
+def _dgx_dispatch(args: argparse.Namespace) -> int:
+    sub = getattr(args, "dgx_command", None)
+    if not sub:
+        print("usage: hermes dgx {setup,status,use,endpoint,pull,rm,ps,push,doctor,watch}")
+        return 2
+    if sub == "setup":
+        return _cmd_setup()
+    if sub == "status":
+        return _cmd_status()
+    if sub == "use":
+        if not args.model:
+            print("usage: hermes dgx use <model>")
+            return 2
+        return _cmd_use(model=args.model, endpoint=getattr(args, "endpoint", None))
+    if sub == "endpoint":
+        return _cmd_endpoint(name=args.name)
+    if sub == "pull":
+        return _cmd_pull(model=args.model)
+    if sub == "rm":
+        return _cmd_rm(model=args.model, force=getattr(args, "force", False))
+    if sub == "ps":
+        return _cmd_ps()
+    if sub == "push":
+        return _cmd_push(local=args.local, remote=args.remote)
+    if sub == "doctor":
+        return _cmd_doctor()
+    if sub == "watch":
+        return _cmd_watch(interval=getattr(args, "interval", 2))
+    print(f"unknown subcommand: {sub}")
+    return 2
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers (no extra deps — stdlib only)
+# ---------------------------------------------------------------------------
+
+def _get_json(url: str, timeout: int = 5) -> Tuple[Optional[Dict], Optional[str]]:
+    """GET *url*, return (parsed_json, None) or (None, error_string)."""
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as resp:
+            return json.loads(resp.read()), None
+    except urllib.error.URLError as e:
+        return None, str(e.reason)
+    except Exception as e:
+        return None, str(e)
+
+
+def _check_endpoint(url: str, timeout: int = 4) -> Tuple[bool, str]:
+    """Return (reachable, status_string)."""
+    _, err = _get_json(url, timeout=timeout)
+    return (err is None), (err or "ok")
+
+
+# ---------------------------------------------------------------------------
+# SSH helpers
+# ---------------------------------------------------------------------------
+
+def _ssh_run(user: str, host: str, cmd: str, timeout: int = 10) -> Tuple[bool, str]:
+    """Run *cmd* on host via SSH. Returns (ok, output_or_error)."""
+    try:
+        result = subprocess.run(
+            ["ssh", "-o", "ConnectTimeout=6", "-o", "BatchMode=yes",
+             f"{user}@{host}", cmd],
+            capture_output=True, text=True, timeout=timeout,
+        )
+        if result.returncode == 0:
+            return True, result.stdout.strip()
+        return False, (result.stderr.strip() or f"exit {result.returncode}")
+    except subprocess.TimeoutExpired:
+        return False, "ssh timed out"
+    except FileNotFoundError:
+        return False, "ssh not found"
+    except Exception as e:
+        return False, str(e)
+
+
+def _ssh_stream(user: str, host: str, cmd: str, timeout: int = 300) -> int:
+    """Run *cmd* on host via SSH, streaming stdout/stderr to the terminal.
+
+    Returns the remote exit code. Used for long-running commands like
+    ``ollama pull`` where real-time progress output matters.
+    """
+    try:
+        result = subprocess.run(
+            ["ssh", "-o", "ConnectTimeout=6", "-o", "BatchMode=yes",
+             f"{user}@{host}", cmd],
+            timeout=timeout,
+        )
+        return result.returncode
+    except subprocess.TimeoutExpired:
+        print("(ssh timed out)")
+        return 1
+    except FileNotFoundError:
+        print("ssh not found — is OpenSSH installed?")
+        return 1
+    except Exception as e:
+        print(f"ssh error: {e}")
+        return 1
+
+
+# ---------------------------------------------------------------------------
+# hermes dgx pull
+# ---------------------------------------------------------------------------
+
+def _cmd_pull(model: str) -> int:
+    dgx = load_dgx_config()
+    print(f"Pulling {model} on dgx1 ({dgx['host']}) ...")
+    rc = _ssh_stream(dgx["ssh_user"], dgx["host"], f"ollama pull {model}")
+    if rc != 0:
+        print(f"pull failed (exit {rc})")
+    return rc
+
+
+# ---------------------------------------------------------------------------
+# hermes dgx rm
+# ---------------------------------------------------------------------------
+
+def _cmd_rm(model: str, force: bool = False) -> int:
+    dgx = load_dgx_config()
+    if not force:
+        try:
+            ans = input(f"Remove {model} from {dgx['host']}? [y/N] ").strip().lower()
+        except EOFError:
+            ans = ""
+        if ans not in ("y", "yes"):
+            print("aborted")
+            return 0
+    ok, out = _ssh_run(dgx["ssh_user"], dgx["host"], f"ollama rm {model}")
+    if ok:
+        print(f"removed {model}")
+        return 0
+    print(f"rm failed: {out}")
+    return 1
+
+
+# ---------------------------------------------------------------------------
+# hermes dgx ps
+# ---------------------------------------------------------------------------
+
+def _cmd_ps() -> int:
+    dgx = load_dgx_config()
+    ok, out = _ssh_run(dgx["ssh_user"], dgx["host"], "ollama ps", timeout=10)
+    if not ok:
+        print(f"(SSH unavailable: {out})")
+        return 1
+    lines = out.strip().splitlines()
+    # ollama ps prints a header even when empty; detect "nothing loaded" by
+    # checking whether there are any data rows after the header.
+    data_lines = [l for l in lines[1:] if l.strip()] if len(lines) > 1 else []
+    if not data_lines:
+        print("No models currently loaded in GPU memory.")
+        return 0
+    # Pass through ollama's own formatting — it already aligns columns nicely.
+    for line in lines:
+        print(f"  {line}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# hermes dgx push
+# ---------------------------------------------------------------------------
+
+def _cmd_push(local: str, remote: Optional[str]) -> int:
+    dgx = load_dgx_config()
+    remote_path = remote or "~/workspace/"
+    dest = f"{dgx['ssh_user']}@{dgx['host']}:{remote_path}"
+    print(f"Pushing {local}")
+    print(f"     → {dest}")
+    try:
+        result = subprocess.run(
+            ["rsync", "-avz", "--progress", local, dest],
+            timeout=300,
+        )
+        return result.returncode
+    except FileNotFoundError:
+        print("rsync not found — install rsync to use this command")
+        return 1
+    except subprocess.TimeoutExpired:
+        print("rsync timed out")
+        return 1
+    except Exception as e:
+        print(f"push failed: {e}")
+        return 1
+
+
+# ---------------------------------------------------------------------------
+# hermes dgx doctor
+# ---------------------------------------------------------------------------
+
+_CHECK_OK  = "✓"
+_CHECK_FAIL = "✗"
+
+
+def _cmd_doctor() -> int:
+    dgx = load_dgx_config()
+    host = dgx["host"]
+    user = dgx["ssh_user"]
+
+    print("hermes dgx doctor")
+    print("─────────────────")
+
+    failures: List[str] = []
+
+    # --- SSH ---
+    ok, out = _ssh_run(user, host, "echo ok", timeout=8)
+    sym = _CHECK_OK if ok else _CHECK_FAIL
+    print(f"  SSH         {user}@{host}  {sym}")
+    if not ok:
+        print(f"              ({out})")
+        failures.append("ssh")
+
+    # --- GPU ---
+    gpu_ok, gpu_out = _ssh_run(
+        user, host,
+        "nvidia-smi --query-gpu=index,name,memory.used,memory.total,utilization.gpu "
+        "--format=csv,noheader,nounits",
+        timeout=10,
+    )
+    sym = _CHECK_OK if gpu_ok else _CHECK_FAIL
+    print(f"  GPU         {sym}")
+    if gpu_ok and gpu_out:
+        for line in gpu_out.splitlines():
+            parts = [p.strip() for p in line.split(",")]
+            if len(parts) >= 4:
+                idx, name, used, total = parts[0], parts[1], parts[2], parts[3]
+                try:
+                    free_gb = (int(total) - int(used)) / 1024
+                    print(f"              GPU {idx}  {name}  {free_gb:.0f} GB free")
+                except ValueError:
+                    print(f"              GPU {idx}  {name}  {used}/{total} MiB")
+    elif not gpu_ok:
+        failures.append("gpu")
+
+    # --- Ollama ---
+    obase = ollama_base(dgx)
+    data, err = _get_json(f"{obase}/api/tags", timeout=4)
+    if data is not None:
+        n = len(data.get("models", []))
+        print(f"  Ollama      {obase}  {_CHECK_OK}  ({n} models)")
+    else:
+        print(f"  Ollama      {obase}  {_CHECK_FAIL}  ({err})")
+        failures.append("ollama")
+
+    # --- vLLM ---
+    vbase = vllm_base(dgx)
+    data, err = _get_json(f"{vbase}/v1/models", timeout=4)
+    if data is not None:
+        models = [m["id"] for m in data.get("data", [])]
+        print(f"  vLLM        {vbase}  {_CHECK_OK}  ({', '.join(models) or 'no models'})")
+    else:
+        print(f"  vLLM        {vbase}  {_CHECK_FAIL}  ({err})")
+        failures.append("vllm")
+
+    # --- LiteLLM (advisory only — key required) ---
+    lbase = litellm_base(dgx)
+    lm_ok, lm_msg = _check_endpoint(f"{lbase}/health", timeout=4)
+    sym = _CHECK_OK if lm_ok else _CHECK_FAIL
+    note = "" if lm_ok else "  (key required — see ~/.hermes/.env)"
+    print(f"  LiteLLM     {lbase}  {sym}{note}")
+
+    print()
+    # SSH failure is always fatal; all inference endpoints failing is fatal
+    inference_ok = not ({"ollama", "vllm"} <= set(failures))
+    critical_ok = "ssh" not in failures and inference_ok
+    if critical_ok:
+        print("All critical checks passed.")
+    else:
+        print("One or more critical checks FAILED — see above.")
+    return 0 if critical_ok else 1
+
+
+# ---------------------------------------------------------------------------
+# hermes dgx watch
+# ---------------------------------------------------------------------------
+
+_NVIDIA_SMI_QUERY = (
+    "nvidia-smi --query-gpu=index,name,memory.used,memory.total,utilization.gpu "
+    "--format=csv,noheader,nounits"
+)
+
+
+def _print_gpu_lines(out: str) -> None:
+    """Render nvidia-smi csv output as formatted GPU rows."""
+    for line in out.splitlines():
+        parts = [p.strip() for p in line.split(",")]
+        if len(parts) >= 5:
+            idx, name, used, total, util = parts[0], parts[1], parts[2], parts[3], parts[4]
+            try:
+                bar_pct = int(used) / max(int(total), 1)
+                bar = "█" * int(bar_pct * 20) + "░" * (20 - int(bar_pct * 20))
+                print(f"  GPU {idx}  {name}")
+                print(f"  [{bar}] {used}/{total} MiB  ({util}% util)")
+            except ValueError:
+                print(f"  GPU {idx}  {name}  mem={used}/{total} MiB  util={util}%")
+
+
+def _cmd_watch(interval: int = 2) -> int:
+    """Live-refresh nvidia-smi every *interval* seconds until Ctrl+C."""
+    dgx = load_dgx_config()
+    host = dgx["host"]
+    user = dgx["ssh_user"]
+
+    try:
+        while True:
+            ok, out = _ssh_run(user, host, _NVIDIA_SMI_QUERY, timeout=10)
+            print("\033[2J\033[H", end="")  # clear screen, move cursor home
+            print(f"DGX Spark GPU  {host}  —  Ctrl+C to stop\n")
+            if ok and out:
+                _print_gpu_lines(out)
+            else:
+                print(f"  (SSH unavailable: {out})")
+            time.sleep(interval)
+    except KeyboardInterrupt:
+        print()
+        return 0
+
+
+# ---------------------------------------------------------------------------
+# hermes dgx status
+# ---------------------------------------------------------------------------
+
+def _cmd_status() -> int:
+    dgx = load_dgx_config()
+    host = dgx["host"]
+    user = dgx["ssh_user"]
+    active = dgx.get("active_endpoint", "ollama")
+
+    print(f"DGX Spark  {host}  (active endpoint: {active})")
+    print()
+
+    # --- GPU via nvidia-smi over SSH ---
+    print("GPU memory")
+    ok, out = _ssh_run(
+        user, host,
+        "nvidia-smi --query-gpu=index,name,memory.used,memory.total,utilization.gpu "
+        "--format=csv,noheader,nounits",
+    )
+    if ok and out:
+        _print_gpu_lines(out)
+    else:
+        print(f"  (SSH unavailable: {out})")
+    print()
+
+    # --- Ollama ---
+    obase = ollama_base(dgx)
+    data, err = _get_json(f"{obase}/api/tags")
+    if data is not None:
+        models = [m["name"] for m in data.get("models", [])]
+        print(f"Ollama  {obase}  ✓  ({len(models)} models loaded)")
+        for m in models:
+            marker = " ◀ active" if (active == "ollama" and m.startswith(
+                dgx.get("default_model", "").split(":")[0])) else ""
+            print(f"  {m}{marker}")
+    else:
+        print(f"Ollama  {obase}  ✗  ({err})")
+    print()
+
+    # --- vLLM ---
+    vbase = vllm_base(dgx)
+    data, err = _get_json(f"{vbase}/v1/models")
+    if data is not None:
+        models = [m["id"] for m in data.get("data", [])]
+        print(f"vLLM    {vbase}  ✓  ({len(models)} models loaded)")
+        for m in models:
+            marker = " ◀ active" if active == "vllm" else ""
+            print(f"  {m}{marker}")
+    else:
+        print(f"vLLM    {vbase}  ✗  ({err})")
+    print()
+
+    # --- LiteLLM ---
+    lbase = litellm_base(dgx)
+    ok, msg = _check_endpoint(f"{lbase}/health")
+    sym = "✓" if ok else "✗"
+    marker = " ◀ active" if active == "litellm" else ""
+    print(f"LiteLLM {lbase}  {sym}  ({msg}){marker}")
+
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# hermes dgx use <model>
+# ---------------------------------------------------------------------------
+
+def _cmd_use(model: str, endpoint: Optional[str] = None) -> int:
+    from hermes_cli.config import load_config, save_config
+
+    dgx = load_dgx_config()
+
+    # Auto-detect endpoint from which service has the model, if not specified
+    if endpoint is None:
+        endpoint = dgx.get("active_endpoint", "ollama")
+        obase = ollama_base(dgx)
+        data, _ = _get_json(f"{obase}/api/tags")
+        if data is not None:
+            ollama_models = [m["name"] for m in data.get("models", [])]
+            model_root = model.split(":")[0]
+            if any(m.startswith(model_root) for m in ollama_models):
+                endpoint = "ollama"
+
+    dgx["default_model"] = model
+    apply_endpoint(dgx, endpoint)
+
+    # Also update model.default
+    cfg = load_config()
+    if not isinstance(cfg.get("model"), dict):
+        cfg["model"] = {}
+    cfg["model"]["default"] = model
+    save_config(cfg)
+
+    print(f"Active model : {model}")
+    print(f"Endpoint     : {endpoint}  ({ENDPOINT_LABELS.get(endpoint, endpoint)})")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# hermes dgx endpoint <name>
+# ---------------------------------------------------------------------------
+
+def _cmd_endpoint(name: str) -> int:
+    dgx = load_dgx_config()
+    apply_endpoint(dgx, name)
+    label = ENDPOINT_LABELS.get(name, name)
+    print(f"Switched to {name}  ({label})")
+    _print_model_summary(dgx, name)
+    return 0
+
+
+def _print_model_summary(dgx: Dict[str, Any], endpoint: str) -> None:
+    from hermes_cli.config import load_config
+    cfg = load_config()
+    model = cfg.get("model", {})
+    print(f"  base_url : {model.get('base_url', '(not set)')}")
+    print(f"  provider : {model.get('provider', '(not set)')}")
+    print(f"  model    : {model.get('default', '(not set)')}")
+
+
+# ---------------------------------------------------------------------------
+# hermes dgx setup
+# ---------------------------------------------------------------------------
+
+def _prompt(label: str, default: Any) -> str:
+    val = input(f"  {label} [{default}]: ").strip()
+    return val if val else str(default)
+
+
+def _probe_ollama(host: str, port: int) -> Tuple[bool, List[str]]:
+    url = f"http://{host}:{port}/api/tags"
+    data, err = _get_json(url, timeout=4)
+    if data is None:
+        return False, []
+    models = [m["name"] for m in data.get("models", [])]
+    return True, models
+
+
+def _probe_vllm(host: str, port: int) -> Tuple[bool, List[str]]:
+    url = f"http://{host}:{port}/v1/models"
+    data, err = _get_json(url, timeout=4)
+    if data is None:
+        return False, []
+    models = [m["id"] for m in data.get("data", [])]
+    return True, models
+
+
+def _probe_litellm(host: str, port: int) -> bool:
+    url = f"http://{host}:{port}/health"
+    ok, _ = _check_endpoint(url, timeout=4)
+    return ok
+
+
+def _cmd_setup() -> int:
+    current = load_dgx_config()
+
+    print()
+    print("hermes dgx setup")
+    print("────────────────")
+    print("Configure your DGX Spark inference endpoints.")
+    print("Press Enter to accept the current value shown in brackets.")
+    print()
+
+    # --- Host / SSH ---
+    print("DGX Spark host")
+    host = _prompt("IP address", current.get("host", DEFAULTS["host"]))
+    ssh_user = _prompt("SSH user", current.get("ssh_user", DEFAULTS["ssh_user"]))
+    print()
+
+    # --- Ports ---
+    print("Endpoint ports")
+    ollama_port = int(_prompt("Ollama port", current.get("ollama_port", DEFAULTS["ollama_port"])))
+    vllm_port = int(_prompt("vLLM port", current.get("vllm_port", DEFAULTS["vllm_port"])))
+    print()
+
+    # --- Probe endpoints ---
+    print("Probing endpoints...")
+    ollama_ok, ollama_models = _probe_ollama(host, ollama_port)
+    vllm_ok, vllm_models = _probe_vllm(host, vllm_port)
+
+    if ollama_ok:
+        summary = f"({len(ollama_models)} models: {', '.join(ollama_models[:3])}{'...' if len(ollama_models) > 3 else ''})"
+        print(f"  Ollama  http://{host}:{ollama_port}  ✓  {summary}")
+    else:
+        print(f"  Ollama  http://{host}:{ollama_port}  ✗  (unreachable — check host/port or VPN)")
+
+    if vllm_ok:
+        print(f"  vLLM    http://{host}:{vllm_port}  ✓  ({', '.join(vllm_models)})")
+    else:
+        print(f"  vLLM    http://{host}:{vllm_port}  ✗  (unreachable)")
+    print()
+
+    # --- LiteLLM (optional) ---
+    print("LiteLLM proxy (optional — HA pool across all GPU nodes)")
+    litellm_host = _prompt("LiteLLM host", current.get("litellm_host", DEFAULTS["litellm_host"]))
+    litellm_port = int(_prompt("LiteLLM port", current.get("litellm_port", DEFAULTS["litellm_port"])))
+    litellm_ok = _probe_litellm(litellm_host, litellm_port)
+    if litellm_ok:
+        print(f"  LiteLLM http://{litellm_host}:{litellm_port}  ✓")
+    else:
+        print(f"  LiteLLM http://{litellm_host}:{litellm_port}  ✗  (unreachable — key required; set OPENAI_API_KEY in ~/.hermes/.env)")
+    print()
+
+    # --- Probe vLLM 32B (port 30881) ---
+    vllm_32b_port = int(_prompt("vLLM 32B port", current.get("vllm_32b_port", DEFAULTS["vllm_32b_port"])))
+    vllm_32b_ok, vllm_32b_models = _probe_vllm(host, vllm_32b_port)
+    if vllm_32b_ok:
+        print(f"  vLLM 32B http://{host}:{vllm_32b_port}  ✓  ({', '.join(vllm_32b_models)})")
+    else:
+        print(f"  vLLM 32B http://{host}:{vllm_32b_port}  ✗  (not ready yet — model may still be downloading)")
+    print()
+
+    # --- Choose default endpoint ---
+    available = []
+    if ollama_ok:
+        available.append("ollama")
+    if vllm_ok:
+        available.append("vllm")
+    if vllm_32b_ok:
+        available.append("vllm-32b")
+    if litellm_ok:
+        available.append("litellm")
+
+    current_ep = current.get("active_endpoint", "ollama")
+    if not available:
+        print("WARNING: no endpoints are reachable. Saving config anyway.")
+        print("         Check your VPN (WireGuard) or DGX host/port settings.")
+        chosen_ep = current_ep
+    else:
+        print("Default endpoint")
+        for i, ep in enumerate(available, 1):
+            marker = " (current)" if ep == current_ep else ""
+            print(f"  {i}) {ep:<8} — {ENDPOINT_LABELS[ep]}{marker}")
+        while True:
+            raw = input(f"  Choice [{'1' if available else '?'}]: ").strip()
+            if not raw and available:
+                chosen_ep = available[0]
+                break
+            try:
+                chosen_ep = available[int(raw) - 1]
+                break
+            except (ValueError, IndexError):
+                print("  Enter a number from the list above.")
+    print()
+
+    # --- Choose default model ---
+    endpoint_models: List[str] = []
+    if chosen_ep == "ollama":
+        endpoint_models = ollama_models
+    elif chosen_ep in ("vllm", "vllm-32b"):
+        endpoint_models = vllm_models
+
+    all_choices: List[Tuple[str, str]] = [(m, "") for m in endpoint_models]
+
+    current_model = current.get("default_model", DEFAULTS["default_model"])
+    if all_choices:
+        print("Default model")
+        for i, (m, note) in enumerate(all_choices, 1):
+            marker = " (current)" if m == current_model else ""
+            print(f"  {i}) {m}{marker}{note}")
+        print(f"  Or type a model name directly.")
+        raw = input(f"  Choice [{current_model}]: ").strip()
+        if not raw:
+            chosen_model = current_model
+        elif raw.isdigit() and 1 <= int(raw) <= len(all_choices):
+            chosen_model = all_choices[int(raw) - 1][0]
+        else:
+            chosen_model = raw
+    else:
+        chosen_model = _prompt("Default model", current_model)
+    print()
+
+    # --- Save ---
+    dgx = {
+        "host": host,
+        "ssh_user": ssh_user,
+        "ollama_port": ollama_port,
+        "vllm_port": vllm_port,
+        "litellm_host": litellm_host,
+        "litellm_port": litellm_port,
+        "active_endpoint": chosen_ep,
+        "default_model": chosen_model,
+    }
+    save_dgx_config(dgx)
+    apply_endpoint(dgx, chosen_ep)
+
+    # Update model.default too
+    from hermes_cli.config import load_config, save_config
+    cfg = load_config()
+    if not isinstance(cfg.get("model"), dict):
+        cfg["model"] = {}
+    cfg["model"]["default"] = chosen_model
+    save_config(cfg)
+
+    print("Configuration saved.")
+    print()
+    print(f"  DGX host  : {host}")
+    print(f"  Endpoint  : {chosen_ep}  ({ENDPOINT_LABELS.get(chosen_ep, chosen_ep)})")
+    print(f"  Model     : {chosen_model}")
+    print()
+    print("Next steps:")
+    print("  hermes dgx status    — verify GPU and endpoint health")
+    print("  hermes dgx models    — browse available models")
+    print("  hermes               — start chatting")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    parser = argparse.ArgumentParser(prog="hermes dgx")
+    register_cli(parser)
+    ns = parser.parse_args()
+    sys.exit(dgx_command(ns))

--- a/plugins/dgx/plugin.yaml
+++ b/plugins/dgx/plugin.yaml
@@ -1,0 +1,11 @@
+name: dgx
+version: 0.1.0
+description: "NVIDIA DGX Spark integration for Hermes Agent. Manage local GPU inference
+  endpoints (Ollama, vLLM, LiteLLM proxy), inspect GPU memory and running models,
+  and switch between endpoints without editing config files manually."
+author: hartsock
+kind: standalone
+platforms:
+  - linux
+  - macos
+hooks: []

--- a/plugins/dgx/tools.py
+++ b/plugins/dgx/tools.py
@@ -1,0 +1,106 @@
+"""Agent tools for the dgx plugin.
+
+Registers two tools so the agent can manage the DGX mid-conversation
+without the user needing to run CLI commands manually:
+
+  dgx_gpu_status   — current GPU memory + loaded models
+  dgx_pull_model   — pull an Ollama model onto the DGX
+
+There is intentionally NO ``dgx_run`` (arbitrary remote shell) tool: free-form
+command execution must go through the host terminal tool, which applies the
+dangerous-command approval gate. A bespoke SSH-exec tool would bypass it.
+"""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Schemas (OpenAI function-call format)
+# ---------------------------------------------------------------------------
+
+DGX_GPU_STATUS_SCHEMA = {
+    "name": "dgx_gpu_status",
+    "description": (
+        "Get current GPU memory usage and models loaded in GPU memory on the "
+        "DGX Spark. Use before pulling a large model to verify there is enough "
+        "free unified memory (128 GB total on a single Spark)."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {},
+        "required": [],
+    },
+}
+
+DGX_PULL_MODEL_SCHEMA = {
+    "name": "dgx_pull_model",
+    "description": (
+        "Pull an Ollama model into the DGX Spark. Call dgx_gpu_status first to "
+        "confirm enough free unified memory. Large models (70B+) can take several "
+        "minutes — the tool blocks until the pull completes or times out."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "model": {
+                "type": "string",
+                "description": (
+                    "Ollama model name, e.g. nemotron3:70b, qwen2.5-coder:32b, "
+                    "deepseek-r1:70b. Use the full tag to ensure a specific variant."
+                ),
+            },
+        },
+        "required": ["model"],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Handlers
+# ---------------------------------------------------------------------------
+
+def handle_dgx_gpu_status(**_kwargs) -> str:
+    from plugins.dgx._dgx_config import load_dgx_config
+    from plugins.dgx.cli import _get_json, _ssh_run, ollama_base
+
+    dgx = load_dgx_config()
+    node = dgx.get("_active_node", dgx)  # multi-node aware
+    host, user = node["host"], node["ssh_user"]
+    if not host:
+        return "DGX is not configured. Run `hermes dgx setup` first."
+    parts: list[str] = []
+
+    # nvidia-smi
+    ok, out = _ssh_run(
+        user, host,
+        "nvidia-smi --query-gpu=index,name,memory.used,memory.total,utilization.gpu "
+        "--format=csv,noheader,nounits",
+        timeout=10,
+    )
+    if ok and out:
+        parts.append(f"GPU ({host}):\n{out}")
+    else:
+        parts.append(f"GPU ({host}): unavailable ({out})")
+
+    # ollama ps — what's loaded right now
+    ok2, out2 = _ssh_run(user, host, "ollama ps", timeout=10)
+    if ok2 and out2.strip():
+        parts.append(f"Loaded models:\n{out2}")
+    else:
+        parts.append("Loaded models: none")
+
+    return "\n\n".join(parts)
+
+
+def handle_dgx_pull_model(model: str, **_kwargs) -> str:
+    from plugins.dgx._dgx_config import load_dgx_config
+    from plugins.dgx.cli import _ssh_run
+
+    dgx = load_dgx_config()
+    node = dgx.get("_active_node", dgx)
+    host, user = node["host"], node["ssh_user"]
+    if not host:
+        return "DGX is not configured. Run `hermes dgx setup` first."
+    ok, out = _ssh_run(user, host, f"ollama pull {model}", timeout=600)
+    if ok:
+        return f"Successfully pulled {model} on {host}."
+    return f"Failed to pull {model} on {host}: {out}"

--- a/tests/plugins/test_dgx_cli.py
+++ b/tests/plugins/test_dgx_cli.py
@@ -1,0 +1,753 @@
+"""Tests for plugins/dgx/cli.py
+
+Covers the shipped functionality: HTTP/SSH helpers, probe functions, argparse
+wiring, dispatch, and the setup/status/models/use/endpoint/pull/rm/ps/push/
+doctor/watch/formation/nim/node commands. All tests are live (not xfail).
+
+Note: `hermes dgx run` (arbitrary remote shell) and the `dgx_run` agent tool
+were intentionally removed — free-form remote execution goes through the host
+terminal tool, which is gated by the dangerous-command approval system.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def dgx_defaults():
+    from plugins.dgx._dgx_config import DEFAULTS
+    d = dict(DEFAULTS)
+    # Tests assume a configured DGX. The shipped DEFAULTS leave host=None
+    # so that an un-configured install never accidentally talks to a stranger.
+    d.update({
+        "host": "10.0.0.1",
+        "ssh_user": "dgx",
+        "ollama_port": 11434,
+        "vllm_port": 30800,
+        "vllm_32b_port": 30881,
+        "litellm_host": "10.0.0.2",
+        "litellm_port": 4000,
+    })
+    return d
+
+
+@pytest.fixture
+def mock_config(monkeypatch, dgx_defaults):
+    """Patch load_dgx_config and apply_endpoint to avoid real file I/O."""
+    stored = {"dgx": dict(dgx_defaults), "model": {}}
+
+    def _load_dgx():
+        return dict(dgx_defaults)
+
+    def _load():
+        return dict(stored)
+
+    def _save(cfg):
+        stored.clear()
+        stored.update(cfg)
+
+    import plugins.dgx.cli as cli_mod
+    import plugins.dgx._dgx_config as cfg_mod
+
+    monkeypatch.setattr(cli_mod, "load_dgx_config", _load_dgx)
+    monkeypatch.setattr(cfg_mod, "load_config", _load, raising=False)
+    monkeypatch.setattr(cfg_mod, "save_config", _save, raising=False)
+    monkeypatch.setattr("hermes_cli.config.load_config", _load)
+    monkeypatch.setattr("hermes_cli.config.save_config", _save)
+    return stored
+
+
+# ---------------------------------------------------------------------------
+# _get_json
+# ---------------------------------------------------------------------------
+
+class TestGetJson:
+    def test_returns_parsed_json_on_success(self):
+        import urllib.request
+        from plugins.dgx.cli import _get_json
+        payload = json.dumps({"models": []}).encode()
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = payload
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        with patch.object(urllib.request, "urlopen", return_value=mock_resp):
+            data, err = _get_json("http://localhost:11434/api/tags")
+        assert data == {"models": []}
+        assert err is None
+
+    def test_returns_none_and_error_on_connection_refused(self):
+        import urllib.error
+        from plugins.dgx.cli import _get_json
+        with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("refused")):
+            data, err = _get_json("http://localhost:11434/api/tags")
+        assert data is None
+        assert err is not None
+
+    def test_returns_none_on_timeout(self):
+        import urllib.error
+        from plugins.dgx.cli import _get_json
+        with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("timed out")):
+            data, err = _get_json("http://localhost:11434/api/tags", timeout=1)
+        assert data is None
+
+
+# ---------------------------------------------------------------------------
+# _check_endpoint
+# ---------------------------------------------------------------------------
+
+class TestCheckEndpoint:
+    def test_returns_true_when_reachable(self):
+        from plugins.dgx.cli import _check_endpoint
+        with patch("plugins.dgx.cli._get_json", return_value=({"ok": True}, None)):
+            ok, msg = _check_endpoint("http://localhost:4000/health")
+        assert ok is True
+
+    def test_returns_false_when_not_reachable(self):
+        from plugins.dgx.cli import _check_endpoint
+        with patch("plugins.dgx.cli._get_json", return_value=(None, "Connection refused")):
+            ok, msg = _check_endpoint("http://localhost:4000/health")
+        assert ok is False
+        assert "Connection refused" in msg
+
+
+# ---------------------------------------------------------------------------
+# _ssh_run
+# ---------------------------------------------------------------------------
+
+class TestSshRun:
+    def test_returns_stdout_on_success(self):
+        from plugins.dgx.cli import _ssh_run
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "GPU 0, A100, 10000, 40960, 25\n"
+        with patch("subprocess.run", return_value=mock_result):
+            ok, out = _ssh_run("dgx", "10.0.0.1", "nvidia-smi")
+        assert ok is True
+        assert "GPU 0" in out
+
+    def test_returns_false_on_nonzero_exit(self):
+        from plugins.dgx.cli import _ssh_run
+        mock_result = MagicMock()
+        mock_result.returncode = 255
+        mock_result.stdout = ""
+        mock_result.stderr = "Connection refused"
+        with patch("subprocess.run", return_value=mock_result):
+            ok, out = _ssh_run("dgx", "10.0.0.1", "nvidia-smi")
+        assert ok is False
+
+    def test_returns_false_on_timeout(self):
+        from plugins.dgx.cli import _ssh_run
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("ssh", 10)):
+            ok, out = _ssh_run("dgx", "10.0.0.1", "nvidia-smi")
+        assert ok is False
+        assert "timed out" in out
+
+    def test_returns_false_when_ssh_not_found(self):
+        from plugins.dgx.cli import _ssh_run
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            ok, out = _ssh_run("dgx", "10.0.0.1", "nvidia-smi")
+        assert ok is False
+        assert "not found" in out
+
+
+# ---------------------------------------------------------------------------
+# _probe_ollama / _probe_vllm / _probe_litellm
+# ---------------------------------------------------------------------------
+
+class TestProbes:
+    def test_probe_ollama_returns_model_names_on_success(self):
+        from plugins.dgx.cli import _probe_ollama
+        payload = {"models": [{"name": "nemotron3:33b"}, {"name": "qwen2.5-coder:14b"}]}
+        with patch("plugins.dgx.cli._get_json", return_value=(payload, None)):
+            ok, models = _probe_ollama("10.0.0.1", 11434)
+        assert ok is True
+        assert "nemotron3:33b" in models
+        assert len(models) == 2
+
+    def test_probe_ollama_returns_false_on_failure(self):
+        from plugins.dgx.cli import _probe_ollama
+        with patch("plugins.dgx.cli._get_json", return_value=(None, "refused")):
+            ok, models = _probe_ollama("10.0.0.1", 11434)
+        assert ok is False
+        assert models == []
+
+    def test_probe_vllm_returns_model_ids_on_success(self):
+        from plugins.dgx.cli import _probe_vllm
+        payload = {"data": [{"id": "qwen2.5-coder-3b"}]}
+        with patch("plugins.dgx.cli._get_json", return_value=(payload, None)):
+            ok, models = _probe_vllm("10.0.0.1", 30800)
+        assert ok is True
+        assert "qwen2.5-coder-3b" in models
+
+    def test_probe_vllm_returns_false_on_failure(self):
+        from plugins.dgx.cli import _probe_vllm
+        with patch("plugins.dgx.cli._get_json", return_value=(None, "refused")):
+            ok, models = _probe_vllm("10.0.0.1", 30800)
+        assert ok is False
+
+    def test_probe_litellm_returns_true_when_healthy(self):
+        from plugins.dgx.cli import _probe_litellm
+        with patch("plugins.dgx.cli._check_endpoint", return_value=(True, "ok")):
+            assert _probe_litellm("10.0.0.2", 4000) is True
+
+    def test_probe_litellm_returns_false_when_down(self):
+        from plugins.dgx.cli import _probe_litellm
+        with patch("plugins.dgx.cli._check_endpoint", return_value=(False, "refused")):
+            assert _probe_litellm("10.0.0.2", 4000) is False
+
+
+# ---------------------------------------------------------------------------
+# Argparse wiring
+# ---------------------------------------------------------------------------
+
+class TestArgparseWiring:
+    def _parser(self):
+        from plugins.dgx.cli import register_cli
+        p = argparse.ArgumentParser(prog="hermes dgx")
+        register_cli(p)
+        return p
+
+    def test_no_subcommand_dispatches_to_dgx_command(self):
+        from plugins.dgx.cli import dgx_command
+        p = self._parser()
+        ns = p.parse_args([])
+        assert ns.func is dgx_command
+
+    def test_setup_subcommand_parses(self):
+        p = self._parser()
+        ns = p.parse_args(["setup"])
+        assert ns.dgx_command == "setup"
+
+    def test_status_subcommand_parses(self):
+        p = self._parser()
+        ns = p.parse_args(["status"])
+        assert ns.dgx_command == "status"
+
+    def test_use_subcommand_parses_model_arg(self):
+        p = self._parser()
+        ns = p.parse_args(["use", "nemotron3:33b"])
+        assert ns.dgx_command == "use"
+        assert ns.model == "nemotron3:33b"
+
+    def test_use_subcommand_parses_endpoint_flag(self):
+        p = self._parser()
+        ns = p.parse_args(["use", "qwen2.5-coder:14b", "--endpoint", "vllm"])
+        assert ns.endpoint == "vllm"
+
+    def test_endpoint_subcommand_parses_name(self):
+        p = self._parser()
+        for ep in ("ollama", "vllm", "litellm"):
+            ns = p.parse_args(["endpoint", ep])
+            assert ns.name == ep
+
+    def test_endpoint_rejects_unknown_name(self):
+        p = self._parser()
+        with pytest.raises(SystemExit):
+            p.parse_args(["endpoint", "bogus"])
+
+    # --- Tier 1: implemented ---
+
+    def test_pull_subcommand_parses_model_arg(self):
+        p = self._parser()
+        ns = p.parse_args(["pull", "nemotron3:70b"])
+        assert ns.dgx_command == "pull"
+        assert ns.model == "nemotron3:70b"
+
+    def test_rm_subcommand_parses_model_arg(self):
+        p = self._parser()
+        ns = p.parse_args(["rm", "old-model:latest"])
+        assert ns.dgx_command == "rm"
+
+    def test_rm_force_flag(self):
+        p = self._parser()
+        ns = p.parse_args(["rm", "old-model:latest", "--force"])
+        assert ns.force is True
+
+    def test_ps_subcommand_parses(self):
+        p = self._parser()
+        ns = p.parse_args(["ps"])
+        assert ns.dgx_command == "ps"
+
+    # --- Tier 2: implemented ---
+
+    def test_run_subcommand_removed(self):
+        # Regression: the `dgx run` arbitrary-command subcommand was removed.
+        # Free-form remote shell belongs to the host terminal tool (gated by
+        # the dangerous-command approval system), not a bespoke unguarded
+        # SSH-exec path. argparse must now reject `run` as an unknown command.
+        p = self._parser()
+        with pytest.raises(SystemExit):
+            p.parse_args(["run", "nvidia-smi"])
+
+    def test_push_subcommand_parses_local_path(self):
+        p = self._parser()
+        ns = p.parse_args(["push", "./myproject"])
+        assert ns.dgx_command == "push"
+        assert ns.local == "./myproject"
+        assert ns.remote is None
+
+    def test_push_subcommand_parses_remote_path(self):
+        p = self._parser()
+        ns = p.parse_args(["push", "./myproject", "~/code/"])
+        assert ns.remote == "~/code/"
+
+    def test_doctor_subcommand_parses(self):
+        p = self._parser()
+        ns = p.parse_args(["doctor"])
+        assert ns.dgx_command == "doctor"
+
+    def test_watch_subcommand_parses(self):
+        p = self._parser()
+        ns = p.parse_args(["watch"])
+        assert ns.dgx_command == "watch"
+
+    def test_watch_interval_flag(self):
+        p = self._parser()
+        ns = p.parse_args(["watch", "--interval", "5"])
+        assert ns.interval == 5
+
+
+# ---------------------------------------------------------------------------
+# dgx_command dispatch
+# ---------------------------------------------------------------------------
+
+class TestDgxCommandDispatch:
+    def test_no_subcommand_prints_usage_and_returns_2(self, capsys):
+        from plugins.dgx.cli import dgx_command
+        ret = dgx_command(SimpleNamespace(dgx_command=None))
+        assert ret == 2
+        assert "usage" in capsys.readouterr().out.lower()
+
+    def test_unknown_subcommand_returns_2(self, capsys):
+        from plugins.dgx.cli import dgx_command
+        ret = dgx_command(SimpleNamespace(dgx_command="bogus"))
+        assert ret == 2
+
+
+# ---------------------------------------------------------------------------
+# Unconfigured-DGX dispatch (C5)
+# ---------------------------------------------------------------------------
+
+class TestUnconfiguredDispatch:
+    """Regression (C5): on an unconfigured install (host=None), commands that
+    call the URL helpers must surface the "run hermes dgx setup" guidance and
+    exit 1 — NOT raise an uncaught DGXNotConfigured traceback. dgx_command
+    catches it at one shared point.
+    """
+
+    @pytest.fixture
+    def unconfigured(self, monkeypatch):
+        from plugins.dgx._dgx_config import DEFAULTS
+        d = dict(DEFAULTS)  # host is None — the unconfigured default
+        monkeypatch.setattr("plugins.dgx.cli.load_dgx_config", lambda: dict(d))
+        # Never spawn real ssh / http; the point under test is the raise path.
+        monkeypatch.setattr("plugins.dgx.cli._ssh_run", lambda *a, **k: (False, "no host"))
+        monkeypatch.setattr("plugins.dgx.cli._get_json", lambda *a, **k: (None, "no host"))
+
+    def test_status_unconfigured_returns_1_with_setup_hint(self, unconfigured, capsys):
+        from plugins.dgx.cli import dgx_command
+        ret = dgx_command(SimpleNamespace(dgx_command="status"))
+        out = capsys.readouterr().out
+        assert ret == 1
+        assert "hermes dgx setup" in out
+
+    def test_doctor_unconfigured_returns_1_with_setup_hint(self, unconfigured, capsys):
+        from plugins.dgx.cli import dgx_command
+        ret = dgx_command(SimpleNamespace(dgx_command="doctor"))
+        out = capsys.readouterr().out
+        assert ret == 1
+        assert "hermes dgx setup" in out
+
+
+# ---------------------------------------------------------------------------
+# _cmd_status: GPU [N/A] handling
+# ---------------------------------------------------------------------------
+
+class TestStatusNvidiaNA:
+    """Regression: DGX Spark (aarch64/GB10) returns [N/A] for some smi fields."""
+
+    def test_status_handles_na_memory_fields_without_crash(self, mock_config, capsys, monkeypatch):
+        from plugins.dgx.cli import _cmd_status
+
+        na_line = "[N/A], NVIDIA GH200 120GB, [N/A], 98304, [N/A]"
+        monkeypatch.setattr("plugins.dgx.cli._ssh_run", lambda *a, **k: (True, na_line))
+        monkeypatch.setattr("plugins.dgx.cli._get_json", lambda url, **k: ({"models": [], "data": []}, None))
+        monkeypatch.setattr("plugins.dgx.cli._check_endpoint", lambda *a, **k: (False, "unreachable"))
+
+        ret = _cmd_status()
+        out = capsys.readouterr().out
+        assert "GH200" in out
+        assert ret == 0
+
+    def test_status_renders_bar_for_numeric_fields(self, mock_config, capsys, monkeypatch):
+        from plugins.dgx.cli import _cmd_status
+
+        line = "0, NVIDIA A100, 20480, 40960, 50"
+        monkeypatch.setattr("plugins.dgx.cli._ssh_run", lambda *a, **k: (True, line))
+        monkeypatch.setattr("plugins.dgx.cli._get_json", lambda url, **k: ({"models": [], "data": []}, None))
+        monkeypatch.setattr("plugins.dgx.cli._check_endpoint", lambda *a, **k: (False, "unreachable"))
+
+        _cmd_status()
+        out = capsys.readouterr().out
+        assert "█" in out
+        assert "20480/40960" in out
+
+
+# ---------------------------------------------------------------------------
+# _cmd_endpoint
+# ---------------------------------------------------------------------------
+
+class TestCmdEndpoint:
+    # _cmd_endpoint calls the `apply_endpoint` name imported INTO
+    # plugins.dgx.cli, so the mock must patch the cli namespace. Patching
+    # plugins.dgx._dgx_config.apply_endpoint is a no-op (it doesn't rebind the
+    # already-imported name) — the prior tests did that and silently ran the
+    # real apply_endpoint. Assert the call to lock the isolation in.
+    def test_switches_to_ollama(self, mock_config, capsys, monkeypatch):
+        from plugins.dgx.cli import _cmd_endpoint
+        import plugins.dgx.cli as cli_mod
+        calls = []
+        monkeypatch.setattr(cli_mod, "apply_endpoint",
+                            lambda dgx, ep=None, **k: calls.append(ep))
+        ret = _cmd_endpoint("ollama")
+        assert ret == 0
+        assert calls == ["ollama"]
+        assert "ollama" in capsys.readouterr().out.lower()
+
+    def test_switches_to_vllm(self, mock_config, capsys, monkeypatch):
+        from plugins.dgx.cli import _cmd_endpoint
+        import plugins.dgx.cli as cli_mod
+        calls = []
+        monkeypatch.setattr(cli_mod, "apply_endpoint",
+                            lambda dgx, ep=None, **k: calls.append(ep))
+        ret = _cmd_endpoint("vllm")
+        assert ret == 0
+        assert calls == ["vllm"]
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 feature tests (red — implement these next)
+# ---------------------------------------------------------------------------
+
+class TestTier1Pull:
+    def test_pull_runs_ollama_pull_via_ssh(self, mock_config, monkeypatch):
+        from plugins.dgx.cli import _cmd_pull
+        calls = []
+        monkeypatch.setattr("plugins.dgx.cli._ssh_stream", lambda u, h, cmd, **k: calls.append(cmd) or 0)
+        _cmd_pull("nemotron3:70b")
+        assert any("ollama pull nemotron3:70b" in c for c in calls)
+
+    def test_pull_returns_nonzero_on_ssh_failure(self, mock_config, monkeypatch):
+        from plugins.dgx.cli import _cmd_pull
+        monkeypatch.setattr("plugins.dgx.cli._ssh_stream", lambda *a, **k: 1)
+        ret = _cmd_pull("some-model:latest")
+        assert ret != 0
+
+    def test_pull_prints_host_before_streaming(self, mock_config, monkeypatch, capsys):
+        from plugins.dgx.cli import _cmd_pull
+        monkeypatch.setattr("plugins.dgx.cli._ssh_stream", lambda *a, **k: 0)
+        _cmd_pull("gemma4:26b")
+        out = capsys.readouterr().out
+        assert "gemma4:26b" in out
+
+
+class TestTier1Rm:
+    def test_rm_runs_ollama_rm_via_ssh(self, mock_config, monkeypatch, capsys):
+        from plugins.dgx.cli import _cmd_rm
+        calls = []
+        monkeypatch.setattr("plugins.dgx.cli._ssh_run", lambda u, h, cmd, **k: calls.append(cmd) or (True, ""))
+        monkeypatch.setattr("builtins.input", lambda _: "y")
+        _cmd_rm("old-model:latest")
+        assert any("ollama rm old-model:latest" in c for c in calls)
+
+    def test_rm_aborts_on_no_confirmation(self, mock_config, monkeypatch, capsys):
+        from plugins.dgx.cli import _cmd_rm
+        calls = []
+        monkeypatch.setattr("plugins.dgx.cli._ssh_run", lambda *a, **k: calls.append(True) or (True, ""))
+        monkeypatch.setattr("builtins.input", lambda _: "n")
+        _cmd_rm("old-model:latest")
+        assert len(calls) == 0
+
+    def test_rm_force_skips_prompt(self, mock_config, monkeypatch):
+        from plugins.dgx.cli import _cmd_rm
+        calls = []
+        monkeypatch.setattr("plugins.dgx.cli._ssh_run", lambda u, h, cmd, **k: calls.append(cmd) or (True, ""))
+        _cmd_rm("old-model:latest", force=True)
+        assert any("ollama rm" in c for c in calls)
+
+    def test_rm_returns_nonzero_on_ssh_failure(self, mock_config, monkeypatch):
+        from plugins.dgx.cli import _cmd_rm
+        monkeypatch.setattr("plugins.dgx.cli._ssh_run", lambda *a, **k: (False, "error"))
+        monkeypatch.setattr("builtins.input", lambda _: "y")
+        assert _cmd_rm("bad-model:latest") != 0
+
+
+class TestTier1Ps:
+    def test_ps_shows_loaded_models(self, mock_config, monkeypatch, capsys):
+        from plugins.dgx.cli import _cmd_ps
+        ollama_ps_output = "NAME\t\tID\t\tSIZE\tPROCESSOR\nnemotron3:33b\tabc123\t20 GB\tgpu"
+        monkeypatch.setattr("plugins.dgx.cli._ssh_run", lambda *a, **k: (True, ollama_ps_output))
+        ret = _cmd_ps()
+        out = capsys.readouterr().out
+        assert "nemotron3:33b" in out
+        assert ret == 0
+
+    def test_ps_graceful_when_nothing_loaded(self, mock_config, monkeypatch, capsys):
+        from plugins.dgx.cli import _cmd_ps
+        monkeypatch.setattr("plugins.dgx.cli._ssh_run", lambda *a, **k: (True, "NAME\tID\tSIZE\tPROCESSOR"))
+        ret = _cmd_ps()
+        assert ret == 0
+
+    def test_ps_returns_1_when_ssh_fails(self, mock_config, monkeypatch, capsys):
+        from plugins.dgx.cli import _cmd_ps
+        monkeypatch.setattr("plugins.dgx.cli._ssh_run", lambda *a, **k: (False, "refused"))
+        assert _cmd_ps() == 1
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 feature tests (red)
+# ---------------------------------------------------------------------------
+
+class TestTier2Push:
+    def test_push_calls_rsync(self, mock_config, monkeypatch, tmp_path):
+        from plugins.dgx.cli import _cmd_push
+        calls = []
+        monkeypatch.setattr("subprocess.run",
+                            lambda cmd, **k: calls.append(cmd) or MagicMock(returncode=0))
+        (tmp_path / "file.py").write_text("x = 1")
+        ret = _cmd_push(str(tmp_path / "file.py"), None)
+        assert any("rsync" in str(c) for c in calls)
+        assert ret == 0
+
+    def test_push_uses_default_remote_path(self, mock_config, monkeypatch, tmp_path):
+        from plugins.dgx.cli import _cmd_push
+        calls = []
+        monkeypatch.setattr("subprocess.run",
+                            lambda cmd, **k: calls.append(cmd) or MagicMock(returncode=0))
+        _cmd_push("/some/local/path", None)
+        assert any("~/workspace/" in str(c) for c in calls)
+
+    def test_push_uses_specified_remote_path(self, mock_config, monkeypatch):
+        from plugins.dgx.cli import _cmd_push
+        calls = []
+        monkeypatch.setattr("subprocess.run",
+                            lambda cmd, **k: calls.append(cmd) or MagicMock(returncode=0))
+        _cmd_push("/local/path", "~/code/myproject/")
+        assert any("~/code/myproject/" in str(c) for c in calls)
+
+    def test_push_returns_1_when_rsync_not_found(self, mock_config, monkeypatch, capsys):
+        from plugins.dgx.cli import _cmd_push
+        monkeypatch.setattr("subprocess.run", MagicMock(side_effect=FileNotFoundError))
+        ret = _cmd_push("/some/path", None)
+        assert ret == 1
+        assert "rsync not found" in capsys.readouterr().out
+
+
+class TestTier2Doctor:
+    def _all_ok(self):
+        """Mock SSH returning ok for all calls."""
+        def _ssh(u, h, cmd, **k):
+            if cmd == "echo ok":
+                return (True, "ok")
+            # nvidia-smi call
+            return (True, "0, NVIDIA GH200, 20480, 98304, 25")
+        return _ssh
+
+    def test_doctor_reports_all_checks(self, mock_config, monkeypatch, capsys):
+        from plugins.dgx.cli import _cmd_doctor
+        monkeypatch.setattr("plugins.dgx.cli._ssh_run", self._all_ok())
+        monkeypatch.setattr("plugins.dgx.cli._get_json",
+                            lambda url, **k: ({"models": [], "data": []}, None))
+        monkeypatch.setattr("plugins.dgx.cli._check_endpoint", lambda *a, **k: (True, "ok"))
+        ret = _cmd_doctor()
+        out = capsys.readouterr().out
+        for check in ("ssh", "ollama", "vllm", "gpu"):
+            assert check.lower() in out.lower(), f"missing check: {check}"
+        assert ret == 0
+
+    def test_doctor_returns_nonzero_when_ssh_unreachable(self, mock_config, monkeypatch, capsys):
+        from plugins.dgx.cli import _cmd_doctor
+        monkeypatch.setattr("plugins.dgx.cli._ssh_run", lambda *a, **k: (False, "refused"))
+        monkeypatch.setattr("plugins.dgx.cli._get_json", lambda *a, **k: (None, "refused"))
+        monkeypatch.setattr("plugins.dgx.cli._check_endpoint", lambda *a, **k: (False, "refused"))
+        ret = _cmd_doctor()
+        assert ret != 0
+
+    def test_doctor_returns_nonzero_when_all_inference_down(self, mock_config, monkeypatch, capsys):
+        from plugins.dgx.cli import _cmd_doctor
+        monkeypatch.setattr("plugins.dgx.cli._ssh_run", self._all_ok())
+        monkeypatch.setattr("plugins.dgx.cli._get_json", lambda *a, **k: (None, "refused"))
+        monkeypatch.setattr("plugins.dgx.cli._check_endpoint", lambda *a, **k: (False, "ok"))
+        ret = _cmd_doctor()
+        assert ret != 0
+
+    def test_doctor_passes_when_litellm_down_but_ollama_ok(self, mock_config, monkeypatch, capsys):
+        from plugins.dgx.cli import _cmd_doctor
+        monkeypatch.setattr("plugins.dgx.cli._ssh_run", self._all_ok())
+        def _get(url, **k):
+            if "api/tags" in url:
+                return ({"models": []}, None)
+            if "v1/models" in url:
+                return (None, "refused")   # vLLM down
+            return (None, "refused")
+        monkeypatch.setattr("plugins.dgx.cli._get_json", _get)
+        monkeypatch.setattr("plugins.dgx.cli._check_endpoint", lambda *a, **k: (False, "key required"))
+        ret = _cmd_doctor()
+        # Ollama up → inference_ok → passes
+        assert ret == 0
+
+
+class TestTier2Watch:
+    def test_watch_exits_cleanly_on_keyboard_interrupt(self, mock_config, monkeypatch):
+        import time
+        from plugins.dgx.cli import _cmd_watch
+
+        call_count = [0]
+
+        def _fake_ssh_run(*a, **k):
+            call_count[0] += 1
+            if call_count[0] >= 2:
+                raise KeyboardInterrupt
+            return (True, "0, A100, 20480, 40960, 50")
+
+        monkeypatch.setattr("plugins.dgx.cli._ssh_run", _fake_ssh_run)
+        monkeypatch.setattr("time.sleep", lambda s: None)
+        ret = _cmd_watch(interval=0)
+        assert ret == 0
+
+    def test_watch_handles_ssh_failure_gracefully(self, mock_config, monkeypatch, capsys):
+        import time
+        from plugins.dgx.cli import _cmd_watch
+
+        call_count = [0]
+
+        def _fail_then_interrupt(*a, **k):
+            call_count[0] += 1
+            if call_count[0] >= 2:
+                raise KeyboardInterrupt
+            return (False, "connection refused")
+
+        monkeypatch.setattr("plugins.dgx.cli._ssh_run", _fail_then_interrupt)
+        monkeypatch.setattr("time.sleep", lambda s: None)
+        ret = _cmd_watch(interval=0)
+        assert ret == 0
+
+
+# ---------------------------------------------------------------------------
+# Tier 3 feature tests (red)
+# ---------------------------------------------------------------------------
+
+class TestTier3AgentTools:
+    def _registered_tools(self):
+        from plugins.dgx import register
+        tools = []
+
+        class FakeCtx:
+            def register_cli_command(self, **k): pass
+            def register_tool(self, name, **k): tools.append(name)
+
+        register(FakeCtx())
+        return tools
+
+    def _registered_tool_kwargs(self):
+        from plugins.dgx import register
+        captured = {}
+
+        class FakeCtx:
+            def register_cli_command(self, **k): pass
+            def register_tool(self, name, **k): captured[name] = k
+
+        register(FakeCtx())
+        return captured
+
+    def test_dgx_gpu_status_tool_registered(self):
+        assert "dgx_gpu_status" in self._registered_tools()
+
+    def test_dgx_run_tool_not_registered(self):
+        # Regression: dgx_run was an unguarded arbitrary-RCE agent tool — a
+        # model could run any shell command on the DGX over SSH, bypassing the
+        # host's dangerous-command approval gate. It must NOT be registered.
+        assert "dgx_run" not in self._registered_tools()
+
+    def test_dgx_pull_model_tool_registered(self):
+        assert "dgx_pull_model" in self._registered_tools()
+
+    def test_handle_dgx_run_removed(self):
+        # The handler is gone too — importing it must fail.
+        import plugins.dgx.tools as dgx_tools
+        assert not hasattr(dgx_tools, "handle_dgx_run")
+        assert not hasattr(dgx_tools, "DGX_RUN_SCHEMA")
+
+    def test_agent_tools_gated_by_check_fn(self):
+        # C3: each agent tool must carry a check_fn so an enabled-but-
+        # unconfigured plugin doesn't expose it (with host=None) to the model.
+        kw = self._registered_tool_kwargs()
+        for name in ("dgx_gpu_status", "dgx_pull_model"):
+            assert kw[name].get("check_fn") is not None, f"{name} has no check_fn"
+
+    def test_check_fn_false_when_unconfigured(self, monkeypatch):
+        from plugins.dgx import _dgx_configured
+        from plugins.dgx._dgx_config import DEFAULTS
+        monkeypatch.setattr("plugins.dgx._dgx_config.load_dgx_config",
+                            lambda: dict(DEFAULTS))  # host=None
+        assert _dgx_configured() is False
+
+    def test_check_fn_true_when_configured(self, monkeypatch):
+        from plugins.dgx import _dgx_configured
+        from plugins.dgx._dgx_config import DEFAULTS
+        d = dict(DEFAULTS); d["host"] = "10.0.0.1"
+        monkeypatch.setattr("plugins.dgx._dgx_config.load_dgx_config", lambda: dict(d))
+        assert _dgx_configured() is True
+
+    def test_handle_dgx_gpu_status_unconfigured_returns_hint(self, monkeypatch):
+        from plugins.dgx.tools import handle_dgx_gpu_status
+        from plugins.dgx._dgx_config import DEFAULTS
+        monkeypatch.setattr("plugins.dgx._dgx_config.load_dgx_config",
+                            lambda: dict(DEFAULTS))  # host=None
+        out = handle_dgx_gpu_status()
+        assert "hermes dgx setup" in out
+
+    def test_handle_dgx_pull_model_unconfigured_returns_hint(self, monkeypatch):
+        from plugins.dgx.tools import handle_dgx_pull_model
+        from plugins.dgx._dgx_config import DEFAULTS
+        monkeypatch.setattr("plugins.dgx._dgx_config.load_dgx_config",
+                            lambda: dict(DEFAULTS))  # host=None
+        out = handle_dgx_pull_model(model="foo:latest")
+        assert "hermes dgx setup" in out
+
+    def test_handle_dgx_pull_model_success(self, mock_config, monkeypatch):
+        from plugins.dgx.tools import handle_dgx_pull_model
+        monkeypatch.setattr("plugins.dgx.cli._ssh_run",
+                            lambda *a, **k: (True, ""))
+        out = handle_dgx_pull_model(model="nemotron3:33b")
+        assert "successfully" in out.lower()
+
+    def test_handle_dgx_pull_model_failure(self, mock_config, monkeypatch):
+        from plugins.dgx.tools import handle_dgx_pull_model
+        monkeypatch.setattr("plugins.dgx.cli._ssh_run",
+                            lambda *a, **k: (False, "no space left"))
+        out = handle_dgx_pull_model(model="huge-model:latest")
+        assert "failed" in out.lower()
+
+    def test_handle_dgx_gpu_status_includes_gpu_line(self, mock_config, monkeypatch):
+        from plugins.dgx.tools import handle_dgx_gpu_status
+        monkeypatch.setattr("plugins.dgx.cli._ssh_run",
+                            lambda u, h, cmd, **k: (True, "0, A100, 20480, 40960, 50")
+                            if "nvidia-smi" in cmd else (True, "model:latest"))
+        out = handle_dgx_gpu_status()
+        # Assert the actual GPU data line is present, not just the constant
+        # "GPU" label (which the failure branch also emits) — see the test-
+        # quality finding: `assert "GPU" in out` passed even when SSH failed.
+        assert "A100" in out
+        assert "40960" in out

--- a/tests/plugins/test_dgx_config.py
+++ b/tests/plugins/test_dgx_config.py
@@ -1,0 +1,253 @@
+"""Tests for plugins/dgx/_dgx_config.py
+
+Covers config load/save, endpoint application, and URL helpers.
+All tests use an isolated HERMES_HOME (from conftest) so they never
+touch the developer's real ~/.hermes/config.yaml.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_config(monkeypatch, initial: dict):
+    """Patch load_config / save_config with a simple in-memory store."""
+    store = dict(initial)
+
+    def _load():
+        return dict(store)
+
+    def _save(cfg):
+        store.clear()
+        store.update(cfg)
+
+    import plugins.dgx._dgx_config as dc
+    monkeypatch.setattr("hermes_cli.config.load_config", _load)
+    monkeypatch.setattr("hermes_cli.config.save_config", _save)
+    monkeypatch.setattr(dc, "load_config", _load, raising=False)
+    monkeypatch.setattr(dc, "save_config", _save, raising=False)
+    return store
+
+
+# ---------------------------------------------------------------------------
+# load_dgx_config
+# ---------------------------------------------------------------------------
+
+class TestLoadDgxConfig:
+    def test_returns_defaults_when_no_dgx_section(self, monkeypatch):
+        from plugins.dgx._dgx_config import load_dgx_config
+        _make_config(monkeypatch, {})
+        cfg = load_dgx_config()
+        # host defaults to None until configured via `hermes dgx setup`
+        assert cfg["host"] is None
+        assert cfg["ollama_port"] == 11434
+        assert cfg["vllm_port"] == 30800
+        assert cfg["active_endpoint"] == "ollama"
+
+    def test_merges_user_values_over_defaults(self, monkeypatch):
+        from plugins.dgx._dgx_config import load_dgx_config
+        _make_config(monkeypatch, {"dgx": {"host": "10.0.0.5", "ssh_user": "admin"}})
+        cfg = load_dgx_config()
+        assert cfg["host"] == "10.0.0.5"
+        assert cfg["ssh_user"] == "admin"
+        assert cfg["ollama_port"] == 11434  # default preserved
+
+    def test_partial_override_preserves_remaining_defaults(self, monkeypatch):
+        from plugins.dgx._dgx_config import load_dgx_config
+        _make_config(monkeypatch, {"dgx": {"vllm_port": 9000}})
+        cfg = load_dgx_config()
+        assert cfg["vllm_port"] == 9000
+        assert cfg["ollama_port"] == 11434  # untouched
+
+
+# ---------------------------------------------------------------------------
+# save_dgx_config
+# ---------------------------------------------------------------------------
+
+class TestSaveDgxConfig:
+    def test_writes_dgx_key(self, monkeypatch):
+        from plugins.dgx._dgx_config import save_dgx_config
+        store = _make_config(monkeypatch, {})
+        save_dgx_config({"host": "10.0.0.1", "active_endpoint": "vllm"})
+        assert store.get("dgx", {}).get("host") == "10.0.0.1"
+        assert store.get("dgx", {}).get("active_endpoint") == "vllm"
+
+    def test_preserves_existing_non_dgx_keys(self, monkeypatch):
+        from plugins.dgx._dgx_config import save_dgx_config
+        store = _make_config(monkeypatch, {"model": {"default": "some-model"}})
+        save_dgx_config({"host": "10.0.0.1"})
+        assert store.get("model", {}).get("default") == "some-model"
+
+
+# ---------------------------------------------------------------------------
+# apply_endpoint
+# ---------------------------------------------------------------------------
+
+class TestApplyEndpoint:
+    # A representative configured DGX (host set) — defaults alone leave host=None,
+    # which is the "unconfigured" state.
+    _CONFIGURED = {
+        "host": "10.0.0.1",
+        "ssh_user": "dgx",
+        "ollama_port": 11434,
+        "vllm_port": 30800,
+        "vllm_32b_port": 30881,
+        "litellm_host": "10.0.0.2",
+        "litellm_port": 4000,
+    }
+
+    def _run(self, monkeypatch, endpoint: str, dgx: dict | None = None):
+        from plugins.dgx._dgx_config import DEFAULTS, apply_endpoint
+        base_dgx = dict(DEFAULTS)
+        base_dgx.update(self._CONFIGURED)
+        if dgx:
+            base_dgx.update(dgx)
+        store = _make_config(monkeypatch, {})
+        apply_endpoint(base_dgx, endpoint)
+        return store
+
+    def test_ollama_sets_correct_provider_and_url(self, monkeypatch):
+        store = self._run(monkeypatch, "ollama")
+        model = store.get("model", {})
+        assert model["provider"] == "ollama"
+        assert "10.0.0.1" in model["base_url"]
+        assert "11434" in model["base_url"]
+
+    def test_vllm_sets_correct_provider_and_url(self, monkeypatch):
+        store = self._run(monkeypatch, "vllm")
+        model = store.get("model", {})
+        assert model["provider"] == "custom"
+        assert "30800" in model["base_url"]
+
+    def test_litellm_sets_correct_provider_and_url(self, monkeypatch):
+        store = self._run(monkeypatch, "litellm")
+        model = store.get("model", {})
+        assert model["provider"] == "custom"
+        assert "10.0.0.2" in model["base_url"]
+        assert "4000" in model["base_url"]
+
+    def test_litellm_without_host_raises(self, monkeypatch):
+        from plugins.dgx._dgx_config import DEFAULTS, apply_endpoint
+        monkeypatch.delenv("HERMES_DGX_LITELLM_HOST", raising=False)
+        _make_config(monkeypatch, {})
+        # configured DGX but no litellm_host
+        d = dict(DEFAULTS)
+        d.update({"host": "10.0.0.1", "litellm_host": None})
+        with pytest.raises(ValueError, match="litellm endpoint requires"):
+            apply_endpoint(d, "litellm")
+
+    def test_updates_active_endpoint_in_dgx_block(self, monkeypatch):
+        store = self._run(monkeypatch, "vllm")
+        assert store.get("dgx", {}).get("active_endpoint") == "vllm"
+
+    def test_unknown_endpoint_raises(self, monkeypatch):
+        from plugins.dgx._dgx_config import DEFAULTS, apply_endpoint
+        _make_config(monkeypatch, {})
+        d = dict(DEFAULTS)
+        d.update(self._CONFIGURED)
+        with pytest.raises(ValueError, match="Unknown endpoint"):
+            apply_endpoint(d, "bogus")
+
+    def test_custom_host_reflected_in_url(self, monkeypatch):
+        store = self._run(monkeypatch, "ollama", dgx={"host": "10.0.0.99"})
+        assert "10.0.0.99" in store["model"]["base_url"]
+
+
+# ---------------------------------------------------------------------------
+# URL helpers
+# ---------------------------------------------------------------------------
+
+class TestUrlHelpers:
+    def _dgx(self, **overrides):
+        from plugins.dgx._dgx_config import DEFAULTS
+        d = dict(DEFAULTS)
+        d.update({
+            "host": "10.0.0.1",
+            "ssh_user": "dgx",
+            "ollama_port": 11434,
+            "vllm_port": 30800,
+            "litellm_host": "10.0.0.2",
+            "litellm_port": 4000,
+        })
+        d.update(overrides)
+        return d
+
+    def test_ollama_base_default(self):
+        from plugins.dgx._dgx_config import ollama_base
+        assert ollama_base(self._dgx()) == "http://10.0.0.1:11434"
+
+    def test_vllm_base_default(self):
+        from plugins.dgx._dgx_config import vllm_base
+        assert vllm_base(self._dgx()) == "http://10.0.0.1:30800"
+
+    def test_litellm_base_default(self):
+        from plugins.dgx._dgx_config import litellm_base
+        assert litellm_base(self._dgx()) == "http://10.0.0.2:4000"
+
+    def test_litellm_base_returns_none_when_unset(self, monkeypatch):
+        from plugins.dgx._dgx_config import litellm_base
+        monkeypatch.delenv("HERMES_DGX_LITELLM_HOST", raising=False)
+        d = self._dgx(litellm_host=None)
+        assert litellm_base(d) is None
+
+    def test_ollama_base_raises_when_host_missing(self):
+        from plugins.dgx._dgx_config import DEFAULTS, DGXNotConfigured, ollama_base
+        d = dict(DEFAULTS)
+        d["host"] = None
+        d.pop("_active_node", None)
+        with pytest.raises(DGXNotConfigured):
+            ollama_base(d)
+
+    def test_custom_host_and_port(self):
+        from plugins.dgx._dgx_config import ollama_base
+        assert ollama_base(self._dgx(host="10.0.0.5", ollama_port=9999)) == "http://10.0.0.5:9999"
+
+
+# ---------------------------------------------------------------------------
+# Config policy — no HERMES_* env vars for non-secret settings (AGENTS.md)
+# ---------------------------------------------------------------------------
+
+class TestNoHermesEnvVars:
+    """AGENTS.md ("What we don't want"): non-secret behavioral config — host,
+    ports, the LiteLLM host — must live in config.yaml via `hermes dgx setup`,
+    NOT in new ``HERMES_*`` env vars (``.env`` is for secrets only).
+    """
+
+    def _dgx_source_files(self):
+        from pathlib import Path
+        pkg = Path(__file__).parents[2] / "plugins" / "dgx"
+        return sorted(pkg.glob("*.py"))
+
+    def test_no_hermes_dgx_env_vars_in_source(self):
+        offenders = []
+        for py in self._dgx_source_files():
+            for i, line in enumerate(py.read_text().splitlines(), 1):
+                if "HERMES_DGX" in line:
+                    offenders.append(f"{py.name}:{i}: {line.strip()}")
+        assert not offenders, (
+            "HERMES_DGX_* env vars are banned for non-secret config "
+            "(AGENTS.md — use config.yaml via `hermes dgx setup`):\n"
+            + "\n".join(offenders)
+        )
+
+    def test_defaults_do_not_read_host_from_environment(self, monkeypatch):
+        # Even with a HERMES_DGX_HOST exported, a fresh import must leave the
+        # host unset — the value comes only from config.yaml.
+        import importlib
+        import plugins.dgx._dgx_config as dc
+        monkeypatch.setenv("HERMES_DGX_HOST", "10.9.9.9")
+        monkeypatch.setenv("HERMES_DGX_SSH_USER", "intruder")
+        monkeypatch.setenv("HERMES_DGX_OLLAMA_PORT", "59999")
+        try:
+            importlib.reload(dc)
+            assert dc.DEFAULTS["host"] is None
+            assert dc.NODE_DEFAULTS["host"] is None
+            assert dc.DEFAULTS["ssh_user"] != "intruder"
+            assert dc.DEFAULTS["ollama_port"] == 11434
+        finally:
+            monkeypatch.undo()
+            importlib.reload(dc)

--- a/tests/plugins/test_dgx_plugin.py
+++ b/tests/plugins/test_dgx_plugin.py
@@ -1,0 +1,104 @@
+"""Tests for plugins/dgx/__init__.py — plugin registration and YAML manifest."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+# ---------------------------------------------------------------------------
+# Plugin manifest
+# ---------------------------------------------------------------------------
+
+class TestPluginYaml:
+    def _manifest(self) -> dict:
+        path = Path(__file__).parents[2] / "plugins" / "dgx" / "plugin.yaml"
+        with open(path) as f:
+            return yaml.safe_load(f)
+
+    def test_manifest_is_valid_yaml(self):
+        assert self._manifest() is not None
+
+    def test_manifest_has_required_fields(self):
+        m = self._manifest()
+        for field in ("name", "version", "description"):
+            assert field in m, f"missing field: {field}"
+
+    def test_manifest_name_is_dgx(self):
+        assert self._manifest()["name"] == "dgx"
+
+
+# ---------------------------------------------------------------------------
+# register()
+# ---------------------------------------------------------------------------
+
+class TestRegister:
+    def _register(self):
+        from plugins.dgx import register
+        tools = []
+        commands = []
+
+        class FakeCtx:
+            def register_cli_command(self, **kw):
+                commands.append(kw)
+
+            def register_tool(self, name, **kw):
+                tools.append(name)
+
+        register(FakeCtx())
+        return tools, commands
+
+    def test_registers_dgx_cli_command(self):
+        _, commands = self._register()
+        names = [c["name"] for c in commands]
+        assert "dgx" in names
+
+    def test_dgx_command_has_help_text(self):
+        _, commands = self._register()
+        dgx_cmd = next(c for c in commands if c["name"] == "dgx")
+        assert dgx_cmd.get("help")
+
+    def test_handler_is_callable(self):
+        _, commands = self._register()
+        dgx_cmd = next(c for c in commands if c["name"] == "dgx")
+        assert callable(dgx_cmd["handler_fn"])
+
+    def test_setup_fn_accepts_argparse_subparser(self):
+        import argparse
+        _, commands = self._register()
+        dgx_cmd = next(c for c in commands if c["name"] == "dgx")
+        sub = argparse.ArgumentParser()
+        dgx_cmd["setup_fn"](sub)  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# dgx-ollama model provider removal (C2)
+# ---------------------------------------------------------------------------
+
+class TestDgxOllamaProviderRemoved:
+    """C2: the dedicated dgx-ollama provider was dead. It declared
+    auth_type="api_key" with env_vars=(), so auth.py's auto-extension skipped
+    it (it only adds api_key providers with NON-empty env_vars), and
+    resolve_provider() then raised "Unknown provider 'dgx-ollama'". It also
+    could not be fixed without either a core edit to auth.py (which the repo's
+    own auto-extension comment forbids for new providers) or a new *_BASE_URL
+    env var (which would recreate the HERMES_* config violation). The DGX is
+    reachable via the working custom path, so the dead provider is removed.
+    """
+
+    def test_provider_plugin_source_removed(self):
+        # Assert the source module is gone (robust against a stray __pycache__,
+        # which Python 3 won't import without the .py anyway).
+        provider_dir = Path(__file__).parents[2] / "plugins" / "model-providers" / "dgx-ollama"
+        assert not (provider_dir / "__init__.py").exists()
+        assert not (provider_dir / "plugin.yaml").exists()
+
+    def test_dgx_endpoint_resolves_to_a_runnable_provider(self):
+        # apply_endpoint(ollama) writes model.provider="ollama"; vllm/litellm
+        # write "custom". Both resolve to a runnable provider — no dedicated
+        # dgx-ollama profile is needed.
+        from hermes_cli.auth import resolve_provider
+        assert resolve_provider("ollama") == "custom"
+        assert resolve_provider("custom") == "custom"


### PR DESCRIPTION
## Summary

Following the review feedback about surface area, I've split the original `hermes dgx` plugin into a reviewable **stack**. **This PR is now just the core** — point Hermes at a DGX Spark / Ollama / vLLM host and switch models/endpoints. The larger surface (router, vLLM model lifecycle, multi-node, NIM) moves into focused follow-up PRs that stack on this one once it lands.

### What this PR ships (core)
- `hermes dgx setup` — interactive wizard (host, ports, default model/endpoint), written to `config.yaml` (no `HERMES_*` env vars, per AGENTS.md)
- `hermes dgx status` / `doctor` / `watch` — GPU + endpoint health
- `hermes dgx use` / `endpoint` — switch the active model / endpoint (ollama / vllm / vllm-32b / litellm)
- `hermes dgx pull` / `rm` / `ps` / `push` — Ollama model + workspace helpers
- Agent tools `dgx_gpu_status`, `dgx_pull_model`, gated on a configured host (`check_fn`). There is deliberately **no** arbitrary-remote-shell tool — free-form exec stays behind the host terminal tool's approval gate.

The security posture from the earlier review is already baked in here: the unguarded `dgx_run` RCE tool is gone, config lives in `config.yaml` (not env vars), tools are gated on a configured host, and an unconfigured install exits cleanly with a "run `hermes dgx setup`" hint instead of dumping a traceback.

### Follow-up stack (each a separate PR, after this lands)
1. **router** — `hermes dgx route` smart task router + `formation` presets
2. **models / vLLM** — `hermes dgx models add/rm` HF model lifecycle (bind-to-host, PID-tracked stop, launch verification)
3. **multi-node + NIM** — `hermes dgx node` and `hermes dgx nim` scaffolding

### Test plan
- `scripts/run_tests.sh tests/plugins/test_dgx_cli.py tests/plugins/test_dgx_config.py tests/plugins/test_dgx_plugin.py`
- 101 tests pass; `ruff check` clean.
