### PR TITLE
fix(packaging): ship dashboard plugin assets in wheel (#23737)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,6 +213,11 @@ py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajector
 [tool.setuptools.package-data]
 hermes_cli = ["web_dist/**/*", "tui_dist/**/*", "scripts/install.sh", "scripts/install.ps1"]
 gateway = ["assets/**/*"]
+plugins = [
+  "*/dashboard/manifest.json",
+  "*/dashboard/dist/*",
+  "*/dashboard/dist/**/*",
+]
 
 [tool.setuptools.packages.find]
 include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*"]

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -11,6 +11,13 @@ def _load_optional_dependencies():
     return project["optional-dependencies"]
 
 
+def _load_package_data():
+    pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    with pyproject_path.open("rb") as handle:
+        tool = tomllib.load(handle)["tool"]
+    return tool["setuptools"]["package-data"]
+
+
 def test_matrix_extra_not_in_all():
     """The [matrix] extra pulls `mautrix[encryption]` -> `python-olm`,
     which has Linux-only wheels and no native build path on Windows or
@@ -103,3 +110,15 @@ def test_feishu_extra_includes_qrcode_for_qr_login():
 
     feishu_extra = optional_dependencies["feishu"]
     assert any(dep.startswith("qrcode") for dep in feishu_extra)
+
+
+def test_dashboard_plugin_manifests_and_assets_are_packaged():
+    """Bundled dashboard plugins need their manifests and built assets in
+    wheel installs so /api/dashboard/plugins can discover them outside a
+    source checkout."""
+    package_data = _load_package_data()
+    plugin_data = package_data["plugins"]
+
+    assert "*/dashboard/manifest.json" in plugin_data
+    assert "*/dashboard/dist/*" in plugin_data
+    assert "*/dashboard/dist/**/*" in plugin_data


### PR DESCRIPTION
Salvages #23737 by @LeonSGP43.

Adds `plugins/*` manifest.json and dist/ globs to setuptools package-data so wheel installs ship the bundled dashboard plugin assets. Without these, `/api/dashboard/plugins` can't discover plugin assets outside a source checkout.

Original branch was stale; applied the substantive change manually onto current main. Authorship preserved via rebase merge.

## Validation
- New regression test (test_dashboard_plugin_manifests_and_assets_are_packaged) passes.