### PR TITLE
fix(image_gen/openai): config-driven model selection with multi-model…

### DIFF
--- a/plugins/image_gen/openai/__init__.py
+++ b/plugins/image_gen/openai/__init__.py
@@ -1,23 +1,21 @@
 """OpenAI image generation backend.
 
-Exposes OpenAI's ``gpt-image-2`` model at three quality tiers as an
-:class:`ImageGenProvider` implementation. The tiers are implemented as
-three virtual model IDs so the ``hermes tools`` model picker and the
-``image_gen.model`` config key behave like any other multi-model backend:
+Exposes OpenAI image models (gpt-image-1, gpt-image-1.5, gpt-image-2) as an
+:class:`ImageGenProvider` implementation. Models that support the ``quality``
+parameter (gpt-image-2, gpt-image-1.5) expose three quality tiers:
 
-    gpt-image-2-low     ~15s   fastest, good for iteration
-    gpt-image-2-medium  ~40s   default — balanced
-    gpt-image-2-high    ~2min  slowest, highest fidelity
+    <model>-low     ~15s   fastest, good for iteration
+    <model>-medium  ~40s   default — balanced
+    <model>-high    ~2min  slowest, highest fidelity
 
-All three hit the same underlying API model (``gpt-image-2``) with a
-different ``quality`` parameter. Output is base64 JSON → saved under
-``$HERMES_HOME/cache/images/``.
+Models without quality support (gpt-image-1, gpt-image-1-mini) use a flat
+tier mapped directly to the model name, sending no ``quality`` parameter.
 
-Selection precedence (first hit wins):
+Configuration precedence (first hit wins):
 
-1. ``OPENAI_IMAGE_MODEL`` env var (escape hatch for scripts / tests)
+1. ``OPENAI_IMAGE_MODEL`` env var (any model name or tier ID)
 2. ``image_gen.openai.model`` in ``config.yaml``
-3. ``image_gen.model`` in ``config.yaml`` (when it's one of our tier IDs)
+3. ``image_gen.model`` in ``config.yaml``
 4. :data:`DEFAULT_MODEL` — ``gpt-image-2-medium``
 """
 
@@ -43,30 +41,68 @@ logger = logging.getLogger(__name__)
 # Model catalog
 # ---------------------------------------------------------------------------
 #
-# All three IDs resolve to the same underlying API model with a different
-# ``quality`` setting. ``api_model`` is what gets sent to OpenAI;
-# ``quality`` is the knob that changes generation time and output fidelity.
-
-API_MODEL = "gpt-image-2"
+# ``_MODELS`` maps tier IDs (e.g. "gpt-image-2-medium") to their metadata.
+# Each entry has an ``api_model`` field that determines what's sent to OpenAI.
+# Models that support ``quality`` include it; others omit it.
 
 _MODELS: Dict[str, Dict[str, Any]] = {
+    # gpt-image-2 tiers (supports quality parameter)
     "gpt-image-2-low": {
+        "api_model": "gpt-image-2",
         "display": "GPT Image 2 (Low)",
         "speed": "~15s",
         "strengths": "Fast iteration, lowest cost",
         "quality": "low",
     },
     "gpt-image-2-medium": {
+        "api_model": "gpt-image-2",
         "display": "GPT Image 2 (Medium)",
         "speed": "~40s",
         "strengths": "Balanced — default",
         "quality": "medium",
     },
     "gpt-image-2-high": {
+        "api_model": "gpt-image-2",
         "display": "GPT Image 2 (High)",
         "speed": "~2min",
         "strengths": "Highest fidelity, strongest prompt adherence",
         "quality": "high",
+    },
+    # gpt-image-1.5 tiers (supports quality parameter)
+    "gpt-image-1.5-low": {
+        "api_model": "gpt-image-1.5",
+        "display": "GPT Image 1.5 (Low)",
+        "speed": "~15s",
+        "strengths": "Fast iteration, lowest cost",
+        "quality": "low",
+    },
+    "gpt-image-1.5-medium": {
+        "api_model": "gpt-image-1.5",
+        "display": "GPT Image 1.5 (Medium)",
+        "speed": "~40s",
+        "strengths": "Balanced",
+        "quality": "medium",
+    },
+    "gpt-image-1.5-high": {
+        "api_model": "gpt-image-1.5",
+        "display": "GPT Image 1.5 (High)",
+        "speed": "~2min",
+        "strengths": "Highest fidelity",
+        "quality": "high",
+    },
+    # gpt-image-1 (no quality parameter — flat tier)
+    "gpt-image-1": {
+        "api_model": "gpt-image-1",
+        "display": "GPT Image 1",
+        "speed": "~40s",
+        "strengths": "Balanced quality, no quality tiers",
+    },
+    # gpt-image-1-mini (no quality parameter — flat tier)
+    "gpt-image-1-mini": {
+        "api_model": "gpt-image-1-mini",
+        "display": "GPT Image 1 Mini",
+        "speed": "~10s",
+        "strengths": "Fastest, lowest cost",
     },
 }
 
@@ -93,25 +129,41 @@ def _load_openai_config() -> Dict[str, Any]:
 
 
 def _resolve_model() -> Tuple[str, Dict[str, Any]]:
-    """Decide which tier to use and return ``(model_id, meta)``."""
-    env_override = os.environ.get("OPENAI_IMAGE_MODEL")
-    if env_override and env_override in _MODELS:
-        return env_override, _MODELS[env_override]
+    """Decide which model/tier to use and return ``(tier_id, meta)``.
 
+    Accepts both tier IDs (e.g. ``gpt-image-2-medium``) and bare model names
+    (e.g. ``gpt-image-1``). Bare names that aren't in the catalog are passed
+    through as-is with default metadata (no quality parameter).
+    """
+    # 1. Env override
+    env_override = os.environ.get("OPENAI_IMAGE_MODEL")
+    if env_override:
+        if env_override in _MODELS:
+            return env_override, _MODELS[env_override]
+        # Pass through unknown model names with default metadata
+        return env_override, {"api_model": env_override, "display": env_override,
+                              "speed": "unknown", "strengths": "Custom model"}
+
+    # 2-3. Config file: image_gen.openai.model, then image_gen.model
     cfg = _load_openai_config()
     openai_cfg = cfg.get("openai") if isinstance(cfg.get("openai"), dict) else {}
     candidate: Optional[str] = None
     if isinstance(openai_cfg, dict):
         value = openai_cfg.get("model")
-        if isinstance(value, str) and value in _MODELS:
-            candidate = value
+        if isinstance(value, str) and value.strip():
+            candidate = value.strip()
     if candidate is None:
         top = cfg.get("model")
-        if isinstance(top, str) and top in _MODELS:
-            candidate = top
+        if isinstance(top, str) and top.strip():
+            candidate = top.strip()
 
     if candidate is not None:
-        return candidate, _MODELS[candidate]
+        # Exact tier ID match
+        if candidate in _MODELS:
+            return candidate, _MODELS[candidate]
+        # Pass through bare model names or custom values
+        return candidate, {"api_model": candidate, "display": candidate,
+                           "speed": "unknown", "strengths": "Custom model"}
 
     return DEFAULT_MODEL, _MODELS[DEFAULT_MODEL]
 
@@ -122,7 +174,7 @@ def _resolve_model() -> Tuple[str, Dict[str, Any]]:
 
 
 class OpenAIImageGenProvider(ImageGenProvider):
-    """OpenAI ``images.generate`` backend — gpt-image-2 at low/medium/high."""
+    """OpenAI ``images.generate`` backend — supports gpt-image-1/1.5/2."""
 
     @property
     def name(self) -> str:
@@ -160,7 +212,7 @@ class OpenAIImageGenProvider(ImageGenProvider):
         return {
             "name": "OpenAI",
             "badge": "paid",
-            "tag": "gpt-image-2 at low/medium/high quality tiers",
+            "tag": "gpt-image-1 / gpt-image-1.5 / gpt-image-2 with quality tiers",
             "env_vars": [
                 {
                     "key": "OPENAI_API_KEY",
@@ -212,15 +264,22 @@ class OpenAIImageGenProvider(ImageGenProvider):
         tier_id, meta = _resolve_model()
         size = _SIZES.get(aspect, _SIZES["square"])
 
-        # gpt-image-2 returns b64_json unconditionally and REJECTS
+        # Determine the actual API model name to send to OpenAI.
+        api_model = meta.get("api_model", tier_id)
+
+        # gpt-image-2/1.5 return b64_json unconditionally and REJECT
         # ``response_format`` as an unknown parameter. Don't send it.
+        # gpt-image-1/1-mini also return b64_json but do NOT support
+        # the ``quality`` parameter.
         payload: Dict[str, Any] = {
-            "model": API_MODEL,
+            "model": api_model,
             "prompt": prompt,
             "size": size,
             "n": 1,
-            "quality": meta["quality"],
         }
+        # Only include quality for models that support it
+        if "quality" in meta:
+            payload["quality"] = meta["quality"]
 
         try:
             client = openai.OpenAI()
@@ -279,7 +338,9 @@ class OpenAIImageGenProvider(ImageGenProvider):
                 aspect_ratio=aspect,
             )
 
-        extra: Dict[str, Any] = {"size": size, "quality": meta["quality"]}
+        extra: Dict[str, Any] = {"size": size, "api_model": api_model}
+        if "quality" in meta:
+            extra["quality"] = meta["quality"]
         if revised_prompt:
             extra["revised_prompt"] = revised_prompt
 

--- a/tests/plugins/image_gen/test_openai_provider.py
+++ b/tests/plugins/image_gen/test_openai_provider.py
@@ -1,4 +1,4 @@
-"""Tests for the bundled OpenAI image_gen plugin (gpt-image-2, three tiers)."""
+"""Tests for the bundled OpenAI image_gen plugin (gpt-image-1/1.5/2 models)."""
 
 from __future__ import annotations
 
@@ -57,15 +57,25 @@ class TestMetadata:
     def test_default_model(self, provider):
         assert provider.default_model() == "gpt-image-2-medium"
 
-    def test_list_models_three_tiers(self, provider):
+    def test_list_models_includes_all_models(self, provider):
         ids = [m["id"] for m in provider.list_models()]
-        assert ids == ["gpt-image-2-low", "gpt-image-2-medium", "gpt-image-2-high"]
+        # Must include all 8 entries: 3 gpt-image-2 tiers + 3 gpt-image-1.5 tiers + gpt-image-1 + gpt-image-1-mini
+        assert "gpt-image-2-low" in ids
+        assert "gpt-image-2-medium" in ids
+        assert "gpt-image-2-high" in ids
+        assert "gpt-image-1.5-low" in ids
+        assert "gpt-image-1.5-medium" in ids
+        assert "gpt-image-1.5-high" in ids
+        assert "gpt-image-1" in ids
+        assert "gpt-image-1-mini" in ids
+        assert len(ids) == 8
 
-    def test_catalog_entries_have_display_speed_strengths(self, provider):
+    def test_catalog_entries_have_required_fields(self, provider):
         for entry in provider.list_models():
-            assert entry["display"].startswith("GPT Image 2")
+            assert entry["display"]
             assert entry["speed"]
             assert entry["strengths"]
+            assert entry["price"]
 
 
 # ── Availability ────────────────────────────────────────────────────────────
@@ -89,17 +99,34 @@ class TestModelResolution:
         model_id, meta = openai_plugin._resolve_model()
         assert model_id == "gpt-image-2-medium"
         assert meta["quality"] == "medium"
+        assert meta["api_model"] == "gpt-image-2"
 
-    def test_env_var_override(self, monkeypatch):
+    def test_env_var_override_tier_id(self, monkeypatch):
         monkeypatch.setenv("OPENAI_IMAGE_MODEL", "gpt-image-2-high")
         model_id, meta = openai_plugin._resolve_model()
         assert model_id == "gpt-image-2-high"
         assert meta["quality"] == "high"
+        assert meta["api_model"] == "gpt-image-2"
 
-    def test_env_var_unknown_falls_back(self, monkeypatch):
-        monkeypatch.setenv("OPENAI_IMAGE_MODEL", "bogus-tier")
-        model_id, _ = openai_plugin._resolve_model()
-        assert model_id == openai_plugin.DEFAULT_MODEL
+    def test_env_var_override_bare_model(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_IMAGE_MODEL", "gpt-image-1")
+        model_id, meta = openai_plugin._resolve_model()
+        assert model_id == "gpt-image-1"
+        assert meta["api_model"] == "gpt-image-1"
+        assert "quality" not in meta  # gpt-image-1 has no quality tiers
+
+    def test_env_var_override_unknown_model_passthrough(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_IMAGE_MODEL", "some-future-model")
+        model_id, meta = openai_plugin._resolve_model()
+        assert model_id == "some-future-model"
+        assert meta["api_model"] == "some-future-model"
+        assert "quality" not in meta
+
+    def test_env_var_override_empty_falls_back(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_IMAGE_MODEL", "")
+        # Empty string env var should not override; falls back to default
+        model_id, meta = openai_plugin._resolve_model()
+        assert model_id == "gpt-image-2-medium"
 
     def test_config_openai_model(self, tmp_path):
         import yaml
@@ -109,6 +136,7 @@ class TestModelResolution:
         model_id, meta = openai_plugin._resolve_model()
         assert model_id == "gpt-image-2-low"
         assert meta["quality"] == "low"
+        assert meta["api_model"] == "gpt-image-2"
 
     def test_config_top_level_model(self, tmp_path):
         """``image_gen.model: gpt-image-2-high`` also works (top-level)."""
@@ -119,6 +147,27 @@ class TestModelResolution:
         model_id, meta = openai_plugin._resolve_model()
         assert model_id == "gpt-image-2-high"
         assert meta["quality"] == "high"
+
+    def test_config_bare_model_name(self, tmp_path):
+        """Bare model names like ``gpt-image-1`` pass through config."""
+        import yaml
+        (tmp_path / "config.yaml").write_text(
+            yaml.safe_dump({"image_gen": {"model": "gpt-image-1"}})
+        )
+        model_id, meta = openai_plugin._resolve_model()
+        assert model_id == "gpt-image-1"
+        assert meta["api_model"] == "gpt-image-1"
+        assert "quality" not in meta
+
+    def test_config_custom_model_passthrough(self, tmp_path):
+        """Unknown model names from config pass through with default metadata."""
+        import yaml
+        (tmp_path / "config.yaml").write_text(
+            yaml.safe_dump({"image_gen": {"model": "my-custom-model"}})
+        )
+        model_id, meta = openai_plugin._resolve_model()
+        assert model_id == "my-custom-model"
+        assert meta["api_model"] == "my-custom-model"
 
 
 # ── Generate ────────────────────────────────────────────────────────────────
@@ -150,6 +199,7 @@ class TestGenerate:
         assert result["aspect_ratio"] == "landscape"
         assert result["provider"] == "openai"
         assert result["quality"] == "medium"
+        assert result["api_model"] == "gpt-image-2"
 
         saved = Path(result["image"])
         assert saved.exists()
@@ -157,19 +207,19 @@ class TestGenerate:
         assert saved.read_bytes() == png_bytes
 
         call_kwargs = fake_client.images.generate.call_args.kwargs
-        # All tiers hit the single underlying API model.
+        # Model sent to API should be the api_model, not the tier ID.
         assert call_kwargs["model"] == "gpt-image-2"
         assert call_kwargs["quality"] == "medium"
         assert call_kwargs["size"] == "1536x1024"
         # gpt-image-2 rejects response_format — we must NOT send it.
         assert "response_format" not in call_kwargs
 
-    @pytest.mark.parametrize("tier,expected_quality", [
-        ("gpt-image-2-low", "low"),
-        ("gpt-image-2-medium", "medium"),
-        ("gpt-image-2-high", "high"),
+    @pytest.mark.parametrize("tier,api_model,expected_quality", [
+        ("gpt-image-2-low", "gpt-image-2", "low"),
+        ("gpt-image-2-medium", "gpt-image-2", "medium"),
+        ("gpt-image-2-high", "gpt-image-2", "high"),
     ])
-    def test_tier_maps_to_quality(self, provider, monkeypatch, tier, expected_quality):
+    def test_gpt_image_2_tier_maps_correctly(self, provider, monkeypatch, tier, api_model, expected_quality):
         monkeypatch.setenv("OPENAI_IMAGE_MODEL", tier)
         fake_client = MagicMock()
         fake_client.images.generate.return_value = _fake_response(b64=_b64_png())
@@ -179,9 +229,60 @@ class TestGenerate:
 
         assert result["model"] == tier
         assert result["quality"] == expected_quality
+        assert result["api_model"] == api_model
         assert fake_client.images.generate.call_args.kwargs["quality"] == expected_quality
-        # Always the same underlying API model regardless of tier.
-        assert fake_client.images.generate.call_args.kwargs["model"] == "gpt-image-2"
+        assert fake_client.images.generate.call_args.kwargs["model"] == api_model
+
+    @pytest.mark.parametrize("tier,api_model,expected_quality", [
+        ("gpt-image-1.5-low", "gpt-image-1.5", "low"),
+        ("gpt-image-1.5-medium", "gpt-image-1.5", "medium"),
+        ("gpt-image-1.5-high", "gpt-image-1.5", "high"),
+    ])
+    def test_gpt_image_1_5_tier_maps_correctly(self, provider, monkeypatch, tier, api_model, expected_quality):
+        monkeypatch.setenv("OPENAI_IMAGE_MODEL", tier)
+        fake_client = MagicMock()
+        fake_client.images.generate.return_value = _fake_response(b64=_b64_png())
+
+        with _patched_openai(fake_client):
+            result = provider.generate("a cat")
+
+        assert result["model"] == tier
+        assert result["quality"] == expected_quality
+        assert result["api_model"] == api_model
+        assert fake_client.images.generate.call_args.kwargs["quality"] == expected_quality
+        assert fake_client.images.generate.call_args.kwargs["model"] == api_model
+
+    @pytest.mark.parametrize("model_id", ["gpt-image-1", "gpt-image-1-mini"])
+    def test_flat_models_no_quality_param(self, provider, monkeypatch, model_id):
+        """gpt-image-1 and gpt-image-1-mini do NOT accept the quality parameter."""
+        monkeypatch.setenv("OPENAI_IMAGE_MODEL", model_id)
+        fake_client = MagicMock()
+        fake_client.images.generate.return_value = _fake_response(b64=_b64_png())
+
+        with _patched_openai(fake_client):
+            result = provider.generate("a cat")
+
+        assert result["success"] is True
+        assert result["model"] == model_id
+        assert result["api_model"] == model_id
+        assert "quality" not in result
+        call_kwargs = fake_client.images.generate.call_args.kwargs
+        assert call_kwargs["model"] == model_id
+        assert "quality" not in call_kwargs
+
+    def test_custom_model_passthrough_generate(self, provider, monkeypatch):
+        """Unknown model names from env should pass through to the API."""
+        monkeypatch.setenv("OPENAI_IMAGE_MODEL", "future-model-x")
+        fake_client = MagicMock()
+        fake_client.images.generate.return_value = _fake_response(b64=_b64_png())
+
+        with _patched_openai(fake_client):
+            result = provider.generate("a cat")
+
+        assert result["success"] is True
+        assert result["api_model"] == "future-model-x"
+        assert fake_client.images.generate.call_args.kwargs["model"] == "future-model-x"
+        assert "quality" not in fake_client.images.generate.call_args.kwargs
 
     @pytest.mark.parametrize("aspect,expected_size", [
         ("landscape", "1536x1024"),


### PR DESCRIPTION
… support

The OpenAI image gen plugin hardcoded API_MODEL='gpt-image-2', making it impossible to use other OpenAI image models (gpt-image-1, gpt-image-1-mini, gpt-image-1.5) even when they are available on the user's project. The config key image_gen.model only selected quality tiers, and bare model names silently fell through to the default.

Changes:
- Replace hardcoded API_MODEL with per-entry api_model in _MODELS catalog
- Expand catalog: gpt-image-2 (low/med/high), gpt-image-1.5 (low/med/high), gpt-image-1 (flat), gpt-image-1-mini (flat)
- _resolve_model now accepts bare model names and unknown strings, passing them through with sensible defaults
- Conditionally include quality parameter only for models that support it (gpt-image-2, gpt-image-1.5); gpt-image-1 and gpt-image-1-mini omit it
- Config precedence unchanged: OPENAI_IMAGE_MODEL env > openai.model > model > default
- Default remains gpt-image-2-medium for backward compatibility

This also addresses the core issue raised in #18793 where third-party OpenAI-compatible backends need non-default model identifiers.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

