### PR TITLE
governor(G2): add xAI header-derived usage tracking

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -2,13 +2,19 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Optional
+from pathlib import Path
+from typing import Any, Mapping, Optional
 
 import httpx
 
 from agent.anthropic_adapter import _is_oauth_token, resolve_anthropic_token
 from hermes_cli.auth import _read_codex_tokens, resolve_codex_runtime_credentials
 from hermes_cli.runtime_provider import resolve_runtime_provider
+from agent.governor_state import (
+    get_provider_state,
+    get_xai_bucket_rows,
+    record_xai_rate_limit_headers,
+)
 
 
 def _utc_now() -> datetime:
@@ -305,11 +311,96 @@ def _fetch_openrouter_account_usage(base_url: Optional[str], api_key: Optional[s
     )
 
 
+def _fetch_xai_account_usage(*, governor_db_path: Optional[Path | str] = None) -> Optional[AccountUsageSnapshot]:
+    try:
+        provider_state = get_provider_state("xai", db_path=governor_db_path) or {}
+        buckets = get_xai_bucket_rows(db_path=governor_db_path)
+    except FileNotFoundError:
+        return AccountUsageSnapshot(
+            provider="xai",
+            source="observed_headers",
+            fetched_at=_utc_now(),
+            unavailable_reason="governor.db has not been created by ADR-0010 G1.",
+        )
+    if not buckets:
+        return AccountUsageSnapshot(
+            provider="xai",
+            source="observed_headers",
+            fetched_at=_utc_now(),
+            unavailable_reason="No xAI rate-limit headers have been observed yet.",
+        )
+    windows: list[AccountUsageWindow] = []
+    for bucket in buckets:
+        raw_scope = str(bucket.get("bucket_scope") or "bucket").replace("_", " ")
+        scope = "request" if raw_scope == "requests" else ("token" if raw_scope == "tokens" else raw_scope)
+        reset_at = _parse_dt(bucket.get("reset_at"))
+        used_pct = bucket.get("used_pct")
+        remaining = bucket.get("remaining_value")
+        limit = bucket.get("limit_value")
+        detail = None
+        if isinstance(remaining, (int, float)) and isinstance(limit, (int, float)):
+            remaining_text = f"{remaining:g}"
+            limit_text = f"{limit:g}"
+            detail = f"{remaining_text} of {limit_text} {raw_scope} remaining"
+        windows.append(
+            AccountUsageWindow(
+                label=f"xAI {scope} bucket",
+                used_percent=float(used_pct) if isinstance(used_pct, (int, float)) else None,
+                reset_at=reset_at,
+                detail=detail,
+            )
+        )
+    details = []
+    band = provider_state.get("band")
+    if band:
+        details.append(f"Governor band: {band}")
+    details.append("Source: observed x-ratelimit-* response headers")
+    return AccountUsageSnapshot(
+        provider="xai",
+        source="observed_headers",
+        fetched_at=_utc_now(),
+        windows=tuple(windows),
+        details=tuple(details),
+    )
+
+
+def observe_xai_rate_limit_headers(
+    headers: Mapping[str, Any], *, db_path: Optional[Path | str] = None
+) -> bool:
+    return record_xai_rate_limit_headers(headers, db_path=db_path)
+
+
+def maybe_observe_xai_rate_limit_headers(
+    provider: Optional[str], model: Optional[str], response: Any, *, db_path: Optional[Path | str] = None
+) -> bool:
+    normalized_provider = str(provider or "").strip().lower()
+    normalized_model = str(model or "").strip().lower()
+    if normalized_provider not in {"xai", "xai-oauth", "grok", "x-ai", "x.ai"} and "grok" not in normalized_model:
+        return False
+    headers = getattr(response, "headers", None)
+    if headers is None:
+        # Some SDK response wrappers keep the raw HTTP response under a private
+        # or provider-specific attribute. These accesses are intentionally best
+        # effort and no-op if absent.
+        for attr in ("http_response", "response", "_response"):
+            candidate = getattr(response, attr, None)
+            headers = getattr(candidate, "headers", None)
+            if headers is not None:
+                break
+    if not headers:
+        return False
+    try:
+        return observe_xai_rate_limit_headers(headers, db_path=db_path)
+    except Exception:
+        return False
+
+
 def fetch_account_usage(
     provider: Optional[str],
     *,
     base_url: Optional[str] = None,
     api_key: Optional[str] = None,
+    governor_db_path: Optional[Path | str] = None,
 ) -> Optional[AccountUsageSnapshot]:
     normalized = str(provider or "").strip().lower()
     if normalized in {"", "auto", "custom"}:
@@ -321,6 +412,8 @@ def fetch_account_usage(
             return _fetch_anthropic_account_usage()
         if normalized == "openrouter":
             return _fetch_openrouter_account_usage(base_url, api_key)
+        if normalized in {"xai", "xai-oauth", "grok", "x-ai", "x.ai"}:
+            return _fetch_xai_account_usage(governor_db_path=governor_db_path)
     except Exception:
         return None
     return None

--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -5,6 +5,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Mapping, Optional
 
+import sqlite3
+
 import httpx
 
 from agent.anthropic_adapter import _is_oauth_token, resolve_anthropic_token
@@ -391,7 +393,7 @@ def maybe_observe_xai_rate_limit_headers(
         return False
     try:
         return observe_xai_rate_limit_headers(headers, db_path=db_path)
-    except Exception:
+    except (AttributeError, sqlite3.Error, OSError, ValueError):
         return False
 
 

--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Mapping, Optional
 
+import logging
 import sqlite3
 
 import httpx
@@ -17,6 +18,8 @@ from agent.governor_state import (
     get_xai_bucket_rows,
     record_xai_rate_limit_headers,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def _utc_now() -> datetime:
@@ -416,6 +419,7 @@ def fetch_account_usage(
             return _fetch_openrouter_account_usage(base_url, api_key)
         if normalized in {"xai", "xai-oauth", "grok", "x-ai", "x.ai"}:
             return _fetch_xai_account_usage(governor_db_path=governor_db_path)
-    except Exception:
+    except Exception as exc:
+        logger.debug("Account usage fetch suppressed for provider %s: %s", normalized, exc)
         return None
     return None

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1309,6 +1309,12 @@ def run_conversation(
                             )
                     continue  # Retry the API call
 
+                try:
+                    from agent.account_usage import maybe_observe_xai_rate_limit_headers as _maybe_observe_xai_headers
+                    _maybe_observe_xai_headers(agent.provider, agent.model, response)
+                except Exception:
+                    pass
+
                 # Check finish_reason before proceeding
                 if agent.api_mode == "codex_responses":
                     status = getattr(response, "status", None)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1709,6 +1709,8 @@ def run_conversation(
                 if agent.thinking_callback:
                     agent.thinking_callback("")
 
+                _observe_xai_headers_best_effort(agent.provider, agent.model, api_error)
+
                 # -----------------------------------------------------------
                 # UnicodeEncodeError recovery.  Two common causes:
                 #   1. Lone surrogates (U+D800..U+DFFF) from clipboard paste

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -21,6 +21,7 @@ import logging
 import os
 import random
 import re
+import sqlite3
 import ssl
 import threading
 import time
@@ -80,6 +81,21 @@ def _ra():
     """
     import run_agent
     return run_agent
+
+
+def _observe_xai_headers_best_effort(provider, model, response, *, db_path=None) -> bool:
+    """Best-effort xAI/Grok rate-limit observation for the post-response hook.
+
+    The agent loop must not fail merely because observed-header accounting is
+    unavailable, but expected integration failures should be visible in debug
+    logs rather than silently masking a broken internal contract.
+    """
+    try:
+        from agent.account_usage import maybe_observe_xai_rate_limit_headers as _maybe_observe_xai_headers
+        return _maybe_observe_xai_headers(provider, model, response, db_path=db_path)
+    except (ImportError, AttributeError, sqlite3.Error, OSError) as exc:
+        logger.debug("xAI/Grok rate-limit header observation skipped: %s", exc)
+        return False
 
 
 def _restore_or_build_system_prompt(agent, system_message, conversation_history):
@@ -1309,11 +1325,7 @@ def run_conversation(
                             )
                     continue  # Retry the API call
 
-                try:
-                    from agent.account_usage import maybe_observe_xai_rate_limit_headers as _maybe_observe_xai_headers
-                    _maybe_observe_xai_headers(agent.provider, agent.model, response)
-                except Exception:
-                    pass
+                _observe_xai_headers_best_effort(agent.provider, agent.model, response)
 
                 # Check finish_reason before proceeding
                 if agent.api_mode == "codex_responses":

--- a/agent/governor_state.py
+++ b/agent/governor_state.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from hermes_constants import get_hermes_home
+
+GOVERNOR_SCHEMA_VERSION = 2
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def get_governor_db_path() -> Path:
+    return get_hermes_home() / "state" / "governor.db"
+
+
+def _to_iso(dt: Optional[datetime]) -> Optional[str]:
+    if dt is None:
+        return None
+    return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _parse_reset(value: Any) -> Optional[datetime]:
+    if value in {None, ""}:
+        return None
+    if isinstance(value, (int, float)):
+        number = float(value)
+    else:
+        text = str(value).strip()
+        if not text:
+            return None
+        try:
+            number = float(text)
+        except ValueError:
+            if text.endswith("Z"):
+                text = text[:-1] + "+00:00"
+            try:
+                parsed = datetime.fromisoformat(text)
+                return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+            except ValueError:
+                return None
+    # x-ratelimit-reset values are normally epoch seconds. If a provider ever
+    # sends a small relative delta, interpreting it as epoch would point at 1970;
+    # treat small values as seconds from now instead.
+    if number < 10_000_000:
+        return datetime.fromtimestamp(_utc_now().timestamp() + number, tz=timezone.utc)
+    return datetime.fromtimestamp(number, tz=timezone.utc)
+
+
+def compute_governor_band(daily_used_pct: Optional[float], weekly_used_pct: Optional[float]) -> str:
+    pressure = max(float(daily_used_pct or 0.0), float(weekly_used_pct or 0.0))
+    if pressure >= 98.0:
+        return "post-reserve"
+    if pressure >= 95.0:
+        return "black"
+    if pressure >= 85.0:
+        return "red"
+    if pressure >= 70.0:
+        return "amber"
+    return "green"
+
+
+def ensure_governor_schema(db_path: Optional[Path | str] = None) -> Path:
+    path = Path(db_path) if db_path is not None else get_governor_db_path()
+    if not path.exists():
+        raise FileNotFoundError(
+            f"governor.db does not exist at {path}; G2 must migrate the canonical G1 database, not recreate it"
+        )
+    with sqlite3.connect(path) as db:
+        db.execute("PRAGMA foreign_keys = ON")
+        db.execute("PRAGMA journal_mode = WAL")
+        db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS xai_buckets (
+              bucket_key TEXT PRIMARY KEY,
+              bucket_scope TEXT NOT NULL,
+              window_label TEXT NOT NULL,
+              limit_value REAL NOT NULL,
+              remaining_value REAL NOT NULL,
+              used_value REAL NOT NULL,
+              used_pct REAL NOT NULL,
+              reset_at TEXT,
+              observed_at TEXT NOT NULL,
+              raw_headers_json TEXT NOT NULL
+            )
+            """
+        )
+        db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_xai_buckets_observed_at ON xai_buckets(observed_at)"
+        )
+        db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_xai_buckets_scope ON xai_buckets(bucket_scope, window_label)"
+        )
+        db.execute(f"PRAGMA user_version = {GOVERNOR_SCHEMA_VERSION}")
+    return path
+
+
+def _normalize_headers(headers: Mapping[str, Any]) -> dict[str, str]:
+    return {str(k).lower(): str(v).strip() for k, v in headers.items() if v not in {None, ""}}
+
+
+def _float_header(headers: Mapping[str, str], key: str) -> Optional[float]:
+    value = headers.get(key)
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
+def _window_label_from_reset(reset_at: Optional[datetime]) -> str:
+    if reset_at is None:
+        return "observed"
+    seconds = max(0, int((reset_at - _utc_now()).total_seconds()))
+    if seconds <= 90:
+        return "minute"
+    if seconds <= 3900:
+        return "hour"
+    if seconds <= 93_600:
+        return "day"
+    if seconds <= 691_200:
+        return "week"
+    return "observed"
+
+
+def _iter_xai_bucket_observations(headers: Mapping[str, str]) -> list[dict[str, Any]]:
+    scopes = set()
+    for key in headers:
+        match = re.match(r"x-ratelimit-limit-(.+)", key)
+        if match:
+            scopes.add(match.group(1))
+    observations: list[dict[str, Any]] = []
+    for scope in sorted(scopes):
+        limit_value = _float_header(headers, f"x-ratelimit-limit-{scope}")
+        remaining_value = _float_header(headers, f"x-ratelimit-remaining-{scope}")
+        if limit_value is None or remaining_value is None or limit_value <= 0:
+            continue
+        remaining_value = max(0.0, min(remaining_value, limit_value))
+        used_value = limit_value - remaining_value
+        used_pct = max(0.0, min(100.0, (used_value / limit_value) * 100.0))
+        reset_at = _parse_reset(headers.get(f"x-ratelimit-reset-{scope}"))
+        explicit_window = headers.get(f"x-ratelimit-window-{scope}")
+        window_label = explicit_window or _window_label_from_reset(reset_at)
+        observations.append(
+            {
+                "bucket_scope": scope,
+                "window_label": window_label,
+                "limit_value": limit_value,
+                "remaining_value": remaining_value,
+                "used_value": used_value,
+                "used_pct": used_pct,
+                "reset_at": reset_at,
+            }
+        )
+    return observations
+
+
+def record_xai_rate_limit_headers(headers: Mapping[str, Any], *, db_path: Optional[Path | str] = None) -> bool:
+    normalized = _normalize_headers(headers)
+    observations = _iter_xai_bucket_observations(normalized)
+    if not observations:
+        return False
+    path = ensure_governor_schema(db_path)
+    observed_at = _to_iso(_utc_now()) or ""
+    raw = json.dumps(normalized, sort_keys=True)
+    highest_used = max(obs["used_pct"] for obs in observations)
+    band = compute_governor_band(highest_used, highest_used)
+    with sqlite3.connect(path) as db:
+        db.execute("PRAGMA foreign_keys = ON")
+        for obs in observations:
+            bucket_key = f"{obs['bucket_scope']}:{obs['window_label']}"
+            db.execute(
+                """
+                INSERT INTO xai_buckets(
+                  bucket_key, bucket_scope, window_label, limit_value, remaining_value,
+                  used_value, used_pct, reset_at, observed_at, raw_headers_json
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(bucket_key) DO UPDATE SET
+                  bucket_scope=excluded.bucket_scope,
+                  window_label=excluded.window_label,
+                  limit_value=excluded.limit_value,
+                  remaining_value=excluded.remaining_value,
+                  used_value=excluded.used_value,
+                  used_pct=excluded.used_pct,
+                  reset_at=excluded.reset_at,
+                  observed_at=excluded.observed_at,
+                  raw_headers_json=excluded.raw_headers_json
+                """,
+                (
+                    bucket_key,
+                    obs["bucket_scope"],
+                    obs["window_label"],
+                    obs["limit_value"],
+                    obs["remaining_value"],
+                    obs["used_value"],
+                    obs["used_pct"],
+                    _to_iso(obs["reset_at"]),
+                    observed_at,
+                    raw,
+                ),
+            )
+        db.execute(
+            """
+            UPDATE provider_state
+               SET band=?, daily_used_pct=?, weekly_used_pct=?, last_polled_at=?, source='observed'
+             WHERE provider='xai'
+            """,
+            (band, highest_used, highest_used, observed_at),
+        )
+    return True
+
+
+def get_xai_bucket_rows(*, db_path: Optional[Path | str] = None) -> list[dict[str, Any]]:
+    path = ensure_governor_schema(db_path)
+    with sqlite3.connect(path) as db:
+        db.row_factory = sqlite3.Row
+        return [dict(row) for row in db.execute("SELECT * FROM xai_buckets ORDER BY used_pct DESC, bucket_key")]
+
+
+def get_provider_state(provider: str, *, db_path: Optional[Path | str] = None) -> Optional[dict[str, Any]]:
+    path = ensure_governor_schema(db_path)
+    with sqlite3.connect(path) as db:
+        db.row_factory = sqlite3.Row
+        row = db.execute("SELECT * FROM provider_state WHERE provider=?", (provider,)).fetchone()
+        return dict(row) if row else None
+
+
+def get_transition_rate(transition_key: str, *, db_path: Optional[Path | str] = None) -> Optional[int]:
+    path = ensure_governor_schema(db_path)
+    key = str(transition_key or "").strip()
+    if not key:
+        return None
+    with sqlite3.connect(path) as db:
+        row = db.execute(
+            "SELECT current_rate_per_hour FROM transition_rates WHERE transition_key=?",
+            (key,),
+        ).fetchone()
+        if row is not None:
+            return int(row[0])
+        if key.startswith("PlatformOps.PlatformChange->"):
+            row = db.execute(
+                "SELECT current_rate_per_hour FROM transition_rates WHERE transition_key=?",
+                ("PlatformOps.PlatformChange->*",),
+            ).fetchone()
+            if row is not None:
+                return int(row[0])
+    return None

--- a/agent/governor_state.py
+++ b/agent/governor_state.py
@@ -10,6 +10,7 @@ from typing import Any, Mapping, Optional
 from hermes_constants import get_hermes_home
 
 GOVERNOR_SCHEMA_VERSION = 2
+_RELATIVE_RESET_CUTOFF_SECONDS = 30 * 86_400
 
 
 def _utc_now() -> datetime:
@@ -45,10 +46,11 @@ def _parse_reset(value: Any) -> Optional[datetime]:
                 return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
             except ValueError:
                 return None
-    # x-ratelimit-reset values are normally epoch seconds. If a provider ever
-    # sends a small relative delta, interpreting it as epoch would point at 1970;
-    # treat small values as seconds from now instead.
-    if number < 10_000_000:
+    # x-ratelimit-reset values are normally epoch seconds. If xAI or a
+    # compatible gateway returns a small relative delta, interpreting it as an
+    # epoch would point at 1970. Keep the delta path deliberately narrow and
+    # named: anything above 30 days is treated as an epoch timestamp.
+    if 0 <= number <= _RELATIVE_RESET_CUTOFF_SECONDS:
         return datetime.fromtimestamp(_utc_now().timestamp() + number, tz=timezone.utc)
     return datetime.fromtimestamp(number, tz=timezone.utc)
 

--- a/docs/governor-xai-usage.md
+++ b/docs/governor-xai-usage.md
@@ -1,0 +1,65 @@
+# ADR-0010 G2: xAI header-derived governor usage
+
+This note documents the Hermes-side G2 implementation used by Special Circumstances Capital ADR-0010.
+
+## Scope
+
+G2 adds provider usage support for xAI/Grok without activating the governor service or webhook admission layer.
+
+It provides:
+
+- `agent.governor_state.ensure_governor_schema()` — migrates the canonical G1 `governor.db` in place to schema version 2.
+- `xai_buckets` table — stores observed `x-ratelimit-*` response-header buckets.
+- `agent.account_usage.observe_xai_rate_limit_headers()` — records synthetic or real xAI response headers.
+- `fetch_account_usage("xai")` / aliases — returns an `AccountUsageSnapshot` derived from observed headers.
+- A best-effort post-response hook in the conversation loop. If an xAI/Grok SDK response exposes headers, Hermes records them; if the SDK hides headers, the hook no-ops safely.
+- `agent.governor_state.get_transition_rate()` — implements the documented literal lexical fallback for `PlatformOps.PlatformChange->*`.
+
+## Canonical DB rule
+
+The live database is canonical. G2 must migrate it; it must not recreate it.
+
+`ensure_governor_schema()` raises `FileNotFoundError` if `governor.db` is absent. This is intentional: G1 owns first creation and seed data. G2 only adds the `xai_buckets` table, indexes, and `PRAGMA user_version = 2`.
+
+## xAI source rule
+
+G1 seeds:
+
+```text
+provider_state.provider = 'xai'
+provider_state.source = 'observed'
+```
+
+G2 honours that. xAI usage is not polled from an account-usage endpoint. It is derived from observed response headers and reported as `source='observed_headers'` in `AccountUsageSnapshot`, while `provider_state.source` remains `observed`.
+
+## Band derivation
+
+For each valid observed bucket, G2 computes:
+
+```text
+used_pct = ((limit - remaining) / limit) * 100
+```
+
+The xAI provider band is derived from the highest observed bucket pressure and written to both daily/weekly governor pressure fields as a conservative approximation until a real xAI account-usage endpoint exists:
+
+| Pressure | Band |
+|---:|---|
+| `<70%` | `green` |
+| `70–84%` | `amber` |
+| `85–94%` | `red` |
+| `95–97%` | `black` |
+| `>=98%` | `post-reserve` |
+
+## Wildcard transition-rate lookup
+
+`PlatformOps.PlatformChange->*` is a literal config-row fallback pattern, not a regex and not SQL `LIKE`.
+
+Lookup order:
+
+1. exact `transition_key` match;
+2. if key starts with `PlatformOps.PlatformChange->`, fall back lexically to literal `PlatformOps.PlatformChange->*`;
+3. otherwise no match.
+
+## Deferred watchlist
+
+The allocation-sum trigger remains deferred. G2 does not write dynamic `mind_allocation` changes. The trigger decision belongs with #46/G4, as directed by SCO/AA.

--- a/docs/governor-xai-usage.md
+++ b/docs/governor-xai-usage.md
@@ -1,6 +1,6 @@
 # ADR-0010 G2: xAI header-derived governor usage
 
-This note documents the Hermes-side G2 implementation used by Special Circumstances Capital ADR-0010.
+This note documents the Hermes-side G2 implementation used by Special Circumstances Capital ADR-0010 (`special-circumstances-capital/special-circumstances-capital`, `architecture/decisions/2026-05-17-ADR-0010-rate-limit-governor.md`: https://github.com/special-circumstances-capital/special-circumstances-capital/blob/main/architecture/decisions/2026-05-17-ADR-0010-rate-limit-governor.md).
 
 ## Scope
 

--- a/tests/test_governor_xai_usage.py
+++ b/tests/test_governor_xai_usage.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+from agent.account_usage import (
+    AccountUsageWindow,
+    fetch_account_usage,
+    observe_xai_rate_limit_headers,
+)
+from agent.governor_state import (
+    compute_governor_band,
+    ensure_governor_schema,
+    get_transition_rate,
+)
+
+
+def _build_g1_db(path: Path) -> None:
+    with sqlite3.connect(path) as db:
+        db.execute("PRAGMA user_version = 1")
+        db.executescript(
+            """
+            CREATE TABLE provider_state (
+              provider TEXT PRIMARY KEY,
+              band TEXT NOT NULL,
+              daily_used_pct REAL,
+              weekly_used_pct REAL,
+              daily_reset_at TEXT,
+              weekly_reset_at TEXT,
+              observed_429_count_60min INTEGER,
+              last_polled_at TEXT,
+              source TEXT
+            );
+            CREATE TABLE mind_allocation (
+              mind TEXT PRIMARY KEY,
+              provider TEXT NOT NULL REFERENCES provider_state(provider),
+              daily_share_pct REAL,
+              weekly_share_pct REAL,
+              daily_used_pct REAL,
+              weekly_used_pct REAL
+            );
+            CREATE TABLE transition_rates (
+              transition_key TEXT PRIMARY KEY,
+              base_rate_per_hour INTEGER,
+              current_rate_per_hour INTEGER,
+              last_updated_at TEXT
+            );
+            CREATE TABLE governor_decisions (
+              event_id TEXT PRIMARY KEY,
+              ts TEXT NOT NULL,
+              decision TEXT NOT NULL,
+              reason TEXT,
+              layer TEXT NOT NULL,
+              provider TEXT REFERENCES provider_state(provider),
+              mind TEXT REFERENCES mind_allocation(mind),
+              card_id TEXT,
+              defer_until TEXT
+            );
+            INSERT INTO provider_state(provider, band, daily_used_pct, weekly_used_pct, observed_429_count_60min, source)
+            VALUES ('xai', 'green', 0.0, 0.0, 0, 'observed');
+            INSERT INTO transition_rates(transition_key, base_rate_per_hour, current_rate_per_hour)
+            VALUES ('PlatformOps.PlatformChange->*', 6, 6), ('SDLC.Research->Spec', 4, 4);
+            """
+        )
+
+
+def test_ensure_governor_schema_migrates_g1_without_recreating(tmp_path):
+    db_path = tmp_path / "governor.db"
+    _build_g1_db(db_path)
+
+    with sqlite3.connect(db_path) as db:
+        db.execute("INSERT INTO governor_decisions(event_id, ts, decision, layer) VALUES ('keep-me', '2026-05-18T16:00:00Z', 'admit', 'A')")
+        before_version = db.execute("PRAGMA user_version").fetchone()[0]
+
+    ensure_governor_schema(db_path)
+
+    with sqlite3.connect(db_path) as db:
+        assert before_version == 1
+        assert db.execute("PRAGMA user_version").fetchone()[0] == 2
+        assert db.execute("SELECT COUNT(*) FROM governor_decisions WHERE event_id='keep-me'").fetchone()[0] == 1
+        assert db.execute("SELECT COUNT(*) FROM xai_buckets").fetchone()[0] == 0
+        assert db.execute("SELECT source FROM provider_state WHERE provider='xai'").fetchone()[0] == "observed"
+
+
+def test_xai_header_observations_update_buckets_and_fetch_snapshot(tmp_path, monkeypatch):
+    db_path = tmp_path / "governor.db"
+    _build_g1_db(db_path)
+    fixed_now = datetime(2026, 5, 18, 16, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr("agent.governor_state._utc_now", lambda: fixed_now)
+    monkeypatch.setattr("agent.account_usage._utc_now", lambda: fixed_now)
+
+    observe_xai_rate_limit_headers(
+        {
+            "x-ratelimit-limit-requests": "1000",
+            "x-ratelimit-remaining-requests": "50",
+            "x-ratelimit-reset-requests": "1900000000",
+        },
+        db_path=db_path,
+    )
+
+    snapshot = fetch_account_usage("xai", governor_db_path=db_path)
+
+    assert snapshot is not None
+    assert snapshot.provider == "xai"
+    assert snapshot.source == "observed_headers"
+    assert snapshot.windows == (
+        AccountUsageWindow(
+            label="xAI request bucket",
+            used_percent=95.0,
+            reset_at=datetime.fromtimestamp(1_900_000_000, tz=timezone.utc),
+            detail="50 of 1000 requests remaining",
+        ),
+    )
+    assert "Governor band: black" in snapshot.details
+
+    with sqlite3.connect(db_path) as db:
+        provider = db.execute(
+            "SELECT band, daily_used_pct, weekly_used_pct, source FROM provider_state WHERE provider='xai'"
+        ).fetchone()
+        bucket = db.execute(
+            "SELECT bucket_scope, limit_value, remaining_value, used_pct FROM xai_buckets"
+        ).fetchone()
+
+    assert provider == ("black", 95.0, 95.0, "observed")
+    assert bucket == ("requests", 1000.0, 50.0, 95.0)
+
+
+def test_xai_fetch_honours_observed_source_and_missing_headers(tmp_path):
+    db_path = tmp_path / "governor.db"
+    _build_g1_db(db_path)
+    ensure_governor_schema(db_path)
+
+    snapshot = fetch_account_usage("xai", governor_db_path=db_path)
+
+    assert snapshot is not None
+    assert snapshot.provider == "xai"
+    assert snapshot.source == "observed_headers"
+    assert snapshot.unavailable_reason == "No xAI rate-limit headers have been observed yet."
+
+
+def test_band_derivation_uses_daily_or_weekly_thresholds():
+    assert compute_governor_band(69.9, 0.0) == "green"
+    assert compute_governor_band(70.0, 0.0) == "amber"
+    assert compute_governor_band(85.0, 0.0) == "red"
+    assert compute_governor_band(95.0, 0.0) == "black"
+    assert compute_governor_band(98.0, 0.0) == "post-reserve"
+    assert compute_governor_band(0.0, 96.0) == "black"
+
+
+def test_platformops_wildcard_transition_lookup_is_literal_lexical_fallback(tmp_path):
+    db_path = tmp_path / "governor.db"
+    _build_g1_db(db_path)
+    ensure_governor_schema(db_path)
+
+    assert get_transition_rate("SDLC.Research->Spec", db_path=db_path) == 4
+    assert get_transition_rate("PlatformOps.PlatformChange->Review", db_path=db_path) == 6
+    assert get_transition_rate("PlatformOps.PlatformChange->Deployed", db_path=db_path) == 6
+    assert get_transition_rate("PlatformOps.Other->Review", db_path=db_path) is None
+    assert get_transition_rate("PlatformOps.PlatformChange->*", db_path=db_path) == 6

--- a/tests/test_governor_xai_usage.py
+++ b/tests/test_governor_xai_usage.py
@@ -7,9 +7,12 @@ from pathlib import Path
 from agent.account_usage import (
     AccountUsageWindow,
     fetch_account_usage,
+    maybe_observe_xai_rate_limit_headers,
     observe_xai_rate_limit_headers,
 )
+from agent.conversation_loop import _observe_xai_headers_best_effort
 from agent.governor_state import (
+    _parse_reset,
     compute_governor_band,
     ensure_governor_schema,
     get_transition_rate,
@@ -137,6 +140,69 @@ def test_xai_fetch_honours_observed_source_and_missing_headers(tmp_path):
     assert snapshot.provider == "xai"
     assert snapshot.source == "observed_headers"
     assert snapshot.unavailable_reason == "No xAI rate-limit headers have been observed yet."
+
+
+def test_xai_reset_parsing_uses_named_relative_cutoff(monkeypatch):
+    fixed_now = datetime(2026, 5, 18, 16, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr("agent.governor_state._utc_now", lambda: fixed_now)
+
+    assert _parse_reset("0") == fixed_now
+    assert _parse_reset("-1") == datetime.fromtimestamp(-1, tz=timezone.utc)
+    assert _parse_reset(str(30 * 86_400)) == datetime.fromtimestamp(
+        fixed_now.timestamp() + 30 * 86_400, tz=timezone.utc
+    )
+    assert _parse_reset(str(30 * 86_400 + 1)) == datetime.fromtimestamp(
+        30 * 86_400 + 1, tz=timezone.utc
+    )
+    assert _parse_reset("10000000") == datetime.fromtimestamp(10_000_000, tz=timezone.utc)
+    assert _parse_reset("10000001") == datetime.fromtimestamp(10_000_001, tz=timezone.utc)
+    assert _parse_reset("1900000000") == datetime.fromtimestamp(1_900_000_000, tz=timezone.utc)
+
+
+class _MockXaiResponse:
+    def __init__(self, headers):
+        self.headers = headers
+
+
+def test_conversation_loop_xai_header_hook_records_real_shaped_response(tmp_path, monkeypatch):
+    db_path = tmp_path / "governor.db"
+    _build_g1_db(db_path)
+    fixed_now = datetime(2026, 5, 18, 16, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr("agent.governor_state._utc_now", lambda: fixed_now)
+
+    response = _MockXaiResponse(
+        {
+            "x-ratelimit-limit-requests": "1000",
+            "x-ratelimit-remaining-requests": "100",
+            "x-ratelimit-reset-requests": "1900000000",
+        }
+    )
+
+    assert _observe_xai_headers_best_effort("xai", "grok-4", response, db_path=db_path) is True
+
+    with sqlite3.connect(db_path) as db:
+        assert db.execute("SELECT used_pct FROM xai_buckets WHERE bucket_key='requests:observed'").fetchone()[0] == 90.0
+        assert db.execute("SELECT source FROM provider_state WHERE provider='xai'").fetchone()[0] == "observed"
+
+
+def test_conversation_loop_xai_header_hook_short_circuits_non_xai_without_db_touch(tmp_path):
+    missing_db_path = tmp_path / "missing-governor.db"
+    response = _MockXaiResponse(
+        {
+            "x-ratelimit-limit-requests": "1000",
+            "x-ratelimit-remaining-requests": "0",
+            "x-ratelimit-reset-requests": "1900000000",
+        }
+    )
+
+    assert (
+        maybe_observe_xai_rate_limit_headers(
+            "anthropic", "claude-sonnet", response, db_path=missing_db_path
+        )
+        is False
+    )
+    assert _observe_xai_headers_best_effort("anthropic", "claude-sonnet", response, db_path=missing_db_path) is False
+    assert not missing_db_path.exists()
 
 
 def test_band_derivation_uses_daily_or_weekly_thresholds():

--- a/tests/test_governor_xai_usage.py
+++ b/tests/test_governor_xai_usage.py
@@ -146,6 +146,9 @@ def test_xai_reset_parsing_uses_named_relative_cutoff(monkeypatch):
     fixed_now = datetime(2026, 5, 18, 16, 0, tzinfo=timezone.utc)
     monkeypatch.setattr("agent.governor_state._utc_now", lambda: fixed_now)
 
+    assert _parse_reset("86400") == datetime.fromtimestamp(
+        fixed_now.timestamp() + 86_400, tz=timezone.utc
+    )
     assert _parse_reset("0") == fixed_now
     assert _parse_reset("-1") == datetime.fromtimestamp(-1, tz=timezone.utc)
     assert _parse_reset(str(30 * 86_400)) == datetime.fromtimestamp(
@@ -162,6 +165,12 @@ def test_xai_reset_parsing_uses_named_relative_cutoff(monkeypatch):
 class _MockXaiResponse:
     def __init__(self, headers):
         self.headers = headers
+
+
+class _MockHttpError(Exception):
+    def __init__(self, headers):
+        super().__init__("429 Too Many Requests")
+        self.response = _MockXaiResponse(headers)
 
 
 def test_conversation_loop_xai_header_hook_records_real_shaped_response(tmp_path, monkeypatch):
@@ -183,6 +192,29 @@ def test_conversation_loop_xai_header_hook_records_real_shaped_response(tmp_path
     with sqlite3.connect(db_path) as db:
         assert db.execute("SELECT used_pct FROM xai_buckets WHERE bucket_key='requests:observed'").fetchone()[0] == 90.0
         assert db.execute("SELECT source FROM provider_state WHERE provider='xai'").fetchone()[0] == "observed"
+
+
+def test_conversation_loop_xai_header_hook_records_429_error_response(tmp_path, monkeypatch):
+    db_path = tmp_path / "governor.db"
+    _build_g1_db(db_path)
+    fixed_now = datetime(2026, 5, 18, 16, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr("agent.governor_state._utc_now", lambda: fixed_now)
+
+    error = _MockHttpError(
+        {
+            "x-ratelimit-limit-requests": "1000",
+            "x-ratelimit-remaining-requests": "0",
+            "x-ratelimit-reset-requests": "86400",
+        }
+    )
+
+    assert _observe_xai_headers_best_effort("xai", "grok-4", error, db_path=db_path) is True
+
+    with sqlite3.connect(db_path) as db:
+        bucket = db.execute(
+            "SELECT used_pct, window_label FROM xai_buckets WHERE bucket_key='requests:day'"
+        ).fetchone()
+    assert bucket == (100.0, "day")
 
 
 def test_conversation_loop_xai_header_hook_short_circuits_non_xai_without_db_touch(tmp_path):


### PR DESCRIPTION
## Summary
- Adds ADR-0010 G2 xAI/Grok usage tracking from observed `x-ratelimit-*` response headers.
- Migrates the canonical G1 governor DB in place to `PRAGMA user_version = 2` by adding `xai_buckets`; it deliberately does not recreate `governor.db`.
- Wires `fetch_account_usage("xai")` / `xai-oauth` / Grok aliases to header-derived `AccountUsageSnapshot` output.
- Adds best-effort post-response header observation for xAI/Grok responses when SDK response headers are exposed.
- Implements the documented literal lexical fallback semantics for `PlatformOps.PlatformChange->*` transition-rate lookup.
- Documents the design in `docs/governor-xai-usage.md`.

## Design / gate notes
SCC ADR-0010 G2 scope only. No Layer A admission, no Layer B tick loop, no service activation, no webhook gating, and no allocation mutation.

Watchlist handling:
- Live `governor.db` remains canonical. `ensure_governor_schema()` raises if the DB is missing; G2 migrates G1 instead of creating a fresh DB.
- `provider_state.source='observed'` for `xai` is preserved; account usage source is reported as `observed_headers`.
- xAI band is derived from the highest observed header bucket pressure using ADR-0010 thresholds.
- Allocation-sum trigger remains deferred pending #46/G4; G2 does not write `mind_allocation`.
- `PlatformOps.PlatformChange->*` is implemented as exact lookup first, then literal lexical fallback for keys beginning `PlatformOps.PlatformChange->`; no regex/SQL-LIKE wildcarding.

## Test plan
- [x] RED: `tests/test_governor_xai_usage.py` failed before the implementation because the G2 API/module did not exist.
- [x] `/home/robert/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_governor_xai_usage.py tests/test_account_usage.py -q -o 'addopts='`
- [x] `/home/robert/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_governor_xai_usage.py tests/test_account_usage.py tests/agent/transports/test_chat_completions.py -q -o 'addopts='`

## SCC tracking
Refs special-circumstances-capital/special-circumstances-capital#48.
Pre-gating/watchlist: #46, #47, #35, #36.
