### PR TITLE
fix(agent): guard against empty choices in title generation

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -62,6 +62,9 @@ def generate_title(
             timeout=timeout,
             main_runtime=main_runtime,
         )
+        if not response.choices:
+            logger.warning("Title generation returned empty choices (content filtered?)")
+            return None
         title = (response.choices[0].message.content or "").strip()
         # Clean up: remove quotes, trailing punctuation, prefixes like "Title: "
         title = title.strip('"\'')


### PR DESCRIPTION
## Problem

`generate_title()` in `agent/title_generator.py` accesses `response.choices[0]` without checking if the choices list is empty. Some providers return an empty choices list on content filtering or certain error conditions, causing an `IndexError`.

The outer `except Exception` handler catches this, but generates expensive full tracebacks in the log and obscures the root cause.

## Fix

Add an explicit empty-check with a clear warning message before accessing `response.choices[0]`:

```python
if not response.choices:
    logger.warning("Title generation returned empty choices (content filtered?)")
    return None
title = (response.choices[0].message.content or "").strip()
```

This is consistent with the guard pattern already used in `tools/mcp_tool.py:985`.

## Testing

- Verified the fix compiles and the function logic is unchanged
- The early return preserves the existing behavior (returns None on failure)
