### PR TITLE
fix(api_server): pop model from runtime_kwargs to prevent kwarg colli…

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -878,8 +878,11 @@ class APIServerAdapter(BasePlatformAdapter):
         from hermes_cli.tools_config import _get_platform_tools
 
         runtime_kwargs = _resolve_runtime_agent_kwargs()
+        runtime_model = runtime_kwargs.pop("model", None)
         reasoning_config = GatewayRunner._load_reasoning_config()
         model = _resolve_gateway_model()
+        if runtime_model:
+            model = runtime_model
 
         user_config = _load_gateway_config()
         enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))


### PR DESCRIPTION
fix/agent-model-kwarg-collision → fixes #27540

fix(api_server): pop model from runtime_kwargs to prevent kwarg collision with explicit model=

When the primary provider auth fails (e.g. OAuth token exhausted), _try_resolve_fallback_provider() returns a dict that includes 'model'. _resolve_runtime_agent_kwargs() passes this through, and _create_agent() then passes both model=model and 
**runtime_kwargs to AIAgent(), causing TypeError on the second turn of a session.

Mirrors the existing pattern in _resolve_session_agent_runtime() (gateway/run.py:1866) which already pops model from runtime_kwargs. Fixes #27540.

Related Issue
Fixes #27540

Type of Change
- [x] 🐛 Bug fix

Changes Made
- gateway/platforms/api_server.py:880-884 — Added runtime_model = runtime_kwargs.pop("model", None) before passing kwargs to AIAgent(). When fallback provider injects "model" into runtime kwargs, it is popped out and used as the effective model instead of _resolve_gateway_model(), preventing the duplicate keyword argument crash.

How to Test
1. Configure a primary provider with limited OAuth pool (e.g., Anthropic OAuth)  
2. Configure a fallback provider with a different model  
3. Start a session and send 2 messages  
4. Expected: second turn processes normally (not TypeError: multiple values for keyword argument 'model')