### PR TITLE
fix(auth): reject malformed API key pastes

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4711,6 +4711,40 @@ def _check_non_ascii_credential(key: str, value: str) -> str:
     return sanitized
 
 
+_API_KEY_PATH_LIKE_RE = re.compile(
+    r"(?i)(?:file://|text/uri-list|[A-Za-z]:\\\\|(?:^|[\\\\/])(?:users|home)[\\\\/]|"
+    r"\.(?:png|jpe?g|webp|gif|bmp|pdf|txt)\b)"
+)
+
+
+def validate_api_key_input(key: str, value: str) -> Optional[str]:
+    """Return a user-facing error when an interactive API key paste looks broken.
+
+    Keep this narrow: only ``*_API_KEY`` values are checked so we do not reject
+    OAuth tokens, passwords, or other secret types that may legitimately carry
+    whitespace or different shapes.
+    """
+    if not key.endswith("_API_KEY") or not value:
+        return None
+
+    reasons: list[str] = []
+    if any(ch.isspace() for ch in value):
+        reasons.append("contains whitespace")
+    if _API_KEY_PATH_LIKE_RE.search(value):
+        reasons.append("contains path-like text")
+    if value.count("sk-") > 1:
+        reasons.append("appears to contain more than one key")
+
+    if not reasons:
+        return None
+
+    return (
+        f"{key} looks malformed: "
+        + ", ".join(reasons)
+        + ". Hermes did not save it."
+    )
+
+
 def save_env_value(key: str, value: str):
     """Save or update a value in ~/.hermes/.env."""
     if is_managed():

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4571,7 +4571,7 @@ def _prompt_api_key(pconfig, existing_key: str, provider_id: str = "") -> tuple:
     import getpass
 
     from hermes_cli.auth import LMSTUDIO_NOAUTH_PLACEHOLDER
-    from hermes_cli.config import save_env_value
+    from hermes_cli.config import save_env_value, validate_api_key_input
 
     key_env = pconfig.api_key_env_vars[0] if pconfig.api_key_env_vars else ""
 
@@ -4589,6 +4589,18 @@ def _prompt_api_key(pconfig, existing_key: str, provider_id: str = "") -> tuple:
             return LMSTUDIO_NOAUTH_PLACEHOLDER
         return entered
 
+    def _reject_if_malformed(candidate: str, *, keep_existing: bool) -> bool:
+        problem = validate_api_key_input(key_env, candidate)
+        if not problem:
+            return False
+        print(f"  Warning: {problem}")
+        if keep_existing:
+            print("  No change.")
+            print()
+        else:
+            print("Cancelled.")
+        return True
+
     # First-time entry ────────────────────────────────────────────────────
     if not existing_key:
         print(f"No {pconfig.name} API key configured.")
@@ -4597,6 +4609,8 @@ def _prompt_api_key(pconfig, existing_key: str, provider_id: str = "") -> tuple:
         new_key = _prompt_new_key(allow_lmstudio_default=True)
         if not new_key:
             print("Cancelled.")
+            return "", True
+        if _reject_if_malformed(new_key, keep_existing=False):
             return "", True
         save_env_value(key_env, new_key)
         print("API key saved.")
@@ -4620,6 +4634,8 @@ def _prompt_api_key(pconfig, existing_key: str, provider_id: str = "") -> tuple:
         if not new_key:
             print("  No change.")
             print()
+            return existing_key, False
+        if _reject_if_malformed(new_key, keep_existing=True):
             return existing_key, False
         save_env_value(key_env, new_key)
         print("  API key updated.")

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -140,6 +140,7 @@ from hermes_cli.config import (
     load_config,
     save_config,
     save_env_value,
+    validate_api_key_input,
     remove_env_value,
     get_env_value,
     ensure_hermes_home,
@@ -350,6 +351,11 @@ def _prompt_api_key(var: dict):
         value = prompt(f"  {var.get('prompt', var['name'])}")
 
     if value:
+        problem = validate_api_key_input(var["name"], value)
+        if problem:
+            print_warning(f"  {problem}")
+            print_warning("  Skipped (fix the pasted value and try again)")
+            return
         save_env_value(var["name"], value)
         print_success("  ✓ Saved")
     else:

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -20,6 +20,7 @@ from hermes_cli.config import (
     save_env_value_secure,
     sanitize_env_file,
     _sanitize_env_lines,
+    validate_api_key_input,
 )
 
 
@@ -225,6 +226,28 @@ class TestSaveEnvValueSecure:
             save_env_value("TENOR_API_KEY", "sk-test-secret")
             env_mode = (tmp_path / ".env").stat().st_mode & 0o777
             assert env_mode == 0o600
+
+
+class TestValidateApiKeyInput:
+    def test_accepts_normal_api_key(self):
+        assert validate_api_key_input("DEEPSEEK_API_KEY", "sk-valid-123456") is None
+
+    def test_rejects_whitespace_and_path_like_text(self):
+        problem = validate_api_key_input(
+            "DEEPSEEK_API_KEY",
+            "sk-valid-123456 /home/user/Pictures/Capture.png",
+        )
+        assert problem is not None
+        assert "contains whitespace" in problem
+        assert "contains path-like text" in problem
+
+    def test_rejects_multiple_sk_like_tokens(self):
+        problem = validate_api_key_input(
+            "DEEPSEEK_API_KEY",
+            "sk-old-1234567sk-new-7654321",
+        )
+        assert problem is not None
+        assert "more than one key" in problem
 
 
 class TestRemoveEnvValue:

--- a/tests/hermes_cli/test_prompt_api_key.py
+++ b/tests/hermes_cli/test_prompt_api_key.py
@@ -103,6 +103,22 @@ def test_replace_cancelled_preserves_key(profile_env):
     assert get_env_value("DEEPSEEK_API_KEY") == "sk-existing"
 
 
+def test_replace_rejects_composite_secret_and_preserves_key(profile_env, capsys):
+    """Composite pastes with whitespace/path fragments should be refused."""
+    from hermes_cli.config import get_env_value, save_env_value
+    save_env_value("DEEPSEEK_API_KEY", "sk-existing")
+
+    bad = "sk-old-123456 /home/user/Pictures/Capture.png"
+    key, abort = _run_prompt(existing_key="sk-existing", choice="r", new_key=bad)
+
+    assert key == "sk-existing"
+    assert abort is False
+    assert get_env_value("DEEPSEEK_API_KEY") == "sk-existing"
+    captured = capsys.readouterr()
+    assert "looks malformed" in captured.out
+    assert "No change." in captured.out
+
+
 def test_clear_wipes_env_and_aborts(profile_env):
     from hermes_cli.config import get_env_value, save_env_value
     save_env_value("DEEPSEEK_API_KEY", "sk-existing")


### PR DESCRIPTION
## Summary

Closes #28158.

This hardens interactive API-key entry so Hermes refuses obviously composite pastes before they ever reach `.env`:

- add a narrow `validate_api_key_input()` helper for `*_API_KEY` values
- reject values with whitespace, path-like fragments, or multiple `sk-` tokens
- wire the validation into both `hermes model`'s shared Replace flow and the setup wizard's API-key prompt
- add regression coverage for both the helper and the Replace path

## Why this is narrow

This does not add a global save-time block in `save_env_value()`. The validation only runs in the interactive API-key entry points that the issue reported, which avoids surprising non-API secret flows.

## Verification

- `python3 -m pytest -o addopts='' tests/hermes_cli/test_config.py tests/hermes_cli/test_prompt_api_key.py -q`
- `git diff --check`
- `uv run --frozen ruff check hermes_cli/config.py hermes_cli/main.py hermes_cli/setup.py tests/hermes_cli/test_config.py tests/hermes_cli/test_prompt_api_key.py`
- inline repro: confirmed `_prompt_api_key()` now preserves the existing DeepSeek key instead of saving `sk-old ... /home/.../Capture.png`

## Attribution

Recent Leon Hermes PRs are sharing the same unrelated GitHub Actions `test` red while e2e/lint/attribution checks pass; if that lane stays red here too, treat it as preexisting baseline noise rather than introduced by this diff.