### PR TITLE
fix(packaging): ship plugin.yaml manifests in wheel and sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,9 @@
 graft skills
 graft optional-skills
+# Bundled plugin manifests (plugin.yaml / plugin.yml). Without these the
+# PluginManager scan finds zero plugins on installs built from the sdist (e.g.
+# Homebrew, see #28149). package-data already covers the wheel; this covers
+# the sdist that downstream packagers build from.
+recursive-include plugins plugin.yaml plugin.yml
 global-exclude __pycache__
 global-exclude *.py[cod]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,6 +213,18 @@ py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajector
 [tool.setuptools.package-data]
 hermes_cli = ["web_dist/**/*", "tui_dist/**/*", "scripts/install.sh", "scripts/install.ps1"]
 gateway = ["assets/**/*"]
+# Plugin discovery (hermes_cli/plugins.py::_scan_directory_level) reads a
+# ``plugin.yaml`` (or ``plugin.yml``) manifest from each plugin directory to
+# register the plugin. Without these manifests in the installed package the
+# scan returns zero hits and built-in providers go missing, most visibly the
+# web-search providers under ``plugins/web/``, which surfaces as
+# "No web search provider configured" on Homebrew installs (#28149).
+#
+# Pin plugin manifests in package-data as defense against future
+# MANIFEST.in or include_package_data changes; under current setuptools
+# the recursive-include in MANIFEST.in also covers the wheel, so this
+# entry is belt-and-suspenders rather than strictly required today.
+plugins = ["**/plugin.yaml", "**/plugin.yml"]
 
 [tool.setuptools.packages.find]
 include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*"]

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -20,3 +20,91 @@ def test_manifest_includes_bundled_skills():
 
     assert "graft skills" in manifest
     assert "graft optional-skills" in manifest
+
+
+def test_pyproject_ships_plugin_yaml_manifests():
+    """Regression test for #28149.
+
+    Plugin discovery (``hermes_cli/plugins.py::_scan_directory_level``) reads
+    a ``plugin.yaml`` manifest from each bundled plugin directory. Wheels
+    only carry files declared in ``[tool.setuptools.package-data]``, so an
+    entry for the ``plugins`` package is required, otherwise the installed
+    wheel ships every plugin's Python code but none of its manifests and
+    ``hermes web_search`` fails with "No web search provider configured".
+    """
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    package_data = data["tool"]["setuptools"]["package-data"]
+
+    assert "plugins" in package_data, (
+        "[tool.setuptools.package-data] must declare a 'plugins' entry so "
+        "plugin.yaml manifests ship in the wheel (#28149)."
+    )
+    patterns = package_data["plugins"]
+    joined = " ".join(patterns)
+    assert "plugin.yaml" in joined, (
+        "plugins package-data must include 'plugin.yaml' so wheels carry "
+        "the manifests the PluginManager scans for (#28149)."
+    )
+    assert "plugin.yml" in joined, (
+        "plugins package-data must also include 'plugin.yml'. "
+        "_scan_directory_level accepts both suffixes, and dropping the "
+        "legacy one would silently lose any plugin that uses it."
+    )
+
+
+def test_manifest_includes_bundled_plugin_manifests():
+    """Regression test for #28149.
+
+    ``MANIFEST.in`` controls the sdist (downstream packagers such as
+    Homebrew build from sdist). It must list the ``plugin.yaml`` files so
+    they survive the sdist trip, mirroring the wheel-side package-data
+    entry. ``recursive-include plugins plugin.yaml plugin.yml`` is the
+    minimal pattern that satisfies both ``.yaml`` and the legacy ``.yml``
+    suffix accepted by ``_scan_directory_level``.
+    """
+    manifest = (REPO_ROOT / "MANIFEST.in").read_text(encoding="utf-8")
+
+    assert "plugins" in manifest, (
+        "MANIFEST.in must reference the plugins tree so plugin manifests "
+        "survive the sdist trip (#28149)."
+    )
+    assert "plugin.yaml" in manifest, (
+        "MANIFEST.in must include 'plugin.yaml' so the sdist (and "
+        "downstream Homebrew bottles) ship plugin manifests (#28149)."
+    )
+    assert "plugin.yml" in manifest, (
+        "MANIFEST.in must also include 'plugin.yml'. _scan_directory_level "
+        "accepts both suffixes, and dropping the legacy one would silently "
+        "lose any plugin that uses it from the sdist."
+    )
+
+
+def test_bundled_web_search_plugin_manifests_resolve_via_importlib():
+    """Regression test for #28149.
+
+    Each bundled web-search provider must expose its ``plugin.yaml`` via
+    the ``importlib.resources`` API so ``PluginManager._scan_directory()``
+    can find it. This probe resolves through the ``plugins.web`` package
+    only (avoiding per-provider package imports), which keeps the test
+    cheap while still asserting the manifests are discoverable through
+    the resources API the loader uses.
+    """
+    from importlib.resources import files
+
+    expected_providers = (
+        "firecrawl",
+        "tavily",
+        "exa",
+        "parallel",
+        "ddgs",
+        "searxng",
+        "brave_free",
+    )
+    web_root = files("plugins.web")
+    for provider in expected_providers:
+        manifest = web_root.joinpath(provider, "plugin.yaml")
+        assert manifest.is_file(), (
+            f"plugins/web/{provider}/plugin.yaml is not accessible via "
+            "importlib.resources; rebuild the wheel after restoring the "
+            "'plugins' entry in [tool.setuptools.package-data] (#28149)."
+        )


### PR DESCRIPTION
## Summary
- salvage the clean packaging fix from #28162 without the unrelated ACP stack
- ship plugin manifest files in both wheel and sdist builds
- keep the focused packaging regression test for plugin manifests

## Test plan
- scripts/run_tests.sh tests/test_packaging_metadata.py
- build wheel and sdist, then verify plugin.yaml/plugin.yml files are included

Fixes #28149
Supersedes #28162
