### PR TITLE
fix(agent): strip reasoning_content for providers that reject it

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1788,6 +1788,25 @@ def copy_reasoning_content_for_api(agent, source_msg: dict, api_msg: dict) -> No
     if source_msg.get("role") != "assistant":
         return
 
+    # 0. Provider rejects reasoning_content — strip and bail out immediately.
+    #
+    # Most OpenAI-compatible providers (Cerebras, Groq, Fireworks, Together,
+    # etc.) return HTTP 400 when ``reasoning_content`` appears on an assistant
+    # message.  The field is only meaningful to the small set of providers that
+    # require it echoed back (DeepSeek V4 thinking, Kimi/Moonshot thinking,
+    # MiMo thinking).  When the session history was written by one of those
+    # providers — or by a streaming-only reasoning model like GLM or
+    # gpt-oss-120b that promotes its delta reasoning into ``reasoning_content``
+    # at write time (refs #16844) — replaying through a non-echo-back provider
+    # poisons the request and triggers an immediate non-retryable 400.
+    #
+    # Safe default: strip unless the current provider is known to require the
+    # echo-back.  The inverse check (``_needs_thinking_reasoning_pad``) is
+    # already battle-tested for DeepSeek/Kimi/MiMo detection.
+    if agent._rejects_reasoning_content():
+        api_msg.pop("reasoning_content", None)
+        return
+
     # 1. Explicit reasoning_content already set — preserve it verbatim
     # (includes DeepSeek/Kimi's own space-placeholder written at creation
     # time, and any valid reasoning content from the same provider).

--- a/run_agent.py
+++ b/run_agent.py
@@ -3657,6 +3657,24 @@ class AIAgent:
             or base_url_host_matches(self.base_url, "xiaomimimo.com")
         )
 
+    def _rejects_reasoning_content(self) -> bool:
+        """Return True when the active provider does NOT accept ``reasoning_content`` in messages.
+
+        Most OpenAI-compatible providers (Cerebras, Groq, Fireworks, Together,
+        etc.) reject ``reasoning_content`` on assistant messages with HTTP 400.
+        The field is only meaningful to the small set of providers that require
+        it echoed back (DeepSeek V4 thinking, Kimi/Moonshot thinking, MiMo
+        thinking).  For every other provider, passing it through causes failures
+        when the session history was previously written by one of those
+        reasoning-aware providers or by a streaming-only reasoning model (GLM,
+        MiniMax, gpt-oss-120b) that emits ``reasoning_content`` deltas.
+
+        The safe default is: strip unless the current provider is known to
+        require the echo-back.  This is the inverse of
+        ``_needs_thinking_reasoning_pad()``.
+        """
+        return not self._needs_thinking_reasoning_pad()
+
     def _copy_reasoning_content_for_api(self, source_msg: dict, api_msg: dict) -> None:
         """Forwarder — see ``agent.agent_runtime_helpers.copy_reasoning_content_for_api``."""
         from agent.agent_runtime_helpers import copy_reasoning_content_for_api

--- a/tests/run_agent/test_deepseek_reasoning_content_echo.py
+++ b/tests/run_agent/test_deepseek_reasoning_content_echo.py
@@ -160,10 +160,11 @@ class TestCopyReasoningContentForApi:
         agent._copy_reasoning_content_for_api(source, api_msg)
         assert api_msg["reasoning_content"] == " "
 
-    def test_non_thinking_provider_preserves_empty_reasoning_content_verbatim(self) -> None:
-        """The stale-placeholder upgrade ONLY fires when the active provider
-        enforces thinking-mode echo. On non-thinking providers, an empty
-        reasoning_content must still round-trip verbatim.
+    def test_non_thinking_provider_strips_reasoning_content(self) -> None:
+        """Non-echo-back providers (OpenRouter, Cerebras, Groq, etc.) reject
+        ``reasoning_content`` on assistant messages with HTTP 400. The field
+        must be stripped before replay regardless of its value, including the
+        empty-string placeholder written by pre-#17341 sessions.
         """
         agent = _make_agent(
             provider="openrouter",
@@ -175,9 +176,9 @@ class TestCopyReasoningContentForApi:
             "content": "hi",
             "reasoning_content": "",
         }
-        api_msg: dict = {}
+        api_msg: dict = {"reasoning_content": ""}
         agent._copy_reasoning_content_for_api(source, api_msg)
-        assert api_msg["reasoning_content"] == ""
+        assert "reasoning_content" not in api_msg
 
     def test_deepseek_reasoning_field_promoted(self) -> None:
         """When only 'reasoning' is set, it gets promoted to reasoning_content."""
@@ -481,3 +482,88 @@ class TestNeedsKimiToolReasoning:
         )
         # model name contains 'moonshot' but host is openrouter — should be False
         assert agent._needs_kimi_tool_reasoning() is False
+
+
+class TestRejectsReasoningContent:
+    """_rejects_reasoning_content() is the inverse of _needs_thinking_reasoning_pad().
+
+    Regression guard for the cross-provider poisoning introduced by #16844:
+    streaming-only reasoning models (GLM, gpt-oss-120b) promote their delta
+    reasoning into ``reasoning_content`` at write time. When the next turn
+    targets a provider that rejects the field (Cerebras, Groq, Fireworks,
+    Together, ...), the replay 400s. The fix: strip for any provider that
+    is not an explicit echo-back provider.
+    """
+
+    def test_deepseek_does_not_reject(self) -> None:
+        agent = _make_agent(provider="deepseek", model="deepseek-v4-flash")
+        assert agent._rejects_reasoning_content() is False
+
+    def test_kimi_does_not_reject(self) -> None:
+        agent = _make_agent(provider="kimi-coding", model="kimi-k2")
+        assert agent._rejects_reasoning_content() is False
+
+    def test_mimo_does_not_reject(self) -> None:
+        agent = _make_agent(provider="custom", model="mimo-v2-pro",
+                            base_url="https://api.xiaomimimo.com/v1")
+        assert agent._rejects_reasoning_content() is False
+
+    @pytest.mark.parametrize("provider,model,base_url", [
+        ("custom", "zai-glm-4.7", "https://proxy.example.com/v1"),
+        ("custom", "gpt-oss-120b", "https://proxy.example.com/v1"),
+        ("custom", "llama3.1-8b", "https://proxy.example.com/v1"),
+        ("custom", "qwen-3-235b-a22b-instruct-2507", "https://proxy.example.com/v1"),
+        ("groq", "llama-3.1-70b-versatile", "https://api.groq.com/openai/v1"),
+        ("fireworks", "llama-v3-70b", "https://api.fireworks.ai/inference/v1"),
+        ("together", "meta-llama/Llama-3-70b", "https://api.together.xyz/v1"),
+        ("openrouter", "anthropic/claude-sonnet-4.6", "https://openrouter.ai/api/v1"),
+    ])
+    def test_non_echo_back_provider_rejects(
+        self, provider: str, model: str, base_url: str
+    ) -> None:
+        agent = _make_agent(provider=provider, model=model, base_url=base_url)
+        assert agent._rejects_reasoning_content() is True
+
+    def test_glm_history_stripped_for_cerebras(self) -> None:
+        """GLM turn stored with reasoning_content must be stripped when replaying
+        through a Cerebras (or any non-echo-back) custom provider.
+
+        This is the exact failure reported: switch from zai-glm-4.7 to
+        gpt-oss-120b on Cerebras 400s with::
+
+            messages.2.assistant.reasoning_content: property ... is unsupported
+
+        Root cause: commit d63abbc3 (refs #16844) promotes delta reasoning_content
+        from streaming-only providers (GLM, MiniMax) into the stored history so
+        DeepSeek/Kimi history replay works. The promotion is correct but the
+        field must be stripped when the *next* provider is not an echo-back provider.
+        """
+        # Custom provider (e.g. Cerebras) — not a DeepSeek/Kimi/MiMo echo-back provider
+        cerebras_agent = _make_agent(
+            provider="custom:cerebras",
+            model="gpt-oss-120b",
+            base_url="https://proxy.example.com/v1",
+        )
+        # History turn written by zai-glm-4.7 with promoted reasoning_content
+        glm_history_turn = {
+            "role": "assistant",
+            "content": "Hello!",
+            "reasoning": "Let me think...",
+            "reasoning_content": "Let me think...",  # promoted by #16844
+        }
+        api_msg: dict = {"reasoning_content": "Let me think..."}
+        cerebras_agent._copy_reasoning_content_for_api(glm_history_turn, api_msg)
+        assert "reasoning_content" not in api_msg
+
+    def test_deepseek_history_preserved_for_deepseek(self) -> None:
+        """DeepSeek history replayed on DeepSeek must keep reasoning_content."""
+        agent = _make_agent(provider="deepseek", model="deepseek-v4-flash")
+        source = {
+            "role": "assistant",
+            "content": "",
+            "reasoning_content": "some thought",
+            "tool_calls": [{"id": "c1", "function": {"name": "terminal"}}],
+        }
+        api_msg: dict = {}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert api_msg["reasoning_content"] == "some thought"


### PR DESCRIPTION
## Summary

Fixes a cross-provider HTTP 400 regression introduced by d63abbc3 (refs #16844).

### Root cause

Commit d63abbc3 correctly promoted delta `reasoning_content` from streaming-only reasoning providers (GLM, MiniMax, gpt-oss-120b) into stored session history so DeepSeek/Kimi history replay works. However, when the *next* turn targets a provider that **rejects** the field (Cerebras, Groq, Fireworks, Together, and most other OpenAI-compatible providers), the promoted field poisons the request:

```
HTTP 400: messages.2.assistant.reasoning_content:
  property 'messages.2.assistant.reasoning_content' is unsupported
```

**Reproducer:** Start a session with `zai-glm-4.7` (a streaming-only reasoning model that emits `reasoning_content` deltas). Switch to `gpt-oss-120b` on a Cerebras custom provider. The second request immediately 400s.

### Fix

Add `_rejects_reasoning_content()` to `AIAgent` — the logical inverse of `_needs_thinking_reasoning_pad()`:

```python
def _rejects_reasoning_content(self) -> bool:
    return not self._needs_thinking_reasoning_pad()
```

Add an early-exit guard at the top of `copy_reasoning_content_for_api` in `agent/agent_runtime_helpers.py`:

```python
if agent._rejects_reasoning_content():
    api_msg.pop("reasoning_content", None)
    return
```

The safe default is **strip**: `reasoning_content` echo-back is an unusual protocol extension specific to DeepSeek V4 thinking, Kimi/Moonshot thinking, and MiMo thinking. Every other provider should never see the field in outgoing messages.

### Test changes

- Updates `test_non_thinking_provider_preserves_empty_reasoning_content_verbatim`: the original assertion that `reasoning_content=""` should round-trip verbatim to OpenRouter was incorrect — OpenRouter also rejects the field. Updated to assert it is stripped.
- Adds `TestRejectsReasoningContent` (12 new tests) covering:
  - DeepSeek / Kimi / MiMo correctly return `False` from `_rejects_reasoning_content()`
  - Cerebras, Groq, Fireworks, Together, OpenRouter, and generic custom providers return `True`
  - The exact GLM→Cerebras regression scenario: `reasoning_content` promoted by #16844 is stripped before replay
  - DeepSeek→DeepSeek history still preserves `reasoning_content` correctly

## Test plan

- [ ] Switch from a GLM/reasoning model to a Cerebras/Groq custom provider mid-session — verify no HTTP 400
- [ ] Verify DeepSeek V4 thinking mode still receives `reasoning_content` on replay (existing `TestCopyReasoningContentForApi` tests cover this)
- [ ] Verify Kimi/Moonshot tool-call turns still get `reasoning_content` padded on replay
- [ ] `python -m pytest tests/run_agent/test_deepseek_reasoning_content_echo.py` — all 49 tests pass

Generated with [Devin](https://cli.devin.ai/docs)