### PR TITLE
fix(compressor): count tool_call envelope in tail-budget token estimate (#28053)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -147,6 +147,27 @@ def _content_length_for_budget(raw_content: Any) -> int:
     return total
 
 
+def _estimate_msg_tokens_for_budget(msg: Dict[str, Any]) -> int:
+    """Rough token estimate of one message for tail-budget walks.
+
+    Counts the content via ``_content_length_for_budget`` (which weights
+    image parts at ``_IMAGE_TOKEN_ESTIMATE`` rather than dropping them) and
+    then folds in the JSON-envelope cost of any ``tool_calls`` — ``id``,
+    ``type``, ``function.name``, and the dict-syntax overhead the prior
+    ``len(arguments)``-only path was missing. Assistant messages with
+    several tool_calls underestimated 2-15x without this (see #28053).
+    """
+    raw_content = msg.get("content") or ""
+    msg_tokens = _content_length_for_budget(raw_content) // _CHARS_PER_TOKEN + 10
+    for tc in msg.get("tool_calls") or []:
+        # ``str(tc)`` captures the full envelope for both dict-shaped and
+        # SDK-object tool_calls. ``arguments`` alone misses the ~30-50
+        # chars of metadata per tc, which is the dominant blind spot when
+        # an assistant turn fans out into multiple parallel tool calls.
+        msg_tokens += len(str(tc)) // _CHARS_PER_TOKEN
+    return msg_tokens
+
+
 def _content_text_for_contains(content: Any) -> str:
     """Return a best-effort text view of message content.
 
@@ -774,13 +795,7 @@ class ContextCompressor(ContextEngine):
             min_protect = min(protect_tail_count, len(result))
             for i in range(len(result) - 1, -1, -1):
                 msg = result[i]
-                raw_content = msg.get("content") or ""
-                content_len = _content_length_for_budget(raw_content)
-                msg_tokens = content_len // _CHARS_PER_TOKEN + 10
-                for tc in msg.get("tool_calls") or []:
-                    if isinstance(tc, dict):
-                        args = tc.get("function", {}).get("arguments", "")
-                        msg_tokens += len(args) // _CHARS_PER_TOKEN
+                msg_tokens = _estimate_msg_tokens_for_budget(msg)
                 if accumulated + msg_tokens > protect_tail_tokens and (len(result) - i) >= min_protect:
                     boundary = i
                     break
@@ -1718,14 +1733,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
 
         for i in range(n - 1, head_end - 1, -1):
             msg = messages[i]
-            raw_content = msg.get("content") or ""
-            content_len = _content_length_for_budget(raw_content)
-            msg_tokens = content_len // _CHARS_PER_TOKEN + 10  # +10 for role/metadata
-            # Include tool call arguments in estimate
-            for tc in msg.get("tool_calls") or []:
-                if isinstance(tc, dict):
-                    args = tc.get("function", {}).get("arguments", "")
-                    msg_tokens += len(args) // _CHARS_PER_TOKEN
+            msg_tokens = _estimate_msg_tokens_for_budget(msg)
             # Stop once we exceed the soft ceiling (unless we haven't hit min_tail yet)
             if accumulated + msg_tokens > soft_ceiling and (n - i) >= min_tail:
                 break

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -1957,6 +1957,118 @@ class TestTokenBudgetTailProtection:
         assert isinstance(cut, int)
         assert 0 <= cut <= len(messages)
 
+    def test_tool_calls_envelope_counted_in_token_estimate(self, budget_compressor):
+        """_find_tail_cut_by_tokens must account for the full tool_call envelope
+        (id, type, function.name), not just len(arguments). Regression guard
+        for #28053.
+
+        Setup: 40 messages alternating ``assistant`` (3 short tool_calls each,
+        ``arguments="{}"``) and ``user`` (short text). Budget=200,
+        soft_ceiling=300.
+
+        With the buggy args-only count, each assistant message totalled
+        ~10 tokens (10 base + 3*(2/4)=0 per tc), so the walk backtracked
+        through ~30 messages before tripping the soft_ceiling — protecting
+        an oversized tail.  With the envelope cost folded in (each tc
+        envelope adds ~25 tokens), the walk trips much earlier and the
+        tail collapses to the few most-recent turns the budget can fit.
+        """
+        c = budget_compressor
+        c.tail_token_budget = 200  # soft_ceiling = 300
+
+        def tcs(prefix: str):
+            return [
+                {"id": f"call_{prefix}_{i}_abcdef0123456789",
+                 "type": "function",
+                 "function": {"name": "long_named_tool_function",
+                              "arguments": "{}"}}
+                for i in range(3)
+            ]
+
+        messages = [
+            {"role": "user", "content": "head1"},
+            {"role": "assistant", "content": "head2"},
+        ]
+        # 38 alternating turns
+        for i in range(19):
+            messages.append({"role": "assistant", "content": None,
+                             "tool_calls": tcs(f"a{i}")})
+            messages.append({"role": "user", "content": f"u{i}"})
+        head_end = 2
+        cut = c._find_tail_cut_by_tokens(messages, head_end)
+        protected = len(messages) - cut
+        # With buggy estimation (each assistant ≈ 10 tokens), the walk
+        # protects ~25-30 messages before exhausting the soft_ceiling.
+        # With the fix (each assistant ≈ 85 tokens), it should protect
+        # closer to 5-10.  Asserting < 20 keeps the test stable against
+        # minor estimation drift while still failing on the original bug.
+        assert protected < 20, (
+            f"Walk protected {protected} tail messages — tool_calls "
+            "envelope is being underestimated, so the walk goes too "
+            "deep before hitting soft_ceiling."
+        )
+
+    def test_estimate_msg_tokens_envelope_counted(self):
+        """Direct unit test for the shared helper used by the two budget
+        walks.  Asserts the id/type/function.name envelope contributes
+        meaningfully — the old args-only count dropped these entirely.
+        """
+        from agent.context_compressor import _estimate_msg_tokens_for_budget
+
+        args_only = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{"function": {"arguments": "{}"}}],
+        }
+        full_envelope = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{
+                "id": "call_abc123def456_ghi789jkl012",
+                "type": "function",
+                "function": {"name": "web_search_with_options",
+                             "arguments": "{}"},
+            }],
+        }
+        diff = (
+            _estimate_msg_tokens_for_budget(full_envelope)
+            - _estimate_msg_tokens_for_budget(args_only)
+        )
+        # The added envelope is ~80 chars of JSON metadata → ≥ 15 tokens.
+        # The old args-only path would have produced diff == 0.
+        assert diff >= 15, (
+            f"Envelope diff was {diff} tokens — id/type/function.name "
+            "are not being counted."
+        )
+
+    def test_estimate_msg_tokens_handles_sdk_tool_calls(self):
+        """Helper must handle non-dict tool_calls (openai SDK objects)
+        without crashing or returning 0.  The prior args-only branch
+        silently skipped these via ``isinstance(tc, dict)``.
+        """
+        from agent.context_compressor import _estimate_msg_tokens_for_budget
+
+        class _FakeFn:
+            name = "web_search"
+            arguments = '{"query": "hello"}'
+
+        class _FakeTc:
+            id = "call_abc123"
+            type = "function"
+            function = _FakeFn()
+
+            def __str__(self) -> str:
+                return (
+                    f"ToolCall(id={self.id!r}, type={self.type!r}, "
+                    f"function=Fn(name={self.function.name!r}, "
+                    f"arguments={self.function.arguments!r}))"
+                )
+
+        msg = {"role": "assistant", "content": None,
+               "tool_calls": [_FakeTc()]}
+        # Just below 10 (the base overhead) would mean the tc was skipped.
+        assert _estimate_msg_tokens_for_budget(msg) > 10
+
     def test_generous_budget_protects_everything_floor_does_not_override(
         self, budget_compressor
     ):


### PR DESCRIPTION
## What does this PR do?

Fixes the compression tail-budget walk to include the full `tool_call` envelope (`id`, `type`, `function.name`, plus JSON syntax overhead) when estimating per-message tokens. The previous estimate of `content_length + len(arguments)` dropped every other field on each `tool_call`, which for assistant turns that fan out into 3-5 parallel tool calls is the bulk of the real token cost — the issue measures 2.27× divergence on assistant messages overall and 10-15× on individual turns (4 tool_calls: 73 vs 1,090 tokens). The walks in `_find_tail_cut_by_tokens` and `_prune_old_tool_results` over-protect the tail (137 msgs kept where the budget targets ~25), and compression saves ~40% instead of ~80%. This PR introduces a shared `_estimate_msg_tokens_for_budget(msg)` helper, uses it at both sites, and folds in `len(str(tc))` per tool_call to capture the envelope for both dict-shaped and SDK-object tool calls.

## Related Issue

Fixes #28053

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/context_compressor.py` — extract `_estimate_msg_tokens_for_budget(msg)` helper. Preserves `_content_length_for_budget` (so the multimodal `image_url` accounting from #16087 still works) and adds `len(str(tc)) // _CHARS_PER_TOKEN` per tool_call. `_find_tail_cut_by_tokens` and `_prune_old_tool_results` now call the shared helper.
- `tests/agent/test_context_compressor.py` — new regression `TestTokenBudgetTailProtection::test_tool_calls_envelope_counted_in_token_estimate` (40-msg transcript: buggy walk protects 30 tail msgs, fixed walk protects <20) + helper unit tests (`test_estimate_msg_tokens_envelope_counted`, `test_estimate_msg_tokens_handles_sdk_tool_calls`).

## How to Test

1. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/agent/test_context_compressor.py -v` — 15/15 in `TestTokenBudgetTailProtection` pass.
2. Regression guard: temporarily revert the production change → new test fails with `assert 30 < 20`. Restore → passes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Sibling Audit

> The issue names `_find_tail_cut_by_tokens` only, but the same inline pattern lived in `_prune_old_tool_results` (line 681-686). Both call sites are fixed by the same helper so the invariant — token-budget walks must account for tool_call envelope — holds across the compressor. No other compressor call sites compute a per-message budget rough. No widening needed.

## Related

- Builds on #16369 (multimodal `len(content)` fix) which patched a different root cause in the same function; this PR keeps that fix intact via `_content_length_for_budget`.
- Issue notes #13164 and #16087 as related; the helper covers both since image accounting routes through the existing `_content_length_for_budget` path.
