### PR TITLE
fix(windows): handle redirected stdout in _cprint fallback

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1785,7 +1785,16 @@ def _cprint(text: str):
     # direct prompt_toolkit print is safe and matches existing behavior
     # (spinner frames, streamed tokens, tool activity prefixes, …).
     if app is None or not getattr(app, "_is_running", False):
-        _pt_print(_PT_ANSI(text))
+        try:
+            _pt_print(_PT_ANSI(text))
+        except Exception:
+            # Fallback when stdout is not a real console (e.g. subprocess
+            # worker logging to a file). prompt_toolkit raises
+            # NoConsoleScreenBufferError (Windows) or OSError (other).
+            try:
+                print(text)
+            except Exception:
+                pass
         return
 
     try:


### PR DESCRIPTION
## Summary

Wraps `_pt_print` in try/except with a `print()` fallback in `_cprint`. When a kanban worker's stdout is piped to a log file, `prompt_toolkit` raises `NoConsoleScreenBufferError` (Windows) or `OSError` (other) because there is no real console buffer. The fallback keeps worker output flowing instead of crashing.

## Why

The `_cprint` function is used by kanban workers to print status messages. On Windows, git-bash sets `TERM=xterm-256color`, which causes `prompt_toolkit` to attempt terminal initialization and fail when stdout is redirected to a log file. This was discovered when kanban workers spawned by the gateway would crash silently.

## How to test

On Windows 11: run a kanban worker via the dispatcher with stdout redirected to a log file. Without this fix, the worker crashes with `NoConsoleScreenBufferError` on the first `_cprint` call. With the fix, output falls through to `print()` and the worker continues normally.

Tests: `pytest tests/cli/test_cprint_bg_thread.py` — 13 passed. Full `tests/cli/` suite: 634 passed, 7 pre-existing failures (tilde paths, secret capture — verified identical on `main`).
