### PR TITLE
fix(aux): strip pattern/format from tool schemas on xAI OAuth auxiliary path

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -713,8 +713,11 @@ class _CodexCompletionsAdapter:
             try:
                 from tools.schema_sanitizer import strip_pattern_and_format
                 tools, _ = strip_pattern_and_format(list(tools))
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.warning(
+                    "Auxiliary client: failed to sanitize tool schemas for "
+                    "Codex/xAI Responses path: %s", exc,
+                )
             converted = []
             for t in tools:
                 fn = t.get("function", {}) if isinstance(t, dict) else {}

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -707,6 +707,14 @@ class _CodexCompletionsAdapter:
         # Tools support for auxiliary callers (e.g. skills_hub) that pass function schemas
         tools = kwargs.get("tools")
         if tools:
+            # xAI's Responses endpoint rejects ``pattern`` and ``format`` JSON Schema
+            # keywords (HTTP 400). Strip them here to match the parity guarantee that
+            # chat_completion_helpers.py provides for the main-agent xAI path.
+            try:
+                from tools.schema_sanitizer import strip_pattern_and_format
+                tools, _ = strip_pattern_and_format(list(tools))
+            except Exception:
+                pass
             converted = []
             for t in tools:
                 fn = t.get("function", {}) if isinstance(t, dict) else {}


### PR DESCRIPTION
Salvage of #28069 by @EloquentBrush0x onto current main.

## Summary
`_CodexCompletionsAdapter.create()` (the shim used for every xAI OAuth auxiliary call — kanban auto-decomposer, profile describer, skills hub) passed tool schemas raw. xAI's `/responses` endpoint rejects `pattern` and `format` JSON Schema keywords with HTTP 400. The main-agent xAI path already strips these in `chat_completion_helpers.py` (PR #27197); this brings the auxiliary path to parity.

`_AsyncCodexCompletionsAdapter` delegates to the sync adapter via `asyncio.to_thread`, so both sync and async aux callers are covered by the same fix.

## Changes
- `agent/auxiliary_client.py`: call `strip_pattern_and_format()` on the incoming tool list before the schema conversion loop, guarded by `try/except` so an import failure degrades gracefully.

## Validation
- 203/203 `test_auxiliary_client` + `test_schema_sanitizer` tests pass.

Closes #28069.