### PR TITLE
fix(kanban-dashboard): make Orchestration mode checkbox label static (#28258)

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -1593,10 +1593,12 @@
                   saveSettings({ auto_decompose: !!e.target.checked });
                 },
               }),
-              settings.auto_decompose ? "Auto (default)" : "Manual",
+              "Auto-decompose triage tasks",
             ),
             h("div", { className: "text-[10px] text-muted-foreground" },
-              "When on, the dispatcher decomposes new triage tasks automatically."),
+              settings.auto_decompose
+                ? "The dispatcher decomposes new triage tasks automatically."
+                : "Triage tasks stay in triage until you click ⚗ Decompose."),
           ),
         ) : h("div", { className: "text-xs text-muted-foreground" },
           "Loading…"),


### PR DESCRIPTION
Salvages #28258 by @maxmilian.

Confirmed: line 1591 of dist/index.js in main still has the dynamic `Auto (default)/Manual` ternary the PR replaces with a static action label; trivial 4/-2 dist patch.

Cherry-picked onto current main with original authorship preserved via rebase merge.