### PR TITLE
feat: add dry-run model routing preview

### DIFF
--- a/agent/model_routing/__init__.py
+++ b/agent/model_routing/__init__.py
@@ -1,0 +1,12 @@
+"""Policy-as-data model routing helpers."""
+
+from .policy import RoutingContext, RoutingDecision, RoutingPolicy, load_policy
+from .policy_router import recommend_model
+
+__all__ = [
+    "RoutingContext",
+    "RoutingDecision",
+    "RoutingPolicy",
+    "load_policy",
+    "recommend_model",
+]

--- a/agent/model_routing/caelus_policy.yaml
+++ b/agent/model_routing/caelus_policy.yaml
@@ -1,0 +1,136 @@
+version: 1
+profile: caelus
+modes:
+  dry_run_default: true
+  require_reason_for_strong_model: true
+  forbid_free_final_authority: true
+
+tiers:
+  F:
+    name: Free Models
+    cost_class: free
+    final_authority_allowed: false
+  B:
+    name: Paid Budget Models
+    cost_class: budget
+    final_authority_allowed: false
+  S:
+    name: Paid Strong Models
+    cost_class: strong
+    final_authority_allowed: true
+
+models:
+  openai/gpt-oss-120b:free:
+    tier: F
+    fallback: deepseek/deepseek-v4-flash
+  qwen/qwen3-coder:free:
+    tier: F
+    fallback: qwen/qwen3-coder-next
+  deepseek/deepseek-v4-flash:free:
+    tier: F
+    fallback: deepseek/deepseek-v4-flash
+  google/gemma-4-31b-it:free:
+    tier: F
+    fallback: qwen/qwen3.6-plus
+  google/gemma-4-26b-a4b-it:free:
+    tier: F
+    fallback: qwen/qwen3.6-plus
+  minimax/minimax-m2.5:free:
+    tier: F
+    fallback: minimax/minimax-m2.7
+  nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free:
+    tier: F
+    fallback: qwen/qwen3.6-flash
+  openrouter/free:
+    tier: F
+    governed_default_allowed: false
+    fallback: deepseek/deepseek-v4-flash
+  deepseek/deepseek-v4-flash:
+    tier: B
+    fallback: qwen/qwen3.6-flash
+  qwen/qwen3.6-flash:
+    tier: B
+    fallback: qwen/qwen3.6-plus
+  qwen/qwen3-coder-next:
+    tier: B
+    fallback: moonshotai/kimi-k2.6
+  minimax/minimax-m2.7:
+    tier: B
+    fallback: qwen/qwen3.6-plus
+  qwen/qwen3.6-plus:
+    tier: S
+    fallback: deepseek/deepseek-v4-pro
+  moonshotai/kimi-k2.6:
+    tier: S
+    fallback: qwen/qwen3-coder-next
+  deepseek/deepseek-v4-pro:
+    tier: S
+    fallback: qwen/qwen3.6-plus
+
+task_routes:
+  daily_ops:
+    model: deepseek/deepseek-v4-flash
+    reason: daily Hermes operations need repeatable paid-budget reliability without strong-model spend.
+  summaries:
+    model: deepseek/deepseek-v4-flash:free
+    reason: low-risk first-pass summaries may use free models when not final authority.
+  extraction:
+    model: deepseek/deepseek-v4-flash:free
+    reason: low-risk first-pass extraction may use free models when not final authority.
+  strategy:
+    model: qwen/qwen3.6-plus
+    escalation_reason: Strategy is a high-leverage business decision and may become reusable source-of-truth guidance.
+  client_facing_draft:
+    model: qwen/qwen3.6-plus
+    escalation_reason: client-facing work affects Alan's reputation and cannot use free models as final authority.
+  security_privacy_review:
+    model: qwen/qwen3.6-plus
+    escalation_reason: Security/privacy judgment is high-risk and requires paid strong review.
+  code_explanation:
+    model: qwen/qwen3-coder:free
+    reason: Code explanation is low-risk and reversible when it is not final authority or implementation.
+  coding_implementation_planning:
+    model: qwen/qwen3-coder-next
+    reason: Bounded implementation planning needs a budget coding model and must not use free final authority.
+  agentic_coding_orchestration:
+    model: moonshotai/kimi-k2.6
+    escalation_reason: Agentic coding orchestration is complex technical work requiring strong CTO-level reasoning.
+  office_workflow:
+    model: minimax/minimax-m2.7
+    reason: Office automation workflows are best routed to the paid budget office-workflow specialist.
+  financial_modeling:
+    model: qwen/qwen3.6-plus
+    escalation_reason: Financial modeling and offer economics require strong reasoning and human approval.
+  legal_contract_drafting:
+    model: qwen/qwen3.6-plus
+    escalation_reason: Legal-adjacent drafting requires strong reasoning and human/legal review.
+
+agent_routes:
+  Hermes: qwen/qwen3.6-plus
+  Chief of Staff: qwen/qwen3.6-plus
+  COO: deepseek/deepseek-v4-flash
+  Operations Analyst: deepseek/deepseek-v4-flash
+  Documentation Quality Specialist: qwen/qwen3.6-plus
+  CTO: moonshotai/kimi-k2.6
+  Senior Engineering Manager: moonshotai/kimi-k2.6
+  Front-End Engineer: qwen/qwen3-coder-next
+  Back-End Engineer: qwen/qwen3-coder-next
+  Database Engineer: qwen/qwen3-coder-next
+  QA/Test Engineer: deepseek/deepseek-v4-flash
+  CPO: qwen/qwen3.6-plus
+  CMO: qwen/qwen3.6-plus
+  CRO: qwen/qwen3.6-plus
+  CFO: qwen/qwen3.6-plus
+  CISO: qwen/qwen3.6-plus
+  Legal / Contract Advisor: qwen/qwen3.6-plus
+  Advisory Board: qwen/qwen3.6-plus
+
+fallbacks:
+  unknown_task: deepseek/deepseek-v4-flash
+
+forbidden:
+  governed_default_models:
+    - openrouter/free
+  free_final_authority: true
+  free_client_facing_final: true
+  free_sensitive_final: true

--- a/agent/model_routing/policy.py
+++ b/agent/model_routing/policy.py
@@ -1,0 +1,93 @@
+"""Policy-as-data primitives for dry-run model routing.
+
+This module intentionally performs no network calls and does not mutate Hermes
+runtime configuration. It only loads structured policy data and exposes typed
+inputs/outputs for policy dry-runs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+_POLICY_PATH = Path(__file__).with_name("caelus_policy.yaml")
+
+
+@dataclass(frozen=True)
+class RoutingContext:
+    """Inputs used to recommend a model without changing runtime state."""
+
+    task_type: str
+    agent_role: str
+    risk_level: str
+    client_facing: bool
+    sensitive_data: bool
+    final_authority: bool
+    complexity: str
+    current_provider: str | None = None
+    current_model: str | None = None
+
+
+@dataclass(frozen=True)
+class RoutingPolicy:
+    """Structured model-routing policy loaded from YAML."""
+
+    version: int
+    profile: str
+    modes: dict[str, Any]
+    tiers: dict[str, dict[str, Any]]
+    models: dict[str, dict[str, Any]]
+    task_routes: dict[str, dict[str, Any]]
+    agent_routes: dict[str, str]
+    fallbacks: dict[str, str]
+    forbidden: dict[str, Any]
+
+    @classmethod
+    def from_mapping(cls, data: dict[str, Any]) -> "RoutingPolicy":
+        return cls(
+            version=int(data["version"]),
+            profile=str(data["profile"]),
+            modes=dict(data.get("modes") or {}),
+            tiers=dict(data.get("tiers") or {}),
+            models=dict(data.get("models") or {}),
+            task_routes=dict(data.get("task_routes") or {}),
+            agent_routes=dict(data.get("agent_routes") or {}),
+            fallbacks=dict(data.get("fallbacks") or {}),
+            forbidden=dict(data.get("forbidden") or {}),
+        )
+
+
+@dataclass(frozen=True)
+class RoutingDecision:
+    """Dry-run recommendation produced by the policy router."""
+
+    provider: str
+    model: str
+    tier: str
+    fallback_model: str | None
+    free_model_allowed: bool
+    reason: str
+    estimated_cost_class: str
+    approval_required: bool
+    policy_warnings: list[str] = field(default_factory=list)
+    escalation_reason: str | None = None
+    dry_run: bool = True
+
+
+def load_policy(path: str | Path | None = None) -> RoutingPolicy:
+    """Load the Caelus model-routing policy from YAML.
+
+    The loader is deliberately local-file only: no API calls, config writes, or
+    provider validation happen here.
+    """
+
+    policy_path = Path(path) if path else _POLICY_PATH
+    with policy_path.open("r", encoding="utf-8") as fh:
+        raw = yaml.safe_load(fh) or {}
+    if not isinstance(raw, dict):
+        raise ValueError(f"Routing policy must be a mapping: {policy_path}")
+    return RoutingPolicy.from_mapping(raw)

--- a/agent/model_routing/policy_router.py
+++ b/agent/model_routing/policy_router.py
@@ -1,0 +1,184 @@
+"""Dry-run model routing decisions for policy-as-data.
+
+The router is intentionally deterministic and side-effect free. It recommends a
+provider/model pair plus governance metadata, but it does not switch the active
+Hermes model, call an LLM, write config, or spend OpenRouter credits.
+"""
+
+from __future__ import annotations
+
+from .policy import RoutingContext, RoutingDecision, RoutingPolicy
+
+
+_HIGH_RISK_TASK_TYPES = {
+    "strategy",
+    "client_facing_draft",
+    "security_privacy_review",
+    "financial_modeling",
+    "legal_contract_drafting",
+}
+
+_SENSITIVE_FINAL_TASK_TYPES = {
+    "security_privacy_review",
+    "financial_modeling",
+    "legal_contract_drafting",
+}
+
+_COMPLEX_TECHNICAL_TASK_TYPES = {
+    "agentic_coding_orchestration",
+}
+
+
+def recommend_model(context: RoutingContext, policy: RoutingPolicy) -> RoutingDecision:
+    """Return a dry-run model recommendation for ``context``.
+
+    The function encodes the approved Caelus boundaries:
+    free models are draft/low-risk only, strong models require a reason, and
+    unknown governed work fails safe to the paid-budget workhorse instead of a
+    random or free router.
+    """
+
+    warnings: list[str] = []
+    route = policy.task_routes.get(context.task_type)
+
+    if route is None:
+        model = policy.fallbacks.get("unknown_task", "deepseek/deepseek-v4-flash")
+        reason = (
+            f"Unknown task type '{context.task_type}' failed safe to the paid-budget "
+            "daily workhorse instead of a free or random model."
+        )
+        escalation_reason = None
+        warnings.append(f"Unknown task type: {context.task_type}")
+    else:
+        model = route["model"]
+        reason = route.get("reason") or route.get("escalation_reason") or "Policy route matched."
+        escalation_reason = route.get("escalation_reason")
+
+    model, guardrail_warnings = _apply_guardrails(model, context, policy)
+    warnings.extend(guardrail_warnings)
+
+    model_config = policy.models.get(model)
+    if model_config is None:
+        fallback = policy.fallbacks.get("unknown_task", "deepseek/deepseek-v4-flash")
+        warnings.append(f"Model '{model}' missing from policy; fell back to {fallback}")
+        model = fallback
+        model_config = policy.models[model]
+
+    tier = str(model_config["tier"])
+    tier_config = policy.tiers[tier]
+    cost_class = str(tier_config["cost_class"])
+    fallback_model = model_config.get("fallback")
+    free_model_allowed = _free_model_allowed(model, tier, context, policy)
+
+    if tier == "S" and not escalation_reason:
+        escalation_reason = _derive_escalation_reason(context)
+        if policy.modes.get("require_reason_for_strong_model", True) and not escalation_reason:
+            warnings.append("Strong model selected without an explicit escalation reason")
+
+    approval_required = _approval_required(context, tier)
+
+    if tier == "S" and escalation_reason:
+        reason = escalation_reason
+
+    return RoutingDecision(
+        provider="openrouter",
+        model=model,
+        tier=tier,
+        fallback_model=fallback_model,
+        free_model_allowed=free_model_allowed,
+        reason=reason,
+        estimated_cost_class=cost_class,
+        approval_required=approval_required,
+        policy_warnings=warnings,
+        escalation_reason=escalation_reason,
+        dry_run=bool(policy.modes.get("dry_run_default", True)),
+    )
+
+
+def _apply_guardrails(
+    model: str,
+    context: RoutingContext,
+    policy: RoutingPolicy,
+) -> tuple[str, list[str]]:
+    warnings: list[str] = []
+
+    if model in set(policy.forbidden.get("governed_default_models") or []):
+        warnings.append(f"Forbidden governed default '{model}' replaced with budget fallback")
+        return policy.fallbacks.get("unknown_task", "deepseek/deepseek-v4-flash"), warnings
+
+    model_config = policy.models.get(model, {})
+    tier = model_config.get("tier")
+    is_free = tier == "F" or model.endswith(":free") or model == "openrouter/free"
+
+    if is_free and _free_forbidden_for_context(context, policy):
+        warnings.append(f"Free model '{model}' not allowed for this context; escalated to strong model")
+        return "qwen/qwen3.6-plus", warnings
+
+    if _requires_strong_model(context) and tier != "S":
+        warnings.append(f"Task context requires Tier S; escalated from {model} to qwen/qwen3.6-plus")
+        return "qwen/qwen3.6-plus", warnings
+
+    return model, warnings
+
+
+def _free_forbidden_for_context(context: RoutingContext, policy: RoutingPolicy) -> bool:
+    if policy.forbidden.get("free_final_authority", True) and context.final_authority:
+        return True
+    if policy.forbidden.get("free_client_facing_final", True) and context.client_facing:
+        return True
+    if policy.forbidden.get("free_sensitive_final", True) and context.sensitive_data:
+        return True
+    return context.risk_level.lower() == "high"
+
+
+def _requires_strong_model(context: RoutingContext) -> bool:
+    if context.client_facing and context.final_authority:
+        return True
+    if context.sensitive_data and context.final_authority:
+        return True
+    if context.task_type in _SENSITIVE_FINAL_TASK_TYPES and context.final_authority:
+        return True
+    if context.task_type in _HIGH_RISK_TASK_TYPES and context.risk_level.lower() == "high":
+        return True
+    if context.task_type in _COMPLEX_TECHNICAL_TASK_TYPES:
+        return True
+    return False
+
+
+def _free_model_allowed(
+    model: str,
+    tier: str,
+    context: RoutingContext,
+    policy: RoutingPolicy,
+) -> bool:
+    if tier != "F":
+        return False
+    if model in set(policy.forbidden.get("governed_default_models") or []):
+        return False
+    return not _free_forbidden_for_context(context, policy)
+
+
+def _approval_required(context: RoutingContext, tier: str) -> bool:
+    return any(
+        [
+            context.client_facing,
+            context.sensitive_data,
+            context.final_authority,
+            tier == "S",
+            context.risk_level.lower() == "high",
+        ]
+    )
+
+
+def _derive_escalation_reason(context: RoutingContext) -> str | None:
+    if context.task_type == "strategy":
+        return "Strategy work is a high-leverage business decision requiring Tier S review."
+    if context.client_facing:
+        return "Client-facing work affects Alan's reputation and requires Tier S review."
+    if context.sensitive_data:
+        return "Sensitive-data work requires Tier S review and human approval."
+    if context.task_type in _COMPLEX_TECHNICAL_TASK_TYPES:
+        return "Complex technical orchestration requires Tier S reasoning."
+    if context.risk_level.lower() == "high":
+        return "High-risk work requires Tier S review."
+    return None

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9734,7 +9734,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
         "dump", "fallback", "gateway", "hooks", "import", "insights",
         "kanban", "login", "logout", "logs", "lsp", "mcp", "memory",
         "model", "pairing", "plugins", "postinstall", "profile", "proxy",
-        "send", "sessions", "setup",
+        "routing", "send", "sessions", "setup",
         "skills", "slack", "status", "tools", "uninstall", "update",
         "version", "webhook", "whatsapp", "chat",
         # Help-ish invocations — plugin commands not being listed in
@@ -10241,6 +10241,12 @@ def main():
         "into an existing manifest manually).",
     )
     slack_parser.set_defaults(func=cmd_slack)
+
+    # =========================================================================
+    # routing command — dry-run policy router previews
+    # =========================================================================
+    from hermes_cli.model_routing_cmd import register_routing_subparser
+    register_routing_subparser(subparsers)
 
     # =========================================================================
     # send command — pipe shell-script output to any configured platform

--- a/hermes_cli/model_routing_cmd.py
+++ b/hermes_cli/model_routing_cmd.py
@@ -1,0 +1,202 @@
+"""CLI subcommand for dry-run model-routing previews.
+
+This module intentionally does not mutate Hermes runtime configuration. It loads
+local policy data, calls the pure dry-run router, and prints the recommendation
+for human review.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict
+from pathlib import Path
+
+from agent.model_routing import RoutingContext, load_policy, recommend_model
+
+_SUCCESS_EXIT = 0
+_USAGE_EXIT = 2
+_FAILURE_EXIT = 1
+
+
+def _build_context(args: argparse.Namespace) -> RoutingContext:
+    """Translate argparse inputs into a router context."""
+
+    return RoutingContext(
+        task_type=args.task_type,
+        agent_role=args.agent_role,
+        risk_level=args.risk_level,
+        client_facing=bool(args.client_facing),
+        sensitive_data=bool(args.sensitive_data),
+        final_authority=bool(args.final_authority),
+        complexity=args.complexity,
+        current_provider=args.current_provider,
+        current_model=args.current_model,
+    )
+
+
+def _decision_payload(context: RoutingContext, decision) -> dict:
+    """Return stable JSON for scripts and tests."""
+
+    payload = asdict(decision)
+    payload["context"] = asdict(context)
+    payload["runtime_config_changed"] = False
+    return payload
+
+
+def _print_human_preview(context: RoutingContext, payload: dict) -> None:
+    """Print a concise human-readable route preview."""
+
+    print("Routing preview (DRY RUN)")
+    print("=========================")
+    print(f"Task type: {context.task_type}")
+    print(f"Agent role: {context.agent_role}")
+    print(f"Risk level: {context.risk_level}")
+    print(f"Client-facing: {'yes' if context.client_facing else 'no'}")
+    print(f"Sensitive data: {'yes' if context.sensitive_data else 'no'}")
+    print(f"Final authority: {'yes' if context.final_authority else 'no'}")
+    print()
+    print(f"Recommended provider: {payload['provider']}")
+    print(f"Recommended model: {payload['model']}")
+    print(f"Tier: {payload['tier']}")
+    print(f"Estimated cost class: {payload['estimated_cost_class']}")
+    print(f"Fallback model: {payload['fallback_model'] or '(none)'}")
+    print(f"Approval required: {'yes' if payload['approval_required'] else 'no'}")
+    print(f"Runtime config changed: {'yes' if payload['runtime_config_changed'] else 'no'}")
+    print()
+    print(f"Reason: {payload['reason']}")
+    if payload.get("escalation_reason"):
+        print(f"Escalation reason: {payload['escalation_reason']}")
+    warnings = payload.get("policy_warnings") or []
+    if warnings:
+        print("Policy warnings:")
+        for warning in warnings:
+            print(f"  - {warning}")
+
+
+def _cmd_preview(args: argparse.Namespace) -> int:
+    """Run the dry-run router and print the decision."""
+
+    try:
+        policy_path = Path(args.policy) if args.policy else None
+        policy = load_policy(policy_path)
+        context = _build_context(args)
+        decision = recommend_model(context, policy)
+        payload = _decision_payload(context, decision)
+    except Exception as exc:  # noqa: BLE001 - CLI should report errors cleanly
+        print(f"hermes routing preview: {exc}", file=sys.stderr)
+        return _FAILURE_EXIT
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        _print_human_preview(context, payload)
+    return _SUCCESS_EXIT
+
+
+def cmd_routing(args: argparse.Namespace) -> None:
+    """Entry point wired into the top-level argparse dispatcher."""
+
+    command = getattr(args, "routing_command", None)
+    if command is None:
+        print(
+            "hermes routing: subcommand required (try: hermes routing preview --help)",
+            file=sys.stderr,
+        )
+        sys.exit(_USAGE_EXIT)
+
+    if command == "preview":
+        sys.exit(_cmd_preview(args))
+
+    print(f"hermes routing: unknown subcommand {command!r}", file=sys.stderr)
+    sys.exit(_USAGE_EXIT)
+
+
+def register_routing_subparser(subparsers) -> argparse.ArgumentParser:
+    """Create the ``routing`` subparser and return it."""
+
+    parser = subparsers.add_parser(
+        "routing",
+        help="Preview policy-driven model routing decisions (dry run).",
+        description=(
+            "Preview which provider/model Hermes would recommend under the local "
+            "model-routing policy. This is dry-run only: it does not call a model, "
+            "write config, change runtime selection, or spend credits."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    routing_subparsers = parser.add_subparsers(dest="routing_command")
+
+    preview = routing_subparsers.add_parser(
+        "preview",
+        help="Preview a route decision for a task context.",
+        description="Run the local dry-run router for a supplied task context.",
+    )
+    preview.add_argument(
+        "--task-type",
+        required=True,
+        help=(
+            "Policy task key, e.g. daily_ops, strategy, client_facing_draft, "
+            "security_privacy_review, code_explanation."
+        ),
+    )
+    preview.add_argument(
+        "--agent-role",
+        default="hermes",
+        help="Agent/persona role requesting the route (default: hermes).",
+    )
+    preview.add_argument(
+        "--risk-level",
+        choices=["low", "medium", "high"],
+        default="medium",
+        help="Risk level for the task (default: medium).",
+    )
+    preview.add_argument(
+        "--complexity",
+        choices=["low", "medium", "high", "standard"],
+        default="standard",
+        help="Task complexity signal (default: standard).",
+    )
+    preview.add_argument(
+        "--client-facing",
+        action="store_true",
+        help="Mark the task as client/prospect/public-facing.",
+    )
+    preview.add_argument(
+        "--sensitive-data",
+        action="store_true",
+        help="Mark the task as involving sensitive/private data.",
+    )
+    preview.add_argument(
+        "--final-authority",
+        action="store_true",
+        help="Mark the model output as intended final authority rather than draft/critique.",
+    )
+    preview.add_argument(
+        "--current-provider",
+        default=None,
+        help="Optional currently configured provider for comparison metadata.",
+    )
+    preview.add_argument(
+        "--current-model",
+        default=None,
+        help="Optional currently configured model for comparison metadata.",
+    )
+    preview.add_argument(
+        "--policy",
+        default=None,
+        help="Optional path to a routing policy YAML file (default: bundled Caelus policy).",
+    )
+    preview.add_argument(
+        "--json",
+        action="store_true",
+        default=False,
+        help="Emit JSON instead of human-readable output.",
+    )
+
+    parser.set_defaults(func=cmd_routing)
+    return parser
+
+
+__all__ = ["cmd_routing", "register_routing_subparser"]

--- a/tests/agent/test_model_routing_policy_router.py
+++ b/tests/agent/test_model_routing_policy_router.py
@@ -1,0 +1,105 @@
+from agent.model_routing.policy import RoutingContext, load_policy
+from agent.model_routing.policy_router import recommend_model
+
+
+def _decision(**overrides):
+    defaults = {
+        "task_type": "daily_ops",
+        "agent_role": "COO",
+        "risk_level": "medium",
+        "client_facing": False,
+        "sensitive_data": False,
+        "final_authority": False,
+        "complexity": "routine",
+    }
+    defaults.update(overrides)
+    context = RoutingContext(**defaults)
+    return recommend_model(context, load_policy())
+
+
+def test_client_facing_final_authority_never_uses_free_model():
+    decision = _decision(
+        task_type="client_facing_draft",
+        agent_role="CMO",
+        risk_level="high",
+        client_facing=True,
+        final_authority=True,
+    )
+
+    assert decision.tier == "S"
+    assert decision.model == "qwen/qwen3.6-plus"
+    assert decision.free_model_allowed is False
+    assert "client-facing" in decision.reason
+
+
+def test_security_privacy_final_decision_routes_to_strong_model():
+    decision = _decision(
+        task_type="security_privacy_review",
+        agent_role="CISO",
+        risk_level="high",
+        sensitive_data=True,
+        final_authority=True,
+    )
+
+    assert decision.tier == "S"
+    assert decision.model == "qwen/qwen3.6-plus"
+    assert decision.approval_required is True
+
+
+def test_daily_operations_default_to_paid_budget_not_strong():
+    decision = _decision(task_type="daily_ops", agent_role="COO", risk_level="medium")
+
+    assert decision.tier == "B"
+    assert decision.model == "deepseek/deepseek-v4-flash"
+    assert decision.estimated_cost_class == "budget"
+
+
+def test_code_explanation_can_use_free_coding_model():
+    decision = _decision(
+        task_type="code_explanation",
+        agent_role="Front-End Engineer",
+        risk_level="low",
+        final_authority=False,
+        complexity="simple",
+    )
+
+    assert decision.tier == "F"
+    assert decision.model == "qwen/qwen3-coder:free"
+    assert decision.free_model_allowed is True
+
+
+def test_coding_implementation_planning_routes_to_budget_or_strong_not_free():
+    decision = _decision(
+        task_type="coding_implementation_planning",
+        agent_role="CTO",
+        risk_level="medium",
+        final_authority=False,
+        complexity="moderate",
+    )
+
+    assert decision.tier == "B"
+    assert decision.model == "qwen/qwen3-coder-next"
+    assert decision.free_model_allowed is False
+
+
+def test_openrouter_free_is_never_selected_for_governed_workflows():
+    for task_type in ["daily_ops", "strategy", "client_facing_draft", "code_explanation"]:
+        decision = _decision(task_type=task_type)
+        assert decision.model != "openrouter/free"
+
+
+def test_strong_model_decision_includes_escalation_reason():
+    decision = _decision(task_type="strategy", agent_role="Hermes", risk_level="high")
+
+    assert decision.tier == "S"
+    assert decision.escalation_reason
+    assert "strategy" in decision.escalation_reason.lower()
+
+
+def test_unknown_task_fails_safe_to_budget_model_not_free_or_random():
+    decision = _decision(task_type="unknown_new_task", agent_role="Unknown", risk_level="medium")
+
+    assert decision.tier == "B"
+    assert decision.model == "deepseek/deepseek-v4-flash"
+    assert decision.model != "openrouter/free"
+    assert decision.policy_warnings

--- a/tests/hermes_cli/test_model_routing_cmd.py
+++ b/tests/hermes_cli/test_model_routing_cmd.py
@@ -1,0 +1,129 @@
+"""Tests for the ``hermes routing preview`` dry-run command."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+import pytest
+
+
+def _parse(argv: list[str]) -> argparse.Namespace:
+    from hermes_cli.model_routing_cmd import register_routing_subparser
+
+    parser = argparse.ArgumentParser(prog="hermes")
+    subparsers = parser.add_subparsers(dest="command")
+    register_routing_subparser(subparsers)
+    return parser.parse_args(argv)
+
+
+def test_registers_routing_preview_subcommand():
+    args = _parse(
+        [
+            "routing",
+            "preview",
+            "--task-type",
+            "daily_ops",
+            "--risk-level",
+            "low",
+        ]
+    )
+
+    assert args.command == "routing"
+    assert args.routing_command == "preview"
+    assert args.task_type == "daily_ops"
+    assert callable(args.func)
+
+
+def test_preview_json_emits_dry_run_decision_without_config_mutation(capsys):
+    from hermes_cli.model_routing_cmd import cmd_routing
+
+    args = _parse(
+        [
+            "routing",
+            "preview",
+            "--task-type",
+            "client_facing_draft",
+            "--agent-role",
+            "cmo",
+            "--risk-level",
+            "high",
+            "--client-facing",
+            "--final-authority",
+            "--json",
+        ]
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cmd_routing(args)
+
+    assert exc.value.code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["dry_run"] is True
+    assert payload["provider"] == "openrouter"
+    assert payload["tier"] == "S"
+    assert payload["approval_required"] is True
+    assert "would_change_runtime" not in payload
+
+
+def test_preview_human_output_calls_out_dry_run_and_approval(capsys):
+    from hermes_cli.model_routing_cmd import cmd_routing
+
+    args = _parse(
+        [
+            "routing",
+            "preview",
+            "--task-type",
+            "security_privacy_review",
+            "--risk-level",
+            "high",
+            "--sensitive-data",
+            "--final-authority",
+        ]
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cmd_routing(args)
+
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "Routing preview" in out
+    assert "DRY RUN" in out
+    assert "Approval required: yes" in out
+    assert "Runtime config changed: no" in out
+    assert "openrouter" in out
+
+
+def test_preview_defaults_are_safe_for_unknown_tasks(capsys):
+    from hermes_cli.model_routing_cmd import cmd_routing
+
+    args = _parse(
+        [
+            "routing",
+            "preview",
+            "--task-type",
+            "brand_new_workflow",
+            "--json",
+        ]
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cmd_routing(args)
+
+    assert exc.value.code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["tier"] == "B"
+    assert payload["model"] == "deepseek/deepseek-v4-flash"
+    assert payload["policy_warnings"] == ["Unknown task type: brand_new_workflow"]
+
+
+def test_routing_command_without_subcommand_is_usage_error(capsys):
+    from hermes_cli.model_routing_cmd import cmd_routing
+
+    args = _parse(["routing"])
+
+    with pytest.raises(SystemExit) as exc:
+        cmd_routing(args)
+
+    assert exc.value.code == 2
+    assert "hermes routing: subcommand required" in capsys.readouterr().err


### PR DESCRIPTION
## Summary
- Add a dry-run `agent.model_routing` policy module for Caelus model-tier recommendations.
- Add `hermes routing preview` CLI command for human/JSON dry-run route inspection.
- Add policy-router and CLI tests covering governance guardrails and no-runtime-mutation behavior.

## Safety / scope
- Dry-run only: does not call an LLM, write config, switch runtime provider/model, or spend credits.
- Keeps live `AIAgent`, gateway, cron, delegation, and config routing unchanged.
- JSON output includes `runtime_config_changed: false`; human output states runtime config did not change.

## Test plan
- [x] `scripts/run_tests.sh tests/hermes_cli/test_model_routing_cmd.py -q` — 5 passed
- [x] `scripts/run_tests.sh tests/agent/test_model_routing_policy_router.py tests/hermes_cli/test_model_routing_cmd.py -q` — 13 passed
- [x] `scripts/run_tests.sh tests/agent/test_model_routing_policy_router.py tests/hermes_cli/test_model_routing_cmd.py tests/hermes_cli/test_send_cmd.py -q` — 34 passed
- [x] `git diff --check`
- [x] Manual: `venv/bin/python -m hermes_cli.main routing preview --task-type daily_ops --risk-level low --json`

## Broader validation note
`scripts/run_tests.sh tests/agent tests/hermes_cli -q` currently reports 2 failures in `tests/hermes_cli/test_aux_config.py` concerning `DEFAULT_CONFIG["auxiliary"]["session_search"]`. This PR does not modify `hermes_cli/config.py` or `tests/hermes_cli/test_aux_config.py`; focused and adjacent model-routing/CLI tests pass.
