### PR TITLE
fix(kanban): align board_exists with board discovery rules (#24086)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -266,7 +266,7 @@ def board_dir(board: Optional[str] = None) -> Path:
 
 
 def board_exists(board: Optional[str] = None) -> bool:
-    """Return True if the board has a DB or a metadata dir on disk.
+    """Return True if the board has persisted metadata or a DB on disk.
 
     ``default`` is considered to always exist — its DB is created
     on first :func:`connect` and there's no way for it to be missing
@@ -276,7 +276,7 @@ def board_exists(board: Optional[str] = None) -> bool:
     if slug == DEFAULT_BOARD:
         return True
     d = board_dir(slug)
-    return d.is_dir() or (d / "kanban.db").exists()
+    return (d / "board.json").exists() or (d / "kanban.db").exists()
 
 
 def kanban_db_path(board: Optional[str] = None) -> Path:

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -169,6 +169,13 @@ class TestCurrentBoard:
         assert not kb.board_exists("missing-board")
         assert [b["slug"] for b in kb.list_boards()] == ["default"]
 
+    def test_empty_board_dir_does_not_count_as_existing(self, fresh_home):
+        ghost = fresh_home / "kanban" / "boards" / "ghost"
+        ghost.mkdir(parents=True)
+
+        assert not kb.board_exists("ghost")
+        assert [b["slug"] for b in kb.list_boards()] == ["default"]
+
     def test_env_beats_file(self, fresh_home, monkeypatch):
         kb.create_board("a")
         kb.create_board("b")
@@ -531,6 +538,13 @@ class TestCLI:
         # main.py's dispatcher doesn't propagate return codes today, so we
         # assert the user-visible signal: a stderr error message. Whether
         # the exit code stays 0 is a separate (pre-existing) issue.
+        assert "does not exist" in r.stderr
+
+    def test_board_flag_rejects_empty_board_dir(self, tmp_path):
+        env = {"HERMES_HOME": str(tmp_path)}
+        ghost = tmp_path / "kanban" / "boards" / "ghost"
+        ghost.mkdir(parents=True)
+        r = _cli(["--board", "ghost", "list"], env_extra=env)
         assert "does not exist" in r.stderr
 
     def test_boards_rm_archives(self, tmp_path):


### PR DESCRIPTION
Salvages #24086 by @soynchux.

board_exists alignment still applies — main still uses `d.is_dir() or` fallthrough (18 LOC).

Cherry-picked onto current main with original authorship preserved via rebase merge.