### PR TITLE
fix(security): redact AWS STS temporary access key IDs in logs

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -83,6 +83,7 @@ _PREFIX_PATTERNS = [
     r"bb_live_[A-Za-z0-9_-]{10,}",      # BrowserBase
     r"gAAAA[A-Za-z0-9_=-]{20,}",        # Codex encrypted tokens
     r"AKIA[A-Z0-9]{16}",                # AWS Access Key ID
+    r"ASIA[A-Z0-9]{16}",                # AWS STS temporary access key ID (EC2/ECS/Lambda role creds)
     r"sk_live_[A-Za-z0-9]{10,}",        # Stripe secret key (live)
     r"sk_test_[A-Za-z0-9]{10,}",        # Stripe secret key (test)
     r"rk_live_[A-Za-z0-9]{10,}",        # Stripe restricted key

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -537,3 +537,43 @@ class TestXaiToken:
     def test_prefix_visible_in_masked_output(self):
         result = redact_sensitive_text(self.KEY, force=True)
         assert result.startswith("xai-AB")
+
+
+class TestAwsStsAccessKey:
+    # AWS documents ASIA as the prefix for temporary (STS) access key IDs,
+    # parallel to AKIA for long-term IAM user keys (same 4-letter prefix
+    # + 16 base32 chars shape). Anything running on EC2/ECS/Lambda with
+    # an IAM role receives ASIA-prefixed credentials, so the leak surface
+    # is identical to AKIA which has been redacted since the initial
+    # _PREFIX_PATTERNS landed.
+    # Ref: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html
+    KEY = "ASIAIOSFODNN7EXAMPLE"  # AWS-docs-shaped: 4-letter prefix + 16 base32
+
+    def test_bare_token_masked(self):
+        result = redact_sensitive_text(f"using key {self.KEY} from STS", force=True)
+        assert self.KEY not in result
+        assert "ASIAIO" in result
+
+    def test_env_assignment_masked(self):
+        result = redact_sensitive_text(
+            f"AWS_ACCESS_KEY_ID={self.KEY}", force=True
+        )
+        assert self.KEY not in result
+
+    def test_too_short_not_masked(self):
+        # ASIA followed by < 16 chars is not a valid access key ID and
+        # must not match — partial IDs aren't credentials.
+        short = "ASIAIOSFODNN"
+        result = redact_sensitive_text(f"text {short} here", force=True)
+        assert short in result
+
+    def test_word_starting_with_asia_not_masked(self):
+        # Plain prose like "Asia Pacific" must not trigger redaction —
+        # the pattern requires uppercase ASIA followed by exactly 16
+        # uppercase alphanumerics with no intervening character.
+        result = redact_sensitive_text("Servers in Asia Pacific region", force=True)
+        assert result == "Servers in Asia Pacific region"
+
+    def test_prefix_visible_in_masked_output(self):
+        result = redact_sensitive_text(self.KEY, force=True)
+        assert result.startswith("ASIAIO")


### PR DESCRIPTION
## What does this PR do?

Adds `ASIA[A-Z0-9]{16}` to `_PREFIX_PATTERNS` in `agent/redact.py` so AWS STS
temporary access key IDs are masked in logs and tool output the same way
long-term `AKIA`-prefixed IAM access key IDs already are.

AWS documents `ASIA` as the prefix for "Temporary (AWS STS) access key IDs"
in the IAM identifiers reference, parallel to `AKIA` for long-term IAM user
keys — same 4-letter prefix + 16 base32 chars shape. Every Hermes deployment
on EC2 / ECS / Lambda with an IAM role receives `ASIA`-prefixed credentials,
so the leak surface is identical to `AKIA` (which has been redacted since the
initial `_PREFIX_PATTERNS` landed) but a raw token in a stack trace, tool
result, or debug print had no protection.

Verified before fix:

```
redact_sensitive_text("using key ASIAIOSFODNN7EXAMPLE from STS", force=True)
# "using key ASIAIOSFODNN7EXAMPLE from STS"   <- exposed
```

After fix:

```
# "using key ASIAIO...MPLE from STS"          <- masked
```

Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html

## Related Issue

N/A — direct follow-up to the same redaction-coverage pattern as
`fix(security): redact xAI (Grok) API keys in logs` and
`fix(security): extend secret redaction to ElevenLabs, Tavily and Exa API keys` (#3920).

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/redact.py` — added one entry to `_PREFIX_PATTERNS`: `ASIA[A-Z0-9]{16}` with a comment noting it covers EC2 / ECS / Lambda role credentials.
- `tests/agent/test_redact.py` — added `TestAwsStsAccessKey` mirroring `TestXaiToken`: bare-token masked, env assignment masked, too-short ID not matched, "Asia Pacific" prose not matched (false-positive guard), prefix visible in masked output.

## How to Test

1. `scripts/run_tests.sh tests/agent/test_redact.py -q` — passes locally (85/85).
2. Manually verify:
   ```python
   from agent.redact import redact_sensitive_text
   redact_sensitive_text("ASIAIOSFODNN7EXAMPLE", force=True)
   # → "ASIAIO...MPLE"
   redact_sensitive_text("Asia Pacific region", force=True)
   # → "Asia Pacific region"   (no false positive)
   ```


## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(security): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the redact test file and all tests pass
- [x] I've added tests for my changes


### Documentation & Housekeeping

- [x] N/A — no docs / config / arch / schema changes; existing comment style preserved
- [x] N/A — no config keys added
- [x] N/A — no architecture or workflow changes
- [x] No cross-platform impact — pure regex literal added to an already cross-platform module; `scripts/check-windows-footguns.py` clean on the two changed files
- [x] N/A — no tool descriptions or schemas changed