### PR TITLE
fix(codex-responses): final_answer phase overrides top-level incomplete status (#27988)

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -1245,7 +1245,12 @@ def _normalize_codex_response(
         finish_reason = "tool_calls"
     elif leaked_tool_call_text:
         finish_reason = "incomplete"
-    elif has_incomplete_items or (saw_commentary_phase and not saw_final_answer_phase):
+    elif (has_incomplete_items or saw_commentary_phase) and not saw_final_answer_phase:
+        # A `phase=final_answer` message indicates the model produced a
+        # complete user-visible answer, even if the top-level
+        # `response.status` is "incomplete" (Azure Foundry sometimes sets
+        # this on otherwise-complete gpt-5.x responses). Trust the
+        # per-message phase signal over the top-level accounting status.
         finish_reason = "incomplete"
     elif (reasoning_items_raw or reasoning_parts or saw_reasoning_item) and not final_text:
         # Response contains only reasoning (encrypted thinking state and/or

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -1074,6 +1074,15 @@ def _normalize_codex_response(
     message_items_raw: List[Dict[str, Any]] = []
     tool_calls: List[Any] = []
     has_incomplete_items = response_status in {"queued", "in_progress", "incomplete"}
+    # Track the genuinely-still-streaming signals separately from the
+    # Azure-Foundry "top-level status == incomplete on an otherwise-complete
+    # response" artifact. The `final_answer` phase override below may only
+    # suppress the latter; a queued/in_progress response (top-level or
+    # per-item) or a per-item `incomplete` status means the stream is not
+    # done and must still resolve to finish_reason="incomplete" even when a
+    # final_answer message is present.
+    response_still_streaming = response_status in {"queued", "in_progress"}
+    saw_streaming_or_item_incomplete = response_still_streaming
     saw_commentary_phase = False
     saw_final_answer_phase = False
     saw_reasoning_item = False
@@ -1088,6 +1097,7 @@ def _normalize_codex_response(
 
         if item_status in {"queued", "in_progress", "incomplete"}:
             has_incomplete_items = True
+            saw_streaming_or_item_incomplete = True
 
         if item_type == "message":
             item_phase = getattr(item, "phase", None)
@@ -1245,12 +1255,21 @@ def _normalize_codex_response(
         finish_reason = "tool_calls"
     elif leaked_tool_call_text:
         finish_reason = "incomplete"
+    elif saw_streaming_or_item_incomplete:
+        # The response is genuinely still streaming: the top-level status is
+        # queued/in_progress, or some output item is queued/in_progress/
+        # incomplete. A `phase=final_answer` message does NOT make this
+        # complete — more items may still arrive — so we always treat it as
+        # incomplete and let the continuation path drain the stream.
+        finish_reason = "incomplete"
     elif (has_incomplete_items or saw_commentary_phase) and not saw_final_answer_phase:
-        # A `phase=final_answer` message indicates the model produced a
-        # complete user-visible answer, even if the top-level
-        # `response.status` is "incomplete" (Azure Foundry sometimes sets
-        # this on otherwise-complete gpt-5.x responses). Trust the
-        # per-message phase signal over the top-level accounting status.
+        # The only remaining incomplete signal here is a top-level
+        # `response.status == "incomplete"` (Azure Foundry sometimes sets
+        # this on otherwise-complete gpt-5.x responses, see has_incomplete_items
+        # init) or a commentary/analysis phase. A `phase=final_answer` message
+        # indicates the model produced a complete user-visible answer, so trust
+        # the per-message phase signal over the top-level accounting status and
+        # let it fall through to "stop". Without final_answer, stay incomplete.
         finish_reason = "incomplete"
     elif (reasoning_items_raw or reasoning_parts or saw_reasoning_item) and not final_text:
         # Response contains only reasoning (encrypted thinking state and/or

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -154,6 +154,45 @@ def _codex_ack_message_response(text: str):
     )
 
 
+def _codex_final_answer_with_top_level_incomplete_response(text: str):
+    # Azure Foundry shape: top-level response.status="incomplete" but the
+    # output contains a `phase=final_answer, status=completed` message with
+    # substantive text content. See issue #27988.
+    return SimpleNamespace(
+        output=[
+            SimpleNamespace(
+                type="message",
+                phase="final_answer",
+                status="completed",
+                content=[SimpleNamespace(type="output_text", text=text)],
+            )
+        ],
+        usage=SimpleNamespace(input_tokens=4, output_tokens=2, total_tokens=6),
+        status="incomplete",
+        model="gpt-5.4",
+    )
+
+
+class _FakeResponsesStream:
+    def __init__(self, *, final_response=None, final_error=None):
+        self._final_response = final_response
+        self._final_error = final_error
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def __iter__(self):
+        return iter(())
+
+    def get_final_response(self):
+        if self._final_error is not None:
+            raise self._final_error
+        return self._final_response
+
+
 class _FakeCreateStream:
     """Iterable-only fake for ``responses.create(stream=True)`` outputs.
 
@@ -1349,6 +1388,53 @@ def test_normalize_codex_response_marks_commentary_only_message_as_incomplete(mo
 
     assert finish_reason == "incomplete"
     assert "inspect the repository" in (assistant_message.content or "")
+
+
+def test_normalize_codex_response_final_answer_overrides_top_level_incomplete(monkeypatch):
+    """Azure Foundry can set top-level `response.status="incomplete"` on
+    otherwise-complete gpt-5.x responses. A per-message
+    `phase=final_answer, status=completed` carrying substantive text
+    indicates the user-visible answer is complete; the top-level status
+    is an accounting/streaming-edge artifact and must not promote a
+    complete response to `finish_reason="incomplete"` (issue #27988).
+    """
+    agent = _build_agent(monkeypatch)
+    from agent.codex_responses_adapter import _normalize_codex_response
+
+    assistant_message, finish_reason = _normalize_codex_response(
+        _codex_final_answer_with_top_level_incomplete_response(
+            "Briefly:\n\n- I'm Ramsay, your assistant."
+        )
+    )
+
+    assert finish_reason == "stop"
+    assert "Ramsay" in (assistant_message.content or "")
+
+
+def test_normalize_codex_response_top_level_incomplete_without_final_answer_phase_stays_incomplete(monkeypatch):
+    """Negative: if the top-level status is `incomplete` and there is no
+    `phase=final_answer` message in output, finish_reason must remain
+    `incomplete` so the continuation path can re-elicit the answer.
+    """
+    agent = _build_agent(monkeypatch)
+    from agent.codex_responses_adapter import _normalize_codex_response
+
+    response = SimpleNamespace(
+        output=[
+            SimpleNamespace(
+                type="message",
+                status="completed",
+                content=[SimpleNamespace(type="output_text", text="Partial...")],
+            )
+        ],
+        usage=SimpleNamespace(input_tokens=4, output_tokens=2, total_tokens=6),
+        status="incomplete",
+        model="gpt-5.4",
+    )
+
+    _, finish_reason = _normalize_codex_response(response)
+
+    assert finish_reason == "incomplete"
 
 
 def test_normalize_codex_response_preserves_message_status_for_replay(monkeypatch):

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1437,6 +1437,74 @@ def test_normalize_codex_response_top_level_incomplete_without_final_answer_phas
     assert finish_reason == "incomplete"
 
 
+@pytest.mark.parametrize("top_level_status", ["queued", "in_progress"])
+def test_normalize_codex_response_final_answer_does_not_override_streaming_status(
+    monkeypatch, top_level_status
+):
+    """A `phase=final_answer` message must NOT short-circuit a response whose
+    top-level status is still `queued`/`in_progress`. The final_answer override
+    only exists to neutralize the Azure-Foundry top-level `incomplete` artifact;
+    a genuinely-streaming response can still emit more items, so it must stay
+    `finish_reason="incomplete"` and let the continuation path drain the stream
+    (regression for the over-broad override, Copilot review on #28039).
+    """
+    agent = _build_agent(monkeypatch)
+    from agent.codex_responses_adapter import _normalize_codex_response
+
+    response = SimpleNamespace(
+        output=[
+            SimpleNamespace(
+                type="message",
+                phase="final_answer",
+                status="completed",
+                content=[SimpleNamespace(type="output_text", text="Interim answer.")],
+            )
+        ],
+        usage=SimpleNamespace(input_tokens=4, output_tokens=2, total_tokens=6),
+        status=top_level_status,
+        model="gpt-5.4",
+    )
+
+    _, finish_reason = _normalize_codex_response(response)
+
+    assert finish_reason == "incomplete"
+
+
+def test_normalize_codex_response_final_answer_does_not_override_per_item_in_progress(
+    monkeypatch,
+):
+    """Even with a top-level `completed` status and a `phase=final_answer`
+    message, a sibling output item that is still `in_progress` means the
+    stream is not done; finish_reason must stay `incomplete` rather than
+    `stop` (Copilot review on #28039).
+    """
+    agent = _build_agent(monkeypatch)
+    from agent.codex_responses_adapter import _normalize_codex_response
+
+    response = SimpleNamespace(
+        output=[
+            SimpleNamespace(
+                type="message",
+                phase="final_answer",
+                status="completed",
+                content=[SimpleNamespace(type="output_text", text="Partial final.")],
+            ),
+            SimpleNamespace(
+                type="message",
+                status="in_progress",
+                content=[SimpleNamespace(type="output_text", text="")],
+            ),
+        ],
+        usage=SimpleNamespace(input_tokens=4, output_tokens=2, total_tokens=6),
+        status="completed",
+        model="gpt-5.4",
+    )
+
+    _, finish_reason = _normalize_codex_response(response)
+
+    assert finish_reason == "incomplete"
+
+
 def test_normalize_codex_response_preserves_message_status_for_replay(monkeypatch):
     """Incomplete Codex output messages must not be replayed as completed."""
     agent = _build_agent(monkeypatch)


### PR DESCRIPTION
## What does this PR do?

Restores the invariant in `_normalize_codex_response`: a `phase=final_answer` message implies the user-visible answer is complete, regardless of top-level `response.status`. The current `elif has_incomplete_items or (saw_commentary_phase and not saw_final_answer_phase)` short-circuits on `has_incomplete_items` and never consults `saw_final_answer_phase`, so Azure Foundry's top-level `response.status="incomplete"` on otherwise-complete gpt-5.x responses gets promoted to `finish_reason="incomplete"`. That triggers `run_agent.py`'s continuation loop, which produces canned refusals, trips Azure's content filter, and the user sees the correct answer followed by three `"I'm sorry, but I cannot assist…"` messages and a `⚠️ Codex response remained incomplete after 3 continuation attempts` warning. Minimal one-line fix: `elif (has_incomplete_items or saw_commentary_phase) and not saw_final_answer_phase`.

## Related Issue

Fixes #27988

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/codex_responses_adapter.py:1072` — single-line condition swap. Truth table preserved for every case existing tests cover; only the bolded row (`has_incomplete_items=T, saw_commentary_phase=F, saw_final_answer_phase=T`) flips from `incomplete` (bug) to `stop` (fixed) — the exact #27988 trigger condition.
- `tests/run_agent/test_run_agent_codex_responses.py` — new positive case `test_normalize_codex_response_final_answer_overrides_top_level_incomplete` and new negative case `test_normalize_codex_response_top_level_incomplete_without_final_answer_phase_stays_incomplete`.

| `has_incomplete_items` | `saw_commentary_phase` | `saw_final_answer_phase` | before | after |
| --- | --- | --- | --- | --- |
| T | F | F | incomplete | incomplete |
| T | T | F | incomplete | incomplete |
| **T** | **F** | **T** | **incomplete (bug)** | **stop (fixed)** |
| T | T | T | incomplete | stop |
| F | T | F | incomplete | incomplete |
| F | T | T | stop | stop |
| F | F | F | stop (fall through) | stop (fall through) |

## How to Test

1. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/run_agent/test_run_agent_codex_responses.py -v` — all 9 `_normalize_codex_response` tests pass (`marks_commentary_only_message_as_incomplete`, `preserves_message_status_for_replay`, `detects_leaked_tool_call_text`, `ignores_tool_call_text_when_real_tool_call_present`, `reasoning_with_content_is_stop`, `marks_reasoning_only_as_incomplete`, `no_leak_passes_through`, plus the two new ones).
2. Regression guard: with the old condition, the new positive test fails because `has_incomplete_items=True` short-circuits before `saw_final_answer_phase` is consulted; with the new condition both new tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Sibling Audit

> Audited siblings: confirmed `saw_final_answer_phase` / `saw_commentary_phase` / `has_incomplete_items` are only consumed in this one finish_reason mapping inside `_normalize_codex_response`. The `_TOOL_CALL_LEAK_PATTERN` branch (line 1071) and the `reasoning_items_raw and not final_text` branch (line 1077) are untouched and continue to force `incomplete` for their respective cases. No widening needed.
