### PR TITLE
fix: handle JSON Schema union type lists in moonshot_schema (both crash sites)

### DIFF
--- a/agent/moonshot_schema.py
+++ b/agent/moonshot_schema.py
@@ -144,7 +144,7 @@ def _repair_schema(node: Any, is_schema: bool = True) -> Any:
     # empty, drop it entirely.
     if "enum" in repaired and isinstance(repaired["enum"], list):
         node_type = repaired.get("type")
-        if node_type in {"string", "integer", "number", "boolean"}:
+        if isinstance(node_type, str) and node_type in {"string", "integer", "number", "boolean"}:
             cleaned = [v for v in repaired["enum"]
                        if v is not None and v != ""]
             if cleaned:
@@ -166,8 +166,16 @@ def _repair_schema(node: Any, is_schema: bool = True) -> Any:
 
 def _fill_missing_type(node: Dict[str, Any]) -> Dict[str, Any]:
     """Infer a reasonable ``type`` if this schema node has none."""
-    if "type" in node and node["type"] not in {None, ""}:
-        return node
+    if "type" in node:
+        t = node["type"]
+        # JSON Schema allows ``type`` to be a list for union types
+        # (e.g. ["number", "string"]).  These are valid type declarations
+        # and should be left as-is — they cannot be hashed for set
+        # membership checks.  Fixes #28291.
+        if isinstance(t, list):
+            return node
+        if t not in {None, ""}:
+            return node
 
     # Heuristic: presence of ``properties`` → object, ``items`` → array, ``enum``
     # → type of first enum value, else fall back to ``string`` (safest scalar).

--- a/tests/agent/test_moonshot_schema.py
+++ b/tests/agent/test_moonshot_schema.py
@@ -560,3 +560,54 @@ class TestEnumNullStripping:
         assert db_type["type"] == "string"
         assert db_type["enum"] == ["mysql", "postgresql"], \
             "null/empty enum values must be stripped after anyOf collapse"
+
+
+class TestUnionTypeList:
+    """Fixes #28291: JSON Schema union type lists must not crash."""
+
+    def test_fill_missing_type_preserves_list_type(self):
+        """``_fill_missing_type`` should return node unchanged when type is a list."""
+        from agent.moonshot_schema import _fill_missing_type
+        node = {"type": ["number", "string"], "description": "timestamp or string"}
+        result = _fill_missing_type(node)
+        assert result is node
+        assert result["type"] == ["number", "string"]
+
+    def test_fill_missing_type_still_infers_for_missing_type(self):
+        """``_fill_missing_type`` should still infer type when absent."""
+        from agent.moonshot_schema import _fill_missing_type
+        node = {"properties": {"x": {"type": "integer"}}}
+        result = _fill_missing_type(node)
+        assert result["type"] == "object"
+
+    def test_repair_schema_does_not_crash_on_list_type_with_enum(self):
+        """``_repair_schema`` enum cleanup should not crash when type is a list."""
+        from agent.moonshot_schema import _repair_schema
+        node = {
+            "type": ["string", "integer"],
+            "enum": ["a", "b", None, ""],
+        }
+        result = _repair_schema(node, is_schema=True)
+        # Union type with enum: enum cleanup should be skipped (type is list, not scalar)
+        assert result["type"] == ["string", "integer"]
+        assert "enum" in result  # enum not cleaned because type is not a scalar
+
+    def test_end_to_end_union_type_tool_parameter(self):
+        """Full sanitize pipeline should not crash on union-type parameters."""
+        from agent.moonshot_schema import sanitize_moonshot_tool_parameters
+        params = {
+            "type": "object",
+            "properties": {
+                "time_from": {
+                    "type": ["number", "string"],
+                    "description": "Optional timestamp or string",
+                },
+                "name": {
+                    "type": "string",
+                    "description": "A name",
+                },
+            },
+        }
+        out = sanitize_moonshot_tool_parameters(params)
+        assert out["properties"]["time_from"]["type"] == ["number", "string"]
+        assert out["properties"]["name"]["type"] == "string"


### PR DESCRIPTION
## Problem

`sanitize_moonshot_tools()` raises `TypeError: unhashable type: 'list'` when a tool parameter uses JSON Schema union types like `"type": ["number", "string"]`. This is a **non-retryable error** that completely blocks any conversation using kimi-* models when the toolset contains union-type parameters.

Fixes #28291

## Root Cause

Two crash sites in `agent/moonshot_schema.py`:

1. **`_fill_missing_type` (L169)**: `node["type"] not in {None, ""}` — the `not in` set membership check requires the operand to be hashable, which `list` is not.
2. **`_repair_schema` enum cleanup (L147)**: `node_type in {"string", "integer", ...}` — same issue.

The existing PR #28322 only addresses crash site 2. This PR fixes **both**.

## Fix

- L169: Add `isinstance(t, list)` guard — union types are valid declarations, return node as-is.
- L147: Add `isinstance(node_type, str)` guard — enum cleanup only applies to scalar types.

## Changes

- `agent/moonshot_schema.py` (+14/-3): Two isinstance guards for list-type handling
- `tests/agent/test_moonshot_schema.py` (+51): 4 new tests in `TestUnionTypeList` class

## Testing

```
46 passed, 0 failed (including 4 new tests)
```