### PR TITLE
feat: make CONTEXT_FILE_MAX_CHARS configurable via env var

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -825,7 +825,7 @@ def build_environment_hints() -> str:
     return "\n\n".join(hints)
 
 
-CONTEXT_FILE_MAX_CHARS = 20_000
+CONTEXT_FILE_MAX_CHARS = int(os.environ.get("HERMES_CONTEXT_FILE_MAX_CHARS", "50000"))
 CONTEXT_TRUNCATE_HEAD_RATIO = 0.7
 CONTEXT_TRUNCATE_TAIL_RATIO = 0.2
 


### PR DESCRIPTION
Replace hardcoded `CONTEXT_FILE_MAX_CHARS = 20_000` with an environment-variable override:

```python
CONTEXT_FILE_MAX_CHARS = int(os.environ.get("HERMES_CONTEXT_FILE_MAX_CHARS", "50000"))
```

## What does this PR do?

Users with large `SOUL.md` / `AGENTS.md` files hit the 20k truncation limit.
This raises the default to 50k and allows per-user override without editing source.

## Related Issue

N/A

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/prompt_builder.py`: +1/−1 line — replace hardcoded `20_000` with `int(os.environ.get(...))`

## How to Test

```bash
HERMES_CONTEXT_FILE_MAX_CHARS=30000 hermes   # uses 30k limit
hermes                                         # uses default 50k
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat:`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (N/A — one-liner, backward compatible)
- [x] I've tested on my platform: Debian 12

### Documentation & Housekeeping

- [ ] I've updated relevant documentation — N/A
- [ ] I've updated `cli-config.yaml.example` — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — stdlib `os.environ.get()`, works on all platforms
- [ ] I've updated tool descriptions/schemas — N/A
