### PR TITLE
fix(conversation_loop): detect structured reasoning exhaustion from Ollama fallback models

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1388,12 +1388,24 @@ def run_conversation(
                             re.IGNORECASE,
                         )
                     )
+                    _has_structured_reasoning = bool(
+                        _trunc_msg and (
+                            getattr(_trunc_msg, "reasoning", None)
+                            or getattr(_trunc_msg, "reasoning_content", None)
+                        )
+                    )
+                    _content_is_empty = not (
+                        _trunc_content and agent._has_content_after_think_block(_trunc_content)
+                    )
                     _thinking_exhausted = (
                         not _trunc_has_tool_calls
-                        and _has_think_tags
                         and (
-                            (_trunc_content is not None and not agent._has_content_after_think_block(_trunc_content))
-                            or _trunc_content is None
+                            (_has_think_tags
+                             and (
+                                 (_trunc_content is not None and not agent._has_content_after_think_block(_trunc_content))
+                                 or _trunc_content is None
+                             ))
+                            or (_has_structured_reasoning and _content_is_empty)
                         )
                     )
 
@@ -1419,6 +1431,18 @@ def run_conversation(
                             "→ Lower reasoning effort: `/thinkon low` or `/thinkon minimal`\n"
                             "→ Or switch to a larger/non-reasoning model with `/model`"
                         )
+                        _structured_reasoning = (
+                            getattr(_trunc_msg, "reasoning", None)
+                            or getattr(_trunc_msg, "reasoning_content", None)
+                        ) if _trunc_msg else None
+                        if _structured_reasoning and not _has_think_tags:
+                            _preview = _structured_reasoning[:600].strip()
+                            if len(_structured_reasoning) > 600:
+                                _preview += "…"
+                            _exhaust_response += (
+                                f"\n\n💭 **Reasoning captured before exhaustion:**\n> "
+                                + _preview.replace("\n", "\n> ")
+                            )
                         agent._cleanup_task_resources(effective_task_id)
                         agent._persist_session(messages, conversation_history)
                         return {


### PR DESCRIPTION
## Summary
- Extends `_thinking_exhausted` detection in `conversation_loop.py` to recognize **structured reasoning** (`message.reasoning` / `message.reasoning_content`) in addition to inline `<think>` tags
- When exhaustion is triggered via structured reasoning, appends a 600-char preview of the captured reasoning to the user-facing error message

## Problem
Models like `qwen3:8b` via Ollama return reasoning in the structured `message.reasoning` field instead of inline `<think>` tags. The existing detection only checked for `<think>` tags, so these responses fell through to 3 useless continuation retries + 2 prefills before returning "(empty)" to the user — making the fallback appear "dumb."

## Changes
**`agent/conversation_loop.py`** — two blocks added:

1. **Detection** (line ~1391): New `_has_structured_reasoning` and `_content_is_empty` checks. `_thinking_exhausted` now triggers on `(has_think_tags AND no_visible_content) OR (has_structured_reasoning AND content_is_empty)`.

2. **Reasoning preview** (line ~1431): When exhaustion is detected via structured reasoning (not think tags), the user sees the first 600 chars of what the model was thinking instead of a blank response.

## Test plan
- [ ] Verify with a model that returns `content=""` + `reasoning="..."` (e.g., `qwen3:8b` via Ollama with `/thinkon` enabled)
- [ ] Verify existing `<think>` tag exhaustion detection still works unchanged
- [ ] Verify models that return `content=""` without any reasoning (e.g., GLM-4.7 truncation) still get normal continuation retries, not false-positive exhaustion

## Reproduction
```bash
# Force fallback to qwen3:8b and ask a question
# Before fix: returns "(empty)" after 5 retries
# After fix: returns "Thinking Budget Exhausted" + reasoning preview
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)