### PR TITLE
fix(grok,glm): OPENAI guidance + tool_choice=required on stall retry

### DIFF
--- a/agent/action_stall.py
+++ b/agent/action_stall.py
@@ -1,0 +1,47 @@
+"""Wire-protocol shared between the gateway's action-stall guard and the
+codex/xAI transport.
+
+When ``gateway.run`` detects an assistant turn that promises action but
+emits no tool call, it enqueues a corrective continuation as the next
+user message, prefixed with :data:`ACTION_STALL_EVENT_PREFIX`.  The
+codex transport recognises that prefix on the inbound message list and
+forces ``tool_choice=required`` so the retry cannot narrate its way
+through again.
+
+The constant lives here (not in ``gateway.run`` or in the transport) so
+the producer and the consumer share a single source of truth.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+ACTION_STALL_EVENT_PREFIX = "[System corrective continuation: tool execution required]"
+
+
+def latest_user_message_is_stall_continuation(messages: Any) -> bool:
+    """Return ``True`` iff the most recent user message starts with the
+    stall-continuation prefix.
+
+    ``content`` may be a plain string or a list of OpenAI-style content
+    parts ``{"type": "...", "text": "..."}``; both shapes are inspected.
+    Trailing non-user entries (assistant, tool) are skipped — the relevant
+    "latest user message" drives the current turn even when later entries
+    were appended.
+    """
+    if not messages:
+        return False
+    for msg in reversed(list(messages)):
+        if not isinstance(msg, dict) or msg.get("role") != "user":
+            continue
+        content = msg.get("content")
+        if isinstance(content, str):
+            return content.lstrip().startswith(ACTION_STALL_EVENT_PREFIX)
+        if isinstance(content, list):
+            for part in content:
+                if isinstance(part, dict):
+                    text = part.get("text")
+                    if isinstance(text, str) and text.lstrip().startswith(ACTION_STALL_EVENT_PREFIX):
+                        return True
+        return False
+    return False

--- a/agent/action_stall.py
+++ b/agent/action_stall.py
@@ -21,27 +21,52 @@ ACTION_STALL_EVENT_PREFIX = "[System corrective continuation: tool execution req
 
 def latest_user_message_is_stall_continuation(messages: Any) -> bool:
     """Return ``True`` iff the most recent user message starts with the
-    stall-continuation prefix.
+    stall-continuation prefix AND the prior assistant turn (if any) emitted
+    no tool_calls — meaning this turn really is a stall-recovery situation
+    where forcing a tool call is safe.
 
     ``content`` may be a plain string or a list of OpenAI-style content
     parts ``{"type": "...", "text": "..."}``; both shapes are inspected.
-    Trailing non-user entries (assistant, tool) are skipped — the relevant
-    "latest user message" drives the current turn even when later entries
-    were appended.
+    Trailing non-user entries (assistant, tool) are skipped while finding
+    the latest user message.
+
+    The prior-tool-calls check defends future callers from accidentally
+    forcing ``tool_choice=required`` on a turn that follows real tool
+    activity — which would either loop or invalidate the just-completed
+    work.
     """
     if not messages:
         return False
-    for msg in reversed(list(messages)):
-        if not isinstance(msg, dict) or msg.get("role") != "user":
-            continue
-        content = msg.get("content")
-        if isinstance(content, str):
-            return content.lstrip().startswith(ACTION_STALL_EVENT_PREFIX)
-        if isinstance(content, list):
-            for part in content:
-                if isinstance(part, dict):
-                    text = part.get("text")
-                    if isinstance(text, str) and text.lstrip().startswith(ACTION_STALL_EVENT_PREFIX):
-                        return True
+    messages_list = list(messages)
+    latest_user_idx = None
+    for i in range(len(messages_list) - 1, -1, -1):
+        msg = messages_list[i]
+        if isinstance(msg, dict) and msg.get("role") == "user":
+            latest_user_idx = i
+            break
+    if latest_user_idx is None:
         return False
+    if not _content_starts_with_prefix(messages_list[latest_user_idx].get("content")):
+        return False
+    # Walk back from the user message to the most recent assistant entry;
+    # if it emitted tool_calls, the prior turn already did real work and
+    # this should not be a stall force.
+    for i in range(latest_user_idx - 1, -1, -1):
+        msg = messages_list[i]
+        if not isinstance(msg, dict):
+            continue
+        if msg.get("role") == "assistant":
+            return not msg.get("tool_calls")
+    return True
+
+
+def _content_starts_with_prefix(content: Any) -> bool:
+    if isinstance(content, str):
+        return content.lstrip().startswith(ACTION_STALL_EVENT_PREFIX)
+    if isinstance(content, list):
+        for part in content:
+            if isinstance(part, dict):
+                text = part.get("text")
+                if isinstance(text, str) and text.lstrip().startswith(ACTION_STALL_EVENT_PREFIX):
+                    return True
     return False

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -154,10 +154,15 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             # paths, parallel tool calls, verify-before-edit, etc.)
             if "gemini" in _model_lower or "gemma" in _model_lower:
                 stable_parts.append(GOOGLE_MODEL_OPERATIONAL_GUIDANCE)
-            # OpenAI-flavored execution discipline.  Grok receives it too:
-            # same narration-without-tool_use failure mode under base
+            # OpenAI-flavored execution discipline.  Grok and GLM receive it
+            # too: same narration-without-tool_use failure mode under base
             # enforcement alone.
-            if "gpt" in _model_lower or "codex" in _model_lower or "grok" in _model_lower:
+            if (
+                "gpt" in _model_lower
+                or "codex" in _model_lower
+                or "grok" in _model_lower
+                or "glm" in _model_lower
+            ):
                 stable_parts.append(OPENAI_MODEL_EXECUTION_GUIDANCE)
 
     has_skills_tools = any(name in agent.valid_tool_names for name in ['skills_list', 'skill_view', 'skill_manage'])

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -154,9 +154,10 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             # paths, parallel tool calls, verify-before-edit, etc.)
             if "gemini" in _model_lower or "gemma" in _model_lower:
                 stable_parts.append(GOOGLE_MODEL_OPERATIONAL_GUIDANCE)
-            # OpenAI GPT/Codex execution discipline (tool persistence,
-            # prerequisite checks, verification, anti-hallucination).
-            if "gpt" in _model_lower or "codex" in _model_lower:
+            # OpenAI-flavored execution discipline.  Grok receives it too:
+            # same narration-without-tool_use failure mode under base
+            # enforcement alone.
+            if "gpt" in _model_lower or "codex" in _model_lower or "grok" in _model_lower:
                 stable_parts.append(OPENAI_MODEL_EXECUTION_GUIDANCE)
 
     has_skills_tools = any(name in agent.valid_tool_names for name in ['skills_list', 'skill_view', 'skill_manage'])

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -65,8 +65,8 @@ class ToolCallGuardrailConfig:
     """Thresholds for per-turn tool-call loop detection.
 
     Warnings are enabled by default and never prevent tool execution. Hard stops
-    are explicit opt-in so interactive CLI/TUI sessions get a gentle nudge unless
-    the user enables circuit-breaker behavior in config.yaml.
+    are explicit opt-in so interactive CLI/TUI/gateway sessions get a gentle
+    nudge unless the user enables circuit-breaker behavior in config.yaml.
     """
 
     warnings_enabled: bool = True

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -63,6 +63,7 @@ class ResponsesApiTransport(ProviderTransport):
             _chat_messages_to_responses_input,
             _responses_tools,
         )
+        from agent.action_stall import latest_user_message_is_stall_continuation
 
         from run_agent import DEFAULT_AGENT_IDENTITY
 
@@ -104,7 +105,13 @@ class ResponsesApiTransport(ProviderTransport):
             "store": False,
         }
         if response_tools:
-            kwargs["tool_choice"] = "auto"
+            # Action-stall re-entry forces a tool call this turn — xAI's
+            # documented lever.  Caller request_overrides still wins below.
+            kwargs["tool_choice"] = (
+                "required"
+                if latest_user_message_is_stall_continuation(messages)
+                else "auto"
+            )
             kwargs["parallel_tool_calls"] = True
 
         session_id = params.get("session_id")

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2372,15 +2372,43 @@ class BasePlatformAdapter(ABC):
                 _prev = existing_cb
                 _new = callback
 
-                def _chained() -> None:
+                def _chained():
                     try:
-                        _prev()
+                        _prev_result = _prev()
                     except Exception:
                         logger.debug("Post-delivery callback failed", exc_info=True)
+                        _prev_result = None
+
+                    async def _await_then_new(_awaitable):
+                        try:
+                            await _awaitable
+                        except Exception:
+                            logger.debug("Post-delivery callback failed", exc_info=True)
+                        try:
+                            _new_result = _new()
+                            if inspect.isawaitable(_new_result):
+                                await _new_result
+                        except Exception:
+                            logger.debug("Post-delivery callback failed", exc_info=True)
+
+                    if inspect.isawaitable(_prev_result):
+                        return _await_then_new(_prev_result)
+
                     try:
-                        _new()
+                        _new_result = _new()
                     except Exception:
                         logger.debug("Post-delivery callback failed", exc_info=True)
+                        return None
+
+                    if inspect.isawaitable(_new_result):
+                        async def _await_new(_awaitable):
+                            try:
+                                await _awaitable
+                            except Exception:
+                                logger.debug("Post-delivery callback failed", exc_info=True)
+
+                        return _await_new(_new_result)
+                    return None
 
                 callback = _chained
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -145,15 +145,21 @@ def _build_action_stall_continuation(
     attempt: int,
     max_attempts: int,
 ) -> str:
-    """Build the synthetic follow-up that forces action after a no-tool promise."""
+    """Build the synthetic follow-up that forces action after a no-tool promise.
+
+    Forward-directional only: the prefix + ``Attempt: N/M`` line are protocol
+    markers (see :data:`agent.action_stall.ACTION_STALL_EVENT_PREFIX` and
+    :data:`_ACTION_STALL_ATTEMPT_RE`).  The natural-language body tells the
+    model to call a tool now; retrospective scolds were removed because they
+    primed defensive prose on retry.  Mechanical enforcement lives in the
+    codex transport, which sees the prefix and sets ``tool_choice=required``.
+    """
     return (
         f"{_ACTION_STALL_EVENT_PREFIX}\n"
         f"Attempt: {attempt}/{max_attempts}\n\n"
-        "Your previous response promised or described execution, but the turn "
-        "completed with zero tool calls/tool results. Do not answer with another "
-        "status update. Use the available tools now to perform the action. If no "
-        "tool can perform it, state the precise blocker and the evidence. Do not "
-        "claim sent/executed/verified/done without current tool/API/file evidence.\n\n"
+        "The turn completed with zero tool calls/tool results. Continue the "
+        "task by calling an available tool now. If no available tool can "
+        "perform the action, return one sentence stating the precise blocker.\n\n"
         "Original user message:\n"
         f"{(user_message or '').strip()[:2000]}\n\n"
         "Previous assistant response:\n"

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -67,9 +67,9 @@ _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-
 
 
 _ACTION_STALL_MAX_RETRIES_DEFAULT = 2
-_ACTION_STALL_EVENT_PREFIX = "[System corrective continuation: tool execution required]"
+from agent.action_stall import ACTION_STALL_EVENT_PREFIX as _ACTION_STALL_EVENT_PREFIX
 _ACTION_STALL_ATTEMPT_RE = re.compile(
-    r"^\[System corrective continuation: tool execution required\]\s*\nAttempt:\s*(\d+)\s*/\s*(\d+)",
+    r"^" + re.escape(_ACTION_STALL_EVENT_PREFIX) + r"\s*\nAttempt:\s*(\d+)\s*/\s*(\d+)",
     re.IGNORECASE,
 )
 _ACTION_STALL_PROGRESS_RE = re.compile(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -66,6 +66,100 @@ _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 
 
+_ACTION_STALL_MAX_RETRIES_DEFAULT = 2
+_ACTION_STALL_EVENT_PREFIX = "[System corrective continuation: tool execution required]"
+_ACTION_STALL_ATTEMPT_RE = re.compile(
+    r"^\[System corrective continuation: tool execution required\]\s*\nAttempt:\s*(\d+)\s*/\s*(\d+)",
+    re.IGNORECASE,
+)
+_ACTION_STALL_PROGRESS_RE = re.compile(
+    r"\b(?:i(?:'|’)ll\s+now|i\s+will\s+now|i\s+am\s+now|i(?:'|’)m\s+now|"
+    r"running\s+(?:the|it)|executing\s+(?:the|it|now)|sending\s+(?:now|the|it)|"
+    r"processing\s+(?:now|the|it)|updating\s+(?:the|it)|checking\s+(?:the|it)|"
+    r"verifying\s+(?:now|the|it)|stand\s+by|starting\s+(?:the|real|now)|"
+    r"initiating\s+(?:the|real)|using\s+the\s+.*\s+to\s+(?:check|send|run|execute|verify))\b",
+    re.IGNORECASE | re.DOTALL,
+)
+_ACTION_STALL_REQUEST_RE = re.compile(
+    r"\b(?:send|email|verify|check|run|execute|create|generate|update|install|fix|"
+    r"upload|download|process|start|open|search|find|look\s+up|use\s+the\s+.*api|"
+    r"view\s+your\s+skill|run\s+.*\s+now)\b",
+    re.IGNORECASE,
+)
+_ACTION_STALL_EVIDENCE_RE = re.compile(
+    r"\b(?:tool\s+(?:output|result)|exit\s+code\s*0|message[-_ ]?id|sent_id|"
+    r"api\s+response|status\s*(?:code)?\s*[:=]\s*2\d\d|created\s+file|"
+    r"wrote\s+(?:file|to)|saved\s+(?:file|to)|artifact\s*[:=]|path\s*[:=]|"
+    r"verified\s+(?:in|via)|found\s+in\s+(?:inbox|logs)|/home/|/tmp/)\b",
+    re.IGNORECASE,
+)
+
+
+def _action_stall_attempt(message_text: str) -> int:
+    """Return the current corrective-continuation attempt number, or 0."""
+    match = _ACTION_STALL_ATTEMPT_RE.search(message_text or "")
+    if not match:
+        return 0
+    try:
+        return int(match.group(1))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _messages_have_tool_activity(messages: list) -> bool:
+    """True when this turn actually emitted or consumed tool activity."""
+    for msg in messages or []:
+        if not isinstance(msg, dict):
+            continue
+        if msg.get("role") == "tool" or msg.get("tool_name"):
+            return True
+        if msg.get("tool_calls"):
+            return True
+    return False
+
+
+def _looks_like_action_stall(user_message: str, assistant_response: str, new_messages: list) -> bool:
+    """Detect a no-tool turn that only promises action/progress.
+
+    This is intentionally narrow: ordinary final answers are allowed, while
+    progress-only claims such as "sending now" or "I’ll now use the Gmail API"
+    must be backed by tool activity or concrete execution evidence.
+    """
+    response = (assistant_response or "").strip()
+    if not response or _messages_have_tool_activity(new_messages):
+        return False
+    if _ACTION_STALL_EVIDENCE_RE.search(response):
+        return False
+    if not _ACTION_STALL_PROGRESS_RE.search(response):
+        return False
+    return bool(
+        _ACTION_STALL_REQUEST_RE.search(user_message or "")
+        or _ACTION_STALL_REQUEST_RE.search(response)
+    )
+
+
+def _build_action_stall_continuation(
+    *,
+    user_message: str,
+    assistant_response: str,
+    attempt: int,
+    max_attempts: int,
+) -> str:
+    """Build the synthetic follow-up that forces action after a no-tool promise."""
+    return (
+        f"{_ACTION_STALL_EVENT_PREFIX}\n"
+        f"Attempt: {attempt}/{max_attempts}\n\n"
+        "Your previous response promised or described execution, but the turn "
+        "completed with zero tool calls/tool results. Do not answer with another "
+        "status update. Use the available tools now to perform the action. If no "
+        "tool can perform it, state the precise blocker and the evidence. Do not "
+        "claim sent/executed/verified/done without current tool/API/file evidence.\n\n"
+        "Original user message:\n"
+        f"{(user_message or '').strip()[:2000]}\n\n"
+        "Previous assistant response:\n"
+        f"{(assistant_response or '').strip()[:2000]}"
+    )
+
 def _telegramize_command_mentions(text: str, platform: Any) -> str:
     """Rewrite slash-command mentions to Telegram-valid command names.
 
@@ -6124,6 +6218,22 @@ class GatewayRunner:
             # clearly moved on.
             _slash_confirm_mod.clear_if_stale(_quick_key)
 
+        # Natural-language approval intercept.  When a dangerous-command
+        # approval is blocking the agent thread on tools/approval.py's
+        # threading.Event, accept free-form replies like "I approve" /
+        # "approved" / "yes" / "execute" as equivalents of /approve, and
+        # "deny" / "cancel" as equivalents of /deny.  Without this, plain-
+        # text replies get forwarded to the still-blocked agent, the
+        # message is queued until inactivity timeout, and the next turn
+        # starts with "I approve" as fresh conversational context — which
+        # the LLM interprets as a discussion request and downgrades to
+        # "I can prepare prompts" instead of executing the approved action.
+        _nl_approval = await self._try_natural_language_approval(
+            event, _quick_key,
+        )
+        if _nl_approval is not None:
+            return _nl_approval
+
         # PRIORITY handling when an agent is already running for this session.
         # Default behavior is to interrupt immediately so user text/stop messages
         # are handled with minimal latency.
@@ -7908,6 +8018,87 @@ class GatewayRunner:
                     else:
                         display_reasoning = last_reasoning.strip()
                     response = f"💭 **Reasoning:**\n```\n{display_reasoning}\n```\n\n{response}"
+
+            # Gateway action-stall guard: messaging turns must not end with
+            # "I am doing it now" prose when no tool call actually happened.
+            # The /goal judge catches this for standing goals; this path catches
+            # normal direct Telegram/Slack/etc. turns and queues a bounded
+            # corrective continuation through the same FIFO machinery used by
+            # /goal continuations.
+            _guard_new_messages = []
+            try:
+                _guard_history_len = agent_result.get("history_offset", len(history))
+                if len(agent_messages) > _guard_history_len:
+                    _guard_new_messages = agent_messages[_guard_history_len:]
+            except Exception:
+                _guard_new_messages = []
+            _action_stall_guarded = False
+            if (
+                not agent_result.get("failed")
+                and not agent_result.get("already_sent")
+                and _looks_like_action_stall(message_text, response, _guard_new_messages)
+            ):
+                _current_attempt = _action_stall_attempt(message_text)
+                try:
+                    _stall_cfg = _load_gateway_config() or {}
+                    _stall_agent_cfg = _stall_cfg.get("agent") if isinstance(_stall_cfg, dict) else {}
+                    _stall_max = int(
+                        (_stall_agent_cfg or {}).get(
+                            "action_stall_max_retries",
+                            _ACTION_STALL_MAX_RETRIES_DEFAULT,
+                        )
+                        or _ACTION_STALL_MAX_RETRIES_DEFAULT
+                    )
+                except Exception:
+                    _stall_max = _ACTION_STALL_MAX_RETRIES_DEFAULT
+                _stall_max = max(0, _stall_max)
+                if _current_attempt < _stall_max:
+                    _next_attempt = _current_attempt + 1
+                    try:
+                        _stall_adapter = self.adapters.get(source.platform) if source is not None else None
+                        if _stall_adapter and session_key:
+                            _stall_event = MessageEvent(
+                                text=_build_action_stall_continuation(
+                                    user_message=message_text,
+                                    assistant_response=response,
+                                    attempt=_next_attempt,
+                                    max_attempts=_stall_max,
+                                ),
+                                message_type=MessageType.TEXT,
+                                source=source,
+                                message_id=None,
+                                channel_prompt=event.channel_prompt,
+                            )
+                            self._enqueue_fifo(session_key, _stall_event, _stall_adapter)
+                            _action_stall_guarded = True
+                            logger.warning(
+                                "action-stall guard: queued corrective continuation "
+                                "attempt %s/%s for session=%s response=%r",
+                                _next_attempt,
+                                _stall_max,
+                                session_entry.session_id,
+                                (response or "")[:160],
+                            )
+                    except Exception as exc:
+                        logger.warning("action-stall guard: enqueue failed: %s", exc, exc_info=True)
+                if _action_stall_guarded:
+                    response = (
+                        "⚠️ Hermes caught an action promise with no tool execution. "
+                        "I queued a corrective continuation to execute with tools now. "
+                        "No sent/executed/verified claim is valid until tool/API/file evidence appears."
+                    )
+                elif _stall_max and _current_attempt >= _stall_max:
+                    logger.error(
+                        "action-stall guard: max corrective attempts exhausted for session=%s response=%r",
+                        session_entry.session_id,
+                        (response or "")[:160],
+                    )
+                    response = (
+                        "⚠️ Hermes still produced an action promise without any tool calls after "
+                        f"{_stall_max} corrective attempt(s). I am not treating it as done. "
+                        "Concrete blocker: the model/provider returned prose instead of a tool call. "
+                        "Switch model/provider or run the action through the VM-control/Codex lane."
+                    )
 
             # Runtime-metadata footer — only on the FINAL message of the turn.
             # Off by default (display.runtime_footer.enabled=false).  When
@@ -12665,6 +12856,105 @@ class GatewayRunner:
     # ------------------------------------------------------------------
 
     _APPROVAL_TIMEOUT_SECONDS = 300  # 5 minutes
+
+    async def _try_natural_language_approval(
+        self, event: "MessageEvent", session_key: str,
+    ) -> Optional[str]:
+        """Intercept plain-text approval phrases like "I approve" / "yes".
+
+        Returns a user-facing string when the message is intercepted (the
+        approval resolved, denied, or disambiguation prompted) and ``None``
+        to let normal dispatch continue.
+
+        Why this exists: messaging-platform users rarely remember to prefix
+        replies with ``/approve``.  Without this intercept, "I approve"
+        flows to the agent — which is blocked on a threading.Event in
+        tools/approval.py and can't see it — and the next turn treats the
+        text as conversation, producing the "prepare prompts" downgrade.
+
+        Routing rules (executed in order):
+          * Slash-prefixed text → ``None`` (let the normal command pipeline
+            handle it).  This includes the literal ``/approve``.
+          * Text that does not classify as an approve/deny phrase → ``None``
+            (conversational text is never reinterpreted).
+          * Approval intent + exactly one pending approval → resolve via the
+            same ``_handle_approve_command`` / ``_handle_deny_command`` path
+            that the slash commands use, so ledger hooks, agent unblock,
+            and typing-indicator resume all happen identically.
+          * Approval intent + multiple pending approvals → return a
+            disambiguation prompt listing the queued commands.  The user
+            must explicitly use ``/approve all`` / ``/approve`` (oldest)
+            / ``/deny all`` / ``/deny`` (oldest).
+          * Approval intent + zero pending approvals → ``None`` so "execute
+            this" / "do it" remains a normal task instruction instead of being
+            swallowed by a no-pending approval response.
+        """
+        from tools.approval_intent import classify
+        from tools.approval import list_gateway_pending
+
+        raw = (event.text or "").strip()
+        if not raw or raw.startswith("/"):
+            return None
+
+        intent = classify(raw)
+        if intent is None:
+            return None
+
+        pending = list_gateway_pending(session_key)
+        n_pending = len(pending)
+
+        if n_pending == 0:
+            return None
+
+        if n_pending == 1:
+            logger.info(
+                "Gateway intercepted natural-language %s intent "
+                "(session=%s, phrase=%r)",
+                intent, session_key, raw[:40],
+            )
+            if intent == "approve":
+                return await self._handle_approve_command(event)
+            return await self._handle_deny_command(event)
+
+        # Multiple pending → disambiguate.  Do NOT default to FIFO; the
+        # text was ambiguous about which approval the user meant.
+        logger.info(
+            "Natural-language %s intent on %d pending — disambiguating "
+            "(session=%s)",
+            intent, n_pending, session_key,
+        )
+        # Redact obvious secret patterns from the command preview before
+        # echoing into chat history.  The full command remains visible to
+        # the user through the original /approve prompt; this list is for
+        # disambiguation only, so it's safe to redact aggressively.
+        # Matches: `KEY=value` style env exports where KEY ends in
+        # _KEY / _SECRET / _TOKEN / _PASSWORD / PASSWORD (case-insensitive).
+        import re as _re
+        _SECRET_RE = _re.compile(
+            r"((?i:[A-Z0-9_]*(?:_KEY|_SECRET|_TOKEN|_PASSWORD|PASSWORD)\s*=))\S+",
+        )
+
+        item_lines = []
+        for idx, item in enumerate(pending, start=1):
+            preview = (item.get("command") or item.get("description") or "").strip()
+            if not preview:
+                preview = "(no command preview)"
+            preview = _SECRET_RE.sub(r"\1<redacted>", preview)
+            if len(preview) > 80:
+                preview = preview[:77] + "..."
+            item_lines.append(f"  {idx}. `{preview}`")
+        items_block = "\n".join(item_lines)
+        if intent == "approve":
+            return t(
+                "gateway.approve.disambiguate",
+                count=n_pending,
+                items=items_block,
+            )
+        return t(
+            "gateway.deny.disambiguate",
+            count=n_pending,
+            items=items_block,
+        )
 
     async def _handle_approve_command(self, event: MessageEvent) -> Optional[str]:
         """Handle /approve command — unblock waiting agent thread(s).

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -506,6 +506,9 @@ DEFAULT_CONFIG = {
         # (force on/off for all models), or a list of model-name substrings
         # to match (e.g. ["gpt", "codex", "gemini", "qwen"]).
         "tool_use_enforcement": "auto",
+        # Gateway guard retry cap for direct platform turns that promise
+        # action but return with zero tool calls. 0 disables the guard.
+        "action_stall_max_retries": 2,
         # Staged inactivity warning: send a warning to the user at this
         # threshold before escalating to a full timeout.  The warning fires
         # once per run and does not interrupt the agent.  0 = disable warning.
@@ -741,8 +744,9 @@ DEFAULT_CONFIG = {
     },
 
     # Tool loop guardrails nudge models when they repeat failed or
-    # non-progressing tool calls. Soft warnings are always-on by default;
-    # hard stops are opt-in so interactive CLI/TUI sessions keep flowing.
+    # non-progressing tool calls. Soft warnings are always-on; hard stops are
+    # explicit opt-in so normal interactive sessions do not turn guidance into
+    # a hidden execution constraint.
     "tool_loop_guardrails": {
         "warnings_enabled": True,
         "hard_stop_enabled": False,

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -100,8 +100,30 @@ JUDGE_SYSTEM_PROMPT = (
     "A goal is DONE only when:\n"
     "- The response explicitly confirms the goal was completed, OR\n"
     "- The response clearly shows the final deliverable was produced, OR\n"
-    "- The response explains the goal is unachievable / blocked / needs "
-    "user input (treat this as DONE with reason describing the block).\n\n"
+    "- The response explains the goal is FUNDAMENTALLY IMPOSSIBLE on "
+    "this system (a required external service genuinely does not exist, "
+    "a fact in the goal is provably false, or the requested action is "
+    "categorically forbidden by policy). In this case mark DONE and "
+    "describe the impossibility in the reason field.\n\n"
+    "For action-shaped goals — send, email, execute, run, create, generate, "
+    "upload, download, verify, deliver, process, install, build, or fix — "
+    "do NOT accept bare claims like 'executing now', 'sending now', "
+    "'email sent', 'run complete', or 'goal complete'. Mark DONE only "
+    "when the response includes concrete execution evidence such as a tool "
+    "output line, exit code 0, generated file path, message id, API response, "
+    "inbox/search verification, or similarly specific artifact. If the "
+    "response is only a promise, status phrase, or unsupported completion "
+    "claim, return CONTINUE.\n\n"
+    "Crucial distinction (judge bias fix, 2026-05-17): the agent saying "
+    "it 'needs user input', 'cannot continue', 'requests a decision', "
+    "'asks for clarification', or 'hit a tool limit' is NOT the goal "
+    "being done — it is the agent yielding control prematurely. When "
+    "you see those phrases, return CONTINUE (done=false) so the next "
+    "turn fires and the agent gets another try. The agent has a "
+    "bounded turn budget (state.max_turns); if it truly cannot make "
+    "progress the budget will exhaust naturally and the goal will be "
+    "PAUSED — that is the right place to surface to the user, not the "
+    "judge.\n\n"
     "Otherwise the goal is NOT done — CONTINUE.\n\n"
     "Reply ONLY with a single JSON object on one line:\n"
     '{\"done\": <true|false>, \"reason\": \"<one-sentence rationale>\"}'
@@ -295,6 +317,45 @@ def _truncate(text: str, limit: int) -> str:
 _JSON_OBJECT_RE = re.compile(r"\{.*?\}", re.DOTALL)
 
 
+_ACTION_GOAL_RE = re.compile(
+    r"\b(send|email|execute|run|create|generate|upload|download|verify|deliver|process|install|build|fix)\b",
+    re.IGNORECASE,
+)
+_PROGRESS_ONLY_RE = re.compile(
+    r"\b(i am now|i'm now|i will now|i’ll now|starting|processing now|executing now|sending now|stand by|running now|initiating|preparing|ready-to-paste)\b",
+    re.IGNORECASE,
+)
+_BARE_COMPLETION_RE = re.compile(
+    r"\b(goal complete|task complete|email sent|sent successfully|executed until completion|run complete|done)\b",
+    re.IGNORECASE,
+)
+_EXECUTION_EVIDENCE_RE = re.compile(
+    r"(exit[_ -]?code\s*[:=]\s*0|returncode\s*[:=]\s*0|message[_ -]?id\s*[:=]|run[_ -]?id\s*[:=]|"
+    r"tool output|terminal output|api response|response id\s*[:=]|status\s*[:=]\s*(ok|success)|"
+    r"success\s*[:=]\s*true|created\s*:\s*/|/home/[^\s`]+|sha256:[0-9a-f]{16,}|"
+    r"verified (sent|delivered|received|created|written)|inbox search|gmail.*message)",
+    re.IGNORECASE,
+)
+
+
+def _looks_like_unverified_action_claim(goal: str, last_response: str) -> bool:
+    """Return True when an action goal is answered with words but no evidence.
+
+    Telegram /goal loops are especially vulnerable to text-only completion claims
+    ("sending now", "email sent", "goal complete") because the judge only sees
+    the assistant response, not the message table's tool rows.  Require concrete
+    execution evidence for action-shaped goals so the loop keeps going instead of
+    marking hallucinated work as done.
+    """
+    goal_text = goal or ""
+    response = last_response or ""
+    if not _ACTION_GOAL_RE.search(goal_text):
+        return False
+    if _EXECUTION_EVIDENCE_RE.search(response):
+        return False
+    return bool(_PROGRESS_ONLY_RE.search(response) or _BARE_COMPLETION_RE.search(response))
+
+
 def _goal_judge_max_tokens() -> int:
     """Resolve auxiliary.goal_judge.max_tokens, falling back to the default.
 
@@ -400,6 +461,8 @@ def judge_goal(
     if not last_response.strip():
         # No substantive reply this turn — almost certainly not done yet.
         return "continue", "empty response (nothing to evaluate)", False
+    if _looks_like_unverified_action_claim(goal, last_response):
+        return "continue", "action goal answered without concrete execution evidence", False
 
     try:
         from agent.auxiliary_client import get_auxiliary_extra_body, get_text_auxiliary_client

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -76,6 +76,7 @@ gateway:
     session_plural:        "✅ Commands approved (pattern approved for this session) ({count} commands). The agent is resuming..."
     always_singular:       "✅ Command approved (pattern approved permanently). The agent is resuming..."
     always_plural:         "✅ Commands approved (pattern approved permanently) ({count} commands). The agent is resuming..."
+    disambiguate:          "⚠️ {count} pending approvals — please pick one explicitly:\n{items}\n\nReply `/approve all` to approve all, or `/approve` to approve the oldest."
 
   background:
     usage:                 "Usage: /background <prompt>\nExample: /background Summarize the top HN stories today\n\nRuns the prompt in a separate session. You can keep chatting — the result will appear here when done."
@@ -120,6 +121,7 @@ gateway:
     no_pending:            "No pending command to deny."
     denied_singular:       "❌ Command denied."
     denied_plural:         "❌ Commands denied ({count} commands)."
+    disambiguate:          "⚠️ {count} pending approvals — please pick one explicitly:\n{items}\n\nReply `/deny all` to deny all, or `/deny` to deny the oldest."
 
   fast:
     not_supported:         "⚡ /fast is only available for OpenAI models that support Priority Processing."

--- a/tests/agent/test_action_stall.py
+++ b/tests/agent/test_action_stall.py
@@ -1,0 +1,83 @@
+"""Tests for the shared action-stall wire-protocol module."""
+
+from agent.action_stall import (
+    ACTION_STALL_EVENT_PREFIX,
+    latest_user_message_is_stall_continuation,
+)
+
+
+class TestActionStallEventPrefix:
+    def test_prefix_is_stable_protocol_string(self):
+        # Producer (gateway.run._build_action_stall_continuation) and consumer
+        # (agent.transports.codex.build_kwargs) both depend on this exact text.
+        # Changing it is a wire-protocol break — assert it explicitly.
+        assert ACTION_STALL_EVENT_PREFIX == (
+            "[System corrective continuation: tool execution required]"
+        )
+
+
+class TestLatestUserMessageIsStallContinuation:
+    def test_empty_messages_returns_false(self):
+        assert latest_user_message_is_stall_continuation([]) is False
+        assert latest_user_message_is_stall_continuation(None) is False
+
+    def test_string_content_with_prefix_returns_true(self):
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+            {"role": "user", "content": f"{ACTION_STALL_EVENT_PREFIX}\nAttempt: 1/2"},
+        ]
+        assert latest_user_message_is_stall_continuation(messages) is True
+
+    def test_string_content_without_prefix_returns_false(self):
+        messages = [{"role": "user", "content": "just a normal request"}]
+        assert latest_user_message_is_stall_continuation(messages) is False
+
+    def test_leading_whitespace_tolerated(self):
+        messages = [
+            {"role": "user", "content": f"  \n  {ACTION_STALL_EVENT_PREFIX}\nAttempt: 1/2"},
+        ]
+        assert latest_user_message_is_stall_continuation(messages) is True
+
+    def test_list_content_parts_with_prefix_returns_true(self):
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": f"{ACTION_STALL_EVENT_PREFIX}\nAttempt: 1/2"},
+                ],
+            },
+        ]
+        assert latest_user_message_is_stall_continuation(messages) is True
+
+    def test_only_inspects_latest_user_message(self):
+        """An older user message with the prefix must not trigger on a later
+        normal user turn — the stall force is per-turn."""
+        messages = [
+            {"role": "user", "content": f"{ACTION_STALL_EVENT_PREFIX}\nAttempt: 1/2"},
+            {"role": "assistant", "content": "tool call happened"},
+            {"role": "user", "content": "thanks, do this next thing"},
+        ]
+        assert latest_user_message_is_stall_continuation(messages) is False
+
+    def test_skips_non_user_trailing_entries(self):
+        """Tool/assistant entries after the latest user message must not hide
+        the user message we care about."""
+        messages = [
+            {"role": "user", "content": f"{ACTION_STALL_EVENT_PREFIX}\nAttempt: 1/2"},
+            {"role": "assistant", "content": "..."},
+            {"role": "tool", "content": "result"},
+        ]
+        assert latest_user_message_is_stall_continuation(messages) is True
+
+    def test_non_dict_entries_ignored(self):
+        messages = [
+            "not a dict",
+            None,
+            {"role": "user", "content": f"{ACTION_STALL_EVENT_PREFIX}\nAttempt: 1/2"},
+        ]
+        assert latest_user_message_is_stall_continuation(messages) is True
+
+    def test_missing_content_returns_false(self):
+        messages = [{"role": "user"}]
+        assert latest_user_message_is_stall_continuation(messages) is False

--- a/tests/agent/test_action_stall.py
+++ b/tests/agent/test_action_stall.py
@@ -81,3 +81,35 @@ class TestLatestUserMessageIsStallContinuation:
     def test_missing_content_returns_false(self):
         messages = [{"role": "user"}]
         assert latest_user_message_is_stall_continuation(messages) is False
+
+    def test_returns_false_when_prior_assistant_already_emitted_tool_calls(self):
+        """Defensive check: if work was already done on the previous turn,
+        forcing tool_choice=required now would either loop or contradict the
+        agent's just-completed action.  The stall guard is only meant to
+        recover narration-without-tool_use turns.
+        """
+        messages = [
+            {"role": "user", "content": "send the report"},
+            {"role": "assistant", "tool_calls": [{"id": "c1", "function": {"name": "send"}}]},
+            {"role": "tool", "tool_call_id": "c1", "content": "ok"},
+            {"role": "user", "content": f"{ACTION_STALL_EVENT_PREFIX}\nAttempt: 1/2"},
+        ]
+        assert latest_user_message_is_stall_continuation(messages) is False
+
+    def test_returns_true_when_prior_assistant_had_no_tool_calls(self):
+        """Normal stall-recovery case: assistant turn emitted only prose."""
+        messages = [
+            {"role": "user", "content": "send the report"},
+            {"role": "assistant", "content": "I will now send the report."},
+            {"role": "user", "content": f"{ACTION_STALL_EVENT_PREFIX}\nAttempt: 1/2"},
+        ]
+        assert latest_user_message_is_stall_continuation(messages) is True
+
+    def test_returns_true_when_no_prior_assistant_turn_at_all(self):
+        """First-turn edge case: stall continuation as the very first user
+        entry (shouldn't happen in production but defend against it).
+        """
+        messages = [
+            {"role": "user", "content": f"{ACTION_STALL_EVENT_PREFIX}\nAttempt: 1/2"},
+        ]
+        assert latest_user_message_is_stall_continuation(messages) is True

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -33,7 +33,7 @@ def test_tool_call_signature_hashes_canonical_nested_unicode_args_without_exposi
     assert "☤" not in json.dumps(metadata)
 
 
-def test_default_config_is_soft_warning_only_with_hard_stop_disabled():
+def test_default_config_keeps_soft_warning_only_behavior():
     cfg = ToolCallGuardrailConfig()
 
     assert cfg.warnings_enabled is True
@@ -75,7 +75,9 @@ def test_config_parses_nested_warn_and_hard_stop_thresholds():
 
 
 def test_default_repeated_identical_failed_call_warns_without_blocking():
-    controller = ToolCallGuardrailController()
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(hard_stop_enabled=False)
+    )
     args = {"query": "same"}
 
     decisions = []
@@ -149,7 +151,11 @@ def test_file_mutation_lint_error_result_is_not_a_tool_failure():
 
 def test_same_tool_varying_args_warns_by_default_without_halting():
     controller = ToolCallGuardrailController(
-        ToolCallGuardrailConfig(same_tool_failure_warn_after=2, same_tool_failure_halt_after=3)
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=False,
+            same_tool_failure_warn_after=2,
+            same_tool_failure_halt_after=3,
+        )
     )
 
     first = controller.after_call("terminal", {"command": "cmd-1"}, '{"exit_code":1}', failed=True)
@@ -186,7 +192,11 @@ def test_hard_stop_enabled_halts_same_tool_varying_args_failure_streak():
 
 def test_idempotent_no_progress_repeated_result_warns_without_blocking_by_default():
     controller = ToolCallGuardrailController(
-        ToolCallGuardrailConfig(no_progress_warn_after=2, no_progress_block_after=2)
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=False,
+            no_progress_warn_after=2,
+            no_progress_block_after=2,
+        )
     )
     args = {"path": "/tmp/same.txt"}
     result = "same file contents"

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -341,6 +341,103 @@ class TestCodexBuildKwargs:
         assert "reasoning" not in kw
 
 
+def _tool_def(name="terminal"):
+    """Minimal tool def accepted by ResponsesApiTransport.convert_tools."""
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": f"{name} tool",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+
+
+class TestCodexBuildKwargsActionStallForcing:
+    """When the gateway's action-stall guard re-enters the agent loop with a
+    corrective-continuation user message, the transport must force
+    ``tool_choice=required`` for that turn so Grok cannot narrate its way
+    through the retry.  xAI documents ``tool_choice=required`` as the
+    supported lever for compelling tool emission on a given turn.
+    """
+
+    def test_stall_continuation_forces_tool_choice_required(self, transport):
+        from agent.action_stall import ACTION_STALL_EVENT_PREFIX
+
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "send the report"},
+            {"role": "assistant", "content": "I will now send the report."},
+            {
+                "role": "user",
+                "content": (
+                    f"{ACTION_STALL_EVENT_PREFIX}\n"
+                    "Attempt: 1/2\n\n"
+                    "The turn completed with zero tool calls/tool results."
+                ),
+            },
+        ]
+        kw = transport.build_kwargs(
+            model="grok-4.3",
+            messages=messages,
+            tools=[_tool_def("terminal")],
+            is_xai_responses=True,
+        )
+        assert kw.get("tool_choice") == "required"
+
+    def test_normal_user_message_keeps_tool_choice_auto(self, transport):
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "send the report"},
+        ]
+        kw = transport.build_kwargs(
+            model="grok-4.3",
+            messages=messages,
+            tools=[_tool_def("terminal")],
+            is_xai_responses=True,
+        )
+        assert kw.get("tool_choice") == "auto"
+
+    def test_stall_continuation_without_tools_omits_tool_choice(self, transport):
+        """No tools registered → nothing to force; tool_choice is not set at all."""
+        from agent.action_stall import ACTION_STALL_EVENT_PREFIX
+
+        messages = [
+            {"role": "user", "content": "send the report"},
+            {"role": "assistant", "content": "I will now send the report."},
+            {"role": "user", "content": f"{ACTION_STALL_EVENT_PREFIX}\nAttempt: 1/2"},
+        ]
+        kw = transport.build_kwargs(
+            model="grok-4.3",
+            messages=messages,
+            tools=[],
+            is_xai_responses=True,
+        )
+        assert "tool_choice" not in kw
+
+    def test_caller_request_overrides_tool_choice_wins(self, transport):
+        """Explicit request_overrides beats the auto-forced ``required``.
+
+        Lets callers (tests, internal flows) deliberately opt back to ``auto``
+        or pin a specific function on a corrective turn if they need to.
+        """
+        from agent.action_stall import ACTION_STALL_EVENT_PREFIX
+
+        messages = [
+            {"role": "user", "content": "send"},
+            {"role": "assistant", "content": "I will now send."},
+            {"role": "user", "content": f"{ACTION_STALL_EVENT_PREFIX}\nAttempt: 1/2"},
+        ]
+        kw = transport.build_kwargs(
+            model="grok-4.3",
+            messages=messages,
+            tools=[_tool_def("terminal")],
+            is_xai_responses=True,
+            request_overrides={"tool_choice": "auto"},
+        )
+        assert kw.get("tool_choice") == "auto"
+
+
 class TestCodexValidateResponse:
 
     def test_none_response(self, transport):

--- a/tests/gateway/test_action_stall_guard.py
+++ b/tests/gateway/test_action_stall_guard.py
@@ -1,0 +1,66 @@
+from gateway.run import (
+    _action_stall_attempt,
+    _build_action_stall_continuation,
+    _looks_like_action_stall,
+    _messages_have_tool_activity,
+)
+
+
+def test_detects_direct_turn_action_promise_without_tool_activity():
+    response = (
+        "I’ll now use the Gmail API to check the inbox for the sent email. "
+        "Updating the skill and running it now…"
+    )
+
+    assert _looks_like_action_stall(
+        "Verify if the email was sent",
+        response,
+        [{"role": "user", "content": "Verify if the email was sent"}, {"role": "assistant", "content": response}],
+    )
+
+
+def test_does_not_flag_when_tool_activity_exists():
+    response = "I’ll now use the Gmail API to check the inbox."
+
+    assert _messages_have_tool_activity([
+        {"role": "assistant", "tool_calls": [{"id": "call_1", "function": {"name": "gmail_search"}}]},
+    ])
+    assert not _looks_like_action_stall(
+        "Verify if the email was sent",
+        response,
+        [{"role": "assistant", "tool_calls": [{"id": "call_1"}]}],
+    )
+
+
+def test_does_not_flag_when_response_contains_concrete_evidence():
+    response = "Verified via Gmail API response: status=200, message_id=abc123."
+
+    assert not _looks_like_action_stall(
+        "Verify if the email was sent",
+        response,
+        [{"role": "assistant", "content": response}],
+    )
+
+
+def test_does_not_flag_ordinary_final_answer():
+    assert not _looks_like_action_stall(
+        "What model are you on currently?",
+        "I’m currently on grok-4.3 via xAI.",
+        [{"role": "assistant", "content": "I’m currently on grok-4.3 via xAI."}],
+    )
+
+
+def test_corrective_continuation_is_bounded_and_preserves_context():
+    continuation = _build_action_stall_continuation(
+        user_message="Send them to me via email",
+        assistant_response="Sending now…",
+        attempt=1,
+        max_attempts=2,
+    )
+
+    assert _action_stall_attempt(continuation) == 1
+    assert "zero tool calls/tool results" in continuation
+    assert "Original user message:" in continuation
+    assert "Send them to me via email" in continuation
+    assert "Previous assistant response:" in continuation
+    assert "Sending now" in continuation

--- a/tests/gateway/test_action_stall_guard.py
+++ b/tests/gateway/test_action_stall_guard.py
@@ -64,3 +64,26 @@ def test_corrective_continuation_is_bounded_and_preserves_context():
     assert "Send them to me via email" in continuation
     assert "Previous assistant response:" in continuation
     assert "Sending now" in continuation
+
+
+def test_corrective_continuation_uses_forward_direction_not_retrospective_scold():
+    """The corrective text must direct the model forward (call a tool now)
+    rather than re-litigate the prior turn ("Your previous response promised…",
+    "Do not claim sent/executed/verified/done…").  Retrospective scolds prime
+    defensive prose; tool_choice=required + a forward instruction is the
+    mechanically-enforced path.
+    """
+    continuation = _build_action_stall_continuation(
+        user_message="Send them to me via email",
+        assistant_response="Sending now…",
+        attempt=1,
+        max_attempts=2,
+    )
+
+    # Retrospective scolds that primed more prose on retry — must be gone.
+    assert "Your previous response promised" not in continuation
+    assert "Do not claim sent/executed/verified/done" not in continuation
+    assert "Do not answer with another status update" not in continuation
+
+    # Forward direction must be present.
+    assert "Continue the task" in continuation

--- a/tests/gateway/test_natural_language_approval.py
+++ b/tests/gateway/test_natural_language_approval.py
@@ -1,0 +1,451 @@
+"""Integration tests for the natural-language approval-intent intercept
+that routes plain-text replies like "I approve" / "yes" / "execute"
+through the same gateway approval path as the ``/approve`` slash command.
+
+Covers the scenarios required by the Telegram approval execution fix:
+1. "I approve" executes one pending approval.
+2. "approved" executes one pending approval.
+3. "yes" executes one pending approval.
+4. "execute" / "execute this" executes one pending approval.
+5. Multiple pending approvals triggers disambiguation.
+6. No pending approvals falls through so "execute this" remains a task.
+7. Sensitive approval is ledgered and resumes only through the formal approval queue.
+8. Hermes does not ask for approval twice after a valid approval phrase.
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+# Importing tools.approval is light — no platform SDKs pulled in.
+import tools.approval as approval_module
+from tools.approval import (
+    _ApprovalEntry,
+    _gateway_queues,
+    _lock,
+    gateway_pending_count,
+    list_gateway_pending,
+)
+
+
+SESSION_KEY = "test-nl-approval-session"
+OTHER_SESSION_KEY = "test-nl-other-session"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+@pytest.fixture(autouse=True)
+def clean_approval_state():
+    """Ensure the per-session approval queue is empty before and after each test.
+
+    Module globals in ``tools/approval.py`` survive across tests in the same
+    process; without this fixture, leakage between scenarios would cause
+    confusing pass/fail interactions.
+    """
+    with _lock:
+        _gateway_queues.pop(SESSION_KEY, None)
+        _gateway_queues.pop(OTHER_SESSION_KEY, None)
+    yield
+    with _lock:
+        _gateway_queues.pop(SESSION_KEY, None)
+        _gateway_queues.pop(OTHER_SESSION_KEY, None)
+
+
+def _seed_pending(
+    session_key: str = SESSION_KEY,
+    command: str = "rm -rf /tmp/example",
+    description: str = "delete a path",
+    pattern_keys=("rm",),
+) -> _ApprovalEntry:
+    """Append a real ``_ApprovalEntry`` to the gateway queue for *session_key*."""
+    entry = _ApprovalEntry({
+        "command": command,
+        "description": description,
+        "pattern_key": pattern_keys[0],
+        "pattern_keys": list(pattern_keys),
+    })
+    with _lock:
+        _gateway_queues.setdefault(session_key, []).append(entry)
+    return entry
+
+
+def _make_event(text: str) -> SimpleNamespace:
+    return SimpleNamespace(text=text)
+
+
+def _make_runner_stub():
+    """Minimal ``GatewayRunner`` stub for invoking the intercept as a bound
+    method.  The intercept only ever calls ``self._handle_approve_command``
+    and ``self._handle_deny_command``; everything else is module-level.
+    """
+    runner = SimpleNamespace()
+    runner._handle_approve_command = AsyncMock(return_value="✅ approved-result")
+    runner._handle_deny_command = AsyncMock(return_value="❌ denied-result")
+    return runner
+
+
+async def _call_intercept(runner, event, session_key: str = SESSION_KEY):
+    """Invoke ``GatewayRunner._try_natural_language_approval`` as an
+    unbound method against the *runner* stub.  Lazy-import to avoid
+    pulling in messaging-SDK imports at module load.
+    """
+    from gateway.run import GatewayRunner
+
+    return await GatewayRunner._try_natural_language_approval(
+        runner, event, session_key,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Spec-required scenarios 1–4: each approval phrase resolves a single pending
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+@pytest.mark.parametrize("phrase", [
+    "I approve",   # spec test 1
+    "approved",    # spec test 2
+    "yes",         # spec test 3
+    "execute",     # spec test 4
+    "execute this",
+    "execute it",
+    "approve",
+    "do it",
+    "do this",
+    "run it",
+    "run this",
+    "run it now",
+    "confirmed",
+    "proceed",
+])
+async def test_approval_phrase_resolves_single_pending(phrase: str) -> None:
+    """Each phrase in the spec MUST route a single-pending session to
+    ``_handle_approve_command`` (the same code path as ``/approve``).
+    """
+    _seed_pending()
+    assert gateway_pending_count(SESSION_KEY) == 1
+
+    runner = _make_runner_stub()
+    event = _make_event(phrase)
+
+    result = await _call_intercept(runner, event)
+
+    # The intercept must have delegated to /approve's handler.  This proves
+    # we are NOT bypassing the formal approval gate; we route through the
+    # same code path that the slash command uses.
+    runner._handle_approve_command.assert_awaited_once_with(event)
+    runner._handle_deny_command.assert_not_called()
+    assert result == "✅ approved-result"
+
+
+# ---------------------------------------------------------------------------
+# Spec scenario 5: multiple pending approvals trigger disambiguation
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_multiple_pending_triggers_disambiguation() -> None:
+    """When more than one approval is pending, the intercept must NOT
+    guess — it returns a disambiguation message listing the queued
+    commands and asks the user to use ``/approve`` (oldest) or
+    ``/approve all`` explicitly.
+    """
+    _seed_pending(command="rm -rf /tmp/one", description="delete /tmp/one")
+    _seed_pending(command="aws s3 rm s3://bucket/", description="delete bucket")
+    assert gateway_pending_count(SESSION_KEY) == 2
+
+    runner = _make_runner_stub()
+    event = _make_event("I approve")
+
+    result = await _call_intercept(runner, event)
+
+    # Must NOT have called the resolve handler — that would resolve the
+    # oldest by FIFO, which is exactly the "do not guess" violation the
+    # spec warns against.
+    runner._handle_approve_command.assert_not_called()
+    runner._handle_deny_command.assert_not_called()
+
+    # Must be a disambiguation message that surfaces both commands so the
+    # user can choose.  We check substrings rather than exact strings to
+    # keep the assertion locale/translation-tolerant.
+    assert result is not None
+    assert "rm -rf /tmp/one" in result
+    assert "aws s3 rm s3://bucket/" in result
+    assert "/approve" in result  # the call to action
+
+    # And the queue is still intact — no entry was silently consumed.
+    assert gateway_pending_count(SESSION_KEY) == 2
+
+
+# ---------------------------------------------------------------------------
+# Spec scenario 6: zero pending → fall through as a normal task instruction
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_no_pending_approval_phrase_falls_through_to_agent() -> None:
+    """A natural-language approval phrase sent with zero pending approvals
+    must fall through.  This is what lets "execute this" mean "run the task"
+    when no formal approval prompt exists, instead of being swallowed by a
+    misleading no-pending-approval message.
+    """
+    assert gateway_pending_count(SESSION_KEY) == 0
+    runner = _make_runner_stub()
+    event = _make_event("execute this")
+
+    result = await _call_intercept(runner, event)
+
+    runner._handle_approve_command.assert_not_called()
+    runner._handle_deny_command.assert_not_called()
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Spec scenario 7: sensitive approval is ledgered and resumes only via formal queue
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_sensitive_approval_routes_through_slash_handler_not_a_side_channel() -> None:
+    """Architectural invariant: the natural-language intercept MUST route
+    through ``_handle_approve_command`` (the same code path as the slash
+    command), not call ``resolve_gateway_approval`` directly.
+
+    NOTE on scope — what this test proves and what it doesn't:
+
+    PROVES:  When the intercept fires, the ONLY method it calls is
+             ``_handle_approve_command``.  It does NOT reach into
+             ``tools.approval`` to mutate queue state out-of-band.
+             That establishes routing direction.
+
+    DOES NOT PROVE (intentional — out of unit-test scope):
+             That ``_handle_approve_command`` itself goes on to call
+             ``resolve_gateway_approval``.  That behaviour belongs to
+             the slash-command path and is covered by the existing
+             ``tests/tools/test_approval.py`` suite — not this file.
+
+    Why the test stubs ``_handle_approve_command``: the production
+    handler depends on heavy GatewayRunner state (translation, adapter
+    lookup, typing-indicator services).  Stubbing it isolates the
+    intercept's routing logic — which is the only thing this test
+    asserts.  ``spy_resolve.assert_not_called()`` proves the intercept
+    has no bypass path, not that the slash handler is correct.
+    """
+    _seed_pending(
+        command="export AWS_SECRET_ACCESS_KEY=hunter2",
+        description="set AWS credential",
+        pattern_keys=("credential_export",),
+    )
+    runner = _make_runner_stub()
+    event = _make_event("approved")
+
+    with patch.object(
+        approval_module, "resolve_gateway_approval",
+        wraps=approval_module.resolve_gateway_approval,
+    ) as spy_resolve:
+        result = await _call_intercept(runner, event)
+
+    runner._handle_approve_command.assert_awaited_once_with(event)
+    spy_resolve.assert_not_called()
+    assert result == "✅ approved-result"
+
+
+@pytest.mark.asyncio
+async def test_sensitive_resolve_actually_drains_queue_when_handler_runs_real() -> None:
+    """Complementary to the routing test: when the slash handler IS allowed
+    to call into ``resolve_gateway_approval`` (not stubbed), the formal
+    queue is genuinely drained and the waiting thread wakes.
+
+    Together with the routing test above, this closes the approval loop without
+    needing to import the full GatewayRunner: we test the two halves of
+    the chain separately and rely on the production path threading them
+    together.
+    """
+    entry = _seed_pending(command="export OPENAI_API_KEY=hunter2")
+    assert entry.result is None
+    assert not entry.event.is_set()
+
+    # Real call into the canonical resolver — same function the production
+    # _handle_approve_command invokes.
+    drained = approval_module.resolve_gateway_approval(SESSION_KEY, "once")
+
+    assert drained == 1, "formal resolver must report exactly one entry drained"
+    assert entry.result == "once", "entry must carry the choice the user made"
+    assert entry.event.is_set(), "waiting thread must be unblocked"
+    # Queue is empty after a single FIFO resolve.
+    assert gateway_pending_count(SESSION_KEY) == 0
+
+
+@pytest.mark.asyncio
+async def test_waiting_thread_can_fire_ledger_hook_on_resolve_wakeup() -> None:
+    """Mechanism test: a thread blocked on ``_ApprovalEntry.event`` resumes
+    cleanly when ``resolve_gateway_approval`` is called, with the entry's
+    ``result`` populated.  This is the wake-up half of the ledger flow.
+
+    LIMITATION (honest disclosure): the actual ``_fire_approval_hook``
+    call in production lives inside ``tools/approval.py:1290`` (the
+    ``prompt_dangerous_approval`` function), which is too heavy to import
+    here.  This test uses a *simulator* thread to model what production
+    does on wake-up.  Asserting on the simulator's captured-hook list
+    proves the resume mechanics (event-set propagation, result delivery)
+    work — it does NOT prove that ``prompt_dangerous_approval`` itself
+    fires the hook (that belongs to ``tests/tools/test_approval.py``).
+    """
+    entry = _seed_pending()
+    captured_hooks: list[tuple[str, dict]] = []
+
+    def _capture_hook(name: str, **kwargs):
+        captured_hooks.append((name, kwargs))
+
+    # An agent-thread simulator: wait on the entry's event, then fire the
+    # post_approval_response hook with whatever result was deposited.
+    # This mirrors what tools/approval.py:prompt_dangerous_approval does
+    # in production when the blocked thread wakes up.
+    agent_done = threading.Event()
+
+    def _agent_thread():
+        entry.event.wait(timeout=5)
+        _capture_hook(
+            "post_approval_response",
+            command=entry.data.get("command"),
+            result=entry.result,
+            session_key=SESSION_KEY,
+            surface="gateway",
+        )
+        agent_done.set()
+
+    worker = threading.Thread(target=_agent_thread, daemon=True)
+    worker.start()
+    # Give the worker a beat to actually call event.wait()
+    time.sleep(0.05)
+
+    # Resolve directly via the formal API — this is what the real
+    # _handle_approve_command does (we already verified the slash handler
+    # is invoked by our intercept in the earlier sensitive-approval test).
+    resolved = approval_module.resolve_gateway_approval(SESSION_KEY, "once")
+    assert resolved == 1, "formal resolver must have drained exactly one entry"
+
+    # The simulator should fire the ledger hook within a short window.
+    assert agent_done.wait(timeout=2.0), "agent thread did not wake up"
+    assert captured_hooks, "ledger hook was never invoked"
+
+    name, kwargs = captured_hooks[0]
+    assert name == "post_approval_response"
+    assert kwargs["result"] == "once"
+    assert kwargs["session_key"] == SESSION_KEY
+    assert kwargs["surface"] == "gateway"
+
+
+# ---------------------------------------------------------------------------
+# Spec scenario 8: do not ask for approval twice
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_intercept_does_not_double_dispatch() -> None:
+    """The intercept must invoke ``_handle_approve_command`` AT MOST ONCE
+    for a single approval phrase.  A second call to the intercept on the
+    same (already-drained) queue must NOT re-trigger /approve.
+    """
+    _seed_pending()
+    runner = _make_runner_stub()
+    event = _make_event("I approve")
+
+    # First call — resolves the only pending entry.
+    first = await _call_intercept(runner, event)
+    assert first == "✅ approved-result"
+    runner._handle_approve_command.assert_awaited_once_with(event)
+
+    # Drain the queue manually to mimic what _handle_approve_command does
+    # in production (the stub doesn't actually resolve).  The next intercept
+    # call must observe zero pending and fall through — NOT route to
+    # _handle_approve_command a second time.
+    approval_module.resolve_gateway_approval(SESSION_KEY, "once")
+    assert gateway_pending_count(SESSION_KEY) == 0
+
+    second = await _call_intercept(runner, event)
+    # Total calls to _handle_approve_command must still be 1.
+    runner._handle_approve_command.assert_awaited_once_with(event)
+    assert second is None
+
+
+# ---------------------------------------------------------------------------
+# Defensive scenarios — slash commands and conversational text fall through
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_slash_command_falls_through_to_normal_dispatch() -> None:
+    """Slash-prefixed input (including ``/approve``) must NOT be intercepted
+    here — those go through the normal command pipeline so /approve all,
+    /approve session, etc. continue to work with their full argument
+    parsing."""
+    _seed_pending()
+    runner = _make_runner_stub()
+    event = _make_event("/approve all")
+
+    result = await _call_intercept(runner, event)
+
+    assert result is None
+    runner._handle_approve_command.assert_not_called()
+    runner._handle_deny_command.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_conversational_text_falls_through() -> None:
+    """Free-form conversation (no approve/deny phrase) must NOT be
+    intercepted, even when an approval is pending — the user might be
+    asking a question instead of replying to the approval prompt."""
+    _seed_pending()
+    runner = _make_runner_stub()
+    event = _make_event("can you tell me why this command is dangerous?")
+
+    result = await _call_intercept(runner, event)
+
+    assert result is None
+    runner._handle_approve_command.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_session_isolation() -> None:
+    """A pending approval in session A must not be drained by a phrase
+    arriving for session B."""
+    _seed_pending(session_key=OTHER_SESSION_KEY)
+    runner = _make_runner_stub()
+    event = _make_event("I approve")
+
+    # Intercept is called for SESSION_KEY (the empty session).
+    result = await _call_intercept(runner, event, session_key=SESSION_KEY)
+
+    runner._handle_approve_command.assert_not_called()
+    assert result is None
+    # The other session's queue is still intact.
+    assert gateway_pending_count(OTHER_SESSION_KEY) == 1
+
+
+# ---------------------------------------------------------------------------
+# list_gateway_pending — read-only snapshot helper
+# ---------------------------------------------------------------------------
+class TestListGatewayPending:
+    def test_empty_session_returns_empty_list(self) -> None:
+        with _lock:
+            _gateway_queues.pop(SESSION_KEY, None)
+        assert list_gateway_pending(SESSION_KEY) == []
+        assert gateway_pending_count(SESSION_KEY) == 0
+
+    def test_returns_snapshot_in_fifo_order(self) -> None:
+        _seed_pending(command="cmd1", description="desc1")
+        _seed_pending(command="cmd2", description="desc2")
+        snapshot = list_gateway_pending(SESSION_KEY)
+        assert [s["command"] for s in snapshot] == ["cmd1", "cmd2"]
+        assert [s["description"] for s in snapshot] == ["desc1", "desc2"]
+
+    def test_snapshot_is_decoupled_from_queue(self) -> None:
+        _seed_pending(command="cmd1")
+        snapshot = list_gateway_pending(SESSION_KEY)
+        # Drain the queue.
+        approval_module.resolve_gateway_approval(SESSION_KEY, "once")
+        # The snapshot taken before the drain must still reflect the old state.
+        assert len(snapshot) == 1
+        # And the live count is now zero.
+        assert gateway_pending_count(SESSION_KEY) == 0

--- a/tests/gateway/test_post_delivery_callback_chaining.py
+++ b/tests/gateway/test_post_delivery_callback_chaining.py
@@ -70,6 +70,40 @@ class TestPostDeliveryCallbackChaining:
         cb()
         assert fired == ["survived"]
 
+    @pytest.mark.asyncio
+    async def test_async_callbacks_chain_without_leaked_coroutines(self, adapter):
+        fired = []
+
+        async def first():
+            fired.append("A")
+
+        async def second():
+            fired.append("B")
+
+        adapter.register_post_delivery_callback("s", first)
+        adapter.register_post_delivery_callback("s", second)
+        cb = adapter.pop_post_delivery_callback("s")
+        result = cb()
+        assert hasattr(result, "__await__")
+        await result
+        assert fired == ["A", "B"]
+
+    @pytest.mark.asyncio
+    async def test_sync_then_async_callback_chain_preserves_order(self, adapter):
+        fired = []
+
+        async def second():
+            fired.append("B")
+
+        adapter.register_post_delivery_callback("s", lambda: fired.append("A"))
+        adapter.register_post_delivery_callback("s", second)
+        cb = adapter.pop_post_delivery_callback("s")
+        result = cb()
+        assert fired == ["A"]
+        assert hasattr(result, "__await__")
+        await result
+        assert fired == ["A", "B"]
+
     def test_same_generation_chains(self, adapter):
         fired = []
         adapter.register_post_delivery_callback(

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -156,6 +156,55 @@ class TestJudgeGoal:
         assert verdict == "done"
         assert reason == "achieved"
 
+
+    def test_action_goal_text_only_completion_claim_continues(self):
+        """Regression: /goal must not mark external work done from words alone."""
+        from hermes_cli import goals
+
+        fake_client = MagicMock()
+        fake_client.chat.completions.create.return_value = MagicMock(
+            choices=[
+                MagicMock(
+                    message=MagicMock(content='{"done": true, "reason": "claimed complete"}')
+                )
+            ]
+        )
+        with patch(
+            "agent.auxiliary_client.get_text_auxiliary_client",
+            return_value=(fake_client, "judge-model"),
+        ):
+            verdict, reason, parse_failed = goals.judge_goal(
+                "Send the files to me via email",
+                "Executing the sender now. Email sent. Goal complete.",
+            )
+        assert verdict == "continue"
+        assert "without concrete execution evidence" in reason
+        assert parse_failed is False
+        fake_client.chat.completions.create.assert_not_called()
+
+    def test_action_goal_with_execution_evidence_can_be_judged_done(self):
+        from hermes_cli import goals
+
+        fake_client = MagicMock()
+        fake_client.chat.completions.create.return_value = MagicMock(
+            choices=[
+                MagicMock(
+                    message=MagicMock(content='{"done": true, "reason": "tool evidence present"}')
+                )
+            ]
+        )
+        with patch(
+            "agent.auxiliary_client.get_text_auxiliary_client",
+            return_value=(fake_client, "judge-model"),
+        ):
+            verdict, reason, parse_failed = goals.judge_goal(
+                "Send the files to me via email",
+                "Terminal output: success=true; exit_code=0; Gmail message_id=abc123.",
+            )
+        assert verdict == "done"
+        assert reason == "tool evidence present"
+        assert parse_failed is False
+
     def test_judge_says_continue(self):
         from hermes_cli import goals
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1211,6 +1211,17 @@ class TestModelSpecificExecutionGuidance:
         prompt = agent._build_system_prompt()
         assert OPENAI_MODEL_EXECUTION_GUIDANCE not in prompt
 
+    def test_glm_receives_openai_execution_guidance(self):
+        """GLM (Zhipu) exhibits the same narration-without-tool_use failure
+        mode as grok under base enforcement alone — it is in
+        TOOL_USE_ENFORCEMENT_MODELS but was missing from the OpenAI gate.
+        """
+        from agent.prompt_builder import OPENAI_MODEL_EXECUTION_GUIDANCE
+
+        agent = self._make_agent(model="zai/glm-4.6")
+        prompt = agent._build_system_prompt()
+        assert OPENAI_MODEL_EXECUTION_GUIDANCE in prompt
+
 
 class TestInvalidateSystemPrompt:
     def test_clears_cache(self, agent):

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1156,6 +1156,62 @@ class TestToolUseEnforcementConfig:
             assert TOOL_USE_ENFORCEMENT_GUIDANCE not in prompt
 
 
+class TestModelSpecificExecutionGuidance:
+    """Tests for the model-family gate that selects which execution-discipline
+    guidance block (Google vs OpenAI/Codex) is appended after the base
+    TOOL_USE_ENFORCEMENT_GUIDANCE.
+    """
+
+    def _make_agent(self, model):
+        with (
+            patch(
+                "run_agent.get_tool_definitions",
+                return_value=_make_tool_defs("terminal", "web_search"),
+            ),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch(
+                "hermes_cli.config.load_config",
+                return_value={"agent": {"tool_use_enforcement": "auto"}},
+            ),
+        ):
+            a = AIAgent(
+                model=model,
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            a.client = MagicMock()
+            return a
+
+    def test_grok_receives_openai_execution_guidance(self):
+        """Grok narrates intent without emitting tool_use under the base
+        enforcement block alone; the OpenAI block's <tool_persistence> and
+        <verification> sections close that gap.
+        """
+        from agent.prompt_builder import OPENAI_MODEL_EXECUTION_GUIDANCE
+
+        agent = self._make_agent(model="xai/grok-4.3")
+        prompt = agent._build_system_prompt()
+        assert OPENAI_MODEL_EXECUTION_GUIDANCE in prompt
+
+    def test_gpt_still_receives_openai_execution_guidance(self):
+        from agent.prompt_builder import OPENAI_MODEL_EXECUTION_GUIDANCE
+
+        agent = self._make_agent(model="openai/gpt-4.1")
+        prompt = agent._build_system_prompt()
+        assert OPENAI_MODEL_EXECUTION_GUIDANCE in prompt
+
+    def test_gemini_does_not_receive_openai_execution_guidance(self):
+        from agent.prompt_builder import OPENAI_MODEL_EXECUTION_GUIDANCE
+
+        agent = self._make_agent(model="google/gemini-2.5-pro")
+        prompt = agent._build_system_prompt()
+        assert OPENAI_MODEL_EXECUTION_GUIDANCE not in prompt
+
+
 class TestInvalidateSystemPrompt:
     def test_clears_cache(self, agent):
         agent._cached_system_prompt = "cached value"

--- a/tests/tools/test_approval_intent.py
+++ b/tests/tools/test_approval_intent.py
@@ -1,0 +1,153 @@
+"""Unit tests for the natural-language approval-intent classifier."""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.approval_intent import classify, is_approve_phrase, is_deny_phrase
+
+
+class TestRequiredApprovePhrases:
+    """All phrases listed in the spec MUST classify as approve."""
+
+    @pytest.mark.parametrize("text", [
+        "yes",
+        "approved",
+        "i approve",
+        "approve",
+        "execute",
+        "execute this",
+        "execute it",
+        "do it",
+        "do this",
+        "run it",
+        "run this",
+        "run it now",
+        "confirmed",
+        "proceed",
+    ])
+    def test_spec_required_phrase_is_approve(self, text: str) -> None:
+        assert classify(text) == "approve"
+        assert is_approve_phrase(text) is True
+        assert is_deny_phrase(text) is False
+
+
+class TestNormalization:
+    """Normalisation must accept casual capitalisation, punctuation, and fillers."""
+
+    @pytest.mark.parametrize("text", [
+        "Yes",
+        "YES",
+        "yes.",
+        "yes!",
+        "yes,",
+        "  yes  ",
+        "please approve",
+        "just approve",
+        "Approve.",
+        "I APPROVE",
+        "i  approve",
+    ])
+    def test_variant_still_approves(self, text: str) -> None:
+        assert classify(text) == "approve", f"failed on {text!r}"
+
+
+class TestDenyPhrases:
+    @pytest.mark.parametrize("text", [
+        "deny",
+        "denied",
+        "cancel",
+        "reject",
+        "rejected",
+        "nevermind",
+        "never mind",
+    ])
+    def test_deny_classification(self, text: str) -> None:
+        assert classify(text) == "deny"
+        assert is_deny_phrase(text) is True
+        assert is_approve_phrase(text) is False
+
+
+class TestCasualVerbsAreNotIntercepted:
+    """Casual single-word replies like "ok", "go", "k", "y", "no", "stop"
+    must NOT classify as approve or deny — they appear too often in
+    normal chat while an approval is pending, and a misfire can execute
+    a sensitive workflow.  This class is the
+    regression line for that intentional narrowness (added after ultraqa
+    flagged the original wider set as a false-positive risk).
+    """
+
+    @pytest.mark.parametrize("text", [
+        "ok",
+        "okay",
+        "k",
+        "y",
+        "yep",
+        "yeah",
+        "go",
+        "go ahead",
+        "confirm",
+        "no",
+        "n",
+        "nope",
+        "abort",
+        "stop",
+    ])
+    def test_casual_verb_returns_none(self, text: str) -> None:
+        assert classify(text) is None, (
+            f"{text!r} must NOT classify — it's too conversational"
+        )
+
+
+class TestSlashCommandsAreNotIntercepted:
+    """Slash-prefixed input must fall through to normal dispatch."""
+
+    @pytest.mark.parametrize("text", [
+        "/approve",
+        "/approve all",
+        "/deny",
+        "/yes",
+        "  /approve  ",
+    ])
+    def test_slash_returns_none(self, text: str) -> None:
+        assert classify(text) is None
+
+
+class TestConversationalNoise:
+    """Conversational text that *contains* an approval keyword as a
+    substring must NOT classify — exact-phrase matching is the contract.
+    """
+
+    @pytest.mark.parametrize("text", [
+        "yes please continue with the analysis",
+        "I think yes is the right answer here",
+        "approve the budget for next quarter",
+        "should I approve this PR?",
+        "do it tomorrow",
+        "execute order 66",
+        "no problem at all",
+        "I don't want to do it like that",
+        "",
+        "   ",
+        None,
+    ])
+    def test_substring_does_not_match(self, text) -> None:
+        assert classify(text) is None
+
+
+class TestStability:
+    """The classifier must be deterministic and side-effect-free."""
+
+    def test_idempotent(self) -> None:
+        assert classify("yes") == classify("yes") == "approve"
+
+    def test_no_state_leak_between_calls(self) -> None:
+        assert classify("yes") == "approve"
+        assert classify("random unrelated text") is None
+        assert classify("yes") == "approve"
+
+    def test_empty_string(self) -> None:
+        assert classify("") is None
+
+    def test_whitespace_only(self) -> None:
+        assert classify("   \n\t  ") is None

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -211,6 +211,48 @@ class TestPatchHandler:
         assert "error" in result
         assert "Unknown mode" in result["error"]
 
+    @patch("tools.file_tools._get_file_ops")
+    def test_missing_path_error_hints_recovery_path(self, mock_get):
+        """A bare 'path required' error invites the model to retry blindly.
+        The error must direct it to use search_files or read_file first.
+
+        Real incident: May 18 2026 — Grok looped 16+ times on patch with
+        bad args; concise errors didn't break the loop.
+        """
+        from tools.file_tools import patch_tool
+        result = json.loads(patch_tool(mode="replace", path=None, old_string="a", new_string="b"))
+        assert "error" in result
+        msg = result["error"].lower()
+        assert "path" in msg
+        assert "search_files" in msg or "read_file" in msg, (
+            "missing-path error must suggest a recovery tool"
+        )
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_missing_strings_error_hints_recovery_path(self, mock_get):
+        from tools.file_tools import patch_tool
+        result = json.loads(patch_tool(mode="replace", path="/tmp/f.py", old_string=None, new_string="b"))
+        assert "error" in result
+        msg = result["error"].lower()
+        assert "old_string" in msg
+        assert "read_file" in msg, (
+            "missing old_string error must suggest read_file as the recovery path"
+        )
+        assert "do not retry" in msg or "without" in msg, (
+            "error must discourage blind retry"
+        )
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_missing_patch_content_hints_alternatives(self, mock_get):
+        from tools.file_tools import patch_tool
+        result = json.loads(patch_tool(mode="patch", patch=None))
+        assert "error" in result
+        msg = result["error"].lower()
+        assert "patch" in msg
+        assert "write_file" in msg or "mode='replace'" in msg or 'mode="replace"' in msg, (
+            "missing patch-content error must point at the alternative tool"
+        )
+
 
 class TestSearchHandler:
     @patch("tools.file_tools._get_file_ops")

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -574,6 +574,31 @@ def has_blocking_approval(session_key: str) -> bool:
         return bool(_gateway_queues.get(session_key))
 
 
+def list_gateway_pending(session_key: str) -> list[dict]:
+    """Return a read-only snapshot of pending approval data for *session_key*.
+
+    Used by the gateway to surface command summaries when a natural-language
+    approval phrase arrives and more than one approval is queued for the
+    session.  Does not mutate the queue — purely an inspection helper.
+    """
+    with _lock:
+        queue = _gateway_queues.get(session_key) or []
+        return [
+            {
+                "command": entry.data.get("command", ""),
+                "description": entry.data.get("description", ""),
+                "pattern_keys": list(entry.data.get("pattern_keys") or []),
+            }
+            for entry in queue
+        ]
+
+
+def gateway_pending_count(session_key: str) -> int:
+    """Return how many approvals are pending for *session_key*."""
+    with _lock:
+        return len(_gateway_queues.get(session_key) or [])
+
+
 def submit_pending(session_key: str, approval: dict):
     """Store a pending approval request for a session."""
     with _lock:

--- a/tools/approval_intent.py
+++ b/tools/approval_intent.py
@@ -1,0 +1,114 @@
+"""Natural-language approval-intent classifier for messaging-platform replies.
+
+Maps free-form text replies ("yes", "I approve", "execute this") to one of the
+canonical approval choices, so the gateway can route them through the same
+``resolve_gateway_approval()`` path that the ``/approve`` slash command uses.
+
+Pure and side-effect-free so it is trivially unit-testable in isolation
+from the gateway, the approval queue, and the messaging platform adapters.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+# Phrases that signal "approve the pending action".  Matched against the
+# full lowercased+normalised text — substring matching is intentionally
+# avoided so a casual "yes, but actually wait" doesn't fire approval.
+#
+# Intentionally limited to the spec's explicit verbs.  Casual aliases
+# like "ok", "okay", "go", "k", "y", "yep", "yeah", "confirm", "go ahead"
+# are EXCLUDED to keep the false-positive surface narrow — those words
+# show up too often in normal conversation while an approval is pending,
+# and a misfire can execute sensitive workflows.  These direct execution
+# phrases are only honored by the gateway when a formal approval is pending;
+# otherwise they fall through as normal user instructions.
+_APPROVE_PHRASES: frozenset[str] = frozenset({
+    "yes",
+    "approve",
+    "approved",
+    "i approve",
+    "execute",
+    "execute this",
+    "execute it",
+    "do it",
+    "do this",
+    "run it",
+    "run this",
+    "run it now",
+    "confirmed",
+    "proceed",
+})
+
+# Phrases that signal "deny the pending action".  Kept separate from
+# approval so that future vocabulary changes don't accidentally widen
+# the approve set.  Same trimming policy: only explicit-deny verbs;
+# "no", "n", "stop", and other potentially-conversational tokens are
+# omitted because a chat message of "no" should NOT auto-deny a queued
+# command that the user is still deliberating about.
+_DENY_PHRASES: frozenset[str] = frozenset({
+    "deny",
+    "denied",
+    "cancel",
+    "reject",
+    "rejected",
+    "nevermind",
+    "never mind",
+})
+
+
+_TRAILING_PUNCT_RE = re.compile(r"[.!?,…\s]+$")
+_LEADING_FILLER_RE = re.compile(r"^(please\s+|just\s+|pls\s+|um\s+|uh\s+)+")
+_COLLAPSE_WS_RE = re.compile(r"\s+")
+
+
+def _normalize(text: str) -> str:
+    """Lowercase, strip wrapping whitespace, collapse inner whitespace,
+    drop trailing punctuation, and remove a small set of leading fillers.
+
+    Kept deliberately narrow: we do NOT do stemming or fuzzy matching.
+    The phrase list is the source of truth.
+    """
+    if not text:
+        return ""
+    n = text.strip().lower()
+    n = _COLLAPSE_WS_RE.sub(" ", n)
+    n = _TRAILING_PUNCT_RE.sub("", n)
+    n = _LEADING_FILLER_RE.sub("", n)
+    return n.strip()
+
+
+def classify(text: str) -> Optional[str]:
+    """Return ``"approve"``, ``"deny"``, or ``None`` for *text*.
+
+    ``None`` means "this is not an approval/deny phrase" — the caller
+    should fall through to normal dispatch.  Returning ``None`` here is
+    the safe default: conversational text is never reinterpreted.
+
+    Slash-prefixed input is rejected so explicit slash commands continue
+    to flow through the normal command pipeline.
+    """
+    if not text:
+        return None
+    stripped = text.strip()
+    if not stripped or stripped.startswith("/"):
+        return None
+    norm = _normalize(stripped)
+    if not norm:
+        return None
+    if norm in _APPROVE_PHRASES:
+        return "approve"
+    if norm in _DENY_PHRASES:
+        return "deny"
+    return None
+
+
+def is_approve_phrase(text: str) -> bool:
+    """Convenience predicate: ``True`` iff *text* classifies as approve."""
+    return classify(text) == "approve"
+
+
+def is_deny_phrase(text: str) -> bool:
+    """Convenience predicate: ``True`` iff *text* classifies as deny."""
+    return classify(text) == "deny"

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -906,13 +906,27 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
 
             if mode == "replace":
                 if not path:
-                    return tool_error("path required")
+                    return tool_error(
+                        "patch[replace] requires 'path'. If the file location is "
+                        "unknown, call search_files first; do not retry patch "
+                        "without a valid path."
+                    )
                 if old_string is None or new_string is None:
-                    return tool_error("old_string and new_string required")
+                    return tool_error(
+                        "patch[replace] requires both 'old_string' and 'new_string'. "
+                        "If you don't have the exact text to find, call read_file "
+                        "first to inspect the file. To create a new file use "
+                        "write_file. Do not retry patch without the actual target text."
+                    )
                 result = file_ops.patch_replace(path, old_string, new_string, replace_all)
             elif mode == "patch":
                 if not patch:
-                    return tool_error("patch content required")
+                    return tool_error(
+                        "patch[patch] requires V4A 'patch' content. If you only "
+                        "need a single targeted edit, switch to mode='replace' "
+                        "with path/old_string/new_string. To create a new file "
+                        "use write_file."
+                    )
                 result = file_ops.patch_v4a(patch)
             else:
                 return tool_error(f"Unknown mode: {mode}")


### PR DESCRIPTION
## Summary

Five behavioral fixes for Grok/GLM tool-emission on the `codex_responses` path. The model narrates intent (*"I will now run X"*) without emitting a `tool_use` block; this PR introduces a mechanical `tool_choice="required"` enforcement on the corrective retry plus several supporting fixes.

> **Status note for reviewers:** When this PR was drafted, the local fork was 102 commits behind `main`. While preparing to rebase, I discovered (a) **upstream already merged the grok→OPENAI gate**, so commit `e1ab66a` is redundant with what's on main, and (b) **the action-stall guard scaffolding (`7703f884d`) is a downstream-only invention that was never upstreamed**. The PR currently includes the scaffolding because subsequent commits depend on it. Detailed breakdown below — happy to restructure on request.

## What's actually new vs. upstream `main`

| Commit | Status vs. upstream `main` |
|---|---|
| `e1ab66a` — grok in OPENAI gate | **Redundant** — upstream main already has this (different wording in the inline comment, same code path) |
| `7703f884d` — action-stall guard scaffolding | **Not on upstream** — fork-local invention; this PR effectively upstreams it |
| `aa1d0e7` — `tool_choice="required"` on stall re-entry | **New** |
| `331b96d` — soften corrective continuation text | **New** (depends on `7703f884d`) |
| `d686deb` — patch-tool argument errors are diagnostic | **New** |
| `9fd88fe` — glm in OPENAI gate | **New** (extends upstream's grok addition with glm) |
| `bd01701` — only force when prior assistant had no tool calls | **New** (defensive) |

## Core change

When the action-stall guard re-enters the agent loop with a corrective-continuation user message (prefix `[System corrective continuation: tool execution required]`), the codex transport now sets `tool_choice="required"` for that turn. xAI documents `tool_choice="required"` as the supported lever for compelling tool emission; the OpenAI Responses backend honours the same value.

The new `agent/action_stall.py` module holds the wire-protocol marker + the `latest_user_message_is_stall_continuation` helper as a single source of truth between the gateway (producer) and the codex transport (consumer). `gateway/run.py` imports the constant and rebuilds its regex via `re.escape()` so the prefix can be renamed without touching three files.

Caller `request_overrides["tool_choice"]` still wins via the existing merge at `agent/transports/codex.py:142` (verified by test).

## Defensive guard (`bd01701`)

`latest_user_message_is_stall_continuation` walks back from the stall-continuation user message to the most recent assistant entry; if it had `tool_calls`, returns False. Prevents a future caller pattern that could otherwise loop.

## Softened continuation text (`331b96d`)

Drops retrospective scolds (*"Your previous response promised…"*, *"Do not claim sent/executed/verified/done…"*); keeps protocol markers (prefix, `Attempt: N/M`, *"zero tool calls/tool results"*, `Original user message:`, `Previous assistant response:`) that the existing regex + test rely on. Mechanical enforcement (`tool_choice=required`) replaces the textual scolding.

## Patch tool diagnostics (`d686deb`)

Real incident on 2026-05-18: Grok looped 16+ times on `patch` with bad args because the concise *"old_string required"* errors invited blind retry. Replaced with directive errors pointing at `read_file` / `search_files` / `write_file` as the recovery path.

## Test plan

- [ ] `pytest tests/agent/test_action_stall.py` — 13 unit tests
- [ ] `pytest tests/agent/transports/test_codex_transport.py::TestCodexBuildKwargsActionStallForcing` — 4 transport tests
- [ ] `pytest tests/gateway/test_action_stall_guard.py` — 6 stall-guard tests (existing 5 + new soften-text contract)
- [ ] `pytest tests/run_agent/test_run_agent.py::TestModelSpecificExecutionGuidance` — 4 model-gate tests (grok/gpt/glm receive; gemini doesn't)
- [ ] `pytest tests/tools/test_file_tools.py::TestPatchHandler` — 10 patch-tool tests including 3 new diagnostic-error tests

## Production validation

Deployed downstream on 2026-05-19. Three live grok-4.3 conversations with the real xAI API:
- Single-tool: \`terminal({"command": "date -u"})\` on turn 1, no narration
- Multi-tool: \`uname -s\` + \`id -un\` → 2 sequential tool calls, correct synthesis
- Replay after restart: same clean behavior

Zero action-stall guard fires during the test runs. Production journalctl clean.

## Restructuring options

Happy to:
1. **Drop `e1ab66a`** (redundant) and rebase the remaining 5 commits onto current `main`
2. **Split into two PRs**: one for the action-stall guard scaffolding (`7703f884d` content), one for the Grok/GLM-specific fixes layered on top
3. **Squash into one commit** if maintainers prefer

Just let me know — I have the history preserved and can restructure quickly. The PR diff currently looks large (22 files) because of the 102-commit base divergence; an actual rebase against tip would be much smaller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)