### PR TITLE
fix(conversation_loop): resolve NameError for `_pool_may_recover_from_rate_limit`

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2317,7 +2317,7 @@ def run_conversation(
                     # still recover.  See _pool_may_recover_from_rate_limit
                     # for the single-credential-pool and CloudCode-quota
                     # exceptions.  Fixes #11314 and #13636.
-                    pool_may_recover = _pool_may_recover_from_rate_limit(
+                    pool_may_recover = _ra()._pool_may_recover_from_rate_limit(
                         agent._credential_pool,
                         provider=agent.provider,
                         base_url=getattr(agent, "base_url", None),


### PR DESCRIPTION
## Summary

`run_conversation` was extracted from `run_agent.py` into `agent/conversation_loop.py` (commit 053025238). During that extraction, one call to `_pool_may_recover_from_rate_limit` was not routed through `_ra()` — the lazy import helper that every other cross-module reference in `conversation_loop.py` uses to reach symbols defined in `run_agent.py`.

The result is a `NameError` at runtime, but only when the agent loop encounters a 429 rate-limit response and needs to decide whether to wait for credential pool rotation or fall back. That is a narrow code path, so this can sit dormant for a long time between hits.

## Fix

One-line change: `_pool_may_recover_from_rate_limit(...)` becomes `_ra()._pool_may_recover_from_rate_limit(...)`.

## How to reproduce

1. Configure a single-credential provider (no fallback chain).
2. Trigger a 429 rate-limit from the upstream API.
3. The agent loop crashes with `NameError: name '_pool_may_recover_from_rate_limit' is not defined`.

With a multi-credential pool or when no rate-limiting occurs, the branch is never reached.