### PR TITLE
feat(api-server): add API_SERVER_STATELESS env for true stateless multi-tenant mode

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2,7 +2,9 @@
 OpenAI-compatible API server platform adapter.
 
 Exposes an HTTP server with endpoints:
-- POST /v1/chat/completions        — OpenAI Chat Completions format (stateless; opt-in session continuity via X-Hermes-Session-Id header; opt-in long-term memory scoping via X-Hermes-Session-Key header)
+- POST /v1/chat/completions        — OpenAI Chat Completions format (stateless; opt-in session continuity via X-Hermes-Session-Id header; opt-in long-term memory scoping via X-Hermes-Session-Key header).
+                                      Set API_SERVER_STATELESS=true to disable server-side SessionDB persistence entirely
+                                      (useful for multi-tenant SaaS frontends that manage their own session storage).
 - POST /v1/responses               — OpenAI Responses API format (stateful via previous_response_id; X-Hermes-Session-Key supported)
 - GET  /v1/responses/{response_id} — Retrieve a stored response
 - DELETE /v1/responses/{response_id} — Delete a stored response
@@ -835,7 +837,20 @@ class APIServerAdapter(BasePlatformAdapter):
 
         Sessions are persisted to ``state.db`` so that ``hermes sessions list``
         shows API-server conversations alongside CLI and gateway ones.
+
+        When ``API_SERVER_STATELESS=true`` is set in the environment, this
+        returns ``None`` unconditionally — the API server then runs in a
+        truly stateless mode where ``/v1/chat/completions`` does not write
+        to ``state.db``. This is intended for multi-tenant SaaS frontends
+        that manage their own session storage externally (e.g. in Redis).
+
+        ``AIAgent`` already supports ``session_db=None`` (see
+        ``run_agent.py``'s ``_flush_messages_to_session_db`` early-return),
+        so this only exposes that existing capability via an env-var switch.
         """
+        if os.getenv("API_SERVER_STATELESS", "").lower() in ("true", "1", "yes"):
+            return None
+
         if self._session_db is None:
             try:
                 from hermes_state import SessionDB
@@ -1094,6 +1109,16 @@ class APIServerAdapter(BasePlatformAdapter):
         # read arbitrary session history by guessing/enumerating session IDs.
         provided_session_id = request.headers.get("X-Hermes-Session-Id", "").strip()
         if provided_session_id:
+            if os.getenv("API_SERVER_STATELESS", "").lower() in ("true", "1", "yes"):
+                return web.json_response(
+                    _openai_error(
+                        "X-Hermes-Session-Id is not supported when API_SERVER_STATELESS=true. "
+                        "Either unset API_SERVER_STATELESS or remove the X-Hermes-Session-Id "
+                        "header and pass full conversation history in the messages array."
+                    ),
+                    status=400,
+                )
+
             if not self._api_key:
                 logger.warning(
                     "Session continuation via X-Hermes-Session-Id rejected: "

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -3311,3 +3311,70 @@ class TestSessionKeyHeader:
             assert resp.status == 200
             data = await resp.json()
             assert data["features"]["session_key_header"] == "X-Hermes-Session-Key"
+
+
+# ---------------------------------------------------------------------------
+# API_SERVER_STATELESS env variable (multi-tenant SaaS use case)
+# ---------------------------------------------------------------------------
+
+
+class TestStatelessMode:
+    """Tests for API_SERVER_STATELESS=true — server skips SessionDB entirely."""
+
+    def test_ensure_session_db_returns_none_when_stateless_env_set(self, adapter, monkeypatch):
+        """With API_SERVER_STATELESS=true, _ensure_session_db returns None."""
+        monkeypatch.setenv("API_SERVER_STATELESS", "true")
+        assert adapter._ensure_session_db() is None
+        # The cached instance stays None — no implicit SessionDB() created.
+        assert adapter._session_db is None
+
+    def test_ensure_session_db_accepts_alternate_truthy_values(self, adapter, monkeypatch):
+        """Accept '1', 'yes', 'true' (case-insensitive)."""
+        for value in ("true", "True", "TRUE", "1", "yes", "YES"):
+            monkeypatch.setenv("API_SERVER_STATELESS", value)
+            # Reset _session_db so we re-evaluate the env on each iteration.
+            adapter._session_db = None
+            assert adapter._ensure_session_db() is None, f"Failed for value={value!r}"
+
+    def test_ensure_session_db_unchanged_when_env_unset(self, adapter, monkeypatch):
+        """Default behavior preserved when API_SERVER_STATELESS is unset."""
+        monkeypatch.delenv("API_SERVER_STATELESS", raising=False)
+
+        sentinel = object()
+        with patch("hermes_state.SessionDB", return_value=sentinel):
+            result = adapter._ensure_session_db()
+            assert result is sentinel
+
+    def test_ensure_session_db_unchanged_when_env_falsy(self, adapter, monkeypatch):
+        """API_SERVER_STATELESS=false (or other falsy values) behaves like unset."""
+        for value in ("false", "False", "0", "no", ""):
+            monkeypatch.setenv("API_SERVER_STATELESS", value)
+            adapter._session_db = None
+            sentinel = object()
+            with patch("hermes_state.SessionDB", return_value=sentinel):
+                result = adapter._ensure_session_db()
+                assert result is sentinel, f"Failed for value={value!r}"
+
+    @pytest.mark.asyncio
+    async def test_chat_completions_rejects_session_id_in_stateless_mode(
+        self, auth_adapter, monkeypatch
+    ):
+        """When stateless mode is on, sending X-Hermes-Session-Id returns 400 with a clear error."""
+        monkeypatch.setenv("API_SERVER_STATELESS", "true")
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                headers={
+                    "Authorization": "Bearer sk-secret",
+                    "X-Hermes-Session-Id": "some-session-id",
+                },
+                json={
+                    "model": "hermes-agent",
+                    "messages": [{"role": "user", "content": "hello"}],
+                },
+            )
+            assert resp.status == 400
+            body = await resp.json()
+            assert "API_SERVER_STATELESS" in body["error"]["message"]
+            assert "X-Hermes-Session-Id" in body["error"]["message"]

--- a/website/docs/user-guide/docker.md
+++ b/website/docs/user-guide/docker.md
@@ -58,6 +58,8 @@ docker run -d \
 
 Opening any port on an internet facing machine is a security risk. You should not do it unless you understand the risks.
 
+For multi-tenant SaaS frontends that manage their own session storage, also set `API_SERVER_STATELESS=true` to disable server-side SessionDB persistence. See [Stateless Mode](./features/api-server.md#stateless-mode-for-saas-frontends).
+
 ## Running the dashboard
 
 The built-in web dashboard runs as an optional side-process inside the same container as the gateway. Set `HERMES_DASHBOARD=1` and expose port `9119` alongside the gateway's `8642`:

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -430,6 +430,49 @@ In Open WebUI, add each as a separate connection. The model dropdown shows `alic
 - **No file upload** — inline images are supported on both `/v1/chat/completions` and `/v1/responses`, but uploaded files (`file`, `input_file`, `file_id`) and non-image document inputs are not supported through the API.
 - **Model field is cosmetic** — the `model` field in requests is accepted but the actual LLM model used is configured server-side in config.yaml.
 
+## Stateless Mode (for SaaS Frontends)
+
+For frontends that manage their own conversation storage externally (e.g. multi-tenant SaaS platforms storing history in Redis or Postgres), set:
+
+```bash
+API_SERVER_STATELESS=true
+```
+
+In stateless mode:
+
+- `/v1/chat/completions` does **not** write to `state.db`. Each request is treated as a self-contained conversation, fully described by the `messages` array.
+- `X-Hermes-Session-Id` header is **not supported** — sending it returns `400` with a clear error.
+- `X-Hermes-Session-Key` (long-term memory scoping) is also bypassed since SessionDB is the persistence layer.
+- `hermes sessions list` will not show API-server conversations (they are not persisted).
+- `/v1/responses` (the OpenAI Responses API endpoint) is **unaffected** — it has its own `ResponseStore` persistence for `previous_response_id` chaining.
+
+### When to use
+
+Enable stateless mode when:
+
+- You're building a multi-tenant frontend where conversation history is per-tenant in *your* database, and shadow copies in Hermes's `state.db` would conflict with your tenant isolation
+- You want `/v1/chat/completions` to behave exactly like OpenAI's API (no server-side state)
+- You're running many concurrent users against a single Hermes process and don't want SQLite write contention
+
+### When NOT to use
+
+Keep stateless mode **off** (default) when:
+
+- You're using Open WebUI, LobeChat, or other frontends that benefit from server-side session continuation via `X-Hermes-Session-Id`
+- You want `session_search` to work across API-server conversations
+- You need `hermes sessions list` to show API-server conversations
+
+### Example
+
+```bash
+docker run \
+  -e API_SERVER_ENABLED=true \
+  -e API_SERVER_STATELESS=true \
+  -e API_SERVER_KEY=$(openssl rand -hex 32) \
+  -p 8642:8642 \
+  nousresearch/hermes-agent
+```
+
 ## Proxy Mode
 
 The API server also serves as the backend for **gateway proxy mode**. When another Hermes gateway instance is configured with `GATEWAY_PROXY_URL` pointing at this API server, it forwards all messages here instead of running its own agent. This enables split deployments — for example, a Docker container handling Matrix E2EE that relays to a host-side agent.


### PR DESCRIPTION
## What

Add an opt-in `API_SERVER_STATELESS` environment variable to the OpenAI-compatible API server platform. When enabled, the API server skips SessionDB creation, making `/v1/chat/completions` truly stateless on the server side (no SQLite writes for inbound requests).

## Why

The current implementation always persists conversations to `state.db` via `_ensure_session_db()` (api_server.py:833), even though:

1. The docstring at api_server.py:5 advertises `/v1/chat/completions` as "stateless — opt-in session continuity via X-Hermes-Session-Id header"
2. `AIAgent._flush_messages_to_session_db()` (run_agent.py:1239) already gracefully handles `session_db=None` with an early return
3. Multi-tenant SaaS frontends that manage their own session storage (Redis, Postgres, etc.) don't want a shadow copy of every conversation in Hermes's SQLite — it conflicts with their tenant-isolation guarantees and bloats `state.db` unnecessarily

This patch exposes the existing `session_db=None` capability through a single environment variable. No behavior change when the variable is unset.

## Use case

Building a multi-tenant LLM platform that wraps Hermes as the agent runtime. The platform's control plane:

- Stores conversation history in Redis (per-tenant isolation, TTL-managed)
- Injects tenant-scoped system prompts and tools per request
- Already manages the full conversation lifecycle externally

Without `API_SERVER_STATELESS=true`, Hermes silently duplicates this state into its own SQLite, which:

- Doubles storage of conversation content (bad for compliance: harder to honor "delete my data" requests when state is in two places)
- Creates write contention when many tenants share one Hermes process
- Mixes multiple tenants' data into one `state.db` file (no built-in tenant isolation in SessionDB)

## Behavior

| Mode | `_ensure_session_db()` | `state.db` writes for `/v1/chat/completions` |
|---|---|---|
| Default (env unset or `false`) | Creates `SessionDB()` (unchanged) | Persists as today |
| `API_SERVER_STATELESS=true` (new) | Returns `None` | None — fully stateless |

When `API_SERVER_STATELESS=true` and a client sends `X-Hermes-Session-Id`, the request returns `400` with a clear error message instructing the caller that session continuation is disabled in stateless mode. (The header was previously ignored when SessionDB was unavailable — now it's explicit.)

`/v1/responses` (which uses `previous_response_id` and is *intentionally* stateful via `ResponseStore`) is unaffected — that's a separate persistence layer for the Responses API spec.

## Compatibility

- **Backward compatible:** Default behavior unchanged. Existing deployments need no action.
- **No new dependencies.**
- **Docker:** Set `-e API_SERVER_STATELESS=true` in the container.

## Tests

Added 3 unit tests to `tests/gateway/test_api_server.py`:

1. `test_ensure_session_db_returns_none_when_stateless_env_set` — verifies env var takes effect
2. `test_ensure_session_db_unchanged_when_env_unset` — verifies default behavior preserved
3. `test_chat_completions_rejects_session_id_in_stateless_mode` — verifies clear error when header is sent in stateless mode

Tests pass locally with `pytest tests/gateway/test_api_server.py -v`.

## Docs

Updated `website/docs/user-guide/features/api-server.md` with a new "Stateless Mode" section.

## Discussion welcome on

- Naming: `API_SERVER_STATELESS` vs `API_SERVER_NO_SESSION_DB` vs `API_SERVER_EPHEMERAL`
- Whether to also surface this via `config.yaml` (currently env-only matches existing `API_SERVER_*` pattern)
- Whether `X-Hermes-Session-Id` in stateless mode should `400` or just silently ignore (I chose `400` for explicitness, happy to change)