### PR TITLE
refactor(tui): share session section list rendering

### DIFF
--- a/ui-tui/src/components/branding.tsx
+++ b/ui-tui/src/components/branding.tsx
@@ -129,6 +129,25 @@ export function SessionPanel({ info, sid, t }: SessionPanelProps) {
     return line
   }
 
+  const sectionListBody = (entries: [string, string[]][], maxItems: number, overflowLabel: string) => {
+    const shown = entries.slice(0, maxItems)
+    const overflow = entries.length - maxItems
+
+    return (
+      <>
+        {shown.map(([k, vs]) => (
+          <Text key={k} wrap="truncate">
+            <Text color={t.color.muted}>{strip(k)}: </Text>
+            <Text color={t.color.text}>{truncLine(strip(k) + ': ', vs)}</Text>
+          </Text>
+        ))}
+        {overflow > 0 && (
+          <Text color={t.color.muted}>(and {overflow} more {overflowLabel}…)</Text>
+        )}
+      </>
+    )
+  }
+
   // ── Collapsible skills section ──
   const skillEntries = Object.entries(info.skills).sort()
   const skillsTotal = flat(info.skills).length
@@ -139,46 +158,14 @@ export function SessionPanel({ info, sid, t }: SessionPanelProps) {
       return <InlineLoader label="scanning skills" t={t} />
     }
 
-    const shown = skillEntries.slice(0, SKILLS_MAX)
-    const overflow = skillEntries.length - SKILLS_MAX
-
-    return (
-      <>
-        {shown.map(([k, vs]) => (
-          <Text key={k} wrap="truncate">
-            <Text color={t.color.muted}>{strip(k)}: </Text>
-            <Text color={t.color.text}>{truncLine(strip(k) + ': ', vs)}</Text>
-          </Text>
-        ))}
-        {overflow > 0 && (
-          <Text color={t.color.muted}>(and {overflow} more categories…)</Text>
-        )}
-      </>
-    )
+    return sectionListBody(skillEntries, SKILLS_MAX, 'categories')
   }
 
   // ── Collapsible tools section ──
   const toolEntries = Object.entries(info.tools).sort()
   const toolsTotal = flat(info.tools).length
 
-  const toolsBody = () => {
-    const shown = toolEntries.slice(0, TOOLSETS_MAX)
-    const overflow = toolEntries.length - TOOLSETS_MAX
-
-    return (
-      <>
-        {shown.map(([k, vs]) => (
-          <Text key={k} wrap="truncate">
-            <Text color={t.color.muted}>{strip(k)}: </Text>
-            <Text color={t.color.text}>{truncLine(strip(k) + ': ', vs)}</Text>
-          </Text>
-        ))}
-        {overflow > 0 && (
-          <Text color={t.color.muted}>(and {overflow} more toolsets…)</Text>
-        )}
-      </>
-    )
-  }
+  const toolsBody = () => sectionListBody(toolEntries, TOOLSETS_MAX, 'toolsets')
 
   // ── Collapsible MCP section ──
   const mcpBody = () => (


### PR DESCRIPTION
## Summary
- Extracts the duplicated Available Tools / Available Skills list rendering in `branding.tsx` into one shared helper.
- Refs #20670.

## Why
- `skillsBody()` and `toolsBody()` had the same slice/map/truncate/overflow logic with only the item limit and overflow label differing.

## Changes
- `ui-tui/src/components/branding.tsx`: adds `sectionListBody(entries, maxItems, overflowLabel)` and routes both tools and skills sections through it.

## Validation
- `npm run type-check`
- `npx eslint src/components/branding.tsx`
- `npm run lint` *(fails on pre-existing lint issues outside `branding.tsx`, e.g. `packages/hermes-ink/src/entry-exports.ts`, `src/components/markdown.tsx`, `src/lib/text.ts`; touched file passes targeted eslint.)*

## Scope
- In scope: deduplicating the session panel tools/skills section body rendering.
- Out of scope: broader shared collapsible/Chevron extraction and unrelated TUI lint cleanup.
