### PR TITLE
fix: notify gateway-origin kanban_create tasks

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -679,6 +679,8 @@ def test_create_happy_path(worker_env):
     assert d["ok"] is True
     assert d["task_id"]
     assert d["status"] == "todo"  # parent isn't done yet
+    assert d["notify_subscribed"] is False
+    assert d["notify_error"] is None
     from hermes_cli import kanban_db as kb
     conn = kb.connect()
     try:
@@ -687,6 +689,65 @@ def test_create_happy_path(worker_env):
         assert child.assignee == "peer"
     finally:
         conn.close()
+
+
+def test_create_auto_subscribes_gateway_origin(worker_env):
+    """Gateway-origin kanban_create calls attach native notify subs."""
+    from gateway.session_context import set_session_vars
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    tokens = set_session_vars(
+        platform="discord",
+        chat_id="chat-123",
+        thread_id="thread-456",
+        user_id="user-789",
+        session_key="discord:chat-123:thread-456",
+    )
+    try:
+        out = kt._handle_create({
+            "title": "gateway child task",
+            "assignee": "researcher",
+        })
+        d = json.loads(out)
+        assert d["ok"] is True
+        assert d["notify_subscribed"] is True
+        assert d["notify_error"] is None
+
+        with kb.connect() as conn:
+            subs = kb.list_notify_subs(conn, d["task_id"])
+        assert len(subs) == 1
+        assert subs[0]["platform"] == "discord"
+        assert subs[0]["chat_id"] == "chat-123"
+        assert subs[0]["thread_id"] == "thread-456"
+        assert subs[0]["user_id"] == "user-789"
+        assert subs[0]["notifier_profile"] == "test-worker"
+    finally:
+        for token in reversed(tokens):
+            token.var.reset(token)
+
+
+def test_create_stays_board_only_without_gateway_origin(monkeypatch, worker_env):
+    """CLI/local/no-origin calls must not invent a callback target."""
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    for name in (
+        "HERMES_SESSION_PLATFORM",
+        "HERMES_SESSION_CHAT_ID",
+        "HERMES_SESSION_THREAD_ID",
+        "HERMES_SESSION_USER_ID",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    out = kt._handle_create({"title": "board only", "assignee": "peer"})
+    d = json.loads(out)
+    assert d["ok"] is True
+    assert d["notify_subscribed"] is False
+    assert d["notify_error"] is None
+
+    with kb.connect() as conn:
+        assert kb.list_notify_subs(conn, d["task_id"]) == []
 
 
 def test_create_rejects_no_title(worker_env):

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -151,6 +151,38 @@ def _connect():
     return kb, kb.connect()
 
 
+def _gateway_notify_origin() -> Optional[dict[str, Optional[str]]]:
+    """Return the current gateway origin for Kanban completion pings.
+
+    Orchestrator profiles may create specialist-dispatch tasks via the
+    structured ``kanban_create`` tool instead of the textual ``/kanban create``
+    command. When that tool runs inside a gateway turn, the gateway exposes the
+    concrete platform/chat/thread through session contextvars. Use those native
+    values to attach a ``kanban_notify_subs`` row immediately after task
+    creation. CLI/local sessions and workers without a concrete origin stay
+    board-only.
+    """
+    try:
+        from gateway.session_context import get_session_env
+    except Exception:
+        return None
+
+    platform = (get_session_env("HERMES_SESSION_PLATFORM", "") or "").strip().lower()
+    chat_id = (get_session_env("HERMES_SESSION_CHAT_ID", "") or "").strip()
+    if not platform or platform in {"cli", "local"} or not chat_id:
+        return None
+
+    thread_id = (get_session_env("HERMES_SESSION_THREAD_ID", "") or "").strip()
+    user_id = (get_session_env("HERMES_SESSION_USER_ID", "") or "").strip()
+    return {
+        "platform": platform,
+        "chat_id": chat_id,
+        "thread_id": thread_id or None,
+        "user_id": user_id or None,
+        "notifier_profile": os.environ.get("HERMES_PROFILE") or None,
+    }
+
+
 def _ok(**fields: Any) -> str:
     return json.dumps({"ok": True, **fields})
 
@@ -653,10 +685,30 @@ def _handle_create(args: dict, **kw) -> str:
                 skills=skills,
                 created_by=os.environ.get("HERMES_PROFILE") or "worker",
             )
+            notify_subscribed = False
+            notify_error = None
+            notify_origin = _gateway_notify_origin()
+            if notify_origin:
+                try:
+                    kb.add_notify_sub(conn, task_id=new_tid, **notify_origin)
+                    notify_subscribed = True
+                except Exception as exc:
+                    # The task already exists; preserve the successful create
+                    # result and surface the board-only notification failure so
+                    # the orchestrator can report the precise dispatch state
+                    # instead of retrying into duplicate-task risk.
+                    notify_error = str(exc)
+                    logger.warning(
+                        "kanban_create auto-notify subscription failed for %s: %s",
+                        new_tid,
+                        exc,
+                    )
             new_task = kb.get_task(conn, new_tid)
             return _ok(
                 task_id=new_tid,
                 status=new_task.status if new_task else None,
+                notify_subscribed=notify_subscribed,
+                notify_error=notify_error,
             )
         finally:
             conn.close()
@@ -971,7 +1023,10 @@ KANBAN_CREATE_SCHEMA = {
         "orchestrator workers to fan out — decompose work into child "
         "tasks with specific assignees, link them into a pipeline, "
         "then complete your own task. The dispatcher picks up the new "
-        "tasks on its next tick and spawns the assigned profiles."
+        "tasks on its next tick and spawns the assigned profiles. "
+        "When called from a messaging gateway turn with a concrete "
+        "platform/chat/thread origin, the runtime also attaches a native "
+        "kanban_notify_subs completion-notification subscription."
     ),
     "parameters": {
         "type": "object",


### PR DESCRIPTION
## Summary
- Auto-subscribe structured `kanban_create` tasks to native Kanban completion notifications when a concrete messaging gateway origin is present.
- Keep CLI/local/no-origin `kanban_create` calls board-only and return explicit `notify_subscribed` / `notify_error` fields.
- Add regression coverage for gateway-origin subscription creation and no-origin behavior.

## Diff summary
- `tools/kanban_tools.py`: adds `_gateway_notify_origin()` using `gateway.session_context.get_session_env(...)`; after `kb.create_task(...)`, calls `kb.add_notify_sub(...)` only when platform/chat origin exists; preserves successful task creation if subscription fails and reports `notify_error`; documents gateway-origin behavior in the structured tool schema.
- `tests/tools/test_kanban_tools.py`: asserts default create results are board-only, tests gateway-origin native `kanban_notify_subs` row creation, and tests no-origin calls do not create subscriptions.

## Safety / privacy check
- Uses existing Hermes Kanban primitives only: `kb.create_task(...)`, `kb.add_notify_sub(...)`, `kanban_notify_subs`, and gateway session contextvars.
- No wrapper services, custom callback protocols, stdout scraping, or setup-specific routing.
- Diff privacy scan checked for user-specific names, business/project-specific names, local filesystem paths, host/workspace identifiers, real-looking Discord snowflakes, phone-number patterns, and raw token/secret assignments. All returned 0 hits.
- Test IDs are synthetic placeholders (`chat-123`, `thread-456`, `user-789`).

## Test plan
- `python -m pytest tests/tools/test_kanban_tools.py::test_create_happy_path tests/tools/test_kanban_tools.py::test_create_auto_subscribes_gateway_origin tests/tools/test_kanban_tools.py::test_create_stays_board_only_without_gateway_origin -q -o 'addopts='` — passed.
- `python -m ruff check tools/kanban_tools.py tests/tools/test_kanban_tools.py` — passed.
- Temp-DB smoke test: gateway-origin structured create produced one `kanban_notify_subs` row; no-origin structured create produced none.

## Note
- Full `tests/tools/test_kanban_tools.py` currently has one unrelated existing failure in `test_heartbeat_extends_claim_expires` on this checkout; the focused create/notification tests pass.
