### PR TITLE
fix(acp): refresh Zed session title after auto-title

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -46,6 +46,7 @@ from acp.schema import (
     ResourceContentBlock,
     SessionCapabilities,
     SessionForkCapabilities,
+    SessionInfoUpdate,
     SessionListCapabilities,
     SessionMode,
     SessionModeState,
@@ -706,6 +707,35 @@ class HermesACPAgent(acp.Agent):
                 state.session_id,
                 exc_info=True,
             )
+
+    async def _send_session_info_update(self, session_id: str) -> None:
+        """Send ACP native session metadata after Hermes changes it."""
+        if not self._conn:
+            return
+        try:
+            row = self.session_manager._get_db().get_session(session_id)
+        except Exception:
+            logger.debug("Could not read ACP session info for %s", session_id, exc_info=True)
+            return
+        if not row:
+            return
+
+        title = row.get("title")
+        updated_at = row.get("updated_at")
+        if updated_at is not None and not isinstance(updated_at, str):
+            updated_at = str(updated_at)
+        update = SessionInfoUpdate(
+            session_update="session_info_update",
+            title=title if isinstance(title, str) and title.strip() else None,
+            updated_at=updated_at,
+        )
+        try:
+            await self._conn.session_update(
+                session_id=session_id,
+                update=update,
+            )
+        except Exception:
+            logger.debug("Could not send ACP session info update for %s", session_id, exc_info=True)
 
     def _schedule_usage_update(self, state: SessionState) -> None:
         """Schedule native context indicator refresh after ACP responses."""
@@ -1471,12 +1501,20 @@ class HermesACPAgent(acp.Agent):
             try:
                 from agent.title_generator import maybe_auto_title
 
+                def _notify_title_update(_title: str) -> None:
+                    if conn:
+                        loop.call_soon_threadsafe(
+                            asyncio.create_task,
+                            self._send_session_info_update(session_id),
+                        )
+
                 maybe_auto_title(
                     self.session_manager._get_db(),
                     session_id,
                     user_text,
                     final_response,
                     state.history,
+                    title_callback=_notify_title_update,
                 )
             except Exception:
                 logger.debug("Failed to auto-title ACP session %s", session_id, exc_info=True)

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime, timezone
 import base64
 import contextvars
 import json
@@ -721,9 +722,11 @@ class HermesACPAgent(acp.Agent):
             return
 
         title = row.get("title")
-        updated_at = row.get("updated_at")
-        if updated_at is not None and not isinstance(updated_at, str):
-            updated_at = str(updated_at)
+        # The `sessions` table does not have an `updated_at` column (see
+        # hermes_state.py schema — only started_at/ended_at). Use "now" as
+        # the updated_at since we're emitting this notification precisely
+        # because the title was just refreshed.
+        updated_at = datetime.now(timezone.utc).isoformat()
         update = SessionInfoUpdate(
             session_update="session_info_update",
             title=title if isinstance(title, str) and title.strip() else None,

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -29,6 +29,7 @@ from acp.schema import (
     SetSessionModelResponse,
     SetSessionModeResponse,
     SessionInfo,
+    SessionInfoUpdate,
     TextContentBlock,
     ToolCallProgress,
     ToolCallStart,
@@ -1140,6 +1141,48 @@ class TestPrompt:
         assert mock_title.call_args.args[1] == new_resp.session_id
         assert mock_title.call_args.args[2] == "fix the broken ACP history"
         assert mock_title.call_args.args[3] == "Here is the fix."
+        assert callable(mock_title.call_args.kwargs["title_callback"])
+
+    @pytest.mark.asyncio
+    async def test_prompt_sends_session_info_update_after_auto_title(self, agent):
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        resp = await agent.new_session(cwd="/tmp")
+        state = agent.session_manager.get_session(resp.session_id)
+        state.agent.run_conversation = MagicMock(return_value={
+            "final_response": "Done.",
+            "messages": [
+                {"role": "user", "content": "fix zed titles"},
+                {"role": "assistant", "content": "Done."},
+            ],
+            "prompt_tokens": 1,
+            "completion_tokens": 1,
+            "total_tokens": 2,
+        })
+
+        def fake_auto_title(db, session_id, user_text, final_response, history, **kwargs):
+            db.set_session_title(session_id, "Fix Zed titles")
+            kwargs["title_callback"]("Fix Zed titles")
+
+        with patch("agent.title_generator.maybe_auto_title", side_effect=fake_auto_title):
+            mock_conn.session_update.reset_mock()
+            await agent.prompt(
+                session_id=resp.session_id,
+                prompt=[TextContentBlock(type="text", text="fix zed titles")],
+            )
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+
+        updates = [
+            call.kwargs.get("update") or call.args[1]
+            for call in mock_conn.session_update.await_args_list
+        ]
+        info_updates = [u for u in updates if isinstance(u, SessionInfoUpdate)]
+        assert len(info_updates) == 1
+        assert info_updates[0].session_update == "session_info_update"
+        assert info_updates[0].title == "Fix Zed titles"
 
     @pytest.mark.asyncio
     async def test_prompt_populates_usage_from_top_level_run_conversation_fields(self, agent):


### PR DESCRIPTION
Salvage of #26543 by @HenkDz cherry-picked onto current main, plus a follow-up commit fixing the dead-`updated_at` nit.

## Summary
Zed's sidebar/tab title stayed frozen at the first-prompt-derived text even after Hermes generated and persisted a real auto-title some seconds later. Now sends a `SessionInfoUpdate` notification when `auto_title_session` finishes, so Zed refreshes the title in-place. Fires at most once per session.

## Changes
### From #26543 (HenkDz, preserved authorship)
- `acp_adapter/server.py`: new `_send_session_info_update()` helper; wired into the prompt path via a `title_callback` passed to `maybe_auto_title()` (existing extension point — already used by gateway/run.py for Telegram topic-title rename). Uses standard ACP `SessionInfoUpdate` via `conn.session_update(...)`. Cross-thread scheduled via `call_soon_threadsafe` (same pattern as `_schedule_usage_update`).
- `tests/acp/test_server.py`: regression test that auto-title triggers exactly one SessionInfoUpdate with the new title.

### Follow-up (this salvage)
- Replaced dead `row.get('updated_at')` read (the sessions table has no `updated_at` column — only started_at/ended_at) with `datetime.now(UTC).isoformat()`, which reflects exactly what the field means at this call site: 'the title was refreshed at this moment'.

## Validation
`scripts/run_tests.sh tests/acp/test_server.py` → 75/75 passing.

Closes #26543 (salvage merge — HenkDz's commit preserved, follow-up as separate commit).