### PR TITLE
fix(gateway): include hermes_plugins in gateway.log component filter (#28196)

### DIFF
--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -141,7 +141,7 @@ class _ComponentFilter(logging.Filter):
 # Logger name prefixes that belong to each component.
 # Used by _ComponentFilter and exposed for ``hermes logs --component``.
 COMPONENT_PREFIXES = {
-    "gateway": ("gateway",),
+    "gateway": ("gateway", "hermes_plugins"),
     "agent": ("agent", "run_agent", "model_tools", "batch_runner"),
     "tools": ("tools",),
     "cli": ("hermes_cli", "cli"),


### PR DESCRIPTION
Salvage of #28196 by @zccyman.

**What:** `COMPONENT_PREFIXES["gateway"]` only included `("gateway",)`, so `_ComponentFilter` silently dropped all plugin log records (`hermes_plugins.*`) from `gateway.log`. Plugins running under the gateway had no visible logs.

**How:** Add `"hermes_plugins"` to the gateway prefix tuple.

Original PR: https://github.com/NousResearch/hermes-agent/pull/28196
Fixes #28138.