### PR TITLE
 feat(google-drive-pipeline): add Drive artifact publish workflow

### DIFF
--- a/plugins/google_drive_pipeline/README.md
+++ b/plugins/google_drive_pipeline/README.md
@@ -1,0 +1,86 @@
+# google_drive_pipeline
+
+CLI-backed Google Drive artifact publishing on top of the existing
+`google-workspace` skill primitives.
+
+This plugin does not add new Google API capabilities by itself. Instead, it
+turns the lower-level Drive commands from `google_api.py` into a higher-level
+workflow for publishing artifacts:
+
+- resolve a target folder
+- create the folder if missing
+- upload a local file
+- optionally apply sharing
+- return a canonical Drive link
+- persist publish records for later inspection/reuse
+
+## Why this exists
+
+`feat(google-workspace): Drive write ops + Docs/Sheets create/append` added the
+raw Drive write commands:
+
+- `drive search`
+- `drive get`
+- `drive upload`
+- `drive create-folder`
+- `drive share`
+
+Those commands are the toolbox. This plugin is the operator workflow layer on
+top of that toolbox.
+
+## Commands
+
+```bash
+hermes google-drive-pipeline resolve-folder --folder-name Reports
+
+hermes google-drive-pipeline publish ./report.pdf \
+  --folder-name Reports \
+  --create-missing-folder
+
+hermes google-drive-pipeline publish ./report.pdf \
+  --folder-name Reports \
+  --duplicate-policy reuse
+
+hermes google-drive-pipeline publish ./report.pdf \
+  --folder-name Reports \
+  --share-type anyone \
+  --share-role reader
+
+hermes google-drive-pipeline list
+hermes google-drive-pipeline show RECORD_ID
+```
+
+## Duplicate policies
+
+- `fail`: error if a same-named file already exists in the target folder
+- `reuse`: reuse an existing matching publish record or same-named Drive file
+- `version`: upload with a timestamped filename when a conflict exists
+
+## Store
+
+The plugin stores publish records in:
+
+```text
+$HERMES_HOME/google_drive_pipeline_store.json
+```
+
+It keeps:
+
+- publish records
+- source-key index for `reuse`
+- folder cache for resolved folders
+
+## Requirements
+
+- `google_drive_pipeline` must be enabled in `plugins.enabled`
+- Google Workspace auth must already exist in the current Hermes profile
+- The underlying `google-workspace` setup/token is still the source of truth
+
+## Out of scope
+
+- Gmail / Calendar orchestration
+- Docs / Sheets publish flows
+- background scheduling
+- webhook/event ingestion
+
+This plugin is intentionally narrow: Drive artifact logistics only.

--- a/plugins/google_drive_pipeline/__init__.py
+++ b/plugins/google_drive_pipeline/__init__.py
@@ -1,0 +1,26 @@
+"""Google Drive artifact pipeline plugin.
+
+Registers only operator-facing CLI surfaces. The pipeline reuses the existing
+google-workspace Drive primitives and adds orchestration on top.
+"""
+
+from __future__ import annotations
+
+from plugins.google_drive_pipeline.cli import (
+    google_drive_pipeline_command,
+    register_cli,
+)
+
+
+def register(ctx) -> None:
+    ctx.register_cli_command(
+        name="google-drive-pipeline",
+        help="Inspect and operate the Google Drive artifact pipeline",
+        setup_fn=register_cli,
+        handler_fn=google_drive_pipeline_command,
+        description=(
+            "Operator CLI for publishing artifacts into Google Drive. "
+            "Resolves target folders, handles duplicate naming policies, "
+            "applies sharing, and returns canonical Drive links."
+        ),
+    )

--- a/plugins/google_drive_pipeline/cli.py
+++ b/plugins/google_drive_pipeline/cli.py
@@ -1,0 +1,145 @@
+"""CLI commands for the Google Drive artifact pipeline plugin."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from plugins.google_drive_pipeline.models import PublishArtifactRequest, SharePolicy
+from plugins.google_drive_pipeline.pipeline import GoogleDrivePipeline, GoogleDrivePipelineError
+from plugins.google_drive_pipeline.store import (
+    GoogleDrivePipelineStore,
+    resolve_google_drive_pipeline_store_path,
+)
+
+
+def register_cli(subparser: argparse.ArgumentParser) -> None:
+    subs = subparser.add_subparsers(dest="google_drive_pipeline_action")
+
+    resolve_p = subs.add_parser("resolve-folder", help="Resolve a Drive folder by id or exact name")
+    resolve_p.add_argument("--folder-id", default="")
+    resolve_p.add_argument("--folder-name", default="")
+    resolve_p.add_argument("--parent-folder-id", default="")
+    resolve_p.add_argument("--create-missing", action="store_true")
+    resolve_p.add_argument("--store-path", default="")
+
+    publish_p = subs.add_parser("publish", help="Publish a local artifact into Drive")
+    publish_p.add_argument("file_path")
+    publish_p.add_argument("--drive-name", default="")
+    publish_p.add_argument("--folder-id", default="")
+    publish_p.add_argument("--folder-name", default="")
+    publish_p.add_argument("--parent-folder-id", default="")
+    publish_p.add_argument("--create-missing-folder", action="store_true")
+    publish_p.add_argument(
+        "--duplicate-policy",
+        default="version",
+        choices=["fail", "reuse", "version"],
+    )
+    publish_p.add_argument("--share-type", default="")
+    publish_p.add_argument("--share-role", default="reader")
+    publish_p.add_argument("--share-email", default="")
+    publish_p.add_argument("--share-domain", default="")
+    publish_p.add_argument("--notify", action="store_true")
+    publish_p.add_argument("--dry-run", action="store_true")
+    publish_p.add_argument("--store-path", default="")
+
+    list_p = subs.add_parser("list", aliases=["ls"], help="List recent publish records")
+    list_p.add_argument("--limit", type=int, default=20)
+    list_p.add_argument("--store-path", default="")
+
+    show_p = subs.add_parser("show", help="Show a stored publish record")
+    show_p.add_argument("record_id")
+    show_p.add_argument("--store-path", default="")
+
+    subparser.set_defaults(func=google_drive_pipeline_command)
+
+
+def google_drive_pipeline_command(args: argparse.Namespace) -> int:
+    action = getattr(args, "google_drive_pipeline_action", None)
+    if not action:
+        print("Usage: hermes google-drive-pipeline {resolve-folder|publish|list|show}")
+        return 2
+
+    try:
+        if action == "resolve-folder":
+            _cmd_resolve_folder(args)
+        elif action == "publish":
+            _cmd_publish(args)
+        elif action in ("list", "ls"):
+            _cmd_list(args)
+        elif action == "show":
+            _cmd_show(args)
+        else:
+            print(f"Unknown google-drive-pipeline action: {action}")
+            return 2
+        return 0
+    except GoogleDrivePipelineError as exc:
+        print(str(exc))
+        return 1
+
+
+def _store(args: argparse.Namespace) -> GoogleDrivePipelineStore:
+    return GoogleDrivePipelineStore(
+        resolve_google_drive_pipeline_store_path(getattr(args, "store_path", None))
+    )
+
+
+def _pipeline(args: argparse.Namespace) -> GoogleDrivePipeline:
+    return GoogleDrivePipeline(store=_store(args))
+
+
+def _build_share_policy(args: argparse.Namespace) -> SharePolicy | None:
+    share_type = str(getattr(args, "share_type", "") or "").strip()
+    if not share_type:
+        return None
+    try:
+        return SharePolicy(
+            access_type=share_type,
+            role=str(getattr(args, "share_role", "") or "reader").strip() or "reader",
+            email=str(getattr(args, "share_email", "") or "").strip() or None,
+            domain=str(getattr(args, "share_domain", "") or "").strip() or None,
+            notify=bool(getattr(args, "notify", False)),
+        )
+    except ValueError as exc:
+        raise GoogleDrivePipelineError(str(exc)) from exc
+
+
+def _cmd_resolve_folder(args: argparse.Namespace) -> None:
+    folder = _pipeline(args).resolve_folder(
+        folder_id=str(args.folder_id or "").strip() or None,
+        folder_name=str(args.folder_name or "").strip() or None,
+        parent_folder_id=str(args.parent_folder_id or "").strip() or None,
+        create_missing=bool(args.create_missing),
+    )
+    print(json.dumps(folder.to_dict(), indent=2, ensure_ascii=False))
+
+
+def _cmd_publish(args: argparse.Namespace) -> None:
+    request = PublishArtifactRequest(
+        file_path=Path(args.file_path),
+        drive_name=str(args.drive_name or "").strip() or None,
+        folder_id=str(args.folder_id or "").strip() or None,
+        folder_name=str(args.folder_name or "").strip() or None,
+        parent_folder_id=str(args.parent_folder_id or "").strip() or None,
+        create_missing_folder=bool(args.create_missing_folder),
+        duplicate_policy=str(args.duplicate_policy or "version"),
+        share_policy=_build_share_policy(args),
+        dry_run=bool(args.dry_run),
+    )
+    result = _pipeline(args).publish_artifact(request)
+    print(json.dumps(result.to_dict(), indent=2, ensure_ascii=False))
+
+
+def _cmd_list(args: argparse.Namespace) -> None:
+    records = list(_store(args).list_records().values())
+    records = [record for record in records if record.get("kind") != "folder_cache"]
+    records.sort(key=lambda item: str(item.get("updated_at") or ""), reverse=True)
+    print(json.dumps(records[: max(0, int(args.limit))], indent=2, ensure_ascii=False))
+
+
+def _cmd_show(args: argparse.Namespace) -> None:
+    record = _store(args).get_record(args.record_id)
+    if record is None:
+        raise GoogleDrivePipelineError(f"Unknown record_id: {args.record_id}")
+    print(json.dumps(record, indent=2, ensure_ascii=False))

--- a/plugins/google_drive_pipeline/models.py
+++ b/plugins/google_drive_pipeline/models.py
@@ -1,0 +1,204 @@
+"""Normalized models for the Google Drive artifact pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Literal
+
+
+DuplicatePolicy = Literal["fail", "reuse", "version"]
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if value is None or isinstance(value, datetime):
+        return value
+    text = str(value).strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = f"{text[:-1]}+00:00"
+    parsed = datetime.fromisoformat(text)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _serialize_datetime(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _clean_dict(payload: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in payload.items() if value is not None}
+
+
+@dataclass
+class DriveFolderRef:
+    folder_id: str
+    name: str
+    web_view_link: str | None = None
+    parent_folder_id: str | None = None
+    existed: bool = True
+
+    def __post_init__(self) -> None:
+        self.folder_id = str(self.folder_id).strip()
+        self.name = str(self.name).strip()
+        if not self.folder_id:
+            raise ValueError("DriveFolderRef.folder_id is required.")
+        if not self.name:
+            raise ValueError("DriveFolderRef.name is required.")
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "DriveFolderRef":
+        parents = payload.get("parents") or []
+        parent_folder_id = None
+        if isinstance(parents, list) and parents:
+            parent_folder_id = str(parents[0]).strip() or None
+        return cls(
+            folder_id=payload.get("folder_id") or payload.get("id") or "",
+            name=payload.get("name") or "",
+            web_view_link=payload.get("web_view_link") or payload.get("webViewLink"),
+            parent_folder_id=payload.get("parent_folder_id") or parent_folder_id,
+            existed=bool(payload.get("existed", True)),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return _clean_dict(
+            {
+                "folder_id": self.folder_id,
+                "name": self.name,
+                "web_view_link": self.web_view_link,
+                "parent_folder_id": self.parent_folder_id,
+                "existed": self.existed,
+            }
+        )
+
+
+@dataclass
+class SharePolicy:
+    access_type: Literal["user", "group", "domain", "anyone"] = "user"
+    role: str = "reader"
+    email: str | None = None
+    domain: str | None = None
+    notify: bool = False
+
+    def __post_init__(self) -> None:
+        if self.access_type in ("user", "group") and not _clean_optional(self.email):
+            raise ValueError(f"email is required for share access_type={self.access_type}.")
+        if self.access_type == "domain" and not _clean_optional(self.domain):
+            raise ValueError("domain is required for share access_type=domain.")
+        self.email = _clean_optional(self.email)
+        self.domain = _clean_optional(self.domain)
+
+    def to_cli_args(self, file_id: str) -> list[str]:
+        args = [
+            "drive",
+            "share",
+            file_id,
+            "--type",
+            self.access_type,
+            "--role",
+            self.role,
+        ]
+        if self.email:
+            args.extend(["--email", self.email])
+        if self.domain:
+            args.extend(["--domain", self.domain])
+        if self.notify:
+            args.append("--notify")
+        return args
+
+    def to_dict(self) -> dict[str, Any]:
+        return _clean_dict(
+            {
+                "access_type": self.access_type,
+                "role": self.role,
+                "email": self.email,
+                "domain": self.domain,
+                "notify": self.notify,
+            }
+        )
+
+
+def _clean_optional(value: str | None) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+@dataclass
+class PublishArtifactRequest:
+    file_path: Path
+    drive_name: str | None = None
+    folder_id: str | None = None
+    folder_name: str | None = None
+    parent_folder_id: str | None = None
+    create_missing_folder: bool = False
+    duplicate_policy: DuplicatePolicy = "version"
+    share_policy: SharePolicy | None = None
+    dry_run: bool = False
+
+    def __post_init__(self) -> None:
+        self.file_path = Path(self.file_path).expanduser()
+        if self.duplicate_policy not in ("fail", "reuse", "version"):
+            raise ValueError("duplicate_policy must be fail, reuse, or version.")
+        if not self.folder_id and not self.folder_name:
+            raise ValueError("folder_id or folder_name is required.")
+
+    @property
+    def desired_name(self) -> str:
+        return (self.drive_name or self.file_path.name).strip()
+
+
+@dataclass
+class PublishArtifactResult:
+    record_id: str
+    source_path: str
+    source_sha256: str
+    folder: DriveFolderRef
+    file_id: str
+    file_name: str
+    web_view_link: str
+    duplicate_policy: DuplicatePolicy
+    action: Literal["uploaded", "reused", "planned"]
+    sharing: dict[str, Any] | None = None
+    created_at: datetime | None = None
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "PublishArtifactResult":
+        return cls(
+            record_id=str(payload.get("record_id") or "").strip(),
+            source_path=str(payload.get("source_path") or "").strip(),
+            source_sha256=str(payload.get("source_sha256") or "").strip(),
+            folder=DriveFolderRef.from_dict(payload.get("folder") or {}),
+            file_id=str(payload.get("file_id") or "").strip(),
+            file_name=str(payload.get("file_name") or "").strip(),
+            web_view_link=str(payload.get("web_view_link") or payload.get("webViewLink") or "").strip(),
+            duplicate_policy=payload.get("duplicate_policy") or "version",
+            action=payload.get("action") or "uploaded",
+            sharing=payload.get("sharing"),
+            created_at=_parse_datetime(payload.get("created_at")),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return _clean_dict(
+            {
+                "record_id": self.record_id,
+                "source_path": self.source_path,
+                "source_sha256": self.source_sha256,
+                "folder": self.folder.to_dict(),
+                "file_id": self.file_id,
+                "file_name": self.file_name,
+                "web_view_link": self.web_view_link,
+                "duplicate_policy": self.duplicate_policy,
+                "action": self.action,
+                "sharing": self.sharing,
+                "created_at": _serialize_datetime(self.created_at) or _utc_now_iso(),
+            }
+        )

--- a/plugins/google_drive_pipeline/pipeline.py
+++ b/plugins/google_drive_pipeline/pipeline.py
@@ -1,0 +1,347 @@
+"""Pipeline orchestration for Google Drive artifact publishing."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from plugins.google_drive_pipeline.models import (
+    DriveFolderRef,
+    PublishArtifactRequest,
+    PublishArtifactResult,
+    SharePolicy,
+)
+from plugins.google_drive_pipeline.store import GoogleDrivePipelineStore
+
+
+DRIVE_FOLDER_MIME_TYPE = "application/vnd.google-apps.folder"
+
+
+class GoogleDrivePipelineError(RuntimeError):
+    """Base class for Drive pipeline failures."""
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _escape_drive_query(text: str) -> str:
+    return text.replace("\\", "\\\\").replace("'", "\\'")
+
+
+def _normalize_string(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _build_source_key(source_sha256: str, folder_id: str, desired_name: str) -> str:
+    return f"{source_sha256}:{folder_id}:{desired_name}"
+
+
+def _drive_query_for_exact_name(name: str, parent_folder_id: str | None = None) -> str:
+    clauses = [
+        f"mimeType = '{DRIVE_FOLDER_MIME_TYPE}'",
+        "trashed = false",
+        f"name = '{_escape_drive_query(name)}'",
+    ]
+    if parent_folder_id:
+        clauses.append(f"'{_escape_drive_query(parent_folder_id)}' in parents")
+    return " and ".join(clauses)
+
+
+def _file_query_for_name(name: str, parent_folder_id: str) -> str:
+    clauses = [
+        "trashed = false",
+        f"name = '{_escape_drive_query(name)}'",
+        f"'{_escape_drive_query(parent_folder_id)}' in parents",
+    ]
+    return " and ".join(clauses)
+
+
+@dataclass
+class GoogleDrivePipeline:
+    store: GoogleDrivePipelineStore
+    python_executable: str = sys.executable
+    script_path: Path | None = None
+
+    def __post_init__(self) -> None:
+        if self.script_path is None:
+            self.script_path = (
+                Path(__file__).resolve().parents[2]
+                / "skills/productivity/google-workspace/scripts/google_api.py"
+            )
+
+    def resolve_folder(
+        self,
+        *,
+        folder_id: str | None = None,
+        folder_name: str | None = None,
+        parent_folder_id: str | None = None,
+        create_missing: bool = False,
+    ) -> DriveFolderRef:
+        explicit_folder_id = _normalize_string(folder_id)
+        explicit_folder_name = _normalize_string(folder_name)
+        explicit_parent = _normalize_string(parent_folder_id)
+
+        if explicit_folder_id:
+            payload = self._run_google_api(["drive", "get", explicit_folder_id])
+            if payload.get("mimeType") != DRIVE_FOLDER_MIME_TYPE:
+                raise GoogleDrivePipelineError(f"Drive item is not a folder: {explicit_folder_id}")
+            return DriveFolderRef.from_dict(payload)
+
+        if not explicit_folder_name:
+            raise GoogleDrivePipelineError("folder_name is required when folder_id is not provided.")
+
+        cache_key = f"{explicit_parent}:{explicit_folder_name}"
+        cached_folder = self.store.get_cached_folder(cache_key)
+        if isinstance(cached_folder, dict):
+            return DriveFolderRef.from_dict(cached_folder)
+
+        results = self._run_google_api(
+            [
+                "drive",
+                "search",
+                _drive_query_for_exact_name(explicit_folder_name, explicit_parent or None),
+                "--raw-query",
+                "--max",
+                "10",
+            ]
+        )
+        if not isinstance(results, list):
+            raise GoogleDrivePipelineError("Drive search returned unexpected payload.")
+
+        folder_hits = [
+            item for item in results if item.get("mimeType") == DRIVE_FOLDER_MIME_TYPE
+        ]
+        if folder_hits:
+            folder = DriveFolderRef.from_dict(folder_hits[0])
+            self.store.upsert_record(
+                f"folder-cache:{cache_key}",
+                {
+                    "folder_cache_key": cache_key,
+                    "folder": folder.to_dict(),
+                    "source_key": "",
+                    "kind": "folder_cache",
+                },
+            )
+            return folder
+
+        if not create_missing:
+            raise GoogleDrivePipelineError(
+                f"No Drive folder matched '{explicit_folder_name}'."
+            )
+
+        args = ["drive", "create-folder", explicit_folder_name]
+        if explicit_parent:
+            args.extend(["--parent", explicit_parent])
+        payload = self._run_google_api(args)
+        folder = DriveFolderRef.from_dict(
+            {
+                **payload,
+                "parent_folder_id": explicit_parent or None,
+                "existed": False,
+            }
+        )
+        self.store.upsert_record(
+            f"folder-cache:{cache_key}",
+            {
+                "folder_cache_key": cache_key,
+                "folder": folder.to_dict(),
+                "source_key": "",
+                "kind": "folder_cache",
+            },
+        )
+        return folder
+
+    def publish_artifact(self, request: PublishArtifactRequest) -> PublishArtifactResult:
+        if not request.dry_run and not request.file_path.exists():
+            raise GoogleDrivePipelineError(f"Local file does not exist: {request.file_path}")
+
+        folder = self.resolve_folder(
+            folder_id=request.folder_id,
+            folder_name=request.folder_name,
+            parent_folder_id=request.parent_folder_id,
+            create_missing=request.create_missing_folder,
+        )
+        source_sha256 = self._compute_sha256(request.file_path) if request.file_path.exists() else ""
+        source_key = _build_source_key(source_sha256, folder.folder_id, request.desired_name)
+
+        if request.duplicate_policy == "reuse":
+            existing_record = self.store.get_record_by_source_key(source_key)
+            if existing_record:
+                result = PublishArtifactResult.from_dict(existing_record)
+                if not request.dry_run and result.file_id:
+                    refreshed = self._refresh_existing_file(result.file_id)
+                    if refreshed is not None:
+                        result.file_name = str(refreshed.get("name") or result.file_name)
+                        result.web_view_link = str(
+                            refreshed.get("webViewLink") or result.web_view_link
+                        )
+                    else:
+                        existing_record = None
+                if existing_record is not None:
+                    if request.share_policy:
+                        sharing = self._apply_share_policy(
+                            result.file_id,
+                            request.share_policy,
+                            request.dry_run,
+                        )
+                        result.sharing = sharing
+                    return self._persist_result(result, source_key)
+
+        existing_file = self._find_existing_file(folder.folder_id, request.desired_name)
+        final_name = request.desired_name
+        action = "uploaded"
+
+        if existing_file:
+            if request.duplicate_policy == "fail":
+                raise GoogleDrivePipelineError(
+                    f"A Drive file named '{request.desired_name}' already exists in folder {folder.folder_id}."
+                )
+            if request.duplicate_policy == "reuse":
+                action = "reused"
+                result = PublishArtifactResult(
+                    record_id=f"gdpl_{uuid.uuid4().hex[:12]}",
+                    source_path=str(request.file_path),
+                    source_sha256=source_sha256,
+                    folder=folder,
+                    file_id=str(existing_file["id"]),
+                    file_name=str(existing_file["name"]),
+                    web_view_link=str(existing_file.get("webViewLink") or ""),
+                    duplicate_policy=request.duplicate_policy,
+                    action=action,
+                    created_at=_utc_now(),
+                )
+                if request.share_policy:
+                    result.sharing = self._apply_share_policy(result.file_id, request.share_policy, request.dry_run)
+                return self._persist_result(result, source_key)
+            if request.duplicate_policy == "version":
+                final_name = self._versioned_name(request.desired_name)
+
+        if request.dry_run:
+            result = PublishArtifactResult(
+                record_id=f"gdpl_{uuid.uuid4().hex[:12]}",
+                source_path=str(request.file_path),
+                source_sha256=source_sha256,
+                folder=folder,
+                file_id="",
+                file_name=final_name,
+                web_view_link="",
+                duplicate_policy=request.duplicate_policy,
+                action="planned",
+                created_at=_utc_now(),
+            )
+            if request.share_policy:
+                result.sharing = {
+                    "status": "planned",
+                    **request.share_policy.to_dict(),
+                }
+            return result
+
+        payload = self._run_google_api(
+            [
+                "drive",
+                "upload",
+                str(request.file_path),
+                "--name",
+                final_name,
+                "--parent",
+                folder.folder_id,
+            ]
+        )
+        result = PublishArtifactResult(
+            record_id=f"gdpl_{uuid.uuid4().hex[:12]}",
+            source_path=str(request.file_path),
+            source_sha256=source_sha256,
+            folder=folder,
+            file_id=str(payload.get("id") or ""),
+            file_name=str(payload.get("name") or final_name),
+            web_view_link=str(payload.get("webViewLink") or ""),
+            duplicate_policy=request.duplicate_policy,
+            action=action,
+            created_at=_utc_now(),
+        )
+        if request.share_policy:
+            result.sharing = self._apply_share_policy(result.file_id, request.share_policy, False)
+        return self._persist_result(result, source_key)
+
+    def _persist_result(self, result: PublishArtifactResult, source_key: str) -> PublishArtifactResult:
+        payload = result.to_dict()
+        payload["source_key"] = source_key
+        payload["folder_cache_key"] = f"{result.folder.parent_folder_id or ''}:{result.folder.name}"
+        payload["folder"] = result.folder.to_dict()
+        saved = self.store.upsert_record(result.record_id, payload)
+        return PublishArtifactResult.from_dict(saved)
+
+    def _apply_share_policy(
+        self,
+        file_id: str,
+        share_policy: SharePolicy,
+        dry_run: bool,
+    ) -> dict[str, Any]:
+        if dry_run:
+            return {"status": "planned", **share_policy.to_dict()}
+        return self._run_google_api(share_policy.to_cli_args(file_id))
+
+    def _find_existing_file(self, folder_id: str, name: str) -> dict[str, Any] | None:
+        results = self._run_google_api(
+            [
+                "drive",
+                "search",
+                _file_query_for_name(name, folder_id),
+                "--raw-query",
+                "--max",
+                "10",
+            ]
+        )
+        if not isinstance(results, list):
+            return None
+        for item in results:
+            if item.get("mimeType") != DRIVE_FOLDER_MIME_TYPE:
+                return item
+        return None
+
+    def _refresh_existing_file(self, file_id: str) -> dict[str, Any] | None:
+        try:
+            payload = self._run_google_api(["drive", "get", file_id])
+        except GoogleDrivePipelineError:
+            return None
+        if not isinstance(payload, dict):
+            return None
+        return payload
+
+    def _versioned_name(self, name: str) -> str:
+        stamp = _utc_now().strftime("%Y%m%d-%H%M%S")
+        path = Path(name)
+        if path.suffix:
+            return f"{path.stem}-{stamp}{path.suffix}"
+        return f"{name}-{stamp}"
+
+    def _compute_sha256(self, path: Path) -> str:
+        digest = hashlib.sha256()
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
+
+    def _run_google_api(self, args: list[str]) -> dict[str, Any] | list[Any]:
+        cmd = [self.python_executable, str(self.script_path), *args]
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            error = (result.stderr or result.stdout or "Unknown google_api failure").strip()
+            raise GoogleDrivePipelineError(error)
+        stdout = result.stdout.strip()
+        if not stdout:
+            return {}
+        try:
+            return json.loads(stdout)
+        except json.JSONDecodeError as exc:
+            raise GoogleDrivePipelineError(
+                f"google_api.py returned non-JSON output: {stdout}"
+            ) from exc

--- a/plugins/google_drive_pipeline/plugin.yaml
+++ b/plugins/google_drive_pipeline/plugin.yaml
@@ -1,0 +1,5 @@
+name: google_drive_pipeline
+version: 0.1.0
+description: "CLI-backed Google Drive artifact pipeline for resolving folders, publishing files, sharing access, and returning canonical links."
+author: NousResearch
+kind: standalone

--- a/plugins/google_drive_pipeline/store.py
+++ b/plugins/google_drive_pipeline/store.py
@@ -1,0 +1,110 @@
+"""Durable local state for the Google Drive artifact pipeline."""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from copy import deepcopy
+from datetime import datetime, timezone
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Any
+
+from hermes_constants import get_hermes_home
+
+
+DEFAULT_GOOGLE_DRIVE_PIPELINE_STORE_FILENAME = "google_drive_pipeline_store.json"
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def resolve_google_drive_pipeline_store_path(path: str | Path | None = None) -> Path:
+    if path is not None:
+        explicit = str(path).strip()
+        if explicit:
+            return Path(explicit)
+
+    env_path = os.getenv("GOOGLE_DRIVE_PIPELINE_STORE_PATH", "").strip()
+    if env_path:
+        return Path(env_path)
+
+    return get_hermes_home() / DEFAULT_GOOGLE_DRIVE_PIPELINE_STORE_FILENAME
+
+
+class GoogleDrivePipelineStore:
+    """JSON-backed durable store for Drive publish records."""
+
+    def __init__(self, path: str | Path):
+        self.path = Path(path)
+        self._lock = threading.RLock()
+        self._state: dict[str, dict[str, Any]] = {
+            "records": {},
+            "source_index": {},
+            "folder_cache": {},
+        }
+        self._load()
+
+    def _load(self) -> None:
+        with self._lock:
+            if not self.path.exists():
+                return
+            data = json.loads(self.path.read_text(encoding="utf-8") or "{}")
+            if not isinstance(data, dict):
+                return
+            self._state["records"] = dict(data.get("records") or {})
+            self._state["source_index"] = dict(data.get("source_index") or {})
+            self._state["folder_cache"] = dict(data.get("folder_cache") or {})
+
+    def _persist(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with NamedTemporaryFile("w", encoding="utf-8", dir=str(self.path.parent), delete=False) as tmp:
+            json.dump(self._state, tmp, indent=2, sort_keys=True)
+            tmp.flush()
+            tmp_path = Path(tmp.name)
+        tmp_path.replace(self.path)
+
+    def list_records(self) -> dict[str, dict[str, Any]]:
+        with self._lock:
+            return deepcopy(self._state["records"])
+
+    def get_record(self, record_id: str) -> dict[str, Any] | None:
+        with self._lock:
+            record = self._state["records"].get(record_id)
+            return deepcopy(record) if isinstance(record, dict) else None
+
+    def upsert_record(self, record_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+        with self._lock:
+            existing = self._state["records"].get(record_id, {})
+            merged = {**existing, **deepcopy(payload)}
+            merged["record_id"] = record_id
+            merged.setdefault("created_at", existing.get("created_at") or _utc_now_iso())
+            merged["updated_at"] = _utc_now_iso()
+            self._state["records"][record_id] = merged
+
+            source_key = str(merged.get("source_key") or "").strip()
+            if source_key:
+                self._state["source_index"][source_key] = record_id
+
+            folder_key = str(merged.get("folder_cache_key") or "").strip()
+            folder = merged.get("folder")
+            if folder_key and isinstance(folder, dict):
+                self._state["folder_cache"][folder_key] = deepcopy(folder)
+
+            self._persist()
+            return deepcopy(merged)
+
+    def get_record_by_source_key(self, source_key: str) -> dict[str, Any] | None:
+        with self._lock:
+            record_id = self._state["source_index"].get(source_key)
+            if not record_id:
+                return None
+            record = self._state["records"].get(record_id)
+            return deepcopy(record) if isinstance(record, dict) else None
+
+    def get_cached_folder(self, cache_key: str) -> dict[str, Any] | None:
+        with self._lock:
+            record = self._state["folder_cache"].get(cache_key)
+            return deepcopy(record) if isinstance(record, dict) else None

--- a/tests/plugins/test_google_drive_pipeline_plugin.py
+++ b/tests/plugins/test_google_drive_pipeline_plugin.py
@@ -1,0 +1,312 @@
+"""Tests for the Google Drive pipeline plugin package."""
+
+from __future__ import annotations
+
+from argparse import Namespace
+from pathlib import Path
+
+from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+from plugins.google_drive_pipeline import register
+from plugins.google_drive_pipeline.cli import google_drive_pipeline_command
+from plugins.google_drive_pipeline.models import PublishArtifactRequest
+from plugins.google_drive_pipeline.pipeline import GoogleDrivePipeline
+from plugins.google_drive_pipeline.store import GoogleDrivePipelineStore
+
+
+def test_register_adds_cli_only():
+    mgr = PluginManager()
+    manifest = PluginManifest(name="google_drive_pipeline")
+    ctx = PluginContext(manifest, mgr)
+
+    register(ctx)
+
+    assert "google-drive-pipeline" in mgr._cli_commands
+    entry = mgr._cli_commands["google-drive-pipeline"]
+    assert entry["plugin"] == "google_drive_pipeline"
+    assert callable(entry["setup_fn"])
+    assert callable(entry["handler_fn"])
+
+
+def test_store_persists_publish_record(tmp_path):
+    store_path = tmp_path / "drive-store.json"
+    store = GoogleDrivePipelineStore(store_path)
+    store.upsert_record(
+        "rec-1",
+        {
+            "source_key": "sha:folder:file",
+            "source_path": "/tmp/report.pdf",
+            "file_id": "file-1",
+            "folder_cache_key": "root:Reports",
+            "folder": {"folder_id": "folder-1", "name": "Reports"},
+        },
+    )
+
+    reloaded = GoogleDrivePipelineStore(store_path)
+    record = reloaded.get_record("rec-1")
+
+    assert record is not None
+    assert record["file_id"] == "file-1"
+    assert reloaded.get_record_by_source_key("sha:folder:file")["record_id"] == "rec-1"
+    assert reloaded.get_cached_folder("root:Reports")["folder_id"] == "folder-1"
+
+
+def test_publish_artifact_reuses_existing_record(monkeypatch, tmp_path):
+    file_path = tmp_path / "report.pdf"
+    file_path.write_text("hello")
+    store = GoogleDrivePipelineStore(tmp_path / "drive-store.json")
+    pipeline = GoogleDrivePipeline(store=store)
+
+    def fake_resolve_folder(**kwargs):
+        from plugins.google_drive_pipeline.models import DriveFolderRef
+        return DriveFolderRef(folder_id="folder-1", name="Reports")
+
+    def fake_find_existing_file(folder_id, name):
+        return {"id": "file-1", "name": name, "webViewLink": "https://drive/file-1"}
+
+    monkeypatch.setattr(pipeline, "resolve_folder", fake_resolve_folder)
+    monkeypatch.setattr(pipeline, "_find_existing_file", fake_find_existing_file)
+    monkeypatch.setattr(
+        pipeline,
+        "_refresh_existing_file",
+        lambda file_id: {
+            "id": file_id,
+            "name": "report.pdf",
+            "webViewLink": "https://drive/file-1",
+        },
+    )
+
+    first = pipeline.publish_artifact(
+        PublishArtifactRequest(
+            file_path=file_path,
+            folder_name="Reports",
+            duplicate_policy="reuse",
+        )
+    )
+    second = pipeline.publish_artifact(
+        PublishArtifactRequest(
+            file_path=file_path,
+            folder_name="Reports",
+            duplicate_policy="reuse",
+        )
+    )
+
+    assert first.file_id == "file-1"
+    assert second.file_id == "file-1"
+    assert second.record_id == first.record_id
+
+
+def test_publish_artifact_versions_on_duplicate(monkeypatch, tmp_path):
+    file_path = tmp_path / "report.pdf"
+    file_path.write_text("hello")
+    store = GoogleDrivePipelineStore(tmp_path / "drive-store.json")
+    pipeline = GoogleDrivePipeline(store=store)
+
+    def fake_resolve_folder(**kwargs):
+        from plugins.google_drive_pipeline.models import DriveFolderRef
+        return DriveFolderRef(folder_id="folder-1", name="Reports")
+
+    monkeypatch.setattr(pipeline, "resolve_folder", fake_resolve_folder)
+    monkeypatch.setattr(
+        pipeline,
+        "_find_existing_file",
+        lambda folder_id, name: {"id": "existing-1", "name": name, "webViewLink": "https://drive/existing-1"},
+    )
+    monkeypatch.setattr(
+        pipeline,
+        "_run_google_api",
+        lambda args: {
+            "id": "uploaded-1",
+            "name": args[args.index("--name") + 1],
+            "webViewLink": "https://drive/uploaded-1",
+        },
+    )
+
+    result = pipeline.publish_artifact(
+        PublishArtifactRequest(
+            file_path=file_path,
+            folder_name="Reports",
+            duplicate_policy="version",
+        )
+    )
+
+    assert result.file_id == "uploaded-1"
+    assert result.file_name.startswith("report-")
+    assert result.file_name.endswith(".pdf")
+
+
+def test_publish_artifact_preserves_parent_folder_on_created_folder(monkeypatch, tmp_path):
+    file_path = tmp_path / "report.pdf"
+    file_path.write_text("hello")
+    store = GoogleDrivePipelineStore(tmp_path / "drive-store.json")
+    pipeline = GoogleDrivePipeline(store=store)
+
+    def fake_run_google_api(args):
+        if args[:2] == ["drive", "search"]:
+            return []
+        if args[:2] == ["drive", "create-folder"]:
+            return {
+                "id": "folder-1",
+                "name": "Reports",
+                "webViewLink": "https://drive/folder-1",
+            }
+        if args[:2] == ["drive", "upload"]:
+            return {
+                "id": "file-1",
+                "name": "report.pdf",
+                "webViewLink": "https://drive/file-1",
+            }
+        raise AssertionError(args)
+
+    monkeypatch.setattr(pipeline, "_run_google_api", fake_run_google_api)
+    monkeypatch.setattr(pipeline, "_find_existing_file", lambda folder_id, name: None)
+
+    result = pipeline.publish_artifact(
+        PublishArtifactRequest(
+            file_path=file_path,
+            folder_name="Reports",
+            parent_folder_id="parent-123",
+            create_missing_folder=True,
+        )
+    )
+
+    assert result.folder.parent_folder_id == "parent-123"
+    assert store.get_cached_folder("parent-123:Reports")["parent_folder_id"] == "parent-123"
+
+
+def test_publish_artifact_reuse_reuploads_when_cached_record_is_stale(monkeypatch, tmp_path):
+    file_path = tmp_path / "report.pdf"
+    file_path.write_text("hello")
+    store = GoogleDrivePipelineStore(tmp_path / "drive-store.json")
+    pipeline = GoogleDrivePipeline(store=store)
+
+    def fake_resolve_folder(**kwargs):
+        from plugins.google_drive_pipeline.models import DriveFolderRef
+        return DriveFolderRef(folder_id="folder-1", name="Reports")
+
+    monkeypatch.setattr(pipeline, "resolve_folder", fake_resolve_folder)
+
+    uploaded = {"count": 0}
+
+    def fake_run_google_api(args):
+        if args[:2] == ["drive", "upload"]:
+            uploaded["count"] += 1
+            return {
+                "id": f"uploaded-{uploaded['count']}",
+                "name": args[args.index("--name") + 1],
+                "webViewLink": f"https://drive/uploaded-{uploaded['count']}",
+            }
+        raise AssertionError(args)
+
+    def fake_refresh_existing_file(file_id):
+        return None
+
+    monkeypatch.setattr(pipeline, "_run_google_api", fake_run_google_api)
+    monkeypatch.setattr(pipeline, "_find_existing_file", lambda folder_id, name: None)
+    monkeypatch.setattr(pipeline, "_refresh_existing_file", fake_refresh_existing_file)
+
+    first = pipeline.publish_artifact(
+        PublishArtifactRequest(
+            file_path=file_path,
+            folder_name="Reports",
+            duplicate_policy="reuse",
+        )
+    )
+    second = pipeline.publish_artifact(
+        PublishArtifactRequest(
+            file_path=file_path,
+            folder_name="Reports",
+            duplicate_policy="reuse",
+        )
+    )
+
+    assert first.file_id == "uploaded-1"
+    assert second.file_id == "uploaded-2"
+    assert uploaded["count"] == 2
+
+
+def test_publish_artifact_dry_run_returns_planned_result(monkeypatch, tmp_path):
+    file_path = tmp_path / "report.pdf"
+    file_path.write_text("hello")
+    store = GoogleDrivePipelineStore(tmp_path / "drive-store.json")
+    pipeline = GoogleDrivePipeline(store=store)
+
+    def fake_resolve_folder(**kwargs):
+        from plugins.google_drive_pipeline.models import DriveFolderRef
+        return DriveFolderRef(folder_id="folder-1", name="Reports")
+
+    monkeypatch.setattr(pipeline, "resolve_folder", fake_resolve_folder)
+    monkeypatch.setattr(pipeline, "_find_existing_file", lambda folder_id, name: None)
+
+    result = pipeline.publish_artifact(
+        PublishArtifactRequest(
+            file_path=file_path,
+            folder_name="Reports",
+            dry_run=True,
+        )
+    )
+
+    assert result.action == "planned"
+    assert result.file_id == ""
+    assert result.file_name == "report.pdf"
+
+
+def test_resolve_folder_by_id(monkeypatch, tmp_path):
+    store = GoogleDrivePipelineStore(tmp_path / "drive-store.json")
+    pipeline = GoogleDrivePipeline(store=store)
+
+    monkeypatch.setattr(
+        pipeline,
+        "_run_google_api",
+        lambda args: {
+            "id": "folder-1",
+            "name": "Reports",
+            "mimeType": "application/vnd.google-apps.folder",
+            "parents": ["parent-123"],
+            "webViewLink": "https://drive/folder-1",
+        },
+    )
+
+    folder = pipeline.resolve_folder(folder_id="folder-1")
+
+    assert folder.folder_id == "folder-1"
+    assert folder.parent_folder_id == "parent-123"
+
+
+def test_cli_publish_validates_share_args(tmp_path, capsys):
+    rc = google_drive_pipeline_command(
+        Namespace(
+            google_drive_pipeline_action="publish",
+            file_path=str(tmp_path / "report.pdf"),
+            drive_name="",
+            folder_id="",
+            folder_name="Reports",
+            parent_folder_id="",
+            create_missing_folder=False,
+            duplicate_policy="version",
+            share_type="user",
+            share_role="reader",
+            share_email="",
+            share_domain="",
+            notify=False,
+            dry_run=True,
+            store_path=str(tmp_path / "drive-store.json"),
+        )
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert "email is required" in captured.out
+
+
+def test_cli_show_returns_error_for_unknown_record(tmp_path, capsys):
+    rc = google_drive_pipeline_command(
+        Namespace(
+            google_drive_pipeline_action="show",
+            record_id="missing",
+            store_path=str(tmp_path / "drive-store.json"),
+        )
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert "Unknown record_id" in captured.out


### PR DESCRIPTION
 ## Summary

  Adds a standalone `google_drive_pipeline` plugin that turns the existing`google-workspace` Drive write primitives into a higher-level artifact publish workflow.

  This builds on top of the Drive write surface added in:
  - #21895

  ## What this adds

  - `hermes google-drive-pipeline resolve-folder`
  - `hermes google-drive-pipeline publish`
  - `hermes google-drive-pipeline list`
  - `hermes google-drive-pipeline show`

  The publish flow handles:

  - resolving a target folder
  - creating the folder if missing
  - uploading a local file
  - optional sharing
  - returning a canonical Drive link
  - persisting publish records for later inspection/reuse

  ## Why

  `#21895` added the underlying Drive write commands (`search`, `get`, `upload`, `create-folder`, `share`, `delete`), but those are still lower-level building blocks.

  This plugin adds the operator workflow layer on top of that toolbox.

  ## Behavior details

  - duplicate policies:
    - `fail`
    - `reuse`
    - `version`
  - durable local store:
    - publish records
    - source-key index for reuse
    - folder cache

  ## Validation

  - added plugin tests for:
    - registration
    - parent-folder cache correctness
    - stale reuse recovery
    - dry-run behavior
    - folder-id resolution
    - share argument validation
  - local test result:
    - `pytest -q tests/plugins/test_google_drive_pipeline_plugin.py` -> `10 passed`

  ## Manual verification

  Verified end-to-end against a real Google Drive profile:

  - enabled the plugin
  - completed Google Workspace OAuth for the current Hermes profile
  - published a local test artifact into Drive
  - created a new folder when missing
  - returned a canonical Drive file link
  - verified `anyone reader` sharing flow
