### PR TITLE
fix(wecom): handle WSMsgType.CLOSING to prevent CPU spin

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -361,7 +361,7 @@ class WeComAdapter(BasePlatformAdapter):
                 payload = self._parse_json(msg.data)
                 if payload:
                     await self._dispatch_payload(payload)
-            elif msg.type in {aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.ERROR}:
+            elif msg.type in {aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.ERROR, aiohttp.WSMsgType.CLOSING}:
                 raise RuntimeError("WeCom websocket closed")
 
     async def _heartbeat_loop(self) -> None:


### PR DESCRIPTION
## What

Handle `aiohttp.WSMsgType.CLOSING` in WeCom gateway's `_read_events()` to prevent CPU spin.

## Why

When the WebSocket enters CLOSING state, the current code does not recognize it as terminal. `receive()` returns CLOSING immediately, causing a tight loop. This was observed in production at 45-100% CPU until the process was restarted.

## How to test

1. Start WeCom gateway: `hermes gateway run`
2. Interrupt network or trigger server-side close
3. CPU should remain normal; gateway should log "WeCom WebSocket closed" and reconnect

## Platforms tested

- Linux (Ubuntu 22.04)

Fixes #28293