### PR TITLE
fix(plugins): raise plugin discovery failures to WARNING level

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3474,7 +3474,7 @@ class GatewayRunner:
             from hermes_cli.plugins import discover_plugins
             discover_plugins()
         except Exception:
-            logger.debug(
+            logger.warning(
                 "plugin discovery failed at gateway startup", exc_info=True,
             )
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12660,7 +12660,7 @@ Examples:
 
             discover_plugins()
         except Exception:
-            logger.debug(
+            logger.warning(
                 "plugin discovery failed at CLI startup",
                 exc_info=True,
             )


### PR DESCRIPTION
## Summary

Fixes #28137.

`discover_plugins()` exceptions were caught and logged at `DEBUG` in two startup paths, making them invisible at the default `INFO` log level. Operators deploying broken plugins got no feedback.

- `gateway/run.py` line 3477: `logger.debug` → `logger.warning`
- `hermes_cli/main.py` line 12663: `logger.debug` → `logger.warning`

## Test plan

- [ ] Install a plugin with a syntax error in `__init__.py`
- [ ] Restart gateway / CLI at default log level (`INFO`)
- [ ] Confirm the failure now appears in `gateway.log` / stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)