### PR TITLE
proxy: add opt-in inbound bearer middleware (HERMES_API_KEY)

### DIFF
--- a/hermes_cli/proxy/server.py
+++ b/hermes_cli/proxy/server.py
@@ -52,6 +52,24 @@ _HOP_BY_HOP_HEADERS = frozenset(
 DEFAULT_PORT = 8645
 DEFAULT_HOST = "127.0.0.1"
 
+# Env var the proxy checks for inbound-bearer enforcement. When the
+# variable resolves to a non-empty value via
+# ``hermes_cli.config.get_env_value`` (i.e. set in ``~/.hermes/.env``
+# or the process environment), the proxy refuses requests whose
+# ``Authorization: Bearer <token>`` does not match the configured
+# value. When the variable is unset, the proxy preserves its legacy
+# behavior of accepting any inbound bearer and replacing it with the
+# upstream credential.
+#
+# Why opt-in rather than opt-out: existing localhost callers (the
+# nous adapter, for example) rely on the bind-to-127.0.0.1 boundary
+# alone. Forcing inbound bearer on those would be a regression.
+# Opt-in lets a deployment that exposes the proxy beyond localhost
+# (e.g. via a Cloudflare Tunnel pointing at hermes-bridge.<domain>)
+# add the credential gate without disturbing the localhost-only
+# default.
+INBOUND_BEARER_ENV_VAR = "HERMES_API_KEY"
+
 
 def _json_error(status: int, message: str, code: str = "proxy_error") -> "web.Response":
     """Return an OpenAI-style error JSON response."""
@@ -82,6 +100,72 @@ def _filter_response_headers(headers) -> dict:
     return out
 
 
+def _resolve_inbound_bearer(env_var: str = INBOUND_BEARER_ENV_VAR) -> Optional[str]:
+    """Resolve the expected inbound bearer.
+
+    Reads ``env_var`` via ``hermes_cli.config.get_env_value`` so values
+    in ``~/.hermes/.env`` are honored — not just ones already exported
+    into ``os.environ``. Returns ``None`` when unset/empty (signal to
+    skip enforcement)."""
+    try:
+        from hermes_cli.config import get_env_value
+    except Exception:
+        import os
+        value = os.environ.get(env_var, "")
+    else:
+        value = get_env_value(env_var) or ""
+    value = str(value).strip()
+    return value or None
+
+
+def _inbound_bearer_middleware(env_var: str = INBOUND_BEARER_ENV_VAR):
+    """Build an aiohttp middleware that enforces the inbound bearer.
+
+    When ``_resolve_inbound_bearer`` returns ``None`` the middleware
+    is a no-op (legacy localhost-only deployments). When set, every
+    forwarded request must carry ``Authorization: Bearer <value>``
+    matching exactly; otherwise the middleware returns 401 with an
+    OpenAI-style error body. ``/health`` is exempt — operators need
+    to probe status without sending the credential."""
+
+    @web.middleware
+    async def middleware(request: "web.Request", handler):
+        # /health is always open. Anything else requires the credential
+        # if one is configured.
+        if request.path == "/health":
+            return await handler(request)
+
+        expected = _resolve_inbound_bearer(env_var)
+        if expected is None:
+            # Legacy: no enforcement configured. Localhost-only
+            # callers (nous on 127.0.0.1, etc.) keep working.
+            return await handler(request)
+
+        auth = request.headers.get("Authorization", "")
+        scheme, _, token = auth.partition(" ")
+        if scheme.lower() != "bearer" or not token.strip():
+            return _json_error(
+                401,
+                "Missing or malformed Authorization header. "
+                "Expected: Bearer <token>.",
+                code="inbound_auth_missing",
+            )
+        # Constant-time compare. The bearer is a static secret and
+        # localhost is the dominant case; timing-side-channel risk
+        # is low, but ``secrets.compare_digest`` costs nothing.
+        import secrets as _secrets
+        if not _secrets.compare_digest(token.strip(), expected):
+            return _json_error(
+                401,
+                "Inbound bearer token does not match the proxy's "
+                "configured HERMES_API_KEY.",
+                code="inbound_auth_mismatch",
+            )
+        return await handler(request)
+
+    return middleware
+
+
 def create_app(adapter: UpstreamAdapter) -> "web.Application":
     """Build the aiohttp application bound to a specific upstream adapter."""
     if not AIOHTTP_AVAILABLE:
@@ -90,7 +174,7 @@ def create_app(adapter: UpstreamAdapter) -> "web.Application":
             "pip install 'hermes-agent[messaging]' or `pip install aiohttp`."
         )
 
-    app = web.Application()
+    app = web.Application(middlewares=[_inbound_bearer_middleware()])
     # AppKey ensures forward-compat with future aiohttp versions that strip
     # bare-string keys.
     _adapter_key = web.AppKey("adapter", UpstreamAdapter)

--- a/tests/hermes_cli/test_proxy.py
+++ b/tests/hermes_cli/test_proxy.py
@@ -609,6 +609,195 @@ def test_server_strips_client_auth_header():
 
 
 # ---------------------------------------------------------------------------
+# Inbound bearer middleware
+#
+# When HERMES_API_KEY (or the configured env var) is set, the proxy
+# requires every inbound /v1/* call to carry a matching
+# ``Authorization: Bearer <token>``. When unset, the legacy localhost-
+# only behavior (no inbound auth) is preserved. ``/health`` is always
+# open so operators can probe status without sending the credential.
+# ---------------------------------------------------------------------------
+
+
+def test_inbound_bearer_unset_no_enforcement(monkeypatch):
+    """Legacy: no env var → any inbound bearer accepted (forwarded
+    after replacement). Preserves the nous-on-localhost contract."""
+    monkeypatch.delenv("HERMES_API_KEY", raising=False)
+    # Also disable dotenv resolution by patching get_env_value to
+    # return None for the relevant key.
+    import hermes_cli.proxy.server as srv
+
+    monkeypatch.setattr(srv, "_resolve_inbound_bearer", lambda env_var=None: None)
+
+    async def run():
+        captured: Dict[str, Any] = {"requests": []}
+        upstream_runner, upstream_base = await _start_runner(_build_fake_upstream(captured))
+        adapter = FakeAdapter(f"{upstream_base}/v1", bearer="ours")
+        proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{proxy_base}/v1/chat/completions",
+                    json={},
+                    # NO Authorization header at all
+                ) as resp:
+                    assert resp.status == 200
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    asyncio.run(run())
+
+
+def test_inbound_bearer_set_missing_auth_401(monkeypatch):
+    """Env set, request has NO Authorization header → 401 with
+    inbound_auth_missing code. Request never reaches upstream."""
+    import hermes_cli.proxy.server as srv
+    monkeypatch.setattr(srv, "_resolve_inbound_bearer", lambda env_var=None: "hb_secret")
+
+    async def run():
+        captured: Dict[str, Any] = {"requests": []}
+        upstream_runner, upstream_base = await _start_runner(_build_fake_upstream(captured))
+        adapter = FakeAdapter(f"{upstream_base}/v1", bearer="ours")
+        proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{proxy_base}/v1/chat/completions", json={},
+                ) as resp:
+                    assert resp.status == 401
+                    body = await resp.json()
+                    assert body["error"]["code"] == "inbound_auth_missing"
+            # Upstream never hit.
+            assert captured["requests"] == []
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    asyncio.run(run())
+
+
+def test_inbound_bearer_set_wrong_token_401(monkeypatch):
+    """Env set, request has wrong bearer → 401 with
+    inbound_auth_mismatch code. Request never reaches upstream."""
+    import hermes_cli.proxy.server as srv
+    monkeypatch.setattr(srv, "_resolve_inbound_bearer", lambda env_var=None: "hb_secret")
+
+    async def run():
+        captured: Dict[str, Any] = {"requests": []}
+        upstream_runner, upstream_base = await _start_runner(_build_fake_upstream(captured))
+        adapter = FakeAdapter(f"{upstream_base}/v1", bearer="ours")
+        proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{proxy_base}/v1/chat/completions", json={},
+                    headers={"Authorization": "Bearer hb_wrong"},
+                ) as resp:
+                    assert resp.status == 401
+                    body = await resp.json()
+                    assert body["error"]["code"] == "inbound_auth_mismatch"
+            assert captured["requests"] == []
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    asyncio.run(run())
+
+
+def test_inbound_bearer_set_malformed_auth_401(monkeypatch):
+    """Authorization header without the ``Bearer`` scheme → 401."""
+    import hermes_cli.proxy.server as srv
+    monkeypatch.setattr(srv, "_resolve_inbound_bearer", lambda env_var=None: "hb_secret")
+
+    async def run():
+        captured: Dict[str, Any] = {"requests": []}
+        upstream_runner, upstream_base = await _start_runner(_build_fake_upstream(captured))
+        adapter = FakeAdapter(f"{upstream_base}/v1", bearer="ours")
+        proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{proxy_base}/v1/chat/completions", json={},
+                    headers={"Authorization": "Basic hb_secret"},
+                ) as resp:
+                    assert resp.status == 401
+                    body = await resp.json()
+                    assert body["error"]["code"] == "inbound_auth_missing"
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    asyncio.run(run())
+
+
+def test_inbound_bearer_set_correct_token_forwards(monkeypatch):
+    """Env set, request has matching bearer → request reaches upstream
+    with the inbound bearer REPLACED by the adapter's bearer (existing
+    proxy contract preserved)."""
+    import hermes_cli.proxy.server as srv
+    monkeypatch.setattr(srv, "_resolve_inbound_bearer", lambda env_var=None: "hb_secret")
+
+    async def run():
+        captured: Dict[str, Any] = {"requests": []}
+        upstream_runner, upstream_base = await _start_runner(_build_fake_upstream(captured))
+        adapter = FakeAdapter(f"{upstream_base}/v1", bearer="upstream-key")
+        proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{proxy_base}/v1/chat/completions", json={"a": 1},
+                    headers={"Authorization": "Bearer hb_secret"},
+                ) as resp:
+                    assert resp.status == 200
+            # Inbound bearer was replaced by adapter's; not leaked
+            # to upstream.
+            assert captured["requests"][0]["auth"] == "Bearer upstream-key"
+            assert "hb_secret" not in captured["requests"][0]["auth"]
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    asyncio.run(run())
+
+
+def test_inbound_bearer_set_health_endpoint_still_open(monkeypatch):
+    """Operators must be able to probe /health without sending the
+    credential. The middleware exempts /health regardless of env."""
+    import hermes_cli.proxy.server as srv
+    monkeypatch.setattr(srv, "_resolve_inbound_bearer", lambda env_var=None: "hb_secret")
+
+    async def run():
+        adapter = FakeAdapter("https://upstream.invalid/v1", bearer="x")
+        runner, base = await _start_runner(create_app(adapter))
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(f"{base}/health") as resp:
+                    assert resp.status == 200
+                    body = await resp.json()
+                    assert body["status"] == "ok"
+        finally:
+            await runner.cleanup()
+
+    asyncio.run(run())
+
+
+def test_resolve_inbound_bearer_reads_env(monkeypatch):
+    """The helper honors os.environ when hermes_cli.config is
+    unavailable, and strips whitespace."""
+    from hermes_cli.proxy.server import _resolve_inbound_bearer
+
+    monkeypatch.delenv("HERMES_API_KEY", raising=False)
+    assert _resolve_inbound_bearer() is None
+
+    monkeypatch.setenv("HERMES_API_KEY", "  hb_padded  ")
+    assert _resolve_inbound_bearer() == "hb_padded"
+
+    monkeypatch.setenv("HERMES_API_KEY", "")
+    assert _resolve_inbound_bearer() is None
+
+
+# ---------------------------------------------------------------------------
 # CLI handlers
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Adds an opt-in inbound bearer middleware to `hermes proxy`. When `HERMES_API_KEY` resolves to a non-empty value (via `hermes_cli.config.get_env_value` so `~/.hermes/.env` is honored), the proxy enforces a constant-time bearer match on every inbound `/v1/*` request. When unset, the legacy localhost-only behavior is preserved unchanged — existing `nous`-on-127.0.0.1 deployments are not regressed.

## Why

`hermes proxy` today assumes the bind-to-127.0.0.1 boundary is the security perimeter. That's fine for the `nous` upstream when callers are the operator's own local apps. It's not sufficient the moment the proxy is exposed beyond localhost — e.g. a Cloudflare Tunnel terminating at the proxy's `127.0.0.1:8645` to make Hermes-managed OAuth-backed inference reachable from another machine (the case the new `xai-oauth` upstream is being used for).

Without this gate, anyone who learns the tunnel URL can spend the operator's OAuth-attributed quota anonymously.

## Design choices

- **Opt-in**, not mandatory: deployments that don't set the env var keep working unchanged.
- **`/health` exempt**: operators need to probe status without sending the credential.
- **Constant-time compare** via `secrets.compare_digest` — defense-in-depth.
- **Inbound bearer replaced before forwarding**: preserves the existing contract that the client's `Authorization` header never leaks to upstream.
- **Env resolution via `hermes_cli.config.get_env_value`** so `~/.hermes/.env` (the standard Hermes location) is honored, matching the pattern already used by `tools/xai_http.py:resolve_xai_http_credentials`.

## Tests

7 new tests, all green. The full proxy test file now has 35 passing:

- env unset → no enforcement (legacy contract preserved)
- env set, missing Authorization → 401 with code `inbound_auth_missing`
- env set, wrong token → 401 with code `inbound_auth_mismatch`
- env set, malformed scheme (e.g. `Basic`) → 401
- env set, matching token → request forwarded; inbound bearer NOT leaked to upstream (replaced by adapter's bearer per the existing contract)
- `/health` always open regardless of env
- `_resolve_inbound_bearer` strips whitespace + treats empty as unset

## Test plan

- [x] `pytest tests/hermes_cli/test_proxy.py` — 35 passed
- [x] Manual verification: started `hermes proxy start --provider xai-oauth` with `HERMES_API_KEY` set, confirmed unauthenticated requests get 401 and matching-bearer requests forward to xAI cleanly