### PR TITLE
fix(dingtalk): add pre_start() to _IncomingHandler for SDK compatibility (#27952)

### DIFF
--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -1395,6 +1395,16 @@ class _IncomingHandler(
         self._adapter = adapter
         self._loop = loop
 
+    def pre_start(self) -> None:
+        """No-op pre-start hook required by dingtalk-stream SDK.
+
+        The SDK calls ``pre_start()`` on every registered handler before
+        opening the WebSocket connection.  Without this method, the SDK
+        raises ``AttributeError: '_IncomingHandler' object has no
+        attribute 'pre_start'`` and kills the stream connection.
+        """
+        return
+
     async def process(self, message: "CallbackMessage"):
         """Called by dingtalk-stream (>=0.20) when a message arrives.
 


### PR DESCRIPTION
Salvage of #27952 by @samggggflynn.

**What:** `dingtalk-stream` SDK (>=0.20) calls `pre_start()` on every registered handler before opening the WebSocket connection. `_IncomingHandler` didn't implement it, so the SDK raised `AttributeError: '_IncomingHandler' object has no attribute 'pre_start'` and killed the stream connection.

**How:** Add a no-op `pre_start()` method.

Original PR: https://github.com/NousResearch/hermes-agent/pull/27952