### PR TITLE
fix(gateway,cron): guard json.loads() against invalid TTS and skill_view responses (#27923)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1034,7 +1034,12 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
     parts = []
     skipped: list[str] = []
     for skill_name in skill_names:
-        loaded = json.loads(skill_view(skill_name))
+        try:
+            loaded = json.loads(skill_view(skill_name))
+        except (json.JSONDecodeError, TypeError):
+            logger.warning("Cron job '%s': skill '%s' returned invalid JSON, skipping", job.get("name", job.get("id")), skill_name)
+            skipped.append(skill_name)
+            continue
         if not loaded.get("success"):
             error = loaded.get("error") or f"Failed to load skill '{skill_name}'"
             logger.warning("Cron job '%s': skill not found, skipping — %s", job.get("name", job.get("id")), error)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10592,7 +10592,11 @@ class GatewayRunner:
             result_json = await asyncio.to_thread(
                 text_to_speech_tool, text=tts_text, output_path=audio_path
             )
-            result = json.loads(result_json)
+            try:
+                result = json.loads(result_json)
+            except (json.JSONDecodeError, TypeError):
+                logger.warning("Auto voice reply TTS returned invalid JSON: %s", result_json[:200] if result_json else result_json)
+                return
 
             # Use the actual file path from result (may differ after opus conversion)
             actual_path = result.get("file_path", audio_path)


### PR DESCRIPTION
Salvage of #27923 by @vanthinh6886.

**What:** Two `json.loads()` call sites crashed the cron scheduler / voice-reply path when the upstream tool returned non-JSON (truncated output, exception strings, empty bytes): `cron/scheduler.py:_build_job_prompt` and `gateway/run.py:_send_voice_reply`.

**How:** Wrap both in try/except for `(JSONDecodeError, TypeError)`. Cron scheduler logs a warning and skips the bad skill entry; voice-reply path logs and returns early.

Original PR: https://github.com/NousResearch/hermes-agent/pull/27923