### PR TITLE
docs(kanban): align dispatcher failure_limit text with current default (5→2 from #21183, +max_retries from #21330) (#21402)

### DIFF
--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -692,7 +692,9 @@ schema footprint is zero outside worker processes.
 - **Dispatcher** runs inside the gateway by default
   (`kanban.dispatch_in_gateway: true`) — reclaims stale claims,
   promotes ready tasks, atomically claims, spawns assigned profiles.
-  Auto-blocks a task after ~5 consecutive spawn failures.
+  Auto-blocks a task after `failure_limit` consecutive spawn failures
+  (default 2; configurable via `kanban.failure_limit` or per-task
+  `max_retries`).
 - **Isolation:** board is the hard boundary (workers get
   `HERMES_KANBAN_BOARD` pinned in env); tenant is a soft namespace
   within a board for workspace-path + memory-key isolation.


### PR DESCRIPTION
Salvages #21402 by @r266-tech.

kanban.md docs already updated, but AGENTS.md (line 852) and skills SKILL.md (line 695) still say '~5 consecutive spawn failures'; remaining doc fix still applies.

Cherry-picked onto current main with original authorship preserved via rebase merge.