### PR TITLE
fix(gateway): align kanban artifact _IMAGE_EXTS with response dispatch (#28002)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4680,7 +4680,7 @@ class GatewayRunner:
         if not candidates:
             return
 
-        _IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".tiff", ".svg"}
+        _IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".gif", ".webp"}
         _VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".webm", ".3gp"}
 
         from urllib.parse import quote as _quote


### PR DESCRIPTION
Salvage of #28002 by @EloquentBrush0x.

**What:** `_deliver_kanban_artifacts` used a wider `_IMAGE_EXTS` set (`.bmp`, `.tiff`, `.svg`) than the response-dispatch path, so files routed by extension diverged between the two paths.

**How:** Narrow the kanban-artifact set to match the dispatch set.

Original PR: https://github.com/NousResearch/hermes-agent/pull/28002