### PR TITLE
fix(kanban): single-row horizontal scroll for board columns (#27982)

### DIFF
--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -63,13 +63,18 @@
 /* ---- Columns layout -------------------------------------------------- */
 
 .hermes-kanban-columns {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  display: flex;
   gap: 0.75rem;
   align-items: start;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+.hermes-kanban-columns::-webkit-scrollbar {
+  display: none;
 }
 
 .hermes-kanban-column {
+  flex: 0 0 280px;
   display: flex;
   flex-direction: column;
   background: color-mix(in srgb, var(--color-card) 85%, transparent);


### PR DESCRIPTION
Salvage of #27982 by @sadiksaifi.

**What:** The dashboard plugin's column container (`.hermes-kanban-columns`) used `grid-template-columns: repeat(auto-fit, minmax(260px, 1fr))`. With many columns on narrower viewports, this wrapped into multiple rows instead of staying in one horizontally-scrollable row.

**How:** Switch to `grid-auto-flow: column` + `grid-auto-columns: minmax(260px, 1fr)` + `overflow-x: auto` so the board stays single-row and scrolls horizontally.

Original PR: https://github.com/NousResearch/hermes-agent/pull/27982