### PR TITLE
fix(kanban): remove orphan conflict markers from config.py

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1530,7 +1530,6 @@ DEFAULT_CONFIG = {
         # same task/profile (spawn_failed, timed_out, or crashed). Reassignment
         # resets the streak for the new profile.
         "failure_limit": 2,
-<<<<<<< HEAD
         # Worker stdout/stderr logs rotate at spawn time. Defaults preserve
         # the historical 2 MiB + one-backup behavior; long-running workers can
         # raise these to keep more early failure evidence.
@@ -1555,14 +1554,12 @@ DEFAULT_CONFIG = {
         # large bulk-load of triage tasks from spending a burst of aux
         # LLM calls in one tick. Excess tasks defer to the next tick.
         "auto_decompose_per_tick": 3,
-=======
         # Stale detection: running tasks that have exceeded this many
         # seconds without a heartbeat (since ``last_heartbeat_at``) are
         # auto-reclaimed to ``ready`` on the next dispatcher tick. The
         # worker process (if still running host-locally) is terminated
         # before the reclaim.  0 disables stale detection entirely.
         "dispatch_stale_timeout_seconds": 14400,
->>>>>>> 0b6d673e7 (feat(kanban): stale detection for running tasks in dispatcher)
     },
 
     # execute_code settings — controls the tool used for programmatic tool calls.


### PR DESCRIPTION
PR #28452 (salvage of #23790) merged with leftover git conflict markers in `hermes_cli/config.py` around the `dispatch_stale_timeout_seconds` block, breaking config import. This patch cleans them up and keeps both config blocks. Self-fix for a regression I introduced earlier in the kanban-PR salvage batch.

Validation: `python -c 'import ast; ast.parse(open("hermes_cli/config.py").read())'` passes; cron-profile tests pass.