### PR TITLE
fix(gateway): exit code 75 on service restart so launchd relaunches (#28200)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17346,6 +17346,19 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         )
         return False  # → sys.exit(1) in the caller
 
+    # When the gateway is restarting via the service manager (SIGUSR1 →
+    # launchd_restart or /restart / /update commands), exit with code 75 so
+    # that launchd's ``KeepAlive → SuccessfulExit → false`` policy treats
+    # the exit as *unsuccessful* and relaunches the service.  This mirrors
+    # the systemd ``RestartForceExitStatus=75`` convention already used by
+    # the systemd unit template.
+    if runner._restart_via_service:
+        logger.info(
+            "Exiting with code 75 (service-restart requested) so "
+            "launchd KeepAlive relaunches the gateway."
+        )
+        raise SystemExit(75)
+
     return True
 
 


### PR DESCRIPTION
Salvage of #28200 by @zccyman.

**What:** When the gateway restarts via the service manager (SIGUSR1 `launchd_restart` or `/restart` / `/update` commands), it was exiting 0 — which launchd's `KeepAlive → SuccessfulExit → false` policy treats as a clean shutdown that should NOT be relaunched. The user-initiated restart therefore left the gateway dead.

**How:** Raise `SystemExit(75)` when `_restart_via_service` is set, mirroring the systemd `RestartForceExitStatus=75` convention already used in the systemd unit template. launchd sees the non-zero exit and relaunches.

Original PR: https://github.com/NousResearch/hermes-agent/pull/28200
Fixes #28135.