### PR TITLE
fix(security): strip directory components from Teams recording display_name to prevent path traversal

### DIFF
--- a/plugins/teams_pipeline/pipeline.py
+++ b/plugins/teams_pipeline/pipeline.py
@@ -458,7 +458,11 @@ class TeamsMeetingPipeline:
         temp_root = self.config.tmp_dir or (get_hermes_home() / "tmp" / "teams_pipeline")
         temp_root.mkdir(parents=True, exist_ok=True)
         with tempfile.TemporaryDirectory(dir=str(temp_root), prefix="teams-recording-") as tmp_dir:
-            recording_name = recording.display_name or f"{recording.artifact_id}.mp4"
+            # display_name comes from Graph API and is ultimately set by
+            # the meeting organizer — strip any directory components so a
+            # crafted name like "../../etc/cron.d/evil" can't escape tmp_dir.
+            raw_name = recording.display_name or f"{recording.artifact_id}.mp4"
+            recording_name = Path(raw_name).name or f"{recording.artifact_id}.mp4"
             recording_path = Path(tmp_dir) / recording_name
             await download_recording_artifact(
                 self.graph_client,


### PR DESCRIPTION
## What does this PR do?

The Teams meeting pipeline (`plugins/teams_pipeline/pipeline.py`,
landed in v0.14.0 via #22007) downloads meeting recording artifacts
to a per-job temp directory before passing them to STT. The local
filename used to write the artifact comes straight from the Graph
API's `recording.display_name`:

```python
# Before — plugins/teams_pipeline/pipeline.py:461-462
recording_name = recording.display_name or f"{recording.artifact_id}.mp4"
recording_path = Path(tmp_dir) / recording_name
```

`Path / user_input` does **not** strip `..` segments — it just
concatenates. If `display_name` contains directory components, the
resulting `recording_path` escapes `tmp_dir`.

## Attack scenario

`recording.display_name` is sourced from
`payload.get("displayName")` in `meetings.py:102`, which is the
recording's `displayName` field as returned by the Graph
`/communications/callRecords/{id}/sessions/{sid}/recordings`
endpoint. That field is ultimately set by the meeting organizer
when the recording is created.

A meeting organizer (any M365 user with rights to record a meeting
the agent is connected to) creates a recording with:

```
displayName = "../../../../etc/cron.d/hermes-pwn"
```

When the pipeline picks the artifact up:

```python
recording_path = Path(tmp_dir) / "../../../../etc/cron.d/hermes-pwn"
# → /etc/cron.d/hermes-pwn  (on Linux, if process has write)
```

`download_recording_artifact` then opens that path for writing and
streams the attacker-controlled recording bytes into it. The
attacker now controls a file at an arbitrary path the Hermes
process can write to — common targets include:

- `~/.ssh/authorized_keys` (any user-writable path)
- `~/.hermes/auth.json` (overwrite agent credentials)
- `/etc/cron.d/...` (if Hermes runs as root, e.g. some Docker setups)
- `~/.bashrc`, `~/.zshrc` (next-shell-spawn code execution)

The artifact body is fully attacker-controlled — they uploaded
whatever they wanted as the recording content. Combined with the
filename traversal, that's an arbitrary write primitive triggered
by every meeting the agent processes.

### CVSS 3.1 estimate

`AV:N/AC:L/PR:L/UI:N/S:C/C:N/I:H/A:N` → **7.3 (HIGH)**

PR:L because the attacker needs to be a meeting participant /
organizer the agent is connected to, not anonymous. S:C and I:H
because arbitrary file write at the Hermes process's privilege
level can pivot to credential theft, persistence, or code
execution depending on what's writable.

## Fix

One-line — strip directory components with `Path(...).name`:

```python
raw_name = recording.display_name or f"{recording.artifact_id}.mp4"
recording_name = Path(raw_name).name or f"{recording.artifact_id}.mp4"
recording_path = Path(tmp_dir) / recording_name
```

`Path("../../etc/cron.d/evil").name` → `"evil"` — directory
components are dropped, only the basename survives. The
`or f"{...}.mp4"` fallback covers the edge case where the
sanitized name is empty (e.g. `display_name = "../"` → `""`).

## Why this matters

- `meetings.py:201` already handles `display_name` correctly — it
  uses `Path(display_name).suffix` which is safe.
- Only `pipeline.py:461` was joining the raw value into a path.
- This is a small, surgical fix at the trust boundary — no behavior
  change for legitimate recordings whose displayName is just a
  human-readable label.

Mirrors the defense-in-depth pattern in:
- `#21277` — dashboard plugin SRI integrity
- `#19597` — Meet node localhost binding + chmod
- `#22432` — Google Chat sender_type coercion
- `#27825` — LSP diagnostic sanitization (in review)

## Type of Change

- [x] 🔒 Security fix (HIGH — path traversal → arbitrary file write via Graph-sourced filename)

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Fix applied at the trust boundary where untrusted data enters the path join
- [x] Fallback for empty sanitized name preserves behavior for edge cases
- [x] No change in behavior for legitimate recordings
- [x] Defense-in-depth — works alongside any future server-side validation Graph may add