### PR TITLE
fix(gateway): handle malformed HERMES_MAX_ITERATIONS values

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -175,6 +175,22 @@ def _float_env(name: str, default: float) -> float:
         return float(default)
 
 
+def _int_env(name: str, default: int) -> int:
+    """Read an env var as int, falling back to ``default`` on typos/empty.
+
+    A misconfigured env var (e.g. ``HERMES_MAX_ITERATIONS=abc`` or an empty
+    value left over after a stale ``.env`` edit) must not crash a background
+    task spawn or a gateway agent turn.  Unset/empty also falls back.
+    """
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return int(default)
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return int(default)
+
+
 def _is_fresh_gateway_interruption(
     value: Any,
     *,
@@ -3332,7 +3348,7 @@ class GatewayRunner:
         # config.yaml → env bridge did the right thing at a glance (instead
         # of silently running at a stale .env value for weeks).
         try:
-            _effective_max_iter = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
+            _effective_max_iter = _int_env("HERMES_MAX_ITERATIONS", 90)
             logger.info(
                 "Agent budget: max_iterations=%d (agent.max_turns from config.yaml, "
                 "or HERMES_MAX_ITERATIONS from .env, or default 90)",
@@ -10881,7 +10897,7 @@ class GatewayRunner:
             disabled_toolsets = agent_cfg.get("disabled_toolsets") or None
 
             pr = self._provider_routing
-            max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
+            max_iterations = _int_env("HERMES_MAX_ITERATIONS", 90)
             reasoning_config = self._resolve_session_reasoning_config(source=source)
             self._reasoning_config = reasoning_config
             self._service_tier = self._load_service_tier()
@@ -15356,8 +15372,10 @@ class GatewayRunner:
             # (concurrency-safe). Keep os.environ as fallback for CLI/cron.
             os.environ["HERMES_SESSION_KEY"] = session_key or ""
 
-            # Read from env var or use default (same as CLI)
-            max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
+            # Read from env var or use default (same as CLI). _int_env falls
+            # back to 90 if the value is missing or malformed so a stale .env
+            # entry can never abort a gateway turn with ValueError.
+            max_iterations = _int_env("HERMES_MAX_ITERATIONS", 90)
             
             # Map platform enum to the platform hint key the agent understands.
             # Platform.LOCAL ("local") maps to "cli"; others pass through as-is.

--- a/tests/gateway/test_int_env_helper.py
+++ b/tests/gateway/test_int_env_helper.py
@@ -1,0 +1,87 @@
+"""Regression tests for ``gateway.run._int_env``.
+
+The gateway reads ``HERMES_MAX_ITERATIONS`` from the environment in three
+places — the startup budget log, the background-task agent spawn, and the
+per-turn agent spawn.  The previous bare ``int(os.getenv(...))`` calls
+raised ``ValueError`` if a user's ``.env`` carried a typo such as
+``HERMES_MAX_ITERATIONS=abc`` or an empty value left over after a stale
+edit, which aborted every gateway turn for that platform.
+
+``_int_env`` mirrors the existing ``_float_env`` helper so a misconfigured
+env var falls back to the default instead of crashing the agent loop.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gateway.run import _int_env
+
+
+@pytest.mark.parametrize("raw", ["abc", "100k", "1.5", "  ", "1,000", "-"])
+def test_int_env_falls_back_on_malformed(monkeypatch, raw):
+    """Non-integer values must fall back to the default, not raise."""
+    monkeypatch.setenv("HERMES_TEST_INT_ENV", raw)
+    assert _int_env("HERMES_TEST_INT_ENV", 90) == 90
+
+
+def test_int_env_falls_back_on_empty(monkeypatch):
+    """Empty string (common after a botched ``.env`` edit) falls back."""
+    monkeypatch.setenv("HERMES_TEST_INT_ENV", "")
+    assert _int_env("HERMES_TEST_INT_ENV", 90) == 90
+
+
+def test_int_env_falls_back_when_unset(monkeypatch):
+    """Unset env var returns the default."""
+    monkeypatch.delenv("HERMES_TEST_INT_ENV", raising=False)
+    assert _int_env("HERMES_TEST_INT_ENV", 90) == 90
+
+
+def test_int_env_parses_valid_value(monkeypatch):
+    """A well-formed integer is honored."""
+    monkeypatch.setenv("HERMES_TEST_INT_ENV", "500")
+    assert _int_env("HERMES_TEST_INT_ENV", 90) == 500
+
+
+def test_int_env_parses_negative_value(monkeypatch):
+    """Negative integers parse — caller is responsible for clamping."""
+    monkeypatch.setenv("HERMES_TEST_INT_ENV", "-1")
+    assert _int_env("HERMES_TEST_INT_ENV", 90) == -1
+
+
+def test_int_env_default_is_returned_as_int(monkeypatch):
+    """The default is coerced to int so callers can pass numeric literals freely."""
+    monkeypatch.setenv("HERMES_TEST_INT_ENV", "abc")
+    result = _int_env("HERMES_TEST_INT_ENV", 90)
+    assert isinstance(result, int)
+    assert result == 90
+
+
+def test_int_env_rejects_float_string(monkeypatch):
+    """``int("1.5")`` raises ValueError — must fall back, not silently truncate."""
+    monkeypatch.setenv("HERMES_TEST_INT_ENV", "1.5")
+    assert _int_env("HERMES_TEST_INT_ENV", 90) == 90
+
+
+def test_max_iterations_env_uses_int_env_helper():
+    """The three ``HERMES_MAX_ITERATIONS`` reads in gateway/run.py must route
+    through ``_int_env`` so a malformed value can never abort an agent turn.
+
+    Guards against regressions that reintroduce ``int(os.getenv(...))``
+    against this env var.
+    """
+    import pathlib
+    import re
+
+    src = pathlib.Path(__file__).resolve().parents[2] / "gateway" / "run.py"
+    text = src.read_text(encoding="utf-8")
+
+    bare_int_calls = re.findall(
+        r'int\(\s*os\.getenv\(\s*["\']HERMES_MAX_ITERATIONS["\']',
+        text,
+    )
+    assert bare_int_calls == [], (
+        f"Found {len(bare_int_calls)} bare int(os.getenv('HERMES_MAX_ITERATIONS', ...)) "
+        f"call(s) in gateway/run.py. Use _int_env() instead so malformed values fall back "
+        f"to the default rather than raising ValueError mid-turn."
+    )


### PR DESCRIPTION
## What does this PR do?

`gateway/run.py` had three `int(os.getenv("HERMES_MAX_ITERATIONS", "90"))` calls. Two of them (lines 10884, 15360) were not wrapped in `try/except`, so a stale `.env` with `HERMES_MAX_ITERATIONS=abc` or an empty value crashed every background task spawn and every per-turn agent run with `ValueError` across all gateway platforms (Telegram, Discord, Slack, WhatsApp, ...).

Add an `_int_env(name, default)` helper next to the existing `_float_env` (same shape, same fallback semantics) and route all three callsites through it.

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `gateway/run.py`: add `_int_env` helper; route the 3 `HERMES_MAX_ITERATIONS` reads through it.
- `tests/gateway/test_int_env_helper.py`: 13 tests covering malformed / empty / unset / valid / negative inputs, plus a guard test asserting no bare `int(os.getenv("HERMES_MAX_ITERATIONS", ...))` remains in `gateway/run.py`.

## How to Test

```
scripts/run_tests.sh tests/gateway/test_int_env_helper.py -q
```

Repro without the fix: set `HERMES_MAX_ITERATIONS=abc` in `~/.hermes/.env`, start the gateway, send any message — every turn raises `ValueError`. With the fix it falls back to `90` silently.

## Checklist

- [x] Conventional Commits
- [x] Tests added & passing (13/13)
- [x] PR is single-purpose
- [x] N/A: no docs, config keys, or schemas changed