### PR TITLE
fix(mattermost): use thread root_id from metadata for CRT thread replies

### DIFF
--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -269,9 +269,14 @@ class MattermostAdapter(BasePlatformAdapter):
                 "channel_id": chat_id,
                 "message": chunk,
             }
-            # Thread support: reply_to is the root post ID.
+            # Thread support: use the thread's root_id from metadata when
+            # replying inside an existing CRT Thread.  Mattermost requires
+            # root_id to point to the root-level post, not a nested reply.
+            # Fall back to reply_to for top-level channel messages (where
+            # the user's message itself is a valid thread root).
             if reply_to and self._reply_mode == "thread":
-                payload["root_id"] = reply_to
+                thread_root = (metadata or {}).get("thread_id")
+                payload["root_id"] = thread_root or reply_to
 
             data = await self._api_post("posts", payload)
             if not data or "id" not in data:

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -206,6 +206,31 @@ class TestMattermostSend:
         assert payload["root_id"] == "root_post"
 
     @pytest.mark.asyncio
+    async def test_send_with_thread_reply_uses_metadata_thread_root(self):
+        """CRT thread replies should use the root post id from metadata."""
+        self.adapter._reply_mode = "thread"
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"id": "post_metadata"})
+        mock_resp.text = AsyncMock(return_value="")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        self.adapter._session.post = MagicMock(return_value=mock_resp)
+
+        result = await self.adapter.send(
+            "channel_1",
+            "Reply!",
+            reply_to="nested_reply_post",
+            metadata={"thread_id": "root_thread_post"},
+        )
+
+        assert result.success is True
+        payload = self.adapter._session.post.call_args[1]["json"]
+        assert payload["root_id"] == "root_thread_post"
+
+    @pytest.mark.asyncio
     async def test_send_without_thread_no_root_id(self):
         """When reply_mode is 'off', reply_to should NOT set root_id."""
         self.adapter._reply_mode = "off"


### PR DESCRIPTION
## Summary
- fix Mattermost CRT thread replies to use the root post id from metadata instead of the nested reply id
- add focused regression coverage so CRT thread replies keep using metadata.thread_id when present

## Why
The upstream PR #28012 is conceptually right but stacked with an unrelated gateway restart notification config fix. This branch keeps only the Mattermost CRT fix.

## Test Plan
- scripts/run_tests.sh tests/gateway/test_mattermost.py

Closes #28005
Supersedes #28012
