### PR TITLE
docs(skills): add hermes tescmd plugin

### DIFF
--- a/optional-skills/smart-home/hermes-tescmd-plugin/SKILL.md
+++ b/optional-skills/smart-home/hermes-tescmd-plugin/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: hermes-tescmd-plugin
+description: Install and operate the native Hermes Tesla Fleet plugin for vehicle state, guarded controls, /tescmd dashboard widgets, and /tescmd-* slash commands.
+version: 0.5.0a17
+author: Sean McLellan
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [tesla, fleet-api, smart-home, vehicle, hermes-plugin, dashboard, slash-commands]
+    homepage: https://github.com/Oceanswave/hermes-tescmd-plugin
+prerequisites:
+  commands: [hermes, python3]
+---
+
+# Hermes Tesla Fleet plugin
+
+Use this skill when a user wants to install, configure, or operate `hermes-tescmd-plugin`, a standalone Hermes plugin that adds Tesla Fleet API operations to Hermes as native tools, quick slash commands, and a dashboard tab.
+
+The plugin lets Hermes answer and act on requests such as checking charge state, warming the cabin, locking the vehicle, sending destinations to navigation, reviewing Fleet readiness, and using the `/tescmd` dashboard for visual vehicle status. It is designed for Hermes-native operation: install the package, enable the plugin, restart Hermes, then use the registered `tescmd_*` tools, `/tescmd-*` slash commands, and dashboard route.
+
+## Install the plugin
+
+Install the Python package into the same environment that runs Hermes. From GitHub:
+
+```bash
+python3 -m pip install 'git+https://github.com/Oceanswave/hermes-tescmd-plugin.git'
+hermes plugins enable hermes-tescmd-plugin
+hermes gateway restart
+```
+
+For local editable development, install the checkout into Hermes' runtime venv:
+
+```bash
+~/.hermes/hermes-agent/venv/bin/python -m pip install -e ~/hermes-tescmd-plugin
+hermes plugins enable hermes-tescmd-plugin
+hermes gateway restart
+```
+
+If the Hermes dashboard is already running, restart it or use the dashboard plugin rescan control so the Tesla tab appears.
+
+## First-time setup
+
+1. Create a Tesla Developer app that you control.
+2. Configure Tesla app URLs using your public HTTPS domain:
+   - Allowed Origin URL(s): `https://<your-domain>`
+   - Allowed Redirect URI(s): `https://<your-domain>/callback`
+   - Allowed Returned URL(s): leave blank unless Tesla requires it.
+3. Create the plugin config file at:
+
+```text
+$HERMES_HOME/plugins/hermes-tescmd-plugin/config.json
+```
+
+4. Include your Tesla app client ID, optional client secret, region, callback/domain, requested scopes, and optional default VIN. Keep this app config in plugin-owned state, not in Hermes core `config.yaml`.
+5. Run `tescmd_status` to see readiness booleans, missing prerequisites, derived callback/public-key URLs, and recommended next actions.
+6. Start OAuth with `tescmd_auth_login`, open the returned Tesla authorization URL, then finish with `tescmd_auth_complete` using the callback URL or `code` + `state`.
+7. For signed vehicle commands, generate and host a virtual-key public key with `tescmd_key_generate` and `tescmd_key_deploy(method="local")`, then validate the hosted key before enrollment.
+
+Read the plugin README and onboarding guide for the complete flow:
+
+- https://github.com/Oceanswave/hermes-tescmd-plugin
+- https://github.com/Oceanswave/hermes-tescmd-plugin/blob/main/docs/ONBOARDING.md
+
+## Daily operation
+
+Prefer the native Hermes tool surface for agent work:
+
+- `tescmd_status` for readiness and next steps.
+- `tescmd_vehicle_list`, `tescmd_charge_status`, `tescmd_vehicle_location`, `tescmd_climate_status`, `tescmd_security_status`, and other read tools for state.
+- `tescmd_charge_*`, `tescmd_climate_*`, `tescmd_security_*`, `tescmd_navigation_*`, `tescmd_media_*`, and `tescmd_vehicle_*` tools for operations.
+- `tescmd_key_*` and `tescmd_auth_*` for admin/bootstrap flows.
+
+Common human-facing shortcuts are also registered as `/tescmd-*` slash commands. Side-effecting slash commands require an explicit `confirm=true` token, for example:
+
+```text
+/tescmd-honk confirm=true
+/tescmd-lock confirm=true
+/tescmd-climate-on temp=70 confirm=true
+```
+
+The Hermes dashboard gets a Tesla tab at `/tescmd`. The dashboard should show visual, read-only overview widgets such as charge state, climate/security summaries, and a Leaflet map when vehicle coordinates are available. Quick actions in the dashboard must use the plugin's existing validation/redaction/confirmation paths.
+
+## Safety model
+
+Tesla operations can have real-world effects. Keep these rules:
+
+- Side-effecting operations require `confirm=true` or `confirm: true` and must fail closed before network/file side effects when confirmation is missing.
+- Waking a sleeping vehicle is a side effect; only set `wake=true` when explicitly requested or required.
+- Prefer read tools before write tools when the target vehicle, readiness, or current state is uncertain.
+- Do not paste OAuth tokens, client secrets, vehicle-command private keys, or exported auth blobs into chat.
+- OAuth token persistence should use Hermes' intrinsic auth store when the plugin runs inside Hermes, with a plugin-local mirror for compatibility.
+- Plugin-owned operational state belongs under `$HERMES_HOME/plugins/hermes-tescmd-plugin/`.
+
+## Troubleshooting
+
+If the tools, slash commands, or dashboard tab do not appear:
+
+1. Verify the package is installed in the Hermes runtime environment.
+2. Run `hermes plugins enable hermes-tescmd-plugin`.
+3. Restart the Hermes CLI session or gateway so plugin entry points reload.
+4. Restart or rescan the dashboard so dashboard assets are rediscovered.
+5. Run `tescmd_status` after reload to inspect app config, auth, key, and cache readiness.
+
+If a side-effecting slash command returns a confirmation error, retry with the exact `confirm=true` form shown in the response.

--- a/optional-skills/smart-home/hermes-tescmd-plugin/SKILL.md
+++ b/optional-skills/smart-home/hermes-tescmd-plugin/SKILL.md
@@ -1,43 +1,39 @@
 ---
 name: hermes-tescmd-plugin
-description: Install and operate the native Hermes Tesla Fleet plugin for vehicle state, guarded controls, /tescmd dashboard widgets, and /tescmd-* slash commands.
-version: 0.5.0a17
-author: Sean McLellan
+description: Install and operate the native Hermes Tesla Fleet plugin for vehicle state and guarded Tesla Fleet API controls.
+version: 0.5.0a11
+author: Oceanswave
 license: MIT
 platforms: [linux, macos]
 metadata:
   hermes:
-    tags: [tesla, fleet-api, smart-home, vehicle, hermes-plugin, dashboard, slash-commands]
-    homepage: https://github.com/Oceanswave/hermes-tescmd-plugin
+    tags: [tesla, fleet-api, smart-home, vehicle, hermes-plugin]
+    homepage: https://pypi.org/project/hermes-tescmd-plugin/
 prerequisites:
-  commands: [hermes, python3]
+  commands: [hermes, python3, uv]
 ---
 
 # Hermes Tesla Fleet plugin
 
-Use this skill when a user wants to install, configure, or operate `hermes-tescmd-plugin`, a standalone Hermes plugin that adds Tesla Fleet API operations to Hermes as native tools, quick slash commands, and a dashboard tab.
+Use this skill when a user wants to install, configure, or operate `hermes-tescmd-plugin`, a standalone Hermes plugin that adds Tesla Fleet API operations to Hermes as native tools.
 
-The plugin lets Hermes answer and act on requests such as checking charge state, warming the cabin, locking the vehicle, sending destinations to navigation, reviewing Fleet readiness, and using the `/tescmd` dashboard for visual vehicle status. It is designed for Hermes-native operation: install the package, enable the plugin, restart Hermes, then use the registered `tescmd_*` tools, `/tescmd-*` slash commands, and dashboard route.
+The plugin lets Hermes answer and act on requests such as checking charge state, warming the cabin, locking the vehicle, sending destinations to navigation, and reviewing Fleet readiness. It is designed for Hermes-native operation: install the package, restart Hermes so Python entry points reload, then use the registered `tescmd_*` tools.
 
 ## Install the plugin
 
-Install the Python package into the same environment that runs Hermes. From GitHub:
+Install the Python package into the same environment that runs Hermes:
 
 ```bash
-python3 -m pip install 'git+https://github.com/Oceanswave/hermes-tescmd-plugin.git'
-hermes plugins enable hermes-tescmd-plugin
+uv pip install --python ~/.hermes/hermes-agent/venv/bin/python hermes-tescmd-plugin
 hermes gateway restart
 ```
 
-For local editable development, install the checkout into Hermes' runtime venv:
+For local editable development, install a checkout into Hermes' runtime venv:
 
 ```bash
-~/.hermes/hermes-agent/venv/bin/python -m pip install -e ~/hermes-tescmd-plugin
-hermes plugins enable hermes-tescmd-plugin
+uv pip install --python ~/.hermes/hermes-agent/venv/bin/python -e ~/hermes-tescmd-plugin
 hermes gateway restart
 ```
-
-If the Hermes dashboard is already running, restart it or use the dashboard plugin rescan control so the Tesla tab appears.
 
 ## First-time setup
 
@@ -55,12 +51,11 @@ $HERMES_HOME/plugins/hermes-tescmd-plugin/config.json
 4. Include your Tesla app client ID, optional client secret, region, callback/domain, requested scopes, and optional default VIN. Keep this app config in plugin-owned state, not in Hermes core `config.yaml`.
 5. Run `tescmd_status` to see readiness booleans, missing prerequisites, derived callback/public-key URLs, and recommended next actions.
 6. Start OAuth with `tescmd_auth_login`, open the returned Tesla authorization URL, then finish with `tescmd_auth_complete` using the callback URL or `code` + `state`.
-7. For signed vehicle commands, generate and host a virtual-key public key with `tescmd_key_generate` and `tescmd_key_deploy(method="local")`, then validate the hosted key before enrollment.
+7. For signed vehicle commands, generate and host a virtual-key public key with `tescmd_key_generate(confirm=true)` and `tescmd_key_deploy(method="local", confirm=true)`, then validate the hosted key before enrollment.
 
-Read the plugin README and onboarding guide for the complete flow:
+Read the package page for the complete public overview:
 
-- https://github.com/Oceanswave/hermes-tescmd-plugin
-- https://github.com/Oceanswave/hermes-tescmd-plugin/blob/main/docs/ONBOARDING.md
+- https://pypi.org/project/hermes-tescmd-plugin/
 
 ## Daily operation
 
@@ -71,35 +66,22 @@ Prefer the native Hermes tool surface for agent work:
 - `tescmd_charge_*`, `tescmd_climate_*`, `tescmd_security_*`, `tescmd_navigation_*`, `tescmd_media_*`, and `tescmd_vehicle_*` tools for operations.
 - `tescmd_key_*` and `tescmd_auth_*` for admin/bootstrap flows.
 
-Common human-facing shortcuts are also registered as `/tescmd-*` slash commands. Side-effecting slash commands require an explicit `confirm=true` token, for example:
-
-```text
-/tescmd-honk confirm=true
-/tescmd-lock confirm=true
-/tescmd-climate-on temp=70 confirm=true
-```
-
-The Hermes dashboard gets a Tesla tab at `/tescmd`. The dashboard should show visual, read-only overview widgets such as charge state, climate/security summaries, and a Leaflet map when vehicle coordinates are available. Quick actions in the dashboard must use the plugin's existing validation/redaction/confirmation paths.
-
 ## Safety model
 
 Tesla operations can have real-world effects. Keep these rules:
 
-- Side-effecting operations require `confirm=true` or `confirm: true` and must fail closed before network/file side effects when confirmation is missing.
+- Side-effecting operations require `confirm: true` in tool arguments and must fail closed before network/file side effects when confirmation is missing.
 - Waking a sleeping vehicle is a side effect; only set `wake=true` when explicitly requested or required.
 - Prefer read tools before write tools when the target vehicle, readiness, or current state is uncertain.
 - Do not paste OAuth tokens, client secrets, vehicle-command private keys, or exported auth blobs into chat.
-- OAuth token persistence should use Hermes' intrinsic auth store when the plugin runs inside Hermes, with a plugin-local mirror for compatibility.
 - Plugin-owned operational state belongs under `$HERMES_HOME/plugins/hermes-tescmd-plugin/`.
 
 ## Troubleshooting
 
-If the tools, slash commands, or dashboard tab do not appear:
+If the tools do not appear:
 
 1. Verify the package is installed in the Hermes runtime environment.
-2. Run `hermes plugins enable hermes-tescmd-plugin`.
-3. Restart the Hermes CLI session or gateway so plugin entry points reload.
-4. Restart or rescan the dashboard so dashboard assets are rediscovered.
-5. Run `tescmd_status` after reload to inspect app config, auth, key, and cache readiness.
+2. Restart the Hermes CLI session or gateway so plugin entry points reload.
+3. Run `tescmd_status` after reload to inspect app config, auth, key, and cache readiness.
 
-If a side-effecting slash command returns a confirmation error, retry with the exact `confirm=true` form shown in the response.
+If a side-effecting tool returns a confirmation error, retry with `confirm: true` only after verifying the requested action and target.

--- a/tests/website/test_extract_skills.py
+++ b/tests/website/test_extract_skills.py
@@ -114,3 +114,40 @@ def test_guess_category_empty_tags(mod):
 def test_guess_category_skips_first_junk_tag_for_later_known_tag(mod):
     # First tag is junk, second is curated — we should still find the curated one.
     assert mod._guess_category(["Some Brand", "security"]) == "security"
+
+
+# --------------------------------------------------------------------------
+# _consolidate_small_categories
+# --------------------------------------------------------------------------
+
+def test_consolidate_small_categories_keeps_fixed_category_but_not_its_siblings(mod):
+    skills = [
+        {"name": "fixed", "category": "security", "categoryLabel": "Vendor Security", "fixedCategory": True},
+        {"name": "plain-1", "category": "security", "categoryLabel": ""},
+        {"name": "plain-2", "category": "security", "categoryLabel": ""},
+        {"name": "plain-3", "category": "security", "categoryLabel": ""},
+    ]
+
+    out = mod._consolidate_small_categories(skills)
+
+    assert out[0]["category"] == "security"
+    assert out[0]["categoryLabel"] == "Vendor Security"
+    assert [s["category"] for s in out[1:]] == ["other", "other", "other"]
+
+
+def test_consolidate_small_categories_keeps_curated_smart_home_small_category(mod):
+    skills = [
+        {"name": "tescmd", "category": "smart-home", "categoryLabel": ""},
+        {"name": "odd", "category": "one-off-tag", "categoryLabel": ""},
+    ]
+
+    out = mod._consolidate_small_categories(skills)
+
+    assert out[0]["category"] == "smart-home"
+    assert out[0]["categoryLabel"] == "Smart Home"
+    assert out[1]["category"] == "other"
+    assert out[1]["categoryLabel"] == "Other"
+
+
+def test_curated_small_category_exemption_is_explicitly_limited(mod):
+    assert mod.CURATED_SMALL_CATEGORIES == {"smart-home"}

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -64,6 +64,7 @@ hermes skills uninstall <skill-name>
 | [**kanban-video-orchestrator**](/docs/user-guide/skills/optional/creative/creative-kanban-video-orchestrator) | Plan, set up, and monitor a multi-agent video production pipeline backed by Hermes Kanban. Use when the user wants to make ANY video — narrative film, product/marketing, music video, explainer, ASCII/terminal art, abstract/generative loo... |
 | [**meme-generation**](/docs/user-guide/skills/optional/creative/creative-meme-generation) | Generate real meme images by picking a template and overlaying text with Pillow. Produces actual .png meme files. |
 | [**pixel-art**](/docs/user-guide/skills/optional/creative/creative-pixel-art) | Pixel art w/ era palettes (NES, Game Boy, PICO-8). |
+| [**unreal-mcp**](/docs/user-guide/skills/optional/creative/creative-unreal-mcp) | Use when the user wants to do anything in Unreal Engine through Epic's official editor-embedded MCP server (catalog entry: unreal-engine) — build/light/populate scenes, place and transform actors, author Blueprints, animate with Sequence... |
 
 ## devops
 
@@ -207,13 +208,14 @@ hermes skills uninstall <skill-name>
 | [**godmode**](/docs/user-guide/skills/optional/security/security-godmode) | Jailbreak LLMs: Parseltongue, GODMODE, ULTRAPLINIAN. |
 | [**oss-forensics**](/docs/user-guide/skills/optional/security/security-oss-forensics) | Supply chain investigation, evidence recovery, and forensic analysis for GitHub repositories. Covers deleted commit recovery, force-push detection, IOC extraction, multi-source evidence collection, hypothesis formation/validation, and st... |
 | [**sherlock**](/docs/user-guide/skills/optional/security/security-sherlock) | OSINT username search across 400+ social networks. Hunt down social media accounts by username. |
+| [**unbroker**](/docs/user-guide/skills/optional/security/security-unbroker) | Autonomously remove your info from data-broker sites. |
 | [**web-pentest**](/docs/user-guide/skills/optional/security/security-web-pentest) | Authorized web application penetration testing — reconnaissance, vulnerability analysis, proof-based exploitation, and professional reporting. Adapts Shannon's "No Exploit, No Report" methodology with hard guardrails for scope, authoriza... |
 
 ## smart-home
 
 | Skill | Description |
 |-------|-------------|
-| [**hermes-tescmd-plugin**](/docs/user-guide/skills/optional/smart-home/smart-home-hermes-tescmd-plugin) | Install and operate the native Hermes Tesla Fleet plugin for vehicle state, guarded controls, /tescmd dashboard widgets, and /tescmd-* slash commands. |
+| [**hermes-tescmd-plugin**](/docs/user-guide/skills/optional/smart-home/smart-home-hermes-tescmd-plugin) | Install and operate the native Hermes Tesla Fleet plugin for vehicle state and guarded Tesla Fleet API controls. |
 
 ## software-development
 
@@ -227,6 +229,7 @@ hermes skills uninstall <skill-name>
 
 | Skill | Description |
 |-------|-------------|
+| [**cloudflare-temporary-deploy**](/docs/user-guide/skills/optional/web-development/web-development-cloudflare-temporary-deploy) | Deploy a Worker live, no account, via wrangler --temporary. |
 | [**page-agent**](/docs/user-guide/skills/optional/web-development/web-development-page-agent) | Embed alibaba/page-agent into your own web application — a pure-JavaScript in-page GUI agent that ships as a single &lt;script> tag or npm package and lets end-users of your site drive the UI with natural language ("click login, fill userna... |
 
 ---

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -209,6 +209,12 @@ hermes skills uninstall <skill-name>
 | [**sherlock**](/docs/user-guide/skills/optional/security/security-sherlock) | OSINT username search across 400+ social networks. Hunt down social media accounts by username. |
 | [**web-pentest**](/docs/user-guide/skills/optional/security/security-web-pentest) | Authorized web application penetration testing — reconnaissance, vulnerability analysis, proof-based exploitation, and professional reporting. Adapts Shannon's "No Exploit, No Report" methodology with hard guardrails for scope, authoriza... |
 
+## smart-home
+
+| Skill | Description |
+|-------|-------------|
+| [**hermes-tescmd-plugin**](/docs/user-guide/skills/optional/smart-home/smart-home-hermes-tescmd-plugin) | Install and operate the native Hermes Tesla Fleet plugin for vehicle state, guarded controls, /tescmd dashboard widgets, and /tescmd-* slash commands. |
+
 ## software-development
 
 | Skill | Description |

--- a/website/docs/user-guide/skills/optional/smart-home/smart-home-hermes-tescmd-plugin.md
+++ b/website/docs/user-guide/skills/optional/smart-home/smart-home-hermes-tescmd-plugin.md
@@ -1,0 +1,120 @@
+---
+title: "Hermes Tescmd Plugin"
+sidebar_label: "Hermes Tescmd Plugin"
+description: "Install and operate the native Hermes Tesla Fleet plugin for vehicle state, guarded controls, /tescmd dashboard widgets, and /tescmd-* slash commands"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Hermes Tescmd Plugin
+
+Install and operate the native Hermes Tesla Fleet plugin for vehicle state, guarded controls, /tescmd dashboard widgets, and /tescmd-* slash commands.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/smart-home/hermes-tescmd-plugin` |
+| Path | `optional-skills/smart-home/hermes-tescmd-plugin` |
+| Version | `0.5.0a17` |
+| Author | Sean McLellan |
+| License | MIT |
+| Platforms | linux, macos |
+| Tags | `tesla`, `fleet-api`, `smart-home`, `vehicle`, `hermes-plugin`, `dashboard`, `slash-commands` |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Hermes Tesla Fleet plugin
+
+Use this skill when a user wants to install, configure, or operate `hermes-tescmd-plugin`, a standalone Hermes plugin that adds Tesla Fleet API operations to Hermes as native tools, quick slash commands, and a dashboard tab.
+
+The plugin lets Hermes answer and act on requests such as checking charge state, warming the cabin, locking the vehicle, sending destinations to navigation, reviewing Fleet readiness, and using the `/tescmd` dashboard for visual vehicle status. It is designed for Hermes-native operation: install the package, enable the plugin, restart Hermes, then use the registered `tescmd_*` tools, `/tescmd-*` slash commands, and dashboard route.
+
+## Install the plugin
+
+Install the Python package into the same environment that runs Hermes. From GitHub:
+
+```bash
+python3 -m pip install 'git+https://github.com/Oceanswave/hermes-tescmd-plugin.git'
+hermes plugins enable hermes-tescmd-plugin
+hermes gateway restart
+```
+
+For local editable development, install the checkout into Hermes' runtime venv:
+
+```bash
+~/.hermes/hermes-agent/venv/bin/python -m pip install -e ~/hermes-tescmd-plugin
+hermes plugins enable hermes-tescmd-plugin
+hermes gateway restart
+```
+
+If the Hermes dashboard is already running, restart it or use the dashboard plugin rescan control so the Tesla tab appears.
+
+## First-time setup
+
+1. Create a Tesla Developer app that you control.
+2. Configure Tesla app URLs using your public HTTPS domain:
+   - Allowed Origin URL(s): `https://<your-domain>`
+   - Allowed Redirect URI(s): `https://<your-domain>/callback`
+   - Allowed Returned URL(s): leave blank unless Tesla requires it.
+3. Create the plugin config file at:
+
+```text
+$HERMES_HOME/plugins/hermes-tescmd-plugin/config.json
+```
+
+4. Include your Tesla app client ID, optional client secret, region, callback/domain, requested scopes, and optional default VIN. Keep this app config in plugin-owned state, not in Hermes core `config.yaml`.
+5. Run `tescmd_status` to see readiness booleans, missing prerequisites, derived callback/public-key URLs, and recommended next actions.
+6. Start OAuth with `tescmd_auth_login`, open the returned Tesla authorization URL, then finish with `tescmd_auth_complete` using the callback URL or `code` + `state`.
+7. For signed vehicle commands, generate and host a virtual-key public key with `tescmd_key_generate` and `tescmd_key_deploy(method="local")`, then validate the hosted key before enrollment.
+
+Read the plugin README and onboarding guide for the complete flow:
+
+- https://github.com/Oceanswave/hermes-tescmd-plugin
+- https://github.com/Oceanswave/hermes-tescmd-plugin/blob/main/docs/ONBOARDING.md
+
+## Daily operation
+
+Prefer the native Hermes tool surface for agent work:
+
+- `tescmd_status` for readiness and next steps.
+- `tescmd_vehicle_list`, `tescmd_charge_status`, `tescmd_vehicle_location`, `tescmd_climate_status`, `tescmd_security_status`, and other read tools for state.
+- `tescmd_charge_*`, `tescmd_climate_*`, `tescmd_security_*`, `tescmd_navigation_*`, `tescmd_media_*`, and `tescmd_vehicle_*` tools for operations.
+- `tescmd_key_*` and `tescmd_auth_*` for admin/bootstrap flows.
+
+Common human-facing shortcuts are also registered as `/tescmd-*` slash commands. Side-effecting slash commands require an explicit `confirm=true` token, for example:
+
+```text
+/tescmd-honk confirm=true
+/tescmd-lock confirm=true
+/tescmd-climate-on temp=70 confirm=true
+```
+
+The Hermes dashboard gets a Tesla tab at `/tescmd`. The dashboard should show visual, read-only overview widgets such as charge state, climate/security summaries, and a Leaflet map when vehicle coordinates are available. Quick actions in the dashboard must use the plugin's existing validation/redaction/confirmation paths.
+
+## Safety model
+
+Tesla operations can have real-world effects. Keep these rules:
+
+- Side-effecting operations require `confirm=true` or `confirm: true` and must fail closed before network/file side effects when confirmation is missing.
+- Waking a sleeping vehicle is a side effect; only set `wake=true` when explicitly requested or required.
+- Prefer read tools before write tools when the target vehicle, readiness, or current state is uncertain.
+- Do not paste OAuth tokens, client secrets, vehicle-command private keys, or exported auth blobs into chat.
+- OAuth token persistence should use Hermes' intrinsic auth store when the plugin runs inside Hermes, with a plugin-local mirror for compatibility.
+- Plugin-owned operational state belongs under `$HERMES_HOME/plugins/hermes-tescmd-plugin/`.
+
+## Troubleshooting
+
+If the tools, slash commands, or dashboard tab do not appear:
+
+1. Verify the package is installed in the Hermes runtime environment.
+2. Run `hermes plugins enable hermes-tescmd-plugin`.
+3. Restart the Hermes CLI session or gateway so plugin entry points reload.
+4. Restart or rescan the dashboard so dashboard assets are rediscovered.
+5. Run `tescmd_status` after reload to inspect app config, auth, key, and cache readiness.
+
+If a side-effecting slash command returns a confirmation error, retry with the exact `confirm=true` form shown in the response.

--- a/website/docs/user-guide/skills/optional/smart-home/smart-home-hermes-tescmd-plugin.md
+++ b/website/docs/user-guide/skills/optional/smart-home/smart-home-hermes-tescmd-plugin.md
@@ -1,14 +1,14 @@
 ---
 title: "Hermes Tescmd Plugin"
 sidebar_label: "Hermes Tescmd Plugin"
-description: "Install and operate the native Hermes Tesla Fleet plugin for vehicle state, guarded controls, /tescmd dashboard widgets, and /tescmd-* slash commands"
+description: "Install and operate the native Hermes Tesla Fleet plugin for vehicle state and guarded Tesla Fleet API controls"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Hermes Tescmd Plugin
 
-Install and operate the native Hermes Tesla Fleet plugin for vehicle state, guarded controls, /tescmd dashboard widgets, and /tescmd-* slash commands.
+Install and operate the native Hermes Tesla Fleet plugin for vehicle state and guarded Tesla Fleet API controls.
 
 ## Skill metadata
 
@@ -16,11 +16,11 @@ Install and operate the native Hermes Tesla Fleet plugin for vehicle state, guar
 |---|---|
 | Source | Optional — install with `hermes skills install official/smart-home/hermes-tescmd-plugin` |
 | Path | `optional-skills/smart-home/hermes-tescmd-plugin` |
-| Version | `0.5.0a17` |
-| Author | Sean McLellan |
+| Version | `0.5.0a11` |
+| Author | Oceanswave |
 | License | MIT |
 | Platforms | linux, macos |
-| Tags | `tesla`, `fleet-api`, `smart-home`, `vehicle`, `hermes-plugin`, `dashboard`, `slash-commands` |
+| Tags | `tesla`, `fleet-api`, `smart-home`, `vehicle`, `hermes-plugin` |
 
 ## Reference: full SKILL.md
 
@@ -30,29 +30,25 @@ The following is the complete skill definition that Hermes loads when this skill
 
 # Hermes Tesla Fleet plugin
 
-Use this skill when a user wants to install, configure, or operate `hermes-tescmd-plugin`, a standalone Hermes plugin that adds Tesla Fleet API operations to Hermes as native tools, quick slash commands, and a dashboard tab.
+Use this skill when a user wants to install, configure, or operate `hermes-tescmd-plugin`, a standalone Hermes plugin that adds Tesla Fleet API operations to Hermes as native tools.
 
-The plugin lets Hermes answer and act on requests such as checking charge state, warming the cabin, locking the vehicle, sending destinations to navigation, reviewing Fleet readiness, and using the `/tescmd` dashboard for visual vehicle status. It is designed for Hermes-native operation: install the package, enable the plugin, restart Hermes, then use the registered `tescmd_*` tools, `/tescmd-*` slash commands, and dashboard route.
+The plugin lets Hermes answer and act on requests such as checking charge state, warming the cabin, locking the vehicle, sending destinations to navigation, and reviewing Fleet readiness. It is designed for Hermes-native operation: install the package, restart Hermes so Python entry points reload, then use the registered `tescmd_*` tools.
 
 ## Install the plugin
 
-Install the Python package into the same environment that runs Hermes. From GitHub:
+Install the Python package into the same environment that runs Hermes:
 
 ```bash
-python3 -m pip install 'git+https://github.com/Oceanswave/hermes-tescmd-plugin.git'
-hermes plugins enable hermes-tescmd-plugin
+uv pip install --python ~/.hermes/hermes-agent/venv/bin/python hermes-tescmd-plugin
 hermes gateway restart
 ```
 
-For local editable development, install the checkout into Hermes' runtime venv:
+For local editable development, install a checkout into Hermes' runtime venv:
 
 ```bash
-~/.hermes/hermes-agent/venv/bin/python -m pip install -e ~/hermes-tescmd-plugin
-hermes plugins enable hermes-tescmd-plugin
+uv pip install --python ~/.hermes/hermes-agent/venv/bin/python -e ~/hermes-tescmd-plugin
 hermes gateway restart
 ```
-
-If the Hermes dashboard is already running, restart it or use the dashboard plugin rescan control so the Tesla tab appears.
 
 ## First-time setup
 
@@ -70,12 +66,11 @@ $HERMES_HOME/plugins/hermes-tescmd-plugin/config.json
 4. Include your Tesla app client ID, optional client secret, region, callback/domain, requested scopes, and optional default VIN. Keep this app config in plugin-owned state, not in Hermes core `config.yaml`.
 5. Run `tescmd_status` to see readiness booleans, missing prerequisites, derived callback/public-key URLs, and recommended next actions.
 6. Start OAuth with `tescmd_auth_login`, open the returned Tesla authorization URL, then finish with `tescmd_auth_complete` using the callback URL or `code` + `state`.
-7. For signed vehicle commands, generate and host a virtual-key public key with `tescmd_key_generate` and `tescmd_key_deploy(method="local")`, then validate the hosted key before enrollment.
+7. For signed vehicle commands, generate and host a virtual-key public key with `tescmd_key_generate(confirm=true)` and `tescmd_key_deploy(method="local", confirm=true)`, then validate the hosted key before enrollment.
 
-Read the plugin README and onboarding guide for the complete flow:
+Read the package page for the complete public overview:
 
-- https://github.com/Oceanswave/hermes-tescmd-plugin
-- https://github.com/Oceanswave/hermes-tescmd-plugin/blob/main/docs/ONBOARDING.md
+- https://pypi.org/project/hermes-tescmd-plugin/
 
 ## Daily operation
 
@@ -86,35 +81,22 @@ Prefer the native Hermes tool surface for agent work:
 - `tescmd_charge_*`, `tescmd_climate_*`, `tescmd_security_*`, `tescmd_navigation_*`, `tescmd_media_*`, and `tescmd_vehicle_*` tools for operations.
 - `tescmd_key_*` and `tescmd_auth_*` for admin/bootstrap flows.
 
-Common human-facing shortcuts are also registered as `/tescmd-*` slash commands. Side-effecting slash commands require an explicit `confirm=true` token, for example:
-
-```text
-/tescmd-honk confirm=true
-/tescmd-lock confirm=true
-/tescmd-climate-on temp=70 confirm=true
-```
-
-The Hermes dashboard gets a Tesla tab at `/tescmd`. The dashboard should show visual, read-only overview widgets such as charge state, climate/security summaries, and a Leaflet map when vehicle coordinates are available. Quick actions in the dashboard must use the plugin's existing validation/redaction/confirmation paths.
-
 ## Safety model
 
 Tesla operations can have real-world effects. Keep these rules:
 
-- Side-effecting operations require `confirm=true` or `confirm: true` and must fail closed before network/file side effects when confirmation is missing.
+- Side-effecting operations require `confirm: true` in tool arguments and must fail closed before network/file side effects when confirmation is missing.
 - Waking a sleeping vehicle is a side effect; only set `wake=true` when explicitly requested or required.
 - Prefer read tools before write tools when the target vehicle, readiness, or current state is uncertain.
 - Do not paste OAuth tokens, client secrets, vehicle-command private keys, or exported auth blobs into chat.
-- OAuth token persistence should use Hermes' intrinsic auth store when the plugin runs inside Hermes, with a plugin-local mirror for compatibility.
 - Plugin-owned operational state belongs under `$HERMES_HOME/plugins/hermes-tescmd-plugin/`.
 
 ## Troubleshooting
 
-If the tools, slash commands, or dashboard tab do not appear:
+If the tools do not appear:
 
 1. Verify the package is installed in the Hermes runtime environment.
-2. Run `hermes plugins enable hermes-tescmd-plugin`.
-3. Restart the Hermes CLI session or gateway so plugin entry points reload.
-4. Restart or rescan the dashboard so dashboard assets are rediscovered.
-5. Run `tescmd_status` after reload to inspect app config, auth, key, and cache readiness.
+2. Restart the Hermes CLI session or gateway so plugin entry points reload.
+3. Run `tescmd_status` after reload to inspect app config, auth, key, and cache readiness.
 
-If a side-effecting slash command returns a confirmation error, retry with the exact `confirm=true` form shown in the response.
+If a side-effecting tool returns a confirmation error, retry with `confirm: true` only after verifying the requested action and target.

--- a/website/scripts/extract-skills.py
+++ b/website/scripts/extract-skills.py
@@ -588,6 +588,12 @@ def _guess_category(tags: list) -> str:
 
 MIN_CATEGORY_SIZE = 4
 
+# Curated categories that should stay visible even before they reach the
+# normal consolidation threshold. "smart-home" currently has a small official
+# optional-skill footprint, but it is a durable top-level domain alongside the
+# bundled smart-home skills rather than noisy tag drift.
+CURATED_SMALL_CATEGORIES = {"smart-home"}
+
 
 def _consolidate_small_categories(skills: list) -> list:
     for s in skills:
@@ -597,11 +603,16 @@ def _consolidate_small_categories(skills: list) -> list:
 
     # Skills with a sidecar-declared category (skills.sh.json grouping) keep
     # their category even if it's the only skill in it — the tap explicitly
-    # chose that label, so it's not a heuristic guess to collapse away.
+    # chose that label, so it's not a heuristic guess to collapse away. Curated
+    # small categories are also exempt from the collapse, but they still don't
+    # contribute to non-fixed category counts for other categories.
     counts = Counter(
         s["category"] for s in skills if not s.get("fixedCategory")
     )
-    small_cats = {cat for cat, n in counts.items() if n < MIN_CATEGORY_SIZE}
+    small_cats = {
+        cat for cat, n in counts.items()
+        if n < MIN_CATEGORY_SIZE and cat not in CURATED_SMALL_CATEGORIES
+    }
 
     for s in skills:
         if s.get("fixedCategory"):

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -576,6 +576,15 @@ const sidebars: SidebarsConfig = {
                 },
                 {
                   type: 'category',
+                  label: 'smart-home',
+                  key: 'skills-optional-smart-home',
+                  collapsed: true,
+                  items: [
+                    'user-guide/skills/optional/smart-home/smart-home-hermes-tescmd-plugin',
+                  ],
+                },
+                {
+                  type: 'category',
                   label: 'software-development',
                   key: 'skills-optional-software-development',
                   collapsed: true,


### PR DESCRIPTION
## Summary
- add an official optional smart-home skill for hermes-tescmd-plugin
- generate the optional skill docs/catalog/sidebar entry so it appears in the Skills Hub
- preserve Smart Home as a visible category in the Skills Hub even with a small category count

## Test Plan
- python3 website/scripts/generate-skill-docs.py
- python3 website/scripts/extract-skills.py
- python3 -m py_compile website/scripts/extract-skills.py website/scripts/generate-skill-docs.py
- npm run build

Note: npm run typecheck currently fails on main with src/components/UserStoriesCollage/index.tsx(148,47): Cannot find namespace 'JSX'.