### PR TITLE
fix: restrict kanban worker toolsets

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4320,6 +4320,13 @@ def _default_spawn(
                 cmd.extend(["--skills", sk])
     cmd.extend([
         "chat",
+        # Keep dispatcher-spawned workers lean enough for local models.
+        # Kanban workers need terminal/file for implementation work and
+        # kanban to report completion/blocking. Loading the default CLI
+        # toolset includes the full skills catalogue and many extra tool
+        # schemas, which pushed tiny local-coder smoke tasks to ~25k input
+        # tokens on llama.cpp.
+        "-t", "terminal,file,kanban",
         "-q", prompt,
     ])
     # Redirect output to a per-task log under <board-root>/logs/.

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -2699,6 +2699,11 @@ def test_default_spawn_auto_loads_kanban_worker_skill(kanban_home, monkeypatch):
     assert cmd[idx + 1] == "kanban-worker", (
         f"expected 'kanban-worker', got {cmd[idx + 1]!r}"
     )
+    # Worker toolsets are restricted so local model dispatches do not load
+    # the full default CLI context / skills catalogue for every card.
+    assert "-t" in cmd, f"spawn argv missing restricted toolsets: {cmd}"
+    toolset_idx = cmd.index("-t")
+    assert cmd[toolset_idx + 1] == "terminal,file,kanban"
     # Assignee + task env are still present
     assert "some-profile" in cmd
     env = captured["env"]


### PR DESCRIPTION
## Summary
- restrict dispatcher-spawned Kanban workers to terminal,file,kanban toolsets
- add regression assertion for the restricted worker toolset
- reduces local llama.cpp worker prompt bloat from default skills/tool context

## Test Plan
- ./venv/bin/python -m py_compile hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_core_functionality.py
- ./venv/bin/python -m pytest tests/hermes_cli/test_kanban_core_functionality.py::test_default_spawn_auto_loads_kanban_worker_skill tests/hermes_cli/test_kanban_core_functionality.py::test_default_spawn_appends_per_task_skills tests/hermes_cli/test_kanban_core_functionality.py::test_default_spawn_dedupes_kanban_worker_from_task_skills -q -o 'addopts='