### PR TITLE
fix: preserve substantive content in oneshot/chat() when model appends short follow-up after tool calls

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3420,6 +3420,30 @@ def run_conversation(
                 # No tool calls - this is the final response
                 final_response = assistant_message.content or ""
                 
+                # If a prior turn delivered substantive content alongside tool
+                # calls (stored in _last_content_with_tools) and the model's
+                # follow-up is a short epilogue ("Anything else?", "还需要深挖吗？"),
+                # prepend the earlier content so the oneshot/chat() caller
+                # receives the full answer instead of just the trailing remark.
+                # Fixes #28326: -z/oneshot final_response overwritten.
+                _prior = getattr(agent, "_last_content_with_tools", None)
+                if (
+                    _prior
+                    and final_response
+                    and len(final_response) < len(_prior) * 0.3
+                    and agent._has_content_after_think_block(_prior)
+                ):
+                    _prior_clean = agent._strip_think_blocks(_prior).strip()
+                    _follow_clean = agent._strip_think_blocks(final_response).strip()
+                    final_response = f"{_prior_clean}\n\n{_follow_clean}"
+                    logger.info(
+                        "Prepended prior-turn content (%d chars) before "
+                        "short follow-up (%d chars) to prevent "
+                        "final_response overwrite",
+                        len(_prior_clean), len(_follow_clean),
+                    )
+                agent._last_content_with_tools = None
+                
                 # Fix: unmute output when entering the no-tool-call branch
                 # so the user can see empty-response warnings and recovery
                 # status messages.  _mute_post_response was set during a

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3015,6 +3015,46 @@ class TestRunConversation:
         assert result["final_response"] == "Fresh partial content from this turn"
         assert result["api_calls"] == 1
 
+    def test_oneshot_final_response_not_overwritten_by_short_followup(self, agent):
+        """Fix #28326: when model returns content+tool_call then short follow-up,
+        final_response should include the substantive content, not just the tail."""
+        self._setup_agent(agent)
+        # Simulate 2-step conversation:
+        #   Turn 1: model returns long content + todo tool call
+        #   Turn 2: model returns short follow-up only (no tool calls)
+        _substantive = "这是一份详细的分析报告，包含多个要点和深入见解。" * 10
+        _short_followup = "还需要深挖吗？"
+
+        tc = _mock_tool_call(name="web_search", arguments='{"query":"test"}')
+        resp1 = _mock_response(
+            content=_substantive,
+            tool_calls=[tc],
+            finish_reason="tool_calls",
+        )
+        resp2 = _mock_response(
+            content=_short_followup,
+            finish_reason="stop",
+        )
+        agent.client.chat.completions.create.side_effect = [resp1, resp2]
+
+        with (
+            patch("run_agent.handle_function_call", return_value="ok"),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("分析一下")
+
+        # The final_response should contain the substantive content,
+        # not just the short follow-up
+        assert _substantive in result["final_response"], (
+            f"Expected substantive content in final_response, got: {result['final_response'][:100]}..."
+        )
+        assert _short_followup in result["final_response"], (
+            "Short follow-up should also be preserved"
+        )
+        assert result["api_calls"] == 2
+
     def test_nous_401_refreshes_after_remint_and_retries(self, agent):
         self._setup_agent(agent)
         agent.provider = "nous"


### PR DESCRIPTION
## Problem

When the model returns substantive content alongside a tool call (e.g. a detailed analysis + a `todo` housekeeping call), then the follow-up turn after tool execution produces a short epilogue ("还需要深挖吗？", "Anything else?"), the `final_response` is overwritten with just that tail — losing the substantive answer entirely.

This affects the `oneshot`/`-z` mode (`chat()`) most severely, since the caller only receives `final_response` and has no way to access the intermediate content.

Fixes #28326

## Root Cause

In `conversation_loop.py`, when the model returns a response with no tool calls (the `else` branch at L3419), `final_response` is unconditionally set to `assistant_message.content`. The prior turn's content (stored in `_last_content_with_tools`) is only used in the empty-content recovery path, not when the follow-up is non-empty but short.

## Fix

When `_last_content_with_tools` exists and the follow-up is less than 30% of the prior content's length, prepend the prior content before the short follow-up. This preserves the full answer while keeping the model's closing remark.

**Heuristic rationale**: A follow-up that is <30% of the substantive content is almost always a conversational tail ("还需要深挖吗？", "Let me know if you need more", etc.), not a substantive addition. This threshold is conservative enough to avoid false positives while catching the reported bug pattern.

## Changes

- `agent/conversation_loop.py` (+24 lines): Add short-followup detection and content prepending logic in the no-tool-call branch
- `tests/run_agent/test_run_agent.py` (+40 lines): New test `test_oneshot_final_response_not_overwritten_by_short_followup`

## Testing

```
337 tests passed, 0 failed (including the new test)
```

The new test simulates the exact scenario: Turn 1 returns 240-char Chinese content + `web_search` tool call, Turn 2 returns 7-char follow-up. Asserts both are present in `final_response`.