### PR TITLE
fix(model-picker): ignore empty credential-pool entries

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1156,6 +1156,20 @@ def list_authenticated_providers(
         except Exception:
             return False
 
+    def _credential_pool_has_entries(pool_store: object, *provider_ids: str) -> bool:
+        """True only when auth.json has a non-empty credential pool list.
+
+        Empty placeholder entries like {"minimax-cn": []} should not make a
+        provider appear authenticated in the /model picker.
+        """
+        if not isinstance(pool_store, dict):
+            return False
+        for provider_id in provider_ids:
+            entries = pool_store.get(provider_id)
+            if isinstance(entries, list) and entries:
+                return True
+        return False
+
     data = fetch_models_dev()
 
     # Build curated model lists keyed by hermes provider ID
@@ -1232,7 +1246,9 @@ def list_authenticated_providers(
             try:
                 from hermes_cli.auth import _load_auth_store
                 store = _load_auth_store()
-                if store and hermes_id in store.get("credential_pool", {}):
+                if store and _credential_pool_has_entries(
+                    store.get("credential_pool", {}), hermes_id
+                ):
                     has_creds = True
             except Exception:
                 pass
@@ -1410,7 +1426,11 @@ def list_authenticated_providers(
                 from hermes_cli.auth import _load_auth_store
                 _cp_store = _load_auth_store()
                 _cp_providers_store = _cp_store.get("providers", {})
-                if _cp_store and _cp.slug in _cp_providers_store:
+                _cp_pool_store = _cp_store.get("credential_pool", {})
+                if _cp_store and (
+                    _cp.slug in _cp_providers_store
+                    or _credential_pool_has_entries(_cp_pool_store, _cp.slug)
+                ):
                     _cp_has_creds = True
             except Exception:
                 pass

--- a/tests/hermes_cli/test_model_switch_auth_store_credentials.py
+++ b/tests/hermes_cli/test_model_switch_auth_store_credentials.py
@@ -1,0 +1,80 @@
+from types import SimpleNamespace
+
+from hermes_cli.model_switch import list_authenticated_providers
+import hermes_cli.providers as providers_mod
+
+
+class _EmptyPool:
+    def has_credentials(self):
+        return False
+
+
+def test_list_authenticated_providers_ignores_empty_builtin_credential_pool_entries(monkeypatch):
+    monkeypatch.setattr(
+        "agent.models_dev.fetch_models_dev",
+        lambda: {"minimax-cn": {"env": ["MINIMAX_CN_API_KEY"]}},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth._load_auth_store",
+        lambda: {"credential_pool": {"minimax-cn": []}, "providers": {}},
+    )
+    monkeypatch.setattr("agent.credential_pool.load_pool", lambda _slug: _EmptyPool())
+    monkeypatch.delenv("MINIMAX_CN_API_KEY", raising=False)
+    monkeypatch.delenv("MINIMAX_CN_BASE_URL", raising=False)
+
+    providers = list_authenticated_providers(
+        current_provider="",
+        user_providers={},
+        custom_providers=[],
+        max_models=50,
+    )
+
+    assert all(p["slug"] != "minimax-cn" for p in providers)
+
+
+def test_list_authenticated_providers_keeps_nonempty_builtin_credential_pool_entries(monkeypatch):
+    monkeypatch.setattr(
+        "agent.models_dev.fetch_models_dev",
+        lambda: {"minimax-cn": {"env": ["MINIMAX_CN_API_KEY"]}},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth._load_auth_store",
+        lambda: {"credential_pool": {"minimax-cn": [{"api_key": "sk-test"}]}, "providers": {}},
+    )
+    monkeypatch.setattr("agent.credential_pool.load_pool", lambda _slug: _EmptyPool())
+    monkeypatch.delenv("MINIMAX_CN_API_KEY", raising=False)
+    monkeypatch.delenv("MINIMAX_CN_BASE_URL", raising=False)
+
+    providers = list_authenticated_providers(
+        current_provider="",
+        user_providers={},
+        custom_providers=[],
+        max_models=50,
+    )
+
+    assert any(p["slug"] == "minimax-cn" for p in providers)
+
+
+def test_list_authenticated_providers_ignores_empty_canonical_credential_pool_entries(monkeypatch):
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    monkeypatch.setattr(
+        "hermes_cli.models.CANONICAL_PROVIDERS",
+        [SimpleNamespace(slug="minimax-cn", label="MiniMax CN")],
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth._load_auth_store",
+        lambda: {"credential_pool": {"minimax-cn": []}, "providers": {}},
+    )
+    monkeypatch.setattr("agent.credential_pool.load_pool", lambda _slug: _EmptyPool())
+    monkeypatch.delenv("MINIMAX_CN_API_KEY", raising=False)
+    monkeypatch.delenv("MINIMAX_CN_BASE_URL", raising=False)
+
+    providers = list_authenticated_providers(
+        current_provider="",
+        user_providers={},
+        custom_providers=[],
+        max_models=50,
+    )
+
+    assert all(p["slug"] != "minimax-cn" for p in providers)


### PR DESCRIPTION
## Summary
- ignore empty `credential_pool` placeholder entries when deciding whether `/model` should show a provider as authenticated
- keep non-empty pool entries working for built-in/canonical provider rows
- add regression tests for empty vs non-empty auth-store credential-pool entries

## Why
Issue #28140 reports that deleting an env var can leave `auth.json` with `"provider": []`, which the picker was treating as authenticated just because the key existed.

## Test Plan
- `scripts/run_tests.sh tests/hermes_cli/test_model_switch_auth_store_credentials.py tests/hermes_cli/test_model_switch_custom_providers.py tests/hermes_cli/test_user_providers_model_switch.py`

Closes #28140
