### PR TITLE
fix(spotify): return 400 when loopback callback receives no code or error

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2276,6 +2276,27 @@ def _make_spotify_callback_handler(expected_path: str) -> tuple[type[BaseHTTPReq
             result["error"] = params.get("error", [None])[0]
             result["error_description"] = params.get("error_description", [None])[0]
 
+            # Treat a hit on the callback path with neither `code` nor `error`
+            # as a missing OAuth callback (e.g. Spotify's auth backend failed to
+            # redirect and the user navigated to the bare loopback URL by hand).
+            # Show an explicit "not received" page rather than the success page —
+            # otherwise the browser claims authorization succeeded while the CLI
+            # is still waiting for a real callback and eventually times out.
+            if result["code"] is None and result["error"] is None:
+                self.send_response(400)
+                self.send_header("Content-Type", "text/html; charset=utf-8")
+                self.end_headers()
+                body = (
+                    "<html><body>"
+                    "<h1>Spotify authorization not received.</h1>"
+                    "<p>No authorization code was present in this callback URL. "
+                    "Return to the terminal and re-run "
+                    "<code>hermes auth add spotify</code> to retry.</p>"
+                    "</body></html>"
+                )
+                self.wfile.write(body.encode("utf-8"))
+                return
+
             self.send_response(200)
             self.send_header("Content-Type", "text/html; charset=utf-8")
             self.end_headers()

--- a/tests/hermes_cli/test_spotify_auth.py
+++ b/tests/hermes_cli/test_spotify_auth.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import socket
+import threading
+import urllib.request
+from http.server import HTTPServer
 from types import SimpleNamespace
 
 import pytest
@@ -181,3 +185,91 @@ def test_spotify_interactive_setup_empty_aborts(
     env_path = tmp_path / ".env"
     if env_path.exists():
         assert "HERMES_SPOTIFY_CLIENT_ID" not in env_path.read_text()
+
+
+# ── Callback handler tests ─────────────────────────────────────────────────
+
+
+class _ReuseHTTPServer(HTTPServer):
+    allow_reuse_address = True
+
+
+def _start_spotify_callback_server(path: str = "/callback") -> tuple[HTTPServer, threading.Thread, dict, str]:
+    """Start a Spotify loopback callback server on an OS-assigned port."""
+    handler_cls, result = auth_mod._make_spotify_callback_handler(path)
+    server = _ReuseHTTPServer(("127.0.0.1", 0), handler_cls)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, kwargs={"poll_interval": 0.1}, daemon=True)
+    thread.start()
+    redirect_uri = f"http://127.0.0.1:{port}{path}"
+    return server, thread, result, redirect_uri
+
+
+def _get_callback(redirect_uri: str, query: str = "") -> tuple[int, str]:
+    """GET the loopback callback URL with an optional query string."""
+    from urllib.error import HTTPError
+    from urllib.request import Request, urlopen
+
+    target = redirect_uri + (("?" + query) if query else "")
+    req = Request(target, method="GET")
+    try:
+        with urlopen(req, timeout=5.0) as resp:
+            return resp.getcode(), resp.read().decode("utf-8", "replace")
+    except HTTPError as exc:
+        return exc.code, exc.read().decode("utf-8", "replace")
+
+
+def test_spotify_callback_handler_returns_400_when_callback_url_lacks_code_and_error():
+    """Bare loopback URL (no code, no error) must not claim authorization received.
+
+    Mirrors the xAI OAuth regression fix: when Spotify's auth backend fails to
+    redirect and the user manually navigates to http://127.0.0.1:<port>/callback,
+    the handler must return 400 "not received" rather than 200 "authorization
+    received" — otherwise the browser shows a success page while the CLI wait
+    loop still times out, leaving the user with a contradictory outcome.
+    """
+    server, thread, result, redirect_uri = _start_spotify_callback_server()
+    try:
+        status, body = _get_callback(redirect_uri)
+        assert status == 400
+        assert "not received" in body.lower()
+        assert "hermes auth add spotify" in body
+        # Wait loop must still see no code/error so it raises a real timeout,
+        # rather than treating this empty hit as a successful callback.
+        assert result["code"] is None
+        assert result["error"] is None
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=1.0)
+
+
+def test_spotify_callback_handler_accepts_callback_with_code():
+    """A real OAuth redirect (code + state) still records both and shows success."""
+    server, thread, result, redirect_uri = _start_spotify_callback_server()
+    try:
+        status, body = _get_callback(redirect_uri, query="code=abc&state=xyz")
+        assert status == 200
+        assert "Spotify authorization received" in body
+        assert result["code"] == "abc"
+        assert result["state"] == "xyz"
+        assert result["error"] is None
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=1.0)
+
+
+def test_spotify_callback_handler_records_error_callback():
+    """A redirect carrying an `error` param must surface the failure page."""
+    server, thread, result, redirect_uri = _start_spotify_callback_server()
+    try:
+        status, body = _get_callback(redirect_uri, query="error=access_denied")
+        assert status == 200
+        assert "Spotify authorization failed" in body
+        assert result["error"] == "access_denied"
+        assert result["code"] is None
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=1.0)


### PR DESCRIPTION
`_SpotifyCallbackHandler` returned `200 "Spotify authorization received"` when
the callback URL carried neither `code` nor `error` — for example when Spotify's
auth backend failed to redirect and the user navigated to the bare loopback URL
by hand.  The browser showed a success page while the CLI wait loop kept polling
and eventually raised `"Spotify authorization timed out waiting for the local
callback."`, leaving the user with a contradictory outcome.

Return `400` with an explicit "not received" page instead, so the user knows
to retry.

Symmetric with the fix applied to `_XAICallbackHandler` in bf6eeb3f9.

**Root cause:** `_SpotifyCallbackHandler.do_GET()` — when `code is None` and
`error is None` (bare URL, no query string), the handler fell through to the
`else` branch and sent the success body.

**Fix:** Add the same early-return guard that `_XAICallbackHandler` already has.

**Tests added** (`tests/hermes_cli/test_spotify_auth.py`):
- `test_spotify_callback_handler_returns_400_when_callback_url_lacks_code_and_error` — bare URL → 400 + "not received" body + result dict unchanged
- `test_spotify_callback_handler_accepts_callback_with_code` — valid redirect → 200 + result populated
- `test_spotify_callback_handler_records_error_callback` — error redirect → 200 failure page + result populated