### PR TITLE
fix(cli): empty credential pool entries no longer authenticate provider (#28140)

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1232,8 +1232,14 @@ def list_authenticated_providers(
             try:
                 from hermes_cli.auth import _load_auth_store
                 store = _load_auth_store()
-                if store and hermes_id in store.get("credential_pool", {}):
-                    has_creds = True
+                # An empty credential pool entry (e.g. "minimax-cn": [])
+                # left over after a user deletes their env var must NOT
+                # be treated as authenticated — only an entry with at
+                # least one real credential counts.  Fixes #28140.
+                if store:
+                    pool_entries = store.get("credential_pool", {}).get(hermes_id) or []
+                    if pool_entries:
+                        has_creds = True
             except Exception:
                 pass
         if not has_creds:

--- a/tests/hermes_cli/test_credential_pool_empty.py
+++ b/tests/hermes_cli/test_credential_pool_empty.py
@@ -1,0 +1,122 @@
+"""Regression tests for the empty credential pool bug (#28140).
+
+Before the fix, an empty `auth.json` credential_pool entry (e.g.
+``"minimax-cn": []``) left over after the user deleted their API-key env
+var still caused the provider to appear authenticated in the `/model`
+picker, because the check was a presence check on the dict key — not on
+the array contents.
+
+The fix lives in ``hermes_cli/model_switch.py::list_authenticated_providers``
+inside the env-var fallback that consults the auth store.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.model_switch import list_authenticated_providers
+
+
+# Models.dev mapping must include a provider that uses an env-var auth
+# type (so we hit the fallback branch).  minimax-cn is the canonical
+# example from the bug report.
+_FAKE_MODELS_DEV = {
+    "minimax-cn": {
+        "id": "minimax-cn",
+        "name": "MiniMax CN",
+        "env": ["MINIMAX_CN_API_KEY"],
+        "models": {
+            "minimax-m2.7": {"id": "minimax-m2.7", "name": "MiniMax M2.7"},
+        },
+    },
+}
+
+
+def _isolate_env_and_overlays(monkeypatch):
+    """Strip the test environment down to a clean slate.
+
+    - Remove MINIMAX env vars so the fallback path is exercised.
+    - Mock models.dev so the test needs no network.
+    - Restrict PROVIDER_TO_MODELS_DEV to only minimax-cn so the loop is
+      single-pass and predictable.
+    """
+    for key in ("MINIMAX_API_KEY", "MINIMAX_CN_API_KEY"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: _FAKE_MODELS_DEV)
+    # PROVIDER_TO_MODELS_DEV lives on agent.models_dev and is imported into
+    # model_switch via `from agent.models_dev import PROVIDER_TO_MODELS_DEV`
+    # — the imported binding refers to the same dict object, so patching the
+    # source module is enough.
+    monkeypatch.setattr(
+        "agent.models_dev.PROVIDER_TO_MODELS_DEV",
+        {"minimax-cn": "minimax-cn"},
+    )
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+
+def test_empty_credential_pool_does_not_authenticate_provider(monkeypatch):
+    """Reproduces #28140: an empty pool array must not count as credentials."""
+    _isolate_env_and_overlays(monkeypatch)
+
+    # Simulate the leftover empty array: user deleted MINIMAX_CN_API_KEY
+    # from .env but auth.json still has "minimax-cn": [] from earlier setup.
+    with patch(
+        "hermes_cli.auth._load_auth_store",
+        return_value={"credential_pool": {"minimax-cn": []}},
+    ):
+        providers = list_authenticated_providers()
+
+    slugs = [p.get("slug") for p in providers]
+    assert "minimax-cn" not in slugs, (
+        "Empty credential pool entry must not authenticate the provider — "
+        "this is the #28140 regression."
+    )
+
+
+def test_populated_credential_pool_does_authenticate_provider(monkeypatch):
+    """Sanity check: a real pool entry MUST still authenticate."""
+    _isolate_env_and_overlays(monkeypatch)
+
+    fake_entry = {"key": "test-key-value", "label": "test"}
+    with patch(
+        "hermes_cli.auth._load_auth_store",
+        return_value={"credential_pool": {"minimax-cn": [fake_entry]}},
+    ):
+        providers = list_authenticated_providers()
+
+    slugs = [p.get("slug") for p in providers]
+    assert "minimax-cn" in slugs, (
+        "A non-empty credential pool entry must still authenticate the provider — "
+        "do not over-correct #28140."
+    )
+
+
+def test_missing_credential_pool_key_does_not_authenticate_provider(monkeypatch):
+    """No env var, no pool entry at all → provider must be hidden."""
+    _isolate_env_and_overlays(monkeypatch)
+
+    with patch(
+        "hermes_cli.auth._load_auth_store",
+        return_value={"credential_pool": {}},
+    ):
+        providers = list_authenticated_providers()
+
+    slugs = [p.get("slug") for p in providers]
+    assert "minimax-cn" not in slugs
+
+
+def test_env_var_still_authenticates_even_with_empty_pool(monkeypatch):
+    """If the env var IS set, the pool state is irrelevant — provider shows up."""
+    _isolate_env_and_overlays(monkeypatch)
+    monkeypatch.setenv("MINIMAX_CN_API_KEY", "real-key-from-env")
+
+    with patch(
+        "hermes_cli.auth._load_auth_store",
+        return_value={"credential_pool": {"minimax-cn": []}},
+    ):
+        providers = list_authenticated_providers()
+
+    slugs = [p.get("slug") for p in providers]
+    assert "minimax-cn" in slugs, (
+        "Env-var auth must take precedence over auth-store state."
+    )


### PR DESCRIPTION
## Summary

Closes #28140.

When the user removes an API-key env var (e.g. `MINIMAX_CN_API_KEY`) from `.env`, an empty `credential_pool` array left behind in `~/.hermes/auth.json` (e.g. `"minimax-cn": []`) still caused the provider to appear authenticated in the `/model` picker.

## Root cause

In `hermes_cli/model_switch.py::list_authenticated_providers`, the auth-store fallback checked only whether the provider key existed in the pool dict, not whether the value held any actual credentials:

```python
if store and hermes_id in store.get("credential_pool", {}):
    has_creds = True
```

`"minimax-cn": []` satisfies `hermes_id in {...}` even though the list is empty, so `has_creds` flipped to `True` with zero usable credentials, and the provider appeared in the `/model` picker.

## Fix

Pull the list out and gate on its truthiness:

```python
if store:
    pool_entries = store.get("credential_pool", {}).get(hermes_id) or []
    if pool_entries:
        has_creds = True
```

This matches the intent ("any usable credential in the pool?") and is consistent with how `agent/credential_pool.py` itself treats empty lists elsewhere.

## Test plan

- [x] Added 4 unit tests in `tests/hermes_cli/test_credential_pool_empty.py`:
  - `test_empty_credential_pool_does_not_authenticate_provider` — the regression case
  - `test_populated_credential_pool_does_authenticate_provider` — sanity check: real entries still work
  - `test_missing_credential_pool_key_does_not_authenticate_provider` — no entry at all → hidden
  - `test_env_var_still_authenticates_even_with_empty_pool` — env-var path still wins
- [x] All 4 pass with the fix; the first one fails without it (verified true regression test)
- [x] No other tests touched (`tests/hermes_cli/test_credential_pool_empty.py` is new and self-contained)