### PR TITLE
fix: include hermes_plugins in gateway.log component filter

### DIFF
--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -141,7 +141,7 @@ class _ComponentFilter(logging.Filter):
 # Logger name prefixes that belong to each component.
 # Used by _ComponentFilter and exposed for ``hermes logs --component``.
 COMPONENT_PREFIXES = {
-    "gateway": ("gateway",),
+    "gateway": ("gateway", "hermes_plugins"),
     "agent": ("agent", "run_agent", "model_tools", "batch_runner"),
     "tools": ("tools",),
     "cli": ("hermes_cli", "cli"),


### PR DESCRIPTION
## Problem

`gateway.log` uses a `_ComponentFilter` that only passes records from loggers starting with `("gateway",)`. Plugin modules are loaded under the `hermes_plugins.*` namespace, so all plugin log output is silently dropped from `gateway.log`.

This makes plugin registration — which directly affects gateway hooks (`pre_gateway_dispatch`, `transform_llm_output`, etc.) — invisible in the gateway-specific log. Operators debugging gateway behavior check `gateway.log` and see no plugin activity, even when plugins are working correctly.

Closes #28138

## Fix

Add `"hermes_plugins"` to the gateway `COMPONENT_PREFIXES` tuple in `hermes_logging.py`.

## Files Changed

- `hermes_logging.py` — 1 line: `("gateway",)` → `("gateway", "hermes_plugins")`

## Testing

- Pure logging config tuple change, no behavioral logic modified
- No test changes needed — the filter mechanism is unchanged, only the prefix list expanded