### PR TITLE
feat: show names of user-modified skills in bundled skill sync summary

### DIFF
--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -425,7 +425,12 @@ if __name__ == "__main__":
         f"{result['skipped']} unchanged",
     ]
     if result["user_modified"]:
-        parts.append(f"{len(result['user_modified'])} user-modified (kept)")
+        names = result["user_modified"]
+        MAX_SHOW = 5
+        shown = ", ".join(names[:MAX_SHOW])
+        if len(names) > MAX_SHOW:
+            shown += f", +{len(names) - MAX_SHOW} more"
+        parts.append(f"{len(names)} user-modified (kept): {shown}")
     if result["cleaned"]:
         parts.append(f"{len(result['cleaned'])} cleaned from manifest")
     print(f"\nDone: {', '.join(parts)}. {result['total_bundled']} total bundled.")


### PR DESCRIPTION
## Problem

When `hermes update` syncs bundled skills, the summary line only shows the count of user-modified skills that were kept (e.g. `3 user-modified (kept)`), but not *which* skills. Once the update finishes, the user has no way to know which skills need triage.

Closes #28121

## Fix

Append the skill names to the summary line, truncated to 5 with a `+N more` suffix for long lists:

```
Done: 12 new, 3 updated, 7 unchanged, 3 user-modified (kept): hermes-agent, debugging-hermes-tui-commands, system-health. 25 total bundled.
```

## Files Changed

- `tools/skills_sync.py` — +6/-1 lines: append names list to user-modified summary

## Testing

- 45/45 tests passed in `tests/tools/test_skills_sync.py`
