### PR TITLE
fix(gateway): bridge gateway_restart_notification from YAML platform sections (#28245)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -322,15 +322,21 @@ class PlatformConfig:
         if "home_channel" in data:
             home_channel = HomeChannel.from_dict(data["home_channel"])
 
+        # gateway_restart_notification may be bridged into extra via the
+        # shared-key loop in load_gateway_config(); check both top-level
+        # and extra so YAML ``discord: gateway_restart_notification: false``
+        # works without needing a separate platforms: block.
+        _grn = data.get("gateway_restart_notification")
+        if _grn is None:
+            _grn = data.get("extra", {}).get("gateway_restart_notification")
+
         return cls(
             enabled=_coerce_bool(data.get("enabled"), False),
             token=data.get("token"),
             api_key=data.get("api_key"),
             home_channel=home_channel,
             reply_to_mode=data.get("reply_to_mode", "first"),
-            gateway_restart_notification=_coerce_bool(
-                data.get("gateway_restart_notification"), True
-            ),
+            gateway_restart_notification=_coerce_bool(_grn, True),
             extra=data.get("extra", {}),
         )
 
@@ -849,6 +855,8 @@ def load_gateway_config() -> GatewayConfig:
                         bridged["channel_prompts"] = {str(k): v for k, v in channel_prompts.items()}
                     else:
                         bridged["channel_prompts"] = channel_prompts
+                if "gateway_restart_notification" in platform_cfg:
+                    bridged["gateway_restart_notification"] = platform_cfg["gateway_restart_notification"]
                 enabled_was_explicit = "enabled" in platform_cfg
                 if not bridged and not enabled_was_explicit:
                     continue


### PR DESCRIPTION
Salvage of #28245 by @colin-chang.

**What:** Users writing `discord: gateway_restart_notification: false` directly under the platform's YAML section had the setting silently ignored — `load_gateway_config()`'s key-bridging loop didn't include this field, so it never reached `PlatformConfig.from_dict()`.

**How:** Add `gateway_restart_notification` to the bridged-keys list and have `from_dict()` fall back to the `extra` bucket so YAML platform sections work without needing a separate `platforms:` block.

Original PR: https://github.com/NousResearch/hermes-agent/pull/28245