### PR TITLE
fix(gateway): close /proc cmdline file handle in PID scan loop

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -409,7 +409,8 @@ def _scan_gateway_pids(exclude_pids: set[int], all_profiles: bool = False) -> li
                         if pid == my_pid or pid in exclude_pids:
                             continue
                         try:
-                            cmdline = open(f"/proc/{pid}/cmdline", "rb").read().decode("utf-8", errors="replace")
+                            with open(f"/proc/{pid}/cmdline", "rb") as fh:
+                                cmdline = fh.read().decode("utf-8", errors="replace")
                             cmdline = cmdline.replace("\x00", " ")
                             if any(p in cmdline for p in patterns) and (
                                 all_profiles or _matches_current_profile(cmdline)


### PR DESCRIPTION
## Problem

`_find_gateway_pids_by_profile()` in `hermes_cli/gateway.py` opens `/proc/{pid}/cmdline` for every numeric PID entry without closing the file handle. On busy systems with hundreds of PIDs, this leaks file descriptors.

## Fix

Use a `with` statement for deterministic cleanup:

```python
with open(f"/proc/{pid}/cmdline", "rb") as fh:
    cmdline = fh.read().decode("utf-8", errors="replace")
```
