### PR TITLE
fix(profiles): preserve custom hermes home in wrappers

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -296,6 +296,33 @@ def _get_wrapper_dir() -> Path:
     return Path.home() / ".local" / "bin"
 
 
+def _get_platform_standard_hermes_home() -> Path:
+    """Return the platform-native Hermes root used when HERMES_HOME is unset."""
+    if sys.platform == "win32":
+        local_appdata = os.environ.get("LOCALAPPDATA", "").strip()
+        base = (
+            Path(local_appdata)
+            if local_appdata
+            else Path.home() / "AppData" / "Local"
+        )
+        return base / "hermes"
+    return Path.home() / ".hermes"
+
+
+def _wrapper_hermes_home() -> Optional[Path]:
+    """Return HERMES_HOME to preserve in generated wrappers, if non-standard."""
+    default_root = _get_default_hermes_home()
+    standard_root = _get_platform_standard_hermes_home()
+    if default_root.resolve(strict=False) == standard_root.resolve(strict=False):
+        return None
+    return default_root
+
+
+def _quote_bat_env_value(value: str) -> str:
+    """Escape a value written inside a batch ``set "NAME=value"`` command."""
+    return value.replace("%", "%%")
+
+
 # ---------------------------------------------------------------------------
 # Validation
 # ---------------------------------------------------------------------------
@@ -458,7 +485,12 @@ def create_wrapper_script(name: str, target: Optional[str] = None) -> Optional[P
     if is_windows:
         wrapper_path = wrapper_dir / f"{canon}.bat"
         try:
-            wrapper_path.write_text(f"@echo off\r\nhermes -p {profile} %*\r\n", encoding="utf-8")
+            lines = ["@echo off"]
+            hermes_home = _wrapper_hermes_home()
+            if hermes_home is not None:
+                lines.append(f'set "HERMES_HOME={_quote_bat_env_value(str(hermes_home))}"')
+            lines.append(f"hermes -p {profile} %*")
+            wrapper_path.write_text("\r\n".join(lines) + "\r\n", encoding="utf-8")
             return wrapper_path
         except OSError as e:
             print(f"⚠ Could not create wrapper at {wrapper_path}: {e}")
@@ -467,7 +499,12 @@ def create_wrapper_script(name: str, target: Optional[str] = None) -> Optional[P
         wrapper_path = wrapper_dir / canon
         try:
             hermes_exe = shutil.which("hermes") or "hermes"
-            wrapper_path.write_text(f'#!/bin/sh\nexec {shlex.quote(hermes_exe)} -p {profile} "$@"\n', encoding="utf-8")
+            lines = ["#!/bin/sh"]
+            hermes_home = _wrapper_hermes_home()
+            if hermes_home is not None:
+                lines.append(f"export HERMES_HOME={shlex.quote(str(hermes_home))}")
+            lines.append(f'exec {shlex.quote(hermes_exe)} -p {profile} "$@"')
+            wrapper_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
             wrapper_path.chmod(wrapper_path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
             return wrapper_path
         except OSError as e:
@@ -566,6 +603,38 @@ def find_alias_for_profile(profile_name: str) -> Optional[str]:
 _WRAPPER_READ_LIMIT = 8192
 
 
+def _extract_wrapper_profile(content: str, is_windows: bool) -> Optional[str]:
+    """Extract the profile id from a Hermes alias wrapper body."""
+    for raw_line in content.splitlines():
+        line = raw_line.strip()
+        if (
+            not line
+            or line.startswith("#")
+            or line.startswith("export ")
+            or line.lower().startswith("set ")
+        ):
+            continue
+        if is_windows:
+            parts = line.split()
+            if len(parts) >= 3 and parts[0].lower() == "hermes" and parts[1] == "-p":
+                return parts[2]
+            continue
+        try:
+            parts = shlex.split(line)
+        except ValueError:
+            continue
+        if parts and parts[0] == "exec":
+            parts = parts[1:]
+        if len(parts) >= 3 and PurePosixPath(parts[0]).name == "hermes":
+            try:
+                profile_index = parts.index("-p") + 1
+            except ValueError:
+                continue
+            if profile_index < len(parts):
+                return parts[profile_index]
+    return None
+
+
 def build_alias_map() -> dict[str, str]:
     """Single-pass reverse map ``{canonical_profile -> alias_name}``.
 
@@ -580,7 +649,6 @@ def build_alias_map() -> dict[str, str]:
     if not wrapper_dir.is_dir():
         return result
     is_windows = sys.platform == "win32"
-    prefix = "hermes -p "
 
     for entry in sorted(wrapper_dir.iterdir()):
         if not entry.is_file():
@@ -596,12 +664,7 @@ def build_alias_map() -> dict[str, str]:
         except (OSError, UnicodeDecodeError):
             # UnicodeDecodeError = a binary on PATH (ffmpeg etc.) — not a wrapper.
             continue
-        idx = content.find(prefix)
-        if idx == -1:
-            continue
-        rest = content[idx + len(prefix):]
-        # Profile id is the first whitespace-delimited token after the flag.
-        canon = rest.split(None, 1)[0].strip() if rest.strip() else ""
+        canon = _extract_wrapper_profile(content, is_windows) or ""
         if not canon:
             continue
         canon = normalize_profile_name(canon)

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -8,6 +8,7 @@ and shell completion generation.
 import json
 import io
 import os
+import shlex
 import shutil
 import sys
 import tarfile
@@ -443,6 +444,70 @@ class TestWrapperScript:
         assert content.startswith("#!/bin/sh")
         assert "exec /opt/hermes/bin/hermes -p mybot" in content
 
+    def test_posix_standard_root_does_not_export_hermes_home(self, profile_env, monkeypatch):
+        monkeypatch.setattr("sys.platform", "darwin")
+        monkeypatch.setattr("hermes_cli.profiles.shutil.which", lambda name: "/opt/hermes/bin/hermes")
+        from hermes_cli.profiles import create_wrapper_script
+
+        wrapper = create_wrapper_script("mybot")
+
+        assert wrapper is not None
+        assert wrapper.read_text(encoding="utf-8") == (
+            '#!/bin/sh\nexec /opt/hermes/bin/hermes -p mybot "$@"\n'
+        )
+
+    def test_posix_custom_root_exports_hermes_home_and_keeps_target(self, profile_env, monkeypatch):
+        monkeypatch.setattr("sys.platform", "darwin")
+        monkeypatch.setattr("hermes_cli.profiles.shutil.which", lambda name: "/opt/Hermes Bin/hermes")
+        custom_root = profile_env / "custom hermes root"
+        custom_root.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(custom_root))
+        from hermes_cli.profiles import create_wrapper_script
+
+        wrapper = create_wrapper_script("rq", target="redqueen")
+
+        assert wrapper is not None
+        assert wrapper.name == "rq"
+        assert wrapper.read_text(encoding="utf-8") == (
+            "#!/bin/sh\n"
+            f"export HERMES_HOME={shlex.quote(str(custom_root))}\n"
+            f"exec {shlex.quote('/opt/Hermes Bin/hermes')} -p redqueen \"$@\"\n"
+        )
+
+    def test_windows_standard_root_does_not_set_hermes_home(self, profile_env, monkeypatch):
+        monkeypatch.setattr("sys.platform", "win32")
+        local_appdata = profile_env / "AppData" / "Local"
+        standard_root = local_appdata / "hermes"
+        standard_root.mkdir(parents=True)
+        monkeypatch.setenv("LOCALAPPDATA", str(local_appdata))
+        monkeypatch.setenv("HERMES_HOME", str(standard_root))
+        from hermes_cli.profiles import create_wrapper_script
+
+        wrapper = create_wrapper_script("mybot")
+
+        assert wrapper is not None
+        assert wrapper.name == "mybot.bat"
+        assert wrapper.read_text(encoding="utf-8") == "@echo off\nhermes -p mybot %*\n"
+
+    def test_windows_custom_root_sets_hermes_home_and_keeps_target(self, profile_env, monkeypatch):
+        monkeypatch.setattr("sys.platform", "win32")
+        local_appdata = profile_env / "AppData" / "Local"
+        custom_root = profile_env / "custom%root"
+        custom_root.mkdir()
+        monkeypatch.setenv("LOCALAPPDATA", str(local_appdata))
+        monkeypatch.setenv("HERMES_HOME", str(custom_root))
+        from hermes_cli.profiles import create_wrapper_script
+
+        wrapper = create_wrapper_script("rq", target="redqueen")
+
+        assert wrapper is not None
+        assert wrapper.name == "rq.bat"
+        assert wrapper.read_text(encoding="utf-8") == (
+            "@echo off\n"
+            f"set \"HERMES_HOME={str(custom_root).replace('%', '%%')}\"\n"
+            "hermes -p redqueen %*\n"
+        )
+
 
     def test_remove_finds_bat_on_windows(self, profile_env, monkeypatch):
         monkeypatch.setattr("sys.platform", "win32")
@@ -814,6 +879,3 @@ class TestProfilesToServe:
         assert set(serve) == {"default", "coder", "writer"}
         assert serve["default"] == _get_default_hermes_home()
         assert serve["coder"] == get_profile_dir("coder")
-
-
-


### PR DESCRIPTION
Fixes #28292

`hermes profile import` can create a wrapper that does not preserve a custom `HERMES_HOME`.

The imported profile itself lands in the correct custom root, but the generated wrapper is still just a plain `hermes -p <name>` launcher. That makes the alias resolve profiles against the default Hermes root instead of the custom one used during import.

This patch keeps standard-root wrappers unchanged, but when Hermes is running from a non-default root it writes the wrapper so that it exports the resolved `HERMES_HOME` before launching the profile.

Validation:
`uv run --extra dev pytest tests/hermes_cli/test_profiles.py -q -k 'WrapperScripts or custom_root_wrapper_exports_hermes_home or standard_root_wrapper_uses_plain_profile_exec'`

Result:
`2 passed`
