### PR TITLE
fix(daytona): make sandbox names unique per instance to unblock concurrent multi-agent

### DIFF
--- a/tests/tools/test_daytona_environment.py
+++ b/tests/tools/test_daytona_environment.py
@@ -148,9 +148,7 @@ class TestPersistence:
         env = make_env(get_side_effect=lambda name: existing, persistent=True,
                        task_id="mytask")
         existing.start.assert_called_once()
-        env._mock_client.get.assert_called_once()
-        get_name = env._mock_client.get.call_args[0][0]
-        assert get_name.startswith("hermes-mytask-")
+        env._mock_client.get.assert_called_once_with("hermes-mytask")
         env._mock_client.create.assert_not_called()
 
     def test_persistent_resumes_legacy_via_list(self, make_env, daytona_sdk):
@@ -174,11 +172,10 @@ class TestPersistence:
             task_id="mytask",
         )
         env._mock_client.create.assert_called_once()
-        # Sandbox name is uuid-suffixed for uniqueness (#28299); verify the
-        # prefix only and that the label-based legacy lookup still uses the
-        # logical task id.
-        get_name = env._mock_client.get.call_args[0][0]
-        assert get_name.startswith("hermes-mytask-")
+        # Persistent sandboxes keep deterministic names so name-based
+        # `get()` resume works on the next start. Verify both the name-based
+        # lookup and the label-based legacy fallback use the logical id.
+        env._mock_client.get.assert_called_with("hermes-mytask")
         env._mock_client.list.assert_called_with(
             labels={"hermes_task_id": "mytask"}, limit=1)
 
@@ -214,9 +211,11 @@ class TestSandboxNameUniqueness:
     """
 
     @pytest.fixture(autouse=True)
-    def _capture_params(self, daytona_sdk):
+    def _capture_params(self, daytona_sdk, monkeypatch):
         _ParamsCapture.instances.clear()
-        daytona_sdk.CreateSandboxFromImageParams = _ParamsCapture
+        monkeypatch.setattr(
+            daytona_sdk, "CreateSandboxFromImageParams", _ParamsCapture
+        )
         yield
         _ParamsCapture.instances.clear()
 
@@ -251,6 +250,19 @@ class TestSandboxNameUniqueness:
         # And the name still carries the logical task id (Daytona ops still
         # need a recognizable prefix even though uniqueness is on the suffix).
         assert kwargs["name"].startswith("hermes-mytask-")
+
+    def test_persistent_keeps_deterministic_name(self, make_env, daytona_sdk):
+        # Persistent sandboxes must NOT get a uuid suffix or the name-based
+        # `get()` resume path is broken on every restart. Concurrent
+        # persistent starts on the same task_id intentionally converge.
+        make_env(
+            get_side_effect=daytona_sdk.DaytonaError("not found"),
+            persistent=True,
+            task_id="mytask",
+        )
+        kwargs = _ParamsCapture.instances[-1].kwargs
+        assert kwargs["name"] == "hermes-mytask"
+        assert kwargs["labels"] == {"hermes_task_id": "mytask"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_daytona_environment.py
+++ b/tests/tools/test_daytona_environment.py
@@ -148,7 +148,9 @@ class TestPersistence:
         env = make_env(get_side_effect=lambda name: existing, persistent=True,
                        task_id="mytask")
         existing.start.assert_called_once()
-        env._mock_client.get.assert_called_once_with("hermes-mytask")
+        env._mock_client.get.assert_called_once()
+        get_name = env._mock_client.get.call_args[0][0]
+        assert get_name.startswith("hermes-mytask-")
         env._mock_client.create.assert_not_called()
 
     def test_persistent_resumes_legacy_via_list(self, make_env, daytona_sdk):
@@ -172,9 +174,11 @@ class TestPersistence:
             task_id="mytask",
         )
         env._mock_client.create.assert_called_once()
-        # Verify the name and labels were passed to CreateSandboxFromImageParams
-        # by checking get() was called with the right sandbox name
-        env._mock_client.get.assert_called_with("hermes-mytask")
+        # Sandbox name is uuid-suffixed for uniqueness (#28299); verify the
+        # prefix only and that the label-based legacy lookup still uses the
+        # logical task id.
+        get_name = env._mock_client.get.call_args[0][0]
+        assert get_name.startswith("hermes-mytask-")
         env._mock_client.list.assert_called_with(
             labels={"hermes_task_id": "mytask"}, limit=1)
 
@@ -183,6 +187,70 @@ class TestPersistence:
         env._mock_client.get.assert_not_called()
         env._mock_client.list.assert_not_called()
         env._mock_client.create.assert_called_once()
+
+
+class _ParamsCapture:
+    """Records constructor kwargs so tests can verify what was passed to
+    ``CreateSandboxFromImageParams`` (a MagicMock won't expose the ``name``
+    kwarg as a real attribute -- ``name`` is a reserved constructor arg)."""
+
+    instances: list["_ParamsCapture"] = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        _ParamsCapture.instances.append(self)
+
+
+class TestSandboxNameUniqueness:
+    """Regression guard for #28299.
+
+    ``tools.terminal_tool._resolve_container_task_id`` collapses subagent
+    task ids back to ``"default"`` so subagents share their parent's
+    container. Two concurrent gateway / Kanban workers therefore both hit
+    the Daytona backend with ``task_id="default"``; Daytona requires
+    globally-unique sandbox names, so the second ``create`` previously
+    failed with ``DaytonaConflictError: Sandbox with name hermes-default
+    already exists``.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _capture_params(self, daytona_sdk):
+        _ParamsCapture.instances.clear()
+        daytona_sdk.CreateSandboxFromImageParams = _ParamsCapture
+        yield
+        _ParamsCapture.instances.clear()
+
+    def test_default_task_id_gets_unique_sandbox_names(self, make_env):
+        make_env(persistent=False, task_id="default")
+        make_env(persistent=False, task_id="default")
+
+        name_a = _ParamsCapture.instances[-2].kwargs["name"]
+        name_b = _ParamsCapture.instances[-1].kwargs["name"]
+
+        assert name_a.startswith("hermes-default-")
+        assert name_b.startswith("hermes-default-")
+        assert name_a != name_b
+
+    def test_named_task_id_also_gets_unique_suffix(self, make_env):
+        # Even for explicit task ids, two concurrent instances must not
+        # collide on the Daytona side. Logical identity stays on the label.
+        make_env(persistent=False, task_id="mytask")
+        make_env(persistent=False, task_id="mytask")
+
+        name_a = _ParamsCapture.instances[-2].kwargs["name"]
+        name_b = _ParamsCapture.instances[-1].kwargs["name"]
+
+        assert name_a.startswith("hermes-mytask-")
+        assert name_b.startswith("hermes-mytask-")
+        assert name_a != name_b
+
+    def test_create_passes_hermes_task_id_label(self, make_env):
+        make_env(persistent=False, task_id="mytask")
+        kwargs = _ParamsCapture.instances[-1].kwargs
+        assert kwargs["labels"] == {"hermes_task_id": "mytask"}
+        # And the name still carries the logical task id (Daytona ops still
+        # need a recognizable prefix even though uniqueness is on the suffix).
+        assert kwargs["name"].startswith("hermes-mytask-")
 
 
 # ---------------------------------------------------------------------------

--- a/tools/environments/daytona.py
+++ b/tools/environments/daytona.py
@@ -87,10 +87,14 @@ class DaytonaEnvironment(BaseEnvironment):
         labels = {"hermes_task_id": task_id}
         # task_id collapses to "default" for subagents sharing a parent's
         # container; Daytona requires globally-unique names so concurrent
-        # processes need a uuid suffix to avoid DaytonaConflictError.  The
-        # hermes_task_id label still carries logical task identity for
-        # persistent-resume via list(labels=...).
-        sandbox_name = f"hermes-{task_id}-{uuid.uuid4().hex[:8]}"
+        # non-persistent processes need a uuid suffix to avoid
+        # DaytonaConflictError. Persistent sandboxes keep the deterministic
+        # `hermes-<task_id>` name so name-based `get()` resume continues to
+        # work; concurrent persistent starts converge on the same sandbox.
+        if self._persistent:
+            sandbox_name = f"hermes-{task_id}"
+        else:
+            sandbox_name = f"hermes-{task_id}-{uuid.uuid4().hex[:12]}"
 
         if self._persistent:
             try:

--- a/tools/environments/daytona.py
+++ b/tools/environments/daytona.py
@@ -10,6 +10,7 @@ import math
 import os
 import shlex
 import threading
+import uuid
 from pathlib import Path
 
 from tools.environments.base import (
@@ -84,7 +85,12 @@ class DaytonaEnvironment(BaseEnvironment):
         resources = Resources(cpu=cpu, memory=memory_gib, disk=disk_gib)
 
         labels = {"hermes_task_id": task_id}
-        sandbox_name = f"hermes-{task_id}"
+        # task_id collapses to "default" for subagents sharing a parent's
+        # container; Daytona requires globally-unique names so concurrent
+        # processes need a uuid suffix to avoid DaytonaConflictError.  The
+        # hermes_task_id label still carries logical task identity for
+        # persistent-resume via list(labels=...).
+        sandbox_name = f"hermes-{task_id}-{uuid.uuid4().hex[:8]}"
 
         if self._persistent:
             try:


### PR DESCRIPTION
## What does this PR do?

`tools.terminal_tool._resolve_container_task_id` collapses subagent task ids back to `"default"` so subagents share their parent's long-lived container. Daytona requires globally-unique sandbox names, so two concurrent gateway / Kanban workers both landing on `task_id="default"` race the `daytona.create(...)` call and the loser fails with `DaytonaConflictError: Sandbox with name hermes-default already exists`. The Docker backend already avoids this with a uuid-suffixed `container_name = f"hermes-{uuid.uuid4().hex[:8]}"` (`tools/environments/docker.py:505`); Daytona was the odd one out.

This PR mirrors the Docker pattern by appending `-{uuid4()[:8]}` to the Daytona sandbox name. Logical task identity stays on the existing `hermes_task_id` label — `list(labels=...)` is already the persistent-resume mechanism for legacy sandboxes (`daytona.py:107`), so the opportunistic `get(sandbox_name)` fast-path now always falls through to the label-based lookup. No behaviour change for persistent resume — just one extra `list` call before reaching the label path.

Mirrors `tools/environments/docker.py` naming precedence (`hermes-{uuid4()[:8]}` per container, label carries logical id).

## Related Issue

Fixes #28299

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/environments/daytona.py` — append `-{uuid4()[:8]}` to `sandbox_name`; add `import uuid`.
- `tests/tools/test_daytona_environment.py` — relax existing `get()`/`create()` name assertions to prefix-match; add `TestSandboxNameUniqueness` with three regression tests (concurrent `task_id="default"`, concurrent explicit task id, label still carries logical id) using a `_ParamsCapture` helper because `MagicMock(name=...)` doesn't expose `name` as a real attribute.

## How to Test

1. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/tools/test_daytona_environment.py -v` — 28 pass (1 pre-existing baseline timeout in `tools/registry.py` fixture setup on `test_explicit_cwd_not_overridden`, reproduces on clean `origin/main`).
2. Regression guard: `git stash push tools/environments/daytona.py && pytest tests/tools/test_daytona_environment.py::TestSandboxNameUniqueness && git stash pop` — all 3 fail without the fix, all 3 pass with it.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(daytona):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (3 new regression tests + 2 updated for the new name shape)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (internal naming change, label-based external lookup unchanged)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — backend code, OS-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

> Audited siblings: `tools/environments/docker.py:505` already uses a uuid-suffixed `container_name`; `tools/environments/ssh.py` and `tools/environments/modal.py` don't construct globally-unique names against an external scheduler so they don't have the same Daytona-conflict shape. No widening needed.