### PR TITLE
fix(kanban-dashboard): make Orchestration mode checkbox label static

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -1588,10 +1588,12 @@
                   saveSettings({ auto_decompose: !!e.target.checked });
                 },
               }),
-              settings.auto_decompose ? "Auto (default)" : "Manual",
+              "Auto-decompose triage tasks",
             ),
             h("div", { className: "text-[10px] text-muted-foreground" },
-              "When on, the dispatcher decomposes new triage tasks automatically."),
+              settings.auto_decompose
+                ? "The dispatcher decomposes new triage tasks automatically."
+                : "Triage tasks stay in triage until you click ⚗ Decompose."),
           ),
         ) : h("div", { className: "text-xs text-muted-foreground" },
           "Loading…"),


### PR DESCRIPTION
## Summary

Fixes #28178. The kanban board's **Orchestration mode** checkbox label echoed its own state ("Auto (default)" / "Manual") instead of describing the action it controls, which inverts the usual convention that a checkbox label describes what happens **when checked**.

## Root cause

`plugins/kanban/dashboard/dist/index.js:1591`:

```js
settings.auto_decompose ? "Auto (default)" : "Manual",
```

The ternary on `settings.auto_decompose` made the label a state mirror. The sub-description on the next line was also static and began with `"When on, ..."`, which reads awkwardly when the box is unchecked.

## Fix

- Replace the dynamic label with a static action label: `"Auto-decompose triage tasks"` (matches the reporter's suggestion).
- Flip the sub-description between the two modes (`"The dispatcher decomposes new triage tasks automatically."` vs `"Triage tasks stay in triage until you click ⚗ Decompose."`) so it stays accurate either way. The "Manual" copy mirrors the existing language already used elsewhere (`plugins/kanban/dashboard/dist/index.js:1495` and `website/docs/user-guide/features/kanban.md:447`).

Net diff: +4 / -2 in the dist bundle.

## Tests

No automated tests for the dashboard plugin's rendered text. Verified:

- `node --check plugins/kanban/dashboard/dist/index.js` — parses clean.
- Grep confirms the only other `"Manual"` occurrence in this file is the top-of-page **Orchestration: Auto/Manual** pill (`:1512`), which intentionally doubles as a status badge / toggle and is documented that way; it is left unchanged.

## Scope

Intentionally not touching:

- The page-top Orchestration pill — by design a state badge + toggle.
- The `"Orchestration mode"` section label above the checkbox — unrelated, reads as a settings group title.
- No separate source tree exists for this plugin; the dist file has been historically edited directly (e.g. #27893, #24547, #26413), so editing `dist/index.js` follows the established convention.