### PR TITLE
test(cli): accept force= kwarg on DummyAgent._compress_context

### DIFF
--- a/tests/test_cli_manual_compress.py
+++ b/tests/test_cli_manual_compress.py
@@ -10,13 +10,14 @@ class DummyAgent:
         self.session_id = "new-session"
         self.calls = []
 
-    def _compress_context(self, messages, system_message, *, approx_tokens=None, focus_topic=None):
+    def _compress_context(self, messages, system_message, *, approx_tokens=None, focus_topic=None, force=False):
         self.calls.append(
             {
                 "messages": messages,
                 "system_message": system_message,
                 "approx_tokens": approx_tokens,
                 "focus_topic": focus_topic,
+                "force": force,
             }
         )
         return ([{"role": "user", "content": "[CONTEXT SUMMARY]: compacted"}], "new system prompt")
@@ -53,5 +54,10 @@ def test_manual_compress_does_not_pass_cached_system_prompt(monkeypatch):
     assert call["system_message"] is None
     assert call["system_message"] != cli.agent._cached_system_prompt
     assert call["focus_topic"] == "database schema"
+    # Manual /compress must pass force=True so the user can retry after an
+    # auto-compress abort (the summary-failure cooldown is bypassed). Added
+    # by PR #28102; the DummyAgent.signature now accepts the kwarg to keep
+    # this assertion meaningful instead of swallowing the TypeError.
+    assert call["force"] is True
     assert cli.session_id == "new-session"
     assert cli._pending_title is None


### PR DESCRIPTION
## What does this PR do?

Aligns the `DummyAgent._compress_context` stub in `tests/test_cli_manual_compress.py` with the production signature after PR #28102 added `force=True` to the manual `/compress` code path.

Without this fix, `tests/test_cli_manual_compress.py::test_manual_compress_does_not_pass_cached_system_prompt` is a baseline failure on every open PR's CI. The CLI passes `force=True` ([cli.py:9194](https://github.com/NousResearch/hermes-agent/blob/main/cli.py#L9194)), the stub raises `TypeError: got an unexpected keyword argument 'force'`, the surrounding `except Exception` prints `❌ Compression failed`, and the test fails on `assert len(cli.agent.calls) == 1` because the append never ran.

## Related Issue

N/A — baseline CI fix surfaced by PR #28102 and observed on every open PR (e.g. https://github.com/NousResearch/hermes-agent/actions/runs/26068814560/job/76645496736).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tests/test_cli_manual_compress.py` — add `force=False` to `DummyAgent._compress_context` so the production call from `cli.HermesCLI._manual_compress` reaches the stub cleanly. Capture `force` in the call record and assert `call["force"] is True` so the manual-`/compress` contract from #28102 is covered by an explicit regression check rather than swallowed by the `TypeError → except Exception` path.

## How to Test

1. Reproduce the baseline failure on clean `origin/main`:
   `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/test_cli_manual_compress.py -v`
   → fails with `❌ Compression failed: DummyAgent._compress_context() got an unexpected keyword argument 'force'` and `assert 0 == 1`.
2. Apply this PR and rerun the same command → passes (1 passed).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`test(cli):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — only #27931 was touching CI drift and it covers the kanban dashboard fixture, not this test.
- [x] My PR contains **only** changes related to this fix (one test file)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added an explicit assertion for the production contract (`call["force"] is True`)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, test-only change
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — test is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Baseline failure on origin/main (from PR #24395's CI run, 2026-05-18):

```
FAILED tests/test_cli_manual_compress.py::test_manual_compress_does_not_pass_cached_system_prompt - assert 0 == 1
  ❌ Compression failed: DummyAgent._compress_context() got an unexpected keyword argument 'force'
```

Local run after this PR:

```
tests/test_cli_manual_compress.py::test_manual_compress_does_not_pass_cached_system_prompt PASSED
======================== 1 passed in 122.65s ========================
```

> Audited siblings: the other compression-test fallout from PR #28102 lives in `tests/run_agent/test_compression_boundary_hook.py` (MagicMock auto-creates a truthy `_last_compress_aborted` and steers the production code into the abort branch). That's addressed in [#27659](https://github.com/NousResearch/hermes-agent/pull/27659) — different test file, different root mechanism, kept separate to keep each diff minimal. No further widening needed.