### PR TITLE
fix(windows): handle redirected stdout in _cprint fallback (#28083)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1785,7 +1785,16 @@ def _cprint(text: str):
     # direct prompt_toolkit print is safe and matches existing behavior
     # (spinner frames, streamed tokens, tool activity prefixes, …).
     if app is None or not getattr(app, "_is_running", False):
-        _pt_print(_PT_ANSI(text))
+        try:
+            _pt_print(_PT_ANSI(text))
+        except Exception:
+            # Fallback when stdout is not a real console (e.g. subprocess
+            # worker logging to a file). prompt_toolkit raises
+            # NoConsoleScreenBufferError (Windows) or OSError (other).
+            try:
+                print(text)
+            except Exception:
+                pass
         return
 
     try:


### PR DESCRIPTION
Salvage of #28083 by @Grogger.

**What:** `_cprint()` called `_pt_print(_PT_ANSI(text))` unconditionally when prompt_toolkit's app wasn't running. On Windows or when stdout was redirected to a file (e.g. subprocess workers logging), prompt_toolkit raised `NoConsoleScreenBufferError` / `OSError` and crashed the printer.

**How:** Wrap the prompt_toolkit call in try/except and fall back to plain `print(text)`, then a final silent except — so a non-console stdout never crashes the CLI.

Original PR: https://github.com/NousResearch/hermes-agent/pull/28083