### PR TITLE
fix(gateway): bridge gateway_restart_notification from YAML platform sections

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -322,15 +322,21 @@ class PlatformConfig:
         if "home_channel" in data:
             home_channel = HomeChannel.from_dict(data["home_channel"])
 
+        # gateway_restart_notification may be bridged into extra via the
+        # shared-key loop in load_gateway_config(); check both top-level
+        # and extra so YAML ``discord: gateway_restart_notification: false``
+        # works without needing a separate platforms: block.
+        _grn = data.get("gateway_restart_notification")
+        if _grn is None:
+            _grn = data.get("extra", {}).get("gateway_restart_notification")
+
         return cls(
             enabled=_coerce_bool(data.get("enabled"), False),
             token=data.get("token"),
             api_key=data.get("api_key"),
             home_channel=home_channel,
             reply_to_mode=data.get("reply_to_mode", "first"),
-            gateway_restart_notification=_coerce_bool(
-                data.get("gateway_restart_notification"), True
-            ),
+            gateway_restart_notification=_coerce_bool(_grn, True),
             extra=data.get("extra", {}),
         )
 
@@ -849,6 +855,8 @@ def load_gateway_config() -> GatewayConfig:
                         bridged["channel_prompts"] = {str(k): v for k, v in channel_prompts.items()}
                     else:
                         bridged["channel_prompts"] = channel_prompts
+                if "gateway_restart_notification" in platform_cfg:
+                    bridged["gateway_restart_notification"] = platform_cfg["gateway_restart_notification"]
                 enabled_was_explicit = "enabled" in platform_cfg
                 if not bridged and not enabled_was_explicit:
                     continue


### PR DESCRIPTION
## Problem

Two related bugs in `gateway/config.py` prevent per-platform `gateway_restart_notification` from working through `config.yaml`:

1. **Missing bridge key**: The shared-key bridging loop (`load_gateway_config()`) bridges `channel_prompts` and other keys, but omits `gateway_restart_notification`. When set under e.g. `discord:` or `mattermost:` sections, the value never reaches `platform_data["extra"]`.

2. **from_dict() blind spot**: `PlatformConfig.from_dict()` reads `gateway_restart_notification` only from the top-level `data` dict, ignoring the `extra` sub-dict where bridged keys are stored by the bridging loop.

## Reproduction

```yaml
# config.yaml
mattermost:
  gateway_restart_notification: false
```

Expected: `"⚠️ Gateway shutting down"` message is suppressed on gateway restart for Mattermost.
Actual: Setting has no effect — `from_dict()` receives `data={"extra": {"gateway_restart_notification": false}}`, but reads `data.get("gateway_restart_notification")` → `None` → defaults to `True`.

## Fix

1. Add `gateway_restart_notification` to the shared-key bridging loop (same pattern as `channel_prompts`)
2. Add an `extra` fallback in `PlatformConfig.from_dict()` so bridged values in `extra` resolve correctly

## Testing

- [x] `config.yaml` per-platform `gateway_restart_notification: false` now takes effect
- [x] Env var `MATTERMOST_GATEWAY_RESTART_NOTIFICATION` still works (unchanged path)
- [x] Default behavior (no config) unchanged: defaults to `true`
