### PR TITLE
fix(kanban): use 'is not None' check for max_runtime_seconds in create_task (#24021)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1408,7 +1408,7 @@ def create_task(
                         workspace_path,
                         tenant,
                         idempotency_key,
-                        int(max_runtime_seconds) if max_runtime_seconds else None,
+                        int(max_runtime_seconds) if max_runtime_seconds is not None else None,
                         json.dumps(skills_list) if skills_list is not None else None,
                         int(max_retries) if max_retries is not None else None,
                     ),


### PR DESCRIPTION
Salvages #24021 by @sprmn24.

One-line bug: max_runtime_seconds=0 silently becomes None; confirmed still buggy at hermes_cli/kanban_db.py:1397. Trivial salvage.

Cherry-picked onto current main with original authorship preserved via rebase merge.