### PR TITLE
fix: make diagnostics secret-safe

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -7,6 +7,7 @@ Short tokens (< 18 chars) are fully masked. Longer tokens preserve
 the first 6 and last 4 characters for debuggability.
 """
 
+import hashlib
 import logging
 import os
 import re
@@ -25,9 +26,13 @@ _SENSITIVE_QUERY_PARAMS = frozenset({
     "apikey",
     "client_secret",
     "password",
+    "passwd",
     "auth",
     "jwt",
     "session",
+    "cookie",
+    "credential",
+    "bearer",
     "secret",
     "key",
     "code",           # OAuth authorization codes
@@ -47,9 +52,13 @@ _SENSITIVE_BODY_KEYS = frozenset({
     "apikey",
     "client_secret",
     "password",
+    "passwd",
     "auth",
     "jwt",
+    "bearer",
     "secret",
+    "cookie",
+    "credential",
     "private_key",
     "authorization",
     "key",
@@ -110,6 +119,16 @@ _PREFIX_PATTERNS = [
 _SECRET_ENV_NAMES = r"(?:API_?KEY|TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIAL|AUTH)"
 _ENV_ASSIGN_RE = re.compile(
     rf"([A-Z0-9_]{{0,50}}{_SECRET_ENV_NAMES}[A-Z0-9_]{{0,50}})\s*=\s*(['\"]?)(\S+)\2",
+)
+
+_SENSITIVE_NAME_RE = re.compile(
+    r"(?:api_?key|token|secret|password|passwd|auth|bearer|credential|cookie|jwt|private_?key)",
+    re.IGNORECASE,
+)
+
+_FINGERPRINTABLE_SECRET_NAME_RE = re.compile(
+    r"(?:api_?key|token|jwt|bearer)",
+    re.IGNORECASE,
 )
 
 # JSON field patterns: "apiKey": "value", "token": "value", etc.
@@ -182,6 +201,10 @@ _FORM_BODY_RE = re.compile(
     r"^[A-Za-z_][A-Za-z0-9_.-]*=[^&\s]*(?:&[A-Za-z_][A-Za-z0-9_.-]*=[^&\s]*)+$"
 )
 
+_DIAGNOSTIC_ASSIGN_RE = re.compile(
+    r"(?<![A-Za-z0-9_.-])([A-Za-z_][A-Za-z0-9_.-]*)(\s*=\s*)(['\"]?)([^\s;&]+)\3"
+)
+
 # Compile known prefix patterns into one alternation
 _PREFIX_RE = re.compile(
     r"(?<![A-Za-z0-9_-])(" + "|".join(_PREFIX_PATTERNS) + r")(?![A-Za-z0-9_-])"
@@ -233,6 +256,46 @@ def mask_secret(
     if len(value) < floor:
         return placeholder
     return f"{value[:head]}...{value[-tail:]}"
+
+
+def is_sensitive_name(name: str) -> bool:
+    """Return True when a setting/env name is secret-bearing by convention."""
+    return bool(name and _SENSITIVE_NAME_RE.search(str(name)))
+
+
+def should_fingerprint_secret_name(name: str) -> bool:
+    """Return True when a secret name is likely high-entropy enough to fingerprint.
+
+    Diagnostic fingerprints are useful for API keys/tokens but risky for
+    low-entropy or human-chosen secrets such as passwords, cookies, and generic
+    credentials because a public hash prefix can enable offline confirmation.
+    """
+    return bool(name and _FINGERPRINTABLE_SECRET_NAME_RE.search(str(name)))
+
+
+def secret_fingerprint(value: str) -> str:
+    """Return a non-reversible diagnostic fingerprint for a configured secret."""
+    if value is None:
+        value = ""
+    if not isinstance(value, str):
+        value = str(value)
+    digest = hashlib.sha256(value.encode("utf-8")).hexdigest()[:12]
+    return f"sha256:{digest}, len={len(value)}"
+
+
+def format_secret_status(value: str, *, empty: str = "(not set)", fingerprint: bool = True) -> str:
+    """Format secret presence for shareable diagnostics without revealing characters.
+
+    Unlike :func:`mask_secret`, this helper never preserves the head/tail of
+    the secret. Use it for status/config surfaces that users may paste into
+    support chats. ``fingerprint=True`` provides stable identity/debugging
+    value without exposing reversible substrings.
+    """
+    if not value:
+        return empty
+    if fingerprint:
+        return f"configured ({secret_fingerprint(value)})"
+    return "configured"
 
 
 def _mask_token(token: str) -> str:
@@ -309,7 +372,35 @@ def _redact_form_body(text: str) -> str:
     return _redact_query_string(text.strip())
 
 
-def redact_sensitive_text(text: str, *, force: bool = False, code_file: bool = False) -> str:
+def _is_exact_sensitive_key(key: str) -> bool:
+    normalized = key.lower().replace("-", "_")
+    return normalized in _SENSITIVE_BODY_KEYS or normalized in _SENSITIVE_QUERY_PARAMS
+
+
+def _redact_diagnostic_assignments(text: str, placeholder: str) -> str:
+    """Redact exact sensitive k=v snippets inside diagnostic text.
+
+    This is intentionally diagnostics-only: unlike the uppercase env-var pass,
+    it catches lower-case snippets such as `password=hunter2` while avoiding
+    substring matches like `prompt_tokens=123`.
+    """
+    def _sub(m: re.Match) -> str:
+        key, sep, quote, _value = m.group(1), m.group(2), m.group(3), m.group(4)
+        if not _is_exact_sensitive_key(key):
+            return m.group(0)
+        return f"{key}{sep}{quote}{placeholder}{quote}"
+
+    return _DIAGNOSTIC_ASSIGN_RE.sub(_sub, text)
+
+
+def redact_sensitive_text(
+    text: str,
+    *,
+    force: bool = False,
+    code_file: bool = False,
+    preserve_tokens: bool = True,
+    placeholder: str = "***",
+) -> str:
     """Apply all redaction patterns to a block of text.
 
     Safe to call on any string -- non-matching text passes through unchanged.
@@ -321,6 +412,9 @@ def redact_sensitive_text(text: str, *, force: bool = False, code_file: bool = F
     patterns when the text is known to be source code (e.g. MAX_TOKENS=***
     constants, "apiKey": "test" fixtures). Prefix patterns, auth headers,
     private keys, DB connstrings, JWTs, and URL secrets are still redacted.
+
+    Set preserve_tokens=False for shareable diagnostics where even prefix/suffix
+    token fragments must not be emitted.
     """
     if text is None:
         return None
@@ -331,32 +425,42 @@ def redact_sensitive_text(text: str, *, force: bool = False, code_file: bool = F
     if not (force or _REDACT_ENABLED):
         return text
 
+    def _display_token(token: str) -> str:
+        if preserve_tokens:
+            return _mask_token(token)
+        return placeholder
+
     # Known prefixes (sk-, ghp_, etc.)
-    text = _PREFIX_RE.sub(lambda m: _mask_token(m.group(1)), text)
+    text = _PREFIX_RE.sub(lambda m: _display_token(m.group(1)), text)
 
     # ENV assignments: OPENAI_API_KEY=***  (skip for code files — false positives)
     if not code_file:
         def _redact_env(m):
             name, quote, value = m.group(1), m.group(2), m.group(3)
-            return f"{name}={quote}{_mask_token(value)}{quote}"
+            return f"{name}={quote}{_display_token(value)}{quote}"
         text = _ENV_ASSIGN_RE.sub(_redact_env, text)
 
         # JSON fields: "apiKey": "***"  (skip for code files — false positives)
         def _redact_json(m):
             key, value = m.group(1), m.group(2)
-            return f'{key}: "{_mask_token(value)}"'
+            return f'{key}: "{_display_token(value)}"'
         text = _JSON_FIELD_RE.sub(_redact_json, text)
 
     # Authorization headers
     text = _AUTH_HEADER_RE.sub(
-        lambda m: m.group(1) + _mask_token(m.group(2)),
+        lambda m: m.group(1) + _display_token(m.group(2)),
         text,
     )
+
+    if not preserve_tokens:
+        text = _redact_diagnostic_assignments(text, placeholder)
 
     # Telegram bot tokens
     def _redact_telegram(m):
         prefix = m.group(1) or ""
         digits = m.group(2)
+        if not preserve_tokens:
+            return placeholder
         return f"{prefix}{digits}:***"
     text = _TELEGRAM_RE.sub(_redact_telegram, text)
 
@@ -364,10 +468,10 @@ def redact_sensitive_text(text: str, *, force: bool = False, code_file: bool = F
     text = _PRIVATE_KEY_RE.sub("[REDACTED PRIVATE KEY]", text)
 
     # Database connection string passwords
-    text = _DB_CONNSTR_RE.sub(lambda m: f"{m.group(1)}***{m.group(3)}", text)
+    text = _DB_CONNSTR_RE.sub(lambda m: f"{m.group(1)}{placeholder}{m.group(3)}", text)
 
     # JWT tokens (eyJ... — base64-encoded JSON headers)
-    text = _JWT_RE.sub(lambda m: _mask_token(m.group(0)), text)
+    text = _JWT_RE.sub(lambda m: _display_token(m.group(0)), text)
 
     # URL userinfo (http(s)://user:pass@host) — redact for non-DB schemes.
     # DB schemes are handled above by _DB_CONNSTR_RE.
@@ -391,6 +495,36 @@ def redact_sensitive_text(text: str, *, force: bool = False, code_file: bool = F
     text = _SIGNAL_PHONE_RE.sub(_redact_phone, text)
 
     return text
+
+
+def redact_diagnostic_text(text: str) -> str:
+    """Redact free-form diagnostic text without preserving token fragments."""
+    return redact_sensitive_text(
+        text,
+        force=True,
+        preserve_tokens=False,
+        placeholder="[REDACTED]",
+    )
+
+
+def redact_diagnostic_value(value, *, name: str | None = None):
+    """Recursively sanitize a structured value for status/config diagnostics."""
+    if is_sensitive_name(name or ""):
+        if value in (None, ""):
+            return "not configured"
+        if isinstance(value, (str, int, float, bool)):
+            return format_secret_status(
+                str(value),
+                fingerprint=should_fingerprint_secret_name(name or ""),
+            )
+        return "[REDACTED]"
+    if isinstance(value, dict):
+        return {k: redact_diagnostic_value(v, name=str(k)) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [redact_diagnostic_value(item) for item in value]
+    if isinstance(value, str):
+        return redact_diagnostic_text(value)
+    return value
 
 
 class RedactingFormatter(logging.Formatter):

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4908,13 +4908,15 @@ def get_env_value(key: str) -> Optional[str]:
 # =============================================================================
 
 def redact_key(key: str) -> str:
-    """Redact an API key for display.
+    """Format API-key state for shareable config output."""
+    from agent.redact import format_secret_status
+    return format_secret_status(key, empty=color("(not set)", Colors.DIM))
 
-    Thin wrapper over :func:`agent.redact.mask_secret` — preserves the
-    "(not set)" placeholder in dim color for the empty case.
-    """
-    from agent.redact import mask_secret
-    return mask_secret(key, empty=color("(not set)", Colors.DIM))
+
+def _diagnostic_config_value(value):
+    """Format arbitrary config data without leaking embedded secrets."""
+    from agent.redact import redact_diagnostic_value
+    return redact_diagnostic_value(value)
 
 
 def show_config():
@@ -4959,7 +4961,7 @@ def show_config():
     # Model settings
     print()
     print(color("◆ Model", Colors.CYAN, Colors.BOLD))
-    print(f"  Model:        {config.get('model', 'not set')}")
+    print(f"  Model:        {_diagnostic_config_value(config.get('model', 'not set'))}")
     print(f"  Max turns:    {config.get('agent', {}).get('max_turns', DEFAULT_CONFIG['agent']['max_turns'])}")
     
     # Display
@@ -5044,8 +5046,8 @@ def show_config():
         print()
         print(color("◆ Auxiliary Models (overrides)", Colors.CYAN, Colors.BOLD))
         for label, task_cfg in aux_tasks.items():
-            prov = task_cfg.get('provider', 'auto')
-            mdl = task_cfg.get('model', '')
+            prov = _diagnostic_config_value(task_cfg.get('provider', 'auto'))
+            mdl = _diagnostic_config_value(task_cfg.get('model', ''))
             if prov != 'auto' or mdl:
                 parts = [f"provider={prov}"]
                 if mdl:
@@ -5064,6 +5066,12 @@ def show_config():
     
     # Skill config
     try:
+        from agent.redact import (
+            format_secret_status,
+            is_sensitive_name,
+            redact_diagnostic_text,
+            should_fingerprint_secret_name,
+        )
         from agent.skill_utils import discover_all_skill_config_vars, resolve_skill_config_values
         skill_vars = discover_all_skill_config_vars()
         if skill_vars:
@@ -5074,7 +5082,14 @@ def show_config():
                 key = var["key"]
                 value = resolved.get(key, "")
                 skill_name = var.get("skill", "")
-                display_val = str(value) if value else color("(not set)", Colors.DIM)
+                if is_sensitive_name(key):
+                    display_val = format_secret_status(
+                        value,
+                        empty=color("(not set)", Colors.DIM),
+                        fingerprint=should_fingerprint_secret_name(key),
+                    )
+                else:
+                    display_val = redact_diagnostic_text(str(value)) if value else color("(not set)", Colors.DIM)
                 print(f"  {key:<20s} {display_val}  {color(f'[{skill_name}]', Colors.DIM)}")
     except Exception:
         pass

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2657,6 +2657,18 @@ def systemd_restart(system: bool = False):
 
 
 
+def _print_redacted_subprocess_output(result: subprocess.CompletedProcess) -> None:
+    """Print captured subprocess output after diagnostic secret redaction."""
+    from agent.redact import redact_diagnostic_text
+
+    stdout = redact_diagnostic_text(getattr(result, "stdout", "") or "")
+    stderr = redact_diagnostic_text(getattr(result, "stderr", "") or "")
+    if stdout:
+        print(stdout, end="" if stdout.endswith("\n") else "\n")
+    if stderr:
+        print(stderr, end="" if stderr.endswith("\n") else "\n", file=sys.stderr)
+
+
 def systemd_status(deep: bool = False, system: bool = False, full: bool = False):
     system = _select_systemd_scope(system)
     unit_path = get_systemd_unit_path(system=system)
@@ -2686,12 +2698,14 @@ def systemd_status(deep: bool = False, system: bool = False, full: bool = False)
     if full:
         status_cmd.append("-l")
 
-    _run_systemctl(
+    status_result = _run_systemctl(
         status_cmd,
         system=system,
-        capture_output=False,
+        capture_output=True,
+        text=True,
         timeout=10,
     )
+    _print_redacted_subprocess_output(status_result)
 
     result = _run_systemctl(
         ["is-active", get_service_name()],
@@ -2755,7 +2769,8 @@ def systemd_status(deep: bool = False, system: bool = False, full: bool = False)
         log_cmd = _journalctl_cmd(system) + ["-u", get_service_name(), "-n", "20", "--no-pager"]
         if full:
             log_cmd.append("-l")
-        subprocess.run(log_cmd, timeout=10)
+        result = subprocess.run(log_cmd, timeout=10, capture_output=True, text=True)
+        _print_redacted_subprocess_output(result)
 
 
 # =============================================================================
@@ -3822,6 +3837,8 @@ def _runtime_health_lines() -> list[str]:
         return []
 
     lines: list[str] = []
+    from agent.redact import redact_diagnostic_text
+
     gateway_state = state.get("gateway_state")
     exit_reason = state.get("exit_reason")
     active_agents = state.get("active_agents")
@@ -3831,16 +3848,17 @@ def _runtime_health_lines() -> list[str]:
     for platform, pdata in platforms.items():
         if pdata.get("state") == "fatal":
             message = pdata.get("error_message") or "unknown error"
+            message = redact_diagnostic_text(message)
             lines.append(f"⚠ {platform}: {message}")
 
     if gateway_state == "startup_failed" and exit_reason:
-        lines.append(f"⚠ Last startup issue: {exit_reason}")
+        lines.append(f"⚠ Last startup issue: {redact_diagnostic_text(exit_reason)}")
     elif gateway_state == "draining":
         action = "restart" if restart_requested else "shutdown"
         count = int(active_agents or 0)
         lines.append(f"⏳ Gateway draining for {action} ({count} active agent(s))")
     elif gateway_state == "stopped" and exit_reason:
-        lines.append(f"⚠ Last shutdown reason: {exit_reason}")
+        lines.append(f"⚠ Last shutdown reason: {redact_diagnostic_text(exit_reason)}")
 
     return lines
 

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -28,15 +28,15 @@ def check_mark(ok: bool) -> str:
     return color("✗", Colors.RED)
 
 def redact_key(key: str) -> str:
-    """Redact an API key for display.
+    """Format API-key state for shareable status output."""
+    from agent.redact import format_secret_status
+    return format_secret_status(key, empty=color("(not set)", Colors.DIM))
 
-    Thin wrapper over :func:`agent.redact.mask_secret`. Preserves the
-    "(not set)" placeholder in dim color to match ``hermes config``'s
-    output (previously this variant was missing the DIM color —
-    consolidated via PR that also introduced ``mask_secret``).
-    """
-    from agent.redact import mask_secret
-    return mask_secret(key, empty=color("(not set)", Colors.DIM))
+
+def redact_diagnostic_text(text) -> str:
+    """Redact free-form diagnostic text before printing status output."""
+    from agent.redact import redact_diagnostic_text as _redact_diagnostic_text
+    return _redact_diagnostic_text(text)
 
 
 def _format_iso_timestamp(value) -> str:
@@ -89,7 +89,6 @@ from hermes_constants import is_termux as _is_termux
 
 def show_status(args):
     """Show status of all Hermes Agent components."""
-    show_all = getattr(args, 'all', False)
     deep = getattr(args, 'deep', False)
 
     print()
@@ -163,12 +162,12 @@ def show_status(args):
             continue
         value = _resolve_env(env_ref)
         has_key = bool(value)
-        display = redact_key(value) if not show_all else value
+        display = redact_key(value)
         print(f"  {name:<12}  {check_mark(has_key)} {display}")
 
     from hermes_cli.auth import get_anthropic_key
     anthropic_value = get_anthropic_key()
-    anthropic_display = redact_key(anthropic_value) if not show_all else anthropic_value
+    anthropic_display = redact_key(anthropic_value)
     print(f"  {'Anthropic':<12}  {check_mark(bool(anthropic_value))} {anthropic_display}")
 
     # =========================================================================
@@ -201,7 +200,7 @@ def show_status(args):
         f"  {'Nous Portal':<12}  {check_mark(nous_logged_in)} "
         f"{nous_label}"
     )
-    portal_url = nous_status.get("portal_base_url") or "(unknown)"
+    portal_url = redact_diagnostic_text(nous_status.get("portal_base_url") or "(unknown)")
     access_exp = _format_iso_timestamp(nous_status.get("access_expires_at"))
     key_exp = _format_iso_timestamp(nous_status.get("agent_key_expires_at"))
     refresh_label = "yes" if nous_status.get("has_refresh_token") else "no"
@@ -214,7 +213,7 @@ def show_status(args):
     if nous_logged_in or nous_status.get("has_refresh_token"):
         print(f"    Refresh:    {refresh_label}")
     if nous_error and not nous_logged_in:
-        print(f"    Error:      {nous_error}")
+        print(f"    Error:      {redact_diagnostic_text(nous_error)}")
 
     codex_logged_in = bool(codex_status.get("logged_in"))
     print(
@@ -228,7 +227,7 @@ def show_status(args):
     if codex_status.get("last_refresh"):
         print(f"    Refreshed:  {codex_last_refresh}")
     if codex_status.get("error") and not codex_logged_in:
-        print(f"    Error:      {codex_status.get('error')}")
+        print(f"    Error:      {redact_diagnostic_text(codex_status.get('error'))}")
 
     qwen_logged_in = bool(qwen_status.get("logged_in"))
     print(
@@ -243,7 +242,7 @@ def show_status(args):
         from datetime import datetime, timezone
         print(f"    Access exp: {datetime.fromtimestamp(int(qwen_exp) / 1000, tz=timezone.utc).isoformat()}")
     if qwen_status.get("error") and not qwen_logged_in:
-        print(f"    Error:      {qwen_status.get('error')}")
+        print(f"    Error:      {redact_diagnostic_text(qwen_status.get('error'))}")
 
     minimax_logged_in = bool(minimax_status.get("logged_in"))
     print(
@@ -257,7 +256,7 @@ def show_status(args):
     if minimax_exp:
         print(f"    Access exp: {minimax_exp}")
     if minimax_status.get("error") and not minimax_logged_in:
-        print(f"    Error:      {minimax_status.get('error')}")
+        print(f"    Error:      {redact_diagnostic_text(minimax_status.get('error'))}")
 
     # xAI OAuth — separate try/except so an import failure here cannot
     # disrupt the already-printed Nous/Codex/Qwen/MiniMax rows above.
@@ -278,7 +277,7 @@ def show_status(args):
     if xai_oauth_status.get("last_refresh"):
         print(f"    Refreshed:  {_format_iso_timestamp(xai_oauth_status.get('last_refresh'))}")
     if xai_oauth_status.get("error") and not xai_oauth_logged_in:
-        print(f"    Error:      {xai_oauth_status.get('error')}")
+        print(f"    Error:      {redact_diagnostic_text(xai_oauth_status.get('error'))}")
 
     # =========================================================================
     # Nous Subscription Features
@@ -311,7 +310,7 @@ def show_status(args):
         print("  Your free-tier Nous account does not include Tool Gateway access.")
         print("  Upgrade your subscription to unlock managed web, image, TTS, and browser tools.")
         try:
-            portal_url = nous_status.get("portal_base_url", "").rstrip("/")
+            portal_url = redact_diagnostic_text(nous_status.get("portal_base_url", "")).rstrip("/")
             if portal_url:
                 print(f"  Upgrade: {portal_url}")
         except Exception:

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -5,7 +5,12 @@ import os
 
 import pytest
 
-from agent.redact import redact_sensitive_text, RedactingFormatter
+from agent.redact import (
+    redact_diagnostic_text,
+    redact_diagnostic_value,
+    redact_sensitive_text,
+    RedactingFormatter,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -183,6 +188,51 @@ class TestPassthrough:
     def test_url_without_key_unchanged(self):
         text = "Connecting to https://api.openai.com/v1/chat/completions"
         assert redact_sensitive_text(text) == text
+
+
+class TestDiagnosticRedaction:
+    def test_diagnostic_text_does_not_preserve_token_fragments(self):
+        token = "sk-proj-abcdefghijklmnopqrstuvwxyz123456"
+        result = redact_diagnostic_text(f"Authorization: Bearer {token}")
+        assert token not in result
+        assert "sk-proj" not in result
+        assert "3456" not in result
+        assert "[REDACTED]" in result
+
+    def test_diagnostic_text_redacts_lowercase_sensitive_assignments(self):
+        result = redact_diagnostic_text(
+            "token=opaque123 password=hunter2 cookie=session=abc credential='hunter2' prompt_tokens=123"
+        )
+        assert "opaque123" not in result
+        assert "hunter2" not in result
+        assert "session=abc" not in result
+        assert "token=[REDACTED]" in result
+        assert "password=[REDACTED]" in result
+        assert "cookie=[REDACTED]" in result
+        assert "credential='[REDACTED]'" in result
+        assert "prompt_tokens=123" in result
+
+    def test_diagnostic_value_fingerprints_api_keys_but_not_passwords(self):
+        api_key = "sk-proj-abcdefghijklmnopqrstuvwxyz123456"
+        password = "hunter2"
+        result = redact_diagnostic_value(
+            {
+                "api_key": api_key,
+                "bearer": api_key,
+                "password": password,
+                "cookie": "session=abc",
+            }
+        )
+        assert isinstance(result, dict)
+        assert result["api_key"].startswith("configured (sha256:")
+        assert result["bearer"].startswith("configured (sha256:")
+        assert f"len={len(api_key)}" in result["api_key"]
+        assert result["password"] == "configured"
+        assert result["cookie"] == "configured"
+        assert password not in str(result)
+        assert "hunter" not in str(result)
+        assert "sha256" not in result["password"]
+        assert "sha256" not in result["cookie"]
 
 
 class TestRedactingFormatter:

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -8,7 +8,44 @@ from types import SimpleNamespace
 from gateway import status
 
 
+def test_runtime_health_lines_redacts_secret_bearing_gateway_errors(monkeypatch):
+    from hermes_cli.gateway import _runtime_health_lines
+
+    secret = "tvly-runtime-secret-0123456789abcdef"
+    bearer_secret = "sk-" + "runtimeerror" + "0123456789abcdef"
+    monkeypatch.setattr(
+        status,
+        "read_runtime_status",
+        lambda: {
+            "gateway_state": "startup_failed",
+            "exit_reason": f"failed callback https://api.example.test/cb?api_key={secret}",
+            "platforms": {
+                "telegram": {
+                    "state": "fatal",
+                    "error_message": (
+                        f"unauthorized at https://api.example.test/send?token={secret}; "
+                        f"Authorization: Bearer {bearer_secret}"
+                    ),
+                }
+            },
+        },
+    )
+
+    lines = _runtime_health_lines()
+    output = "\n".join(lines)
+
+    assert "telegram" in output
+    assert "Last startup issue" in output
+    assert secret not in output
+    assert bearer_secret not in output
+    assert "runtimeerror" not in output
+    assert "api_key=***" in output
+    assert "token=***" in output
+    assert "Authorization: Bearer [REDACTED]" in output
+
+
 class TestGatewayPidState:
+
     def test_write_pid_file_records_gateway_metadata(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 

--- a/tests/hermes_cli/test_config_display_redaction.py
+++ b/tests/hermes_cli/test_config_display_redaction.py
@@ -1,0 +1,66 @@
+"""Regression tests for secret-safe `hermes config` display output."""
+
+import hashlib
+
+
+def _safe_secret_status(value: str) -> str:
+    digest = hashlib.sha256(value.encode("utf-8")).hexdigest()[:12]
+    return f"configured (sha256:{digest}, len={len(value)})"
+
+
+def test_show_config_redacts_api_key_rows(monkeypatch, capsys, tmp_path):
+    from hermes_cli import auth as auth_mod
+    from hermes_cli import config as config_mod
+    import agent.skill_utils as skill_utils
+
+    secret = "tvly-config-secret-0123456789abcdef"
+    model_secret = "sk-" + "modelconfig" + "0123456789abcdef"
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("TAVILY_API_KEY", secret)
+    monkeypatch.setattr(
+        config_mod,
+        "load_config",
+        lambda: {"model": {"default": "gpt-test", "api_key": model_secret}, "agent": {}},
+        raising=False,
+    )
+    monkeypatch.setattr(auth_mod, "get_anthropic_key", lambda: "", raising=False)
+    monkeypatch.setattr(skill_utils, "discover_all_skill_config_vars", lambda: [], raising=False)
+
+    config_mod.show_config()
+
+    output = capsys.readouterr().out
+    assert "Tavily" in output
+    assert secret not in output
+    assert model_secret not in output
+    assert "modelconfig" not in output
+    assert "tvly-config" not in output
+    assert "89abcdef" not in output
+    assert _safe_secret_status(secret) in output
+
+
+def test_show_config_redacts_secret_like_skill_settings(monkeypatch, capsys, tmp_path):
+    from hermes_cli import auth as auth_mod
+    from hermes_cli import config as config_mod
+    import agent.skill_utils as skill_utils
+
+    secret = "sk-testskillsecret0123456789abcdef"
+    skill_vars = [{"key": "EXAMPLE_API_TOKEN", "skill": "demo-skill"}]
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(auth_mod, "get_anthropic_key", lambda: "", raising=False)
+    monkeypatch.setattr(skill_utils, "discover_all_skill_config_vars", lambda: skill_vars, raising=False)
+    monkeypatch.setattr(
+        skill_utils,
+        "resolve_skill_config_values",
+        lambda vars: {"EXAMPLE_API_TOKEN": secret},
+        raising=False,
+    )
+
+    config_mod.show_config()
+
+    output = capsys.readouterr().out
+    assert "EXAMPLE_API_TOKEN" in output
+    assert "demo-skill" in output
+    assert secret not in output
+    assert "sk-testskill" not in output
+    assert "89abcdef" not in output
+    assert _safe_secret_status(secret) in output

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -962,6 +962,55 @@ class TestGatewaySystemServiceRouting:
         out = capsys.readouterr().out
         assert "Planned restart is stuck in systemd failed state" in out
 
+    def test_systemd_status_redacts_captured_status_and_journal_output(self, monkeypatch, capsys):
+        unit = SimpleNamespace(exists=lambda: True)
+        status_secret = "sk-" + "systemdstatus" + "0123456789abcdef"
+        journal_secret = "tvly-" + "journalredaction" + "0123456789abcdef"
+        monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
+        monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit)
+        monkeypatch.setattr(gateway_cli, "has_conflicting_systemd_units", lambda: False)
+        monkeypatch.setattr(gateway_cli, "has_legacy_hermes_units", lambda: False)
+        monkeypatch.setattr(gateway_cli, "systemd_unit_is_current", lambda system=False: True)
+        monkeypatch.setattr(gateway_cli, "_runtime_health_lines", lambda: [])
+        monkeypatch.setattr(gateway_cli, "get_systemd_linger_status", lambda: (True, ""))
+        monkeypatch.setattr(gateway_cli, "_read_systemd_unit_properties", lambda system=False: {})
+
+        def fake_run_systemctl(args, **kwargs):
+            if args[:2] == ["status", gateway_cli.get_service_name()]:
+                assert kwargs.get("capture_output") is True
+                assert kwargs.get("text") is True
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout=f"Loaded: active Authorization: Bearer {status_secret}\n",
+                    stderr="",
+                )
+            if args[:2] == ["is-active", gateway_cli.get_service_name()]:
+                return SimpleNamespace(returncode=0, stdout="active\n", stderr="")
+            raise AssertionError(f"Unexpected args: {args}")
+
+        def fake_run(cmd, **kwargs):
+            assert cmd[:2] == ["journalctl", "--user"]
+            assert kwargs.get("capture_output") is True
+            assert kwargs.get("text") is True
+            return SimpleNamespace(
+                returncode=0,
+                stdout=f"gateway failed token={journal_secret}\n",
+                stderr="",
+            )
+
+        monkeypatch.setattr(gateway_cli, "_run_systemctl", fake_run_systemctl)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.systemd_status(deep=True)
+
+        output = capsys.readouterr().out
+        assert "Loaded: active Authorization: Bearer [REDACTED]" in output
+        assert "gateway failed token=[REDACTED]" in output
+        assert status_secret not in output
+        assert journal_secret not in output
+        assert "systemdstatus" not in output
+        assert "journalredaction" not in output
+
     def test_gateway_status_dispatches_full_flag(self, monkeypatch):
         user_unit = SimpleNamespace(exists=lambda: True)
         system_unit = SimpleNamespace(exists=lambda: False)

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -1,17 +1,28 @@
+import hashlib
 from types import SimpleNamespace
 
 from hermes_cli.status import show_status
 
 
-def test_show_status_includes_tavily_key(monkeypatch, capsys, tmp_path):
+def _safe_secret_status(value: str) -> str:
+    digest = hashlib.sha256(value.encode("utf-8")).hexdigest()[:12]
+    return f"configured (sha256:{digest}, len={len(value)})"
+
+
+def test_show_status_redacts_tavily_key_in_default_and_all_modes(monkeypatch, capsys, tmp_path):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    monkeypatch.setenv("TAVILY_API_KEY", "tvly-1234567890abcdef")
+    secret = "tvly-test-secret-0123456789abcdef"
+    monkeypatch.setenv("TAVILY_API_KEY", secret)
 
-    show_status(SimpleNamespace(all=False, deep=False))
+    for show_all in (False, True):
+        show_status(SimpleNamespace(all=show_all, deep=False))
+        output = capsys.readouterr().out
 
-    output = capsys.readouterr().out
-    assert "Tavily" in output
-    assert "tvly...cdef" in output
+        assert "Tavily" in output
+        assert secret not in output
+        assert "tvly-test" not in output
+        assert "89abcdef" not in output
+        assert _safe_secret_status(secret) in output
 
 
 def test_show_status_termux_gateway_section_skips_systemctl(monkeypatch, capsys, tmp_path):
@@ -81,6 +92,81 @@ def test_show_status_reports_nous_auth_error(monkeypatch, capsys, tmp_path):
     assert "Error:      Refresh session has been revoked" in output
     assert "Access exp:" in output
     assert "Key exp:" in output
+
+
+def test_show_status_redacts_secret_bearing_auth_errors(monkeypatch, capsys, tmp_path):
+    from hermes_cli import status as status_mod
+    import hermes_cli.auth as auth_mod
+    import hermes_cli.gateway as gateway_mod
+
+    secret = "tvly-auth-error-secret-0123456789abcdef"
+    bearer_secret = "sk-" + "statusdiagnostic" + "0123456789abcdef"
+    monkeypatch.setattr(status_mod, "get_env_path", lambda: tmp_path / ".env", raising=False)
+    monkeypatch.setattr(status_mod, "get_hermes_home", lambda: tmp_path, raising=False)
+    monkeypatch.setattr(status_mod, "load_config", lambda: {"model": "gpt-5.4"}, raising=False)
+    monkeypatch.setattr(status_mod, "resolve_requested_provider", lambda requested=None: "openai-codex", raising=False)
+    monkeypatch.setattr(status_mod, "resolve_provider", lambda requested=None, **kwargs: "openai-codex", raising=False)
+    monkeypatch.setattr(status_mod, "provider_label", lambda provider: "OpenAI Codex", raising=False)
+    monkeypatch.setattr(
+        auth_mod,
+        "get_nous_auth_status",
+        lambda: {
+            "logged_in": False,
+            "error": (
+                f"refresh failed at https://auth.example.test/cb?api_key={secret}; "
+                f"Authorization: Bearer {bearer_secret}"
+            ),
+        },
+        raising=False,
+    )
+    monkeypatch.setattr(auth_mod, "get_codex_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_qwen_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_xai_oauth_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(gateway_mod, "find_gateway_pids", lambda exclude_pids=None: [], raising=False)
+
+    status_mod.show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    assert secret not in output
+    assert bearer_secret not in output
+    assert "statusdiagnostic" not in output
+    assert "api_key=***" in output
+    assert "Authorization: Bearer [REDACTED]" in output
+
+
+def test_show_status_redacts_nous_upgrade_url(monkeypatch, capsys, tmp_path):
+    from hermes_cli import status as status_mod
+    import hermes_cli.auth as auth_mod
+    import hermes_cli.gateway as gateway_mod
+
+    secret = "tvly-upgrade-url-secret-0123456789abcdef"
+    monkeypatch.setattr(status_mod, "get_env_path", lambda: tmp_path / ".env", raising=False)
+    monkeypatch.setattr(status_mod, "get_hermes_home", lambda: tmp_path, raising=False)
+    monkeypatch.setattr(status_mod, "load_config", lambda: {"model": "gpt-5.4"}, raising=False)
+    monkeypatch.setattr(status_mod, "resolve_requested_provider", lambda requested=None: "openai-codex", raising=False)
+    monkeypatch.setattr(status_mod, "resolve_provider", lambda requested=None, **kwargs: "openai-codex", raising=False)
+    monkeypatch.setattr(status_mod, "provider_label", lambda provider: "OpenAI Codex", raising=False)
+    monkeypatch.setattr(status_mod, "managed_nous_tools_enabled", lambda: False, raising=False)
+    monkeypatch.setattr(
+        auth_mod,
+        "get_nous_auth_status",
+        lambda: {
+            "logged_in": True,
+            "portal_base_url": f"https://portal.example.test/upgrade?api_key={secret}",
+        },
+        raising=False,
+    )
+    monkeypatch.setattr(auth_mod, "get_codex_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_qwen_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_xai_oauth_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(gateway_mod, "find_gateway_pids", lambda exclude_pids=None: [], raising=False)
+
+    status_mod.show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    assert "Upgrade:" in output
+    assert secret not in output
+    assert "api_key=***" in output
 
 
 def test_show_status_reports_vercel_backend_contract(monkeypatch, capsys, tmp_path):


### PR DESCRIPTION
## Summary

- Makes shareable `hermes status`, `hermes config`, and gateway/service diagnostics avoid preserving raw secret head/tail fragments.
- Adds diagnostic redaction helpers for structured values and free-form diagnostic text, including lower-case `token=...`, `password=...`, `cookie=...`, `credential=...`, and `bearer=...` snippets.
- Keeps useful non-reversible fingerprints for high-entropy API key/token/JWT/bearer-style values while reporting low-entropy password/cookie/credential-like values as `configured` only.
- Adds regression coverage for status, config display, gateway service diagnostics, and diagnostic redaction edge cases.

## Validation

- `scripts/run_tests.sh tests/hermes_cli/test_gateway_service.py tests/agent/test_redact.py tests/hermes_cli/test_status.py tests/hermes_cli/test_config_display_redaction.py tests/gateway/test_status.py -q` → 288 passed
- `python -m ruff check agent/redact.py hermes_cli/config.py hermes_cli/gateway.py hermes_cli/status.py tests/agent/test_redact.py tests/gateway/test_status.py tests/hermes_cli/test_gateway_service.py tests/hermes_cli/test_status.py tests/hermes_cli/test_config_display_redaction.py` → passed
- Independent security review after fixes: PASS
