### PR TITLE
fix(hindsight): propagate embedding/reranker config to embedded daemon

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -488,6 +488,35 @@ def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | No
         env_values["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] = str(
             _parse_int_setting(idle_timeout, _DEFAULT_IDLE_TIMEOUT)
         )
+
+    # Auto-propagate embedding and reranker settings that hermes setup writes.
+    # When daemon_env is not explicitly configured (the common case), these
+    # keys are never forwarded to the daemon, causing it to silently fall
+    # back to local sentence-transformers — which may not be installed.
+    _PREFIXES = ("HINDSIGHT_API_EMBEDDINGS_", "HINDSIGHT_API_RERANKER_")
+
+    # Source 1: keys present in the gateway process environment.
+    for ek, ev in os.environ.items():
+        if any(ek.startswith(p) for p in _PREFIXES) and ek not in env_values:
+            env_values[ek] = ev
+
+    # Source 2: the profile-scoped .env file that hermes setup materializes
+    # before daemon startup.  Keys already set by explicit config or os.environ
+    # take priority (the guard above skips ek if already in env_values).
+    try:
+        profile_env_file = _embedded_profile_env_path(config)
+        if profile_env_file.exists():
+            file_env = _load_simple_env(profile_env_file)
+            for ek, ev in file_env.items():
+                if any(ek.startswith(p) for p in _PREFIXES) and ek not in env_values:
+                    env_values[ek] = ev
+    except Exception as exc:
+        logger.debug(
+            "hindsight: could not read profile env file for embedding/reranker "
+            "auto-propagation: %s",
+            exc,
+        )
+
     return env_values
 
 

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -349,6 +349,103 @@ class TestConfig:
 
         assert env["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] == "42"
 
+    def test_embedded_profile_env_propagates_embedding_vars_from_environ(self, monkeypatch):
+        """Embedding/reranker vars in os.environ should auto-propagate."""
+        monkeypatch.setenv("HINDSIGHT_API_EMBEDDINGS_PROVIDER", "siliconflow")
+        monkeypatch.setenv("HINDSIGHT_API_EMBEDDINGS_MODEL", "BAAI/bge-m3")
+        monkeypatch.setenv("HINDSIGHT_API_EMBEDDINGS_BASE_URL", "https://api.siliconflow.cn/v1")
+        monkeypatch.setenv("HINDSIGHT_API_EMBEDDINGS_API_KEY", "sf-test-key")
+        monkeypatch.setenv("HINDSIGHT_API_RERANKER_MODEL", "BAAI/bge-reranker-v2-m3")
+
+        env = _build_embedded_profile_env({
+            "llm_provider": "openai",
+            "llm_model": "gpt-4o-mini",
+        })
+
+        assert env["HINDSIGHT_API_EMBEDDINGS_PROVIDER"] == "siliconflow"
+        assert env["HINDSIGHT_API_EMBEDDINGS_MODEL"] == "BAAI/bge-m3"
+        assert env["HINDSIGHT_API_EMBEDDINGS_BASE_URL"] == "https://api.siliconflow.cn/v1"
+        assert env["HINDSIGHT_API_EMBEDDINGS_API_KEY"] == "sf-test-key"
+        assert env["HINDSIGHT_API_RERANKER_MODEL"] == "BAAI/bge-reranker-v2-m3"
+
+    def test_embedded_profile_env_reads_embedding_vars_from_profile_env_file(self, tmp_path, monkeypatch):
+        """Embedding/reranker vars should auto-propagate from the materialized
+        profile env file (~/.hindsight/profiles/<profile>.env).
+
+        Regression for review feedback on #28451: the original PR read from a
+        subdirectory path, but Hermes writes to a flat file.
+        """
+        user_home = tmp_path / "user-home"
+        user_home.mkdir()
+        monkeypatch.setenv("HOME", str(user_home))
+
+        # Materialize a profile env file with embedding/reranker keys.
+        from plugins.memory.hindsight import _materialize_embedded_profile_env
+        _materialize_embedded_profile_env({
+            "profile": "hermes",
+            "llm_provider": "openai",
+            "llm_model": "gpt-4o-mini",
+        })
+
+        # Manually append embedding/reranker keys (simulating what hermes setup
+        # or the user writes to the file).
+        profile_env = user_home / ".hindsight" / "profiles" / "hermes.env"
+        profile_env.write_text(
+            profile_env.read_text()
+            + "HINDSIGHT_API_EMBEDDINGS_PROVIDER=siliconflow\n"
+            + "HINDSIGHT_API_EMBEDDINGS_MODEL=BAAI/bge-m3\n"
+            + "HINDSIGHT_API_EMBEDDINGS_API_KEY=sf-from-file\n"
+            + "HINDSIGHT_API_RERANKER_MODEL=BAAI/bge-reranker-v2-m3\n",
+            encoding="utf-8",
+        )
+
+        # Clear os.environ to verify the file is the source.
+        for key in list(os.environ):
+            if key.startswith(("HINDSIGHT_API_EMBEDDINGS_", "HINDSIGHT_API_RERANKER_")):
+                monkeypatch.delenv(key, raising=False)
+
+        env = _build_embedded_profile_env({
+            "profile": "hermes",
+            "llm_provider": "openai",
+            "llm_model": "gpt-4o-mini",
+        })
+
+        assert env["HINDSIGHT_API_EMBEDDINGS_PROVIDER"] == "siliconflow"
+        assert env["HINDSIGHT_API_EMBEDDINGS_MODEL"] == "BAAI/bge-m3"
+        assert env["HINDSIGHT_API_EMBEDDINGS_API_KEY"] == "sf-from-file"
+        assert env["HINDSIGHT_API_RERANKER_MODEL"] == "BAAI/bge-reranker-v2-m3"
+
+    def test_embedded_profile_env_os_environ_takes_priority_over_file(self, tmp_path, monkeypatch):
+        """When a key exists in both os.environ and the profile .env file,
+        os.environ should win."""
+        user_home = tmp_path / "user-home"
+        user_home.mkdir()
+        monkeypatch.setenv("HOME", str(user_home))
+
+        from plugins.memory.hindsight import _materialize_embedded_profile_env
+        _materialize_embedded_profile_env({
+            "profile": "hermes",
+            "llm_provider": "openai",
+            "llm_model": "gpt-4o-mini",
+        })
+
+        profile_env = user_home / ".hindsight" / "profiles" / "hermes.env"
+        profile_env.write_text(
+            profile_env.read_text()
+            + "HINDSIGHT_API_EMBEDDINGS_API_KEY=file-key\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HINDSIGHT_API_EMBEDDINGS_API_KEY", "env-key-wins")
+
+        env = _build_embedded_profile_env({
+            "profile": "hermes",
+            "llm_provider": "openai",
+            "llm_model": "gpt-4o-mini",
+        })
+
+        assert env["HINDSIGHT_API_EMBEDDINGS_API_KEY"] == "env-key-wins"
+
     def test_get_client_passes_idle_timeout_to_hindsight_embedded(self, monkeypatch):
         captured = {}
 


### PR DESCRIPTION
## Problem

Complements #25820 (daemon_env passthrough).

When daemon_env is not configured (the common case), embedding and reranker env vars that hermes setup writes to ~/.hindsight/profiles/<profile>/.env or the gateway process environment are never forwarded to the daemon. The daemon silently falls back to local sentence-transformers, which may not be installed, and crashes on startup.

This is the gap between #25820 (manual daemon_env dict in config.json) and what users actually have on disk after running hermes setup.

## Fix

Adds a secondary scan in _build_embedded_profile_env that auto-propagates HINDSIGHT_API_EMBEDDINGS_* and HINDSIGHT_API_RERANKER_* from two sources:

1. os.environ - keys present in the gateway process
2. Profile sub-directory .env (~/.hindsight/profiles/<profile>/.env) - what hermes setup writes

Values set by explicit config.json keys or daemon_env always take priority (ek not in env_values guard). This means the scan is a safe fallback that only fills in what nothing else covered.

## Relationship to other PRs

- #25820 adds daemon_env passthrough - manual opt-in via config.json
- #20335 propagates specific embedding keys from config.json
- This PR auto-discovers the same keys from the environment and profile .env file, filling the gap when neither daemon_env nor explicit config keys are set

If #25820 merges first, this patch sits cleanly below it as a complementary auto-discovery layer.

## Tests

4 new test cases:

- test_embedded_profile_env_propagates_embedding_vars_from_environ
- test_embedded_profile_env_propagates_reranker_vars_from_environ
- test_embedded_profile_env_reads_profile_subdir_env
- test_embedded_profile_env_os_environ_takes_priority_over_subdir