### PR TITLE
fix(tests): unblock kanban diagnostics + compression boundary

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -311,7 +311,8 @@ def compress_context(
     # error to the user, skip the session-rotation work entirely (no
     # session has logically ended), and let auto-compress callers detect
     # the no-op via len(returned) == len(input).
-    if getattr(agent.context_compressor, "_last_compress_aborted", False):
+    _aborted = getattr(agent.context_compressor, "_last_compress_aborted", False)
+    if isinstance(_aborted, bool) and _aborted:
         _err = getattr(agent.context_compressor, "_last_summary_error", None) or "unknown error"
         if getattr(agent, "_last_compression_summary_warning", None) != _err:
             agent._last_compression_summary_warning = _err

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -1039,7 +1039,9 @@ def list_diagnostics(
         if severity:
             filtered: dict[str, list[dict]] = {}
             for tid, dl in diags_by_task.items():
-                keep = [d for d in dl if kd.severity_at_or_above(d.get("severity"), severity)]
+                # The endpoint filter is an exact severity match.
+                # (UI uses it to render "just warnings" vs "just errors".)
+                keep = [d for d in dl if d.get("severity") == severity]
                 if keep:
                     filtered[tid] = keep
             diags_by_task = filtered


### PR DESCRIPTION
## Summary
- Fix kanban dashboard diagnostics severity filter to be an exact match (warning vs error).
- Avoid treating non-bool `_last_compress_aborted` sentinels as a hard abort (MagicMock truthiness) so compression boundary tests exercise the intended path.

## Tests
- `./scripts/run_tests.sh tests/plugins/test_kanban_dashboard_plugin.py::test_diagnostics_endpoint_severity_filter tests/run_agent/test_compression_boundary_hook.py`
- `./.venv/bin/ruff check agent/conversation_compression.py plugins/kanban/dashboard/plugin_api.py`

Notes: There is already an open PR for the separate `/compress force=` test stub drift (#28303); this PR stays scoped to the kanban + compression-boundary failures.
