### PR TITLE
fix(acp): workspace auto-approve fails for /tmp paths on macOS

### DIFF
--- a/acp_adapter/edit_approval.py
+++ b/acp_adapter/edit_approval.py
@@ -154,11 +154,15 @@ def should_auto_approve_edit(proposal: EditProposal, policy: str, cwd: str | Non
     policy = str(policy or AUTO_APPROVE_ASK).strip()
     if policy == AUTO_APPROVE_ASK or _is_sensitive_auto_approve_path(proposal.path):
         return False
-    path = Path(proposal.path).expanduser().resolve(strict=False)
+    raw_path = Path(proposal.path).expanduser()
+    # resolve() follows symlinks — on macOS /tmp → /private/tmp, so the
+    # resolved form never starts with "/tmp/". Use raw_path for the /tmp
+    # check and the resolved form only for the cwd relative_to() test.
+    path = raw_path.resolve(strict=False)
     if policy == AUTO_APPROVE_SESSION:
         return True
     if policy == AUTO_APPROVE_WORKSPACE:
-        if str(path).startswith("/tmp/"):
+        if str(raw_path).startswith("/tmp/"):
             return True
         if cwd:
             root = Path(cwd).expanduser().resolve(strict=False)


### PR DESCRIPTION
## Problem

`should_auto_approve_edit()` calls `Path.resolve()` before checking whether a path is under `/tmp/`:

```python
path = Path(proposal.path).expanduser().resolve(strict=False)
...
if str(path).startswith("/tmp/"):   # always False on macOS
    return True
```

On macOS, `/tmp` is a symlink to `/private/tmp`. After `resolve()`, `/tmp/foo.py` becomes `/private/tmp/foo.py`, so `startswith("/tmp/")` is always `False`. Every write to a `/tmp/` path silently falls through to the `cwd` check, which rejects it unless the workspace root happens to be inside `/tmp/` too.

**User-visible result:** the ACP "Accept Edits" (`workspace_session`) mode never auto-approves `/tmp/` writes on macOS, even though the server UI describes it as "Auto-allow workspace and /tmp edits". Users receive unexpected approval prompts for every temp-file write.

The existing test `test_workspace_auto_approval_allows_workspace_and_tmp_but_not_sensitive` reproduces the failure:

```
AssertionError: assert False
  where False = should_auto_approve_edit(
      EditProposal(path='/tmp/hermes-acp-auto-approve-test.txt', ...),
      'workspace_session',
      '/private/var/folders/...',
  )
```

## Fix

Check the raw (pre-`resolve`) expanded path for the `/tmp/` prefix. Continue using the resolved form only for the `cwd relative_to()` test, where resolving both sides is correct.

```python
raw_path = Path(proposal.path).expanduser()
path = raw_path.resolve(strict=False)   # only used for relative_to()
...
if str(raw_path).startswith("/tmp/"):   # correct on macOS and Linux
    return True
```

All ten edge cases verified manually (sensitive paths, `.ssh`, `.env`, session vs workspace_session policy, paths outside cwd). The previously-failing test now passes.

## Test plan

- [x] `test_workspace_auto_approval_allows_workspace_and_tmp_but_not_sensitive` — was **FAIL**, now **PASS** on macOS
- [x] All other `tests/acp/test_edit_approval.py` results unchanged (pre-existing unrelated failures in the test environment)
- [x] Sensitive paths (`.env`, `.ssh/*`) still blocked under all policies
- [x] `/var/tmp/` is NOT auto-approved (only `/tmp/` is in scope)