### PR TITLE
chore(release): AUTHOR_MAP entries for batch salvage (May 2026 group 7) + #27964 (Jack Yang)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -582,6 +582,7 @@ AUTHOR_MAP = {
     "kopjop926@gmail.com": "cesareth",
     "fuleinist@gmail.com": "fuleinist",
     "jack.47@gmail.com": "JackTheGit",
+    "jack@jackyang.com": "0xjackyang",
     "dalvidjr2022@gmail.com": "Jr-kenny",
     "m@statecraft.systems": "mbierling",
     "balyan.sid@gmail.com": "alt-glitch",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1173,6 +1173,16 @@ AUTHOR_MAP = {
     "hoangv.pham0803@gmail.com": "hehehe0803",  # PR #26212 salvage (codex kanban writable root)
     "26063003+hehehe0803@users.noreply.github.com": "hehehe0803",
     "38348871+vaddisrinivas@users.noreply.github.com": "vaddisrinivas",  # PR #26394 salvage (Docker messaging extra)
+    # batch salvage (May 2026 LHF run, group 7)
+    "198679067+02356abc@users.noreply.github.com": "02356abc",  # PR #28286 salvage (wecom CLOSING)
+    "1743117+burjorjee@users.noreply.github.com": "burjorjee",  # PR #28201 salvage (inline-shell timeout guard)
+    "keki@MacBookPro.attlocal.net": "burjorjee",
+    "264690993+oseftg@users.noreply.github.com": "oseftg",  # PR #28168 salvage (natural ending emoji/caret)
+    "hex.hermes@agentmail.to": "oseftg",
+    "236912655+rudi193-cmd@users.noreply.github.com": "rudi193-cmd",  # PR #28241 salvage (empty credential pool)
+    "rudi193@gmail.com": "rudi193-cmd",
+    "86684667+sadiksaifi@users.noreply.github.com": "sadiksaifi",  # PR #27982 salvage (kanban horiz scroll)
+    "mail@sadiksaifi.dev": "sadiksaifi",
 }
 
 


### PR DESCRIPTION
Two AUTHOR_MAP chore commits:

1. **#27964 salvage** — adds `jack@jackyang.com` → `0xjackyang` (authored by @0xjackyang, his attribution preserved).
2. **Pre-stage for batch group 7** — adds AUTHOR_MAP entries for 5 new contributors whose PRs are being salvaged in the May 2026 LHF batch group 7, so the per-PR salvage commits don't fail CI's email-mapping check.

Contributors staged in commit 2:
- @02356abc (#28286 — wecom WSMsgType.CLOSING)
- @burjorjee (#28201 — inline-shell timeout guard)
- @oseftg (#28168 — natural response ending: emoji + caret)
- @rudi193-cmd (#28241 — empty credential pool entries)
- @sadiksaifi (#27982 — kanban horizontal scroll)

Per `references/batch-pr-salvage-may14-additions.md`.