### PR TITLE
fix: scope plugin manager by profile home

### DIFF
--- a/docs/ADR.md
+++ b/docs/ADR.md
@@ -1,0 +1,16 @@
+# Architecture Decision Records
+
+## 2026-05-18: Scope plugin manager state by Hermes home/profile
+
+Status: Accepted
+
+Context:
+Hermes supports multiple profiles via different `HERMES_HOME` directories. The plugin manager was a process-global singleton, while user-installed plugins are discovered from `get_hermes_home() / "plugins"`. Context-engine plugins such as `hermes-lcm` capture profile-scoped state during registration, including the LCM database path.
+
+Decision:
+The plugin manager cache is now keyed to the active Hermes home. When `HERMES_HOME` changes inside a long-lived process, Hermes creates a fresh `PluginManager` so context engines and plugin state are loaded from the correct profile. Legacy tests/embedders that monkeypatch `_plugin_manager` directly are still supported by adopting the injected manager for the current home.
+
+Consequences:
+- Per-profile LCM instances use their own `{HERMES_HOME}/lcm.db` instead of reusing the first profile loaded in a process.
+- Plugin discovery remains cached within a profile for normal performance.
+- Sequential profile switching in tests, gateway workers, or embedded callers no longer leaks context-engine state across profiles.

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1382,13 +1382,45 @@ class PluginManager:
 # ---------------------------------------------------------------------------
 
 _plugin_manager: Optional[PluginManager] = None
+_plugin_manager_home: Optional[Path] = None
+_plugin_manager_obj_id: Optional[int] = None
+
+
+def _plugin_home_key() -> Path:
+    """Return the profile/home key for process-global plugin state.
+
+    Plugins are discovered from ``get_hermes_home() / "plugins"`` and some
+    plugins (notably context engines such as hermes-lcm) capture that home at
+    registration time for profile-scoped storage.  A long-lived process can
+    temporarily switch ``HERMES_HOME`` while serving another profile, so the
+    singleton manager must be scoped to the active Hermes home instead of being
+    one process-wide cache.
+    """
+    try:
+        return get_hermes_home().expanduser().resolve()
+    except Exception:
+        return get_hermes_home().expanduser()
 
 
 def get_plugin_manager() -> PluginManager:
-    """Return (and lazily create) the global PluginManager singleton."""
-    global _plugin_manager
-    if _plugin_manager is None:
+    """Return the plugin manager for the active Hermes profile/home."""
+    global _plugin_manager, _plugin_manager_home, _plugin_manager_obj_id
+    current_home = _plugin_home_key()
+    current_obj_id = id(_plugin_manager) if _plugin_manager is not None else None
+
+    # Tests and embedders historically monkeypatch ``_plugin_manager``
+    # directly.  If that happened, adopt the injected manager for the current
+    # home instead of throwing it away because our profile-scope bookkeeping is
+    # stale.
+    if _plugin_manager is not None and current_obj_id != _plugin_manager_obj_id:
+        _plugin_manager_home = current_home
+        _plugin_manager_obj_id = current_obj_id
+        return _plugin_manager
+
+    if _plugin_manager is None or _plugin_manager_home != current_home:
         _plugin_manager = PluginManager()
+        _plugin_manager_home = current_home
+        _plugin_manager_obj_id = id(_plugin_manager)
     return _plugin_manager
 
 

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1207,6 +1207,64 @@ class TestPluginCommands:
             assert engine is not None
             assert engine.name == "stub-engine"
 
+    def test_plugin_context_engine_is_scoped_by_hermes_home(self, tmp_path, monkeypatch):
+        """Profile switches must not reuse a context engine from another home."""
+        import hermes_cli.plugins as plugins_mod
+
+        def write_engine_plugin(home: Path) -> None:
+            plugin_dir = home / "plugins" / "engine-plugin"
+            plugin_dir.mkdir(parents=True)
+            (plugin_dir / "plugin.yaml").write_text(
+                yaml.safe_dump({
+                    "name": "engine-plugin",
+                    "version": "0.1.0",
+                    "description": "Context engine plugin for profile-scope test",
+                })
+            )
+            (plugin_dir / "__init__.py").write_text(
+                "import os\n"
+                "from agent.context_engine import ContextEngine\n\n"
+                "class HomeEngine(ContextEngine):\n"
+                "    def __init__(self):\n"
+                "        self.home = os.environ.get('HERMES_HOME')\n\n"
+                "    @property\n"
+                "    def name(self):\n"
+                "        return 'home-engine'\n\n"
+                "    def update_from_response(self, usage):\n"
+                "        return None\n\n"
+                "    def should_compress(self, prompt_tokens=None):\n"
+                "        return False\n\n"
+                "    def compress(self, messages, current_tokens=None, focus_topic=None):\n"
+                "        return messages\n\n"
+                "def register(ctx):\n"
+                "    ctx.register_context_engine(HomeEngine())\n"
+            )
+            (home / "config.yaml").write_text(
+                yaml.safe_dump({"plugins": {"enabled": ["engine-plugin"]}})
+            )
+
+        home_a = tmp_path / "profile-a"
+        home_b = tmp_path / "profile-b"
+        write_engine_plugin(home_a)
+        write_engine_plugin(home_b)
+
+        with (
+            patch.object(plugins_mod, "_plugin_manager", None),
+            patch.object(plugins_mod, "_plugin_manager_home", None),
+            patch.object(plugins_mod, "_plugin_manager_obj_id", None),
+        ):
+            monkeypatch.setenv("HERMES_HOME", str(home_a))
+            engine_a = plugins_mod.get_plugin_context_engine()
+
+            monkeypatch.setenv("HERMES_HOME", str(home_b))
+            engine_b = plugins_mod.get_plugin_context_engine()
+
+        assert engine_a is not None
+        assert engine_b is not None
+        assert engine_a is not engine_b
+        assert engine_a.home == str(home_a)
+        assert engine_b.home == str(home_b)
+
     def test_commands_tracked_on_loaded_plugin(self, tmp_path, monkeypatch):
         """Commands registered during discover_and_load() are tracked on LoadedPlugin."""
         plugins_dir = tmp_path / "hermes_test" / "plugins"

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1212,35 +1212,29 @@ class TestPluginCommands:
         import hermes_cli.plugins as plugins_mod
 
         def write_engine_plugin(home: Path) -> None:
-            plugin_dir = home / "plugins" / "engine-plugin"
-            plugin_dir.mkdir(parents=True)
-            (plugin_dir / "plugin.yaml").write_text(
-                yaml.safe_dump({
-                    "name": "engine-plugin",
-                    "version": "0.1.0",
+            _make_plugin_dir(
+                home / "plugins",
+                "engine-plugin",
+                manifest_extra={
                     "description": "Context engine plugin for profile-scope test",
-                })
-            )
-            (plugin_dir / "__init__.py").write_text(
-                "import os\n"
-                "from agent.context_engine import ContextEngine\n\n"
-                "class HomeEngine(ContextEngine):\n"
-                "    def __init__(self):\n"
-                "        self.home = os.environ.get('HERMES_HOME')\n\n"
-                "    @property\n"
-                "    def name(self):\n"
-                "        return 'home-engine'\n\n"
-                "    def update_from_response(self, usage):\n"
-                "        return None\n\n"
-                "    def should_compress(self, prompt_tokens=None):\n"
-                "        return False\n\n"
-                "    def compress(self, messages, current_tokens=None, focus_topic=None):\n"
-                "        return messages\n\n"
-                "def register(ctx):\n"
-                "    ctx.register_context_engine(HomeEngine())\n"
-            )
-            (home / "config.yaml").write_text(
-                yaml.safe_dump({"plugins": {"enabled": ["engine-plugin"]}})
+                },
+                register_body=(
+                    "import os\n"
+                    "    from agent.context_engine import ContextEngine\n\n"
+                    "    class HomeEngine(ContextEngine):\n"
+                    "        def __init__(self):\n"
+                    "            self.home = os.environ.get('HERMES_HOME')\n\n"
+                    "        @property\n"
+                    "        def name(self):\n"
+                    "            return 'home-engine'\n\n"
+                    "        def update_from_response(self, usage):\n"
+                    "            return None\n\n"
+                    "        def should_compress(self, prompt_tokens=None):\n"
+                    "            return False\n\n"
+                    "        def compress(self, messages, current_tokens=None, focus_topic=None):\n"
+                    "            return messages\n\n"
+                    "    ctx.register_context_engine(HomeEngine())"
+                ),
             )
 
         home_a = tmp_path / "profile-a"


### PR DESCRIPTION
## Summary\n- Scope the plugin manager cache to the active Hermes home/profile instead of one process-global singleton\n- Prevent context-engine plugins like hermes-lcm from reusing another profile's engine and lcm.db\n- Add regression coverage for switching HERMES_HOME between profiles\n- Document the decision in docs/ADR.md\n\n## Verification\n- venv/bin/python -m pytest tests/hermes_cli/test_plugins.py tests/agent/test_context_engine.py tests/hermes_cli/test_plugins_cmd.py -q\n- venv/bin/python -m pytest /Users/blake/.hermes/plugins/hermes-lcm/tests -q\n- Manual smoke: daneel/friend/quentin/argus/dessin each resolve LCM to their own profile lcm.db\n