### PR TITLE
fix: import _pool_may_recover_from_rate_limit via _ra() in conversation_loop.py

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2332,7 +2332,7 @@ def run_conversation(
                     # still recover.  See _pool_may_recover_from_rate_limit
                     # for the single-credential-pool and CloudCode-quota
                     # exceptions.  Fixes #11314 and #13636.
-                    pool_may_recover = _pool_may_recover_from_rate_limit(
+                    pool_may_recover = _ra()._pool_may_recover_from_rate_limit(
                         agent._credential_pool,
                         provider=agent.provider,
                         base_url=getattr(agent, "base_url", None),


### PR DESCRIPTION
The `run_conversation` function was extracted from `run_agent.py` to the new `agent/conversation_loop.py` (commit 053025238). During extraction, the call to `_pool_may_recover_from_rate_limit()` was left as a bare name but the function wasn't imported in the new file.

All other `run_agent`-level symbols (`handle_function_call`, `_set_interrupt`, `OpenAI`) are accessed via the `_ra()` lazy-import helper in this file, so this change is consistent with the existing pattern.

Fixes `NameError: name '_pool_may_recover_from_rate_limit' is not defined` at runtime.
