### PR TITLE
fix(agent): recognize emoji and caret as natural response endings (#28168)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1019,7 +1019,15 @@ class AIAgent:
             return False
         if stripped.endswith("```"):
             return True
-        return stripped[-1] in '.!?:)"\']}。！？：）】」』》'
+        if stripped.endswith('^'):
+            return True
+        last = stripped[-1]
+        if last in '.!?:)"\']}。！？：）】」』》^':
+            return True
+        # Emoji ranges (Misc Symbols, Dingbats, Emoticons, Supplemental, etc.)
+        if ord(last) >= 0x1F300:
+            return True
+        return False
 
     def _is_ollama_glm_backend(self) -> bool:
         """Detect the narrow backend family affected by Ollama/GLM stop misreports."""


### PR DESCRIPTION
Salvage of #28168 by @oseftg.

**What:** GLM models via Ollama report `finish_reason='stop'` even when the response was truncated by max_tokens. The continuation heuristic uses `_has_natural_response_ending()` to detect truncation, but the regex didn't cover responses ending in emoji or caret (`^`), so legitimate model outputs ending that way were misclassified as truncated and re-prompted unnecessarily.

**How:** Add caret to the punctuation set, and accept any character with `ord() >= 0x1F300` (covers Misc Symbols, Dingbats, Emoticons, Supplemental) as a natural ending.

Original PR: https://github.com/NousResearch/hermes-agent/pull/28168