### PR TITLE
feat(nvidia): native reasoning_effort support for NIM (#19883)

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -298,6 +298,30 @@ class ChatCompletionsTransport(ProviderTransport):
                         _tokenhub_effort = _e
                 api_kwargs["reasoning_effort"] = _tokenhub_effort
 
+        # NVIDIA NIM (integrate.api.nvidia.com): top-level reasoning_effort.
+        # NIM hosts several reasoning-capable model families (DeepSeek V4 Pro/
+        # Flash, Kimi K2 Thinking, GPT-OSS 120B, Qwen3-thinking, Nemotron-3)
+        # that gate their <think> chain on this exact field.  Without it, NIM
+        # silently returns reasoning_content=null even when the user has
+        # agent.reasoning_effort set in their config.  Verified against the
+        # public NIM reference at docs.api.nvidia.com — accepts "low" |
+        # "medium" | "high".  Default "high" matches NIM's documented default
+        # and Hermes' general posture (favour quality unless told otherwise).
+        # Fixes #19883.
+        if is_nvidia_nim:
+            _nim_thinking_off = bool(
+                reasoning_config
+                and isinstance(reasoning_config, dict)
+                and reasoning_config.get("enabled") is False
+            )
+            if not _nim_thinking_off:
+                _nim_effort = "high"
+                if reasoning_config and isinstance(reasoning_config, dict):
+                    _e = (reasoning_config.get("effort") or "").strip().lower()
+                    if _e in {"low", "medium", "high"}:
+                        _nim_effort = _e
+                api_kwargs["reasoning_effort"] = _nim_effort
+
         # LM Studio: top-level reasoning_effort. Only emit when the model
         # declares reasoning support via /api/v1/models capabilities (gated
         # upstream by params["supports_reasoning"]). resolve_lmstudio_effort

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -480,6 +480,55 @@ class TestChatCompletionsKimi:
         # Mirror Kimi CLI: omit reasoning_effort entirely when thinking off
         assert "reasoning_effort" not in kw
 
+    # ── NVIDIA NIM reasoning_effort (#19883) ──────────────────────────
+    # NIM uses the same top-level reasoning_effort field as Kimi/TokenHub,
+    # but it was never wired up.  These tests mirror the Kimi suite.
+
+    def test_nvidia_nim_reasoning_effort_top_level(self, transport):
+        kw = transport.build_kwargs(
+            model="deepseek-ai/deepseek-v4-flash",
+            messages=[{"role": "user", "content": "Hi"}],
+            is_nvidia_nim=True,
+            reasoning_config={"effort": "high"},
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        # NIM gates <think> on a top-level reasoning_effort field — see
+        # docs.api.nvidia.com/nim/reference/ and issue #19883.
+        assert kw["reasoning_effort"] == "high"
+
+    def test_nvidia_nim_reasoning_effort_defaults_to_high(self, transport):
+        kw = transport.build_kwargs(
+            model="deepseek-ai/deepseek-v4-flash",
+            messages=[{"role": "user", "content": "Hi"}],
+            is_nvidia_nim=True,
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        # No reasoning_config → use NIM's documented default of "high".
+        assert kw["reasoning_effort"] == "high"
+
+    def test_nvidia_nim_reasoning_effort_omitted_when_thinking_disabled(self, transport):
+        kw = transport.build_kwargs(
+            model="deepseek-ai/deepseek-v4-flash",
+            messages=[{"role": "user", "content": "Hi"}],
+            is_nvidia_nim=True,
+            reasoning_config={"enabled": False},
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        # Opt-out: omit reasoning_effort entirely when thinking is disabled.
+        assert "reasoning_effort" not in kw
+
+    def test_nvidia_nim_reasoning_effort_only_low_medium_high(self, transport):
+        # NIM rejects efforts outside {low, medium, high}; we silently fall
+        # back to the default rather than forwarding an invalid value.
+        kw = transport.build_kwargs(
+            model="deepseek-ai/deepseek-v4-flash",
+            messages=[{"role": "user", "content": "Hi"}],
+            is_nvidia_nim=True,
+            reasoning_config={"effort": "max"},  # not in NIM's vocabulary
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        assert kw["reasoning_effort"] == "high"
+
     def test_kimi_thinking_enabled_extra_body(self, transport):
         from providers import get_provider_profile
         profile = get_provider_profile("kimi-coding")


### PR DESCRIPTION
## Summary

Closes #19883.

NVIDIA NIM (`integrate.api.nvidia.com`) gates `<think>` on the top-level `reasoning_effort` request field — the same shape Kimi, TokenHub, and LM Studio already use in Hermes. Before this change, `is_nvidia_nim` was recognised in two other branches of `build_kwargs()` (max_tokens default, extra_body assembly) but never forwarded `reasoning_effort`, so every NIM-hosted reasoning model (DeepSeek V4 Pro/Flash, Kimi K2 Thinking, GPT-OSS 120B, Qwen3-thinking, Nemotron-3) was silently locked into Non-think mode even with `agent.reasoning_effort: high` configured.

## Implementation

Mirrors the existing `is_kimi`/`is_tokenhub` blocks one screen up in `agent/transports/chat_completions.py`:

- Accepts NIM's documented vocabulary: `low` / `medium` / `high`
- Defaults to `high` (NIM's documented default and consistent with TokenHub)
- Honours `reasoning_config.enabled=False` opt-out by omitting the field entirely
- Silently falls back to the default when an out-of-vocabulary effort is passed (e.g. `"max"` from a previous-generation config)

## Verification

Reproduced the original issue against `https://integrate.api.nvidia.com/v1/chat/completions` with `deepseek-ai/deepseek-v4-flash`:

| Request body                              | `reasoning_content`           |
| ----------------------------------------- | ----------------------------- |
| (no `reasoning_effort`)                   | `null`                        |
| `reasoning_effort: "high"` (this PR)      | populated (~100–200 chars)    |

Also verified against `nvidia/nemotron-3-super-120b-a12b` — same behaviour.

## Test plan

- [x] Added 4 unit tests in `tests/agent/transports/test_chat_completions.py` mirroring the Kimi suite:
  - `test_nvidia_nim_reasoning_effort_top_level` — explicit effort forwarded
  - `test_nvidia_nim_reasoning_effort_defaults_to_high` — default when no config
  - `test_nvidia_nim_reasoning_effort_omitted_when_thinking_disabled` — opt-out via `enabled=False`
  - `test_nvidia_nim_reasoning_effort_only_low_medium_high` — out-of-vocabulary fallback
- [x] Full `test_chat_completions.py` suite passes (70/70, no regressions)
- [x] Confirmed against the live NIM endpoint as described above