### PR TITLE
feat(kanban): add proposal approval gate

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -296,6 +296,41 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                                f"(default {kb.DEFAULT_FAILURE_LIMIT}).")
     p_create.add_argument("--json", action="store_true", help="Emit JSON output")
 
+    # --- proposal gate ---
+    p_propose = sub.add_parser(
+        "propose",
+        help="Propose recommended next work that requires approve/deny before dispatch",
+    )
+    p_propose.add_argument("title", help="Recommendation title")
+    p_propose.add_argument("--rationale", required=True,
+                           help="Why this is the right next thing")
+    p_propose.add_argument("--guardrail", action="append", default=[],
+                           help="Direction/safety guardrail (repeatable)")
+    p_propose.add_argument("--assignee", default=None,
+                           help="Profile intended to execute after approval")
+    p_propose.add_argument("--tenant", default=None, help="Tenant namespace")
+    p_propose.add_argument("--priority", type=int, default=0, help="Priority tiebreaker")
+    p_propose.add_argument("--idempotency-key", default=None,
+                           help="Dedup key for repeated recommendations")
+    p_propose.add_argument("--json", action="store_true", help="Emit JSON output")
+
+    p_approve = sub.add_parser(
+        "approve",
+        help="Approve a proposed task and make it eligible for dispatch",
+    )
+    p_approve.add_argument("task_id")
+    p_approve.add_argument("--assignee", default=None,
+                           help="Assign/reassign the execution profile before approval")
+    p_approve.add_argument("--json", action="store_true", help="Emit JSON output")
+
+    p_deny = sub.add_parser(
+        "deny",
+        help="Deny a proposed task and block it with a reason",
+    )
+    p_deny.add_argument("task_id")
+    p_deny.add_argument("reason", nargs="+", help="Reason this proposal is not aligned")
+    p_deny.add_argument("--json", action="store_true", help="Emit JSON output")
+
     # --- list ---
     p_list = sub.add_parser("list", aliases=["ls"], help="List tasks")
     p_list.add_argument("--mine", action="store_true",
@@ -746,6 +781,9 @@ def kanban_command(args: argparse.Namespace) -> int:
     handlers = {
         "init":     _cmd_init,
         "create":   _cmd_create,
+        "propose":  _cmd_propose,
+        "approve":  _cmd_approve,
+        "deny":     _cmd_deny,
         "list":     _cmd_list,
         "ls":       _cmd_list,
         "show":     _cmd_show,
@@ -1084,7 +1122,11 @@ def _cmd_assignees(args: argparse.Namespace) -> int:
 
 
 def _cmd_create(args: argparse.Namespace) -> int:
-    ws_kind, ws_path = _parse_workspace_flag(args.workspace)
+    try:
+        ws_kind, ws_path = _parse_workspace_flag(args.workspace)
+    except argparse.ArgumentTypeError as exc:
+        print(f"kanban: {exc}", file=sys.stderr)
+        return 2
     try:
         max_runtime = _parse_duration(getattr(args, "max_runtime", None))
     except ValueError as exc:
@@ -1133,6 +1175,88 @@ def _cmd_create(args: argparse.Namespace) -> int:
             running, message = _check_dispatcher_presence()
             if not running and message:
                 print(f"\n⚠  {message}", file=sys.stderr)
+    return 0
+
+
+def _proposal_body(title: str, rationale: str, guardrails: list[str]) -> str:
+    guardrail_lines = guardrails or ["Human approval is required before dispatch."]
+    return "\n\n".join([
+        "## Recommendation\n" + title.strip(),
+        "## Rationale\n" + rationale.strip(),
+        "## Guardrails\n" + "\n".join(f"- {g.strip()}" for g in guardrail_lines if g.strip()),
+        "## Approval\nApprove this proposal with `hermes kanban approve <task_id>` "
+        "or deny it with `hermes kanban deny <task_id> <reason>`. The task "
+        "stays in triage until approved, so workers will not dispatch it by accident.",
+    ])
+
+
+def _proposal_response(task: kb.Task, *, decision: Optional[str] = None) -> dict[str, Any]:
+    data = _task_to_dict(task)
+    proposal: dict[str, Any] = {"approval_gate": "approve_or_deny"}
+    if decision:
+        proposal["decision"] = decision
+    data["proposal"] = proposal
+    return data
+
+
+def _cmd_propose(args: argparse.Namespace) -> int:
+    body = _proposal_body(args.title, args.rationale, list(args.guardrail or []))
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title=args.title,
+            body=body,
+            assignee=args.assignee,
+            created_by=_profile_author(),
+            tenant=args.tenant,
+            priority=args.priority,
+            triage=True,
+            idempotency_key=getattr(args, "idempotency_key", None),
+        )
+        task = kb.get_task(conn, task_id)
+    if getattr(args, "json", False):
+        print(json.dumps(_proposal_response(task), indent=2, ensure_ascii=False))
+    else:
+        print(f"Proposed {task.id}  (triage, assignee={task.assignee or '-'})")
+        print(f"Approve: hermes kanban approve {task.id}")
+        print(f"Deny:    hermes kanban deny {task.id} <reason>")
+    return 0
+
+
+def _cmd_approve(args: argparse.Namespace) -> int:
+    with kb.connect() as conn:
+        task = kb.approve_proposal(
+            conn,
+            args.task_id,
+            assignee=getattr(args, "assignee", None),
+            author=_profile_author(),
+        )
+    if not task:
+        print(f"no such task: {args.task_id}", file=sys.stderr)
+        return 1
+    if getattr(args, "json", False):
+        print(json.dumps(_proposal_response(task, decision="approved"), indent=2, ensure_ascii=False))
+    else:
+        print(f"Approved {task.id}  ({task.status}, assignee={task.assignee or '-'})")
+    return 0
+
+
+def _cmd_deny(args: argparse.Namespace) -> int:
+    reason = " ".join(args.reason).strip()
+    with kb.connect() as conn:
+        task = kb.deny_proposal(
+            conn,
+            args.task_id,
+            reason=reason,
+            author=_profile_author(),
+        )
+    if not task:
+        print(f"no such task: {args.task_id}", file=sys.stderr)
+        return 1
+    if getattr(args, "json", False):
+        print(json.dumps(_proposal_response(task, decision="denied"), indent=2, ensure_ascii=False))
+    else:
+        print(f"Denied {task.id}  (blocked): {reason}")
     return 0
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1507,6 +1507,101 @@ def assign_task(conn: sqlite3.Connection, task_id: str, profile: Optional[str]) 
         return True
 
 
+def approve_proposal(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    assignee: Optional[str] = None,
+    author: str = "user",
+) -> Optional[Task]:
+    """Approve a triage proposal and promote it into the executable queue.
+
+    The proposal gate intentionally reuses existing statuses: proposed work
+    sits in ``triage`` so the dispatcher never claims it accidentally. Approval
+    moves it to ``ready`` when dependencies are satisfied, otherwise ``todo``.
+    """
+    assignee = _canonical_assignee(assignee) if assignee is not None else None
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT status, assignee FROM tasks WHERE id = ?", (task_id,),
+        ).fetchone()
+        if not row:
+            return None
+        if row["status"] != "triage":
+            raise ValueError(f"task {task_id} is not awaiting proposal approval")
+        parent_rows = conn.execute(
+            "SELECT t.status FROM tasks t "
+            "JOIN task_links l ON l.parent_id = t.id "
+            "WHERE l.child_id = ?",
+            (task_id,),
+        ).fetchall()
+        new_status = (
+            "ready"
+            if all(p["status"] in {"done", "archived"} for p in parent_rows)
+            else "todo"
+        )
+        final_assignee = assignee if assignee is not None else row["assignee"]
+        conn.execute(
+            "UPDATE tasks SET status = ?, assignee = ? WHERE id = ?",
+            (new_status, final_assignee, task_id),
+        )
+        body = (
+            f"Proposal approved by {author}. "
+            f"Status: {new_status}. Assignee: {final_assignee or '-'}"
+        )
+        conn.execute(
+            "INSERT INTO task_comments (task_id, author, body, created_at) "
+            "VALUES (?, ?, ?, ?)",
+            (task_id, author, body, int(time.time())),
+        )
+        _append_event(
+            conn,
+            task_id,
+            "proposal_approved",
+            {"status": new_status, "assignee": final_assignee, "author": author},
+        )
+    return get_task(conn, task_id)
+
+
+def deny_proposal(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    reason: str,
+    author: str = "user",
+) -> Optional[Task]:
+    """Deny a proposal and park it in ``blocked`` with an audit comment."""
+    if not reason or not reason.strip():
+        raise ValueError("denial reason is required")
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT status FROM tasks WHERE id = ?", (task_id,),
+        ).fetchone()
+        if not row:
+            return None
+        if row["status"] not in {"triage", "todo", "ready"}:
+            raise ValueError(f"task {task_id} cannot be denied from status {row['status']!r}")
+        conn.execute(
+            "UPDATE tasks SET status = 'blocked', claim_lock = NULL, "
+            "claim_expires = NULL, worker_pid = NULL WHERE id = ?",
+            (task_id,),
+        )
+        clean_reason = reason.strip()
+        body = f"Proposal denied by {author}: {clean_reason}"
+        conn.execute(
+            "INSERT INTO task_comments (task_id, author, body, created_at) "
+            "VALUES (?, ?, ?, ?)",
+            (task_id, author, body, int(time.time())),
+        )
+        _append_event(
+            conn,
+            task_id,
+            "proposal_denied",
+            {"reason": clean_reason, "author": author},
+        )
+    return get_task(conn, task_id)
+
+
 # ---------------------------------------------------------------------------
 # Links
 # ---------------------------------------------------------------------------

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -2671,6 +2671,36 @@
       });
     };
 
+    const doApprove = function () {
+      return SDK.fetchJSON(
+        withBoard(`${API}/tasks/${encodeURIComponent(props.taskId)}/approve`, boardSlug),
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ author: "dashboard" }),
+        }
+      ).then(function (res) {
+        load();
+        props.onRefresh();
+        return res;
+      });
+    };
+
+    const doDeny = function (reason) {
+      return SDK.fetchJSON(
+        withBoard(`${API}/tasks/${encodeURIComponent(props.taskId)}/deny`, boardSlug),
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ reason: reason, author: "dashboard" }),
+        }
+      ).then(function (res) {
+        load();
+        props.onRefresh();
+        return res;
+      });
+    };
+
     // POST /tasks/:id/decompose — fan a triage task out into a graph
     // of child tasks routed to specialist profiles by description.
     // Refreshes both the drawer (so the user sees the root flip to
@@ -2781,6 +2811,8 @@
           boardSlug: boardSlug,
           onPatch: doPatch,
           onSpecify: doSpecify,
+          onApprove: doApprove,
+          onDeny: doDeny,
           onDecompose: doDecompose,
           onAddParent: addLink,
           onRemoveParent: removeLink,
@@ -2855,6 +2887,8 @@
         task: t,
         onPatch: props.onPatch,
         onSpecify: props.onSpecify,
+        onApprove: props.onApprove,
+        onDeny: props.onDeny,
         onDecompose: props.onDecompose,
       }),
       h(DiagnosticsSection, {
@@ -3320,6 +3354,8 @@
     const task = props.task;
     const [specifyBusy, setSpecifyBusy] = useState(false);
     const [specifyMsg, setSpecifyMsg] = useState(null);
+    const [decisionBusy, setDecisionBusy] = useState(false);
+    const [decisionMsg, setDecisionMsg] = useState(null);
     const [decomposeBusy, setDecomposeBusy] = useState(false);
     const [decomposeMsg, setDecomposeMsg] = useState(null);
     const b = function (label, patch, enabled, confirmMsg) {
@@ -3365,6 +3401,44 @@
           size: "sm",
         }, specifyBusy ? "Specifying…" : "✨ Specify")
       : null;
+
+    const proposalButtons = (task.status === "triage" && props.onApprove && props.onDeny)
+      ? [
+          h(Button, {
+            key: "approve",
+            onClick: function () {
+              if (decisionBusy) return;
+              setDecisionBusy(true);
+              setDecisionMsg(null);
+              props.onApprove().then(function () {
+                setDecisionMsg({ ok: true, text: "Approved for dispatch" });
+              }).catch(function (err) {
+                setDecisionMsg({ ok: false, text: "Approve failed: " + (err.message || String(err)) });
+              }).then(function () { setDecisionBusy(false); });
+            },
+            disabled: decisionBusy,
+            size: "sm",
+          }, decisionBusy ? "Approving…" : "✓ Approve"),
+          h(Button, {
+            key: "deny",
+            variant: "outline",
+            onClick: function () {
+              if (decisionBusy) return;
+              const reason = window.prompt("Why deny this proposal?");
+              if (!reason || !reason.trim()) return;
+              setDecisionBusy(true);
+              setDecisionMsg(null);
+              props.onDeny(reason.trim()).then(function () {
+                setDecisionMsg({ ok: true, text: "Denied and blocked" });
+              }).catch(function (err) {
+                setDecisionMsg({ ok: false, text: "Deny failed: " + (err.message || String(err)) });
+              }).then(function () { setDecisionBusy(false); });
+            },
+            disabled: decisionBusy,
+            size: "sm",
+          }, "✕ Deny"),
+        ]
+      : [];
 
     // "Decompose" is the orchestrator-driven fan-out. Like Specify, only
     // makes sense on triage-column tasks — elsewhere the backend short-
@@ -3416,6 +3490,7 @@
     return h("div", null,
       h("div", { className: "hermes-kanban-actions" },
         specifyButton,
+        proposalButtons,
         decomposeButton,
         b("→ triage",  { status: "triage" },   task.status !== "triage"),
         b("→ ready",   { status: "ready" },    task.status !== "ready"),
@@ -3438,6 +3513,11 @@
           ? "hermes-kanban-msg-ok"
           : "hermes-kanban-msg-err",
       }, specifyMsg.text) : null,
+      decisionMsg ? h("div", {
+        className: decisionMsg.ok
+          ? "hermes-kanban-msg-ok"
+          : "hermes-kanban-msg-err",
+      }, decisionMsg.text) : null,
       decomposeMsg ? h("div", {
         className: decomposeMsg.ok
           ? "hermes-kanban-msg-ok"

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -584,6 +584,16 @@ class UpdateTaskBody(BaseModel):
     metadata: Optional[dict] = None
 
 
+class ApproveTaskBody(BaseModel):
+    assignee: Optional[str] = None
+    author: Optional[str] = "dashboard"
+
+
+class DenyTaskBody(BaseModel):
+    reason: str
+    author: Optional[str] = "dashboard"
+
+
 @router.patch("/tasks/{task_id}")
 def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Query(None)):
     board = _resolve_board(board)
@@ -746,9 +756,57 @@ def _set_status_direct(
             (task_id, run_id, json.dumps({"status": new_status}), int(time.time())),
         )
     # If we re-opened something, children may have gone stale.
-    if new_status in {"done", "ready"}:
+    if new_status in ("done", "ready"):
         kanban_db.recompute_ready(conn)
     return True
+
+
+@router.post("/tasks/{task_id}/approve")
+def approve_task(task_id: str, payload: ApproveTaskBody, board: Optional[str] = Query(None)):
+    board = _resolve_board(board)
+    conn = _conn(board=board)
+    try:
+        try:
+            task = kanban_db.approve_proposal(
+                conn,
+                task_id,
+                assignee=payload.assignee,
+                author=payload.author or "dashboard",
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=409, detail=str(exc))
+        if task is None:
+            raise HTTPException(status_code=404, detail=f"task {task_id} not found")
+        return {
+            "task": _task_dict(task),
+            "proposal": {"approval_gate": "approve_or_deny", "decision": "approved"},
+        }
+    finally:
+        conn.close()
+
+
+@router.post("/tasks/{task_id}/deny")
+def deny_task(task_id: str, payload: DenyTaskBody, board: Optional[str] = Query(None)):
+    board = _resolve_board(board)
+    conn = _conn(board=board)
+    try:
+        try:
+            task = kanban_db.deny_proposal(
+                conn,
+                task_id,
+                reason=payload.reason,
+                author=payload.author or "dashboard",
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=409, detail=str(exc))
+        if task is None:
+            raise HTTPException(status_code=404, detail=f"task {task_id} not found")
+        return {
+            "task": _task_dict(task),
+            "proposal": {"approval_gate": "approve_or_deny", "decision": "denied"},
+        }
+    finally:
+        conn.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -402,3 +402,60 @@ def test_run_slash_board_override_restores_prior_env(kanban_home, monkeypatch):
     kc.run_slash("--board alpha list")
 
     assert os.environ.get("HERMES_KANBAN_BOARD") == "beta"
+
+
+# ---------------------------------------------------------------------------
+# /kanban proposal approval gate
+# ---------------------------------------------------------------------------
+
+def test_run_slash_propose_creates_triage_recommendation(kanban_home):
+    out = kc.run_slash(
+        "propose 'add safe autopilot' "
+        "--rationale 'keeps the project aligned' "
+        "--guardrail 'no merge without approval' "
+        "--guardrail 'prefer tests first' "
+        "--assignee dori-fixer --json"
+    )
+    payload = json.loads(out)
+
+    assert payload["status"] == "triage"
+    assert payload["assignee"] == "dori-fixer"
+    assert payload["proposal"]["approval_gate"] == "approve_or_deny"
+    assert "Recommendation" in payload["body"]
+    assert "Rationale" in payload["body"]
+    assert "Guardrails" in payload["body"]
+    assert "Approval" in payload["body"]
+
+
+def test_run_slash_approve_promotes_proposal_to_ready(kanban_home):
+    created = json.loads(kc.run_slash(
+        "propose 'ship proposal gate' --rationale 'direction control' --json"
+    ))
+
+    approved = json.loads(kc.run_slash(
+        f"approve {created['id']} --assignee dori-fixer --json"
+    ))
+
+    assert approved["status"] == "ready"
+    assert approved["assignee"] == "dori-fixer"
+    assert approved["proposal"]["decision"] == "approved"
+
+    show = kc.run_slash(f"show {created['id']}")
+    assert "proposal approved" in show.lower()
+
+
+def test_run_slash_deny_blocks_proposal_with_reason(kanban_home):
+    created = json.loads(kc.run_slash(
+        "propose 'chase vanity metric' --rationale 'looks impressive' --json"
+    ))
+
+    denied = json.loads(kc.run_slash(
+        f"deny {created['id']} not aligned with roadmap --json"
+    ))
+
+    assert denied["status"] == "blocked"
+    assert denied["proposal"]["decision"] == "denied"
+
+    show = kc.run_slash(f"show {created['id']}")
+    assert "proposal denied" in show.lower()
+    assert "not aligned with roadmap" in show

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -238,6 +238,41 @@ def test_patch_block_then_unblock(client):
     assert r.json()["task"]["status"] == "ready"
 
 
+def test_proposal_approve_and_deny_endpoints(client):
+    approved_task = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "proposal", "triage": True},
+    ).json()["task"]
+
+    r = client.post(
+        f"/api/plugins/kanban/tasks/{approved_task['id']}/approve",
+        json={"assignee": "dori-fixer"},
+    )
+    assert r.status_code == 200, r.text
+    approved = r.json()["task"]
+    assert approved["status"] == "ready"
+    assert approved["assignee"] == "dori-fixer"
+    assert r.json()["proposal"]["decision"] == "approved"
+
+    denied_task = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "bad proposal", "triage": True},
+    ).json()["task"]
+    r = client.post(
+        f"/api/plugins/kanban/tasks/{denied_task['id']}/deny",
+        json={"reason": "not aligned"},
+    )
+    assert r.status_code == 200, r.text
+    denied = r.json()["task"]
+    assert denied["status"] == "blocked"
+    assert r.json()["proposal"]["decision"] == "denied"
+
+    detail = client.get(f"/api/plugins/kanban/tasks/{denied_task['id']}").json()
+    comments = "\n".join(c["body"] for c in detail["comments"])
+    assert "proposal denied" in comments.lower()
+    assert "not aligned" in comments
+
+
 def test_patch_drag_drop_move_todo_to_ready(client):
     """Direct status write: the drag-drop path for statuses without a
     dedicated verb (e.g. manually promoting todo -> ready).
@@ -1542,8 +1577,15 @@ def test_diagnostics_endpoint_surfaces_blocked_hallucination(client):
     assert "t_ffff00001234" in row["diagnostics"][0]["data"]["phantom_ids"]
 
 
-def test_diagnostics_endpoint_severity_filter(client):
+def test_diagnostics_endpoint_severity_filter(client, monkeypatch):
     """Warning-severity filter excludes error-severity entries."""
+    from hermes_cli import config as hermes_config
+
+    monkeypatch.setattr(
+        hermes_config,
+        "load_config",
+        lambda: {"kanban": {"diagnostics": {"failure_threshold": 5}}},
+    )
     conn = kb.connect()
     try:
         # A warning-severity diagnostic (prose phantom) on one task.


### PR DESCRIPTION
## Summary
- Add a Kanban proposal gate for recommended next work: `hermes kanban propose`, `approve`, and `deny`.
- Keep recommendations in `triage` until human approve/deny; approval promotes to `ready` or `todo` depending on parent dependencies, denial moves to `blocked` with an audit reason.
- Add dashboard REST endpoints and drawer Approve/Deny controls for triage proposals.
- Add CLI/API regression tests and isolate diagnostics severity test config.

## Testing
- `/home/claw/.hermes-agent/venv/bin/python -m py_compile hermes_cli/kanban.py hermes_cli/kanban_db.py plugins/kanban/dashboard/plugin_api.py`
- `node --check plugins/kanban/dashboard/dist/index.js`
- `/home/claw/.hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_kanban_cli.py tests/plugins/test_kanban_dashboard_plugin.py -q -o addopts=` → 122 passed

Note: a full local `pytest -q` run was attempted and hit unrelated existing environment/suite failures (108 failed, 24043 passed, 82 skipped), so this PR is verified with the focused Kanban CLI/dashboard coverage above.
