### PR TITLE
fix(auth): treat empty credential pool entries as unauthenticated in /model picker

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1232,7 +1232,7 @@ def list_authenticated_providers(
             try:
                 from hermes_cli.auth import _load_auth_store
                 store = _load_auth_store()
-                if store and hermes_id in store.get("credential_pool", {}):
+                if store and store.get("credential_pool", {}).get(hermes_id):
                     has_creds = True
             except Exception:
                 pass


### PR DESCRIPTION
## Summary

Fixes #28140.

The `/model` picker checked whether a provider key *existed* in `credential_pool`, not whether it had any entries. An empty list (`"minimax-cn": []`) left after removing an API key from `.env` still caused the provider to appear as selectable.

**`hermes_cli/model_switch.py` line 1235** — one-line change:

```python
# before — key presence is enough to pass
if store and hermes_id in store.get("credential_pool", {}):

# after — requires at least one non-empty entry
if store and store.get("credential_pool", {}).get(hermes_id):
```

## Test plan

- [ ] Configure a provider via `hermes model`, then delete its API key from `.env`
- [ ] Confirm `~/.hermes/auth.json` still has `"provider-id": []` in `credential_pool`
- [ ] Run `/model` — provider should no longer appear as available

🤖 Generated with [Claude Code](https://claude.com/claude-code)