### PR TITLE
fix(compression): set last_prompt_tokens=0 after compression to preve…

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -415,7 +415,7 @@ def compress_context(
         system_prompt=new_system_prompt or "",
         tools=agent.tools or None,
     )
-    agent.context_compressor.last_prompt_tokens = _compressed_est
+    agent.context_compressor.last_prompt_tokens = 0
     agent.context_compressor.last_completion_tokens = 0
 
     # Clear the file-read dedup cache.  After compression the original


### PR DESCRIPTION
fix/compression-thrash-loop → fixes #27566

fix(compression): set last_prompt_tokens=0 after compression to prevent thrash loop

After compression, last_prompt_tokens was set to estimate_request_tokens_rough() which overcounts by 30-50% for tool-heavy sessions (tool schemas counted twice). This inflated value caused should_compress() to return True on the very next turn, triggering compression every 1-2 turns in a never-ending loop.

Setting to 0 forces the preflight to recalculate from the actual compressed messages on the next turn, which produces a value well below threshold_tokens. Real API response usage data overwrites last_prompt_tokens via update_from_response() on the next API call. Fixes #27566.

Related Issue
Fixes #27566

Type of Change
- [x] 🐛 Bug fix

Changes Made
- agent/conversation_compression.py:418 — Changed agent.context_compressor.last_prompt_tokens = _compressed_est to agent.context_compressor.last_prompt_tokens = 0. The rough post-compression estimate overcounts by 30-50% for tool-heavy sessions, causing should_compress() to fire again immediately. Setting to 0 forces recalculation from the actual compressed messages on the next preflight, which are genuinely short.

How to Test
1. Enable 50+ tool schemas in a session  
2. Send messages until compression fires  
3. Send one more message  
4. Expected: compression does NOT fire again on the next turn (previously it would fire every 1-2 turns in an infinite loop)