### PR TITLE
fix(acp): mark failed tool completions in Zed

### DIFF
--- a/acp_adapter/tools.py
+++ b/acp_adapter/tools.py
@@ -202,6 +202,28 @@ def _json_loads_maybe(value: Optional[str]) -> Any:
         return None
 
 
+def _tool_result_failed(result: Optional[str]) -> bool:
+    """Return True when a structured Hermes tool result clearly failed.
+
+    Keep this deliberately conservative. Plain text can contain words like
+    "error" because tests failed or a command printed diagnostics; Zed should
+    only receive ACP failed status for structured tool-level failures.
+    """
+    data = _json_loads_maybe(result)
+    if not isinstance(data, dict):
+        return False
+
+    for key in ("success", "ok"):
+        if data.get(key) is False:
+            return True
+
+    exit_code = data.get("exit_code", data.get("returncode"))
+    if isinstance(exit_code, int) and exit_code != 0:
+        return True
+
+    return False
+
+
 def _truncate_text(text: str, limit: int = 5000) -> str:
     if len(text) <= limit:
         return text
@@ -1296,7 +1318,7 @@ def build_tool_complete(
     return acp.update_tool_call(
         tool_call_id,
         kind=kind,
-        status="completed",
+        status="failed" if _tool_result_failed(result) else "completed",
         content=content,
         raw_output=None if tool_name in _POLISHED_TOOLS or _is_structured_json_result(result) else result,
     )

--- a/acp_adapter/tools.py
+++ b/acp_adapter/tools.py
@@ -202,7 +202,7 @@ def _json_loads_maybe(value: Optional[str]) -> Any:
         return None
 
 
-def _tool_result_failed(result: Optional[str]) -> bool:
+def _tool_result_failed(result: Optional[str], tool_name: str | None = None) -> bool:
     """Return True when a structured Hermes tool result clearly failed.
 
     Keep this deliberately conservative. Plain text can contain words like
@@ -219,6 +219,13 @@ def _tool_result_failed(result: Optional[str]) -> bool:
 
     exit_code = data.get("exit_code", data.get("returncode"))
     if isinstance(exit_code, int) and exit_code != 0:
+        return True
+
+    # Hermes core/polished tools commonly report tool-level failures as a
+    # structured {"error": "..."} payload without an explicit success flag.
+    # Keep generic plugin/unknown tool payloads conservative to avoid marking
+    # optional diagnostic messages as failed.
+    if tool_name in _POLISHED_TOOLS and data.get("error") and not data.get("content"):
         return True
 
     return False
@@ -1318,7 +1325,7 @@ def build_tool_complete(
     return acp.update_tool_call(
         tool_call_id,
         kind=kind,
-        status="failed" if _tool_result_failed(result) else "completed",
+        status="failed" if _tool_result_failed(result, tool_name) else "completed",
         content=content,
         raw_output=None if tool_name in _POLISHED_TOOLS or _is_structured_json_result(result) else result,
     )

--- a/acp_adapter/tools.py
+++ b/acp_adapter/tools.py
@@ -209,6 +209,15 @@ def _tool_result_failed(result: Optional[str], tool_name: str | None = None) -> 
     "error" because tests failed or a command printed diagnostics; Zed should
     only receive ACP failed status for structured tool-level failures.
     """
+    # Raised exceptions from the agent's tool executor get wrapped in a
+    # canonical "Error executing tool '<name>': ..." prefix (see
+    # agent/tool_executor.py around the try/except). That prefix is uniquely
+    # produced by the wrapper itself — it cannot legitimately appear in
+    # well-behaved tool output. Catch it so a tool that blew up shows as
+    # failed in Zed instead of misleadingly green.
+    if isinstance(result, str) and result.startswith("Error executing tool '"):
+        return True
+
     data = _json_loads_maybe(result)
     if not isinstance(data, dict):
         return False

--- a/tests/acp/test_tools.py
+++ b/tests/acp/test_tools.py
@@ -365,6 +365,10 @@ class TestBuildToolComplete:
         result = build_tool_complete("tc-ok", "terminal", "tests failed: 1 assertion error")
         assert result.status == "completed"
 
+    def test_build_tool_complete_marks_structured_polished_tool_error_as_failed(self):
+        result = build_tool_complete("tc-fail", "read_file", '{"error": "File not found"}')
+        assert result.status == "failed"
+
     def test_build_tool_complete_keeps_json_error_without_failure_flag_completed(self):
         result = build_tool_complete("tc-ok", "some_tool", '{"error": "timeout while reading optional source"}')
         assert result.status == "completed"

--- a/tests/acp/test_tools.py
+++ b/tests/acp/test_tools.py
@@ -365,6 +365,31 @@ class TestBuildToolComplete:
         result = build_tool_complete("tc-ok", "terminal", "tests failed: 1 assertion error")
         assert result.status == "completed"
 
+    def test_build_tool_complete_marks_raised_exception_prefix_as_failed(self):
+        """The agent's tool executor wraps raised exceptions in a canonical
+        "Error executing tool '<name>': ..." prefix. That prefix is unique to
+        the wrapper and means the tool blew up, so it must surface as failed
+        in Zed regardless of whether the body parses as JSON.
+        """
+        result = build_tool_complete(
+            "tc-fail-exc",
+            "patch",
+            "Error executing tool 'patch': KeyError: 'foo'",
+        )
+        assert result.status == "failed"
+
+    def test_build_tool_complete_does_not_match_error_word_alone(self):
+        """Bare 'Error: ...' messages (without the unique 'Error executing
+        tool '<name>':' prefix) must still be reported as completed — they
+        legitimately appear in compiler/linter/test output.
+        """
+        result = build_tool_complete(
+            "tc-ok-error-word",
+            "terminal",
+            "Error: pytest collected 0 items",
+        )
+        assert result.status == "completed"
+
     def test_build_tool_complete_marks_structured_polished_tool_error_as_failed(self):
         result = build_tool_complete("tc-fail", "read_file", '{"error": "File not found"}')
         assert result.status == "failed"

--- a/tests/acp/test_tools.py
+++ b/tests/acp/test_tools.py
@@ -345,6 +345,30 @@ class TestBuildToolComplete:
         assert "hello" in text
         assert result.raw_output is None
 
+    def test_build_tool_complete_marks_success_false_as_failed(self):
+        result = build_tool_complete("tc-fail", "skill_manage", '{"success": false, "error": "boom"}')
+        assert result.status == "failed"
+
+    def test_build_tool_complete_marks_ok_false_as_failed(self):
+        result = build_tool_complete("tc-fail", "some_tool", '{"ok": false, "error": "boom"}')
+        assert result.status == "failed"
+
+    def test_build_tool_complete_marks_exit_code_nonzero_as_failed(self):
+        result = build_tool_complete("tc-fail", "terminal", '{"output": "bad", "exit_code": 2}')
+        assert result.status == "failed"
+
+    def test_build_tool_complete_marks_returncode_nonzero_as_failed(self):
+        result = build_tool_complete("tc-fail", "execute_code", '{"output": "bad", "returncode": 2}')
+        assert result.status == "failed"
+
+    def test_build_tool_complete_keeps_plain_error_text_completed(self):
+        result = build_tool_complete("tc-ok", "terminal", "tests failed: 1 assertion error")
+        assert result.status == "completed"
+
+    def test_build_tool_complete_keeps_json_error_without_failure_flag_completed(self):
+        result = build_tool_complete("tc-ok", "some_tool", '{"error": "timeout while reading optional source"}')
+        assert result.status == "completed"
+
     def test_build_tool_complete_for_skill_manage_summarizes_without_raw_json(self):
         result = build_tool_complete(
             "tc-skill-manage",


### PR DESCRIPTION
Salvage of #26573 by @HenkDz cherry-picked onto current main, plus a follow-up commit extending the rule to cover raised exceptions.

## Summary
Before this PR, every tool call rendered as a green 'completed' row in Zed regardless of whether it succeeded — `build_tool_complete` unconditionally sent `status='completed'`. Now failures are surfaced as red 'failed' rows.

## Changes
### From #26573 (HenkDz, preserved authorship)
- `acp_adapter/tools.py`: new `_tool_result_failed()` helper that flags structured JSON results with `success:false` / `ok:false` / non-zero `exit_code` / non-zero `returncode`, plus `{error:...}` payloads from polished tools. Wired into `build_tool_complete`'s status field.
- `tests/acp/test_tools.py`: 7 tests covering each positive case + negative cases (plain 'tests failed' text stays completed, polished-only gate on bare {error:...}).

### Extension (this salvage)
- Also flags results starting with `"Error executing tool '"` — the unique prefix the agent's tool executor wraps around raised exceptions (`agent/tool_executor.py`). Without this, raised exceptions still rendered green. 2 new tests (positive: raised-exception prefix → failed; negative: bare `Error:` word in legit output stays completed).

## Validation
`scripts/run_tests.sh tests/acp/test_tools.py` → 70/70 passing.

Closes #26573 (salvage merge — HenkDz's commits preserved verbatim, extension as separate commit).