### PR TITLE
fix(security): redact NVIDIA NIM API keys in logs

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -104,6 +104,7 @@ _PREFIX_PATTERNS = [
     r"mem0_[A-Za-z0-9]{10,}",           # Mem0 Platform API key
     r"brv_[A-Za-z0-9]{10,}",            # ByteRover API key
     r"xai-[A-Za-z0-9]{30,}",            # xAI (Grok) API key
+    r"nvapi-[A-Za-z0-9_-]{30,}",        # NVIDIA NIM API key
 ]
 
 # ENV assignment patterns: KEY=value where KEY contains a secret-like name

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -537,3 +537,29 @@ class TestXaiToken:
     def test_prefix_visible_in_masked_output(self):
         result = redact_sensitive_text(self.KEY, force=True)
         assert result.startswith("xai-AB")
+
+
+class TestNvidiaNimToken:
+    KEY = "nvapi-ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstu"
+
+    def test_bare_token_masked(self):
+        result = redact_sensitive_text(f"using key {self.KEY}", force=True)
+        assert self.KEY not in result
+        assert "nvapi-" in result
+
+    def test_env_assignment_masked(self):
+        result = redact_sensitive_text(f"NVIDIA_API_KEY={self.KEY}", force=True)
+        assert self.KEY not in result
+
+    def test_too_short_not_masked(self):
+        short = "nvapi-tooshort"
+        result = redact_sensitive_text(f"text {short} here", force=True)
+        assert short in result
+
+    def test_company_name_not_masked(self):
+        result = redact_sensitive_text("nvidia is a company", force=True)
+        assert result == "nvidia is a company"
+
+    def test_prefix_visible_in_masked_output(self):
+        result = redact_sensitive_text(self.KEY, force=True)
+        assert result.startswith("nvapi-")


### PR DESCRIPTION
## Summary

NVIDIA NIM is a first-class provider in hermes-agent (`NVIDIA_API_KEY` / `nvidia`), but its `nvapi-<60+ chars>` key prefix was absent from `_PREFIX_PATTERNS` in `agent/redact.py`. A raw token in a stack trace or debug print passed through completely unmasked. ENV-assign and Bearer header paths were already covered.

Mirrors the recent xAI fix (commit `5613dfea9`) for the same class of bug.

## Test plan

- [x] 5 new unit tests in `TestNvidiaNimToken` mirroring `TestXaiToken` (bare token, env assign, short-prefix false positive, company-name false positive, visible prefix in masked output)
- [x] `pytest tests/agent/test_redact.py -q` → 85 passed