### PR TITLE
fix(cron): cap session_id at 64 chars to satisfy prompt_cache_key limit

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -11,6 +11,7 @@ runs at a time if multiple processes overlap.
 import asyncio
 import concurrent.futures
 import contextvars
+import hashlib
 import json
 import logging
 import os
@@ -231,6 +232,22 @@ def _resolve_origin(job: dict) -> Optional[dict]:
     if platform and chat_id:
         return origin
     return None
+
+
+# OpenAI/xAI `prompt_cache_key` has a 64-char hard limit. The cron session id
+# is `cron_{job_id}_{YYYYMMDD_HHMMSS}` (21 chars overhead), leaving 43 chars
+# for the job_id. Longer job_ids get a hash suffix so two truncated names
+# don't share a cache scope.
+_CRON_SESSION_KEY_MAX = 64
+_CRON_SESSION_KEY_OVERHEAD = len("cron__YYYYMMDD_HHMMSS")  # 21
+_MAX_JOB_ID_IN_SESSION_KEY = _CRON_SESSION_KEY_MAX - _CRON_SESSION_KEY_OVERHEAD
+
+
+def _safe_job_id_for_session(job_id: str) -> str:
+    if len(job_id) <= _MAX_JOB_ID_IN_SESSION_KEY:
+        return job_id
+    digest = hashlib.sha1(job_id.encode("utf-8")).hexdigest()[:8]
+    return f"{job_id[:_MAX_JOB_ID_IN_SESSION_KEY - 9]}-{digest}"
 
 
 def _plugin_cron_env_var(platform_name: str) -> str:
@@ -1285,7 +1302,10 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         logger.info("Job '%s': script produced no output, skipping AI call.", job_name)
         return True, "", SILENT_MARKER, None
     origin = _resolve_origin(job)
-    _cron_session_id = f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"
+    _cron_session_id = (
+        f"cron_{_safe_job_id_for_session(job_id)}_"
+        f"{_hermes_now().strftime('%Y%m%d_%H%M%S')}"
+    )
 
     logger.info("Running job '%s' (ID: %s)", job_name, job_id)
     logger.info("Prompt: %s", prompt[:100])

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
 
-from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, run_job, SILENT_MARKER, _build_job_prompt
+from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, run_job, SILENT_MARKER, _build_job_prompt, _safe_job_id_for_session, _MAX_JOB_ID_IN_SESSION_KEY
 from tools.env_passthrough import clear_env_passthrough
 from tools.credential_files import clear_credential_files
 
@@ -2386,3 +2386,27 @@ class TestSendMediaTimeoutCancelsFuture:
         # 2. Second file still got dispatched — one timeout doesn't abort the batch
         adapter.send_video.assert_called_once()
         assert adapter.send_video.call_args[1]["video_path"] == "/tmp/fast.mp4"
+
+
+class TestSafeJobIdForSession:
+    """Regression: prompt_cache_key (=session_id) must stay <=64 chars (API limit)."""
+
+    def test_short_job_id_passthrough(self):
+        assert _safe_job_id_for_session("foo") == "foo"
+        boundary = "a" * _MAX_JOB_ID_IN_SESSION_KEY
+        assert _safe_job_id_for_session(boundary) == boundary
+
+    def test_long_job_id_truncated_with_hash(self):
+        # The job that originally tripped the 400 from OpenAI/xAI.
+        job_id = "oneshot-plan-b-merge-transition-into-evaluation"
+        assert len(job_id) > _MAX_JOB_ID_IN_SESSION_KEY
+        out = _safe_job_id_for_session(job_id)
+        assert len(out) == _MAX_JOB_ID_IN_SESSION_KEY
+        # Final session_id stays under the 64-char API ceiling.
+        sid = f"cron_{out}_20260519_093057"
+        assert len(sid) == 64
+
+    def test_truncated_ids_dont_collide_on_shared_prefix(self):
+        a = _safe_job_id_for_session("oneshot-plan-b-merge-transition-into-evaluation")
+        b = _safe_job_id_for_session("oneshot-plan-b-merge-transition-into-evaluation-v2")
+        assert a != b


### PR DESCRIPTION
## What does this PR do?

Cron jobs with a job_id longer than 43 characters fail at first fire with HTTP 400 from OpenAI / xAI:

```
RuntimeError: Error code: 400 - {'error': {'message': "Invalid 'prompt_cache_key': string too long. Expected a string with maximum length 64, but got a string with length 68 instead.", 'type': 'invalid_request_error', 'param': 'prompt_cache_key', 'code': 'string_above_max_length'}}
```

Root cause is in `cron/scheduler.py`: the session id passed to `run_agent(...)` (and from there to `prompt_cache_key` on the Responses API) is built as

```python
_cron_session_id = f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"
```

The fixed `cron_` + `_YYYYMMDD_HHMMSS` overhead is 21 chars, leaving only 43 chars for `job_id` before the assembled key blows past the API's 64-char `prompt_cache_key` cap. There is no length validation when jobs are created, and no defensive truncation at the transport layer (`agent/transports/codex.py` passes the session id straight through), so a single long-named oneshot is enough to silently break.

This PR truncates over-long job_ids when building the cache key, appending an 8-char sha1 suffix so two long names that share a prefix don't collide on the same cache scope. Short job_ids (≤ 43 chars) are unchanged — there is no behavior change for any existing cron job whose id fits.

## Related Issue

No existing issue — I searched `prompt_cache_key`, `session_id length`, and `cron 400` against the open issue list and found nothing matching.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cron/scheduler.py`:
  - Add `_safe_job_id_for_session(job_id)` helper near `_resolve_origin` that truncates long job_ids to `64 - len("cron__YYYYMMDD_HHMMSS") = 43` chars and appends an 8-char sha1 digest for collision resistance.
  - Use it when building `_cron_session_id` at the existing call site.
  - Add `import hashlib`.
- `tests/cron/test_scheduler.py`:
  - New `TestSafeJobIdForSession` class with three regression tests:
    - Short id is passed through unchanged (including the 43-char boundary).
    - The originally tripping job_id (`oneshot-plan-b-merge-transition-into-evaluation`, 47 chars) yields a 43-char safe id and a final session id of exactly 64 chars.
    - Two long job_ids that share the truncation prefix don't collide.

## How to Test

Reproduce the bug on `main`:

1. Create a oneshot whose id is > 43 chars (e.g. via `hermes cron create` with a long `--name`, or any job whose auto-generated id ends up long).
2. Let it fire. The job fails with the 400 above and never runs.

Verify the fix on this branch:

1. Same setup. The job fires successfully; `prompt_cache_key` is now ≤ 64 chars.
2. Run the new regression tests:
   ```
   pytest tests/cron/test_scheduler.py -k SafeJobId -v
   ```
3. Full cron suite still passes:
   ```
   pytest tests/cron/ -q   # 370 passed
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(cron): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/cron/ -q` and `pytest tests/cron/test_scheduler.py -k SafeJobId -v` and all relevant tests pass. The broader `pytest tests/ -q` run on my machine surfaces 5 pre-existing failures in `tests/gateway/test_discord_*`, `tests/agent/test_anthropic_adapter.py`, and `tests/acp/test_edit_approval.py` that are unrelated to this change (they reproduce on `HEAD~1` without these edits; the acp failure is an env-specific `/private/var/folders` sensitive-path refusal).
- [x] I've added tests for my changes (3 new regression tests in `TestSafeJobIdForSession`)
- [x] I've tested on my platform: macOS 15 (Darwin 25.3.0), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (helper is private; behavior change is invisible to anyone whose job_ids already fit)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (pure stdlib, sha1 + slicing)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

The error as observed in the wild (cron output dump):

```
Cron job 'oneshot-<elided-long-id>' failed:
RuntimeError: Error code: 400 - {'error': {'message': "Invalid 'prompt_cache_key': string too long. Expected a string with maximum length 64, but got a string with length 68 instead.", 'type': 'invalid_request_error', 'param': 'prompt_cache_key', 'code': 'string_above_max_length'}}
```

After the fix, the corresponding `prompt_cache_key` is 64 chars exactly:

```
cron_<34-char-prefix>-<8-char-sha1>_20260519_093057
```