### PR TITLE
fix(plugins): raise plugin discovery failures to WARNING level (#28193)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3474,7 +3474,7 @@ class GatewayRunner:
             from hermes_cli.plugins import discover_plugins
             discover_plugins()
         except Exception:
-            logger.debug(
+            logger.warning(
                 "plugin discovery failed at gateway startup", exc_info=True,
             )
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12672,7 +12672,7 @@ Examples:
 
             discover_plugins()
         except Exception:
-            logger.debug(
+            logger.warning(
                 "plugin discovery failed at CLI startup",
                 exc_info=True,
             )


### PR DESCRIPTION
Salvage of #28193 by @zccyman.

**What:** `discover_plugins()` exceptions were caught and logged at DEBUG in two startup paths (gateway and CLI), making broken plugins invisible at the default INFO log level.

**How:** Promote both call sites to `logger.warning` so operators see plugin discovery failures by default.

Original PR: https://github.com/NousResearch/hermes-agent/pull/28193
Fixes #28137.