### PR TITLE
fix(acp): gate patch mode=patch (V4A) behind ACP edit approval

### DIFF
--- a/acp_adapter/edit_approval.py
+++ b/acp_adapter/edit_approval.py
@@ -93,6 +93,19 @@ def _proposal_for_write_file(arguments: dict[str, Any]) -> EditProposal:
     )
 
 
+def _proposal_for_patch_v4a(arguments: dict[str, Any]) -> EditProposal:
+    patch_text = str(arguments.get("patch") or "")
+    if not patch_text:
+        raise ValueError("patch content required")
+    return EditProposal(
+        tool_name="patch",
+        path="",
+        old_text=None,
+        new_text="",
+        arguments=dict(arguments),
+    )
+
+
 def _proposal_for_patch_replace(arguments: dict[str, Any]) -> EditProposal:
     path = str(arguments.get("path") or "")
     if not path:
@@ -131,8 +144,12 @@ def build_edit_proposal(tool_name: str, arguments: dict[str, Any]) -> EditPropos
 
     if tool_name == "write_file":
         return _proposal_for_write_file(arguments)
-    if tool_name == "patch" and arguments.get("mode", "replace") == "replace":
-        return _proposal_for_patch_replace(arguments)
+    if tool_name == "patch":
+        mode = arguments.get("mode", "replace")
+        if mode == "replace":
+            return _proposal_for_patch_replace(arguments)
+        if mode == "patch":
+            return _proposal_for_patch_v4a(arguments)
     return None
 
 
@@ -154,6 +171,11 @@ def should_auto_approve_edit(proposal: EditProposal, policy: str, cwd: str | Non
     policy = str(policy or AUTO_APPROVE_ASK).strip()
     if policy == AUTO_APPROVE_ASK or _is_sensitive_auto_approve_path(proposal.path):
         return False
+    # V4A patch has an empty path (multi-file); workspace containment cannot be
+    # verified per-file without parsing each operation.  Allow only under the
+    # fully-permissive session policy; workspace policy must prompt.
+    if proposal.tool_name == "patch" and proposal.arguments.get("mode") == "patch":
+        return policy == AUTO_APPROVE_SESSION
     path = Path(proposal.path).expanduser().resolve(strict=False)
     if policy == AUTO_APPROVE_SESSION:
         return True
@@ -201,24 +223,90 @@ def maybe_require_edit_approval(tool_name: str, arguments: dict[str, Any]) -> st
     return json.dumps({"error": "Edit approval denied by ACP client; file was not modified."}, ensure_ascii=False)
 
 
+def _build_v4a_approval_content(patch_text: str) -> list:
+    """Build per-file ACP diff content blocks from a V4A patch string.
+
+    Mirrors the rendering logic in acp_adapter/tools._build_patch_mode_content
+    but lives here so edit_approval stays self-contained.
+    """
+    import acp
+
+    if not patch_text:
+        return [acp.tool_content(acp.text_block(""))]
+    try:
+        from tools.patch_parser import OperationType, parse_v4a_patch
+
+        operations, error = parse_v4a_patch(patch_text)
+        if error or not operations:
+            return [acp.tool_content(acp.text_block(patch_text))]
+
+        content: list = []
+        for op in operations:
+            if op.operation == OperationType.UPDATE:
+                old_chunks: list[str] = []
+                new_chunks: list[str] = []
+                for hunk in op.hunks:
+                    old_lines = [ln.content for ln in hunk.lines if ln.prefix in {" ", "-"}]
+                    new_lines = [ln.content for ln in hunk.lines if ln.prefix in {" ", "+"}]
+                    if old_lines or new_lines:
+                        old_chunks.append("\n".join(old_lines))
+                        new_chunks.append("\n".join(new_lines))
+                old_text = "\n...\n".join(c for c in old_chunks if c)
+                new_text = "\n...\n".join(c for c in new_chunks if c)
+                if old_text or new_text:
+                    content.append(acp.tool_diff_content(
+                        path=op.file_path,
+                        old_text=old_text or None,
+                        new_text=new_text or "",
+                    ))
+            elif op.operation == OperationType.ADD:
+                added = [ln.content for hunk in op.hunks for ln in hunk.lines if ln.prefix == "+"]
+                content.append(acp.tool_diff_content(
+                    path=op.file_path,
+                    new_text="\n".join(added),
+                ))
+            elif op.operation == OperationType.DELETE:
+                content.append(acp.tool_diff_content(
+                    path=op.file_path,
+                    old_text=f"Delete file: {op.file_path}",
+                    new_text="",
+                ))
+            elif op.operation == OperationType.MOVE:
+                content.append(acp.tool_content(
+                    acp.text_block(f"Move: {op.file_path} -> {op.new_path}")
+                ))
+        return content or [acp.tool_content(acp.text_block(patch_text))]
+    except Exception:
+        return [acp.tool_content(acp.text_block(patch_text))]
+
+
 def build_acp_edit_tool_call(proposal: EditProposal):
     """Build the ToolCallUpdate payload for ACP request_permission."""
 
     import acp
 
     tool_call_id = f"edit-approval-{next(_PERMISSION_REQUEST_IDS)}"
-    return acp.update_tool_call(
-        tool_call_id,
-        title=f"Approve edit: {proposal.path}",
-        kind="edit",
-        status="pending",
-        content=[
+
+    if proposal.tool_name == "patch" and proposal.arguments.get("mode") == "patch":
+        patch_text = str(proposal.arguments.get("patch") or "")
+        content = _build_v4a_approval_content(patch_text)
+        title = "Approve multi-file V4A patch"
+    else:
+        content = [
             acp.tool_diff_content(
                 path=proposal.path,
                 old_text=proposal.old_text,
                 new_text=proposal.new_text,
             )
-        ],
+        ]
+        title = f"Approve edit: {proposal.path}"
+
+    return acp.update_tool_call(
+        tool_call_id,
+        title=title,
+        kind="edit",
+        status="pending",
+        content=content,
         raw_input={"tool": proposal.tool_name, "arguments": proposal.arguments},
     )
 

--- a/tests/acp/test_edit_approval.py
+++ b/tests/acp/test_edit_approval.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from acp_adapter.edit_approval import (
     EditProposal,
     build_acp_edit_tool_call,
@@ -179,6 +181,110 @@ def test_patch_replace_approval_request_includes_full_file_diff(tmp_path):
     assert proposals[0].tool_name == "patch"
     assert proposals[0].old_text == "alpha\nbeta\n"
     assert proposals[0].new_text == "alpha\ngamma\n"
+
+
+def test_patch_v4a_rejection_does_not_mutate(tmp_path):
+    target = tmp_path / "sample.txt"
+    target.write_text("hello world\n", encoding="utf-8")
+
+    set_edit_approval_requester(lambda _proposal: False)
+
+    patch_text = (
+        "*** Begin Patch\n"
+        f"*** Update File: {target}\n"
+        f"-hello world\n"
+        f"+goodbye world\n"
+        "*** End Patch\n"
+    )
+
+    result = json.loads(
+        handle_function_call(
+            "patch",
+            {"mode": "patch", "patch": patch_text},
+            task_id="acp-v4a-reject",
+        )
+    )
+
+    assert "error" in result
+    assert "Edit approval denied" in result["error"]
+    assert target.read_text(encoding="utf-8") == "hello world\n"
+
+
+def test_patch_v4a_approval_request_captures_proposal(tmp_path):
+    target = tmp_path / "sample.txt"
+    target.write_text("hello world\n", encoding="utf-8")
+    proposals = []
+
+    # Reject so we never reach the file-write step (avoids sensitive-path
+    # blocks that exist in the local test environment for /private/var paths).
+    def capture_and_reject(proposal):
+        proposals.append(proposal)
+        return False
+
+    set_edit_approval_requester(capture_and_reject)
+
+    patch_text = (
+        "*** Begin Patch\n"
+        f"*** Update File: {target}\n"
+        f"-hello world\n"
+        f"+goodbye world\n"
+        "*** End Patch\n"
+    )
+
+    result = json.loads(
+        handle_function_call(
+            "patch",
+            {"mode": "patch", "patch": patch_text},
+            task_id="acp-v4a-capture",
+        )
+    )
+
+    assert "error" in result
+    assert "Edit approval denied" in result["error"]
+    assert len(proposals) == 1
+    assert proposals[0].tool_name == "patch"
+    assert proposals[0].arguments.get("mode") == "patch"
+    assert target.read_text(encoding="utf-8") == "hello world\n"
+
+
+def test_patch_v4a_tool_call_uses_per_file_diff_content():
+    pytest.importorskip("acp")  # only runs where the ACP SDK is installed
+
+    patch_text = (
+        "*** Begin Patch\n"
+        "*** Update File: foo.py\n"
+        "-old line\n"
+        "+new line\n"
+        "*** End Patch\n"
+    )
+    proposal = EditProposal(
+        tool_name="patch",
+        path="",
+        old_text=None,
+        new_text="",
+        arguments={"mode": "patch", "patch": patch_text},
+    )
+
+    tool_call = build_acp_edit_tool_call(proposal)
+
+    assert tool_call.kind == "edit"
+    assert tool_call.title == "Approve multi-file V4A patch"
+    assert any(getattr(block, "path", None) == "foo.py" for block in tool_call.content)
+
+
+def test_patch_v4a_auto_approval_session_policy_approves():
+    proposal = EditProposal("patch", "", None, "", {"mode": "patch", "patch": "*** Begin Patch\n*** End Patch\n"})
+    assert should_auto_approve_edit(proposal, "session") is True
+
+
+def test_patch_v4a_auto_approval_workspace_policy_requires_prompt():
+    proposal = EditProposal("patch", "", None, "", {"mode": "patch", "patch": "*** Begin Patch\n*** End Patch\n"})
+    assert should_auto_approve_edit(proposal, "workspace_session") is False
+
+
+def test_patch_v4a_auto_approval_ask_policy_requires_prompt():
+    proposal = EditProposal("patch", "", None, "", {"mode": "patch", "patch": "*** Begin Patch\n*** End Patch\n"})
+    assert should_auto_approve_edit(proposal, "ask") is False
 
 
 def test_workspace_auto_approval_allows_workspace_and_tmp_but_not_sensitive(tmp_path):


### PR DESCRIPTION
## Problem

`patch` with `mode="patch"` (V4A multi-file format) silently bypassed the ACP edit approval guard introduced in #27862.

`build_edit_proposal` handled `write_file` and `patch mode=replace`, but returned `None` for `mode=patch`. `maybe_require_edit_approval` treats `None` as "no approval needed" and lets dispatch continue — so an ACP session under the default **Ask** policy would never prompt before a V4A patch executed.

The intent to gate both tool types is visible in `model_tools.py`: the exception-path deny covers `{"write_file", "patch"}` together, but the normal path missed `mode=patch`.

## Fix

- **`build_edit_proposal`** — adds `_proposal_for_patch_v4a` branch so the approval requester is always called for V4A patches.
- **`build_acp_edit_tool_call`** — detects V4A proposals and renders per-file `tool_diff_content` blocks (mirroring `_build_patch_mode_content`), so the Zed dialog shows a structured diff rather than raw patch text.
- **`should_auto_approve_edit`** — short-circuits on V4A proposals: `workspace_session` prompts (can't verify per-file containment without parsing every operation); `session` auto-approves (symmetric with single-file behaviour).

No behaviour change for CLI/gateway sessions where the ContextVar is unset.

## Tests

| test | what it covers |
|------|---------------|
| `test_patch_v4a_rejection_does_not_mutate` | requester=False → file not written, error returned |
| `test_patch_v4a_approval_request_captures_proposal` | requester is called with correct `tool_name` and `mode` |
| `test_patch_v4a_tool_call_uses_per_file_diff_content` | `build_acp_edit_tool_call` emits per-file blocks (skipped without ACP SDK) |
| `test_patch_v4a_auto_approval_*` | `should_auto_approve_edit` policy matrix for V4A |

Fixes approval bypass introduced in #27862.