### PR TITLE
fix(browser): avoid auto-install during tool discovery

### DIFF
--- a/tests/tools/test_browser_homebrew_paths.py
+++ b/tests/tools/test_browser_homebrew_paths.py
@@ -212,7 +212,10 @@ class TestBrowserRequirements:
     def test_cdp_override_does_not_require_agent_browser_cli(self, monkeypatch):
         monkeypatch.setenv("BROWSER_CDP_URL", "ws://127.0.0.1:9222/devtools/browser/test")
         monkeypatch.setattr("tools.browser_tool._is_camofox_mode", lambda: False)
-        monkeypatch.setattr("tools.browser_tool._find_agent_browser", lambda: (_ for _ in ()).throw(FileNotFoundError("not found")))
+        monkeypatch.setattr(
+            "tools.browser_tool._find_agent_browser",
+            lambda *args, **kwargs: (_ for _ in ()).throw(FileNotFoundError("not found")),
+        )
 
         assert check_browser_requirements() is True
 
@@ -221,7 +224,22 @@ class TestBrowserRequirements:
         monkeypatch.setenv("PREFIX", "/data/data/com.termux/files/usr")
         monkeypatch.setattr("tools.browser_tool._is_camofox_mode", lambda: False)
         monkeypatch.setattr("tools.browser_tool._get_cloud_provider", lambda: None)
-        monkeypatch.setattr("tools.browser_tool._find_agent_browser", lambda: "npx agent-browser")
+        monkeypatch.setattr(
+            "tools.browser_tool._find_agent_browser",
+            lambda *args, **kwargs: "npx agent-browser",
+        )
+
+        assert check_browser_requirements() is False
+
+    def test_browser_requirements_does_not_auto_install(self, monkeypatch):
+        monkeypatch.setattr("tools.browser_tool._is_camofox_mode", lambda: False)
+        monkeypatch.setattr("tools.browser_tool._get_cdp_override", lambda: None)
+        monkeypatch.setattr(
+            "tools.browser_tool._find_agent_browser",
+            lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("unexpected auto-install lookup"))
+            if kwargs.get("auto_install") is not False
+            else (_ for _ in ()).throw(FileNotFoundError("not found")),
+        )
 
         assert check_browser_requirements() is False
 
@@ -230,7 +248,10 @@ class TestRunBrowserCommandTermuxFallback:
     def test_termux_local_mode_rejects_bare_npx_fallback(self, monkeypatch):
         monkeypatch.setenv("TERMUX_VERSION", "0.118.3")
         monkeypatch.setenv("PREFIX", "/data/data/com.termux/files/usr")
-        monkeypatch.setattr("tools.browser_tool._find_agent_browser", lambda: "npx agent-browser")
+        monkeypatch.setattr(
+            "tools.browser_tool._find_agent_browser",
+            lambda *args, **kwargs: "npx agent-browser",
+        )
         monkeypatch.setattr("tools.browser_tool._get_cloud_provider", lambda: None)
 
         result = _run_browser_command("task-1", "navigate", ["https://example.com"])

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1632,12 +1632,17 @@ def _get_session_info(task_id: Optional[str] = None) -> Dict[str, str]:
 
 
 
-def _find_agent_browser() -> str:
+def _find_agent_browser(*, auto_install: bool = True) -> str:
     """
     Find the agent-browser CLI executable.
 
     Checks in order: current PATH, Homebrew/common bin dirs, Hermes-managed
     node, local node_modules/.bin/, npx fallback.
+
+    Args:
+        auto_install: When True, try Hermes' dependency bootstrap before
+            failing. Availability checks should pass False so tool discovery
+            never blocks on dependency installation.
 
     Returns:
         Path to agent-browser executable
@@ -1704,21 +1709,22 @@ def _find_agent_browser() -> str:
         return _cached_agent_browser
 
     # Nothing found — try lazy installation before giving up.
-    try:
-        from hermes_cli.dep_ensure import ensure_dependency
-        if ensure_dependency("browser"):
-            recheck = shutil.which("agent-browser")
-            if not recheck and extended_path:
-                recheck = shutil.which("agent-browser", path=extended_path)
-            if not recheck:
-                hermes_nm = str(get_hermes_home() / "node_modules" / ".bin")
-                recheck = shutil.which("agent-browser", path=hermes_nm)
-            if recheck:
-                _cached_agent_browser = recheck
-                _agent_browser_resolved = True
-                return recheck
-    except Exception:
-        pass
+    if auto_install:
+        try:
+            from hermes_cli.dep_ensure import ensure_dependency
+            if ensure_dependency("browser"):
+                recheck = shutil.which("agent-browser")
+                if not recheck and extended_path:
+                    recheck = shutil.which("agent-browser", path=extended_path)
+                if not recheck:
+                    hermes_nm = str(get_hermes_home() / "node_modules" / ".bin")
+                    recheck = shutil.which("agent-browser", path=hermes_nm)
+                if recheck:
+                    _cached_agent_browser = recheck
+                    _agent_browser_resolved = True
+                    return recheck
+        except Exception:
+            pass
 
     _agent_browser_resolved = True
     raise FileNotFoundError(
@@ -3497,7 +3503,7 @@ def check_browser_requirements() -> bool:
 
     # The agent-browser CLI is required for local launch and cloud-provider flows.
     try:
-        browser_cmd = _find_agent_browser()
+        browser_cmd = _find_agent_browser(auto_install=False)
     except FileNotFoundError:
         return False
 


### PR DESCRIPTION
## What does this PR do?

Fixes a gateway hang where Hermes could go silent on Discord/Mattermost before any model call if browser tools were unavailable.

The root cause was `check_browser_requirements()` calling `_find_agent_browser()`, which could trigger `ensure_dependency("browser")` during normal tool discovery. In a Docker deployment without browser/Node prerequisites, that path attempted dependency bootstrap and blocked agent initialization instead of simply marking browser tools unavailable.

This change makes browser tool discovery non-installing by default: availability checks call `_find_agent_browser(auto_install=False)`, while explicit browser execution paths keep the existing install-capable lookup behavior.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `tools/browser_tool.py` so `_find_agent_browser()` accepts `auto_install=True|False`
- Changed `check_browser_requirements()` to use `_find_agent_browser(auto_install=False)`
- Added regression coverage in `tests/tools/test_browser_homebrew_paths.py` to verify browser requirements checks do not attempt auto-install
- Updated existing test doubles to accept the new kwarg where needed

## How to Test

1. Run `scripts/run_tests.sh tests/tools/test_browser_homebrew_paths.py tests/tools/test_browser_hardening.py`
2. Verify browser availability still works when `agent-browser` is installed
3. Verify `check_browser_requirements()` returns `False` rather than attempting install/bootstrap when browser dependencies are missing

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 / Dockerized Hermes gateway repro

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Relevant repro milestone before this fix in a live gateway deployment:

- `Agent init: loading tool definitions provider=xai-oauth model=grok-4.3 platform=discord`
- `Tool definitions: checking availability for browser_back (toolset=browser)`
- no subsequent `Agent init: loaded ...` or conversation start/return log

After applying this change in the same deployment, both Discord and Mattermost resumed responding normally.
