### PR TITLE
feat(kanban): surface per-task model_override in show + tool output (#26897)

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1319,6 +1319,8 @@ def _cmd_show(args: argparse.Namespace) -> int:
           (f" @ {task.workspace_path}" if task.workspace_path else ""))
     if task.skills:
         print(f"  skills:    {', '.join(task.skills)}")
+    if task.model_override:
+        print(f"  model:     {task.model_override}")
     # Effective retry threshold. Show the per-task override if set,
     # otherwise the dispatcher's resolved value from config (or the
     # default if config doesn't set it either). Helps operators see

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -232,6 +232,7 @@ def _task_summary_dict(kb, conn, task) -> dict[str, Any]:
         "started_at": task.started_at,
         "completed_at": task.completed_at,
         "current_run_id": task.current_run_id,
+        "model_override": task.model_override,
         "parents": parents,
         "children": children,
         "parent_count": len(parents),
@@ -275,6 +276,7 @@ def _handle_show(args: dict, **kw) -> str:
                     "completed_at": t.completed_at,
                     "result": t.result,
                     "current_run_id": t.current_run_id,
+                    "model_override": t.model_override,
                 }
 
             def _run_dict(r):


### PR DESCRIPTION
Salvages #26897 by @loicnico96.

The per-task `model_override` DB column already exists on main, but it wasn't exposed in user-facing surfaces. Adds:
- `hermes kanban show` prints `model: <name>` when `model_override` is set
- `kanban_show` and `kanban_list` tool responses include the `model_override` field

PR's branch was authored against an older field name (`model`); applied the substantive surface exposure manually using the current `model_override` field name. Authorship preserved via rebase merge.