### PR TITLE
fix(auth): share xAI OAuth refresh across profiles

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -562,12 +562,8 @@ class CredentialPool:
         if self.provider != "xai-oauth" or entry.source != "loopback_pkce":
             return entry
         try:
-            with _auth_store_lock():
-                auth_store = _load_auth_store()
-                state = _load_provider_state(auth_store, "xai-oauth")
-            if not isinstance(state, dict):
-                return entry
-            tokens = state.get("tokens")
+            data = auth_mod._read_xai_oauth_tokens()
+            tokens = data.get("tokens")
             if not isinstance(tokens, dict):
                 return entry
             store_access = tokens.get("access_token", "")
@@ -579,8 +575,8 @@ class CredentialPool:
                 or (store_refresh and store_refresh != entry_refresh)
             ):
                 logger.debug(
-                    "Pool entry %s: syncing xAI OAuth tokens from auth.json "
-                    "(refreshed by another process)",
+                    "Pool entry %s: syncing xAI OAuth tokens from shared auth.json "
+                    "(refreshed by another process/profile)",
                     entry.id,
                 )
                 field_updates: Dict[str, Any] = {
@@ -593,8 +589,8 @@ class CredentialPool:
                     "last_error_message": None,
                     "last_error_reset_at": None,
                 }
-                if state.get("last_refresh"):
-                    field_updates["last_refresh"] = state["last_refresh"]
+                if data.get("last_refresh"):
+                    field_updates["last_refresh"] = data["last_refresh"]
                 updated = replace(entry, **field_updates)
                 self._replace_entry(entry, updated)
                 self._persist()
@@ -697,6 +693,22 @@ class CredentialPool:
         whatever provider happened to refresh last, not whatever the
         user actually chose.
         """
+        # xAI OAuth is shared at the global Hermes root across profiles; write
+        # token rotations there before touching the profile-local auth store.
+        if self.provider == "xai-oauth" and entry.source == "loopback_pkce":
+            try:
+                auth_mod._save_xai_oauth_tokens(
+                    {
+                        "access_token": entry.access_token,
+                        "refresh_token": entry.refresh_token,
+                        "token_type": "Bearer",
+                    },
+                    last_refresh=entry.last_refresh,
+                )
+            except Exception as exc:
+                logger.debug("Failed to sync xAI OAuth pool entry back to shared auth store: %s", exc)
+            return
+
         # Only sync entries that were seeded *from* a singleton.  Manually
         # added pool entries (source="manual:*") are independent credentials
         # and must not write back to the singleton.

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -892,6 +892,7 @@ def _auth_lock_path() -> Path:
 
 
 _auth_lock_holder = threading.local()
+_xai_oauth_lock_holder = threading.local()
 
 
 @contextmanager
@@ -978,6 +979,29 @@ def _auth_store_lock(timeout_seconds: float = AUTH_LOCK_TIMEOUT_SECONDS):
         _auth_lock_holder,
         timeout_seconds,
         "Timed out waiting for auth store lock",
+    ):
+        yield
+
+
+def _xai_oauth_auth_file_path() -> Path:
+    """Return the shared xAI OAuth auth store path.
+
+    xAI OAuth refresh tokens are single-use.  Profile-local copies race each
+    other: the first profile to refresh rotates the token and leaves every
+    other profile with a revoked refresh token.  Store xAI OAuth state in the
+    global root auth.json so all profiles and agents share one rotating token
+    pair.
+    """
+    return _global_auth_file_path() or _auth_file_path()
+
+
+@contextmanager
+def _xai_oauth_store_lock(timeout_seconds: float = AUTH_LOCK_TIMEOUT_SECONDS):
+    with _file_lock(
+        _xai_oauth_auth_file_path().with_suffix(".lock"),
+        _xai_oauth_lock_holder,
+        timeout_seconds,
+        "Timed out waiting for shared xAI OAuth auth store lock",
     ):
         yield
 
@@ -3179,49 +3203,51 @@ def resolve_codex_runtime_credentials(
 # =============================================================================
 
 def _read_xai_oauth_tokens(*, _lock: bool = True) -> Dict[str, Any]:
+    def _read_from_shared_store() -> Dict[str, Any]:
+        auth_store = _load_auth_store(_xai_oauth_auth_file_path())
+        state = _load_provider_state(auth_store, "xai-oauth")
+        if not state:
+            raise AuthError(
+                "No xAI OAuth credentials stored. Select xAI Grok OAuth (SuperGrok Subscription) in `hermes model`.",
+                provider="xai-oauth",
+                code="xai_auth_missing",
+                relogin_required=True,
+            )
+        tokens = state.get("tokens")
+        if not isinstance(tokens, dict):
+            raise AuthError(
+                "xAI OAuth state is missing tokens. Re-authenticate with `hermes model`.",
+                provider="xai-oauth",
+                code="xai_auth_invalid_shape",
+                relogin_required=True,
+            )
+        access_token = str(tokens.get("access_token", "") or "").strip()
+        refresh_token = str(tokens.get("refresh_token", "") or "").strip()
+        if not access_token:
+            raise AuthError(
+                "xAI OAuth state is missing access_token. Re-authenticate with `hermes model`.",
+                provider="xai-oauth",
+                code="xai_auth_missing_access_token",
+                relogin_required=True,
+            )
+        if not refresh_token:
+            raise AuthError(
+                "xAI OAuth state is missing refresh_token. Re-authenticate with `hermes model`.",
+                provider="xai-oauth",
+                code="xai_auth_missing_refresh_token",
+                relogin_required=True,
+            )
+        return {
+            "tokens": tokens,
+            "last_refresh": state.get("last_refresh"),
+            "discovery": state.get("discovery") or {},
+            "redirect_uri": state.get("redirect_uri"),
+        }
+
     if _lock:
-        with _auth_store_lock():
-            auth_store = _load_auth_store()
-    else:
-        auth_store = _load_auth_store()
-    state = _load_provider_state(auth_store, "xai-oauth")
-    if not state:
-        raise AuthError(
-            "No xAI OAuth credentials stored. Select xAI Grok OAuth (SuperGrok Subscription) in `hermes model`.",
-            provider="xai-oauth",
-            code="xai_auth_missing",
-            relogin_required=True,
-        )
-    tokens = state.get("tokens")
-    if not isinstance(tokens, dict):
-        raise AuthError(
-            "xAI OAuth state is missing tokens. Re-authenticate with `hermes model`.",
-            provider="xai-oauth",
-            code="xai_auth_invalid_shape",
-            relogin_required=True,
-        )
-    access_token = str(tokens.get("access_token", "") or "").strip()
-    refresh_token = str(tokens.get("refresh_token", "") or "").strip()
-    if not access_token:
-        raise AuthError(
-            "xAI OAuth state is missing access_token. Re-authenticate with `hermes model`.",
-            provider="xai-oauth",
-            code="xai_auth_missing_access_token",
-            relogin_required=True,
-        )
-    if not refresh_token:
-        raise AuthError(
-            "xAI OAuth state is missing refresh_token. Re-authenticate with `hermes model`.",
-            provider="xai-oauth",
-            code="xai_auth_missing_refresh_token",
-            relogin_required=True,
-        )
-    return {
-        "tokens": tokens,
-        "last_refresh": state.get("last_refresh"),
-        "discovery": state.get("discovery") or {},
-        "redirect_uri": state.get("redirect_uri"),
-    }
+        with _xai_oauth_store_lock():
+            return _read_from_shared_store()
+    return _read_from_shared_store()
 
 
 def _save_xai_oauth_tokens(
@@ -3233,8 +3259,9 @@ def _save_xai_oauth_tokens(
 ) -> None:
     if last_refresh is None:
         last_refresh = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
-    with _auth_store_lock():
-        auth_store = _load_auth_store()
+    with _xai_oauth_store_lock():
+        auth_file = _xai_oauth_auth_file_path()
+        auth_store = _load_auth_store(auth_file)
         state = _load_provider_state(auth_store, "xai-oauth") or {}
         state["tokens"] = tokens
         state["last_refresh"] = last_refresh
@@ -3243,8 +3270,29 @@ def _save_xai_oauth_tokens(
             state["discovery"] = discovery
         if redirect_uri:
             state["redirect_uri"] = redirect_uri
-        _save_provider_state(auth_store, "xai-oauth", state)
-        _save_auth_store(auth_store)
+        _store_provider_state(auth_store, "xai-oauth", state, set_active=False)
+        auth_file.parent.mkdir(parents=True, exist_ok=True)
+        auth_store["version"] = AUTH_STORE_VERSION
+        auth_store["updated_at"] = datetime.now(timezone.utc).isoformat()
+        payload = json.dumps(auth_store, ensure_ascii=False, indent=2) + "\n"
+        tmp_path = auth_file.with_name(f"{auth_file.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}")
+        fd = os.open(
+            str(tmp_path),
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            stat.S_IRUSR | stat.S_IWUSR,
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(payload)
+                handle.flush()
+                os.fsync(handle.fileno())
+            atomic_replace(tmp_path, auth_file)
+        finally:
+            try:
+                if tmp_path.exists():
+                    tmp_path.unlink()
+            except OSError:
+                pass
 
 
 def _xai_access_token_is_expiring(access_token: str, skew_seconds: int = 0) -> bool:
@@ -3480,7 +3528,7 @@ def resolve_xai_oauth_runtime_credentials(
     if (not should_refresh) and refresh_if_expiring:
         should_refresh = _xai_access_token_is_expiring(access_token, refresh_skew_seconds)
     if should_refresh:
-        with _auth_store_lock(timeout_seconds=max(float(AUTH_LOCK_TIMEOUT_SECONDS), refresh_timeout_seconds + 5.0)):
+        with _xai_oauth_store_lock(timeout_seconds=max(float(AUTH_LOCK_TIMEOUT_SECONDS), refresh_timeout_seconds + 5.0)):
             data = _read_xai_oauth_tokens(_lock=False)
             tokens = dict(data["tokens"])
             access_token = str(tokens.get("access_token", "") or "").strip()

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -16,12 +16,72 @@ def _write_auth_store(tmp_path, payload: dict) -> None:
     (hermes_home / "auth.json").write_text(json.dumps(payload, indent=2))
 
 
+def _write_auth_file(path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2))
+
+
 def _jwt_with_claims(claims: dict) -> str:
     def _part(payload: dict) -> str:
         raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
         return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
 
     return f"{_part({'alg': 'none', 'typ': 'JWT'})}.{_part(claims)}.sig"
+
+
+def test_xai_oauth_pool_entry_syncs_from_global_root_singleton(tmp_path, monkeypatch):
+    """Profile-local xAI pool entries must see rotations from the shared root store."""
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    global_root = tmp_path / ".hermes"
+    profile_home = global_root / "profiles" / "coder"
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+    _write_auth_file(global_root / "auth.json", {
+        "version": 1,
+        "providers": {
+            "xai-oauth": {
+                "tokens": {
+                    "access_token": "shared-access",
+                    "refresh_token": "shared-refresh",
+                },
+                "last_refresh": "2026-05-19T02:00:00Z",
+            }
+        },
+    })
+    _write_auth_file(profile_home / "auth.json", {
+        "version": 1,
+        "credential_pool": {
+            "xai-oauth": [
+                {
+                    "id": "xai-profile",
+                    "label": "loopback_pkce",
+                    "auth_type": "oauth",
+                    "priority": 0,
+                    "source": "loopback_pkce",
+                    "access_token": "stale-access",
+                    "refresh_token": "stale-refresh",
+                    "last_status": "exhausted",
+                    "last_status_at": time.time(),
+                }
+            ]
+        },
+    })
+
+    from agent.credential_pool import load_pool
+
+    entry = load_pool("xai-oauth").select()
+
+    assert entry is not None
+    assert entry.access_token == "shared-access"
+    assert entry.refresh_token == "shared-refresh"
+    assert entry.last_refresh == "2026-05-19T02:00:00Z"
+    assert entry.last_status is None
+
+    profile_data = json.loads((profile_home / "auth.json").read_text())
+    persisted = profile_data["credential_pool"]["xai-oauth"][0]
+    assert persisted["access_token"] == "shared-access"
+    assert persisted["refresh_token"] == "shared-refresh"
+    assert persisted["last_status"] is None
 
 
 def test_fill_first_selection_skips_recently_exhausted_entry(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -276,6 +276,106 @@ def test_provider_auth_state_returns_none_when_neither_has_it(profile_env):
 
 
 # ---------------------------------------------------------------------------
+# xAI OAuth — shared singleton reads/writes
+# ---------------------------------------------------------------------------
+
+
+def test_xai_oauth_tokens_read_from_global_root_in_profile_mode(profile_env):
+    """xAI OAuth is a singleton auth state; profile agents inherit the root login."""
+    from hermes_cli.auth import _read_xai_oauth_tokens
+
+    _write(profile_env["global"] / "auth.json", _make_auth_store(providers={
+        "xai-oauth": {
+            "tokens": {
+                "access_token": "xai-global-access",
+                "refresh_token": "xai-global-refresh",
+            },
+            "last_refresh": "2026-05-19T00:00:00Z",
+        },
+    }))
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(providers={}))
+
+    data = _read_xai_oauth_tokens()
+
+    assert data["tokens"]["access_token"] == "xai-global-access"
+    assert data["tokens"]["refresh_token"] == "xai-global-refresh"
+    assert data["last_refresh"] == "2026-05-19T00:00:00Z"
+
+
+def test_xai_oauth_token_save_targets_global_root_not_profile(profile_env):
+    """Refresh-token rotation must be shared because xAI refresh tokens are single-use."""
+    from hermes_cli.auth import _save_xai_oauth_tokens
+
+    _write(profile_env["global"] / "auth.json", {
+        "version": 1,
+        "active_provider": "anthropic",
+        "providers": {
+            "anthropic": {"access_token": "anthropic-global"},
+            "xai-oauth": {
+                "tokens": {
+                    "access_token": "xai-old-access",
+                    "refresh_token": "xai-old-refresh",
+                },
+            },
+        },
+    })
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(providers={}))
+
+    _save_xai_oauth_tokens(
+        {
+            "access_token": "xai-new-access",
+            "refresh_token": "xai-new-refresh",
+            "token_type": "Bearer",
+        },
+        last_refresh="2026-05-19T01:00:00Z",
+    )
+
+    global_data = json.loads((profile_env["global"] / "auth.json").read_text())
+    profile_data = json.loads((profile_env["profile"] / "auth.json").read_text())
+
+    assert global_data["providers"]["xai-oauth"]["tokens"]["access_token"] == "xai-new-access"
+    assert global_data["providers"]["xai-oauth"]["tokens"]["refresh_token"] == "xai-new-refresh"
+    assert global_data["providers"]["xai-oauth"]["last_refresh"] == "2026-05-19T01:00:00Z"
+    # Saving xAI's shared singleton must not silently flip the user's active provider.
+    assert global_data["active_provider"] == "anthropic"
+    assert "xai-oauth" not in profile_data.get("providers", {})
+
+
+def test_xai_oauth_refresh_written_by_one_profile_is_visible_to_another(profile_env, monkeypatch):
+    from hermes_cli.auth import _read_xai_oauth_tokens, _save_xai_oauth_tokens
+
+    _write(profile_env["global"] / "auth.json", _make_auth_store(providers={
+        "xai-oauth": {
+            "tokens": {
+                "access_token": "xai-old-access",
+                "refresh_token": "xai-old-refresh",
+            },
+        },
+    }))
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(providers={}))
+
+    _save_xai_oauth_tokens(
+        {
+            "access_token": "xai-rotated-access",
+            "refresh_token": "xai-rotated-refresh",
+            "token_type": "Bearer",
+        },
+        last_refresh="2026-05-19T02:00:00Z",
+    )
+
+    other_profile = profile_env["global"] / "profiles" / "reviewer"
+    other_profile.mkdir(parents=True)
+    _write(other_profile / "auth.json", _make_auth_store(providers={}))
+    monkeypatch.setenv("HERMES_HOME", str(other_profile))
+
+    data = _read_xai_oauth_tokens()
+
+    assert data["tokens"]["access_token"] == "xai-rotated-access"
+    assert data["tokens"]["refresh_token"] == "xai-rotated-refresh"
+    assert data["last_refresh"] == "2026-05-19T02:00:00Z"
+
+
+# ---------------------------------------------------------------------------
 # Classic mode — no fallback path should ever trigger
 # ---------------------------------------------------------------------------
 

--- a/website/docs/guides/xai-grok-oauth.md
+++ b/website/docs/guides/xai-grok-oauth.md
@@ -47,7 +47,7 @@ hermes model
 hermes
 ```
 
-After the first login, credentials are stored under `~/.hermes/auth.json` and refreshed automatically before they expire.
+After the first login, credentials are stored under the global root `~/.hermes/auth.json` and refreshed automatically before they expire. Named profiles reuse that same xAI OAuth state instead of keeping independent refresh-token copies, because xAI refresh tokens are single-use and must rotate from one canonical store.
 
 ## Logging In Manually
 
@@ -80,8 +80,8 @@ See [OAuth over SSH / Remote Hosts](./oauth-over-ssh.md) for the full step-by-st
 
 1. Hermes opens your browser to `accounts.x.ai`.
 2. You sign in (or confirm your existing session) and approve access.
-3. xAI redirects back to Hermes and the tokens are saved to `~/.hermes/auth.json`.
-4. From then on, Hermes refreshes the access token in the background — you stay signed in until you `hermes auth remove xai-oauth` or revoke access from your xAI account settings.
+3. xAI redirects back to Hermes and the tokens are saved to the global root `~/.hermes/auth.json`.
+4. From then on, Hermes refreshes the access token in the background — you stay signed in until you `hermes auth remove xai-oauth` or revoke access from your xAI account settings. Named profiles read and write this same canonical xAI token pair so one profile's refresh is immediately visible to the others.
 
 ## Checking Login Status
 


### PR DESCRIPTION
## Summary
- store xAI OAuth token reads/writes in the global root auth store so named profiles share one rotating token pair
- add a dedicated xAI OAuth auth-store lock and keep xAI saves from changing `active_provider`
- sync profile-local `loopback_pkce` pool entries from the shared root singleton and write token rotations back there
- document the cross-profile xAI OAuth behavior

## Test Plan
- `python -m pytest tests/agent/test_credential_pool.py tests/hermes_cli/test_auth_profile_fallback.py tests/hermes_cli/test_auth_xai_oauth_provider.py tests/hermes_cli/test_xai_oauth_pkce_token_exchange.py tests/run_agent/test_codex_xai_oauth_recovery.py tests/hermes_cli/test_tools_config.py -q -o 'addopts='`
- `python -m py_compile hermes_cli/auth.py agent/credential_pool.py`
