### PR TITLE
fix(skills): add timeout to Google OAuth urlopen calls

### DIFF
--- a/plugins/platforms/google_chat/oauth.py
+++ b/plugins/platforms/google_chat/oauth.py
@@ -586,7 +586,8 @@ def revoke(email: Optional[str] = None) -> None:
                 f"https://oauth2.googleapis.com/revoke?token={creds.token}",
                 method="POST",
                 headers={"Content-Type": "application/x-www-form-urlencoded"},
-            )
+            ),
+            timeout=15,
         )
         print("Token revoked with Google.")
     except Exception as exc:

--- a/skills/productivity/google-workspace/scripts/gws_bridge.py
+++ b/skills/productivity/google-workspace/scripts/gws_bridge.py
@@ -51,12 +51,15 @@ def refresh_token(token_data: dict) -> dict:
 
     req = urllib.request.Request(token_data["token_uri"], data=params)
     try:
-        with urllib.request.urlopen(req) as resp:
+        with urllib.request.urlopen(req, timeout=15) as resp:
             result = json.loads(resp.read())
     except urllib.error.HTTPError as e:
         body = e.read().decode("utf-8", errors="replace")
         print(f"ERROR: Token refresh failed (HTTP {e.code}): {body}", file=sys.stderr)
         print("Re-run setup.py to re-authenticate.", file=sys.stderr)
+        sys.exit(1)
+    except (urllib.error.URLError, TimeoutError) as e:
+        print(f"ERROR: Token refresh failed (network): {e}", file=sys.stderr)
         sys.exit(1)
 
     token_data["token"] = result["access_token"]

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -411,7 +411,8 @@ def revoke():
                 f"https://oauth2.googleapis.com/revoke?token={creds.token}",
                 method="POST",
                 headers={"Content-Type": "application/x-www-form-urlencoded"},
-            )
+            ),
+            timeout=15,
         )
         print("Token revoked with Google.")
     except Exception as e:

--- a/tests/skills/test_google_workspace_api.py
+++ b/tests/skills/test_google_workspace_api.py
@@ -103,6 +103,51 @@ def test_bridge_refreshes_expired_token(bridge_module, tmp_path):
     assert saved["type"] == "authorized_user"
 
 
+def test_bridge_refresh_passes_timeout_to_urlopen(bridge_module):
+    """Token refresh must pass an explicit timeout so a hung Google endpoint
+    cannot block the agent turn indefinitely (no `timeout=` defaults to the
+    global socket timeout, which is unset)."""
+    past = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+    token_path = bridge_module.get_token_path()
+    _write_token(token_path, token="ya29.old", expiry=past)
+
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = json.dumps({
+        "access_token": "ya29.refreshed",
+        "expires_in": 3600,
+    }).encode()
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+
+    with patch("urllib.request.urlopen", return_value=mock_resp) as mocked:
+        bridge_module.get_valid_token()
+
+    assert mocked.call_count == 1
+    _, kwargs = mocked.call_args
+    assert kwargs.get("timeout") is not None, (
+        "urlopen call must pass timeout= to avoid hanging on unreachable upstream"
+    )
+
+
+def test_bridge_refresh_exits_cleanly_on_network_error(bridge_module):
+    """URLError/timeout during refresh exits 1 with a readable message
+    instead of crashing with a raw traceback."""
+    import urllib.error
+
+    past = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+    token_path = bridge_module.get_token_path()
+    _write_token(token_path, token="ya29.old", expiry=past)
+
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=urllib.error.URLError("timed out"),
+    ):
+        with pytest.raises(SystemExit) as exc_info:
+            bridge_module.get_valid_token()
+
+    assert exc_info.value.code == 1
+
+
 def test_bridge_exits_on_missing_token(bridge_module):
     """Missing token file causes exit with code 1."""
     with pytest.raises(SystemExit):


### PR DESCRIPTION
## What does this PR do?

Three `urllib.request.urlopen()` calls in the Google OAuth flows were missing a `timeout=` argument, while every other urlopen call in the codebase (15+ sites across `hermes_cli/`, `agent/`, `providers/`, etc.) passes one explicitly. Without a timeout, urlopen blocks on `socket._GLOBAL_DEFAULT_TIMEOUT`, which is unset by default — meaning a slow or unreachable Google endpoint hangs the call forever.

The most user-visible one is `gws_bridge.py::refresh_token`: the google-workspace skill invokes this on every Gmail / Calendar / Drive operation, so a hung refresh blocks the entire agent turn with no recoverable error. The two `revoke()` paths (google_chat plugin and google-workspace setup) have the same shape and the same risk during the user-initiated revoke step.

**Fix:**
- Add `timeout=15` to all three urlopen calls (matches the convention used elsewhere in the repo — e.g. `hermes_cli/copilot_auth.py`, `agent/anthropic_adapter.py`).
- In `gws_bridge.py`, also catch `(urllib.error.URLError, TimeoutError)` alongside the existing `HTTPError` handler so a network/timeout failure exits `1` with a readable message instead of a raw traceback.

## Related Issue

N/A — proactive reliability fix surfaced by auditing urlopen call sites for consistency.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/google_chat/oauth.py` — add `timeout=15` to `revoke()` urlopen.
- `skills/productivity/google-workspace/scripts/gws_bridge.py` — add `timeout=15` to token-refresh urlopen + catch `URLError` / `TimeoutError` for clean exit.
- `skills/productivity/google-workspace/scripts/setup.py` — add `timeout=15` to `revoke()` urlopen.
- `tests/skills/test_google_workspace_api.py` — add two regression tests (`timeout=` kwarg is passed; `URLError` exits `1` cleanly).

## How to Test

1. Run the affected test file:
   ```
   pytest tests/skills/test_google_workspace_api.py -v
   ```
   All 9 tests pass (7 pre-existing + 2 new regression tests).

2. Manual: with a mocked unreachable upstream, calling `bridge_module.get_valid_token()` on an expired token now exits `1` within ~15s with a clean `ERROR: Token refresh failed (network): ...` message, instead of hanging indefinitely.

3. Static audit — confirm the convention is now consistent:
   ```
   python -c "import ast; [print(f, [k.arg for k in n.keywords]) for f in ['plugins/platforms/google_chat/oauth.py','skills/productivity/google-workspace/scripts/gws_bridge.py','skills/productivity/google-workspace/scripts/setup.py'] for n in ast.walk(ast.parse(open(f,encoding='utf-8').read())) if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute) and n.func.attr=='urlopen']"
   ```
   Every match prints `['timeout']`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(skills): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/skills/test_google_workspace_api.py -q` and all tests pass
- [x] I've added regression tests for the fix

