### PR TITLE
fix(spotify): make callback server threaded and latch first terminal result

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2260,6 +2260,7 @@ def _make_spotify_callback_handler(expected_path: str) -> tuple[type[BaseHTTPReq
         "error": None,
         "error_description": None,
     }
+    result_lock = threading.Lock()
 
     class _SpotifyCallbackHandler(BaseHTTPRequestHandler):
         def do_GET(self) -> None:  # noqa: N802
@@ -2271,15 +2272,25 @@ def _make_spotify_callback_handler(expected_path: str) -> tuple[type[BaseHTTPReq
                 return
 
             params = parse_qs(parsed.query)
-            result["code"] = params.get("code", [None])[0]
-            result["state"] = params.get("state", [None])[0]
-            result["error"] = params.get("error", [None])[0]
-            result["error_description"] = params.get("error_description", [None])[0]
+            incoming = {
+                "code": params.get("code", [None])[0],
+                "state": params.get("state", [None])[0],
+                "error": params.get("error", [None])[0],
+                "error_description": params.get("error_description", [None])[0],
+            }
+            # ThreadingHTTPServer handles each connection on its own thread.
+            # Once we have a terminal OAuth result (code or error), keep the
+            # first one so a concurrent or retry callback cannot overwrite
+            # state before _spotify_wait_for_callback() reads it.
+            if incoming["code"] or incoming["error"]:
+                with result_lock:
+                    if not (result["code"] or result["error"]):
+                        result.update(incoming)
 
             self.send_response(200)
             self.send_header("Content-Type", "text/html; charset=utf-8")
             self.end_headers()
-            if result["error"]:
+            if incoming["error"]:
                 body = "<html><body><h1>Spotify authorization failed.</h1>You can close this tab.</body></html>"
             else:
                 body = "<html><body><h1>Spotify authorization received.</h1>You can close this tab.</body></html>"
@@ -2299,8 +2310,9 @@ def _spotify_wait_for_callback(
     host, port, path = _spotify_validate_redirect_uri(redirect_uri)
     handler_cls, result = _make_spotify_callback_handler(path)
 
-    class _ReuseHTTPServer(HTTPServer):
+    class _ReuseHTTPServer(ThreadingHTTPServer):
         allow_reuse_address = True
+        daemon_threads = True
 
     try:
         server = _ReuseHTTPServer((host, port), handler_cls)

--- a/tests/hermes_cli/test_spotify_auth.py
+++ b/tests/hermes_cli/test_spotify_auth.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import urllib.request
+from http.server import ThreadingHTTPServer
 from types import SimpleNamespace
 
 import pytest
 
 from hermes_cli import auth as auth_mod
+from hermes_cli.auth import _make_spotify_callback_handler
 
 
 def test_store_provider_state_can_skip_active_provider() -> None:
@@ -181,3 +184,81 @@ def test_spotify_interactive_setup_empty_aborts(
     env_path = tmp_path / ".env"
     if env_path.exists():
         assert "HERMES_SPOTIFY_CLIENT_ID" not in env_path.read_text()
+
+
+# ---------------------------------------------------------------------------
+# Callback server — threading and result-latch regression tests
+# ---------------------------------------------------------------------------
+
+def _spotify_start_test_server() -> tuple[ThreadingHTTPServer, object, dict, str]:
+    """Spin up a Spotify callback server on a random port for testing."""
+    import threading
+    path = "/spotify/callback"
+    handler_cls, result = _make_spotify_callback_handler(path)
+
+    class _ReuseServer(ThreadingHTTPServer):
+        allow_reuse_address = True
+        daemon_threads = True
+
+    server = _ReuseServer(("127.0.0.1", 0), handler_cls)
+    port = server.server_address[1]
+    redirect_uri = f"http://127.0.0.1:{port}{path}"
+    thread = threading.Thread(target=server.serve_forever, kwargs={"poll_interval": 0.05}, daemon=True)
+    thread.start()
+    return server, thread, result, redirect_uri
+
+
+def test_spotify_callback_server_accepts_threaded_connections():
+    """ThreadingHTTPServer must serve a second connection while a first is
+    still being processed.  A single-threaded HTTPServer would deadlock."""
+    import socket
+    import threading
+
+    server, thread, result, redirect_uri = _spotify_start_test_server()
+    try:
+        # Open a raw connection that keeps the socket alive without completing
+        # the HTTP request — simulates Chrome holding a loopback connection open.
+        stuck_sock = socket.create_connection(("127.0.0.1", server.server_address[1]), timeout=2)
+        stuck_sock.send(b"GET /spotify/callback HTTP/1.1\r\nHost: 127.0.0.1\r\n")
+        # Do NOT send the final \r\n — server waits for the full request.
+
+        # The actual OAuth callback must still land on a different thread.
+        port = server.server_address[1]
+        with urllib.request.urlopen(
+            f"http://127.0.0.1:{port}/spotify/callback?code=auth-code&state=s1",
+            timeout=3,
+        ) as response:
+            assert response.status == 200
+        assert result["code"] == "auth-code"
+    finally:
+        stuck_sock.close()
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=1.0)
+
+
+def test_spotify_callback_server_latches_first_terminal_callback_result():
+    """Once a terminal result (code or error) arrives, a later concurrent
+    callback must not overwrite it."""
+    server, thread, result, redirect_uri = _spotify_start_test_server()
+    try:
+        # First: valid authorization code.
+        with urllib.request.urlopen(f"{redirect_uri}?code=first-code&state=s1", timeout=2) as response:
+            assert response.status == 200
+        # Second: error callback arriving concurrently / as a retry.
+        with urllib.request.urlopen(
+            f"{redirect_uri}?error=access_denied&error_description=late&state=s2",
+            timeout=2,
+        ) as response:
+            body = response.read().decode()
+        assert response.status == 200
+        # Response page must reflect the *second* request's own error.
+        assert "authorization failed" in body
+        # But the latched result dict must still hold the first code.
+        assert result["code"] == "first-code"
+        assert result["state"] == "s1"
+        assert result["error"] is None
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=1.0)


### PR DESCRIPTION
## Summary

Chrome can hold a loopback connection open without closing it after completing the OAuth redirect. A single-threaded `HTTPServer` blocks on that connection and never accepts the actual authorization callback, causing the 180-second wait to expire with no code received.

Mirrors the two-part fix applied to the xAI OAuth callback server:
- `eac198b6d` — switch to `ThreadingHTTPServer`
- `0d6366170` — latch the first terminal result

**Change 1 — `_spotify_wait_for_callback`: switch to `ThreadingHTTPServer`**

`_ReuseHTTPServer` now inherits from `ThreadingHTTPServer` (with `daemon_threads = True`) so each incoming connection is dispatched on its own thread. A stuck Chrome connection no longer blocks the actual authorization callback.

**Change 2 — `_make_spotify_callback_handler`: latch first terminal result**

Added `result_lock` and a first-write guard: once a terminal result (`code` or `error`) has been stored, any subsequent concurrent or retry callback cannot overwrite it. The response page still reflects the individual request's own outcome (using `incoming["error"]` rather than the shared `result["error"]`), matching the same pattern applied to `_XAICallbackHandler`.

## Test plan

- [ ] `test_spotify_callback_server_accepts_threaded_connections` — opens a raw socket that holds the connection without completing the HTTP request (simulates Chrome's stuck loopback), then fires the real auth callback on a separate connection; asserts the code is received.
- [ ] `test_spotify_callback_server_latches_first_terminal_callback_result` — sends a valid code first, then a late error callback; asserts the result dict retains the first code and the error page is shown only for the second request.
- [ ] All existing `test_spotify_auth.py` tests pass (8/8).