### PR TITLE
fix(agent): honor custom provider max_tokens

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1247,6 +1247,36 @@ def init_agent(
 
     agent._ensure_lmstudio_runtime_loaded(_config_context_length)
 
+    # Also read max_tokens from custom_providers per-model config.
+    # Mirrors the context_length lookup above — without this the constructor's
+    # max_tokens=None default leaves API calls falling back to 4096 even when
+    # the user configured a higher per-model max_tokens (issue #28046).
+    if agent.max_tokens is None and _custom_providers:
+        _mt_target = agent.base_url.rstrip("/") if agent.base_url else ""
+        for _cp_entry in _custom_providers:
+            if not isinstance(_cp_entry, dict):
+                continue
+            _cp_url = (_cp_entry.get("base_url") or "").rstrip("/")
+            if _mt_target and _cp_url == _mt_target:
+                _cp_models = _cp_entry.get("models", {})
+                if isinstance(_cp_models, dict):
+                    _cp_model_cfg = _cp_models.get(agent.model, {})
+                    if isinstance(_cp_model_cfg, dict):
+                        _cp_mt = _cp_model_cfg.get("max_tokens")
+                        if _cp_mt is not None:
+                            try:
+                                _parsed_mt = int(_cp_mt)
+                                if _parsed_mt <= 0:
+                                    raise ValueError
+                                agent.max_tokens = _parsed_mt
+                            except (TypeError, ValueError):
+                                _ra().logger.warning(
+                                    "Invalid max_tokens for model %r in "
+                                    "custom_providers: %r — must be a positive "
+                                    "integer. Falling back to default.",
+                                    agent.model, _cp_mt,
+                                )
+                break
 
 
     # Select context engine: config-driven (like memory providers).

--- a/tests/run_agent/test_custom_provider_max_tokens.py
+++ b/tests/run_agent/test_custom_provider_max_tokens.py
@@ -1,0 +1,161 @@
+"""Tests that max_tokens is read from custom_providers per-model config."""
+
+from unittest.mock import patch
+
+
+def _build_agent(model_cfg, custom_providers=None, model="gpt5.4"):
+    cfg = {"model": model_cfg}
+    if custom_providers is not None:
+        cfg["custom_providers"] = custom_providers
+
+    base_url = model_cfg.get("base_url", "")
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("agent.model_metadata.get_model_context_length", return_value=128_000),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            model=model,
+            api_key="test-key-1234567890",
+            base_url=base_url,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    return agent
+
+
+def test_custom_providers_max_tokens_applied():
+    custom_providers = [
+        {
+            "name": "LiteLLM",
+            "base_url": "http://localhost:4000/v1",
+            "models": {
+                "gpt5.4": {"max_tokens": 32000},
+            },
+        }
+    ]
+    agent = _build_agent(
+        {"default": "gpt5.4", "provider": "custom", "base_url": "http://localhost:4000/v1"},
+        custom_providers=custom_providers,
+        model="gpt5.4",
+    )
+    assert agent.max_tokens == 32000
+
+
+def test_custom_providers_max_tokens_string_numeric_parses():
+    custom_providers = [
+        {
+            "name": "LiteLLM",
+            "base_url": "http://localhost:4000/v1",
+            "models": {
+                "gpt5.4": {"max_tokens": "16000"},
+            },
+        }
+    ]
+    agent = _build_agent(
+        {"default": "gpt5.4", "provider": "custom", "base_url": "http://localhost:4000/v1"},
+        custom_providers=custom_providers,
+        model="gpt5.4",
+    )
+    assert agent.max_tokens == 16000
+
+
+def test_custom_providers_invalid_max_tokens_warns_and_stays_none():
+    custom_providers = [
+        {
+            "name": "LiteLLM",
+            "base_url": "http://localhost:4000/v1",
+            "models": {
+                "gpt5.4": {"max_tokens": "32K"},
+            },
+        }
+    ]
+    with patch("agent.agent_init._ra") as mock_ra:
+        agent = _build_agent(
+            {"default": "gpt5.4", "provider": "custom", "base_url": "http://localhost:4000/v1"},
+            custom_providers=custom_providers,
+            model="gpt5.4",
+        )
+    assert agent.max_tokens is None
+    warning_calls = [c for c in mock_ra.return_value.logger.warning.call_args_list if "Invalid max_tokens" in str(c) and "32K" in str(c)]
+    assert len(warning_calls) == 1
+
+
+def test_custom_providers_zero_max_tokens_warns_and_stays_none():
+    custom_providers = [
+        {
+            "name": "LiteLLM",
+            "base_url": "http://localhost:4000/v1",
+            "models": {
+                "gpt5.4": {"max_tokens": 0},
+            },
+        }
+    ]
+    with patch("agent.agent_init._ra") as mock_ra:
+        agent = _build_agent(
+            {"default": "gpt5.4", "provider": "custom", "base_url": "http://localhost:4000/v1"},
+            custom_providers=custom_providers,
+            model="gpt5.4",
+        )
+    assert agent.max_tokens is None
+    warning_calls = [c for c in mock_ra.return_value.logger.warning.call_args_list if "Invalid max_tokens" in str(c)]
+    assert len(warning_calls) == 1
+
+
+def test_custom_providers_no_max_tokens_leaves_none():
+    custom_providers = [
+        {
+            "name": "LiteLLM",
+            "base_url": "http://localhost:4000/v1",
+            "models": {
+                "gpt5.4": {"context_length": 256000},
+            },
+        }
+    ]
+    agent = _build_agent(
+        {"default": "gpt5.4", "provider": "custom", "base_url": "http://localhost:4000/v1"},
+        custom_providers=custom_providers,
+        model="gpt5.4",
+    )
+    assert agent.max_tokens is None
+
+
+def test_explicit_max_tokens_not_overridden_by_custom_providers():
+    custom_providers = [
+        {
+            "name": "LiteLLM",
+            "base_url": "http://localhost:4000/v1",
+            "models": {
+                "gpt5.4": {"max_tokens": 32000},
+            },
+        }
+    ]
+    cfg = {
+        "model": {"default": "gpt5.4", "provider": "custom", "base_url": "http://localhost:4000/v1"},
+        "custom_providers": custom_providers,
+    }
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("agent.model_metadata.get_model_context_length", return_value=128_000),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            model="gpt5.4",
+            api_key="test-key-1234567890",
+            base_url="http://localhost:4000/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            max_tokens=8000,
+        )
+    assert agent.max_tokens == 8000


### PR DESCRIPTION
## Summary
- read `max_tokens` from `custom_providers[].models.<model>` during agent init
- preserve explicit `max_tokens` passed by CLI/config instead of overriding it
- add regression coverage for valid, stringified, invalid, zero, and absent custom-provider `max_tokens`

## Why
Issue #28046 reports that custom providers already honor per-model `context_length`, but still fall back to the 4096 default output cap because `max_tokens` was never loaded from the same per-model config.

## Test Plan
- `scripts/run_tests.sh tests/run_agent/test_custom_provider_max_tokens.py`

Closes #28046
