### PR TITLE
fix(auth): replace misleading "No Codex credentials" with rate-limit reset message

### DIFF
--- a/agent/credential_status.py
+++ b/agent/credential_status.py
@@ -1,0 +1,178 @@
+"""Shared helpers for classifying and formatting credential-pool status.
+
+These were previously defined in ``hermes_cli/auth_commands.py``. They live
+here so non-CLI callers (e.g. the runtime resolver, the gateway logger) can
+import them without depending on the ``hermes_cli`` package.
+"""
+
+from __future__ import annotations
+
+import math
+import time
+from typing import Optional
+
+from agent.credential_pool import (
+    STATUS_EXHAUSTED,
+    CredentialPool,
+    PooledCredential,
+    _exhausted_until,
+)
+
+
+def classify_exhausted_status(entry: PooledCredential) -> tuple[str, bool]:
+    """Classify an exhausted pool entry.
+
+    Returns ``(label, show_retry_window)`` where label is one of
+    ``"rate-limited"``, ``"auth failed"``, or ``"exhausted"``.
+    ``show_retry_window`` indicates whether displaying a retry-after window
+    is meaningful (False for auth failures, which need re-login).
+    """
+    code = getattr(entry, "last_error_code", None)
+    reason = str(getattr(entry, "last_error_reason", "") or "").strip().lower()
+    message = str(getattr(entry, "last_error_message", "") or "").strip().lower()
+
+    if code == 429 or any(token in reason for token in ("rate_limit", "usage_limit", "quota", "exhausted")) or any(
+        token in message for token in ("rate limit", "usage limit", "quota", "too many requests")
+    ):
+        return "rate-limited", True
+
+    if code in {401, 403} or any(token in reason for token in ("invalid_token", "invalid_grant", "unauthorized", "forbidden", "auth")) or any(
+        token in message for token in ("unauthorized", "forbidden", "expired", "revoked", "invalid token", "authentication")
+    ):
+        return "auth failed", False
+
+    return "exhausted", True
+
+
+def format_remaining(remaining_seconds: int) -> str:
+    """Format a duration as ``"Xd Yh"`` / ``"Xh Ym"`` / ``"Xm Ys"`` / ``"Xs"``."""
+    remaining = max(0, int(remaining_seconds))
+    minutes, seconds = divmod(remaining, 60)
+    hours, minutes = divmod(minutes, 60)
+    days, hours = divmod(hours, 24)
+    if days:
+        return f"{days}d {hours}h"
+    if hours:
+        return f"{hours}h {minutes}m"
+    if minutes:
+        return f"{minutes}m {seconds}s"
+    return f"{seconds}s"
+
+
+def format_exhausted_status(entry: PooledCredential) -> str:
+    """Render a pool entry's exhausted-status suffix for display.
+
+    Returns an empty string for non-exhausted entries. For exhausted entries,
+    produces strings like ``" rate-limited usage_limit_reached (429) (1h 12m left)"``.
+    """
+    if entry.last_status != STATUS_EXHAUSTED:
+        return ""
+    label, show_retry_window = classify_exhausted_status(entry)
+    reason = getattr(entry, "last_error_reason", None)
+    reason_text = f" {reason}" if isinstance(reason, str) and reason.strip() else ""
+    code = f" ({entry.last_error_code})" if entry.last_error_code else ""
+    if not show_retry_window:
+        return f" {label}{reason_text}{code} (re-auth may be required)"
+    exhausted_until = _exhausted_until(entry)
+    if exhausted_until is None:
+        return f" {label}{reason_text}{code}"
+    remaining = max(0, int(math.ceil(exhausted_until - time.time())))
+    if remaining <= 0:
+        return f" {label}{reason_text}{code} (ready to retry)"
+    return f" {label}{reason_text}{code} ({format_remaining(remaining)} left)"
+
+
+# Priority order for picking the "primary" classification when multiple
+# exhausted entries disagree. Rate-limited wins because it carries an
+# actionable reset time; auth-failed beats generic exhausted because it
+# tells the user re-login is needed.
+_LABEL_PRIORITY = {"rate-limited": 2, "auth failed": 1, "exhausted": 0}
+
+
+def summarize_pool_exhaustion(pool: CredentialPool) -> Optional[dict]:
+    """Summarize exhaustion across a pool's entries.
+
+    Returns None if the pool has no entries, or if any entry is not in
+    exhaustion cooldown (i.e. callers should only rely on this summary
+    when ``pool.has_credentials() and not pool.has_available()``).
+
+    Otherwise returns a dict with keys:
+      - ``kind``: ``"rate_limit"``, ``"auth_failed"``, or ``"exhausted"``
+      - ``label``: human-readable label (``"rate-limited"`` etc.)
+      - ``provider``: pool provider name
+      - ``soonest_reset_at``: unix-ts of earliest reset, or None
+      - ``soonest_remaining_seconds``: int seconds until earliest reset, or None
+      - ``entry_count``: number of entries in the pool
+      - ``last_error_reason``: reason from the best-matching entry, or None
+      - ``last_error_code``: status code from the best-matching entry, or None
+    """
+    entries = pool.entries()
+    if not entries:
+        return None
+    if any(entry.last_status != STATUS_EXHAUSTED for entry in entries):
+        return None
+
+    best_priority = -1
+    best_entry: Optional[PooledCredential] = None
+    best_label = "exhausted"
+    soonest_reset: Optional[float] = None
+
+    for entry in entries:
+        label, _show_window = classify_exhausted_status(entry)
+        priority = _LABEL_PRIORITY.get(label, 0)
+        if priority > best_priority:
+            best_priority = priority
+            best_entry = entry
+            best_label = label
+        reset_at = _exhausted_until(entry)
+        if reset_at is not None and (soonest_reset is None or reset_at < soonest_reset):
+            soonest_reset = reset_at
+
+    kind = {
+        "rate-limited": "rate_limit",
+        "auth failed": "auth_failed",
+        "exhausted": "exhausted",
+    }.get(best_label, "exhausted")
+
+    remaining: Optional[int] = None
+    if soonest_reset is not None:
+        remaining = max(0, int(math.ceil(soonest_reset - time.time())))
+
+    return {
+        "kind": kind,
+        "label": best_label,
+        "provider": pool.provider,
+        "soonest_reset_at": soonest_reset,
+        "soonest_remaining_seconds": remaining,
+        "entry_count": len(entries),
+        "last_error_reason": getattr(best_entry, "last_error_reason", None) if best_entry else None,
+        "last_error_code": getattr(best_entry, "last_error_code", None) if best_entry else None,
+    }
+
+
+def format_pool_exhaustion_message(provider: str, summary: dict) -> str:
+    """Render a one-line user-facing message from a ``summarize_pool_exhaustion`` dict."""
+    label = summary.get("label", "exhausted")
+    reason = summary.get("last_error_reason")
+    code = summary.get("last_error_code")
+    remaining = summary.get("soonest_remaining_seconds")
+
+    parts = [f"{provider} {label}"]
+    detail_bits = []
+    if isinstance(reason, str) and reason.strip():
+        detail_bits.append(reason.strip())
+    if code:
+        detail_bits.append(str(code))
+    if detail_bits:
+        parts.append(f"({', '.join(detail_bits)})")
+
+    if summary.get("kind") == "auth_failed":
+        parts.append("- re-authenticate with `hermes auth`")
+    elif remaining is None:
+        pass
+    elif remaining <= 0:
+        parts.append("- ready to retry")
+    else:
+        parts.append(f"- resets in {format_remaining(remaining)}")
+
+    return " ".join(parts)

--- a/cli.py
+++ b/cli.py
@@ -4227,11 +4227,12 @@ class HermesCLI:
                         continue
                     try:
                         runtime = resolve_runtime_provider(requested=_fb_provider)
+                        from hermes_cli.auth import describe_primary_failure
                         logger.warning(
-                            "Primary provider auth failed (%s). Falling through to fallback: %s/%s",
-                            _primary_exc, _fb_provider, _fb_model,
+                            "%s. Falling through to fallback: %s/%s",
+                            describe_primary_failure(_primary_exc), _fb_provider, _fb_model,
                         )
-                        _cprint(f"⚠️  Primary auth failed — switching to fallback: {_fb_provider} / {_fb_model}")
+                        _cprint(f"⚠️  {describe_primary_failure(_primary_exc)} — switching to fallback: {_fb_provider} / {_fb_model}")
                         self.requested_provider = _fb_provider
                         self.model = _fb_model
                         _primary_exc = None

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1454,8 +1454,9 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 runtime_kwargs["explicit_base_url"] = job.get("base_url")
             runtime = resolve_runtime_provider(**runtime_kwargs)
         except AuthError as auth_exc:
-            # Primary provider auth failed — try fallback chain before giving up.
-            logger.warning("Job '%s': primary auth failed (%s), trying fallback", job_id, auth_exc)
+            # Primary provider unavailable — try fallback chain before giving up.
+            from hermes_cli.auth import describe_primary_failure
+            logger.warning("Job '%s': %s, trying fallback", job_id, describe_primary_failure(auth_exc))
             fb = _cfg.get("fallback_providers") or _cfg.get("fallback_model")
             fb_list = (fb if isinstance(fb, list) else [fb]) if fb else []
             runtime = None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -689,9 +689,12 @@ def _resolve_runtime_agent_kwargs() -> dict:
             requested=os.getenv("HERMES_INFERENCE_PROVIDER"),
         )
     except AuthError as auth_exc:
-        # Primary provider auth failed (expired token, revoked key, etc.).
-        # Try the fallback provider chain before raising.
-        logger.warning("Primary provider auth failed: %s — trying fallback", auth_exc)
+        # Primary provider unavailable. The structured ``kind`` on AuthError
+        # (rate_limit / auth_failed / exhausted) lets us log something
+        # actionable instead of a generic "auth failed".
+        from hermes_cli.auth import describe_primary_failure
+
+        logger.warning("%s — trying fallback", describe_primary_failure(auth_exc))
         fb_config = _try_resolve_fallback_provider()
         if fb_config is not None:
             return fb_config

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -736,16 +736,56 @@ class AuthError(RuntimeError):
         provider: str = "",
         code: Optional[str] = None,
         relogin_required: bool = False,
+        kind: Optional[str] = None,
+        reset_at: Optional[float] = None,
+        retry_after: Optional[float] = None,
     ) -> None:
         super().__init__(message)
         self.provider = provider
         self.code = code
         self.relogin_required = relogin_required
+        # ``kind`` classifies the failure for callers that want structured
+        # logging without parsing the message: "rate_limit", "auth_failed",
+        # "exhausted", or None for generic auth errors.
+        self.kind = kind
+        # ``reset_at`` is a unix timestamp (when the credential becomes usable
+        # again, e.g. after a rate-limit window). ``retry_after`` is seconds.
+        # Either or both may be set; callers should prefer ``reset_at`` when
+        # both are available.
+        self.reset_at = reset_at
+        self.retry_after = retry_after
+
+    @classmethod
+    def from_pool_exhaustion(cls, provider: str, summary: dict) -> "AuthError":
+        """Build an AuthError from a ``summarize_pool_exhaustion`` dict.
+
+        Produces a message that includes the soonest reset time when known,
+        so the gateway logger and CLI can surface actionable information
+        instead of a generic "credentials missing" string.
+        """
+        # Imported locally to avoid a circular import: agent.credential_status
+        # depends on agent.credential_pool, which imports hermes_cli.auth.
+        from agent.credential_status import format_pool_exhaustion_message
+
+        message = format_pool_exhaustion_message(provider, summary)
+        kind = summary.get("kind") or "exhausted"
+        return cls(
+            message,
+            provider=provider,
+            code=f"pool_{kind}",
+            relogin_required=(kind == "auth_failed"),
+            kind=kind,
+            reset_at=summary.get("soonest_reset_at"),
+        )
 
 
 def format_auth_error(error: Exception) -> str:
     """Map auth failures to concise user-facing guidance."""
     if not isinstance(error, AuthError):
+        return str(error)
+
+    if error.kind == "rate_limit":
+        # Message already encodes the reset window; pass through unchanged.
         return str(error)
 
     if error.relogin_required:
@@ -767,6 +807,22 @@ def format_auth_error(error: Exception) -> str:
         return f"{error} Please retry in a few seconds."
 
     return str(error)
+
+
+def describe_primary_failure(error: Exception) -> str:
+    """Build a one-line description of why the primary provider failed.
+
+    Used by callers that log "primary provider unavailable — trying
+    fallback" so the reason is concrete (rate-limited vs auth-failed vs
+    generic) rather than a generic "auth failed".
+    """
+    if not isinstance(error, AuthError):
+        return f"primary provider unavailable: {error}"
+    if error.kind in {"rate_limit", "auth_failed", "exhausted"}:
+        # Pool-exhaustion messages already encode the provider name and
+        # the reason; pass through unchanged with a stable prefix.
+        return f"primary provider {error}"
+    return f"primary provider auth failed: {error}"
 
 
 def _token_fingerprint(token: Any) -> Optional[str]:

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 from getpass import getpass
-import math
 import sys
-import time
 from types import SimpleNamespace
 import uuid
 
@@ -26,6 +24,10 @@ from agent.credential_pool import (
     label_from_token,
     list_custom_pool_providers,
     load_pool,
+)
+from agent.credential_status import (
+    classify_exhausted_status as _classify_exhausted_status,
+    format_exhausted_status as _format_exhausted_status,
 )
 import hermes_cli.auth as auth_mod
 from hermes_cli.auth import PROVIDER_REGISTRY
@@ -110,54 +112,6 @@ def _api_key_default_label(count: int) -> str:
 
 def _display_source(source: str) -> str:
     return source.split(":", 1)[1] if source.startswith("manual:") else source
-
-
-def _classify_exhausted_status(entry) -> tuple[str, bool]:
-    code = getattr(entry, "last_error_code", None)
-    reason = str(getattr(entry, "last_error_reason", "") or "").strip().lower()
-    message = str(getattr(entry, "last_error_message", "") or "").strip().lower()
-
-    if code == 429 or any(token in reason for token in ("rate_limit", "usage_limit", "quota", "exhausted")) or any(
-        token in message for token in ("rate limit", "usage limit", "quota", "too many requests")
-    ):
-        return "rate-limited", True
-
-    if code in {401, 403} or any(token in reason for token in ("invalid_token", "invalid_grant", "unauthorized", "forbidden", "auth")) or any(
-        token in message for token in ("unauthorized", "forbidden", "expired", "revoked", "invalid token", "authentication")
-    ):
-        return "auth failed", False
-
-    return "exhausted", True
-
-
-
-def _format_exhausted_status(entry) -> str:
-    if entry.last_status != STATUS_EXHAUSTED:
-        return ""
-    label, show_retry_window = _classify_exhausted_status(entry)
-    reason = getattr(entry, "last_error_reason", None)
-    reason_text = f" {reason}" if isinstance(reason, str) and reason.strip() else ""
-    code = f" ({entry.last_error_code})" if entry.last_error_code else ""
-    if not show_retry_window:
-        return f" {label}{reason_text}{code} (re-auth may be required)"
-    exhausted_until = _exhausted_until(entry)
-    if exhausted_until is None:
-        return f" {label}{reason_text}{code}"
-    remaining = max(0, int(math.ceil(exhausted_until - time.time())))
-    if remaining <= 0:
-        return f" {label}{reason_text}{code} (ready to retry)"
-    minutes, seconds = divmod(remaining, 60)
-    hours, minutes = divmod(minutes, 60)
-    days, hours = divmod(hours, 24)
-    if days:
-        wait = f"{days}d {hours}h"
-    elif hours:
-        wait = f"{hours}h {minutes}m"
-    elif minutes:
-        wait = f"{minutes}m {seconds}s"
-    else:
-        wait = f"{seconds}s"
-    return f" {label}{reason_text}{code} ({wait} left)"
 
 
 def auth_add_command(args) -> None:

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1182,6 +1182,35 @@ def resolve_runtime_provider(
                 target_model=target_model,
             )
 
+    # If the pool holds entries but none are currently usable (all in
+    # exhaustion cooldown — typically a 429 rate-limit window), raise a
+    # structured AuthError carrying the soonest reset time. Otherwise the
+    # provider-specific fall-throughs below would call into legacy
+    # ``_read_*_tokens`` helpers which read a different storage location
+    # and raise misleading "no credentials stored" errors when the
+    # credential lives only in the pool. The gateway and CLI catch
+    # AuthError and either fall back to another provider or surface this
+    # actionable message to the user.
+    _POOL_EXHAUSTION_PROVIDERS = {
+        "openai-codex",
+        "xai-oauth",
+        "qwen-oauth",
+        "google-gemini-cli",
+        "nous",
+        "anthropic",
+    }
+    if (
+        pool
+        and provider in _POOL_EXHAUSTION_PROVIDERS
+        and pool.has_credentials()
+        and not pool.has_available()
+    ):
+        from agent.credential_status import summarize_pool_exhaustion
+
+        _exhaustion_summary = summarize_pool_exhaustion(pool)
+        if _exhaustion_summary is not None:
+            raise AuthError.from_pool_exhaustion(provider, _exhaustion_summary)
+
     if provider == "nous":
         try:
             creds = resolve_nous_runtime_credentials(

--- a/tests/agent/test_credential_status.py
+++ b/tests/agent/test_credential_status.py
@@ -1,0 +1,239 @@
+"""Tests for agent/credential_status.py helpers."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from agent.credential_pool import (
+    AUTH_TYPE_OAUTH,
+    SOURCE_MANUAL,
+    STATUS_EXHAUSTED,
+    CredentialPool,
+    PooledCredential,
+)
+from agent.credential_status import (
+    classify_exhausted_status,
+    format_exhausted_status,
+    format_pool_exhaustion_message,
+    format_remaining,
+    summarize_pool_exhaustion,
+)
+
+
+def _make_entry(
+    *,
+    provider: str = "openai-codex",
+    entry_id: str = "abc123",
+    last_status: str = STATUS_EXHAUSTED,
+    last_error_code: int | None = 429,
+    last_error_reason: str | None = "usage_limit_reached",
+    last_error_message: str | None = "The usage limit has been reached",
+    last_error_reset_at: float | None = None,
+    last_status_at: float | None = None,
+) -> PooledCredential:
+    return PooledCredential(
+        provider=provider,
+        id=entry_id,
+        label=f"{provider}-oauth-1",
+        auth_type=AUTH_TYPE_OAUTH,
+        priority=0,
+        source=SOURCE_MANUAL,
+        access_token="tok-" + entry_id,
+        refresh_token="ref-" + entry_id,
+        last_status=last_status,
+        last_status_at=last_status_at,
+        last_error_code=last_error_code,
+        last_error_reason=last_error_reason,
+        last_error_message=last_error_message,
+        last_error_reset_at=last_error_reset_at,
+    )
+
+
+def test_classify_rate_limit_from_code() -> None:
+    entry = _make_entry(last_error_code=429, last_error_reason=None, last_error_message=None)
+    assert classify_exhausted_status(entry) == ("rate-limited", True)
+
+
+def test_classify_rate_limit_from_reason() -> None:
+    entry = _make_entry(last_error_code=None, last_error_reason="usage_limit_reached", last_error_message=None)
+    assert classify_exhausted_status(entry) == ("rate-limited", True)
+
+
+def test_classify_auth_failed() -> None:
+    entry = _make_entry(
+        last_error_code=401,
+        last_error_reason="invalid_token",
+        last_error_message="Invalid token",
+    )
+    label, show_window = classify_exhausted_status(entry)
+    assert label == "auth failed"
+    assert show_window is False
+
+
+def test_classify_generic_exhausted() -> None:
+    entry = _make_entry(
+        last_error_code=500,
+        last_error_reason="upstream_error",
+        last_error_message="Server error",
+    )
+    assert classify_exhausted_status(entry) == ("exhausted", True)
+
+
+def test_format_remaining() -> None:
+    assert format_remaining(45) == "45s"
+    assert format_remaining(125) == "2m 5s"
+    assert format_remaining(3600 * 2 + 60 * 30) == "2h 30m"
+    assert format_remaining(86400 * 3 + 3600 * 4) == "3d 4h"
+    assert format_remaining(0) == "0s"
+    assert format_remaining(-5) == "0s"
+
+
+def test_format_exhausted_status_with_reset() -> None:
+    reset_at = time.time() + 4320  # 1h 12m
+    entry = _make_entry(last_error_reset_at=reset_at)
+    rendered = format_exhausted_status(entry)
+    assert "rate-limited" in rendered
+    assert "usage_limit_reached" in rendered
+    assert "(429)" in rendered
+    assert "left" in rendered
+    # Allow off-by-one-second jitter.
+    assert "1h 11m" in rendered or "1h 12m" in rendered
+
+
+def test_format_exhausted_status_non_exhausted_returns_empty() -> None:
+    entry = _make_entry(last_status=None)
+    assert format_exhausted_status(entry) == ""
+
+
+def test_format_exhausted_status_auth_failed_omits_window() -> None:
+    entry = _make_entry(
+        last_error_code=401,
+        last_error_reason="invalid_token",
+        last_error_message="Unauthorized",
+        last_error_reset_at=time.time() + 3600,
+    )
+    rendered = format_exhausted_status(entry)
+    assert "auth failed" in rendered
+    assert "re-auth may be required" in rendered
+    assert "left" not in rendered
+
+
+def _make_pool(provider: str, entries: list[PooledCredential]) -> CredentialPool:
+    return CredentialPool(provider=provider, entries=entries)
+
+
+def test_summarize_empty_pool_returns_none() -> None:
+    pool = _make_pool("openai-codex", [])
+    assert summarize_pool_exhaustion(pool) is None
+
+
+def test_summarize_any_healthy_returns_none() -> None:
+    healthy = _make_entry(entry_id="healthy", last_status=None, last_error_code=None,
+                          last_error_reason=None, last_error_message=None)
+    rate_limited = _make_entry(entry_id="rl")
+    pool = _make_pool("openai-codex", [healthy, rate_limited])
+    assert summarize_pool_exhaustion(pool) is None
+
+
+def test_summarize_all_rate_limited_picks_soonest_reset() -> None:
+    now = time.time()
+    early = _make_entry(entry_id="early", last_error_reset_at=now + 600)   # 10m
+    late = _make_entry(entry_id="late", last_error_reset_at=now + 4320)    # 1h 12m
+    pool = _make_pool("openai-codex", [late, early])
+
+    summary = summarize_pool_exhaustion(pool)
+    assert summary is not None
+    assert summary["kind"] == "rate_limit"
+    assert summary["label"] == "rate-limited"
+    assert summary["provider"] == "openai-codex"
+    assert summary["entry_count"] == 2
+    assert summary["last_error_code"] == 429
+    assert summary["last_error_reason"] == "usage_limit_reached"
+    assert summary["soonest_reset_at"] == pytest.approx(now + 600, abs=2)
+    assert summary["soonest_remaining_seconds"] is not None
+    assert 595 <= summary["soonest_remaining_seconds"] <= 605
+
+
+def test_summarize_mixed_prefers_rate_limit_label() -> None:
+    rate_limited = _make_entry(entry_id="rl")
+    auth_failed = _make_entry(
+        entry_id="af",
+        last_error_code=401,
+        last_error_reason="invalid_token",
+        last_error_message="Unauthorized",
+    )
+    pool = _make_pool("openai-codex", [auth_failed, rate_limited])
+    summary = summarize_pool_exhaustion(pool)
+    assert summary is not None
+    # Rate-limit wins over auth-failed because it carries actionable
+    # reset-time information.
+    assert summary["kind"] == "rate_limit"
+    assert summary["label"] == "rate-limited"
+
+
+def test_summarize_all_auth_failed() -> None:
+    auth_a = _make_entry(
+        entry_id="a",
+        last_error_code=401,
+        last_error_reason="invalid_token",
+        last_error_message="Unauthorized",
+    )
+    auth_b = _make_entry(
+        entry_id="b",
+        last_error_code=403,
+        last_error_reason="forbidden",
+        last_error_message="Forbidden",
+    )
+    pool = _make_pool("openai-codex", [auth_a, auth_b])
+    summary = summarize_pool_exhaustion(pool)
+    assert summary is not None
+    assert summary["kind"] == "auth_failed"
+
+
+def test_format_pool_exhaustion_message_rate_limit() -> None:
+    summary = {
+        "kind": "rate_limit",
+        "label": "rate-limited",
+        "provider": "openai-codex",
+        "soonest_reset_at": None,
+        "soonest_remaining_seconds": 4320,
+        "last_error_reason": "usage_limit_reached",
+        "last_error_code": 429,
+        "entry_count": 1,
+    }
+    msg = format_pool_exhaustion_message("openai-codex", summary)
+    assert msg == "openai-codex rate-limited (usage_limit_reached, 429) - resets in 1h 12m"
+
+
+def test_format_pool_exhaustion_message_auth_failed_skips_window() -> None:
+    summary = {
+        "kind": "auth_failed",
+        "label": "auth failed",
+        "provider": "openai-codex",
+        "soonest_reset_at": None,
+        "soonest_remaining_seconds": 100,
+        "last_error_reason": "invalid_token",
+        "last_error_code": 401,
+        "entry_count": 1,
+    }
+    msg = format_pool_exhaustion_message("openai-codex", summary)
+    assert "auth failed" in msg
+    assert "re-authenticate" in msg
+    assert "resets in" not in msg
+
+
+def test_format_pool_exhaustion_message_ready_to_retry() -> None:
+    summary = {
+        "kind": "rate_limit",
+        "label": "rate-limited",
+        "provider": "openai-codex",
+        "soonest_reset_at": None,
+        "soonest_remaining_seconds": 0,
+        "last_error_reason": "usage_limit_reached",
+        "last_error_code": 429,
+        "entry_count": 1,
+    }
+    msg = format_pool_exhaustion_message("openai-codex", summary)
+    assert "ready to retry" in msg

--- a/tests/gateway/test_auth_fallback_log_message.py
+++ b/tests/gateway/test_auth_fallback_log_message.py
@@ -1,0 +1,116 @@
+"""When the primary provider's credential pool is rate-limited, the gateway
+should log an actionable "rate-limited (resets in X)" line instead of the
+misleading "No Codex credentials stored" message that the legacy
+``_read_codex_tokens`` path used to emit.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from unittest.mock import patch
+
+
+def _write_config_with_openrouter_fallback(tmp_path) -> None:
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "model:\n"
+        "  provider: openai-codex\n"
+        "fallback_model:\n"
+        "  provider: openrouter\n"
+        "  model: meta-llama/llama-4-maverick\n",
+        encoding="utf-8",
+    )
+
+
+def test_rate_limit_authError_produces_actionable_warning(tmp_path, monkeypatch, caplog):
+    """Gateway warning should name the provider and the reset window."""
+    from hermes_cli.auth import AuthError
+
+    _write_config_with_openrouter_fallback(tmp_path)
+    monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+    monkeypatch.setenv("HERMES_INFERENCE_PROVIDER", "openai-codex")
+
+    reset_at = time.time() + 4320  # 1h 12m
+    rate_limit_summary = {
+        "kind": "rate_limit",
+        "label": "rate-limited",
+        "provider": "openai-codex",
+        "soonest_reset_at": reset_at,
+        "soonest_remaining_seconds": 4320,
+        "last_error_reason": "usage_limit_reached",
+        "last_error_code": 429,
+        "entry_count": 1,
+    }
+    primary_exc = AuthError.from_pool_exhaustion("openai-codex", rate_limit_summary)
+
+    def _mock_resolve(**kwargs):
+        requested = kwargs.get("requested", "")
+        if requested and "codex" in str(requested).lower():
+            raise primary_exc
+        return {
+            "api_key": "fallback-key",
+            "base_url": "https://openrouter.ai/api/v1",
+            "provider": "openrouter",
+            "api_mode": "openai_chat",
+            "command": None,
+            "args": None,
+            "credential_pool": None,
+        }
+
+    with patch(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        side_effect=_mock_resolve,
+    ):
+        with caplog.at_level(logging.WARNING, logger="gateway.run"):
+            from gateway.run import _resolve_runtime_agent_kwargs
+
+            result = _resolve_runtime_agent_kwargs()
+
+    # Fallback still works.
+    assert result["provider"] == "openrouter"
+
+    # The warning must describe what actually happened: rate-limit, provider
+    # name, reset window. The pre-fix misleading text must be gone.
+    warnings = "\n".join(rec.getMessage() for rec in caplog.records if rec.levelno >= logging.WARNING)
+    assert "rate-limited" in warnings
+    assert "openai-codex" in warnings
+    assert "1h 11m" in warnings or "1h 12m" in warnings
+    assert "trying fallback" in warnings
+    assert "No Codex credentials stored" not in warnings
+
+
+def test_plain_authError_still_logs_generic_message(tmp_path, monkeypatch, caplog):
+    """Unstructured AuthError (no ``kind``) should keep the legacy log shape."""
+    from hermes_cli.auth import AuthError
+
+    _write_config_with_openrouter_fallback(tmp_path)
+    monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+    monkeypatch.setenv("HERMES_INFERENCE_PROVIDER", "openai-codex")
+
+    def _mock_resolve(**kwargs):
+        requested = kwargs.get("requested", "")
+        if requested and "codex" in str(requested).lower():
+            raise AuthError("token refresh failed")
+        return {
+            "api_key": "fallback-key",
+            "base_url": "https://openrouter.ai/api/v1",
+            "provider": "openrouter",
+            "api_mode": "openai_chat",
+            "command": None,
+            "args": None,
+            "credential_pool": None,
+        }
+
+    with patch(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        side_effect=_mock_resolve,
+    ):
+        with caplog.at_level(logging.WARNING, logger="gateway.run"):
+            from gateway.run import _resolve_runtime_agent_kwargs
+
+            _resolve_runtime_agent_kwargs()
+
+    warnings = "\n".join(rec.getMessage() for rec in caplog.records if rec.levelno >= logging.WARNING)
+    assert "primary provider auth failed" in warnings.lower()
+    assert "token refresh failed" in warnings

--- a/tests/gateway/test_session_model_override_routing.py
+++ b/tests/gateway/test_session_model_override_routing.py
@@ -189,7 +189,16 @@ fallback_providers:
     def fake_resolve_runtime_provider(*, requested=None, explicit_base_url=None, explicit_api_key=None):
         if requested in {None, "", "openai-codex"}:
             from hermes_cli.auth import AuthError
-            raise AuthError("No Codex credentials stored. Run `hermes auth` to authenticate.")
+            # Realistic primary-failure shape: the pool's only credential is
+            # rate-limited. Triggers the gateway's structured-AuthError log
+            # path and the fallback chain.
+            raise AuthError(
+                "openai-codex rate-limited (usage_limit_reached, 429) - resets in 1h 12m",
+                provider="openai-codex",
+                code="pool_rate_limit",
+                kind="rate_limit",
+                reset_at=None,
+            )
         assert requested == "openrouter"
         return {
             "api_key": "sk-openrouter",

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -725,7 +725,7 @@ def test_auth_list_shows_exhausted_cooldown(monkeypatch, capsys):
             return None
 
     monkeypatch.setattr("hermes_cli.auth_commands.load_pool", lambda provider: _Pool())
-    monkeypatch.setattr("hermes_cli.auth_commands.time.time", lambda: 1030.0)
+    monkeypatch.setattr("agent.credential_status.time.time", lambda: 1030.0)
 
     class _Args:
         provider = "openrouter"
@@ -759,7 +759,7 @@ def test_auth_list_shows_auth_failure_when_exhausted_entry_is_unauthorized(monke
             return None
 
     monkeypatch.setattr("hermes_cli.auth_commands.load_pool", lambda provider: _Pool())
-    monkeypatch.setattr("hermes_cli.auth_commands.time.time", lambda: 1030.0)
+    monkeypatch.setattr("agent.credential_status.time.time", lambda: 1030.0)
 
     class _Args:
         provider = "openai-codex"
@@ -796,7 +796,7 @@ def test_auth_list_prefers_explicit_reset_time(monkeypatch, capsys):
 
     monkeypatch.setattr("hermes_cli.auth_commands.load_pool", lambda provider: _Pool())
     monkeypatch.setattr(
-        "hermes_cli.auth_commands.time.time",
+        "agent.credential_status.time.time",
         lambda: datetime(2026, 4, 5, 10, 30, tzinfo=timezone.utc).timestamp(),
     )
 

--- a/tests/hermes_cli/test_runtime_provider_pool_exhaustion.py
+++ b/tests/hermes_cli/test_runtime_provider_pool_exhaustion.py
@@ -1,0 +1,160 @@
+"""Resolver should raise a structured rate-limit AuthError when a pool's
+only credentials are in exhaustion cooldown — instead of falling through
+to legacy ``_read_*_tokens`` helpers that emit the misleading "no
+credentials stored" message.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from hermes_cli import runtime_provider as rp
+from hermes_cli.auth import AuthError
+
+
+class _StubEntry:
+    """Stand-in for PooledCredential with just the fields the helpers read."""
+
+    def __init__(
+        self,
+        *,
+        last_status: str = "exhausted",
+        last_error_code: int = 429,
+        last_error_reason: str = "usage_limit_reached",
+        last_error_message: str = "The usage limit has been reached",
+        last_error_reset_at: float | None = None,
+        last_status_at: float | None = None,
+    ) -> None:
+        self.last_status = last_status
+        self.last_error_code = last_error_code
+        self.last_error_reason = last_error_reason
+        self.last_error_message = last_error_message
+        self.last_error_reset_at = last_error_reset_at
+        self.last_status_at = last_status_at
+
+
+class _StubPool:
+    """Pool stub matching the shape exercised by the resolver."""
+
+    def __init__(self, provider: str, entries: list[_StubEntry]) -> None:
+        self.provider = provider
+        self._entries = list(entries)
+
+    def has_credentials(self) -> bool:
+        return bool(self._entries)
+
+    def has_available(self) -> bool:
+        return any(e.last_status != "exhausted" for e in self._entries)
+
+    def select(self):
+        for entry in self._entries:
+            if entry.last_status != "exhausted":
+                return entry
+        return None
+
+    def entries(self):
+        return list(self._entries)
+
+
+def test_resolver_raises_rate_limit_authError_when_pool_exhausted(monkeypatch):
+    reset_at = time.time() + 4320  # ~1h 12m
+    pool = _StubPool(
+        "openai-codex",
+        [_StubEntry(last_error_reset_at=reset_at)],
+    )
+
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openai-codex")
+    monkeypatch.setattr(rp, "load_pool", lambda provider: pool)
+
+    # If the resolver fell through to legacy ``_read_codex_tokens``, the
+    # test would surface that path's "No Codex credentials stored" error.
+    # The new pool-exhaustion check must intercept and raise a structured
+    # rate-limit AuthError before that happens.
+    with pytest.raises(AuthError) as excinfo:
+        rp.resolve_runtime_provider(requested="openai-codex")
+
+    err = excinfo.value
+    assert err.kind == "rate_limit"
+    assert err.provider == "openai-codex"
+    assert err.code == "pool_rate_limit"
+    assert err.relogin_required is False
+    assert err.reset_at == pytest.approx(reset_at, abs=2)
+    message = str(err)
+    assert "rate-limited" in message
+    assert "openai-codex" in message
+    # The duration string from format_remaining; tolerate the 1-second
+    # boundary between 1h 11m and 1h 12m.
+    assert "1h 11m" in message or "1h 12m" in message
+    # The misleading legacy string must NOT appear anywhere.
+    assert "No Codex credentials stored" not in message
+
+
+def test_resolver_raises_auth_failed_authError_when_pool_only_has_auth_failures(monkeypatch):
+    pool = _StubPool(
+        "openai-codex",
+        [
+            _StubEntry(
+                last_error_code=401,
+                last_error_reason="invalid_token",
+                last_error_message="Unauthorized",
+            )
+        ],
+    )
+
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openai-codex")
+    monkeypatch.setattr(rp, "load_pool", lambda provider: pool)
+
+    with pytest.raises(AuthError) as excinfo:
+        rp.resolve_runtime_provider(requested="openai-codex")
+
+    err = excinfo.value
+    assert err.kind == "auth_failed"
+    assert err.code == "pool_auth_failed"
+    assert err.relogin_required is True
+
+
+def test_resolver_skips_exhaustion_check_for_non_pool_providers(monkeypatch):
+    """If the requested provider isn't in the pool-exhaustion set, the
+    resolver should fall through unchanged (no new behavior)."""
+    pool = _StubPool("openrouter", [_StubEntry()])
+
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(rp, "load_pool", lambda provider: pool)
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {"provider": "openrouter"})
+
+    # openrouter isn't in _POOL_EXHAUSTION_PROVIDERS, so the new check is
+    # a no-op. The resolver should proceed past the exhaustion check (and
+    # eventually fail via a different path or return env-var creds — both
+    # acceptable; we just assert no AuthError carrying our kind is raised).
+    try:
+        rp.resolve_runtime_provider(requested="openrouter")
+    except AuthError as err:
+        assert err.kind not in {"rate_limit", "auth_failed", "exhausted"}, (
+            f"openrouter should not trigger pool-exhaustion path; got {err.kind=}"
+        )
+    except Exception:
+        # Other downstream failures (e.g. missing env API key) are fine —
+        # we only care that we didn't synthesize a pool-exhaustion error.
+        pass
+
+
+def test_authError_from_pool_exhaustion_message_shape() -> None:
+    summary = {
+        "kind": "rate_limit",
+        "label": "rate-limited",
+        "provider": "openai-codex",
+        "soonest_reset_at": time.time() + 3600,
+        "soonest_remaining_seconds": 3600,
+        "last_error_reason": "usage_limit_reached",
+        "last_error_code": 429,
+        "entry_count": 1,
+    }
+    err = AuthError.from_pool_exhaustion("openai-codex", summary)
+    assert err.kind == "rate_limit"
+    assert err.code == "pool_rate_limit"
+    assert err.provider == "openai-codex"
+    assert err.relogin_required is False
+    assert "rate-limited" in str(err)
+    assert "resets in 1h 0m" in str(err) or "resets in 59m" in str(err)


### PR DESCRIPTION
Clean replacement for #28182 without the unrelated mobile dashboard/web commit from #28127.

What this keeps:
- structured credential-pool exhaustion summaries
- actionable primary-provider fallback logging for CLI/gateway/cron
- pool exhaustion AuthError path in runtime provider resolution
- targeted regression tests covering rate-limit/auth-failure messaging

What this excludes:
- all unrelated web/mobile dashboard changes

Validation:
- scripts/run_tests.sh tests/agent/test_credential_status.py tests/hermes_cli/test_runtime_provider_pool_exhaustion.py tests/gateway/test_auth_fallback_log_message.py tests/gateway/test_session_model_override_routing.py tests/hermes_cli/test_auth_commands.py
- 71 passed
