### PR TITLE
feat: add tool result compaction plugin

### DIFF
--- a/plugins/tool-result-compaction/__init__.py
+++ b/plugins/tool-result-compaction/__init__.py
@@ -1,0 +1,213 @@
+"""Opt-in tool-result compaction for noisy terminal outputs.
+
+This plugin is a clean-room Hermes implementation of a narrow idea surfaced
+while reviewing OpenHuman: compress large tool payloads before they re-enter
+LLM context. It does not import or copy OpenHuman code.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+
+
+_DEFAULT_MODE = "observe"
+_DEFAULT_THRESHOLD_CHARS = 12_000
+_DEFAULT_HEAD_LINES = 40
+_DEFAULT_TAIL_LINES = 80
+_SUPPORTED_TOOLS = {"terminal"}
+_ERROR_MARKERS = (
+    "error",
+    "failed",
+    "failure",
+    "traceback",
+    "exception",
+    "assertionerror",
+    "syntaxerror",
+    "typeerror",
+    "valueerror",
+    "modulenotfounderror",
+)
+
+
+def _as_int(value: Any, default: int, *, minimum: int = 0) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed >= minimum else default
+
+
+def _load_settings() -> dict[str, Any]:
+    """Read plugin settings from config.yaml, fail-closed to observe mode."""
+    try:
+        from hermes_cli.config import cfg_get, load_config
+
+        config = load_config()
+        settings = cfg_get(
+            config,
+            "plugins",
+            "entries",
+            "tool-result-compaction",
+            default={},
+        )
+        return settings if isinstance(settings, dict) else {}
+    except Exception:
+        return {}
+
+
+def _interesting_lines(lines: list[str], *, limit: int = 40) -> list[str]:
+    selected: list[str] = []
+    seen: set[int] = set()
+    for idx, line in enumerate(lines):
+        lower = line.lower()
+        if any(marker in lower for marker in _ERROR_MARKERS):
+            start = max(0, idx - 1)
+            end = min(len(lines), idx + 2)
+            for pos in range(start, end):
+                if pos not in seen:
+                    seen.add(pos)
+                    selected.append(lines[pos])
+                    if len(selected) >= limit:
+                        return selected
+    return selected
+
+
+def _interesting_span(text: str, *, radius: int = 160) -> str:
+    lower = text.lower()
+    marker_positions = [
+        lower.find(marker)
+        for marker in _ERROR_MARKERS
+        if lower.find(marker) >= 0
+    ]
+    if not marker_positions:
+        return ""
+    pos = min(marker_positions)
+    start = max(0, pos - radius)
+    end = min(len(text), pos + radius)
+    return text[start:end]
+
+
+def _compact_single_line(text: str) -> tuple[str, dict[str, Any]]:
+    head_chars = 500
+    tail_chars = 500
+    diagnostic = _interesting_span(text)
+    omitted = max(0, len(text) - head_chars - tail_chars - len(diagnostic))
+    parts = [
+        text[:head_chars],
+        f"... [tool-result-compaction omitted {omitted} middle char(s)] ...",
+    ]
+    if diagnostic and diagnostic not in parts[0] and diagnostic not in text[-tail_chars:]:
+        parts.extend(["--- preserved diagnostic span ---", diagnostic])
+    parts.extend(["--- tail ---", text[-tail_chars:]])
+    compacted = "\n".join(parts)
+    return compacted, {
+        "original_lines": 1,
+        "compacted_lines": len(compacted.splitlines()),
+        "strategy": "single-line-head-diagnostics-tail",
+    }
+
+
+def _compact_text(text: str, *, head_lines: int, tail_lines: int) -> tuple[str, dict[str, Any]]:
+    lines = text.splitlines()
+    if len(lines) <= head_lines + tail_lines:
+        if len(lines) <= 1 and len(text) > 1_200:
+            return _compact_single_line(text)
+        return text, {
+            "original_lines": len(lines),
+            "compacted_lines": len(lines),
+            "strategy": "unchanged-line-count",
+        }
+
+    head = lines[:head_lines]
+    tail = lines[-tail_lines:]
+    interesting = _interesting_lines(lines)
+
+    omitted = max(0, len(lines) - len(head) - len(tail))
+    parts: list[str] = []
+    parts.extend(head)
+    parts.append(f"... [tool-result-compaction omitted {omitted} middle line(s)] ...")
+    if interesting:
+        parts.append("--- preserved diagnostic lines ---")
+        parts.extend(interesting)
+    parts.append("--- tail ---")
+    parts.extend(tail)
+
+    compacted = "\n".join(parts)
+    return compacted, {
+        "original_lines": len(lines),
+        "compacted_lines": len(compacted.splitlines()),
+        "strategy": "head-diagnostics-tail",
+    }
+
+
+def compact_tool_result(
+    *,
+    tool_name: str,
+    result: Any,
+    threshold_chars: int = _DEFAULT_THRESHOLD_CHARS,
+    head_lines: int = _DEFAULT_HEAD_LINES,
+    tail_lines: int = _DEFAULT_TAIL_LINES,
+    mode: str = _DEFAULT_MODE,
+) -> Optional[str]:
+    """Return a compacted replacement JSON string, or ``None`` to pass through.
+
+    ``mode='observe'`` deliberately returns ``None`` so enabling the plugin is
+    safe before users opt into actual compaction.
+    """
+    if tool_name not in _SUPPORTED_TOOLS:
+        return None
+    if mode != "compact":
+        return None
+    if not isinstance(result, str) or len(result) < threshold_chars:
+        return None
+
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+
+    output = payload.get("output")
+    if not isinstance(output, str) or len(output) < threshold_chars:
+        return None
+
+    compacted_output, metadata = _compact_text(
+        output,
+        head_lines=head_lines,
+        tail_lines=tail_lines,
+    )
+    if len(compacted_output) >= len(output):
+        return None
+
+    compacted_payload = dict(payload)
+    compacted_payload["output"] = compacted_output
+    compacted_payload["tool_result_compaction"] = {
+        "mode": "compact",
+        "original_chars": len(result),
+        "compacted_chars": len(json.dumps(compacted_payload, ensure_ascii=False)),
+        **metadata,
+    }
+    return json.dumps(compacted_payload, ensure_ascii=False)
+
+
+def _transform_tool_result(**kwargs: Any) -> Optional[str]:
+    settings = _load_settings()
+    mode = str(settings.get("mode", _DEFAULT_MODE)).strip().lower()
+    return compact_tool_result(
+        tool_name=str(kwargs.get("tool_name") or ""),
+        result=kwargs.get("result"),
+        threshold_chars=_as_int(
+            settings.get("threshold_chars"),
+            _DEFAULT_THRESHOLD_CHARS,
+            minimum=1,
+        ),
+        head_lines=_as_int(settings.get("head_lines"), _DEFAULT_HEAD_LINES, minimum=1),
+        tail_lines=_as_int(settings.get("tail_lines"), _DEFAULT_TAIL_LINES, minimum=1),
+        mode=mode,
+    )
+
+
+def register(ctx) -> None:
+    ctx.register_hook("transform_tool_result", _transform_tool_result)

--- a/plugins/tool-result-compaction/plugin.yaml
+++ b/plugins/tool-result-compaction/plugin.yaml
@@ -1,0 +1,6 @@
+name: tool-result-compaction
+version: 0.1.0
+description: "Compact high-noise tool results before they enter the LLM context. Opt-in via plugins.enabled; defaults to observe-only unless configured."
+author: "Hermes Agent"
+hooks:
+  - transform_tool_result

--- a/tests/test_tool_result_compaction_plugin.py
+++ b/tests/test_tool_result_compaction_plugin.py
@@ -1,0 +1,144 @@
+"""Tests for the bundled tool-result-compaction plugin.
+
+The plugin is inspired by OpenHuman-style token compression, but implemented
+from scratch for Hermes' existing ``transform_tool_result`` hook.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+
+PLUGIN_PATH = Path(__file__).resolve().parents[1] / "plugins" / "tool-result-compaction" / "__init__.py"
+
+
+def _load_plugin_module():
+    spec = importlib.util.spec_from_file_location("tool_result_compaction_plugin", PLUGIN_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_compacts_large_terminal_json_while_preserving_failure_context():
+    plugin = _load_plugin_module()
+    noisy_output = "\n".join(
+        ["collecting tests"]
+        + [f"tests/test_many.py::{i} PASSED" for i in range(80)]
+        + ["FAILED tests/test_critical.py::test_breakage - AssertionError: boom"]
+        + ["Traceback (most recent call last):", "AssertionError: boom"]
+    )
+    raw = json.dumps({"output": noisy_output, "exit_code": 1})
+
+    compacted = plugin.compact_tool_result(
+        tool_name="terminal",
+        result=raw,
+        threshold_chars=350,
+        head_lines=3,
+        tail_lines=5,
+        mode="compact",
+    )
+
+    assert compacted is not None
+    assert len(compacted) < len(raw)
+    payload = json.loads(compacted)
+    assert payload["exit_code"] == 1
+    assert payload["tool_result_compaction"]["original_chars"] == len(raw)
+    assert payload["tool_result_compaction"]["mode"] == "compact"
+    assert "FAILED tests/test_critical.py::test_breakage" in payload["output"]
+    assert "AssertionError: boom" in payload["output"]
+    assert "tests/test_many.py::79 PASSED" in payload["output"]
+
+
+def test_small_or_non_terminal_results_passthrough():
+    plugin = _load_plugin_module()
+    raw = json.dumps({"output": "short", "exit_code": 0})
+
+    assert plugin.compact_tool_result(
+        tool_name="terminal",
+        result=raw,
+        threshold_chars=350,
+        mode="compact",
+    ) is None
+    assert plugin.compact_tool_result(
+        tool_name="web_extract",
+        result=raw,
+        threshold_chars=1,
+        mode="compact",
+    ) is None
+
+
+def test_observe_mode_records_metadata_without_replacing_result():
+    plugin = _load_plugin_module()
+    raw = json.dumps({"output": "x" * 1000, "exit_code": 0})
+
+    assert plugin.compact_tool_result(
+        tool_name="terminal",
+        result=raw,
+        threshold_chars=100,
+        mode="observe",
+    ) is None
+
+
+def test_compacts_large_single_line_terminal_output():
+    plugin = _load_plugin_module()
+    long_line = "prefix-" + ("x" * 5000) + "-ERROR-critical-failure-" + ("y" * 5000) + "-suffix"
+    raw = json.dumps({"output": long_line, "exit_code": 1})
+
+    compacted = plugin.compact_tool_result(
+        tool_name="terminal",
+        result=raw,
+        threshold_chars=500,
+        head_lines=3,
+        tail_lines=5,
+        mode="compact",
+    )
+
+    assert compacted is not None
+    assert len(compacted) < len(raw)
+    payload = json.loads(compacted)
+    assert payload["exit_code"] == 1
+    assert payload["tool_result_compaction"]["strategy"] == "single-line-head-diagnostics-tail"
+    assert "prefix-" in payload["output"]
+    assert "ERROR-critical-failure" in payload["output"]
+    assert "-suffix" in payload["output"]
+    assert "omitted" in payload["output"]
+
+
+def test_register_wires_transform_tool_result_hook():
+    plugin = _load_plugin_module()
+    registered = {}
+
+    class Ctx:
+        def register_hook(self, name, fn):
+            registered[name] = fn
+
+    plugin.register(Ctx())
+
+    assert "transform_tool_result" in registered
+    assert callable(registered["transform_tool_result"])
+
+
+def test_registered_hook_respects_compact_mode_settings(monkeypatch):
+    plugin = _load_plugin_module()
+    raw = json.dumps({"output": "\n".join(f"line {i}" for i in range(100)), "exit_code": 0})
+    monkeypatch.setattr(
+        plugin,
+        "_load_settings",
+        lambda: {
+            "mode": "compact",
+            "threshold_chars": 100,
+            "head_lines": 2,
+            "tail_lines": 2,
+        },
+    )
+
+    compacted = plugin._transform_tool_result(tool_name="terminal", result=raw)
+
+    assert compacted is not None
+    payload = json.loads(compacted)
+    assert payload["tool_result_compaction"]["mode"] == "compact"
+    assert "line 0" in payload["output"]
+    assert "line 99" in payload["output"]

--- a/website/docs/user-guide/features/built-in-plugins.md
+++ b/website/docs/user-guide/features/built-in-plugins.md
@@ -56,6 +56,7 @@ The repo ships these bundled plugins under `plugins/`. All are opt-in — enable
 | Plugin | Kind | Purpose |
 |---|---|---|
 | `disk-cleanup` | hooks + slash command | Auto-track ephemeral files and clean them on session end |
+| `tool-result-compaction` | hook | Observe or compact high-noise terminal tool results before they enter LLM context |
 | `observability/langfuse` | hooks | Trace turns / LLM calls / tools to [Langfuse](https://langfuse.com) |
 | `spotify` | backend (7 tools) | Native Spotify playback, queue, search, playlists, albums, library |
 | `google_meet` | standalone | Join Meet calls, live-caption transcription, optional realtime duplex audio |
@@ -114,6 +115,56 @@ Auto-tracks and removes ephemeral files created during sessions — test scripts
 **Enabling:** `hermes plugins enable disk-cleanup` (or check the box in `hermes plugins`).
 
 **Disabling again:** `hermes plugins disable disk-cleanup`.
+
+### tool-result-compaction
+
+Compacts high-noise `terminal` tool results before they are appended back into the conversation context. This is useful for test runs, build logs, and command output where the important information is usually at the head, tail, or around failure markers.
+
+The plugin is deliberately conservative:
+
+- It is opt-in like other bundled standalone plugins.
+- Its default mode is `observe`, so enabling it does not rewrite tool results until you explicitly switch to `compact`.
+- It only targets `terminal` results for now.
+- It preserves `exit_code`, head lines, tail lines, and diagnostic lines containing markers such as `FAILED`, `Traceback`, `Exception`, or `AssertionError`.
+- For very long single-line output, it falls back to character-level head / diagnostic span / tail compaction so minified logs and build blobs still shrink.
+- It fails open: invalid JSON, small outputs, unsupported tools, or plugin errors leave the original tool result unchanged.
+
+**Setup:**
+
+```bash
+hermes plugins enable tool-result-compaction
+```
+
+Then choose the operating mode in `~/.hermes/config.yaml`:
+
+```yaml
+plugins:
+  enabled:
+    - tool-result-compaction
+  entries:
+    tool-result-compaction:
+      mode: observe        # observe | compact
+      threshold_chars: 12000
+      head_lines: 40
+      tail_lines: 80
+```
+
+Switch `mode` to `compact` only after you are comfortable with the compressed format.
+
+**How it works:**
+
+| Hook | Behaviour |
+|---|---|
+| `transform_tool_result` | Receives the final tool-result string after `post_tool_call`. In `compact` mode, large terminal JSON payloads get rewritten with a shorter `output` plus a `tool_result_compaction` metadata block. |
+
+**Verify:**
+
+```bash
+hermes plugins list                 # tool-result-compaction should show "enabled"
+python -m pytest tests/test_tool_result_compaction_plugin.py -q -o 'addopts='
+```
+
+**Disabling:** `hermes plugins disable tool-result-compaction`.
 
 ### observability/langfuse
 


### PR DESCRIPTION
## Summary
- Add a built-in tool result compaction plugin for shrinking large tool outputs before they enter context.
- Wire plugin discovery/configuration and CLI plugin visibility.
- Document the plugin in the built-in plugins docs.

## Test Plan
- pytest tests/test_tool_result_compaction_plugin.py tests/test_transform_tool_result_hook.py tests/hermes_cli/test_plugins.py tests/hermes_cli/test_plugins_cmd.py

Result: 152 passed