### PR TITLE
fix(web): portal Change Model modal so it renders above the app sidebar

### DIFF
--- a/web/src/components/ModelPickerDialog.tsx
+++ b/web/src/components/ModelPickerDialog.tsx
@@ -5,6 +5,7 @@ import { Input } from "@/components/ui/input";
 import type { GatewayClient } from "@/lib/gatewayClient";
 import { Check, Search, X } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 
 /**
  * Two-stage model picker modal.
@@ -194,7 +195,14 @@ export function ModelPickerDialog(props: Props) {
     }
   };
 
-  return (
+  // Portal to document.body: the main dashboard column in App.tsx is
+  // `relative z-2`, which creates a stacking context that traps fixed
+  // descendants below the app sidebar (z-50). Without the portal this
+  // modal's z-[100] is scoped to z-2 and the sidebar covers its left
+  // edge — visible especially in the Large theme variants where the
+  // larger root font widens the dialog into the sidebar's column. See
+  // Toast.tsx for the same pattern.
+  return createPortal(
     <div
       className="fixed inset-0 z-[100] flex items-center justify-center bg-background/85 backdrop-blur-sm p-4"
       onClick={(e) => e.target === e.currentTarget && onClose()}
@@ -296,7 +304,8 @@ export function ModelPickerDialog(props: Props) {
           </div>
         </footer>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }
 


### PR DESCRIPTION
## Summary

Fixes #28103. The **Change Model** modal in the dashboard renders behind the left sidebar's frame because its `z-[100]` is trapped in a parent stacking context. Most visible in the **Hermes Teal (Large)** theme (and other `*-large` variants) because the larger root font widens the dialog into the sidebar's column.

## Root cause

The main dashboard column is `relative z-2` in [`web/src/App.tsx:588`](https://github.com/NousResearch/hermes-agent/blob/main/web/src/App.tsx#L588). That establishes a stacking context. `ModelPickerDialog` returns `fixed inset-0 z-[100]` directly inside that column, so its z-100 is scoped to the `z-2` context — and the app sidebar at [`App.tsx:478`](https://github.com/NousResearch/hermes-agent/blob/main/web/src/App.tsx#L478) (`fixed top-0 left-0 z-50`) sits in the outer (document-root) stacking context, putting it visually above the modal's left edge.

The Toast component already documents and works around the same trap — see [`Toast.tsx:22`](https://github.com/NousResearch/hermes-agent/blob/main/web/src/components/Toast.tsx#L22):
> "above the app sidebar (`z-50`) and mobile chrome (`z-40`). The main dashboard column uses `relative z-2`, which traps `position:fixed` descendants below those layers."

## Fix

Wrap `ModelPickerDialog`'s return in `createPortal(..., document.body)` so the dialog mounts at the document root and its `z-[100]` competes with the sidebar's `z-50` directly. +1 import / +1 portal wrap + a short comment explaining the trap.

## Tests

- `npx tsc -b` clean
- `npx eslint src/components/ModelPickerDialog.tsx` clean
- Verified the existing `inset-0` / `bg-background/85` / `backdrop-blur-sm` backdrop semantics + the `onClick={(e) => e.target === e.currentTarget && onClose()}` outside-click-to-close still work (the click target chain isn't affected by portaling — the JSX shape is unchanged).
- No frontend tests for this component exist; not adding one for a 3-line z-index fix in a hand-written .tsx.

## Scope

Intentionally **not** touching:

- **Other z-[100] inline modals** (`OAuthLoginModal`, `CronPage`, `ModelsPage`, `ProfilesPage`) — they have the same trap and benefit from the same fix, but the reporter's specific complaint was the Change Model picker, and CONTRIBUTING says one logical change per PR. Happy to send a follow-up PR (or split this into a per-modal series) if you'd prefer the broader sweep.
- **Lifting `relative z-2` on the main column** — would fix all trapped modals at once but risks breaking the explicit ordering the comment in Toast.tsx documents (Toast / sidebar / mobile chrome layering relies on the current setup).
- **The related sidebar overlap fix in #21065** — different problem (sidebar over content vs. sidebar over modal); doesn't fix this one.

## Follow-up

If maintainers prefer, the same portal pattern can be lifted into a shared `<DashboardModal>` wrapper that the remaining z-[100] sites adopt incrementally. Reporter [confirmed](https://github.com/NousResearch/hermes-agent/issues/28103#issuecomment-) they're happy to retest against candidate fixes when the related work lands.