### PR TITLE
fix(gateway/feishu): always route outbound via post + md tag

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -149,13 +149,6 @@ logger = logging.getLogger(__name__)
 # Regex patterns
 # ---------------------------------------------------------------------------
 
-_MARKDOWN_HINT_RE = re.compile(
-    r"(^#{1,6}\s)|(^\s*[-*]\s)|(^\s*\d+\.\s)|(^\s*---+\s*$)|(```)|(`[^`\n]+`)|(\*\*[^*\n].+?\*\*)|(~~[^~\n].+?~~)|(<u>.+?</u>)|(\*[^*\n]+\*)|(\[[^\]]+\]\([^)]+\))|(^>\s)",
-    re.MULTILINE,
-)
-# Detect markdown tables: a line starting with | followed by a separator line.
-# Feishu post-type 'md' elements do not render tables, so we force text mode.
-_MARKDOWN_TABLE_RE = re.compile(r"^\|.*\|\n\|[-|: ]+\|", re.MULTILINE)
 _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 _MARKDOWN_FENCE_OPEN_RE = re.compile(r"^```([^\n`]*)\s*$")
 _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
@@ -4222,16 +4215,31 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
-        # Feishu post-type 'md' elements do not render markdown tables; sending
-        # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
-        if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
-            return "text", json.dumps(text_payload, ensure_ascii=False)
-        if _MARKDOWN_HINT_RE.search(content):
-            return "post", _build_markdown_post_payload(content)
-        text_payload = {"text": content}
-        return "text", json.dumps(text_payload, ensure_ascii=False)
+        # Always route outbound messages through the post + `md` tag path.
+        #
+        # Background: Feishu's post-type `md` tag renders markdown (including
+        # tables) correctly on current Lark (international) and Feishu (CN)
+        # clients. Earlier versions of this method maintained a "markdown
+        # detection" regex that downgraded plain-looking text to msg_type=text
+        # and downgraded table-containing content even harder. Both heuristics
+        # were sources of bugs:
+        #   - The table-downgrade caused the *entire* message (headers, bold,
+        #     lists, code, the lot) to render as raw markdown source whenever
+        #     a single GFM pipe-table appeared.
+        #   - The hint-regex caused subtle mis-routing for messages that
+        #     happened to contain `_`, `*`, `#`, `>` as literal characters
+        #     (shell output, code traces, prose punctuation) — the regex
+        #     either over-matched and triggered post-mode for no reason, or
+        #     under-matched and lost styling on legitimate markdown that
+        #     didn't fit its patterns.
+        #
+        # Empirically the `md` tag is a strict superset of plain text on both
+        # clients: prose without markup renders identically to msg_type=text,
+        # URLs auto-link, mentions still work. We rely on the outer
+        # `_feishu_send_with_retry` to fall back to msg_type=text if the
+        # Feishu API ever rejects a specific payload with
+        # "content format of the post type is incorrect".
+        return "post", _build_markdown_post_payload(content)
 
     async def _send_uploaded_file_message(
         self,

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -365,10 +365,16 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
         self.assertTrue(result.success)
         self.assertEqual(result.message_id, "om_progress")
         self.assertEqual(captured["request"].message_id, "om_progress")
-        self.assertEqual(captured["request"].request_body.msg_type, "text")
+        self.assertEqual(captured["request"].request_body.msg_type, "post")
         self.assertEqual(
-            captured["request"].request_body.content,
-            json.dumps({"text": "📖 read_file: \"/tmp/image.png\""}, ensure_ascii=False),
+            json.loads(captured["request"].request_body.content),
+            {
+                "zh_cn": {
+                    "content": [
+                        [{"tag": "md", "text": "📖 read_file: \"/tmp/image.png\""}]
+                    ]
+                }
+            },
         )
 
     @patch.dict(os.environ, {}, clear=True)
@@ -2505,6 +2511,67 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(
             rows,
             [[{"tag": "md", "text": "---\n1. 第一项\n  2. 子项\n- 外层\n  - 内层\n<u>下划线</u> 和 ~~删除线~~"}]],
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_outbound_payload_routes_table_to_post_not_text(self):
+        """Regression: markdown tables must go through `post` + md tag.
+
+        Earlier code defensively downgraded any message containing a
+        markdown table to `text` (msg_type=text), under the assumption
+        that Feishu's `md` tag couldn't render tables. That assumption
+        was wrong on both Lark and Feishu — the `md` tag renders tables
+        fine — and the downgrade caused the ENTIRE message (headers,
+        bold, lists, code) to display as raw markdown source whenever a
+        single table appeared. This test pins the fix in place.
+        """
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        content = (
+            "## 标题\n\n"
+            "正文带 **粗体**。\n\n"
+            "| 列 A | 列 B |\n"
+            "|------|------|\n"
+            "| 1 | 2 |\n"
+            "| 3 | 4 |\n"
+        )
+
+        msg_type, payload = adapter._build_outbound_payload(content)
+
+        self.assertEqual(msg_type, "post")
+        parsed = json.loads(payload)
+        # The full content (including the table) must be preserved verbatim
+        # inside an `md` tag — not stripped, not split, not converted.
+        rows = parsed["zh_cn"]["content"]
+        flat_text = "".join(
+            el.get("text", "")
+            for row in rows
+            for el in row
+            if el.get("tag") == "md"
+        )
+        self.assertIn("| 列 A | 列 B |", flat_text)
+        self.assertIn("|------|------|", flat_text)
+        self.assertIn("## 标题", flat_text)
+        self.assertIn("**粗体**", flat_text)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_outbound_payload_plain_text_uses_post_md(self):
+        """Plain text now also routes through post + md tag (md is a strict
+        superset of text on current Feishu/Lark clients; see
+        _build_outbound_payload for the rationale)."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        msg_type, payload = adapter._build_outbound_payload("你好，今天天气不错。")
+
+        self.assertEqual(msg_type, "post")
+        decoded = json.loads(payload)
+        self.assertEqual(
+            decoded,
+            {"zh_cn": {"content": [[{"tag": "md", "text": "你好，今天天气不错。"}]]}},
         )
 
     @patch.dict(os.environ, {}, clear=True)


### PR DESCRIPTION
## Summary

`FeishuAdapter._build_outbound_payload` previously used two regex heuristics to choose between `msg_type=text` and `msg_type=post`. Both heuristics produced visible misrendering:

1. **`_MARKDOWN_TABLE_RE`** force-downgraded any message containing a GFM table to `msg_type=text`. The downgrade made the *entire* message — headers, bold, lists, code, the table itself — render as raw markdown source on both Lark (international) and Feishu (CN) clients.
2. **`_MARKDOWN_HINT_RE`** over-matched on incidental punctuation (`_ * # >` in shell output, stack traces, prose) and under-matched on legitimate markdown that didn't fit its narrow patterns — yielding inconsistent styling between similar-looking messages.

## Fix

Always route outbound messages through `post` + the `md` tag.

Empirical testing on current Lark and Feishu clients shows the `md` tag is a strict superset of `msg_type=text`:

| Content type | `md` tag result |
|---|---|
| Plain prose | renders identically to `text` |
| URLs | auto-linked |
| Mentions | work |
| Emoji | display correctly |
| Special chars (`_*#>`) | literal |
| Multi-line | preserved |
| Markdown tables | render as native tables ✅ |

The outer `_feishu_send_with_retry` still catches the rare `"content format of the post type is incorrect"` API error and falls back to `msg_type=text`, so the safety net stays.

Drops both regex constants and the conditional branching — one code path, one render mode.

## Tests

- `tests/gateway/test_feishu.py`: 200/200 pass
- Added regression test `test_outbound_payload_routes_table_to_post_not_text` — pins the table-bug fix
- Added regression test `test_outbound_payload_plain_text_uses_post_md` — pins the strict-superset claim
- Updated existing `text`-mode assertion that no longer applies

## Verification

Validated end-to-end through the live gateway adapter (not a raw API bypass) on Lark international — plain text, special chars, URLs, multi-line+emoji, and a markdown table all rendered correctly.
