### PR TITLE
fix(azure-foundry): send Bearer auth to anthropic_messages, keep 1M beta (salvage #27022)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -493,6 +493,21 @@ def _base_url_needs_context_1m_beta(base_url: str | None) -> bool:
     return "azure.com" in normalized
 
 
+def _is_minimax_anthropic_endpoint(base_url: str | None) -> bool:
+    """Return True for MiniMax's Anthropic-compatible endpoints.
+
+    MiniMax rejects the fine-grained-tool-streaming and context-1m betas;
+    those need to be stripped even though MiniMax also uses Bearer auth.
+    """
+    normalized = _normalize_base_url_text(base_url)
+    if not normalized:
+        return False
+    normalized = normalized.rstrip("/").lower()
+    return normalized.startswith(
+        ("https://api.minimax.io/anthropic", "https://api.minimaxi.com/anthropic")
+    )
+
+
 def _common_betas_for_base_url(
     base_url: str | None,
     *,
@@ -502,7 +517,9 @@ def _common_betas_for_base_url(
 
     MiniMax's Anthropic-compatible endpoints (Bearer-auth) reject requests
     that include Anthropic's ``fine-grained-tool-streaming`` beta — every
-    tool-use message triggers a connection error.
+    tool-use message triggers a connection error. They also reject the
+    1M-context beta. Azure AI Foundry's Anthropic endpoint also uses
+    Bearer auth but keeps both betas (it needs the 1M beta for 1M context).
 
     The ``context-1m-2025-08-07`` beta is not sent to native Anthropic by
     default because some subscriptions reject it. Add it only for endpoint
@@ -515,7 +532,7 @@ def _common_betas_for_base_url(
     betas = list(_COMMON_BETAS)
     if _base_url_needs_context_1m_beta(base_url) and not drop_context_1m_beta:
         betas.append(_CONTEXT_1M_BETA)
-    if _requires_bearer_auth(base_url):
+    if _is_minimax_anthropic_endpoint(base_url):
         _stripped = {_TOOL_STREAMING_BETA, _CONTEXT_1M_BETA}
         return [b for b in betas if b not in _stripped]
     if drop_context_1m_beta:

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -471,14 +471,18 @@ def _requires_bearer_auth(base_url: str | None) -> bool:
     """Return True for Anthropic-compatible providers that require Bearer auth.
 
     Some third-party /anthropic endpoints implement Anthropic's Messages API but
-    require Authorization: Bearer *** of Anthropic's native x-api-key header.
-    MiniMax's global and China Anthropic-compatible endpoints follow this pattern.
+    require Authorization: Bearer instead of Anthropic's native x-api-key header.
+    MiniMax's global and China Anthropic-compatible endpoints, and Azure AI
+    Foundry's Anthropic-style endpoint follow this pattern.
     """
     normalized = _normalize_base_url_text(base_url)
     if not normalized:
         return False
     normalized = normalized.rstrip("/").lower()
-    return normalized.startswith(("https://api.minimax.io/anthropic", "https://api.minimaxi.com/anthropic"))
+    return (
+        normalized.startswith(("https://api.minimax.io/anthropic", "https://api.minimaxi.com/anthropic"))
+        or "azure.com" in normalized
+    )
 
 
 def _base_url_needs_context_1m_beta(base_url: str | None) -> bool:

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -155,6 +155,27 @@ class TestBuildAnthropicClient:
                 "anthropic-beta": "interleaved-thinking-2025-05-14"
             }
 
+    def test_azure_foundry_anthropic_endpoint_uses_bearer_auth(self):
+        """Azure AI Foundry's /anthropic endpoint requires Authorization: Bearer.
+
+        Regression test for #26970: without this, builds set api_key (x-api-key)
+        and the endpoint returns HTTP 401. Also verifies that Azure retains the
+        1M-context beta even though it now matches `_requires_bearer_auth`.
+        """
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
+            build_anthropic_client(
+                "azure-foundry-secret-123",
+                base_url="https://my-resource.openai.azure.com/anthropic",
+            )
+            kwargs = mock_sdk.Anthropic.call_args[1]
+            assert kwargs["auth_token"] == "azure-foundry-secret-123"
+            assert "api_key" not in kwargs
+            # Azure endpoints still get the api-version query param plumbing.
+            assert kwargs.get("default_query") == {"api-version": "2025-04-15"}
+            # Azure keeps the 1M-context beta (it's not MiniMax).
+            betas = kwargs["default_headers"]["anthropic-beta"]
+            assert "context-1m-2025-08-07" in betas
+
 
 class TestReadClaudeCodeCredentials:
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
Salvages @sharziki's #27022 and fixes a hidden side-effect.

## Summary
Azure AI Foundry's `/anthropic` endpoint requires `Authorization: Bearer` instead of `x-api-key`. Without this, requests return HTTP 401.

## Changes
- `agent/anthropic_adapter.py::_requires_bearer_auth` — add `azure.com` (sharziki's #27022).
- `agent/anthropic_adapter.py::_common_betas_for_base_url` — guard the beta-strip on a new `_is_minimax_anthropic_endpoint` predicate instead of `_requires_bearer_auth`. Otherwise, folding Azure into the bearer-auth branch silently triggered the MiniMax-specific strip of `fine-grained-tool-streaming` + `context-1m-2025-08-07`, killing the 1M context window on Azure Foundry.
- `tests/agent/test_anthropic_adapter.py` — regression test: Azure → `auth_token` (Bearer), `api-version` query param plumbing, and `context-1m-2025-08-07` survives.

## Validation
- `scripts/run_tests.sh tests/agent/` → 3073/3073 passing (no regressions).
- New test exercises the exact `azure.com` host shape end-to-end through `build_anthropic_client`.

## Credit
Cherry-picked @sharziki's commit on top of current main; the follow-up fix to keep the 1M beta is on top. Rebase-merge preserves their authorship.

Fixes #26970
Closes #27022