### PR TITLE
fix(web): discover provider plugins before web dispatch

### DIFF
--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -482,6 +482,27 @@ class TestWebSearchSchema:
         assert result == '{"success": true}'
         mock_search.assert_called_once_with("docs", limit=5)
 
+    def test_web_search_discovers_provider_plugins_before_registry_lookup(self):
+        import tools.web_tools
+
+        fake_search = MagicMock(return_value={"success": True, "data": {"web": []}})
+        fake_provider = MagicMock(supports_search=MagicMock(return_value=True))
+        fake_provider.name = "brave-free"
+        fake_provider.search = fake_search
+        tools.web_tools._web_provider_plugins_discovered = False
+
+        with patch("tools.web_tools._get_search_backend", return_value="brave-free"), \
+             patch("hermes_cli.plugins.discover_plugins") as mock_discover, \
+             patch("agent.web_search_registry.get_provider", return_value=fake_provider), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch.object(tools.web_tools._debug, "log_call"), \
+             patch.object(tools.web_tools._debug, "save"):
+            result = json.loads(tools.web_tools.web_search_tool("docs", limit=2))
+
+        assert result == {"success": True, "data": {"web": []}}
+        mock_discover.assert_called_once_with()
+        fake_search.assert_called_once_with("docs", 2)
+
     def test_web_search_clamps_limit_before_backend_call(self):
         import tools.web_tools
 

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -120,6 +120,30 @@ logger = logging.getLogger(__name__)
 
 # ─── Backend Selection ────────────────────────────────────────────────────────
 
+_web_provider_plugins_discovered = False
+
+
+def _ensure_web_provider_plugins_discovered() -> None:
+    """Ensure bundled web provider plugins are registered before dispatch.
+
+    The web tool functions can be imported and called directly by tests,
+    smoke checks, and tool dispatch paths that have not otherwise initialized
+    the CLI plugin manager. Without this idempotent discovery step, configured
+    backends such as brave-free/firecrawl resolve from config but the provider
+    registry is empty, producing false "No provider configured" errors.
+    """
+    global _web_provider_plugins_discovered
+    if _web_provider_plugins_discovered:
+        return
+    try:
+        from hermes_cli.plugins import discover_plugins
+        discover_plugins()
+    except Exception as exc:  # noqa: BLE001 - keep web tools error-path friendly
+        logger.debug("Could not discover web provider plugins: %s", exc)
+    finally:
+        _web_provider_plugins_discovered = True
+
+
 def _has_env(name: str) -> bool:
     val = os.getenv(name)
     return bool(val and val.strip())
@@ -793,6 +817,7 @@ def web_search_tool(query: str, limit: int = 5) -> str:
         # (brave-free, ddgs, searxng, exa, parallel, tavily, firecrawl)
         # now live as plugins; the dispatcher is just a registry lookup +
         # delegation. Sync only — every provider's search() is sync.
+        _ensure_web_provider_plugins_discovered()
         from agent.web_search_registry import (
             get_active_search_provider,
             get_provider as _wsp_get_provider,
@@ -925,6 +950,7 @@ async def web_extract_tool(
             # detect coroutine functions and await; sync functions run
             # inline (the policy gate, SSRF re-check, etc. live inside the
             # provider itself for the firecrawl per-URL loop).
+            _ensure_web_provider_plugins_discovered()
             from agent.web_search_registry import (
                 get_active_extract_provider,
                 get_provider as _wsp_get_provider,
@@ -1177,6 +1203,7 @@ async def web_crawl_tool(
         # dispatches through agent.web_search_registry. The crawl response
         # shape — {"results": [{"url", "title", "content", ...}]} — is then
         # post-processed by the shared LLM-summarization path below.
+        _ensure_web_provider_plugins_discovered()
         from agent.web_search_registry import (
             get_active_crawl_provider,
             get_provider as _wsp_get_provider,


### PR DESCRIPTION
## Summary
- Ensure web provider plugins are discovered before search/extract/crawl registry dispatch.
- Prevent configured plugin backends such as `brave-free` and `firecrawl` from appearing unavailable when web tools are called outside normal CLI plugin initialization.
- Add regression coverage for direct web search dispatch.

## Test plan
- `python -m pytest tests/tools/test_web_tools_config.py::TestWebSearchSchema::test_web_search_discovers_provider_plugins_before_registry_lookup -q -o 'addopts='`

## Operational context
This is the second local carried hotfix from Tim/Petra's production Hermes instance. Kept separate from #27680 so the SMTPS fix PR remains narrowly scoped.