### PR TITLE
fix: sort kanban dashboard cards newest first

### DIFF
--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -137,6 +137,29 @@ BOARD_COLUMNS: list[str] = [
 _CARD_SUMMARY_PREVIEW_CHARS = 200
 
 
+def _sort_cards_newest_first(tasks: list[dict]) -> None:
+    """Sort dashboard cards by creation time without affecting scheduler order.
+
+    ``kanban_db.list_tasks`` intentionally keeps the dispatcher/CLI priority
+    order (priority DESC, created_at ASC).  The dashboard board is a display
+    surface, so it applies its own per-column newest-first ordering here.
+    Python's sort is stable, which keeps the existing relative order for equal
+    timestamps and for legacy rows with no ``created_at``; missing timestamps
+    are grouped at the end.
+    """
+
+    def key(task: dict) -> tuple[int, int]:
+        created_at = task.get("created_at")
+        if created_at is None:
+            return (1, 0)
+        try:
+            return (0, -int(created_at))
+        except (TypeError, ValueError):
+            return (1, 0)
+
+    tasks.sort(key=key)
+
+
 def _task_dict(
     task: kanban_db.Task,
     *,
@@ -435,8 +458,11 @@ def get_board(
             col = t.status if t.status in columns else "todo"
             columns[col].append(d)
 
-        # Stable per-column ordering already applied by list_tasks
-        # (priority DESC, created_at ASC), keep as-is.
+        # Dashboard display order is intentionally separate from
+        # ``kanban_db.list_tasks`` / dispatcher ordering: cards inside each
+        # column are newest-first, with legacy rows missing ``created_at`` last.
+        for column_tasks in columns.values():
+            _sort_cards_newest_first(column_tasks)
 
         # List of known tenants for the UI filter dropdown.
         tenants = [

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -25,8 +25,8 @@ from hermes_cli import kanban_db as kb
 # ---------------------------------------------------------------------------
 
 
-def _load_plugin_router():
-    """Dynamically load plugins/kanban/dashboard/plugin_api.py and return its router."""
+def _load_plugin_module():
+    """Dynamically load plugins/kanban/dashboard/plugin_api.py."""
     repo_root = Path(__file__).resolve().parents[2]
     plugin_file = repo_root / "plugins" / "kanban" / "dashboard" / "plugin_api.py"
     assert plugin_file.exists(), f"plugin file missing: {plugin_file}"
@@ -38,6 +38,12 @@ def _load_plugin_router():
     mod = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = mod
     spec.loader.exec_module(mod)
+    return mod
+
+
+def _load_plugin_router():
+    """Dynamically load plugins/kanban/dashboard/plugin_api.py and return its router."""
+    mod = _load_plugin_module()
     return mod.router
 
 
@@ -111,6 +117,66 @@ def test_create_task_appears_on_board(client):
     assert ready["tasks"][0]["id"] == task_id
     assert "acme" in data["tenants"]
     assert "researcher" in data["assignees"]
+
+
+def test_board_column_orders_cards_newest_first_independent_of_priority(client):
+    """Dashboard board display order is newest-first, not scheduler priority order."""
+
+    oldest_high_priority = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "oldest high priority", "priority": 100},
+    ).json()["task"]
+    middle = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "middle", "priority": 50},
+    ).json()["task"]
+    newest_low_priority = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "newest low priority", "priority": 0},
+    ).json()["task"]
+
+    conn = kb.connect()
+    try:
+        conn.execute(
+            "UPDATE tasks SET created_at = CASE id "
+            "WHEN ? THEN 100 "
+            "WHEN ? THEN 200 "
+            "WHEN ? THEN 300 "
+            "END WHERE id IN (?, ?, ?)",
+            (
+                oldest_high_priority["id"],
+                middle["id"],
+                newest_low_priority["id"],
+                oldest_high_priority["id"],
+                middle["id"],
+                newest_low_priority["id"],
+            ),
+        )
+    finally:
+        conn.close()
+
+    r = client.get("/api/plugins/kanban/board")
+    assert r.status_code == 200
+    ready = next(c for c in r.json()["columns"] if c["name"] == "ready")
+    assert [t["id"] for t in ready["tasks"]] == [
+        newest_low_priority["id"],
+        middle["id"],
+        oldest_high_priority["id"],
+    ]
+
+
+def test_dashboard_card_sort_puts_missing_created_at_at_end_stably():
+    mod = _load_plugin_module()
+    cards = [
+        {"id": "missing-a"},
+        {"id": "newest", "created_at": 30},
+        {"id": "missing-b", "created_at": None},
+        {"id": "oldest", "created_at": 10},
+    ]
+
+    mod._sort_cards_newest_first(cards)
+
+    assert [c["id"] for c in cards] == ["newest", "oldest", "missing-a", "missing-b"]
 
 
 def test_tenant_filter(client):


### PR DESCRIPTION
## Summary
- Sort Kanban dashboard board cards per column by created_at descending (newest first)
- Keep missing/invalid created_at values stable at the end of each column
- Leave hermes_cli.kanban_db.list_tasks and dispatcher/claim ordering unchanged

## Test Plan
- [x] python -m pytest tests/plugins/test_kanban_dashboard_plugin.py::test_board_column_orders_cards_newest_first_independent_of_priority tests/plugins/test_kanban_dashboard_plugin.py::test_dashboard_card_sort_puts_missing_created_at_at_end_stably -q -o 'addopts='
- [x] python -m pytest tests/hermes_cli/test_kanban_db.py::test_list_tasks_assignee_filter_case_insensitive -q -o 'addopts='

Note: full tests/plugins/test_kanban_dashboard_plugin.py currently has an unrelated existing failure in test_diagnostics_endpoint_severity_filter when run locally (diagnostics severity count), not touched by this change.