### PR TITLE
fix(aux): remove stale session_search model menu entry (#27926)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2142,7 +2142,6 @@ _AUX_TASKS: list[tuple[str, str, str]] = [
     ("vision", "Vision", "image/screenshot analysis"),
     ("compression", "Compression", "context summarization"),
     ("web_extract", "Web extract", "web page summarization"),
-    ("session_search", "Session search", "past-conversation recall"),
     ("approval", "Approval", "smart command approval"),
     ("mcp", "MCP", "MCP tool reasoning"),
     ("title_generation", "Title generation", "session titles"),

--- a/tests/hermes_cli/test_aux_config.py
+++ b/tests/hermes_cli/test_aux_config.py
@@ -42,12 +42,10 @@ def test_title_generation_present_in_default_config():
     assert tg["extra_body"] == {}
 
 
-def test_session_search_defaults_include_extra_body_and_concurrency():
-    ss = DEFAULT_CONFIG["auxiliary"]["session_search"]
-    assert ss["provider"] == "auto"
-    assert ss["model"] == ""
-    assert ss["extra_body"] == {}
-    assert ss["max_concurrency"] == 3
+def test_session_search_no_longer_appears_in_auxiliary_model_config():
+    """session_search is a direct DB-backed tool, not an auxiliary LLM task."""
+    assert "session_search" not in DEFAULT_CONFIG["auxiliary"]
+    assert "session_search" not in {key for key, _name, _desc in _AUX_TASKS}
 
 
 def test_aux_tasks_keys_all_exist_in_default_config():


### PR DESCRIPTION
Salvage of #27926 by @hehehe0803.

**What:** `session_search` is now a direct DB-backed tool (FTS5 over conversation history) and no longer uses an auxiliary LLM, so its entry in the `hermes tools` auxiliary-model picker was stale: selecting it had no effect.

**How:** Remove `session_search` from `_AUX_TASKS` in `hermes_cli/main.py`. Test inverted to assert the key is absent.

Original PR: https://github.com/NousResearch/hermes-agent/pull/27926
Fixes #27925.