### PR TITLE
feat(skills): add CloudBase private ops overlay

### DIFF
--- a/skills/software-development/cloudbase-private-ops/SKILL.md
+++ b/skills/software-development/cloudbase-private-ops/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: cloudbase-private-ops
+description: Use when operating CloudBase for this user's production/dev projects with project-local MCP isolation, multi-account safety, route-A wrapper, and CLI deprecation rules. Load official cloudbase first, then this overlay; this overlay wins for this profile's production operations.
+version: 1.0.0
+author: Hermes Agent
+license: Private
+metadata:
+  hermes:
+    tags: [cloudbase, mcp, isolation, production, private]
+    related_skills: [cloudbase]
+---
+
+# CloudBase Private Ops Overlay
+
+## Overview
+
+This is a private overlay on top of the official `cloudbase` skill. Use the official skill for general CloudBase capabilities and product/API references. Use this overlay for this user's production and multi-environment operations.
+
+When rules conflict, this overlay wins for this profile's CloudBase production operations.
+
+## When to Use
+
+Load this skill after `cloudbase` when the task involves:
+
+- Vibe Photoing or meme CloudBase operations;
+- any new CloudBase project that shares this machine/profile with other CloudBase projects;
+- CloudBase MCP setup, deployment, backfill, DB/storage operations, or environment/account isolation;
+- migration from `tcb` CLI to MCP;
+- questions about route-A, project-local MCP, mcporter, preflight, diff, rollback, or write gates.
+
+Do not use this overlay as a replacement for official CloudBase development docs. It is an operational safety layer.
+
+## Non-negotiable Rules
+
+- Do not use raw `tcb` for production operations.
+- Do not call `npx mcporter call ...` directly for production operations.
+- Do not register multiple CloudBase projects as Hermes profile-level MCP servers for production use.
+- Do not use `auth action=set_env` or `auth action=logout` to fix environment mismatch.
+- Use route-A wrapper only: `scripts/cloudbase-mcp-call.mjs <project> <tool> ...`.
+- Every project must have a fixed EnvId, project-local MCP config, project-local credentials, and preflight checks.
+- Write operations require explicit user authorization and `--write-ok`.
+
+## Required References
+
+Read as needed:
+
+- `references/route-a-policy.md` — wrapper, blocked actions, required files.
+- `references/operation-levels.md` — read-only vs code deploy vs high-risk writes.
+- `references/project-template.md` — onboarding a new CloudBase project.
+- `references/vibe-meme-example.md` — validated Vibe/meme reference implementation.
+- `references/route-a-migration-closeout.md` — how to stop migration-mode over-testing, run the closeout audit, and operate afterward.
+- `references/sync-upstream.md` — keeping this overlay aligned with official CloudBase skills.
+
+## Default Production Path
+
+```text
+scripts/cloudbase-mcp-call.mjs
+  -> cloudbase-preflight.mjs
+  -> project config/mcporter.json
+  -> project-local CloudBase MCP
+  -> fixed EnvId + project-local credentials
+```
+
+## Communication Cadence for This User
+
+For long CloudBase migration/ops runs over chat, work in batches and avoid reporting after every small substep unless the user asks for a live trace. Prefer compact checkpoints after meaningful milestones, with evidence paths and pass/fail counts.
+
+If the user says they did not receive the latest message, do not blindly repeat an older status. First distinguish whether any new work happened after the last delivered milestone. If no new action happened, say so plainly; if new action happened, resend only that newest result.
+
+## Operation Levels
+
+Use the least-heavy safe workflow for the operation:
+
+- Level 0 read-only: wrapper call only.
+- Level 1 single-function code-only deploy: preflight, function diff, code update, post-check.
+- Level 2 config/env/trigger writes: per-operation runbook, rollback, explicit confirmation.
+- Level 3 DB/storage/backfill/destructive writes: dry-run/read-only counts, runbook, rollback, explicit confirmation.
+
+## Verification Checklist
+
+Before reporting success, verify:
+
+- [ ] Target project is in `config/cloudbase-projects.json`.
+- [ ] EnvId matches the project and CloudBase namespace.
+- [ ] Operation used route-A wrapper, not raw CLI/direct mcporter.
+- [ ] Dangerous actions were blocked or explicitly authorized.
+- [ ] For writes, post-check confirms function status/health/diff.
+- [ ] No real secrets were written into shareable docs or chat output.
+
+## Common Pitfalls
+
+1. Treating MCP availability as permission to skip project isolation. MCP still needs route-A guards.
+2. Using `auth.set_env` to switch environments. Fix config or credentials instead.
+3. Passing a single function directory as `functionRootPath`. It must be the directory containing function subdirectories.
+4. Deploying config/envVariables just to test MCP. Code-only writes are enough for migration validation.
+5. Copying live function detail into docs without redacting secrets.
+6. Modifying the official CloudBase skill heavily. Keep this private policy in the overlay to reduce upstream sync conflicts.

--- a/skills/software-development/cloudbase-private-ops/references/operation-levels.md
+++ b/skills/software-development/cloudbase-private-ops/references/operation-levels.md
@@ -1,0 +1,84 @@
+# CloudBase Operation Levels
+
+Use operation levels to avoid migration-era over-verification while preserving safety for high-risk writes.
+
+## Level 0 — Read-only
+
+Examples:
+
+- `envQuery`
+- `queryFunctions`
+- `querySqlDatabase` read-only queries
+- `queryStorage list/info/url`
+- function detail/log inspection
+
+Workflow:
+
+```bash
+scripts/cloudbase-mcp-call.mjs <project> <queryTool> ...
+```
+
+No rollback or diff required. Still use route-A wrapper to prevent project/environment mixups.
+
+## Level 1 — Single-function code-only deploy
+
+Examples:
+
+- `manageFunctions action=updateFunctionCode` for one function.
+
+Workflow:
+
+```bash
+scripts/cloudbase-preflight.mjs <project> deploy <functionName>
+scripts/cloudbase-function-diff.mjs <project>
+scripts/cloudbase-function-deploy-command.mjs <project> <functionName> --code
+scripts/cloudbase-mcp-call.mjs <project> manageFunctions action=updateFunctionCode functionName=<functionName> functionRootPath=<functionRoot> --write-ok
+scripts/cloudbase-function-diff.mjs <project>
+scripts/cloudbase-mcp-call.mjs <project> queryFunctions action=getFunctionDetail functionName=<functionName>
+```
+
+Use a rollback source from git or a prepared snapshot. Do not combine with config/env/trigger updates.
+
+## Level 2 — Config/env/trigger writes
+
+Examples:
+
+- `updateFunctionConfig`
+- envVariables / secret changes
+- timeout/memory/runtime-adjacent changes
+- trigger create/delete
+
+Workflow:
+
+- create a per-operation runbook;
+- prepare rollback;
+- run preflight and diff;
+- require explicit user confirmation naming project, EnvId, function, operation, and rollback;
+- execute one operation only;
+- post-check detail and health.
+
+Do not perform these merely to test MCP. Code-only deploys already validate MCP migration.
+
+## Level 3 — DB/storage/backfill/destructive writes
+
+Examples:
+
+- SQL writes, schema changes, backfills;
+- NoSQL writes/deletes;
+- Storage overwrite/delete;
+- batch operations.
+
+Workflow:
+
+- run read-only counts / dry-run first;
+- scope data by allowlist or prefix;
+- prepare rollback or export where possible;
+- require explicit confirmation;
+- verify with post-counts and sample reads.
+
+## Always forbidden in production
+
+- `auth.set_env`
+- `auth.logout`
+- raw `tcb` environment switching
+- using one global CloudBase credential/profile for multiple projects

--- a/skills/software-development/cloudbase-private-ops/references/project-template.md
+++ b/skills/software-development/cloudbase-private-ops/references/project-template.md
@@ -1,0 +1,118 @@
+# New Project Template
+
+Use this to onboard a new CloudBase project into the private multi-account MCP isolation pattern.
+
+Assume:
+
+```text
+project = new-app
+envId = new-env-xxxx
+projectRoot = /abs/path/new-app
+server = cloudbase-new-app
+```
+
+## 1. Register in project map
+
+Add to `config/cloudbase-projects.json`:
+
+```json
+{
+  "new-app": {
+    "envId": "new-env-xxxx",
+    "mcpServer": "cloudbase-new-app",
+    "projectRoot": "/abs/path/new-app",
+    "cloudbaserc": "/abs/path/new-app/cloudbaserc.json",
+    "mcpConfig": "/abs/path/new-app/config/mcporter.json",
+    "envFile": "/abs/path/new-app/.cloudbase-mcp.env",
+    "logDir": "/abs/path/new-app/.cloudbase-mcp-logs",
+    "allowlist": {
+      "functions": [],
+      "collections": [],
+      "storagePrefixes": []
+    }
+  }
+}
+```
+
+## 2. Create project-local mcporter config
+
+`new-app/config/mcporter.json`:
+
+```json
+{
+  "mcpServers": {
+    "cloudbase-new-app": {
+      "command": "node",
+      "args": [
+        "/home/openclaw/hermes_workspace/hermes_sc/scripts/cloudbase-mcp-local.mjs",
+        "new-app"
+      ],
+      "description": "Project-local CloudBase MCP for new-app only",
+      "lifecycle": "keep-alive"
+    }
+  }
+}
+```
+
+## 3. Create optional IDE MCP config
+
+`new-app/.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "cloudbase-new-app": {
+      "command": "node",
+      "args": [
+        "/home/openclaw/hermes_workspace/hermes_sc/scripts/cloudbase-mcp-local.mjs",
+        "new-app"
+      ]
+    }
+  }
+}
+```
+
+Production operations still use route-A wrapper, not IDE auto-loaded tools.
+
+## 4. Create credentials template
+
+`new-app/.cloudbase-mcp.env.example`:
+
+```env
+NEW_APP_TENCENTCLOUD_SECRETID=
+NEW_APP_TENCENTCLOUD_SECRETKEY=
+CLOUDBASE_ENV_ID=new-env-xxxx
+CLOUDBASE_LOG_DIR=.cloudbase-mcp-logs
+```
+
+Real credentials go to `new-app/.cloudbase-mcp.env`, which must be ignored.
+
+## 5. Patch .gitignore
+
+```gitignore
+.cloudbase-mcp.env
+.cloudbase-mcp-logs/
+cloudbaserc.local.json
+```
+
+## 6. Create cloudbaserc
+
+`new-app/cloudbaserc.json`:
+
+```json
+{
+  "envId": "new-env-xxxx",
+  "functionRoot": "cloudfunctions",
+  "functions": []
+}
+```
+
+## 7. Smoke test
+
+```bash
+scripts/cloudbase-preflight.mjs new-app status
+scripts/cloudbase-mcp-call.mjs new-app envQuery action=info envId=new-env-xxxx
+scripts/cloudbase-mcp-call.mjs new-app queryFunctions action=listFunctions
+```
+
+The returned EnvId must be the new project EnvId, not any existing Vibe/meme environment.

--- a/skills/software-development/cloudbase-private-ops/references/route-a-migration-closeout.md
+++ b/skills/software-development/cloudbase-private-ops/references/route-a-migration-closeout.md
@@ -1,0 +1,41 @@
+# Route-A Migration Closeout Pattern
+
+Use this after proving that project-local CloudBase MCP can replace `tcb` for production operations.
+
+## What to prove once
+
+For each major project class, validate one low-risk code-only write:
+
+- preflight passes;
+- whole-project function diff is clean;
+- `manageFunctions action=updateFunctionCode` succeeds for one function;
+- post-write diff remains clean;
+- function status is `Active / Available`;
+- health/read-only verification passes when available;
+- rollback artifact exists but is not needed.
+
+After this succeeds in representative projects, do not keep testing higher-risk write types merely to prove MCP. Code-only deployment proves the transport, project isolation, and write gate. Treat config/env/trigger/DB/storage writes as separate real operations with their own runbook.
+
+## Closeout audit
+
+Before declaring the migration done:
+
+1. Check which directories are actually git repositories. Do not assume the workspace root is a repo.
+2. Inspect status/diff for each real repo touched.
+3. Scan generated docs/reports for literal secrets; redact values, but key names such as `SecretKey` or `VIBE_PHOTOING_API_TOKEN` may remain as labels.
+4. Confirm `.cloudbase-mcp.env`, local logs, rollback archives, and local `cloudbaserc.local.json` are ignored or outside repos.
+5. Write a concise closeout document listing:
+   - production path;
+   - verified write operations;
+   - core scripts/config/docs;
+   - local-only rollback artifacts;
+   - known caveats and future operation levels.
+
+## Post-migration operating model
+
+- Level 0 read-only: wrapper call only.
+- Level 1 code-only single-function deploy: preflight + diff + post-check.
+- Level 2 config/env/trigger: per-operation runbook + rollback + explicit confirmation.
+- Level 3 DB/storage/backfill/destructive: dry-run/read-only counts + runbook + rollback + explicit confirmation.
+
+Do not delete CloudBase CLI immediately just because MCP migration worked. Prefer a short observation period where `tcb` is retained only as an emergency/read-only comparison tool and is forbidden as a production entry point. Later, disable or uninstall it if no fallback was needed.

--- a/skills/software-development/cloudbase-private-ops/references/route-a-policy.md
+++ b/skills/software-development/cloudbase-private-ops/references/route-a-policy.md
@@ -1,0 +1,79 @@
+# Route-A Project-local MCP Policy
+
+Route-A is the production CloudBase operation path for this profile.
+
+## Production path
+
+```text
+scripts/cloudbase-mcp-call.mjs <project> <tool> [key=value ...]
+  -> scripts/cloudbase-preflight.mjs
+  -> <project>/config/mcporter.json
+  -> scripts/cloudbase-mcp-local.mjs <project>
+  -> npx @cloudbase/cloudbase-mcp@latest
+```
+
+## Required files
+
+Repository/workspace-level:
+
+```text
+config/cloudbase-projects.json
+scripts/cloudbase-preflight.mjs
+scripts/cloudbase-mcp-local.mjs
+scripts/cloudbase-mcp-call.mjs
+scripts/cloudbase-function-diff.mjs
+scripts/cloudbase-function-deploy-command.mjs
+```
+
+Project-level:
+
+```text
+<project>/cloudbaserc.json
+<project>/config/mcporter.json
+<project>/.mcp.json
+<project>/.cloudbase-mcp.env.example
+<project>/.cloudbase-mcp.env        # ignored, local only
+<project>/.cloudbase-mcp-logs/      # ignored, local only
+```
+
+## Hard blocks
+
+Production operations must not use:
+
+- raw `tcb` CLI;
+- direct `npx mcporter call ...`;
+- Hermes profile-level CloudBase MCP for multiple projects;
+- `auth action=set_env`;
+- `auth action=logout`.
+
+The wrapper should reject auth environment switching and write/manage tools without `--write-ok`.
+
+## Preflight checks
+
+Before writes, verify:
+
+- project exists in `config/cloudbase-projects.json`;
+- MCP server name matches the project;
+- `cloudbaserc.json` EnvId matches expected EnvId;
+- MCP env `CLOUDBASE_ENV_ID` matches expected EnvId;
+- credentials are present and project-specific;
+- resource is allowed when an allowlist exists.
+
+## Safe invocation examples
+
+Read-only:
+
+```bash
+scripts/cloudbase-mcp-call.mjs meme envQuery action=info envId=meme-d9gg2ac1p467b701c
+scripts/cloudbase-mcp-call.mjs meme queryFunctions action=listFunctions
+```
+
+Code-only deploy after explicit confirmation:
+
+```bash
+scripts/cloudbase-mcp-call.mjs meme manageFunctions action=updateFunctionCode functionName=api functionRootPath=/abs/path/cloudbase/functions --write-ok
+```
+
+## Notes
+
+`functionRootPath` must be the directory containing function subdirectories, not the function directory itself.

--- a/skills/software-development/cloudbase-private-ops/references/sync-upstream.md
+++ b/skills/software-development/cloudbase-private-ops/references/sync-upstream.md
@@ -1,0 +1,52 @@
+# Syncing with Official CloudBase Skill
+
+This private skill is an overlay. Do not fork the whole official `cloudbase` skill unless absolutely necessary.
+
+## Source-of-truth split
+
+- Official `cloudbase`: product capabilities, generic MCP/tool docs, platform guides.
+- `cloudbase-private-ops`: this user's production safety policy, project-local MCP isolation, route-A wrapper, operation levels.
+
+When rules conflict for this user's production environment, this overlay wins.
+
+## Recommended sync process
+
+1. Update or inspect official CloudBase skill through normal Hermes skill update flow.
+2. Check official version and changed references.
+3. Review only areas that may affect this overlay:
+   - MCP setup examples;
+   - mcporter call syntax;
+   - CloudBase function deployment schema;
+   - auth/environment binding guidance;
+   - database/storage write tools.
+4. If official docs add useful generic guidance, link to it or summarize it in this overlay.
+5. Do not merge private route-A policy back into official skill unless it is intentionally becoming general public guidance.
+
+## Local review record
+
+Maintain this section when syncing:
+
+```text
+upstream skill: cloudbase
+upstream version reviewed: 2.18.0
+private overlay version: 1.0.0
+last reviewed: 2026-05-18
+review notes: initial overlay extracted from Vibe Photoing + meme migration validation
+```
+
+## Minimal official skill patch
+
+A small pointer inside official `cloudbase` is acceptable:
+
+```text
+For this profile's production CloudBase operations, load `cloudbase-private-ops` after this skill. Its project-local MCP isolation and route-A rules override generic CLI/MCP examples.
+```
+
+Avoid large edits to official `cloudbase/SKILL.md` because they create upstream merge conflicts.
+
+## What to verify after sync
+
+- The official skill still loads.
+- This overlay still loads.
+- `related_skills: [cloudbase]` remains valid.
+- Any new official recommendation involving `tcb`, global MCP, direct mcporter, or `auth.set_env` is either not production-relevant or explicitly overridden here.

--- a/skills/software-development/cloudbase-private-ops/references/vibe-meme-example.md
+++ b/skills/software-development/cloudbase-private-ops/references/vibe-meme-example.md
@@ -1,0 +1,74 @@
+# Vibe Photoing + meme Example
+
+This is the validated reference implementation for project-local CloudBase MCP isolation in this profile. Do not copy secrets from live project files into shared docs.
+
+## Project map
+
+| Project | EnvId | MCP server | Function root |
+|---|---|---|---|
+| `vibe-photoing` | `cloudbase-d6gflq1jq7012a851` | `cloudbase-vibe-photoing` | `miniapps/vibe-photoing/cloudfunctions` |
+| `meme` | `meme-d9gg2ac1p467b701c` | `cloudbase-meme` | `meme/cloudbase/functions` |
+
+## Files
+
+Workspace-level:
+
+```text
+config/cloudbase-projects.json
+scripts/cloudbase-preflight.mjs
+scripts/cloudbase-mcp-local.mjs
+scripts/cloudbase-mcp-call.mjs
+scripts/cloudbase-function-diff.mjs
+scripts/cloudbase-function-deploy-command.mjs
+```
+
+Vibe:
+
+```text
+miniapps/vibe-photoing/.mcp.json
+miniapps/vibe-photoing/config/mcporter.json
+miniapps/vibe-photoing/.cloudbase-mcp.env.example
+miniapps/vibe-photoing/.cloudbase-mcp.env        # ignored
+miniapps/vibe-photoing/cloudbaserc.json
+```
+
+meme:
+
+```text
+meme/.mcp.json
+meme/config/mcporter.json
+meme/.cloudbase-mcp.env.example
+meme/.cloudbase-mcp.env        # ignored
+meme/cloudbaserc.json
+```
+
+## Validated operations
+
+Read-only:
+
+```bash
+scripts/cloudbase-mcp-call.mjs vibe-photoing envQuery action=info envId=cloudbase-d6gflq1jq7012a851
+scripts/cloudbase-mcp-call.mjs vibe-photoing queryFunctions action=listFunctions
+scripts/cloudbase-mcp-call.mjs meme envQuery action=info envId=meme-d9gg2ac1p467b701c
+scripts/cloudbase-mcp-call.mjs meme queryFunctions action=listFunctions
+```
+
+Code-only writes validated:
+
+```text
+meme / api / updateFunctionCode -> success; health OK
+vibe-photoing / listImageJobs / updateFunctionCode -> success; detail OK
+```
+
+## Pitfalls found during validation
+
+- `getImageJob` had live envVariables missing from local `cloudbaserc.json`; merge live env shape before config deploys.
+- Timer triggers return live as `TriggerName` / `Type` / `TriggerDesc={"cron":"..."}`. Normalize before diffing against local `{name,type,config}`.
+- `functionRootPath` must point to the directory containing function subdirectories.
+- Root workspace may not be a git repo; do not assume root docs/scripts/config are governed by git.
+- Generated reports and deploy plans must redact real SecretId/SecretKey/API_TOKEN values.
+- Do not test config/env/trigger/DB/storage writes just to prove MCP; code-only writes already proved migration viability.
+
+## Current policy outcome
+
+Production CloudBase operations should use MCP route-A. Raw `tcb`, direct `mcporter`, and Hermes profile-level CloudBase MCP are not production entry points for these projects.


### PR DESCRIPTION
## Summary
- Add `cloudbase-private-ops` skill as a private/operational CloudBase overlay
- Document project-local MCP route-A policy, operation levels, onboarding template, and Vibe/meme reference example
- Include upstream sync guidance while keeping official `cloudbase` skill unmodified in the repo

## Test Plan
- Validated SKILL.md frontmatter and size constraints
- Scanned new skill files for known real secret literals
