### PR TITLE
Add SaladCloud model provider plugin

### DIFF
--- a/plugins/model-providers/saladcloud/__init__.py
+++ b/plugins/model-providers/saladcloud/__init__.py
@@ -1,0 +1,60 @@
+"""SaladCloud AI Gateway provider profile."""
+
+from typing import Any
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+class SaladCloudProfile(ProviderProfile):
+    """Salad AI Gateway - OpenAI-compatible endpoint."""
+
+    def build_api_kwargs_extras(
+        self,
+        *,
+        reasoning_config: dict | None = None,
+        model: str | None = None,
+        **context: Any,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        extra_body: dict[str, Any] = {}
+
+        model_name = (model or "").strip().lower()
+        is_qwen_model = model_name.startswith("qwen") or "/qwen" in model_name
+        if not is_qwen_model or reasoning_config is None:
+            return extra_body, {}
+
+        enabled = reasoning_config.get("enabled")
+        effort = (reasoning_config.get("effort") or "").strip().lower()
+
+        if enabled is False or effort == "none":
+            extra_body["chat_template_kwargs"] = {"enable_thinking": False}
+        elif enabled is True or effort:
+            extra_body["chat_template_kwargs"] = {"enable_thinking": True}
+
+        return extra_body, {}
+
+
+saladcloud = SaladCloudProfile(
+    name="saladcloud",
+    aliases=(
+        "salad",
+        "salad-cloud",
+        "salad-ai-gateway",
+        "saladcloud-ai-gateway",
+    ),
+    display_name="Salad AI Gateway",
+    description="Salad AI Gateway - OpenAI-compatible open model API",
+    signup_url="https://salad.com/ai-gateway",
+    env_vars=("SALAD_CLOUD_API_KEY",),
+    base_url="https://ai.salad.cloud/v1",
+    models_url="https://ai.salad.cloud/v1/models",
+    auth_type="api_key",
+    default_aux_model="qwen3.5-9b",
+    fallback_models=(
+        "qwen3.6-35b-a3b",
+        "qwen3.6-27b",
+        "qwen3.5-9b",
+    ),
+)
+
+register_provider(saladcloud)

--- a/plugins/model-providers/saladcloud/plugin.yaml
+++ b/plugins/model-providers/saladcloud/plugin.yaml
@@ -1,0 +1,5 @@
+name: saladcloud-provider
+kind: model-provider
+version: 1.0.0
+description: Salad AI Gateway
+author: Salad Technologies

--- a/tests/providers/test_plugin_discovery.py
+++ b/tests/providers/test_plugin_discovery.py
@@ -46,19 +46,19 @@ def test_bundled_plugins_discovered():
         assert (child / "plugin.yaml").exists(), f"{child.name} missing plugin.yaml"
 
 
-def test_all_34_profiles_register():
-    """After discovery, the registry must contain exactly 34 distinct profiles."""
+def test_all_35_profiles_register():
+    """After discovery, the registry must contain exactly 35 distinct profiles."""
     _clear_provider_caches()
     from providers import list_providers
 
     profiles = list_providers()
     names = sorted(p.name for p in profiles)
-    assert len(names) == 34, f"Expected 34 profiles, got {len(names)}: {names}"
+    assert len(names) == 35, f"Expected 35 profiles, got {len(names)}: {names}"
 
     # Spot-check representative providers from different categories
     for required in (
         "openrouter", "anthropic", "custom", "bedrock", "openai-codex",
-        "minimax-oauth", "gmi", "xiaomi", "alibaba-coding-plan",
+        "minimax-oauth", "gmi", "xiaomi", "alibaba-coding-plan", "saladcloud",
     ):
         assert required in names, f"Missing profile: {required}"
 

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -277,6 +277,63 @@ class TestQwenProfile:
         assert "metadata" not in eb
 
 
+class TestSaladCloudProfile:
+    def test_profile_metadata(self):
+        p = get_provider_profile("saladcloud")
+        assert p.display_name == "Salad AI Gateway"
+        assert p.base_url == "https://ai.salad.cloud/v1"
+        assert p.models_url == "https://ai.salad.cloud/v1/models"
+        assert p.env_vars == ("SALAD_CLOUD_API_KEY",)
+        assert p.auth_type == "api_key"
+        assert "salad-cloud" in p.aliases
+        assert get_provider_profile("salad-cloud").name == "saladcloud"
+        assert p.default_aux_model == "qwen3.5-9b"
+        assert "qwen3.6-35b-a3b" in p.fallback_models
+
+    def test_reasoning_disabled_maps_to_chat_template_kwargs(self):
+        p = get_provider_profile("saladcloud")
+        eb, tl = p.build_api_kwargs_extras(
+            model="qwen3.6-35b-a3b",
+            reasoning_config={"enabled": False},
+        )
+        assert eb == {"chat_template_kwargs": {"enable_thinking": False}}
+        assert tl == {}
+
+    def test_reasoning_none_effort_maps_to_chat_template_kwargs(self):
+        p = get_provider_profile("saladcloud")
+        eb, _ = p.build_api_kwargs_extras(
+            model="qwen3.6-35b-a3b",
+            reasoning_config={"enabled": True, "effort": "none"},
+        )
+        assert eb == {"chat_template_kwargs": {"enable_thinking": False}}
+
+    def test_reasoning_enabled_maps_to_chat_template_kwargs(self):
+        p = get_provider_profile("saladcloud")
+        eb, _ = p.build_api_kwargs_extras(
+            model="qwen3.6-35b-a3b",
+            reasoning_config={"enabled": True, "effort": "medium"},
+        )
+        assert eb == {"chat_template_kwargs": {"enable_thinking": True}}
+
+    def test_reasoning_omitted_by_default(self):
+        p = get_provider_profile("saladcloud")
+        eb, tl = p.build_api_kwargs_extras(
+            model="qwen3.6-35b-a3b",
+            reasoning_config=None,
+        )
+        assert eb == {}
+        assert tl == {}
+
+    def test_reasoning_omitted_for_non_qwen_models(self):
+        p = get_provider_profile("saladcloud")
+        eb, tl = p.build_api_kwargs_extras(
+            model="example-non-qwen-model",
+            reasoning_config={"enabled": False, "effort": "none"},
+        )
+        assert eb == {}
+        assert tl == {}
+
+
 class TestBaseProfile:
     def test_prepare_messages_passthrough(self):
         p = ProviderProfile(name="test")

--- a/tests/providers/test_transport_parity.py
+++ b/tests/providers/test_transport_parity.py
@@ -257,3 +257,28 @@ class TestCustomOllamaParity:
             reasoning_config={"enabled": False, "effort": "none"},
         )
         assert kw["extra_body"]["think"] is False
+
+
+class TestSaladCloudParity:
+    """SaladCloud: Qwen thinking uses vLLM chat_template_kwargs."""
+
+    def test_reasoning_disabled_without_generic_supports_reasoning_gate(self, transport):
+        kw = transport.build_kwargs(
+            model="qwen3.6-35b-a3b",
+            messages=_simple_messages(),
+            tools=None,
+            provider_profile=get_provider_profile("saladcloud"),
+            reasoning_config={"enabled": False, "effort": "none"},
+        )
+        assert kw["extra_body"]["chat_template_kwargs"] == {
+            "enable_thinking": False
+        }
+
+    def test_no_default_thinking_override(self, transport):
+        kw = transport.build_kwargs(
+            model="qwen3.6-35b-a3b",
+            messages=_simple_messages(),
+            tools=None,
+            provider_profile=get_provider_profile("saladcloud"),
+        )
+        assert "extra_body" not in kw


### PR DESCRIPTION
## What does this PR do?

Adds SaladCloud AI Gateway as a bundled model-provider plugin.

This lets Hermes users select `saladcloud` as an OpenAI-compatible provider using `SALAD_CLOUD_API_KEY`. The profile includes the default SaladCloud API base URL, model listing URL, common aliases, and fallback Qwen models.


## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `plugins/model-providers/saladcloud/__init__.py` with the SaladCloud provider profile.
- Added `plugins/model-providers/saladcloud/plugin.yaml` manifest.
- Updated `tests/providers/test_plugin_discovery.py` for the new bundled provider count and spot check.
- Added SaladCloud profile tests in `tests/providers/test_provider_profiles.py`.
- Added transport parity tests in `tests/providers/test_transport_parity.py` for SaladCloud Qwen thinking behavior.

## How to Test

1. Run provider tests:

   ```bash
   scripts/run_tests.sh tests/providers/test_plugin_discovery.py tests/providers/test_provider_profiles.py tests/providers/test_transport_parity.py
   ```

2. Run lint:

   ```bash
   .venv/bin/ruff check plugins/model-providers/saladcloud tests/providers/test_plugin_discovery.py tests/providers/test_provider_profiles.py tests/providers/test_transport_parity.py
   ```

3. Optional live smoke test with `SALAD_CLOUD_API_KEY`:

   ```bash
   .venv/bin/python ./hermes chat -Q \
     --provider saladcloud \
     -m qwen3.6-35b-a3b \
     --ignore-user-config \
     --ignore-rules \
     -q "Reply with only the number: 12 * 37"
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu/Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A

## Screenshots / Logs

Targeted test run:

```text
73 passed
```

Live smoke test returned the expected answer using `saladcloud` and `qwen3.6-35b-a3b`.
