### PR TITLE
feat(providers): add ssl_verify field to custom_providers for self-signed HTTPS endpoints

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1187,6 +1187,19 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     client_kwargs = dict(client_kwargs)
     _validate_proxy_env_urls()
     _validate_base_url(client_kwargs.get("base_url"))
+    # Resolve any custom-provider ``ssl_verify`` override for THIS base_url so a
+    # self-signed / private-CA endpoint is honored on the primary chat client's
+    # keepalive httpx.Client, not just the auxiliary client (#28260).  Resolved
+    # per build (covers init, /model switch, and post-interrupt rebuild) and
+    # threaded into the keepalive transport below; ``client_kwargs`` is never
+    # mutated, preserving the read-only invariant documented above.
+    try:
+        from hermes_cli.config import get_custom_provider_ssl_verify
+        _ssl_verify = get_custom_provider_ssl_verify(
+            str(client_kwargs.get("base_url", "") or "")
+        )
+    except Exception:
+        _ssl_verify = None
     if agent.provider == "copilot-acp" or str(client_kwargs.get("base_url", "")).startswith("acp://copilot"):
         from agent.copilot_acp_client import CopilotACPClient
 
@@ -1224,7 +1237,7 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
                 if k in {"api_key", "base_url", "default_headers", "timeout", "http_client"}
             }
             if "http_client" not in safe_kwargs:
-                keepalive_http = agent._build_keepalive_http_client(base_url)
+                keepalive_http = agent._build_keepalive_http_client(base_url, verify=_ssl_verify)
                 if keepalive_http is not None:
                     safe_kwargs["http_client"] = keepalive_http
             client = GeminiNativeClient(**safe_kwargs)
@@ -1253,7 +1266,9 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     # Tests in ``tests/run_agent/test_create_openai_client_reuse.py`` and
     # ``tests/run_agent/test_sequential_chats_live.py`` pin this invariant.
     if "http_client" not in client_kwargs:
-        keepalive_http = agent._build_keepalive_http_client(client_kwargs.get("base_url", ""))
+        keepalive_http = agent._build_keepalive_http_client(
+            client_kwargs.get("base_url", ""), verify=_ssl_verify
+        )
         if keepalive_http is not None:
             client_kwargs["http_client"] = keepalive_http
     # Uses the module-level `OpenAI` name, resolved lazily on first

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1693,7 +1693,7 @@ def clear_runtime_main() -> None:
     _RUNTIME_MAIN_MODEL = ""
 
 
-def _resolve_custom_runtime() -> Tuple[Optional[str], Optional[str], Optional[str]]:
+def _resolve_custom_runtime() -> Tuple[Optional[str], Optional[str], Optional[str], Optional[Any]]:
     """Resolve the active custom/main endpoint the same way the main CLI does.
 
     This covers both env-driven OPENAI_BASE_URL setups and config-saved custom
@@ -1712,7 +1712,7 @@ def _resolve_custom_runtime() -> Tuple[Optional[str], Optional[str], Optional[st
         openai_base = os.getenv("OPENAI_BASE_URL", "").strip().rstrip("/")
         openai_key = os.getenv("OPENAI_API_KEY", "").strip()
         if not openai_base:
-            return None, None, None
+            return None, None, None, None
         runtime = {
             "base_url": openai_base,
             "api_key": openai_key,
@@ -1721,14 +1721,15 @@ def _resolve_custom_runtime() -> Tuple[Optional[str], Optional[str], Optional[st
     custom_base = runtime.get("base_url")
     custom_key = runtime.get("api_key")
     custom_mode = runtime.get("api_mode")
+    custom_ssl_verify = runtime.get("ssl_verify")
     if not isinstance(custom_base, str) or not custom_base.strip():
-        return None, None, None
+        return None, None, None, None
 
     custom_base = custom_base.strip().rstrip("/")
     if base_url_host_matches(custom_base, "openrouter.ai"):
         # requested='custom' falls back to OpenRouter when no custom endpoint is
         # configured. Treat that as "no custom endpoint" for auxiliary routing.
-        return None, None, None
+        return None, None, None, None
 
     # Local servers (Ollama, llama.cpp, vLLM, LM Studio) don't require auth.
     # Use a placeholder key — the OpenAI SDK requires a non-empty string but
@@ -1740,11 +1741,11 @@ def _resolve_custom_runtime() -> Tuple[Optional[str], Optional[str], Optional[st
     if not isinstance(custom_mode, str) or not custom_mode.strip():
         custom_mode = None
 
-    return custom_base, custom_key.strip(), custom_mode
+    return custom_base, custom_key.strip(), custom_mode, custom_ssl_verify
 
 
 def _current_custom_base_url() -> str:
-    custom_base, _, _ = _resolve_custom_runtime()
+    custom_base, _, _, _ = _resolve_custom_runtime()
     return custom_base or ""
 
 
@@ -1797,11 +1798,7 @@ def _validate_base_url(base_url: str) -> None:
 
 def _try_custom_endpoint() -> Tuple[Optional[Any], Optional[str]]:
     runtime = _resolve_custom_runtime()
-    if len(runtime) == 2:
-        custom_base, custom_key = runtime
-        custom_mode = None
-    else:
-        custom_base, custom_key, custom_mode = runtime
+    custom_base, custom_key, custom_mode, custom_ssl_verify = runtime
     if not custom_base or not custom_key:
         return None, None
     if custom_base.lower().startswith(_CODEX_AUX_BASE_URL.lower()):
@@ -1810,6 +1807,9 @@ def _try_custom_endpoint() -> Tuple[Optional[Any], Optional[str]]:
     logger.debug("Auxiliary client: custom endpoint (%s, api_mode=%s)", model, custom_mode or "chat_completions")
     _clean_base, _dq = _extract_url_query_params(custom_base)
     _extra = {"default_query": _dq} if _dq else {}
+    if custom_ssl_verify is not None:
+        import httpx as _httpx
+        _extra["http_client"] = _httpx.Client(verify=custom_ssl_verify)
     if custom_mode == "codex_responses":
         real_client = OpenAI(api_key=custom_key, base_url=_clean_base, **_extra)
         return CodexAuxiliaryClient(real_client, model), model
@@ -3382,6 +3382,10 @@ def resolve_provider_client(
                     raw_base_for_wrap = custom_base
                 _clean_base2, _dq2 = _extract_url_query_params(openai_base)
                 _extra2 = {"default_query": _dq2} if _dq2 else {}
+                _entry_ssl_verify = custom_entry.get("ssl_verify")
+                if _entry_ssl_verify is not None:
+                    import httpx as _httpx
+                    _extra2["http_client"] = _httpx.Client(verify=_entry_ssl_verify)
                 logger.debug(
                     "resolve_provider_client: named custom provider %r (%s, api_mode=%s)",
                     provider, final_model, entry_api_mode or "chat_completions")
@@ -3404,6 +3408,8 @@ def resolve_provider_client(
                         _fallback_base = _to_openai_base_url(custom_base)
                         _fb_clean, _fb_dq = _extract_url_query_params(_fallback_base)
                         _fb_extra = {"default_query": _fb_dq} if _fb_dq else {}
+                        if _entry_ssl_verify is not None:
+                            _fb_extra["http_client"] = _httpx.Client(verify=_entry_ssl_verify)
                         client = OpenAI(api_key=custom_key, base_url=_fb_clean, **_fb_extra)
                         return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                                 else (client, final_model))

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3238,10 +3238,61 @@ def get_custom_provider_context_length(
     return None
 
 
+def get_custom_provider_ssl_verify(
+    base_url: str,
+    custom_providers: Optional[List[Dict[str, Any]]] = None,
+    config: Optional[Dict[str, Any]] = None,
+) -> Optional[Any]:
+    """Look up a provider-level ``ssl_verify`` override from custom providers.
+
+    Matches the custom-provider entry whose ``base_url`` equals ``base_url``
+    (trailing-slash insensitive) and returns its ``ssl_verify`` value — a
+    ``bool`` (``False`` disables TLS verification for a self-signed endpoint)
+    or a ``str`` path to a custom CA bundle.  Returns ``None`` when no entry
+    matches or the entry declares no ``ssl_verify``; callers then leave httpx's
+    default full verification in place.
+
+    This is the primary-chat-client counterpart to the auxiliary-client lookup
+    in ``agent.auxiliary_client``.  Both read the same normalized field so a
+    custom provider behaves identically on the primary and auxiliary paths
+    (#28260: previously only the auxiliary client honored ``ssl_verify``).
+    """
+    if not base_url:
+        return None
+    if custom_providers is None:
+        try:
+            custom_providers = get_compatible_custom_providers(config)
+        except Exception:
+            if config is None:
+                return None
+            raw = config.get("custom_providers")
+            custom_providers = raw if isinstance(raw, list) else []
+    if not isinstance(custom_providers, list):
+        return None
+
+    target_url = (base_url or "").rstrip("/")
+    if not target_url:
+        return None
+
+    for entry in custom_providers:
+        if not isinstance(entry, dict):
+            continue
+        entry_url = (entry.get("base_url") or "").rstrip("/")
+        if not entry_url or entry_url != target_url:
+            continue
+        ssl_verify = entry.get("ssl_verify")
+        if isinstance(ssl_verify, bool):
+            return ssl_verify
+        if isinstance(ssl_verify, str) and ssl_verify.strip():
+            return ssl_verify.strip()
+        return None
+    return None
+
+
 def check_config_version() -> Tuple[int, int]:
     """
     Check config version.
-    
+
     Returns (current_version, latest_version).
     """
     config = load_config()

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2991,6 +2991,7 @@ def _normalize_custom_provider_entry(
         "defaultModel": "default_model",
         "contextLength": "context_length",
         "rateLimitDelay": "rate_limit_delay",
+        "sslVerify": "ssl_verify",
     }
     # api_key_env is a documented snake_case alias for key_env (see
     # website/docs/guides/azure-foundry.md).  Normalize it up front so the
@@ -3002,7 +3003,7 @@ def _normalize_custom_provider_entry(
         "api_mode", "transport", "model", "default_model", "models",
         "context_length", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
-        "discover_models",
+        "discover_models", "ssl_verify",
     }
     for camel, snake in _CAMEL_ALIASES.items():
         if camel in entry and snake not in entry:
@@ -3096,6 +3097,14 @@ def _normalize_custom_provider_entry(
     discover_models = entry.get("discover_models")
     if isinstance(discover_models, bool):
         normalized["discover_models"] = discover_models
+
+    ssl_verify_raw = entry.get("ssl_verify")
+    if ssl_verify_raw is not None:
+        if isinstance(ssl_verify_raw, bool):
+            normalized["ssl_verify"] = ssl_verify_raw
+        elif isinstance(ssl_verify_raw, str) and ssl_verify_raw.strip():
+            # Path to a custom CA certificate bundle
+            normalized["ssl_verify"] = ssl_verify_raw.strip()
 
     return normalized
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -469,6 +469,9 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                     api_mode = _parse_api_mode(entry.get("api_mode") or entry.get("transport"))
                     if api_mode:
                         result["api_mode"] = api_mode
+                    ssl_verify = entry.get("ssl_verify")
+                    if ssl_verify is not None:
+                        result["ssl_verify"] = ssl_verify
                     return result
             # Also check the 'name' field if present
             display_name = entry.get("name", "")
@@ -487,6 +490,9 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                         api_mode = _parse_api_mode(entry.get("api_mode") or entry.get("transport"))
                         if api_mode:
                             result["api_mode"] = api_mode
+                        ssl_verify = entry.get("ssl_verify")
+                        if ssl_verify is not None:
+                            result["ssl_verify"] = ssl_verify
                         return result
 
     # Fall back to custom_providers: list (legacy format)
@@ -533,6 +539,9 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
         model_name = str(entry.get("model", "") or "").strip()
         if model_name:
             result["model"] = model_name
+        ssl_verify = entry.get("ssl_verify")
+        if ssl_verify is not None:
+            result["ssl_verify"] = ssl_verify
         return result
 
     return None
@@ -618,6 +627,9 @@ def _resolve_named_custom_runtime(
     # provider name differs from the actual model string the API expects.
     if custom_provider.get("model"):
         result["model"] = custom_provider["model"]
+    ssl_verify = custom_provider.get("ssl_verify")
+    if ssl_verify is not None:
+        result["ssl_verify"] = ssl_verify
     return result
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -2385,7 +2385,7 @@ class AIAgent:
         return False
 
     @staticmethod
-    def _build_keepalive_http_client(base_url: str = "") -> Any:
+    def _build_keepalive_http_client(base_url: str = "", verify: Any = None) -> Any:
         try:
             import httpx as _httpx
             import socket as _socket
@@ -2402,8 +2402,17 @@ class AIAgent:
             # Explicitly read proxy settings while still honoring NO_PROXY for
             # loopback / local endpoints such as a locally hosted sub2api.
             _proxy = _get_proxy_for_base_url(base_url)
+            # Custom providers that point at self-signed / private-CA HTTPS
+            # endpoints set ``ssl_verify`` (#28260).  httpx applies ``verify``
+            # on the transport that performs the TLS handshake and IGNORES a
+            # ``verify`` passed to ``Client`` whenever an explicit ``transport``
+            # is supplied — so the value has to land on the transport here.
+            # Left unset (``None``), httpx keeps its default full verification.
+            _transport_kwargs: dict = {"socket_options": _sock_opts}
+            if verify is not None:
+                _transport_kwargs["verify"] = verify
             return _httpx.Client(
-                transport=_httpx.HTTPTransport(socket_options=_sock_opts),
+                transport=_httpx.HTTPTransport(**_transport_kwargs),
                 proxy=_proxy,
             )
         except Exception:

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -492,3 +492,150 @@ class TestCustomProviderAliasCollision:
         assert isinstance(client, OpenAI)
         assert "override.example.com" in str(client.base_url)
         assert client.api_key == "override-key"
+
+
+class TestCustomProviderSslVerify:
+    """ssl_verify config field disables TLS verification for self-signed endpoints.
+
+    Regression guard for #28260 — custom_providers entries pointing at
+    self-signed HTTPS servers need a way to opt out of certificate
+    verification without touching global SSL settings.
+    """
+
+    def test_normalize_ssl_verify_false(self):
+        from hermes_cli.config import _normalize_custom_provider_entry
+        entry = {
+            "name": "local-llm",
+            "base_url": "https://192.168.1.50:8443/v1",
+            "api_key": "k",
+            "ssl_verify": False,
+        }
+        result = _normalize_custom_provider_entry(entry)
+        assert result is not None
+        assert result["ssl_verify"] is False
+
+    def test_normalize_ssl_verify_true_is_preserved(self):
+        from hermes_cli.config import _normalize_custom_provider_entry
+        entry = {
+            "name": "local-llm",
+            "base_url": "https://192.168.1.50:8443/v1",
+            "api_key": "k",
+            "ssl_verify": True,
+        }
+        result = _normalize_custom_provider_entry(entry)
+        assert result is not None
+        assert result["ssl_verify"] is True
+
+    def test_normalize_ssl_verify_ca_bundle_path(self):
+        from hermes_cli.config import _normalize_custom_provider_entry
+        entry = {
+            "name": "corp-llm",
+            "base_url": "https://llm.corp.internal/v1",
+            "api_key": "k",
+            "ssl_verify": "/etc/ssl/certs/corp-ca.pem",
+        }
+        result = _normalize_custom_provider_entry(entry)
+        assert result is not None
+        assert result["ssl_verify"] == "/etc/ssl/certs/corp-ca.pem"
+
+    def test_normalize_ssl_verify_absent_is_not_in_result(self):
+        from hermes_cli.config import _normalize_custom_provider_entry
+        entry = {
+            "name": "local-llm",
+            "base_url": "http://localhost:11434/v1",
+            "api_key": "k",
+        }
+        result = _normalize_custom_provider_entry(entry)
+        assert result is not None
+        assert "ssl_verify" not in result
+
+    def test_normalize_camelcase_ssl_verify_alias(self):
+        from hermes_cli.config import _normalize_custom_provider_entry
+        entry = {
+            "name": "local-llm",
+            "base_url": "https://192.168.1.50:8443/v1",
+            "api_key": "k",
+            "sslVerify": False,
+        }
+        result = _normalize_custom_provider_entry(entry)
+        assert result is not None
+        assert result["ssl_verify"] is False
+
+    def test_get_named_custom_provider_passes_ssl_verify(self, tmp_path):
+        _write_config(tmp_path, {
+            "custom_providers": [
+                {
+                    "name": "selfsigned",
+                    "base_url": "https://192.168.1.50:8443/v1",
+                    "api_key": "k",
+                    "ssl_verify": False,
+                }
+            ],
+        })
+        from hermes_cli.runtime_provider import _get_named_custom_provider
+        entry = _get_named_custom_provider("selfsigned")
+        assert entry is not None
+        assert entry.get("ssl_verify") is False
+
+    def test_providers_dict_passes_ssl_verify(self, tmp_path):
+        _write_config(tmp_path, {
+            "providers": {
+                "selfsigned": {
+                    "name": "selfsigned",
+                    "base_url": "https://192.168.1.50:8443/v1",
+                    "api_key": "k",
+                    "ssl_verify": False,
+                }
+            },
+        })
+        from hermes_cli.runtime_provider import _get_named_custom_provider
+        entry = _get_named_custom_provider("selfsigned")
+        assert entry is not None
+        assert entry.get("ssl_verify") is False
+
+    def test_resolve_provider_client_passes_http_client_when_ssl_verify_false(self, tmp_path):
+        """resolve_provider_client must pass httpx.Client(verify=False) to OpenAI
+        when the provider entry declares ssl_verify: false."""
+        import httpx
+        _write_config(tmp_path, {
+            "custom_providers": [
+                {
+                    "name": "selfsigned",
+                    "base_url": "https://192.168.1.50:8443/v1",
+                    "api_key": "k",
+                    "ssl_verify": False,
+                }
+            ],
+        })
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            from agent.auxiliary_client import resolve_provider_client
+            client, _ = resolve_provider_client("selfsigned", "test-model")
+
+        assert mock_openai.called
+        call_kwargs = mock_openai.call_args[1]
+        assert "http_client" in call_kwargs, (
+            "OpenAI() was not passed an http_client — ssl_verify was not threaded through"
+        )
+        http_client = call_kwargs["http_client"]
+        assert isinstance(http_client, httpx.Client)
+
+    def test_resolve_provider_client_no_http_client_when_ssl_verify_absent(self, tmp_path):
+        """When ssl_verify is not set, no http_client override should be injected."""
+        _write_config(tmp_path, {
+            "custom_providers": [
+                {
+                    "name": "normal",
+                    "base_url": "https://api.example.com/v1",
+                    "api_key": "k",
+                }
+            ],
+        })
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            from agent.auxiliary_client import resolve_provider_client
+            resolve_provider_client("normal", "test-model")
+
+        assert mock_openai.called
+        call_kwargs = mock_openai.call_args[1]
+        assert "http_client" not in call_kwargs

--- a/tests/run_agent/test_create_openai_client_ssl_verify.py
+++ b/tests/run_agent/test_create_openai_client_ssl_verify.py
@@ -1,0 +1,204 @@
+"""Regression guard: ssl_verify must reach the PRIMARY chat client (#28260).
+
+PR #28271 first threaded the custom-provider ``ssl_verify`` field into the
+auxiliary client only (``agent/auxiliary_client.py``).  But the bug in #28260 is
+``hermes chat`` — the main ``AIAgent`` client.  That client takes a different
+path: ``create_openai_client`` builds its ``http_client`` via
+``AIAgent._build_keepalive_http_client``, whose ``httpx.Client`` was constructed
+with httpx's default certificate verification.  So ``ssl_verify: false`` (or a
+CA-bundle path) never reached the client ``hermes chat`` actually uses, and a
+self-signed endpoint still raised ``APIConnectionError`` / ``CERTIFICATE_VERIFY_FAILED``.
+
+These tests pin that:
+  * ``_build_keepalive_http_client(verify=...)`` lands the value on the transport
+    that performs the TLS handshake (httpx ignores ``verify`` on ``Client`` when
+    a custom ``transport`` is supplied, so it MUST be on the transport).
+  * ``create_openai_client`` resolves the custom-provider override for the active
+    base_url and threads it into that keepalive client — the main-path coverage
+    the reviewer asked for, for both ``ssl_verify: false`` and a CA-bundle path.
+  * the default (no override) still uses full verification.
+"""
+import ssl
+
+import certifi
+import httpx
+import pytest
+
+from run_agent import AIAgent
+
+
+def _make_agent():
+    return AIAgent(
+        api_key="test-key",
+        base_url="https://gpu.internal:8443/v1",
+        provider="custom",
+        model="local-model",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+
+def _ssl_context_of(http_client: httpx.Client) -> ssl.SSLContext:
+    """The TLS context the keepalive client's base transport will hand to the OS."""
+    return http_client._transport._pool._ssl_context
+
+
+def _extract_http_client(call_kwargs: dict) -> httpx.Client:
+    return call_kwargs.get("http_client")
+
+
+# --------------------------------------------------------------------------- #
+# Builder-level: verify lands on the transport, not the Client.
+# --------------------------------------------------------------------------- #
+
+def test_keepalive_builder_disables_verification_when_false():
+    client = AIAgent._build_keepalive_http_client("https://gpu.internal:8443/v1", verify=False)
+    try:
+        ctx = _ssl_context_of(client)
+        assert ctx.verify_mode == ssl.CERT_NONE
+        assert ctx.check_hostname is False
+    finally:
+        client.close()
+
+
+def test_keepalive_builder_keeps_full_verification_by_default():
+    # verify omitted -> default httpx behaviour (full verification) preserved.
+    client = AIAgent._build_keepalive_http_client("https://api.openai.com/v1")
+    try:
+        ctx = _ssl_context_of(client)
+        assert ctx.verify_mode == ssl.CERT_REQUIRED
+        assert ctx.check_hostname is True
+    finally:
+        client.close()
+
+
+def test_keepalive_builder_accepts_ca_bundle_path():
+    # A CA-bundle path string must be accepted and still verify (against that CA).
+    client = AIAgent._build_keepalive_http_client(
+        "https://corp.internal:8443/v1", verify=certifi.where()
+    )
+    try:
+        ctx = _ssl_context_of(client)
+        assert ctx.verify_mode == ssl.CERT_REQUIRED
+    finally:
+        client.close()
+
+
+# --------------------------------------------------------------------------- #
+# Main path: create_openai_client resolves the override and threads it through.
+# --------------------------------------------------------------------------- #
+
+@pytest.fixture
+def _patch_openai(monkeypatch):
+    """Capture the kwargs passed to ``OpenAI(**client_kwargs)``."""
+    calls = {}
+
+    def _fake_openai(**kwargs):
+        calls["kwargs"] = kwargs
+        return object()
+
+    monkeypatch.setattr("run_agent.OpenAI", _fake_openai)
+    return calls
+
+
+def test_main_path_threads_ssl_verify_false(monkeypatch, _patch_openai):
+    """ssl_verify: false on the active custom provider disables verification on
+    the primary chat client's keepalive httpx.Client."""
+    monkeypatch.setattr(
+        "hermes_cli.config.get_custom_provider_ssl_verify",
+        lambda base_url, *a, **k: False,
+    )
+    agent = _make_agent()
+    agent._create_openai_client(
+        {"api_key": "test-key", "base_url": "https://gpu.internal:8443/v1"},
+        reason="test", shared=False,
+    )
+
+    http_client = _extract_http_client(_patch_openai["kwargs"])
+    assert isinstance(http_client, httpx.Client), (
+        "primary client was not given a keepalive httpx.Client"
+    )
+    try:
+        assert _ssl_context_of(http_client).verify_mode == ssl.CERT_NONE, (
+            "ssl_verify:false did not reach the main chat client's transport"
+        )
+    finally:
+        http_client.close()
+
+
+def test_main_path_threads_ca_bundle_path(monkeypatch, _patch_openai):
+    """A CA-bundle path resolves through to the primary client without error."""
+    monkeypatch.setattr(
+        "hermes_cli.config.get_custom_provider_ssl_verify",
+        lambda base_url, *a, **k: certifi.where(),
+    )
+    agent = _make_agent()
+    agent._create_openai_client(
+        {"api_key": "test-key", "base_url": "https://corp.internal:8443/v1"},
+        reason="test", shared=False,
+    )
+
+    http_client = _extract_http_client(_patch_openai["kwargs"])
+    assert isinstance(http_client, httpx.Client)
+    try:
+        # Custom CA bundle => still verifying (just against the provided CA).
+        assert _ssl_context_of(http_client).verify_mode == ssl.CERT_REQUIRED
+    finally:
+        http_client.close()
+
+
+def test_main_path_keeps_default_verification_without_override(monkeypatch, _patch_openai):
+    """No ssl_verify configured -> primary client keeps full verification."""
+    monkeypatch.setattr(
+        "hermes_cli.config.get_custom_provider_ssl_verify",
+        lambda base_url, *a, **k: None,
+    )
+    agent = _make_agent()
+    agent._create_openai_client(
+        {"api_key": "test-key", "base_url": "https://api.openai.com/v1"},
+        reason="test", shared=False,
+    )
+
+    http_client = _extract_http_client(_patch_openai["kwargs"])
+    assert isinstance(http_client, httpx.Client)
+    try:
+        assert _ssl_context_of(http_client).verify_mode == ssl.CERT_REQUIRED
+    finally:
+        http_client.close()
+
+
+# --------------------------------------------------------------------------- #
+# Resolver: reads the normalized field from both config schemas.
+# --------------------------------------------------------------------------- #
+
+def test_resolver_reads_false_and_ca_path_across_schemas():
+    from hermes_cli.config import get_custom_provider_ssl_verify
+
+    config = {
+        # legacy list schema
+        "custom_providers": [
+            {
+                "name": "gpu",
+                "base_url": "https://gpu.internal:8443/v1",
+                "ssl_verify": False,
+            },
+        ],
+        # newer keyed schema
+        "providers": {
+            "corp": {
+                "base_url": "https://corp.internal:8443/v1",
+                "ssl_verify": "/etc/ssl/certs/corp-ca.pem",
+            },
+        },
+    }
+
+    assert get_custom_provider_ssl_verify(
+        "https://gpu.internal:8443/v1", config=config) is False
+    # trailing-slash insensitive
+    assert get_custom_provider_ssl_verify(
+        "https://corp.internal:8443/v1/", config=config) == "/etc/ssl/certs/corp-ca.pem"
+    # no match / no override -> None (default verification preserved)
+    assert get_custom_provider_ssl_verify(
+        "https://other.example.com/v1", config=config) is None
+    assert get_custom_provider_ssl_verify("", config=config) is None


### PR DESCRIPTION
Fixes #28260

  ## Problem

  Custom provider entries pointing at internal or self-hosted HTTPS servers
  (local GPU clusters, corporate proxies, home lab vLLM) often use
  self-signed certificates. The OpenAI SDK rejects these by default,
  producing a cryptic `APIConnectionError` with no config-level workaround.

  ## Solution

  Add an `ssl_verify` field to the `custom_providers` / `providers` config schema:

  ```yaml
  custom_providers:
    - name: "my-gpu-server"
      base_url: "https://192.168.1.50:8443/v1"
      api_key: "secret"
      ssl_verify: false              # disable cert check for self-signed cert
      # or: ssl_verify: "/etc/ssl/certs/corp-ca.pem"  # custom CA bundle

  Accepted values follow the httpx/requests convention — false, true
  (default, no change in behaviour), or a path string to a CA bundle.
  The sslVerify camelCase alias is also accepted.

  The value threads from config normalisation → runtime provider resolution
  → httpx.Client(verify=...) passed as http_client to the OpenAI SDK,
  which is the officially documented override path.

  This mirrors the existing ssl_verify field already supported for MCP
  servers (mcp_tool.py), keeping the config convention consistent.

  Changes

  - hermes_cli/config.py — add ssl_verify / sslVerify to normaliser
  - hermes_cli/runtime_provider.py — thread field through named-provider lookup
  - agent/auxiliary_client.py — inject httpx.Client(verify=...) into custom-provider client construction
  - tests/agent/test_auxiliary_named_custom_providers.py — 9 new tests covering config normalisation, runtime resolution, and client construction