### PR TITLE
fix: wrap _pool_may_recover_from_rate_limit call through run_agent namespace

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2251,7 +2251,7 @@ def run_conversation(
                     # still recover.  See _pool_may_recover_from_rate_limit
                     # for the single-credential-pool and CloudCode-quota
                     # exceptions.  Fixes #11314 and #13636.
-                    pool_may_recover = _pool_may_recover_from_rate_limit(
+                    pool_may_recover = _ra()._pool_may_recover_from_rate_limit(
                         agent._credential_pool,
                         provider=agent.provider,
                         base_url=getattr(agent, "base_url", None),

--- a/tests/agent/test_gemini_fast_fallback.py
+++ b/tests/agent/test_gemini_fast_fallback.py
@@ -5,8 +5,10 @@ rotation and fallback-provider activation.  For CloudCode (Gemini CLI /
 Gemini OAuth) the 429 is an account-wide throttle, so waiting for pool
 rotation is pointless — prefer fallback immediately.
 """
+import inspect
 from unittest.mock import MagicMock
 
+from agent import conversation_loop
 from run_agent import _pool_may_recover_from_rate_limit
 
 
@@ -60,3 +62,17 @@ def test_exhausted_pool_skips_rotation():
 
 def test_no_pool_skips_rotation():
     assert _pool_may_recover_from_rate_limit(None) is False
+
+
+def test_conversation_loop_resolves_pool_helper_through_run_agent_module():
+    """Extracted conversation loop must honor tests/patches on run_agent.
+
+    conversation_loop intentionally lazy-loads run_agent via _ra().  If this
+    call site uses a bare imported helper, monkeypatching run_agent in tests (and
+    production wrappers that patch run_agent) will not propagate into the
+    extracted loop; older code also hit NameError in this branch.
+    """
+    source = inspect.getsource(conversation_loop.run_conversation)
+
+    assert "_ra()._pool_may_recover_from_rate_limit(" in source
+    assert "pool_may_recover = _pool_may_recover_from_rate_limit(" not in source


### PR DESCRIPTION
## Problem
`_pool_may_recover_from_rate_limit` is defined in `run_agent.py` but called directly in `agent/conversation_loop.py`, causing a `NameError` at runtime when the fast-fallback path is hit.

This breaks at least 3 scheduled jobs:
- Weekly Memory Consolidation
- Memory Health Check  
- FORGE Proactive Code Quality

## Fix
Wrap the call through the `run_agent` namespace (`_ra()`) so the function resolves correctly at runtime.

## Changes
- `agent/conversation_loop.py`: 1-line fix — call `_ra._pool_may_recover_from_rate_limit(...)` instead of bare `_pool_may_recover_from_rate_limit(...)`
- `tests/agent/test_gemini_fast_fallback.py`: new regression test (7/7 pass)

## Testing
```
$ python -m pytest tests/agent/test_gemini_fast_fallback.py -v
7 passed
```

Verified over 2+ clean MAILROOM triage cycles post-fix.