### PR TITLE
fix: add qwen, deepseek, claude to TOOL_USE_ENFORCEMENT_MODELS

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -268,7 +268,7 @@ TOOL_USE_ENFORCEMENT_GUIDANCE = (
 
 # Model name substrings that trigger tool-use enforcement guidance.
 # Add new patterns here when a model family needs explicit steering.
-TOOL_USE_ENFORCEMENT_MODELS = ("gpt", "codex", "gemini", "gemma", "grok", "glm")
+TOOL_USE_ENFORCEMENT_MODELS = ("gpt", "codex", "gemini", "gemma", "grok", "glm", "qwen", "deepseek", "claude", "anthropic")
 
 # OpenAI GPT/Codex-specific execution guidance.  Addresses known failure modes
 # where GPT models abandon work on partial results, skip prerequisite lookups,


### PR DESCRIPTION
## Problem\nModels like Qwen (qwen3.6-plus), DeepSeek, and Anthropic Claude were not triggering tool-use enforcement instructions in `auto` mode. This caused agents to hallucinate actions ("saying but not doing") instead of actually executing tools.\n\n## Solution\nAdded `"qwen"`, `"deepseek"`, `"claude"`, and `"anthropic"` to the `TOOL_USE_ENFORCEMENT_MODELS` tuple in `agent/prompt_builder.py`.\n\n## Impact\nThis ensures that when users use Qwen, DeepSeek, or Claude with `tool_use_enforcement: auto`, the agent receives the strict instructions to actually call tools instead of just describing them.