### PR TITLE
fix(bedrock): bedrock.region in config.yaml should beat AWS_DEFAULT_REGION

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4284,24 +4284,26 @@ def _resolve_task_provider_model(
     model: str = None,
     base_url: str = None,
     api_key: str = None,
-) -> Tuple[str, Optional[str], Optional[str], Optional[str], Optional[str]]:
+) -> Tuple[str, Optional[str], Optional[str], Optional[str], Optional[str], Optional[str]]:
     """Determine provider + model for a call.
 
     Priority:
       1. Explicit provider/model/base_url/api_key args (always win)
-      2. Config file (auxiliary.{task}.provider/model/base_url)
+      2. Config file (auxiliary.{task}.provider/model/base_url/region)
       3. "auto" (full auto-detection chain)
 
-    Returns (provider, model, base_url, api_key, api_mode) where model may
-    be None (use provider default). When base_url is set, provider is forced
+    Returns (provider, model, base_url, api_key, api_mode, region) where model
+    may be None (use provider default). When base_url is set, provider is forced
     to "custom" and the task uses that direct endpoint. api_mode is one of
     "chat_completions", "codex_responses", or None (auto-detect).
+    region is only populated for providers like bedrock where it must be explicit.
     """
     cfg_provider = None
     cfg_model = None
     cfg_base_url = None
     cfg_api_key = None
     cfg_api_mode = None
+    cfg_region = None
 
     if task:
         task_config = _get_auxiliary_task_config(task)
@@ -4310,31 +4312,32 @@ def _resolve_task_provider_model(
         cfg_base_url = str(task_config.get("base_url", "")).strip() or None
         cfg_api_key = str(task_config.get("api_key", "")).strip() or None
         cfg_api_mode = str(task_config.get("api_mode", "")).strip() or None
+        cfg_region = str(task_config.get("region", "")).strip() or None
 
     resolved_model = model or cfg_model
     resolved_api_mode = cfg_api_mode
 
     if base_url:
-        return "custom", resolved_model, base_url, api_key, resolved_api_mode
+        return "custom", resolved_model, base_url, api_key, resolved_api_mode, None
     if provider:
-        return provider, resolved_model, base_url, api_key, resolved_api_mode
+        return provider, resolved_model, base_url, api_key, resolved_api_mode, None
 
     if task:
         # Config.yaml is the primary source for per-task overrides.
         if cfg_base_url and cfg_api_key:
             # Both base_url and api_key explicitly set → custom endpoint.
-            return "custom", resolved_model, cfg_base_url, cfg_api_key, resolved_api_mode
+            return "custom", resolved_model, cfg_base_url, cfg_api_key, resolved_api_mode, None
         if cfg_base_url and cfg_provider and cfg_provider != "auto":
             # base_url set without api_key but with a known provider — use
             # the provider so it can resolve credentials from env vars
             # (e.g. OPENROUTER_API_KEY) instead of locking into "custom".
-            return cfg_provider, resolved_model, cfg_base_url, None, resolved_api_mode
+            return cfg_provider, resolved_model, cfg_base_url, None, resolved_api_mode, None
         if cfg_provider and cfg_provider != "auto":
-            return cfg_provider, resolved_model, cfg_base_url, cfg_api_key, resolved_api_mode
+            return cfg_provider, resolved_model, cfg_base_url, cfg_api_key, resolved_api_mode, cfg_region
 
-        return "auto", resolved_model, None, None, resolved_api_mode
+        return "auto", resolved_model, None, None, resolved_api_mode, None
 
-    return "auto", resolved_model, None, None, resolved_api_mode
+    return "auto", resolved_model, None, None, resolved_api_mode, None
 
 
 _DEFAULT_AUX_TIMEOUT = 30.0
@@ -4605,7 +4608,7 @@ def call_llm(
     Raises:
         RuntimeError: If no provider is configured.
     """
-    resolved_provider, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _resolve_task_provider_model(
+    resolved_provider, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode, resolved_region = _resolve_task_provider_model(
         task, provider, model, base_url, api_key)
     effective_extra_body = _get_task_extra_body(task)
     effective_extra_body.update(extra_body or {})
@@ -4634,6 +4637,26 @@ def call_llm(
                 f"Run: hermes setup"
             )
         resolved_provider = effective_provider or resolved_provider
+    elif resolved_provider == "bedrock" and resolved_region:
+        # auxiliary.{task}.region is explicitly set in config — build the
+        # Bedrock client directly with that region, bypassing
+        # resolve_bedrock_region() which reads AWS_REGION/AWS_DEFAULT_REGION
+        # env vars and would pick the wrong region on ECS/cloud deployments
+        # where the container region differs from the Bedrock region.
+        try:
+            from agent.anthropic_adapter import build_anthropic_bedrock_client
+            real_client = build_anthropic_bedrock_client(resolved_region)
+            final_model = resolved_model or "anthropic.claude-haiku-4-5-20251001-v1:0"
+            client = AnthropicAuxiliaryClient(
+                real_client, final_model, api_key="aws-sdk",
+                base_url=f"https://bedrock-runtime.{resolved_region}.amazonaws.com",
+            )
+            logger.debug("Auxiliary %s: bedrock client built with explicit region %s",
+                         task or "call", resolved_region)
+        except Exception as exc:
+            logger.warning("Auxiliary %s: failed to build bedrock client with region %s: %s",
+                           task or "call", resolved_region, exc)
+            client, final_model = None, resolved_model
     else:
         client, final_model = _get_cached_client(
             resolved_provider,

--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -305,10 +305,14 @@ def resolve_bedrock_region(env: Optional[Dict[str, str]] = None) -> str:
     """Resolve the AWS region for Bedrock API calls.
 
     Priority:
-      1. AWS_REGION env var
-      2. AWS_DEFAULT_REGION env var
-      3. boto3/botocore configured region (from ~/.aws/config or SSO profile)
-      4. us-east-1 (hard fallback)
+      1. AWS_REGION env var (explicit override, highest priority)
+      2. bedrock.region from config.yaml (user-configured Bedrock region;
+         beats AWS_DEFAULT_REGION so that cloud deployments where the host
+         region differs from the Bedrock region — e.g. ECS in ap-southeast-1
+         calling Bedrock in us-east-1 — work without touching env vars)
+      3. AWS_DEFAULT_REGION env var
+      4. boto3/botocore configured region (from ~/.aws/config or SSO profile)
+      5. us-east-1 (hard fallback)
 
     The boto3 fallback is critical for EU/AP users who configure their region
     in ~/.aws/config via a named profile rather than env vars — without it,
@@ -316,12 +320,27 @@ def resolve_bedrock_region(env: Optional[Dict[str, str]] = None) -> str:
     the user's actual region.
     """
     env = env if env is not None else os.environ
-    explicit = (
-        env.get("AWS_REGION", "").strip()
-        or env.get("AWS_DEFAULT_REGION", "").strip()
-    )
-    if explicit:
-        return explicit
+    # AWS_REGION is an explicit user override — always wins.
+    aws_region = env.get("AWS_REGION", "").strip()
+    if aws_region:
+        return aws_region
+    # bedrock.region in config.yaml beats the ambient AWS_DEFAULT_REGION so
+    # that deployments where the host region (e.g. ap-southeast-1 on ECS) is
+    # different from the Bedrock region (us-east-1) work without touching env.
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        cfg_region = (
+            (cfg.get("bedrock") or {}).get("region", "").strip()
+            if isinstance(cfg, dict) else ""
+        )
+        if cfg_region:
+            return cfg_region
+    except Exception:
+        pass
+    aws_default = env.get("AWS_DEFAULT_REGION", "").strip()
+    if aws_default:
+        return aws_default
     try:
         import botocore.session
         region = botocore.session.get_session().get_config_variable("region")

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -149,6 +149,48 @@ class TestResolveBedrocRegion:
         with _mock_botocore_session(side_effect=Exception("no botocore")):
             assert resolve_bedrock_region({}) == "us-east-1"
 
+    def test_config_region_beats_aws_default_region(self):
+        """bedrock.region in config.yaml should override AWS_DEFAULT_REGION.
+
+        This covers ECS/cloud deployments where the container's ambient region
+        (e.g. ap-southeast-1) differs from the Bedrock region (us-east-1).
+        Without this, auxiliary Bedrock calls routed to the wrong region and
+        returned HTTP 400 / invalid model identifier errors.
+        """
+        from agent.bedrock_adapter import resolve_bedrock_region
+        from unittest.mock import patch, MagicMock
+        mock_session = MagicMock()
+        mock_session.get_config_variable.return_value = None
+        fake_config = {"bedrock": {"region": "us-east-1"}}
+        with _mock_botocore_session(return_value=mock_session):
+            with patch("hermes_cli.config.load_config", return_value=fake_config):
+                # AWS_DEFAULT_REGION simulates the ECS container ambient region
+                result = resolve_bedrock_region({"AWS_DEFAULT_REGION": "ap-southeast-1"})
+        assert result == "us-east-1"
+
+    def test_aws_region_beats_config_region(self):
+        """AWS_REGION env var (explicit) must still take highest priority."""
+        from agent.bedrock_adapter import resolve_bedrock_region
+        from unittest.mock import patch, MagicMock
+        mock_session = MagicMock()
+        mock_session.get_config_variable.return_value = None
+        fake_config = {"bedrock": {"region": "us-east-1"}}
+        with _mock_botocore_session(return_value=mock_session):
+            with patch("hermes_cli.config.load_config", return_value=fake_config):
+                result = resolve_bedrock_region({"AWS_REGION": "eu-west-1"})
+        assert result == "eu-west-1"
+
+    def test_config_load_failure_falls_through_gracefully(self):
+        """If load_config raises, we fall through to AWS_DEFAULT_REGION."""
+        from agent.bedrock_adapter import resolve_bedrock_region
+        from unittest.mock import patch, MagicMock
+        mock_session = MagicMock()
+        mock_session.get_config_variable.return_value = None
+        with _mock_botocore_session(return_value=mock_session):
+            with patch("hermes_cli.config.load_config", side_effect=Exception("no config")):
+                result = resolve_bedrock_region({"AWS_DEFAULT_REGION": "ap-southeast-1"})
+        assert result == "ap-southeast-1"
+
 
 # ---------------------------------------------------------------------------
 # Tool conversion


### PR DESCRIPTION
## Problem

In cloud deployments where the host region differs from the Bedrock region — e.g. an ECS task running in `ap-southeast-1` calling Bedrock models hosted in `us-east-1` — `resolve_bedrock_region()` was picking up the container's ambient `AWS_DEFAULT_REGION=ap-southeast-1` env var instead of the user-configured `bedrock.region: us-east-1` in `config.yaml`.

This caused all auxiliary task calls (title generation, vision, compression, session_search) to route to the wrong Bedrock endpoint and fail with:
```
HTTP 400: The provided model identifier is invalid
```

The `region: us-east-1` key under each `auxiliary.*` task in config.yaml was already documented as a workaround but was also silently ignored — it was never wired into `resolve_provider_client`.

## Fix

Insert a `config.yaml` lookup between `AWS_REGION` (still highest) and `AWS_DEFAULT_REGION` in `resolve_bedrock_region()`'s priority chain:

| Priority | Source |
|---|---|
| 1 | `AWS_REGION` env var (explicit override, unchanged) |
| 2 | `bedrock.region` from `config.yaml` (**new**) |
| 3 | `AWS_DEFAULT_REGION` env var |
| 4 | boto3/botocore profile region |
| 5 | `us-east-1` fallback |

The config lookup is wrapped in a broad `try/except` so any import or parse failure falls through silently — no regression risk for non-Bedrock users.

## Tests

Added 3 new test cases to `TestResolveBedrocRegion`:
- `test_config_region_beats_aws_default_region` — the core fix
- `test_aws_region_beats_config_region` — `AWS_REGION` still wins
- `test_config_load_failure_falls_through_gracefully` — safe fallthrough

All 8 tests in the class pass.