### PR TITLE
fix(gateway): mark final voice reply as notify-worthy so Telegram delivers it audibly

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10610,13 +10610,24 @@ class GatewayRunner:
             elif adapter and hasattr(adapter, "send_voice"):
                 reply_anchor = self._reply_anchor_for_event(event)
                 thread_meta = self._thread_metadata_for_source(event.source, reply_anchor)
+                # Mark the auto voice reply as notify-worthy.  Mirrors the
+                # final-text path in gateway/platforms/base.py which sets
+                # ``notify=True`` so platform adapters that gate push
+                # notifications (Telegram "important" mode) deliver the
+                # final voice reply as a normal notification instead of a
+                # silent message.  Clone first so we don't mutate metadata
+                # shared with concurrent typing-indicator state.
+                if thread_meta is not None:
+                    thread_meta = dict(thread_meta)
+                    thread_meta["notify"] = True
+                else:
+                    thread_meta = {"notify": True}
                 send_kwargs: Dict[str, Any] = {
                     "chat_id": event.source.chat_id,
                     "audio_path": actual_path,
                     "reply_to": reply_anchor,
+                    "metadata": thread_meta,
                 }
-                if thread_meta:
-                    send_kwargs["metadata"] = thread_meta
                 await adapter.send_voice(**send_kwargs)
         except Exception as e:
             logger.warning("Auto voice reply failed: %s", e, exc_info=True)

--- a/tests/gateway/test_send_voice_reply_notify.py
+++ b/tests/gateway/test_send_voice_reply_notify.py
@@ -1,0 +1,116 @@
+"""Regression test for issue #27970 Bug 2.
+
+The auto Telegram voice reply (``GatewayRunner._send_voice_reply``) is the
+final response of a turn. It must mark its metadata as ``notify=True`` so
+adapters that gate push notifications (Telegram's "important" mode) deliver
+it as a normal push instead of a silent message — mirroring the existing
+final-text path in ``gateway/platforms/base.py``.
+"""
+
+import json
+import os
+import tempfile
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+def _make_event(thread_id=None):
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="208214988",
+        user_id="208214988",
+        chat_type="dm",
+        thread_id=thread_id,
+    )
+    return MessageEvent(
+        text="hi",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="m1",
+    )
+
+
+def _runner_with_adapter(send_voice_mock):
+    runner = object.__new__(GatewayRunner)
+    adapter = SimpleNamespace(
+        send_voice=send_voice_mock,
+        is_in_voice_channel=lambda *_a, **_k: False,
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    return runner
+
+
+def _fake_tts_call(monkeypatch, audio_bytes=b"\x00" * 32):
+    """Patch the TTS tool so it writes a real file at the requested path."""
+
+    def _fake_text_to_speech_tool(*, text, output_path, **_kwargs):
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        with open(output_path, "wb") as fh:
+            fh.write(audio_bytes)
+        return json.dumps({"success": True, "file_path": output_path})
+
+    monkeypatch.setattr(
+        "tools.tts_tool.text_to_speech_tool",
+        _fake_text_to_speech_tool,
+    )
+    monkeypatch.setattr(
+        "tools.tts_tool._strip_markdown_for_tts",
+        lambda text: text,
+    )
+
+
+@pytest.mark.asyncio
+async def test_voice_reply_marks_metadata_notify_true_for_dm(monkeypatch, tmp_path):
+    """Final voice reply with no thread metadata gets a fresh notify=True dict."""
+    monkeypatch.setattr(tempfile, "gettempdir", lambda: str(tmp_path))
+    _fake_tts_call(monkeypatch)
+
+    send_voice = AsyncMock()
+    runner = _runner_with_adapter(send_voice)
+    event = _make_event()
+
+    await runner._send_voice_reply(event, "Hello there.")
+
+    send_voice.assert_awaited_once()
+    kwargs = send_voice.await_args.kwargs
+    assert kwargs["metadata"] is not None, "metadata must be set so notify flag reaches adapter"
+    assert kwargs["metadata"].get("notify") is True
+
+
+@pytest.mark.asyncio
+async def test_voice_reply_marks_existing_thread_metadata_without_mutation(monkeypatch, tmp_path):
+    """When thread metadata exists (Telegram DM-topic), notify=True is added without mutating the source dict."""
+    monkeypatch.setattr(tempfile, "gettempdir", lambda: str(tmp_path))
+    _fake_tts_call(monkeypatch)
+
+    send_voice = AsyncMock()
+    runner = _runner_with_adapter(send_voice)
+    # Use a DM topic source so _thread_metadata_for_source returns a non-None dict.
+    event = _make_event(thread_id="17585")
+    source_meta_snapshot = runner._thread_metadata_for_source(
+        event.source, runner._reply_anchor_for_event(event)
+    )
+    assert source_meta_snapshot is not None
+    snapshot_copy = dict(source_meta_snapshot)
+
+    await runner._send_voice_reply(event, "Hello there.")
+
+    send_voice.assert_awaited_once()
+    kwargs = send_voice.await_args.kwargs
+    assert kwargs["metadata"].get("notify") is True
+    # All pre-existing thread keys are preserved.
+    for k, v in snapshot_copy.items():
+        assert kwargs["metadata"].get(k) == v
+    # The freshly-computed source-side metadata must NOT have been mutated
+    # (would otherwise leak notify=True into the typing-indicator state).
+    fresh = runner._thread_metadata_for_source(
+        event.source, runner._reply_anchor_for_event(event)
+    )
+    assert "notify" not in fresh

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -463,6 +463,9 @@ class TestSendVoiceReply:
             "telegram_dm_topic_reply_fallback": True,
             "direct_messages_topic_id": "20197",
             "telegram_reply_to_message_id": "462",
+            # Final voice reply is notify-worthy (issue #27970 Bug 2):
+            # mirrors the final-text path in gateway/platforms/base.py.
+            "notify": True,
         }
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Marks Hermes's auto voice reply (the TTS-generated final response for users with `voice.auto_tts` enabled) as **notify-worthy** so Telegram delivers the final voice note as a normal push instead of a silent message. Mirrors the final-text precedent in `gateway/platforms/base.py:3214`, which already sets `metadata["notify"] = True` for the final text response. In Telegram's default `notifications=important` mode, `TelegramPlatformAdapter._notification_kwargs()` returns `disable_notification=True` for every send unless `metadata["notify"]` is truthy; the auto-TTS path through `GatewayRunner._send_voice_reply` was forwarding thread metadata unmodified, so the final voice note arrived silently. The fix clones the thread metadata and sets `notify=True` before passing it to `adapter.send_voice` (clone-then-mark so we don't leak `notify=True` back into the typing-indicator state that shares this metadata).

## Related Issue

Fixes #27970 (Bug 2 of 2 — the silent-final-voice-reply piece; Bug 1, MP3 vs. native OGG fallback, is already covered by open PRs #20182 and #20878 per alt-glitch's pointer on the issue thread, and the reporter agreed to split).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py` — in `_send_voice_reply`, clone `thread_meta` and set `notify=True` before passing it to `adapter.send_voice` so Telegram's `_notification_kwargs` does not strip the push notification. Clone-then-mark to avoid leaking `notify=True` into the shared typing-indicator metadata.
- `tests/gateway/test_send_voice_reply_notify.py` — new regression file with two cases (DM with no thread metadata gets a fresh `{"notify": True}`; DM topic with existing thread metadata gets `notify=True` added without mutating the source dict).
- `tests/gateway/test_voice_command.py` — updated `TestSendVoiceReply::test_auto_voice_reply_uses_thread_metadata_helper` to assert `notify: True` in the dispatched metadata.

## How to Test

1. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/gateway/test_voice_command.py tests/gateway/test_send_voice_reply_notify.py -v` — 8 passed.
2. Adjacent suites also pass: `tests/gateway/test_tts_media_routing.py`, `tests/gateway/test_voice_mode_platform_isolation.py`, `tests/gateway/test_matrix_voice.py`.
3. Regression guard: the two new tests fail against `origin/main` with `AssertionError: notify is None`, and pass with the fix applied.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Sibling Audit

> Sibling code paths that may need the same fix: `GatewayRunner._deliver_media_from_response` (`gateway/run.py:10630`) also delivers final-turn voice/audio media via `adapter.send_voice` without `notify=True`. Intentionally left out of this PR's scope to keep the diff small — happy to widen if preferred.

Other platforms (Discord, Slack, Matrix) ignore `metadata["notify"]`, so they are unaffected.
