### PR TITLE
fix(gateway): deliver fallback tail when flood-control trips on final send

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -545,6 +545,12 @@ class GatewayStreamConsumer:
                             self._final_response_sent = await self._send_or_edit(
                                 self._accumulated, finalize=True,
                             )
+                            # _send_or_edit may have exhausted flood-control
+                            # strikes and entered fallback mode just now.
+                            # Deliver the unseen tail before returning so the
+                            # user sees the complete response.
+                            if self._fallback_final_send:
+                                await self._send_fallback_final(self._accumulated)
                         elif not self._already_sent:
                             self._final_response_sent = await self._send_or_edit(self._accumulated)
                     return


### PR DESCRIPTION
When the stream consumer reaches `got_done` with a `message_id` set, it
  calls `_send_or_edit(finalize=True)` in the `elif self._message_id` branch.
  If that call exhausts the flood-control strike budget (the third consecutive
  flood error), `_send_or_edit` sets `_fallback_final_send = True` — but we
  had already passed the only `_fallback_final_send` check at the top of the
  if/elif chain, so `_send_fallback_final` was never called and the unseen
  tail of the response was silently dropped.

  ## Root cause

  `383db3592` added the fallback check before `elif self._message_id` but not
  after it. That covered fallback entered mid-stream (flag already True before
  `got_done`), not fallback entered during the final `_send_or_edit` call. The
  test `test_edit_failure_sends_only_unsent_tail_at_finish` was failing from
  the day it was committed.

  ## Fix

  Add a `_fallback_final_send` check immediately after `_send_or_edit` returns
  in the `elif self._message_id` branch. No behavior change on the success
  path — the check only fires when `_send_or_edit` just set the flag to True.

  ## Tests

  `test_edit_failure_sends_only_unsent_tail_at_finish` now passes.
  All 89 tests in `tests/gateway/test_stream_consumer.py` pass with no regressions.