### PR TITLE
feat(kanban): profile-describer - opt-in --tag-skills and --include-soul -include-agents

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9223,6 +9223,7 @@ def cmd_profile(args):
         from hermes_cli import profile_describer as _pd
 
         include_soul_flag = bool(getattr(args, "include_soul", False))
+        include_agents_flag = bool(getattr(args, "include_agents", False))
         tag_skills_flag = bool(getattr(args, "tag_skills", False))
 
         if all_flag:
@@ -9240,6 +9241,7 @@ def cmd_profile(args):
                 tgt,
                 overwrite=overwrite_flag,
                 include_soul=include_soul_flag,
+                include_agents=include_agents_flag,
                 tag_builtins=tag_skills_flag,
             )
             if outcome.ok:
@@ -12202,6 +12204,16 @@ Examples:
              "in the prompt. Off by default — per the canonical Hermes docs "
              "SOUL.md is for voice/tone only. Enable when your SOUL.md "
              "encodes lane/role information you want the describer to read.",
+    )
+    profile_describe.add_argument(
+        "--include-agents",
+        dest="include_agents",
+        action="store_true",
+        help="With --auto, include AGENTS.md content as the canonical "
+             "role/lane signal in the prompt. AGENTS.md is the docs-blessed "
+             "location for project-specific role information; this is the "
+             "doc-correct way to feed lane signal to the describer. Off by "
+             "default to preserve existing prompt shape.",
     )
 
     profile_show = profile_subparsers.add_parser("show", help="Show profile details")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9225,6 +9225,7 @@ def cmd_profile(args):
         include_soul_flag = bool(getattr(args, "include_soul", False))
         include_agents_flag = bool(getattr(args, "include_agents", False))
         tag_skills_flag = bool(getattr(args, "tag_skills", False))
+        skill_desc_flag = bool(getattr(args, "with_skill_descriptions", False))
 
         if all_flag:
             targets = _pd.list_describable_profiles(missing_only=True)
@@ -9243,6 +9244,7 @@ def cmd_profile(args):
                 include_soul=include_soul_flag,
                 include_agents=include_agents_flag,
                 tag_builtins=tag_skills_flag,
+                with_skill_descriptions=skill_desc_flag,
             )
             if outcome.ok:
                 ok_count += 1
@@ -12214,6 +12216,16 @@ Examples:
              "location for project-specific role information; this is the "
              "doc-correct way to feed lane signal to the describer. Off by "
              "default to preserve existing prompt shape.",
+    )
+    profile_describe.add_argument(
+        "--with-skill-descriptions",
+        dest="with_skill_descriptions",
+        action="store_true",
+        help="With --auto, include each skill's frontmatter description "
+             "alongside its name in the prompt. Helps the describer reason "
+             "about bespoke skills it has never seen before. Costs more "
+             "characters per skill so the per-prompt skill cap is tightened "
+             "automatically. Off by default.",
     )
 
     profile_show = profile_subparsers.add_parser("show", help="Show profile details")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9222,6 +9222,9 @@ def cmd_profile(args):
         # --auto path: invoke the LLM describer.
         from hermes_cli import profile_describer as _pd
 
+        include_soul_flag = bool(getattr(args, "include_soul", False))
+        tag_skills_flag = bool(getattr(args, "tag_skills", False))
+
         if all_flag:
             targets = _pd.list_describable_profiles(missing_only=True)
             if not targets:
@@ -9233,7 +9236,12 @@ def cmd_profile(args):
         ok_count = 0
         fail_count = 0
         for tgt in targets:
-            outcome = _pd.describe_profile(tgt, overwrite=overwrite_flag)
+            outcome = _pd.describe_profile(
+                tgt,
+                overwrite=overwrite_flag,
+                include_soul=include_soul_flag,
+                tag_builtins=tag_skills_flag,
+            )
             if outcome.ok:
                 ok_count += 1
                 print(f"Described '{outcome.profile_name}': {outcome.description}")
@@ -12174,6 +12182,26 @@ Examples:
         dest="all_missing",
         action="store_true",
         help="With --auto, run on every profile missing a description",
+    )
+    profile_describe.add_argument(
+        "--tag-skills",
+        dest="tag_skills",
+        action="store_true",
+        help="With --auto, label each skill in the prompt as [user] or "
+             "[built-in] (built-ins ship with Hermes; user skills were "
+             "deliberately added) and instruct the LLM to weight [user] "
+             "skills as the dominant role/domain signal. Off by default "
+             "to keep prompt shape stable. Enable when profiles are "
+             "heavy with built-in skills that drown out the lane.",
+    )
+    profile_describe.add_argument(
+        "--include-soul",
+        dest="include_soul",
+        action="store_true",
+        help="With --auto, include SOUL.md content as a role-identity signal "
+             "in the prompt. Off by default — per the canonical Hermes docs "
+             "SOUL.md is for voice/tone only. Enable when your SOUL.md "
+             "encodes lane/role information you want the describer to read.",
     )
 
     profile_show = profile_subparsers.add_parser("show", help="Show profile details")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9226,6 +9226,20 @@ def cmd_profile(args):
         include_agents_flag = bool(getattr(args, "include_agents", False))
         tag_skills_flag = bool(getattr(args, "tag_skills", False))
         skill_desc_flag = bool(getattr(args, "with_skill_descriptions", False))
+        # --reject-boilerplate defaults: ON when any role-aware knob is set
+        # (the user opted into quality mode and the input is grounded enough
+        # for a safe retry); OFF in vanilla mode for upstream parity.
+        # Explicit --reject-boilerplate / --no-reject-boilerplate overrides.
+        _rb = getattr(args, "reject_boilerplate", None)
+        if _rb is None:
+            reject_boilerplate_flag = (
+                tag_skills_flag
+                or include_soul_flag
+                or include_agents_flag
+                or skill_desc_flag
+            )
+        else:
+            reject_boilerplate_flag = bool(_rb)
 
         if all_flag:
             targets = _pd.list_describable_profiles(missing_only=True)
@@ -9245,6 +9259,7 @@ def cmd_profile(args):
                 include_agents=include_agents_flag,
                 tag_builtins=tag_skills_flag,
                 with_skill_descriptions=skill_desc_flag,
+                reject_boilerplate=reject_boilerplate_flag,
             )
             if outcome.ok:
                 ok_count += 1
@@ -12226,6 +12241,21 @@ Examples:
              "about bespoke skills it has never seen before. Costs more "
              "characters per skill so the per-prompt skill cap is tightened "
              "automatically. Off by default.",
+    )
+    profile_describe.add_argument(
+        "--reject-boilerplate",
+        dest="reject_boilerplate",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="With --auto, scan the LLM's first output for generic filler "
+             "phrases ('versatile generalist', 'powerhouse', 'manages "
+             "workflows across', etc.) and retry once with an explicit "
+             "rule against the matched phrase if found. Default: ON when "
+             "any role-aware knob (--tag-skills, --include-soul, "
+             "--include-agents, --with-skill-descriptions) is set — those "
+             "modes signal you want concrete output and the input data is "
+             "grounded enough to retry safely. OFF in vanilla mode for "
+             "upstream parity. Pass --no-reject-boilerplate to force off.",
     )
 
     profile_show = profile_subparsers.add_parser("show", help="Show profile details")

--- a/hermes_cli/profile_describer.py
+++ b/hermes_cli/profile_describer.py
@@ -53,6 +53,23 @@ logger = logging.getLogger(__name__)
 # is per-category — see _collect_skills.
 MAX_SKILLS_FOR_PROMPT = 60
 
+# Tighter cap when --with-skill-descriptions is on, because each skill
+# line carries the full description and costs roughly 5-10x more chars.
+MAX_SKILLS_WITH_DESC = 30
+
+# Per-skill description cap when --with-skill-descriptions is on. Skill
+# frontmatter descriptions are typically 50-200 chars; we trim to keep
+# the prompt bounded against pathological cases.
+MAX_SKILL_DESC_CHARS = 200
+
+# Frontmatter pattern: matches the leading YAML block delimited by ---
+# lines. We don't pull in PyYAML for this — descriptions are simple
+# scalars and a regex is reliable enough for the common cases (single
+# line, double-quoted, single-quoted, or YAML folded). If parsing fails
+# the loader returns an empty string and the skill ID is still emitted.
+_FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---", re.DOTALL)
+_DESC_RE = re.compile(r"^description:\s*(.+?)\s*$", re.MULTILINE)
+
 # Cap on SOUL.md content fed when --include-soul is passed. SOUL.md is
 # meant to be small per Hermes docs, but we cap to be safe.
 MAX_SOUL_CHARS = 4000
@@ -223,12 +240,43 @@ def _builtin_skill_ids() -> set[str]:
     return out
 
 
+def _extract_skill_description(md_path: Path) -> str:
+    """Extract the ``description:`` field from a SKILL.md frontmatter block.
+
+    Returns an empty string when the file can't be read, has no frontmatter,
+    or no description field. Strips surrounding quotes and trims to
+    ``MAX_SKILL_DESC_CHARS``.
+    """
+    try:
+        # SKILL.md files are typically tiny; read at most 4 KB which covers
+        # any reasonable frontmatter without slurping huge skill bodies.
+        with md_path.open("r", errors="replace") as f:
+            head = f.read(4096)
+    except Exception:
+        return ""
+    fm_match = _FRONTMATTER_RE.match(head)
+    if not fm_match:
+        return ""
+    desc_match = _DESC_RE.search(fm_match.group(1))
+    if not desc_match:
+        return ""
+    desc = desc_match.group(1).strip()
+    # Strip surrounding quotes (single or double).
+    if len(desc) >= 2 and desc[0] in ("'", '"') and desc[-1] == desc[0]:
+        desc = desc[1:-1]
+    desc = desc.strip()
+    if len(desc) > MAX_SKILL_DESC_CHARS:
+        desc = desc[: MAX_SKILL_DESC_CHARS - 1] + "…"
+    return desc
+
+
 def _collect_skills(
     profile_dir: Path,
     *,
     classify_builtins: bool = False,
-) -> list[Tuple[str, bool]]:
-    """Return a stable, capped list of ``(skill_id, is_user_authored)`` tuples.
+    cap: Optional[int] = None,
+) -> list[Tuple[str, bool, Path]]:
+    """Return a stable, capped list of ``(skill_id, is_user_authored, md_path)`` tuples.
 
     Format: ``category/skill_name`` where category is the immediate
     subdir under ``skills/`` (e.g. ``devops``, ``research``). Skills
@@ -239,12 +287,21 @@ def _collect_skills(
     ``classify_builtins=False`` the boolean is always ``False`` and the
     cap is enforced via even sampling across the full sorted list rather
     than by biasing toward user-authored skills.
+
+    ``cap`` overrides ``MAX_SKILLS_FOR_PROMPT`` for callers that want to
+    include richer per-skill detail (e.g. description text) and need a
+    tighter cap to keep the prompt bounded.
+
+    The returned ``md_path`` is the path to the skill's ``SKILL.md``
+    file; callers can pass it to ``_extract_skill_description`` if they
+    want the frontmatter description.
     """
     skills_dir = profile_dir / "skills"
     if not skills_dir.is_dir():
         return []
+    effective_cap = cap if cap is not None else MAX_SKILLS_FOR_PROMPT
     builtin = _builtin_skill_ids() if classify_builtins else set()
-    pairs: list[Tuple[str, bool]] = []
+    pairs: list[Tuple[str, bool, Path]] = []
     seen: set[str] = set()
     for md in skills_dir.rglob("SKILL.md"):
         path_str = str(md)
@@ -269,27 +326,27 @@ def _collect_skills(
         # is_user=False so callers don't accidentally emit [user]/[built-in]
         # tags. The flag is purely about how the prompt is shaped.
         is_user = (sid not in builtin) if classify_builtins else False
-        pairs.append((sid, is_user))
+        pairs.append((sid, is_user, md))
     pairs.sort(key=lambda p: p[0])
 
-    if len(pairs) <= MAX_SKILLS_FOR_PROMPT:
+    if len(pairs) <= effective_cap:
         return pairs
 
     if not classify_builtins:
         # Sample evenly across the sorted list — caller asked us not
         # to differentiate built-ins, so don't bias the sample either.
-        step = len(pairs) / MAX_SKILLS_FOR_PROMPT
-        return [pairs[int(i * step)] for i in range(MAX_SKILLS_FOR_PROMPT)]
+        step = len(pairs) / effective_cap
+        return [pairs[int(i * step)] for i in range(effective_cap)]
 
     # Classified path: prioritize user-authored skills, then sample built-ins.
     user_pairs = [p for p in pairs if p[1]]
     builtin_pairs = [p for p in pairs if not p[1]]
-    if len(user_pairs) >= MAX_SKILLS_FOR_PROMPT:
-        step = len(user_pairs) / MAX_SKILLS_FOR_PROMPT
-        return [user_pairs[int(i * step)] for i in range(MAX_SKILLS_FOR_PROMPT)]
-    remaining = MAX_SKILLS_FOR_PROMPT - len(user_pairs)
+    if len(user_pairs) >= effective_cap:
+        step = len(user_pairs) / effective_cap
+        return [user_pairs[int(i * step)] for i in range(effective_cap)]
+    remaining = effective_cap - len(user_pairs)
     if not builtin_pairs or remaining <= 0:
-        return user_pairs[:MAX_SKILLS_FOR_PROMPT]
+        return user_pairs[:effective_cap]
     step = max(1.0, len(builtin_pairs) / remaining)
     sampled_builtin = [
         builtin_pairs[int(i * step)] for i in range(remaining)
@@ -387,6 +444,7 @@ def describe_profile(
     tag_builtins: bool = False,
     include_soul: bool = False,
     include_agents: bool = False,
+    with_skill_descriptions: bool = False,
 ) -> DescribeOutcome:
     """Auto-generate a description for one profile.
 
@@ -416,6 +474,12 @@ def describe_profile(
     is the docs-blessed location for project-specific role information,
     but it's off by default to keep existing prompt shape unchanged for
     callers who don't pass the flag.
+
+    ``with_skill_descriptions`` (default False) appends each skill's
+    frontmatter ``description:`` field to its line in the prompt. Costs
+    roughly 5-10x more characters per skill so the per-prompt skill cap
+    is tightened to ``MAX_SKILLS_WITH_DESC`` when enabled. Helps the LLM
+    reason about bespoke skills it's never seen before.
     """
     canon = profiles_mod.normalize_profile_name(profile_name)
     if not profiles_mod.profile_exists(canon):
@@ -442,15 +506,27 @@ def describe_profile(
             "(use --overwrite to replace)",
         )
 
-    skill_pairs = _collect_skills(profile_dir, classify_builtins=tag_builtins)
+    # Pick a tighter cap when we'll be emitting per-skill descriptions
+    # so the prompt doesn't balloon.
+    skill_cap = MAX_SKILLS_WITH_DESC if with_skill_descriptions else MAX_SKILLS_FOR_PROMPT
+    skill_pairs = _collect_skills(
+        profile_dir,
+        classify_builtins=tag_builtins,
+        cap=skill_cap,
+    )
     if skill_pairs:
         skill_lines = []
-        for sid, is_user in skill_pairs:
+        for sid, is_user, md_path in skill_pairs:
             if tag_builtins:
                 tag = "[user] " if is_user else "[built-in] "
             else:
                 tag = ""
-            skill_lines.append(f"  - {tag}{sid}")
+            line = f"  - {tag}{sid}"
+            if with_skill_descriptions:
+                desc = _extract_skill_description(md_path)
+                if desc:
+                    line += f" — {desc}"
+            skill_lines.append(line)
         skill_list = "\n".join(skill_lines)
     else:
         skill_list = "  (no skills installed)"
@@ -458,9 +534,11 @@ def describe_profile(
         1 for _ in (profile_dir / "skills").rglob("SKILL.md")
         if "/.hub/" not in str(_) and "/.git/" not in str(_)
     ) if (profile_dir / "skills").is_dir() else 0
-    user_count = sum(1 for _, u in skill_pairs if u) if tag_builtins else 0
+    user_count = (
+        sum(1 for _, u, _md in skill_pairs if u) if tag_builtins else 0
+    )
     builtin_count = (
-        sum(1 for _, u in skill_pairs if not u) if tag_builtins else 0
+        sum(1 for _, u, _md in skill_pairs if not u) if tag_builtins else 0
     )
     # Format the count line conditionally so unclassified runs don't
     # emit a misleading "(0 user, 0 built-in)" suffix.

--- a/hermes_cli/profile_describer.py
+++ b/hermes_cli/profile_describer.py
@@ -57,6 +57,11 @@ MAX_SKILLS_FOR_PROMPT = 60
 # meant to be small per Hermes docs, but we cap to be safe.
 MAX_SOUL_CHARS = 4000
 
+# Cap on AGENTS.md content fed when --include-agents is passed. AGENTS.md
+# is the canonical place for lane/role information so we allow a slightly
+# larger budget than SOUL.md, but still bounded.
+MAX_AGENTS_CHARS = 6000
+
 
 _SYSTEM_PROMPT_BASE = """You are a profile-describer for the Hermes Agent kanban board.
 
@@ -68,7 +73,7 @@ profile needs a short, concrete description of what it's good at.
 You are given a profile's:
   - Name
   - Model / provider
-  - List of installed skill names{tag_blurb}{soul_blurb}
+  - List of installed skill names{tag_blurb}{soul_blurb}{agents_blurb}
 
 Produce a single JSON object with exactly one key:
 
@@ -82,7 +87,7 @@ Rules:
   - Stay concrete. Bad: "an AI agent that helps users."
                   Good: "Reads and modifies Python codebases — runs tests,
                          refactors functions, opens GitHub PRs."
-  - 1-2 sentences, <= 280 characters total.{tag_rule}{soul_rule}
+  - 1-2 sentences, <= 280 characters total.{tag_rule}{soul_rule}{agents_rule}
   - Never invent capabilities the skills don't suggest.
   - Never write "Hermes Agent profile" or other meta-narration.
   - No code fences, no preamble, no closing remarks. Output only JSON.
@@ -97,6 +102,11 @@ _SOUL_BLURB = (
     "\n  - SOUL.md content describing role/identity (only when the user "
     "explicitly opted in)"
 )
+_AGENTS_BLURB = (
+    "\n  - AGENTS.md content describing the profile's lane, role, and "
+    "workflow (the canonical Hermes location for project-specific role "
+    "information)"
+)
 _TAG_RULE = (
     "\n  - Weight [user] skills as the dominant signal of role and domain. "
     "[built-in] skills are present in most profiles and carry weak lane "
@@ -108,15 +118,26 @@ _SOUL_RULE = (
     "portion as authoritative for the agent's purpose; let skills inform "
     "capability detail but not override stated role."
 )
+_AGENTS_RULE = (
+    "\n  - When AGENTS.md content is provided, treat its role/lane "
+    "statements as the highest-priority signal — AGENTS.md is the "
+    "canonical Hermes location for declaring what an agent does. Skills "
+    "and other signals fill in capability detail; they do not override "
+    "stated role."
+)
 
 
-def _build_system_prompt(*, tag_builtins: bool, include_soul: bool) -> str:
+def _build_system_prompt(
+    *, tag_builtins: bool, include_soul: bool, include_agents: bool
+) -> str:
     """Build the system prompt with sections gated to the active flags."""
     return _SYSTEM_PROMPT_BASE.format(
         tag_blurb=_TAG_BLURB if tag_builtins else "",
         soul_blurb=_SOUL_BLURB if include_soul else "",
+        agents_blurb=_AGENTS_BLURB if include_agents else "",
         tag_rule=_TAG_RULE if tag_builtins else "",
         soul_rule=_SOUL_RULE if include_soul else "",
+        agents_rule=_AGENTS_RULE if include_agents else "",
     )
 
 
@@ -126,7 +147,7 @@ Provider: {provider}
 Installed skill count: {skill_count_text}
 Notable skills (up to {skill_cap}):
 {skill_list}
-{soul_block}"""
+{soul_block}{agents_block}"""
 
 
 _FENCE_RE = re.compile(r"^```(?:json)?\s*|\s*```$", re.MULTILINE)
@@ -299,6 +320,47 @@ def _load_soul_md(profile_dir: Path) -> str:
     return text
 
 
+# Candidate locations for AGENTS.md, in priority order. Hermes itself supports
+# AGENTS.md at the project cwd (canonical) or anywhere in the profile tree;
+# operators commonly stash a fleet-style AGENTS.md under a workspace/
+# subdirectory of the profile when the profile maps to a fixed working
+# directory. We try the canonical profile-root location first, then fall
+# back to workspace/ which is the convention used in the multi-agent fleet
+# layout this feature was originally designed to support.
+_AGENTS_MD_CANDIDATES = (
+    Path("AGENTS.md"),
+    Path("workspace") / "AGENTS.md",
+)
+
+
+def _load_agents_md(profile_dir: Path) -> str:
+    """Return AGENTS.md content for the profile, capped to ``MAX_AGENTS_CHARS``.
+
+    AGENTS.md is the canonical place for project-specific lane / role /
+    workflow information per the Hermes docs. We check the profile root
+    first, then ``workspace/AGENTS.md`` as a fallback for fleet layouts
+    that keep agent context in a workspace subdirectory.
+
+    Returns empty string if no AGENTS.md is found, the file is empty, or
+    it cannot be read.
+    """
+    for rel in _AGENTS_MD_CANDIDATES:
+        candidate = profile_dir / rel
+        if not candidate.is_file():
+            continue
+        try:
+            text = candidate.read_text(errors="replace").strip()
+        except Exception as exc:
+            logger.debug("describe: could not read AGENTS.md at %s: %s", candidate, exc)
+            continue
+        if not text:
+            continue
+        if len(text) > MAX_AGENTS_CHARS:
+            text = text[:MAX_AGENTS_CHARS] + "\n... (truncated)"
+        return text
+    return ""
+
+
 def _extract_json_blob(raw: str) -> Optional[dict]:
     if not raw:
         return None
@@ -324,6 +386,7 @@ def describe_profile(
     timeout: Optional[int] = None,
     tag_builtins: bool = False,
     include_soul: bool = False,
+    include_agents: bool = False,
 ) -> DescribeOutcome:
     """Auto-generate a description for one profile.
 
@@ -347,6 +410,12 @@ def describe_profile(
     into the prompt as a role-identity signal. Per the canonical Hermes
     docs SOUL.md is voice/tone only, so this is off by default — only
     set True when the profile keeps lane/role information in SOUL.md.
+
+    ``include_agents`` (default False) pulls the profile's AGENTS.md
+    content into the prompt as the canonical role/lane signal. AGENTS.md
+    is the docs-blessed location for project-specific role information,
+    but it's off by default to keep existing prompt shape unchanged for
+    callers who don't pass the flag.
     """
     canon = profiles_mod.normalize_profile_name(profile_name)
     if not profiles_mod.profile_exists(canon):
@@ -412,6 +481,18 @@ def describe_profile(
                 f"---\n{soul_text}\n---"
             )
 
+    # Optional AGENTS.md lane/role block (opt-in). This is the canonical
+    # docs-blessed home for role information; SOUL.md is the escape hatch
+    # for fleets that pollute SOUL with lane content.
+    agents_block = ""
+    if include_agents:
+        agents_text = _load_agents_md(profile_dir)
+        if agents_text:
+            agents_block = (
+                "\nProfile AGENTS.md (canonical lane/role/workflow):\n"
+                f"---\n{agents_text}\n---"
+            )
+
     # Read model + provider from the profile's config.
     try:
         model, provider = profiles_mod._read_config_model(profile_dir)
@@ -437,7 +518,9 @@ def describe_profile(
         return DescribeOutcome(canon, False, "no auxiliary client configured")
 
     system_prompt = _build_system_prompt(
-        tag_builtins=tag_builtins, include_soul=include_soul
+        tag_builtins=tag_builtins,
+        include_soul=include_soul,
+        include_agents=include_agents,
     )
     user_msg = _USER_TEMPLATE.format(
         name=canon,
@@ -447,6 +530,7 @@ def describe_profile(
         skill_cap=MAX_SKILLS_FOR_PROMPT,
         skill_list=skill_list,
         soul_block=soul_block,
+        agents_block=agents_block,
     )
 
     try:

--- a/hermes_cli/profile_describer.py
+++ b/hermes_cli/profile_describer.py
@@ -18,10 +18,20 @@ Design notes
 - Reads at most ``MAX_SKILLS_FOR_PROMPT`` skill names to keep the
   prompt bounded. No skill body — names + categories are enough
   signal and avoid blowing context on profiles with 100+ skills.
+- Each skill name is tagged ``[built-in]`` or ``[user]`` based on
+  whether it ships with Hermes (in ``skills/`` or ``optional-skills/``
+  under the install root) or was added by the user. The system prompt
+  instructs the LLM to weight ``[user]`` skills as the strongest signal
+  of role/domain — built-ins are present in nearly every profile by
+  default and carry minimal lane information.
 - Memory is intentionally NOT read here. Memories are personal and
   the orchestrator routes work to a *role* not a *biography*. If we
   find later that memory adds signal we can wire it; for now,
   skills + name + model is plenty.
+- ``include_soul=True`` (opt-in via CLI flag) pulls the profile's
+  SOUL.md content into the prompt when the user keeps lane/role info
+  in SOUL.md. Per the canonical Hermes docs SOUL.md is voice/tone
+  only, so this is opt-in and never default.
 """
 
 from __future__ import annotations
@@ -32,7 +42,7 @@ import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Tuple
 
 from hermes_cli import profiles as profiles_mod
 
@@ -43,8 +53,12 @@ logger = logging.getLogger(__name__)
 # is per-category — see _collect_skills.
 MAX_SKILLS_FOR_PROMPT = 60
 
+# Cap on SOUL.md content fed when --include-soul is passed. SOUL.md is
+# meant to be small per Hermes docs, but we cap to be safe.
+MAX_SOUL_CHARS = 4000
 
-_SYSTEM_PROMPT = """You are a profile-describer for the Hermes Agent kanban board.
+
+_SYSTEM_PROMPT_BASE = """You are a profile-describer for the Hermes Agent kanban board.
 
 A user runs multiple "profiles" — distinct agent identities, each with their
 own skills, model, and configuration. The kanban board's orchestrator routes
@@ -54,13 +68,13 @@ profile needs a short, concrete description of what it's good at.
 You are given a profile's:
   - Name
   - Model / provider
-  - List of installed skill names (a strong signal of role / domain)
+  - List of installed skill names{tag_blurb}{soul_blurb}
 
 Produce a single JSON object with exactly one key:
 
-  {
+  {{
     "description": "<1-2 sentence description, plain prose, no preamble>"
-  }
+  }}
 
 Rules:
   - The description is what an orchestrator will read to decide whether to
@@ -68,20 +82,51 @@ Rules:
   - Stay concrete. Bad: "an AI agent that helps users."
                   Good: "Reads and modifies Python codebases — runs tests,
                          refactors functions, opens GitHub PRs."
-  - 1-2 sentences, <= 280 characters total.
+  - 1-2 sentences, <= 280 characters total.{tag_rule}{soul_rule}
   - Never invent capabilities the skills don't suggest.
   - Never write "Hermes Agent profile" or other meta-narration.
   - No code fences, no preamble, no closing remarks. Output only JSON.
 """
 
+_TAG_BLURB = (
+    ", each tagged either [built-in] (ships with Hermes by default — "
+    "present in nearly every profile) or [user] (deliberately added by "
+    "this user — strong role/domain signal)"
+)
+_SOUL_BLURB = (
+    "\n  - SOUL.md content describing role/identity (only when the user "
+    "explicitly opted in)"
+)
+_TAG_RULE = (
+    "\n  - Weight [user] skills as the dominant signal of role and domain. "
+    "[built-in] skills are present in most profiles and carry weak lane "
+    "information — a profile with 80 [built-in] skills and 5 [user] skills "
+    "is defined by those 5, not the 80."
+)
+_SOUL_RULE = (
+    "\n  - When SOUL.md content is provided, treat the role/identity "
+    "portion as authoritative for the agent's purpose; let skills inform "
+    "capability detail but not override stated role."
+)
+
+
+def _build_system_prompt(*, tag_builtins: bool, include_soul: bool) -> str:
+    """Build the system prompt with sections gated to the active flags."""
+    return _SYSTEM_PROMPT_BASE.format(
+        tag_blurb=_TAG_BLURB if tag_builtins else "",
+        soul_blurb=_SOUL_BLURB if include_soul else "",
+        tag_rule=_TAG_RULE if tag_builtins else "",
+        soul_rule=_SOUL_RULE if include_soul else "",
+    )
+
 
 _USER_TEMPLATE = """Profile name: {name}
 Default model: {model}
 Provider: {provider}
-Installed skill count: {skill_count}
+Installed skill count: {skill_count_text}
 Notable skills (up to {skill_cap}):
 {skill_list}
-"""
+{soul_block}"""
 
 
 _FENCE_RE = re.compile(r"^```(?:json)?\s*|\s*```$", re.MULTILINE)
@@ -97,17 +142,89 @@ class DescribeOutcome:
     description: Optional[str] = None
 
 
-def _collect_skills(profile_dir: Path) -> list[str]:
-    """Return a stable, capped list of skill names for the prompt.
+def _hermes_install_root() -> Optional[Path]:
+    """Locate the Hermes install root so we can find the canonical
+    ``skills/`` and ``optional-skills/`` directories.
+
+    Resolves from ``hermes_cli`` package location: walk up from
+    ``hermes_cli/__file__`` until we find a parent that has both
+    ``skills/`` and ``hermes_cli/`` siblings. Returns ``None`` if
+    we can't locate it (e.g. site-packages install where the source
+    tree isn't present); caller falls back to treating every skill
+    as ``[user]`` which is safe — labels just become less informative.
+    """
+    try:
+        from hermes_cli import __file__ as _cli_file
+    except Exception:
+        return None
+    p = Path(_cli_file).resolve().parent  # .../hermes_cli/
+    for candidate in [p.parent, p.parent.parent]:
+        if (candidate / "skills").is_dir() and (candidate / "hermes_cli").is_dir():
+            return candidate
+    return None
+
+
+def _builtin_skill_ids() -> set[str]:
+    """Return the set of skill IDs that ship with Hermes.
+
+    A skill ID is the same shape ``_collect_skills`` produces:
+    ``category/name`` for nested skills, bare ``name`` for top-level
+    ones. We scan both ``skills/`` (auto-installed on profile create)
+    and ``optional-skills/`` (opt-in but still upstream-shipped).
+
+    Result is cached on the module to avoid re-walking on every call.
+    """
+    cached = getattr(_builtin_skill_ids, "_cache", None)
+    if cached is not None:
+        return cached
+    out: set[str] = set()
+    root = _hermes_install_root()
+    if root is None:
+        _builtin_skill_ids._cache = out  # type: ignore[attr-defined]
+        return out
+    for sub in ("skills", "optional-skills"):
+        d = root / sub
+        if not d.is_dir():
+            continue
+        for md in d.rglob("SKILL.md"):
+            try:
+                rel = md.relative_to(d)
+            except ValueError:
+                continue
+            parts = rel.parts[:-1]
+            if not parts:
+                continue
+            if len(parts) == 1:
+                out.add(parts[0])
+            else:
+                out.add(f"{parts[0]}/{parts[-1]}")
+    _builtin_skill_ids._cache = out  # type: ignore[attr-defined]
+    return out
+
+
+def _collect_skills(
+    profile_dir: Path,
+    *,
+    classify_builtins: bool = False,
+) -> list[Tuple[str, bool]]:
+    """Return a stable, capped list of ``(skill_id, is_user_authored)`` tuples.
 
     Format: ``category/skill_name`` where category is the immediate
     subdir under ``skills/`` (e.g. ``devops``, ``research``). Skills
     that live directly under ``skills/`` show as bare ``skill_name``.
+
+    The boolean is ``True`` when the skill is NOT a built-in Hermes skill
+    (i.e. the user added it deliberately — strong lane signal). When
+    ``classify_builtins=False`` the boolean is always ``False`` and the
+    cap is enforced via even sampling across the full sorted list rather
+    than by biasing toward user-authored skills.
     """
     skills_dir = profile_dir / "skills"
     if not skills_dir.is_dir():
         return []
-    names: list[str] = []
+    builtin = _builtin_skill_ids() if classify_builtins else set()
+    pairs: list[Tuple[str, bool]] = []
+    seen: set[str] = set()
     for md in skills_dir.rglob("SKILL.md"):
         path_str = str(md)
         if "/.hub/" in path_str or "/.git/" in path_str:
@@ -121,19 +238,65 @@ def _collect_skills(profile_dir: Path) -> list[str]:
             continue
         # parts[-1] is the skill dir name; parts[:-1] is the category path
         if len(parts) == 1:
-            names.append(parts[0])
+            sid = parts[0]
         else:
-            names.append(f"{parts[0]}/{parts[-1]}")
-    names.sort()
-    # Keep within prompt budget. Skills earlier in alphabet aren't more
-    # important — we'll let the LLM see a sample. Pick evenly-spaced
-    # entries instead of just the head so a profile with skills A..Z
-    # doesn't get described as "starts with A".
-    if len(names) <= MAX_SKILLS_FOR_PROMPT:
-        return names
-    step = len(names) / MAX_SKILLS_FOR_PROMPT
-    sampled = [names[int(i * step)] for i in range(MAX_SKILLS_FOR_PROMPT)]
-    return sampled
+            sid = f"{parts[0]}/{parts[-1]}"
+        if sid in seen:
+            continue
+        seen.add(sid)
+        # When classify_builtins is False we report every skill as
+        # is_user=False so callers don't accidentally emit [user]/[built-in]
+        # tags. The flag is purely about how the prompt is shaped.
+        is_user = (sid not in builtin) if classify_builtins else False
+        pairs.append((sid, is_user))
+    pairs.sort(key=lambda p: p[0])
+
+    if len(pairs) <= MAX_SKILLS_FOR_PROMPT:
+        return pairs
+
+    if not classify_builtins:
+        # Sample evenly across the sorted list — caller asked us not
+        # to differentiate built-ins, so don't bias the sample either.
+        step = len(pairs) / MAX_SKILLS_FOR_PROMPT
+        return [pairs[int(i * step)] for i in range(MAX_SKILLS_FOR_PROMPT)]
+
+    # Classified path: prioritize user-authored skills, then sample built-ins.
+    user_pairs = [p for p in pairs if p[1]]
+    builtin_pairs = [p for p in pairs if not p[1]]
+    if len(user_pairs) >= MAX_SKILLS_FOR_PROMPT:
+        step = len(user_pairs) / MAX_SKILLS_FOR_PROMPT
+        return [user_pairs[int(i * step)] for i in range(MAX_SKILLS_FOR_PROMPT)]
+    remaining = MAX_SKILLS_FOR_PROMPT - len(user_pairs)
+    if not builtin_pairs or remaining <= 0:
+        return user_pairs[:MAX_SKILLS_FOR_PROMPT]
+    step = max(1.0, len(builtin_pairs) / remaining)
+    sampled_builtin = [
+        builtin_pairs[int(i * step)] for i in range(remaining)
+        if int(i * step) < len(builtin_pairs)
+    ]
+    out = user_pairs + sampled_builtin
+    out.sort(key=lambda p: p[0])
+    return out
+
+
+def _load_soul_md(profile_dir: Path) -> str:
+    """Return SOUL.md content for the profile, capped to ``MAX_SOUL_CHARS``.
+
+    Returns empty string if SOUL.md is missing, empty, or unreadable.
+    """
+    soul_path = profile_dir / "SOUL.md"
+    if not soul_path.is_file():
+        return ""
+    try:
+        text = soul_path.read_text(errors="replace").strip()
+    except Exception as exc:
+        logger.debug("describe: could not read SOUL.md at %s: %s", soul_path, exc)
+        return ""
+    if not text:
+        return ""
+    if len(text) > MAX_SOUL_CHARS:
+        text = text[:MAX_SOUL_CHARS] + "\n... (truncated)"
+    return text
 
 
 def _extract_json_blob(raw: str) -> Optional[dict]:
@@ -159,6 +322,8 @@ def describe_profile(
     *,
     overwrite: bool = False,
     timeout: Optional[int] = None,
+    tag_builtins: bool = False,
+    include_soul: bool = False,
 ) -> DescribeOutcome:
     """Auto-generate a description for one profile.
 
@@ -171,6 +336,17 @@ def describe_profile(
     is replaced. By default we refuse to overwrite a description with
     ``description_auto: false`` to protect curated text. Auto-generated
     descriptions (``description_auto: true``) are always replaceable.
+
+    ``tag_builtins`` (default False) labels each skill in the prompt as
+    [user] or [built-in] based on whether it ships with Hermes, and
+    instructs the LLM to weight [user] skills as the dominant role/domain
+    signal. Off by default so existing behavior is unchanged. Enable when
+    profiles are heavy with built-in skills that drown out the lane.
+
+    ``include_soul`` (default False) pulls the profile's SOUL.md content
+    into the prompt as a role-identity signal. Per the canonical Hermes
+    docs SOUL.md is voice/tone only, so this is off by default — only
+    set True when the profile keeps lane/role information in SOUL.md.
     """
     canon = profiles_mod.normalize_profile_name(profile_name)
     if not profiles_mod.profile_exists(canon):
@@ -197,12 +373,44 @@ def describe_profile(
             "(use --overwrite to replace)",
         )
 
-    skill_names = _collect_skills(profile_dir)
-    skill_list = "\n".join(f"  - {n}" for n in skill_names) or "  (no skills installed)"
+    skill_pairs = _collect_skills(profile_dir, classify_builtins=tag_builtins)
+    if skill_pairs:
+        skill_lines = []
+        for sid, is_user in skill_pairs:
+            if tag_builtins:
+                tag = "[user] " if is_user else "[built-in] "
+            else:
+                tag = ""
+            skill_lines.append(f"  - {tag}{sid}")
+        skill_list = "\n".join(skill_lines)
+    else:
+        skill_list = "  (no skills installed)"
     skill_count = sum(
         1 for _ in (profile_dir / "skills").rglob("SKILL.md")
         if "/.hub/" not in str(_) and "/.git/" not in str(_)
     ) if (profile_dir / "skills").is_dir() else 0
+    user_count = sum(1 for _, u in skill_pairs if u) if tag_builtins else 0
+    builtin_count = (
+        sum(1 for _, u in skill_pairs if not u) if tag_builtins else 0
+    )
+    # Format the count line conditionally so unclassified runs don't
+    # emit a misleading "(0 user, 0 built-in)" suffix.
+    if tag_builtins:
+        skill_count_text = (
+            f"{skill_count} ({user_count} user, {builtin_count} built-in)"
+        )
+    else:
+        skill_count_text = str(skill_count)
+
+    # Optional SOUL.md identity block (opt-in).
+    soul_block = ""
+    if include_soul:
+        soul_text = _load_soul_md(profile_dir)
+        if soul_text:
+            soul_block = (
+                "\nProfile SOUL.md (role/identity per user opt-in):\n"
+                f"---\n{soul_text}\n---"
+            )
 
     # Read model + provider from the profile's config.
     try:
@@ -228,20 +436,24 @@ def describe_profile(
     if client is None or not aux_model:
         return DescribeOutcome(canon, False, "no auxiliary client configured")
 
+    system_prompt = _build_system_prompt(
+        tag_builtins=tag_builtins, include_soul=include_soul
+    )
     user_msg = _USER_TEMPLATE.format(
         name=canon,
         model=(model or "(unset)"),
         provider=(provider or "(unset)"),
-        skill_count=skill_count,
+        skill_count_text=skill_count_text,
         skill_cap=MAX_SKILLS_FOR_PROMPT,
         skill_list=skill_list,
+        soul_block=soul_block,
     )
 
     try:
         resp = client.chat.completions.create(
             model=aux_model,
             messages=[
-                {"role": "system", "content": _SYSTEM_PROMPT},
+                {"role": "system", "content": system_prompt},
                 {"role": "user", "content": user_msg},
             ],
             temperature=0.3,

--- a/hermes_cli/profile_describer.py
+++ b/hermes_cli/profile_describer.py
@@ -70,6 +70,47 @@ MAX_SKILL_DESC_CHARS = 200
 _FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---", re.DOTALL)
 _DESC_RE = re.compile(r"^description:\s*(.+?)\s*$", re.MULTILINE)
 
+# Boilerplate phrases that signal the describer fell back to filler
+# instead of producing a concrete role description. Detected only when
+# ``--reject-boilerplate`` is set; the describer retries once with an
+# explicit rule against these phrases. Phrases were sourced from real
+# pre-improvement output ("highly versatile generalist", "powerhouse",
+# "multi-tool agent"). Match is case-insensitive substring against the
+# returned description.
+_BOILERPLATE_PHRASES = (
+    "versatile generalist",
+    "highly versatile",
+    "versatile multi-tool",
+    "versatile powerhouse",
+    "versatile creative and",
+    "versatile technical agent",
+    "versatile multi-modal",
+    "versatile developer",
+    "manages workflows across",
+    "manages complex workflows",
+    "handles everything from",
+    "handles complex workflows",
+    "capable of macos computer use",
+    "ai agent that helps users",
+    "hermes agent profile",
+)
+
+
+def _contains_boilerplate(text: str) -> Optional[str]:
+    """Return the matched boilerplate phrase, or ``None`` if clean.
+
+    Match is case-insensitive substring. We return the matched phrase
+    (not just a bool) so the retry prompt can call out exactly what the
+    first attempt produced.
+    """
+    if not text:
+        return None
+    lower = text.lower()
+    for phrase in _BOILERPLATE_PHRASES:
+        if phrase in lower:
+            return phrase
+    return None
+
 # Cap on SOUL.md content fed when --include-soul is passed. SOUL.md is
 # meant to be small per Hermes docs, but we cap to be safe.
 MAX_SOUL_CHARS = 4000
@@ -445,6 +486,7 @@ def describe_profile(
     include_soul: bool = False,
     include_agents: bool = False,
     with_skill_descriptions: bool = False,
+    reject_boilerplate: bool = False,
 ) -> DescribeOutcome:
     """Auto-generate a description for one profile.
 
@@ -480,6 +522,13 @@ def describe_profile(
     roughly 5-10x more characters per skill so the per-prompt skill cap
     is tightened to ``MAX_SKILLS_WITH_DESC`` when enabled. Helps the LLM
     reason about bespoke skills it's never seen before.
+
+    ``reject_boilerplate`` (default False) scans the LLM's first output
+    for filler phrases ("versatile generalist", "powerhouse", "manages
+    workflows across", etc.) and retries once with an explicit rule
+    against the matched phrase if found. Only one retry — the second
+    result is accepted unconditionally to bound cost. Off by default
+    so existing single-call behavior is unchanged.
     """
     canon = profiles_mod.normalize_profile_name(profile_name)
     if not profiles_mod.profile_exists(canon):
@@ -611,41 +660,83 @@ def describe_profile(
         agents_block=agents_block,
     )
 
-    try:
-        resp = client.chat.completions.create(
-            model=aux_model,
-            messages=[
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": user_msg},
-            ],
-            temperature=0.3,
-            max_tokens=400,
-            timeout=timeout or 60,
-            extra_body=get_auxiliary_extra_body() or None,
-        )
-    except Exception as exc:
-        logger.info("describe: API call failed for %s (%s)", canon, exc)
-        return DescribeOutcome(canon, False, f"LLM error: {type(exc).__name__}")
+    def _call(extra_system: str = "") -> Tuple[Optional[str], Optional[str]]:
+        """Run one describer LLM call. Returns (description, error_reason).
 
-    try:
-        raw = resp.choices[0].message.content or ""
-    except Exception:
-        raw = ""
+        Exactly one of the two is non-None. ``extra_system`` is appended
+        to the system prompt and is used by the retry path to add an
+        explicit prohibition against the boilerplate phrase that tripped
+        the first attempt.
+        """
+        sys_content = system_prompt + (extra_system or "")
+        try:
+            resp = client.chat.completions.create(
+                model=aux_model,
+                messages=[
+                    {"role": "system", "content": sys_content},
+                    {"role": "user", "content": user_msg},
+                ],
+                temperature=0.3,
+                max_tokens=400,
+                timeout=timeout or 60,
+                extra_body=get_auxiliary_extra_body() or None,
+            )
+        except Exception as call_exc:
+            logger.info(
+                "describe: API call failed for %s (%s)", canon, call_exc
+            )
+            return None, f"LLM error: {type(call_exc).__name__}"
 
-    parsed = _extract_json_blob(raw)
-    if parsed is None:
-        # Fall back: take the raw text trimmed to one paragraph.
-        text = raw.strip().split("\n\n", 1)[0]
-        if not text:
-            return DescribeOutcome(canon, False, "LLM returned an empty response")
-        description = text[:280]
-    else:
+        try:
+            raw = resp.choices[0].message.content or ""
+        except Exception:
+            raw = ""
+
+        parsed = _extract_json_blob(raw)
+        if parsed is None:
+            text = raw.strip().split("\n\n", 1)[0]
+            if not text:
+                return None, "LLM returned an empty response"
+            return text[:280], None
         val = parsed.get("description")
         if not isinstance(val, str) or not val.strip():
-            return DescribeOutcome(
-                canon, False, "LLM response missing 'description' field"
+            return None, "LLM response missing 'description' field"
+        return val.strip()[:280], None
+
+    description, err = _call()
+    if description is None:
+        return DescribeOutcome(canon, False, err or "LLM call failed")
+
+    if reject_boilerplate:
+        matched = _contains_boilerplate(description)
+        if matched is not None:
+            logger.info(
+                "describe: %s first attempt hit boilerplate phrase %r — retrying",
+                canon,
+                matched,
             )
-        description = val.strip()[:280]
+            extra_rule = (
+                f"\n\nIMPORTANT: A previous attempt produced a generic "
+                f"description containing the phrase '{matched}'. Do NOT use "
+                f"that phrase or any near variant. Avoid generic filler like "
+                f"'versatile', 'powerhouse', 'multi-tool', 'manages workflows "
+                f"across', 'handles everything from'. Lead with the profile's "
+                f"actual concrete role — name a specific lane, not a list of "
+                f"capabilities."
+            )
+            retry_desc, retry_err = _call(extra_rule)
+            if retry_desc is not None:
+                # Use the retry result even if it still contains boilerplate;
+                # at this point we've spent two calls and the second is
+                # almost certainly an improvement. The describer treats
+                # boilerplate as a soft signal, not a hard rejection.
+                description = retry_desc
+            elif retry_err:
+                logger.info(
+                    "describe: %s retry failed (%s) — keeping first attempt",
+                    canon,
+                    retry_err,
+                )
 
     try:
         profiles_mod.write_profile_meta(

--- a/tests/hermes_cli/test_profile_describer.py
+++ b/tests/hermes_cli/test_profile_describer.py
@@ -462,3 +462,113 @@ def test_describer_caps_skill_list_and_keeps_user_skills(profile_env, monkeypatc
     builtin_count = user_text.count("[built-in]")
     assert builtin_count <= 20
     assert builtin_count > 0
+
+
+def test_describer_does_not_emit_skill_descriptions_by_default(profile_env, monkeypatch):
+    """Without the flag, a skill's frontmatter description must not appear."""
+    monkeypatch.setattr(profiles_mod, "profile_exists", lambda n: n == "myprof")
+    monkeypatch.setattr(profiles_mod, "normalize_profile_name", lambda n: n)
+    monkeypatch.setattr(profiles_mod, "get_profile_dir", lambda n: profile_env)
+    monkeypatch.setattr(describer, "_builtin_skill_ids", lambda: set())
+
+    skills_dir = profile_env / "skills" / "trading"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "binance-trading-ops").mkdir()
+    (skills_dir / "binance-trading-ops" / "SKILL.md").write_text(
+        "---\nname: binance-trading-ops\n"
+        "description: Execute Binance bucket strategy with risk monitoring\n---\nbody"
+    )
+
+    patch_ctx, captured = _capture_user_msg()
+    with patch_ctx, patch(
+        "agent.auxiliary_client.get_auxiliary_extra_body", return_value={}
+    ):
+        outcome = describer.describe_profile("myprof")  # no flags
+    assert outcome.ok
+    user_text = captured[0][1]["content"]
+    # Skill ID still appears, but not the description text.
+    assert "binance-trading-ops" in user_text
+    assert "Execute Binance bucket strategy" not in user_text
+
+
+def test_describer_emits_skill_descriptions_when_opt_in(profile_env, monkeypatch):
+    """with_skill_descriptions=True appends each skill's frontmatter description."""
+    monkeypatch.setattr(profiles_mod, "profile_exists", lambda n: n == "myprof")
+    monkeypatch.setattr(profiles_mod, "normalize_profile_name", lambda n: n)
+    monkeypatch.setattr(profiles_mod, "get_profile_dir", lambda n: profile_env)
+    monkeypatch.setattr(describer, "_builtin_skill_ids", lambda: set())
+
+    skills_dir = profile_env / "skills" / "trading"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "binance-trading-ops").mkdir()
+    (skills_dir / "binance-trading-ops" / "SKILL.md").write_text(
+        "---\nname: binance-trading-ops\n"
+        "description: Execute Binance bucket strategy with risk monitoring\n---\nbody"
+    )
+
+    patch_ctx, captured = _capture_user_msg()
+    with patch_ctx, patch(
+        "agent.auxiliary_client.get_auxiliary_extra_body", return_value={}
+    ):
+        outcome = describer.describe_profile(
+            "myprof", with_skill_descriptions=True
+        )
+    assert outcome.ok
+    user_text = captured[0][1]["content"]
+    assert "Execute Binance bucket strategy with risk monitoring" in user_text
+
+
+def test_describer_skill_descriptions_strip_quotes(profile_env, monkeypatch):
+    """Quoted description values get stripped and surfaced cleanly."""
+    monkeypatch.setattr(profiles_mod, "profile_exists", lambda n: n == "myprof")
+    monkeypatch.setattr(profiles_mod, "normalize_profile_name", lambda n: n)
+    monkeypatch.setattr(profiles_mod, "get_profile_dir", lambda n: profile_env)
+    monkeypatch.setattr(describer, "_builtin_skill_ids", lambda: set())
+
+    skills_dir = profile_env / "skills" / "trading"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "polymarket").mkdir()
+    (skills_dir / "polymarket" / "SKILL.md").write_text(
+        '---\nname: polymarket\n'
+        'description: "Query Polymarket: markets, prices, orderbooks."\n---\nbody'
+    )
+
+    patch_ctx, captured = _capture_user_msg()
+    with patch_ctx, patch(
+        "agent.auxiliary_client.get_auxiliary_extra_body", return_value={}
+    ):
+        outcome = describer.describe_profile(
+            "myprof", with_skill_descriptions=True
+        )
+    assert outcome.ok
+    user_text = captured[0][1]["content"]
+    assert "Query Polymarket: markets, prices, orderbooks." in user_text
+    # The wrapping quotes should not appear in the rendered line.
+    assert '"Query Polymarket' not in user_text
+
+
+def test_describer_skill_descriptions_handles_missing_frontmatter(profile_env, monkeypatch):
+    """A SKILL.md without frontmatter must not crash the run."""
+    monkeypatch.setattr(profiles_mod, "profile_exists", lambda n: n == "myprof")
+    monkeypatch.setattr(profiles_mod, "normalize_profile_name", lambda n: n)
+    monkeypatch.setattr(profiles_mod, "get_profile_dir", lambda n: profile_env)
+    monkeypatch.setattr(describer, "_builtin_skill_ids", lambda: set())
+
+    skills_dir = profile_env / "skills" / "research"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "no-frontmatter").mkdir()
+    (skills_dir / "no-frontmatter" / "SKILL.md").write_text(
+        "# Just a body, no frontmatter at all."
+    )
+
+    patch_ctx, captured = _capture_user_msg()
+    with patch_ctx, patch(
+        "agent.auxiliary_client.get_auxiliary_extra_body", return_value={}
+    ):
+        outcome = describer.describe_profile(
+            "myprof", with_skill_descriptions=True
+        )
+    assert outcome.ok
+    user_text = captured[0][1]["content"]
+    # Skill ID still appears even without a description to attach.
+    assert "research/no-frontmatter" in user_text

--- a/tests/hermes_cli/test_profile_describer.py
+++ b/tests/hermes_cli/test_profile_describer.py
@@ -339,6 +339,92 @@ def test_describer_include_soul_tolerates_missing_file(profile_env, monkeypatch)
     assert "SOUL.md" not in user_text
 
 
+def test_describer_does_not_include_agents_by_default(profile_env, monkeypatch):
+    """AGENTS.md content must not leak into the prompt when include_agents=False."""
+    monkeypatch.setattr(profiles_mod, "profile_exists", lambda n: n == "myprof")
+    monkeypatch.setattr(profiles_mod, "normalize_profile_name", lambda n: n)
+    monkeypatch.setattr(profiles_mod, "get_profile_dir", lambda n: profile_env)
+    monkeypatch.setattr(describer, "_builtin_skill_ids", lambda: set())
+
+    (profile_env / "AGENTS.md").write_text(
+        "# Newton — Delivery Engineer\nLane: All coding tasks for project repos."
+    )
+
+    patch_ctx, captured = _capture_user_msg()
+    with patch_ctx, patch(
+        "agent.auxiliary_client.get_auxiliary_extra_body", return_value={}
+    ):
+        outcome = describer.describe_profile("myprof")  # no flags
+    assert outcome.ok
+    user_text = captured[0][1]["content"]
+    assert "Newton" not in user_text
+    assert "AGENTS.md" not in user_text
+
+
+def test_describer_includes_agents_when_opt_in(profile_env, monkeypatch):
+    """include_agents=True pulls AGENTS.md content into the prompt."""
+    monkeypatch.setattr(profiles_mod, "profile_exists", lambda n: n == "myprof")
+    monkeypatch.setattr(profiles_mod, "normalize_profile_name", lambda n: n)
+    monkeypatch.setattr(profiles_mod, "get_profile_dir", lambda n: profile_env)
+    monkeypatch.setattr(describer, "_builtin_skill_ids", lambda: set())
+
+    (profile_env / "AGENTS.md").write_text(
+        "# Newton — Delivery Engineer\nLane: All coding tasks for project repos."
+    )
+
+    patch_ctx, captured = _capture_user_msg()
+    with patch_ctx, patch(
+        "agent.auxiliary_client.get_auxiliary_extra_body", return_value={}
+    ):
+        outcome = describer.describe_profile("myprof", include_agents=True)
+    assert outcome.ok
+    user_text = captured[0][1]["content"]
+    assert "Newton" in user_text
+    assert "Delivery Engineer" in user_text
+    assert "All coding tasks" in user_text
+
+
+def test_describer_include_agents_falls_back_to_workspace(profile_env, monkeypatch):
+    """When AGENTS.md isn't at profile root, fall back to workspace/AGENTS.md."""
+    monkeypatch.setattr(profiles_mod, "profile_exists", lambda n: n == "myprof")
+    monkeypatch.setattr(profiles_mod, "normalize_profile_name", lambda n: n)
+    monkeypatch.setattr(profiles_mod, "get_profile_dir", lambda n: profile_env)
+    monkeypatch.setattr(describer, "_builtin_skill_ids", lambda: set())
+
+    workspace = profile_env / "workspace"
+    workspace.mkdir()
+    (workspace / "AGENTS.md").write_text(
+        "# Edison — Architect\nLane: Specs and architecture authoring."
+    )
+
+    patch_ctx, captured = _capture_user_msg()
+    with patch_ctx, patch(
+        "agent.auxiliary_client.get_auxiliary_extra_body", return_value={}
+    ):
+        outcome = describer.describe_profile("myprof", include_agents=True)
+    assert outcome.ok
+    user_text = captured[0][1]["content"]
+    assert "Edison" in user_text
+    assert "Architect" in user_text
+
+
+def test_describer_include_agents_tolerates_missing_file(profile_env, monkeypatch):
+    """include_agents=True must not error when no AGENTS.md exists."""
+    monkeypatch.setattr(profiles_mod, "profile_exists", lambda n: n == "myprof")
+    monkeypatch.setattr(profiles_mod, "normalize_profile_name", lambda n: n)
+    monkeypatch.setattr(profiles_mod, "get_profile_dir", lambda n: profile_env)
+    monkeypatch.setattr(describer, "_builtin_skill_ids", lambda: set())
+
+    patch_ctx, captured = _capture_user_msg()
+    with patch_ctx, patch(
+        "agent.auxiliary_client.get_auxiliary_extra_body", return_value={}
+    ):
+        outcome = describer.describe_profile("myprof", include_agents=True)
+    assert outcome.ok
+    user_text = captured[0][1]["content"]
+    assert "AGENTS.md" not in user_text
+
+
 def test_describer_caps_skill_list_and_keeps_user_skills(profile_env, monkeypatch):
     """When skill count exceeds MAX_SKILLS_FOR_PROMPT, user skills must all survive."""
     monkeypatch.setattr(profiles_mod, "profile_exists", lambda n: n == "myprof")

--- a/tests/hermes_cli/test_profile_describer.py
+++ b/tests/hermes_cli/test_profile_describer.py
@@ -197,6 +197,35 @@ def _capture_user_msg():
     )
 
 
+def _capture_with_responses(responses: list[str]):
+    """Like _capture_user_msg but returns a queued sequence of LLM responses.
+
+    Each entry in ``responses`` is the ``description`` value the fake LLM
+    will emit on the corresponding call. Used to simulate boilerplate
+    on the first attempt followed by a clean retry.
+    """
+    captured: list = []
+    client = MagicMock()
+    queue = list(responses)
+
+    def _fake_create(**kwargs):
+        captured.append(kwargs.get("messages", []))
+        if queue:
+            content = queue.pop(0)
+        else:
+            content = responses[-1] if responses else "ok"
+        return _fake_aux_response(jsonlib.dumps({"description": content}))
+
+    client.chat.completions.create = MagicMock(side_effect=_fake_create)
+    return (
+        patch(
+            "agent.auxiliary_client.get_text_auxiliary_client",
+            return_value=(client, "test-model"),
+        ),
+        captured,
+    )
+
+
 def test_describer_does_not_tag_skills_by_default(profile_env, monkeypatch):
     """Default behavior: no [user]/[built-in] labels appear in the prompt."""
     monkeypatch.setattr(profiles_mod, "profile_exists", lambda n: n == "myprof")
@@ -572,3 +601,96 @@ def test_describer_skill_descriptions_handles_missing_frontmatter(profile_env, m
     user_text = captured[0][1]["content"]
     # Skill ID still appears even without a description to attach.
     assert "research/no-frontmatter" in user_text
+
+
+# ---------------------------------------------------------------------------
+# Boilerplate detection + retry
+# ---------------------------------------------------------------------------
+
+
+def test_contains_boilerplate_detects_known_phrases():
+    """Sanity check: the matcher returns the matched phrase or None."""
+    assert describer._contains_boilerplate(
+        "Highly versatile generalist for development tasks."
+    ) == "versatile generalist"
+    assert describer._contains_boilerplate(
+        "A powerhouse agent that manages workflows across many domains."
+    ) == "manages workflows across"
+    # Case-insensitive
+    assert describer._contains_boilerplate(
+        "VERSATILE GENERALIST"
+    ) == "versatile generalist"
+    # Clean concrete role
+    assert describer._contains_boilerplate(
+        "Reads and modifies Python codebases — runs tests, opens PRs."
+    ) is None
+    # Empty / None
+    assert describer._contains_boilerplate("") is None
+    assert describer._contains_boilerplate(None) is None  # type: ignore[arg-type]
+
+
+def test_describer_does_not_retry_when_flag_off(profile_env, monkeypatch):
+    """Without reject_boilerplate, a boilerplate first attempt is accepted."""
+    monkeypatch.setattr(profiles_mod, "profile_exists", lambda n: n == "myprof")
+    monkeypatch.setattr(profiles_mod, "normalize_profile_name", lambda n: n)
+    monkeypatch.setattr(profiles_mod, "get_profile_dir", lambda n: profile_env)
+    monkeypatch.setattr(describer, "_builtin_skill_ids", lambda: set())
+
+    boilerplate = "Highly versatile generalist for development tasks."
+    clean = "Reads Python repos and ships PRs."
+    patch_ctx, captured = _capture_with_responses([boilerplate, clean])
+    with patch_ctx, patch(
+        "agent.auxiliary_client.get_auxiliary_extra_body", return_value={}
+    ):
+        outcome = describer.describe_profile("myprof")  # no flag
+    assert outcome.ok
+    assert outcome.description == boilerplate
+    # Only one LLM call should have been made.
+    assert len(captured) == 1
+
+
+def test_describer_retries_on_boilerplate_when_flag_on(profile_env, monkeypatch):
+    """With reject_boilerplate, boilerplate triggers exactly one retry."""
+    monkeypatch.setattr(profiles_mod, "profile_exists", lambda n: n == "myprof")
+    monkeypatch.setattr(profiles_mod, "normalize_profile_name", lambda n: n)
+    monkeypatch.setattr(profiles_mod, "get_profile_dir", lambda n: profile_env)
+    monkeypatch.setattr(describer, "_builtin_skill_ids", lambda: set())
+
+    boilerplate = "Highly versatile generalist that manages workflows across domains."
+    clean = "Reads Python repos and ships PRs against project codebases."
+    patch_ctx, captured = _capture_with_responses([boilerplate, clean])
+    with patch_ctx, patch(
+        "agent.auxiliary_client.get_auxiliary_extra_body", return_value={}
+    ):
+        outcome = describer.describe_profile(
+            "myprof", reject_boilerplate=True
+        )
+    assert outcome.ok
+    # Retry result should win.
+    assert outcome.description == clean
+    # Two LLM calls — first attempt + retry.
+    assert len(captured) == 2
+    # Second call's system prompt must contain the explicit phrase prohibition.
+    second_system = captured[1][0]["content"]
+    assert "Do NOT use" in second_system
+    assert "versatile generalist" in second_system
+
+
+def test_describer_no_retry_when_first_response_is_clean(profile_env, monkeypatch):
+    """Clean first response must not trigger a retry even with the flag on."""
+    monkeypatch.setattr(profiles_mod, "profile_exists", lambda n: n == "myprof")
+    monkeypatch.setattr(profiles_mod, "normalize_profile_name", lambda n: n)
+    monkeypatch.setattr(profiles_mod, "get_profile_dir", lambda n: profile_env)
+    monkeypatch.setattr(describer, "_builtin_skill_ids", lambda: set())
+
+    clean = "Reads Python repos and ships PRs against project codebases."
+    patch_ctx, captured = _capture_with_responses([clean])
+    with patch_ctx, patch(
+        "agent.auxiliary_client.get_auxiliary_extra_body", return_value={}
+    ):
+        outcome = describer.describe_profile(
+            "myprof", reject_boilerplate=True
+        )
+    assert outcome.ok
+    assert outcome.description == clean
+    assert len(captured) == 1

--- a/tests/hermes_cli/test_profile_describer.py
+++ b/tests/hermes_cli/test_profile_describer.py
@@ -166,3 +166,213 @@ def test_describer_returns_false_when_profile_missing(profile_env, monkeypatch):
     outcome = describer.describe_profile("ghost")
     assert outcome.ok is False
     assert "not found" in outcome.reason
+
+
+# ---------------------------------------------------------------------------
+# Built-in vs user-authored skill tagging + opt-in SOUL.md
+# ---------------------------------------------------------------------------
+
+
+def _capture_user_msg():
+    """Helper that returns (patch_ctx, captured_messages_list).
+
+    The patch_ctx is the unittest.mock context manager you `with`-enter.
+    captured_messages_list is appended to on each LLM call so tests can
+    assert on the prompt content the describer assembled.
+    """
+    captured: list = []
+    client = MagicMock()
+
+    def _fake_create(**kwargs):
+        captured.append(kwargs.get("messages", []))
+        return _fake_aux_response(jsonlib.dumps({"description": "ok"}))
+
+    client.chat.completions.create = MagicMock(side_effect=_fake_create)
+    return (
+        patch(
+            "agent.auxiliary_client.get_text_auxiliary_client",
+            return_value=(client, "test-model"),
+        ),
+        captured,
+    )
+
+
+def test_describer_does_not_tag_skills_by_default(profile_env, monkeypatch):
+    """Default behavior: no [user]/[built-in] labels appear in the prompt."""
+    monkeypatch.setattr(profiles_mod, "profile_exists", lambda n: n == "myprof")
+    monkeypatch.setattr(profiles_mod, "normalize_profile_name", lambda n: n)
+    monkeypatch.setattr(profiles_mod, "get_profile_dir", lambda n: profile_env)
+    monkeypatch.setattr(describer, "_builtin_skill_ids", lambda: set())
+
+    skills_dir = profile_env / "skills" / "trading"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "binance-trading-ops").mkdir()
+    (skills_dir / "binance-trading-ops" / "SKILL.md").write_text(
+        "---\nname: binance-trading-ops\n---\nbody"
+    )
+
+    patch_ctx, captured = _capture_user_msg()
+    with patch_ctx, patch(
+        "agent.auxiliary_client.get_auxiliary_extra_body", return_value={}
+    ):
+        outcome = describer.describe_profile("myprof")  # no flags
+    assert outcome.ok
+    user_text = captured[0][1]["content"]
+    # Skill name still appears, but no tags either way.
+    assert "trading/binance-trading-ops" in user_text
+    assert "[user]" not in user_text
+    assert "[built-in]" not in user_text
+
+
+def test_describer_tags_user_skill_when_not_in_builtin_set(profile_env, monkeypatch):
+    """A skill that doesn't exist in the install-root catalogue is tagged [user]."""
+    monkeypatch.setattr(profiles_mod, "profile_exists", lambda n: n == "myprof")
+    monkeypatch.setattr(profiles_mod, "normalize_profile_name", lambda n: n)
+    monkeypatch.setattr(profiles_mod, "get_profile_dir", lambda n: profile_env)
+    # Force the describer to think no skills are built-in.
+    monkeypatch.setattr(describer, "_builtin_skill_ids", lambda: set())
+
+    skills_dir = profile_env / "skills" / "trading"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "binance-trading-ops").mkdir()
+    (skills_dir / "binance-trading-ops" / "SKILL.md").write_text(
+        "---\nname: binance-trading-ops\n---\nbody"
+    )
+
+    patch_ctx, captured = _capture_user_msg()
+    with patch_ctx, patch(
+        "agent.auxiliary_client.get_auxiliary_extra_body", return_value={}
+    ):
+        outcome = describer.describe_profile("myprof", tag_builtins=True)
+    assert outcome.ok
+    assert captured, "describer should have called the LLM"
+    user_text = captured[0][1]["content"]
+    assert "[user] trading/binance-trading-ops" in user_text
+    assert "[built-in]" not in user_text
+
+
+def test_describer_tags_builtin_skill_when_in_builtin_set(profile_env, monkeypatch):
+    """A skill present in the install-root catalogue is tagged [built-in]."""
+    monkeypatch.setattr(profiles_mod, "profile_exists", lambda n: n == "myprof")
+    monkeypatch.setattr(profiles_mod, "normalize_profile_name", lambda n: n)
+    monkeypatch.setattr(profiles_mod, "get_profile_dir", lambda n: profile_env)
+    monkeypatch.setattr(
+        describer, "_builtin_skill_ids", lambda: {"github/codebase-inspection"}
+    )
+
+    skills_dir = profile_env / "skills" / "github"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "codebase-inspection").mkdir()
+    (skills_dir / "codebase-inspection" / "SKILL.md").write_text(
+        "---\nname: codebase-inspection\n---\nbody"
+    )
+
+    patch_ctx, captured = _capture_user_msg()
+    with patch_ctx, patch(
+        "agent.auxiliary_client.get_auxiliary_extra_body", return_value={}
+    ):
+        outcome = describer.describe_profile("myprof", tag_builtins=True)
+    assert outcome.ok
+    user_text = captured[0][1]["content"]
+    assert "[built-in] github/codebase-inspection" in user_text
+
+
+def test_describer_does_not_include_soul_by_default(profile_env, monkeypatch):
+    """SOUL.md content must not leak into the prompt when include_soul=False."""
+    monkeypatch.setattr(profiles_mod, "profile_exists", lambda n: n == "myprof")
+    monkeypatch.setattr(profiles_mod, "normalize_profile_name", lambda n: n)
+    monkeypatch.setattr(profiles_mod, "get_profile_dir", lambda n: profile_env)
+    monkeypatch.setattr(describer, "_builtin_skill_ids", lambda: set())
+
+    (profile_env / "SOUL.md").write_text(
+        "You are Hopper. Role: Fleet Performance Researcher."
+    )
+
+    patch_ctx, captured = _capture_user_msg()
+    with patch_ctx, patch(
+        "agent.auxiliary_client.get_auxiliary_extra_body", return_value={}
+    ):
+        outcome = describer.describe_profile("myprof")  # include_soul defaults to False
+    assert outcome.ok
+    user_text = captured[0][1]["content"]
+    assert "Hopper" not in user_text
+    assert "SOUL.md" not in user_text
+
+
+def test_describer_includes_soul_when_opt_in(profile_env, monkeypatch):
+    """include_soul=True pulls SOUL.md content into the prompt."""
+    monkeypatch.setattr(profiles_mod, "profile_exists", lambda n: n == "myprof")
+    monkeypatch.setattr(profiles_mod, "normalize_profile_name", lambda n: n)
+    monkeypatch.setattr(profiles_mod, "get_profile_dir", lambda n: profile_env)
+    monkeypatch.setattr(describer, "_builtin_skill_ids", lambda: set())
+
+    (profile_env / "SOUL.md").write_text(
+        "You are Hopper. Role: Fleet Performance Researcher."
+    )
+
+    patch_ctx, captured = _capture_user_msg()
+    with patch_ctx, patch(
+        "agent.auxiliary_client.get_auxiliary_extra_body", return_value={}
+    ):
+        outcome = describer.describe_profile("myprof", include_soul=True)
+    assert outcome.ok
+    user_text = captured[0][1]["content"]
+    assert "Hopper" in user_text
+    assert "Fleet Performance Researcher" in user_text
+
+
+def test_describer_include_soul_tolerates_missing_file(profile_env, monkeypatch):
+    """include_soul=True must not error when SOUL.md doesn't exist."""
+    monkeypatch.setattr(profiles_mod, "profile_exists", lambda n: n == "myprof")
+    monkeypatch.setattr(profiles_mod, "normalize_profile_name", lambda n: n)
+    monkeypatch.setattr(profiles_mod, "get_profile_dir", lambda n: profile_env)
+    monkeypatch.setattr(describer, "_builtin_skill_ids", lambda: set())
+
+    patch_ctx, captured = _capture_user_msg()
+    with patch_ctx, patch(
+        "agent.auxiliary_client.get_auxiliary_extra_body", return_value={}
+    ):
+        outcome = describer.describe_profile("myprof", include_soul=True)
+    assert outcome.ok
+    user_text = captured[0][1]["content"]
+    # No SOUL block should appear.
+    assert "SOUL.md" not in user_text
+
+
+def test_describer_caps_skill_list_and_keeps_user_skills(profile_env, monkeypatch):
+    """When skill count exceeds MAX_SKILLS_FOR_PROMPT, user skills must all survive."""
+    monkeypatch.setattr(profiles_mod, "profile_exists", lambda n: n == "myprof")
+    monkeypatch.setattr(profiles_mod, "normalize_profile_name", lambda n: n)
+    monkeypatch.setattr(profiles_mod, "get_profile_dir", lambda n: profile_env)
+
+    # Set up a small built-in catalogue containing 80 skills, plus 5 user skills.
+    builtin_ids = {f"category/builtin-{i:02d}" for i in range(80)}
+    monkeypatch.setattr(describer, "_builtin_skill_ids", lambda: builtin_ids)
+    # Lower the cap so the test stays compact.
+    monkeypatch.setattr(describer, "MAX_SKILLS_FOR_PROMPT", 20)
+
+    skills_root = profile_env / "skills" / "category"
+    skills_root.mkdir(parents=True)
+    for i in range(80):
+        sd = skills_root / f"builtin-{i:02d}"
+        sd.mkdir()
+        (sd / "SKILL.md").write_text("---\nname: x\n---\n")
+    for i in range(5):
+        sd = skills_root / f"user-{i:02d}"
+        sd.mkdir()
+        (sd / "SKILL.md").write_text("---\nname: x\n---\n")
+
+    patch_ctx, captured = _capture_user_msg()
+    with patch_ctx, patch(
+        "agent.auxiliary_client.get_auxiliary_extra_body", return_value={}
+    ):
+        outcome = describer.describe_profile("myprof", tag_builtins=True)
+    assert outcome.ok
+    user_text = captured[0][1]["content"]
+    # All 5 user skills must appear despite the cap.
+    for i in range(5):
+        assert f"[user] category/user-{i:02d}" in user_text
+    # Some built-ins should appear (sampled), but not all 80.
+    builtin_count = user_text.count("[built-in]")
+    assert builtin_count <= 20
+    assert builtin_count > 0


### PR DESCRIPTION
The describer was producing generic, "versatile generalist" output that gave the kanban orchestrator nothing useful to route. Built-in skills crowd out user-added ones, AGENTS.md is never read, and skills appear as bare IDs that the model has to guess at.

Four opt-in flags, all default off:

--tag-skills labels each skill as [user] or [built-in] and tells the model to weight user skills as the lane signal.
--include-soul reads SOUL.md as a role-identity input.
--include-agents reads AGENTS.md, which is the docs-canonical place for project role information.
--with-skill-descriptions includes each skill's frontmatter description instead of just the ID.

Plus --reject-boilerplate, which scans the first response for filler phrases and retries once with the matched phrase explicitly forbidden. It defaults to on whenever any of the four flags above is set, off otherwise.

Vanilla Hermes profile describes --auto behaviour is unchanged.

Two examples from a 17-agent fleet, base vs all flags on:

Delivery Engineer Agent

Before:
A versatile developer and creative agent capable of full-stack software engineering, codebase inspection, and technical research. It handles everything from Flutter and Python development to visual design, music generation, and complex document processing.

After:
Build an orchestrator and delivery engineer who validates task cards, manages git worktrees, and dispatches subagents to execute code implementations and open PRs.

CI and Tests Agent

Before:
Expert in full-stack software development, codebase inspection, and debugging. Handles GitHub repository management, CI/CD infrastructure, and advanced testing methodologies like TDD and subagent-driven development.

After:
CI/CD and Test Architect. Manages GitHub Actions, test infrastructure, and the type layer to ensure code builds and passes quality gates before review.