### PR TITLE
fix(linear): guard update-issue --description against accidental description wipes

### DIFF
--- a/skills/productivity/linear/scripts/linear_api.py
+++ b/skills/productivity/linear/scripts/linear_api.py
@@ -243,7 +243,28 @@ def cmd_update_issue(args: argparse.Namespace) -> None:
     inp: dict[str, Any] = {}
     if args.title:
         inp["title"] = args.title
-    if args.description:
+    if args.description is not None:
+        # Safety: refuse to overwrite a description with an error-shaped or trivially-short payload
+        # unless --allow-truncate is set. This catches the classic shell antipattern where stage-1
+        # of a pipeline writes "FATAL: ..." to stdout (instead of stderr) on failure, and stage-2
+        # blindly uses that as the new description, silently replacing the entire issue body with
+        # the error string.
+        if not args.allow_truncate:
+            desc = args.description
+            looks_error = False
+            error_prefixes = ("FATAL", "Error:", "error:", "ERROR:", "Traceback", "Exception")
+            if any(desc.lstrip().startswith(p) for p in error_prefixes):
+                looks_error = True
+            # heuristic: a real description has either markdown, newlines, or substantial length
+            has_structure = ("\n" in desc) or ("#" in desc) or ("*" in desc) or ("- " in desc)
+            if (looks_error or (len(desc) < 200 and not has_structure)):
+                sys.stderr.write(
+                    f"REFUSED: description payload looks suspicious "
+                    f"({len(desc)} chars, error_shape={looks_error}, structured={has_structure}).\n"
+                    f"  preview: {desc[:120]!r}\n"
+                    f"  If this is intentional, pass --allow-truncate to bypass.\n"
+                )
+                sys.exit(2)
         inp["description"] = args.description
     if args.priority is not None:
         inp["priority"] = args.priority
@@ -255,7 +276,32 @@ def cmd_update_issue(args: argparse.Namespace) -> None:
         success issue { identifier title url }
       }
     }"""
-    emit(gql(q, {"id": args.identifier, "input": inp}).get("issueUpdate"))
+    result = gql(q, {"id": args.identifier, "input": inp}).get("issueUpdate")
+
+    # Read-after-write sanity check for description updates: re-fetch the issue and confirm
+    # the description didn't shrink to a degenerate length. Doesn't gate the operation
+    # (mutation already succeeded), but emits a loud warning to stderr if it looks wrong.
+    if "description" in inp and not args.skip_verify:
+        verify_q = """query($id: String!) {
+          issue(id: $id) { description }
+        }"""
+        try:
+            current = (gql(verify_q, {"id": args.identifier}).get("issue") or {}).get("description") or ""
+            sent_len = len(inp["description"])
+            current_len = len(current)
+            # Flag if the persisted description is < 50% of what we sent (and below a soft floor),
+            # which catches both the FATAL-shaped wipe and any future API-side regressions.
+            if current_len < 100 or (sent_len > 0 and current_len < sent_len * 0.5):
+                sys.stderr.write(
+                    f"WARNING: post-write verify shows description may have been truncated.\n"
+                    f"  sent {sent_len} chars, persisted {current_len} chars.\n"
+                    f"  persisted preview: {current[:160]!r}\n"
+                    f"  Inspect the issue in the Linear UI and restore from history if needed.\n"
+                )
+        except Exception as e:
+            sys.stderr.write(f"NOTE: post-write verify failed ({e}); update itself succeeded.\n")
+
+    emit(result)
 
 
 def cmd_update_status(args: argparse.Namespace) -> None:
@@ -402,6 +448,17 @@ def build_parser() -> argparse.ArgumentParser:
     ui.add_argument("--title")
     ui.add_argument("--description")
     ui.add_argument("--priority", type=int, choices=[0, 1, 2, 3, 4])
+    ui.add_argument(
+        "--allow-truncate",
+        action="store_true",
+        help="Bypass the safety check that refuses error-shaped or trivially-short description payloads. "
+             "Only set when you genuinely want to replace the description with a short value.",
+    )
+    ui.add_argument(
+        "--skip-verify",
+        action="store_true",
+        help="Skip the post-write read-after-write sanity check. Default is to verify.",
+    )
     ui.set_defaults(func=cmd_update_issue)
 
     us = sub.add_parser("update-status")

--- a/tests/skills/test_linear_api_update_issue.py
+++ b/tests/skills/test_linear_api_update_issue.py
@@ -1,0 +1,246 @@
+"""Tests for linear_api.py update-issue safety guardrails.
+
+The guardrails added to cmd_update_issue catch the classic shell antipattern
+where a stage-1 script writes an error sentinel to stdout (e.g. "FATAL: ...")
+on failure, the outer shell does not gate on exit code, and the calling
+update-issue --description "$(cat tmp)" silently replaces the issue body with
+the error string. Two guardrails:
+
+  1. Pre-write: refuse FATAL-shaped or trivially-short payloads unless
+     --allow-truncate is set.
+  2. Post-write: re-fetch and emit stderr WARNING if persisted description
+     shrank significantly. Skippable via --skip-verify.
+"""
+
+import importlib.util
+import io
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+API_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "skills/productivity/linear/scripts/linear_api.py"
+)
+
+
+@pytest.fixture
+def api_module(monkeypatch):
+    """Load linear_api.py as a module without invoking its CLI entry point."""
+    monkeypatch.setenv("LINEAR_API_KEY", "test-key-not-used")
+    spec = importlib.util.spec_from_file_location("linear_api_test", API_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_args(api_module, **overrides):
+    """Build a Namespace for cmd_update_issue with sensible defaults."""
+    defaults = dict(
+        identifier="TEST-1",
+        title=None,
+        description=None,
+        priority=None,
+        allow_truncate=False,
+        skip_verify=False,
+    )
+    defaults.update(overrides)
+    return api_module.argparse.Namespace(**defaults)
+
+
+# ── Pre-write guardrail ────────────────────────────────────────────────────
+
+def test_refuses_fatal_prefix(api_module, capsys):
+    """A FATAL-prefixed payload trips the error-shape check."""
+    args = _make_args(api_module, description="FATAL: ordering section not found verbatim")
+    with patch.object(api_module, "gql") as mock_gql:
+        with pytest.raises(SystemExit) as exc:
+            api_module.cmd_update_issue(args)
+    assert exc.value.code == 2
+    captured = capsys.readouterr()
+    assert "REFUSED" in captured.err
+    assert "error_shape=True" in captured.err
+    # Mutation must not have been attempted
+    mock_gql.assert_not_called()
+
+
+def test_refuses_error_traceback(api_module, capsys):
+    """A Traceback-prefixed payload also trips the error-shape check."""
+    args = _make_args(
+        api_module,
+        description="Traceback (most recent call last):\n  File ...",
+    )
+    with patch.object(api_module, "gql") as mock_gql:
+        with pytest.raises(SystemExit) as exc:
+            api_module.cmd_update_issue(args)
+    assert exc.value.code == 2
+    assert "REFUSED" in capsys.readouterr().err
+    mock_gql.assert_not_called()
+
+
+def test_refuses_short_unstructured(api_module, capsys):
+    """A 33-char single-line payload with no markdown structure trips the length+structure check."""
+    args = _make_args(api_module, description="just a single line of normal text")
+    with patch.object(api_module, "gql") as mock_gql:
+        with pytest.raises(SystemExit) as exc:
+            api_module.cmd_update_issue(args)
+    assert exc.value.code == 2
+    captured = capsys.readouterr()
+    assert "REFUSED" in captured.err
+    assert "structured=False" in captured.err
+    mock_gql.assert_not_called()
+
+
+def test_accepts_markdown_description(api_module):
+    """A real markdown body with multiple lines passes the guardrail."""
+    desc = (
+        "## Context\n\n"
+        "This is a real description with **markdown** structure and multiple lines.\n"
+        "It should not be refused by the safety check."
+    )
+    args = _make_args(api_module, description=desc)
+    with patch.object(api_module, "gql") as mock_gql:
+        # First call = mutation; second = read-after-write verify
+        mock_gql.side_effect = [
+            {"issueUpdate": {"success": True, "issue": {"identifier": "TEST-1"}}},
+            {"issue": {"description": desc}},
+        ]
+        api_module.cmd_update_issue(args)
+    assert mock_gql.call_count == 2  # mutation + verify
+
+
+def test_accepts_long_payload_without_markdown(api_module):
+    """A 500-char payload passes even without markdown structure (length floor satisfied)."""
+    desc = "a" * 500
+    args = _make_args(api_module, description=desc)
+    with patch.object(api_module, "gql") as mock_gql:
+        mock_gql.side_effect = [
+            {"issueUpdate": {"success": True, "issue": {"identifier": "TEST-1"}}},
+            {"issue": {"description": desc}},
+        ]
+        api_module.cmd_update_issue(args)
+    assert mock_gql.call_count == 2
+
+
+def test_allow_truncate_bypasses_guardrail(api_module):
+    """--allow-truncate lets a short payload through."""
+    args = _make_args(api_module, description="short", allow_truncate=True)
+    with patch.object(api_module, "gql") as mock_gql:
+        mock_gql.side_effect = [
+            {"issueUpdate": {"success": True, "issue": {"identifier": "TEST-1"}}},
+            {"issue": {"description": "short"}},
+        ]
+        api_module.cmd_update_issue(args)
+    assert mock_gql.call_count == 2  # mutation invoked; verify still runs
+
+
+def test_allow_truncate_bypasses_error_shape(api_module):
+    """--allow-truncate also lets a FATAL-shaped payload through (operator override)."""
+    args = _make_args(
+        api_module,
+        description="FATAL but intentional",
+        allow_truncate=True,
+    )
+    with patch.object(api_module, "gql") as mock_gql:
+        mock_gql.side_effect = [
+            {"issueUpdate": {"success": True, "issue": {"identifier": "TEST-1"}}},
+            {"issue": {"description": "FATAL but intentional"}},
+        ]
+        api_module.cmd_update_issue(args)
+    assert mock_gql.call_count == 2
+
+
+# ── Post-write read-after-write verify ─────────────────────────────────────
+
+def test_post_write_verify_warns_on_truncation(api_module, capsys):
+    """If persisted description is much shorter than sent, emit a stderr WARNING."""
+    desc = "## Section\n\n" + ("real content paragraph " * 50)  # ~1100 chars, markdown
+    args = _make_args(api_module, description=desc)
+    with patch.object(api_module, "gql") as mock_gql:
+        # Mutation returns success; verify returns a degenerate persisted body.
+        mock_gql.side_effect = [
+            {"issueUpdate": {"success": True, "issue": {"identifier": "TEST-1"}}},
+            {"issue": {"description": "got truncated somehow"}},
+        ]
+        api_module.cmd_update_issue(args)
+    captured = capsys.readouterr()
+    assert "WARNING" in captured.err
+    assert "truncated" in captured.err
+    assert "persisted" in captured.err
+
+
+def test_post_write_verify_silent_on_match(api_module, capsys):
+    """When the persisted description matches what was sent, no warning is emitted."""
+    desc = "## Section\n\n" + ("real content paragraph " * 50)
+    args = _make_args(api_module, description=desc)
+    with patch.object(api_module, "gql") as mock_gql:
+        mock_gql.side_effect = [
+            {"issueUpdate": {"success": True, "issue": {"identifier": "TEST-1"}}},
+            {"issue": {"description": desc}},  # full body persisted
+        ]
+        api_module.cmd_update_issue(args)
+    captured = capsys.readouterr()
+    assert "WARNING" not in captured.err
+
+
+def test_skip_verify_bypasses_read_after_write(api_module):
+    """--skip-verify suppresses the post-write re-fetch entirely."""
+    desc = "## Section\n\n" + ("real content paragraph " * 50)
+    args = _make_args(api_module, description=desc, skip_verify=True)
+    with patch.object(api_module, "gql") as mock_gql:
+        mock_gql.return_value = {
+            "issueUpdate": {"success": True, "issue": {"identifier": "TEST-1"}}
+        }
+        api_module.cmd_update_issue(args)
+    # Only the mutation was called; no follow-up query.
+    assert mock_gql.call_count == 1
+
+
+def test_verify_failure_does_not_propagate(api_module, capsys):
+    """If the read-after-write query itself raises, the mutation result still emits."""
+    desc = "## Section\n\n" + ("real content paragraph " * 50)
+    args = _make_args(api_module, description=desc)
+
+    call_count = {"n": 0}
+
+    def fake_gql(*a, **kw):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return {"issueUpdate": {"success": True, "issue": {"identifier": "TEST-1"}}}
+        raise RuntimeError("network blip on verify")
+
+    with patch.object(api_module, "gql", side_effect=fake_gql):
+        api_module.cmd_update_issue(args)
+
+    captured = capsys.readouterr()
+    assert "post-write verify failed" in captured.err
+    # The mutation itself still succeeded, so the operation as a whole is OK.
+
+
+# ── Argparse wiring ────────────────────────────────────────────────────────
+
+def test_argparse_accepts_allow_truncate_and_skip_verify(api_module):
+    """The new flags are wired through build_parser()."""
+    parser = api_module.build_parser()
+    parsed = parser.parse_args([
+        "update-issue", "TEST-1",
+        "--description", "short",
+        "--allow-truncate",
+        "--skip-verify",
+    ])
+    assert parsed.allow_truncate is True
+    assert parsed.skip_verify is True
+
+
+def test_argparse_defaults_are_safe(api_module):
+    """allow_truncate and skip_verify default to False (guardrails on)."""
+    parser = api_module.build_parser()
+    parsed = parser.parse_args([
+        "update-issue", "TEST-1",
+        "--description", "## hi\n\nworld",
+    ])
+    assert parsed.allow_truncate is False
+    assert parsed.skip_verify is False


### PR DESCRIPTION
# fix(linear): guard `update-issue --description` against accidental description wipes

## What

Adds two safety nets to `skills/productivity/linear/scripts/linear_api.py update-issue` so a misshapen `--description` payload no longer silently overwrites a Linear issue's body with an error string or trivial junk:

1. **Pre-write guardrail** - refuses payloads that look like a stage-1 abort sentinel (starts with `FATAL`, `Error:`, `Traceback`, etc.) OR are shorter than 200 chars with no markdown structure (`\n`, `#`, `*`, `- `). Opt out via `--allow-truncate`.
2. **Post-write read-after-write verify** - re-fetches the issue's description after the GraphQL mutation succeeds and emits a `WARNING` to stderr if the persisted length is < 100 chars or < 50% of what was sent. Doesn't gate the operation (already committed), but the warning is loud and actionable. Opt out via `--skip-verify`.

Both checks default ON. Both have explicit opt-out flags for the rare case where you genuinely want to set a short description.

## Why

Real incident: The agent was using this script inside a two-stage shell pipeline to do a find-and-replace on a Linear issue description:

```bash
python3 <<'PY' > /tmp/new-desc.txt
import json
desc = json.load(open('/tmp/issue.json'))['description']
OLD = """..."""
NEW = """..."""
if OLD not in desc:
    print("FATAL: ordering section not found verbatim")   # ← stdout!
    raise SystemExit(1)
print(desc.replace(OLD, NEW), end='')
PY

linear_api.py update-issue ABC-NNN --description "$(cat /tmp/new-desc.txt)"
```

Three things converged into a silent data wipe:

1. The Python heredoc printed its abort sentinel to **stdout** (`print(...)`) instead of stderr - so the redirect captured the error message *as the payload*.
2. The outer shell didn't gate on stage-1's exit code (`;` between commands, not `&&`, no `set -e`) - so the `SystemExit(1)` was ignored.
3. `linear_api.py update-issue --description` is a full-overwrite primitive with no length floor or shape check - so the 43-character error string replaced the entire issue body.

The script returned `{"success": true}` because the GraphQL mutation itself returned 200 - "success" meant HTTP success, not content correctness. The corruption was discovered days later when reviewers noticed the issue description had become a single line of error text.

Two issues in an internal workspace were affected. Both were recovered manually via Linear's edit history. No data permanently lost, but the failure was completely silent at the script layer and would happen again to anyone scripting Linear updates this way.

## What changes

| Before | After |
|---|---|
| `update-issue X --description "FATAL: ..."` → silently replaces body, returns `success: true` | `update-issue X --description "FATAL: ..."` → refused with explanatory stderr message, exit 2 |
| `update-issue X --description "short text"` → silently replaces multi-thousand-char body with `"short text"` | Same payload → refused unless `--allow-truncate` |
| Successful mutation returns immediately | Successful mutation triggers a read-after-write check; emits `WARNING` to stderr if persisted body looks truncated |

Existing well-formed callers (markdown bodies, multi-paragraph descriptions) are unaffected. CI behavior is unchanged.

## Test plan

`tests/skills/test_linear_api_update_issue.py` (new):

Pre-write guardrail:
- `test_refuses_fatal_prefix` - `FATAL: ...` payload → exit 2, no API call
- `test_refuses_error_traceback` - `Traceback ...` payload → exit 2, no API call
- `test_refuses_short_unstructured` - 33-char single line → exit 2
- `test_accepts_markdown_description` - real markdown body → passes
- `test_accepts_long_payload_without_markdown` - 500-char single line → passes (length floor satisfied)
- `test_allow_truncate_bypasses_guardrail` - `--allow-truncate "short"` → mutation invoked
- `test_allow_truncate_bypasses_error_shape` - `--allow-truncate "FATAL..."` → mutation invoked

Read-after-write verify:
- `test_post_write_verify_warns_on_truncation` - mocked verify returns 21-char body for 1100-char sent → stderr contains `WARNING`
- `test_post_write_verify_silent_on_match` - mocked verify returns full body → no warning emitted
- `test_skip_verify_bypasses_read_after_write` - `--skip-verify` → no follow-up query made
- `test_verify_failure_does_not_propagate` - verify raises → noted to stderr but mutation result still emits

Argparse wiring:
- `test_argparse_accepts_allow_truncate_and_skip_verify` - new flags parse correctly
- `test_argparse_defaults_are_safe` - both flags default to False (guardrails on)

Pattern follows `tests/skills/test_google_workspace_api.py` (importlib-loaded module, mocked `gql`).

`scripts/run_tests.sh tests/skills/test_linear_api_update_issue.py` → **13 passed in 1.25s** on the canonical runner.

## Backward compatibility

- Pre-existing well-formed `update-issue --description` calls: no behavior change.
- Pre-existing CI/automation that updated descriptions with short content: would now exit 2. **Migration path: add `--allow-truncate`.** This is a deliberate breaking change for the failure mode the PR is fixing.
- The read-after-write verify adds one extra GraphQL query per `update-issue` call that includes `--description`. Skippable via `--skip-verify` for bandwidth-sensitive use cases.

## Why this shape (and not alternatives)

- **Length floor at 200 + markdown structure heuristic** vs `--require-confirmation`: a confirmation flag is annoying for the common case where you legitimately want to replace the body with a long markdown payload. The heuristic catches the realistic failure mode (error strings, accidentally-empty buffers) without imposing friction on real edits.
- **Refuse vs warn**: the failure mode is silent data loss. A warning that the user can ignore is exactly what got us into the original incident. Hard-refuse with an explicit opt-out is the right shape for "almost certainly a bug" payloads.
- **Read-after-write as warning, not gate**: by the time the mutation returns success, the corruption is already persisted. The verify can't undo it, but it ensures the operator sees the problem in the same session - critical for catching the failure before context is lost.
- **In-script guardrail vs SKILL.md doc note**: a doc note would have prevented the original incident only if I'd re-read the docs each time. The script is the actual API surface; the guardrail belongs there.

## Files touched

- `skills/productivity/linear/scripts/linear_api.py` (+58 lines, -2): guardrail block in `cmd_update_issue`, read-after-write verify after the mutation, two new argparse flags (`--allow-truncate`, `--skip-verify`).
- `tests/skills/test_linear_api_update_issue.py` (new, 237 lines): 13 test cases per the test plan above.

Stretch: `skills/productivity/linear/SKILL.md` could pick up a "Safe-edit pattern" snippet showing the recommended `set -euo pipefail` + stderr-only sentinels + `&&` chaining pattern. Happy to include in this PR or as a follow-up.

## Author note

Cherry-picked from a local patch the operator has been running against this fork after the incident. Tested live against a real Linear workspace - the guardrail refused the synthetic FATAL payload as expected, and the read-after-write check correctly flagged a simulated truncation. No regression observed for well-formed `update-issue` calls (the patched version has been used to do legitimate multi-paragraph edits without incident).