### PR TITLE
fix(process-registry): detach stdin from background subprocesses to prevent freeze (#27999)

### DIFF
--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -555,7 +555,7 @@ class ProcessRegistry:
             errors="replace",
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
-            stdin=subprocess.PIPE,
+            stdin=subprocess.DEVNULL,
             preexec_fn=None if _IS_WINDOWS else os.setsid,
             creationflags=subprocess.CREATE_NO_WINDOW if _IS_WINDOWS else 0,
         )


### PR DESCRIPTION
Salvage of #27999 by @LifeJiggy.

**What:** Background process non-PTY path used `stdin=subprocess.PIPE` unconditionally, creating an orphan pipe that was never written to and never closed. Child processes that read stdin would block indefinitely.

**How:** Switch to `stdin=subprocess.DEVNULL` so children see EOF immediately.

Original PR: https://github.com/NousResearch/hermes-agent/pull/27999
Fixes #17959.