### PR TITLE
fix: add default base_url_override for ollama-cloud provider

### DIFF
--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -198,6 +198,7 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
     ),
     "ollama-cloud": HermesOverlay(
         transport="openai_chat",
+        base_url_override="https://ollama.com/v1",
         base_url_env_var="OLLAMA_BASE_URL",
     ),
     # Azure Foundry: supports both OpenAI-style and Anthropic-style endpoints.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -57,6 +57,7 @@ AUTHOR_MAP = {
     "0x.badfriend@gmail.com": "discodirector",
     "altriatree@gmail.com": "TruaShamu",
     "m@mobrienv.dev": "mikeyobrien",
+    "saeed919@pm.me": "falasi",
     "qiyin.zuo@pcitc.com": "qiyin-code",
     "mr.aashiz@gmail.com": "aashizpoudel",
     "70629228+shaun0927@users.noreply.github.com": "shaun0927",


### PR DESCRIPTION
Salvages #20108 by @falasi onto current main.

## Summary
ollama-cloud overlay was missing `base_url_override`, so `resolve_provider_info()` fell through to whatever models.dev returns (the wrong `ollama.com/api` endpoint), and the setup wizard cached that into auth.json. Every other ollama-cloud code path in the repo (plugin, models.py default, auth.py DEFAULT_OLLAMA_CLOUD_BASE_URL, model_switch.py, tests) already uses the OpenAI-compatible `https://ollama.com/v1`. This adds that override to the overlay too.

Fixes #12703.

## Changes
- `hermes_cli/providers.py`: add `base_url_override="https://ollama.com/v1"` to the ollama-cloud HermesOverlay (contributor commit, authorship preserved)
- `scripts/release.py`: add AUTHOR_MAP entry for falasi so contributor-check passes