### PR TITLE
fix(conversation_loop): _ra()._pool_may_recover_from_rate_limit (NameError) (#28159)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2332,7 +2332,7 @@ def run_conversation(
                     # still recover.  See _pool_may_recover_from_rate_limit
                     # for the single-credential-pool and CloudCode-quota
                     # exceptions.  Fixes #11314 and #13636.
-                    pool_may_recover = _pool_may_recover_from_rate_limit(
+                    pool_may_recover = _ra()._pool_may_recover_from_rate_limit(
                         agent._credential_pool,
                         provider=agent.provider,
                         base_url=getattr(agent, "base_url", None),

--- a/tests/agent/test_gemini_fast_fallback.py
+++ b/tests/agent/test_gemini_fast_fallback.py
@@ -5,8 +5,10 @@ rotation and fallback-provider activation.  For CloudCode (Gemini CLI /
 Gemini OAuth) the 429 is an account-wide throttle, so waiting for pool
 rotation is pointless — prefer fallback immediately.
 """
+import inspect
 from unittest.mock import MagicMock
 
+from agent import conversation_loop
 from run_agent import _pool_may_recover_from_rate_limit
 
 
@@ -60,3 +62,17 @@ def test_exhausted_pool_skips_rotation():
 
 def test_no_pool_skips_rotation():
     assert _pool_may_recover_from_rate_limit(None) is False
+
+
+def test_conversation_loop_resolves_pool_helper_through_run_agent_module():
+    """Extracted conversation loop must honor tests/patches on run_agent.
+
+    conversation_loop intentionally lazy-loads run_agent via _ra().  If this
+    call site uses a bare imported helper, monkeypatching run_agent in tests (and
+    production wrappers that patch run_agent) will not propagate into the
+    extracted loop; older code also hit NameError in this branch.
+    """
+    source = inspect.getsource(conversation_loop.run_conversation)
+
+    assert "_ra()._pool_may_recover_from_rate_limit(" in source
+    assert "pool_may_recover = _pool_may_recover_from_rate_limit(" not in source


### PR DESCRIPTION
Salvage of #28159 by @AceWattGit. Supersedes #28189, #28254, #28268 (all already-closed 1-line duplicates).

**What:** `agent/conversation_loop.py` line ~2335 called `_pool_may_recover_from_rate_limit(...)` bare, but the symbol was never imported in the file (it lives in `run_agent` and the rest of the module accesses it via the `_ra()` lazy loader). Any rate-limit fallback path hit `NameError: name '_pool_may_recover_from_rate_limit' is not defined`.

**How:** Route the call through `_ra()._pool_may_recover_from_rate_limit(...)` like every other run_agent symbol in this module, plus an inspect-based regression test that asserts the call site uses the namespace form (and that tests/monkeypatches on `run_agent` propagate correctly into the extracted loop).

Original PR: https://github.com/NousResearch/hermes-agent/pull/28159