### PR TITLE
fix(acp): use tempfile.gettempdir() in workspace auto-approve

### DIFF
--- a/acp_adapter/edit_approval.py
+++ b/acp_adapter/edit_approval.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import tempfile
 from concurrent.futures import TimeoutError as FutureTimeout
 from contextvars import ContextVar, Token
 from dataclasses import dataclass
@@ -158,8 +159,15 @@ def should_auto_approve_edit(proposal: EditProposal, policy: str, cwd: str | Non
     if policy == AUTO_APPROVE_SESSION:
         return True
     if policy == AUTO_APPROVE_WORKSPACE:
-        if str(path).startswith("/tmp/"):
+        # `/tmp` is the POSIX path but tempfile.gettempdir() is the real one on
+        # every platform: `/private/tmp` on macOS (because `/tmp` is a symlink
+        # and Path.resolve() follows it) and the per-user Temp dir on Windows.
+        tmp_root = Path(tempfile.gettempdir()).resolve(strict=False)
+        try:
+            path.relative_to(tmp_root)
             return True
+        except ValueError:
+            pass
         if cwd:
             root = Path(cwd).expanduser().resolve(strict=False)
             try:

--- a/tests/acp/test_edit_approval.py
+++ b/tests/acp/test_edit_approval.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import tempfile
 from pathlib import Path
 
 from acp_adapter.edit_approval import (
@@ -183,7 +184,10 @@ def test_patch_replace_approval_request_includes_full_file_diff(tmp_path):
 
 def test_workspace_auto_approval_allows_workspace_and_tmp_but_not_sensitive(tmp_path):
     workspace_file = tmp_path / "src.py"
-    tmp_file = Path("/tmp/hermes-acp-auto-approve-test.txt")
+    # Use tempfile.gettempdir() so this test exercises the same code path on
+    # Linux (`/tmp`), macOS (`/private/var/folders/...`) and Windows
+    # (`%LOCALAPPDATA%\Temp`). Before the fix this branch only worked on Linux.
+    tmp_file = Path(tempfile.gettempdir()) / "hermes-acp-auto-approve-test.txt"
     env_file = tmp_path / ".env"
 
     assert should_auto_approve_edit(


### PR DESCRIPTION
## What does this PR do?

Fixes the `workspace_session` ACP edit auto-approval branch so it works on macOS and Windows, not just Linux.

`should_auto_approve_edit` checked `str(path).startswith("/tmp/")` after `Path.resolve()`. That comparison is broken outside Linux:

- **macOS:** `/tmp` is a symlink to `/private/tmp`; `Path("/tmp/foo").resolve()` returns `/private/tmp/foo`, so the prefix check is always `False`.
- **Windows:** `Path("/tmp/foo").resolve()` returns `<drive>:\tmp\foo`; the branch is unreachable.

Replaced the hardcoded prefix with `Path(tempfile.gettempdir()).resolve()` + `Path.relative_to()` — the same idiom already used three lines below for the `cwd` branch. The existing regression test now constructs its tmp path via `tempfile.gettempdir()` so it exercises the branch on every platform.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `acp_adapter/edit_approval.py` — drop `startswith("/tmp/")`, use `tempfile.gettempdir()` + `Path.relative_to()`.
- `tests/acp/test_edit_approval.py` — build the tmp path via `tempfile.gettempdir()` instead of `Path("/tmp/...")`.

## How to Test

```
python -m pytest tests/acp/test_edit_approval.py::test_workspace_auto_approval_allows_workspace_and_tmp_but_not_sensitive -v
```

Before the fix the assertion on the tmp file fails on macOS and Windows; after the fix it passes on all three platforms.

Manual reproduction (Windows / macOS):

```python
from pathlib import Path
from acp_adapter.edit_approval import EditProposal, should_auto_approve_edit
import tempfile

p = Path(tempfile.gettempdir()) / "x.txt"
# Pre-fix: False on macOS/Windows. Post-fix: True everywhere.
print(should_auto_approve_edit(EditProposal("write_file", str(p), None, "x", {}), "workspace_session", "."))
```

## Checklist

- [x] Conventional commit message
- [x] Single logical change, no unrelated edits
- [x] Existing test tightened (not a change-detector — asserts the cross-platform contract, no hardcoded names/counts)
- [x] No new dependencies, no config keys, no schema/doc changes needed