### PR TITLE
fix(approval): surface pending-approval state with explicit marker (#28000)

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1332,7 +1332,8 @@ def check_all_command_guards(command: str, env_type: str,
         return {
             "approved": False,
             "pattern_key": primary_key,
-            "status": "approval_required",
+            "status": "pending_approval",
+            "approval_pending": True,
             "command": command,
             "description": combined_desc,
             "message": (

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1863,12 +1863,13 @@ def terminal_tool(
             approval = _check_all_guards(command, env_type)
             if not approval["approved"]:
                 # Check if this is an approval_required (gateway ask mode)
-                if approval.get("status") == "approval_required":
+                if approval.get("status") == "pending_approval":
                     return json.dumps({
                         "output": "",
                         "exit_code": -1,
-                        "error": approval.get("message", "Waiting for user approval"),
-                        "status": "approval_required",
+                        "error": "",
+                        "status": "pending_approval",
+                        "approval_pending": True,
                         "command": approval.get("command", command),
                         "description": approval.get("description", "command flagged"),
                         "pattern_key": approval.get("pattern_key", ""),


### PR DESCRIPTION
Salvage of #28000 by @LifeJiggy.

**What:** When a tool requires approval (e.g. write_file, patch on sensitive paths), the approval prompt fires asynchronously but the tool result returned to the LLM was indistinguishable from a normal failure (`exit_code=-1` plus a generic error string). The model couldn't tell whether to retry, wait, or give up.

**How:** Promote the status field from `approval_required` to `pending_approval` and add an explicit `approval_pending: True` field on both the guard payload (`tools/approval.py`) and the terminal-tool fallthrough (`tools/terminal_tool.py`). Clears the `error` field so the model sees the pending state directly instead of as a failure.

Original PR: https://github.com/NousResearch/hermes-agent/pull/28000
Fixes #14806.