### PR TITLE
fix(auth): treat empty credential pool entries as unauthenticated in /model picker (#28241)

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1232,7 +1232,7 @@ def list_authenticated_providers(
             try:
                 from hermes_cli.auth import _load_auth_store
                 store = _load_auth_store()
-                if store and hermes_id in store.get("credential_pool", {}):
+                if store and store.get("credential_pool", {}).get(hermes_id):
                     has_creds = True
             except Exception:
                 pass


### PR DESCRIPTION
Salvage of #28241 by @rudi193-cmd.

**What:** The `/model` picker checked whether a provider key *existed* in `credential_pool`, not whether the entry list was non-empty. An empty list (e.g. `"minimax-cn": []`) left after removing an account incorrectly marked the provider as authenticated.

**How:** Check `bool(pool.get(name))` (which is truthy only for non-empty sequences) instead of `name in pool`.

Original PR: https://github.com/NousResearch/hermes-agent/pull/28241
Fixes #28140.