### PR TITLE
Add redacted credential wrapper

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -120,6 +120,44 @@ class PooledCredential:
         if self.extra is None:
             self.extra = {}
 
+    def __repr__(self) -> str:
+        sensitive_fields = {"access_token", "refresh_token", "agent_key"}
+        sensitive_extra_names = {
+            "access_token",
+            "refresh_token",
+            "id_token",
+            "token",
+            "api_key",
+            "apikey",
+            "client_secret",
+            "password",
+            "auth",
+            "jwt",
+            "secret",
+            "private_key",
+            "authorization",
+            "key",
+        }
+
+        def _repr_value(name: str, value: Any) -> str:
+            if name in sensitive_fields and value:
+                return repr("<redacted>")
+            if name == "extra" and isinstance(value, dict):
+                safe_extra = {
+                    key: "<redacted>"
+                    if str(key).lower() in sensitive_extra_names and extra_value
+                    else extra_value
+                    for key, extra_value in value.items()
+                }
+                return repr(safe_extra)
+            return repr(value)
+
+        parts = [
+            f"{field_def.name}={_repr_value(field_def.name, getattr(self, field_def.name))}"
+            for field_def in fields(self)
+        ]
+        return f"{type(self).__name__}(" + ", ".join(parts) + ")"
+
     def __getattr__(self, name: str):
         if name in _EXTRA_KEYS:
             return self.extra.get(name)

--- a/agent/redacted.py
+++ b/agent/redacted.py
@@ -1,0 +1,44 @@
+"""Explicit wrapper for values that must not leak through logs or repr output."""
+
+from __future__ import annotations
+
+from typing import Any, Generic, TypeVar
+from weakref import WeakKeyDictionary
+
+A = TypeVar("A")
+_REDACTED = "<redacted>"
+_registry: WeakKeyDictionary[Any, object] = WeakKeyDictionary()
+
+
+class Redacted(Generic[A]):
+    """Container whose string/representation forms never reveal its value.
+
+    The wrapped value is stored in a weak side registry rather than on the
+    instance, so accidental ``repr()``, ``str()``, logging, or formatting of the
+    wrapper produces only ``<redacted>``. Code that genuinely needs the secret
+    must call ``Redacted.value(...)`` explicitly at the use boundary.
+    """
+
+    __slots__ = ("__weakref__",)
+
+    def __repr__(self) -> str:
+        return _REDACTED
+
+    def __str__(self) -> str:
+        return _REDACTED
+
+    def __format__(self, format_spec: str) -> str:
+        return format(str(self), format_spec)
+
+    @classmethod
+    def make(cls, value: A) -> "Redacted[A]":
+        redacted = cls()
+        _registry[redacted] = value
+        return redacted
+
+    @staticmethod
+    def value(self: "Redacted[A]") -> A:
+        try:
+            return _registry[self]  # type: ignore[return-value]
+        except (KeyError, TypeError) as exc:
+            raise ValueError("Redacted value was not in registry") from exc

--- a/tests/agent/test_redacted.py
+++ b/tests/agent/test_redacted.py
@@ -1,0 +1,54 @@
+import logging
+
+import pytest
+
+from agent.credential_pool import PooledCredential
+from agent.redacted import Redacted
+
+
+def test_redacted_hides_value_in_logging_and_repr(caplog):
+    secret = Redacted.make("sk-test-super-secret-value")
+
+    assert str(secret) == "<redacted>"
+    assert repr(secret) == "<redacted>"
+    assert f"{secret}" == "<redacted>"
+    assert Redacted.value(secret) == "sk-test-super-secret-value"
+
+    logger = logging.getLogger("tests.redacted")
+    with caplog.at_level(logging.INFO, logger="tests.redacted"):
+        logger.info("credential=%s repr=%r", secret, secret)
+
+    assert "<redacted>" in caplog.text
+    assert "sk-test-super-secret-value" not in caplog.text
+
+
+def test_redacted_value_rejects_non_redacted_object():
+    with pytest.raises(ValueError, match="not in registry"):
+        Redacted.value(object())  # type: ignore[arg-type]
+
+
+def test_pooled_credential_repr_does_not_include_tokens():
+    credential = PooledCredential(
+        provider="openai",
+        id="cred-1",
+        label="prod",
+        auth_type="api_key",
+        priority=0,
+        source="manual",
+        access_token="sk-live-super-secret-token",
+        refresh_token="refresh-super-secret-token",
+        agent_key="agent-super-secret-token",
+        extra={"api_key": "extra-super-secret-token", "scope": "read"},
+    )
+
+    rendered = repr(credential)
+
+    assert "sk-live-super-secret-token" not in rendered
+    assert "refresh-super-secret-token" not in rendered
+    assert "agent-super-secret-token" not in rendered
+    assert "extra-super-secret-token" not in rendered
+    assert "access_token='<redacted>'" in rendered
+    assert "refresh_token='<redacted>'" in rendered
+    assert "agent_key='<redacted>'" in rendered
+    assert "'api_key': '<redacted>'" in rendered
+    assert "'scope': 'read'" in rendered


### PR DESCRIPTION
## Summary
- Add a small Redacted wrapper whose string/repr/format forms render as <redacted> while explicit Redacted.value(...) unwraps at use boundaries.
- Harden PooledCredential.__repr__ so access tokens, refresh tokens, agent keys, and common sensitive extra fields are masked if credential objects are logged or printed.
- Add tests covering logging/repr behavior and pooled credential masking.

## Verification
- python -m pytest tests/agent/test_redacted.py tests/agent/test_redact.py -q
- git diff --check HEAD~1..HEAD