### PR TITLE
feat(kanban): route code review through agents

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -839,13 +839,9 @@ def init_agent(
     # Kanban worker/orchestrator lifecycle guidance is session-static:
     # the dispatcher decides at spawn time whether this process is a kanban
     # worker (kanban_show tool is present iff HERMES_KANBAN_TASK is set).
-    # Resolving the ~835-token block once here avoids re-running the
-    # membership test + reference on every system-prompt rebuild
-    # (init + each context compression).
-    from agent.prompt_builder import KANBAN_GUIDANCE
-    agent._kanban_worker_guidance = (
-        KANBAN_GUIDANCE if "kanban_show" in agent.valid_tool_names else ""
-    )
+    # The concrete guidance is built after config/env policy is loaded.
+    agent._kanban_code_review_policy = None
+    agent._kanban_worker_guidance = ""
 
     # Check tool requirements
     if agent.tools and not agent.quiet_mode:
@@ -949,6 +945,24 @@ def init_agent(
         )
     except Exception as _tlg_err:
         _ra().logger.warning("Tool loop guardrail config ignored: %s", _tlg_err)
+    try:
+        from hermes_cli.kanban_policy import (
+            policy_from_config as _kanban_policy_from_config,
+            policy_from_env as _kanban_policy_from_env,
+        )
+
+        agent._kanban_code_review_policy = _kanban_policy_from_env(
+            os.environ,
+            base_policy=_kanban_policy_from_config(_agent_cfg),
+        )
+    except Exception:
+        agent._kanban_code_review_policy = None
+    if "kanban_show" in agent.valid_tool_names:
+        from agent.prompt_builder import build_kanban_guidance
+
+        agent._kanban_worker_guidance = build_kanban_guidance(
+            agent._kanban_code_review_policy
+        )
     # Cache only the derived auxiliary compression context override that is
     # needed later by the startup feasibility check.  Avoid exposing a
     # broad pseudo-public config object on the agent instance.

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -24,6 +24,10 @@ from agent.skill_utils import (
     parse_frontmatter,
     skill_matches_platform,
 )
+from hermes_cli.kanban_policy import (
+    KanbanCodeReviewPolicy,
+    normalize_kanban_code_review_policy,
+)
 from utils import atomic_json_write
 
 logger = logging.getLogger(__name__)
@@ -185,71 +189,116 @@ SKILLS_GUIDANCE = (
     "Skills that aren't maintained become liabilities."
 )
 
-KANBAN_GUIDANCE = (
-    "# Kanban task execution protocol\n"
-    "You have been assigned ONE task from "
-    "the shared board at `~/.hermes/kanban.db`. Your task id is in "
-    "`$HERMES_KANBAN_TASK`; your workspace is `$HERMES_KANBAN_WORKSPACE`. "
-    "The `kanban_*` tools in your schema are your primary coordination surface — "
-    "they write directly to the shared SQLite DB and work regardless of terminal "
-    "backend (local/docker/modal/ssh).\n"
-    "\n"
-    "## Lifecycle\n"
-    "\n"
-    "1. **Orient.** Call `kanban_show()` first (no args — it defaults to your "
-    "task). The response includes title, body, parent-task handoffs (summary + "
-    "metadata), any prior attempts on this task if you're a retry, the full "
-    "comment thread, and a pre-formatted `worker_context` you can treat as "
-    "ground truth.\n"
-    "2. **Work inside the workspace.** `cd $HERMES_KANBAN_WORKSPACE` before "
-    "any file operations. The workspace is yours for this run. Don't modify "
-    "files outside it unless the task explicitly asks.\n"
-    "3. **Heartbeat on long operations.** Call `kanban_heartbeat(note=...)` "
-    "every few minutes during long subprocesses (training, encoding, crawling). "
-    "Skip heartbeats for short tasks.\n"
-    "4. **Block on genuine ambiguity.** If you need a human decision you cannot "
-    "infer (missing credentials, UX choice, paywalled source, peer output you "
-    "need first), call `kanban_block(reason=\"...\")` and stop. Don't guess. "
-    "The user will unblock with context and the dispatcher will respawn you.\n"
-    "5. **Complete with structured handoff.** Call `kanban_complete(summary=..., "
-    "metadata=...)`. `summary` is 1–3 human-readable sentences naming concrete "
-    "artifacts. `metadata` is machine-readable facts "
-    "(`{changed_files: [...], tests_run: N, decisions: [...]}`). Downstream "
-    "workers read both via their own `kanban_show`. Never put secrets / "
-    "tokens / raw PII in either field — run rows are durable forever. "
-    "Exception: if your output is a code change that needs human review "
-    "before counting as merged/done (most coding tasks), drop the "
-    "structured metadata (changed_files / tests_run / diff_path) into a "
-    "`kanban_comment` first, then end with "
-    "`kanban_block(reason=\"review-required: <one-line summary>\")` so a "
-    "reviewer can approve+unblock or request changes. Reviewing-then-"
-    "completing is more honest than auto-completing work that still needs "
-    "eyes on it.\n"
-    "6. **If follow-up work appears, create it; don't do it.** Use "
-    "`kanban_create(title=..., assignee=<right-profile>, parents=[your-task-id])` "
-    "to spawn a child task for the appropriate specialist profile instead of "
-    "scope-creeping into the next thing.\n"
-    "\n"
-    "## Orchestrator mode\n"
-    "\n"
-    "If your task is itself a decomposition task (e.g. a planner profile given "
-    "a high-level goal), use `kanban_create` to fan out into child tasks — one "
-    "per specialist, each with an explicit `assignee` and `parents=[...]` to "
-    "express dependencies. Then `kanban_complete` your own task with a summary "
-    "of the decomposition. Do NOT execute the work yourself; your job is "
-    "routing, not implementation.\n"
-    "\n"
-    "## Do NOT\n"
-    "\n"
-    "- Do not shell out to `hermes kanban <verb>` for board operations. Use "
-    "the `kanban_*` tools — they work across all terminal backends.\n"
-    "- Do not complete a task you didn't actually finish. Block it.\n"
-    "- Do not assign follow-up work to yourself. Assign it to the right "
-    "specialist profile.\n"
-    "- Do not call `delegate_task` as a board substitute. `delegate_task` is "
-    "for short reasoning subtasks inside your own run; board tasks are for "
-    "cross-agent handoffs that outlive one API loop."
-)
+def build_kanban_guidance(
+    policy: KanbanCodeReviewPolicy | dict | None = None,
+) -> str:
+    """Build Kanban worker guidance from a normalized code-review policy."""
+
+    p = normalize_kanban_code_review_policy(policy)
+    review_lines: list[str]
+    if p.mode == "ai_reviewer" and p.require_for_coding_tasks:
+        review_lines = [
+            f"technical review belongs to agents, not the human user. For code changes, run the relevant automated checks/tests yourself, then create a child review task assigned to `{p.reviewer_profile}` when independent review is needed or required by policy; use the current task id from `kanban_show()`/`$HERMES_KANBAN_TASK` as the parent.",
+            "Complete your implementation task with a structured handoff that names changed files, tests run, and the review task id in `created_cards`; the reviewer agent owns code-review approval or follow-up findings.",
+        ]
+    elif p.mode == "human_review" and p.human_blocks_for_code_review:
+        review_lines = [
+            "Human code review is explicitly enabled by policy. Leave structured metadata in a comment before blocking for review.",
+        ]
+    else:
+        review_lines = [
+            "Technical review belongs to agents when requested; otherwise self-verify with automated checks/tests and complete with a structured handoff.",
+        ]
+
+    if not p.human_blocks_for_code_review:
+        review_lines.append(
+            "Do not create a human-facing technical code-review block for ordinary coding tasks."
+        )
+
+    if p.permission_mode == "default":
+        permission_line = (
+            "For permissions, use configured permission defaults unless the task explicitly instructs otherwise; do not request permission or pause for permissions."
+        )
+    elif p.permission_mode == "deny":
+        permission_line = (
+            "For permissions, default to deny/skip unless the task explicitly authorizes the action; document the skipped action in your handoff."
+        )
+    else:
+        permission_line = (
+            "For permissions, ask only when the active policy explicitly requires asking."
+        )
+
+    if p.mode == "human_review" and p.human_blocks_for_code_review:
+        block_line = (
+            "4. **Block only on policy-approved human decisions/review.** Human code-review blocks are allowed by the active policy: leave structured metadata in a comment, call `kanban_block(reason=\"review-required: ...\")`, and stop. Otherwise, block only for product intent or business-priority decisions you cannot infer. Routine permissions are "
+            f"not a human block condition: {permission_line}\n"
+        )
+    else:
+        block_line = (
+            "4. **Block only on human product/business ambiguity.** If you need a "
+            "product intent or business-priority decision you cannot infer, call "
+            "`kanban_block(reason=\"...\")` and stop. Routine permissions are "
+            f"not a human block condition: {permission_line}\n"
+        )
+
+    return (
+        "# Kanban task execution protocol\n"
+        "You have been assigned ONE task from "
+        "the shared board at `~/.hermes/kanban.db`. Your task id is in "
+        "`$HERMES_KANBAN_TASK`; your workspace is `$HERMES_KANBAN_WORKSPACE`. "
+        "The `kanban_*` tools in your schema are your primary coordination surface — "
+        "they write directly to the shared SQLite DB and work regardless of terminal "
+        "backend (local/docker/modal/ssh).\n"
+        "\n"
+        "## Lifecycle\n"
+        "\n"
+        "1. **Orient.** Call `kanban_show()` first (no args — it defaults to your "
+        "task). The response includes title, body, parent-task handoffs (summary + "
+        "metadata), any prior attempts on this task if you're a retry, the full "
+        "comment thread, and a pre-formatted `worker_context` you can treat as "
+        "ground truth.\n"
+        "2. **Work inside the workspace.** `cd $HERMES_KANBAN_WORKSPACE` before "
+        "any file operations. The workspace is yours for this run. Don't modify "
+        "files outside it unless the task explicitly asks.\n"
+        "3. **Heartbeat on long operations.** Call `kanban_heartbeat(note=...)` "
+        "every few minutes during long subprocesses (training, encoding, crawling). "
+        "Skip heartbeats for short tasks.\n"
+        + block_line
+        + "5. **Complete with structured handoff.** Call `kanban_complete(summary=..., "
+        "metadata=...)`. `summary` is 1–3 human-readable sentences naming concrete "
+        "artifacts. `metadata` is machine-readable facts "
+        "(`{changed_files: [...], tests_run: N, decisions: [...]}`). Downstream "
+        "workers read both via their own `kanban_show`. Never put secrets / "
+        "tokens / raw PII in either field — run rows are durable forever. "
+        f"{' '.join(review_lines)}\n"
+        "6. **If follow-up work appears, create it; don't do it.** Use "
+        "`kanban_create(title=..., assignee=<right-profile>, parents=[your-task-id])` "
+        "to spawn a child task for the appropriate specialist profile instead of "
+        "scope-creeping into the next thing.\n"
+        "\n"
+        "## Orchestrator mode\n"
+        "\n"
+        "If your task is itself a decomposition task (e.g. a planner profile given "
+        "a high-level goal), use `kanban_create` to fan out into child tasks — one "
+        "per specialist, each with an explicit `assignee` and `parents=[...]` to "
+        "express dependencies. Then `kanban_complete` your own task with a summary "
+        "of the decomposition. Do NOT execute the work yourself; your job is "
+        "routing, not implementation.\n"
+        "\n"
+        "## Do NOT\n"
+        "\n"
+        "- Do not shell out to `hermes kanban <verb>` for board operations. Use "
+        "the `kanban_*` tools — they work across all terminal backends.\n"
+        "- Do not complete a task you didn't actually finish. Block it.\n"
+        "- Do not assign follow-up work to yourself. Assign it to the right "
+        "specialist profile.\n"
+        "- Do not call `delegate_task` as a board substitute. `delegate_task` is "
+        "for short reasoning subtasks inside your own run; board tasks are for "
+        "cross-agent handoffs that outlive one API loop."
+    )
+
+
+KANBAN_GUIDANCE = build_kanban_guidance()
 
 TOOL_USE_ENFORCEMENT_GUIDANCE = (
     "# Tool-use enforcement\n"

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -117,7 +117,10 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         tool_guidance.append(_kanban_guidance)
     elif _kanban_guidance is None and "kanban_show" in agent.valid_tool_names:
         # Fallback for code paths that bypass agent_init (rare).
-        tool_guidance.append(KANBAN_GUIDANCE)
+        from agent.prompt_builder import build_kanban_guidance
+        tool_guidance.append(
+            build_kanban_guidance(getattr(agent, "_kanban_code_review_policy", None))
+        )
     if tool_guidance:
         stable_parts.append(" ".join(tool_guidance))
 

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -887,6 +887,25 @@ delegation:
   #                                           # Supported: openrouter, nous, zai, kimi-coding, minimax
 
 # =============================================================================
+# Kanban Multi-Agent Coordination
+# =============================================================================
+kanban:
+  # Run the dispatcher inside the gateway process.
+  dispatch_in_gateway: true
+  dispatch_interval_seconds: 60
+  failure_limit: 2
+
+  # Coding-task review policy for dispatched workers.
+  # Default keeps routine technical review inside the agent system: implementers
+  # run checks/tests and create reviewer-agent child cards when review is needed.
+  code_review:
+    mode: "ai_reviewer"              # ai_reviewer | self_verify | human_review
+    reviewer_profile: "reviewer"
+    require_for_coding_tasks: true
+    human_blocks_for_code_review: false
+    permission_mode: "default"       # default | ask | deny
+
+# =============================================================================
 # Honcho Integration (Cross-Session User Modeling)
 # =============================================================================
 # AI-native persistent memory via Honcho (https://honcho.dev/).

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1554,6 +1554,19 @@ DEFAULT_CONFIG = {
         # large bulk-load of triage tasks from spending a burst of aux
         # LLM calls in one tick. Excess tasks defer to the next tick.
         "auto_decompose_per_tick": 3,
+        # Coding review policy for dispatched workers. Default behavior keeps
+        # routine technical review inside the agent system: coding workers run
+        # checks/tests, create reviewer-agent tasks when independent review is
+        # needed, and only block humans for product/business ambiguity.
+        "code_review": {
+            "mode": "ai_reviewer",  # ai_reviewer | self_verify | human_review
+            "reviewer_profile": "reviewer",
+            "require_for_coding_tasks": True,
+            "human_blocks_for_code_review": False,
+            # Permissions are not human decisions by default; workers follow
+            # the configured permission/approval defaults unless instructed.
+            "permission_mode": "default",  # default | ask | deny
+        },
     },
 
     # execute_code settings — controls the tool used for programmatic tool calls.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4679,6 +4679,18 @@ def _default_spawn(
     # attributed correctly regardless of how the child loads config.
     env["HERMES_PROFILE"] = profile_arg
 
+    from hermes_cli.kanban_policy import (
+        kanban_policy_env,
+        load_kanban_code_review_policy,
+        policy_from_env,
+    )
+
+    env.update(
+        kanban_policy_env(
+            policy_from_env(env, base_policy=load_kanban_code_review_policy())
+        )
+    )
+
     cmd = [
         *_resolve_hermes_argv(),
         "-p", profile_arg,
@@ -5082,11 +5094,20 @@ def _to_epoch(val) -> Optional[int]:
         pass
     # ISO-8601 fallback (e.g. '2026-05-10T15:00:00Z')
     try:
-        from datetime import datetime, timezone
+        from datetime import datetime
         dt = datetime.fromisoformat(s.replace("Z", "+00:00"))
         return int(dt.timestamp())
     except (ValueError, OSError):
         return None
+
+
+def _safe_int(val) -> Optional[int]:
+    """Best-effort integer conversion used by timestamp callers.
+
+    Kept as a narrow compatibility helper for tests and callers that only need
+    an int-or-None guard around corrupt SQLite values.
+    """
+    return _to_epoch(val)
 
 
 def task_age(task: Task) -> dict:

--- a/hermes_cli/kanban_policy.py
+++ b/hermes_cli/kanban_policy.py
@@ -1,0 +1,171 @@
+"""Kanban worker policy helpers.
+
+This module is intentionally small and dependency-light so both the agent
+prompt builder and the dispatcher can share one normalized view of Kanban
+code-review behavior.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import asdict, dataclass
+from typing import Any, Mapping
+
+
+TRUE_STRINGS = {"1", "true", "yes", "on"}
+FALSE_STRINGS = {"0", "false", "no", "off"}
+
+VALID_REVIEW_MODES = {"ai_reviewer", "self_verify", "human_review"}
+VALID_PERMISSION_MODES = {"default", "ask", "deny"}
+
+
+@dataclass(frozen=True)
+class KanbanCodeReviewPolicy:
+    """Normalized policy controlling coding-task completion/review behavior."""
+
+    mode: str = "ai_reviewer"
+    reviewer_profile: str = "reviewer"
+    require_for_coding_tasks: bool = True
+    human_blocks_for_code_review: bool = False
+    permission_mode: str = "default"
+
+
+def _coerce_bool(value: Any, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in TRUE_STRINGS:
+            return True
+        if lowered in FALSE_STRINGS:
+            return False
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return default
+
+
+def normalize_kanban_code_review_policy(
+    raw: KanbanCodeReviewPolicy | Mapping[str, Any] | None = None,
+) -> KanbanCodeReviewPolicy:
+    """Return a valid policy from user config, falling back per-field.
+
+    Unknown modes deliberately fall back to the default agent-review path
+    rather than disabling review or routing technical review to humans.
+    """
+
+    if isinstance(raw, KanbanCodeReviewPolicy):
+        return raw
+    cfg = raw if isinstance(raw, Mapping) else {}
+
+    mode = str(cfg.get("mode", KanbanCodeReviewPolicy.mode)).strip().lower()
+    if mode not in VALID_REVIEW_MODES:
+        mode = KanbanCodeReviewPolicy.mode
+
+    reviewer_profile = str(
+        cfg.get("reviewer_profile", KanbanCodeReviewPolicy.reviewer_profile)
+    ).strip()
+    if not reviewer_profile:
+        reviewer_profile = KanbanCodeReviewPolicy.reviewer_profile
+
+    permission_mode = str(
+        cfg.get("permission_mode", KanbanCodeReviewPolicy.permission_mode)
+    ).strip().lower()
+    if permission_mode not in VALID_PERMISSION_MODES:
+        permission_mode = KanbanCodeReviewPolicy.permission_mode
+
+    return KanbanCodeReviewPolicy(
+        mode=mode,
+        reviewer_profile=reviewer_profile,
+        require_for_coding_tasks=_coerce_bool(
+            cfg.get(
+                "require_for_coding_tasks",
+                KanbanCodeReviewPolicy.require_for_coding_tasks,
+            ),
+            KanbanCodeReviewPolicy.require_for_coding_tasks,
+        ),
+        human_blocks_for_code_review=_coerce_bool(
+            cfg.get(
+                "human_blocks_for_code_review",
+                KanbanCodeReviewPolicy.human_blocks_for_code_review,
+            ),
+            KanbanCodeReviewPolicy.human_blocks_for_code_review,
+        ),
+        permission_mode=permission_mode,
+    )
+
+
+def policy_from_config(config: Mapping[str, Any] | None) -> KanbanCodeReviewPolicy:
+    """Extract and normalize ``kanban.code_review`` from a config mapping."""
+
+    if not isinstance(config, Mapping):
+        return normalize_kanban_code_review_policy()
+    kanban = config.get("kanban", {})
+    if not isinstance(kanban, Mapping):
+        return normalize_kanban_code_review_policy()
+    code_review = kanban.get("code_review", {})
+    if not isinstance(code_review, Mapping):
+        return normalize_kanban_code_review_policy()
+    return normalize_kanban_code_review_policy(code_review)
+
+
+def policy_from_env(
+    env: Mapping[str, str] | None = None,
+    *,
+    base_policy: KanbanCodeReviewPolicy | Mapping[str, Any] | None = None,
+) -> KanbanCodeReviewPolicy:
+    """Return policy with dispatcher-provided env vars overriding config.
+
+    The gateway dispatcher can run under a shared/root profile while spawned
+    workers run under assignee profiles. Passing the normalized policy through
+    env keeps board-level worker behavior consistent without requiring every
+    profile to duplicate ``kanban.code_review`` config.
+    """
+
+    raw: dict[str, Any] = asdict(normalize_kanban_code_review_policy(base_policy))
+    env = os.environ if env is None else env
+    env_map = {
+        "HERMES_KANBAN_CODE_REVIEW_MODE": "mode",
+        "HERMES_KANBAN_REVIEWER_PROFILE": "reviewer_profile",
+        "HERMES_KANBAN_REQUIRE_CODE_REVIEW": "require_for_coding_tasks",
+        "HERMES_KANBAN_HUMAN_CODE_REVIEW_BLOCKS": "human_blocks_for_code_review",
+        "HERMES_KANBAN_PERMISSION_MODE": "permission_mode",
+    }
+    for env_key, policy_key in env_map.items():
+        if env_key in env:
+            raw[policy_key] = env[env_key]
+    return normalize_kanban_code_review_policy(raw)
+
+
+def load_kanban_code_review_policy() -> KanbanCodeReviewPolicy:
+    """Load the active profile's Kanban code-review policy.
+
+    Config loading is optional by design: prompt construction and dispatcher
+    spawn must stay robust even if config parsing fails.
+    """
+
+    try:
+        from hermes_cli.config import load_config
+
+        return policy_from_config(load_config())
+    except Exception:
+        return normalize_kanban_code_review_policy()
+
+
+def kanban_policy_env(
+    policy: KanbanCodeReviewPolicy | Mapping[str, Any] | None = None,
+) -> dict[str, str]:
+    """Serialize policy into worker env vars for subprocess consumers/logging."""
+
+    if not isinstance(policy, KanbanCodeReviewPolicy):
+        policy = normalize_kanban_code_review_policy(policy)
+    return {
+        "HERMES_KANBAN_CODE_REVIEW_MODE": policy.mode,
+        "HERMES_KANBAN_REVIEWER_PROFILE": policy.reviewer_profile,
+        "HERMES_KANBAN_REQUIRE_CODE_REVIEW": str(
+            policy.require_for_coding_tasks
+        ).lower(),
+        "HERMES_KANBAN_HUMAN_CODE_REVIEW_BLOCKS": str(
+            policy.human_blocks_for_code_review
+        ).lower(),
+        "HERMES_KANBAN_PERMISSION_MODE": policy.permission_mode,
+    }

--- a/run_agent.py
+++ b/run_agent.py
@@ -128,7 +128,7 @@ from agent.prompt_builder import (
     DEFAULT_AGENT_IDENTITY, PLATFORM_HINTS,
     MEMORY_GUIDANCE, SESSION_SEARCH_GUIDANCE, SKILLS_GUIDANCE,
     HERMES_AGENT_HELP_GUIDANCE,
-    KANBAN_GUIDANCE,
+    build_kanban_guidance,
     build_nous_subscription_prompt,
 )
 from agent.model_metadata import (

--- a/skills/devops/kanban-worker/SKILL.md
+++ b/skills/devops/kanban-worker/SKILL.md
@@ -36,39 +36,35 @@ The `kanban_complete(summary=..., metadata=...)` handoff is how downstream worke
 
 **Coding task:**
 ```python
+import os
+
+review = kanban_create(
+    title="Review rate limiter implementation",
+    assignee="reviewer",
+    parents=[os.environ["HERMES_KANBAN_TASK"]],
+    body="Please review changed files, tests, and residual risks from the implementation handoff.",
+)
+
 kanban_complete(
-    summary="shipped rate limiter — token bucket, keys on user_id with IP fallback, 14 tests pass",
+    summary="shipped rate limiter — token bucket, keys on user_id with IP fallback, 14 tests pass; review task created",
     metadata={
         "changed_files": ["rate_limiter.py", "tests/test_rate_limiter.py"],
         "tests_run": 14,
         "tests_passed": 14,
         "decisions": ["user_id primary, IP fallback for unauthenticated requests"],
+        "review_task_id": review["task_id"],
     },
+    created_cards=[review["task_id"]],
 )
 ```
 
-**Coding task that needs human review (review-required):**
-
-For most code-changing tasks, the work isn't truly *done* until a human reviewer has eyes on it. Block instead of complete, with `reason` prefixed `review-required: ` so the dashboard surfaces the row as needing review. Drop the structured metadata (changed files, test counts, diff/PR url) into a comment first, since `kanban_block` only carries the human-readable reason — comments are the durable annotation channel. Reviewer either approves and runs `hermes kanban unblock <id>` (which re-spawns you with the comment thread for any follow-ups) or asks for changes via another comment.
-
-```python
-import json
-
-kanban_comment(
-    body="review-required handoff:\n" + json.dumps({
-        "changed_files": ["rate_limiter.py", "tests/test_rate_limiter.py"],
-        "tests_run": 14,
-        "tests_passed": 14,
-        "diff_path": "/path/to/worktree",  # or PR url if pushed
-        "decisions": ["user_id primary, IP fallback for unauthenticated requests"],
-    }, indent=2),
-)
-kanban_block(
-    reason="review-required: rate limiter shipped, 14/14 tests pass — needs eyes on the user_id/IP fallback choice before merging",
-)
-```
-
-Use `kanban_complete` only when the task is genuinely terminal — e.g. a one-line typo fix, a docs change with no functional consequences, or a research task where the artifact IS the writeup itself.
+Coding workers own technical self-verification: run the relevant checks/tests,
+record changed files and residual risk, and create a reviewer-agent child card
+when independent review is needed or required by policy. Do not block the human
+operator for ordinary code review. Use `kanban_block` only for product intent,
+business-priority, or requirements decisions that cannot be inferred. Permission
+choices follow configured defaults unless the task explicitly instructs the
+worker to ask.
 
 **Research task:**
 ```python

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -4,6 +4,7 @@ import builtins
 import importlib
 import logging
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -24,6 +25,8 @@ from agent.prompt_builder import (
     TOOL_USE_ENFORCEMENT_GUIDANCE,
     TOOL_USE_ENFORCEMENT_MODELS,
     OPENAI_MODEL_EXECUTION_GUIDANCE,
+    KANBAN_GUIDANCE,
+    build_kanban_guidance,
     MEMORY_GUIDANCE,
     SESSION_SEARCH_GUIDANCE,
     PLATFORM_HINTS,
@@ -48,6 +51,67 @@ class TestGuidanceConstants:
     def test_session_search_guidance_is_simple_cross_session_recall(self):
         assert "relevant cross-session context exists" in SESSION_SEARCH_GUIDANCE
         assert "recent turns of the current session" not in SESSION_SEARCH_GUIDANCE
+
+    def test_default_kanban_guidance_routes_code_review_to_agent(self):
+        assert "technical review belongs to agents" in KANBAN_GUIDANCE
+        assert "reviewer" in KANBAN_GUIDANCE
+        assert "kanban_create" in KANBAN_GUIDANCE
+        assert "review-required:" not in KANBAN_GUIDANCE
+        assert "needs human review" not in KANBAN_GUIDANCE.lower()
+
+    def test_kanban_guidance_uses_permission_defaults_not_human_permission_blocks(self):
+        guidance = build_kanban_guidance({"permission_mode": "default"})
+        lowered = guidance.lower()
+        assert "permission defaults" in lowered
+        assert "ask for permission" not in lowered
+        assert "block on permissions" not in lowered
+
+    def test_kanban_guidance_is_policy_driven_and_modular(self):
+        guidance = build_kanban_guidance(
+            {
+                "mode": "ai_reviewer",
+                "reviewer_profile": "review-bot",
+                "require_for_coding_tasks": True,
+                "human_blocks_for_code_review": False,
+            }
+        )
+        assert "review-bot" in guidance
+        assert "create a child review task" in guidance
+        assert "technical code-review block" in guidance
+        assert "parents=[$HERMES_KANBAN_TASK]" not in guidance
+
+    def test_kanban_guidance_supports_explicit_human_review_policy(self):
+        guidance = build_kanban_guidance(
+            {
+                "mode": "human_review",
+                "human_blocks_for_code_review": True,
+                "permission_mode": "ask",
+            }
+        )
+        assert "Human code review is explicitly enabled by policy" in guidance
+        assert "Human code-review blocks are allowed by the active policy" in guidance
+        assert "Block only on human product/business ambiguity" not in guidance
+        assert "ask only when the active policy explicitly requires asking" in guidance
+
+    def test_kanban_guidance_supports_self_verify_policy(self):
+        guidance = build_kanban_guidance(
+            {
+                "mode": "self_verify",
+                "require_for_coding_tasks": False,
+                "permission_mode": "deny",
+            }
+        )
+        assert "self-verify with automated checks/tests" in guidance
+        assert "default to deny/skip" in guidance
+
+    def test_auto_loaded_kanban_worker_skill_matches_agent_review_default(self):
+        skill = Path("skills/devops/kanban-worker/SKILL.md").read_text(
+            encoding="utf-8"
+        )
+        assert "reviewer-agent child card" in skill
+        assert "Do not block the human" in skill
+        assert "review-required:" not in skill
+        assert "For most code-changing tasks" not in skill
 
 
 # =========================================================================

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -71,6 +71,60 @@ class TestLoadConfigDefaults:
             assert config["terminal"]["backend"] == "local"
             assert config["display"]["interim_assistant_messages"] is True
 
+    def test_kanban_code_review_policy_defaults_to_ai_reviewer(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            policy = load_config()["kanban"]["code_review"]
+            assert policy["mode"] == "ai_reviewer"
+            assert policy["reviewer_profile"] == "reviewer"
+            assert policy["require_for_coding_tasks"] is True
+            assert policy["human_blocks_for_code_review"] is False
+            assert policy["permission_mode"] == "default"
+
+    def test_kanban_policy_env_overrides_worker_profile_config(self):
+        from hermes_cli.kanban_policy import policy_from_env
+
+        base_config = {
+            "kanban": {
+                "code_review": {
+                    "mode": "human_review",
+                    "reviewer_profile": "profile-reviewer",
+                    "require_for_coding_tasks": False,
+                    "human_blocks_for_code_review": True,
+                    "permission_mode": "ask",
+                }
+            }
+        }
+        policy = policy_from_env(
+            {
+                "HERMES_KANBAN_CODE_REVIEW_MODE": "ai_reviewer",
+                "HERMES_KANBAN_REVIEWER_PROFILE": "board-reviewer",
+                "HERMES_KANBAN_REQUIRE_CODE_REVIEW": "true",
+                "HERMES_KANBAN_HUMAN_CODE_REVIEW_BLOCKS": "false",
+                "HERMES_KANBAN_PERMISSION_MODE": "default",
+            },
+            base_policy=base_config["kanban"]["code_review"],
+        )
+        assert policy.mode == "ai_reviewer"
+        assert policy.reviewer_profile == "board-reviewer"
+        assert policy.require_for_coding_tasks is True
+        assert policy.human_blocks_for_code_review is False
+        assert policy.permission_mode == "default"
+
+    def test_kanban_policy_env_malformed_values_fall_back_to_safe_defaults(self):
+        from hermes_cli.kanban_policy import policy_from_env
+
+        policy = policy_from_env(
+            {
+                "HERMES_KANBAN_CODE_REVIEW_MODE": "not-a-mode",
+                "HERMES_KANBAN_REQUIRE_CODE_REVIEW": "not-bool",
+                "HERMES_KANBAN_PERMISSION_MODE": "not-a-permission-mode",
+            },
+            base_policy={"mode": "self_verify", "require_for_coding_tasks": False},
+        )
+        assert policy.mode == "ai_reviewer"
+        assert policy.require_for_coding_tasks is True
+        assert policy.permission_mode == "default"
+
     def test_legacy_root_level_max_turns_migrates_to_agent_config(self, tmp_path):
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
             config_path = tmp_path / "config.yaml"

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1309,6 +1309,59 @@ class TestSharedBoardPaths:
             default_home / "kanban" / "workspaces"
         )
         assert env["HERMES_KANBAN_TASK"] == "t_dispatch_env"
+        assert env["HERMES_KANBAN_CODE_REVIEW_MODE"] == "ai_reviewer"
+        assert env["HERMES_KANBAN_REVIEWER_PROFILE"] == "reviewer"
+        assert env["HERMES_KANBAN_REQUIRE_CODE_REVIEW"] == "true"
+        assert env["HERMES_KANBAN_HUMAN_CODE_REVIEW_BLOCKS"] == "false"
+        assert env["HERMES_KANBAN_PERMISSION_MODE"] == "default"
+
+    def test_dispatcher_spawn_preserves_operator_kanban_policy_env(
+        self, tmp_path, monkeypatch
+    ):
+        default_home = tmp_path / ".hermes"
+        default_home.mkdir()
+        self._set_home(monkeypatch, tmp_path, default_home)
+        monkeypatch.setenv("HERMES_KANBAN_CODE_REVIEW_MODE", "human_review")
+        monkeypatch.setenv("HERMES_KANBAN_REVIEWER_PROFILE", "security-reviewer")
+        monkeypatch.setenv("HERMES_KANBAN_REQUIRE_CODE_REVIEW", "false")
+        monkeypatch.setenv("HERMES_KANBAN_HUMAN_CODE_REVIEW_BLOCKS", "true")
+        monkeypatch.setenv("HERMES_KANBAN_PERMISSION_MODE", "ask")
+
+        captured = {}
+
+        class _FakePopen:
+            def __init__(self, cmd, **kwargs):
+                captured["cmd"] = cmd
+                captured["env"] = kwargs.get("env", {})
+                self.pid = 4243
+
+        monkeypatch.setattr("subprocess.Popen", _FakePopen)
+
+        task = kb.Task(
+            id="t_dispatch_policy_env",
+            title="x",
+            body=None,
+            assignee="coder",
+            status="ready",
+            priority=0,
+            created_by=None,
+            created_at=0,
+            started_at=None,
+            completed_at=None,
+            workspace_kind="scratch",
+            workspace_path=None,
+            claim_lock=None,
+            claim_expires=None,
+            tenant=None,
+        )
+        kb._default_spawn(task, str(tmp_path / "ws"))
+
+        env = captured["env"]
+        assert env["HERMES_KANBAN_CODE_REVIEW_MODE"] == "human_review"
+        assert env["HERMES_KANBAN_REVIEWER_PROFILE"] == "security-reviewer"
+        assert env["HERMES_KANBAN_REQUIRE_CODE_REVIEW"] == "false"
+        assert env["HERMES_KANBAN_HUMAN_CODE_REVIEW_BLOCKS"] == "true"
+        assert env["HERMES_KANBAN_PERMISSION_MODE"] == "ask"
 
 
 # ---------------------------------------------------------------------------

--- a/website/docs/user-guide/features/kanban-worker-lanes.md
+++ b/website/docs/user-guide/features/kanban-worker-lanes.md
@@ -56,15 +56,21 @@ Every claim must end in exactly one of:
 
 The kanban kernel enforces that exactly one of these terminates each run. A worker that calls neither and exits normally is treated as crashed.
 
-## Outputs and the review-required convention
+## Outputs and code-review routing
 
-For most code-changing tasks, the work isn't truly *done* the moment the worker finishes — it needs a human reviewer. The kanban kernel doesn't enforce this distinction (a "code-changing task" is fuzzy and forcing block-instead-of-complete on every code worker would break flows where no review is wanted). It's a convention layered on top:
+Coding workers are expected to self-verify with automated checks/tests and then
+complete with a structured handoff. Routine technical code review should stay
+inside the agent system rather than becoming a human-facing block:
 
-- **Block instead of complete**, with `reason` prefixed `review-required: ` so the dashboard / `hermes kanban show` surfaces the row as awaiting review.
-- **Drop structured metadata into a `kanban_comment` first** since `kanban_block` only carries the human-readable `reason`. Comments are the durable annotation channel — every audit-relevant field (changed_files, tests_run, diff_path or PR url, decisions) belongs there.
-- **Reviewer either approves and unblocks**, which respawns the worker with the comment thread for follow-ups; or asks for changes via another comment, which the next worker run sees as part of `kanban_show`'s context.
+- **Complete the implementation task** with `kanban_complete(summary=..., metadata=...)`, including audit fields such as `changed_files`, `tests_run`, `diff_path` or PR url, decisions, and residual risk.
+- **Create a reviewer-agent child card** with `kanban_create(..., assignee=<reviewer_profile>, parents=[...])` when independent review is required by policy or useful for confidence.
+- **Reserve `kanban_block` for human product/business/requirements ambiguity.** Permission choices use configured defaults unless the task explicitly instructs the worker to ask.
 
-The [`kanban-worker`](https://github.com/NousResearch/hermes-agent/blob/main/skills/devops/kanban-worker/SKILL.md) skill has worked examples for both `kanban_complete` (truly terminal tasks — typo fixes, docs changes, research writeups) and the `review-required` block pattern.
+The legacy `review-required:` human-block convention is only for deployments that
+explicitly set `kanban.code_review.mode: human_review` and
+`kanban.code_review.human_blocks_for_code_review: true`.
+
+The [`kanban-worker`](https://github.com/NousResearch/hermes-agent/blob/main/skills/devops/kanban-worker/SKILL.md) skill has worked examples for implementation handoffs and review-agent child cards.
 
 ## Logs and audit trail
 

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -190,7 +190,33 @@ up on the next tick (60s by default).
 kanban:
   dispatch_in_gateway: true        # default
   dispatch_interval_seconds: 60    # default
+  code_review:
+    mode: ai_reviewer              # ai_reviewer | self_verify | human_review
+    reviewer_profile: reviewer     # profile assigned child review cards
+    require_for_coding_tasks: true
+    human_blocks_for_code_review: false
+    permission_mode: default       # use configured defaults unless instructed
 ```
+
+By default, coding workers do not block the human operator for routine technical
+code review. They run the relevant checks/tests themselves and, when independent
+review is required, create a child review task assigned to `reviewer_profile`.
+Human-facing `kanban_block` calls should be reserved for product intent,
+business-priority, or requirements decisions that cannot be inferred. Permission
+choices follow the configured defaults unless the task explicitly instructs the
+worker to ask.
+
+The dispatcher also serializes this policy into worker subprocesses so assignee
+profiles see the same board-level behavior. Operator env overrides take
+precedence over config and are useful for temporary experiments:
+
+| Env var | Config field |
+|---|---|
+| `HERMES_KANBAN_CODE_REVIEW_MODE` | `kanban.code_review.mode` |
+| `HERMES_KANBAN_REVIEWER_PROFILE` | `kanban.code_review.reviewer_profile` |
+| `HERMES_KANBAN_REQUIRE_CODE_REVIEW` | `kanban.code_review.require_for_coding_tasks` |
+| `HERMES_KANBAN_HUMAN_CODE_REVIEW_BLOCKS` | `kanban.code_review.human_blocks_for_code_review` |
+| `HERMES_KANBAN_PERMISSION_MODE` | `kanban.code_review.permission_mode` |
 
 Override the config flag at runtime via `HERMES_KANBAN_DISPATCH_IN_GATEWAY=0`
 for debugging. Standard gateway supervision applies: run `hermes gateway

--- a/website/docs/user-guide/skills/bundled/devops/devops-kanban-worker.md
+++ b/website/docs/user-guide/skills/bundled/devops/devops-kanban-worker.md
@@ -54,39 +54,35 @@ The `kanban_complete(summary=..., metadata=...)` handoff is how downstream worke
 
 **Coding task:**
 ```python
+import os
+
+review = kanban_create(
+    title="Review rate limiter implementation",
+    assignee="reviewer",
+    parents=[os.environ["HERMES_KANBAN_TASK"]],
+    body="Please review changed files, tests, and residual risks from the implementation handoff.",
+)
+
 kanban_complete(
-    summary="shipped rate limiter — token bucket, keys on user_id with IP fallback, 14 tests pass",
+    summary="shipped rate limiter — token bucket, keys on user_id with IP fallback, 14 tests pass; review task created",
     metadata={
         "changed_files": ["rate_limiter.py", "tests/test_rate_limiter.py"],
         "tests_run": 14,
         "tests_passed": 14,
         "decisions": ["user_id primary, IP fallback for unauthenticated requests"],
+        "review_task_id": review["task_id"],
     },
+    created_cards=[review["task_id"]],
 )
 ```
 
-**Coding task that needs human review (review-required):**
-
-For most code-changing tasks, the work isn't truly *done* until a human reviewer has eyes on it. Block instead of complete, with `reason` prefixed `review-required: ` so the dashboard surfaces the row as needing review. Drop the structured metadata (changed files, test counts, diff/PR url) into a comment first, since `kanban_block` only carries the human-readable reason — comments are the durable annotation channel. Reviewer either approves and runs `hermes kanban unblock <id>` (which re-spawns you with the comment thread for any follow-ups) or asks for changes via another comment.
-
-```python
-import json
-
-kanban_comment(
-    body="review-required handoff:\n" + json.dumps({
-        "changed_files": ["rate_limiter.py", "tests/test_rate_limiter.py"],
-        "tests_run": 14,
-        "tests_passed": 14,
-        "diff_path": "/path/to/worktree",  # or PR url if pushed
-        "decisions": ["user_id primary, IP fallback for unauthenticated requests"],
-    }, indent=2),
-)
-kanban_block(
-    reason="review-required: rate limiter shipped, 14/14 tests pass — needs eyes on the user_id/IP fallback choice before merging",
-)
-```
-
-Use `kanban_complete` only when the task is genuinely terminal — e.g. a one-line typo fix, a docs change with no functional consequences, or a research task where the artifact IS the writeup itself.
+Coding workers own technical self-verification: run the relevant checks/tests,
+record changed files and residual risk, and create a reviewer-agent child card
+when independent review is needed or required by policy. Do not block the human
+operator for ordinary code review. Use `kanban_block` only for product intent,
+business-priority, or requirements decisions that cannot be inferred. Permission
+choices follow configured defaults unless the task explicitly instructs the
+worker to ask.
 
 **Research task:**
 ```python


### PR DESCRIPTION
## Summary
- Route Kanban coding-task review through agent policy instead of blocking the human operator for routine technical verification.
- Add `kanban.code_review` config plus `HERMES_KANBAN_CODE_REVIEW_*` env overrides for board/worker review mode, reviewer profile, permission mode, and human-blocking behavior.
- Propagate board-level review policy into dispatcher-spawned workers and update worker guidance/docs so agents self-verify or spawn reviewer-agent child tasks by default.

## Why
Kanban workers were treating code-review verification as a human operator responsibility, but the operator may be non-technical. The default workflow should reserve human blocks for product/business/access/risk approvals, while technical code review is handled by agents and tests.

## Verification
- `git diff --cached --check`
- Python compile check on changed Python modules
- `scripts/run_tests.sh tests/agent/test_prompt_builder.py tests/hermes_cli/test_config.py tests/hermes_cli/test_kanban_db.py -q` → 294 passed, 1 skipped
- Static staged-additions scan for hardcoded secrets, shell injection primitives, eval/exec, pickle loads, and SQL string formatting
- Independent agent review passed; follow-up suggestions applied where concrete
