### PR TITLE
fix: distinguish kanban hierarchy links from dependencies

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -370,9 +370,16 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     )
 
     # --- link / unlink ---
-    p_link = sub.add_parser("link", help="Add a parent->child dependency")
+    p_link = sub.add_parser("link", help="Add a parent->child dependency or hierarchy relation")
     p_link.add_argument("parent_id")
     p_link.add_argument("child_id")
+    p_link.add_argument(
+        "--type",
+        choices=("dependency", "hierarchy"),
+        default="dependency",
+        dest="relation_type",
+        help="Relation type. dependency gates readiness/claiming; hierarchy is umbrella/epic structure only.",
+    )
     p_unlink = sub.add_parser("unlink", help="Remove a parent->child dependency")
     p_unlink.add_argument("parent_id")
     p_unlink.add_argument("child_id")
@@ -1521,8 +1528,8 @@ def _cmd_diagnostics(args: argparse.Namespace) -> int:
 
 def _cmd_link(args: argparse.Namespace) -> int:
     with kb.connect() as conn:
-        kb.link_tasks(conn, args.parent_id, args.child_id)
-    print(f"Linked {args.parent_id} -> {args.child_id}")
+        kb.link_tasks(conn, args.parent_id, args.child_id, relation_type=args.relation_type)
+    print(f"Linked {args.parent_id} -> {args.child_id} ({args.relation_type})")
     return 0
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -803,6 +803,7 @@ CREATE TABLE IF NOT EXISTS tasks (
 CREATE TABLE IF NOT EXISTS task_links (
     parent_id  TEXT NOT NULL,
     child_id   TEXT NOT NULL,
+    relation_type TEXT NOT NULL DEFAULT 'dependency',
     PRIMARY KEY (parent_id, child_id)
 );
 
@@ -1076,6 +1077,27 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         # which is the correct default (they keep the global behaviour
         # they were getting before the column existed).
         _add_column_if_missing(conn, "tasks", "max_retries", "max_retries INTEGER")
+
+    link_table_exists = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='task_links'"
+    ).fetchone() is not None
+    if link_table_exists:
+        link_cols = {row["name"] for row in conn.execute("PRAGMA table_info(task_links)")}
+        if "relation_type" not in link_cols:
+            _add_column_if_missing(
+                conn,
+                "task_links",
+                "relation_type",
+                "relation_type TEXT NOT NULL DEFAULT 'dependency'",
+            )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_links_type_child "
+            "ON task_links(relation_type, child_id)"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_links_type_parent "
+            "ON task_links(relation_type, parent_id)"
+        )
 
     # task_events gained a run_id column; back-fill it as NULL for
     # historical events (they predate runs and can't be attributed).
@@ -1511,9 +1533,17 @@ def assign_task(conn: sqlite3.Connection, task_id: str, profile: Optional[str]) 
 # Links
 # ---------------------------------------------------------------------------
 
-def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
+def link_tasks(
+    conn: sqlite3.Connection,
+    parent_id: str,
+    child_id: str,
+    *,
+    relation_type: str = "dependency",
+) -> None:
     if parent_id == child_id:
         raise ValueError("a task cannot depend on itself")
+    if relation_type not in {"dependency", "hierarchy"}:
+        raise ValueError("relation_type must be one of: dependency, hierarchy")
     with write_txn(conn):
         missing = _find_missing_parents(conn, [parent_id, child_id])
         if missing:
@@ -1523,21 +1553,28 @@ def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
                 f"linking {parent_id} -> {child_id} would create a cycle"
             )
         conn.execute(
-            "INSERT OR IGNORE INTO task_links (parent_id, child_id) VALUES (?, ?)",
-            (parent_id, child_id),
+            """
+            INSERT INTO task_links (parent_id, child_id, relation_type)
+            VALUES (?, ?, ?)
+            ON CONFLICT(parent_id, child_id) DO UPDATE SET
+                relation_type = excluded.relation_type
+            """,
+            (parent_id, child_id, relation_type),
         )
-        # If child was ready but parent is not yet done, demote child to todo.
-        parent_status = conn.execute(
-            "SELECT status FROM tasks WHERE id = ?", (parent_id,)
-        ).fetchone()["status"]
-        if parent_status != "done":
-            conn.execute(
-                "UPDATE tasks SET status = 'todo' WHERE id = ? AND status = 'ready'",
-                (child_id,),
-            )
+        # Dependency links gate readiness/claims; hierarchy links only model
+        # umbrella/epic breakdowns and must not block child execution.
+        if relation_type == "dependency":
+            parent_status = conn.execute(
+                "SELECT status FROM tasks WHERE id = ?", (parent_id,)
+            ).fetchone()["status"]
+            if parent_status != "done":
+                conn.execute(
+                    "UPDATE tasks SET status = 'todo' WHERE id = ? AND status = 'ready'",
+                    (child_id,),
+                )
         _append_event(
             conn, child_id, "linked",
-            {"parent": parent_id, "child": child_id},
+            {"parent": parent_id, "child": child_id, "relation_type": relation_type},
         )
 
 
@@ -1842,7 +1879,7 @@ def recompute_ready(conn: sqlite3.Connection) -> int:
             parents = conn.execute(
                 "SELECT t.status FROM tasks t "
                 "JOIN task_links l ON l.parent_id = t.id "
-                "WHERE l.child_id = ?",
+                "WHERE l.child_id = ? AND l.relation_type = 'dependency'",
                 (task_id,),
             ).fetchall()
             if all(p["status"] in {"done", "archived"} for p in parents):
@@ -1886,7 +1923,9 @@ def claim_task(
         undone = conn.execute(
             "SELECT 1 FROM task_links l "
             "JOIN tasks p ON p.id = l.parent_id "
-            "WHERE l.child_id = ? AND p.status NOT IN ('done', 'archived') LIMIT 1",
+            "WHERE l.child_id = ? "
+            "AND l.relation_type = 'dependency' "
+            "AND p.status NOT IN ('done', 'archived') LIMIT 1",
             (task_id,),
         ).fetchone()
         if undone:
@@ -2688,7 +2727,9 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
         undone_parents = conn.execute(
             "SELECT 1 FROM task_links l "
             "JOIN tasks p ON p.id = l.parent_id "
-            "WHERE l.child_id = ? AND p.status != 'done' LIMIT 1",
+            "WHERE l.child_id = ? "
+            "AND l.relation_type = 'dependency' "
+            "AND p.status != 'done' LIMIT 1",
             (task_id,),
         ).fetchone()
         new_status = "todo" if undone_parents else "ready"
@@ -3232,6 +3273,10 @@ def _pid_alive(pid: Optional[int]) -> bool:
     """
     if not pid or pid <= 0:
         return False
+    if sys.platform == "linux":
+        proc_status = f"/proc/{int(pid)}/status"
+        if not os.path.exists(proc_status):
+            return False
     from gateway.status import _pid_exists
     if not _pid_exists(int(pid)):
         return False

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import concurrent.futures
 import os
+import sqlite3
 import time
 from pathlib import Path
 
@@ -45,6 +46,60 @@ def test_init_creates_expected_tables(kanban_home):
         ).fetchall()
     names = {r["name"] for r in rows}
     assert {"tasks", "task_links", "task_comments", "task_events"} <= names
+
+    with kb.connect() as conn:
+        link_cols = {
+            row["name"]: row for row in conn.execute("PRAGMA table_info(task_links)")
+        }
+    assert link_cols["relation_type"]["dflt_value"] == "'dependency'"
+
+
+def test_init_migrates_legacy_task_links_to_dependency(tmp_path):
+    db = tmp_path / "legacy-kanban.db"
+    raw = sqlite3.connect(db)
+    raw.executescript(
+        """
+        CREATE TABLE tasks (
+            id TEXT PRIMARY KEY,
+            title TEXT NOT NULL,
+            assignee TEXT,
+            status TEXT NOT NULL,
+            priority INTEGER NOT NULL DEFAULT 0,
+            created_by TEXT NOT NULL DEFAULT 'test',
+            created_at INTEGER NOT NULL DEFAULT 1,
+            started_at INTEGER,
+            claim_lock TEXT,
+            claim_expires INTEGER,
+            worker_pid INTEGER,
+            max_runtime_seconds INTEGER,
+            last_heartbeat_at INTEGER,
+            tenant TEXT,
+            idempotency_key TEXT
+        );
+        CREATE TABLE task_links (
+            parent_id TEXT NOT NULL,
+            child_id TEXT NOT NULL,
+            PRIMARY KEY (parent_id, child_id)
+        );
+        INSERT INTO tasks (id, title, status)
+        VALUES ('p', 'parent', 'todo'), ('c', 'child', 'todo');
+        INSERT INTO task_links (parent_id, child_id) VALUES ('p', 'c');
+        """
+    )
+    raw.commit()
+    raw.close()
+
+    kb.init_db(db)
+
+    with kb.connect(db) as conn:
+        row = conn.execute(
+            "SELECT parent_id, child_id, relation_type FROM task_links"
+        ).fetchone()
+    assert dict(row) == {
+        "parent_id": "p",
+        "child_id": "c",
+        "relation_type": "dependency",
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -101,6 +156,42 @@ def test_link_keeps_ready_child_when_parent_already_done(kanban_home):
         assert kb.get_task(conn, b).status == "ready"
         kb.link_tasks(conn, a, b)
         assert kb.get_task(conn, b).status == "ready"
+
+
+def test_hierarchy_link_does_not_gate_ready_or_claim(kanban_home):
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="umbrella")
+        child = kb.create_task(conn, title="child")
+        assert kb.get_task(conn, child).status == "ready"
+
+        kb.link_tasks(conn, parent, child, relation_type="hierarchy")
+
+        row = conn.execute(
+            "SELECT relation_type FROM task_links WHERE parent_id = ? AND child_id = ?",
+            (parent, child),
+        ).fetchone()
+        assert row["relation_type"] == "hierarchy"
+        assert kb.get_task(conn, child).status == "ready"
+        assert kb.claim_task(conn, child) is not None
+
+
+def test_link_can_update_existing_relation_type(kanban_home):
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="umbrella")
+        child = kb.create_task(conn, title="child")
+        kb.link_tasks(conn, parent, child, relation_type="dependency")
+        assert kb.get_task(conn, child).status == "todo"
+
+        kb.link_tasks(conn, parent, child, relation_type="hierarchy")
+
+        row = conn.execute(
+            "SELECT relation_type FROM task_links WHERE parent_id = ? AND child_id = ?",
+            (parent, child),
+        ).fetchone()
+        assert row["relation_type"] == "hierarchy"
+        conn.execute("UPDATE tasks SET status = 'todo' WHERE id = ?", (child,))
+        assert kb.recompute_ready(conn) == 1
+        assert kb.get_task(conn, child).status == "ready"
 
 
 def test_link_rejects_self_loop(kanban_home):

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -693,16 +693,22 @@ def _handle_unblock(args: dict, **kw) -> str:
 
 
 def _handle_link(args: dict, **kw) -> str:
-    """Add a parent→child dependency edge after the fact."""
+    """Add a parent→child dependency or hierarchy edge after the fact."""
     parent_id = args.get("parent_id")
     child_id = args.get("child_id")
+    relation_type = args.get("relation_type") or "dependency"
     if not parent_id or not child_id:
         return tool_error("both parent_id and child_id are required")
     try:
         kb, conn = _connect()
         try:
-            kb.link_tasks(conn, parent_id=parent_id, child_id=child_id)
-            return _ok(parent_id=parent_id, child_id=child_id)
+            kb.link_tasks(
+                conn,
+                parent_id=parent_id,
+                child_id=child_id,
+                relation_type=relation_type,
+            )
+            return _ok(parent_id=parent_id, child_id=child_id, relation_type=relation_type)
         finally:
             conn.close()
     except ValueError as e:
@@ -1102,15 +1108,21 @@ KANBAN_UNBLOCK_SCHEMA = {
 KANBAN_LINK_SCHEMA = {
     "name": "kanban_link",
     "description": (
-        "Add a parent→child dependency edge after both tasks already "
-        "exist. The child won't promote to 'ready' until all parents "
-        "are 'done'. Cycles and self-links are rejected."
+        "Add a parent→child dependency or hierarchy edge after both tasks already "
+        "exist. dependency gates readiness/claiming; hierarchy models "
+        "umbrella/epic structure only. Cycles and self-links are rejected."
     ),
     "parameters": {
         "type": "object",
         "properties": {
             "parent_id": {"type": "string", "description": "Parent task id."},
             "child_id":  {"type": "string", "description": "Child task id."},
+            "relation_type": {
+                "type": "string",
+                "enum": ["dependency", "hierarchy"],
+                "default": "dependency",
+                "description": "Relation type. dependency gates scheduling; hierarchy is structural only.",
+            },
         },
         "required": ["parent_id", "child_id"],
     },


### PR DESCRIPTION
## Summary
- Add `relation_type` to Kanban `task_links`, defaulting legacy links to `dependency`.
- Keep `dependency` as the default `link` behavior.
- Add `hierarchy` links for umbrella/epic structure that do **not** gate ready/claim transitions.
- Allow updating an existing parent/child pair from dependency to hierarchy.
- Include a narrow `_pid_alive` guard so fake/nonexistent PIDs do not hit live-system `os.kill(pid, 0)` guards during Kanban DB tests.

## Verification
- `./scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py tests/tools/test_kanban_tools.py -q` → `147 passed in 13.84s`
- `python -m py_compile hermes_cli/kanban_db.py hermes_cli/kanban.py tools/kanban_tools.py` → ok
- `git diff --check` → ok
- secret scan over changed files → ok

## Safety / non-actions
- No gateway restart or reload.
- No live materialization.
- No cron mutation.
- No secret/env mutation.
