### PR TITLE
fix(agent): add qwen and deepseek to TOOL_USE_ENFORCEMENT_MODELS

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -268,7 +268,7 @@ TOOL_USE_ENFORCEMENT_GUIDANCE = (
 
 # Model name substrings that trigger tool-use enforcement guidance.
 # Add new patterns here when a model family needs explicit steering.
-TOOL_USE_ENFORCEMENT_MODELS = ("gpt", "codex", "gemini", "gemma", "grok", "glm")
+TOOL_USE_ENFORCEMENT_MODELS = ("gpt", "codex", "gemini", "gemma", "grok", "glm", "qwen", "deepseek")
 
 # OpenAI GPT/Codex-specific execution guidance.  Addresses known failure modes
 # where GPT models abandon work on partial results, skip prerequisite lookups,

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1144,6 +1144,12 @@ class TestToolUseEnforcementGuidance:
     def test_enforcement_models_includes_grok(self):
         assert "grok" in TOOL_USE_ENFORCEMENT_MODELS
 
+    def test_enforcement_models_includes_qwen(self):
+        assert "qwen" in TOOL_USE_ENFORCEMENT_MODELS
+
+    def test_enforcement_models_includes_deepseek(self):
+        assert "deepseek" in TOOL_USE_ENFORCEMENT_MODELS
+
     def test_enforcement_models_is_tuple(self):
         assert isinstance(TOOL_USE_ENFORCEMENT_MODELS, tuple)
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1106,7 +1106,7 @@ class TestToolUseEnforcementConfig:
     def test_auto_injects_for_qwen(self):
         """Qwen models default to chatty/hallucinatory tool use without enforcement."""
         from agent.prompt_builder import TOOL_USE_ENFORCEMENT_GUIDANCE
-        agent = self._make_agent(model="qwen/qwen3.6-plus", tool_use_enforcement="auto")
+        agent = self._make_agent(model="qwen/qwen-plus", tool_use_enforcement="auto")
         prompt = agent._build_system_prompt()
         assert TOOL_USE_ENFORCEMENT_GUIDANCE in prompt
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1103,6 +1103,20 @@ class TestToolUseEnforcementConfig:
         prompt = agent._build_system_prompt()
         assert TOOL_USE_ENFORCEMENT_GUIDANCE in prompt
 
+    def test_auto_injects_for_qwen(self):
+        """Qwen models default to chatty/hallucinatory tool use without enforcement."""
+        from agent.prompt_builder import TOOL_USE_ENFORCEMENT_GUIDANCE
+        agent = self._make_agent(model="qwen/qwen3.6-plus", tool_use_enforcement="auto")
+        prompt = agent._build_system_prompt()
+        assert TOOL_USE_ENFORCEMENT_GUIDANCE in prompt
+
+    def test_auto_injects_for_deepseek(self):
+        """DeepSeek models default to chatty/hallucinatory tool use without enforcement."""
+        from agent.prompt_builder import TOOL_USE_ENFORCEMENT_GUIDANCE
+        agent = self._make_agent(model="deepseek/deepseek-r1", tool_use_enforcement="auto")
+        prompt = agent._build_system_prompt()
+        assert TOOL_USE_ENFORCEMENT_GUIDANCE in prompt
+
     def test_auto_injects_execution_guidance_for_grok(self):
         """Grok also gets OPENAI_MODEL_EXECUTION_GUIDANCE (verification,
         mandatory_tool_use, act_dont_ask). Same failure modes as GPT in


### PR DESCRIPTION
## What does this PR do?

When `agent.tool_use_enforcement` is left at its default `"auto"`, `agent/system_prompt.py` only injects `TOOL_USE_ENFORCEMENT_GUIDANCE` if the active model name contains a substring from `TOOL_USE_ENFORCEMENT_MODELS` in `agent/prompt_builder.py:271`. The tuple was `("gpt", "codex", "gemini", "gemma", "grok", "glm")` — both `qwen` and `deepseek` were missing, even though both families exhibit the exact failure mode the enforcement prompt was written for (describing intended actions instead of calling tools, hallucinating execution, ignoring existing context/memory, silently stopping mid-task).

This PR adds `"qwen"` and `"deepseek"` to the tuple, mirroring the established additive pattern in this area (merged #5595 added `grok`, #24715 added `glm`, #27797 widened grok to `xai-oauth`).

> Mirrors `agent/system_prompt.py::_build_system_prompt` matching logic (substring `in` model_lower against the tuple) — this is the single source of truth for `tool_use_enforcement="auto"`, so no other input precedence chain needs covering.

The "robust" alternative from the issue (default-true for *all* models) is intentionally not taken — it would silently flip behavior for users who currently rely on `auto` leaving Claude and other non-listed families unsteered, and every prior merged change in this area has been additive.

## Related Issue

Fixes #28079

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/prompt_builder.py` — append `"qwen"` and `"deepseek"` to `TOOL_USE_ENFORCEMENT_MODELS`. 1-line tuple edit.
- `tests/agent/test_prompt_builder.py` — add `test_enforcement_models_includes_qwen` and `test_enforcement_models_includes_deepseek`, mirroring the existing `_includes_gpt` / `_includes_codex` / `_includes_grok` pattern.
- `tests/run_agent/test_run_agent.py` — add `test_auto_injects_for_qwen` (model `qwen/qwen3.6-plus`) and `test_auto_injects_for_deepseek` (model `deepseek/deepseek-r1`) in `TestToolUseEnforcementConfig`, confirming that `tool_use_enforcement="auto"` now causes the guidance string to appear in the system prompt for both families.

## How to Test

1. Regression guard (proves the fix is necessary):
   ```bash
   git stash push -- agent/prompt_builder.py
   uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest \
     tests/run_agent/test_run_agent.py::TestToolUseEnforcementConfig::test_auto_injects_for_qwen \
     tests/run_agent/test_run_agent.py::TestToolUseEnforcementConfig::test_auto_injects_for_deepseek \
     tests/agent/test_prompt_builder.py::TestToolUseEnforcementGuidance::test_enforcement_models_includes_qwen \
     tests/agent/test_prompt_builder.py::TestToolUseEnforcementGuidance::test_enforcement_models_includes_deepseek -v
   # 4 failures (regression proved)
   git stash pop
   ```
2. With the production fix:
   ```bash
   uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest \
     tests/agent/test_prompt_builder.py::TestToolUseEnforcementGuidance \
     tests/run_agent/test_run_agent.py::TestToolUseEnforcementConfig -v
   # 9 + 18 = 27 passed
   ```
3. Real-world: set `model.default: qwen/qwen3.6-plus` (or any deepseek model), leave `agent.tool_use_enforcement` at its default `"auto"`, run `hermes chat -q "list files in this directory"`. Before the fix the agent often replies with a narrated plan and no tool call; after the fix `TOOL_USE_ENFORCEMENT_GUIDANCE` appears in the system prompt and tool use is enforced.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(agent):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass (9 unit + 18 integration assertions in the two test classes)
- [x] I've added tests for my changes — 4 new tests that all fail without the production change
- [x] I've tested on my platform: macOS 26.x, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (the tuple has an inline `# Add new patterns here when a model family needs explicit steering.` comment that already documents the maintenance pattern)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys changed; the existing `agent.tool_use_enforcement` key behaviour is unchanged for explicit values, only the `auto` default is widened)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (pure string-substring match, no platform-specific code paths)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Sibling code paths that may need the same fix

The issue body explicitly flags `mistral` and `llama` as *potentially* affected (no concrete repro provided). I left them out of this PR's scope to keep the diff minimal and the additions evidence-driven — happy to widen to `("mistral", "llama")` during cherry-pick if the same chatty-narration failure mode is confirmed on those families.

## Screenshots / Logs

_N/A — guidance-string injection has no UI surface; the change is observable only via system-prompt assembly, which is exercised by the new tests._