### PR TITLE
fix(aux): strip pattern/format from tool schemas on xAI OAuth auxiliary path

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -707,6 +707,14 @@ class _CodexCompletionsAdapter:
         # Tools support for auxiliary callers (e.g. skills_hub) that pass function schemas
         tools = kwargs.get("tools")
         if tools:
+            # xAI's Responses endpoint rejects ``pattern`` and ``format`` JSON Schema
+            # keywords (HTTP 400). Strip them here to match the parity guarantee that
+            # chat_completion_helpers.py provides for the main-agent xAI path.
+            try:
+                from tools.schema_sanitizer import strip_pattern_and_format
+                tools, _ = strip_pattern_and_format(list(tools))
+            except Exception:
+                pass
             converted = []
             for t in tools:
                 fn = t.get("function", {}) if isinstance(t, dict) else {}


### PR DESCRIPTION
## Problem

`chat_completion_helpers.py` already sanitizes tool schemas before sending to xAI's `/responses` endpoint:

```python
# chat_completion_helpers.py lines 294-302
if is_xai_responses:
    from tools.schema_sanitizer import strip_pattern_and_format
    tools_for_api, _ = strip_pattern_and_format(tools_for_api)
```

But `_CodexCompletionsAdapter.create()` — the shim used for every xAI OAuth **auxiliary** call (kanban auto-decomposer, profile describer, skills hub, etc.) — passes tool schemas raw:

```python
# auxiliary_client.py — BEFORE this fix
tools = kwargs.get("tools")
if tools:
    converted = []
    for t in tools:
        fn = t.get("function", {}) if isinstance(t, dict) else {}
        converted.append({
            ...
            "parameters": fn.get("parameters", {}),  # no sanitization
        })
```

xAI's `/responses` endpoint rejects `pattern` and `format` JSON Schema keywords with:

```
HTTP 400: Invalid arguments passed to the model
```

MCP tools routinely carry these keywords on string fields (e.g. `{"type": "string", "format": "uri", "pattern": "^https?://"}`). Any auxiliary call that includes such a tool over xAI OAuth silently fails with HTTP 400, while the exact same call through the main-agent path succeeds.

`_AsyncCodexCompletionsAdapter` is unaffected separately — it delegates to the sync adapter via `asyncio.to_thread`, so this fix covers both.

## Fix

Call `strip_pattern_and_format()` on the incoming tool list before the schema conversion loop, matching the main-agent guarantee:

```python
tools = kwargs.get("tools")
if tools:
    try:
        from tools.schema_sanitizer import strip_pattern_and_format
        tools, _ = strip_pattern_and_format(list(tools))
    except Exception:
        pass
    converted = []
    ...
```

`list(tools)` creates a fresh list so the caller's list reference is not replaced. The `try/except` ensures the fix degrades gracefully if the sanitizer import is unavailable.

## Verification

Edge cases confirmed:
- [x] Empty tool list → no-op
- [x] Tools without `pattern`/`format` → 0 stripped, schemas unchanged
- [x] Tools with `pattern` and `format` on string fields → both stripped, `type` preserved
- [x] Property literally named `"pattern"` (e.g. `search_files`) → NOT stripped (schema_sanitizer only strips siblings of `type`, not property names inside `properties`)
- [x] Import failure → `except Exception: pass` — proceeds with original tools, no crash
- [x] Non-dict entries in tool list → handled by `strip_pattern_and_format` internally

Test suite: `4 failed, 168 passed` — identical before and after the fix. The 4 failures are pre-existing (missing `openai` package in this test environment, unrelated to this change).

## Reference

Parity target: `chat_completion_helpers.py` lines 290–302, introduced in #27197.