### PR TITLE
Add sharedSessions config for cross-session recall in Honcho plugin

### DIFF
--- a/plugins/memory/honcho/README.md
+++ b/plugins/memory/honcho/README.md
@@ -326,3 +326,32 @@ Presets:
   }
 }
 ```
+
+### Shared sessions: merging canonical content into recall
+
+When canonical knowledge lives in dedicated Honcho sessions populated by
+separate tooling (hydration pipelines, governance corpora, knowledge bases
+ingested out-of-band), the default per-thread session isolation hides that
+content from dialogue recall. Set `sharedSessions` to a list of session IDs
+to merge their context into the recall payload, in addition to the per-thread
+session resolved by `sessionStrategy` / `gateway_session_key`.
+
+```jsonc
+{
+  "workspace": "hermes",
+  "peerName": "user",
+  "aiPeer": "hermes",
+  "sessionStrategy": "per-directory",
+  "sharedSessions": ["governance-canonical", "knowledge-base-2026"]
+}
+```
+
+Each shared session contributes its `summary` (if Honcho has built one) and
+last 5 messages. Results land under the `shared_context` key returned by
+`get_session_context`. The `honcho_context` tool renders them under a
+`## Shared canonical context` section so consumers can distinguish active-session
+content from shared content.
+
+Each shared-session lookup is isolated in try/except: a failed fetch logs at
+debug level and falls through; other shared sessions still contribute. Default
+is an empty list — no behavior change for users who do not opt in.

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -1279,6 +1279,22 @@ class HonchoMemoryProvider(MemoryProvider):
                         for m in msgs[-5:]  # last 5 for brevity
                     )
                     parts.append(f"## Recent messages\n{msg_str}")
+                if ctx.get("shared_context"):
+                    shared_parts = []
+                    for s in ctx["shared_context"]:
+                        section = [f"### Shared session: {s.get('session_id', 'unknown')}"]
+                        if s.get("summary"):
+                            section.append(f"Summary: {s['summary'][:500]}")
+                        if s.get("recent_messages"):
+                            msgs = s["recent_messages"]
+                            section.append("Messages:")
+                            section.extend(
+                                f"  [{m['role']}] {m['content'][:200]}"
+                                for m in msgs[-3:]
+                            )
+                        shared_parts.append("\n".join(section))
+                    if shared_parts:
+                        parts.append("## Shared canonical context\n" + "\n\n".join(shared_parts))
                 return json.dumps({"result": "\n\n".join(parts) or "No context available."})
 
             elif tool_name == "honcho_conclude":

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -315,6 +315,12 @@ class HonchoClientConfig:
     session_strategy: str = "per-directory"
     session_peer_prefix: bool = False
     sessions: dict[str, str] = field(default_factory=dict)
+    # Shared sessions: optional list of additional Honcho session IDs whose
+    # context is merged into recall. Use this to make canonical / hydrated
+    # content (e.g. governance docs, knowledge corpora ingested by separate
+    # tooling) available to dialogue recall without changing per-thread
+    # session isolation. Default empty (no behavior change).
+    shared_sessions: list[str] = field(default_factory=list)
     # Raw global config for anything else consumers need
     raw: dict[str, Any] = field(default_factory=dict)
     # True when Honcho was explicitly configured for this host (hosts.hermes
@@ -538,6 +544,7 @@ class HonchoClientConfig:
                 host_block.get("observation") or raw.get("observation"),
             ),
             session_strategy=session_strategy,
+shared_sessions=raw.get("sharedSessions") or host_block.get("sharedSessions") or [],
             session_peer_prefix=session_peer_prefix,
             sessions=raw.get("sessions", {}),
             raw=raw,

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -133,6 +133,11 @@ class HonchoSessionManager:
         self._dialectic_max_input_chars: int = (
             config.dialectic_max_input_chars if config else 10000
         )
+        # Shared sessions: optional Honcho sessions whose context is merged
+        # into recall (cross-session retrieval for canonical / hydrated corpora).
+        self._shared_sessions: list[str] = list(
+            getattr(config, "shared_sessions", []) or []
+        )
 
         # Async write queue — started lazily on first enqueue
         self._async_queue: queue.Queue | None = None
@@ -963,6 +968,32 @@ class HonchoSessionManager:
                     {"role": getattr(m, "peer_id", "unknown"), "content": (m.content or "")[:500]}
                     for m in recent
                 ]
+
+            # Shared sessions: merge canonical / hydrated corpus context.
+            # Each shared session contributes its summary and recent messages
+            # to the recall payload under a labelled key so consumers can
+            # distinguish active-session content from shared content.
+            if self._shared_sessions:
+                shared = []
+                for shared_sid in self._shared_sessions:
+                    try:
+                        shared_session = self.honcho.session(shared_sid)
+                        shared_ctx = shared_session.context(summary=True)
+                        entry = {"session_id": shared_sid}
+                        if getattr(shared_ctx, "summary", None):
+                            entry["summary"] = shared_ctx.summary.content
+                        if getattr(shared_ctx, "messages", None):
+                            entry["recent_messages"] = [
+                                {"role": getattr(m, "peer_id", "unknown"),
+                                 "content": (m.content or "")[:500]}
+                                for m in shared_ctx.messages[-5:]
+                            ]
+                        if len(entry) > 1:
+                            shared.append(entry)
+                    except Exception as e:
+                        logger.debug("Shared session context fetch failed for %s: %s", shared_sid, e)
+                if shared:
+                    result["shared_context"] = shared
 
             return result
         except Exception as e:

--- a/tests/honcho_plugin/test_shared_sessions.py
+++ b/tests/honcho_plugin/test_shared_sessions.py
@@ -1,0 +1,182 @@
+"""Tests for the sharedSessions cross-session recall feature.
+
+Added in PR introducing `shared_sessions` config field on HonchoClientConfig.
+Exercises three paths:
+
+  1. Config default — `shared_sessions` defaults to empty list and the merge
+     path is a no-op.
+  2. Config with a shared session — `get_session_context` calls into the
+     shared session's `context()` method and merges the result under a
+     `shared_context` key.
+  3. Failure isolation — when a shared session's `context()` raises, the
+     exception is swallowed at debug level and other shared sessions still
+     contribute.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from plugins.memory.honcho.client import HonchoClientConfig
+from plugins.memory.honcho.session import HonchoSessionManager
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_message(peer_id: str, content: str) -> SimpleNamespace:
+    return SimpleNamespace(peer_id=peer_id, content=content)
+
+
+def _make_context(summary_text: str | None = None, messages: list | None = None) -> SimpleNamespace:
+    summary_obj = SimpleNamespace(content=summary_text) if summary_text else None
+    return SimpleNamespace(
+        summary=summary_obj,
+        peer_representation=None,
+        peer_card=None,
+        messages=messages or [],
+    )
+
+
+def _build_manager(shared_sessions: list[str]) -> HonchoSessionManager:
+    """Build a HonchoSessionManager with a mocked Honcho client + config."""
+    config = HonchoClientConfig(
+        host="hermes",
+        workspace_id="hermes",
+        peer_name="user",
+        ai_peer="assistant",
+        shared_sessions=shared_sessions,
+    )
+    honcho_mock = MagicMock()
+    return HonchoSessionManager(honcho=honcho_mock, config=config)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_shared_sessions_default_empty():
+    """Default config has empty shared_sessions; no merge work happens."""
+    config = HonchoClientConfig(host="hermes", workspace_id="hermes")
+    assert config.shared_sessions == []
+    assert isinstance(config.shared_sessions, list)
+
+    manager = HonchoSessionManager(config=config)
+    assert manager._shared_sessions == []
+
+
+def test_shared_sessions_field_accepts_explicit_list():
+    """Explicit list is preserved through dataclass init."""
+    config = HonchoClientConfig(
+        host="hermes",
+        workspace_id="hermes",
+        shared_sessions=["canonical-knowledge", "team-decisions"],
+    )
+    assert config.shared_sessions == ["canonical-knowledge", "team-decisions"]
+
+
+def test_get_session_context_merges_shared_session(monkeypatch):
+    """When shared_sessions is set and the current session resolves, the
+    result includes a shared_context entry for each configured session."""
+    manager = _build_manager(shared_sessions=["canonical"])
+
+    # Mock the current-session lookup so get_session_context proceeds.
+    current_session = SimpleNamespace(
+        honcho_session_id="current",
+        user_peer_id="user",
+        assistant_peer_id="assistant",
+    )
+    manager._cache["current"] = current_session
+
+    # Mock the honcho_session for the current session.
+    honcho_session_mock = MagicMock()
+    honcho_session_mock.context.return_value = _make_context(
+        summary_text="current session summary",
+        messages=[_make_message("user", "hello")],
+    )
+    manager._sessions_cache[current_session.honcho_session_id] = honcho_session_mock
+
+    # Mock the shared session lookup.
+    shared_session_mock = MagicMock()
+    shared_session_mock.context.return_value = _make_context(
+        summary_text="canonical content",
+        messages=[
+            _make_message("user", "Widget X uses protocol Y"),
+            _make_message("assistant", "noted"),
+        ],
+    )
+    manager.honcho.session = MagicMock(return_value=shared_session_mock)
+
+    result = manager.get_session_context("current", peer="user")
+
+    assert "shared_context" in result
+    assert len(result["shared_context"]) == 1
+    entry = result["shared_context"][0]
+    assert entry["session_id"] == "canonical"
+    assert entry["summary"] == "canonical content"
+    assert len(entry["recent_messages"]) == 2
+    assert entry["recent_messages"][0]["content"] == "Widget X uses protocol Y"
+
+
+def test_shared_session_exception_is_isolated(monkeypatch, caplog):
+    """A shared session raising during context() does not break the response,
+    and other shared sessions still contribute."""
+    manager = _build_manager(shared_sessions=["bad-id", "good-id"])
+
+    current_session = SimpleNamespace(
+        honcho_session_id="current",
+        user_peer_id="user",
+        assistant_peer_id="assistant",
+    )
+    manager._cache["current"] = current_session
+
+    honcho_session_mock = MagicMock()
+    honcho_session_mock.context.return_value = _make_context(summary_text="ok")
+    manager._sessions_cache[current_session.honcho_session_id] = honcho_session_mock
+
+    def session_factory(sid: str):
+        s = MagicMock()
+        if sid == "bad-id":
+            s.context.side_effect = RuntimeError("simulated network failure")
+        else:
+            s.context.return_value = _make_context(
+                summary_text="good content",
+                messages=[_make_message("user", "still works")],
+            )
+        return s
+
+    manager.honcho.session = MagicMock(side_effect=session_factory)
+
+    result = manager.get_session_context("current", peer="user")
+
+    # The good session contributed; the bad one was silently isolated.
+    assert "shared_context" in result
+    sids = [e["session_id"] for e in result["shared_context"]]
+    assert "good-id" in sids
+    assert "bad-id" not in sids
+
+
+def test_shared_sessions_empty_list_skips_merge_loop():
+    """Empty list means the merge code path is skipped entirely — result
+    does not contain a shared_context key."""
+    manager = _build_manager(shared_sessions=[])
+
+    current_session = SimpleNamespace(
+        honcho_session_id="current",
+        user_peer_id="user",
+        assistant_peer_id="assistant",
+    )
+    manager._cache["current"] = current_session
+
+    honcho_session_mock = MagicMock()
+    honcho_session_mock.context.return_value = _make_context(summary_text="ok")
+    manager._sessions_cache[current_session.honcho_session_id] = honcho_session_mock
+
+    result = manager.get_session_context("current", peer="user")
+    assert "shared_context" not in result


### PR DESCRIPTION
When sharedSessions is set in honcho.json, the plugin merges context from each listed Honcho session into the recall payload. Lets canonical / hydrated corpora populated by separate tooling be available to dialogue recall without changing per-thread session isolation.

Default: empty list (no behavior change).

- HonchoClientConfig: new shared_sessions field, parsed from sharedSessions
- HonchoMemoryManager: stores list, get_session_context merges shared session context as result[shared_context] = [{session_id, summary, recent_messages}, ...]
- honcho_context tool: renders shared_context under "Shared canonical context" section

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

## Description

### Problem

The Honcho plugin resolves a per-thread session ID for each chat (via `sessionStrategy: per-directory` or `gateway_session_key` for gateway platforms). Dialogue recall (`get_session_context`) reads from that session only. Canonical knowledge that lives in dedicated Honcho sessions populated by external tooling (hydration pipelines, governance corpora, knowledge bases ingested by separate processes) is invisible to Hermes during dialogue.

This is intentional behavior for chat isolation, but it blocks a real use case: operators who maintain canonical knowledge stores in Honcho want that content available to Hermes recall without breaking the per-thread isolation that protects user privacy across conversations.

### Solution

Add an opt-in `sharedSessions` config field to the honcho plugin. When set, the plugin merges context from each listed session into the recall payload, in addition to the per-thread session that's resolved by the existing logic.

```jsonc
// honcho.json
{
  "workspace": "hermes",
  "peerName": "user",
  "aiPeer": "hermes",
  "sessionStrategy": "per-directory",
  // NEW: optional list of additional sessions whose context is merged into recall
  "sharedSessions": ["governance-canonical", "knowledge-base-2026"]
}
```

Default: empty list. No behavior change for existing users.

### Code structure

Three files modified, ~54 lines added:

1. **`plugins/memory/honcho/client.py`** — `HonchoClientConfig` gains a `shared_sessions: list[str]` field. Parsed from `sharedSessions` in the JSON config (with `host_block` fallback consistent with other fields).

2. **`plugins/memory/honcho/session.py`** — `HonchoMemoryManager.__init__` stores `self._shared_sessions`. `get_session_context` calls `self.honcho.session(sid).context(summary=True)` for each shared session, extracts summary + recent messages, and appends to the result under a new `shared_context` key:
   ```python
   result["shared_context"] = [
       {"session_id": "...", "summary": "...", "recent_messages": [...]},
       ...
   ]
   ```

3. **`plugins/memory/honcho/__init__.py`** — The `honcho_context` tool renders `shared_context` under a labelled `## Shared canonical context` section so consumers can distinguish active-session content from shared content.

### Failure modes

Each shared session fetch is wrapped in try/except. A failed lookup (session doesn't exist, network blip, permissions) logs at debug level and falls through. No exception propagates to break the dialogue. Per-shared-session failures are isolated; one bad ID doesn't kill the whole recall.

### Backward compatibility

- New field defaults to `[]`.
- No change to existing recall, session resolution, observation, or write paths.
- Existing tests should continue to pass without modification.

### Use case (motivating the change)

The reporter maintains a self-hosted federated memory architecture where Cowork (Claude Desktop) writes session summaries to a canonical Honcho session via separate hydration tooling. With this change, the operator sets `sharedSessions: ["hermes-canonical"]` in `honcho.json` and Hermes-via-Discord can answer questions grounded in the Cowork-written corpus while still maintaining per-thread isolation for live chat conversations.

### Verification

Locally verified end-to-end:

1. Branch checked out: `feature/shared-sessions-recall`, commit `42d2962d4`.
2. Module imports clean: `from plugins.memory.honcho.client import HonchoClientConfig` shows the new field with default `[]`.
3. Config parses: `HonchoClientConfig.from_global_config()` correctly loads `sharedSessions: ["hermes"]` into `shared_sessions: ['hermes']`.
4. Gateway restarted with patched plugin, clean startup, single process.
5. Discord retest: `"What is MARKER_FEDARCH_REVIEW_LAVENDER?"` — Hermes responds `"The injected memory context confirms..."` and surfaces the marker from the shared session content, confirming the merge path is functioning.

### Optional follow-up

- Add a `sharedSessionsMaxMessages` int field if 5 recent messages per session isn't the right default for some operators.
- Consider plumbing the user's query through to `get_session_context` so each shared session can also do a semantic search instead of just returning the last N messages. Separate PR.
- Add tests under `tests/honcho_plugin/` exercising the merge path with mock Honcho sessions.

### Diff stat

```
 plugins/memory/honcho/__init__.py | 16 ++++++++++++++++
 plugins/memory/honcho/client.py   |  8 ++++++++
 plugins/memory/honcho/session.py  | 30 ++++++++++++++++++++++++++++++
 3 files changed, 54 insertions(+)
```

---

## How to submit

From the dell WSL shell with the feature branch checked out:

```bash
cd ~/.hermes/hermes-agent
# Push the branch to your own fork (you'll need to fork on GitHub first)
git remote add fork https://github.com/<your-username>/hermes-agent.git
git push fork feature/shared-sessions-recall

# Open the PR via GitHub web UI:
#   https://github.com/<your-username>/hermes-agent/pull/new/feature/shared-sessions-recall
# Target: NousResearch/hermes-agent main branch
# Use the title + description above
```

Or use `gh` if installed:

```bash
gh pr create \
  --repo NousResearch/hermes-agent \
  --head <your-username>:feature/shared-sessions-recall \
  --title "Add sharedSessions config for cross-session recall in Honcho plugin" \
  --body-file /mnt/c/Users/GrahamNewlon/Documents/Claude/Projects/Hermes\ Agent/hermes-agent-PR-description.md
```
