### PR TITLE
fix(kanban): close sqlite connection on init failure to prevent fd leak

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -921,21 +921,25 @@ def connect(
     resolved = str(path.resolve())
     needs_init = resolved not in _INITIALIZED_PATHS
     conn = sqlite3.connect(str(path), isolation_level=None, timeout=30)
-    conn.row_factory = sqlite3.Row
-    # WAL doesn't work on network filesystems (NFS/SMB/FUSE).  Shared helper
-    # falls back to DELETE with one WARNING so kanban stays usable there.
-    # See hermes_state._WAL_INCOMPAT_MARKERS for detection logic.
-    from hermes_state import apply_wal_with_fallback
-    apply_wal_with_fallback(conn, db_label=f"kanban.db ({path.name})")
-    conn.execute("PRAGMA synchronous=NORMAL")
-    conn.execute("PRAGMA foreign_keys=ON")
-    if needs_init:
-        # Idempotent: runs CREATE TABLE IF NOT EXISTS + the additive
-        # migrations. Cached so subsequent connect() calls in the same
-        # process are cheap.
-        conn.executescript(SCHEMA_SQL)
-        _migrate_add_optional_columns(conn)
-        _INITIALIZED_PATHS.add(resolved)
+    try:
+        conn.row_factory = sqlite3.Row
+        # WAL doesn't work on network filesystems (NFS/SMB/FUSE).  Shared helper
+        # falls back to DELETE with one WARNING so kanban stays usable there.
+        # See hermes_state._WAL_INCOMPAT_MARKERS for detection logic.
+        from hermes_state import apply_wal_with_fallback
+        apply_wal_with_fallback(conn, db_label=f"kanban.db ({path.name})")
+        conn.execute("PRAGMA synchronous=NORMAL")
+        conn.execute("PRAGMA foreign_keys=ON")
+        if needs_init:
+            # Idempotent: runs CREATE TABLE IF NOT EXISTS + the additive
+            # migrations. Cached so subsequent connect() calls in the same
+            # process are cheap.
+            conn.executescript(SCHEMA_SQL)
+            _migrate_add_optional_columns(conn)
+            _INITIALIZED_PATHS.add(resolved)
+    except Exception:
+        conn.close()
+        raise
     return conn
 
 


### PR DESCRIPTION
## What does this PR do?
Root cause: kanban_db.connect() opens a sqlite3 connection, then runs multiple initialization steps (WAL pragma, foreign_keys, schema migration). If any of those steps raises, the function propagates the exception without calling conn.close() -- leaking the file descriptor.

The leak accumulates over time in the gateway's kanban dispatcher and notifier coroutines, which open a new connection per tick. After enough failures the process hits ulimit -n and everything breaks:

    sqlite3.OperationalError: unable to open database file
    [Errno 24] Too many open files

## Related Issue

Closes #28285

## Type of Change

wrap all initialization steps in try/except, calling conn.close() before re-raising. This is the same defensive pattern used by hermes_state.SessionDB.

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

