### PR TITLE
fix(tui): preserve dunder identifiers in markdown

### DIFF
--- a/ui-tui/src/__tests__/markdown.test.ts
+++ b/ui-tui/src/__tests__/markdown.test.ts
@@ -46,7 +46,7 @@ const renderPlain = (node: React.ReactNode) => {
 describe('INLINE_RE emphasis', () => {
   it('matches word-boundary italic/bold', () => {
     expect(matches('say _hi_ there')).toEqual(['_hi_'])
-    expect(matches('very __bold__ move')).toEqual(['__bold__'])
+    expect(matches('very __bold move__ today')).toEqual(['__bold move__'])
     expect(matches('(_paren_) and [_bracket_]')).toEqual(['_paren_', '_bracket_'])
   })
 
@@ -56,6 +56,12 @@ describe('INLINE_RE emphasis', () => {
     expect(matches(path)).toEqual([])
     expect(matches('snake_case_var and MY_CONST')).toEqual([])
     expect(matches('foo__bar__baz')).toEqual([])
+  })
+
+  it('keeps Python dunder identifiers literal', () => {
+    expect(matches('if __name__ == "__main__":')).toEqual([])
+    expect(matches('def __init__(self):')).toEqual([])
+    expect(matches('print(__file__)')).toEqual([])
   })
 
   it('still matches asterisk emphasis intraword', () => {
@@ -93,7 +99,12 @@ describe('stripInlineMarkup', () => {
   it('strips word-boundary emphasis only', () => {
     expect(stripInlineMarkup('say _hi_ there')).toBe('say hi there')
     expect(stripInlineMarkup('browser_screenshot_ecc.png')).toBe('browser_screenshot_ecc.png')
-    expect(stripInlineMarkup('__bold__ and foo__bar__')).toBe('bold and foo__bar__')
+    expect(stripInlineMarkup('__bold move__ and foo__bar__')).toBe('bold move and foo__bar__')
+  })
+
+  it('preserves Python dunder identifiers', () => {
+    expect(stripInlineMarkup('if __name__ == "__main__":')).toBe('if __name__ == "__main__":')
+    expect(stripInlineMarkup('class X: def __init__(self): pass')).toBe('class X: def __init__(self): pass')
   })
 
   it('leaves ~!/~? kaomoji alone and still handles real subscript', () => {
@@ -215,6 +226,24 @@ describe('Md wrapping', () => {
     )
 
     expect(lines.some(line => line.startsWith(' hi  ok'))).toBe(true)
+  })
+
+  it('renders Python dunder identifiers literally outside code fences', () => {
+    const lines = renderPlain(
+      React.createElement(
+        Box,
+        { width: 80 },
+        React.createElement(Md, {
+          t: DEFAULT_THEME,
+          text: 'if __name__ == "__main__":\n    obj.__init__()'
+        })
+      )
+    )
+
+    const rendered = lines.join('\n')
+
+    expect(rendered).toContain('if __name__ == "__main__":')
+    expect(rendered).toContain('obj.__init__()')
   })
 })
 

--- a/ui-tui/src/components/markdown.tsx
+++ b/ui-tui/src/components/markdown.tsx
@@ -70,6 +70,12 @@ const NUMBERED_RE = /^(\s*)(\d+)[.)]\s+(.*)$/
 const QUOTE_RE = /^\s*(?:>\s*)+/
 const TABLE_DIVIDER_CELL_RE = /^:?-{3,}:?$/
 const MD_URL_RE = '((?:[^\\s()]|\\([^\\s()]*\\))+?)'
+const MD_IDENTIFIER_RE = '[A-Za-z_][A-Za-z0-9_]*'
+const MD_DUNDER_IDENTIFIER_RE = `(?:${MD_IDENTIFIER_RE}__(?!\\w))`
+const MD_UNDERSCORE_BOLD_RE = `(?<!\\w)__(?!${MD_DUNDER_IDENTIFIER_RE})(.+?)__(?!\\w)`
+const MD_UNDERSCORE_ITALIC_RE = `(?<![\\w_])_(?!_)(.+?)(?<!_)_(?![\\w_])`
+const STRIP_UNDERSCORE_BOLD_RE = new RegExp(MD_UNDERSCORE_BOLD_RE, 'g')
+const STRIP_UNDERSCORE_ITALIC_RE = new RegExp(MD_UNDERSCORE_ITALIC_RE, 'g')
 
 // Display math openers: `$$ ... $$` (TeX) and `\[ ... \]` (LaTeX). The
 // opener is matched only when `$$` / `\[` appears at the very start of the
@@ -107,9 +113,9 @@ export const INLINE_RE = new RegExp(
     `~~(.+?)~~`, // 6    strike
     `\`([^\\\`]+)\``, // 7    code
     `\\*\\*(.+?)\\*\\*`, // 8    bold *
-    `(?<!\\w)__(.+?)__(?!\\w)`, // 9    bold _
+    MD_UNDERSCORE_BOLD_RE, // 9    bold _
     `\\*(.+?)\\*`, // 10   italic *
-    `(?<!\\w)_(.+?)_(?!\\w)`, // 11   italic _
+    MD_UNDERSCORE_ITALIC_RE, // 11   italic _
     `==(.+?)==`, // 12   highlight
     `\\[\\^([^\\]]+)\\]`, // 13   footnote ref
     `\\^([^^\\s][^^]*?)\\^`, // 14   superscript
@@ -190,9 +196,9 @@ export const stripInlineMarkup = (v: string) =>
     .replace(/~~(.+?)~~/g, '$1')
     .replace(/`([^`]+)`/g, '$1')
     .replace(/\*\*(.+?)\*\*/g, '$1')
-    .replace(/(?<!\w)__(.+?)__(?!\w)/g, '$1')
+    .replace(STRIP_UNDERSCORE_BOLD_RE, '$1')
     .replace(/\*(.+?)\*/g, '$1')
-    .replace(/(?<!\w)_(.+?)_(?!\w)/g, '$1')
+    .replace(STRIP_UNDERSCORE_ITALIC_RE, '$1')
     .replace(/==(.+?)==/g, '$1')
     .replace(/\[\^([^\]]+)\]/g, '[$1]')
     .replace(/\^([^^\s][^^]*?)\^/g, '^$1')


### PR DESCRIPTION
## What does this PR do?

Preserves Python-style dunder identifiers such as `__name__`, `__main__`, `__init__`, and `__file__` in the TUI Markdown renderer. Previously, assistant output that was not inside a real Markdown code fence could parse those identifiers as underscore-bold Markdown, causing the visible TUI output to show `name` / `main` / `init` without the underscores. The same delimiter pattern was also used by `stripInlineMarkup`, so plain-text wrapping/export-style paths using that helper could strip the underscores too.

This keeps dunder identifiers literal while leaving `**bold**`, `_italic_`, and multi-word `__bold text__` emphasis available.

## Related Issue

Discord support thread: https://discord.com/channels/1053877538025386074/1505494151527923752

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `ui-tui/src/components/markdown.tsx`: add guarded underscore-emphasis regexes so bare dunder identifiers remain literal in both `INLINE_RE` rendering and `stripInlineMarkup`.
- `ui-tui/src/__tests__/markdown.test.ts`: add regression coverage for dunder identifiers in inline matching, markup stripping, and rendered TUI output.

## How to Test

1. In the TUI, render assistant output containing `if __name__ == "__main__":` outside a fenced code block.
2. Confirm the TUI displays the double underscores literally instead of rendering `name` / `main` without underscores.
3. Run the focused test commands below.

Focused verification run locally:

- `cd ui-tui && npm test -- src/__tests__/markdown.test.ts`
- `cd ui-tui && npm run type-check`
- `git diff --check -- ui-tui/src/components/markdown.tsx ui-tui/src/__tests__/markdown.test.ts`

Full-suite verification run locally after opening this draft:

- `scripts/run_tests.sh -n 4`
- Result: failed with `46 failed, 23869 passed, 54 skipped, 256 warnings, 19 errors in 675.89s`
- The failures/errors were broad and outside the touched TUI markdown regression file. The current workstation also had pre-existing unrelated dirty files (`AGENTS.md`, `pyproject.toml`, `optional-skills/autonomous-ai-agents/cursor/`, `support-replies`) that are not part of this PR.
- `HERMES_HOME` was unset before and after the run; no restoration was needed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL/Linux local checkout

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — JS regex lookbehind is already used in this file
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A

## Screenshots / Logs

Focused local test output:

`cd ui-tui && npm test -- src/__tests__/markdown.test.ts`

Result: 1 file passed, 28 tests passed.

`cd ui-tui && npm run type-check`

Result: passed.

Full local suite output summary:

`scripts/run_tests.sh -n 4`

Result: `46 failed, 23869 passed, 54 skipped, 256 warnings, 19 errors in 675.89s`.
