### PR TITLE
fix(kanban): clear _INITIALIZED_PATHS in remove_board so recycled DBs re-init schema (#23852)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -534,6 +534,11 @@ def remove_board(slug: str, *, archive: bool = True) -> dict:
     if get_current_board() == normed:
         clear_current_board()
 
+    # A concurrent connect(board=normed) after the rename/delete recreates
+    # an empty sqlite file via mkdir(exist_ok=True); the cache entry must be
+    # dropped first so the schema init pass re-runs on that fresh file.
+    _INITIALIZED_PATHS.discard(str((d / "kanban.db").resolve()))
+
     if archive:
         archive_root = boards_root() / "_archived"
         archive_root.mkdir(parents=True, exist_ok=True)

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -258,6 +258,37 @@ class TestBoardCRUD:
         kb.remove_board("pinned")
         assert kb.get_current_board() == "default"
 
+    @pytest.mark.parametrize("archive", [True, False])
+    def test_remove_clears_init_cache_for_recreated_db(self, fresh_home, archive):
+        # Regression for #23833: poll loops that call connect(board=slug) right
+        # after remove_board() recreate an empty kanban.db at the same path
+        # (connect() does mkdir(exist_ok=True)). If _INITIALIZED_PATHS still
+        # contains the resolved path, the CREATE TABLE pass is skipped and
+        # downstream readers hit `no such table: task_events`.
+        kb.create_board("recycle")
+        # First connect populates _INITIALIZED_PATHS for this DB.
+        with kb.connect(board="recycle") as conn:
+            kb.create_task(conn, title="t1", assignee="dev")
+        db_path = kb.board_dir("recycle") / "kanban.db"
+        assert str(db_path.resolve()) in kb._INITIALIZED_PATHS
+
+        kb.remove_board("recycle", archive=archive)
+        # remove_board must drop the cache entry so a re-create through
+        # connect() gets a fresh schema-init pass.
+        assert str(db_path.resolve()) not in kb._INITIALIZED_PATHS
+
+        # Simulate the event-stream poll: re-open the same slug. connect()
+        # recreates the directory + empty .db; the schema must be re-applied.
+        with kb.connect(board="recycle") as conn:
+            tables = {
+                row[0]
+                for row in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                )
+            }
+        assert "task_events" in tables
+        assert "tasks" in tables
+
     def test_rename_updates_metadata(self, fresh_home):
         kb.create_board("slug-immutable")
         kb.write_board_metadata("slug-immutable", name="New Display Name")


### PR DESCRIPTION
Salvages #23852 by @briandevans.

Bug fix: remove_board doesn't discard _INITIALIZED_PATHS in main; confirmed missing. 36-LOC targeted fix + test.

Cherry-picked onto current main with original authorship preserved via rebase merge.