### PR TITLE
fix(gateway): refresh cached prompts when SOUL.md changes

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -153,6 +153,48 @@ def _ra():
     return run_agent
 
 
+def _stored_system_prompt_stale_for_soul(agent: Any, stored_prompt: str) -> bool:
+    """Return True when a persisted prompt no longer matches current identity.
+
+    Gateway profiles often create a fresh AIAgent for each incoming message and
+    restore the frozen prompt from the session DB for cache stability. That is
+    correct for normal turns, but profile identity edits such as SOUL.md changes
+    must take effect without forcing users to abandon the current chat session.
+    """
+    if not stored_prompt:
+        return False
+
+    should_load_soul = (
+        getattr(agent, "load_soul_identity", False)
+        or not getattr(agent, "skip_context_files", False)
+    )
+    if not should_load_soul:
+        return False
+
+    try:
+        run_agent = _ra()
+        current_soul = run_agent.load_soul_md()
+        default_identity = getattr(run_agent, "DEFAULT_AGENT_IDENTITY", "")
+        guidance = getattr(run_agent, "HERMES_AGENT_HELP_GUIDANCE", "")
+    except Exception as exc:
+        logger.debug(
+            "Could not load SOUL.md while validating stored system prompt: %s",
+            exc,
+        )
+        return False
+
+    expected_identity = current_soul or default_identity
+    if not expected_identity:
+        return False
+
+    marker = f"\n\n{guidance}" if guidance else ""
+    identity_block, sep, _ = stored_prompt.partition(marker)
+    if not sep:
+        return True
+
+    return identity_block.strip() != expected_identity.strip()
+
+
 def _nous_entitlement_message(capability: str) -> str:
     try:
         from hermes_cli.nous_account import (
@@ -250,7 +292,6 @@ def _try_refresh_nous_paid_entitlement_credentials(agent) -> bool:
     except Exception:
         return False
 
-
 def _restore_or_build_system_prompt(agent, system_message, conversation_history):
     """Restore the cached system prompt from the session DB or build it fresh.
 
@@ -280,6 +321,7 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
     """
     stored_prompt = None
     stored_state = "missing"
+    stored_prompt_stale = False
     if conversation_history and agent._session_db:
         try:
             session_row = agent._session_db.get_session(agent.session_id)
@@ -301,10 +343,18 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
             )
 
     if stored_prompt:
-        # Continuing session — reuse the exact system prompt from the
-        # previous turn so the Anthropic cache prefix matches.
-        agent._cached_system_prompt = stored_prompt
-        return
+        if _stored_system_prompt_stale_for_soul(agent, stored_prompt):
+            stored_prompt_stale = True
+            logger.info(
+                "Stored system prompt for session %s is stale relative to "
+                "SOUL.md/default identity; rebuilding.",
+                agent.session_id,
+            )
+        else:
+            # Continuing session — reuse the exact system prompt from the
+            # previous turn so the Anthropic cache prefix matches.
+            agent._cached_system_prompt = stored_prompt
+            return
 
     if conversation_history and stored_state in ("null", "empty"):
         # Continuing session whose stored prompt is unusable.  The
@@ -323,19 +373,20 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
     # prompt) — build from scratch.
     agent._cached_system_prompt = agent._build_system_prompt(system_message)
 
-    # Plugin hook: on_session_start — fired once when a brand-new
-    # session is created (not on continuation).  Plugins can use this
-    # to initialise session-scoped state (e.g. warm a memory cache).
-    try:
-        from hermes_cli.plugins import invoke_hook as _invoke_hook
-        _invoke_hook(
-            "on_session_start",
-            session_id=agent.session_id,
-            model=agent.model,
-            platform=getattr(agent, "platform", None) or "",
-        )
-    except Exception as exc:
-        logger.warning("on_session_start hook failed: %s", exc)
+    if not stored_prompt_stale:
+        # Plugin hook: on_session_start — fired once when a brand-new
+        # session is created (not on continuation).  Plugins can use this
+        # to initialise session-scoped state (e.g. warm a memory cache).
+        try:
+            from hermes_cli.plugins import invoke_hook as _invoke_hook
+            _invoke_hook(
+                "on_session_start",
+                session_id=agent.session_id,
+                model=agent.model,
+                platform=getattr(agent, "platform", None) or "",
+            )
+        except Exception as exc:
+            logger.warning("on_session_start hook failed: %s", exc)
 
     # Cold-start credits seed (L3) — fallback for the first-turn path. The TUI/
     # desktop build seeds at session OPEN (see seed_credits_at_session_start in

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -176,6 +176,10 @@ def _stored_system_prompt_stale_for_soul(agent: Any, stored_prompt: str) -> bool
         current_soul = run_agent.load_soul_md()
         default_identity = getattr(run_agent, "DEFAULT_AGENT_IDENTITY", "")
         guidance = getattr(run_agent, "HERMES_AGENT_HELP_GUIDANCE", "")
+        if not guidance:
+            from agent.prompt_builder import HERMES_AGENT_HELP_GUIDANCE
+
+            guidance = HERMES_AGENT_HELP_GUIDANCE
     except Exception as exc:
         logger.debug(
             "Could not load SOUL.md while validating stored system prompt: %s",
@@ -187,7 +191,10 @@ def _stored_system_prompt_stale_for_soul(agent: Any, stored_prompt: str) -> bool
     if not expected_identity:
         return False
 
-    marker = f"\n\n{guidance}" if guidance else ""
+    marker = f"\n\n{guidance}" if guidance else None
+    if not marker:
+        return True
+
     identity_block, sep, _ = stored_prompt.partition(marker)
     if not sep:
         return True

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12535,7 +12535,33 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         else:
             out.update(cls._empty_honcho_cache_busting_config())
 
+        out["identity.soul_md"] = cls._soul_md_cache_key()
         return out
+
+    @staticmethod
+    def _soul_md_cache_key() -> dict:
+        """Return a compact fingerprint for the active profile's SOUL.md.
+
+        Gateway agents freeze their system prompt for prompt-cache reuse. That
+        is great for latency, but it means editing a profile's SOUL.md would
+        otherwise keep using the old identity/rules until a manual reset or
+        unrelated cache eviction. Include cheap filesystem metadata in the
+        agent signature so persona/rule edits take effect on the next message.
+        """
+        soul_path = _hermes_home / "SOUL.md"
+        try:
+            stat = soul_path.stat()
+        except OSError:
+            return {"exists": False}
+        return {
+            "exists": True,
+            "mtime_ns": getattr(
+                stat,
+                "st_mtime_ns",
+                int(stat.st_mtime * 1_000_000_000),
+            ),
+            "size": stat.st_size,
+        }
 
     @staticmethod
     def _agent_config_signature(

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -337,6 +337,7 @@ AUTHOR_MAP = {
     "zhekinmaksim@gmail.com": "Zhekinmaksim",
     "obafemiferanmi1999@gmail.com": "KvnGz",
     "159539633+MottledShadow@users.noreply.github.com": "MottledShadow",
+    "18210507492@126.com": "qindongliang",
     "aludwin+gh@gmail.com": "adamludwin",
     "ngusev@astralinux.ru": "NikolayGusev-astra",
     "liuguangyong201@hellobike.com": "liuguangyong93",

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -276,7 +276,6 @@ class TestExtractCacheBustingConfig:
 
         assert out["tools.registry_generation"] == 12345
 
-
     def test_skips_honcho_config_read_when_provider_is_not_honcho(self, monkeypatch):
         """Non-Honcho gateways must not read/parse honcho.json on every message."""
         from gateway.run import GatewayRunner
@@ -380,6 +379,48 @@ class TestExtractCacheBustingConfig:
 
         assert third == first
         assert parse_calls == [config_path, config_path]
+
+    def test_extract_includes_soul_md_fingerprint(self, tmp_path, monkeypatch):
+        import gateway.run as gateway_run
+        from gateway.run import GatewayRunner
+
+        monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+        before = GatewayRunner._extract_cache_busting_config({})
+        (tmp_path / "SOUL.md").write_text("updated gateway persona", encoding="utf-8")
+        after = GatewayRunner._extract_cache_busting_config({})
+
+        assert before["identity.soul_md"] == {"exists": False}
+        assert after["identity.soul_md"]["exists"] is True
+        assert after["identity.soul_md"]["size"] == len("updated gateway persona")
+        assert before["identity.soul_md"] != after["identity.soul_md"]
+
+    def test_soul_md_fingerprint_change_busts_signature(self):
+        from gateway.run import GatewayRunner
+
+        runtime = {"api_key": "k", "base_url": "u", "provider": "p"}
+        sig_before = GatewayRunner._agent_config_signature(
+            "m",
+            runtime,
+            ["telegram"],
+            "",
+            cache_keys={"identity.soul_md": {"exists": False}},
+        )
+        sig_after = GatewayRunner._agent_config_signature(
+            "m",
+            runtime,
+            ["telegram"],
+            "",
+            cache_keys={
+                "identity.soul_md": {
+                    "exists": True,
+                    "mtime_ns": 123,
+                    "size": 22,
+                }
+            },
+        )
+
+        assert sig_before != sig_after
 
     def test_full_round_trip_busts_cache_on_real_edit(self):
         """End-to-end: simulate a config edit on main and verify the

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5215,6 +5215,81 @@ class TestGpt5ApiModeRouting:
 class TestSystemPromptStability:
     """Verify that the system prompt stays stable across turns for cache hits."""
 
+    def test_stored_prompt_marked_stale_when_soul_changed(self):
+        from agent.conversation_loop import _stored_system_prompt_stale_for_soul
+
+        agent = SimpleNamespace(load_soul_identity=False, skip_context_files=False)
+
+        with patch(
+            "run_agent.load_soul_md",
+            return_value="current SOUL with Feishu bot open_ids",
+        ):
+            assert (
+                _stored_system_prompt_stale_for_soul(agent, "old SOUL without mapping")
+                is True
+            )
+
+    def test_stored_prompt_not_stale_when_current_soul_present(self):
+        from agent.conversation_loop import _stored_system_prompt_stale_for_soul
+
+        agent = SimpleNamespace(load_soul_identity=False, skip_context_files=False)
+        stored = "current SOUL with Feishu bot open_ids\n\nOther system prompt sections"
+
+        with patch(
+            "run_agent.load_soul_md",
+            return_value="current SOUL with Feishu bot open_ids",
+        ):
+            assert _stored_system_prompt_stale_for_soul(agent, stored) is False
+
+    def test_stored_prompt_marked_stale_when_soul_removed(self):
+        from agent.conversation_loop import _stored_system_prompt_stale_for_soul
+
+        agent = SimpleNamespace(load_soul_identity=False, skip_context_files=False)
+
+        with patch("run_agent.load_soul_md", return_value=None):
+            assert (
+                _stored_system_prompt_stale_for_soul(
+                    agent,
+                    "custom SOUL that used to be loaded\n\nOther system prompt sections",
+                )
+                is True
+            )
+
+    def test_stored_prompt_soul_check_respects_skip_context_files(self):
+        from agent.conversation_loop import _stored_system_prompt_stale_for_soul
+
+        agent = SimpleNamespace(load_soul_identity=False, skip_context_files=True)
+
+        with patch("run_agent.load_soul_md", return_value="current SOUL") as load_soul:
+            assert _stored_system_prompt_stale_for_soul(agent, "old SOUL") is False
+
+        load_soul.assert_not_called()
+
+    def test_stale_soul_prompt_rebuilds_without_session_start_hook(self, agent):
+        from agent.conversation_loop import _restore_or_build_system_prompt
+
+        mock_db = MagicMock()
+        mock_db.get_session.return_value = {"system_prompt": "old SOUL rules"}
+        agent._session_db = mock_db
+        agent._cached_system_prompt = None
+        agent.load_soul_identity = True
+        agent._build_system_prompt = MagicMock(return_value="current SOUL rules")
+        history = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ]
+
+        with patch("run_agent.load_soul_md", return_value="current SOUL rules"):
+            with patch("hermes_cli.plugins.invoke_hook") as invoke_hook:
+                _restore_or_build_system_prompt(agent, None, history)
+
+        assert agent._cached_system_prompt == "current SOUL rules"
+        mock_db.update_system_prompt.assert_called_once_with(
+            agent.session_id,
+            "current SOUL rules",
+        )
+        invoke_hook.assert_not_called()
+
     def test_stored_prompt_reused_for_continuing_session(self, agent):
         """When conversation_history is non-empty and session DB has a stored
         prompt, it should be reused instead of rebuilding from disk."""

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5217,23 +5217,26 @@ class TestSystemPromptStability:
 
     def test_stored_prompt_marked_stale_when_soul_changed(self):
         from agent.conversation_loop import _stored_system_prompt_stale_for_soul
+        from agent.prompt_builder import HERMES_AGENT_HELP_GUIDANCE
 
         agent = SimpleNamespace(load_soul_identity=False, skip_context_files=False)
+        stored = f"old SOUL without mapping\n\n{HERMES_AGENT_HELP_GUIDANCE}"
 
         with patch(
             "run_agent.load_soul_md",
             return_value="current SOUL with Feishu bot open_ids",
         ):
             assert (
-                _stored_system_prompt_stale_for_soul(agent, "old SOUL without mapping")
+                _stored_system_prompt_stale_for_soul(agent, stored)
                 is True
             )
 
     def test_stored_prompt_not_stale_when_current_soul_present(self):
         from agent.conversation_loop import _stored_system_prompt_stale_for_soul
+        from agent.prompt_builder import HERMES_AGENT_HELP_GUIDANCE
 
         agent = SimpleNamespace(load_soul_identity=False, skip_context_files=False)
-        stored = "current SOUL with Feishu bot open_ids\n\nOther system prompt sections"
+        stored = f"current SOUL with Feishu bot open_ids\n\n{HERMES_AGENT_HELP_GUIDANCE}"
 
         with patch(
             "run_agent.load_soul_md",
@@ -5254,6 +5257,16 @@ class TestSystemPromptStability:
                 )
                 is True
             )
+
+    def test_stored_prompt_marked_stale_when_soul_shortened(self):
+        from agent.conversation_loop import _stored_system_prompt_stale_for_soul
+        from agent.prompt_builder import HERMES_AGENT_HELP_GUIDANCE
+
+        agent = SimpleNamespace(load_soul_identity=False, skip_context_files=False)
+        stored = f"You are Jasper. Be helpful.\n\n{HERMES_AGENT_HELP_GUIDANCE}"
+
+        with patch("run_agent.load_soul_md", return_value="Be helpful."):
+            assert _stored_system_prompt_stale_for_soul(agent, stored) is True
 
     def test_stored_prompt_soul_check_respects_skip_context_files(self):
         from agent.conversation_loop import _stored_system_prompt_stale_for_soul


### PR DESCRIPTION
## What does this PR do?

Refresh cached gateway prompts when the active profile's `SOUL.md` changes.

Gateway sessions intentionally reuse cached `AIAgent` instances and persisted `system_prompt` snapshots to preserve prompt-cache hits. That is useful for normal turns, but it also means edits to `SOUL.md` can keep using stale identity/rules in existing sessions.

This PR adds two cache invalidation layers:

- Include the active profile's `SOUL.md` filesystem fingerprint in the gateway agent config signature so cached agents rebuild after `SOUL.md` is created, edited, or removed.
- When a fresh agent restores a persisted `system_prompt` from the session DB, detect if it no longer matches the current `SOUL.md` or default identity and rebuild/persist a fresh prompt instead of reusing the stale snapshot.

Behavior change: `on_session_start` now only fires when a brand-new session is created; rebuilding after a stored prompt is stale no longer runs that hook.

Implementation note: Gateway agent cache invalidation uses `SOUL.md` file metadata (`mtime_ns` plus size) as a cheap fingerprint; on very low-resolution filesystems, multiple same-size edits inside one timestamp tick may require another edit or restart to bust the cache.

## Related Issue

Complements #26789, which wires gateway sessions to honor `SOUL.md` initially. This PR handles the follow-up case where `SOUL.md` changes after a session already has a cached/persisted prompt.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`: add the active profile's `SOUL.md` metadata fingerprint to gateway agent cache-busting config.
- `agent/conversation_loop.py`: detect persisted system prompts whose stored identity block no longer matches the current `SOUL.md` or default identity before reusing them.
- `scripts/release.py`: add `18210507492@126.com` to `AUTHOR_MAP` for contributor attribution.
- `tests/gateway/test_agent_cache.py`: cover `SOUL.md` fingerprint extraction and signature busting.
- `tests/run_agent/test_run_agent.py`: cover stale prompt rebuilds, SOUL removal, shortened-SOUL regression, and hook behavior.

## How to Test

1. `python -m ruff check agent/conversation_loop.py gateway/run.py scripts/release.py tests/run_agent/test_run_agent.py tests/gateway/test_agent_cache.py`
2. `python -m pytest tests/gateway/test_agent_cache.py tests/run_agent/test_run_agent.py::TestSystemPromptStability -q`
3. `python -m py_compile agent/conversation_loop.py gateway/run.py scripts/release.py`
4. `git diff --check`

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
