### PR TITLE
fix(cli): finalize single-query sessions

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -745,6 +745,42 @@ def _run_cleanup():
         pass
 
 
+def _finalize_single_query_session(cli, result=None) -> None:
+    """Mark a non-interactive CLI query session ended.
+
+    Interactive CLI sessions close in ``HermesCLI.run()``.  Single-query
+    invocations (``hermes chat -q ...``) bypass that loop, so they need their
+    own DB finalization.  Prefer ``agent.session_id`` because compression can
+    rotate the active session during the turn.
+    """
+    db = getattr(cli, "_session_db", None)
+    if not db:
+        return
+
+    agent = getattr(cli, "agent", None)
+    session_id = getattr(agent, "session_id", None) or getattr(cli, "session_id", None)
+    if not session_id:
+        return
+
+    interrupted = bool(getattr(cli, "_last_turn_interrupted", False))
+    failed = False
+    if isinstance(result, dict):
+        interrupted = interrupted or bool(result.get("interrupted"))
+        failed = bool(result.get("failed"))
+
+    if interrupted:
+        end_reason = "single_query_interrupted"
+    elif failed:
+        end_reason = "single_query_failed"
+    else:
+        end_reason = "single_query_complete"
+
+    try:
+        db.end_session(session_id, end_reason)
+    except (Exception, KeyboardInterrupt) as exc:
+        logger.debug("Could not close single-query session in DB: %s", exc)
+
+
 # =============================================================================
 # Git Worktree Isolation (#652)
 # =============================================================================
@@ -14187,47 +14223,61 @@ def main(
                     runtime_override=turn_route["runtime"],
                     request_overrides=turn_route.get("request_overrides"),
                 ):
-                    cli.agent.quiet_mode = True
-                    cli.agent.suppress_status_output = True
+                    agent = cli.agent
+                    if agent is None:
+                        _finalize_single_query_session(cli, {"failed": True})
+                        sys.exit(1)
+                    setattr(agent, "quiet_mode", True)
+                    setattr(agent, "suppress_status_output", True)
                     # Suppress streaming display callbacks so stdout stays
                     # machine-readable (no styled "Hermes" box, no tool-gen
                     # status lines).  The response is printed once below.
-                    cli.agent.stream_delta_callback = None
-                    cli.agent.tool_gen_callback = None
-                    result = cli.agent.run_conversation(
-                        user_message=effective_query,
-                        conversation_history=cli.conversation_history,
-                    )
-                    # Sync session_id if mid-run compression created a
-                    # continuation session. The exit line below reports
-                    # session_id to stderr for automation wrappers; without
-                    # this sync it would point at the ended parent.
-                    if (
-                        getattr(cli.agent, "session_id", None)
-                        and cli.agent.session_id != cli.session_id
-                    ):
-                        cli.session_id = cli.agent.session_id
-                    response = result.get("final_response", "") if isinstance(result, dict) else str(result)
-                    # Surface backend errors that produced no visible output
-                    # (e.g. invalid model slug → provider 4xx). Mirrors the
-                    # interactive CLI path. Write to stderr so piped stdout
-                    # stays clean for automation wrappers.
-                    if (
-                        not response
-                        and isinstance(result, dict)
-                        and result.get("error")
-                        and (result.get("failed") or result.get("partial"))
-                    ):
-                        print(f"Error: {result['error']}", file=sys.stderr)
-                    elif response:
-                        print(response)
-                    # Session ID goes to stderr so piped stdout is clean.
-                    print(f"\nsession_id: {cli.session_id}", file=sys.stderr)
-                    
-                    # Ensure proper exit code for automation wrappers
-                    sys.exit(1 if isinstance(result, dict) and result.get("failed") else 0)
+                    setattr(agent, "stream_delta_callback", None)
+                    setattr(agent, "tool_gen_callback", None)
+                    result = None
+                    try:
+                        result = agent.run_conversation(
+                            user_message=effective_query,
+                            conversation_history=cli.conversation_history,
+                        )
+                        # Sync session_id if mid-run compression created a
+                        # continuation session. The exit line below reports
+                        # session_id to stderr for automation wrappers; without
+                        # this sync it would point at the ended parent.
+                        agent_session_id = getattr(agent, "session_id", None)
+                        if agent_session_id and agent_session_id != cli.session_id:
+                            cli.session_id = agent_session_id
+                        response = result.get("final_response", "") if isinstance(result, dict) else str(result)
+                        # Surface backend errors that produced no visible output
+                        # (e.g. invalid model slug → provider 4xx). Mirrors the
+                        # interactive CLI path. Write to stderr so piped stdout
+                        # stays clean for automation wrappers.
+                        if (
+                            not response
+                            and isinstance(result, dict)
+                            and result.get("error")
+                            and (result.get("failed") or result.get("partial"))
+                        ):
+                            print(f"Error: {result['error']}", file=sys.stderr)
+                        elif response:
+                            print(response)
+                        # Session ID goes to stderr so piped stdout is clean.
+                        print(f"\nsession_id: {cli.session_id}", file=sys.stderr)
+
+                        # Ensure proper exit code for automation wrappers
+                        sys.exit(1 if isinstance(result, dict) and result.get("failed") else 0)
+                    except KeyboardInterrupt:
+                        result = result or {"interrupted": True, "failed": True}
+                        raise
+                    except Exception:
+                        result = result or {"failed": True}
+                        raise
+                    finally:
+                        _finalize_single_query_session(cli, result)
             
-            # Exit with error code if credentials or agent init fails
+            # Exit with error code if credentials or agent init fails.  A
+            # session row may already exist, so close it as a failed one-shot.
+            _finalize_single_query_session(cli, {"failed": True})
             sys.exit(1)
         else:
             # Single-query mode (`hermes chat -q "…"`): skip the welcome
@@ -14249,8 +14299,23 @@ def main(
             # Surface security advisories before the agent runs — short
             # banner, doesn't depend on the welcome banner being shown.
             cli._show_security_advisories()
-            cli.chat(query, images=single_query_images or None)
-            cli._print_exit_summary()
+            response = None
+            finalize_result = None
+            try:
+                response = cli.chat(query, images=single_query_images or None)
+                finalize_result = {
+                    "failed": response is None,
+                    "interrupted": bool(getattr(cli, "_last_turn_interrupted", False)),
+                }
+                cli._print_exit_summary()
+            except KeyboardInterrupt:
+                finalize_result = {"interrupted": True, "failed": True}
+                raise
+            except Exception:
+                finalize_result = {"failed": True}
+                raise
+            finally:
+                _finalize_single_query_session(cli, finalize_result)
         return
     
     # Run interactive mode

--- a/cli.py
+++ b/cli.py
@@ -766,7 +766,7 @@ def _finalize_single_query_session(cli, result=None) -> None:
     failed = False
     if isinstance(result, dict):
         interrupted = interrupted or bool(result.get("interrupted"))
-        failed = bool(result.get("failed"))
+        failed = bool(result.get("failed") or result.get("partial"))
 
     if interrupted:
         end_reason = "single_query_interrupted"
@@ -2860,6 +2860,11 @@ class HermesCLI:
         # don't auto-queue another continuation on top of a user-cancelled
         # turn (which would make Ctrl+C feel like it did nothing).
         self._last_turn_interrupted = False
+        # Raw ``run_conversation()`` result from the most recent chat() call.
+        # Single-query finalization needs this because chat() can render an
+        # error string for failed turns; the response text alone is not enough
+        # to decide the DB end_reason accurately.
+        self._last_chat_result: Optional[Dict[str, Any]] = None
         self._should_exit = False
         # /exit --delete: when True, the current session's SQLite history and
         # on-disk transcripts are deleted during shutdown. Set by
@@ -10815,6 +10820,7 @@ class HermesCLI:
         # this to True. Early returns (credential refresh failure, etc.)
         # leave it False, which is correct — those aren't user interrupts.
         self._last_turn_interrupted = False
+        self._last_chat_result = None
 
         # Refresh provider credentials if needed (handles key rotation transparently)
         if not self._ensure_runtime_credentials():
@@ -11179,6 +11185,7 @@ class HermesCLI:
             time.sleep(0.15)
 
             # Update history with full conversation
+            self._last_chat_result = result if isinstance(result, dict) else None
             self.conversation_history = result.get("messages", self.conversation_history) if result else self.conversation_history
 
             # If auto-compression fired mid-turn, the agent created a new
@@ -11774,6 +11781,7 @@ class HermesCLI:
         # See constructor note. Mirrored here for the run() path that skips
         # the earlier __init__ branch.
         self._last_turn_interrupted = False
+        self._last_chat_result = None
         self._should_exit = False
         self._last_ctrl_c_time = 0  # Track double Ctrl+C for force exit
 
@@ -14303,10 +14311,14 @@ def main(
             finalize_result = None
             try:
                 response = cli.chat(query, images=single_query_images or None)
-                finalize_result = {
-                    "failed": response is None,
-                    "interrupted": bool(getattr(cli, "_last_turn_interrupted", False)),
-                }
+                chat_result = getattr(cli, "_last_chat_result", None)
+                if isinstance(chat_result, dict):
+                    finalize_result = chat_result
+                else:
+                    finalize_result = {
+                        "failed": response is None,
+                        "interrupted": bool(getattr(cli, "_last_turn_interrupted", False)),
+                    }
                 cli._print_exit_summary()
             except KeyboardInterrupt:
                 finalize_result = {"interrupted": True, "failed": True}

--- a/tests/cli/test_cli_single_query_finalize.py
+++ b/tests/cli/test_cli_single_query_finalize.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+
+class _FakeSessionDB:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    def end_session(self, session_id: str, end_reason: str) -> None:
+        self.calls.append((session_id, end_reason))
+
+
+def test_finalize_single_query_uses_current_agent_session_id() -> None:
+    """Single-query cleanup must close the live continuation session.
+
+    Auto-compression can rotate ``agent.session_id`` during the turn.  The
+    finalizer should therefore prefer the agent's current session id over the
+    CLI object's initially-created session id.
+    """
+    import cli as cli_mod
+
+    db = _FakeSessionDB()
+    shell = SimpleNamespace(
+        session_id="parent-session",
+        agent=SimpleNamespace(session_id="continuation-session"),
+        _session_db=db,
+        _last_turn_interrupted=False,
+    )
+
+    cli_mod._finalize_single_query_session(shell, {"completed": True})
+
+    assert db.calls == [("continuation-session", "single_query_complete")]
+
+
+def test_finalize_single_query_records_failed_result() -> None:
+    import cli as cli_mod
+
+    db = _FakeSessionDB()
+    shell = SimpleNamespace(
+        session_id="single-query-session",
+        agent=SimpleNamespace(session_id="single-query-session"),
+        _session_db=db,
+        _last_turn_interrupted=False,
+    )
+
+    cli_mod._finalize_single_query_session(shell, {"failed": True})
+
+    assert db.calls == [("single-query-session", "single_query_failed")]
+
+
+def test_finalize_single_query_records_interrupted_result() -> None:
+    import cli as cli_mod
+
+    db = _FakeSessionDB()
+    shell = SimpleNamespace(
+        session_id="single-query-session",
+        agent=SimpleNamespace(session_id="single-query-session"),
+        _session_db=db,
+        _last_turn_interrupted=True,
+    )
+
+    cli_mod._finalize_single_query_session(shell, {"failed": True})
+
+    assert db.calls == [("single-query-session", "single_query_interrupted")]
+
+
+def test_quiet_single_query_main_finalizes_session(monkeypatch) -> None:
+    """The machine-readable ``hermes chat -q -Q`` path exits via sys.exit()."""
+    import cli as cli_mod
+
+    db = _FakeSessionDB()
+
+    class FakeAgent:
+        session_id = "quiet-agent-session"
+
+        def run_conversation(self, **_kwargs):
+            return {"final_response": "done", "completed": True, "failed": False}
+
+    class FakeCLI:
+        def __init__(self, **_kwargs) -> None:
+            self.session_id = "initial-cli-session"
+            self.agent = FakeAgent()
+            self._session_db = db
+            self.conversation_history = []
+            self._active_agent_route_signature = "same"
+            self.tool_progress_mode = "all"
+            self._last_turn_interrupted = False
+
+        def _ensure_runtime_credentials(self) -> bool:
+            return True
+
+        def _resolve_turn_agent_config(self, _message):
+            return {
+                "signature": "same",
+                "model": None,
+                "runtime": None,
+                "request_overrides": None,
+            }
+
+        def _init_agent(self, **_kwargs) -> bool:
+            return True
+
+    monkeypatch.setattr(cli_mod, "HermesCLI", FakeCLI)
+    monkeypatch.setattr(cli_mod.atexit, "register", lambda *_args, **_kwargs: None)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_mod.main(query="hello", quiet=True, toolsets="terminal")
+
+    assert exc_info.value.code == 0
+    assert db.calls == [("quiet-agent-session", "single_query_complete")]
+
+
+def test_human_single_query_main_finalizes_session(monkeypatch) -> None:
+    """The normal human-facing ``hermes chat -q`` path should also close DB state."""
+    import cli as cli_mod
+
+    db = _FakeSessionDB()
+
+    class _Console:
+        def print(self, *_args, **_kwargs) -> None:
+            pass
+
+    class FakeAgent:
+        session_id = "human-agent-session"
+
+    class FakeCLI:
+        def __init__(self, **_kwargs) -> None:
+            self.session_id = "initial-cli-session"
+            self.agent = FakeAgent()
+            self._session_db = db
+            self.conversation_history = []
+            self.console = _Console()
+            self._last_turn_interrupted = False
+
+        def _show_security_advisories(self) -> None:
+            pass
+
+        def chat(self, _query, images=None):
+            assert images is None
+            return "done"
+
+        def _print_exit_summary(self) -> None:
+            pass
+
+    monkeypatch.setattr(cli_mod, "HermesCLI", FakeCLI)
+    monkeypatch.setattr(cli_mod.atexit, "register", lambda *_args, **_kwargs: None)
+
+    cli_mod.main(query="hello", quiet=False, toolsets="terminal")
+
+    assert db.calls == [("human-agent-session", "single_query_complete")]

--- a/tests/cli/test_cli_single_query_finalize.py
+++ b/tests/cli/test_cli_single_query_finalize.py
@@ -51,6 +51,22 @@ def test_finalize_single_query_records_failed_result() -> None:
     assert db.calls == [("single-query-session", "single_query_failed")]
 
 
+def test_finalize_single_query_records_partial_result_as_failed() -> None:
+    import cli as cli_mod
+
+    db = _FakeSessionDB()
+    shell = SimpleNamespace(
+        session_id="single-query-session",
+        agent=SimpleNamespace(session_id="single-query-session"),
+        _session_db=db,
+        _last_turn_interrupted=False,
+    )
+
+    cli_mod._finalize_single_query_session(shell, {"partial": True})
+
+    assert db.calls == [("single-query-session", "single_query_failed")]
+
+
 def test_finalize_single_query_records_interrupted_result() -> None:
     import cli as cli_mod
 
@@ -65,6 +81,82 @@ def test_finalize_single_query_records_interrupted_result() -> None:
     cli_mod._finalize_single_query_session(shell, {"failed": True})
 
     assert db.calls == [("single-query-session", "single_query_interrupted")]
+
+
+def test_chat_preserves_failed_turn_result_for_single_query_finalizer() -> None:
+    """Human ``chat -q`` needs the full turn result, not only rendered text."""
+    import queue
+    import cli as cli_mod
+
+    result = {
+        "final_response": "Error: provider failed",
+        "messages": [],
+        "api_calls": 1,
+        "completed": False,
+        "failed": True,
+        "error": "provider failed",
+    }
+
+    class FakeAgent:
+        session_id = "single-query-session"
+        max_iterations = 90
+
+        def run_conversation(self, **_kwargs):
+            return result
+
+        def interrupt(self, _message=None) -> None:
+            pass
+
+    shell = cli_mod.HermesCLI.__new__(cli_mod.HermesCLI)
+    shell.session_id = "single-query-session"
+    shell.agent = FakeAgent()
+    shell._session_db = None
+    shell.conversation_history = []
+    shell._active_agent_route_signature = "same"
+    shell._last_turn_interrupted = False
+    shell._last_chat_result = {"failed": False}
+    shell._ensure_runtime_credentials = lambda: True
+    shell._resolve_turn_agent_config = lambda _message: {
+        "signature": "same",
+        "model": None,
+        "runtime": None,
+        "request_overrides": None,
+    }
+    shell._init_agent = lambda **_kwargs: True
+    shell._preprocess_images_with_vision = lambda message, _images: message
+    shell._reset_stream_state = lambda: None
+    shell._flush_stream = lambda: None
+    shell._scrollback_box_width = lambda *_, **__: 80
+    shell._voice_speak_response_async = lambda _response: None
+    shell._sudo_password_callback = lambda *_, **__: None
+    shell._approval_callback = lambda *_, **__: None
+    shell._secret_capture_callback = lambda *_, **__: None
+    shell._pending_model_switch_note = None
+    shell._pending_skills_reload_note = None
+    shell._interrupt_queue = queue.Queue()
+    shell._pending_input = queue.Queue()
+    shell._clarify_state = None
+    shell._clarify_freetext = False
+    shell._should_exit = False
+    shell._voice_tts = False
+    shell._voice_mode = False
+    shell._voice_continuous = False
+    shell.show_timestamps = False
+    shell.show_reasoning = False
+    shell._stream_started = False
+    shell._stream_box_opened = False
+    shell.final_response_markdown = False
+    shell.bell_on_complete = False
+    shell.provider = ""
+    shell.model = ""
+    shell.base_url = ""
+    shell.api_key = ""
+    shell.api_mode = ""
+
+    response = cli_mod.HermesCLI.chat(shell, "hello")
+
+    assert response == "Error: provider failed"
+    assert shell._last_chat_result is result
 
 
 def test_quiet_single_query_main_finalizes_session(monkeypatch) -> None:
@@ -151,3 +243,49 @@ def test_human_single_query_main_finalizes_session(monkeypatch) -> None:
     cli_mod.main(query="hello", quiet=False, toolsets="terminal")
 
     assert db.calls == [("human-agent-session", "single_query_complete")]
+
+
+def test_human_single_query_main_uses_failed_chat_result(monkeypatch) -> None:
+    """A failed turn with a rendered error string should close as failed."""
+    import cli as cli_mod
+
+    db = _FakeSessionDB()
+
+    class _Console:
+        def print(self, *_args, **_kwargs) -> None:
+            pass
+
+    class FakeAgent:
+        session_id = "human-agent-session"
+
+    class FakeCLI:
+        def __init__(self, **_kwargs) -> None:
+            self.session_id = "initial-cli-session"
+            self.agent = FakeAgent()
+            self._session_db = db
+            self.conversation_history = []
+            self.console = _Console()
+            self._last_turn_interrupted = False
+            self._last_chat_result = None
+
+        def _show_security_advisories(self) -> None:
+            pass
+
+        def chat(self, _query, images=None):
+            assert images is None
+            self._last_chat_result = {
+                "final_response": "Error: provider failed",
+                "completed": False,
+                "failed": True,
+            }
+            return "Error: provider failed"
+
+        def _print_exit_summary(self) -> None:
+            pass
+
+    monkeypatch.setattr(cli_mod, "HermesCLI", FakeCLI)
+    monkeypatch.setattr(cli_mod.atexit, "register", lambda *_args, **_kwargs: None)
+
+    cli_mod.main(query="hello", quiet=False, toolsets="terminal")
+
+    assert db.calls == [("human-agent-session", "single_query_failed")]


### PR DESCRIPTION
## What does this PR do?

Closes the session database row for non-interactive one-shot CLI runs (`hermes chat -q ...`) after the turn finishes.

Interactive sessions already finalize through the main CLI run loop. The one-shot paths bypass that loop, which can leave `ended_at` as `NULL` after the process has exited. DB-backed session views then report those completed one-shot sessions as still live.

The fix keeps the change local to the one-shot CLI paths and uses the agent's current `session_id` when available, so sessions rotated by compression are finalized on the continuation session rather than the original parent id.

## Related Issue

No linked issue. This addresses stale `ended_at = NULL` rows observed after completed `hermes chat -q` runs.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cli.py`
  - Added `_finalize_single_query_session(...)` for non-interactive CLI cleanup.
  - Finalizes both human-facing `hermes chat -q` and quiet/machine-readable `hermes chat -q -Q` paths.
  - Records `single_query_complete`, `single_query_failed`, or `single_query_interrupted` end reasons.
  - Prefers `agent.session_id` over the initial CLI `session_id` to handle compressed continuation sessions.
- `tests/cli/test_cli_single_query_finalize.py`
  - Covers successful, failed, and interrupted finalization.
  - Covers both one-shot entry paths.
  - Covers continuation-session id selection.

## How to Test

Bug reproduction:

1. Run a one-shot CLI query with `hermes chat -q "hello"`.
2. Inspect the session row in the SQLite session DB.
3. Before this change, the row could remain with `ended_at = NULL` after the process exited.
4. After this change, the row is finalized with a `single_query_*` end reason.

Local verification run on Linux (Arch) with Python 3.11.15:

```bash
python -m py_compile cli.py tests/cli/test_cli_single_query_finalize.py
scripts/run_tests.sh tests/cli/test_cli_single_query_finalize.py -q
scripts/run_tests.sh tests/cli -q
scripts/run_tests.sh tests/test_hermes_state.py tests/test_lazy_session_regressions.py -q
python scripts/check-windows-footguns.py --diff origin/main...HEAD
```

Results:

- `tests/cli/test_cli_single_query_finalize.py`: 5 passed
- `tests/cli`: 720 passed, 1 existing warning
- `tests/test_hermes_state.py tests/test_lazy_session_regressions.py`: 229 passed
- Windows footgun check: no findings for this diff

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (Arch), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable; CLI/session DB lifecycle fix with unit coverage.
