### PR TITLE
fix(whatsapp): restart bridge when WHATSAPP_MODE does not match /health

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -576,6 +576,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
             
             # Check if bridge is already running and connected
             import aiohttp
+            whatsapp_mode = os.getenv("WHATSAPP_MODE", "self-chat")
             try:
                 async with aiohttp.ClientSession() as session:
                     async with session.get(
@@ -585,13 +586,30 @@ class WhatsAppAdapter(BasePlatformAdapter):
                         if resp.status == 200:
                             data = await resp.json()
                             bridge_status = data.get("status", "unknown")
+                            bridge_mode = data.get("mode")
                             if bridge_status == "connected":
-                                print(f"[{self.name}] Using existing bridge (status: {bridge_status})")
-                                self._mark_connected()
-                                self._bridge_process = None  # Not managed by us
-                                self._http_session = aiohttp.ClientSession()
-                                self._poll_task = asyncio.create_task(self._poll_messages())
-                                return True
+                                # Legacy bridges omit ``mode`` from /health; if the
+                                # operator switched to bot mode, recycle rather than
+                                # silently reuse a self-chat process (uptime 30h+).
+                                mode_mismatch = (
+                                    bridge_mode is not None
+                                    and bridge_mode != whatsapp_mode
+                                ) or (
+                                    bridge_mode is None
+                                    and whatsapp_mode != "self-chat"
+                                )
+                                if mode_mismatch:
+                                    print(
+                                        f"[{self.name}] Existing bridge mode={bridge_mode!r} "
+                                        f"but WHATSAPP_MODE={whatsapp_mode!r} — restarting bridge"
+                                    )
+                                else:
+                                    print(f"[{self.name}] Using existing bridge (status: {bridge_status}, mode: {bridge_mode or whatsapp_mode})")
+                                    self._mark_connected()
+                                    self._bridge_process = None  # Not managed by us
+                                    self._http_session = aiohttp.ClientSession()
+                                    self._poll_task = asyncio.create_task(self._poll_messages())
+                                    return True
                             else:
                                 print(f"[{self.name}] Bridge found but not connected (status: {bridge_status}), restarting")
             except Exception:
@@ -605,7 +623,6 @@ class WhatsAppAdapter(BasePlatformAdapter):
             # Start the bridge process in its own process group.
             # Route output to a log file so QR codes, errors, and reconnection
             # messages are preserved for troubleshooting.
-            whatsapp_mode = os.getenv("WHATSAPP_MODE", "self-chat")
             self._bridge_log = self._session_path.parent / "bridge.log"
             bridge_log_fh = open(self._bridge_log, "a", encoding="utf-8")
             self._bridge_log_fh = bridge_log_fh

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -698,6 +698,7 @@ app.get('/chat/:id', async (req, res) => {
 app.get('/health', (req, res) => {
   res.json({
     status: connectionState,
+    mode: WHATSAPP_MODE,
     queueLength: messageQueue.length,
     uptime: process.uptime(),
   });

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -701,3 +701,116 @@ class TestNoCredsPreflight:
         # but the fatal-error code is NOT the "not paired" one.
         assert result is False
         assert adapter._fatal_error_code != "whatsapp_not_paired"
+
+
+# ---------------------------------------------------------------------------
+# Bridge mode reuse (WHATSAPP_MODE vs /health mode)
+# ---------------------------------------------------------------------------
+
+class TestBridgeModeReuse:
+    """Gateway must not reuse a bridge running the wrong WHATSAPP_MODE."""
+
+    @pytest.mark.asyncio
+    async def test_reuses_bridge_when_health_mode_matches(self, monkeypatch):
+        monkeypatch.setenv("WHATSAPP_MODE", "bot")
+        adapter = _make_adapter()
+        adapter._acquire_platform_lock = MagicMock(return_value=True)
+
+        mock_client_cls = _mock_aiohttp(
+            status=200,
+            json_data={"status": "connected", "mode": "bot"},
+        )
+
+        with patch("gateway.platforms.whatsapp.check_whatsapp_requirements", return_value=True), \
+             patch.object(Path, "exists", return_value=True), \
+             patch.object(Path, "mkdir", return_value=None), \
+             patch("subprocess.Popen") as mock_popen, \
+             patch("aiohttp.ClientSession", mock_client_cls), \
+             patch.object(type(adapter), "_poll_messages", return_value=MagicMock()):
+            result = await adapter.connect()
+
+        assert result is True
+        mock_popen.assert_not_called()
+        assert adapter._bridge_process is None
+
+    @pytest.mark.asyncio
+    async def test_restarts_bridge_when_health_mode_mismatches(self, monkeypatch):
+        monkeypatch.setenv("WHATSAPP_MODE", "bot")
+        adapter = _make_adapter()
+        adapter._acquire_platform_lock = MagicMock(return_value=True)
+
+        health_responses = [
+            {"status": "connected", "mode": "self-chat"},
+            {"status": "connected", "mode": "bot"},
+        ]
+        call_count = {"n": 0}
+
+        async def _json():
+            idx = min(call_count["n"], len(health_responses) - 1)
+            call_count["n"] += 1
+            return health_responses[idx]
+
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.json = _json
+        mock_session = MagicMock()
+        mock_session.get = MagicMock(return_value=_AsyncCM(mock_resp))
+        mock_client_cls = MagicMock(return_value=_AsyncCM(mock_session))
+
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None
+        mock_fh = MagicMock()
+        patches = _connect_patches(mock_proc, mock_fh, mock_client_cls)
+
+        with patches[0], patches[1], patches[2], patches[3], \
+             patch("subprocess.Popen", return_value=mock_proc) as mock_popen, \
+             patches[5], patches[6], patches[7], patches[8], \
+             patch("gateway.platforms.whatsapp._kill_port_process"), \
+             patch("gateway.platforms.whatsapp._kill_stale_bridge_by_pidfile"), \
+             patch.object(type(adapter), "_poll_messages", return_value=MagicMock()):
+            result = await adapter.connect()
+
+        assert result is True
+        assert call_count["n"] >= 2
+        mock_popen.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_restarts_legacy_bridge_without_mode_when_bot_requested(self, monkeypatch):
+        monkeypatch.setenv("WHATSAPP_MODE", "bot")
+        adapter = _make_adapter()
+        adapter._acquire_platform_lock = MagicMock(return_value=True)
+
+        health_responses = [
+            {"status": "connected"},  # legacy bridge — no mode field
+            {"status": "connected", "mode": "bot"},
+        ]
+        call_count = {"n": 0}
+
+        async def _json():
+            idx = min(call_count["n"], len(health_responses) - 1)
+            call_count["n"] += 1
+            return health_responses[idx]
+
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.json = _json
+        mock_session = MagicMock()
+        mock_session.get = MagicMock(return_value=_AsyncCM(mock_resp))
+        mock_client_cls = MagicMock(return_value=_AsyncCM(mock_session))
+
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None
+        mock_fh = MagicMock()
+        patches = _connect_patches(mock_proc, mock_fh, mock_client_cls)
+
+        with patches[0], patches[1], patches[2], patches[3], \
+             patch("subprocess.Popen", return_value=mock_proc) as mock_popen, \
+             patches[5], patches[6], patches[7], patches[8], \
+             patch("gateway.platforms.whatsapp._kill_port_process"), \
+             patch("gateway.platforms.whatsapp._kill_stale_bridge_by_pidfile"), \
+             patch.object(type(adapter), "_poll_messages", return_value=MagicMock()):
+            result = await adapter.connect()
+
+        assert result is True
+        assert call_count["n"] >= 2
+        mock_popen.assert_called()


### PR DESCRIPTION
## Summary

- Expose `mode` on the WhatsApp bridge `GET /health` response (`bot` or `self-chat`).
- When the gateway finds an existing bridge on port 3000, compare `/health.mode` to `WHATSAPP_MODE` and restart the bridge on mismatch instead of silently reusing it.
- Legacy bridges that omit `mode` are recycled when `WHATSAPP_MODE` is not `self-chat`, so operators switching to bot mode are not stuck on a stale self-chat process.

## Problem

After changing `WHATSAPP_MODE` from `self-chat` to `bot` and restarting the gateway, Hermes often logged `Using existing bridge (status: connected)` and kept a days-old Node process. That process continued to emit `self_chat_mode_rejects_non_self` for group messages, so nothing reached the Python gateway.

## Test plan

- [x] `pytest tests/gateway/test_whatsapp_connect.py::TestBridgeModeReuse -o addopts=`
- [x] Manual: start bridge in self-chat, set `WHATSAPP_MODE=bot`, restart gateway — bridge should restart and `curl :3000/health` should show `"mode":"bot"` with low uptime
- [x] Manual: group @mention delivers a gateway `inbound message` log line