### PR TITLE
fix(wecom): handle WSMsgType.CLOSING to prevent CPU spin (#28286)

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -361,7 +361,7 @@ class WeComAdapter(BasePlatformAdapter):
                 payload = self._parse_json(msg.data)
                 if payload:
                     await self._dispatch_payload(payload)
-            elif msg.type in {aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.ERROR}:
+            elif msg.type in {aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.ERROR, aiohttp.WSMsgType.CLOSING}:
                 raise RuntimeError("WeCom websocket closed")
 
     async def _heartbeat_loop(self) -> None:


### PR DESCRIPTION
Salvage of #28286 by @02356abc.

**What:** Treat `aiohttp.WSMsgType.CLOSING` as a terminal state in WeCom gateway's `_read_events()` loop instead of falling through and re-reading immediately, which spins CPU until the underlying socket closes.

**Why:** When the WeCom WebSocket enters CLOSING state, the existing code didn't match any of the recognized termination types, so the loop tight-spun the event-read path until the WS reached CLOSED.

Original PR: https://github.com/NousResearch/hermes-agent/pull/28286
Fixes #28293.