### PR TITLE
fix(browser): preserve no-install discovery with legacy stubs

### DIFF
--- a/tests/tools/test_browser_homebrew_paths.py
+++ b/tests/tools/test_browser_homebrew_paths.py
@@ -212,7 +212,10 @@ class TestBrowserRequirements:
     def test_cdp_override_does_not_require_agent_browser_cli(self, monkeypatch):
         monkeypatch.setenv("BROWSER_CDP_URL", "ws://127.0.0.1:9222/devtools/browser/test")
         monkeypatch.setattr("tools.browser_tool._is_camofox_mode", lambda: False)
-        monkeypatch.setattr("tools.browser_tool._find_agent_browser", lambda: (_ for _ in ()).throw(FileNotFoundError("not found")))
+        monkeypatch.setattr(
+            "tools.browser_tool._find_agent_browser",
+            lambda *args, **kwargs: (_ for _ in ()).throw(FileNotFoundError("not found")),
+        )
 
         assert check_browser_requirements() is True
 
@@ -221,7 +224,22 @@ class TestBrowserRequirements:
         monkeypatch.setenv("PREFIX", "/data/data/com.termux/files/usr")
         monkeypatch.setattr("tools.browser_tool._is_camofox_mode", lambda: False)
         monkeypatch.setattr("tools.browser_tool._get_cloud_provider", lambda: None)
-        monkeypatch.setattr("tools.browser_tool._find_agent_browser", lambda: "npx agent-browser")
+        monkeypatch.setattr(
+            "tools.browser_tool._find_agent_browser",
+            lambda *args, **kwargs: "npx agent-browser",
+        )
+
+        assert check_browser_requirements() is False
+
+    def test_browser_requirements_does_not_auto_install(self, monkeypatch):
+        monkeypatch.setattr("tools.browser_tool._is_camofox_mode", lambda: False)
+        monkeypatch.setattr("tools.browser_tool._get_cdp_override", lambda: None)
+        monkeypatch.setattr(
+            "tools.browser_tool._find_agent_browser",
+            lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("unexpected auto-install lookup"))
+            if kwargs.get("auto_install") is not False
+            else (_ for _ in ()).throw(FileNotFoundError("not found")),
+        )
 
         assert check_browser_requirements() is False
 
@@ -230,7 +248,10 @@ class TestRunBrowserCommandTermuxFallback:
     def test_termux_local_mode_rejects_bare_npx_fallback(self, monkeypatch):
         monkeypatch.setenv("TERMUX_VERSION", "0.118.3")
         monkeypatch.setenv("PREFIX", "/data/data/com.termux/files/usr")
-        monkeypatch.setattr("tools.browser_tool._find_agent_browser", lambda: "npx agent-browser")
+        monkeypatch.setattr(
+            "tools.browser_tool._find_agent_browser",
+            lambda *args, **kwargs: "npx agent-browser",
+        )
         monkeypatch.setattr("tools.browser_tool._get_cloud_provider", lambda: None)
 
         result = _run_browser_command("task-1", "navigate", ["https://example.com"])

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1632,12 +1632,17 @@ def _get_session_info(task_id: Optional[str] = None) -> Dict[str, str]:
 
 
 
-def _find_agent_browser() -> str:
+def _find_agent_browser(*, auto_install: bool = True) -> str:
     """
     Find the agent-browser CLI executable.
 
     Checks in order: current PATH, Homebrew/common bin dirs, Hermes-managed
     node, local node_modules/.bin/, npx fallback.
+
+    Args:
+        auto_install: When True, try Hermes' dependency bootstrap before
+            failing. Availability checks should pass False so tool discovery
+            never blocks on dependency installation.
 
     Returns:
         Path to agent-browser executable
@@ -1704,21 +1709,22 @@ def _find_agent_browser() -> str:
         return _cached_agent_browser
 
     # Nothing found — try lazy installation before giving up.
-    try:
-        from hermes_cli.dep_ensure import ensure_dependency
-        if ensure_dependency("browser"):
-            recheck = shutil.which("agent-browser")
-            if not recheck and extended_path:
-                recheck = shutil.which("agent-browser", path=extended_path)
-            if not recheck:
-                hermes_nm = str(get_hermes_home() / "node_modules" / ".bin")
-                recheck = shutil.which("agent-browser", path=hermes_nm)
-            if recheck:
-                _cached_agent_browser = recheck
-                _agent_browser_resolved = True
-                return recheck
-    except Exception:
-        pass
+    if auto_install:
+        try:
+            from hermes_cli.dep_ensure import ensure_dependency
+            if ensure_dependency("browser"):
+                recheck = shutil.which("agent-browser")
+                if not recheck and extended_path:
+                    recheck = shutil.which("agent-browser", path=extended_path)
+                if not recheck:
+                    hermes_nm = str(get_hermes_home() / "node_modules" / ".bin")
+                    recheck = shutil.which("agent-browser", path=hermes_nm)
+                if recheck:
+                    _cached_agent_browser = recheck
+                    _agent_browser_resolved = True
+                    return recheck
+        except Exception:
+            pass
 
     _agent_browser_resolved = True
     raise FileNotFoundError(
@@ -3497,7 +3503,7 @@ def check_browser_requirements() -> bool:
 
     # The agent-browser CLI is required for local launch and cloud-provider flows.
     try:
-        browser_cmd = _find_agent_browser()
+        browser_cmd = _find_agent_browser(auto_install=False)
     except FileNotFoundError:
         return False
 

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -3502,8 +3502,14 @@ def check_browser_requirements() -> bool:
         return True
 
     # The agent-browser CLI is required for local launch and cloud-provider flows.
+    # Prefer the non-installing lookup so availability checks never block on
+    # dependency bootstrap. Fall back to the legacy no-arg call shape for tests
+    # or extensions that monkeypatch _find_agent_browser with an older stub.
     try:
-        browser_cmd = _find_agent_browser(auto_install=False)
+        try:
+            browser_cmd = _find_agent_browser(auto_install=False)
+        except TypeError:
+            browser_cmd = _find_agent_browser()
     except FileNotFoundError:
         return False
 


### PR DESCRIPTION
## Summary
- salvages the browser discovery no-auto-install fix for tool availability checks
- preserves the intended `auto_install=False` behavior in `check_browser_requirements()`
- adds compatibility with existing zero-arg monkeypatched `_find_agent_browser` stubs so the broader browser suite stays green

## Why this replacement exists
Upstream #28027 has the right product direction, but the new kwarg call shape regresses existing browser tests that monkeypatch `_find_agent_browser` with no-arg lambdas. That means the branch is not merge-ready as submitted.

This replacement keeps the non-installing discovery behavior while falling back to the legacy no-arg call shape only when `_find_agent_browser` has been monkeypatched with an older stub.

## Validation
- `python3 -m pytest -q -o addopts='' tests/tools -k 'browser'`
  - result: `344 passed, 20 skipped`

## Issue
Fixes #28027
Supersedes #28027
