### PR TITLE
feat: add speculative context precompression

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1095,6 +1095,9 @@ def init_agent(
         pass
     compression_enabled = str(_compression_cfg.get("enabled", True)).lower() in {"true", "1", "yes"}
     compression_target_ratio = float(_compression_cfg.get("target_ratio", 0.20))
+    compression_background = _compression_cfg.get("background", {})
+    if not isinstance(compression_background, dict):
+        compression_background = {}
     compression_protect_last = int(_compression_cfg.get("protect_last_n", 20))
     # protect_first_n is the number of non-system messages to protect at
     # the head, in addition to the system prompt (which is always
@@ -1323,6 +1326,7 @@ def init_agent(
             provider=agent.provider,
             api_mode=agent.api_mode,
             abort_on_summary_failure=compression_abort_on_summary_failure,
+            background_precompression=compression_background,
         )
     agent.compression_enabled = compression_enabled
 

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -20,7 +20,10 @@ import hashlib
 import json
 import logging
 import re
+import copy
+import threading
 import time
+from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Any, Dict, List, Optional
 
 from agent.auxiliary_client import call_llm, _is_connection_error
@@ -480,6 +483,18 @@ class ContextCompressor(ContextEngine):
         self._last_compression_savings_pct = 100.0
         self._ineffective_compression_count = 0
         self._summary_failure_cooldown_until = 0.0  # transient errors must not block a fresh session
+        self._precompression_generation = getattr(self, "_precompression_generation", 0) + 1
+        future = getattr(self, "_precompression_future", None)
+        if future is not None and not future.done():
+            try:
+                future.cancel()
+            except Exception:
+                pass
+        self._precompression_future = None
+        self._precompression_inflight_key = None
+        self._precompression_inflight_generation = None
+        self._precompression_cache = {}
+        self._last_precompression_cache_hit = False
 
     def update_model(
         self,
@@ -524,6 +539,7 @@ class ContextCompressor(ContextEngine):
         provider: str = "",
         api_mode: str = "",
         abort_on_summary_failure: bool = False,
+        background_precompression: Optional[Dict[str, Any]] = None,
     ):
         self.model = model
         self.base_url = base_url
@@ -604,6 +620,39 @@ class ContextCompressor(ContextEngine):
         # succeeded.  Silent recovery would hide the broken config.
         self._last_aux_model_failure_error: Optional[str] = None
         self._last_aux_model_failure_model: Optional[str] = None
+        self._summary_generation_lock = threading.RLock()
+
+        # Optional speculative/background precompaction.  When enabled, Hermes
+        # can summarize a stable prefix before the foreground turn actually
+        # crosses the hard compression threshold.  Later, compress() reuses the
+        # ready summary iff the exact pruned message window still matches.
+        bg_cfg = background_precompression if isinstance(background_precompression, dict) else {}
+        self.background_precompression_enabled = (
+            str(bg_cfg.get("enabled", False)).lower() in {"true", "1", "yes"}
+        )
+        try:
+            self.background_precompression_trigger_percent = float(
+                bg_cfg.get("trigger_threshold", 0.35)
+            )
+        except (TypeError, ValueError):
+            self.background_precompression_trigger_percent = 0.35
+        self.background_precompression_trigger_percent = max(
+            0.05, min(self.background_precompression_trigger_percent, 0.95)
+        )
+        try:
+            _bg_workers = int(bg_cfg.get("max_workers", 1))
+        except (TypeError, ValueError):
+            _bg_workers = 1
+        self._precompression_executor = ThreadPoolExecutor(
+            max_workers=max(1, min(_bg_workers, 2)),
+            thread_name_prefix="hermes-precompress",
+        )
+        self._precompression_future: Optional[Future] = None
+        self._precompression_inflight_key: Optional[str] = None
+        self._precompression_inflight_generation: Optional[int] = None
+        self._precompression_generation: int = 0
+        self._precompression_cache: Dict[str, str] = {}
+        self._last_precompression_cache_hit: bool = False
 
     def update_from_response(self, usage: Dict[str, Any]):
         """Update tracked token usage from API response."""
@@ -910,7 +959,18 @@ class ContextCompressor(ContextEngine):
         self.summary_model = ""  # empty = use main model
         self._summary_failure_cooldown_until = 0.0  # no cooldown — retry immediately
 
-    def _generate_summary(self, turns_to_summarize: List[Dict[str, Any]], focus_topic: str = None) -> Optional[str]:
+    def _generate_summary(self, turns_to_summarize: List[Dict[str, Any]], focus_topic: Optional[str] = None) -> Optional[str]:
+        """Generate a structured summary of conversation turns."""
+        with self._summary_generation_lock:
+            return self._generate_summary_locked(turns_to_summarize, focus_topic=focus_topic)
+
+    def _generate_summary_locked(
+        self,
+        turns_to_summarize: List[Dict[str, Any]],
+        focus_topic: Optional[str] = None,
+        previous_summary_override: Optional[str] = None,
+        update_state: bool = True,
+    ) -> Optional[str]:
         """Generate a structured summary of conversation turns.
 
         Uses a structured template (Goal, Progress, Decisions, Resolved/Pending
@@ -1016,14 +1076,16 @@ Target ~{summary_budget} tokens. Be CONCRETE — include file paths, command out
 
 Write only the summary body. Do not include any preamble or prefix."""
 
-        if self._previous_summary:
+        previous_summary = previous_summary_override if previous_summary_override is not None else self._previous_summary
+
+        if previous_summary:
             # Iterative update: preserve existing info, add new progress
             prompt = f"""{_summarizer_preamble}
 
 You are updating a context compaction summary. A previous compaction produced the summary below. New conversation turns have occurred since then and need to be incorporated.
 
 PREVIOUS SUMMARY:
-{self._previous_summary}
+{previous_summary}
 
 NEW TURNS TO INCORPORATE:
 {content_to_summarize}
@@ -1077,15 +1139,17 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             # ignore prompt instructions and echo back secrets verbatim.
             summary = redact_sensitive_text(content.strip())
             # Store for iterative updates on next compaction
-            self._previous_summary = summary
-            self._summary_failure_cooldown_until = 0.0
-            self._summary_model_fallen_back = False
-            self._last_summary_error = None
+            if update_state:
+                self._previous_summary = summary
+                self._summary_failure_cooldown_until = 0.0
+                self._summary_model_fallen_back = False
+                self._last_summary_error = None
             return self._with_summary_prefix(summary)
         except RuntimeError:
             # No provider configured — long cooldown, unlikely to self-resolve
-            self._summary_failure_cooldown_until = time.monotonic() + _SUMMARY_FAILURE_COOLDOWN_SECONDS
-            self._last_summary_error = "no auxiliary LLM provider configured"
+            if update_state:
+                self._summary_failure_cooldown_until = time.monotonic() + _SUMMARY_FAILURE_COOLDOWN_SECONDS
+                self._last_summary_error = "no auxiliary LLM provider configured"
             logging.warning("Context compression: no provider available for "
                             "summary. Middle turns will be dropped without summary "
                             "for %d seconds.",
@@ -1153,6 +1217,8 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                     _reason = "closed stream prematurely"
                 else:
                     _reason = "timed out"
+                if not update_state:
+                    return None
                 self._fallback_to_main_for_compression(e, _reason)
                 return self._generate_summary(turns_to_summarize, focus_topic=focus_topic)  # retry immediately
 
@@ -1170,6 +1236,8 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                 and self.summary_model != self.model
                 and not getattr(self, "_summary_model_fallen_back", False)
             ):
+                if not update_state:
+                    return None
                 self._fallback_to_main_for_compression(e, "failed")
                 return self._generate_summary(turns_to_summarize, focus_topic=focus_topic)
 
@@ -1177,11 +1245,12 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             # streaming premature-close) — shorter cooldown for JSON decode and
             # streaming-closed since those conditions can self-resolve quickly.
             _transient_cooldown = 30 if (_is_json_decode or _is_streaming_closed) else 60
-            self._summary_failure_cooldown_until = time.monotonic() + _transient_cooldown
             err_text = str(e).strip() or e.__class__.__name__
             if len(err_text) > 220:
                 err_text = err_text[:217].rstrip() + "..."
-            self._last_summary_error = err_text
+            if update_state:
+                self._summary_failure_cooldown_until = time.monotonic() + _transient_cooldown
+                self._last_summary_error = err_text
             logging.warning(
                 "Failed to generate context summary: %s. "
                 "Further summary attempts paused for %d seconds.",
@@ -1488,10 +1557,152 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         return compress_start < compress_end
 
     # ------------------------------------------------------------------
+    # Speculative/background precompaction
+    # ------------------------------------------------------------------
+
+    def _prepare_precompression_window(
+        self,
+        messages: List[Dict[str, Any]],
+        focus_topic: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Return a stable summarization window for background compaction.
+
+        The foreground ``compress()`` path performs a cheap pruning pass before
+        choosing summary boundaries.  Background precompaction must make the
+        exact same choices and fingerprint the pruned middle window, otherwise
+        a stale summary could be reused for different content.
+        """
+        n_messages = len(messages)
+        _min_for_compress = self._protect_head_size(messages) + 3 + 1
+        if n_messages <= _min_for_compress:
+            return None
+
+        prepared_messages = copy.deepcopy(messages)
+        prepared_messages, _ = self._prune_old_tool_results(
+            prepared_messages,
+            protect_tail_count=self.protect_last_n,
+            protect_tail_tokens=self.tail_token_budget,
+        )
+
+        compress_start = self._protect_head_size(prepared_messages)
+        compress_start = self._align_boundary_forward(prepared_messages, compress_start)
+        compress_end = self._find_tail_cut_by_tokens(prepared_messages, compress_start)
+        if compress_start >= compress_end:
+            return None
+
+        summary_search_start = 1 if prepared_messages and prepared_messages[0].get("role") == "system" else 0
+        summary_idx, summary_body = self._find_latest_context_summary(
+            prepared_messages,
+            summary_search_start,
+            compress_end,
+        )
+        turns_start = compress_start
+        previous_summary = self._previous_summary
+        if summary_idx is not None:
+            turns_start = max(compress_start, summary_idx + 1)
+            if summary_body and not previous_summary:
+                previous_summary = summary_body
+        turns_to_summarize = prepared_messages[turns_start:compress_end]
+        if not turns_to_summarize:
+            return None
+
+        fingerprint_payload = {
+            "focus_topic": focus_topic or "",
+            "previous_summary": previous_summary or "",
+            "turns": turns_to_summarize,
+        }
+        fingerprint = hashlib.sha256(
+            json.dumps(fingerprint_payload, sort_keys=True, default=str).encode("utf-8")
+        ).hexdigest()
+        return {
+            "key": fingerprint,
+            "turns": turns_to_summarize,
+            "previous_summary": previous_summary,
+            "focus_topic": focus_topic,
+        }
+
+    def _harvest_precompression_future(self) -> None:
+        future = self._precompression_future
+        key = self._precompression_inflight_key
+        generation = self._precompression_inflight_generation
+        if future is None or not future.done():
+            return
+        try:
+            summary = future.result()
+            if key and summary and generation == self._precompression_generation:
+                self._precompression_cache = {key: summary}
+        except Exception as exc:
+            logger.debug("background precompression failed: %s", exc, exc_info=True)
+        finally:
+            self._precompression_future = None
+            self._precompression_inflight_key = None
+            self._precompression_inflight_generation = None
+
+    def maybe_start_background_precompression(
+        self,
+        messages: List[Dict[str, Any]],
+        current_tokens: Optional[int] = None,
+        focus_topic: Optional[str] = None,
+    ) -> bool:
+        """Speculatively summarize a stable prefix without blocking callers.
+
+        Returns True when a new background job was submitted. The job is
+        best-effort: failures are logged at debug level and never affect the
+        foreground conversation.
+        """
+        self._harvest_precompression_future()
+        if not self.background_precompression_enabled:
+            return False
+        tokens = current_tokens if current_tokens is not None else self.last_prompt_tokens
+        trigger_tokens = int(self.context_length * self.background_precompression_trigger_percent)
+        if tokens < trigger_tokens or tokens >= self.threshold_tokens:
+            return False
+        if self._precompression_future is not None and not self._precompression_future.done():
+            return False
+
+        prepared = self._prepare_precompression_window(messages, focus_topic=focus_topic)
+        if not prepared:
+            return False
+        key = prepared["key"]
+        if key in self._precompression_cache:
+            return False
+
+        generation = self._precompression_generation
+
+        def _work() -> Optional[str]:
+            # Background precompression must be observational only. It runs
+            # without the foreground summary lock so an in-flight speculative
+            # call cannot block foreground compression from proceeding. A
+            # generation check in _harvest_precompression_future() prevents
+            # stale summaries from being cached after /reset.
+            if generation != self._precompression_generation:
+                return None
+            return self._generate_summary_locked(
+                prepared["turns"],
+                focus_topic=prepared.get("focus_topic"),
+                previous_summary_override=prepared.get("previous_summary"),
+                update_state=False,
+            )
+
+        self._precompression_inflight_key = key
+        self._precompression_inflight_generation = generation
+        self._precompression_future = self._precompression_executor.submit(_work)
+        self._harvest_precompression_future()
+        return True
+
+    def _take_ready_precompression_summary(self, key: str) -> Optional[str]:
+        self._harvest_precompression_future()
+        summary = self._precompression_cache.pop(key, None)
+        self._last_precompression_cache_hit = bool(summary)
+        if summary:
+            self._previous_summary = self._strip_summary_prefix(summary)
+        return summary
+
+    # ------------------------------------------------------------------
     # Main compression entry point
     # ------------------------------------------------------------------
 
-    def compress(self, messages: List[Dict[str, Any]], current_tokens: int = None, focus_topic: str = None, force: bool = False) -> List[Dict[str, Any]]:
+    def compress(self, messages: List[Dict[str, Any]], current_tokens: Optional[int] = None, focus_topic: Optional[str] = None, force: bool = False) -> List[Dict[str, Any]]:
         """Compress conversation messages by summarizing middle turns.
 
         Algorithm:
@@ -1521,6 +1732,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         self._last_aux_model_failure_error = None
         self._last_aux_model_failure_model = None
         self._last_compress_aborted = False
+        self._last_precompression_cache_hit = False
 
         # Manual /compress (force=True) bypasses the failure cooldown so the
         # user can retry immediately after an auto-compress abort.  Without
@@ -1599,8 +1811,22 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                 tail_msgs,
             )
 
-        # Phase 3: Generate structured summary
-        summary = self._generate_summary(turns_to_summarize, focus_topic=focus_topic)
+        # Phase 3: Generate structured summary. If a speculative background
+        # precompaction produced a summary for exactly this pruned middle
+        # window, reuse it and avoid blocking this foreground turn on another
+        # auxiliary LLM call. The fingerprint includes the turns, focus topic,
+        # and previous summary body, so changed conversations fall back safely.
+        precompression_payload = {
+            "focus_topic": focus_topic or "",
+            "previous_summary": self._previous_summary or "",
+            "turns": turns_to_summarize,
+        }
+        precompression_key = hashlib.sha256(
+            json.dumps(precompression_payload, sort_keys=True, default=str).encode("utf-8")
+        ).hexdigest()
+        summary = self._take_ready_precompression_summary(precompression_key)
+        if not summary:
+            summary = self._generate_summary(turns_to_summarize, focus_topic=focus_topic)
 
         # If summary generation failed, behavior splits on
         # ``abort_on_summary_failure`` (config: compression.abort_on_summary_failure):

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3397,6 +3397,15 @@ def run_conversation(
                         messages, tools=agent.tools or None
                     )
 
+                if agent.compression_enabled:
+                    try:
+                        _compressor.maybe_start_background_precompression(
+                            messages,
+                            current_tokens=_real_tokens,
+                        )
+                    except Exception as exc:
+                        logger.debug("background precompression trigger failed: %s", exc, exc_info=True)
+
                 if agent.compression_enabled and _compressor.should_compress(_real_tokens):
                     agent._safe_print("  ⟳ compacting context…")
                     messages, active_system_prompt = agent._compress_context(
@@ -3742,6 +3751,19 @@ def run_conversation(
                     messages.pop()
 
                 messages.append(final_msg)
+                if agent.compression_enabled:
+                    try:
+                        _final_tokens_for_precompression = agent.context_compressor.last_prompt_tokens
+                        if _final_tokens_for_precompression <= 0:
+                            _final_tokens_for_precompression = estimate_request_tokens_rough(
+                                messages, tools=agent.tools or None
+                            )
+                        agent.context_compressor.maybe_start_background_precompression(
+                            messages,
+                            current_tokens=_final_tokens_for_precompression,
+                        )
+                    except Exception as exc:
+                        logger.debug("background precompression trigger failed: %s", exc, exc_info=True)
                 
                 _turn_exit_reason = f"text_response(finish_reason={finish_reason})"
                 if not agent.quiet_mode:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14880,6 +14880,16 @@ class GatewayRunner:
                 and platform_key in _legacy_tp_overrides
             )
         )
+        # Optional hard mute for agent status bubbles on chat platforms. This
+        # suppresses lifecycle/warning messages such as context compaction,
+        # provider retry/fallback notices, and other mid-turn status callbacks
+        # while preserving the final assistant response and logs.
+        _status_messages_enabled = is_truthy_value(
+            _platform_cfg.get("status_messages", _display_cfg.get("status_messages", True))
+            if isinstance(_platform_cfg, dict)
+            else _display_cfg.get("status_messages", True),
+            default=True,
+        )
         progress_mode = (
             _env_tp
             if _env_tp and not _tool_progress_configured
@@ -15318,7 +15328,7 @@ class GatewayRunner:
             _status_thread_metadata = self._thread_metadata_for_source(source, event_message_id) if _progress_thread_id else None
 
         def _status_callback_sync(event_type: str, message: str) -> None:
-            if not _status_adapter or not _run_still_current():
+            if not _status_messages_enabled or not _status_adapter or not _run_still_current():
                 return
             _fut = safe_schedule_threadsafe(
                 _status_adapter.send(

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -797,6 +797,11 @@ DEFAULT_CONFIG = {
         "target_ratio": 0.20,         # fraction of threshold to preserve as recent tail
         "protect_last_n": 20,         # minimum recent messages to keep uncompressed
         "hygiene_hard_message_limit": 400,  # gateway session-hygiene force-compress threshold by message count
+        "background": {
+            "enabled": False,         # speculative precompression before the hard threshold
+            "trigger_threshold": 0.35, # start summary cache around 35% context usage
+            "max_workers": 1,         # keep low so summarization never competes hard with live turns
+        },
         "protect_first_n": 3,         # non-system head messages always preserved
                                       # verbatim, in ADDITION to the system prompt
                                       # (which is always implicitly protected). Set to
@@ -1048,6 +1053,7 @@ DEFAULT_CONFIG = {
             "last_lines": 2,
         },
         "interim_assistant_messages": True,  # Gateway: show natural mid-turn assistant status messages
+        "status_messages": True,  # Gateway: show lifecycle/warning status bubbles (compaction, fallback, retries)
         "tool_progress_command": False,  # Enable /verbose command in messaging gateway
         "tool_progress_overrides": {},  # DEPRECATED — use display.platforms instead
         "tool_preview_length": 0,  # Max chars for tool call previews (0 = no limit, show full paths/commands)

--- a/tests/agent/test_background_precompaction.py
+++ b/tests/agent/test_background_precompaction.py
@@ -1,0 +1,168 @@
+from concurrent.futures import Future
+from types import SimpleNamespace
+
+from agent.context_compressor import ContextCompressor
+
+
+class ImmediateExecutor:
+    """Synchronous executor for deterministic tests."""
+
+    def submit(self, fn, *args, **kwargs):
+        fut = Future()
+        try:
+            fut.set_result(fn(*args, **kwargs))
+        except BaseException as exc:  # pragma: no cover - mirrors Future behavior
+            fut.set_exception(exc)
+        return fut
+
+
+class HoldingExecutor:
+    """Executor that records work without running it."""
+
+    def __init__(self):
+        self.future = Future()
+
+    def submit(self, fn, *args, **kwargs):
+        self.fn = fn
+        self.args = args
+        self.kwargs = kwargs
+        return self.future
+
+
+def make_compressor(**overrides):
+    compressor = ContextCompressor(
+        model="test-model",
+        threshold_percent=0.50,
+        protect_first_n=1,
+        protect_last_n=3,
+        summary_target_ratio=0.10,
+        quiet_mode=True,
+        config_context_length=128_000,
+        background_precompression={
+            "enabled": True,
+            "trigger_threshold": 0.20,
+            "max_workers": 1,
+        },
+        **overrides,
+    )
+    compressor.tail_token_budget = 1_000
+    compressor._precompression_executor = ImmediateExecutor()
+    return compressor
+
+
+def make_messages(extra_middle=""):
+    messages = [{"role": "system", "content": "system"}]
+    for idx in range(12):
+        messages.append({"role": "user", "content": f"user turn {idx} {extra_middle}"})
+        messages.append({"role": "assistant", "content": f"assistant turn {idx} {extra_middle}"})
+    messages.append({"role": "user", "content": "latest user request"})
+    return messages
+
+
+def test_background_precompaction_cache_is_used_by_later_compress(monkeypatch):
+    compressor = make_compressor()
+    calls = []
+
+    def fake_generate(turns, focus_topic=None, previous_summary_override=None, update_state=True):
+        calls.append([m["content"] for m in turns])
+        return "[CONTEXT SUMMARY]: background ready summary"
+
+    monkeypatch.setattr(compressor, "_generate_summary_locked", fake_generate)
+    messages = make_messages()
+
+    assert compressor.maybe_start_background_precompression(messages, current_tokens=30_000) is True
+    assert len(calls) == 1
+
+    def fail_if_called(*args, **kwargs):  # pragma: no cover - should not run
+        raise AssertionError("foreground compression should use ready background summary")
+
+    monkeypatch.setattr(compressor, "_generate_summary", fail_if_called)
+    compressed = compressor.compress(messages, current_tokens=70_000)
+
+    assert any("background ready summary" in str(msg.get("content")) for msg in compressed)
+    assert compressor._last_precompression_cache_hit is True
+
+
+def test_background_precompaction_cache_is_rejected_when_messages_change(monkeypatch):
+    compressor = make_compressor()
+    monkeypatch.setattr(
+        compressor,
+        "_generate_summary_locked",
+        lambda turns, focus_topic=None, previous_summary_override=None, update_state=True: "[CONTEXT SUMMARY]: stale background summary",
+    )
+    original_messages = make_messages()
+
+    assert compressor.maybe_start_background_precompression(original_messages, current_tokens=30_000) is True
+
+    changed_messages = make_messages(extra_middle="changed")
+    monkeypatch.setattr(
+        compressor,
+        "_generate_summary",
+        lambda turns, focus_topic=None: "[CONTEXT SUMMARY]: fresh foreground summary",
+    )
+
+    compressed = compressor.compress(changed_messages, current_tokens=70_000)
+
+    rendered = "\n".join(str(msg.get("content")) for msg in compressed)
+    assert "fresh foreground summary" in rendered
+    assert "stale background summary" not in rendered
+    assert compressor._last_precompression_cache_hit is False
+
+
+def test_background_precompaction_does_not_mutate_live_summary_state(monkeypatch):
+    compressor = make_compressor()
+    compressor._previous_summary = "live foreground summary"
+    compressor._summary_failure_cooldown_until = 123.0
+    compressor._last_summary_error = "keep this foreground error"
+
+    def fake_call_llm(**kwargs):
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="background summary"))]
+        )
+
+    monkeypatch.setattr("agent.context_compressor.call_llm", fake_call_llm)
+
+    assert compressor.maybe_start_background_precompression(make_messages(), current_tokens=30_000) is True
+
+    assert compressor._previous_summary == "live foreground summary"
+    assert compressor._summary_failure_cooldown_until == 123.0
+    assert compressor._last_summary_error == "keep this foreground error"
+
+
+def test_session_reset_cancels_inflight_background_precompaction():
+    compressor = make_compressor()
+    executor = HoldingExecutor()
+    setattr(compressor, "_precompression_executor", executor)
+
+    assert compressor.maybe_start_background_precompression(make_messages(), current_tokens=30_000) is True
+    assert compressor._precompression_future is executor.future
+
+    compressor.on_session_reset()
+
+    assert executor.future.cancelled()
+    assert compressor._precompression_future is None
+    assert compressor._precompression_inflight_key is None
+    assert compressor._precompression_inflight_generation is None
+    assert compressor._precompression_cache == {}
+
+
+def test_abort_on_summary_failure_still_aborts_after_background_failure(monkeypatch):
+    compressor = make_compressor(abort_on_summary_failure=True)
+    messages = make_messages()
+
+    def fail_background(*args, **kwargs):
+        raise RuntimeError("background summary failed")
+
+    monkeypatch.setattr(compressor, "_generate_summary_locked", fail_background)
+    assert compressor.maybe_start_background_precompression(messages, current_tokens=30_000) is True
+    assert compressor._precompression_cache == {}
+
+    monkeypatch.setattr(compressor, "_generate_summary", lambda *args, **kwargs: "")
+
+    compressed = compressor.compress(messages, current_tokens=70_000)
+
+    assert compressed == messages
+    assert compressor._last_compress_aborted is True
+    assert compressor._last_summary_fallback_used is False
+    assert compressor._last_summary_dropped_count == 0
+    assert compressor._last_precompression_cache_hit is False

--- a/website/docs/developer-guide/context-compression-and-caching.md
+++ b/website/docs/developer-guide/context-compression-and-caching.md
@@ -84,6 +84,10 @@ compression:
   threshold: 0.50            # Fraction of context window (default: 0.50 = 50%)
   target_ratio: 0.20         # How much of threshold to keep as tail (default: 0.20)
   protect_last_n: 20         # Minimum protected tail messages (default: 20)
+  background:
+    enabled: false           # Optional speculative summary cache (default: false)
+    trigger_threshold: 0.35  # Start warmup before the hard threshold
+    max_workers: 1           # Keep background summarization low-concurrency
 
 # Summarization model/provider configured under auxiliary:
 auxiliary:
@@ -101,6 +105,9 @@ auxiliary:
 | `target_ratio` | `0.20` | 0.10-0.80 | Controls tail protection token budget: `threshold_tokens × target_ratio` |
 | `protect_last_n` | `20` | ≥1 | Minimum number of recent messages always preserved |
 | `protect_first_n` | `3` | (hardcoded) | System prompt + first exchange always preserved |
+| `background.enabled` | `false` | boolean | Speculatively summarizes a stable middle window before foreground compression needs it |
+| `background.trigger_threshold` | `0.35` | 0.05-0.95 | Starts speculative precompression when prompt tokens reach this fraction of context length but remain below the hard threshold |
+| `background.max_workers` | `1` | 1-2 | Worker count for background summarization |
 
 ### Computed Values (for a 200K context model at defaults)
 
@@ -148,6 +155,14 @@ The `_align_boundary_backward()` method walks past consecutive tool results
 to find the parent assistant message, keeping groups intact.
 
 ### Phase 3: Generate Structured Summary
+
+If `compression.background.enabled` is true, Hermes may already have a cached
+summary for the exact middle window selected above. The cache key includes the
+pruned turns, focus topic, and previous summary body. Foreground compression
+reuses the cached summary only when that fingerprint matches; otherwise it falls
+back to a normal synchronous summary call. Background precompression is
+best-effort and must not mutate live conversation state until a matching
+foreground compression consumes the cached summary.
 
 :::warning Summary model context length
 The summary model must have a context window **at least as large** as the main agent model's. The entire middle section is sent to the summary model in a single `call_llm(task="compression")` call. If the summary model's context is smaller, the API returns a context-length error — `_generate_summary()` catches it, logs a warning, and returns `None`. The compressor then drops the middle turns **without a summary**, silently losing conversation context. This is the most common cause of degraded compaction quality.

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -585,6 +585,10 @@ compression:
   threshold: 0.50
   target_ratio: 0.20         # fraction of threshold to preserve as recent tail
   protect_last_n: 20         # minimum recent messages to keep uncompressed
+  background:
+    enabled: false           # optional speculative precompression cache
+    trigger_threshold: 0.35
+    max_workers: 1
 ```
 
 :::info Legacy migration

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -606,6 +606,10 @@ compression:
   target_ratio: 0.20                                # Fraction of threshold to preserve as recent tail
   protect_last_n: 20                                # Min recent messages to keep uncompressed
   hygiene_hard_message_limit: 400                   # Gateway safety valve — see below
+  background:                                      # Optional speculative precompression cache
+    enabled: false                                  # Disabled by default; enable to reduce later compaction latency
+    trigger_threshold: 0.35                         # Start cache warmup around 35% context usage
+    max_workers: 1                                  # Keep low so background summaries don't compete with live turns
 
 # The summarization model/provider is configured under auxiliary:
 auxiliary:
@@ -620,6 +624,8 @@ Older configs with `compression.summary_model`, `compression.summary_provider`, 
 :::
 
 `hygiene_hard_message_limit` is a gateway-only **pre-compression safety valve**. Runaway sessions with thousands of messages can hit model context limits before the normal percent-of-context threshold fires; when message count crosses this ceiling, Hermes forces compression regardless of token usage. Default `400` — raise it for platforms where very long sessions are normal, lower it to force more aggressive compression. Editing this value on a running gateway takes effect on the next message (see below).
+
+`background` is optional speculative precompression. When enabled, Hermes can summarize the stable middle of a long conversation before the hard compression threshold is reached, then reuse that summary only if the exact pruned message window still matches when foreground compression runs. This keeps the live turn from waiting on a duplicate summarization call. It is disabled by default.
 
 :::tip Gateway hot-reload of compression and context length
 As of recent releases, editing `model.context_length` or any `compression.*` key in `config.yaml` on a running gateway takes effect on the next message — no gateway restart, no `/reset`, no session rotation required. The cached-agent signature includes these keys, so the gateway transparently rebuilds the agent when it sees a change. API keys and tool/skill config still require the usual reload paths.
@@ -1160,6 +1166,7 @@ display:
   platforms: {}           # Per-platform display overrides (see below)
   tool_progress_overrides: {}  # DEPRECATED — use display.platforms instead
   interim_assistant_messages: true  # Gateway: send natural mid-turn assistant updates as separate messages
+  status_messages: true    # Gateway: show lifecycle/warning bubbles (compaction, provider fallback, retries)
   skin: default           # Built-in or custom CLI skin (see user-guide/features/skins)
   personality: "kawaii"  # Legacy cosmetic field still surfaced in some summaries
   compact: false          # Compact output mode (less whitespace)
@@ -1253,6 +1260,15 @@ display:
 Platforms without an override fall back to the global `tool_progress` value. Valid platform keys: `telegram`, `discord`, `slack`, `signal`, `whatsapp`, `matrix`, `mattermost`, `email`, `sms`, `homeassistant`, `dingtalk`, `feishu`, `wecom`, `weixin`, `bluebubbles`, `qqbot`. The legacy `display.tool_progress_overrides` key still loads for backward compatibility but is deprecated and migrated into `display.platforms` on first load.
 
 `interim_assistant_messages` is gateway-only. When enabled, Hermes sends completed mid-turn assistant updates as separate chat messages. This is independent from `tool_progress` and does not require gateway streaming.
+
+`status_messages` is gateway-only. When enabled, Hermes may send short lifecycle or warning bubbles during a turn (for example context compaction, provider retry/fallback, or other status callbacks). Set it globally or per platform to `false` to suppress these mid-turn status notices while still delivering the final assistant response and keeping logs intact:
+
+```yaml
+display:
+  platforms:
+    telegram:
+      status_messages: false
+```
 
 ## Privacy
 


### PR DESCRIPTION
## Summary
- add optional speculative background precompression for context compaction
- reuse cached summaries only when the exact pruned window/focus/previous-summary fingerprint matches
- keep background summarization observational with reset cancellation/generation guards
- preserve `compression.abort_on_summary_failure` semantics after rebasing onto current main
- add gateway `display.status_messages` / per-platform mute for lifecycle status bubbles
- document `compression.background` and `status_messages`

## Test Plan
- `python -m pytest tests/agent/test_context_compressor.py tests/agent/test_context_compressor_summary_continuity.py tests/agent/test_background_precompaction.py tests/gateway/test_pre_gateway_dispatch.py tests/hermes_cli/test_gateway.py tests/hermes_cli/test_config.py -q` — 178 passed
- `git diff --check`
- `python -m compileall -q agent hermes_cli gateway`
- independent pre-push review passed
