### PR TITLE
fix(tui): keep x.com status fallbacks link-like (#28032)

### DIFF
--- a/ui-tui/src/__tests__/externalLink.test.ts
+++ b/ui-tui/src/__tests__/externalLink.test.ts
@@ -30,6 +30,12 @@ describe('external link helpers', () => {
     ).toBe('From Fajardo Icacos Island Full Day Catamaran Trip')
   })
 
+  it('keeps x.com status fallbacks link-like instead of generic Status labels', () => {
+    expect(urlSlugTitleLabel('https://x.com/grok/status/2056065022749479209')).toBe(
+      'x.com/grok/status/2056065022749479209'
+    )
+  })
+
   it('normalizes scheme-less links', () => {
     expect(normalizeExternalUrl(' expedia.com/things-to-do/puerto-rico-el-yunque ')).toBe(
       'https://expedia.com/things-to-do/puerto-rico-el-yunque'

--- a/ui-tui/src/lib/externalLink.ts
+++ b/ui-tui/src/lib/externalLink.ts
@@ -21,6 +21,8 @@ const DOMAIN_RE = /^(?:www\.)?[a-z0-9](?:[a-z0-9-]*\.)+[a-z]{2,}(?::\d+)?(?:[/?#
 const SKIP_PROTO_RE = /^(?:file|data|mailto|javascript|blob|chrome|about|hermes):/i
 const LOCAL_HOSTNAME_RE = /^(?:localhost|localhost\.localdomain)$/i
 const LOCAL_HOST_SUFFIXES = ['.corp', '.home', '.internal', '.lan', '.local', '.localdomain']
+const STATUS_PERMALINK_HOST_RE = /^(?:mobile\.)?(?:x|twitter)\.com$/i
+const STATUS_PERMALINK_PATH_RE = /^\/[^/]+\/status\/\d+\/?$/i
 
 const HTML_ENTITIES: Record<string, string> = {
   '#39': "'",
@@ -100,6 +102,10 @@ function cleanSlug(segment: string): string {
 
 export function urlSlugTitleLabel(value: string): string {
   const url = parseUrl(value)
+
+  if (url && STATUS_PERMALINK_HOST_RE.test(url.hostname) && STATUS_PERMALINK_PATH_RE.test(url.pathname)) {
+    return hostPathLabel(value)
+  }
 
   for (const segment of url?.pathname.split('/').filter(Boolean).reverse() ?? []) {
     const cleaned = cleanSlug(segment)


### PR DESCRIPTION
Salvage of #28032 by @YuanHanzhong.

**What:** `urlSlugTitleLabel()` in `ui-tui/src/lib/externalLink.ts` would title-case x.com/twitter.com status URLs (e.g. `https://x.com/grok/status/2056065022749479209` → generic "Status" label), losing the link-like presentation users expect.

**How:** Detect status permalink hosts/paths and route through `hostPathLabel()` so the displayed text stays link-shaped (`x.com/grok/status/2056065022749479209`).

Original PR: https://github.com/NousResearch/hermes-agent/pull/28032
Fixes #27609.