### PR TITLE
fix(web): add Cache-Control: no-store to plugin static file serving (#23864)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4346,7 +4346,11 @@ async def serve_plugin_asset(plugin_name: str, file_path: str):
         ".woff": "font/woff",
     }
     media_type = content_types.get(suffix, "application/octet-stream")
-    return FileResponse(target, media_type=media_type)
+    return FileResponse(
+        target,
+        media_type=media_type,
+        headers={"Cache-Control": "no-store, no-cache, must-revalidate"},
+    )
 
 
 def _mount_plugin_api_routes():


### PR DESCRIPTION
Salvages #23864 by @momowind.

Adds Cache-Control: no-store to plugin static file serving; serve_plugin_asset FileResponse in main lacks header, only HTMLResponse path has it. 5-line targeted fix.

Cherry-picked onto current main with original authorship preserved via rebase merge.