### PR TITLE
fix(agent): preserve global SOUL identity across isolated runs

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -125,7 +125,7 @@ def init_agent(
     thread_id: str = None,
     gateway_session_key: str = None,
     skip_context_files: bool = False,
-    load_soul_identity: bool = False,
+    load_soul_identity: Optional[bool] = None,
     skip_memory: bool = False,
     session_db=None,
     parent_session_id: str = None,
@@ -179,12 +179,13 @@ def init_agent(
             output_config.format instead of a trailing-assistant prefill.
         platform (str): The interface platform the user is on (e.g. "cli", "telegram", "discord", "whatsapp").
             Used to inject platform-specific formatting hints into the system prompt.
-        skip_context_files (bool): If True, skip auto-injection of SOUL.md, AGENTS.md, and .cursorrules
-            into the system prompt. Use this for batch processing and data generation to avoid
-            polluting trajectories with user-specific persona or project instructions.
-        load_soul_identity (bool): If True, still use ~/.hermes/SOUL.md as the primary
-            identity even when skip_context_files=True. Project context files from the cwd
-            remain skipped.
+        skip_context_files (bool): If True, skip cwd/project context files (AGENTS.md,
+            CLAUDE.md, .cursorrules) and any other context-file discovery. The global
+            ~/.hermes/SOUL.md identity still loads by default unless explicitly disabled.
+        load_soul_identity (Optional[bool]): Controls whether ~/.hermes/SOUL.md is loaded
+            as the primary identity. None (default) and True both load it, including when
+            skip_context_files=True. Pass False only for documented emergency/system-level
+            sterile runs where the operator profile must be intentionally excluded.
     """
     _install_safe_stdio()
 
@@ -213,7 +214,7 @@ def init_agent(
     agent._print_fn = None
     agent.background_review_callback = None  # Optional sync callback for gateway delivery
     agent.skip_context_files = skip_context_files
-    agent.load_soul_identity = load_soul_identity
+    agent.load_soul_identity = True if load_soul_identity is None else bool(load_soul_identity)
     agent.pass_session_id = pass_session_id
     agent._credential_pool = credential_pool
     agent.log_prefix_chars = log_prefix_chars

--- a/agent/curator.py
+++ b/agent/curator.py
@@ -1703,6 +1703,7 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
             quiet_mode=True,
             platform="curator",
             skip_context_files=True,
+            load_soul_identity=True,
             skip_memory=True,
         )
         # Disable recursive nudges — the curator must never spawn its own review.

--- a/batch_runner.py
+++ b/batch_runner.py
@@ -341,7 +341,8 @@ def _process_single_prompt(
             max_tokens=config.get("max_tokens"),
             reasoning_config=config.get("reasoning_config"),
             prefill_messages=config.get("prefill_messages"),
-            skip_context_files=True,  # Don't pollute trajectories with SOUL.md/AGENTS.md
+            skip_context_files=True,  # Keep cwd/project context files out of evaluation prompts
+            load_soul_identity=False,  # Documented sterile/system-level exclusion for reproducible batch evals
             skip_memory=True,  # Don't use persistent memory in batch runs
         )
 

--- a/cli.py
+++ b/cli.py
@@ -2705,8 +2705,8 @@ class HermesCLI:
         self.pass_session_id = pass_session_id
         # --ignore-rules: honor either the constructor flag or the env var set
         # by `hermes chat --ignore-rules` in hermes_cli/main.py. When true we
-        # pass skip_context_files=True and skip_memory=True to AIAgent so
-        # AGENTS.md/SOUL.md/.cursorrules and persistent memory are not loaded.
+        # strip cwd/project rules plus persistent memory, but still retain the
+        # global ~/.hermes/SOUL.md operator identity.
         self.ignore_rules = ignore_rules or os.environ.get("HERMES_IGNORE_RULES") == "1"
         
         # Ephemeral system prompt: env var takes precedence, then config
@@ -4506,6 +4506,7 @@ class HermesCLI:
                 checkpoint_max_file_size_mb=self.checkpoint_max_file_size_mb,
                 pass_session_id=self.pass_session_id,
                 skip_context_files=self.ignore_rules,
+                load_soul_identity=True,
                 skip_memory=self.ignore_rules,
                 tool_progress_callback=self._on_tool_progress,
                 tool_start_callback=self._on_tool_start if self._inline_diffs_enabled else None,

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -907,6 +907,7 @@ class APIServerAdapter(BasePlatformAdapter):
             session_db=self._ensure_session_db(),
             fallback_model=fallback_model,
             reasoning_config=reasoning_config,
+            load_soul_identity=True,
             gateway_session_key=gateway_session_key,
         )
         return agent

--- a/gateway/platforms/feishu_comment.py
+++ b/gateway/platforms/feishu_comment.py
@@ -1080,6 +1080,7 @@ def _run_comment_agent(prompt: str, client: Any, session_key: str = "") -> str:
             credential_pool=runtime_kwargs.get("credential_pool"),
             quiet_mode=True,
             skip_context_files=True,
+            load_soul_identity=True,
             skip_memory=True,
             max_iterations=15,
             enabled_toolsets=["feishu_doc", "feishu_drive"],

--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -208,7 +208,7 @@ def build_top_level_parser():
         "--ignore-rules",
         action="store_true",
         default=False,
-        help="Skip auto-injection of AGENTS.md, SOUL.md, .cursorrules, memory, and preloaded skills",
+        help="Skip cwd/project rules, memory, and preloaded skills while still keeping ~/.hermes/SOUL.md loaded",
     )
     _inherited_flag(
         parser,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1424,8 +1424,9 @@ def cmd_chat(args):
     if getattr(args, "ignore_user_config", False):
         os.environ["HERMES_IGNORE_USER_CONFIG"] = "1"
 
-    # --ignore-rules: skip auto-injection of AGENTS.md/SOUL.md/.cursorrules
-    # (rules), memory entries, and any preloaded skills coming from user config.
+    # --ignore-rules: skip auto-injection of cwd/project rules plus memory
+    # entries and any preloaded skills coming from user config. The global
+    # ~/.hermes/SOUL.md operator identity still loads.
     # Maps to AIAgent(skip_context_files=True, skip_memory=True).
     if getattr(args, "ignore_rules", False):
         os.environ["HERMES_IGNORE_RULES"] = "1"

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -387,7 +387,7 @@ TIPS = [
     "display.tool_progress_command: true exposes /verbose on messaging platforms; it's CLI-only by default.",
     'HERMES_BACKGROUND_NOTIFICATIONS=result only pings when background tasks finish (vs all/error/off).',
     'HERMES_WRITE_SAFE_ROOT restricts write_file and patch to a directory prefix; writes outside require approval.',
-    'HERMES_IGNORE_RULES skips auto-injection of AGENTS.md, SOUL.md, .cursorrules, memory, and preloaded skills.',
+    'HERMES_IGNORE_RULES skips cwd/project rules, memory, and preloaded skills, but still keeps ~/.hermes/SOUL.md loaded.',
     'HERMES_ACCEPT_HOOKS auto-approves unseen shell hooks declared in config.yaml without a TTY prompt.',
     'auxiliary.goal_judge.model routes the /goal judge to a cheap fast model to keep loop cost near zero.',
     'Checkpoints skip directories with more than 50,000 files to avoid slow git operations on massive monorepos.',

--- a/run_agent.py
+++ b/run_agent.py
@@ -400,7 +400,7 @@ class AIAgent:
         thread_id: str = None,
         gateway_session_key: str = None,
         skip_context_files: bool = False,
-        load_soul_identity: bool = False,
+        load_soul_identity: Optional[bool] = None,
         skip_memory: bool = False,
         session_db=None,
         parent_session_id: str = None,

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -304,6 +304,7 @@ class TestAdapterInit:
 
         assert isinstance(agent, FakeAgent)
         assert captured["reasoning_config"] == {"enabled": True, "effort": "xhigh"}
+        assert captured["load_soul_identity"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_ignore_user_config_flags.py
+++ b/tests/hermes_cli/test_ignore_user_config_flags.py
@@ -6,9 +6,9 @@ files. In Hermes the equivalent isolation is:
 
 * ``--ignore-user-config`` → skip ``~/.hermes/config.yaml`` in ``load_cli_config()``
   (credentials in ``.env`` are still loaded).
-* ``--ignore-rules`` → skip AGENTS.md / SOUL.md / .cursorrules auto-injection
-  and persistent memory (maps to ``AIAgent(skip_context_files=True,
-  skip_memory=True)``).
+* ``--ignore-rules`` → skip cwd/project rules plus persistent memory while
+  keeping the global ``~/.hermes/SOUL.md`` identity (maps to
+  ``AIAgent(skip_context_files=True, skip_memory=True)`` with SOUL still on).
 
 Both flags are wired via env vars so they work cleanly across the
 argparse → cmd_chat → cli.main() → HermesCLI → AIAgent call chain.
@@ -110,7 +110,7 @@ class TestIgnoreUserConfigEnvGate:
 class TestIgnoreRulesEnvGate:
     """The constructor / env var must propagate to ``HermesCLI.ignore_rules``
     so ``AIAgent`` is built with ``skip_context_files=True`` and
-    ``skip_memory=True``.
+    ``skip_memory=True`` while global SOUL identity loading remains enabled.
     """
 
     def test_env_var_enables_ignore_rules(self, monkeypatch):

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -948,7 +948,7 @@ class TestBuildSystemPrompt:
         prompt = agent._build_system_prompt()
         assert DEFAULT_AGENT_IDENTITY in prompt
 
-    def test_can_use_soul_identity_even_when_context_files_are_skipped(self):
+    def test_auto_loads_soul_identity_even_when_context_files_are_skipped(self):
         with (
             patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("terminal")),
             patch("run_agent.check_toolset_requirements", return_value={}),
@@ -960,13 +960,32 @@ class TestBuildSystemPrompt:
                 base_url="https://openrouter.ai/api/v1",
                 quiet_mode=True,
                 skip_context_files=True,
-                load_soul_identity=True,
                 skip_memory=True,
             )
             prompt = agent._build_system_prompt()
 
         assert "SOUL IDENTITY" in prompt
         assert DEFAULT_AGENT_IDENTITY not in prompt
+
+    def test_can_disable_soul_identity_for_documented_sterile_runs(self):
+        with (
+            patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("terminal")),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch("run_agent.load_soul_md", return_value="SOUL IDENTITY"),
+        ):
+            agent = AIAgent(
+                api_key="test-k...7890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                load_soul_identity=False,
+                skip_memory=True,
+            )
+            prompt = agent._build_system_prompt()
+
+        assert "SOUL IDENTITY" not in prompt
+        assert DEFAULT_AGENT_IDENTITY in prompt
 
     def test_includes_system_message(self, agent):
         prompt = agent._build_system_prompt(system_message="Custom instruction")

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -391,6 +391,29 @@ class TestDelegateTask(unittest.TestCase):
 
         self.assertIs(mock_child._print_fn, sink)
 
+    def test_child_forces_soul_identity_when_context_files_are_skipped(self):
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            MockAgent.return_value = mock_child
+
+            _build_child_agent(
+                task_index=0,
+                goal="Retain operator identity",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        _, kwargs = MockAgent.call_args
+        self.assertIs(kwargs["skip_context_files"], True)
+        self.assertIs(kwargs["load_soul_identity"], True)
+        self.assertIs(kwargs["skip_memory"], True)
+
     def test_child_uses_thinking_callback_when_progress_callback_available(self):
         parent = _make_mock_parent(depth=0)
         parent.tool_progress_callback = MagicMock()

--- a/tests/tui_gateway/test_make_agent_provider.py
+++ b/tests/tui_gateway/test_make_agent_provider.py
@@ -137,6 +137,7 @@ def test_make_agent_honors_tui_launch_env_flags():
         assert kwargs["checkpoints_enabled"] is True
         assert kwargs["pass_session_id"] is True
         assert kwargs["skip_context_files"] is True
+        assert kwargs["load_soul_identity"] is True
         assert kwargs["skip_memory"] is True
 
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1122,6 +1122,7 @@ def _build_child_agent(
         log_prefix=f"[subagent-{task_index}]",
         platform=parent_agent.platform,
         skip_context_files=True,
+        load_soul_identity=True,
         skip_memory=True,
         clarify_callback=None,
         thinking_callback=child_thinking_cb,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1906,6 +1906,7 @@ def _make_agent(sid: str, key: str, session_id: str | None = None):
         checkpoints_enabled=is_truthy_value(os.environ.get("HERMES_TUI_CHECKPOINTS")),
         pass_session_id=is_truthy_value(os.environ.get("HERMES_TUI_PASS_SESSION_ID")),
         skip_context_files=is_truthy_value(os.environ.get("HERMES_IGNORE_RULES")),
+        load_soul_identity=True,
         skip_memory=is_truthy_value(os.environ.get("HERMES_IGNORE_RULES")),
         **_agent_cbs(sid),
     )

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -28,7 +28,7 @@ hermes [global-options] <command> [subcommand/options]
 | `--yolo` | Bypass dangerous-command approval prompts. |
 | `--pass-session-id` | Include the session ID in the agent's system prompt. |
 | `--ignore-user-config` | Ignore `~/.hermes/config.yaml` and fall back to built-in defaults. Credentials in `.env` are still loaded. |
-| `--ignore-rules` | Skip auto-injection of `AGENTS.md`, `SOUL.md`, `.cursorrules`, memory, and preloaded skills. |
+| `--ignore-rules` | Skip cwd/project rules, persistent memory, and preloaded skills, while still keeping `~/.hermes/SOUL.md` loaded. | 
 | `--tui` | Launch the [TUI](../user-guide/tui.md) instead of the classic CLI. Equivalent to `HERMES_TUI=1`. |
 | `--dev` | With `--tui`: run the TypeScript sources directly via `tsx` instead of the prebuilt bundle (for TUI contributors). |
 
@@ -103,7 +103,7 @@ Common options:
 | `--yolo` | Skip approval prompts. |
 | `--pass-session-id` | Pass the session ID into the system prompt. |
 | `--ignore-user-config` | Ignore `~/.hermes/config.yaml` and use built-in defaults. Credentials in `.env` are still loaded. Useful for isolated CI runs, reproducible bug reports, and third-party integrations. |
-| `--ignore-rules` | Skip auto-injection of `AGENTS.md`, `SOUL.md`, `.cursorrules`, persistent memory, and preloaded skills. Combine with `--ignore-user-config` for a fully isolated run. |
+| `--ignore-rules` | Skip cwd/project rules, persistent memory, and preloaded skills, while still keeping `~/.hermes/SOUL.md` loaded. Combine with `--ignore-user-config` for a globally isolated run that still preserves the operator identity. |
 | `--source <tag>` | Session source tag for filtering (default: `cli`). Use `tool` for third-party integrations that should not appear in user session lists. |
 | `--max-turns <N>` | Maximum tool-calling iterations per conversation turn (default: 90, or `agent.max_turns` in config). |
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -510,7 +510,7 @@ Advanced per-platform knobs for throttling the outbound message batcher. Most us
 | `HERMES_YOLO_MODE` | Set to `1` to bypass dangerous-command approval prompts. Equivalent to `--yolo`. |
 | `HERMES_ACCEPT_HOOKS` | Auto-approve any unseen shell hooks declared in `config.yaml` without a TTY prompt. Equivalent to `--accept-hooks` or `hooks_auto_accept: true`. |
 | `HERMES_IGNORE_USER_CONFIG` | Skip `~/.hermes/config.yaml` and use built-in defaults (credentials in `.env` still load). Equivalent to `--ignore-user-config`. |
-| `HERMES_IGNORE_RULES` | Skip auto-injection of `AGENTS.md`, `SOUL.md`, `.cursorrules`, memory, and preloaded skills. Equivalent to `--ignore-rules`. |
+| `HERMES_IGNORE_RULES` | Skip cwd/project rules, memory, and preloaded skills while still keeping `~/.hermes/SOUL.md` loaded. Equivalent to `--ignore-rules`. |
 | `HERMES_MD_NAMES` | Comma-separated list of rules-file names to auto-inject (default: `AGENTS.md,CLAUDE.md,.cursorrules,SOUL.md`). |
 | `HERMES_TOOL_PROGRESS` | Deprecated compatibility variable for tool progress display. Prefer `display.tool_progress` in `config.yaml`. |
 | `HERMES_TOOL_PROGRESS_MODE` | Deprecated compatibility variable for tool progress mode. Prefer `display.tool_progress` in `config.yaml`. |


### PR DESCRIPTION
## Summary
- default `load_soul_identity` to on so isolated agent forks still keep the global operator identity
- explicitly keep SOUL loaded for CLI/TUI/delegate/curator/Feishu/API server pathways while documenting the batch-eval sterile exception
- update regression tests and docs for `--ignore-rules` / `HERMES_IGNORE_RULES`

## Test Plan
- uv run --extra dev --extra messaging pytest -q tests/run_agent/test_run_agent.py::TestBuildSystemPrompt::test_auto_loads_soul_identity_even_when_context_files_are_skipped tests/run_agent/test_run_agent.py::TestBuildSystemPrompt::test_can_disable_soul_identity_for_documented_sterile_runs tests/tools/test_delegate.py::TestDelegateTask::test_child_forces_soul_identity_when_context_files_are_skipped tests/gateway/test_api_server.py::TestAdapterInit::test_create_agent_forwards_config_reasoning_effort tests/tui_gateway/test_make_agent_provider.py::test_make_agent_honors_tui_launch_env_flags tests/hermes_cli/test_ignore_user_config_flags.py::TestIgnoreRulesEnvGate -n 0