### PR TITLE
fix(kanban): notify tool-created tasks (#25195)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -153,6 +153,7 @@ AUTHOR_MAP = {
     "20nik.nosov21@gmail.com": "nik1t7n",
     "thunderggnn@gmail.com": "ggnnggez",
     "haozhe4547@gmail.com": "ehz0ah",
+    "eloklam2002@gmail.com": "eloklam",
     "kevyan1998@gmail.com": "kyan12",
     "rylen.anil@gmail.com": "rylena",
     "godnanijatin@gmail.com": "jatingodnani",


### PR DESCRIPTION
Salvages #25195 by @eloklam.

Notify tool-created tasks (160 LOC) — bug fix wiring notifications through tool path.

Cherry-picked onto current main with original authorship preserved via rebase merge.