### PR TITLE
fix: elevate plugin discovery failures from debug to warning

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3474,7 +3474,7 @@ class GatewayRunner:
             from hermes_cli.plugins import discover_plugins
             discover_plugins()
         except Exception:
-            logger.debug(
+            logger.warning(
                 "plugin discovery failed at gateway startup", exc_info=True,
             )
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12660,7 +12660,7 @@ Examples:
 
             discover_plugins()
         except Exception:
-            logger.debug(
+            logger.warning(
                 "plugin discovery failed at CLI startup",
                 exc_info=True,
             )


### PR DESCRIPTION
## Problem

Plugin discovery exceptions in gateway startup (`gateway/run.py`) and CLI startup (`hermes_cli/main.py`) are caught and logged at `DEBUG` level, making them invisible at the default `INFO` log level. If any plugin import fails — syntax error, missing dependency, import cycle — operators get zero indication unless they bump the log level to `DEBUG`.

This means broken plugins appear enabled in config but silently do nothing. Diagnosing requires either `HERMES_PLUGINS_DEBUG=1` (undocumented for most users) or editing config to raise log level.

Closes #28137

## Fix

Change `logger.debug(...)` → `logger.warning(...)` in both locations so plugin discovery failures are visible at production log levels.

## Files Changed

- `gateway/run.py` — `logger.debug` → `logger.warning` (1 line)
- `hermes_cli/main.py` — `logger.debug` → `logger.warning` (1 line)

## Testing

- Pure log level change, no behavioral logic modified
- No test changes needed — the catch/except path is unchanged, only the log severity level differs