### PR TITLE
fix(models): live-discover azure-foundry deployments in /model picker (#27989)

### DIFF
--- a/hermes_cli/azure_detect.py
+++ b/hermes_cli/azure_detect.py
@@ -297,4 +297,32 @@ def lookup_context_length(model: str, base_url: str, api_key: str) -> Optional[i
     return None
 
 
-__all__ = ["DetectionResult", "detect", "lookup_context_length"]
+def azure_foundry_model_ids_or_none(
+    base_url: str, api_key: str
+) -> Optional[list[str]]:
+    """Return Azure Foundry deployment IDs visible to ``api_key`` at
+    ``base_url``, or ``None`` when the resource's ``/models`` endpoint
+    is unreachable / does not accept us as an OpenAI-style caller.
+
+    Thin public wrapper over :func:`_probe_openai_models` for callers
+    (e.g. the runtime ``/model`` picker) that need a live deployment list
+    without running the slower Anthropic-path probe from :func:`detect`.
+
+    Mirrors :func:`agent.bedrock_adapter.bedrock_model_ids_or_none` so the
+    picker can fall through to ``_PROVIDER_MODELS`` when discovery fails.
+    """
+    if not base_url or not api_key:
+        return None
+    try:
+        ok, ids = _probe_openai_models(base_url.strip().rstrip("/"), api_key.strip())
+    except Exception:
+        return None
+    return ids if ok else None
+
+
+__all__ = [
+    "DetectionResult",
+    "detect",
+    "lookup_context_length",
+    "azure_foundry_model_ids_or_none",
+]

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2278,6 +2278,27 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
         except Exception:
             pass
 
+    # Azure Foundry deployment IDs are per-resource and can't be hardcoded
+    # (``_PROVIDER_MODELS["azure-foundry"]`` is intentionally ``[]``). The
+    # resource's ``{base}/openai/v1/models`` endpoint does return the catalog
+    # for the configured API key — same probe used by the setup wizard. Without
+    # this branch the runtime ``/model`` picker shows 0 models for users who
+    # have multiple Azure Foundry deployments accessible to their key.
+    if normalized == "azure-foundry":
+        try:
+            from hermes_cli.auth import resolve_api_key_provider_credentials
+            from hermes_cli.azure_detect import azure_foundry_model_ids_or_none
+
+            creds = resolve_api_key_provider_credentials("azure-foundry")
+            api_key = str(creds.get("api_key") or "").strip()
+            base_url = str(creds.get("base_url") or "").strip()
+            if api_key and base_url:
+                ids = azure_foundry_model_ids_or_none(base_url, api_key)
+                if ids:
+                    return ids
+        except Exception:
+            pass
+
     # ── Profile-based generic live fetch (all simple api-key providers) ──
     # Handles any provider registered in providers/ with auth_type="api_key".
     # Replaces per-provider copy-paste blocks (stepfun, gmi, zai, etc.).

--- a/tests/hermes_cli/test_azure_foundry_picker.py
+++ b/tests/hermes_cli/test_azure_foundry_picker.py
@@ -1,0 +1,191 @@
+"""Tests for the runtime ``/model`` picker live-discovery branch on
+``azure-foundry``.
+
+The static catalog ``_PROVIDER_MODELS["azure-foundry"]`` is intentionally
+empty (deployments are per-resource). Without a live-discovery branch in
+``provider_model_ids``, the runtime picker shows 0 models even when the
+resource has multiple deployments visible to the configured API key.
+
+These tests cover the dispatch wiring: credentials resolution, probe
+success, probe failure, and configuration-missing paths.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import patch
+
+if "dotenv" not in sys.modules:
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    sys.modules["dotenv"] = fake_dotenv
+
+from hermes_cli import azure_detect
+from hermes_cli.models import _PROVIDER_MODELS, provider_model_ids
+
+
+# ---------------------------------------------------------------------------
+# azure_foundry_model_ids_or_none — thin probe wrapper
+# ---------------------------------------------------------------------------
+
+class TestAzureFoundryModelIdsOrNone:
+    def test_returns_ids_on_successful_probe(self):
+        with patch(
+            "hermes_cli.azure_detect._probe_openai_models",
+            return_value=(True, ["gpt-5.4", "kimi-k2.6"]),
+        ):
+            assert azure_detect.azure_foundry_model_ids_or_none(
+                "https://res.openai.azure.com/openai/v1",
+                "secret",
+            ) == ["gpt-5.4", "kimi-k2.6"]
+
+    def test_returns_empty_list_when_probe_returns_empty_openai_shape(self):
+        # 200 + OpenAI-shaped empty list — endpoint is reachable but has no
+        # deployments. Caller can still treat this as authoritative.
+        with patch(
+            "hermes_cli.azure_detect._probe_openai_models",
+            return_value=(True, []),
+        ):
+            assert azure_detect.azure_foundry_model_ids_or_none(
+                "https://res.openai.azure.com/openai/v1",
+                "secret",
+            ) == []
+
+    def test_returns_none_when_probe_fails(self):
+        with patch(
+            "hermes_cli.azure_detect._probe_openai_models",
+            return_value=(False, []),
+        ):
+            assert azure_detect.azure_foundry_model_ids_or_none(
+                "https://res.openai.azure.com/openai/v1",
+                "secret",
+            ) is None
+
+    def test_returns_none_when_credentials_missing(self):
+        assert azure_detect.azure_foundry_model_ids_or_none("", "secret") is None
+        assert azure_detect.azure_foundry_model_ids_or_none(
+            "https://res.openai.azure.com/openai/v1", ""
+        ) is None
+
+    def test_returns_none_when_probe_raises(self):
+        with patch(
+            "hermes_cli.azure_detect._probe_openai_models",
+            side_effect=RuntimeError("boom"),
+        ):
+            assert azure_detect.azure_foundry_model_ids_or_none(
+                "https://res.openai.azure.com/openai/v1",
+                "secret",
+            ) is None
+
+    def test_strips_whitespace_and_trailing_slash(self):
+        captured: dict[str, str] = {}
+
+        def _fake_probe(base_url, api_key):
+            captured["base_url"] = base_url
+            captured["api_key"] = api_key
+            return True, ["m"]
+
+        with patch(
+            "hermes_cli.azure_detect._probe_openai_models",
+            side_effect=_fake_probe,
+        ):
+            azure_detect.azure_foundry_model_ids_or_none(
+                "  https://res.openai.azure.com/openai/v1/  ",
+                "  secret  ",
+            )
+
+        assert captured["base_url"] == "https://res.openai.azure.com/openai/v1"
+        assert captured["api_key"] == "secret"
+
+
+# ---------------------------------------------------------------------------
+# provider_model_ids dispatch
+# ---------------------------------------------------------------------------
+
+class TestProviderModelIdsAzureFoundry:
+    def test_dispatches_to_live_probe_when_credentials_resolve(self):
+        with patch(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            return_value={
+                "provider": "azure-foundry",
+                "api_key": "secret",
+                "base_url": "https://res.openai.azure.com/openai/v1",
+                "source": "AZURE_FOUNDRY_API_KEY",
+            },
+        ), patch(
+            "hermes_cli.azure_detect.azure_foundry_model_ids_or_none",
+            return_value=["gpt-5.4", "deepseek-v4-pro"],
+        ):
+            assert provider_model_ids("azure-foundry") == [
+                "gpt-5.4",
+                "deepseek-v4-pro",
+            ]
+
+    def test_falls_back_to_static_when_probe_fails(self):
+        # Before this fix the picker already returned [] for azure-foundry
+        # via the curated static list — verify we preserve that behaviour
+        # when discovery cannot reach the endpoint.
+        with patch(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            return_value={
+                "provider": "azure-foundry",
+                "api_key": "secret",
+                "base_url": "https://res.openai.azure.com/openai/v1",
+                "source": "AZURE_FOUNDRY_API_KEY",
+            },
+        ), patch(
+            "hermes_cli.azure_detect.azure_foundry_model_ids_or_none",
+            return_value=None,
+        ):
+            assert provider_model_ids("azure-foundry") == list(
+                _PROVIDER_MODELS["azure-foundry"]
+            )
+
+    def test_falls_back_to_static_when_credentials_missing(self):
+        # No env vars, no ~/.hermes/.env entry: resolver returns empty
+        # api_key and base_url. Probe must not be invoked, picker returns [].
+        with patch(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            return_value={
+                "provider": "azure-foundry",
+                "api_key": "",
+                "base_url": "",
+                "source": "default",
+            },
+        ), patch(
+            "hermes_cli.azure_detect.azure_foundry_model_ids_or_none",
+        ) as probe_mock:
+            assert provider_model_ids("azure-foundry") == []
+            probe_mock.assert_not_called()
+
+    def test_falls_back_to_static_when_probe_returns_empty_list(self):
+        # 200 OK + empty data on /models — endpoint accepted us but
+        # listed no deployments. Treat the same as failure for picker UX.
+        with patch(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            return_value={
+                "provider": "azure-foundry",
+                "api_key": "secret",
+                "base_url": "https://res.openai.azure.com/openai/v1",
+                "source": "AZURE_FOUNDRY_API_KEY",
+            },
+        ), patch(
+            "hermes_cli.azure_detect.azure_foundry_model_ids_or_none",
+            return_value=[],
+        ):
+            assert provider_model_ids("azure-foundry") == list(
+                _PROVIDER_MODELS["azure-foundry"]
+            )
+
+    def test_swallows_resolver_exception(self):
+        # If credentials resolution blows up (e.g. corrupted auth state),
+        # the picker must not propagate the exception — fall through to the
+        # curated static list, same as before this fix.
+        with patch(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            side_effect=RuntimeError("auth blew up"),
+        ):
+            assert provider_model_ids("azure-foundry") == list(
+                _PROVIDER_MODELS["azure-foundry"]
+            )


### PR DESCRIPTION
## Summary

- `provider_model_ids(\"azure-foundry\")` now live-probes the configured resource's `/models` endpoint instead of returning the hardcoded empty list, so the runtime `/model azure-foundry` picker shows actual deployment IDs.
- Reuses the OpenAI-style probe the setup wizard already runs (`hermes_cli/azure_detect`) — no new network code, no new dependencies.
- Existing UX preserved on probe failure: falls through to the same static `[]` the picker showed before.

Fixes #27989.

## The bug

Every OpenAI-compatible provider with per-resource catalogs (`openai`, `openrouter`, `openai-codex`, `stepfun`, `gmi`, `nous`, `anthropic`, `ai-gateway`, `ollama-cloud`, `copilot`, `copilot-acp`, `custom`) plus `bedrock` has an explicit live-discovery branch in `hermes_cli/models.py::provider_model_ids`. `azure-foundry` was the outlier — `_PROVIDER_MODELS[\"azure-foundry\"] = []` is intentionally empty (deployments are per-resource, the user's `gpt-5.x` / `kimi-*` / `deepseek-v4-*` / `grok-*` deployment names cannot be hardcoded) and there was no live-discovery branch beneath it.

Result: users running `/model azure-foundry` (TUI, Slack, or any picker surface) saw \"0 models\" even when their Azure Foundry resource had multiple deployments visible to the configured API key. The only workarounds were editing `config.yaml model.default` by hand or re-running `hermes setup` to use the wizard's live discovery.

The working probe code already existed in `hermes_cli/azure_detect.py::_probe_openai_models` — used by the setup wizard for the exact same `{resource}.openai.azure.com/openai/v1` endpoint. It handles both the v1 GA path (no `api-version` required) and pre-v1 resources via api-version fallbacks, and sends both `api-key` and `Authorization: Bearer` headers so it works across Azure Foundry resource generations.

## The fix

1. **`hermes_cli/azure_detect.py`** — add a public `azure_foundry_model_ids_or_none(base_url, api_key) -> Optional[list[str]]` wrapper over `_probe_openai_models`. Mirrors the `Optional`-return contract of `agent.bedrock_adapter.bedrock_model_ids_or_none` so callers can fall through to the static list on probe failure.

2. **`hermes_cli/models.py::provider_model_ids`** — add an `azure-foundry` branch (placed next to the existing `bedrock` branch since both share the \"per-resource catalog, no static list\" shape). Resolves credentials through `resolve_api_key_provider_credentials(\"azure-foundry\")` — which checks `AZURE_FOUNDRY_API_KEY` / `AZURE_FOUNDRY_BASE_URL` from env or `~/.hermes/.env` — and dispatches to the new probe wrapper. Returns the live list when probe succeeds; otherwise falls through to the existing static path (unchanged behaviour, still returns `[]`).

The implementation is intentionally narrow: it does not touch the setup wizard, the runtime resolver, or the static catalog. Only the picker dispatch.

## Test plan

- [x] **Focused regression test** (`tests/hermes_cli/test_azure_foundry_picker.py`, 11 cases): probe success, probe failure, empty creds, empty probe response, resolver exception, whitespace normalisation, full dispatch through `provider_model_ids`.
- [x] **Adjacent suite** (`tests/hermes_cli/test_azure_detect.py` + `test_gmi_provider.py` + `test_model_validation.py`, 125 cases) — all pass; no behaviour change for any non-`azure-foundry` provider.
- [x] **Regression guard** — pulled the new `azure_foundry_model_ids_or_none` helper out and confirmed `test_dispatches_to_live_probe_when_credentials_resolve` fails with `AttributeError: module 'hermes_cli.azure_detect' does not have the attribute 'azure_foundry_model_ids_or_none'` (production symbol is load-bearing). Restored: test passes again.

## Related

Wires together two pre-existing pieces: the wizard-time probe in `hermes_cli/azure_detect.py` (already battle-tested for the same endpoint) and the picker dispatcher in `hermes_cli/models.py` (which already handles 13 other live-discovery providers). Same shape as `bedrock` — per-resource catalog, `Optional[list[str]]` discovery helper, fall-through to static list.

> Sibling code paths that may need the same fix: I audited `provider_model_ids` for other per-resource providers without a live-discovery branch and found none — every other provider with a non-empty curated list either has a discovery branch or a generic profile-based fetch in `providers/`. Happy to widen the scope if a maintainer spots one I missed.