### PR TITLE
test: fix mock isolation and environment-leak failures across the suite

### DIFF
--- a/tests/gateway/conftest.py
+++ b/tests/gateway/conftest.py
@@ -47,10 +47,20 @@ def _ensure_telegram_mock() -> None:
     ``setdefault`` so it wins even if a partial/broken import
     already cached a module with ``ChatType = None``.
     """
-    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+    # Local-fix 2026-05-18: original bail-out used `hasattr(mod, "__file__")`,
+    # but MagicMock auto-creates ANY attribute on access — so the check is
+    # always True once any mock exists, blocking the comprehensive mock when
+    # a per-file limited one got installed first. Use ``vars()`` (only
+    # explicitly-set attributes) plus a sentinel so we only bail when OUR
+    # comprehensive mock is the one already in sys.modules.
+    _existing = sys.modules.get("telegram")
+    if _existing is not None and "_hermes_test_mock" in vars(_existing):
+        return  # Our comprehensive mock already installed
+    if _existing is not None and not isinstance(_existing, MagicMock) and hasattr(_existing, "__path__"):
         return  # Real library is installed — nothing to mock
 
     mod = MagicMock()
+    mod._hermes_test_mock = True
     mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
     mod.constants.ParseMode.MARKDOWN = "Markdown"
     mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
@@ -59,6 +69,23 @@ def _ensure_telegram_mock() -> None:
     mod.constants.ChatType.GROUP = "group"
     mod.constants.ChatType.SUPERGROUP = "supergroup"
     mod.constants.ChatType.CHANNEL = "channel"
+
+    # Local-fix 2026-05-18: ``sys.modules["telegram.constants"] = mod``
+    # (set below) means that ``from telegram.constants import ChatType``
+    # resolves to ``mod.ChatType`` (parent-level attribute), NOT
+    # ``mod.constants.ChatType``. Mirror ChatType values onto mod.ChatType
+    # so production code's ``ChatType.SUPERGROUP`` matches the test's
+    # ``_ChatType.SUPERGROUP`` (which goes through the same import path).
+    # See the comment block at the top of tests/gateway/test_dm_topics.py
+    # for the historical context of this two-path quirk.
+    # NOTE: do NOT mirror ParseMode — some tests (telegram_approval_buttons,
+    # telegram_model_picker) assert ``"MARKDOWN_V2" in repr(parse_mode)``
+    # and rely on parse_mode being a MagicMock whose repr contains the
+    # attribute name. Mirroring to a real string breaks those.
+    mod.ChatType.PRIVATE = "private"
+    mod.ChatType.GROUP = "group"
+    mod.ChatType.SUPERGROUP = "supergroup"
+    mod.ChatType.CHANNEL = "channel"
 
     # Real exception classes so ``except (NetworkError, ...)`` clauses
     # in production code don't blow up with TypeError.
@@ -96,12 +123,17 @@ def _ensure_discord_mock() -> None:
     this function (it short-circuits when already present) rather than
     maintaining their own mock setup.
     """
-    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
+    # Local-fix 2026-05-18: see _ensure_telegram_mock for explanation.
+    _existing = sys.modules.get("discord")
+    if _existing is not None and "_hermes_test_mock" in vars(_existing):
+        return  # Our comprehensive mock already installed
+    if _existing is not None and not isinstance(_existing, MagicMock) and hasattr(_existing, "__path__"):
         return  # Real library is installed — nothing to mock
 
     from types import SimpleNamespace
 
     discord_mod = MagicMock()
+    discord_mod._hermes_test_mock = True
     discord_mod.Intents.default.return_value = MagicMock()
     discord_mod.Client = MagicMock
     discord_mod.File = MagicMock
@@ -207,10 +239,57 @@ def _ensure_discord_mock() -> None:
     discord_mod.app_commands = SimpleNamespace(
         describe=lambda **kwargs: (lambda fn: fn),
         choices=lambda **kwargs: (lambda fn: fn),
+        autocomplete=lambda **kwargs: (lambda fn: fn),
         Choice=lambda **kwargs: SimpleNamespace(**kwargs),
         Group=_FakeGroup,
         Command=_FakeCommand,
     )
+
+    # AllowedMentions: real class so tests can assert on .everyone/.roles/.users
+    # default values (which must be False for safe defaults).
+    class _FakeAllowedMentions:
+        def __init__(self, *, everyone=True, roles=True, users=True, replied_user=True):
+            self.everyone = everyone
+            self.roles = roles
+            self.users = users
+            self.replied_user = replied_user
+    discord_mod.AllowedMentions = _FakeAllowedMentions
+
+    # Permissions: simple class with .value used by slash-command auth tests.
+    class _FakePermissions:
+        def __init__(self, value=0, **_):
+            self.value = value
+    discord_mod.Permissions = _FakePermissions
+
+    # opus: voice support stub — tests only check the attribute exists / is loaded.
+    discord_mod.opus = SimpleNamespace(
+        is_loaded=lambda: True,
+        load_opus=lambda *a, **k: None,
+    )
+
+    # Real exception classes so ``except discord.Forbidden`` etc. don't
+    # explode with "catching classes that do not inherit from BaseException".
+    discord_mod.Forbidden = type("Forbidden", (Exception,), {})
+    discord_mod.NotFound = type("NotFound", (Exception,), {})
+    discord_mod.HTTPException = type("HTTPException", (Exception,), {})
+    discord_mod.RateLimited = type("RateLimited", (Exception,), {})
+    discord_mod.ConnectionClosed = type("ConnectionClosed", (Exception,), {})
+
+    # MessageType / Object — used by e2e, dm-topic, and system-message tests.
+    discord_mod.MessageType = SimpleNamespace(
+        default=0, reply=19,
+        new_member=7, recipient_add=1, recipient_remove=2,
+        call=3, channel_name_change=4, channel_icon_change=5,
+        pins_add=6, premium_guild_subscription=8,
+        premium_guild_tier_1=9, premium_guild_tier_2=10, premium_guild_tier_3=11,
+        channel_follow_add=12, guild_stream=13, guild_discovery_disqualified=14,
+        guild_discovery_requalified=15, thread_created=18,
+        chat_input_command=20, thread_starter_message=21,
+        guild_invite_reminder=22, context_menu_command=23,
+        auto_moderation_action=24, role_subscription_purchase=25,
+        thread_rename=27, stage_start=27,
+    )
+    discord_mod.Object = lambda *, id: SimpleNamespace(id=id)
 
     ext_mod = MagicMock()
     commands_mod = MagicMock()

--- a/tests/gateway/test_discord_allowed_mentions.py
+++ b/tests/gateway/test_discord_allowed_mentions.py
@@ -32,52 +32,9 @@ class _FakeAllowedMentions:
 
 
 def _ensure_discord_mock():
-    """Install (or augment) a mock ``discord`` module.
-
-    Other test modules in this directory stub ``discord`` via
-    ``sys.modules.setdefault`` — whichever test file imports first wins and
-    our full module is then silently dropped. We therefore ALWAYS force
-    ``AllowedMentions`` onto whatever is currently in ``sys.modules["discord"]``;
-    that's the only attribute this test file actually needs real behavior from.
-    """
-    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
-        sys.modules["discord"].AllowedMentions = _FakeAllowedMentions
-        return
-
-    if sys.modules.get("discord") is None:
-        discord_mod = MagicMock()
-        discord_mod.Intents.default.return_value = MagicMock()
-        discord_mod.Client = MagicMock
-        discord_mod.File = MagicMock
-        discord_mod.DMChannel = type("DMChannel", (), {})
-        discord_mod.Thread = type("Thread", (), {})
-        discord_mod.ForumChannel = type("ForumChannel", (), {})
-        discord_mod.ui = SimpleNamespace(View=object, button=lambda *a, **k: (lambda fn: fn), Button=object)
-        discord_mod.ButtonStyle = SimpleNamespace(success=1, primary=2, danger=3, green=1, blurple=2, red=3, grey=4, secondary=5)
-        discord_mod.Color = SimpleNamespace(orange=lambda: 1, green=lambda: 2, blue=lambda: 3, red=lambda: 4)
-        discord_mod.Interaction = object
-        discord_mod.Embed = MagicMock
-        discord_mod.app_commands = SimpleNamespace(
-            describe=lambda **kwargs: (lambda fn: fn),
-            choices=lambda **kwargs: (lambda fn: fn),
-            Choice=lambda **kwargs: SimpleNamespace(**kwargs),
-        )
-        discord_mod.opus = SimpleNamespace(is_loaded=lambda: True)
-
-        ext_mod = MagicMock()
-        commands_mod = MagicMock()
-        commands_mod.Bot = MagicMock
-        ext_mod.commands = commands_mod
-
-        sys.modules["discord"] = discord_mod
-        sys.modules.setdefault("discord.ext", ext_mod)
-        sys.modules.setdefault("discord.ext.commands", commands_mod)
-
-    # Whether we just installed the mock OR the mock was already installed
-    # by another test's _ensure_discord_mock, force the AllowedMentions
-    # stand-in onto it — _build_allowed_mentions() reads this attribute.
-    sys.modules["discord"].AllowedMentions = _FakeAllowedMentions
-
+    """Delegate to central comprehensive mock in gateway/conftest.py."""
+    from tests.gateway.conftest import _ensure_discord_mock as _central
+    _central()
 
 _ensure_discord_mock()
 

--- a/tests/gateway/test_discord_attachment_download.py
+++ b/tests/gateway/test_discord_attachment_download.py
@@ -24,37 +24,9 @@ from gateway.config import PlatformConfig
 
 
 def _ensure_discord_mock():
-    """Install a mock discord module when discord.py isn't available."""
-    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
-        return
-
-    discord_mod = MagicMock()
-    discord_mod.Intents.default.return_value = MagicMock()
-    discord_mod.Client = MagicMock
-    discord_mod.File = MagicMock
-    discord_mod.DMChannel = type("DMChannel", (), {})
-    discord_mod.Thread = type("Thread", (), {})
-    discord_mod.ForumChannel = type("ForumChannel", (), {})
-    discord_mod.ui = SimpleNamespace(View=object, button=lambda *a, **k: (lambda fn: fn), Button=object)
-    discord_mod.ButtonStyle = SimpleNamespace(success=1, primary=2, secondary=2, danger=3, green=1, grey=2, blurple=2, red=3)
-    discord_mod.Color = SimpleNamespace(orange=lambda: 1, green=lambda: 2, blue=lambda: 3, red=lambda: 4, purple=lambda: 5)
-    discord_mod.Interaction = object
-    discord_mod.Embed = MagicMock
-    discord_mod.app_commands = SimpleNamespace(
-        describe=lambda **kwargs: (lambda fn: fn),
-        choices=lambda **kwargs: (lambda fn: fn),
-        Choice=lambda **kwargs: SimpleNamespace(**kwargs),
-    )
-
-    ext_mod = MagicMock()
-    commands_mod = MagicMock()
-    commands_mod.Bot = MagicMock
-    ext_mod.commands = commands_mod
-
-    sys.modules.setdefault("discord", discord_mod)
-    sys.modules.setdefault("discord.ext", ext_mod)
-    sys.modules.setdefault("discord.ext.commands", commands_mod)
-
+    """Delegate to central comprehensive mock in gateway/conftest.py."""
+    from tests.gateway.conftest import _ensure_discord_mock as _central
+    _central()
 
 _ensure_discord_mock()
 

--- a/tests/gateway/test_discord_channel_controls.py
+++ b/tests/gateway/test_discord_channel_controls.py
@@ -11,37 +11,9 @@ from gateway.config import PlatformConfig
 
 
 def _ensure_discord_mock():
-    """Install a mock discord module when discord.py isn't available."""
-    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
-        return
-
-    discord_mod = MagicMock()
-    discord_mod.Intents.default.return_value = MagicMock()
-    discord_mod.Client = MagicMock
-    discord_mod.File = MagicMock
-    discord_mod.DMChannel = type("DMChannel", (), {})
-    discord_mod.Thread = type("Thread", (), {})
-    discord_mod.ForumChannel = type("ForumChannel", (), {})
-    discord_mod.ui = SimpleNamespace(View=object, button=lambda *a, **k: (lambda fn: fn), Button=object)
-    discord_mod.ButtonStyle = SimpleNamespace(success=1, primary=2, secondary=2, danger=3, green=1, grey=2, blurple=2, red=3)
-    discord_mod.Color = SimpleNamespace(orange=lambda: 1, green=lambda: 2, blue=lambda: 3, red=lambda: 4, purple=lambda: 5)
-    discord_mod.Interaction = object
-    discord_mod.Embed = MagicMock
-    discord_mod.app_commands = SimpleNamespace(
-        describe=lambda **kwargs: (lambda fn: fn),
-        choices=lambda **kwargs: (lambda fn: fn),
-        Choice=lambda **kwargs: SimpleNamespace(**kwargs),
-    )
-
-    ext_mod = MagicMock()
-    commands_mod = MagicMock()
-    commands_mod.Bot = MagicMock
-    ext_mod.commands = commands_mod
-
-    sys.modules.setdefault("discord", discord_mod)
-    sys.modules.setdefault("discord.ext", ext_mod)
-    sys.modules.setdefault("discord.ext.commands", commands_mod)
-
+    """Delegate to central comprehensive mock in gateway/conftest.py."""
+    from tests.gateway.conftest import _ensure_discord_mock as _central
+    _central()
 
 _ensure_discord_mock()
 

--- a/tests/gateway/test_discord_channel_prompts.py
+++ b/tests/gateway/test_discord_channel_prompts.py
@@ -10,23 +10,9 @@ import pytest
 
 
 def _ensure_discord_mock():
-    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
-        return
-    discord_mod = types.ModuleType("discord")
-    discord_mod.Intents = MagicMock()
-    discord_mod.Intents.default.return_value = MagicMock()
-    discord_mod.DMChannel = type("DMChannel", (), {})
-    discord_mod.Thread = type("Thread", (), {})
-    discord_mod.ForumChannel = type("ForumChannel", (), {})
-    discord_mod.Interaction = object
-    ext_mod = MagicMock()
-    commands_mod = MagicMock()
-    commands_mod.Bot = MagicMock
-    ext_mod.commands = commands_mod
-    sys.modules.setdefault("discord", discord_mod)
-    sys.modules.setdefault("discord.ext", ext_mod)
-    sys.modules.setdefault("discord.ext.commands", commands_mod)
-
+    """Delegate to central comprehensive mock in gateway/conftest.py."""
+    from tests.gateway.conftest import _ensure_discord_mock as _central
+    _central()
 
 import gateway.run as gateway_run
 from gateway.config import Platform

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -22,48 +22,9 @@ class _FakeAllowedMentions:
 
 
 def _ensure_discord_mock():
-    """Install (or augment) a mock ``discord`` module.
-
-    Always force ``AllowedMentions`` onto whatever is in ``sys.modules`` —
-    other test files also stub the module via ``setdefault``, and we need
-    ``_build_allowed_mentions()``'s return value to have real attribute
-    access regardless of which file loaded first.
-    """
-    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
-        sys.modules["discord"].AllowedMentions = _FakeAllowedMentions
-        return
-
-    if sys.modules.get("discord") is None:
-        discord_mod = MagicMock()
-        discord_mod.Intents.default.return_value = MagicMock()
-        discord_mod.Client = MagicMock
-        discord_mod.File = MagicMock
-        discord_mod.DMChannel = type("DMChannel", (), {})
-        discord_mod.Thread = type("Thread", (), {})
-        discord_mod.ForumChannel = type("ForumChannel", (), {})
-        discord_mod.ui = SimpleNamespace(View=object, button=lambda *a, **k: (lambda fn: fn), Button=object)
-        discord_mod.ButtonStyle = SimpleNamespace(success=1, primary=2, danger=3, green=1, blurple=2, red=3, grey=4, secondary=5)
-        discord_mod.Color = SimpleNamespace(orange=lambda: 1, green=lambda: 2, blue=lambda: 3, red=lambda: 4)
-        discord_mod.Interaction = object
-        discord_mod.Embed = MagicMock
-        discord_mod.app_commands = SimpleNamespace(
-            describe=lambda **kwargs: (lambda fn: fn),
-            choices=lambda **kwargs: (lambda fn: fn),
-            Choice=lambda **kwargs: SimpleNamespace(**kwargs),
-        )
-        discord_mod.opus = SimpleNamespace(is_loaded=lambda: True)
-
-        ext_mod = MagicMock()
-        commands_mod = MagicMock()
-        commands_mod.Bot = MagicMock
-        ext_mod.commands = commands_mod
-
-        sys.modules["discord"] = discord_mod
-        sys.modules.setdefault("discord.ext", ext_mod)
-        sys.modules.setdefault("discord.ext.commands", commands_mod)
-
-    sys.modules["discord"].AllowedMentions = _FakeAllowedMentions
-
+    """Delegate to central comprehensive mock in gateway/conftest.py."""
+    from tests.gateway.conftest import _ensure_discord_mock as _central
+    _central()
 
 _ensure_discord_mock()
 

--- a/tests/gateway/test_discord_document_handling.py
+++ b/tests/gateway/test_discord_document_handling.py
@@ -23,37 +23,9 @@ from gateway.platforms.base import MessageType
 # ---------------------------------------------------------------------------
 
 def _ensure_discord_mock():
-    """Install a mock discord module when discord.py isn't available."""
-    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
-        return
-
-    discord_mod = MagicMock()
-    discord_mod.Intents.default.return_value = MagicMock()
-    discord_mod.Client = MagicMock
-    discord_mod.File = MagicMock
-    discord_mod.DMChannel = type("DMChannel", (), {})
-    discord_mod.Thread = type("Thread", (), {})
-    discord_mod.ForumChannel = type("ForumChannel", (), {})
-    discord_mod.ui = SimpleNamespace(View=object, button=lambda *a, **k: (lambda fn: fn), Button=object)
-    discord_mod.ButtonStyle = SimpleNamespace(success=1, primary=2, secondary=2, danger=3, green=1, grey=2, blurple=2, red=3)
-    discord_mod.Color = SimpleNamespace(orange=lambda: 1, green=lambda: 2, blue=lambda: 3, red=lambda: 4, purple=lambda: 5)
-    discord_mod.Interaction = object
-    discord_mod.Embed = MagicMock
-    discord_mod.app_commands = SimpleNamespace(
-        describe=lambda **kwargs: (lambda fn: fn),
-        choices=lambda **kwargs: (lambda fn: fn),
-        Choice=lambda **kwargs: SimpleNamespace(**kwargs),
-    )
-
-    ext_mod = MagicMock()
-    commands_mod = MagicMock()
-    commands_mod.Bot = MagicMock
-    ext_mod.commands = commands_mod
-
-    sys.modules.setdefault("discord", discord_mod)
-    sys.modules.setdefault("discord.ext", ext_mod)
-    sys.modules.setdefault("discord.ext.commands", commands_mod)
-
+    """Delegate to central comprehensive mock in gateway/conftest.py."""
+    from tests.gateway.conftest import _ensure_discord_mock as _central
+    _central()
 
 _ensure_discord_mock()
 

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -11,37 +11,9 @@ from gateway.config import PlatformConfig
 
 
 def _ensure_discord_mock():
-    """Install a mock discord module when discord.py isn't available."""
-    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
-        return
-
-    discord_mod = MagicMock()
-    discord_mod.Intents.default.return_value = MagicMock()
-    discord_mod.Client = MagicMock
-    discord_mod.File = MagicMock
-    discord_mod.DMChannel = type("DMChannel", (), {})
-    discord_mod.Thread = type("Thread", (), {})
-    discord_mod.ForumChannel = type("ForumChannel", (), {})
-    discord_mod.ui = SimpleNamespace(View=object, button=lambda *a, **k: (lambda fn: fn), Button=object)
-    discord_mod.ButtonStyle = SimpleNamespace(success=1, primary=2, secondary=2, danger=3, green=1, grey=2, blurple=2, red=3)
-    discord_mod.Color = SimpleNamespace(orange=lambda: 1, green=lambda: 2, blue=lambda: 3, red=lambda: 4, purple=lambda: 5)
-    discord_mod.Interaction = object
-    discord_mod.Embed = MagicMock
-    discord_mod.app_commands = SimpleNamespace(
-        describe=lambda **kwargs: (lambda fn: fn),
-        choices=lambda **kwargs: (lambda fn: fn),
-        Choice=lambda **kwargs: SimpleNamespace(**kwargs),
-    )
-
-    ext_mod = MagicMock()
-    commands_mod = MagicMock()
-    commands_mod.Bot = MagicMock
-    ext_mod.commands = commands_mod
-
-    sys.modules.setdefault("discord", discord_mod)
-    sys.modules.setdefault("discord.ext", ext_mod)
-    sys.modules.setdefault("discord.ext.commands", commands_mod)
-
+    """Delegate to central comprehensive mock in gateway/conftest.py."""
+    from tests.gateway.conftest import _ensure_discord_mock as _central
+    _central()
 
 _ensure_discord_mock()
 

--- a/tests/gateway/test_discord_reactions.py
+++ b/tests/gateway/test_discord_reactions.py
@@ -13,30 +13,9 @@ from gateway.session import SessionSource, build_session_key
 
 
 def _ensure_discord_mock():
-    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
-        return
-
-    discord_mod = MagicMock()
-    discord_mod.Intents.default.return_value = MagicMock()
-    discord_mod.DMChannel = type("DMChannel", (), {})
-    discord_mod.Thread = type("Thread", (), {})
-    discord_mod.ForumChannel = type("ForumChannel", (), {})
-    discord_mod.Interaction = object
-    discord_mod.app_commands = SimpleNamespace(
-        describe=lambda **kwargs: (lambda fn: fn),
-        choices=lambda **kwargs: (lambda fn: fn),
-        Choice=lambda **kwargs: SimpleNamespace(**kwargs),
-    )
-
-    ext_mod = MagicMock()
-    commands_mod = MagicMock()
-    commands_mod.Bot = MagicMock
-    ext_mod.commands = commands_mod
-
-    sys.modules.setdefault("discord", discord_mod)
-    sys.modules.setdefault("discord.ext", ext_mod)
-    sys.modules.setdefault("discord.ext.commands", commands_mod)
-
+    """Delegate to central comprehensive mock in gateway/conftest.py."""
+    from tests.gateway.conftest import _ensure_discord_mock as _central
+    _central()
 
 _ensure_discord_mock()
 

--- a/tests/gateway/test_discord_reply_mode.py
+++ b/tests/gateway/test_discord_reply_mode.py
@@ -19,37 +19,9 @@ from gateway.config import PlatformConfig, GatewayConfig, Platform, _apply_env_o
 
 
 def _ensure_discord_mock():
-    """Install a mock discord module when discord.py isn't available."""
-    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
-        return
-
-    discord_mod = MagicMock()
-    discord_mod.Intents.default.return_value = MagicMock()
-    discord_mod.Client = MagicMock
-    discord_mod.File = MagicMock
-    discord_mod.DMChannel = type("DMChannel", (), {})
-    discord_mod.Thread = type("Thread", (), {})
-    discord_mod.ForumChannel = type("ForumChannel", (), {})
-    discord_mod.ui = SimpleNamespace(View=object, button=lambda *a, **k: (lambda fn: fn), Button=object)
-    discord_mod.ButtonStyle = SimpleNamespace(success=1, primary=2, secondary=2, danger=3, green=1, grey=2, blurple=2, red=3)
-    discord_mod.Color = SimpleNamespace(orange=lambda: 1, green=lambda: 2, blue=lambda: 3, red=lambda: 4, purple=lambda: 5)
-    discord_mod.Interaction = object
-    discord_mod.Embed = MagicMock
-    discord_mod.app_commands = SimpleNamespace(
-        describe=lambda **kwargs: (lambda fn: fn),
-        choices=lambda **kwargs: (lambda fn: fn),
-        Choice=lambda **kwargs: SimpleNamespace(**kwargs),
-    )
-
-    ext_mod = MagicMock()
-    commands_mod = MagicMock()
-    commands_mod.Bot = MagicMock
-    ext_mod.commands = commands_mod
-
-    sys.modules.setdefault("discord", discord_mod)
-    sys.modules.setdefault("discord.ext", ext_mod)
-    sys.modules.setdefault("discord.ext.commands", commands_mod)
-
+    """Delegate to central comprehensive mock in gateway/conftest.py."""
+    from tests.gateway.conftest import _ensure_discord_mock as _central
+    _central()
 
 _ensure_discord_mock()
 

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -9,36 +9,9 @@ from gateway.config import PlatformConfig
 
 
 def _ensure_discord_mock():
-    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
-        return
-
-    discord_mod = MagicMock()
-    discord_mod.Intents.default.return_value = MagicMock()
-    discord_mod.Client = MagicMock
-    discord_mod.File = MagicMock
-    discord_mod.DMChannel = type("DMChannel", (), {})
-    discord_mod.Thread = type("Thread", (), {})
-    discord_mod.ForumChannel = type("ForumChannel", (), {})
-    discord_mod.ui = SimpleNamespace(View=object, button=lambda *a, **k: (lambda fn: fn), Button=object)
-    discord_mod.ButtonStyle = SimpleNamespace(success=1, primary=2, secondary=2, danger=3, green=1, grey=2, blurple=2, red=3)
-    discord_mod.Color = SimpleNamespace(orange=lambda: 1, green=lambda: 2, blue=lambda: 3, red=lambda: 4, purple=lambda: 5)
-    discord_mod.Interaction = object
-    discord_mod.Embed = MagicMock
-    discord_mod.app_commands = SimpleNamespace(
-        describe=lambda **kwargs: (lambda fn: fn),
-        choices=lambda **kwargs: (lambda fn: fn),
-        Choice=lambda **kwargs: SimpleNamespace(**kwargs),
-    )
-
-    ext_mod = MagicMock()
-    commands_mod = MagicMock()
-    commands_mod.Bot = MagicMock
-    ext_mod.commands = commands_mod
-
-    sys.modules.setdefault("discord", discord_mod)
-    sys.modules.setdefault("discord.ext", ext_mod)
-    sys.modules.setdefault("discord.ext.commands", commands_mod)
-
+    """Delegate to central comprehensive mock in gateway/conftest.py."""
+    from tests.gateway.conftest import _ensure_discord_mock as _central
+    _central()
 
 _ensure_discord_mock()
 

--- a/tests/gateway/test_discord_slash_auth.py
+++ b/tests/gateway/test_discord_slash_auth.py
@@ -27,61 +27,9 @@ from gateway.config import PlatformConfig
 
 
 def _ensure_discord_mock():
-    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
-        return  # real discord installed
-
-    if sys.modules.get("discord") is None:
-        discord_mod = MagicMock()
-        discord_mod.Intents.default.return_value = MagicMock()
-        discord_mod.DMChannel = type("DMChannel", (), {})
-        discord_mod.Thread = type("Thread", (), {})
-        discord_mod.ForumChannel = type("ForumChannel", (), {})
-        discord_mod.Interaction = object
-
-        class _FakePermissions:
-            def __init__(self, value=0, **_):
-                self.value = value
-
-        discord_mod.Permissions = _FakePermissions
-
-        class _FakeGroup:
-            def __init__(self, *, name, description, parent=None):
-                self.name = name
-                self.description = description
-                self.parent = parent
-                self._children: dict[str, object] = {}
-                if parent is not None:
-                    parent.add_command(self)
-
-            def add_command(self, cmd):
-                self._children[cmd.name] = cmd
-
-        class _FakeCommand:
-            def __init__(self, *, name, description, callback, parent=None):
-                self.name = name
-                self.description = description
-                self.callback = callback
-                self.parent = parent
-                self.default_permissions = None
-
-        discord_mod.app_commands = SimpleNamespace(
-            describe=lambda **kwargs: (lambda fn: fn),
-            choices=lambda **kwargs: (lambda fn: fn),
-            autocomplete=lambda **kwargs: (lambda fn: fn),
-            Choice=lambda **kwargs: SimpleNamespace(**kwargs),
-            Group=_FakeGroup,
-            Command=_FakeCommand,
-        )
-
-        ext_mod = MagicMock()
-        commands_mod = MagicMock()
-        commands_mod.Bot = MagicMock
-        ext_mod.commands = commands_mod
-
-        sys.modules["discord"] = discord_mod
-        sys.modules.setdefault("discord.ext", ext_mod)
-        sys.modules.setdefault("discord.ext.commands", commands_mod)
-
+    """Delegate to central comprehensive mock in gateway/conftest.py."""
+    from tests.gateway.conftest import _ensure_discord_mock as _central
+    _central()
 
 _ensure_discord_mock()
 

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -10,68 +10,9 @@ from gateway.config import PlatformConfig
 
 
 def _ensure_discord_mock():
-    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
-        # Real discord is installed — nothing to do.
-        return
-
-    if sys.modules.get("discord") is None:
-        discord_mod = MagicMock()
-        discord_mod.Intents.default.return_value = MagicMock()
-        discord_mod.DMChannel = type("DMChannel", (), {})
-        discord_mod.Thread = type("Thread", (), {})
-        discord_mod.ForumChannel = type("ForumChannel", (), {})
-        discord_mod.Interaction = object
-
-        # Lightweight mock for app_commands.Group and Command used by
-        # _register_skill_group.
-        class _FakeGroup:
-            def __init__(self, *, name, description, parent=None):
-                self.name = name
-                self.description = description
-                self.parent = parent
-                self._children: dict[str, object] = {}
-                if parent is not None:
-                    parent.add_command(self)
-
-            def add_command(self, cmd):
-                self._children[cmd.name] = cmd
-
-        class _FakeCommand:
-            def __init__(self, *, name, description, callback, parent=None):
-                self.name = name
-                self.description = description
-                self.callback = callback
-                self.parent = parent
-
-        discord_mod.app_commands = SimpleNamespace(
-            describe=lambda **kwargs: (lambda fn: fn),
-            choices=lambda **kwargs: (lambda fn: fn),
-            autocomplete=lambda **kwargs: (lambda fn: fn),
-            Choice=lambda **kwargs: SimpleNamespace(**kwargs),
-            Group=_FakeGroup,
-            Command=_FakeCommand,
-        )
-
-        ext_mod = MagicMock()
-        commands_mod = MagicMock()
-        commands_mod.Bot = MagicMock
-        ext_mod.commands = commands_mod
-
-        sys.modules["discord"] = discord_mod
-        sys.modules.setdefault("discord.ext", ext_mod)
-        sys.modules.setdefault("discord.ext.commands", commands_mod)
-
-    # Whether we just installed the mock OR another test module installed
-    # it first via its own _ensure_discord_mock, force the decorators we
-    # need onto discord.app_commands — the flat /skill command uses
-    # @app_commands.autocomplete and not every other mock stub exposes it.
-    _app = getattr(sys.modules["discord"], "app_commands", None)
-    if _app is not None and not hasattr(_app, "autocomplete"):
-        try:
-            _app.autocomplete = lambda **kwargs: (lambda fn: fn)
-        except Exception:
-            pass
-
+    """Delegate to central comprehensive mock in gateway/conftest.py."""
+    from tests.gateway.conftest import _ensure_discord_mock as _central
+    _central()
 
 _ensure_discord_mock()
 

--- a/tests/gateway/test_dm_topics.py
+++ b/tests/gateway/test_dm_topics.py
@@ -22,20 +22,9 @@ from gateway.config import PlatformConfig
 
 
 def _ensure_telegram_mock():
-    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
-        return
-
-    telegram_mod = MagicMock()
-    telegram_mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
-    telegram_mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
-    telegram_mod.constants.ChatType.GROUP = "group"
-    telegram_mod.constants.ChatType.SUPERGROUP = "supergroup"
-    telegram_mod.constants.ChatType.CHANNEL = "channel"
-    telegram_mod.constants.ChatType.PRIVATE = "private"
-
-    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
-        sys.modules.setdefault(name, telegram_mod)
-
+    """Delegate to central comprehensive mock in gateway/conftest.py."""
+    from tests.gateway.conftest import _ensure_telegram_mock as _central
+    _central()
 
 _ensure_telegram_mock()
 

--- a/tests/gateway/test_send_image_file.py
+++ b/tests/gateway/test_send_image_file.py
@@ -64,21 +64,9 @@ class TestExtractMediaImages:
 
 
 def _ensure_telegram_mock():
-    """Install mock telegram modules so TelegramAdapter can be imported."""
-    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
-        return
-
-    telegram_mod = MagicMock()
-    telegram_mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
-    telegram_mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
-    telegram_mod.constants.ChatType.GROUP = "group"
-    telegram_mod.constants.ChatType.SUPERGROUP = "supergroup"
-    telegram_mod.constants.ChatType.CHANNEL = "channel"
-    telegram_mod.constants.ChatType.PRIVATE = "private"
-
-    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
-        sys.modules.setdefault(name, telegram_mod)
-
+    """Delegate to central comprehensive mock in gateway/conftest.py."""
+    from tests.gateway.conftest import _ensure_telegram_mock as _central
+    _central()
 
 _ensure_telegram_mock()
 
@@ -174,18 +162,9 @@ class TestTelegramSendImageFile:
 
 
 def _ensure_discord_mock():
-    """Install mock discord module so DiscordAdapter can be imported."""
-    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
-        return
-
-    discord_mod = MagicMock()
-    discord_mod.Intents.default.return_value = MagicMock()
-    discord_mod.Client = MagicMock
-    discord_mod.File = MagicMock
-
-    for name in ("discord", "discord.ext", "discord.ext.commands"):
-        sys.modules.setdefault(name, discord_mod)
-
+    """Delegate to central comprehensive mock in gateway/conftest.py."""
+    from tests.gateway.conftest import _ensure_discord_mock as _central
+    _central()
 
 _ensure_discord_mock()
 

--- a/tests/gateway/test_send_multiple_images.py
+++ b/tests/gateway/test_send_multiple_images.py
@@ -101,18 +101,9 @@ class TestBaseDefaultLoop:
 
 
 def _ensure_telegram_mock():
-    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
-        return
-    telegram_mod = MagicMock()
-    telegram_mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
-    telegram_mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
-    telegram_mod.constants.ChatType.GROUP = "group"
-    telegram_mod.constants.ChatType.SUPERGROUP = "supergroup"
-    telegram_mod.constants.ChatType.CHANNEL = "channel"
-    telegram_mod.constants.ChatType.PRIVATE = "private"
-    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
-        sys.modules.setdefault(name, telegram_mod)
-
+    """Delegate to central comprehensive mock in gateway/conftest.py."""
+    from tests.gateway.conftest import _ensure_telegram_mock as _central
+    _central()
 
 _ensure_telegram_mock()
 
@@ -198,15 +189,9 @@ class TestTelegramMultiImage:
 
 
 def _ensure_discord_mock():
-    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
-        return
-    discord_mod = MagicMock()
-    discord_mod.Intents.default.return_value = MagicMock()
-    discord_mod.Client = MagicMock
-    discord_mod.File = MagicMock
-    for name in ("discord", "discord.ext", "discord.ext.commands"):
-        sys.modules.setdefault(name, discord_mod)
-
+    """Delegate to central comprehensive mock in gateway/conftest.py."""
+    from tests.gateway.conftest import _ensure_discord_mock as _central
+    _central()
 
 _ensure_discord_mock()
 

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -21,29 +21,9 @@ if _repo not in sys.path:
 # Minimal Telegram mock so TelegramAdapter can be imported
 # ---------------------------------------------------------------------------
 def _ensure_telegram_mock():
-    """Wire up the minimal mocks required to import TelegramAdapter."""
-    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
-        return
-
-    mod = MagicMock()
-    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
-    mod.constants.ParseMode.MARKDOWN = "Markdown"
-    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
-    mod.constants.ParseMode.HTML = "HTML"
-    mod.constants.ChatType.PRIVATE = "private"
-    mod.constants.ChatType.GROUP = "group"
-    mod.constants.ChatType.SUPERGROUP = "supergroup"
-    mod.constants.ChatType.CHANNEL = "channel"
-    # Provide real exception classes so ``except (NetworkError, ...)`` in
-    # connect() doesn't blow up under xdist when this mock leaks.
-    mod.error.NetworkError = type("NetworkError", (OSError,), {})
-    mod.error.TimedOut = type("TimedOut", (OSError,), {})
-    mod.error.BadRequest = type("BadRequest", (Exception,), {})
-
-    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
-        sys.modules.setdefault(name, mod)
-    sys.modules.setdefault("telegram.error", mod.error)
-
+    """Delegate to central comprehensive mock in gateway/conftest.py."""
+    from tests.gateway.conftest import _ensure_telegram_mock as _central
+    _central()
 
 _ensure_telegram_mock()
 

--- a/tests/gateway/test_telegram_clarify_buttons.py
+++ b/tests/gateway/test_telegram_clarify_buttons.py
@@ -26,26 +26,9 @@ if _repo not in sys.path:
 # test_telegram_approval_buttons.py)
 # ---------------------------------------------------------------------------
 def _ensure_telegram_mock():
-    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
-        return
-
-    mod = MagicMock()
-    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
-    mod.constants.ParseMode.MARKDOWN = "Markdown"
-    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
-    mod.constants.ParseMode.HTML = "HTML"
-    mod.constants.ChatType.PRIVATE = "private"
-    mod.constants.ChatType.GROUP = "group"
-    mod.constants.ChatType.SUPERGROUP = "supergroup"
-    mod.constants.ChatType.CHANNEL = "channel"
-    mod.error.NetworkError = type("NetworkError", (OSError,), {})
-    mod.error.TimedOut = type("TimedOut", (OSError,), {})
-    mod.error.BadRequest = type("BadRequest", (Exception,), {})
-
-    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
-        sys.modules.setdefault(name, mod)
-    sys.modules.setdefault("telegram.error", mod.error)
-
+    """Delegate to central comprehensive mock in gateway/conftest.py."""
+    from tests.gateway.conftest import _ensure_telegram_mock as _central
+    _central()
 
 _ensure_telegram_mock()
 

--- a/tests/gateway/test_telegram_conflict.py
+++ b/tests/gateway/test_telegram_conflict.py
@@ -9,28 +9,9 @@ from gateway.config import PlatformConfig
 
 
 def _ensure_telegram_mock():
-    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
-        return
-
-    telegram_mod = MagicMock()
-    telegram_mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
-    telegram_mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
-    telegram_mod.constants.ChatType.GROUP = "group"
-    telegram_mod.constants.ChatType.SUPERGROUP = "supergroup"
-    telegram_mod.constants.ChatType.CHANNEL = "channel"
-    telegram_mod.constants.ChatType.PRIVATE = "private"
-
-    # Provide real exception classes so ``except (NetworkError, ...)`` in
-    # connect() doesn't blow up with "catching classes that do not inherit
-    # from BaseException" when another xdist worker pollutes sys.modules.
-    telegram_mod.error.NetworkError = type("NetworkError", (OSError,), {})
-    telegram_mod.error.TimedOut = type("TimedOut", (OSError,), {})
-    telegram_mod.error.BadRequest = type("BadRequest", (Exception,), {})
-
-    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
-        sys.modules.setdefault(name, telegram_mod)
-    sys.modules.setdefault("telegram.error", telegram_mod.error)
-
+    """Delegate to central comprehensive mock in gateway/conftest.py."""
+    from tests.gateway.conftest import _ensure_telegram_mock as _central
+    _central()
 
 _ensure_telegram_mock()
 

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -32,23 +32,9 @@ from gateway.platforms.base import (
 # ---------------------------------------------------------------------------
 
 def _ensure_telegram_mock():
-    """Install mock telegram modules so TelegramAdapter can be imported."""
-    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
-        # Real library is installed — no mocking needed
-        return
-
-    telegram_mod = MagicMock()
-    # ContextTypes needs DEFAULT_TYPE as an actual attribute for the annotation
-    telegram_mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
-    telegram_mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
-    telegram_mod.constants.ChatType.GROUP = "group"
-    telegram_mod.constants.ChatType.SUPERGROUP = "supergroup"
-    telegram_mod.constants.ChatType.CHANNEL = "channel"
-    telegram_mod.constants.ChatType.PRIVATE = "private"
-
-    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
-        sys.modules.setdefault(name, telegram_mod)
-
+    """Delegate to central comprehensive mock in gateway/conftest.py."""
+    from tests.gateway.conftest import _ensure_telegram_mock as _central
+    _central()
 
 _ensure_telegram_mock()
 

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -20,18 +20,9 @@ from gateway.config import PlatformConfig
 # ---------------------------------------------------------------------------
 
 def _ensure_telegram_mock():
-    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
-        return
-    mod = MagicMock()
-    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
-    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
-    mod.constants.ChatType.GROUP = "group"
-    mod.constants.ChatType.SUPERGROUP = "supergroup"
-    mod.constants.ChatType.CHANNEL = "channel"
-    mod.constants.ChatType.PRIVATE = "private"
-    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
-        sys.modules.setdefault(name, mod)
-
+    """Delegate to central comprehensive mock in gateway/conftest.py."""
+    from tests.gateway.conftest import _ensure_telegram_mock as _central
+    _central()
 
 _ensure_telegram_mock()
 

--- a/tests/gateway/test_telegram_model_picker.py
+++ b/tests/gateway/test_telegram_model_picker.py
@@ -8,26 +8,9 @@ import pytest
 
 
 def _ensure_telegram_mock():
-    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
-        return
-
-    mod = MagicMock()
-    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
-    mod.constants.ParseMode.MARKDOWN = "Markdown"
-    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
-    mod.constants.ParseMode.HTML = "HTML"
-    mod.constants.ChatType.PRIVATE = "private"
-    mod.constants.ChatType.GROUP = "group"
-    mod.constants.ChatType.SUPERGROUP = "supergroup"
-    mod.constants.ChatType.CHANNEL = "channel"
-    mod.error.NetworkError = type("NetworkError", (OSError,), {})
-    mod.error.TimedOut = type("TimedOut", (OSError,), {})
-    mod.error.BadRequest = type("BadRequest", (Exception,), {})
-
-    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
-        sys.modules.setdefault(name, mod)
-    sys.modules.setdefault("telegram.error", mod.error)
-
+    """Delegate to central comprehensive mock in gateway/conftest.py."""
+    from tests.gateway.conftest import _ensure_telegram_mock as _central
+    _central()
 
 _ensure_telegram_mock()
 

--- a/tests/gateway/test_telegram_network_reconnect.py
+++ b/tests/gateway/test_telegram_network_reconnect.py
@@ -16,20 +16,9 @@ from gateway.config import PlatformConfig
 
 
 def _ensure_telegram_mock():
-    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
-        return
-
-    telegram_mod = MagicMock()
-    telegram_mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
-    telegram_mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
-    telegram_mod.constants.ChatType.GROUP = "group"
-    telegram_mod.constants.ChatType.SUPERGROUP = "supergroup"
-    telegram_mod.constants.ChatType.CHANNEL = "channel"
-    telegram_mod.constants.ChatType.PRIVATE = "private"
-
-    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
-        sys.modules.setdefault(name, telegram_mod)
-
+    """Delegate to central comprehensive mock in gateway/conftest.py."""
+    from tests.gateway.conftest import _ensure_telegram_mock as _central
+    _central()
 
 _ensure_telegram_mock()
 

--- a/tests/gateway/test_telegram_reply_mode.py
+++ b/tests/gateway/test_telegram_reply_mode.py
@@ -15,19 +15,9 @@ from gateway.config import PlatformConfig, GatewayConfig, Platform, _apply_env_o
 
 
 def _ensure_telegram_mock():
-    """Mock the telegram package if it's not installed."""
-    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
-        return
-    mod = MagicMock()
-    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
-    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
-    mod.constants.ChatType.GROUP = "group"
-    mod.constants.ChatType.SUPERGROUP = "supergroup"
-    mod.constants.ChatType.CHANNEL = "channel"
-    mod.constants.ChatType.PRIVATE = "private"
-    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
-        sys.modules.setdefault(name, mod)
-
+    """Delegate to central comprehensive mock in gateway/conftest.py."""
+    from tests.gateway.conftest import _ensure_telegram_mock as _central
+    _central()
 
 _ensure_telegram_mock()
 

--- a/tests/gateway/test_telegram_reply_quote.py
+++ b/tests/gateway/test_telegram_reply_quote.py
@@ -16,20 +16,9 @@ from gateway.config import PlatformConfig
 
 
 def _ensure_telegram_mock():
-    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
-        return
-
-    telegram_mod = MagicMock()
-    telegram_mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
-    telegram_mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
-    telegram_mod.constants.ChatType.GROUP = "group"
-    telegram_mod.constants.ChatType.SUPERGROUP = "supergroup"
-    telegram_mod.constants.ChatType.CHANNEL = "channel"
-    telegram_mod.constants.ChatType.PRIVATE = "private"
-
-    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
-        sys.modules.setdefault(name, telegram_mod)
-
+    """Delegate to central comprehensive mock in gateway/conftest.py."""
+    from tests.gateway.conftest import _ensure_telegram_mock as _central
+    _central()
 
 _ensure_telegram_mock()
 

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -13,41 +13,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 
 def _ensure_discord_mock():
-    """Install a lightweight discord mock when discord.py isn't available."""
-    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
-        return
-
-    discord_mod = MagicMock()
-    discord_mod.Intents.default.return_value = MagicMock()
-    discord_mod.Client = MagicMock
-    discord_mod.File = MagicMock
-    discord_mod.DMChannel = type("DMChannel", (), {})
-    discord_mod.Thread = type("Thread", (), {})
-    discord_mod.ForumChannel = type("ForumChannel", (), {})
-    discord_mod.ui = SimpleNamespace(View=object, button=lambda *a, **k: (lambda fn: fn), Button=object)
-    discord_mod.ButtonStyle = SimpleNamespace(success=1, primary=2, secondary=2, danger=3, green=1, grey=2, blurple=2, red=3)
-    discord_mod.Color = SimpleNamespace(orange=lambda: 1, green=lambda: 2, blue=lambda: 3, red=lambda: 4, purple=lambda: 5)
-    discord_mod.Interaction = object
-    discord_mod.Embed = MagicMock
-    discord_mod.app_commands = SimpleNamespace(
-        describe=lambda **kwargs: (lambda fn: fn),
-        choices=lambda **kwargs: (lambda fn: fn),
-        Choice=lambda **kwargs: SimpleNamespace(**kwargs),
-    )
-    discord_mod.opus = SimpleNamespace(is_loaded=lambda: True, load_opus=lambda *_args, **_kwargs: None)
-    discord_mod.FFmpegPCMAudio = MagicMock
-    discord_mod.PCMVolumeTransformer = MagicMock
-    discord_mod.http = SimpleNamespace(Route=MagicMock)
-
-    ext_mod = MagicMock()
-    commands_mod = MagicMock()
-    commands_mod.Bot = MagicMock
-    ext_mod.commands = commands_mod
-
-    sys.modules.setdefault("discord", discord_mod)
-    sys.modules.setdefault("discord.ext", ext_mod)
-    sys.modules.setdefault("discord.ext.commands", commands_mod)
-
+    """Delegate to central comprehensive mock in gateway/conftest.py."""
+    from tests.gateway.conftest import _ensure_discord_mock as _central
+    _central()
 
 _ensure_discord_mock()
 

--- a/tests/hermes_cli/test_list_picker_providers.py
+++ b/tests/hermes_cli/test_list_picker_providers.py
@@ -19,6 +19,18 @@ import pytest
 from hermes_cli import model_switch
 
 
+@pytest.fixture(autouse=True)
+def _no_live_endpoint_probe(monkeypatch):
+    # Local-fix 2026-05-18: list_authenticated_providers probes each custom
+    # endpoint via fetch_api_models. On a dev box with live Ollama at
+    # localhost:11434, the real models leak into picker results and break
+    # assertions. Stub the probe to return empty so tests measure picker
+    # logic, not the dev box.
+    monkeypatch.setattr(
+        "hermes_cli.models.fetch_api_models", lambda *a, **k: []
+    )
+
+
 def _make_provider(slug, name=None, models=None, *, is_current=False,
                    is_user_defined=False, source="built-in", api_url=None):
     """Build a dict shaped like ``list_authenticated_providers`` output."""

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -5,9 +5,26 @@ shared slash-command pipeline (`/model` in CLI/gateway/Telegram) historically
 only looked at `providers:`.
 """
 
+import pytest
+
 import hermes_cli.providers as providers_mod
 from hermes_cli.model_switch import list_authenticated_providers, switch_model
 from hermes_cli.providers import resolve_provider_full
+
+
+@pytest.fixture(autouse=True)
+def _no_live_endpoint_probe(monkeypatch):
+    # Local-fix 2026-05-18: ``list_authenticated_providers`` does a live HTTP
+    # probe of each custom_providers endpoint via ``fetch_api_models`` (see
+    # ``hermes_cli/model_switch.py`` around line 1715). On dev boxes with a
+    # running Ollama at localhost:11434, the probe returns the user's real
+    # models — overwhelming the hand-crafted entries the tests pass in and
+    # breaking assertions like ``total_models == 6``. Stub the probe to
+    # always return an empty list so the tests measure the in-process
+    # grouping logic, not the dev box's environment.
+    monkeypatch.setattr(
+        "hermes_cli.models.fetch_api_models", lambda *a, **k: []
+    )
 
 
 _MOCK_VALIDATION = {

--- a/tests/run_agent/test_agent_guardrails.py
+++ b/tests/run_agent/test_agent_guardrails.py
@@ -8,10 +8,28 @@ Covers three static methods on AIAgent (inspired by PR #1321 — @alireza78a):
 
 import types
 
+import pytest
+
 from run_agent import AIAgent
 from tools.delegate_tool import _get_max_concurrent_children
 
 MAX_CONCURRENT_CHILDREN = _get_max_concurrent_children()
+
+
+@pytest.fixture(autouse=True)
+def _force_default_max_concurrent_children(monkeypatch):
+    # Local-fix 2026-05-18: ``MAX_CONCURRENT_CHILDREN`` is computed at this
+    # test module's import time from ``_get_max_concurrent_children()``,
+    # which reads ``cli.CLI_CONFIG``. If ``cli`` was first imported by a
+    # prior test BEFORE the per-test HERMES_HOME isolation kicked in,
+    # CLI_CONFIG carries Jamie's real ``delegation.max_concurrent_children``
+    # (5 on this box). Later ``AIAgent._cap_delegate_task_calls`` re-reads
+    # the function and may see a different value than the module-level
+    # constant. Pin both so the test is hermetic.
+    monkeypatch.setattr("tools.delegate_tool._load_config", lambda: {})
+    # Also reset the module-level constant to match (default is 3).
+    import tests.run_agent.test_agent_guardrails as _mod
+    monkeypatch.setattr(_mod, "MAX_CONCURRENT_CHILDREN", 3)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -345,7 +345,15 @@ class TestDelegateTask(unittest.TestCase):
             delegate_task(goal="Test tracking", parent_agent=parent)
             self.assertEqual(len(parent._active_children), 0)
 
-    def test_child_inherits_runtime_credentials(self):
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_child_inherits_runtime_credentials(self, mock_load):
+        # Local-fix 2026-05-18: ``cli.CLI_CONFIG`` is module-level state. If
+        # ``cli`` was first imported by a test that ran before the per-test
+        # HERMES_HOME isolation fixture (or before any test fixture at all),
+        # CLI_CONFIG carries the dev box's ``delegation`` block (LiteLLM
+        # router URL). The test expects empty delegation config so child
+        # inherits credentials from parent. Force empty config to make
+        # the test hermetic.
         parent = _make_mock_parent(depth=0)
         parent.base_url = "https://chatgpt.com/backend-api/codex"
         parent.api_key="***"
@@ -836,7 +844,10 @@ class TestBlockedTools(unittest.TestCase):
         for tool in ["delegate_task", "clarify", "memory", "send_message", "execute_code"]:
             self.assertIn(tool, DELEGATE_BLOCKED_TOOLS)
 
-    def test_constants(self):
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_constants(self, mock_load):
+        # Local-fix 2026-05-18: force empty delegation config — see
+        # test_child_inherits_runtime_credentials above for rationale.
         from tools.delegate_tool import (
             _get_max_spawn_depth, _get_orchestrator_enabled,
             _MIN_SPAWN_DEPTH, _MAX_SPAWN_DEPTH_CAP,

--- a/tests/tools/test_terminal_tool_requirements.py
+++ b/tests/tools/test_terminal_tool_requirements.py
@@ -2,9 +2,30 @@
 
 import importlib
 
-from model_tools import get_tool_definitions
+import pytest
+
+from model_tools import _clear_tool_defs_cache, get_tool_definitions
 
 terminal_tool_module = importlib.import_module("tools.terminal_tool")
+
+
+@pytest.fixture(autouse=True)
+def _drop_tool_definitions_cache():
+    # Local-fix 2026-05-18: there are TWO module-level caches that key off
+    # state these tests monkeypatch:
+    #   1. ``model_tools._tool_defs_cache`` — keyed on toolsets + registry
+    #      generation + config mtime (NOT on env_config).
+    #   2. ``tools.registry._check_fn_cache`` — 30s TTL'd memoization of
+    #      ``check_terminal_requirements`` etc. that bypasses our
+    #      ``_get_env_config`` monkeypatch entirely.
+    # Without clearing both, a prior test in any other file can pre-populate
+    # them and these vercel-hide tests get stale results.
+    from tools.registry import invalidate_check_fn_cache
+    _clear_tool_defs_cache()
+    invalidate_check_fn_cache()
+    yield
+    _clear_tool_defs_cache()
+    invalidate_check_fn_cache()
 
 
 class TestTerminalRequirements:

--- a/tests/tools/test_tirith_security.py
+++ b/tests/tools/test_tirith_security.py
@@ -830,8 +830,12 @@ class TestDiskFailureMarker:
         marker = os.path.join(tmpdir, ".tirith-install-failed")
         with patch("tools.tirith_security._failure_marker_path", return_value=marker):
             from tools.tirith_security import _mark_install_failed, _is_install_failed_on_disk
-            _mark_install_failed("cosign_missing")
-            assert _is_install_failed_on_disk()  # cosign still absent
+            # Local-fix 2026-05-18: the first assert expects cosign to be absent,
+            # but on dev machines cosign may actually be installed (Kali, sigstore
+            # users). Force the absence explicitly so the test is hermetic.
+            with patch("tools.tirith_security.shutil.which", return_value=None):
+                _mark_install_failed("cosign_missing")
+                assert _is_install_failed_on_disk()  # cosign still absent
 
             # Now cosign appears on PATH
             with patch("tools.tirith_security.shutil.which", return_value="/usr/local/bin/cosign"):


### PR DESCRIPTION
## What does this PR do?

Fixes a class of cross-test contamination bugs that cause non-deterministic failures in the test suite — both locally and in CI. The fixes fall into three categories:

**1. Mock-installer "first-test wins" pattern (gateway/)**

~27 gateway test files each had their own `_ensure_discord_mock` / `_ensure_telegram_mock` helper that bailed out via `hasattr(mock, "__file__")`. Since `MagicMock` auto-fakes any attribute access, that check always passed once *any* test file had run its installer. Subsequent tests then inherited whatever mock shape the first installer happened to register, dropping attributes other tests needed (e.g. `discord.AllowedMentions`, the full `telegram.constants.ChatType` string enum, `discord.app_commands.autocomplete`, `discord.Forbidden`/`NotFound`/`HTTPException`/`RateLimited`/`ConnectionClosed`).

Fix: centralise the installers in `tests/gateway/conftest.py` with a comprehensive mock surface and a sentinel-attribute (`_hermes_test_mock`) check resolved via `vars()` rather than `getattr()`. Per-file helpers now delegate to the central installer.

One subtle quirk: setting `sys.modules["telegram.constants"] = mod` (the parent telegram mock) means `from telegram.constants import ChatType` resolves to `mod.ChatType`, not `mod.constants.ChatType`. The fix mirrors ChatType strings onto both paths. ParseMode is deliberately *not* mirrored — several telegram tests assert `\"MARKDOWN_V2\" in repr(parse_mode)` and rely on MagicMock's default repr.

**2. Module-state and cache leakage (tools/, hermes_cli/, run_agent/)**

Several tests captured real environment state at module-import time:

- `model_tools._tool_defs_cache` and `tools.registry._check_fn_cache` persisted across tests, defeating later `monkeypatch` of backend probes
- `hermes_cli/model_switch.py:fetch_api_models` made live HTTP probes to Ollama, leaking real local models into model-picker assertions
- `tools.delegate_tool._load_config` read the developer's real `delegation.max_concurrent_children` before HERMES_HOME isolation, so `MAX_CONCURRENT_CHILDREN` froze at the local value (5 on this machine) instead of the test-expected default (3)

Fix: per-file autouse fixtures clear both caches and pin `fetch_api_models` / `_load_config` to deterministic stubs.

**3. Environment-binary detection (tools/test_tirith_security.py)**

`test_cosign_missing_marker_clears_when_cosign_appears` asserted that the \"cosign missing\" marker is set when cosign is absent — but the first assertion ran without monkeypatching `shutil.which`, so on a developer machine with cosign installed the test failed.

Fix: wrap the first assert in `patch(\"shutil.which\", return_value=None)`.

## Related Issue

No issue filed — surfaced while running \`pytest tests/ -q\` locally.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- \`tests/gateway/conftest.py\` — comprehensive central mock + sentinel-attribute installer
- 27× \`tests/gateway/test_*.py\` — per-file installers now delegate to central
- \`tests/tools/test_terminal_tool_requirements.py\` — autouse fixture clears \`_tool_defs_cache\` + \`_check_fn_cache\`
- \`tests/hermes_cli/test_list_picker_providers.py\`, \`test_model_switch_custom_providers.py\` — autouse fixture stubs \`fetch_api_models\` to \`[]\`
- \`tests/run_agent/test_agent_guardrails.py\` — autouse fixture pins \`MAX_CONCURRENT_CHILDREN=3\` + patches \`_load_config\`
- \`tests/tools/test_delegate.py\` — explicit \`_load_config\` patch on the two affected tests
- \`tests/tools/test_tirith_security.py\` — \`shutil.which\` patch on cosign-missing assertion

## How to Test

1. Targeted: \`pytest tests/gateway tests/tools/test_terminal_tool_requirements.py tests/hermes_cli/test_model_switch_custom_providers.py tests/hermes_cli/test_list_picker_providers.py tests/run_agent/test_agent_guardrails.py tests/tools/test_delegate.py tests/tools/test_tirith_security.py -q\` — all pass (5806 passed, 8 skipped).

2. Subset comparison (\`tests/tools tests/plugins tests/gateway\` under default \`-n auto\`):
   - **main**: 28 failed, 11357 passed, 27 errors
   - **this branch**: 25 failed, 11360 passed, 27 errors

3. The 27 errors are pre-existing (unrelated namespace-package monkeypatch issue in \`test_hindsight_provider.py\` where pytest's \`monkeypatch.setattr(\"plugins.memory.hindsight.X\", ...)\` fails when a worker hasn't transitively imported \`plugins.memory\` yet). Same count on both branches — out of scope for this PR.

## Checklist

### Code

- [x] My commit messages follow Conventional Commits (\`test:\`)
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run \`pytest tests/ -q\` and the failures/errors that remain match upstream main except where this PR fixes them
- [x] I've tested on my platform: Linux (Kali 6.19, Python 3.11.11)

### Documentation & Housekeeping

- [x] N/A — test-only changes, no runtime/config/docs impact