### PR TITLE
fix(tui_gateway): support Desktop sessions.patch RPC

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -730,6 +730,94 @@ def _session(agent=None, **extra):
     }
 
 
+def test_sessions_patch_routes_latest_user_message_to_prompt_submit(monkeypatch):
+    calls = []
+    server._sessions["sid"] = _session(session_key="desktop-session")
+    monkeypatch.setattr(server, "_start_agent_build", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(server, "_wait_agent", lambda *_args, **_kwargs: None)
+
+    def fake_run(rid, sid, session, text):
+        calls.append((rid, sid, text))
+        with session["history_lock"]:
+            session["running"] = False
+
+    monkeypatch.setattr(server, "_run_prompt_submit", fake_run)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "sessions.patch",
+                "params": {
+                    "sessionKey": "desktop-session",
+                    "messages": [
+                        {"role": "assistant", "content": "old"},
+                        {"role": "user", "content": [{"type": "text", "text": "hello via desktop"}]},
+                    ],
+                },
+            }
+        )
+
+        assert resp == {"jsonrpc": "2.0", "id": "1", "result": {"status": "streaming"}}
+        deadline = time.time() + 1
+        while not calls and time.time() < deadline:
+            time.sleep(0.01)
+        assert calls == [("1", "sid", "hello via desktop")]
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_sessions_patch_accepts_json_patch_payload_with_single_live_session(monkeypatch):
+    calls = []
+    server._sessions["sid"] = _session()
+    monkeypatch.setattr(server, "_start_agent_build", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(server, "_wait_agent", lambda *_args, **_kwargs: None)
+
+    def fake_run(rid, sid, session, text):
+        calls.append((sid, text))
+        with session["history_lock"]:
+            session["running"] = False
+
+    monkeypatch.setattr(server, "_run_prompt_submit", fake_run)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "session.patch",
+                "params": {
+                    "sessionKey": "client-side-key",
+                    "patches": [
+                        {
+                            "op": "add",
+                            "path": "/messages/-",
+                            "value": {"role": "user", "content": "hello from patch"},
+                        }
+                    ],
+                },
+            }
+        )
+
+        assert resp["result"]["status"] == "streaming"
+        deadline = time.time() + 1
+        while not calls and time.time() < deadline:
+            time.sleep(0.01)
+        assert calls == [("sid", "hello from patch")]
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_sessions_patch_rejects_payload_without_text():
+    server._sessions["sid"] = _session()
+    try:
+        resp = server.handle_request(
+            {"id": "1", "method": "sessions.patch", "params": {"session_id": "sid"}}
+        )
+        assert resp["error"] == {"code": 4002, "message": "message text required"}
+    finally:
+        server._sessions.pop("sid", None)
+
+
 def test_session_close_commits_memory_and_fires_finalize_hook(monkeypatch):
     calls = {"hooks": []}
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -629,6 +629,100 @@ def _sess(params, rid):
     return (s, _wait_agent(s, rid))
 
 
+def _coerce_message_text(value: Any) -> str:
+    """Best-effort text extraction for Desktop/custom-runtime payloads."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, dict):
+        for key in ("text", "content", "input", "prompt"):
+            text = _coerce_message_text(value.get(key))
+            if text:
+                return text
+        return ""
+    if isinstance(value, list):
+        parts: list[str] = []
+        for item in value:
+            text = _coerce_message_text(item)
+            if text:
+                parts.append(text)
+        return "".join(parts).strip()
+    return str(value).strip()
+
+
+def _resolve_session_patch_id(params: dict) -> str:
+    """Resolve Desktop ``sessions.patch`` identifiers to local TUI session IDs."""
+    candidates: list[Any] = []
+    for key in ("session_id", "sessionId", "sessionKey", "key", "id"):
+        candidates.append(params.get(key))
+    session_obj = params.get("session")
+    if isinstance(session_obj, dict):
+        for key in ("session_id", "sessionId", "sessionKey", "key", "id"):
+            candidates.append(session_obj.get(key))
+    elif session_obj is not None:
+        candidates.append(session_obj)
+
+    for raw in candidates:
+        if not isinstance(raw, str):
+            continue
+        value = raw.strip()
+        if not value:
+            continue
+        if value in _sessions:
+            return value
+        for sid, session in _sessions.items():
+            if session.get("session_key") == value:
+                return sid
+
+    # Some custom-runtime bridges keep only one remote Hermes TUI session and
+    # address it with their own client-side key.  In that common case, fall
+    # back to the sole live session instead of failing with "session not found".
+    if len(_sessions) == 1:
+        return next(iter(_sessions))
+    return ""
+
+
+def _extract_session_patch_text(params: dict) -> str:
+    """Extract the latest user prompt from common ``sessions.patch`` shapes."""
+    for key in ("text", "input", "prompt"):
+        text = _coerce_message_text(params.get(key))
+        if text:
+            return text
+
+    message_text = _coerce_message_text(params.get("message"))
+    if message_text:
+        return message_text
+
+    messages = params.get("messages")
+    if isinstance(messages, list):
+        for message in reversed(messages):
+            if not isinstance(message, dict) or message.get("role") == "user":
+                text = _coerce_message_text(message)
+                if text:
+                    return text
+        for message in reversed(messages):
+            text = _coerce_message_text(message)
+            if text:
+                return text
+
+    for key in ("patch", "patches", "ops", "operations"):
+        patch_items = params.get(key)
+        if isinstance(patch_items, dict):
+            patch_items = [patch_items]
+        if not isinstance(patch_items, list):
+            continue
+        for item in reversed(patch_items):
+            if isinstance(item, dict):
+                value = item.get("value", item.get("message", item.get("content")))
+            else:
+                value = item
+            text = _coerce_message_text(value)
+            if text:
+                return text
+    return ""
+
+
 def _normalize_completion_path(path_part: str) -> str:
     expanded = os.path.expanduser(path_part)
     if os.name != "nt":
@@ -3005,6 +3099,26 @@ def _(rid, params: dict) -> dict:
 
 
 # ── Methods: prompt ──────────────────────────────────────────────────
+
+
+@method("sessions.patch")
+@method("session.patch")
+def _(rid, params: dict) -> dict:
+    """Desktop/custom-runtime compatibility shim for sending a chat turn.
+
+    Hermes Desktop v0.4.x may call the plural ``sessions.patch`` RPC while
+    the in-repo TUI has historically exposed only ``prompt.submit``.  Accept
+    common patch/message payload shapes and route them through the existing
+    prompt submission path so SSH-tunnel clients do not fail with "unknown
+    method" or "Custom runtime does not implement sessions.patch".
+    """
+    sid = _resolve_session_patch_id(params)
+    if not sid:
+        return _err(rid, 4001, "session not found")
+    text = _extract_session_patch_text(params)
+    if not text:
+        return _err(rid, 4002, "message text required")
+    return _methods["prompt.submit"](rid, {**params, "session_id": sid, "text": text})
 
 
 @method("prompt.submit")


### PR DESCRIPTION
## Summary
- Add `sessions.patch` and `session.patch` JSON-RPC handlers for Hermes Desktop/custom runtime compatibility.
- Normalize common Desktop/custom-runtime payload shapes into existing `prompt.submit` handling.
- Resolve sessions from `session_id`, `sessionKey`, nested session objects, or a single live session fallback.
- Add regression coverage for direct session-key routing, JSON patch payloads, and missing-text rejection.

## Test Plan
- `python -m pytest tests/test_tui_gateway_server.py -k 'sessions_patch' -q -o 'addopts='`
- `python -m pytest tests/test_tui_gateway_server.py -q -o 'addopts='`
- `python -m py_compile tui_gateway/server.py tests/test_tui_gateway_server.py`
- `python -m ruff check tui_gateway/server.py tests/test_tui_gateway_server.py`

Closes #27455

Note: I saw #27464 after preparing this patch. This PR is an alternate implementation with broad payload normalization and focused regression tests; maintainers can close whichever approach they do not want.
