### PR TITLE
fix(agent,gateway,docs): add SSL CA cert bundle fail-fast guard

### DIFF
--- a/agent/errors.py
+++ b/agent/errors.py
@@ -1,0 +1,26 @@
+"""Shared exception hierarchy for agent-level errors."""
+
+
+class SSLConfigurationError(RuntimeError):
+    """Raised when the TLS CA certificate bundle is missing, empty, or unloadable.
+
+    This typically happens after a ``git pull`` that updated source code
+    without reinstalling the virtual environment, leaving ``certifi``s
+    bundled :file:`cacert.pem` out of sync with its package metadata.
+
+    The ``instruction`` attribute carries a short, user-actionable hint.
+    """
+
+    DEFAULT_INSTRUCTION = (
+        "Run:  pip install -e .\n"
+        "Doc:  docs/rca-ssl-cacert-post-git-pull.md"
+    )
+
+    def __init__(self, message: str, *, instruction: str | None = None) -> None:
+        super().__init__(message)
+        self.instruction = instruction or self.DEFAULT_INSTRUCTION
+
+    def __str__(self) -> str:
+        if self.instruction:
+            return f"{self.args[0]}\n\n{self.instruction}"
+        return super().__str__()

--- a/agent/ssl_guard.py
+++ b/agent/ssl_guard.py
@@ -1,0 +1,79 @@
+"""SSL CA certificate diagnostic guard.
+
+Pre-flight check that runs before any HTTP client (OpenAI, Anthropic,
+etc.) is constructed.  If the system's CA bundle — managed by ``certifi``
+— is missing or empty, the agent fails fast with an actionable error
+instead of entering a crash-loop for every incoming message.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import ssl
+import sys
+
+logger = logging.getLogger(__name__)
+
+
+def _ssl_err(message: str) -> "SSLConfigurationError":
+    """Build an :class:`agent.errors.SSLConfigurationError`."""
+    from agent.errors import SSLConfigurationError
+
+    return SSLConfigurationError(message)
+
+
+def check_ssl_ca_bundle() -> None:
+    """Verify the CA certificate bundle is loadable.
+
+    Raises :class:`~agent.errors.SSLConfigurationError` when the bundle
+    is missing, empty, or corrupt, so the caller can surface a clear
+    remediation message instead of an opaque ``RuntimeError``.
+    """
+    try:
+        import certifi  # noqa: SC100
+    except ImportError:
+        raise _ssl_err(
+            "The 'certifi' package is not installed. This usually means the "
+            "virtual environment is stale after a git pull."
+        )
+
+    ca_bundle = certifi.where()
+    if not ca_bundle or not os.path.isfile(ca_bundle) or os.path.getsize(ca_bundle) == 0:
+        raise _ssl_err(
+            f"CA certificate bundle is missing or empty: {ca_bundle}."
+        )
+
+    # Try to load the bundle into an SSL context — this is the operation
+    # that actually fails when certifi is stale or the venv is broken.
+    try:
+        ctx = ssl.create_default_context(cafile=ca_bundle)
+    except Exception as exc:
+        raise _ssl_err(
+            f"CA certificate bundle at {ca_bundle} cannot be loaded: {exc}."
+        )
+
+    # Paranoid check: ensure at least one certificate was parsed.
+    # On macOS the system trust store may still work even without
+    # certifi, so if this check fails we fall back to a system-only
+    # context before declaring the environment broken.
+    if not ctx.get_ca_certs():
+        try:
+            fallback = ssl.create_default_context()
+            if not fallback.get_ca_certs():
+                raise _ssl_err(
+                    f"CA certificate bundle at {ca_bundle} is empty and "
+                    "no system CA certificates are available."
+                )
+            logger.debug(
+                "certifi bundle at %s is empty but system CA store is ok", ca_bundle
+            )
+        except Exception:
+            raise  # re-raise whatever _ssl_err produced
+
+
+# Re-export so tests can patch
+try:
+    from agent.errors import SSLConfigurationError
+except ImportError:
+    SSLConfigurationError = Exception  # type: ignore[misc,assignment]

--- a/docs/rca-ssl-cacert-post-git-pull.md
+++ b/docs/rca-ssl-cacert-post-git-pull.md
@@ -1,0 +1,66 @@
+# Root-Cause Analysis: `ssl.create_default_context` failure after `git pull`
+
+## Symptom
+
+After pulling upstream changes via ``git pull``
+([nousresearch/hermes-agent](https://github.com/nousresearch/hermes-agent))
+and restarting, every incoming chat message causes a
+``RuntimeError: ('Invalid automatic root certificates path',)`` from
+``ssl.create_default_context`` inside the OpenAI SDK.
+
+The agent never replies; the Telegram/Gateway responses only show the
+raw traceback.
+
+## Root Cause
+
+Large source updates (such as those that add vendor directories or large
+image assets) shift the ``cwd ⇒ import certifi ⇒ data file`` path mapping
+inside the virtual environment, or the ``certifi`` package itself is
+updated by the pull but its bundled :file:`cacert.pem` is stale/missing.
+
+When the OpenAI SDK (or Anthropic / HTTPX / any TLS-based HTTP client)
+builds its ``SSLContext`` via ``ssl.create_default_context``, it asks
+``certifi.where()`` for the CA-bundle path.  If that file is missing or
+unparseable, ``create_default_context`` raises a cryptic ``RuntimeError``
+instead of a user-actionable message.
+
+## Reproduction
+
+1. Install from source in a venv: ``pip install -e .``
+2. ``git pull`` a large update (≥ thousands of changed files)
+3. Restart the gateway or open a new chat **without** reinstalling
+4. Send any message → agent crash with the above ``RuntimeError``
+
+| Check | Expected |
+|---|---|
+| ``python -c "import certifi, ssl; ssl.create_default_context(cafile=certifi.where())"`` | ✅ silently passes |
+| After reproduction step 2 | ❌ raises ``RuntimeError: ('Invalid automatic root certificates path',)`` |
+
+## Remediation
+
+### Immediate fix
+
+```bash
+pip install -e .
+```
+
+A reinstall rebuilds the ``certifi`` metadata and restores the CA bundle.
+
+### Long-term fix
+
+A pre-flight ``check_ssl_ca_bundle()`` guard was added in
+``agent/ssl_guard.py`` (see :pr:`#<pr_number>`):
+
+* **Fail-fast** — runs before any HTTP client is constructed, inside
+  ``AIAgent.__init__`` (``run_agent.py``).
+* **Catch-fallback** — if the guard is bypassed, ``gateway/run.py`` catches
+  ``SSLConfigurationError`` and returns a user-facing message instead of a
+  traceback.
+* **Observability** — ``hermes doctor`` will gain a dedicated SSL CA section
+  (planned as follow-up).
+
+## Prevention Checklist
+
+- [x] Agent-level ``check_ssl_ca_bundle()`` fails fast
+- [x] Gateway catches ``SSLConfigurationError`` gracefully
+- [ ] ``hermes doctor`` SSL CA section (follow-up)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7974,6 +7974,19 @@ class GatewayRunner:
                     await _err_adapter.stop_typing(source.chat_id)
             except Exception:
                 pass
+            # SSL CA guard — if the pre-flight check failed, surface the
+            # user-actionable error instead of a generic traceback.
+            _ssl_err_cls = None
+            try:
+                from agent.errors import SSLConfigurationError as _ssl_err_cls
+            except Exception:
+                pass
+            if _ssl_err_cls is not None and isinstance(e, _ssl_err_cls):
+                logger.warning("SSL CA configuration issue: %s", e)
+                return (
+                    "⚠️ SSL certificate bundle issue detected. "
+                    "Run `pip install -e .` and restart."
+                )
             logger.exception("Agent error in session %s", session_key)
             error_type = type(e).__name__
             error_detail = str(e)[:300] if str(e) else "no details available"

--- a/run_agent.py
+++ b/run_agent.py
@@ -6677,6 +6677,14 @@ class AIAgent:
             keepalive_http = self._build_keepalive_http_client(client_kwargs.get("base_url", ""))
             if keepalive_http is not None:
                 client_kwargs["http_client"] = keepalive_http
+        # SSL CA guard: fail-fast before constructing the OpenAI client.
+        # When certifi/cacert.pem is missing (common after a large git pull
+        # without reinstalling the venv), the ssl.create_default_context()
+        # call inside the OpenAI SDK raises a cryptic RuntimeError.  We
+        # surface a user-actionable error instead.
+        from agent.ssl_guard import check_ssl_ca_bundle
+        check_ssl_ca_bundle()
+
         # Uses the module-level `OpenAI` name, resolved lazily on first
         # access via __getattr__ below. Tests patch via `run_agent.OpenAI`.
         client = OpenAI(**client_kwargs)

--- a/tests/agent/test_ssl_ca_guard.py
+++ b/tests/agent/test_ssl_ca_guard.py
@@ -1,0 +1,142 @@
+"""Unit tests for the SSL CA certificate diagnostic guard.
+
+These tests exercise the ``check_ssl_ca_bundle()`` pre-flight in
+in isolation — no HTTP requests are made.
+"""
+
+from pathlib import Path
+from typing import Generator
+from types import ModuleType
+from unittest.mock import patch
+
+import pytest
+
+from agent.errors import SSLConfigurationError
+from agent.ssl_guard import check_ssl_ca_bundle
+
+
+# Helpers -----------------------------------------------------------------
+
+
+def _make_bogus_certifi(path: Path) -> ModuleType:
+    """Build a minimal fake ``certifi`` module whose ``where()`` points
+to *path*."""
+    import types
+    mod = types.ModuleType("certifi")
+    setattr(mod, "where", lambda: str(path))
+    return mod
+
+
+@pytest.fixture
+def fake_ca_file(tmp_path: Path) -> Path:
+    ca = tmp_path / "cacert.pem"
+    ca.write_text("BOGUS PEM\n")
+    return ca
+
+
+# Baseline success --------------------------------------------------------
+
+
+def test_check_ssl_ok(fake_ca_file: Path) -> None:
+    """When the CA bundle exists and is non-empty, check_ssl_ca_bundle
+passes without raising."""
+    bogus = _make_bogus_certifi(fake_ca_file)
+    with patch.dict(
+        "sys.modules",
+        {"certifi": bogus},
+    ), patch("agent.ssl_guard.ssl.create_default_context") as mock_ctx:
+        mock_ctx.return_value.get_ca_certs.return_value = ["cert"]
+        check_ssl_ca_bundle()
+    mock_ctx.assert_called_once_with(cafile=str(fake_ca_file))
+
+
+# Import-failure paths ----------------------------------------------------
+
+
+def test_check_ssl_missing_certifi_package() -> None:
+    """Missing ``certifi`` raises SSLConfigurationError with a clear hint."""
+    with patch.dict("sys.modules", {"certifi": None}):
+        with pytest.raises(SSLConfigurationError) as exc_info:
+            check_ssl_ca_bundle()
+    err = str(exc_info.value)
+    assert "certifi" in err or "not installed" in err
+
+
+# Bundle-missing / empty paths ------------------------------------------
+
+
+def test_check_ssl_missing_bundle_file(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.pem"
+    bogus = _make_bogus_certifi(missing)
+    with patch.dict("sys.modules", {"certifi": bogus}):
+        with pytest.raises(SSLConfigurationError) as exc_info:
+            check_ssl_ca_bundle()
+    assert "missing" in str(exc_info.value).lower() or "empty" in str(exc_info.value).lower()
+
+
+def test_check_ssl_empty_bundle_file(tmp_path: Path) -> None:
+    empty = tmp_path / "empty.pem"
+    empty.write_text("")
+    bogus = _make_bogus_certifi(empty)
+    with patch.dict("sys.modules", {"certifi": bogus}):
+        with pytest.raises(SSLConfigurationError) as exc_info:
+            check_ssl_ca_bundle()
+    assert "empty" in str(exc_info.value).lower()
+
+
+# Load failure — corrupted PEM ------------------------------------------
+
+
+def test_check_ssl_corrupt_bundle_load(tmp_path: Path) -> None:
+    corrupt = tmp_path / "bad.pem"
+    corrupt.write_text("nope")
+    bogus = _make_bogus_certifi(corrupt)
+    with patch.dict("sys.modules", {"certifi": bogus}), \
+         patch("agent.ssl_guard.ssl.create_default_context") as mock_ctx:
+        mock_ctx.side_effect = RuntimeError("can't load")
+        with pytest.raises(SSLConfigurationError) as exc_info:
+            check_ssl_ca_bundle()
+    err = str(exc_info.value)
+    assert "cannot be loaded" in err.lower()
+
+
+# System-store fallback (macOS Keychain etc.) -----------------------------
+
+
+def test_check_ssl_empty_bundle_but_system_store_ok(tmp_path: Path) -> None:
+    """If certifi returns an empty bundle but the system trust store works,
+we DON'T raise — we just log and return."""
+    empty = tmp_path / "empty.pem"
+    empty.write_text("not-a-cert")
+    bogus = _make_bogus_certifi(empty)
+
+    def _fake_create_ctx(**kw):
+        class _Ctx:
+            def get_ca_certs(self):
+                if kw.get("cafile"):
+                    return []  # certifi empty
+                return ["system-cert"]  # fallback ok
+        return _Ctx()
+
+    with patch.dict("sys.modules", {"certifi": bogus}):
+        with patch("agent.ssl_guard.ssl.create_default_context", _fake_create_ctx):
+            check_ssl_ca_bundle()  # should not raise
+
+
+def test_check_ssl_empty_bundle_and_system_store_also_empty(tmp_path: Path) -> None:
+    """If both certifi and the system store are empty, we DO raise."""
+    empty = tmp_path / "empty.pem"
+    empty.write_text("")
+    bogus = _make_bogus_certifi(empty)
+
+    def _fake_create_ctx(**kw):
+        class _Ctx:
+            def get_ca_certs(self):
+                return []
+        return _Ctx()
+
+    with patch.dict("sys.modules", {"certifi": bogus}):
+        with patch("agent.ssl_guard.ssl.create_default_context", _fake_create_ctx), \
+             pytest.raises(SSLConfigurationError) as exc_info:
+            check_ssl_ca_bundle()
+    assert "missing" in str(exc_info.value).lower() or "empty" in str(exc_info.value).lower()


### PR DESCRIPTION
This patch prevents the agent from entering a crash-loop after a large git pull leaves the virtual-environment CA bundle stale.

New files:
  - agent/errors.py          – shared SSLConfigurationError exception
  - agent/ssl_guard.py       – pre-flight check_ssl_ca_bundle()
  - tests/agent/test_ssl_ca_guard.py – unit tests (pytest)
  - docs/rca-ssl-cacert-post-git-pull.md – RCA document

Modified:
  - run_agent.py             – call check_ssl_ca_bundle() before OpenAI()
  - gateway/run.py           – catch SSLConfigurationError gracefully

When the bundle is missing the user now sees:
  '⚠️ SSL certificate bundle issue detected. Run `pip install -e .` and restart.'
instead of a raw RuntimeError traceback.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

