### PR TITLE
[codex] Update Telegram onboarding client for Worker API

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2117,6 +2117,7 @@ def _setup_standard_platform(platform: dict):
             return
 
     auto_token_saved = False
+    auto_owner_user_id = None
     if platform.get("key") == "telegram":
         print()
         print_info("  Telegram can be configured automatically with a managed bot:")
@@ -2125,15 +2126,16 @@ def _setup_standard_platform(platform: dict):
         choice = prompt("  Choice [1/2]", default="1")
         if choice.strip() == "1":
             try:
-                from hermes_cli.telegram_managed_bot import auto_setup_telegram_bot
+                from hermes_cli.telegram_managed_bot import auto_setup_telegram_bot_result
             except ImportError:
                 print_warning("  Automatic setup is unavailable in this install.")
             else:
-                token = auto_setup_telegram_bot()
-                if token:
-                    save_env_value(token_var, token)
+                result = auto_setup_telegram_bot_result()
+                if result:
+                    save_env_value(token_var, result.token)
                     print_success("  Saved TELEGRAM_BOT_TOKEN")
                     auto_token_saved = True
+                    auto_owner_user_id = result.owner_user_id
                 else:
                     print()
                     print_info("  Falling back to manual setup...")
@@ -2153,6 +2155,24 @@ def _setup_standard_platform(platform: dict):
 
         # Allowlist fields get special handling for the deny-by-default security model
         if var.get("is_allowlist"):
+            if "TELEGRAM" in var["name"] and auto_owner_user_id:
+                detected_id = str(auto_owner_user_id)
+                print_success(f"  Detected your Telegram user ID: {detected_id}")
+                if prompt_yes_no("  Allow this Telegram account to use the bot?", True):
+                    extra = prompt(
+                        "  Additional allowed user IDs (comma-separated, optional)",
+                        password=False,
+                    )
+                    ids = [detected_id]
+                    for uid in extra.replace(" ", "").split(","):
+                        if uid and uid not in ids:
+                            ids.append(uid)
+                    cleaned = ",".join(ids)
+                    save_env_value(var["name"], cleaned)
+                    print_success("  Saved — only these users can interact with the bot.")
+                    allowed_val_set = cleaned
+                    continue
+
             print_info("  The gateway DENIES all users by default for security.")
             print_info("  Enter user IDs to create an allowlist, or leave empty")
             print_info("  and you'll be asked about open access next.")

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2116,6 +2116,28 @@ def _setup_standard_platform(platform: dict):
         if not prompt_yes_no(f"  Reconfigure {label}?", False):
             return
 
+    auto_token_saved = False
+    if platform.get("key") == "telegram":
+        print()
+        print_info("  Telegram can be configured automatically with a managed bot:")
+        print_info("  [1] Automatic (scan QR → confirm in Telegram → done)")
+        print_info("  [2] Manual BotFather token")
+        choice = prompt("  Choice [1/2]", default="1")
+        if choice.strip() == "1":
+            try:
+                from hermes_cli.telegram_managed_bot import auto_setup_telegram_bot
+            except ImportError:
+                print_warning("  Automatic setup is unavailable in this install.")
+            else:
+                token = auto_setup_telegram_bot()
+                if token:
+                    save_env_value(token_var, token)
+                    print_success("  Saved TELEGRAM_BOT_TOKEN")
+                    auto_token_saved = True
+                else:
+                    print()
+                    print_info("  Falling back to manual setup...")
+
     allowed_val_set = None  # Track if user set an allowlist (for home channel offer)
 
     for var in platform["vars"]:
@@ -2124,6 +2146,10 @@ def _setup_standard_platform(platform: dict):
         existing = get_env_value(var["name"])
         if existing and var["name"] != token_var:
             print_info(f"  Current: {existing}")
+
+        if auto_token_saved and var["name"] == token_var:
+            print_info("  Token saved by automatic setup.")
+            continue
 
         # Allowlist fields get special handling for the deny-by-default security model
         if var.get("is_allowlist"):

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1592,13 +1592,10 @@ def setup_agent_settings(config: dict):
 # =============================================================================
 
 
-def _setup_telegram_auto() -> str | None:
-    """Attempt automatic Telegram bot creation via Managed Bots (Bot API 9.6).
-
-    Returns the bot token on success, None on failure/skip.
-    """
+def _setup_telegram_auto_result():
+    """Attempt automatic Telegram bot creation via Managed Bots (Bot API 9.6)."""
     try:
-        from hermes_cli.telegram_managed_bot import auto_setup_telegram_bot
+        from hermes_cli.telegram_managed_bot import auto_setup_telegram_bot_result
     except ImportError:
         return None
 
@@ -1612,7 +1609,13 @@ def _setup_telegram_auto() -> str | None:
     except Exception:
         pass
 
-    return auto_setup_telegram_bot(profile_name=profile_name)
+    return auto_setup_telegram_bot_result(profile_name=profile_name)
+
+
+def _setup_telegram_auto() -> str | None:
+    """Attempt automatic Telegram bot creation and return only the token."""
+    result = _setup_telegram_auto_result()
+    return result.token if result else None
 
 
 def _setup_telegram():
@@ -1646,10 +1649,13 @@ def _setup_telegram():
 
     choice = prompt("Choice [1/2]", default="1")
     token = None
+    setup_result = None
 
     if choice.strip() == "1":
-        token = _setup_telegram_auto()
-        if not token:
+        setup_result = _setup_telegram_auto_result()
+        if setup_result:
+            token = setup_result.token
+        else:
             print()
             print_info("Falling back to manual setup...")
             print()
@@ -1669,11 +1675,30 @@ def _setup_telegram():
     print_info("   1. Message @userinfobot on Telegram")
     print_info("   2. It will reply with your numeric ID (e.g., 123456789)")
     print()
-    allowed_users = prompt(
-        "Allowed user IDs (comma-separated, leave empty for open access)"
-    )
+
+    detected_user_id = getattr(setup_result, "owner_user_id", None)
+    if detected_user_id:
+        detected_id = str(detected_user_id)
+        print_success(f"Detected your Telegram user ID: {detected_id}")
+        if prompt_yes_no("Allow this Telegram account to use the bot?", True):
+            extra = prompt("Additional allowed user IDs (comma-separated, optional)")
+            ids = [detected_id]
+            for uid in extra.replace(" ", "").split(","):
+                if uid and uid not in ids:
+                    ids.append(uid)
+            allowed_users = ",".join(ids)
+        else:
+            allowed_users = prompt(
+                "Allowed user IDs (comma-separated, leave empty for open access)"
+            )
+    else:
+        allowed_users = prompt(
+            "Allowed user IDs (comma-separated, leave empty for open access)"
+        )
+
     if allowed_users:
-        save_env_value("TELEGRAM_ALLOWED_USERS", allowed_users.replace(" ", ""))
+        allowed_users = allowed_users.replace(" ", "")
+        save_env_value("TELEGRAM_ALLOWED_USERS", allowed_users)
         print_success("Telegram allowlist configured - only listed users can use the bot")
     else:
         print_info("⚠️  No allowlist set - anyone who finds your bot can use it!")

--- a/hermes_cli/telegram_managed_bot.py
+++ b/hermes_cli/telegram_managed_bot.py
@@ -45,6 +45,15 @@ class TelegramPairing:
     expires_at: str | None = None
 
 
+@dataclass(frozen=True)
+class TelegramBotSetupResult:
+    """Successful Telegram onboarding result returned by the setup service."""
+
+    token: str
+    bot_username: str | None = None
+    owner_user_id: int | None = None
+
+
 def _api_url(api_url: str | None = None) -> str:
     """Resolve the onboarding API URL, honoring the PoC env override."""
     return (api_url or os.environ.get(TELEGRAM_ONBOARDING_URL_ENV) or DEFAULT_API_URL).rstrip("/")
@@ -176,12 +185,12 @@ def create_pairing(
     )
 
 
-def poll_pairing_once(
+def poll_pairing_result_once(
     api_url: str | None,
     pairing: TelegramPairing,
     timeout: float = 10.0,
-) -> str | None:
-    """Poll the onboarding service once. Returns the token when ready."""
+) -> TelegramBotSetupResult | None:
+    """Poll the onboarding service once. Returns setup metadata when ready."""
     resp = httpx.get(
         f"{_api_url(api_url)}/v1/telegram/pairings/{pairing.pairing_id}",
         headers={"Authorization": f"Bearer {pairing.poll_token}"},
@@ -194,7 +203,47 @@ def poll_pairing_once(
     if data.get("status") != "ready":
         return None
     token = data.get("token")
-    return token if isinstance(token, str) and token else None
+    if not isinstance(token, str) or not token:
+        return None
+
+    bot_username = data.get("bot_username")
+    owner_user_id = data.get("owner_user_id")
+    return TelegramBotSetupResult(
+        token=token,
+        bot_username=bot_username if isinstance(bot_username, str) and bot_username else None,
+        owner_user_id=owner_user_id
+        if isinstance(owner_user_id, int) and not isinstance(owner_user_id, bool) and owner_user_id > 0
+        else None,
+    )
+
+
+def poll_pairing_once(
+    api_url: str | None,
+    pairing: TelegramPairing,
+    timeout: float = 10.0,
+) -> str | None:
+    """Poll the onboarding service once. Returns the token when ready."""
+    result = poll_pairing_result_once(api_url, pairing, timeout=timeout)
+    return result.token if result else None
+
+
+def poll_for_setup_result(
+    api_url: str | None,
+    pairing: TelegramPairing,
+    timeout: float = DEFAULT_POLL_TIMEOUT,
+    interval: float = POLL_INTERVAL,
+) -> Optional[TelegramBotSetupResult]:
+    """Poll the pairing API until setup metadata is available or timeout."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            result = poll_pairing_result_once(api_url, pairing)
+            if result:
+                return result
+        except (httpx.HTTPError, ValueError):
+            pass
+        time.sleep(interval)
+    return None
 
 
 def poll_for_token(
@@ -204,24 +253,16 @@ def poll_for_token(
     interval: float = POLL_INTERVAL,
 ) -> Optional[str]:
     """Poll the pairing API until the bot token is available or timeout."""
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        try:
-            token = poll_pairing_once(api_url, pairing)
-            if token:
-                return token
-        except (httpx.HTTPError, ValueError):
-            pass
-        time.sleep(interval)
-    return None
+    result = poll_for_setup_result(api_url, pairing, timeout=timeout, interval=interval)
+    return result.token if result else None
 
 
-def auto_setup_telegram_bot(
+def auto_setup_telegram_bot_result(
     api_url: str | None = None,
     manager_bot: str = DEFAULT_MANAGER_BOT,
     profile_name: Optional[str] = None,
     poll_timeout: float = DEFAULT_POLL_TIMEOUT,
-) -> Optional[str]:
+) -> Optional[TelegramBotSetupResult]:
     """Run the full automatic Telegram bot creation flow."""
     _ = manager_bot, profile_name
     resolved_api_url = _api_url(api_url)
@@ -262,11 +303,11 @@ def auto_setup_telegram_bot(
         idx += 1
 
         try:
-            token = poll_pairing_once(resolved_api_url, pairing)
-            if token:
+            result = poll_pairing_result_once(resolved_api_url, pairing)
+            if result:
                 sys.stdout.write("\r  ✓ Bot created successfully!                              \n")
                 sys.stdout.flush()
-                return token
+                return result
         except (httpx.HTTPError, ValueError):
             pass
         time.sleep(POLL_INTERVAL)
@@ -276,3 +317,19 @@ def auto_setup_telegram_bot(
     print("    The bot may still be created — check Telegram.")
     print("    You can paste the token manually below, or re-run setup.")
     return None
+
+
+def auto_setup_telegram_bot(
+    api_url: str | None = None,
+    manager_bot: str = DEFAULT_MANAGER_BOT,
+    profile_name: Optional[str] = None,
+    poll_timeout: float = DEFAULT_POLL_TIMEOUT,
+) -> Optional[str]:
+    """Run automatic Telegram bot creation and return only the bot token."""
+    result = auto_setup_telegram_bot_result(
+        api_url=api_url,
+        manager_bot=manager_bot,
+        profile_name=profile_name,
+        poll_timeout=poll_timeout,
+    )
+    return result.token if result else None

--- a/hermes_cli/telegram_managed_bot.py
+++ b/hermes_cli/telegram_managed_bot.py
@@ -1,60 +1,57 @@
-"""Telegram Managed Bot — automatic bot creation via Bot API 9.6.
+"""Telegram Managed Bot onboarding client.
 
-Uses Telegram's Managed Bots feature to create bots for users without
-manual BotFather interaction.  The flow:
-
-1. CLI generates a pairing nonce and a t.me/newbot deep link.
-2. User opens the link in Telegram and confirms bot creation.
-3. A Nous-hosted manager bot receives the ``managed_bot`` update,
-   calls ``getManagedBotToken``, and stores the token keyed by nonce.
-4. CLI polls the pairing API and retrieves the token.
-5. Token is saved to ``.env`` — zero manual copy-paste.
-
-Requires:
-  - A Nous-hosted manager bot with Bot Management Mode enabled.
-  - A pairing API (Cloudflare Worker + KV or equivalent) at
-    ``MANAGED_BOT_API_URL``.
+Uses Telegram's Managed Bots feature to create a user-owned child bot without
+manual BotFather token copy-paste. Hermes talks only to the Nous onboarding
+service; the raw Telegram token is saved locally after one-time retrieval.
 """
 
 from __future__ import annotations
 
+import os
 import secrets
-import string
 import sys
 import time
 import urllib.parse
+from dataclasses import dataclass
 from typing import Optional
 
 import httpx
 
-# ---------------------------------------------------------------------------
-# Constants
-# ---------------------------------------------------------------------------
-
 # Default pairing API base URL (Nous-hosted Cloudflare Worker).
-# Override via config.yaml ``telegram.managed_bot_api_url`` for self-hosted.
+# Override for PoC/staging with TELEGRAM_ONBOARDING_URL.
 DEFAULT_API_URL = "https://setup.hermes-agent.nousresearch.com"
+TELEGRAM_ONBOARDING_URL_ENV = "TELEGRAM_ONBOARDING_URL"
 
-# The Nous-hosted manager bot username (without @).
+# The Nous-hosted manager bot username (without @). The backend returns the
+# actual deep link, so this is only used by local helpers/tests.
 DEFAULT_MANAGER_BOT = "HermesSetupBot"
 
-# How long to poll before giving up (seconds).
+DEFAULT_BOT_NAME = "Hermes Agent"
 DEFAULT_POLL_TIMEOUT = 180
-
-# Poll interval (seconds).
 POLL_INTERVAL = 2
 
-# ---------------------------------------------------------------------------
-# QR code rendering
-# ---------------------------------------------------------------------------
+_USERNAME_SLUG_ALPHABET = "abcdefghijklmnopqrstuvwxyz234567"
+
+
+@dataclass(frozen=True)
+class TelegramPairing:
+    """Pairing record returned by the Telegram onboarding service."""
+
+    pairing_id: str
+    poll_token: str
+    suggested_username: str
+    deep_link: str
+    qr_payload: str
+    expires_at: str | None = None
+
+
+def _api_url(api_url: str | None = None) -> str:
+    """Resolve the onboarding API URL, honoring the PoC env override."""
+    return (api_url or os.environ.get(TELEGRAM_ONBOARDING_URL_ENV) or DEFAULT_API_URL).rstrip("/")
 
 
 def render_qr_terminal(url: str) -> str:
-    """Render a URL as a QR code string suitable for terminal output.
-
-    Uses the ``qrcode`` library if available, otherwise returns an empty
-    string (caller should fall back to printing the URL directly).
-    """
+    """Render a URL as a QR code string suitable for terminal output."""
     try:
         import io
 
@@ -76,40 +73,35 @@ def render_qr_terminal(url: str) -> str:
         return ""
 
 
-def print_qr_code(url: str) -> None:
+def print_qr_code(url: str, *, include_link: bool = True) -> None:
     """Print a QR code to stdout, with URL fallback if qrcode is missing."""
     qr_text = render_qr_terminal(url)
     if qr_text:
         print(qr_text)
     else:
-        print(f"  (Install 'qrcode' for a scannable QR code: pip install qrcode)")
-    print(f"  Link: {url}")
+        print("  (Install 'qrcode' for a scannable QR code: pip install qrcode)")
+    if include_link:
+        print(f"  Link: {url}")
 
 
-# ---------------------------------------------------------------------------
-# Deep link generation
-# ---------------------------------------------------------------------------
+def generate_username_slug(length: int = 16) -> str:
+    """Generate a base32-ish slug for Telegram username correlation.
 
-
-def _random_suffix(length: int = 4) -> str:
-    """Generate a short random alphanumeric suffix for bot usernames."""
-    alphabet = string.ascii_lowercase + string.digits
-    return "".join(secrets.choice(alphabet) for _ in range(length))
+    Sixteen characters from a 32-symbol alphabet gives 80 bits of entropy while
+    keeping ``hermes_<slug>_bot`` under Telegram's 32-character username limit.
+    """
+    return "".join(secrets.choice(_USERNAME_SLUG_ALPHABET) for _ in range(length))
 
 
 def generate_bot_username(profile_name: Optional[str] = None) -> str:
-    """Generate a suggested bot username like ``hermes_work_a7f3_bot``.
+    """Generate a secure suggested bot username like ``hermes_<slug>_bot``.
 
-    Telegram requires bot usernames to end with ``bot`` and be 5-32 chars.
+    ``profile_name`` is accepted for backward compatibility with the original
+    PoC, but is intentionally not embedded in the username. The username has to
+    carry enough entropy for backend correlation.
     """
-    base = "hermes"
-    suffix = _random_suffix()
-    if profile_name and profile_name != "default":
-        # Sanitize profile name for Telegram username rules (a-z, 0-9, _)
-        clean = "".join(c if c.isalnum() else "_" for c in profile_name.lower())
-        clean = clean[:12]  # Keep it short
-        return f"{base}_{clean}_{suffix}_bot"
-    return f"{base}_{suffix}_bot"
+    _ = profile_name
+    return f"hermes_{generate_username_slug()}_bot"
 
 
 def generate_deep_link(
@@ -117,12 +109,14 @@ def generate_deep_link(
     suggested_username: Optional[str] = None,
     suggested_name: Optional[str] = None,
 ) -> str:
-    """Build the ``t.me/newbot`` deep link for managed bot creation.
-
-    Format: ``https://t.me/newbot/{manager_bot}/{suggested_username}[?name={name}]``
-    """
+    """Build a ``t.me/newbot`` deep link for managed bot creation."""
+    manager = manager_bot.lstrip("@")
     username = suggested_username or generate_bot_username()
-    base_url = f"https://t.me/newbot/{manager_bot}/{username}"
+    base_url = (
+        "https://t.me/newbot/"
+        f"{urllib.parse.quote(manager)}/"
+        f"{urllib.parse.quote(username)}"
+    )
 
     if suggested_name:
         params = urllib.parse.urlencode({"name": suggested_name})
@@ -130,112 +124,130 @@ def generate_deep_link(
     return base_url
 
 
-# ---------------------------------------------------------------------------
-# Pairing protocol (client side)
-# ---------------------------------------------------------------------------
-
-
 def generate_pairing_nonce() -> str:
-    """Generate a cryptographically random pairing nonce (32 hex chars)."""
+    """Generate a legacy-compatible random nonce string.
+
+    The new protocol uses service-created ``pairing_id`` + bearer
+    ``poll_token`` instead of a path nonce, but this helper is harmless and
+    still useful for callers/tests that need a generic random id.
+    """
     return secrets.token_hex(16)
 
 
-def register_pairing(api_url: str, nonce: str, timeout: float = 10.0) -> bool:
-    """Register a pairing nonce with the pairing API.
+def create_pairing(
+    api_url: str | None = None,
+    bot_name: str = DEFAULT_BOT_NAME,
+    timeout: float = 10.0,
+) -> TelegramPairing | None:
+    """Create a Telegram onboarding pairing.
 
-    ``POST /pair``  body: ``{"nonce": "..."}``
-
-    Returns True on success, False on failure.
+    ``POST /v1/telegram/pairings`` returns the deep link, QR payload, public
+    pairing id, and secret poll token. The token is only used as a bearer
+    credential while polling.
     """
     try:
         resp = httpx.post(
-            f"{api_url}/pair",
-            json={"nonce": nonce},
+            f"{_api_url(api_url)}/v1/telegram/pairings",
+            json={"bot_name": bot_name},
             timeout=timeout,
         )
-        return resp.status_code in (200, 201)
-    except httpx.HTTPError:
-        return False
+        if resp.status_code not in (200, 201):
+            return None
+        data = resp.json()
+    except (httpx.HTTPError, ValueError):
+        return None
+
+    required = ("pairing_id", "poll_token", "suggested_username", "deep_link")
+    if not all(isinstance(data.get(key), str) and data.get(key) for key in required):
+        return None
+
+    qr_payload = data.get("qr_payload") or data["deep_link"]
+    if not isinstance(qr_payload, str):
+        return None
+
+    expires_at = data.get("expires_at")
+    return TelegramPairing(
+        pairing_id=data["pairing_id"],
+        poll_token=data["poll_token"],
+        suggested_username=data["suggested_username"],
+        deep_link=data["deep_link"],
+        qr_payload=qr_payload,
+        expires_at=expires_at if isinstance(expires_at, str) else None,
+    )
+
+
+def poll_pairing_once(
+    api_url: str | None,
+    pairing: TelegramPairing,
+    timeout: float = 10.0,
+) -> str | None:
+    """Poll the onboarding service once. Returns the token when ready."""
+    resp = httpx.get(
+        f"{_api_url(api_url)}/v1/telegram/pairings/{pairing.pairing_id}",
+        headers={"Authorization": f"Bearer {pairing.poll_token}"},
+        timeout=timeout,
+    )
+    if resp.status_code != 200:
+        return None
+
+    data = resp.json()
+    if data.get("status") != "ready":
+        return None
+    token = data.get("token")
+    return token if isinstance(token, str) and token else None
 
 
 def poll_for_token(
-    api_url: str,
-    nonce: str,
+    api_url: str | None,
+    pairing: TelegramPairing,
     timeout: float = DEFAULT_POLL_TIMEOUT,
     interval: float = POLL_INTERVAL,
 ) -> Optional[str]:
-    """Poll the pairing API until the bot token is available or timeout.
-
-    ``GET /pair/{nonce}`` → 200 with ``{"token": "..."}`` when ready,
-    404 while waiting.
-
-    Returns the bot token string on success, None on timeout/failure.
-    """
+    """Poll the pairing API until the bot token is available or timeout."""
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         try:
-            resp = httpx.get(
-                f"{api_url}/pair/{nonce}",
-                timeout=10.0,
-            )
-            if resp.status_code == 200:
-                data = resp.json()
-                token = data.get("token")
-                if token:
-                    return token
-            # 404 = not yet ready, keep polling
-        except httpx.HTTPError:
-            pass  # Network hiccup, retry
+            token = poll_pairing_once(api_url, pairing)
+            if token:
+                return token
+        except (httpx.HTTPError, ValueError):
+            pass
         time.sleep(interval)
     return None
 
 
-# ---------------------------------------------------------------------------
-# Orchestrator — called from setup wizard
-# ---------------------------------------------------------------------------
-
-
 def auto_setup_telegram_bot(
-    api_url: str = DEFAULT_API_URL,
+    api_url: str | None = None,
     manager_bot: str = DEFAULT_MANAGER_BOT,
     profile_name: Optional[str] = None,
     poll_timeout: float = DEFAULT_POLL_TIMEOUT,
 ) -> Optional[str]:
-    """Run the full automatic Telegram bot creation flow.
-
-    1. Generate nonce + suggested username.
-    2. Register the nonce with the pairing API.
-    3. Print the QR code / deep link for the user.
-    4. Poll until the token arrives (or timeout).
-
-    Returns the bot token on success, None on failure/timeout.
-    """
-    nonce = generate_pairing_nonce()
-    username = generate_bot_username(profile_name)
-    deep_link = generate_deep_link(
-        manager_bot=manager_bot,
-        suggested_username=username,
-        suggested_name="Hermes Agent",
-    )
-
-    # Embed the nonce in the pairing API so the manager bot can match it.
-    # The manager bot receives the suggested_username from Telegram's
-    # managed_bot update and uses it to look up the nonce.
-    if not register_pairing(api_url, nonce):
-        print("  ✗ Could not reach the Hermes setup service.")
+    """Run the full automatic Telegram bot creation flow."""
+    _ = manager_bot, profile_name
+    resolved_api_url = _api_url(api_url)
+    print()
+    print(f"  Contacting Hermes Telegram onboarding service: {resolved_api_url}")
+    sys.stdout.flush()
+    pairing = create_pairing(resolved_api_url)
+    if not pairing:
+        print("  ✗ Could not reach the Hermes Telegram onboarding service.")
         print("    Try the manual setup instead, or check your network.")
         return None
 
+    print("  ✓ Pairing created")
+    print("  Rendering QR code...")
+    sys.stdout.flush()
     print()
     print("  Scan this QR code with your phone, or open the link below:")
     print()
-    print_qr_code(deep_link)
+    print_qr_code(pairing.qr_payload, include_link=False)
+    print()
+    print(f"  Link: {pairing.deep_link}")
     print()
     print("  When Telegram opens, tap 'Create Bot' to confirm.")
-    print("  (You can edit the bot name and username before confirming)")
+    print("  (You can edit the bot display name before confirming)")
     print()
 
-    # Animated waiting
     spinner_chars = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
     start = time.monotonic()
     deadline = start + poll_timeout
@@ -244,21 +256,18 @@ def auto_setup_telegram_bot(
     while time.monotonic() < deadline:
         char = spinner_chars[idx % len(spinner_chars)]
         elapsed = int(time.monotonic() - start)
-        remaining = int(poll_timeout - elapsed)
+        remaining = max(0, int(poll_timeout - elapsed))
         sys.stdout.write(f"\r  {char} Waiting for bot creation... ({remaining}s remaining) ")
         sys.stdout.flush()
         idx += 1
 
         try:
-            resp = httpx.get(f"{api_url}/pair/{nonce}", timeout=10.0)
-            if resp.status_code == 200:
-                data = resp.json()
-                token = data.get("token")
-                if token:
-                    sys.stdout.write("\r  ✓ Bot created successfully!                              \n")
-                    sys.stdout.flush()
-                    return token
-        except httpx.HTTPError:
+            token = poll_pairing_once(resolved_api_url, pairing)
+            if token:
+                sys.stdout.write("\r  ✓ Bot created successfully!                              \n")
+                sys.stdout.flush()
+                return token
+        except (httpx.HTTPError, ValueError):
             pass
         time.sleep(POLL_INTERVAL)
 

--- a/tests/hermes_cli/test_telegram_managed_bot.py
+++ b/tests/hermes_cli/test_telegram_managed_bot.py
@@ -7,11 +7,13 @@ from unittest.mock import MagicMock, patch
 from hermes_cli.telegram_managed_bot import (
     DEFAULT_MANAGER_BOT,
     TELEGRAM_ONBOARDING_URL_ENV,
+    TelegramBotSetupResult,
     TelegramPairing,
     create_pairing,
     generate_bot_username,
     generate_deep_link,
     generate_pairing_nonce,
+    poll_for_setup_result,
     poll_for_token,
     print_qr_code,
     render_qr_terminal,
@@ -170,7 +172,12 @@ class TestPollForToken:
     def test_immediate_success(self):
         mock_resp = MagicMock()
         mock_resp.status_code = 200
-        mock_resp.json.return_value = {"status": "ready", "token": "123:ABCdef"}
+        mock_resp.json.return_value = {
+            "bot_username": "hermes_abcdefghijklmnop_bot",
+            "owner_user_id": 42,
+            "status": "ready",
+            "token": "123:ABCdef",
+        }
 
         with patch("hermes_cli.telegram_managed_bot.httpx.get", return_value=mock_resp) as get:
             with patch("hermes_cli.telegram_managed_bot.time.sleep"):
@@ -179,6 +186,26 @@ class TestPollForToken:
         assert token == "123:ABCdef"
         assert get.call_args.args[0] == "https://api.example.com/v1/telegram/pairings/abcdefghijklmnop"
         assert get.call_args.kwargs["headers"] == {"Authorization": "Bearer secret-token"}
+
+    def test_setup_result_includes_owner_user_id(self):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "bot_username": "hermes_abcdefghijklmnop_bot",
+            "owner_user_id": 42,
+            "status": "ready",
+            "token": "123:ABCdef",
+        }
+
+        with patch("hermes_cli.telegram_managed_bot.httpx.get", return_value=mock_resp):
+            with patch("hermes_cli.telegram_managed_bot.time.sleep"):
+                result = poll_for_setup_result("https://api.example.com", self.pairing(), timeout=5)
+
+        assert result == TelegramBotSetupResult(
+            token="123:ABCdef",
+            bot_username="hermes_abcdefghijklmnop_bot",
+            owner_user_id=42,
+        )
 
     def test_timeout_returns_none(self):
         mock_resp = MagicMock()

--- a/tests/hermes_cli/test_telegram_managed_bot.py
+++ b/tests/hermes_cli/test_telegram_managed_bot.py
@@ -2,70 +2,45 @@
 
 from __future__ import annotations
 
-import time
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from hermes_cli.telegram_managed_bot import (
-    DEFAULT_API_URL,
     DEFAULT_MANAGER_BOT,
+    TELEGRAM_ONBOARDING_URL_ENV,
+    TelegramPairing,
+    create_pairing,
     generate_bot_username,
     generate_deep_link,
     generate_pairing_nonce,
+    poll_for_token,
     print_qr_code,
-    register_pairing,
     render_qr_terminal,
 )
 
 
-# ---------------------------------------------------------------------------
-# Username generation
-# ---------------------------------------------------------------------------
-
-
 class TestGenerateBotUsername:
-    def test_default_format(self):
+    def test_secure_default_format(self):
         name = generate_bot_username()
         assert name.startswith("hermes_")
         assert name.endswith("_bot")
-        # Should be short enough for Telegram (max 32 chars)
+        assert len(name) == len("hermes_") + 16 + len("_bot")
         assert len(name) <= 32
-        assert len(name) >= 5
 
-    def test_with_profile_name(self):
+    def test_profile_name_not_embedded(self):
         name = generate_bot_username("work")
-        assert "work" in name
+        assert "work" not in name
         assert name.startswith("hermes_")
         assert name.endswith("_bot")
 
-    def test_default_profile_ignored(self):
-        name = generate_bot_username("default")
-        assert "default" not in name
-        assert name.startswith("hermes_")
-        assert name.endswith("_bot")
-
-    def test_profile_name_sanitized(self):
-        name = generate_bot_username("My Cool-Profile!")
-        assert name.startswith("hermes_")
-        assert name.endswith("_bot")
-        # Special chars should be replaced with underscores
-        assert "!" not in name
-        assert "-" not in name
-
-    def test_long_profile_name_truncated(self):
-        name = generate_bot_username("a" * 50)
-        assert len(name) <= 32
+    def test_slug_uses_telegram_safe_base32_chars(self):
+        name = generate_bot_username()
+        slug = name.removeprefix("hermes_").removesuffix("_bot")
+        assert len(slug) == 16
+        assert set(slug) <= set("abcdefghijklmnopqrstuvwxyz234567")
 
     def test_uniqueness(self):
         names = {generate_bot_username() for _ in range(20)}
-        # Random suffix should produce unique names
         assert len(names) == 20
-
-
-# ---------------------------------------------------------------------------
-# Deep link generation
-# ---------------------------------------------------------------------------
 
 
 class TestGenerateDeepLink:
@@ -78,7 +53,7 @@ class TestGenerateDeepLink:
 
     def test_with_name(self):
         link = generate_deep_link(
-            manager_bot="TestBot",
+            manager_bot="@TestBot",
             suggested_username="my_bot",
             suggested_name="My Agent",
         )
@@ -96,19 +71,13 @@ class TestGenerateDeepLink:
             suggested_username="test_bot",
             suggested_name="Hermes & Friends",
         )
-        # Ampersand should be URL-encoded
-        assert "Hermes+%26+Friends" in link or "Hermes+&+Friends" not in link
-
-
-# ---------------------------------------------------------------------------
-# Pairing nonce
-# ---------------------------------------------------------------------------
+        assert "Hermes+%26+Friends" in link
 
 
 class TestPairingNonce:
     def test_length(self):
         nonce = generate_pairing_nonce()
-        assert len(nonce) == 32  # 16 bytes = 32 hex chars
+        assert len(nonce) == 32
 
     def test_hex_chars(self):
         nonce = generate_pairing_nonce()
@@ -119,98 +88,118 @@ class TestPairingNonce:
         assert len(nonces) == 100
 
 
-# ---------------------------------------------------------------------------
-# QR code rendering
-# ---------------------------------------------------------------------------
-
-
 class TestQRCode:
     def test_render_returns_string(self):
-        """If qrcode is installed, should return non-empty string."""
         result = render_qr_terminal("https://example.com")
-        # qrcode may or may not be installed in test env
         if result:
             assert isinstance(result, str)
             assert len(result) > 10
 
     def test_render_graceful_without_qrcode(self):
-        """Should return empty string if qrcode not installed."""
         with patch.dict("sys.modules", {"qrcode": None}):
-            # Force ImportError
-            result = render_qr_terminal("https://example.com")
-            # May still succeed if qrcode is cached; that's fine
+            render_qr_terminal("https://example.com")
 
     def test_print_qr_code_with_url(self, capsys):
-        """Should at minimum print the URL."""
         print_qr_code("https://t.me/newbot/Bot/test_bot")
         captured = capsys.readouterr()
         assert "https://t.me/newbot/Bot/test_bot" in captured.out
 
 
-# ---------------------------------------------------------------------------
-# Pairing API client
-# ---------------------------------------------------------------------------
-
-
-class TestRegisterPairing:
+class TestCreatePairing:
     def test_success(self):
         mock_resp = MagicMock()
         mock_resp.status_code = 201
-        with patch("hermes_cli.telegram_managed_bot.httpx.post", return_value=mock_resp):
-            assert register_pairing("https://api.example.com", "abc123") is True
+        mock_resp.json.return_value = {
+            "pairing_id": "abcdefghijklmnop",
+            "poll_token": "secret-token",
+            "suggested_username": "hermes_abcdefghijklmnop_bot",
+            "deep_link": "https://t.me/newbot/HermesSetupBot/hermes_abcdefghijklmnop_bot?name=Hermes+Agent",
+            "qr_payload": "https://t.me/newbot/HermesSetupBot/hermes_abcdefghijklmnop_bot?name=Hermes+Agent",
+            "expires_at": "2026-05-18T00:00:00.000Z",
+        }
+
+        with patch("hermes_cli.telegram_managed_bot.httpx.post", return_value=mock_resp) as post:
+            pairing = create_pairing("https://api.example.com", bot_name="Hermes Agent")
+
+        assert pairing == TelegramPairing(
+            pairing_id="abcdefghijklmnop",
+            poll_token="secret-token",
+            suggested_username="hermes_abcdefghijklmnop_bot",
+            deep_link="https://t.me/newbot/HermesSetupBot/hermes_abcdefghijklmnop_bot?name=Hermes+Agent",
+            qr_payload="https://t.me/newbot/HermesSetupBot/hermes_abcdefghijklmnop_bot?name=Hermes+Agent",
+            expires_at="2026-05-18T00:00:00.000Z",
+        )
+        post.assert_called_once_with(
+            "https://api.example.com/v1/telegram/pairings",
+            json={"bot_name": "Hermes Agent"},
+            timeout=10.0,
+        )
 
     def test_failure_status(self):
         mock_resp = MagicMock()
         mock_resp.status_code = 500
         with patch("hermes_cli.telegram_managed_bot.httpx.post", return_value=mock_resp):
-            assert register_pairing("https://api.example.com", "abc123") is False
+            assert create_pairing("https://api.example.com") is None
 
-    def test_network_error(self):
-        import httpx
+    def test_invalid_payload(self):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 201
+        mock_resp.json.return_value = {"pairing_id": "missing-poll-token"}
+        with patch("hermes_cli.telegram_managed_bot.httpx.post", return_value=mock_resp):
+            assert create_pairing("https://api.example.com") is None
 
-        with patch(
-            "hermes_cli.telegram_managed_bot.httpx.post",
-            side_effect=httpx.ConnectError("connection refused"),
-        ):
-            assert register_pairing("https://api.example.com", "abc123") is False
+    def test_uses_env_override(self, monkeypatch):
+        monkeypatch.setenv(TELEGRAM_ONBOARDING_URL_ENV, "https://worker.example")
+        mock_resp = MagicMock()
+        mock_resp.status_code = 500
+        with patch("hermes_cli.telegram_managed_bot.httpx.post", return_value=mock_resp) as post:
+            create_pairing()
+        assert post.call_args.args[0] == "https://worker.example/v1/telegram/pairings"
 
 
 class TestPollForToken:
-    def test_immediate_success(self):
-        from hermes_cli.telegram_managed_bot import poll_for_token
+    def pairing(self):
+        return TelegramPairing(
+            pairing_id="abcdefghijklmnop",
+            poll_token="secret-token",
+            suggested_username="hermes_abcdefghijklmnop_bot",
+            deep_link="https://t.me/newbot/HermesSetupBot/hermes_abcdefghijklmnop_bot",
+            qr_payload="https://t.me/newbot/HermesSetupBot/hermes_abcdefghijklmnop_bot",
+        )
 
+    def test_immediate_success(self):
         mock_resp = MagicMock()
         mock_resp.status_code = 200
-        mock_resp.json.return_value = {"token": "123:ABCdef"}
+        mock_resp.json.return_value = {"status": "ready", "token": "123:ABCdef"}
 
-        with patch("hermes_cli.telegram_managed_bot.httpx.get", return_value=mock_resp):
+        with patch("hermes_cli.telegram_managed_bot.httpx.get", return_value=mock_resp) as get:
             with patch("hermes_cli.telegram_managed_bot.time.sleep"):
-                token = poll_for_token("https://api.example.com", "nonce123", timeout=5)
-                assert token == "123:ABCdef"
+                token = poll_for_token("https://api.example.com", self.pairing(), timeout=5)
+
+        assert token == "123:ABCdef"
+        assert get.call_args.args[0] == "https://api.example.com/v1/telegram/pairings/abcdefghijklmnop"
+        assert get.call_args.kwargs["headers"] == {"Authorization": "Bearer secret-token"}
 
     def test_timeout_returns_none(self):
-        from hermes_cli.telegram_managed_bot import poll_for_token
-
         mock_resp = MagicMock()
-        mock_resp.status_code = 404
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"status": "waiting"}
 
         with patch("hermes_cli.telegram_managed_bot.httpx.get", return_value=mock_resp):
             with patch("hermes_cli.telegram_managed_bot.time.sleep"):
                 with patch("hermes_cli.telegram_managed_bot.time.monotonic") as mock_time:
-                    # Simulate immediate timeout
                     mock_time.side_effect = [0, 0, 999]
-                    token = poll_for_token("https://api.example.com", "nonce123", timeout=1)
+                    token = poll_for_token("https://api.example.com", self.pairing(), timeout=1)
                     assert token is None
 
     def test_eventual_success(self):
-        from hermes_cli.telegram_managed_bot import poll_for_token
-
         not_ready = MagicMock()
-        not_ready.status_code = 404
+        not_ready.status_code = 200
+        not_ready.json.return_value = {"status": "waiting"}
 
         ready = MagicMock()
         ready.status_code = 200
-        ready.json.return_value = {"token": "789:XYZabc"}
+        ready.json.return_value = {"status": "ready", "token": "789:XYZabc"}
 
         call_count = 0
 
@@ -223,23 +212,12 @@ class TestPollForToken:
 
         with patch("hermes_cli.telegram_managed_bot.httpx.get", side_effect=fake_get):
             with patch("hermes_cli.telegram_managed_bot.time.sleep"):
-                token = poll_for_token("https://api.example.com", "nonce123", timeout=30)
+                token = poll_for_token("https://api.example.com", self.pairing(), timeout=30)
                 assert token == "789:XYZabc"
 
 
-# ---------------------------------------------------------------------------
-# Setup wizard integration
-# ---------------------------------------------------------------------------
-
-
 class TestSetupTelegramAuto:
-    def test_returns_none_on_import_error(self):
-        """_setup_telegram_auto should return None if module import fails."""
+    def test_setup_helper_exists(self):
         from hermes_cli.setup import _setup_telegram_auto
 
-        with patch(
-            "hermes_cli.setup._setup_telegram_auto.__module__",
-            side_effect=ImportError,
-        ):
-            # Just verify the function exists and is callable
-            assert callable(_setup_telegram_auto)
+        assert callable(_setup_telegram_auto)

--- a/uv.lock
+++ b/uv.lock
@@ -300,7 +300,7 @@ wheels = [
 [[package]]
 name = "atroposlib"
 version = "0.4.0"
-source = { git = "https://github.com/NousResearch/atropos.git#c421582b6f7ce8a32f751aab3117d3824ac8f709" }
+source = { git = "https://github.com/NousResearch/atropos.git?rev=c20c85256e5a45ad31edf8b7276e9c5ee1995a30#c20c85256e5a45ad31edf8b7276e9c5ee1995a30" }
 dependencies = [
     { name = "aiofiles" },
     { name = "aiohttp" },
@@ -430,6 +430,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460, upload-time = "2024-11-08T17:25:47.436Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
+]
+
+[[package]]
+name = "boto3"
+version = "1.43.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/cc/42d798fc5305e4636170b50cdfb305ff0a81f470e35131f4a0d2641976ae/boto3-1.43.9.tar.gz", hash = "sha256:37dac72f2921095378c0200caf07918d5e10a82b7c1f611abb70e44f69d0b962", size = 113135, upload-time = "2026-05-15T19:28:31.167Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/dc/51286e9551f7852a79ce5d2a57468d9d905c30d32bcace55204551db202d/boto3-1.43.9-py3-none-any.whl", hash = "sha256:5e967292d361482793471bd80fad1e714515b7401f65a0d5b4aa6ef9d009c030", size = 140523, upload-time = "2026-05-15T19:28:28.948Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/e8/f696c80982685a4cdb3df5f0781919afa50262f40e1aac7066c9c2520deb/botocore-1.43.9.tar.gz", hash = "sha256:93e91c7160678182860f5902ee4cfe6d643cac0d9ee84d3eb65becc9f4c00228", size = 15357963, upload-time = "2026-05-15T19:28:19.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/c9/a1b51a74d476f5cb2f555ce8274f0f6b9fb21d75cc3f57b87dd0632ee17a/botocore-1.43.9-py3-none-any.whl", hash = "sha256:b9bdcd9c87fc552aad30006f00167d9ebb3480e1b06f1902bac5b2c41014fdab", size = 15039827, upload-time = "2026-05-15T19:28:14.543Z" },
 ]
 
 [[package]]
@@ -1609,6 +1637,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/47/16400cb42d18d7a6bb46f0626852c1718612e35dcb0dffa16bbaffdf5dd2/greenlet-3.3.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:c56692189a7d1c7606cb794be0a8381470d95c57ce5be03fb3d0ef57c7853b86", size = 278890, upload-time = "2026-02-20T20:19:39.263Z" },
     { url = "https://files.pythonhosted.org/packages/a3/90/42762b77a5b6aa96cd8c0e80612663d39211e8ae8a6cd47c7f1249a66262/greenlet-3.3.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ebd458fa8285960f382841da585e02201b53a5ec2bac6b156fc623b5ce4499f", size = 581120, upload-time = "2026-02-20T20:47:30.161Z" },
     { url = "https://files.pythonhosted.org/packages/bf/6f/f3d64f4fa0a9c7b5c5b3c810ff1df614540d5aa7d519261b53fba55d4df9/greenlet-3.3.2-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a443358b33c4ec7b05b79a7c8b466f5d275025e750298be7340f8fc63dff2a55", size = 594363, upload-time = "2026-02-20T20:55:56.965Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/8b/1430a04657735a3f23116c2e0d5eb10220928846e4537a938a41b350bed6/greenlet-3.3.2-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4375a58e49522698d3e70cc0b801c19433021b5c37686f7ce9c65b0d5c8677d2", size = 605046, upload-time = "2026-02-20T21:02:45.234Z" },
     { url = "https://files.pythonhosted.org/packages/72/83/3e06a52aca8128bdd4dcd67e932b809e76a96ab8c232a8b025b2850264c5/greenlet-3.3.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e2cd90d413acbf5e77ae41e5d3c9b3ac1d011a756d7284d7f3f2b806bbd6358", size = 594156, upload-time = "2026-02-20T20:20:59.955Z" },
     { url = "https://files.pythonhosted.org/packages/70/79/0de5e62b873e08fe3cef7dbe84e5c4bc0e8ed0c7ff131bccb8405cd107c8/greenlet-3.3.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:442b6057453c8cb29b4fb36a2ac689382fc71112273726e2423f7f17dc73bf99", size = 1554649, upload-time = "2026-02-20T20:49:32.293Z" },
     { url = "https://files.pythonhosted.org/packages/5a/00/32d30dee8389dc36d42170a9c66217757289e2afb0de59a3565260f38373/greenlet-3.3.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:45abe8eb6339518180d5a7fa47fa01945414d7cca5ecb745346fc6a87d2750be", size = 1619472, upload-time = "2026-02-20T20:21:07.966Z" },
@@ -1617,6 +1646,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/ab/1608e5a7578e62113506740b88066bf09888322a311cff602105e619bd87/greenlet-3.3.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:ac8d61d4343b799d1e526db579833d72f23759c71e07181c2d2944e429eb09cd", size = 280358, upload-time = "2026-02-20T20:17:43.971Z" },
     { url = "https://files.pythonhosted.org/packages/a5/23/0eae412a4ade4e6623ff7626e38998cb9b11e9ff1ebacaa021e4e108ec15/greenlet-3.3.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ceec72030dae6ac0c8ed7591b96b70410a8be370b6a477b1dbc072856ad02bd", size = 601217, upload-time = "2026-02-20T20:47:31.462Z" },
     { url = "https://files.pythonhosted.org/packages/f8/16/5b1678a9c07098ecb9ab2dd159fafaf12e963293e61ee8d10ecb55273e5e/greenlet-3.3.2-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a2a5be83a45ce6188c045bcc44b0ee037d6a518978de9a5d97438548b953a1ac", size = 611792, upload-time = "2026-02-20T20:55:58.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/c5/cc09412a29e43406eba18d61c70baa936e299bc27e074e2be3806ed29098/greenlet-3.3.2-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae9e21c84035c490506c17002f5c8ab25f980205c3e61ddb3a2a2a2e6c411fcb", size = 626250, upload-time = "2026-02-20T21:02:46.596Z" },
     { url = "https://files.pythonhosted.org/packages/50/1f/5155f55bd71cabd03765a4aac9ac446be129895271f73872c36ebd4b04b6/greenlet-3.3.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43e99d1749147ac21dde49b99c9abffcbc1e2d55c67501465ef0930d6e78e070", size = 613875, upload-time = "2026-02-20T20:21:01.102Z" },
     { url = "https://files.pythonhosted.org/packages/fc/dd/845f249c3fcd69e32df80cdab059b4be8b766ef5830a3d0aa9d6cad55beb/greenlet-3.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4c956a19350e2c37f2c48b336a3afb4bff120b36076d9d7fb68cb44e05d95b79", size = 1571467, upload-time = "2026-02-20T20:49:33.495Z" },
     { url = "https://files.pythonhosted.org/packages/2a/50/2649fe21fcc2b56659a452868e695634722a6655ba245d9f77f5656010bf/greenlet-3.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c6f8ba97d17a1e7d664151284cb3315fc5f8353e75221ed4324f84eb162b395", size = 1640001, upload-time = "2026-02-20T20:21:09.154Z" },
@@ -1625,6 +1655,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/48/f8b875fa7dea7dd9b33245e37f065af59df6a25af2f9561efa8d822fde51/greenlet-3.3.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4", size = 279120, upload-time = "2026-02-20T20:19:01.9Z" },
     { url = "https://files.pythonhosted.org/packages/49/8d/9771d03e7a8b1ee456511961e1b97a6d77ae1dea4a34a5b98eee706689d3/greenlet-3.3.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986", size = 603238, upload-time = "2026-02-20T20:47:32.873Z" },
     { url = "https://files.pythonhosted.org/packages/59/0e/4223c2bbb63cd5c97f28ffb2a8aee71bdfb30b323c35d409450f51b91e3e/greenlet-3.3.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92", size = 614219, upload-time = "2026-02-20T20:55:59.817Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2b/4d012a69759ac9d77210b8bfb128bc621125f5b20fc398bce3940d036b1c/greenlet-3.3.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ccd21bb86944ca9be6d967cf7691e658e43417782bce90b5d2faeda0ff78a7dd", size = 628268, upload-time = "2026-02-20T21:02:48.024Z" },
     { url = "https://files.pythonhosted.org/packages/7a/34/259b28ea7a2a0c904b11cd36c79b8cef8019b26ee5dbe24e73b469dea347/greenlet-3.3.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab", size = 616774, upload-time = "2026-02-20T20:21:02.454Z" },
     { url = "https://files.pythonhosted.org/packages/0a/03/996c2d1689d486a6e199cb0f1cf9e4aa940c500e01bdf201299d7d61fa69/greenlet-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a", size = 1571277, upload-time = "2026-02-20T20:49:34.795Z" },
     { url = "https://files.pythonhosted.org/packages/d9/c4/2570fc07f34a39f2caf0bf9f24b0a1a0a47bc2e8e465b2c2424821389dfc/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b", size = 1640455, upload-time = "2026-02-20T20:21:10.261Z" },
@@ -1633,6 +1664,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/ae/8bffcbd373b57a5992cd077cbe8858fff39110480a9d50697091faea6f39/greenlet-3.3.2-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:8d1658d7291f9859beed69a776c10822a0a799bc4bfe1bd4272bb60e62507dab", size = 279650, upload-time = "2026-02-20T20:18:00.783Z" },
     { url = "https://files.pythonhosted.org/packages/d1/c0/45f93f348fa49abf32ac8439938726c480bd96b2a3c6f4d949ec0124b69f/greenlet-3.3.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18cb1b7337bca281915b3c5d5ae19f4e76d35e1df80f4ad3c1a7be91fadf1082", size = 650295, upload-time = "2026-02-20T20:47:34.036Z" },
     { url = "https://files.pythonhosted.org/packages/b3/de/dd7589b3f2b8372069ab3e4763ea5329940fc7ad9dcd3e272a37516d7c9b/greenlet-3.3.2-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2e47408e8ce1c6f1ceea0dffcdf6ebb85cc09e55c7af407c99f1112016e45e9", size = 662163, upload-time = "2026-02-20T20:56:01.295Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ac/85804f74f1ccea31ba518dcc8ee6f14c79f73fe36fa1beba38930806df09/greenlet-3.3.2-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e3cb43ce200f59483eb82949bf1835a99cf43d7571e900d7c8d5c62cdf25d2f9", size = 675371, upload-time = "2026-02-20T21:02:49.664Z" },
     { url = "https://files.pythonhosted.org/packages/d2/d8/09bfa816572a4d83bccd6750df1926f79158b1c36c5f73786e26dbe4ee38/greenlet-3.3.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63d10328839d1973e5ba35e98cccbca71b232b14051fd957b6f8b6e8e80d0506", size = 664160, upload-time = "2026-02-20T20:21:04.015Z" },
     { url = "https://files.pythonhosted.org/packages/48/cf/56832f0c8255d27f6c35d41b5ec91168d74ec721d85f01a12131eec6b93c/greenlet-3.3.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e4ab3cfb02993c8cc248ea73d7dae6cec0253e9afa311c9b37e603ca9fad2ce", size = 1619181, upload-time = "2026-02-20T20:49:36.052Z" },
     { url = "https://files.pythonhosted.org/packages/0a/23/b90b60a4aabb4cec0796e55f25ffbfb579a907c3898cd2905c8918acaa16/greenlet-3.3.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:94ad81f0fd3c0c0681a018a976e5c2bd2ca2d9d94895f23e7bb1af4e8af4e2d5", size = 1687713, upload-time = "2026-02-20T20:21:11.684Z" },
@@ -1641,6 +1673,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/98/6d/8f2ef704e614bcf58ed43cfb8d87afa1c285e98194ab2cfad351bf04f81e/greenlet-3.3.2-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:e26e72bec7ab387ac80caa7496e0f908ff954f31065b0ffc1f8ecb1338b11b54", size = 286617, upload-time = "2026-02-20T20:19:29.856Z" },
     { url = "https://files.pythonhosted.org/packages/5e/0d/93894161d307c6ea237a43988f27eba0947b360b99ac5239ad3fe09f0b47/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b466dff7a4ffda6ca975979bab80bdadde979e29fc947ac3be4451428d8b0e4", size = 655189, upload-time = "2026-02-20T20:47:35.742Z" },
     { url = "https://files.pythonhosted.org/packages/f5/2c/d2d506ebd8abcb57386ec4f7ba20f4030cbe56eae541bc6fd6ef399c0b41/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b8bddc5b73c9720bea487b3bffdb1840fe4e3656fba3bd40aa1489e9f37877ff", size = 658225, upload-time = "2026-02-20T20:56:02.527Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/67/8197b7e7e602150938049d8e7f30de1660cfb87e4c8ee349b42b67bdb2e1/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:59b3e2c40f6706b05a9cd299c836c6aa2378cabe25d021acd80f13abf81181cf", size = 666581, upload-time = "2026-02-20T21:02:51.526Z" },
     { url = "https://files.pythonhosted.org/packages/8e/30/3a09155fbf728673a1dea713572d2d31159f824a37c22da82127056c44e4/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b26b0f4428b871a751968285a1ac9648944cea09807177ac639b030bddebcea4", size = 657907, upload-time = "2026-02-20T20:21:05.259Z" },
     { url = "https://files.pythonhosted.org/packages/f3/fd/d05a4b7acd0154ed758797f0a43b4c0962a843bedfe980115e842c5b2d08/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727", size = 1618857, upload-time = "2026-02-20T20:49:37.309Z" },
     { url = "https://files.pythonhosted.org/packages/6f/e1/50ee92a5db521de8f35075b5eff060dd43d39ebd46c2181a2042f7070385/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e", size = 1680010, upload-time = "2026-02-20T20:21:13.427Z" },
@@ -1699,7 +1732,7 @@ wheels = [
 
 [[package]]
 name = "hermes-agent"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
@@ -1717,6 +1750,7 @@ dependencies = [
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-dotenv" },
     { name = "pyyaml" },
+    { name = "qrcode" },
     { name = "requests" },
     { name = "rich" },
     { name = "tenacity" },
@@ -1731,12 +1765,14 @@ all = [
     { name = "aiohttp" },
     { name = "aiosqlite", marker = "sys_platform == 'linux'" },
     { name = "asyncpg", marker = "sys_platform == 'linux'" },
+    { name = "boto3" },
     { name = "croniter" },
     { name = "daytona" },
     { name = "debugpy" },
     { name = "dingtalk-stream" },
     { name = "discord-py", extra = ["voice"] },
     { name = "elevenlabs" },
+    { name = "fastapi" },
     { name = "faster-whisper" },
     { name = "honcho-ai" },
     { name = "lark-oapi" },
@@ -1756,6 +1792,10 @@ all = [
     { name = "slack-bolt" },
     { name = "slack-sdk" },
     { name = "sounddevice" },
+    { name = "uvicorn", extra = ["standard"] },
+]
+bedrock = [
+    { name = "boto3" },
 ]
 cli = [
     { name = "simple-term-menu" },
@@ -1842,6 +1882,10 @@ voice = [
     { name = "numpy" },
     { name = "sounddevice" },
 ]
+web = [
+    { name = "fastapi" },
+    { name = "uvicorn", extra = ["standard"] },
+]
 yc-bench = [
     { name = "yc-bench", marker = "python_full_version >= '3.12'" },
 ]
@@ -1855,7 +1899,8 @@ requires-dist = [
     { name = "aiosqlite", marker = "extra == 'matrix'", specifier = ">=0.20" },
     { name = "anthropic", specifier = ">=0.39.0,<1" },
     { name = "asyncpg", marker = "extra == 'matrix'", specifier = ">=0.29" },
-    { name = "atroposlib", marker = "extra == 'rl'", git = "https://github.com/NousResearch/atropos.git" },
+    { name = "atroposlib", marker = "extra == 'rl'", git = "https://github.com/NousResearch/atropos.git?rev=c20c85256e5a45ad31edf8b7276e9c5ee1995a30" },
+    { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.35.0,<2" },
     { name = "croniter", marker = "extra == 'cron'", specifier = ">=6.0.0,<7" },
     { name = "daytona", marker = "extra == 'daytona'", specifier = ">=0.148.0,<1" },
     { name = "debugpy", marker = "extra == 'dev'", specifier = ">=1.8.0,<2" },
@@ -1866,11 +1911,13 @@ requires-dist = [
     { name = "exa-py", specifier = ">=2.9.0,<3" },
     { name = "fal-client", specifier = ">=0.13.1,<1" },
     { name = "fastapi", marker = "extra == 'rl'", specifier = ">=0.104.0,<1" },
+    { name = "fastapi", marker = "extra == 'web'", specifier = ">=0.104.0,<1" },
     { name = "faster-whisper", marker = "extra == 'voice'", specifier = ">=1.0.0,<2" },
     { name = "fire", specifier = ">=0.7.1,<1" },
     { name = "firecrawl-py", specifier = ">=4.16.0,<5" },
     { name = "hermes-agent", extras = ["acp"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["acp"], marker = "extra == 'termux'" },
+    { name = "hermes-agent", extras = ["bedrock"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["cli"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["cli"], marker = "extra == 'termux'" },
     { name = "hermes-agent", extras = ["cron"], marker = "extra == 'all'" },
@@ -1894,6 +1941,7 @@ requires-dist = [
     { name = "hermes-agent", extras = ["sms"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["tts-premium"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["voice"], marker = "extra == 'all'" },
+    { name = "hermes-agent", extras = ["web"], marker = "extra == 'all'" },
     { name = "honcho-ai", marker = "extra == 'honcho'", specifier = ">=2.0.1,<3" },
     { name = "httpx", extras = ["socks"], specifier = ">=0.28.1,<1" },
     { name = "jinja2", specifier = ">=3.1.5,<4" },
@@ -1918,6 +1966,7 @@ requires-dist = [
     { name = "python-telegram-bot", extras = ["webhooks"], marker = "extra == 'messaging'", specifier = ">=22.6,<23" },
     { name = "pywinpty", marker = "sys_platform == 'win32' and extra == 'pty'", specifier = ">=2.0.0,<3" },
     { name = "pyyaml", specifier = ">=6.0.2,<7" },
+    { name = "qrcode", specifier = ">=8.0,<9" },
     { name = "requests", specifier = ">=2.33.0,<3" },
     { name = "rich", specifier = ">=14.3.3,<15" },
     { name = "simple-term-menu", marker = "extra == 'cli'", specifier = ">=1.0,<2" },
@@ -1927,12 +1976,13 @@ requires-dist = [
     { name = "slack-sdk", marker = "extra == 'slack'", specifier = ">=3.27.0,<4" },
     { name = "sounddevice", marker = "extra == 'voice'", specifier = ">=0.4.6,<1" },
     { name = "tenacity", specifier = ">=9.1.4,<10" },
-    { name = "tinker", marker = "extra == 'rl'", git = "https://github.com/thinking-machines-lab/tinker.git" },
+    { name = "tinker", marker = "extra == 'rl'", git = "https://github.com/thinking-machines-lab/tinker.git?rev=30517b667f18a3dfb7ef33fb56cf686d5820ba2b" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'rl'", specifier = ">=0.24.0,<1" },
+    { name = "uvicorn", extras = ["standard"], marker = "extra == 'web'", specifier = ">=0.24.0,<1" },
     { name = "wandb", marker = "extra == 'rl'", specifier = ">=0.15.0,<1" },
-    { name = "yc-bench", marker = "python_full_version >= '3.12' and extra == 'yc-bench'", git = "https://github.com/collinear-ai/yc-bench.git" },
+    { name = "yc-bench", marker = "python_full_version >= '3.12' and extra == 'yc-bench'", git = "https://github.com/collinear-ai/yc-bench.git?rev=bfb0c88062450f46341bd9a5298903fc2e952a5c" },
 ]
-provides-extras = ["modal", "daytona", "dev", "messaging", "cron", "slack", "matrix", "cli", "tts-premium", "voice", "pty", "honcho", "mcp", "homeassistant", "sms", "acp", "mistral", "termux", "dingtalk", "feishu", "rl", "yc-bench", "all"]
+provides-extras = ["modal", "daytona", "dev", "messaging", "cron", "slack", "matrix", "cli", "tts-premium", "voice", "pty", "honcho", "mcp", "homeassistant", "sms", "acp", "mistral", "bedrock", "termux", "dingtalk", "feishu", "web", "rl", "yc-bench", "all"]
 
 [[package]]
 name = "hf-transfer"
@@ -2257,6 +2307,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/73/a009f41c5eed71c49bec53036c4b33555afcdee70682a18c6f66e396c039/jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:ff732bd0a0e778f43d5009840f20b935e79087b4dc65bd36f1cd0f9b04b8ff7f", size = 303808, upload-time = "2026-02-02T12:37:52.092Z" },
     { url = "https://files.pythonhosted.org/packages/c4/10/528b439290763bff3d939268085d03382471b442f212dca4ff5f12802d43/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab44b178f7981fcaea7e0a5df20e773c663d06ffda0198f1a524e91b2fde7e59", size = 337384, upload-time = "2026-02-02T12:37:53.582Z" },
     { url = "https://files.pythonhosted.org/packages/67/8a/a342b2f0251f3dac4ca17618265d93bf244a2a4d089126e81e4c1056ac50/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bb00b6d26db67a05fe3e12c76edc75f32077fb51deed13822dc648fa373bc19", size = 343768, upload-time = "2026-02-02T12:37:55.055Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -4161,6 +4220,18 @@ wheels = [
 ]
 
 [[package]]
+name = "qrcode"
+version = "8.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/b2/7fc2931bfae0af02d5f53b174e9cf701adbb35f39d69c2af63d4a39f81a9/qrcode-8.2.tar.gz", hash = "sha256:35c3f2a4172b33136ab9f6b3ef1c00260dd2f66f858f24d88418a015f446506c", size = 43317, upload-time = "2025-05-01T15:44:24.726Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/b8/d2d6d731733f51684bbf76bf34dab3b70a9148e8f2cef2bb544fccec681a/qrcode-8.2-py3-none-any.whl", hash = "sha256:16e64e0716c14960108e85d853062c9e8bba5ca8252c0b4d0231b9df4060ff4f", size = 45986, upload-time = "2025-05-01T15:44:22.781Z" },
+]
+
+[[package]]
 name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4424,6 +4495,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/13/64/b4d76f227d5c45a7e0b796c674fd81b0a6c4fbd48dc29271857d8219571c/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a", size = 573981, upload-time = "2025-11-30T20:24:32.934Z" },
     { url = "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4", size = 599782, upload-time = "2025-11-30T20:24:35.169Z" },
     { url = "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e", size = 562191, upload-time = "2025-11-30T20:24:36.853Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/ec/7c692cde9125b77e84b307354d4fb705f98b8ccad59a036d5957ca75bfc3/s3transfer-0.17.0.tar.gz", hash = "sha256:9edeb6d1c3c2f89d6050348548834ad8289610d886e5bf7b7207728bd43ce33a", size = 155337, upload-time = "2026-04-29T22:07:36.33Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/72/c6c32d2b657fa3dad1de340254e14390b1e334ce38268b7ad51abda3c8c2/s3transfer-0.17.0-py3-none-any.whl", hash = "sha256:ce3801712acf4ad3e89fb9990df97b4972e93f4b3b0004d214be5bce12814c20", size = 86811, upload-time = "2026-04-29T22:07:34.966Z" },
 ]
 
 [[package]]
@@ -4776,8 +4859,8 @@ wheels = [
 
 [[package]]
 name = "tinker"
-version = "0.16.1"
-source = { git = "https://github.com/thinking-machines-lab/tinker.git#07bd3c2dd3cd4398ac1c26f0ec0deccbf3c1f913" }
+version = "0.18.0"
+source = { git = "https://github.com/thinking-machines-lab/tinker.git?rev=30517b667f18a3dfb7ef33fb56cf686d5820ba2b#30517b667f18a3dfb7ef33fb56cf686d5820ba2b" }
 dependencies = [
     { name = "anyio" },
     { name = "click" },
@@ -5490,7 +5573,7 @@ wheels = [
 [[package]]
 name = "yc-bench"
 version = "0.1.0"
-source = { git = "https://github.com/collinear-ai/yc-bench.git#0c53c98f01a431db2e391482bc46013045854ab2" }
+source = { git = "https://github.com/collinear-ai/yc-bench.git?rev=bfb0c88062450f46341bd9a5298903fc2e952a5c#bfb0c88062450f46341bd9a5298903fc2e952a5c" }
 dependencies = [
     { name = "litellm", marker = "python_full_version >= '3.12'" },
     { name = "matplotlib", marker = "python_full_version >= '3.12'" },


### PR DESCRIPTION
## Summary

This is a follow-up PR for #10589. It keeps the existing automatic Telegram setup UX, but switches the Hermes CLI side from the original PoC pairing protocol to the Cloudflare Worker onboarding API that we proved end-to-end.

## What changed

- Adds the automatic Telegram setup choice to `hermes setup` / gateway setup for the Telegram platform, while preserving the manual BotFather token fallback.
- Replaces the old `/pair/{nonce}` client flow with `POST /v1/telegram/pairings` plus `GET /v1/telegram/pairings/:pairing_id` using `Authorization: Bearer <poll_token>`.
- Uses the backend-generated deep link / QR payload / suggested username instead of relying on the CLI to register and correlate a nonce.
- Adds `TELEGRAM_ONBOARDING_URL` as a PoC/staging override before a production Nous onboarding URL exists.
- Consumes the Worker `owner_user_id` field when present, asking whether to allow that Telegram account by default and supporting additional allowed user ids.
- Keeps the old token-only helper for compatibility while adding a metadata-returning setup helper for the automatic flow.
- Refreshes the focused Telegram onboarding tests around the new Worker API contract.
- Refreshes `uv.lock` to match the dependency set already declared in `pyproject.toml` on the PR branch.

## Differences from #10589

#10589 implemented the first local CLI PoC around a `/pair` registration and `/pair/{nonce}` polling shape. That made the CLI responsible for generating the correlation nonce and assumed a generic hosted pairing API.

This version moves correlation authority to the onboarding backend: the Worker creates the pairing id, secret poll token, high-entropy username slug, suggested username, and Telegram deep link. Hermes only displays the link/QR and polls with the bearer poll token. That matches the Durable Object design and lets the backend enforce expiry, one-time token claim, webhook secret validation, and username-slug lookup without adding a Python manager service.

The follow-up Worker PR, NousResearch/hermes-telegram-onboarding#1, returns the managed-bot creator id as `owner_user_id`. Hermes uses that only in the trusted local setup path: it offers the detected id as the default allowlist/home id, while still letting users decline it or add more ids.

Operationally, this makes local testing cleaner: point `TELEGRAM_ONBOARDING_URL` at a `workers.dev` deployment, run `hermes setup`, scan the QR, optionally accept the detected Telegram id, and the CLI saves the managed child bot token locally.

## Validation

- `uv lock --check`
- `uv run pytest tests/hermes_cli/test_telegram_managed_bot.py`
- Live PoC smoke: created a Telegram managed bot through the Worker-backed flow; the Hermes gateway connected and responded to a Telegram message.
