### PR TITLE
fix(feishu): serialize outbound structured mentions

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -161,6 +161,14 @@ _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 _MARKDOWN_FENCE_OPEN_RE = re.compile(r"^```([^\n`]*)\s*$")
 _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
 _MENTION_RE = re.compile(r"@_user_\d+")
+_OUTBOUND_AT_TAG_RE = re.compile(r"<at\s+([^>]*)>(.*?)</at>", re.IGNORECASE | re.DOTALL)
+_OUTBOUND_AT_ATTR_RE = re.compile(
+    r"([A-Za-z_][\w:-]*)\s*=\s*(?:\"([^\"]*)\"|'([^']*)'|([^\s>]+))"
+)
+_OUTBOUND_MARKDOWN_MENTION_RE = re.compile(
+    r"@\[([^\]\n]+)\]\((?:feishu|lark):([^) \t\r\n]+)\)"
+)
+_OUTBOUND_OPEN_ID_MENTION_RE = re.compile(r"(?<![\w@])@(ou_[A-Za-z0-9]+)\b")
 _MULTISPACE_RE = re.compile(r"[ \t]{2,}")
 _POST_CONTENT_INVALID_RE = re.compile(r"content format of the post type is incorrect", re.IGNORECASE)
 # ---------------------------------------------------------------------------
@@ -322,6 +330,14 @@ class FeishuMentionRef:
     open_id: str = ""
     is_all: bool = False
     is_self: bool = False
+
+
+@dataclass(frozen=True)
+class _OutboundMention:
+    start: int
+    end: int
+    user_id: str
+    display_name: str
 
 
 @dataclass(frozen=True)
@@ -519,7 +535,7 @@ def _strip_markdown_to_plain_text(text: str) -> str:
     horizontal rules, \\r\\n normalisation).
     """
     from gateway.platforms.helpers import strip_markdown
-    plain = text.replace("\r\n", "\n")
+    plain = _render_outbound_structured_mentions_as_text(text).replace("\r\n", "\n")
     plain = _MARKDOWN_LINK_RE.sub(lambda m: f"{m.group(1)} ({m.group(2).strip()})", plain)
     plain = re.sub(r"^>\s?", "", plain, flags=re.MULTILINE)
     plain = re.sub(r"^\s*---+\s*$", "---", plain, flags=re.MULTILINE)
@@ -558,6 +574,156 @@ def _build_markdown_post_payload(content: str) -> str:
         },
         ensure_ascii=False,
     )
+
+
+def _build_structured_mention_post_payload(content: str) -> str:
+    rows = _build_structured_mention_post_rows(content)
+    return json.dumps(
+        {
+            "zh_cn": {
+                "content": rows,
+            }
+        },
+        ensure_ascii=False,
+    )
+
+
+def _build_structured_mention_post_rows(content: str) -> List[List[Dict[str, str]]]:
+    text_tag = (
+        "md"
+        if _MARKDOWN_HINT_RE.search(content) and not _MARKDOWN_TABLE_RE.search(content)
+        else "text"
+    )
+    if "```" not in content:
+        return [_build_structured_mention_elements(content, text_tag=text_tag)]
+
+    rows: List[List[Dict[str, str]]] = []
+    for row in _build_markdown_post_rows(content):
+        if len(row) != 1:
+            rows.append(row)
+            continue
+        element = row[0]
+        segment = element.get("text", "")
+        # Keep fenced code blocks literal. A sample <at ...> inside code should
+        # not ping anyone.
+        if str(segment).lstrip().startswith("```"):
+            rows.append(row)
+        else:
+            rows.append(_build_structured_mention_elements(str(segment), text_tag=text_tag))
+    return rows or [[{"tag": text_tag, "text": content}]]
+
+
+def _build_structured_mention_elements(content: str, *, text_tag: str) -> List[Dict[str, str]]:
+    mentions = _parse_outbound_structured_mentions(content)
+    if not mentions:
+        return [{"tag": text_tag, "text": content}]
+
+    elements: List[Dict[str, str]] = []
+    cursor = 0
+    for mention in mentions:
+        if mention.start > cursor:
+            elements.append({"tag": text_tag, "text": content[cursor:mention.start]})
+        at_element = {"tag": "at", "user_id": mention.user_id}
+        if mention.display_name:
+            at_element["user_name"] = mention.display_name
+        elements.append(at_element)
+        cursor = mention.end
+    if cursor < len(content):
+        elements.append({"tag": text_tag, "text": content[cursor:]})
+    return elements or [{"tag": text_tag, "text": ""}]
+
+
+def _has_outbound_structured_mentions(content: str) -> bool:
+    return bool(_parse_outbound_structured_mentions(content))
+
+
+def _parse_outbound_structured_mentions(content: str) -> List[_OutboundMention]:
+    mentions: List[_OutboundMention] = []
+
+    for match in _OUTBOUND_AT_TAG_RE.finditer(content):
+        attrs = _parse_outbound_at_attrs(match.group(1))
+        user_id = (
+            attrs.get("user_id")
+            or attrs.get("open_id")
+            or attrs.get("id")
+            or attrs.get("user-id")
+            or attrs.get("open-id")
+            or ""
+        ).strip()
+        if not user_id:
+            continue
+        display_name = (
+            _strip_inline_whitespace(match.group(2))
+            or attrs.get("user_name")
+            or attrs.get("name")
+            or user_id
+        ).strip()
+        mentions.append(
+            _OutboundMention(
+                start=match.start(),
+                end=match.end(),
+                user_id=user_id,
+                display_name=display_name,
+            )
+        )
+
+    for match in _OUTBOUND_MARKDOWN_MENTION_RE.finditer(content):
+        mentions.append(
+            _OutboundMention(
+                start=match.start(),
+                end=match.end(),
+                user_id=match.group(2).strip(),
+                display_name=match.group(1).strip(),
+            )
+        )
+
+    for match in _OUTBOUND_OPEN_ID_MENTION_RE.finditer(content):
+        open_id = match.group(1).strip()
+        mentions.append(
+            _OutboundMention(
+                start=match.start(),
+                end=match.end(),
+                user_id=open_id,
+                display_name=open_id,
+            )
+        )
+
+    mentions.sort(key=lambda item: (item.start, item.end))
+    filtered: List[_OutboundMention] = []
+    last_end = -1
+    for mention in mentions:
+        if mention.start < last_end:
+            continue
+        filtered.append(mention)
+        last_end = mention.end
+    return filtered
+
+
+def _parse_outbound_at_attrs(raw_attrs: str) -> Dict[str, str]:
+    attrs: Dict[str, str] = {}
+    for match in _OUTBOUND_AT_ATTR_RE.finditer(raw_attrs or ""):
+        value = next((group for group in match.groups()[1:] if group is not None), "")
+        attrs[match.group(1).lower()] = value
+    return attrs
+
+
+def _strip_inline_whitespace(value: str) -> str:
+    return _WHITESPACE_RE.sub(" ", value or "").strip()
+
+
+def _render_outbound_structured_mentions_as_text(content: str) -> str:
+    mentions = _parse_outbound_structured_mentions(content)
+    if not mentions:
+        return content
+
+    parts: List[str] = []
+    cursor = 0
+    for mention in mentions:
+        parts.append(content[cursor:mention.start])
+        parts.append(f"@{mention.display_name or mention.user_id}")
+        cursor = mention.end
+    parts.append(content[cursor:])
+    return "".join(parts)
 
 
 def _build_markdown_post_rows(content: str) -> List[List[Dict[str, str]]]:
@@ -4374,6 +4540,8 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
+        if _has_outbound_structured_mentions(content):
+            return "post", _build_structured_mention_post_payload(content)
         # Feishu post-type 'md' elements do not render markdown tables; sending
         # table content as post causes the message to appear blank on the client.
         # Force plain text for anything that looks like a markdown table.

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -169,6 +169,8 @@ _OUTBOUND_MARKDOWN_MENTION_RE = re.compile(
     r"@\[([^\]\n]+)\]\((?:feishu|lark):([^) \t\r\n]+)\)"
 )
 _OUTBOUND_OPEN_ID_MENTION_RE = re.compile(r"(?<![\w@])@(ou_[A-Za-z0-9]+)\b")
+_OUTBOUND_INLINE_CODE_RE = re.compile(r"`+[^`\n]+`+")
+_OUTBOUND_URL_RE = re.compile(r"https?://[^\s<>\])]+")
 _MULTISPACE_RE = re.compile(r"[ \t]{2,}")
 _POST_CONTENT_INVALID_RE = re.compile(r"content format of the post type is incorrect", re.IGNORECASE)
 # ---------------------------------------------------------------------------
@@ -639,8 +641,11 @@ def _has_outbound_structured_mentions(content: str) -> bool:
 
 def _parse_outbound_structured_mentions(content: str) -> List[_OutboundMention]:
     mentions: List[_OutboundMention] = []
+    protected_spans = _outbound_mention_protected_spans(content)
 
     for match in _OUTBOUND_AT_TAG_RE.finditer(content):
+        if _span_overlaps_any(match.start(), match.end(), protected_spans):
+            continue
         attrs = _parse_outbound_at_attrs(match.group(1))
         user_id = (
             attrs.get("user_id")
@@ -668,6 +673,8 @@ def _parse_outbound_structured_mentions(content: str) -> List[_OutboundMention]:
         )
 
     for match in _OUTBOUND_MARKDOWN_MENTION_RE.finditer(content):
+        if _span_overlaps_any(match.start(), match.end(), protected_spans):
+            continue
         mentions.append(
             _OutboundMention(
                 start=match.start(),
@@ -678,6 +685,8 @@ def _parse_outbound_structured_mentions(content: str) -> List[_OutboundMention]:
         )
 
     for match in _OUTBOUND_OPEN_ID_MENTION_RE.finditer(content):
+        if _span_overlaps_any(match.start(), match.end(), protected_spans):
+            continue
         open_id = match.group(1).strip()
         mentions.append(
             _OutboundMention(
@@ -697,6 +706,36 @@ def _parse_outbound_structured_mentions(content: str) -> List[_OutboundMention]:
         filtered.append(mention)
         last_end = mention.end
     return filtered
+
+
+def _outbound_mention_protected_spans(content: str) -> List[tuple[int, int]]:
+    spans: List[tuple[int, int]] = []
+    for match in _OUTBOUND_INLINE_CODE_RE.finditer(content):
+        spans.append((match.start(), match.end()))
+    for match in _MARKDOWN_LINK_RE.finditer(content):
+        href = match.group(2).strip().lower()
+        if match.start() > 0 and content[match.start() - 1] == "@" and href.startswith(("feishu:", "lark:")):
+            continue
+        spans.append((match.start(), match.end()))
+    for match in _OUTBOUND_URL_RE.finditer(content):
+        spans.append((match.start(), match.end()))
+    return _merge_spans(spans)
+
+
+def _merge_spans(spans: List[tuple[int, int]]) -> List[tuple[int, int]]:
+    if not spans:
+        return []
+    merged: List[tuple[int, int]] = []
+    for start, end in sorted(spans):
+        if not merged or start > merged[-1][1]:
+            merged.append((start, end))
+        else:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+    return merged
+
+
+def _span_overlaps_any(start: int, end: int, spans: List[tuple[int, int]]) -> bool:
+    return any(start < protected_end and end > protected_start for protected_start, protected_end in spans)
 
 
 def _parse_outbound_at_attrs(raw_attrs: str) -> Dict[str, str]:
@@ -5020,7 +5059,10 @@ class FeishuAdapter(BasePlatformAdapter):
         return _build_markdown_post_payload(content)
 
     def _build_media_post_payload(self, *, caption: str, media_tag: Dict[str, str]) -> str:
-        payload = json.loads(self._build_post_payload(caption))
+        if _has_outbound_structured_mentions(caption):
+            payload = json.loads(_build_structured_mention_post_payload(caption))
+        else:
+            payload = json.loads(self._build_post_payload(caption))
         content = payload.setdefault("zh_cn", {}).setdefault("content", [])
         content.append([media_tag])
         return json.dumps(payload, ensure_ascii=False)

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2643,6 +2643,72 @@ class TestAdapterBehavior(unittest.TestCase):
         )
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_send_builds_structured_at_tag_for_outbound_mentions(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        msg_type, payload_raw = adapter._build_outbound_payload(
+            '<at user_id="ou_cto">技术总监CTO</at> 联调测试'
+        )
+
+        self.assertEqual(msg_type, "post")
+        payload = json.loads(payload_raw)
+        self.assertEqual(
+            payload["zh_cn"]["content"],
+            [
+                [
+                    {"tag": "at", "user_id": "ou_cto", "user_name": "技术总监CTO"},
+                    {"tag": "text", "text": " 联调测试"},
+                ]
+            ],
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_supports_markdown_style_feishu_mentions(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        msg_type, payload_raw = adapter._build_outbound_payload(
+            "@[技术总监CTO](feishu:ou_cto) 请看 **联调测试**。"
+        )
+
+        self.assertEqual(msg_type, "post")
+        payload = json.loads(payload_raw)
+        self.assertEqual(
+            payload["zh_cn"]["content"],
+            [
+                [
+                    {"tag": "at", "user_id": "ou_cto", "user_name": "技术总监CTO"},
+                    {"tag": "md", "text": " 请看 **联调测试**。"},
+                ]
+            ],
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_supports_bare_open_id_feishu_mentions(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        msg_type, payload_raw = adapter._build_outbound_payload(
+            "@ou_cto 请看一下上线事项"
+        )
+
+        self.assertEqual(msg_type, "post")
+        payload = json.loads(payload_raw)
+        self.assertEqual(
+            payload["zh_cn"]["content"],
+            [
+                [
+                    {"tag": "at", "user_id": "ou_cto", "user_name": "ou_cto"},
+                    {"tag": "text", "text": " 请看一下上线事项"},
+                ]
+            ],
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_build_post_payload_keeps_fence_like_code_lines_inside_code_block(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2709,6 +2709,71 @@ class TestAdapterBehavior(unittest.TestCase):
         )
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_send_does_not_parse_bare_mentions_inside_inline_code(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        msg_type, payload_raw = adapter._build_outbound_payload(
+            "请执行 `@ou_cto` 这个字面量，不要真的提醒。"
+        )
+
+        self.assertEqual(msg_type, "post")
+        payload = json.loads(payload_raw)
+        self.assertEqual(
+            payload["zh_cn"]["content"],
+            [[{"tag": "md", "text": "请执行 `@ou_cto` 这个字面量，不要真的提醒。"}]],
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_does_not_parse_bare_mentions_inside_links_or_urls(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        msg_type, payload_raw = adapter._build_outbound_payload(
+            "查看 [profile](https://example.com/@ou_cto) 或 https://example.com/@ou_ops"
+        )
+
+        self.assertEqual(msg_type, "post")
+        payload = json.loads(payload_raw)
+        self.assertEqual(
+            payload["zh_cn"]["content"],
+            [
+                [
+                    {
+                        "tag": "md",
+                        "text": "查看 [profile](https://example.com/@ou_cto) 或 https://example.com/@ou_ops",
+                    }
+                ]
+            ],
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_media_caption_builds_structured_at_tag_for_outbound_mentions(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        payload = json.loads(
+            adapter._build_media_post_payload(
+                caption="@ou_cto 请看附件",
+                media_tag={"tag": "media", "file_key": "file_123", "file_name": "demo.mp4"},
+            )
+        )
+
+        self.assertEqual(
+            payload["zh_cn"]["content"],
+            [
+                [
+                    {"tag": "at", "user_id": "ou_cto", "user_name": "ou_cto"},
+                    {"tag": "text", "text": " 请看附件"},
+                ],
+                [{"tag": "media", "file_key": "file_123", "file_name": "demo.mp4"}],
+            ],
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_build_post_payload_keeps_fence_like_code_lines_inside_code_block(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter


### PR DESCRIPTION
## Summary

This fixes Feishu outbound @ mentions by serializing supported mention syntaxes into Feishu `post` message elements with `tag: "at"`.

Supported formats:

- `<at user_id="ou_xxx">Display Name</at>`
- `@[Display Name](feishu:ou_xxx)`
- `@ou_xxx`

This preserves compatibility with the simpler `@ou_xxx` approach from #11874, while also supporting explicit display-name syntaxes that are easier for agents to follow from prompt/SOUL instructions.

## Why

Sending plain text like `@name` or `<at ...>` does not create a real Feishu mention. Feishu requires structured `post` content with an `at` element.

## Related

- Extends the behavior proposed in #11874.
- Revisits the idea from #12462 against current main with regression coverage.

## Tests

- `python -m ruff check gateway/platforms/feishu.py tests/gateway/test_feishu.py`
- `python -m pytest tests/gateway/test_feishu.py -q`
