### PR TITLE
fix(agent_init): read max_tokens from custom_providers per-model config

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1241,6 +1241,37 @@ def init_agent(
                                     )
                     break
 
+    # Also read max_tokens from custom_providers per-model config.
+    # Mirrors the context_length lookup above — without this the constructor's
+    # max_tokens=None default leaves API calls falling back to 4096 even when
+    # the user configured a higher per-model max_tokens (issue #28046).
+    if agent.max_tokens is None and _custom_providers:
+        _mt_target = agent.base_url.rstrip("/") if agent.base_url else ""
+        for _cp_entry in _custom_providers:
+            if not isinstance(_cp_entry, dict):
+                continue
+            _cp_url = (_cp_entry.get("base_url") or "").rstrip("/")
+            if _mt_target and _cp_url == _mt_target:
+                _cp_models = _cp_entry.get("models", {})
+                if isinstance(_cp_models, dict):
+                    _cp_model_cfg = _cp_models.get(agent.model, {})
+                    if isinstance(_cp_model_cfg, dict):
+                        _cp_mt = _cp_model_cfg.get("max_tokens")
+                        if _cp_mt is not None:
+                            try:
+                                _parsed_mt = int(_cp_mt)
+                                if _parsed_mt <= 0:
+                                    raise ValueError
+                                agent.max_tokens = _parsed_mt
+                            except (TypeError, ValueError):
+                                _ra().logger.warning(
+                                    "Invalid max_tokens for model %r in "
+                                    "custom_providers: %r — must be a positive "
+                                    "integer. Falling back to default.",
+                                    agent.model, _cp_mt,
+                                )
+                break
+
     # Persist for reuse on switch_model / fallback activation. Must come
     # AFTER the custom_providers branch so per-model overrides aren't lost.
     agent._config_context_length = _config_context_length

--- a/tests/run_agent/test_custom_provider_max_tokens.py
+++ b/tests/run_agent/test_custom_provider_max_tokens.py
@@ -1,0 +1,176 @@
+"""Tests that max_tokens is read from custom_providers per-model config.
+
+Regression test for #28046: prior to the fix, max_tokens in
+custom_providers[].models.<model> was ignored, so API calls fell back to
+the 4096 default even when the user configured a higher value.
+"""
+
+from unittest.mock import patch
+
+
+def _build_agent(model_cfg, custom_providers=None, model="gpt5.4"):
+    """Build an AIAgent with the given model config."""
+    cfg = {"model": model_cfg}
+    if custom_providers is not None:
+        cfg["custom_providers"] = custom_providers
+
+    base_url = model_cfg.get("base_url", "")
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("agent.model_metadata.get_model_context_length", return_value=128_000),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            model=model,
+            api_key="test-key-1234567890",
+            base_url=base_url,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    return agent
+
+
+def test_custom_providers_max_tokens_applied():
+    custom_providers = [
+        {
+            "name": "LiteLLM",
+            "base_url": "http://localhost:4000/v1",
+            "models": {
+                "gpt5.4": {"max_tokens": 32000},
+            },
+        }
+    ]
+    agent = _build_agent(
+        {"default": "gpt5.4", "provider": "custom",
+         "base_url": "http://localhost:4000/v1"},
+        custom_providers=custom_providers,
+        model="gpt5.4",
+    )
+    assert agent.max_tokens == 32000
+
+
+def test_custom_providers_max_tokens_string_numeric_parses():
+    custom_providers = [
+        {
+            "name": "LiteLLM",
+            "base_url": "http://localhost:4000/v1",
+            "models": {
+                "gpt5.4": {"max_tokens": "16000"},
+            },
+        }
+    ]
+    agent = _build_agent(
+        {"default": "gpt5.4", "provider": "custom",
+         "base_url": "http://localhost:4000/v1"},
+        custom_providers=custom_providers,
+        model="gpt5.4",
+    )
+    assert agent.max_tokens == 16000
+
+
+def test_custom_providers_invalid_max_tokens_warns_and_stays_none():
+    custom_providers = [
+        {
+            "name": "LiteLLM",
+            "base_url": "http://localhost:4000/v1",
+            "models": {
+                "gpt5.4": {"max_tokens": "32K"},
+            },
+        }
+    ]
+    with patch("run_agent.logger") as mock_logger:
+        agent = _build_agent(
+            {"default": "gpt5.4", "provider": "custom",
+             "base_url": "http://localhost:4000/v1"},
+            custom_providers=custom_providers,
+            model="gpt5.4",
+        )
+    assert agent.max_tokens is None
+    warning_calls = [c for c in mock_logger.warning.call_args_list
+                     if "Invalid max_tokens" in str(c) and "32K" in str(c)]
+    assert len(warning_calls) == 1
+
+
+def test_custom_providers_zero_max_tokens_warns_and_stays_none():
+    custom_providers = [
+        {
+            "name": "LiteLLM",
+            "base_url": "http://localhost:4000/v1",
+            "models": {
+                "gpt5.4": {"max_tokens": 0},
+            },
+        }
+    ]
+    with patch("run_agent.logger") as mock_logger:
+        agent = _build_agent(
+            {"default": "gpt5.4", "provider": "custom",
+             "base_url": "http://localhost:4000/v1"},
+            custom_providers=custom_providers,
+            model="gpt5.4",
+        )
+    assert agent.max_tokens is None
+    warning_calls = [c for c in mock_logger.warning.call_args_list
+                     if "Invalid max_tokens" in str(c)]
+    assert len(warning_calls) == 1
+
+
+def test_custom_providers_no_max_tokens_leaves_none():
+    custom_providers = [
+        {
+            "name": "LiteLLM",
+            "base_url": "http://localhost:4000/v1",
+            "models": {
+                "gpt5.4": {"context_length": 256000},
+            },
+        }
+    ]
+    agent = _build_agent(
+        {"default": "gpt5.4", "provider": "custom",
+         "base_url": "http://localhost:4000/v1"},
+        custom_providers=custom_providers,
+        model="gpt5.4",
+    )
+    assert agent.max_tokens is None
+
+
+def test_explicit_max_tokens_not_overridden_by_custom_providers():
+    """If max_tokens already set (e.g. via CLI/model config), don't override."""
+    custom_providers = [
+        {
+            "name": "LiteLLM",
+            "base_url": "http://localhost:4000/v1",
+            "models": {
+                "gpt5.4": {"max_tokens": 32000},
+            },
+        }
+    ]
+    cfg = {
+        "model": {"default": "gpt5.4", "provider": "custom",
+                  "base_url": "http://localhost:4000/v1"},
+        "custom_providers": custom_providers,
+    }
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("agent.model_metadata.get_model_context_length", return_value=128_000),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            model="gpt5.4",
+            api_key="test-key-1234567890",
+            base_url="http://localhost:4000/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            max_tokens=8000,
+        )
+    assert agent.max_tokens == 8000


### PR DESCRIPTION
## Summary

Fixes #28046 — `max_tokens` configured under `custom_providers[].models.<model>.max_tokens` was silently ignored. Output token requests fell back to the hard-coded 4096 default in `chat_completion_helpers.py:269` / `conversation_loop.py:2913`, capping responses even when the user configured a higher per-model limit.

## Root cause

`agent/agent_init.py` already had a per-model `context_length` lookup against `custom_providers`, but no equivalent for `max_tokens`. So `self.max_tokens` stayed `None` from the constructor default and the `self.max_tokens or 4096` fallback kicked in at request time.

## Fix

Added a parallel `max_tokens` lookup right after the existing `context_length` block in `agent/agent_init.py`:

- Only runs when `agent.max_tokens is None` (don't override an explicit constructor / CLI value).
- Matches on `base_url` then `model` against the `custom_providers` list — same matching as the `context_length` branch above.
- Coerces via `int()`; positive values win, non-positive / non-numeric values log a warning via `_ra().logger.warning` and leave `max_tokens` unchanged (so the 4096 default still kicks in).

## Tests

`tests/run_agent/test_custom_provider_max_tokens.py` — 6 cases:

1. valid integer `max_tokens` is applied
2. string-numeric (`"16000"`) parses and is applied
3. non-numeric (`"32K"`) is rejected with a warning, stays `None`
4. zero is rejected with a warning, stays `None`
5. missing `max_tokens` leaves it `None`
6. explicit constructor `max_tokens` is **not** overridden by the custom_providers lookup

All 6 pass; broader `tests/run_agent/` smoke run shows no regression.

## Repro (from issue)

```yaml
custom_providers:
  - name: xfyun
    base_url: https://maas-coding-api.cn-huabei-1.xf-yun.com/v2
    api_key: ${API_KEY}
    api_mode: chat_completions
    model: astron-code-latest
    models:
      astron-code-latest:
        context_length: 200000
        max_tokens: 32000
        reasoning: true
```

Before: responses cap at ~4096 tokens with `finish_reason='length'`.
After: configured `max_tokens=32000` is honored.

## Risk

Narrow — additive block, gated on `max_tokens is None and _custom_providers`. Mirrors a well-trodden code path right above it. Default behavior (no `custom_providers.models.<m>.max_tokens` set) is unchanged.
