### PR TITLE
feat(hindsight): add optional bank_id parameter to retain/recall/reflect tools

### DIFF
--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -126,9 +126,9 @@ Available in `hybrid` and `tools` memory modes:
 
 | Tool | Description |
 |------|-------------|
-| `hindsight_retain` | Store information with auto entity extraction; supports optional per-call `tags` |
-| `hindsight_recall` | Multi-strategy search (semantic + entity graph) |
-| `hindsight_reflect` | Cross-memory synthesis (LLM-powered) |
+| `hindsight_retain` | Store information with auto entity extraction; supports optional per-call `tags` and per-call `bank_id` override |
+| `hindsight_recall` | Multi-strategy search (semantic + entity graph); supports optional per-call `bank_id` override |
+| `hindsight_reflect` | Cross-memory synthesis (LLM-powered); supports optional per-call `bank_id` override |
 
 ## Environment Variables
 

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -306,6 +306,10 @@ RETAIN_SCHEMA = {
                 "items": {"type": "string"},
                 "description": "Optional per-call tags to merge with configured default retain tags.",
             },
+            "bank_id": {
+                "type": "string",
+                "description": "Optional target memory bank ID. When omitted, the default configured bank is used.",
+            },
         },
         "required": ["content"],
     },
@@ -321,6 +325,10 @@ RECALL_SCHEMA = {
         "type": "object",
         "properties": {
             "query": {"type": "string", "description": "What to search for."},
+            "bank_id": {
+                "type": "string",
+                "description": "Optional target memory bank ID. When omitted, the default configured bank is used.",
+            },
         },
         "required": ["query"],
     },
@@ -336,6 +344,10 @@ REFLECT_SCHEMA = {
         "type": "object",
         "properties": {
             "query": {"type": "string", "description": "The question to reflect on."},
+            "bank_id": {
+                "type": "string",
+                "description": "Optional target memory bank ID. When omitted, the default configured bank is used.",
+            },
         },
         "required": ["query"],
     },
@@ -1578,9 +1590,13 @@ class HindsightMemoryProvider(MemoryProvider):
         metadata: Dict[str, str] | None = None,
         tags: List[str] | None = None,
         retain_async: bool | None = None,
+        bank_id: str | None = None,
     ) -> Dict[str, Any]:
+        """Build kwargs for retain operations."""
+        # Use provided bank_id, fall back to default configured bank
+        effective_bank_id = bank_id if bank_id is not None else self._bank_id
         kwargs: Dict[str, Any] = {
-            "bank_id": self._bank_id,
+            "bank_id": effective_bank_id,
             "content": content,
             "metadata": metadata or self._build_metadata(message_count=1, turn_index=self._turn_index),
         }
@@ -1706,19 +1722,22 @@ class HindsightMemoryProvider(MemoryProvider):
             if not content:
                 return tool_error("Missing required parameter: content")
             context = args.get("context")
+            bank_id_override = args.get("bank_id")
             try:
                 item = self._build_retain_kwargs(
                     content,
                     context=context,
                     tags=args.get("tags"),
+                    bank_id=bank_id_override,
                 )
                 # aretain_batch takes bank_id/retain_async as call args, not item keys.
                 item.pop("bank_id", None)
                 item.pop("retain_async", None)
+                effective_bank = bank_id_override or self._bank_id
                 logger.debug("Tool hindsight_retain: bank=%s, content_len=%d, context=%s",
-                             self._bank_id, len(content), context)
+                             effective_bank, len(content), context)
                 self._run_hindsight_operation(
-                    lambda client: client.aretain_batch(bank_id=self._bank_id, items=[item])
+                    lambda client: client.aretain_batch(bank_id=effective_bank, items=[item])
                 )
                 logger.debug("Tool hindsight_retain: success")
                 return json.dumps({"result": "Memory stored successfully."})
@@ -1730,9 +1749,11 @@ class HindsightMemoryProvider(MemoryProvider):
             query = args.get("query", "")
             if not query:
                 return tool_error("Missing required parameter: query")
+            bank_id_override = args.get("bank_id")
             try:
+                effective_bank = bank_id_override or self._bank_id
                 recall_kwargs: dict = {
-                    "bank_id": self._bank_id, "query": query, "budget": self._budget,
+                    "bank_id": effective_bank, "query": query, "budget": self._budget,
                     "max_tokens": self._recall_max_tokens,
                 }
                 if self._recall_tags:
@@ -1741,7 +1762,7 @@ class HindsightMemoryProvider(MemoryProvider):
                 if self._recall_types:
                     recall_kwargs["types"] = self._recall_types
                 logger.debug("Tool hindsight_recall: bank=%s, query_len=%d, budget=%s",
-                             self._bank_id, len(query), self._budget)
+                             effective_bank, len(query), self._budget)
                 resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
                 num_results = len(resp.results) if resp.results else 0
                 logger.debug("Tool hindsight_recall: %d results", num_results)
@@ -1757,12 +1778,14 @@ class HindsightMemoryProvider(MemoryProvider):
             query = args.get("query", "")
             if not query:
                 return tool_error("Missing required parameter: query")
+            bank_id_override = args.get("bank_id")
             try:
+                effective_bank = bank_id_override or self._bank_id
                 logger.debug("Tool hindsight_reflect: bank=%s, query_len=%d, budget=%s",
-                             self._bank_id, len(query), self._budget)
+                             effective_bank, len(query), self._budget)
                 resp = self._run_hindsight_operation(
                     lambda client: client.areflect(
-                        bank_id=self._bank_id, query=query, budget=self._budget
+                        bank_id=effective_bank, query=query, budget=self._budget
                     )
                 )
                 logger.debug("Tool hindsight_reflect: response_len=%d", len(resp.text or ""))

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -783,6 +783,68 @@ class TestToolHandlers:
         first_client.arecall.assert_called_once()
         second_client.arecall.assert_called_once()
 
+    # ---------------------------------------------------------------------------
+    # Multi-bank override tests
+    # ---------------------------------------------------------------------------
+
+    def test_retain_uses_override_bank_id(self, provider):
+        """Retain with explicit bank_id overrides the default bank."""
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_retain", {"content": "work note", "bank_id": "test-bank-work"}
+        ))
+        assert result["result"] == "Memory stored successfully."
+        provider._client.aretain_batch.assert_called_once()
+        call_kwargs = provider._client.aretain_batch.call_args.kwargs
+        assert call_kwargs["bank_id"] == "test-bank-work"
+        item = call_kwargs["items"][0]
+        assert item["content"] == "work note"
+
+    def test_retain_without_bank_id_uses_default(self, provider):
+        """Retain without bank_id uses the configured default bank."""
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_retain", {"content": "personal note"}
+        ))
+        assert result["result"] == "Memory stored successfully."
+        provider._client.aretain_batch.assert_called_once()
+        call_kwargs = provider._client.aretain_batch.call_args.kwargs
+        assert call_kwargs["bank_id"] == "test-bank"
+
+    def test_recall_uses_override_bank_id(self, provider):
+        """Recall with explicit bank_id overrides the default bank."""
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_recall", {"query": "test", "bank_id": "test-bank-personal"}
+        ))
+        assert "Memory 1" in result["result"]
+        call_kwargs = provider._client.arecall.call_args.kwargs
+        assert call_kwargs["bank_id"] == "test-bank-personal"
+
+    def test_recall_without_bank_id_uses_default(self, provider):
+        """Recall without bank_id uses the configured default bank."""
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_recall", {"query": "test"}
+        ))
+        assert "Memory 1" in result["result"]
+        call_kwargs = provider._client.arecall.call_args.kwargs
+        assert call_kwargs["bank_id"] == "test-bank"
+
+    def test_reflect_uses_override_bank_id(self, provider):
+        """Reflect with explicit bank_id overrides the default bank."""
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_reflect", {"query": "summarize", "bank_id": "test-bank-work"}
+        ))
+        assert result["result"] == "Synthesized answer"
+        call_kwargs = provider._client.areflect.call_args.kwargs
+        assert call_kwargs["bank_id"] == "test-bank-work"
+
+    def test_reflect_without_bank_id_uses_default(self, provider):
+        """Reflect without bank_id uses the configured default bank."""
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_reflect", {"query": "summarize"}
+        ))
+        assert result["result"] == "Synthesized answer"
+        call_kwargs = provider._client.areflect.call_args.kwargs
+        assert call_kwargs["bank_id"] == "test-bank"
+
 
 # ---------------------------------------------------------------------------
 # Prefetch tests


### PR DESCRIPTION
## Summary

Add an optional `bank_id` parameter to all three Hindsight memory tools (`hindsight_retain`, `hindsight_recall`, `hindsight_reflect`) to enable per-call multi-bank support.

## Motivation

Previously, the Hindsight plugin only supported a single bank ID configured at initialization. Users who wanted to organize memories into separate banks (e.g., personal vs. work vs. project-specific) had to run multiple Hermes profiles or use tags as a workaround. This change allows directing any individual tool call to a specific bank while maintaining full backward compatibility.

## Changes

- **Schemas** (`RETAIN_SCHEMA`, `RECALL_SCHEMA`, `REFLECT_SCHEMA`): Added optional `bank_id` string parameter with description.
- **`_build_retain_kwargs`**: Added optional `bank_id` parameter; defaults to `self._bank_id` when omitted.
- **`handle_tool_call`**: Each tool now extracts `bank_id` from args and overrides the default bank. Log messages updated to reflect the effective bank.
- **Tests**: Added 6 new tests verifying:
  - `retain` with override bank_id
  - `retain` without override (uses default)
  - `recall` with override bank_id
  - `recall` without override (uses default)
  - `reflect` with override bank_id
  - `reflect` without override (uses default)

## Usage Example

```python
# Store work-related memory in a dedicated bank
hindsight_retain(content="API key rotation policy updated", bank_id="hermes-work")

# Search only the personal bank
hindsight_recall(query="birthday", bank_id="hermes-personal")

# Reflect across project memories
hindsight_reflect(query="What were the main blockers?", bank_id="hermes-project-x")
```

When `bank_id` is omitted, behavior is unchanged — the configured default bank is used.

## Backward Compatibility

✅ Fully backward compatible. The `bank_id` parameter is optional in all schemas and defaults to the existing configured bank.

## Testing

All 102 existing Hindsight tests pass, plus 6 new tests for the override behavior.

```bash
pytest tests/plugins/memory/test_hindsight_provider.py -v
# 102 passed in 9.45s
```
