### PR TITLE
fix(security): strip directory components from Teams recording display_name

### DIFF
--- a/plugins/teams_pipeline/pipeline.py
+++ b/plugins/teams_pipeline/pipeline.py
@@ -458,7 +458,11 @@ class TeamsMeetingPipeline:
         temp_root = self.config.tmp_dir or (get_hermes_home() / "tmp" / "teams_pipeline")
         temp_root.mkdir(parents=True, exist_ok=True)
         with tempfile.TemporaryDirectory(dir=str(temp_root), prefix="teams-recording-") as tmp_dir:
-            recording_name = recording.display_name or f"{recording.artifact_id}.mp4"
+            # display_name comes from Graph API and is ultimately set by
+            # the meeting organizer — strip any directory components so a
+            # crafted name like "../../etc/cron.d/evil" can't escape tmp_dir.
+            raw_name = recording.display_name or f"{recording.artifact_id}.mp4"
+            recording_name = Path(raw_name).name or f"{recording.artifact_id}.mp4"
             recording_path = Path(tmp_dir) / recording_name
             await download_recording_artifact(
                 self.graph_client,

--- a/tests/plugins/test_teams_pipeline_plugin.py
+++ b/tests/plugins/test_teams_pipeline_plugin.py
@@ -304,13 +304,16 @@ class TestTeamsMeetingPipeline:
                 MeetingArtifact(
                     artifact_type="recording",
                     artifact_id="rec-1",
-                    display_name="recording.mp4",
+                    display_name="../../nested/recording.mp4",
                     download_url="https://files.example/recording.mp4",
                 )
             ]
 
+        downloaded_targets = []
+
         async def _download(client, meeting_ref, recording, destination):
             target = Path(destination)
+            downloaded_targets.append(target)
             target.write_bytes(b"video-bytes")
             return {"path": str(target), "size_bytes": 11, "content_type": "video/mp4"}
 
@@ -376,6 +379,9 @@ class TestTeamsMeetingPipeline:
         assert job.selected_artifact_strategy == "recording_stt_fallback"
         assert job.summary_payload is not None
         assert job.summary_payload.summary == "Fallback summary"
+        assert downloaded_targets
+        assert downloaded_targets[0].name == "recording.mp4"
+        assert "nested" not in str(downloaded_targets[0])
         notion_record = store.get_sink_record("notion:meeting-456")
         teams_record = store.get_sink_record("teams:meeting-456")
         assert notion_record is not None


### PR DESCRIPTION
Clean replacement for #28173.\n\nWhy:\n- upstream #28173 is stacked on unrelated mobile dashboard/web commits\n- this branch keeps only the Teams pipeline path-traversal hardening\n\nWhat it does:\n- sanitizes Graph-provided recording display_name with Path(...).name before joining it under the temp dir\n- prevents crafted names from escaping the temporary recording directory\n- adds regression coverage for traversal-style display names\n\nVerification:\n- scripts/run_tests.sh tests/plugins/test_teams_pipeline_plugin.py\n- 11 passed\n\nSecurity note:\n- fail-closed path normalization for untrusted recording filenames