### PR TITLE
fix(memory): keep inline memory-context mentions visible (salvage of #18383)

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -126,7 +126,10 @@ class StreamingContextScrubber:
                 idx = self._find_boundary_open_tag(buf)
                 if idx == -1:
                     # No open tag — hold back a potential partial open tag
-                    held = self._max_partial_suffix(buf, self._OPEN_TAG)
+                    held = (
+                        self._max_pending_open_suffix(buf)
+                        or self._max_partial_suffix(buf, self._OPEN_TAG)
+                    )
                     if held:
                         self._append_visible(out, buf[:-held])
                         self._buf = buf[-held:]
@@ -179,9 +182,24 @@ class StreamingContextScrubber:
             idx = buf_lower.find(self._OPEN_TAG, search_start)
             if idx == -1:
                 return -1
-            if self._is_block_boundary(buf, idx):
+            if self._is_block_boundary(buf, idx) and self._has_block_opener_suffix(buf, idx):
                 return idx
             search_start = idx + 1
+
+    def _max_pending_open_suffix(self, buf: str) -> int:
+        """Hold a complete boundary tag until the following char confirms it."""
+        if not buf.lower().endswith(self._OPEN_TAG):
+            return 0
+        idx = len(buf) - len(self._OPEN_TAG)
+        if not self._is_block_boundary(buf, idx):
+            return 0
+        return len(self._OPEN_TAG)
+
+    def _has_block_opener_suffix(self, buf: str, idx: int) -> bool:
+        after_idx = idx + len(self._OPEN_TAG)
+        if after_idx >= len(buf):
+            return False
+        return buf[after_idx] in "\r\n"
 
     def _is_block_boundary(self, buf: str, idx: int) -> bool:
         if idx == 0:

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -91,10 +91,12 @@ class StreamingContextScrubber:
     def __init__(self) -> None:
         self._in_span: bool = False
         self._buf: str = ""
+        self._at_block_boundary: bool = True
 
     def reset(self) -> None:
         self._in_span = False
         self._buf = ""
+        self._at_block_boundary = True
 
     def feed(self, text: str) -> str:
         """Return the visible portion of ``text`` after scrubbing.
@@ -121,19 +123,19 @@ class StreamingContextScrubber:
                 buf = buf[idx + len(self._CLOSE_TAG):]
                 self._in_span = False
             else:
-                idx = buf.lower().find(self._OPEN_TAG)
+                idx = self._find_boundary_open_tag(buf)
                 if idx == -1:
                     # No open tag — hold back a potential partial open tag
                     held = self._max_partial_suffix(buf, self._OPEN_TAG)
                     if held:
-                        out.append(buf[:-held])
+                        self._append_visible(out, buf[:-held])
                         self._buf = buf[-held:]
                     else:
-                        out.append(buf)
+                        self._append_visible(out, buf)
                     return "".join(out)
                 # Emit text before the tag, enter span
                 if idx > 0:
-                    out.append(buf[:idx])
+                    self._append_visible(out, buf[:idx])
                 buf = buf[idx + len(self._OPEN_TAG):]
                 self._in_span = True
 
@@ -168,6 +170,40 @@ class StreamingContextScrubber:
             if tag_lower.startswith(buf_lower[-i:]):
                 return i
         return 0
+
+    def _find_boundary_open_tag(self, buf: str) -> int:
+        """Find an opening fence only when it starts a block-like span."""
+        buf_lower = buf.lower()
+        search_start = 0
+        while True:
+            idx = buf_lower.find(self._OPEN_TAG, search_start)
+            if idx == -1:
+                return -1
+            if self._is_block_boundary(buf, idx):
+                return idx
+            search_start = idx + 1
+
+    def _is_block_boundary(self, buf: str, idx: int) -> bool:
+        if idx == 0:
+            return self._at_block_boundary
+        preceding = buf[:idx]
+        last_newline = preceding.rfind("\n")
+        if last_newline == -1:
+            return self._at_block_boundary and preceding.strip() == ""
+        return preceding[last_newline + 1:].strip() == ""
+
+    def _append_visible(self, out: list[str], text: str) -> None:
+        if not text:
+            return
+        out.append(text)
+        self._update_block_boundary(text)
+
+    def _update_block_boundary(self, text: str) -> None:
+        last_newline = text.rfind("\n")
+        if last_newline != -1:
+            self._at_block_boundary = text[last_newline + 1:].strip() == ""
+        else:
+            self._at_block_boundary = self._at_block_boundary and text.strip() == ""
 
 
 def build_memory_context_block(raw_context: str) -> str:

--- a/tests/agent/test_streaming_context_scrubber.py
+++ b/tests/agent/test_streaming_context_scrubber.py
@@ -37,13 +37,13 @@ class TestStreamingContextScrubberBasics:
         """The real streaming case: tag pair split across deltas."""
         s = StreamingContextScrubber()
         deltas = [
-            "Hello ",
+            "Hello\n",
             "<memory-context>\npayload ",
             "more payload\n",
             "</memory-context> world",
         ]
         out = "".join(s.feed(d) for d in deltas) + s.flush()
-        assert out == "Hello  world"
+        assert out == "Hello\n world"
         assert "payload" not in out
 
     def test_realistic_fragmented_chunks_strip_memory_payload(self):
@@ -72,22 +72,22 @@ class TestStreamingContextScrubberBasics:
         """The open tag itself arriving in two fragments."""
         s = StreamingContextScrubber()
         out = (
-            s.feed("pre <memory")
+            s.feed("pre \n<memory")
             + s.feed("-context>leak</memory-context> post")
             + s.flush()
         )
-        assert out == "pre  post"
+        assert out == "pre \n post"
         assert "leak" not in out
 
     def test_close_tag_split_across_two_deltas(self):
         """The close tag arriving in two fragments."""
         s = StreamingContextScrubber()
         out = (
-            s.feed("pre <memory-context>leak</memory")
+            s.feed("pre \n<memory-context>leak</memory")
             + s.feed("-context> post")
             + s.flush()
         )
-        assert out == "pre  post"
+        assert out == "pre \n post"
         assert "leak" not in out
 
 
@@ -105,13 +105,30 @@ class TestStreamingContextScrubberPartialTagFalsePositives:
         out = s.feed("price < ") + s.feed("10 dollars") + s.flush()
         assert out == "price < 10 dollars"
 
+    def test_inline_memory_context_tag_mention_is_not_scrubbed(self):
+        """A prose mention of the fence tag must not swallow the answer."""
+        s = StreamingContextScrubber()
+        out = (
+            s.feed("In that previous `<memory")
+            + s.feed("-context>` block, ")
+            + s.feed("there was no matching fact.")
+            + s.flush()
+        )
+        assert out == "In that previous `<memory-context>` block, there was no matching fact."
+
+    def test_mid_sentence_memory_context_pair_is_not_scrubbed(self):
+        """Only block-like memory-context spans are treated as leaked context."""
+        s = StreamingContextScrubber()
+        out = s.feed("The <memory-context> tag name is documented here.") + s.flush()
+        assert out == "The <memory-context> tag name is documented here."
+
 
 class TestStreamingContextScrubberUnterminatedSpan:
     def test_unterminated_span_drops_payload(self):
         """Provider drops close tag — better to lose output than to leak."""
         s = StreamingContextScrubber()
-        out = s.feed("pre <memory-context>secret never closed") + s.flush()
-        assert out == "pre "
+        out = s.feed("pre \n<memory-context>secret never closed") + s.flush()
+        assert out == "pre \n"
         assert "secret" not in out
 
     def test_reset_clears_hung_span(self):
@@ -171,7 +188,7 @@ class TestStreamingContextScrubberCrossTurn:
 
     def test_reset_clears_in_span_state(self):
         s = StreamingContextScrubber()
-        s.feed("text<memory-context>secret-tail")
+        s.feed("text\n<memory-context>secret-tail")
         # Mid-span state held — without reset, subsequent text would be
         # discarded until we see </memory-context>.
         s.reset()

--- a/tests/agent/test_streaming_context_scrubber.py
+++ b/tests/agent/test_streaming_context_scrubber.py
@@ -73,7 +73,18 @@ class TestStreamingContextScrubberBasics:
         s = StreamingContextScrubber()
         out = (
             s.feed("pre \n<memory")
-            + s.feed("-context>leak</memory-context> post")
+            + s.feed("-context>\nleak</memory-context> post")
+            + s.flush()
+        )
+        assert out == "pre \n post"
+        assert "leak" not in out
+
+    def test_open_tag_waits_for_newline_confirmation_across_deltas(self):
+        """A boundary tag is only a leaked block when the next char is a newline."""
+        s = StreamingContextScrubber()
+        out = (
+            s.feed("pre \n<memory-context>")
+            + s.feed("\nleak</memory-context> post")
             + s.flush()
         )
         assert out == "pre \n post"
@@ -83,7 +94,7 @@ class TestStreamingContextScrubberBasics:
         """The close tag arriving in two fragments."""
         s = StreamingContextScrubber()
         out = (
-            s.feed("pre \n<memory-context>leak</memory")
+            s.feed("pre \n<memory-context>\nleak</memory")
             + s.feed("-context> post")
             + s.flush()
         )
@@ -116,18 +127,28 @@ class TestStreamingContextScrubberPartialTagFalsePositives:
         )
         assert out == "In that previous `<memory-context>` block, there was no matching fact."
 
-    def test_mid_sentence_memory_context_pair_is_not_scrubbed(self):
+    def test_mid_sentence_memory_context_mention_is_not_scrubbed(self):
         """Only block-like memory-context spans are treated as leaked context."""
         s = StreamingContextScrubber()
         out = s.feed("The <memory-context> tag name is documented here.") + s.flush()
         assert out == "The <memory-context> tag name is documented here."
+
+    def test_line_start_memory_context_mention_without_close_is_not_scrubbed(self):
+        """A plain-text line that starts with the tag name must be preserved."""
+        s = StreamingContextScrubber()
+        out = (
+            s.feed("Visible intro\n")
+            + s.feed("<memory-context> is the literal tag name mentioned here.")
+            + s.flush()
+        )
+        assert out == "Visible intro\n<memory-context> is the literal tag name mentioned here."
 
 
 class TestStreamingContextScrubberUnterminatedSpan:
     def test_unterminated_span_drops_payload(self):
         """Provider drops close tag — better to lose output than to leak."""
         s = StreamingContextScrubber()
-        out = s.feed("pre \n<memory-context>secret never closed") + s.flush()
+        out = s.feed("pre \n<memory-context>\nsecret never closed") + s.flush()
         assert out == "pre \n"
         assert "secret" not in out
 
@@ -144,7 +165,7 @@ class TestStreamingContextScrubberCaseInsensitivity:
     def test_uppercase_tags_still_scrubbed(self):
         s = StreamingContextScrubber()
         out = (
-            s.feed("<MEMORY-CONTEXT>secret")
+            s.feed("<MEMORY-CONTEXT>\nsecret")
             + s.feed("</Memory-Context>visible")
             + s.flush()
         )


### PR DESCRIPTION
## Salvage of #18383

Cherry-picks @BlackishGreen33's fix for the CLI output truncation when an
assistant response mentions the literal `<memory-context>` tag inline
(issue #18351). The PR branch was ~1858 commits behind `main`; cherry-picked
clean onto current `main` with attribution preserved.

Closes #18383
Closes #18351

## What's broken on `main`

`StreamingContextScrubber` enters span-strip mode at the first
`<memory-context>` substring it sees in streamed output and waits for a
closing tag. When the model just *mentions* the tag inline
(e.g. ``` In that previous `<memory-context>` block, ... ```), no close tag
follows and the rest of the answer is silently dropped.

Reproduced on current `origin/main`:

```python
from agent.memory_manager import StreamingContextScrubber
s = StreamingContextScrubber()
inp = "In that previous `<memory-context>` block, there was no info."
print(s.feed(inp) + s.flush())
# -> "In that previous `"          ← rest of the answer swallowed
```

## Fix

Only open a scrub span when the open tag sits at a **block boundary**:

1. `_is_block_boundary`: preceding text on the same line is whitespace-only
2. `_has_block_opener_suffix`: the char immediately after `<memory-context>`
   is `\r` or `\n`

A pending one-tag suffix is held across deltas so a chunk ending exactly at
`<memory-context>` waits for the next char to decide block-vs-inline.

This matches the sole producer `build_memory_context_block()` in
`agent/memory_manager.py`, which always emits:

```
<memory-context>\n
[System note: ...]\n
\n
{clean}\n
</memory-context>
```

— always at line start, always followed by `\n`. Single producer, single
consumer (`agent/agent_init.py` → `run_agent.py`); no other `<memory-context>`
emitter exists in the tree.

## Test plan

Tested 11 scenarios end-to-end on a fresh worktree off current `main`:

- Bug repro (inline + streamed across deltas) — fixed
- Real producer-shaped leak (full `build_memory_context_block()` output) — still scrubbed
- Leak with open tag split across deltas at a block boundary — still scrubbed
- Tag at very start of stream — still scrubbed
- Whitespace-indented tag at line start — still scrubbed
- Inline mention on its own line, no trailing newline — preserved
- Tag at line start followed by a space (not newline) — preserved as inline
- Open tag fragmented mid-tag, with newline boundary — still scrubbed
- Open tag fragmented mid-tag inline (backticked) — preserved

Targeted test suites (scrubber + memory + codex-responses + honcho + vision
memory-leak):

```
264 passed in 25.80s
```

## Trade-off

A single-line `<memory-context>X</memory-context>` shape that does *not*
start the line is now passed through unscrubbed. Acceptable: nothing in the
repo ever emits that shape — `build_memory_context_block()` always uses the
block form. The previous behavior was swallowing legitimate answers for the
inline-mention case, which is the reported P2 bug.

## Attribution

Original commits authored by @BlackishGreen33 (墨綠BG), cherry-picked
unmodified.
