### PR TITLE
fix(acp): workspace auto-approve fails for /tmp paths on macOS (#28063)

### DIFF
--- a/acp_adapter/edit_approval.py
+++ b/acp_adapter/edit_approval.py
@@ -154,11 +154,15 @@ def should_auto_approve_edit(proposal: EditProposal, policy: str, cwd: str | Non
     policy = str(policy or AUTO_APPROVE_ASK).strip()
     if policy == AUTO_APPROVE_ASK or _is_sensitive_auto_approve_path(proposal.path):
         return False
-    path = Path(proposal.path).expanduser().resolve(strict=False)
+    raw_path = Path(proposal.path).expanduser()
+    # resolve() follows symlinks — on macOS /tmp → /private/tmp, so the
+    # resolved form never starts with "/tmp/". Use raw_path for the /tmp
+    # check and the resolved form only for the cwd relative_to() test.
+    path = raw_path.resolve(strict=False)
     if policy == AUTO_APPROVE_SESSION:
         return True
     if policy == AUTO_APPROVE_WORKSPACE:
-        if str(path).startswith("/tmp/"):
+        if str(raw_path).startswith("/tmp/"):
             return True
         if cwd:
             root = Path(cwd).expanduser().resolve(strict=False)


### PR DESCRIPTION
Salvage of #28063 by @EloquentBrush0x.

**What:** `should_auto_approve_edit()` called `Path.resolve()` before checking whether the path was under `/tmp/`. On macOS `/tmp` is a symlink to `/private/tmp`, so after `resolve()` the resolved form never starts with `"/tmp/"` and the workspace policy never auto-approved /tmp paths.

**How:** Keep the raw (un-resolved) path for the `/tmp/` startswith check; use the resolved form only for the `relative_to(cwd)` test, which is what actually needs symlink resolution.

Original PR: https://github.com/NousResearch/hermes-agent/pull/28063