### PR TITLE
fix(conversation_loop): use _ra() to access _pool_may_recover_from_rate_limit

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2317,7 +2317,7 @@ def run_conversation(
                     # still recover.  See _pool_may_recover_from_rate_limit
                     # for the single-credential-pool and CloudCode-quota
                     # exceptions.  Fixes #11314 and #13636.
-                    pool_may_recover = _pool_may_recover_from_rate_limit(
+                    pool_may_recover = _ra()._pool_may_recover_from_rate_limit(
                         agent._credential_pool,
                         provider=agent.provider,
                         base_url=getattr(agent, "base_url", None),


### PR DESCRIPTION
## Summary

One-line fix for a latent `NameError` on the rate-limit eager-fallback path.

`agent/conversation_loop.py:2320` calls `_pool_may_recover_from_rate_limit(...)` as a bare name, but that symbol is defined in `run_agent.py` (line 239) and is never imported into `agent/conversation_loop.py`. Everywhere else in this file, `run_agent` symbols are reached through the `_ra()` lazy-import helper defined on lines 76–82 (also used on 553, 555, 3765, 3814). This single site was missed.

```diff
- pool_may_recover = _pool_may_recover_from_rate_limit(
+ pool_may_recover = _ra()._pool_may_recover_from_rate_limit(
```

## Reproduction

Triggered when a provider returns a rate-limit / quota / billing error **and** a `fallback_chain` is configured. Observed in production on a `homercrm` profile gateway after the primary OpenAI Codex provider returned HTTP 429; the conversation crashed instead of switching to the fallback provider:

```
File ".../agent/conversation_loop.py", line 2320, in run_conversation
    pool_may_recover = _pool_may_recover_from_rate_limit(
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
NameError: name '_pool_may_recover_from_rate_limit' is not defined
```

The existing tests in `tests/run_agent/test_provider_fallback.py` and `tests/agent/test_gemini_fast_fallback.py` exercise the function directly via `from run_agent import _pool_may_recover_from_rate_limit`, so they don't catch this call-site bug — they bypass the conversation-loop import scope.

## Test plan

- [x] Manual: patched gateway restarted (launchd KeepAlive), production conversation that previously crashed now succeeds the rate-limit decision path
- [x] `inspect.getsource(agent.conversation_loop)` contains `_ra()._pool_may_recover_from_rate_limit`
- [ ] (Suggested followup, not in this PR) Add a conversation-loop-level test that simulates a 429 with a configured fallback chain — the existing unit tests cover the helper but not the call site

Refs #11314, #13636 — the issues the existing comment block points to.
