### PR TITLE
fix(skills): treat inline-shell timeout guard as timeout (#28201)

### DIFF
--- a/agent/skill_preprocessing.py
+++ b/agent/skill_preprocessing.py
@@ -79,6 +79,14 @@ def run_inline_shell(command: str, cwd: Path | None, timeout: int) -> str:
         return f"[inline-shell timeout after {timeout}s: {command}]"
     except FileNotFoundError:
         return "[inline-shell error: bash not found]"
+    except RuntimeError as exc:
+        # tests/conftest.py installs a live-system guard that blocks real
+        # os.kill on out-of-tree PIDs. subprocess.run(timeout=...) may trip
+        # that guard while trying to clean up the timed-out shell; treat that
+        # as the same timeout outcome instead of surfacing the guard error.
+        if "live-system guard: blocked os.kill" in str(exc):
+            return f"[inline-shell timeout after {timeout}s: {command}]"
+        return f"[inline-shell error: {exc}]"
     except Exception as exc:
         return f"[inline-shell error: {exc}]"
 


### PR DESCRIPTION
Salvage of #28201 by @burjorjee.

**What:** When pytest's live-system guard intercepts subprocess cleanup, the inline-shell expansion in skill preprocessing was surfacing the guard's `RuntimeError` instead of returning the standard inline-shell timeout marker. This made the failure mode opaque to consumers expecting the timeout shape.

**How:** Normalize the guard-intercept path to return `[inline-shell timeout after Ns: <command>]` like other timeouts.

Original PR: https://github.com/NousResearch/hermes-agent/pull/28201