### PR TITLE
fix: detect macOS PID reuse in gateway locks

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -108,17 +108,34 @@ def _get_scope_lock_path(scope: str, identity: str) -> Path:
     return _get_lock_dir() / f"{scope}-{_scope_hash(identity)}.lock"
 
 
-def _get_process_start_time(pid: int) -> Optional[int]:
-    """Return the kernel start time for a process when available."""
+def _get_process_start_time(pid: int) -> Optional[float]:
+    """Return the process start time when available.
+
+    Linux exposes the kernel start tick in ``/proc/<pid>/stat``. macOS does not
+    have ``/proc``, so fall back to psutil's portable ``create_time()``. This is
+    important for scoped gateway locks: PID reuse on macOS can otherwise make a
+    stale Telegram-token lock look live just because a different app reused the
+    old PID.
+    """
     stat_path = Path(f"/proc/{pid}/stat")
     try:
         # Field 22 in /proc/<pid>/stat is process start time (clock ticks).
         return int(stat_path.read_text(encoding="utf-8").split()[21])
     except (FileNotFoundError, IndexError, PermissionError, ValueError, OSError):
+        pass
+
+    try:
+        import psutil  # type: ignore
+    except ImportError:
+        return None
+
+    try:
+        return float(psutil.Process(int(pid)).create_time())
+    except (ValueError, OSError, psutil.Error):
         return None
 
 
-def get_process_start_time(pid: int) -> Optional[int]:
+def get_process_start_time(pid: int) -> Optional[float]:
     """Public wrapper for retrieving a process start time when available."""
     return _get_process_start_time(pid)
 
@@ -652,7 +669,7 @@ def release_scoped_lock(scope: str, identity: str) -> None:
 def release_all_scoped_locks(
     *,
     owner_pid: Optional[int] = None,
-    owner_start_time: Optional[int] = None,
+    owner_start_time: Optional[float] = None,
 ) -> int:
     """Remove scoped lock files in the lock directory.
 

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -9,6 +10,22 @@ from gateway import status
 
 
 class TestGatewayPidState:
+    def test_get_process_start_time_uses_psutil_when_proc_unavailable(self, monkeypatch):
+        """macOS has no /proc; use psutil so PID-reuse checks still work."""
+
+        class FakeProcess:
+            def __init__(self, pid):
+                self.pid = pid
+
+            def create_time(self):
+                return 1234.5
+
+        monkeypatch.setitem(sys.modules, "psutil", SimpleNamespace(Process=FakeProcess))
+
+        # Pick a PID that will not have a /proc entry even on Linux test hosts,
+        # forcing the portable psutil fallback path.
+        assert status._get_process_start_time(987654321) == 1234.5
+
     def test_write_pid_file_records_gateway_metadata(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 
@@ -460,6 +477,33 @@ class TestScopedLocks:
         acquired, existing = status.acquire_scoped_lock("telegram-bot-token", "secret", metadata={"platform": "telegram"})
 
         assert acquired is True
+        payload = json.loads(lock_path.read_text())
+        assert payload["pid"] == os.getpid()
+        assert payload["metadata"]["platform"] == "telegram"
+
+    def test_acquire_scoped_lock_replaces_reused_pid_record(self, tmp_path, monkeypatch):
+        """A live but different process reusing a stale PID must not own the lock."""
+
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "telegram-bot-token-2bb80d537b1da3e3.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text(json.dumps({
+            "pid": 99999,
+            "start_time": 123,
+            "kind": "hermes-gateway",
+        }))
+
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 456)
+
+        acquired, existing = status.acquire_scoped_lock(
+            "telegram-bot-token",
+            "secret",
+            metadata={"platform": "telegram"},
+        )
+
+        assert acquired is True
+        assert existing is None
         payload = json.loads(lock_path.read_text())
         assert payload["pid"] == os.getpid()
         assert payload["metadata"]["platform"] == "telegram"


### PR DESCRIPTION
## Summary
- Fall back to psutil.Process(pid).create_time() when /proc/<pid>/stat is unavailable
- Prevent stale scoped gateway locks from looking live when macOS reuses a PID
- Add regression coverage for psutil start-time fallback and scoped-lock PID reuse recovery

## Test Plan
- python -m pytest tests/gateway/test_status.py -q

## Context
On macOS, Hermes could report a Telegram bot token as already in use when a stale scoped-lock file pointed at a PID that had since been reused by an unrelated process. Linux avoids this because /proc exposes process start ticks; this gives macOS the same PID-reuse defense using psutil.