### PR TITLE
fix: accept provider type as api mode alias

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2999,7 +2999,7 @@ def _normalize_custom_provider_entry(
         entry["key_env"] = entry["api_key_env"]
     _KNOWN_KEYS = {
         "name", "api", "url", "base_url", "api_key", "key_env", "api_key_env",
-        "api_mode", "transport", "model", "default_model", "models",
+        "api_mode", "transport", "type", "model", "default_model", "models",
         "context_length", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
         "discover_models",
@@ -3065,7 +3065,7 @@ def _normalize_custom_provider_entry(
     if isinstance(key_env, str) and key_env.strip():
         normalized["key_env"] = key_env.strip()
 
-    api_mode = entry.get("api_mode") or entry.get("transport")
+    api_mode = entry.get("api_mode") or entry.get("transport") or entry.get("type")
     if isinstance(api_mode, str) and api_mode.strip():
         normalized["api_mode"] = api_mode.strip()
 

--- a/tests/hermes_cli/test_provider_config_validation.py
+++ b/tests/hermes_cli/test_provider_config_validation.py
@@ -104,6 +104,41 @@ class TestNormalizeCustomProviderEntry:
         assert result is not None
         assert not any("unknown config keys" in r.message.lower() for r in caplog.records)
 
+    def test_type_alias_maps_to_api_mode_without_warning(self, caplog):
+        """Keyed providers may use type as an OpenAI-compatible api_mode alias."""
+        entry = {
+            "base_url": "https://api.example.com/v1",
+            "type": "openai",
+        }
+        with caplog.at_level(logging.WARNING):
+            result = _normalize_custom_provider_entry(entry, provider_key="ollama-local")
+        assert result is not None
+        assert result["api_mode"] == "openai"
+        assert not any("unknown config keys" in r.message.lower() for r in caplog.records)
+
+    def test_api_mode_precedence_over_transport_and_type(self):
+        """api_mode remains the highest-precedence provider transport field."""
+        entry = {
+            "base_url": "https://api.example.com/v1",
+            "api_mode": "chat_completions",
+            "transport": "responses",
+            "type": "openai",
+        }
+        result = _normalize_custom_provider_entry(entry, provider_key="test")
+        assert result is not None
+        assert result["api_mode"] == "chat_completions"
+
+    def test_transport_precedence_over_type(self):
+        """transport keeps precedence over the lower-precedence type alias."""
+        entry = {
+            "base_url": "https://api.example.com/v1",
+            "transport": "chat_completions",
+            "type": "openai",
+        }
+        result = _normalize_custom_provider_entry(entry, provider_key="test")
+        assert result is not None
+        assert result["api_mode"] == "chat_completions"
+
     def test_camel_case_warning_logged(self, caplog):
         """camelCase alias mapping should produce a warning."""
         entry = {


### PR DESCRIPTION
## Summary
- Treat keyed provider `type` as a lowest-precedence alias for `api_mode`.
- Preserve precedence: `api_mode` > `transport` > `type`.
- Stop warning on OpenAI-compatible configs such as Ollama providers using `type: openai`.

## Test plan
- `python -m pytest tests/hermes_cli/test_provider_config_validation.py -q -o 'addopts='`
- `python -m pytest tests/hermes_cli/test_status.py -q -o 'addopts='`
- `hermes status --all` smoke check: confirmed 0 `unknown config keys ignored: type` warnings.
