### PR TITLE
fix(mattermost): resolve thread root_id + route tool progress to threads

### DIFF
--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -249,6 +249,23 @@ class MattermostAdapter(BasePlatformAdapter):
 
         logger.info("Mattermost: disconnected")
 
+
+    async def _resolve_root_id(self, post_id: str) -> str:
+        """Resolve a post_id to the thread root_id for Mattermost.
+
+        Mattermost requires root_id to be the *root* post of a thread.
+        If the post is a reply (has its own root_id), we must use that
+        root_id instead.  Using a reply's own ID as root_id causes
+        "Invalid RootId parameter" errors.
+        """
+        if not post_id:
+            return post_id
+        # Check if this post has a root_id (meaning it's a reply)
+        data = await self._api_get(f"posts/{post_id}")
+        if data and data.get("root_id"):
+            return data["root_id"]
+        return post_id
+
     async def send(
         self,
         chat_id: str,
@@ -271,7 +288,10 @@ class MattermostAdapter(BasePlatformAdapter):
             }
             # Thread support: reply_to is the root post ID.
             if reply_to and self._reply_mode == "thread":
-                payload["root_id"] = reply_to
+                # Ensure root_id points to the thread root, not a reply.
+                # Mattermost rejects non-root post IDs as root_id.
+                resolved_root = await self._resolve_root_id(reply_to)
+                payload["root_id"] = resolved_root
 
             data = await self._api_post("posts", payload)
             if not data or "id" not in data:
@@ -451,7 +471,7 @@ class MattermostAdapter(BasePlatformAdapter):
             "file_ids": [file_id],
         }
         if reply_to and self._reply_mode == "thread":
-            payload["root_id"] = reply_to
+            payload["root_id"] = await self._resolve_root_id(reply_to)
 
         data = await self._api_post("posts", payload)
         if not data or "id" not in data:
@@ -489,7 +509,7 @@ class MattermostAdapter(BasePlatformAdapter):
             "file_ids": [file_id],
         }
         if reply_to and self._reply_mode == "thread":
-            payload["root_id"] = reply_to
+            payload["root_id"] = await self._resolve_root_id(reply_to)
 
         data = await self._api_post("posts", payload)
         if not data or "id" not in data:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15059,7 +15059,7 @@ class GatewayRunner:
         ) if _progress_thread_id else None
         _progress_reply_to = (
             event_message_id
-            if source.platform == Platform.FEISHU and source.thread_id and event_message_id
+            if source.platform in (Platform.FEISHU, Platform.MATTERMOST) and source.thread_id and event_message_id
             else None
         )
 


### PR DESCRIPTION
## Problem

Two related bugs in the Mattermost adapter break thread functionality:

### Bug 1: Invalid root_id in CRT threads

When Mattermost is in CRT (Collapsed Reply Threads) mode with `reply_mode=thread`, every reply must set `root_id` to the **thread root** post. Passing a non-root post ID causes `400 Invalid RootId`.

The current code uses `payload["root_id"] = reply_to` directly in three methods:
- `send()` — the main message send path
- `_send_url_as_file()` — URL-to-file attachment upload
- `_send_local_file()` — local file attachment upload

If any of these receive a `reply_to` that is itself a reply within a thread, the API rejects the post.

### Bug 2: Tool progress messages bypass threads

In `gateway/run.py`, the `_progress_reply_to` variable determines which message to reply to for tool progress updates. The condition only checks `Platform.FEISHU`, omitting Mattermost entirely. When `_progress_reply_to` is `None`, the Mattermost adapter sends progress messages without a `reply_to`, causing them to appear in the **main channel** instead of the thread.

## Fix

### 1. Add `_resolve_root_id()` method

```python
async def _resolve_root_id(self, post_id: str) -> str:
    """Walk up the post chain to find the thread root."""
    if not post_id:
        return post_id
    data = await self._api_get(f"posts/{post_id}")
    if data and data.get("root_id"):
        return data["root_id"]
    return post_id
```

Applied in `send()`, `_send_url_as_file()`, and `_send_local_file()`.

### 2. Extend `_progress_reply_to` to include Mattermost

```diff
-if source.platform == Platform.FEISHU and source.thread_id and event_message_id
+if source.platform in (Platform.FEISHU, Platform.MATTERMOST) and source.thread_id and event_message_id
```

## Testing

- [x] Thread replies with correct root_id → no more 400 Invalid RootId
- [x] Replying to a reply within a thread → root_id auto-resolved to thread root
- [x] Tool progress messages now appear inside the thread, not the main channel
- [x] Non-thread mode (reply_mode=off) unaffected
- [x] First reply in a thread (post_id == root_id) unaffected