### PR TITLE
feat: add OpenRouter media generation backends

### DIFF
--- a/plugins/image_gen/openrouter/__init__.py
+++ b/plugins/image_gen/openrouter/__init__.py
@@ -1,0 +1,346 @@
+"""OpenRouter image generation backend.
+
+Uses OpenRouter's Chat Completions image-output surface:
+``POST /api/v1/chat/completions`` with ``modalities`` and optional
+``image_config``. Responses contain generated images as base64 data URLs in
+``choices[0].message.images[*].image_url.url``. The provider saves data URLs
+under ``$HERMES_HOME/cache/images/`` and returns the absolute file path.
+
+Selection precedence:
+1. ``model=`` passed by the tool wrapper (usually ``image_gen.model``)
+2. ``OPENROUTER_IMAGE_MODEL`` env var
+3. ``image_gen.openrouter.model`` in config.yaml
+4. ``image_gen.model`` in config.yaml
+5. ``DEFAULT_MODEL``
+
+Any configured model string is accepted so users can use newly-added
+OpenRouter image-output models without waiting for Hermes catalog updates.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import os
+from typing import Any, Dict, List, Optional, Tuple
+
+import httpx
+
+from agent.image_gen_provider import (
+    DEFAULT_ASPECT_RATIO,
+    ImageGenProvider,
+    error_response,
+    resolve_aspect_ratio,
+    save_b64_image,
+    success_response,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BASE_URL = "https://openrouter.ai/api/v1"
+DEFAULT_MODEL = "google/gemini-3-pro-image-preview"
+DEFAULT_IMAGE_SIZE = "1K"
+
+_MODELS: Dict[str, Dict[str, Any]] = {
+    "google/gemini-3-pro-image-preview": {
+        "display": "Gemini 3 Pro Image Preview",
+        "speed": "varies",
+        "strengths": "High prompt adherence, reasoning, text rendering",
+        "price": "see OpenRouter",
+        "modalities": ["image", "text"],
+    },
+    "google/gemini-3.1-flash-image-preview": {
+        "display": "Gemini 3.1 Flash Image Preview",
+        "speed": "fast",
+        "strengths": "Fast image generation; extended aspect ratios / 0.5K",
+        "price": "see OpenRouter",
+        "modalities": ["image", "text"],
+    },
+    "google/gemini-2.5-flash-image": {
+        "display": "Gemini 2.5 Flash Image",
+        "speed": "fast",
+        "strengths": "Fast text+image output",
+        "price": "see OpenRouter",
+        "modalities": ["image", "text"],
+    },
+    "black-forest-labs/flux.2-pro": {
+        "display": "FLUX.2 Pro",
+        "speed": "varies",
+        "strengths": "Photorealistic image-only generation",
+        "price": "see OpenRouter",
+        "modalities": ["image"],
+    },
+    "black-forest-labs/flux.2-flex": {
+        "display": "FLUX.2 Flex",
+        "speed": "varies",
+        "strengths": "Flexible image-only generation",
+        "price": "see OpenRouter",
+        "modalities": ["image"],
+    },
+    "sourceful/riverflow-v2-standard-preview": {
+        "display": "Sourceful Riverflow v2 Standard Preview",
+        "speed": "varies",
+        "strengths": "Design/image generation",
+        "price": "see OpenRouter",
+        "modalities": ["image"],
+    },
+}
+
+_ASPECT_RATIOS = {
+    "landscape": "16:9",
+    "square": "1:1",
+    "portrait": "9:16",
+}
+
+
+def _load_image_gen_section() -> Dict[str, Any]:
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        section = cfg.get("image_gen") if isinstance(cfg, dict) else None
+        return section if isinstance(section, dict) else {}
+    except Exception as exc:
+        logger.debug("Could not load image_gen config: %s", exc)
+        return {}
+
+
+def _resolve_model(explicit: Optional[str]) -> Tuple[str, Dict[str, Any]]:
+    candidates: List[Optional[str]] = [explicit, os.environ.get("OPENROUTER_IMAGE_MODEL")]
+    cfg = _load_image_gen_section()
+    or_cfg = cfg.get("openrouter") if isinstance(cfg.get("openrouter"), dict) else {}
+    if isinstance(or_cfg, dict):
+        candidates.append(or_cfg.get("model"))
+    top = cfg.get("model")
+    if isinstance(top, str):
+        candidates.append(top)
+
+    for candidate in candidates:
+        if isinstance(candidate, str) and candidate.strip():
+            model_id = candidate.strip()
+            return model_id, _MODELS.get(model_id, {
+                "display": model_id,
+                "speed": "unknown",
+                "strengths": "Custom OpenRouter image-output model",
+                "price": "see OpenRouter",
+                "modalities": ["image", "text"],
+            })
+    return DEFAULT_MODEL, _MODELS[DEFAULT_MODEL]
+
+
+def _resolve_api_key() -> str:
+    return os.environ.get("OPENROUTER_API_KEY", "").strip()
+
+
+def _resolve_base_url() -> str:
+    return os.environ.get("OPENROUTER_BASE_URL", DEFAULT_BASE_URL).strip().rstrip("/") or DEFAULT_BASE_URL
+
+
+def _modalities_for_model(meta: Dict[str, Any]) -> List[str]:
+    modalities = meta.get("modalities")
+    if isinstance(modalities, list) and "image" in modalities:
+        # Gemini-like models want text+image; image-only models can use image.
+        return [str(m) for m in modalities]
+    return ["image", "text"]
+
+
+def _extract_data_url_b64(data_url: str) -> Tuple[str, str]:
+    if not data_url.startswith("data:") or ";base64," not in data_url:
+        raise ValueError("not a base64 data URL")
+    header, b64 = data_url.split(",", 1)
+    mime = header[5:].split(";", 1)[0].lower()
+    ext = "png"
+    if mime.endswith("jpeg") or mime.endswith("jpg"):
+        ext = "jpg"
+    elif mime.endswith("webp"):
+        ext = "webp"
+    elif mime.endswith("gif"):
+        ext = "gif"
+    return b64, ext
+
+
+class OpenRouterImageGenProvider(ImageGenProvider):
+    @property
+    def name(self) -> str:
+        return "openrouter"
+
+    @property
+    def display_name(self) -> str:
+        return "OpenRouter"
+
+    def is_available(self) -> bool:
+        return bool(_resolve_api_key())
+
+    def list_models(self) -> List[Dict[str, Any]]:
+        return [{"id": mid, **meta} for mid, meta in _MODELS.items()]
+
+    def default_model(self) -> Optional[str]:
+        return DEFAULT_MODEL
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "OpenRouter",
+            "badge": "paid",
+            "tag": "OpenRouter image-output models via Chat Completions (Gemini, FLUX, Sourceful, etc.)",
+            "env_vars": [
+                {
+                    "key": "OPENROUTER_API_KEY",
+                    "prompt": "OpenRouter API key",
+                    "url": "https://openrouter.ai/settings/keys",
+                },
+            ],
+        }
+
+    def generate(
+        self,
+        prompt: str,
+        aspect_ratio: str = DEFAULT_ASPECT_RATIO,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        prompt = (prompt or "").strip()
+        aspect = resolve_aspect_ratio(aspect_ratio)
+        model_id, meta = _resolve_model(kwargs.get("model"))
+
+        if not prompt:
+            return error_response(
+                error="Prompt is required and must be a non-empty string",
+                error_type="invalid_argument",
+                provider="openrouter",
+                model=model_id,
+                aspect_ratio=aspect,
+            )
+
+        api_key = _resolve_api_key()
+        if not api_key:
+            return error_response(
+                error=(
+                    "OPENROUTER_API_KEY not set. Run `hermes tools` → Image "
+                    "Generation → OpenRouter to configure, or set OPENROUTER_API_KEY."
+                ),
+                error_type="auth_required",
+                provider="openrouter",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        cfg = _load_image_gen_section()
+        or_cfg = cfg.get("openrouter") if isinstance(cfg.get("openrouter"), dict) else {}
+        image_size = str(
+            kwargs.get("image_size")
+            or os.environ.get("OPENROUTER_IMAGE_SIZE")
+            or (or_cfg.get("image_size", "") if isinstance(or_cfg, dict) else "")
+            or DEFAULT_IMAGE_SIZE
+        ).strip()
+
+        payload: Dict[str, Any] = {
+            "model": model_id,
+            "messages": [{"role": "user", "content": prompt}],
+            "modalities": _modalities_for_model(meta),
+            "stream": False,
+            "image_config": {
+                "aspect_ratio": _ASPECT_RATIOS.get(aspect, "16:9"),
+                "image_size": image_size,
+            },
+        }
+
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "HTTP-Referer": "https://github.com/NousResearch/hermes-agent",
+            "X-Title": "Hermes Agent",
+        }
+
+        try:
+            with httpx.Client(timeout=180) as client:
+                response = client.post(
+                    f"{_resolve_base_url()}/chat/completions",
+                    headers=headers,
+                    json=payload,
+                )
+                response.raise_for_status()
+                body = response.json()
+        except httpx.HTTPStatusError as exc:
+            detail = exc.response.text[:500] if exc.response is not None else str(exc)
+            return error_response(
+                error=f"OpenRouter image generation failed ({exc.response.status_code}): {detail}",
+                error_type="api_error",
+                provider="openrouter",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+        except Exception as exc:
+            logger.debug("OpenRouter image generation failed", exc_info=True)
+            return error_response(
+                error=f"OpenRouter image generation failed: {exc}",
+                error_type="api_error",
+                provider="openrouter",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        choices = body.get("choices") if isinstance(body, dict) else None
+        message = (choices or [{}])[0].get("message", {}) if choices else {}
+        images = message.get("images") if isinstance(message, dict) else None
+        if not images:
+            return error_response(
+                error="OpenRouter response did not include message.images",
+                error_type="empty_response",
+                provider="openrouter",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        first = images[0] if isinstance(images, list) and images else {}
+        image_url = ((first.get("image_url") or {}).get("url") if isinstance(first, dict) else None) or ""
+        if not image_url:
+            return error_response(
+                error="OpenRouter image entry did not include image_url.url",
+                error_type="empty_response",
+                provider="openrouter",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        image_ref = image_url
+        if image_url.startswith("data:"):
+            try:
+                b64, ext = _extract_data_url_b64(image_url)
+                # Validate base64 early so save_b64_image raises only IO/decode issues.
+                base64.b64decode(b64)
+                image_ref = str(save_b64_image(b64, prefix="openrouter", extension=ext))
+            except Exception as exc:
+                return error_response(
+                    error=f"Could not save OpenRouter data URL image: {exc}",
+                    error_type="io_error",
+                    provider="openrouter",
+                    model=model_id,
+                    prompt=prompt,
+                    aspect_ratio=aspect,
+                )
+
+        extra: Dict[str, Any] = {
+            "image_config": payload["image_config"],
+            "modalities": payload["modalities"],
+        }
+        if message.get("content"):
+            extra["content"] = message["content"]
+        if body.get("usage"):
+            extra["usage"] = body["usage"]
+
+        return success_response(
+            image=image_ref,
+            model=model_id,
+            prompt=prompt,
+            aspect_ratio=aspect,
+            provider="openrouter",
+            extra=extra,
+        )
+
+
+def register(ctx) -> None:
+    ctx.register_image_gen_provider(OpenRouterImageGenProvider())

--- a/plugins/image_gen/openrouter/plugin.yaml
+++ b/plugins/image_gen/openrouter/plugin.yaml
@@ -1,0 +1,7 @@
+name: openrouter
+version: 1.0.0
+description: "OpenRouter image generation backend via Chat Completions modalities. Saves base64 data URLs to $HERMES_HOME/cache/images/."
+author: NousResearch
+kind: backend
+requires_env:
+  - OPENROUTER_API_KEY

--- a/plugins/video_gen/openrouter/__init__.py
+++ b/plugins/video_gen/openrouter/__init__.py
@@ -1,0 +1,368 @@
+"""OpenRouter video generation backend.
+
+Uses OpenRouter's dedicated asynchronous video API:
+
+1. ``POST /api/v1/videos`` with prompt/model/options.
+2. Poll ``polling_url`` (or ``GET /api/v1/videos/{id}``) until terminal.
+3. Return the first URL from ``unsigned_urls``. The gateway can download and
+   deliver that URL; callers may also fetch it directly.
+
+Selection precedence:
+1. ``model=`` passed by the tool wrapper (usually ``video_gen.model``)
+2. ``OPENROUTER_VIDEO_MODEL`` env var
+3. ``video_gen.openrouter.model`` in config.yaml
+4. ``video_gen.model`` in config.yaml
+5. ``DEFAULT_MODEL``
+
+Any configured model string is accepted so newly-added OpenRouter video models
+work before Hermes updates its local picker catalog.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+import httpx
+
+from agent.video_gen_provider import (
+    DEFAULT_ASPECT_RATIO,
+    DEFAULT_RESOLUTION,
+    VideoGenProvider,
+    error_response,
+    success_response,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BASE_URL = "https://openrouter.ai/api/v1"
+DEFAULT_MODEL = "google/veo-3.1"
+DEFAULT_TIMEOUT_SECONDS = 600
+DEFAULT_POLL_INTERVAL_SECONDS = 30
+
+_MODELS: Dict[str, Dict[str, Any]] = {
+    "google/veo-3.1": {
+        "display": "Google Veo 3.1",
+        "speed": "~1-5min",
+        "strengths": "High-quality video generation; supports image inputs on compatible routes",
+        "price": "see OpenRouter",
+        "modalities": ["text", "image"],
+    },
+    "alibaba/wan-2.7": {
+        "display": "Alibaba WAN 2.7",
+        "speed": "varies",
+        "strengths": "Text-to-video and image/reference guided video",
+        "price": "see OpenRouter",
+        "modalities": ["text", "image"],
+    },
+}
+
+_COMMON_ASPECT_RATIOS = {"16:9", "9:16", "1:1", "4:3", "3:4", "3:2", "2:3", "21:9", "9:21"}
+_COMMON_RESOLUTIONS = {"480p", "720p", "1080p", "1K", "2K", "4K"}
+
+
+def _load_video_gen_section() -> Dict[str, Any]:
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        section = cfg.get("video_gen") if isinstance(cfg, dict) else None
+        return section if isinstance(section, dict) else {}
+    except Exception as exc:
+        logger.debug("Could not load video_gen config: %s", exc)
+        return {}
+
+
+def _resolve_model(explicit: Optional[str]) -> Tuple[str, Dict[str, Any]]:
+    candidates: List[Optional[str]] = [explicit, os.environ.get("OPENROUTER_VIDEO_MODEL")]
+    cfg = _load_video_gen_section()
+    or_cfg = cfg.get("openrouter") if isinstance(cfg.get("openrouter"), dict) else {}
+    if isinstance(or_cfg, dict):
+        candidates.append(or_cfg.get("model"))
+    top = cfg.get("model")
+    if isinstance(top, str):
+        candidates.append(top)
+
+    for candidate in candidates:
+        if isinstance(candidate, str) and candidate.strip():
+            model_id = candidate.strip()
+            return model_id, _MODELS.get(model_id, {
+                "display": model_id,
+                "speed": "unknown",
+                "strengths": "Custom OpenRouter video-output model",
+                "price": "see OpenRouter",
+                "modalities": ["text", "image"],
+            })
+    return DEFAULT_MODEL, _MODELS[DEFAULT_MODEL]
+
+
+def _resolve_api_key() -> str:
+    return os.environ.get("OPENROUTER_API_KEY", "").strip()
+
+
+def _resolve_base_url() -> str:
+    return os.environ.get("OPENROUTER_BASE_URL", DEFAULT_BASE_URL).strip().rstrip("/") or DEFAULT_BASE_URL
+
+
+def _headers(api_key: str) -> Dict[str, str]:
+    return {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "HTTP-Referer": "https://github.com/NousResearch/hermes-agent",
+        "X-Title": "Hermes Agent",
+    }
+
+
+def _normalize_aspect_ratio(value: str) -> str:
+    value = (value or DEFAULT_ASPECT_RATIO).strip()
+    return value if value in _COMMON_ASPECT_RATIOS else DEFAULT_ASPECT_RATIO
+
+
+def _normalize_resolution(value: str) -> str:
+    value = (value or DEFAULT_RESOLUTION).strip()
+    return value if value in _COMMON_RESOLUTIONS else DEFAULT_RESOLUTION
+
+
+def _normalize_refs(reference_image_urls: Optional[List[str]]) -> List[Dict[str, Any]]:
+    refs: List[Dict[str, Any]] = []
+    for url in reference_image_urls or []:
+        normalized = (url or "").strip()
+        if normalized:
+            refs.append({"type": "image_url", "image_url": {"url": normalized}})
+    return refs
+
+
+def _frame_image(url: str) -> Dict[str, Any]:
+    return {
+        "type": "image_url",
+        "image_url": {"url": url},
+        "frame_type": "first_frame",
+    }
+
+
+class OpenRouterVideoGenProvider(VideoGenProvider):
+    @property
+    def name(self) -> str:
+        return "openrouter"
+
+    @property
+    def display_name(self) -> str:
+        return "OpenRouter"
+
+    def is_available(self) -> bool:
+        return bool(_resolve_api_key())
+
+    def list_models(self) -> List[Dict[str, Any]]:
+        return [{"id": mid, **meta} for mid, meta in _MODELS.items()]
+
+    def default_model(self) -> Optional[str]:
+        return DEFAULT_MODEL
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "OpenRouter",
+            "badge": "paid",
+            "tag": "OpenRouter /api/v1/videos — text-to-video, image-to-video, references",
+            "env_vars": [
+                {
+                    "key": "OPENROUTER_API_KEY",
+                    "prompt": "OpenRouter API key",
+                    "url": "https://openrouter.ai/settings/keys",
+                },
+            ],
+        }
+
+    def capabilities(self) -> Dict[str, Any]:
+        return {
+            "modalities": ["text", "image"],
+            "aspect_ratios": sorted(_COMMON_ASPECT_RATIOS),
+            "resolutions": sorted(_COMMON_RESOLUTIONS),
+            "max_duration": 30,
+            "min_duration": 1,
+            "supports_audio": True,
+            "supports_negative_prompt": False,
+            "max_reference_images": 8,
+        }
+
+    def generate(
+        self,
+        prompt: str,
+        *,
+        model: Optional[str] = None,
+        image_url: Optional[str] = None,
+        reference_image_urls: Optional[List[str]] = None,
+        duration: Optional[int] = None,
+        aspect_ratio: str = DEFAULT_ASPECT_RATIO,
+        resolution: str = DEFAULT_RESOLUTION,
+        negative_prompt: Optional[str] = None,
+        audio: Optional[bool] = None,
+        seed: Optional[int] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        prompt = (prompt or "").strip()
+        model_id, _meta = _resolve_model(model)
+        normalized_aspect = _normalize_aspect_ratio(aspect_ratio)
+        normalized_resolution = _normalize_resolution(resolution)
+        image_url_norm = (image_url or "").strip() or None
+        modality_used = "image" if image_url_norm else "text"
+
+        if not prompt:
+            return error_response(
+                error="prompt is required for OpenRouter video generation",
+                error_type="missing_prompt",
+                provider="openrouter",
+                model=model_id,
+                aspect_ratio=normalized_aspect,
+            )
+
+        api_key = _resolve_api_key()
+        if not api_key:
+            return error_response(
+                error=(
+                    "OPENROUTER_API_KEY not set. Run `hermes tools` → Video "
+                    "Generation → OpenRouter to configure, or set OPENROUTER_API_KEY."
+                ),
+                error_type="auth_required",
+                provider="openrouter",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=normalized_aspect,
+            )
+
+        payload: Dict[str, Any] = {
+            "model": model_id,
+            "prompt": prompt,
+            "resolution": normalized_resolution,
+            "aspect_ratio": normalized_aspect,
+        }
+        if duration is not None:
+            payload["duration"] = int(duration)
+        if seed is not None:
+            payload["seed"] = int(seed)
+        if audio is not None:
+            payload["generate_audio"] = bool(audio)
+        if image_url_norm:
+            payload["frame_images"] = [_frame_image(image_url_norm)]
+        refs = _normalize_refs(reference_image_urls)
+        if refs and not image_url_norm:
+            payload["input_references"] = refs
+
+        # OpenRouter exposes provider-specific passthrough via provider.options,
+        # but the provider slug varies by route. The unified Hermes surface keeps
+        # negative_prompt advisory-only for OpenRouter instead of guessing a slug.
+
+        timeout_seconds = int(os.environ.get("OPENROUTER_VIDEO_TIMEOUT", DEFAULT_TIMEOUT_SECONDS))
+        poll_interval = int(os.environ.get("OPENROUTER_VIDEO_POLL_INTERVAL", DEFAULT_POLL_INTERVAL_SECONDS))
+        base_url = _resolve_base_url()
+
+        try:
+            with httpx.Client(timeout=60) as client:
+                submit = client.post(
+                    f"{base_url}/videos",
+                    headers=_headers(api_key),
+                    json=payload,
+                )
+                submit.raise_for_status()
+                job = submit.json()
+
+                job_id = job.get("id")
+                polling_url = job.get("polling_url") or (f"{base_url}/videos/{job_id}" if job_id else None)
+                if not job_id or not polling_url:
+                    return error_response(
+                        error="OpenRouter video submit response did not include id/polling_url",
+                        error_type="empty_response",
+                        provider="openrouter",
+                        model=model_id,
+                        prompt=prompt,
+                        aspect_ratio=normalized_aspect,
+                    )
+
+                deadline = time.monotonic() + timeout_seconds
+                status_body: Dict[str, Any] = job
+                while time.monotonic() < deadline:
+                    status = str(status_body.get("status") or "").lower()
+                    if status in {"completed", "failed", "cancelled", "expired"}:
+                        break
+                    time.sleep(poll_interval)
+                    poll = client.get(polling_url, headers=_headers(api_key), timeout=60)
+                    poll.raise_for_status()
+                    status_body = poll.json()
+        except httpx.HTTPStatusError as exc:
+            detail = exc.response.text[:500] if exc.response is not None else str(exc)
+            return error_response(
+                error=f"OpenRouter video generation failed ({exc.response.status_code}): {detail}",
+                error_type="api_error",
+                provider="openrouter",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=normalized_aspect,
+            )
+        except Exception as exc:
+            logger.debug("OpenRouter video generation failed", exc_info=True)
+            return error_response(
+                error=f"OpenRouter video generation failed: {exc}",
+                error_type="api_error",
+                provider="openrouter",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=normalized_aspect,
+            )
+
+        status = str(status_body.get("status") or "").lower()
+        if status != "completed":
+            if time.monotonic() >= deadline and status not in {"failed", "cancelled", "expired"}:
+                return error_response(
+                    error=f"Timed out waiting for OpenRouter video after {timeout_seconds}s",
+                    error_type="timeout",
+                    provider="openrouter",
+                    model=model_id,
+                    prompt=prompt,
+                    aspect_ratio=normalized_aspect,
+                )
+            message = status_body.get("error") or status_body.get("message") or f"status={status}"
+            return error_response(
+                error=f"OpenRouter video generation did not complete: {message}",
+                error_type=f"openrouter_{status or 'unknown'}",
+                provider="openrouter",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=normalized_aspect,
+            )
+
+        urls = status_body.get("unsigned_urls") or []
+        if not urls:
+            return error_response(
+                error="OpenRouter video completed without unsigned_urls",
+                error_type="empty_response",
+                provider="openrouter",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=normalized_aspect,
+            )
+
+        extra: Dict[str, Any] = {
+            "job_id": status_body.get("id") or job_id,
+            "polling_url": status_body.get("polling_url") or polling_url,
+            "resolution": normalized_resolution,
+        }
+        if status_body.get("generation_id"):
+            extra["generation_id"] = status_body["generation_id"]
+        if status_body.get("usage"):
+            extra["usage"] = status_body["usage"]
+
+        return success_response(
+            video=urls[0],
+            model=model_id,
+            prompt=prompt,
+            modality=modality_used,
+            aspect_ratio=normalized_aspect,
+            duration=int(duration) if duration else 0,
+            provider="openrouter",
+            extra=extra,
+        )
+
+
+def register(ctx) -> None:
+    ctx.register_video_gen_provider(OpenRouterVideoGenProvider())

--- a/plugins/video_gen/openrouter/plugin.yaml
+++ b/plugins/video_gen/openrouter/plugin.yaml
@@ -1,0 +1,7 @@
+name: openrouter
+version: 1.0.0
+description: "OpenRouter video generation backend via the async /api/v1/videos API. Supports text-to-video, frame image-to-video, and reference images."
+author: NousResearch
+kind: backend
+requires_env:
+  - OPENROUTER_API_KEY

--- a/tests/tools/test_openrouter_media_generation.py
+++ b/tests/tools/test_openrouter_media_generation.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import base64
+import importlib.util
+from pathlib import Path
+
+
+def _load_plugin(path: str, name: str):
+    root = Path(__file__).resolve().parents[2]
+    spec = importlib.util.spec_from_file_location(name, root / path / "__init__.py")
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeResponse:
+    def __init__(self, payload, status_code=200, text="OK"):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = text
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+class _ImageClient:
+    last_payload = None
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def post(self, url, headers=None, json=None):
+        self.__class__.last_payload = json
+        b64 = base64.b64encode(b"fake-png").decode("ascii")
+        return _FakeResponse({
+            "choices": [{
+                "message": {
+                    "content": "done",
+                    "images": [{
+                        "type": "image_url",
+                        "image_url": {"url": f"data:image/png;base64,{b64}"},
+                    }],
+                }
+            }],
+            "usage": {"cost": 0.01},
+        })
+
+
+class _VideoClient:
+    post_payload = None
+    poll_count = 0
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def post(self, url, headers=None, json=None):
+        self.__class__.post_payload = json
+        return _FakeResponse({
+            "id": "job-1",
+            "polling_url": "https://openrouter.ai/api/v1/videos/job-1",
+            "status": "pending",
+        })
+
+    def get(self, url, headers=None, timeout=None):
+        self.__class__.poll_count += 1
+        return _FakeResponse({
+            "id": "job-1",
+            "polling_url": "https://openrouter.ai/api/v1/videos/job-1",
+            "status": "completed",
+            "unsigned_urls": ["https://openrouter.ai/api/v1/videos/job-1/content?index=0"],
+            "usage": {"cost": 0.25},
+        })
+
+
+def test_openrouter_image_provider_saves_data_url(monkeypatch, tmp_path):
+    module = _load_plugin("plugins/image_gen/openrouter", "openrouter_image_plugin_test")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    monkeypatch.setattr(module.httpx, "Client", _ImageClient)
+
+    provider = module.OpenRouterImageGenProvider()
+    result = provider.generate("draw a cat", aspect_ratio="portrait", model="custom/image-model")
+
+    assert result["success"] is True
+    assert result["provider"] == "openrouter"
+    assert result["model"] == "custom/image-model"
+    assert result["aspect_ratio"] == "portrait"
+    assert result["image"].endswith(".png")
+    assert Path(result["image"]).read_bytes() == b"fake-png"
+    assert _ImageClient.last_payload is not None
+    assert _ImageClient.last_payload["modalities"] == ["image", "text"]
+    assert _ImageClient.last_payload["image_config"]["aspect_ratio"] == "9:16"
+
+
+def test_openrouter_image_provider_reports_missing_key(monkeypatch):
+    module = _load_plugin("plugins/image_gen/openrouter", "openrouter_image_plugin_no_key_test")
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    provider = module.OpenRouterImageGenProvider()
+    result = provider.generate("draw a cat")
+
+    assert result["success"] is False
+    assert result["error_type"] == "auth_required"
+
+
+def test_openrouter_video_provider_submits_and_polls(monkeypatch):
+    module = _load_plugin("plugins/video_gen/openrouter", "openrouter_video_plugin_test")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    monkeypatch.setenv("OPENROUTER_VIDEO_POLL_INTERVAL", "0")
+    monkeypatch.setattr(module.httpx, "Client", _VideoClient)
+    monkeypatch.setattr(module.time, "sleep", lambda _seconds: None)
+
+    provider = module.OpenRouterVideoGenProvider()
+    result = provider.generate(
+        "a beach dog",
+        model="custom/video-model",
+        image_url="https://example.com/first.png",
+        duration=4,
+        aspect_ratio="9:16",
+        resolution="1080p",
+        audio=False,
+        seed=123,
+    )
+
+    assert result["success"] is True
+    assert result["provider"] == "openrouter"
+    assert result["model"] == "custom/video-model"
+    assert result["modality"] == "image"
+    assert result["video"].endswith("/content?index=0")
+    assert _VideoClient.post_payload is not None
+    assert _VideoClient.post_payload["frame_images"][0]["frame_type"] == "first_frame"
+    assert _VideoClient.post_payload["generate_audio"] is False
+    assert _VideoClient.post_payload["seed"] == 123
+    assert _VideoClient.poll_count >= 1
+
+
+def test_openrouter_video_provider_reference_images(monkeypatch):
+    module = _load_plugin("plugins/video_gen/openrouter", "openrouter_video_refs_plugin_test")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    monkeypatch.setenv("OPENROUTER_VIDEO_POLL_INTERVAL", "0")
+    monkeypatch.setattr(module.httpx, "Client", _VideoClient)
+    monkeypatch.setattr(module.time, "sleep", lambda _seconds: None)
+
+    provider = module.OpenRouterVideoGenProvider()
+    result = provider.generate(
+        "match this style",
+        reference_image_urls=["https://example.com/ref.png"],
+    )
+
+    assert result["success"] is True
+    assert result["modality"] == "text"
+    assert _VideoClient.post_payload is not None
+    assert "frame_images" not in _VideoClient.post_payload
+    assert _VideoClient.post_payload["input_references"][0]["image_url"]["url"] == "https://example.com/ref.png"

--- a/website/docs/user-guide/features/built-in-plugins.md
+++ b/website/docs/user-guide/features/built-in-plugins.md
@@ -61,7 +61,9 @@ The repo ships these bundled plugins under `plugins/`. All are opt-in — enable
 | `google_meet` | standalone | Join Meet calls, live-caption transcription, optional realtime duplex audio |
 | `image_gen/openai` | image backend | OpenAI `gpt-image-2` image generation backend (alternative to FAL) |
 | `image_gen/openai-codex` | image backend | OpenAI image generation via Codex OAuth |
+| `image_gen/openrouter` | image backend | OpenRouter image-output models via Chat Completions modalities |
 | `image_gen/xai` | image backend | xAI `grok-2-image` backend |
+| `video_gen/openrouter` | video backend | OpenRouter async `/api/v1/videos` backend for text-to-video, image-to-video, and references |
 | `hermes-achievements` | dashboard tab | Steam-style collectible badges generated from your real Hermes session history |
 | `kanban/dashboard` | dashboard tab | Kanban board UI for the multi-agent dispatcher — tasks, comments, fan-out, board switching. See [Kanban Multi-Agent](./kanban.md). |
 

--- a/website/docs/user-guide/features/image-generation.md
+++ b/website/docs/user-guide/features/image-generation.md
@@ -7,7 +7,7 @@ sidebar_position: 6
 
 # Image Generation
 
-Hermes Agent generates images from text prompts via FAL.ai. Nine models are supported out of the box, each with different speed, quality, and cost tradeoffs. The active model is user-configurable via `hermes tools` and persists in `config.yaml`.
+Hermes Agent generates images from text prompts via FAL.ai by default. Nine FAL models are supported out of the box, each with different speed, quality, and cost tradeoffs. Additional bundled image backends, including OpenAI, xAI, and OpenRouter, can be selected via `hermes tools`; the active backend/model persists in `config.yaml`.
 
 ## Supported Models
 
@@ -62,6 +62,23 @@ Your selection is saved to `config.yaml`:
 image_gen:
   model: fal-ai/flux-2/klein/9b
   use_gateway: false            # true if using Nous Subscription
+```
+
+### OpenRouter Image Models
+
+To use OpenRouter directly, choose **OpenRouter** in `hermes tools` → **Image Generation** and set `OPENROUTER_API_KEY`. Hermes calls OpenRouter's Chat Completions image-output API with `modalities` and saves returned base64 data URLs under `$HERMES_HOME/cache/images/`.
+
+The bundled picker includes common OpenRouter image-output models such as `google/gemini-3-pro-image-preview`, `google/gemini-3.1-flash-image-preview`, `google/gemini-2.5-flash-image`, `black-forest-labs/flux.2-pro`, `black-forest-labs/flux.2-flex`, and `sourceful/riverflow-v2-standard-preview`. You can also set any newer OpenRouter image model manually:
+
+```bash
+hermes config set image_gen.provider openrouter
+hermes config set image_gen.model google/gemini-3-pro-image-preview
+```
+
+Optional knobs:
+
+```bash
+hermes config set image_gen.openrouter.image_size 1K   # 0.5K, 1K, 2K, 4K depending on model
 ```
 
 ### GPT-Image Quality


### PR DESCRIPTION
## Summary
- add bundled `image_gen/openrouter` backend using OpenRouter Chat Completions image output (`modalities` + `image_config`)
- add bundled `video_gen/openrouter` backend using OpenRouter async `/api/v1/videos` polling flow
- add unit tests for data URL image saving, video submit/poll payloads, image-to-video, and reference images
- document OpenRouter image setup and list the new bundled plugins

## Validation
- `scripts/run_tests.sh tests/tools/test_openrouter_media_generation.py -q`
- `scripts/run_tests.sh tests/tools/test_openrouter_media_generation.py tests/tools/test_image_generation_plugin_dispatch.py tests/tools/test_video_generation_dispatch.py tests/agent/test_image_gen_registry.py tests/agent/test_video_gen_registry.py -q`
- `scripts/run_tests.sh tests/hermes_cli/test_image_gen_picker.py tests/hermes_cli/test_video_gen_picker.py tests/tools/test_video_generation_dynamic_schema.py tests/tools/test_video_generation_tool_surface_matrix.py -q`
- `scripts/run_tests.sh tests/tools/test_openrouter_media_generation.py tests/tools/test_image_generation_plugin_dispatch.py tests/tools/test_video_generation_dispatch.py tests/agent/test_image_gen_registry.py tests/agent/test_video_gen_registry.py tests/hermes_cli/test_image_gen_picker.py tests/hermes_cli/test_video_gen_picker.py tests/tools/test_video_generation_dynamic_schema.py tests/tools/test_video_generation_tool_surface_matrix.py -q`
- `python3 -m compileall -q plugins/image_gen/openrouter plugins/video_gen/openrouter tests/tools/test_openrouter_media_generation.py`
