### PR TITLE
fix: keep Telegram progress in one edited bubble

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15890,24 +15890,36 @@ class GatewayRunner:
             _last_edit_ts = 0.0      # Throttle edits to avoid Telegram flood control
             _PROGRESS_EDIT_INTERVAL = 1.5  # Minimum seconds between edits
 
-            _progress_len_fn = (
-                adapter.message_len_fn
-                if isinstance(adapter, BasePlatformAdapter)
-                else len
-            )
+            try:
+                _progress_len_fn = (
+                    adapter.message_len_fn
+                    if isinstance(adapter, BasePlatformAdapter)
+                    else len
+                )
+            except Exception:
+                _progress_len_fn = len
             try:
                 _raw_progress_limit = int(getattr(adapter, "MAX_MESSAGE_LENGTH", 4000) or 4000)
             except Exception:
                 _raw_progress_limit = 4000
-            # Leave a little room for platform quirks / formatting.  For tiny
-            # test adapters keep the limit usable instead of clamping to 500+.
+            # Tool progress is an auxiliary edited status bubble. Never let it
+            # reach platform chunking/overflow paths: Telegram edit overflow can
+            # send fresh continuation messages, which turns cumulative progress
+            # into visible standalone tool-log bubbles. Keep recent tail context
+            # instead of sending extra progress bubbles.
+            _progress_reserve = 128 if _raw_progress_limit > 512 else max(16, _raw_progress_limit // 8)
+            _progress_budget = min(
+                _raw_progress_limit - _progress_reserve,
+                int(_raw_progress_limit * 0.8),
+                3200,
+            )
             _PROGRESS_TEXT_LIMIT = max(
                 1,
-                _raw_progress_limit - (64 if _raw_progress_limit > 128 else 0),
+                min(_raw_progress_limit, max(64, _progress_budget)),
             )
 
             # Detect whether the adapter's edit_message accepts metadata so
-            # overflow edits preserve Telegram topic/thread routing (#27487).
+            # edits preserve Telegram topic/thread routing (#27487).
             _edit_accepts_metadata = False
             if _progress_metadata:
                 try:
@@ -15935,20 +15947,41 @@ class GatewayRunner:
             def _progress_text(lines: list) -> str:
                 return "\n".join(str(line) for line in lines)
 
-            def _split_progress_groups(lines: list) -> list[list]:
-                """Partition progress lines into platform-sized editable bubbles."""
-                groups: list[list] = []
-                current: list = []
-                for line in lines:
-                    candidate = current + [line]
-                    if current and _progress_len_fn(_progress_text(candidate)) > _PROGRESS_TEXT_LIMIT:
-                        groups.append(current)
-                        current = [line]
-                    else:
-                        current = candidate
-                if current:
-                    groups.append(current)
-                return groups
+            def _progress_text_len(text: str) -> int:
+                try:
+                    return int(_progress_len_fn(text))
+                except Exception:
+                    return len(text)
+
+            def _render_progress_text(lines: list) -> str:
+                if not lines:
+                    return ""
+                full_text = _progress_text(lines)
+                if _progress_text_len(full_text) <= _PROGRESS_TEXT_LIMIT:
+                    return full_text
+
+                kept: list = []
+                for line in reversed(lines):
+                    candidate_lines = [line] + kept
+                    omitted = len(lines) - len(candidate_lines)
+                    prefix = f"… {omitted} earlier tool updates omitted\n" if omitted else ""
+                    candidate = prefix + _progress_text(candidate_lines)
+                    if _progress_text_len(candidate) <= _PROGRESS_TEXT_LIMIT:
+                        kept = candidate_lines
+                        continue
+                    break
+
+                if kept:
+                    omitted = len(lines) - len(kept)
+                    prefix = f"… {omitted} earlier tool updates omitted\n" if omitted else ""
+                    return prefix + _progress_text(kept)
+
+                # Defensive fallback for a single pathological verbose line.
+                marker = "… progress line truncated\n"
+                tail = str(lines[-1])
+                while tail and _progress_text_len(marker + tail) > _PROGRESS_TEXT_LIMIT:
+                    tail = tail[1:]
+                return marker + tail
 
             def _track_progress_result(result) -> None:
                 if (
@@ -15967,42 +16000,6 @@ class GatewayRunner:
                 )
                 _track_progress_result(result)
                 return result
-
-            async def _roll_progress_overflow_if_needed() -> bool:
-                """Start fresh editable progress bubbles before a bubble exceeds limit.
-
-                Returns True when it delivered/split the current buffer and the
-                caller should skip the normal send/edit path for this tick.
-                """
-                nonlocal progress_msg_id, progress_lines, can_edit
-                if not progress_lines or not can_edit:
-                    return False
-                groups = _split_progress_groups(progress_lines)
-                if len(groups) <= 1:
-                    return False
-
-                first_text = _progress_text(groups[0])
-                if progress_msg_id is not None:
-                    result = await _edit_progress_message(progress_msg_id, first_text)
-                    if not result.success:
-                        can_edit = False
-                        # Fall back to the existing non-edit behavior below.
-                        return False
-                else:
-                    result = await _send_progress_text(first_text)
-                    if result.success and result.message_id:
-                        progress_msg_id = result.message_id
-
-                for group in groups[1:]:
-                    result = await _send_progress_text(_progress_text(group))
-                    if result.success and result.message_id:
-                        progress_msg_id = result.message_id
-
-                # The newest continuation is now the only mutable bubble.  Keep
-                # just its lines so subsequent edits update it instead of
-                # replaying the full historical transcript into new messages.
-                progress_lines = groups[-1]
-                return True
 
             while True:
                 try:
@@ -16056,13 +16053,6 @@ class GatewayRunner:
                         msg = raw
                         progress_lines.append(msg)
 
-                    if await _roll_progress_overflow_if_needed():
-                        _last_edit_ts = time.monotonic()
-                        await asyncio.sleep(0.3)
-                        if _run_still_current():
-                            await adapter.send_typing(source.chat_id, metadata=_progress_metadata)
-                        continue
-
                     # Throttle edits: batch rapid tool updates into fewer
                     # API calls to avoid hitting Telegram flood control.
                     # (grammY auto-retry pattern: proactively rate-limit
@@ -16081,7 +16071,7 @@ class GatewayRunner:
 
                     if can_edit and progress_msg_id is not None:
                         # Try to edit the existing progress message
-                        full_text = "\n".join(progress_lines)
+                        full_text = _render_progress_text(progress_lines)
                         result = await _edit_progress_message(progress_msg_id, full_text)
                         if not result.success:
                             _err = (getattr(result, "error", "") or "").lower()
@@ -16111,13 +16101,8 @@ class GatewayRunner:
                         result = None
                         if can_edit:
                             # First tool: send all accumulated text as new message
-                            full_text = "\n".join(progress_lines)
-                            result = await adapter.send(
-                                chat_id=source.chat_id,
-                                content=full_text,
-                                reply_to=_progress_reply_to,
-                                metadata=_progress_metadata,
-                            )
+                            full_text = _render_progress_text(progress_lines)
+                            result = await _send_progress_text(full_text)
                         else:
                             # Edits are temporarily disabled (for example after
                             # Telegram flood control). Keep accumulating/silent
@@ -16129,8 +16114,6 @@ class GatewayRunner:
                             )
                         if result is not None and result.success and result.message_id:
                             progress_msg_id = result.message_id
-                            if _cleanup_progress:
-                                _cleanup_msg_ids.append(str(result.message_id))
                         elif result is not None:
                             # We attempted the initial visible progress send but
                             # cannot edit it: either Telegram timed out after the
@@ -16167,14 +16150,12 @@ class GatewayRunner:
                                 _, base_msg, count = raw
                                 if progress_lines:
                                     progress_lines[-1] = f"{base_msg} (×{count + 1})"
-                                    await _roll_progress_overflow_if_needed()
                             elif isinstance(raw, tuple) and len(raw) >= 1 and raw[0] == "__reset__":
                                 # Content-bubble marker during drain: close off
                                 # the current progress bubble and start a fresh
                                 # one for any tool lines that arrived after.
-                                await _roll_progress_overflow_if_needed()
                                 if can_edit and progress_lines and progress_msg_id:
-                                    _pending_text = _progress_text(progress_lines)
+                                    _pending_text = _render_progress_text(progress_lines)
                                     try:
                                         await _edit_progress_message(progress_msg_id, _pending_text)
                                     except Exception:
@@ -16185,14 +16166,11 @@ class GatewayRunner:
                                 repeat_count[0] = 0
                             else:
                                 progress_lines.append(raw)
-                                await _roll_progress_overflow_if_needed()
                         except Exception:
                             break
                     # Final edit with all remaining tools (only if editing works)
                     if can_edit and progress_lines and progress_msg_id:
-                        await _roll_progress_overflow_if_needed()
-                    if can_edit and progress_lines and progress_msg_id:
-                        full_text = _progress_text(progress_lines)
+                        full_text = _render_progress_text(progress_lines)
                         try:
                             await _edit_progress_message(progress_msg_id, full_text)
                         except Exception:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16085,40 +16085,30 @@ class GatewayRunner:
                         result = await _edit_progress_message(progress_msg_id, full_text)
                         if not result.success:
                             _err = (getattr(result, "error", "") or "").lower()
-                            # Transient network errors (ConnectError, timeouts)
-                            # must not permanently disable progress-message
-                            # editing — the next cycle can catch up.  Only
-                            # permanent failures (flood control, message not
-                            # found, permissions) should set can_edit = False.
-                            if getattr(result, "retryable", False):
-                                logger.debug(
-                                    "[%s] Transient edit failure — keeping can_edit=True",
-                                    adapter.name,
-                                )
-                                continue
                             if "flood" in _err or "retry after" in _err:
-                                # Flood control hit — backoff but keep editing.
-                                # Only disable edits for non-recoverable errors.
+                                # Flood control hit — pause progress edits for
+                                # this run. Do not fall back to fresh sends:
+                                # Telegram users experience that as tool-report
+                                # spam, and edit-capable adapters may recover on
+                                # the next turn.
                                 logger.info(
-                                    "[%s] Progress edit flood control, backing off",
+                                    "[%s] Progress edits paused due to flood control; suppressing standalone progress fallback",
                                     adapter.name,
                                 )
-                                _last_edit_ts = time.monotonic()
-                            else:
                                 can_edit = False
-                            _flood_result = await adapter.send(
-                                chat_id=source.chat_id,
-                                content=msg,
-                                reply_to=_progress_reply_to,
-                                metadata=_progress_metadata,
-                            )
-                            if (
-                                _cleanup_progress
-                                and getattr(_flood_result, "success", False)
-                                and getattr(_flood_result, "message_id", None)
-                            ):
-                                _cleanup_msg_ids.append(str(_flood_result.message_id))
+                            else:
+                                # A transient edit failure is not proof that the
+                                # adapter is non-editing. Keep batching in the
+                                # original progress bubble and try again later
+                                # (or in the final drain) instead of creating a
+                                # new visible tool-progress message.
+                                logger.debug(
+                                    "[%s] Progress edit failed; keeping progress batched: %s",
+                                    adapter.name,
+                                    getattr(result, "error", "") or "unknown error",
+                                )
                     else:
+                        result = None
                         if can_edit:
                             # First tool: send all accumulated text as new message
                             full_text = "\n".join(progress_lines)
@@ -16129,17 +16119,35 @@ class GatewayRunner:
                                 metadata=_progress_metadata,
                             )
                         else:
-                            # Editing unsupported: send just this line
-                            result = await adapter.send(
-                                chat_id=source.chat_id,
-                                content=msg,
-                                reply_to=_progress_reply_to,
-                                metadata=_progress_metadata,
+                            # Edits are temporarily disabled (for example after
+                            # Telegram flood control). Keep accumulating/silent
+                            # rather than sending each progress line as a new
+                            # standalone message.
+                            logger.debug(
+                                "[%s] Suppressing standalone tool-progress send while edits are paused",
+                                adapter.name,
                             )
-                        if result.success and result.message_id:
+                        if result is not None and result.success and result.message_id:
                             progress_msg_id = result.message_id
                             if _cleanup_progress:
                                 _cleanup_msg_ids.append(str(result.message_id))
+                        elif result is not None:
+                            # We attempted the initial visible progress send but
+                            # cannot edit it: either Telegram timed out after the
+                            # request may have landed, or the adapter reported
+                            # success without an editable message id. Retrying by
+                            # sending the accumulated progress text again creates
+                            # the duplicated standalone tool-report bubbles users
+                            # see in Telegram. Tool progress is auxiliary, so
+                            # fail closed for this run and keep later updates
+                            # silent instead of sending cumulative fallbacks.
+                            _err = getattr(result, "error", "") or "missing message id"
+                            logger.info(
+                                "[%s] Progress send returned no editable message id; suppressing standalone progress fallback: %s",
+                                adapter.name,
+                                _err,
+                            )
+                            can_edit = False
 
                     _last_edit_ts = time.monotonic()
 

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -59,7 +59,7 @@ class ProgressCaptureAdapter(BasePlatformAdapter):
 
 
 class SmallLimitProgressAdapter(ProgressCaptureAdapter):
-    """Adapter with a tiny platform limit to exercise progress rollover."""
+    """Adapter with a tiny platform limit to exercise progress clipping."""
 
     MAX_MESSAGE_LENGTH = 180
 
@@ -166,6 +166,36 @@ class InitialProgressFailureAdapter(ProgressCaptureAdapter):
         return SendResult(success=False, error="Timed out", retryable=False)
 
 
+class OverflowingProgressEditAdapter(ProgressCaptureAdapter):
+    """Adapter that mimics Telegram edit overflow by sending continuations."""
+
+    MAX_MESSAGE_LENGTH = 180
+
+    async def edit_message(self, chat_id, message_id, content) -> SendResult:
+        self.edits.append(
+            {
+                "chat_id": chat_id,
+                "message_id": message_id,
+                "content": content,
+            }
+        )
+        if len(content) > self.MAX_MESSAGE_LENGTH:
+            self.sent.append(
+                {
+                    "chat_id": chat_id,
+                    "content": content[self.MAX_MESSAGE_LENGTH:],
+                    "reply_to": message_id,
+                    "metadata": {"overflow_continuation": True},
+                }
+            )
+            return SendResult(
+                success=True,
+                message_id="progress-overflow-1",
+                continuation_message_ids=("progress-overflow-1",),
+            )
+        return SendResult(success=True, message_id=message_id)
+
+
 class FakeAgent:
     def __init__(self, **kwargs):
         # Capture anything passed via kwargs (older code path) but don't
@@ -236,8 +266,8 @@ class ManyProgressLinesAgent:
         assert cb is not None
         cb("tool.started", "terminal", "first-short", {})
         # Let the progress task create the first editable bubble, then enqueue
-        # the rest quickly.  The cancellation drain must roll them into fresh
-        # editable bubbles instead of trying to edit the first one past limit.
+        # the rest quickly. The cancellation drain must clip the edited text
+        # before the adapter's platform limit instead of creating fresh bubbles.
         time.sleep(0.35)
         for idx in range(1, 8):
             cb("tool.started", "terminal", f"overflow-line-{idx}-" + "x" * 45, {})
@@ -263,6 +293,26 @@ class ThreeStepProgressAgent:
             time.sleep(1.6)
             cb("tool.started", "read_file", "third command", {})
             time.sleep(0.6)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class ManyStepProgressAgent:
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        cb = self.tool_progress_callback
+        if cb is not None:
+            cb("tool.started", "terminal", "command 00 warmup", {})
+            time.sleep(0.45)
+            for idx in range(1, 18):
+                cb("tool.started", "terminal", f"command {idx:02d} with detailed preview", {})
+            time.sleep(0.2)
         return {
             "final_response": "done",
             "messages": [],
@@ -803,19 +853,18 @@ async def _run_with_agent(
 
 
 @pytest.mark.asyncio
-async def test_run_agent_rolls_progress_bubble_before_platform_limit(monkeypatch, tmp_path):
-    """Tool progress should start a second editable bubble before Telegram's limit.
+async def test_run_agent_clips_progress_before_platform_limit(monkeypatch, tmp_path):
+    """Tool progress should stay in one edited bubble before Telegram's limit.
 
-    Regression: once the first progress bubble grew past the platform limit,
-    the gateway kept trying to edit that same oversized full transcript.  The
-    Telegram adapter then split-and-sent a fresh continuation on every update,
-    causing a noisy trail of one-line messages instead of a new editable bubble.
+    Regression: once cumulative progress grew past the platform limit, the
+    adapter overflow path could send fresh continuation messages. Long progress
+    should be clipped to recent lines before it reaches that path.
     """
     adapter, result = await _run_with_agent(
         monkeypatch,
         tmp_path,
         ManyProgressLinesAgent,
-        session_id="sess-progress-overflow-rollover",
+        session_id="sess-progress-overflow-clipped-small-limit",
         config_data={
             "display": {
                 "tool_progress": "all",
@@ -828,11 +877,12 @@ async def test_run_agent_rolls_progress_bubble_before_platform_limit(monkeypatch
 
     assert result["final_response"] == "done"
     assert isinstance(adapter, SmallLimitProgressAdapter)
-    assert len(adapter.sent) >= 2, "expected a fresh progress bubble after the first filled"
+    assert len(adapter.sent) == 1
     assert adapter.oversized_sends == []
     assert adapter.oversized_edits == []
     all_bubbles = [call["content"] for call in adapter.sent + adapter.edits]
     assert all(len(text) <= adapter.MAX_MESSAGE_LENGTH for text in all_bubbles)
+    assert "earlier tool updates omitted" in adapter.edits[-1]["content"]
 
 
 @pytest.mark.asyncio
@@ -890,6 +940,32 @@ async def test_run_agent_suppresses_later_progress_when_initial_send_fails(monke
         '💻 terminal: "first command"'
     ]
     assert adapter.edits == []
+
+
+@pytest.mark.asyncio
+async def test_run_agent_clips_long_tool_progress_before_adapter_overflow(monkeypatch, tmp_path):
+    """Long cumulative progress must stay one edited bubble, not Telegram overflow continuations."""
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        ManyStepProgressAgent,
+        session_id="sess-progress-overflow-clipped",
+        config_data={"display": {"tool_progress": "all"}},
+        adapter_cls=OverflowingProgressEditAdapter,
+    )
+
+    assert result["final_response"] == "done"
+    assert len(adapter.sent) == 1
+    assert adapter.sent[0]["content"] == '💻 terminal: "command 00 warmup"'
+    assert not any(
+        call.get("metadata", {}).get("overflow_continuation")
+        for call in adapter.sent
+    )
+    assert adapter.edits
+    max_progress_len = getattr(adapter, "MAX_MESSAGE_LENGTH")
+    assert all(len(call["content"]) <= max_progress_len for call in adapter.edits)
+    assert "earlier tool updates omitted" in adapter.edits[-1]["content"]
+    assert '💻 terminal: "command 17 with detailed preview"' in adapter.edits[-1]["content"]
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -121,6 +121,51 @@ class NonEditingProgressCaptureAdapter(ProgressCaptureAdapter):
         raise AssertionError("non-editable adapters should not receive edit_message calls")
 
 
+class TransientEditFailureAdapter(ProgressCaptureAdapter):
+    def __init__(self, platform=Platform.TELEGRAM):
+        super().__init__(platform=platform)
+        self.edit_attempts = 0
+
+    async def edit_message(self, chat_id, message_id, content) -> SendResult:
+        self.edit_attempts += 1
+        self.edits.append(
+            {
+                "chat_id": chat_id,
+                "message_id": message_id,
+                "content": content,
+            }
+        )
+        if self.edit_attempts == 1:
+            return SendResult(success=False, error="temporary edit failure")
+        return SendResult(success=True, message_id=message_id)
+
+
+class InitialProgressNoMessageIdAdapter(ProgressCaptureAdapter):
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self.sent.append(
+            {
+                "chat_id": chat_id,
+                "content": content,
+                "reply_to": reply_to,
+                "metadata": metadata,
+            }
+        )
+        return SendResult(success=True, message_id=None)
+
+
+class InitialProgressFailureAdapter(ProgressCaptureAdapter):
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self.sent.append(
+            {
+                "chat_id": chat_id,
+                "content": content,
+                "reply_to": reply_to,
+                "metadata": metadata,
+            }
+        )
+        return SendResult(success=False, error="Timed out", retryable=False)
+
+
 class FakeAgent:
     def __init__(self, **kwargs):
         # Capture anything passed via kwargs (older code path) but don't
@@ -197,6 +242,27 @@ class ManyProgressLinesAgent:
         for idx in range(1, 8):
             cb("tool.started", "terminal", f"overflow-line-{idx}-" + "x" * 45, {})
         time.sleep(0.1)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class ThreeStepProgressAgent:
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        cb = self.tool_progress_callback
+        if cb is not None:
+            cb("tool.started", "terminal", "first command", {})
+            time.sleep(0.4)
+            cb("tool.started", "browser_navigate", "second command", {})
+            time.sleep(1.6)
+            cb("tool.started", "read_file", "third command", {})
+            time.sleep(0.6)
         return {
             "final_response": "done",
             "messages": [],
@@ -767,6 +833,63 @@ async def test_run_agent_rolls_progress_bubble_before_platform_limit(monkeypatch
     assert adapter.oversized_edits == []
     all_bubbles = [call["content"] for call in adapter.sent + adapter.edits]
     assert all(len(text) <= adapter.MAX_MESSAGE_LENGTH for text in all_bubbles)
+
+
+@pytest.mark.asyncio
+async def test_run_agent_keeps_tool_progress_batched_after_transient_edit_failure(monkeypatch, tmp_path):
+    """A transient edit failure must not turn later tool progress into standalone sends."""
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        ThreeStepProgressAgent,
+        session_id="sess-progress-transient-edit-failure",
+        config_data={"display": {"tool_progress": "all"}},
+        adapter_cls=TransientEditFailureAdapter,
+    )
+
+    assert result["final_response"] == "done"
+    assert getattr(adapter, "edit_attempts", 0) >= 1
+    assert [call["content"] for call in adapter.sent] == [
+        '💻 terminal: "first command"'
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_agent_suppresses_later_progress_when_initial_send_has_no_message_id(monkeypatch, tmp_path):
+    """If the first progress send cannot be edited, do not resend accumulated lines."""
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        ThreeStepProgressAgent,
+        session_id="sess-progress-initial-no-message-id",
+        config_data={"display": {"tool_progress": "all"}},
+        adapter_cls=InitialProgressNoMessageIdAdapter,
+    )
+
+    assert result["final_response"] == "done"
+    assert [call["content"] for call in adapter.sent] == [
+        '💻 terminal: "first command"'
+    ]
+    assert adapter.edits == []
+
+
+@pytest.mark.asyncio
+async def test_run_agent_suppresses_later_progress_when_initial_send_fails(monkeypatch, tmp_path):
+    """A failed initial progress send may have reached Telegram; never retry as cumulative bubbles."""
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        ThreeStepProgressAgent,
+        session_id="sess-progress-initial-send-fails",
+        config_data={"display": {"tool_progress": "all"}},
+        adapter_cls=InitialProgressFailureAdapter,
+    )
+
+    assert result["final_response"] == "done"
+    assert [call["content"] for call in adapter.sent] == [
+        '💻 terminal: "first command"'
+    ]
+    assert adapter.edits == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Keep gateway tool-progress updates batched when an edit-capable adapter has transient edit failures, flood-control responses, or initial sends without an editable message id.
- Cap and condense long cumulative progress text before platform overflow/chunking paths; older tool lines are summarized while the latest tool activity remains visible.
- Avoid fresh continuation messages for Telegram progress overflow so progress stays in one edited status bubble.
- Preserve metadata-aware progress edits and cleanup tracking for the initial progress message.
- Add regression coverage for edit-failure, initial-send no-message-id/failure, platform-limit clipping, and Telegram-like edit-overflow continuation behavior.

## Test Plan
- `python -m pytest tests/gateway/test_run_progress_topics.py tests/gateway/test_stream_consumer.py -q -o 'addopts='`
- `python -m pytest tests/gateway/test_run_progress_topics.py::test_run_agent_clips_progress_before_platform_limit tests/gateway/test_run_progress_topics.py::test_run_agent_clips_long_tool_progress_before_adapter_overflow -q -o 'addopts='`
- `python -m py_compile gateway/run.py tests/gateway/test_run_progress_topics.py`
- `git diff --check -- gateway/run.py tests/gateway/test_run_progress_topics.py`
