### PR TITLE
fix: prevent WeCom adapter CPU spin when reconnect auth fails

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -352,7 +352,7 @@ class WeComAdapter(BasePlatformAdapter):
 
     async def _read_events(self) -> None:
         """Read websocket frames until the connection closes."""
-        if not self._ws:
+        if not self._ws or self._ws.closed:
             raise RuntimeError("WebSocket not connected")
 
         while self._running and self._ws and not self._ws.closed:


### PR DESCRIPTION
## Problem

When WeCom WebSocket authentication fails (e.g. expired secret, invalid bot config), the `_listen_loop` enters a **busy-spin at 100% CPU** that stalls the entire gateway asyncio event loop.

### Root cause

`_open_connection()` leaves `self._ws` pointing to a **closed** WebSocket object after a handshake failure. `_read_events()` only checked `if not self._ws:` — a closed but non-None ws passed this check, the inner `while` loop exited immediately (because `self._ws.closed` is True), and `_read_events()` returned without raising. Since no exception was raised, the outer `_listen_loop` skipped the reconnect-backoff-sleep path and reset `backoff_idx` to 0, creating a tight no-await loop.

### Fix

Add `or self._ws.closed` to the guard in `_read_events()` so that a closed WebSocket correctly raises `RuntimeError("WebSocket not connected")`, allowing the normal exponential backoff reconnection logic to take over.

### Impact

Without this fix, a failed WeCom auth (which happens every ~5min due to WeCom server behavior + expired config) freezes the entire gateway — all other platforms (Feishu, DingTalk) lose message processing. The process survives but consumes ~72% CPU doing nothing useful.
