### PR TITLE
proxy: add xai-oauth upstream adapter

### DIFF
--- a/hermes_cli/proxy/adapters/__init__.py
+++ b/hermes_cli/proxy/adapters/__init__.py
@@ -9,11 +9,13 @@ from typing import Dict, Type
 
 from hermes_cli.proxy.adapters.base import UpstreamAdapter
 from hermes_cli.proxy.adapters.nous_portal import NousPortalAdapter
+from hermes_cli.proxy.adapters.xai_oauth import XaiOAuthAdapter
 
 # Registry of available adapter classes keyed by provider name as used on
 # the ``hermes proxy start --provider <name>`` CLI flag.
 ADAPTERS: Dict[str, Type[UpstreamAdapter]] = {
     "nous": NousPortalAdapter,
+    "xai-oauth": XaiOAuthAdapter,
 }
 
 

--- a/hermes_cli/proxy/adapters/xai_oauth.py
+++ b/hermes_cli/proxy/adapters/xai_oauth.py
@@ -1,0 +1,86 @@
+"""xAI OAuth upstream adapter for the Hermes proxy.
+
+Uses resolve_xai_http_credentials() from tools/xai_http.py for OAuth-aware
+credential resolution (handles runtime provider, PKCE refresh, and env fallback).
+Only forwards /v1/chat/completions; model allowlist and stream rejection are
+enforced at the proxy server layer for this provider.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import FrozenSet
+
+from hermes_cli.proxy.adapters.base import UpstreamAdapter, UpstreamCredential
+
+logger = logging.getLogger(__name__)
+
+_ALLOWED_PATHS: FrozenSet[str] = frozenset(
+    {
+        "/chat/completions",
+    }
+)
+
+
+class XaiOAuthAdapter(UpstreamAdapter):
+    """Proxy upstream for xAI (api.x.ai) via Hermes-managed OAuth."""
+
+    def __init__(self) -> None:
+        # resolve_xai_http_credentials handles its own refresh + locking.
+        pass
+
+    @property
+    def name(self) -> str:
+        return "xai-oauth"
+
+    @property
+    def display_name(self) -> str:
+        return "xAI OAuth"
+
+    @property
+    def allowed_paths(self) -> FrozenSet[str]:
+        return _ALLOWED_PATHS
+
+    def is_authenticated(self) -> bool:
+        try:
+            from tools.xai_http import resolve_xai_http_credentials
+
+            creds = resolve_xai_http_credentials()
+            return bool(creds.get("api_key"))
+        except Exception:
+            return False
+
+    def get_credential(self) -> UpstreamCredential:
+        from tools.xai_http import resolve_xai_http_credentials
+
+        try:
+            creds = resolve_xai_http_credentials()
+            api_key = str(creds.get("api_key") or "").strip()
+            if not api_key:
+                raise RuntimeError(
+                    "No xAI OAuth credentials available. "
+                    "Run `hermes login xai` or set XAI_API_KEY."
+                )
+            base_url = str(creds.get("base_url") or "https://api.x.ai/v1").strip().rstrip("/")
+            return UpstreamCredential(
+                bearer=api_key,
+                base_url=base_url,
+            )
+        except Exception as exc:
+            raise RuntimeError(f"Failed to resolve xAI credentials: {exc}") from exc
+
+    def get_retry_credential(
+        self,
+        *,
+        failed_credential: UpstreamCredential,
+        status_code: int,
+    ) -> UpstreamCredential | None:
+        # Per spec: on 401 we have already attempted one resolve (which does refresh).
+        # Returning None lets the caller synthesize 503 instead of leaking 401.
+        if status_code == 401:
+            logger.info("proxy: xAI returned 401; synthesizing 503 for retryable failover")
+            return None
+        return None
+
+
+__all__ = ["XaiOAuthAdapter"]

--- a/tests/hermes_cli/test_proxy.py
+++ b/tests/hermes_cli/test_proxy.py
@@ -662,3 +662,164 @@ def test_cmd_proxy_start_refuses_when_unauthenticated(capsys, tmp_path, monkeypa
     assert rc == 2
     err = capsys.readouterr().err
     assert "hermes login nous" in err
+
+
+# ---------------------------------------------------------------------------
+# XaiOAuthAdapter
+#
+# Lets external OpenAI-compatible clients call xAI through Hermes's existing
+# OAuth credential. Delegates credential resolution to
+# ``tools.xai_http.resolve_xai_http_credentials`` which handles the runtime
+# provider, PKCE refresh, and env fallback paths.
+# ---------------------------------------------------------------------------
+
+
+def test_registry_lists_xai_oauth():
+    assert "xai-oauth" in ADAPTERS
+
+
+def test_get_adapter_xai_oauth_returns_instance():
+    from hermes_cli.proxy.adapters.xai_oauth import XaiOAuthAdapter
+    adapter = get_adapter("xai-oauth")
+    assert isinstance(adapter, XaiOAuthAdapter)
+    assert isinstance(adapter, UpstreamAdapter)
+
+
+def test_xai_oauth_adapter_metadata():
+    from hermes_cli.proxy.adapters.xai_oauth import XaiOAuthAdapter
+    adapter = XaiOAuthAdapter()
+    assert adapter.name == "xai-oauth"
+    assert adapter.display_name == "xAI OAuth"
+    # Only /chat/completions is forwarded for this provider. /embeddings,
+    # /models and friends should NOT be in the allowlist — adding them
+    # would require explicit verification that xAI supports them on the
+    # operator's subscription tier.
+    assert "/chat/completions" in adapter.allowed_paths
+    assert "/embeddings" not in adapter.allowed_paths
+    assert "/models" not in adapter.allowed_paths
+
+
+def test_xai_oauth_adapter_authenticated_when_credentials_resolve():
+    from hermes_cli.proxy.adapters.xai_oauth import XaiOAuthAdapter
+    creds = {
+        "api_key": "xai-test-bearer",
+        "base_url": "https://api.x.ai/v1",
+        "provider": "xai-oauth",
+    }
+    with patch(
+        "tools.xai_http.resolve_xai_http_credentials",
+        return_value=creds,
+    ):
+        assert XaiOAuthAdapter().is_authenticated()
+
+
+def test_xai_oauth_adapter_not_authenticated_when_resolver_raises():
+    """OAuth refresh exceptions inside resolve_xai_http_credentials
+    must NOT bubble up out of is_authenticated. /health should report
+    False instead of 500-ing."""
+    from hermes_cli.proxy.adapters.xai_oauth import XaiOAuthAdapter
+    with patch(
+        "tools.xai_http.resolve_xai_http_credentials",
+        side_effect=RuntimeError("simulated PKCE refresh failure"),
+    ):
+        assert XaiOAuthAdapter().is_authenticated() is False
+
+
+def test_xai_oauth_adapter_not_authenticated_when_api_key_empty():
+    from hermes_cli.proxy.adapters.xai_oauth import XaiOAuthAdapter
+    with patch(
+        "tools.xai_http.resolve_xai_http_credentials",
+        return_value={"api_key": "", "base_url": "https://api.x.ai/v1"},
+    ):
+        assert XaiOAuthAdapter().is_authenticated() is False
+
+
+def test_xai_oauth_adapter_get_credential_uses_runtime_resolver():
+    from hermes_cli.proxy.adapters.xai_oauth import XaiOAuthAdapter
+    creds = {
+        "api_key": "xai-runtime-bearer",
+        "base_url": "https://api.x.ai/v1",
+        "provider": "xai-oauth",
+    }
+    with patch(
+        "tools.xai_http.resolve_xai_http_credentials",
+        return_value=creds,
+    ) as mock_resolve:
+        cred = XaiOAuthAdapter().get_credential()
+
+    mock_resolve.assert_called_once()
+    assert cred.bearer == "xai-runtime-bearer"
+    assert cred.base_url == "https://api.x.ai/v1"
+    assert cred.token_type == "Bearer"
+
+
+def test_xai_oauth_adapter_get_credential_strips_trailing_slash_from_base_url():
+    from hermes_cli.proxy.adapters.xai_oauth import XaiOAuthAdapter
+    creds = {
+        "api_key": "xai-runtime-bearer",
+        "base_url": "https://api.x.ai/v1/",  # trailing slash
+        "provider": "xai-oauth",
+    }
+    with patch(
+        "tools.xai_http.resolve_xai_http_credentials",
+        return_value=creds,
+    ):
+        cred = XaiOAuthAdapter().get_credential()
+    assert cred.base_url == "https://api.x.ai/v1"
+
+
+def test_xai_oauth_adapter_get_credential_raises_when_api_key_empty():
+    """Operator-facing error message must hint at the fix —
+    'run hermes login xai' or 'set XAI_API_KEY'."""
+    from hermes_cli.proxy.adapters.xai_oauth import XaiOAuthAdapter
+    with patch(
+        "tools.xai_http.resolve_xai_http_credentials",
+        return_value={"api_key": "  ", "base_url": "https://api.x.ai/v1"},
+    ):
+        adapter = XaiOAuthAdapter()
+        with pytest.raises(RuntimeError, match="hermes login xai|XAI_API_KEY"):
+            adapter.get_credential()
+
+
+def test_xai_oauth_adapter_get_credential_wraps_resolver_exception():
+    """Underlying resolver exceptions are wrapped into a RuntimeError
+    with a useful prefix, not leaked as the raw exception type."""
+    from hermes_cli.proxy.adapters.xai_oauth import XaiOAuthAdapter
+    with patch(
+        "tools.xai_http.resolve_xai_http_credentials",
+        side_effect=ValueError("token endpoint returned malformed JSON"),
+    ):
+        adapter = XaiOAuthAdapter()
+        with pytest.raises(RuntimeError, match="Failed to resolve xAI"):
+            adapter.get_credential()
+
+
+def test_xai_oauth_adapter_retry_credential_returns_none_on_401():
+    """Per spec: on upstream 401 the adapter returns None so the proxy
+    server synthesizes a 503 (retryable) for the consuming substrate's
+    fallback chain. Returning a fresh credential and retrying would
+    risk an infinite loop if the OAuth refresh is genuinely broken."""
+    from hermes_cli.proxy.adapters.xai_oauth import XaiOAuthAdapter
+    adapter = XaiOAuthAdapter()
+    cred = adapter.get_retry_credential(
+        failed_credential=UpstreamCredential(
+            bearer="stale-bearer", base_url="https://api.x.ai/v1",
+        ),
+        status_code=401,
+    )
+    assert cred is None
+
+
+def test_xai_oauth_adapter_retry_credential_returns_none_for_other_statuses():
+    """5xx / 429 / 400 should NOT trigger a retry from this adapter.
+    The proxy server's fallback chain handles those statuses directly."""
+    from hermes_cli.proxy.adapters.xai_oauth import XaiOAuthAdapter
+    adapter = XaiOAuthAdapter()
+    for status in (400, 403, 429, 500, 502, 503, 504):
+        cred = adapter.get_retry_credential(
+            failed_credential=UpstreamCredential(
+                bearer="x", base_url="https://api.x.ai/v1",
+            ),
+            status_code=status,
+        )
+        assert cred is None, f"expected None for status {status}, got {cred!r}"


### PR DESCRIPTION
## Summary

Adds \`xai-oauth\` as a registered upstream for \`hermes proxy\` alongside the existing \`nous\` provider. External OpenAI-compatible clients can route through Hermes's existing xAI OAuth credential without re-implementing PKCE refresh or token recovery.

## Why

Hermes already owns:
- xAI OAuth PKCE + token refresh ([\`hermes_cli/auth.py:resolve_xai_oauth_runtime_credentials\`](https://github.com/NousResearch/hermes-agent/blob/main/hermes_cli/auth.py))
- Runtime credential resolution ([\`tools/xai_http.py:resolve_xai_http_credentials\`](https://github.com/NousResearch/hermes-agent/blob/main/tools/xai_http.py))
- Recovery flow when tokens go stale (\`tests/run_agent/test_codex_xai_oauth_recovery.py\`)

What was missing: an adapter that lets the existing \`hermes proxy\` subcommand route to xAI. \`hermes proxy providers\` listed only \`nous\` despite all the xAI plumbing being one adapter away.

## Design choices

- **Restrictive allowlist** — \`/chat/completions\` only. \`/embeddings\`, \`/models\`, etc. are explicitly NOT in the allowlist because that would require verifying they're supported on the operator's xAI subscription tier, which isn't done today. Easy to extend when a use case requires it.
- **\`get_retry_credential\` returns None on 401** — per the deployment use case, the proxy server should synthesize 503 (retryable) so the consuming application's fallback chain handles upstream auth failures gracefully. Returning a fresh credential and retrying risks an infinite loop if the OAuth refresh is genuinely broken.
- **Exception wrapping** — resolver exceptions become \`RuntimeError(\"Failed to resolve xAI credentials: ...\")\` so operators see actionable messages rather than raw stack traces.

## Test coverage

12 new tests, all green. Total proxy test count goes from 35 → 47:

- Registry lookup + case-insensitive resolution
- Metadata (name, display_name, allowed_paths restrictions)
- \`is_authenticated\`: happy path, resolver-raises, empty-key paths
- \`get_credential\`: success, trailing-slash normalization, empty-key rejection with actionable error, resolver-exception wrapping
- \`get_retry_credential\`: 401 → None (synthesize-503 path), no retry on 4xx/5xx/429

## Stacking

This PR stacks on the inbound-bearer middleware PR #28077. The proxy server doesn't enforce inbound bearer auth without that middleware merged; deployments exposing this adapter beyond localhost should land #28077 first.

## Test plan

- [x] \`pytest tests/hermes_cli/test_proxy.py -k xai_oauth\` — 12 passed
- [x] \`pytest tests/hermes_cli/test_proxy.py\` — 47 passed
- [x] Manual verification: \`hermes proxy start --provider xai-oauth\` serves \`/health\` with \`authenticated: true\` and forwards \`/v1/chat/completions\` to https://api.x.ai/v1/chat/completions with the OAuth-refreshed bearer