### PR TITLE
fix(gateway): pre-mark sessions as resume_pending before drain to pre…

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5246,6 +5246,24 @@ class GatewayRunner:
             )
 
             timeout = self._restart_drain_timeout
+
+            # Pre-mark sessions as resume_pending BEFORE the drain wait.
+            # If the process is killed by the service manager during the
+            # drain, the durable marker is already written so the next
+            # gateway boot can recover in-flight sessions (#27856).
+            _pre_drain_keys: list[str] = []
+            for _sk, _agent in list(self._running_agents.items()):
+                if _agent is _AGENT_PENDING_SENTINEL:
+                    continue
+                try:
+                    self.session_store.mark_resume_pending(
+                        _sk,
+                        "restart_timeout" if self._restart_requested else "shutdown_timeout",
+                    )
+                    _pre_drain_keys.append(_sk)
+                except Exception as _e:
+                    logger.debug("pre-drain mark_resume_pending failed for %s: %s", _sk, _e)
+
             _drain_started_at = time.monotonic()
             active_agents, timed_out = await self._drain_active_agents(timeout)
             logger.info(
@@ -5257,6 +5275,21 @@ class GatewayRunner:
                 len(active_agents),
                 self._running_agent_count(),
             )
+
+            if not timed_out:
+                # Drain completed gracefully — all running sessions finished.
+                # Clear the pre-drain resume_pending markers so sessions that
+                # completed during the drain window don't carry a stale flag.
+                for _sk in _pre_drain_keys:
+                    if _sk not in self._running_agents:
+                        try:
+                            self.session_store.clear_resume_pending(_sk)
+                        except Exception as _e:
+                            logger.debug(
+                                "clear_resume_pending after drain failed for %s: %s",
+                                _sk, _e,
+                            )
+
             if timed_out:
                 logger.warning(
                     "Gateway drain timed out after %.1fs with %d active agent(s); interrupting remaining work.",


### PR DESCRIPTION
What does this PR do?

Pre-mark all running agent sessions as resume_pending before the drain wait begins in the gateway shutdown/restart flow. If the service manager kills the process during the drain window, the durable marker is already persisted, so the next gateway boot can recover in-flight sessions via auto-resume. On graceful drain completion (no timeout), the early markers are cleared for sessions that finished successfully.

Related Issue
Fixes #27856

Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

Changes Made
- gateway/run.py (_stop_impl): Snapshot running sessions and call SessionStore.mark_resume_pending() for each before _drain_active_agents(). After a graceful drain, call SessionStore.clear_resume_pending() for sessions that completed during the window. The existing timeout path remains unchanged (pre-mark is already written and the post-timeout mark_resume_pending loop is idempotent).

How to Test
1. Start the gateway with a long-running agent session active
2. Send a restart signal (/restart or SIGTERM → exit code 75)
3. Verify that the new pre-drain mark_resume_pending log line fires for the active session
4. On restart, verify that the interrupted session auto-resumes (the resume_pending marker was persisted before the drain wait)
5. Repeat with graceful (timeout=0) drain and verify clear_resume_pending fires for finished sessions

Checklist
Code
- [x] I've read the Contributing Guide (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits (https://www.conventionalcommits.org/) (fix(gateway): ...)
- [x] I searched for existing PRs (https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run scripts/run_tests.sh tests/gateway/ -q and all tests pass
- [ ] I've added tests for my changes (required for bug fixes)
- [ ] I've tested on my platform: Windows 11

Documentation & Housekeeping
- [x] I've updated relevant documentation — N/A (logic change with no new public API)
- [x] I've updated cli-config.yaml.example — N/A
- [ ] I've considered cross-platform impact (Windows, macOS) — logic is platform-agn