### PR TITLE
fix(web): portal Change Model modal so it renders above the app sidebar (#28267)

### DIFF
--- a/web/src/components/ModelPickerDialog.tsx
+++ b/web/src/components/ModelPickerDialog.tsx
@@ -5,6 +5,7 @@ import { Input } from "@/components/ui/input";
 import type { GatewayClient } from "@/lib/gatewayClient";
 import { Check, Search, X } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 
 /**
  * Two-stage model picker modal.
@@ -194,7 +195,14 @@ export function ModelPickerDialog(props: Props) {
     }
   };
 
-  return (
+  // Portal to document.body: the main dashboard column in App.tsx is
+  // `relative z-2`, which creates a stacking context that traps fixed
+  // descendants below the app sidebar (z-50). Without the portal this
+  // modal's z-[100] is scoped to z-2 and the sidebar covers its left
+  // edge — visible especially in the Large theme variants where the
+  // larger root font widens the dialog into the sidebar's column. See
+  // Toast.tsx for the same pattern.
+  return createPortal(
     <div
       className="fixed inset-0 z-[100] flex items-center justify-center bg-background/85 backdrop-blur-sm p-4"
       onClick={(e) => e.target === e.currentTarget && onClose()}
@@ -296,7 +304,8 @@ export function ModelPickerDialog(props: Props) {
           </div>
         </footer>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }
 


### PR DESCRIPTION
Salvage of #28267 by @maxmilian.

**What:** The main dashboard column in `App.tsx` is `relative z-2`, creating a stacking context that traps fixed descendants below the app sidebar (`z-50`). The Change Model modal's `z-[100]` was scoped to that `z-2` ancestor, so the sidebar covered the modal's left edge — especially visible in Large theme variants.

**How:** Wrap the modal in `createPortal(..., document.body)` so it escapes the stacking context, matching the Toast.tsx pattern.

Original PR: https://github.com/NousResearch/hermes-agent/pull/28267
Fixes #28103.