### PR TITLE
chore(release): AUTHOR_MAP entries for batch salvage group 8

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1184,6 +1184,22 @@ AUTHOR_MAP = {
     "rudi193@gmail.com": "rudi193-cmd",
     "86684667+sadiksaifi@users.noreply.github.com": "sadiksaifi",  # PR #27982 salvage (kanban horiz scroll)
     "mail@sadiksaifi.dev": "sadiksaifi",
+    # batch salvage (May 2026 LHF run, group 8)
+    "266824395+AceWattGit@users.noreply.github.com": "AceWattGit",  # PR #28159 salvage (_pool_may_recover NameError)
+    "57024493+YuanHanzhong@users.noreply.github.com": "YuanHanzhong",  # PR #28032 salvage (x.com status link-like)
+    "24368158+colin-chang@users.noreply.github.com": "colin-chang",  # PR #28245/#28249/#28251 salvage
+    "zhangcheng5468@gmail.com": "colin-chang",
+    "172729123+felix-windsor@users.noreply.github.com": "felix-windsor",  # PR #28019 salvage (cron asterisks)
+    "felixwindsor3344@gmail.com": "felix-windsor",
+    "259054917+houenyang-momo@users.noreply.github.com": "houenyang-momo",  # PR #28205 salvage (charizard contrast)
+    "35931201+iqdoctor@users.noreply.github.com": "iqdoctor",  # PR #28095 salvage (windows installer docs)
+    "29513231+joe102084@users.noreply.github.com": "joe102084",  # PR #28151 salvage (whitespace cron responses)
+    "joe102084@gmail.com": "joe102084",
+    "4139778+jvinals@users.noreply.github.com": "jvinals",  # PR #27936 salvage (Slack U-IDs)
+    "3001335+maxmilian@users.noreply.github.com": "maxmilian",  # PR #28267 salvage (Change Model portal)
+    "maxmilian@gmail.com": "maxmilian",
+    "41468846+samggggflynn@users.noreply.github.com": "samggggflynn",  # PR #27952 salvage (dingtalk pre_start)
+    "abc401011721@gmail.com": "samggggflynn",
 }
 
 


### PR DESCRIPTION
Pre-stages AUTHOR_MAP for 10 new contributors whose PRs are being salvaged in the May 2026 LHF batch group 8, so the per-PR salvage commits don't fail CI's email-mapping check.

Contributors staged:
- @AceWattGit (#28159)
- @YuanHanzhong (#28032)
- @colin-chang (#28245, #28249, #28251)
- @felix-windsor (#28019)
- @houenyang-momo (#28205)
- @iqdoctor (#28095)
- @joe102084 (#28151)
- @jvinals (#27936)
- @maxmilian (#28267)
- @samggggflynn (#27952)

Per `references/batch-pr-salvage-may14-additions.md`.