### PR TITLE
fix(cli): persist global model picker selections

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6772,7 +6772,15 @@ class HermesCLI:
         lines.append(('class:approval-border', '╰' + ('─' * box_width) + '╯\n'))
         return lines
 
-    def _open_model_picker(self, providers: list, current_model: str, current_provider: str, user_provs=None, custom_provs=None) -> None:
+    def _open_model_picker(
+        self,
+        providers: list,
+        current_model: str,
+        current_provider: str,
+        user_provs=None,
+        custom_provs=None,
+        persist_global: bool = False,
+    ) -> None:
         """Open prompt_toolkit-native /model picker modal."""
         self._capture_modal_input_snapshot()
         default_idx = next((i for i, p in enumerate(providers) if p.get("is_current")), 0)
@@ -6784,6 +6792,7 @@ class HermesCLI:
             "current_provider": current_provider,
             "user_provs": user_provs,
             "custom_provs": custom_provs,
+            "persist_global": persist_global,
         }
         self._invalidate(min_interval=0.0)
 
@@ -6908,6 +6917,7 @@ class HermesCLI:
         state = self._model_picker_state
         if not state:
             return
+        persist_global = bool(state.get("persist_global", persist_global))
         selected = state.get("selected", 0)
         stage = state.get("stage")
         if stage == "provider":
@@ -7032,6 +7042,7 @@ class HermesCLI:
                 provider_display,
                 user_provs=user_provs,
                 custom_provs=custom_provs,
+                persist_global=persist_global,
             )
             return
 

--- a/tests/hermes_cli/test_model_picker_global_flag.py
+++ b/tests/hermes_cli/test_model_picker_global_flag.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from hermes_cli.model_switch import ModelSwitchResult
+
+
+class _PickerStub:
+    model = "old-model"
+    provider = "old-provider"
+    base_url = ""
+    api_key = ""
+    _model_picker_state = None
+
+    def __init__(self):
+        self.invalidated = 0
+        self.applied: list[bool] = []
+
+    def _capture_modal_input_snapshot(self):
+        pass
+
+    def _restore_modal_input_snapshot(self):
+        pass
+
+    def _invalidate(self, *args, **kwargs):
+        self.invalidated += 1
+
+    def _close_model_picker(self):
+        import cli as cli_mod
+
+        cli_mod.HermesCLI._close_model_picker(self)
+
+    def _apply_model_switch_result(self, result, persist_global: bool):
+        assert result.success is True
+        self.applied.append(persist_global)
+
+
+def test_model_picker_preserves_global_flag_for_selection(monkeypatch):
+    import cli as cli_mod
+
+    switch_calls: list[dict] = []
+
+    def _fake_switch_model(**kwargs):
+        switch_calls.append(kwargs)
+        return ModelSwitchResult(
+            success=True,
+            new_model=kwargs["raw_input"],
+            target_provider=kwargs["explicit_provider"],
+            provider_changed=True,
+            is_global=kwargs["is_global"],
+        )
+
+    monkeypatch.setattr("hermes_cli.model_switch.switch_model", _fake_switch_model)
+
+    stub = _PickerStub()
+    providers = [
+        {"slug": "openai", "name": "OpenAI", "models": ["gpt-5"], "is_current": False}
+    ]
+    cli_mod.HermesCLI._open_model_picker(
+        stub,
+        providers,
+        current_model="old-model",
+        current_provider="old-provider",
+        persist_global=True,
+    )
+    stub._model_picker_state.update(
+        {
+            "stage": "model",
+            "provider_data": providers[0],
+            "model_list": ["gpt-5"],
+            "selected": 0,
+        }
+    )
+
+    cli_mod.HermesCLI._handle_model_picker_selection(stub)
+
+    assert switch_calls and switch_calls[0]["is_global"] is True
+    assert stub.applied == [True]


### PR DESCRIPTION
## Summary
- preserve the `/model --global` flag when opening the interactive model picker
- pass the stored global flag through picker selection so chosen models are saved globally
- add regression coverage for the picker selection path

Fixes #28034.

## Tests
- `uv run --with pytest --with pytest-xdist pytest tests/hermes_cli/test_model_picker_global_flag.py tests/hermes_cli/test_apply_model_switch_result_context.py tests/hermes_cli/test_model_picker_viewport.py -q`
- `uv run --with pytest --with pytest-xdist pytest tests/hermes_cli/test_model_switch_custom_providers.py -q`
- `git diff --check`
- `uv run python -m py_compile cli.py tests/hermes_cli/test_model_picker_global_flag.py`