### PR TITLE
fix(kanban): create additive-column indexes after migration

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -865,8 +865,6 @@ CREATE TABLE IF NOT EXISTS tasks (
     session_id           TEXT
 );
 
-CREATE INDEX IF NOT EXISTS idx_tasks_session_id ON tasks(session_id);
-
 CREATE TABLE IF NOT EXISTS task_links (
     parent_id  TEXT NOT NULL,
     child_id   TEXT NOT NULL,
@@ -943,7 +941,6 @@ CREATE INDEX IF NOT EXISTS idx_links_child           ON task_links(child_id);
 CREATE INDEX IF NOT EXISTS idx_links_parent          ON task_links(parent_id);
 CREATE INDEX IF NOT EXISTS idx_comments_task         ON task_comments(task_id, created_at);
 CREATE INDEX IF NOT EXISTS idx_events_task           ON task_events(task_id, created_at);
-CREATE INDEX IF NOT EXISTS idx_events_run            ON task_events(run_id, id);
 CREATE INDEX IF NOT EXISTS idx_runs_task             ON task_runs(task_id, started_at);
 CREATE INDEX IF NOT EXISTS idx_runs_status           ON task_runs(status);
 CREATE INDEX IF NOT EXISTS idx_notify_task           ON kanban_notify_subs(task_id);
@@ -1170,24 +1167,30 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         # created from within an agent loop that propagated
         # ``HERMES_SESSION_ID`` (e.g. ACP). NULL on legacy rows and on any
         # creation path that doesn't set the env var (CLI, dashboard).
-        # Index keeps per-session list queries cheap.
         _add_column_if_missing(
             conn, "tasks", "session_id", "session_id TEXT"
         )
-        conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_tasks_session_id "
-            "ON tasks(session_id)"
-        )
+    # Keep this index outside the additive-column branch so fresh databases
+    # (where SCHEMA_SQL already created the column) and legacy databases both
+    # get it. Do not put it in SCHEMA_SQL before migrations: old task tables
+    # without session_id would fail executescript() before the ALTER runs.
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_tasks_session_id "
+        "ON tasks(session_id)"
+    )
 
     # task_events gained a run_id column; back-fill it as NULL for
     # historical events (they predate runs and can't be attributed).
     ev_cols = {row["name"] for row in conn.execute("PRAGMA table_info(task_events)")}
     if "run_id" not in ev_cols:
         _add_column_if_missing(conn, "task_events", "run_id", "run_id INTEGER")
-        conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_events_run "
-            "ON task_events(run_id, id)"
-        )
+    # Same ordering rule as idx_tasks_session_id: create the index after the
+    # additive column migration so legacy task_events tables don't fail during
+    # SCHEMA_SQL execution before run_id exists.
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_events_run "
+        "ON task_events(run_id, id)"
+    )
 
     notify_table_exists = conn.execute(
         "SELECT name FROM sqlite_master WHERE type='table' AND name='kanban_notify_subs'"

--- a/tests/hermes_cli/test_kanban_db_init.py
+++ b/tests/hermes_cli/test_kanban_db_init.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sqlite3
 import threading
 from pathlib import Path
 
@@ -36,3 +37,74 @@ def test_connect_initialization_is_thread_safe(tmp_path, monkeypatch):
     with kb.connect(board="default") as conn:
         cols = {row["name"] for row in conn.execute("PRAGMA table_info(tasks)")}
     assert "max_retries" in cols
+
+
+def test_connect_migrates_legacy_indexed_columns_before_indexes(tmp_path):
+    """Legacy DBs missing additive indexed columns should migrate cleanly.
+
+    SCHEMA_SQL runs before the additive ALTER TABLE pass. Indexes over
+    additive columns therefore must be created after the migration creates
+    those columns, or old boards fail to open before migration can run.
+    """
+    db_path = tmp_path / "legacy-kanban.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE tasks (
+            id TEXT PRIMARY KEY,
+            title TEXT NOT NULL,
+            body TEXT,
+            assignee TEXT,
+            status TEXT NOT NULL,
+            priority INTEGER DEFAULT 0,
+            created_by TEXT,
+            created_at INTEGER NOT NULL,
+            started_at INTEGER,
+            completed_at INTEGER,
+            workspace_kind TEXT NOT NULL DEFAULT 'scratch',
+            workspace_path TEXT,
+            claim_lock TEXT,
+            claim_expires INTEGER,
+            tenant TEXT,
+            result TEXT,
+            idempotency_key TEXT,
+            consecutive_failures INTEGER NOT NULL DEFAULT 0,
+            worker_pid INTEGER,
+            last_failure_error TEXT,
+            max_runtime_seconds INTEGER,
+            last_heartbeat_at INTEGER,
+            current_run_id INTEGER,
+            workflow_template_id TEXT,
+            current_step_key TEXT,
+            skills TEXT,
+            model_override TEXT,
+            max_retries INTEGER
+        );
+        CREATE TABLE task_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            task_id TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            payload TEXT,
+            created_at INTEGER NOT NULL
+        );
+        """
+    )
+    conn.close()
+
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    with kb.connect(db_path) as migrated:
+        task_cols = {row["name"] for row in migrated.execute("PRAGMA table_info(tasks)")}
+        event_cols = {
+            row["name"] for row in migrated.execute("PRAGMA table_info(task_events)")
+        }
+        indexes = {
+            row["name"]
+            for row in migrated.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'index'"
+            )
+        }
+
+    assert "session_id" in task_cols
+    assert "run_id" in event_cols
+    assert "idx_tasks_session_id" in indexes
+    assert "idx_events_run" in indexes


### PR DESCRIPTION
## Summary

Fixes #28464.

Fixes a Kanban DB migration ordering bug that can crash `hermes dashboard` or any Kanban board load for users with an existing/legacy `kanban.db`.

`connect()` runs `SCHEMA_SQL` before `_migrate_add_optional_columns()`. The schema currently creates indexes on additive columns (`tasks.session_id` and `task_events.run_id`) before legacy tables have those columns. On an older board DB, SQLite aborts schema initialization before the migration can add the missing column:

```text
sqlite3.OperationalError: no such column: session_id
```

This moves the indexes for additive columns out of `SCHEMA_SQL` and creates them after the additive migration has guaranteed the columns exist.

## What changed

- Move `idx_tasks_session_id` creation from `SCHEMA_SQL` to `_migrate_add_optional_columns()` after `tasks.session_id` is added if missing.
- Move `idx_events_run` creation from `SCHEMA_SQL` to `_migrate_add_optional_columns()` after `task_events.run_id` is added if missing.
- Add a regression test that starts with a legacy DB missing both additive indexed columns and verifies `connect()` migrates it successfully and creates both indexes.

## Why

Fresh DBs are fine because the additive columns are present when the schema creates the indexes. Existing boards from before these columns were added can fail before migration runs. This is especially visible through the Kanban dashboard plugin because `/api/plugins/kanban/board` opens the board DB during page load.

## Validation

Confirmed the issue against `origin/main` by applying its `SCHEMA_SQL` to a legacy DB shape:

```text
origin/main reproduces: OperationalError no such column: session_id
```

Confirmed this branch migrates the same legacy DB and preserves the expected indexes:

```text
current fix: True True True True
# session_id column, run_id column, idx_tasks_session_id, idx_events_run
```

Ran the focused regression test:

```text
python -m pytest tests/hermes_cli/test_kanban_db_init.py -q
2 passed
```

Also verified local real board DBs migrated/opened successfully after the fix:

```text
OK .hermes/kanban.db: session_id=True idx=True
OK .hermes/kanban/boards/cores-mech-wars/kanban.db: session_id=True idx=True
OK .hermes/kanban/boards/donkey-demo/kanban.db: session_id=True idx=True
OK .hermes/kanban/boards/osint-project/kanban.db: session_id=True idx=True
OK .hermes/kanban/boards/real-project/kanban.db: session_id=True idx=True
```


## Suggested Labels

- `type/bug`
- Kanban / migration area label if maintainers have one

## Platform tested

- OS: Linux 6.19.10-arch1-1 x86_64
- Python: 3.11.15
- Hermes version command currently cannot run on my checkout because `origin/main` contains conflict-marker text in `hermes_cli/config.py` around `dispatch_stale_timeout_seconds`, producing a `SyntaxError` before CLI startup. That appears unrelated to this migration fix.


