### PR TITLE
fix(conversation_loop): resolve pool recovery helper via _ra()

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2332,7 +2332,7 @@ def run_conversation(
                     # still recover.  See _pool_may_recover_from_rate_limit
                     # for the single-credential-pool and CloudCode-quota
                     # exceptions.  Fixes #11314 and #13636.
-                    pool_may_recover = _pool_may_recover_from_rate_limit(
+                    pool_may_recover = _ra()._pool_may_recover_from_rate_limit(
                         agent._credential_pool,
                         provider=agent.provider,
                         base_url=getattr(agent, "base_url", None),

--- a/tests/agent/test_conversation_loop_pool_recovery_guard.py
+++ b/tests/agent/test_conversation_loop_pool_recovery_guard.py
@@ -1,0 +1,24 @@
+"""Regression guard for #28268/#28254-style bugs: conversation loop must
+resolve rate-limit pool recovery helper via _ra().
+
+`agent/conversation_loop.py` is extracted from `run_agent.AIAgent` and uses
+`_ra()` to lazily resolve symbols that production code or tests patch on
+`run_agent`. Referencing `_pool_may_recover_from_rate_limit` directly in this
+module raises NameError at runtime because the helper lives in `run_agent.py`.
+"""
+
+from __future__ import annotations
+
+
+def test_conversation_loop_routes_pool_recovery_helper_through_ra():
+    import inspect
+
+    from agent import conversation_loop
+
+    src = inspect.getsource(conversation_loop)
+    assert "_pool_may_recover_from_rate_limit" in src
+    assert "_ra()._pool_may_recover_from_rate_limit(" in src, (
+        "agent/conversation_loop.py must resolve _pool_may_recover_from_rate_limit "
+        "via _ra() to avoid NameError and preserve patch semantics."
+    )
+


### PR DESCRIPTION
/goal Fix NameError in extracted conversation loop (rate-limit eager fallback) with a minimal patch and a regression guard.

Context
- `agent/conversation_loop.py` is extracted from `run_agent.py` and should resolve `run_agent` helpers via `_ra()`.
- Current upstream `main` calls `_pool_may_recover_from_rate_limit(...)` directly, which raises `NameError` at runtime.

Change
- Route the helper call through `_ra()._pool_may_recover_from_rate_limit(...)`.
- Add a source-level regression guard test to ensure the extracted module keeps the `_ra()` indirection.

Tests
- `python -m pytest -q tests/agent/test_conversation_loop_pool_recovery_guard.py`
- `python -m pytest -q tests/agent/test_gemini_fast_fallback.py`

Notes
- There are multiple open PRs attempting to fix the same NameError; this PR is the smallest patch + test to be a clean canonical fix.