### PR TITLE
feat: add opt-in Codex economy mode

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1079,6 +1079,34 @@ def init_agent(
         _agent_section = {}
     agent._tool_use_enforcement = _agent_section.get("tool_use_enforcement", "auto")
 
+    # Codex economy mode: reduces token pressure by encouraging compact
+    # context packaging without sacrificing final quality.  Read once at
+    # construction; never mutated mid-session to keep prompt cache stable.
+    _codex_economy_cfg = _agent_cfg.get("codex_economy", {})
+    if not isinstance(_codex_economy_cfg, dict):
+        _codex_economy_cfg = {}
+    agent._codex_economy_enabled = bool(_codex_economy_cfg.get("enabled", False))
+    agent._codex_economy_auto_openai_codex = bool(
+        _codex_economy_cfg.get("auto_for_openai_codex", False)
+    )
+    try:
+        _raw_files = _codex_economy_cfg.get("max_changed_files_for_inline_context", 8)
+        _max_changed_files = int(_raw_files)
+        if _max_changed_files < 1:
+            _max_changed_files = 8
+    except (TypeError, ValueError):
+        _max_changed_files = 8
+    agent._codex_economy_max_changed_files = _max_changed_files
+
+    try:
+        _raw_lines = _codex_economy_cfg.get("max_diff_lines_for_review_packet", 400)
+        _max_diff_lines = int(_raw_lines)
+        if _max_diff_lines < 1:
+            _max_diff_lines = 400
+    except (TypeError, ValueError):
+        _max_diff_lines = 400
+    agent._codex_economy_max_diff_lines = _max_diff_lines
+
     # App-level API retry count (wraps each model API call).  Default 3,
     # overridable via agent.api_max_retries in config.yaml.  See #11616.
     try:

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -360,6 +360,69 @@ GOOGLE_MODEL_OPERATIONAL_GUIDANCE = (
     "Don't stop with a plan — execute it.\n"
 )
 
+# Guidance injected when Codex economy mode is active (opt-in).
+# Reduces token pressure by encouraging compact context packaging without
+# sacrificing final quality or skipping verification steps.
+
+def _format_economy_guidance(max_changed_files: int = 8, max_diff_lines: int = 400) -> str:
+    """Build Codex economy guidance with the given budget thresholds."""
+    return (
+        "# Codex economy mode\n"
+        "<context_efficiency>\n"
+        "- Before reading files, run file-discovery or diff-stats to identify "
+        "what is actually relevant. Do not load whole files when offsets and "
+        "snippets suffice.\n"
+        "- Use search_files with targeted patterns and read_file with byte/line "
+        "offsets instead of reading entire files.\n"
+        f"- When the changeset touches more than {max_changed_files} files, switch "
+        "to compact context (snippets + diff summary) instead of loading full files.\n"
+        "- When preparing a review packet, include: original goal/spec, "
+        "changed-file list, diff summary (not raw diff), relevant snippets, "
+        f"test-output tail, and explicit questions. Keep total packet size "
+        f"within {max_diff_lines} diff lines.\n"
+        "- Preserve parallel execution when work is independent — do NOT "
+        "serialize tasks solely to reduce token volume.\n"
+        "- Do NOT skip verification, final tests, security checks, or Codex "
+        "Final whole-system review. These are non-negotiable quality gates.\n"
+        "- Codex is the final/important-review judge. Cheaper tools "
+        "(subscription, local, planning) can handle packaging and planning "
+        "steps; no extra API spend is required for low-value intermediate steps.\n"
+        "</context_efficiency>"
+    )
+
+
+CODEX_ECONOMY_GUIDANCE = _format_economy_guidance()
+
+
+def build_codex_economy_prompt(
+    *,
+    enabled: bool = False,
+    auto_for_openai_codex: bool = False,
+    provider: str = "",
+    api_mode: str = "",
+    model: str = "",
+    max_changed_files: int = 8,
+    max_diff_lines: int = 400,
+) -> str:
+    """Return economy guidance when the mode is active, else empty string.
+
+    Active when enabled=True, OR when auto_for_openai_codex=True and the
+    provider/api_mode/model indicates openai-codex or codex_responses.
+    """
+    if enabled:
+        return _format_economy_guidance(max_changed_files, max_diff_lines)
+    if auto_for_openai_codex:
+        _provider = (provider or "").lower()
+        _api_mode = (api_mode or "").lower()
+        _model = (model or "").lower()
+        if (
+            _provider in {"openai-codex", "xai-oauth"}
+            or _api_mode == "codex_responses"
+            or "codex" in _model
+        ):
+            return _format_economy_guidance(max_changed_files, max_diff_lines)
+    return ""
+
 
 # Guidance injected into the system prompt when the computer_use toolset
 # is active. Universal — works for any model (Claude, GPT, open models).

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -39,6 +39,7 @@ from agent.prompt_builder import (
     SKILLS_GUIDANCE,
     TOOL_USE_ENFORCEMENT_GUIDANCE,
     TOOL_USE_ENFORCEMENT_MODELS,
+    build_codex_economy_prompt,
 )
 
 
@@ -165,6 +166,21 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             # existing tools, replies with plans instead of executing).
             if "gpt" in _model_lower or "codex" in _model_lower or "grok" in _model_lower:
                 stable_parts.append(OPENAI_MODEL_EXECUTION_GUIDANCE)
+
+    # Codex economy mode — inject when enabled or auto-detected.
+    # Placed outside the tool_use_enforcement block so it fires
+    # regardless of whether tool-use enforcement is configured.
+    _eco_prompt = build_codex_economy_prompt(
+        enabled=getattr(agent, "_codex_economy_enabled", False),
+        auto_for_openai_codex=getattr(agent, "_codex_economy_auto_openai_codex", False),
+        provider=getattr(agent, "provider", "") or "",
+        api_mode=getattr(agent, "api_mode", "") or "",
+        model=getattr(agent, "model", "") or "",
+        max_changed_files=getattr(agent, "_codex_economy_max_changed_files", 8),
+        max_diff_lines=getattr(agent, "_codex_economy_max_diff_lines", 400),
+    )
+    if _eco_prompt:
+        stable_parts.append(_eco_prompt)
 
     has_skills_tools = any(name in agent.valid_tool_names for name in ['skills_list', 'skill_view', 'skill_manage'])
     if has_skills_tools:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1003,7 +1003,21 @@ DEFAULT_CONFIG = {
             "extra_body": {},
         },
     },
-    
+
+    "codex_economy": {
+        # Opt-in mode that reduces OpenAI Codex token pressure without
+        # lowering final quality.  See docs/user-guide/codex-economy-mode.md.
+        "enabled": False,
+        # When true, automatically activates for openai-codex / xai-oauth
+        # providers and codex_responses api_mode.
+        "auto_for_openai_codex": False,
+        # Max changed-file count before the agent switches to compact context
+        # (snippets + diff summary instead of full files).
+        "max_changed_files_for_inline_context": 8,
+        # Max diff lines to include in a review packet.
+        "max_diff_lines_for_review_packet": 400,
+    },
+
     "display": {
         "compact": False,
         "personality": "kawaii",

--- a/tests/agent/test_codex_economy.py
+++ b/tests/agent/test_codex_economy.py
@@ -1,0 +1,208 @@
+"""Tests for Codex economy mode — prompt_builder constant + builder function,
+system_prompt integration via build_system_prompt_parts."""
+
+import types
+from unittest.mock import patch
+
+import pytest
+
+from agent.prompt_builder import CODEX_ECONOMY_GUIDANCE, build_codex_economy_prompt, _format_economy_guidance
+
+
+# =========================================================================
+# build_codex_economy_prompt unit tests
+# =========================================================================
+
+
+class TestBuildCodexEconomyPrompt:
+    def test_disabled_returns_empty(self):
+        assert build_codex_economy_prompt(enabled=False) == ""
+
+    def test_all_defaults_return_empty(self):
+        assert build_codex_economy_prompt() == ""
+
+    def test_enabled_returns_guidance(self):
+        result = build_codex_economy_prompt(enabled=True)
+        assert result == CODEX_ECONOMY_GUIDANCE
+        assert "context_efficiency" in result
+        assert "search_files" in result
+
+    def test_enabled_overrides_no_provider(self):
+        # enabled=True should return guidance even without provider/model.
+        result = build_codex_economy_prompt(enabled=True, provider="", model="")
+        assert result == CODEX_ECONOMY_GUIDANCE
+
+    def test_auto_for_openai_codex_provider(self):
+        result = build_codex_economy_prompt(
+            auto_for_openai_codex=True,
+            provider="openai-codex",
+        )
+        assert result == CODEX_ECONOMY_GUIDANCE
+
+    def test_auto_for_xai_oauth_provider(self):
+        result = build_codex_economy_prompt(
+            auto_for_openai_codex=True,
+            provider="xai-oauth",
+        )
+        assert result == CODEX_ECONOMY_GUIDANCE
+
+    def test_auto_for_codex_responses_api_mode(self):
+        result = build_codex_economy_prompt(
+            auto_for_openai_codex=True,
+            api_mode="codex_responses",
+        )
+        assert result == CODEX_ECONOMY_GUIDANCE
+
+    def test_auto_for_codex_in_model_name(self):
+        result = build_codex_economy_prompt(
+            auto_for_openai_codex=True,
+            model="openai/codex-mini-latest",
+        )
+        assert result == CODEX_ECONOMY_GUIDANCE
+
+    def test_auto_off_codex_provider_no_match(self):
+        result = build_codex_economy_prompt(
+            auto_for_openai_codex=False,
+            provider="openai-codex",
+        )
+        assert result == ""
+
+    def test_auto_on_non_codex_provider_no_match(self):
+        result = build_codex_economy_prompt(
+            auto_for_openai_codex=True,
+            provider="anthropic",
+            api_mode="anthropic_messages",
+            model="claude-opus-4-7",
+        )
+        assert result == ""
+
+    def test_guidance_preserves_quality_language(self):
+        assert "Do NOT skip verification" in CODEX_ECONOMY_GUIDANCE
+        assert "final tests" in CODEX_ECONOMY_GUIDANCE
+        assert "non-negotiable" in CODEX_ECONOMY_GUIDANCE
+
+    def test_guidance_preserves_parallel_language(self):
+        assert "parallel execution" in CODEX_ECONOMY_GUIDANCE
+        assert "NOT serialize" in CODEX_ECONOMY_GUIDANCE
+
+    def test_guidance_mentions_codex_final(self):
+        assert "Codex" in CODEX_ECONOMY_GUIDANCE
+
+    def test_guidance_mentions_search_files(self):
+        assert "search_files" in CODEX_ECONOMY_GUIDANCE
+
+    def test_default_budgets_in_guidance(self):
+        assert "8" in CODEX_ECONOMY_GUIDANCE
+        assert "400" in CODEX_ECONOMY_GUIDANCE
+
+    def test_custom_budgets_appear_in_prompt(self):
+        result = build_codex_economy_prompt(enabled=True, max_changed_files=5, max_diff_lines=200)
+        assert "5" in result
+        assert "200" in result
+        assert "8" not in result or "400" not in result  # custom values replace defaults
+
+    def test_custom_budgets_auto_mode(self):
+        result = build_codex_economy_prompt(
+            auto_for_openai_codex=True,
+            provider="openai-codex",
+            max_changed_files=12,
+            max_diff_lines=600,
+        )
+        assert "12" in result
+        assert "600" in result
+
+    def test_format_economy_guidance_injects_values(self):
+        result = _format_economy_guidance(max_changed_files=3, max_diff_lines=150)
+        assert "3" in result
+        assert "150" in result
+        assert "context_efficiency" in result
+        assert "search_files" in result
+
+    def test_format_economy_guidance_defaults_match_constant(self):
+        assert _format_economy_guidance() == CODEX_ECONOMY_GUIDANCE
+
+
+# =========================================================================
+# system_prompt integration tests
+# =========================================================================
+
+
+def _make_agent(**kwargs):
+    """Build a minimal agent namespace for build_system_prompt_parts."""
+    agent = types.SimpleNamespace(
+        model="claude-opus-4-7",
+        provider="anthropic",
+        api_mode="anthropic_messages",
+        platform="",
+        load_soul_identity=False,
+        skip_context_files=True,
+        valid_tool_names=set(),
+        _tool_use_enforcement=False,
+        _kanban_worker_guidance=None,
+        _memory_store=None,
+        _memory_manager=None,
+        _memory_enabled=False,
+        _user_profile_enabled=False,
+        pass_session_id=False,
+        session_id=None,
+        _codex_economy_enabled=False,
+        _codex_economy_auto_openai_codex=False,
+        _codex_economy_max_changed_files=8,
+        _codex_economy_max_diff_lines=400,
+    )
+    for k, v in kwargs.items():
+        setattr(agent, k, v)
+    return agent
+
+
+class TestSystemPromptIntegration:
+    def test_economy_absent_when_disabled(self):
+        from agent.system_prompt import build_system_prompt_parts
+
+        agent = _make_agent(
+            _codex_economy_enabled=False,
+            _codex_economy_auto_openai_codex=False,
+        )
+        parts = build_system_prompt_parts(agent)
+        assert "context_efficiency" not in parts["stable"]
+
+    def test_economy_present_when_enabled(self):
+        from agent.system_prompt import build_system_prompt_parts
+
+        agent = _make_agent(_codex_economy_enabled=True)
+        parts = build_system_prompt_parts(agent)
+        assert "context_efficiency" in parts["stable"]
+
+    def test_economy_present_when_auto_and_codex_provider(self):
+        from agent.system_prompt import build_system_prompt_parts
+
+        agent = _make_agent(
+            _codex_economy_enabled=False,
+            _codex_economy_auto_openai_codex=True,
+            provider="openai-codex",
+            api_mode="codex_responses",
+            model="codex-mini-latest",
+        )
+        parts = build_system_prompt_parts(agent)
+        assert "context_efficiency" in parts["stable"]
+
+    def test_economy_absent_for_anthropic_auto(self):
+        from agent.system_prompt import build_system_prompt_parts
+
+        agent = _make_agent(
+            _codex_economy_enabled=False,
+            _codex_economy_auto_openai_codex=True,
+            provider="anthropic",
+            api_mode="anthropic_messages",
+            model="claude-opus-4-7",
+        )
+        parts = build_system_prompt_parts(agent)
+        assert "context_efficiency" not in parts["stable"]
+
+    def test_economy_in_stable_not_volatile(self):
+        from agent.system_prompt import build_system_prompt_parts
+
+        agent = _make_agent(_codex_economy_enabled=True)
+        parts = build_system_prompt_parts(agent)
+        assert "context_efficiency" in parts["stable"]
+        assert "context_efficiency" not in parts["volatile"]

--- a/website/docs/user-guide/codex-economy-mode.md
+++ b/website/docs/user-guide/codex-economy-mode.md
@@ -1,0 +1,52 @@
+# Codex Economy Mode
+
+Codex economy mode reduces OpenAI Codex token pressure during agent sessions without sacrificing final quality.
+
+## Why it exists
+
+When using `openai-codex` or `xai-oauth` providers (which route through OpenAI Codex), heavy context loading — reading whole files, sending large raw diffs — can exhaust token budgets quickly. Economy mode injects system-prompt guidance that tells the agent to package context more compactly, while keeping all verification and final-review steps intact.
+
+## What it does
+
+Economy mode adds guidance to the stable system prompt tier instructing the agent to:
+
+- Run file-discovery or diff-stats **before** loading files, and prefer offsets/snippets over whole-file reads.
+- Build **compact review packets** (goal/spec, changed-file list, diff summary, relevant snippets, test-output tail, explicit questions) instead of dumping raw diffs.
+- **Preserve parallel execution** — tasks that are independent still run in parallel; economy mode never serializes work just to save tokens.
+- **Never skip** verification, final tests, security checks, or Codex Final whole-system review.
+
+Economy mode reduces **context packaging**, not quality gates.
+
+## Enabling
+
+### Always on
+
+```bash
+hermes config set codex_economy.enabled true
+```
+
+### Auto-detect for Codex providers
+
+Automatically activates when the active provider is `openai-codex` or `xai-oauth`, or the API mode is `codex_responses`:
+
+```bash
+hermes config set codex_economy.auto_for_openai_codex true
+```
+
+## Configuration reference
+
+All keys live under `codex_economy` in `~/.hermes/config.yaml`:
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `enabled` | `false` | Always inject economy guidance |
+| `auto_for_openai_codex` | `false` | Inject when provider/api_mode indicates Codex |
+| `max_changed_files_for_inline_context` | `8` | Threshold above which the agent switches to snippets-only context (informational — the agent reads this as intent) |
+| `max_diff_lines_for_review_packet` | `400` | Max diff lines to include in a review packet |
+
+## What is NOT changed
+
+- Final verification steps are **required**, not optional.
+- Codex Final whole-system review is **still performed** when relevant.
+- Parallel execution for independent subtasks is **preserved**.
+- No new API dependencies are introduced.


### PR DESCRIPTION
## 変更内容
- `codex_economy` 設定を追加し、Codex向けの「節約モード」を opt-in で有効化できるようにしました。
- 有効時、Hermesの安定System Promptに「全文読み込みや巨大diff投入を避け、必要な抜粋・diff要約・テスト末尾に絞る」ガイダンスを注入します。
- ただし、検証・最終テスト・セキュリティ確認・Codex Finalの全体レビューは削らない方針を明記しました。

## 実装方法
- `hermes_cli/config.py` に `codex_economy` のデフォルト設定を追加。
  - `enabled: false`
  - `auto_for_openai_codex: false`
  - `max_changed_files_for_inline_context: 8`
  - `max_diff_lines_for_review_packet: 400`
- `agent/agent_init.py` で設定を読み込み、セッション中は固定値として保持。
- `agent/prompt_builder.py` に予算値入りのCodex economy guidance builderを追加。
- `agent/system_prompt.py` で、設定が有効な場合だけstable tierへ注入。
- `website/docs/user-guide/codex-economy-mode.md` に使い方を追加。

## 実行したテスト
- `python -m pytest tests/agent/test_codex_economy.py tests/agent/test_prompt_builder.py::TestGuidanceConstants tests/run_agent/test_run_agent.py::TestBuildSystemPrompt tests/run_agent/test_run_agent.py::TestToolUseEnforcementConfig -q`
  - 結果: `53 passed in 7.69s`
- `codex review --base origin/main`
  - 1回目: 設定したbudget値がpromptへ渡っていないP2指摘あり
  - 修正後: 追加指摘なし

## 影響範囲
- Hermes AgentのSystem Prompt組み立て部分
- Codex/openai-codex利用時の作業方針ガイダンス
- 設定ファイルのデフォルト値
- ユーザー向けドキュメント

## 注意点
- このPRは実行エンジンそのものを差し替えません。まずは安全なprompt-level制御です。
- 初期値は無効です。既存ユーザーの挙動は変わりません。
- `auto_for_openai_codex` を有効にすると、`openai-codex` / `xai-oauth` / `codex_responses` / model名に`codex`を含む場合に自動注入します。

## 判断理由
- APIモデル追加で要約処理を外出しすると追加課金が増えやすいため、まずは「Codexへ渡す文脈量を減らす」方式を選びました。
- 品質低下を避けるため、節約対象はcontext packagingだけに限定し、最終レビューやテストは削らない設計にしました。
- 他の選択肢として、外部API要約モデルやローカルLLM連携もありますが、今回は費用・リスクを抑えるためデフォルトOFFの軽量実装にしました。
