### PR TITLE
fix(paths): stop legacy Hermes home recreation

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -13,7 +13,7 @@ def _hermes_home_path() -> Path:
         from hermes_constants import get_hermes_home  # local import to avoid cycles
         return get_hermes_home()
     except Exception:
-        return Path(os.path.expanduser("~/.hermes"))
+        return Path(os.path.expanduser("~/.hermes-recommended"))
 
 
 def build_write_denied_paths(home: str) -> set[str]:

--- a/agent/lsp/install.py
+++ b/agent/lsp/install.py
@@ -114,7 +114,7 @@ def hermes_lsp_bin_dir() -> Path:
     """Return the Hermes-owned bin staging dir for LSP servers."""
     home = os.environ.get("HERMES_HOME")
     if home is None:
-        home = os.path.join(os.path.expanduser("~"), ".hermes")
+        home = os.path.join(os.path.expanduser("~"), ".hermes-recommended")
     p = Path(home) / "lsp" / "bin"
     p.mkdir(parents=True, exist_ok=True)
     return p

--- a/agent/nous_rate_guard.py
+++ b/agent/nous_rate_guard.py
@@ -32,7 +32,7 @@ def _state_path() -> str:
         from hermes_constants import get_hermes_home
         base = get_hermes_home()
     except ImportError:
-        base = os.path.join(os.path.expanduser("~"), ".hermes")
+        base = os.path.join(os.path.expanduser("~"), ".hermes-recommended")
     return os.path.join(base, _STATE_SUBDIR, _STATE_FILENAME)
 
 

--- a/agent/transports/codex_app_server.py
+++ b/agent/transports/codex_app_server.py
@@ -94,7 +94,7 @@ class CodexAppServerClient:
                 else spawn_env.get(
                     "HERMES_KANBAN_ROOT",
                     os.path.join(
-                        spawn_env.get("HERMES_HOME", os.path.expanduser("~/.hermes")),
+                        spawn_env.get("HERMES_HOME", os.path.expanduser("~/.hermes-recommended")),
                         "kanban",
                     ),
                 )

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -806,7 +806,7 @@ def _auth_file_path() -> Path:
     # hermetic conftest, or sandbox escapes via threads/subprocesses. In
     # production (no PYTEST_CURRENT_TEST) this is a single dict lookup.
     if os.environ.get("PYTEST_CURRENT_TEST"):
-        real_home_auth = (Path.home() / ".hermes" / "auth.json").resolve(strict=False)
+        real_home_auth = (Path.home() / ".hermes-recommended" / "auth.json").resolve(strict=False)
         try:
             resolved = path.resolve(strict=False)
         except Exception:

--- a/hermes_cli/completion.py
+++ b/hermes_cli/completion.py
@@ -102,7 +102,7 @@ def generate_bash(parser: argparse.ArgumentParser) -> str:
 #   eval "$(hermes completion bash)"
 
 _hermes_profiles() {{
-    local profiles_dir="$HOME/.hermes/profiles"
+    local profiles_dir="${{HERMES_HOME:-$HOME/.hermes-recommended}}/profiles"
     local profiles="default"
     if [ -d "$profiles_dir" ]; then
         profiles="$profiles $(ls "$profiles_dir" 2>/dev/null)"
@@ -205,8 +205,9 @@ def generate_zsh(parser: argparse.ArgumentParser) -> str:
 _hermes_profiles() {{
     local -a profiles
     profiles=(default)
-    if [[ -d "$HOME/.hermes/profiles" ]]; then
-        profiles+=("${{(@f)$(ls $HOME/.hermes/profiles 2>/dev/null)}}")
+    local profiles_dir="${{HERMES_HOME:-$HOME/.hermes-recommended}}/profiles"
+    if [[ -d "$profiles_dir" ]]; then
+        profiles+=("${{(@f)$(ls "$profiles_dir" 2>/dev/null)}}")
     fi
     _describe 'profile' profiles
 }}
@@ -259,8 +260,12 @@ def generate_fish(parser: argparse.ArgumentParser) -> str:
         "# Helper: list available profiles",
         "function __hermes_profiles",
         "    echo default",
-        "    if test -d $HOME/.hermes/profiles",
-        "        ls $HOME/.hermes/profiles 2>/dev/null",
+        "    set -l profiles_dir \"$HERMES_HOME\"",
+        "    if test -z \"$profiles_dir\"",
+        "        set profiles_dir \"$HOME/.hermes-recommended\"",
+        "    end",
+        "    if test -d \"$profiles_dir/profiles\"",
+        "        ls \"$profiles_dir/profiles\" 2>/dev/null",
         "    end",
         "end",
         "",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3475,7 +3475,7 @@ def warn_deprecated_cwd_env_vars(config: Optional[Dict[str, Any]] = None) -> Non
             f"this is deprecated."
         )
     if lines:
-        hint_path = os.environ.get("HERMES_HOME", "~/.hermes")
+        hint_path = os.environ.get("HERMES_HOME", "~/.hermes-recommended")
         lines.insert(0, "\033[33m⚠ Deprecated .env settings detected:\033[0m")
         lines.append(
             f"  \033[2mMove to config.yaml instead:  "

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -154,7 +154,7 @@ def load_hermes_dotenv(
     """
     loaded: list[Path] = []
 
-    home_path = Path(hermes_home or os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+    home_path = Path(hermes_home or os.getenv("HERMES_HOME", Path.home() / ".hermes-recommended"))
     user_env = home_path / ".env"
     project_env_path = Path(project_env) if project_env else None
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2084,25 +2084,30 @@ def _hermes_home_for_target_user(target_home_dir: str) -> str:
 
     When installing a system service via sudo, get_hermes_home() resolves to
     root's home.  This translates it to the target user's equivalent path:
-      /root/.hermes                    → /home/alice/.hermes
-      /root/.hermes/profiles/coder     → /home/alice/.hermes/profiles/coder
+      /root/.hermes-recommended                    → /home/alice/.hermes-recommended
+      /root/.hermes-recommended/profiles/coder     → /home/alice/.hermes-recommended/profiles/coder
+      /root/.hermes                                → /home/alice/.hermes
+      /root/.hermes/profiles/coder                 → /home/alice/.hermes/profiles/coder
       /opt/custom-hermes               → /opt/custom-hermes  (kept as-is)
     """
     current_hermes = get_hermes_home().resolve()
-    current_default = (Path.home() / ".hermes").resolve()
-    target_default = Path(target_home_dir) / ".hermes"
+    for dirname in (".hermes-recommended", ".hermes"):
+        current_default = (Path.home() / dirname).resolve()
+        target_default = Path(target_home_dir) / dirname
 
-    # Default ~/.hermes → remap to target user's default
-    if current_hermes == current_default:
-        return str(target_default)
+        # Default home → remap to target user's default.
+        if current_hermes == current_default:
+            return str(target_default)
 
-    # Profile or subdir of ~/.hermes → preserve the relative structure
-    try:
-        relative = current_hermes.relative_to(current_default)
-        return str(target_default / relative)
-    except ValueError:
-        # Completely custom path (not under ~/.hermes) — keep as-is
-        return str(current_hermes)
+        # Profile or subdir of the home → preserve the relative structure.
+        try:
+            relative = current_hermes.relative_to(current_default)
+            return str(target_default / relative)
+        except ValueError:
+            pass
+
+    # Completely custom path (not under Hermes homes) — keep as-is.
+    return str(current_hermes)
 
 
 def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -989,7 +989,7 @@ def _ensure_tui_node() -> None:
     if not helper.is_file():
         return
 
-    hermes_home = os.environ.get("HERMES_HOME") or str(Path.home() / ".hermes")
+    hermes_home = os.environ.get("HERMES_HOME") or str(Path.home() / ".hermes-recommended")
     try:
         # Helper writes logs to stderr; we ask bash to print `command -v node`
         # on stdout once ensure_node succeeds. Subshell PATH edits don't leak

--- a/hermes_cli/slack_cli.py
+++ b/hermes_cli/slack_cli.py
@@ -135,7 +135,7 @@ def slack_manifest_command(args) -> int:
 
                 target = Path(get_hermes_home()) / "slack-manifest.json"
             except Exception:
-                target = Path(os.environ.get("HERMES_HOME") or str(Path.home() / ".hermes")) / "slack-manifest.json"
+                target = Path(os.environ.get("HERMES_HOME") or str(Path.home() / ".hermes-recommended")) / "slack-manifest.json"
         else:
             target = Path(write_target).expanduser()
         target.parent.mkdir(parents=True, exist_ok=True)

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -40,16 +40,16 @@ def get_hermes_home_override() -> str | None:
 
 
 def get_hermes_home() -> Path:
-    """Return the Hermes home directory (default: ~/.hermes).
+    """Return the Hermes home directory (default: ~/.hermes-recommended).
 
-    Reads HERMES_HOME env var, falls back to ~/.hermes.
+    Reads HERMES_HOME env var, falls back to ~/.hermes-recommended.
     This is the single source of truth — all other copies should import this.
 
     When ``HERMES_HOME`` is unset but an ``active_profile`` file indicates
     a non-default profile is active, logs a loud one-shot warning to
     ``errors.log`` so cross-profile data corruption is diagnosable instead
     of silent.  Behavior is unchanged otherwise — we still return
-    ``~/.hermes`` — because raising here would brick 30+ module-level
+    ``~/.hermes-recommended`` — because raising here would brick 30+ module-level
     callers that import this at load time.  Subprocess spawners are
     expected to propagate ``HERMES_HOME`` explicitly (see the systemd
     template in ``hermes_cli/gateway.py`` and the kanban dispatcher in
@@ -71,7 +71,7 @@ def get_hermes_home() -> Path:
             # Inline the default-root resolution from get_default_hermes_root()
             # to stay import-safe (this function is called from module scope
             # in 30+ files; we cannot afford to trigger logging setup here).
-            active_path = (Path.home() / ".hermes" / "active_profile")
+            active_path = (Path.home() / ".hermes-recommended" / "active_profile")
             active = active_path.read_text().strip() if active_path.exists() else ""
         except (UnicodeDecodeError, OSError):
             active = ""
@@ -85,7 +85,7 @@ def get_hermes_home() -> Path:
             import sys
             msg = (
                 f"[HERMES_HOME fallback] HERMES_HOME is unset but active "
-                f"profile is {active!r}. Falling back to ~/.hermes, which "
+                f"profile is {active!r}. Falling back to ~/.hermes-recommended, which "
                 f"is the DEFAULT profile — not {active!r}. Any data this "
                 f"process writes will land in the wrong profile. The "
                 f"subprocess spawner should pass HERMES_HOME explicitly "
@@ -97,26 +97,26 @@ def get_hermes_home() -> Path:
             except Exception:
                 pass
 
-    return Path.home() / ".hermes"
+    return Path.home() / ".hermes-recommended"
 
 
 def get_default_hermes_root() -> Path:
     """Return the root Hermes directory for profile-level operations.
 
-    In standard deployments this is ``~/.hermes``.
+    In standard deployments this is ``~/.hermes-recommended``.
 
     In Docker or custom deployments where ``HERMES_HOME`` points outside
-    ``~/.hermes`` (e.g. ``/opt/data``), returns ``HERMES_HOME`` directly
+    ``~/.hermes-recommended`` (e.g. ``/opt/data``), returns ``HERMES_HOME`` directly
     — that IS the root.
 
     In profile mode where ``HERMES_HOME`` is ``<root>/profiles/<name>``,
     returns ``<root>`` so that ``profile list`` can see all profiles.
-    Works both for standard (``~/.hermes/profiles/coder``) and Docker
+    Works both for standard (``~/.hermes-recommended/profiles/coder``) and Docker
     (``/opt/data/profiles/coder``) layouts.
 
     Import-safe — no dependencies beyond stdlib.
     """
-    native_home = Path.home() / ".hermes"
+    native_home = Path.home() / ".hermes-recommended"
     env_home = os.environ.get("HERMES_HOME", "")
     if not env_home:
         return native_home
@@ -179,8 +179,8 @@ def display_hermes_home() -> str:
 
     Uses ``~/`` shorthand for readability::
 
-        default:  ``~/.hermes``
-        profile:  ``~/.hermes/profiles/coder``
+        default:  ``~/.hermes-recommended``
+        profile:  ``~/.hermes-recommended/profiles/coder``
         custom:   ``/opt/hermes-custom``
 
     Use this in **user-facing** print/log messages instead of hardcoding

--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -65,7 +65,7 @@ def _get_sessions_dir() -> Path:
         from hermes_constants import get_hermes_home
         return get_hermes_home() / "sessions"
     except ImportError:
-        return Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes")) / "sessions"
+        return Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes-recommended")) / "sessions"
 
 
 def _get_session_db():
@@ -102,7 +102,7 @@ def _load_channel_directory() -> dict:
         directory_file = get_hermes_home() / "channel_directory.json"
     except ImportError:
         directory_file = Path(
-            os.environ.get("HERMES_HOME", Path.home() / ".hermes")
+            os.environ.get("HERMES_HOME", Path.home() / ".hermes-recommended")
         ) / "channel_directory.json"
 
     if not directory_file.exists():
@@ -365,7 +365,7 @@ class EventBridge:
             from hermes_constants import get_hermes_home
             db_file = get_hermes_home() / "state.db"
         except ImportError:
-            db_file = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes")) / "state.db"
+            db_file = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes-recommended")) / "state.db"
 
         try:
             db_mtime = db_file.stat().st_mtime if db_file.exists() else 0.0

--- a/optional-skills/blockchain/hyperliquid/scripts/hyperliquid_client.py
+++ b/optional-skills/blockchain/hyperliquid/scripts/hyperliquid_client.py
@@ -46,7 +46,7 @@ DEFAULT_API_BASE = "https://api.hyperliquid.xyz"
 
 
 def _hermes_home() -> Path:
-    return Path(os.environ.get("HERMES_HOME", "~/.hermes")).expanduser()
+    return Path(os.environ.get("HERMES_HOME", "~/.hermes-recommended")).expanduser()
 
 
 def _dotenv_paths() -> List[Path]:

--- a/optional-skills/creative/kanban-video-orchestrator/assets/setup.sh.tmpl
+++ b/optional-skills/creative/kanban-video-orchestrator/assets/setup.sh.tmpl
@@ -23,8 +23,8 @@ check_key() {
     local var="$1"
     local kc_account="${2:-hermes}"
     local kc_service="${3:-$1}"
-    if grep -q "^${var}=" "$HOME/.hermes/.env" 2>/dev/null && \
-       [ -n "$(grep "^${var}=" "$HOME/.hermes/.env" | cut -d= -f2-)" ]; then
+    if grep -q "^${var}=" "${HERMES_HOME:-$HOME/.hermes-recommended}/.env" 2>/dev/null && \
+       [ -n "$(grep "^${var}=" "${HERMES_HOME:-$HOME/.hermes-recommended}/.env" | cut -d= -f2-)" ]; then
         echo "  ✓ ${var} (env)"
         return 0
     fi

--- a/optional-skills/creative/kanban-video-orchestrator/scripts/bootstrap_pipeline.py
+++ b/optional-skills/creative/kanban-video-orchestrator/scripts/bootstrap_pipeline.py
@@ -361,7 +361,7 @@ def render_setup_sh(plan: dict, brief_md: str, team_md: str) -> str:
     soul_writes = []
     for t in plan["team"]:
         soul_writes.append(
-            f'cat > "$HOME/.hermes/profiles/{t["profile"]}/SOUL.md" <<\'SOUL_EOF\'\n'
+            f'cat > "${{HERMES_HOME:-$HOME/.hermes-recommended}}/profiles/{t["profile"]}/SOUL.md" <<\'SOUL_EOF\'\n'
             f"{render_soul_md(t, plan)}\n"
             f"SOUL_EOF\n"
             f'echo "  ✓ SOUL.md for {t["profile"]}"'

--- a/optional-skills/devops/watchers/scripts/_watermark.py
+++ b/optional-skills/devops/watchers/scripts/_watermark.py
@@ -33,7 +33,7 @@ def _state_dir() -> Path:
     if override:
         return Path(override)
     # Default: $HERMES_HOME/watcher-state/, falling back to ~/.hermes/watcher-state/.
-    hermes_home = os.environ.get("HERMES_HOME") or str(Path.home() / ".hermes")
+    hermes_home = os.environ.get("HERMES_HOME") or str(Path.home() / ".hermes-recommended")
     return Path(hermes_home) / "watcher-state"
 
 

--- a/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
+++ b/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
@@ -2960,7 +2960,7 @@ class Migrator:
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Migrate OpenClaw user state into Hermes Agent.")
     parser.add_argument("--source", default=str(Path.home() / ".openclaw"), help="OpenClaw home directory")
-    parser.add_argument("--target", default=os.environ.get("HERMES_HOME") or str(Path.home() / ".hermes"), help="Hermes home directory")
+    parser.add_argument("--target", default=os.environ.get("HERMES_HOME") or str(Path.home() / ".hermes-recommended"), help="Hermes home directory")
     parser.add_argument(
         "--workspace-target",
         help="Optional workspace root where the workspace instructions file should be copied",

--- a/optional-skills/productivity/memento-flashcards/scripts/memento_cards.py
+++ b/optional-skills/productivity/memento-flashcards/scripts/memento_cards.py
@@ -15,7 +15,7 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-_HERMES_HOME = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+_HERMES_HOME = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes-recommended"))
 DATA_DIR = _HERMES_HOME / "skills" / "productivity" / "memento-flashcards" / "data"
 CARDS_FILE = DATA_DIR / "cards.json"
 

--- a/optional-skills/productivity/telephony/scripts/telephony.py
+++ b/optional-skills/productivity/telephony/scripts/telephony.py
@@ -69,7 +69,7 @@ class OwnedTwilioNumber:
 
 
 def _hermes_home() -> Path:
-    return Path(os.environ.get("HERMES_HOME", "~/.hermes")).expanduser()
+    return Path(os.environ.get("HERMES_HOME", "~/.hermes-recommended")).expanduser()
 
 
 def _env_path() -> Path:

--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -35,7 +35,7 @@ except Exception:  # pragma: no cover — plugin may load before constants resol
 
     def get_hermes_home() -> Path:  # type: ignore[no-redef]
         val = (os.environ.get("HERMES_HOME") or "").strip()
-        return Path(val).resolve() if val else (Path.home() / ".hermes").resolve()
+        return Path(val).resolve() if val else (Path.home() / ".hermes-recommended").resolve()
 
 
 logger = logging.getLogger(__name__)

--- a/plugins/hermes-achievements/dashboard/plugin_api.py
+++ b/plugins/hermes-achievements/dashboard/plugin_api.py
@@ -18,7 +18,7 @@ except ImportError:
     import os as _os
     def get_hermes_home() -> Path:  # type: ignore[misc]
         val = (_os.environ.get("HERMES_HOME") or "").strip()
-        return Path(val) if val else Path.home() / ".hermes"
+        return Path(val) if val else Path.home() / ".hermes-recommended"
 
 try:
     from fastapi import APIRouter

--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -525,7 +525,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
             from hermes_constants import get_hermes_home as _get_hermes_home
             _hermes_home = _get_hermes_home()
         except (ModuleNotFoundError, ImportError):
-            _hermes_home = _Path.home() / ".hermes"
+            _hermes_home = _Path.home() / ".hermes-recommended"
         self._thread_count_store = _ThreadCountStore(
             _hermes_home / "google_chat_thread_counts.json"
         )
@@ -689,7 +689,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
     def _bot_id_cache_path(self) -> _Path:
         """Location where the resolved bot user_id is cached across restarts."""
-        base = os.getenv("HERMES_HOME", str(_Path.home() / ".hermes"))
+        base = os.getenv("HERMES_HOME", str(_Path.home() / ".hermes-recommended"))
         return _Path(base) / "google_chat_bot_id.json"
 
     def _load_cached_bot_id(self) -> Optional[str]:

--- a/plugins/platforms/google_chat/oauth.py
+++ b/plugins/platforms/google_chat/oauth.py
@@ -80,7 +80,7 @@ except (ModuleNotFoundError, ImportError):
     # _hermes_home.py shim).
     def get_hermes_home() -> Path:
         val = os.environ.get("HERMES_HOME", "").strip()
-        return Path(val) if val else Path.home() / ".hermes"
+        return Path(val) if val else Path.home() / ".hermes-recommended"
 
     def display_hermes_home() -> str:
         home = get_hermes_home()

--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -1285,7 +1285,7 @@ class LineAdapter(BasePlatformAdapter):
             from hermes_constants import get_hermes_home
             hermes_home = Path(get_hermes_home()).resolve()
         except Exception:
-            hermes_home = Path.home().joinpath(".hermes").resolve()
+            hermes_home = Path.home().joinpath(".hermes-recommended").resolve()
 
         allowed_roots = {
             Path(tempfile.gettempdir()).resolve(),

--- a/scripts/build_model_catalog.py
+++ b/scripts/build_model_catalog.py
@@ -31,7 +31,7 @@ REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, REPO_ROOT)
 
 # Ensure HERMES_HOME is set for imports that touch it at module level.
-os.environ.setdefault("HERMES_HOME", os.path.join(os.path.expanduser("~"), ".hermes"))
+os.environ.setdefault("HERMES_HOME", os.path.join(os.path.expanduser("~"), ".hermes-recommended"))
 
 from hermes_cli.models import OPENROUTER_MODELS, _PROVIDER_MODELS  # noqa: E402
 

--- a/scripts/build_skills_index.py
+++ b/scripts/build_skills_index.py
@@ -29,7 +29,7 @@ REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, REPO_ROOT)
 
 # Ensure HERMES_HOME is set (needed by tools/skills_hub.py imports)
-os.environ.setdefault("HERMES_HOME", os.path.join(os.path.expanduser("~"), ".hermes"))
+os.environ.setdefault("HERMES_HOME", os.path.join(os.path.expanduser("~"), ".hermes-recommended"))
 
 from tools.skills_hub import (
     GitHubAuth,

--- a/scripts/discord-voice-doctor.py
+++ b/scripts/discord-voice-doctor.py
@@ -19,7 +19,7 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 PROJECT_ROOT = SCRIPT_DIR.parent
 sys.path.insert(0, str(PROJECT_ROOT))
 
-HERMES_HOME = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+HERMES_HOME = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes-recommended"))
 ENV_FILE = HERMES_HOME / ".env"
 
 OK = "\033[92m\u2713\033[0m"

--- a/scripts/hermes-gateway
+++ b/scripts/hermes-gateway
@@ -173,7 +173,7 @@ def generate_launchd_plist() -> str:
     python_path = get_python_path()
     script_path = get_gateway_script_path()
     working_dir = str(PROJECT_DIR)
-    log_dir = Path.home() / ".hermes" / "logs"
+    log_dir = Path.home() / ".hermes-recommended" / "logs"
     
     return f"""<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -222,7 +222,7 @@ def install_launchd():
     plist_path.parent.mkdir(parents=True, exist_ok=True)
     
     # Ensure log directory exists
-    log_dir = Path.home() / ".hermes" / "logs"
+    log_dir = Path.home() / ".hermes-recommended" / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)
     
     print(f"Installing launchd service to: {plist_path}")

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -45,7 +45,7 @@ BOLD='\033[1m'
 # Configuration
 REPO_URL_SSH="git@github.com:NousResearch/hermes-agent.git"
 REPO_URL_HTTPS="https://github.com/NousResearch/hermes-agent.git"
-HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes-recommended}"
 # INSTALL_DIR is resolved AFTER arg parsing and OS detection so we can pick an
 # FHS-style layout for root installs.  Track whether the user gave us an
 # explicit directory — if so we never override it.

--- a/scripts/lib/node-bootstrap.sh
+++ b/scripts/lib/node-bootstrap.sh
@@ -20,12 +20,12 @@
 # Env inputs (set before sourcing to override defaults):
 #   HERMES_NODE_MIN_VERSION   (default: 20)   — accepted on PATH
 #   HERMES_NODE_TARGET_MAJOR  (default: 22)   — installed when we install
-#   HERMES_HOME               (default: $HOME/.hermes)
+#   HERMES_HOME               (default: $HOME/.hermes-recommended)
 # ============================================================================
 
 HERMES_NODE_MIN_VERSION="${HERMES_NODE_MIN_VERSION:-20}"
 HERMES_NODE_TARGET_MAJOR="${HERMES_NODE_TARGET_MAJOR:-22}"
-HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes-recommended}"
 HERMES_NODE_AVAILABLE=false
 
 # ---------------------------------------------------------------------------

--- a/scripts/profile-tui.py
+++ b/scripts/profile-tui.py
@@ -42,7 +42,7 @@ try:
 except ImportError:
     def get_hermes_home() -> Path:  # type: ignore[misc]
         val = (os.environ.get("HERMES_HOME") or "").strip()
-        return Path(val) if val else Path.home() / ".hermes"
+        return Path(val) if val else Path.home() / ".hermes-recommended"
 
 DEFAULT_TUI_DIR = Path(
     os.environ.get("HERMES_TUI_DIR")

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -27,7 +27,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # Prefer a .venv in the current tree, fall back to the main checkout's venv
 # (useful for worktrees where we don't always duplicate the venv).
 VENV=""
-for candidate in "$REPO_ROOT/.venv" "$REPO_ROOT/venv" "$HOME/.hermes/hermes-agent/venv"; do
+for candidate in "$REPO_ROOT/.venv" "$REPO_ROOT/venv" "$HOME/.hermes-recommended/hermes-agent/venv"; do
   if [ -f "$candidate/bin/activate" ]; then
     VENV="$candidate"
     break
@@ -89,14 +89,22 @@ export PYTHONHASHSEED=0
 
 # ── Live-gateway test guard (developer machines) ────────────────────────────
 # If a system-wide hermes pytest_live_guard plugin is installed at
-# $HOME/.hermes/pytest_live_guard.py, force-load it here so every test run
+# $HOME/.hermes-recommended/pytest_live_guard.py, force-load it here so every test run
 # from this script gets the protection regardless of which worktree is
 # checked out (in-tree tests/conftest.py guard may be missing on stale
 # branches). Harmless on CI / fresh machines that don't have the file.
-if [ -f "$HOME/.hermes/pytest_live_guard.py" ]; then
+PYTEST_LIVE_GUARD_HOME=""
+for guard_home in "$HOME/.hermes-recommended"; do
+  if [ -f "$guard_home/pytest_live_guard.py" ]; then
+    PYTEST_LIVE_GUARD_HOME="$guard_home"
+    break
+  fi
+done
+
+if [ -n "$PYTEST_LIVE_GUARD_HOME" ]; then
   case ":${PYTHONPATH:-}:" in
-    *":$HOME/.hermes:"*) ;;
-    *) export PYTHONPATH="${PYTHONPATH:+$PYTHONPATH:}$HOME/.hermes" ;;
+    *":$PYTEST_LIVE_GUARD_HOME:"*) ;;
+    *) export PYTHONPATH="${PYTHONPATH:+$PYTHONPATH:}$PYTEST_LIVE_GUARD_HOME" ;;
   esac
   if [[ ",${PYTEST_PLUGINS:-}," != *,pytest_live_guard,* ]]; then
     export PYTEST_PLUGINS="${PYTEST_PLUGINS:+$PYTEST_PLUGINS,}pytest_live_guard"

--- a/scripts/setup_open_webui.sh
+++ b/scripts/setup_open_webui.sh
@@ -31,14 +31,14 @@ OPEN_WEBUI_ENABLE_SIGNUP="${OPEN_WEBUI_ENABLE_SIGNUP:-true}"
 OPEN_WEBUI_ENABLE_SERVICE="${OPEN_WEBUI_ENABLE_SERVICE:-auto}"
 OPEN_WEBUI_VENV="${OPEN_WEBUI_VENV:-$HOME/.local/open-webui-venv}"
 OPEN_WEBUI_DATA_DIR="${OPEN_WEBUI_DATA_DIR:-$HOME/.local/share/open-webui/data}"
-HERMES_ENV_FILE="${HERMES_ENV_FILE:-$HOME/.hermes/.env}"
+HERMES_ENV_FILE="${HERMES_ENV_FILE:-$HOME/.hermes-recommended/.env}"
 HERMES_API_PORT="${HERMES_API_PORT:-8642}"
 HERMES_API_HOST="${HERMES_API_HOST:-127.0.0.1}"
 HERMES_API_CONNECT_HOST="${HERMES_API_CONNECT_HOST:-127.0.0.1}"
 HERMES_API_MODEL_NAME="${HERMES_API_MODEL_NAME:-Hermes Agent}"
 HERMES_API_BASE_URL="http://${HERMES_API_CONNECT_HOST}:${HERMES_API_PORT}/v1"
 LAUNCHER_PATH="$HOME/.local/bin/start-open-webui-hermes.sh"
-LOG_DIR="$HOME/.hermes/logs"
+LOG_DIR="$HOME/.hermes-recommended/logs"
 
 log() {
   printf '[open-webui-bootstrap] %s\n' "$*"
@@ -184,7 +184,7 @@ set -euo pipefail
 export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 API_KEY=\$(python3 - <<'PY'
 from pathlib import Path
-p = Path.home()/'.hermes'/'.env'
+p = Path.home()/'.hermes-recommended'/'.env'
 for raw in p.read_text().splitlines():
     line = raw.strip()
     if line.startswith('API_SERVER_KEY='):
@@ -271,8 +271,8 @@ ExecStart=/bin/bash %h/.local/bin/start-open-webui-hermes.sh
 Restart=always
 RestartSec=3
 WorkingDirectory=%h
-StandardOutput=append:%h/.hermes/logs/openwebui.log
-StandardError=append:%h/.hermes/logs/openwebui.error.log
+StandardOutput=append:%h/.hermes-recommended/logs/openwebui.log
+StandardError=append:%h/.hermes-recommended/logs/openwebui.error.log
 
 [Install]
 WantedBy=default.target

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -44,10 +44,11 @@ const WHATSAPP_DEBUG =
   ['1', 'true', 'yes', 'on'].includes(process.env.WHATSAPP_DEBUG.toLowerCase());
 
 const PORT = parseInt(getArg('port', '3000'), 10);
-const SESSION_DIR = getArg('session', path.join(process.env.HOME || '~', '.hermes', 'whatsapp', 'session'));
-const IMAGE_CACHE_DIR = path.join(process.env.HOME || '~', '.hermes', 'image_cache');
-const DOCUMENT_CACHE_DIR = path.join(process.env.HOME || '~', '.hermes', 'document_cache');
-const AUDIO_CACHE_DIR = path.join(process.env.HOME || '~', '.hermes', 'audio_cache');
+const HERMES_HOME = process.env.HERMES_HOME || path.join(process.env.HOME || '~', '.hermes-recommended');
+const SESSION_DIR = getArg('session', path.join(HERMES_HOME, 'whatsapp', 'session'));
+const IMAGE_CACHE_DIR = path.join(HERMES_HOME, 'image_cache');
+const DOCUMENT_CACHE_DIR = path.join(HERMES_HOME, 'document_cache');
+const AUDIO_CACHE_DIR = path.join(HERMES_HOME, 'audio_cache');
 const PAIR_ONLY = args.includes('--pair-only');
 const WHATSAPP_MODE = getArg('mode', process.env.WHATSAPP_MODE || 'self-chat'); // "bot" or "self-chat"
 const ALLOWED_USERS = parseAllowedUsers(process.env.WHATSAPP_ALLOWED_USERS || '');

--- a/setup-hermes.sh
+++ b/setup-hermes.sh
@@ -393,7 +393,7 @@ fi
 # Seed bundled skills into ~/.hermes/skills/
 # ============================================================================
 
-HERMES_SKILLS_DIR="${HERMES_HOME:-$HOME/.hermes}/skills"
+HERMES_SKILLS_DIR="${HERMES_HOME:-$HOME/.hermes-recommended}/skills"
 mkdir -p "$HERMES_SKILLS_DIR"
 
 echo ""

--- a/skills/creative/touchdesigner-mcp/scripts/setup.sh
+++ b/skills/creative/touchdesigner-mcp/scripts/setup.sh
@@ -8,7 +8,7 @@ OK="${GREEN}✔${NC}"; FAIL="${RED}✘${NC}"; WARN="${YELLOW}⚠${NC}"
 
 TWOZERO_URL="https://www.404zero.com/pisang/twozero.tox"
 TOX_PATH="$HOME/Downloads/twozero.tox"
-HERMES_HOME_DIR="${HERMES_HOME:-$HOME/.hermes}"
+HERMES_HOME_DIR="${HERMES_HOME:-$HOME/.hermes-recommended}"
 HERMES_CFG="${HERMES_HOME_DIR}/config.yaml"
 MCP_PORT=40404
 MCP_ENDPOINT="http://localhost:${MCP_PORT}/mcp"

--- a/skills/github/github-auth/scripts/gh-env.sh
+++ b/skills/github/github-auth/scripts/gh-env.sh
@@ -23,8 +23,8 @@ if command -v gh &>/dev/null && gh auth status &>/dev/null 2>&1; then
     GH_USER=$(gh api user --jq '.login' 2>/dev/null)
 elif [ -n "$GITHUB_TOKEN" ]; then
     GH_AUTH_METHOD="curl"
-elif [ -f "$HOME/.hermes/.env" ] && grep -q "^GITHUB_TOKEN=" "$HOME/.hermes/.env" 2>/dev/null; then
-    GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" "$HOME/.hermes/.env" | head -1 | cut -d= -f2 | tr -d '\n\r')
+elif [ -f "${HERMES_HOME:-$HOME/.hermes-recommended}/.env" ] && grep -q "^GITHUB_TOKEN=" "${HERMES_HOME:-$HOME/.hermes-recommended}/.env" 2>/dev/null; then
+    GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" "${HERMES_HOME:-$HOME/.hermes-recommended}/.env" | head -1 | cut -d= -f2 | tr -d '\n\r')
     if [ -n "$GITHUB_TOKEN" ]; then
         GH_AUTH_METHOD="curl"
     fi

--- a/skills/productivity/google-workspace/scripts/_hermes_home.py
+++ b/skills/productivity/google-workspace/scripts/_hermes_home.py
@@ -25,11 +25,11 @@ try:
 except (ModuleNotFoundError, ImportError):
 
     def get_hermes_home() -> Path:
-        """Return the Hermes home directory (default: ~/.hermes).
+        """Return the Hermes home directory (default: ~/.hermes-recommended).
 
         Mirrors ``hermes_constants.get_hermes_home()``."""
         val = os.environ.get("HERMES_HOME", "").strip()
-        return Path(val) if val else Path.home() / ".hermes"
+        return Path(val) if val else Path.home() / ".hermes-recommended"
 
     def display_hermes_home() -> str:
         """Return a user-friendly ``~/``-shortened display string.

--- a/skills/red-teaming/godmode/scripts/auto_jailbreak.py
+++ b/skills/red-teaming/godmode/scripts/auto_jailbreak.py
@@ -7,7 +7,7 @@ finds what works, and locks it in by writing config.yaml + prefill.json.
 
 Usage in execute_code:
     exec(open(os.path.expanduser(
-        os.path.join(os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes")), "skills/red-teaming/godmode/scripts/auto_jailbreak.py")
+        os.path.join(os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes-recommended")), "skills/red-teaming/godmode/scripts/auto_jailbreak.py")
     )).read())
     
     result = auto_jailbreak()  # Uses current model from config
@@ -35,7 +35,7 @@ try:
     _SKILL_DIR = Path(__file__).resolve().parent.parent
 except NameError:
     # __file__ not defined when loaded via exec() — search standard paths
-    _SKILL_DIR = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes")) / "skills" / "red-teaming" / "godmode"
+    _SKILL_DIR = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes-recommended")) / "skills" / "red-teaming" / "godmode"
 
 _SCRIPTS_DIR = _SKILL_DIR / "scripts"
 _TEMPLATES_DIR = _SKILL_DIR / "templates"
@@ -57,7 +57,7 @@ if _race_path.exists():
 # Hermes config paths
 # ═══════════════════════════════════════════════════════════════════
 
-HERMES_HOME = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+HERMES_HOME = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes-recommended"))
 CONFIG_PATH = HERMES_HOME / "config.yaml"
 PREFILL_PATH = HERMES_HOME / "prefill.json"
 

--- a/skills/red-teaming/godmode/scripts/godmode_race.py
+++ b/skills/red-teaming/godmode/scripts/godmode_race.py
@@ -7,7 +7,7 @@ Queries multiple models in parallel via OpenRouter, scores responses
 on quality/filteredness/speed, returns the best unfiltered answer.
 
 Usage in execute_code:
-    exec(open(os.path.join(os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes")), "skills/red-teaming/godmode/scripts/godmode_race.py")).read())
+    exec(open(os.path.join(os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes-recommended")), "skills/red-teaming/godmode/scripts/godmode_race.py")).read())
     
     result = race_models(
         query="Your query here",

--- a/skills/red-teaming/godmode/scripts/load_godmode.py
+++ b/skills/red-teaming/godmode/scripts/load_godmode.py
@@ -3,7 +3,7 @@ Loader for G0DM0D3 scripts. Handles the exec-scoping issues.
 
 Usage in execute_code:
     exec(open(os.path.expanduser(
-        os.path.join(os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes")), "skills/red-teaming/godmode/scripts/load_godmode.py")
+        os.path.join(os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes-recommended")), "skills/red-teaming/godmode/scripts/load_godmode.py")
     )).read())
     
     # Now all functions are available:
@@ -17,7 +17,7 @@ Usage in execute_code:
 import os, sys
 from pathlib import Path
 
-_gm_scripts_dir = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes")) / "skills" / "red-teaming" / "godmode" / "scripts"
+_gm_scripts_dir = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes-recommended")) / "skills" / "red-teaming" / "godmode" / "scripts"
 
 _gm_old_argv = sys.argv
 sys.argv = ["_godmode_loader"]

--- a/skills/red-teaming/godmode/scripts/parseltongue.py
+++ b/skills/red-teaming/godmode/scripts/parseltongue.py
@@ -11,7 +11,7 @@ Usage:
     python parseltongue.py "How do I hack a WiFi network?" --tier standard
 
     # As a module in execute_code
-    exec(open(os.path.join(os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes")), "skills/red-teaming/godmode/scripts/parseltongue.py")).read())
+    exec(open(os.path.join(os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes-recommended")), "skills/red-teaming/godmode/scripts/parseltongue.py")).read())
     variants = generate_variants("How do I hack a WiFi network?", tier="standard")
 """
 

--- a/tests/hermes_cli/test_completion.py
+++ b/tests/hermes_cli/test_completion.py
@@ -259,7 +259,7 @@ class TestProfileCompletion:
     def test_bash_has_profiles_helper(self):
         out = generate_bash(_make_parser())
         assert "_hermes_profiles()" in out
-        assert 'profiles_dir="$HOME/.hermes/profiles"' in out
+        assert 'profiles_dir="${HERMES_HOME:-$HOME/.hermes-recommended}/profiles"' in out
 
     def test_bash_completes_profiles_after_p_flag(self):
         out = generate_bash(_make_parser())
@@ -289,7 +289,7 @@ class TestProfileCompletion:
     def test_zsh_has_profiles_helper(self):
         out = generate_zsh(_make_parser())
         assert "_hermes_profiles()" in out
-        assert "$HOME/.hermes/profiles" in out
+        assert '${HERMES_HOME:-$HOME/.hermes-recommended}/profiles' in out
 
     def test_zsh_has_profile_flag_completion(self):
         out = generate_zsh(_make_parser())
@@ -303,7 +303,10 @@ class TestProfileCompletion:
     def test_fish_has_profiles_helper(self):
         out = generate_fish(_make_parser())
         assert "__hermes_profiles" in out
-        assert "$HOME/.hermes/profiles" in out
+        assert 'set -l profiles_dir "$HERMES_HOME"' in out
+        assert "$HOME/.hermes-recommended" in out
+        assert 'test -d "$profiles_dir/profiles"' in out
+        assert 'ls "$profiles_dir/profiles"' in out
 
     def test_fish_has_profile_flag_completion(self):
         out = generate_fish(_make_parser())

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -28,7 +28,7 @@ class TestGetHermesHome:
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("HERMES_HOME", None)
             home = get_hermes_home()
-            assert home == Path.home() / ".hermes"
+            assert home == Path.home() / ".hermes-recommended"
 
     def test_env_override(self):
         with patch.dict(os.environ, {"HERMES_HOME": "/custom/path"}):

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1215,8 +1215,8 @@ class TestSystemUnitHermesHome:
 
         unit = gateway_cli.generate_systemd_unit(system=True, run_as_user="alice")
 
-        assert 'HERMES_HOME=/home/alice/.hermes' in unit
-        assert '/root/.hermes' not in unit
+        assert 'HERMES_HOME=/home/alice/.hermes-recommended' in unit
+        assert '/root/.hermes-recommended' not in unit
 
     def test_system_unit_remaps_profile_to_target_user(self, monkeypatch):
         # Simulate sudo with a profile: HERMES_HOME was resolved under root
@@ -1269,7 +1269,7 @@ class TestHermesHomeForTargetUser:
         monkeypatch.delenv("HERMES_HOME", raising=False)
 
         result = gateway_cli._hermes_home_for_target_user("/home/alice")
-        assert result == "/home/alice/.hermes"
+        assert result == "/home/alice/.hermes-recommended"
 
     def test_remaps_profile_path(self, monkeypatch):
         monkeypatch.setattr(Path, "home", staticmethod(lambda: Path("/root")))
@@ -1290,7 +1290,7 @@ class TestHermesHomeForTargetUser:
         monkeypatch.delenv("HERMES_HOME", raising=False)
 
         result = gateway_cli._hermes_home_for_target_user("/home/alice")
-        assert result == "/home/alice/.hermes"
+        assert result == "/home/alice/.hermes-recommended"
 
 
 class TestGeneratedUnitUsesDetectedVenv:

--- a/tests/skills/test_google_oauth_setup.py
+++ b/tests/skills/test_google_oauth_setup.py
@@ -281,23 +281,23 @@ class TestHermesConstantsFallback:
         module = self._load_helper(monkeypatch)
         assert module.get_hermes_home() == tmp_path / "custom-hermes"
 
-    def test_fallback_defaults_to_dot_hermes(self, monkeypatch):
-        """When hermes_constants is missing and HERMES_HOME unset, default to ~/.hermes."""
+    def test_fallback_defaults_to_dot_hermes_recommended(self, monkeypatch):
+        """When hermes_constants is missing and HERMES_HOME unset, default to ~/.hermes-recommended."""
         monkeypatch.delenv("HERMES_HOME", raising=False)
         module = self._load_helper(monkeypatch)
-        assert module.get_hermes_home() == Path.home() / ".hermes"
+        assert module.get_hermes_home() == Path.home() / ".hermes-recommended"
 
     def test_fallback_ignores_empty_hermes_home(self, monkeypatch):
         """Empty/whitespace HERMES_HOME is treated as unset."""
         monkeypatch.setenv("HERMES_HOME", "  ")
         module = self._load_helper(monkeypatch)
-        assert module.get_hermes_home() == Path.home() / ".hermes"
+        assert module.get_hermes_home() == Path.home() / ".hermes-recommended"
 
     def test_fallback_display_hermes_home_shortens_path(self, monkeypatch):
         """Fallback display_hermes_home() uses ~/ shorthand like the real one."""
         monkeypatch.delenv("HERMES_HOME", raising=False)
         module = self._load_helper(monkeypatch)
-        assert module.display_hermes_home() == "~/.hermes"
+        assert module.display_hermes_home() == "~/.hermes-recommended"
 
     def test_fallback_display_hermes_home_profile_path(self, monkeypatch):
         """Fallback display_hermes_home() handles profile paths under ~/."""

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -19,11 +19,11 @@ class TestGetDefaultHermesRoot:
     """Tests for get_default_hermes_root() — Docker/custom deployment awareness."""
 
     def test_no_hermes_home_returns_native(self, tmp_path, monkeypatch):
-        """When HERMES_HOME is not set, returns ~/.hermes."""
+        """When HERMES_HOME is not set, returns ~/.hermes-recommended."""
         monkeypatch.delenv("HERMES_HOME", raising=False)
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
-        assert get_default_hermes_root() == tmp_path / ".hermes"
+        assert get_default_hermes_root() == tmp_path / ".hermes-recommended"
 
     def test_hermes_home_is_native(self, tmp_path, monkeypatch):
         """When HERMES_HOME = ~/.hermes, returns ~/.hermes."""

--- a/tests/test_hermes_home_profile_warning.py
+++ b/tests/test_hermes_home_profile_warning.py
@@ -4,7 +4,7 @@ Regression test for https://github.com/NousResearch/hermes-agent/issues/18594.
 
 When HERMES_HOME is unset but an active_profile file indicates a non-default
 profile is active, get_hermes_home() should:
-  1. STILL return ~/.hermes (raising would brick 30+ module-level callers)
+  1. STILL return ~/.hermes-recommended (raising would brick 30+ module-level callers)
   2. Emit a loud one-shot warning to stderr so operators can diagnose
      cross-profile data contamination after the fact.
 
@@ -33,34 +33,34 @@ class TestGetHermesHomeProfileWarning:
     def test_classic_mode_no_active_profile_no_warning(
         self, fresh_constants, tmp_path, capsys
     ):
-        """Classic mode: no active_profile file → silent, returns ~/.hermes."""
+        """Classic mode: no active_profile file -> silent, returns ~/.hermes-recommended."""
         result = fresh_constants.get_hermes_home()
-        assert result == tmp_path / ".hermes"
+        assert result == tmp_path / ".hermes-recommended"
         assert "HERMES_HOME fallback" not in capsys.readouterr().err
 
     def test_default_active_profile_no_warning(
         self, fresh_constants, tmp_path, capsys
     ):
-        """active_profile=default → still no warning, returns ~/.hermes."""
-        hermes_dir = tmp_path / ".hermes"
+        """active_profile=default -> still no warning, returns ~/.hermes-recommended."""
+        hermes_dir = tmp_path / ".hermes-recommended"
         hermes_dir.mkdir()
         (hermes_dir / "active_profile").write_text("default\n")
         result = fresh_constants.get_hermes_home()
-        assert result == tmp_path / ".hermes"
+        assert result == tmp_path / ".hermes-recommended"
         assert "HERMES_HOME fallback" not in capsys.readouterr().err
 
     def test_named_profile_unset_home_warns_once(
         self, fresh_constants, tmp_path, capsys
     ):
-        """active_profile=coder + HERMES_HOME unset → warn loudly, still return fallback."""
-        hermes_dir = tmp_path / ".hermes"
+        """active_profile=coder + HERMES_HOME unset -> warn loudly, still return fallback."""
+        hermes_dir = tmp_path / ".hermes-recommended"
         hermes_dir.mkdir()
         (hermes_dir / "active_profile").write_text("coder\n")
 
         result = fresh_constants.get_hermes_home()
 
         # 1. Still returns the fallback — no import-time crash
-        assert result == tmp_path / ".hermes"
+        assert result == tmp_path / ".hermes-recommended"
         # 2. Stderr got the warning exactly once
         err = capsys.readouterr().err
         assert err.count("HERMES_HOME fallback") == 1
@@ -77,9 +77,9 @@ class TestGetHermesHomeProfileWarning:
         self, fresh_constants, tmp_path, capsys, monkeypatch
     ):
         """Even if active_profile is 'coder', setting HERMES_HOME suppresses warning."""
-        profile_dir = tmp_path / ".hermes" / "profiles" / "coder"
+        profile_dir = tmp_path / ".hermes-recommended" / "profiles" / "coder"
         profile_dir.mkdir(parents=True)
-        (tmp_path / ".hermes" / "active_profile").write_text("coder\n")
+        (tmp_path / ".hermes-recommended" / "active_profile").write_text("coder\n")
         monkeypatch.setenv("HERMES_HOME", str(profile_dir))
 
         result = fresh_constants.get_hermes_home()
@@ -91,14 +91,14 @@ class TestGetHermesHomeProfileWarning:
         self, fresh_constants, tmp_path, capsys
     ):
         """active_profile that can't be decoded → fall through silently."""
-        hermes_dir = tmp_path / ".hermes"
+        hermes_dir = tmp_path / ".hermes-recommended"
         hermes_dir.mkdir()
         # Write bytes that aren't valid utf-8
         (hermes_dir / "active_profile").write_bytes(b"\xff\xfe\x00\x00")
 
         result = fresh_constants.get_hermes_home()
 
-        assert result == tmp_path / ".hermes"
+        assert result == tmp_path / ".hermes-recommended"
         # Shouldn't crash; shouldn't warn either (can't tell what profile was intended)
         assert "HERMES_HOME fallback" not in capsys.readouterr().err
 
@@ -106,11 +106,11 @@ class TestGetHermesHomeProfileWarning:
         self, fresh_constants, tmp_path, capsys
     ):
         """Empty active_profile file → treated as default, no warning."""
-        hermes_dir = tmp_path / ".hermes"
+        hermes_dir = tmp_path / ".hermes-recommended"
         hermes_dir.mkdir()
         (hermes_dir / "active_profile").write_text("")
 
         result = fresh_constants.get_hermes_home()
 
-        assert result == tmp_path / ".hermes"
+        assert result == tmp_path / ".hermes-recommended"
         assert "HERMES_HOME fallback" not in capsys.readouterr().err

--- a/tests/test_no_legacy_live_home_paths.py
+++ b/tests/test_no_legacy_live_home_paths.py
@@ -1,0 +1,140 @@
+"""Regression tests for executable Hermes home defaults.
+
+Legacy ``~/.hermes`` references are still allowed in docs, tests, migration code,
+and remote/container compatibility paths. Local executable defaults must not
+recreate or fall back to the legacy user home. New defaults belong under
+``~/.hermes-recommended``.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+ACTIVE_PATH_ROOTS = (
+    "acp_adapter",
+    "agent",
+    "cron",
+    "gateway",
+    "hermes_cli",
+    "plugins",
+    "scripts",
+    "skills",
+    "optional-skills",
+    "nix",
+    "tools",
+    "tui_gateway",
+    "ui-tui",
+)
+
+ACTIVE_ROOT_FILES = (
+    "cli.py",
+    "hermes_constants.py",
+    "hermes_logging.py",
+    "hermes_time.py",
+    "mcp_serve.py",
+    "run_agent.py",
+    "setup-hermes.sh",
+    "utils.py",
+)
+
+CODE_SUFFIXES = {
+    ".py",
+    ".sh",
+    ".bash",
+    ".ps1",
+    ".ts",
+    ".tsx",
+    ".js",
+    ".mjs",
+    ".cjs",
+    ".tmpl",
+}
+
+FORBIDDEN_LIVE_HOME_PATTERNS = (
+    re.compile(r"os\.environ\.setdefault\(\s*[\"']HERMES_HOME[\"'][^\n]*[\"']\.hermes[\"']"),
+    re.compile(r"\bHERMES_HOME=.*\$\{HERMES_HOME:-\$HOME/\.hermes\}"),
+    re.compile(r"\b[A-Z_]*(?:FILE|DIR|HOME)=.*\$HOME/\.hermes(?:/|[\"'])"),
+    re.compile(r"\$HOME/\.hermes/"),
+    re.compile(r"HOME/\.hermes/"),
+    re.compile(r"\$\{HERMES_HOME:-\$HOME/\.hermes\}"),
+    re.compile(r"%h/\.hermes/"),
+    re.compile(r"\bPath\.home\(\)\s*/\s*[\"']\.hermes[\"']"),
+    re.compile(r"\b_Path\.home\(\)\s*/\s*[\"']\.hermes[\"']"),
+    re.compile(r"\bPath\.home\(\)\.joinpath\([\"']\.hermes[\"']"),
+    re.compile(r"\bos\.path\.expanduser\([\"']~/\.hermes[\"']\)"),
+    re.compile(r"\bexpanduser\([\"']~/\.hermes[\"']\)"),
+    re.compile(r"\bos\.getenv\([\"']HERMES_HOME[\"'][^\n]*Path\.home\(\)\s*/\s*[\"']\.hermes[\"']"),
+    re.compile(r"\bos\.environ\.get\([\"']HERMES_HOME[\"'][^\n]*Path\.home\(\)\s*/\s*[\"']\.hermes[\"']"),
+    re.compile(r"\bos\.environ\.get\([\"']HERMES_HOME[\"'][^\n]*[\"']~/\.hermes[\"']"),
+    re.compile(r"\bos\.path\.join\([^\n]*os\.path\.expanduser\([\"']~[\"']\)[^\n]*[\"']\.hermes[\"']"),
+    re.compile(r"\bpath\.join\([^\n]*process\.env\.HOME[^\n]*[\"']\.hermes[\"']"),
+    re.compile(r"\bjoin\([^\n]*homedir\(\)[^\n]*[\"']\.hermes[\"']"),
+)
+
+ALLOWLIST = {
+    # Compatibility/migration plugin intentionally names the old home while
+    # migrating OpenClaw/Hermes installations.
+    "hermes_cli/codex_runtime_plugin_migration.py",
+    # Remote/container paths are not local user-home defaults and intentionally
+    # preserve mounted/sandbox paths used by execution backends.
+    "tools/credential_files.py",
+    "tools/environments/daytona.py",
+    "tools/environments/file_sync.py",
+    "tools/environments/modal.py",
+    "tools/environments/ssh.py",
+    "tools/environments/vercel_sandbox.py",
+}
+
+
+def _active_files() -> list[Path]:
+    files: list[Path] = []
+    for root in ACTIVE_PATH_ROOTS:
+        base = REPO_ROOT / root
+        if not base.exists():
+            continue
+        for path in base.rglob("*"):
+            if not path.is_file() or not _is_executable_code_file(path):
+                continue
+            rel = path.relative_to(REPO_ROOT).as_posix()
+            if rel in ALLOWLIST or "web_dist" in rel:
+                continue
+            if rel.startswith("tests/") and rel != "tests/test_no_legacy_live_home_paths.py":
+                continue
+            files.append(path)
+    for name in ACTIVE_ROOT_FILES:
+        path = REPO_ROOT / name
+        if path.exists():
+            files.append(path)
+    return sorted(files)
+
+
+def _is_executable_code_file(path: Path) -> bool:
+    if path.suffix in CODE_SUFFIXES:
+        return True
+    if os.access(path, os.X_OK):
+        return True
+    try:
+        return path.read_bytes().startswith(b"#!")
+    except OSError:
+        return False
+
+
+def test_active_code_does_not_reference_legacy_live_home() -> None:
+    """Guard against reintroducing live/default ``~/.hermes`` fallbacks."""
+    offenders: list[str] = []
+    for path in _active_files():
+        rel = path.relative_to(REPO_ROOT).as_posix()
+        text = path.read_text(encoding="utf-8")
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            stripped = line.strip()
+            if not stripped or stripped.startswith(("#", "//", "*")):
+                continue
+            if any(pattern.search(line) for pattern in FORBIDDEN_LIVE_HOME_PATTERNS):
+                offenders.append(f"{rel}:{lineno}: {line.strip()}")
+
+    assert not offenders, "legacy live Hermes home references found:\n" + "\n".join(offenders)

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -108,7 +108,7 @@ def _get_token_dir() -> Path:
         from hermes_constants import get_hermes_home
         base = Path(get_hermes_home())
     except ImportError:
-        base = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes")))
+        base = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes-recommended")))
     return base / "mcp-tokens"
 
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -416,7 +416,7 @@ def _resolve_stdio_command(command: str, env: dict) -> tuple[str, dict]:
         elif resolved_command in {"npx", "npm", "node"}:
             hermes_home = os.path.expanduser(
                 os.getenv(
-                    "HERMES_HOME", os.path.join(os.path.expanduser("~"), ".hermes")
+        "HERMES_HOME", os.path.join(os.path.expanduser("~"), ".hermes-recommended")
                 )
             )
             candidates = [

--- a/ui-tui/src/lib/history.ts
+++ b/ui-tui/src/lib/history.ts
@@ -3,7 +3,7 @@ import { homedir } from 'node:os'
 import { join } from 'node:path'
 
 const MAX = 1000
-const dir = process.env.HERMES_HOME ?? join(homedir(), '.hermes')
+const dir = process.env.HERMES_HOME ?? join(homedir(), '.hermes-recommended')
 const file = join(dir, '.hermes_history')
 
 let cache: string[] | null = null

--- a/ui-tui/src/lib/memory.ts
+++ b/ui-tui/src/lib/memory.ts
@@ -145,7 +145,8 @@ export async function performHeapDump(trigger: MemoryTrigger = 'manual'): Promis
     // Diagnostics first — heap-snapshot serialization can crash on very large
     // heaps, and the JSON sidecar is the most actionable artifact if so.
     const diagnostics = await captureMemoryDiagnostics(trigger)
-    const dir = process.env.HERMES_HEAPDUMP_DIR?.trim() || join(homedir() || tmpdir(), '.hermes', 'heapdumps')
+    const home = process.env.HERMES_HOME?.trim() || join(homedir() || tmpdir(), '.hermes-recommended')
+    const dir = process.env.HERMES_HEAPDUMP_DIR?.trim() || join(home, 'heapdumps')
 
     await mkdir(dir, { recursive: true })
 

--- a/ui-tui/src/lib/perfPane.tsx
+++ b/ui-tui/src/lib/perfPane.tsx
@@ -4,7 +4,7 @@
 //   logFrameEvent (ink.onFrame) → yoga / renderer / diff / optimize / write
 //                                 phases + yoga counters + scroll fast-path
 //
-// Both gate on HERMES_DEV_PERF=1 and dump JSON-lines (default ~/.hermes/perf.log,
+// Both gate on HERMES_DEV_PERF=1 and dump JSON-lines (default ~/.hermes-recommended/perf.log,
 // override HERMES_DEV_PERF_LOG). Tagged { src: 'react' | 'frame' } for jq.
 // HERMES_DEV_PERF_MS (default 2) skips sub-ms idle frames; set 0 to capture all.
 //
@@ -21,7 +21,7 @@ import { Profiler, type ProfilerOnRenderCallback, type ReactNode } from 'react'
 
 const ENABLED = /^(?:1|true|yes|on)$/i.test((process.env.HERMES_DEV_PERF ?? '').trim())
 const THRESHOLD_MS = Number(process.env.HERMES_DEV_PERF_MS ?? '2') || 0
-const LOG_PATH = process.env.HERMES_DEV_PERF_LOG?.trim() || join(homedir(), '.hermes', 'perf.log')
+const LOG_PATH = process.env.HERMES_DEV_PERF_LOG?.trim() || join(process.env.HERMES_HOME?.trim() || join(homedir(), '.hermes-recommended'), 'perf.log')
 
 let logReady = false
 


### PR DESCRIPTION
Summary
- Move executable local defaults from legacy ~/.hermes to ~/.hermes-recommended.
- Cover canonical defaults, installer/script defaults, TUI history/perf/heap paths, shell completions, auth/test guards, selected plugin and optional-skill fallbacks.
- Preserve explicit legacy compatibility where needed, including system-service remapping for already-set /root/.hermes paths.
- Add a regression guard for executable local defaults, including suffixless/shebang scripts, .mjs/.cjs entrypoints, and generated launcher/service text.

Verification
- python -m pytest tests/test_no_legacy_live_home_paths.py tests/hermes_cli/test_completion.py tests/test_hermes_home_profile_warning.py tests/test_hermes_constants.py tests/hermes_cli/test_config.py tests/skills/test_google_oauth_setup.py tests/hermes_cli/test_gateway_service.py::TestSystemUnitHermesHome tests/hermes_cli/test_gateway_service.py::TestHermesHomeForTargetUser tests/hermes_cli/test_gateway_service.py::TestSystemUnitPathRemapping -q
  - 150 passed, 1 skipped
- python -m py_compile targeted Python files
  - passed
- bash -n targeted shell scripts/templates
  - passed
- git diff --check
  - passed

Note
- ui-tui type-check was not run in the clean worktree because tsc is not installed there.