### PR TITLE
fix: handle Moonshot union type lists

### DIFF
--- a/agent/moonshot_schema.py
+++ b/agent/moonshot_schema.py
@@ -144,7 +144,12 @@ def _repair_schema(node: Any, is_schema: bool = True) -> Any:
     # empty, drop it entirely.
     if "enum" in repaired and isinstance(repaired["enum"], list):
         node_type = repaired.get("type")
-        if node_type in {"string", "integer", "number", "boolean"}:
+        if isinstance(node_type, str) and node_type in {
+            "string",
+            "integer",
+            "number",
+            "boolean",
+        }:
             cleaned = [v for v in repaired["enum"]
                        if v is not None and v != ""]
             if cleaned:
@@ -166,7 +171,8 @@ def _repair_schema(node: Any, is_schema: bool = True) -> Any:
 
 def _fill_missing_type(node: Dict[str, Any]) -> Dict[str, Any]:
     """Infer a reasonable ``type`` if this schema node has none."""
-    if "type" in node and node["type"] not in {None, ""}:
+    existing_type = node.get("type")
+    if existing_type is not None and existing_type != "":
         return node
 
     # Heuristic: presence of ``properties`` → object, ``items`` → array, ``enum``

--- a/tests/agent/test_moonshot_schema.py
+++ b/tests/agent/test_moonshot_schema.py
@@ -411,6 +411,34 @@ class TestToolListSanitizer:
         out = sanitize_moonshot_tools(tools)
         assert out == tools
 
+    def test_preserves_json_schema_union_type_lists(self):
+        """JSON Schema allows ``type`` to be a list for union types."""
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "convert",
+                    "description": "Convert a value",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "value": {
+                                "description": "number or string input",
+                                "type": ["number", "string"],
+                            },
+                        },
+                    },
+                },
+            },
+        ]
+
+        out = sanitize_moonshot_tools(tools)
+
+        assert out[0]["function"]["parameters"]["properties"]["value"]["type"] == [
+            "number",
+            "string",
+        ]
+
 
 class TestRealWorldMCPShape:
     """End-to-end: a realistic MCP-style schema that used to 400 on Moonshot."""


### PR DESCRIPTION
## Summary
- Preserve JSON Schema union `type` lists when sanitizing Moonshot tool schemas
- Avoid unhashable-list crashes in `_fill_missing_type()` and scalar enum cleanup
- Add a regression test for `sanitize_moonshot_tools()` with `type: ["number", "string"]`

Fixes #28291

## Test Plan
- RED: `python -m pytest tests/agent/test_moonshot_schema.py::TestToolListSanitizer::test_preserves_json_schema_union_type_lists -q` failed with `TypeError: unhashable type: 'list'`
- GREEN: `python -m pytest tests/agent/test_moonshot_schema.py -q` → 43 passed, 11 warnings
- `python -m ruff check agent/moonshot_schema.py tests/agent/test_moonshot_schema.py` → All checks passed
- `git diff --check`