### PR TITLE
fix(xai-oauth): make loopback callback server threaded + latch first result

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -39,7 +39,7 @@ import webbrowser
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from http.server import BaseHTTPRequestHandler, HTTPServer
+from http.server import BaseHTTPRequestHandler, HTTPServer, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 from urllib.parse import parse_qs, urlencode, urlparse
@@ -2426,8 +2426,9 @@ def _xai_start_callback_server(
     expected_path = XAI_OAUTH_REDIRECT_PATH
     handler_cls, result = _make_xai_callback_handler(expected_path)
 
-    class _ReuseHTTPServer(HTTPServer):
+    class _ReuseHTTPServer(ThreadingHTTPServer):
         allow_reuse_address = True
+        daemon_threads = True
 
     ports_to_try = [preferred_port]
     if preferred_port != 0:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2372,6 +2372,7 @@ def _make_xai_callback_handler(expected_path: str) -> tuple[type[BaseHTTPRequest
         "error": None,
         "error_description": None,
     }
+    result_lock = threading.Lock()
 
     class _XAICallbackHandler(BaseHTTPRequestHandler):
         def _maybe_write_cors_headers(self) -> None:
@@ -2398,16 +2399,27 @@ def _make_xai_callback_handler(expected_path: str) -> tuple[type[BaseHTTPRequest
                 return
 
             params = parse_qs(parsed.query)
-            result["code"] = params.get("code", [None])[0]
-            result["state"] = params.get("state", [None])[0]
-            result["error"] = params.get("error", [None])[0]
-            result["error_description"] = params.get("error_description", [None])[0]
+            incoming = {
+                "code": params.get("code", [None])[0],
+                "state": params.get("state", [None])[0],
+                "error": params.get("error", [None])[0],
+                "error_description": params.get("error_description", [None])[0],
+            }
+            # ThreadingHTTPServer allows a fallback/manual callback to complete
+            # while a browser connection is stuck.  Once we have a terminal
+            # OAuth result (code or error), keep the first one so a later
+            # concurrent/invalid callback cannot overwrite state before
+            # validation in _xai_oauth_loopback_login().
+            if incoming["code"] or incoming["error"]:
+                with result_lock:
+                    if not (result["code"] or result["error"]):
+                        result.update(incoming)
 
             self.send_response(200)
             self._maybe_write_cors_headers()
             self.send_header("Content-Type", "text/html; charset=utf-8")
             self.end_headers()
-            if result["error"]:
+            if incoming["error"]:
                 body = "<html><body><h1>xAI authorization failed.</h1>You can close this tab.</body></html>"
             else:
                 body = "<html><body><h1>xAI authorization received.</h1>You can close this tab.</body></html>"

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1137,6 +1137,9 @@ AUTHOR_MAP = {
     "12735938+zwolniony@users.noreply.github.com": "zwolniony",
     "ambuj@dodopayments.com": "that-ambuj",  # PR #26582 (preserve underscores)
     "zccyman@163.com": "zccyman",  # PR #25294 (custom provider api_key_env alias)
+    # xAI cluster batch salvage (May 2026)
+    "lgndscntn@gmail.com": "Fewmanism",  # PR #27420 (threaded xAI OAuth callback)
+    "slimydog@Faisals-Mac-mini.local": "Slimydog21",  # PR #28021 (strip slash enums xAI Responses)
     "bitkyc08@gmail.com": "lidge-jun",  # PR #26814 (api server browser security headers)
     "sp_ps@Mac-mini.lan": "phoenixshen",  # PR #26768 (respect user-configured vision model)
     "1594534+phoenixshen@users.noreply.github.com": "phoenixshen",

--- a/tests/hermes_cli/test_auth_xai_oauth_provider.py
+++ b/tests/hermes_cli/test_auth_xai_oauth_provider.py
@@ -304,6 +304,28 @@ def test_xai_callback_server_accepts_fallback_code_while_browser_connection_is_s
         thread.join(timeout=1.0)
 
 
+def test_xai_callback_server_latches_first_terminal_callback_result():
+    server, thread, result, redirect_uri = _xai_start_callback_server(preferred_port=0)
+    try:
+        with urllib.request.urlopen(f"{redirect_uri}?code=first-code&state=state-1", timeout=2) as response:
+            assert response.status == 200
+        with urllib.request.urlopen(
+            f"{redirect_uri}?error=access_denied&error_description=late&state=state-2",
+            timeout=2,
+        ) as response:
+            body = response.read().decode("utf-8")
+        assert response.status == 200
+        assert "xAI authorization failed" in body
+        assert result["code"] == "first-code"
+        assert result["state"] == "state-1"
+        assert result["error"] is None
+        assert result["error_description"] is None
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=1.0)
+
+
 # ---------------------------------------------------------------------------
 # Token roundtrip + reads
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_auth_xai_oauth_provider.py
+++ b/tests/hermes_cli/test_auth_xai_oauth_provider.py
@@ -2,7 +2,9 @@
 
 import base64
 import json
+import socket
 import time
+import urllib.request
 from pathlib import Path
 
 import pytest
@@ -20,6 +22,7 @@ from hermes_cli.auth import (
     _xai_access_token_is_expiring,
     _xai_callback_cors_origin,
     _xai_oauth_build_authorize_url,
+    _xai_start_callback_server,
     _xai_validate_loopback_redirect_uri,
     get_xai_oauth_auth_status,
     refresh_xai_oauth_pure,
@@ -276,6 +279,29 @@ def test_xai_callback_cors_origin_rejects_unknown_origin():
     assert _xai_callback_cors_origin("https://attacker.example.com") == ""
     assert _xai_callback_cors_origin(None) == ""
     assert _xai_callback_cors_origin("") == ""
+
+
+def test_xai_callback_server_accepts_fallback_code_while_browser_connection_is_stuck():
+    """Regression: Chrome/xAI can leave a loopback connection open after
+    showing the Grok Build fallback code. A single-threaded callback server then
+    blocks forever and cannot accept the manual fallback callback.
+    """
+    server, thread, result, redirect_uri = _xai_start_callback_server(preferred_port=0)
+    stuck = socket.create_connection((XAI_OAUTH_REDIRECT_HOST, server.server_address[1]), timeout=2)
+    try:
+        stuck.sendall(b"GET /callback?code=stuck")
+        callback_url = f"{redirect_uri}?code=fallback-code&state=state-123"
+        with urllib.request.urlopen(callback_url, timeout=2) as response:
+            body = response.read().decode("utf-8")
+        assert response.status == 200
+        assert "xAI authorization received" in body
+        assert result["code"] == "fallback-code"
+        assert result["state"] == "state-123"
+    finally:
+        stuck.close()
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=1.0)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Salvage of #27420 by @Fewmanism cherry-picked onto current main, with AUTHOR_MAP entry.

## Summary
The xAI OAuth loopback callback server is single-threaded; a stuck connection from accounts.x.ai's fallback flow blocks the legitimate `/callback` request and the CLI times out even though the user successfully authorized.

## Changes
- `hermes_cli/auth.py`: switch to `ThreadingHTTPServer` with `daemon_threads=True`; lock-guarded first-wins latch on (code|error); per-request status in the response HTML
- `tests/hermes_cli/test_auth_xai_oauth_provider.py`: regression test for stuck-connection scenario
- `scripts/release.py`: AUTHOR_MAP entry for @Fewmanism

## Validation
`scripts/run_tests.sh tests/hermes_cli/test_auth_xai_oauth_provider.py` → 65/65 passing.

Closes #27420 (salvage merge — author preserved).