### PR TITLE
fix(plugins): include platforms/ namespace in bundled platform plugin keys

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -830,8 +830,12 @@ class PluginManager:
         )
         logger.debug("  bundled (top-level): %d manifest(s)", len(bundled))
         manifests.extend(bundled)
-        bundled_platforms = self._scan_directory(
-            repo_plugins / "platforms", source="bundled"
+        bundled_platforms = self._scan_directory_level(
+            repo_plugins / "platforms",
+            source="bundled",
+            skip_names=None,
+            prefix="platforms",
+            depth=0,
         )
         logger.debug("  bundled/platforms: %d manifest(s)", len(bundled_platforms))
         manifests.extend(bundled_platforms)

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -146,6 +146,71 @@ class TestPluginDiscovery:
         }
         assert len(non_bundled) == 1
 
+    def test_bundled_platform_plugins_have_platforms_namespace_key(
+        self, tmp_path, monkeypatch
+    ):
+        """Bundled platform plugin keys include the platforms/ namespace.
+
+        Regression test for #27548: platform plugins under
+        plugins/platforms/<name>/ should have keys like ``platforms/teams``,
+        not bare manifest names like ``teams-platform``.
+        """
+        # Set up a fake bundled plugins dir with a platforms/ subdirectory.
+        bundled_dir = tmp_path / "bundled_plugins"
+        platforms_dir = bundled_dir / "platforms"
+        teams_dir = platforms_dir / "teams"
+        teams_dir.mkdir(parents=True)
+
+        manifest = {
+            "name": "teams-platform",
+            "label": "Microsoft Teams",
+            "kind": "platform",
+            "version": "1.0.0",
+        }
+        (teams_dir / "plugin.yaml").write_text(yaml.dump(manifest))
+        (teams_dir / "__init__.py").write_text(
+            "def register(ctx): pass\n"
+        )
+
+        # Also create a flat top-level plugin to verify normal scanning
+        # still works.
+        flat_dir = bundled_dir / "disk-cleanup"
+        flat_dir.mkdir()
+        (flat_dir / "plugin.yaml").write_text(
+            yaml.dump({"name": "disk-cleanup", "version": "1.0.0"})
+        )
+        (flat_dir / "__init__.py").write_text(
+            "def register(ctx): pass\n"
+        )
+
+        monkeypatch.setenv("HERMES_BUNDLED_PLUGINS", str(bundled_dir))
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+        (tmp_path / "hermes_test").mkdir(exist_ok=True)
+
+        # Write config that opts-in via the canonical namespaced key.
+        cfg_path = tmp_path / "hermes_test" / "config.yaml"
+        cfg_path.write_text(
+            yaml.safe_dump(
+                {"plugins": {"enabled": ["platforms/teams", "disk-cleanup"]}}
+            )
+        )
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        # The platform plugin must be keyed as platforms/teams.
+        assert "platforms/teams" in mgr._plugins, (
+            f"Expected key 'platforms/teams', got: {sorted(mgr._plugins.keys())}"
+        )
+        # The bare manifest name should NOT appear as a key.
+        assert "teams-platform" not in mgr._plugins, (
+            "Platform plugin should not use bare manifest name as key"
+        )
+        # Verify the flat plugin still works normally.
+        assert "disk-cleanup" in mgr._plugins
+        # The platform plugin manifest name is preserved.
+        assert mgr._plugins["platforms/teams"].manifest.name == "teams-platform"
+
     def test_discover_skips_dir_without_manifest(self, tmp_path, monkeypatch):
         """Directories without plugin.yaml are silently skipped."""
         plugins_dir = tmp_path / "hermes_test" / "plugins"


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where bundled gateway platform plugins under `plugins/platforms/<name>/` (e.g., `plugins/platforms/teams/`) were discovered with keys derived from the manifest `name` field (e.g., `teams-platform`) instead of the path-derived namespaced key (e.g., `platforms/teams`).

This broke `plugins.enabled` / `plugins.disabled` config entries that use canonical namespaced keys, and was inconsistent with the plugin manager's key model for namespaced plugins (`image_gen/openai`, `web/tavily`, etc.).

The fix passes `prefix="platforms"` to `_scan_directory_level()` when scanning the bundled platforms directory so plugin keys are computed as `platforms/<dir_name>`.

## Related Issue

Fixes #27548

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/plugins.py`: Pass `prefix="platforms"` to `_scan_directory_level()` in the bundled platform plugin discovery path
- `tests/hermes_cli/test_plugins.py`: Add regression test `test_bundled_platform_plugins_have_platforms_namespace_key` verifying platform plugin keys include the `platforms/` namespace

## How to Test

1. Run `python -m pytest tests/hermes_cli/test_plugins.py -q -o 'addopts='`
2. Verify the new test passes and existing tests are unaffected
3. Alternatively, inspect plugin keys after discovery — platform plugins should show as `platforms/teams`, `platforms/irc`, etc. instead of `teams-platform`, `irc-platform`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] N/A — no config keys, architecture, or tool behavior changed