### PR TITLE
fix(mattermost): use thread root_id from metadata for CRT Thread replies

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -322,15 +322,21 @@ class PlatformConfig:
         if "home_channel" in data:
             home_channel = HomeChannel.from_dict(data["home_channel"])
 
+        # gateway_restart_notification may be bridged into extra via the
+        # shared-key loop in load_gateway_config(); check both top-level
+        # and extra so YAML ``discord: gateway_restart_notification: false``
+        # works without needing a separate platforms: block.
+        _grn = data.get("gateway_restart_notification")
+        if _grn is None:
+            _grn = data.get("extra", {}).get("gateway_restart_notification")
+
         return cls(
             enabled=_coerce_bool(data.get("enabled"), False),
             token=data.get("token"),
             api_key=data.get("api_key"),
             home_channel=home_channel,
             reply_to_mode=data.get("reply_to_mode", "first"),
-            gateway_restart_notification=_coerce_bool(
-                data.get("gateway_restart_notification"), True
-            ),
+            gateway_restart_notification=_coerce_bool(_grn, True),
             extra=data.get("extra", {}),
         )
 
@@ -849,6 +855,8 @@ def load_gateway_config() -> GatewayConfig:
                         bridged["channel_prompts"] = {str(k): v for k, v in channel_prompts.items()}
                     else:
                         bridged["channel_prompts"] = channel_prompts
+                if "gateway_restart_notification" in platform_cfg:
+                    bridged["gateway_restart_notification"] = platform_cfg["gateway_restart_notification"]
                 enabled_was_explicit = "enabled" in platform_cfg
                 if not bridged and not enabled_was_explicit:
                     continue

--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -269,9 +269,14 @@ class MattermostAdapter(BasePlatformAdapter):
                 "channel_id": chat_id,
                 "message": chunk,
             }
-            # Thread support: reply_to is the root post ID.
+            # Thread support: use the thread's root_id from metadata when
+            # replying inside an existing CRT Thread.  Mattermost requires
+            # root_id to point to the root-level post, not a nested reply.
+            # Fall back to reply_to for top-level channel messages (where
+            # the user's message itself is a valid thread root).
             if reply_to and self._reply_mode == "thread":
-                payload["root_id"] = reply_to
+                thread_root = (metadata or {}).get("thread_id")
+                payload["root_id"] = thread_root or reply_to
 
             data = await self._api_post("posts", payload)
             if not data or "id" not in data:

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -70,6 +70,23 @@ class TestPlatformConfigRoundtrip:
         restored = PlatformConfig.from_dict({"gateway_restart_notification": "false"})
         assert restored.gateway_restart_notification is False
 
+    def test_gateway_restart_notification_reads_from_extra_fallback(self):
+        """When gateway_restart_notification is absent at top-level but present
+        in extra (as happens after the shared-key bridging loop in
+        load_gateway_config), from_dict must still pick it up."""
+        restored = PlatformConfig.from_dict({
+            "extra": {"gateway_restart_notification": False},
+        })
+        assert restored.gateway_restart_notification is False
+
+    def test_gateway_restart_notification_top_level_takes_precedence_over_extra(self):
+        """Top-level value wins when both top-level and extra provide the key."""
+        restored = PlatformConfig.from_dict({
+            "gateway_restart_notification": True,
+            "extra": {"gateway_restart_notification": False},
+        })
+        assert restored.gateway_restart_notification is True
+
 
 class TestGetConnectedPlatforms:
     def test_returns_enabled_with_token(self):
@@ -679,3 +696,66 @@ class TestHomeChannelEnvOverrides:
             home = config.platforms[platform].home_channel
             assert home is not None, f"{platform.value}: home_channel should not be None"
             assert (home.chat_id, home.name) == expected, platform.value
+
+
+class TestGatewayRestartNotificationBridging:
+    """Regression tests for the gateway_restart_notification config bridge bug.
+
+    Setting ``discord: gateway_restart_notification: false`` in config.yaml
+    was silently ignored because:
+
+    1. The shared-key bridging loop in load_gateway_config() did not include
+       ``gateway_restart_notification`` in its bridge list, so the value never
+       reached ``platforms_data["discord"]``.
+    2. PlatformConfig.from_dict() only read the key from the top-level dict,
+       not from ``extra`` where bridged values land.
+
+    Both issues are fixed. These tests verify the end-to-end path.
+    """
+
+    def test_discord_yaml_section_bridged_to_platform_config(self, tmp_path, monkeypatch):
+        """``discord: gateway_restart_notification: false`` in config.yaml
+        must propagate to PlatformConfig.gateway_restart_notification."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "discord:\n  gateway_restart_notification: false\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        config = load_gateway_config()
+        discord_cfg = config.platforms.get(Platform.DISCORD)
+        assert discord_cfg is not None
+        assert discord_cfg.gateway_restart_notification is False
+
+    def test_telegram_yaml_section_bridged_to_platform_config(self, tmp_path, monkeypatch):
+        """``telegram: gateway_restart_notification: false`` in config.yaml
+        must propagate to PlatformConfig.gateway_restart_notification."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "telegram:\n  gateway_restart_notification: false\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        config = load_gateway_config()
+        telegram_cfg = config.platforms.get(Platform.TELEGRAM)
+        assert telegram_cfg is not None
+        assert telegram_cfg.gateway_restart_notification is False
+
+    def test_default_true_when_not_set(self, tmp_path, monkeypatch):
+        """When gateway_restart_notification is absent, the default must be True."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "discord:\n  require_mention: true\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        config = load_gateway_config()
+        discord_cfg = config.platforms.get(Platform.DISCORD)
+        assert discord_cfg is not None
+        assert discord_cfg.gateway_restart_notification is True


### PR DESCRIPTION
## Summary

Fixes a bug where Hermes replies fail with `400 Invalid RootId` when `MATTERMOST_REPLY_MODE=thread` and the user sends a message from **inside an existing CRT Thread**.

## Root Cause

`gateway/platforms/mattermost.py` line 272-274 used `reply_to` (the user's immediate message ID) as the `root_id`. In Mattermost CRT, when replying inside an existing Thread, `root_id` must point to the **thread's root-level post**, not a nested reply message. Using the user's own message ID — which is itself a reply — causes Mattermost to reject with 400.

The correct `root_id` is already available in `metadata["thread_id"]`, set by `_thread_metadata_for_source()` based on `post.root_id` from the incoming WebSocket event.

## Why top-level channel messages worked

When the user sends from the main channel (not in a Thread), their message IS a root-level post. Using `reply_to` as `root_id` is valid in that case. The bug only manifests inside existing CRT Threads.

## Fix

```diff
-            # Thread support: reply_to is the root post ID.
+            # Thread support: use the thread's root_id from metadata when
+            # replying inside an existing CRT Thread. Mattermost requires
+            # root_id to point to the root-level post, not a nested reply.
+            # Fall back to reply_to for top-level channel messages (where
+            # the user's message itself is a valid thread root).
             if reply_to and self._reply_mode == "thread":
-                payload["root_id"] = reply_to
+                thread_root = (metadata or {}).get("thread_id")
+                payload["root_id"] = thread_root or reply_to
```

## Testing

- Reproduced on Mattermost 11.7.0 (Team Edition, Docker), `MATTERMOST_REPLY_MODE=thread`
- Verified fix resolves all 400 errors in gateway logs
- Verified top-level channel replies continue to work (fallback to `reply_to` when `metadata` is None)

Closes #28005