### PR TITLE
fix(gateway): support launchd wrapper override on macOS

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2772,6 +2772,23 @@ def _launchd_domain() -> str:
     return f"gui/{os.getuid()}"  # windows-footgun: ok — POSIX launchd (macOS) helper, never invoked on Windows
 
 
+def _get_launchd_wrapper_override() -> str | None:
+    """Return an optional launchd wrapper script path for gateway services.
+
+    This lets macOS instances use a wrapper (for example, to inject Keychain
+    secrets) while still treating that wrapperized plist as the canonical
+    service definition for staleness checks and `hermes gateway start`.
+    """
+    raw = os.getenv("HERMES_LAUNCHD_WRAPPER", "").strip()
+    if not raw:
+        cfg = read_raw_config()
+        gateway_cfg = cfg.get("gateway", {}) if isinstance(cfg, dict) else {}
+        raw = str(gateway_cfg.get("launchd_wrapper", "") or "").strip()
+    if not raw:
+        return None
+    return str(Path(raw).expanduser())
+
+
 def generate_launchd_plist() -> str:
     python_path = get_python_path()
     working_dir = str(PROJECT_ROOT)
@@ -2780,6 +2797,7 @@ def generate_launchd_plist() -> str:
     log_dir.mkdir(parents=True, exist_ok=True)
     label = get_launchd_label()
     profile_arg = _profile_arg(hermes_home)
+    launchd_wrapper = _get_launchd_wrapper_override()
     # Build a sane PATH for the launchd plist.  launchd provides only a
     # minimal default (/usr/bin:/bin:/usr/sbin:/sbin) which misses Homebrew,
     # nvm, cargo, etc.  We prepend venv/bin and node_modules/.bin (matching
@@ -2799,12 +2817,17 @@ def generate_launchd_plist() -> str:
         dict.fromkeys(priority_dirs + [p for p in os.environ.get("PATH", "").split(":") if p])
     )
 
-    # Build ProgramArguments array, including --profile when using a named profile
-    prog_args = [
-        f"<string>{python_path}</string>",
-        "<string>-m</string>",
-        "<string>hermes_cli.main</string>",
-    ]
+    # Build ProgramArguments array, including --profile when using a named profile.
+    # When a launchd wrapper is configured, treat it as the canonical launcher so
+    # status/currentness checks and `hermes gateway start` preserve the wrapper.
+    if launchd_wrapper:
+        prog_args = [f"<string>{launchd_wrapper}</string>"]
+    else:
+        prog_args = [
+            f"<string>{python_path}</string>",
+            "<string>-m</string>",
+            "<string>hermes_cli.main</string>",
+        ]
     if profile_arg:
         for part in profile_arg.split():
             prog_args.append(f"<string>{part}</string>")

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -227,6 +227,53 @@ class TestLaunchdPlistCurrentness:
 
         assert gateway_cli.launchd_plist_is_current() is True
 
+    def test_plist_uses_configured_launchd_wrapper(self, tmp_path, monkeypatch):
+        wrapper = tmp_path / "hermes-with-keychain.sh"
+        wrapper.write_text("#!/bin/sh\n")
+        monkeypatch.setattr(
+            gateway_cli,
+            "read_raw_config",
+            lambda: {"gateway": {"launchd_wrapper": str(wrapper)}},
+        )
+
+        plist = gateway_cli.generate_launchd_plist()
+
+        assert f"<string>{wrapper}</string>" in plist
+        assert "<string>-m</string>" not in plist
+        assert "<string>hermes_cli.main</string>" not in plist
+        assert "<string>gateway</string>" in plist
+        assert "<string>run</string>" in plist
+        assert "<string>--replace</string>" in plist
+
+    def test_launchd_plist_is_current_with_configured_wrapper(self, tmp_path, monkeypatch):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        wrapper = tmp_path / "hermes-with-keychain.sh"
+        wrapper.write_text("#!/bin/sh\n")
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(
+            gateway_cli,
+            "read_raw_config",
+            lambda: {"gateway": {"launchd_wrapper": str(wrapper)}},
+        )
+
+        monkeypatch.setenv("PATH", "/custom/bin:/usr/bin:/bin")
+        default_plist = gateway_cli.generate_launchd_plist()
+        python_triplet = "\n        ".join([
+            f"<string>{gateway_cli.get_python_path()}</string>",
+            "<string>-m</string>",
+            "<string>hermes_cli.main</string>",
+        ])
+        wrapper_plist = default_plist.replace(
+            python_triplet,
+            f"<string>{wrapper}</string>",
+            1,
+        )
+        plist_path.write_text(wrapper_plist, encoding="utf-8")
+
+        monkeypatch.setenv("PATH", "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin")
+
+        assert gateway_cli.launchd_plist_is_current() is True
+
 
 # ---------------------------------------------------------------------------
 # cmd_update — macOS launchd detection


### PR DESCRIPTION
## Summary
- allow gateway launchd services to treat a configured wrapper script as the canonical launcher
- preserve wrapper-based plists for currentness checks and `hermes gateway start`
- add regression coverage for wrapper-based launchd plist generation and validation

## Testing
- not run locally in this session
