### PR TITLE
fix(dispatch): pass session_id into registry.dispatch

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -1115,6 +1115,7 @@ def handle_function_call(
                     return registry.dispatch(
                         function_name, next_args,
                         task_id=task_id,
+                        session_id=session_id,
                         enabled_tools=sandbox_enabled,
                     )
             else:
@@ -1122,6 +1123,7 @@ def handle_function_call(
                     return registry.dispatch(
                         function_name, next_args,
                         task_id=task_id,
+                        session_id=session_id,
                         user_task=user_task,
                     )
             from hermes_cli.middleware import run_tool_execution_middleware

--- a/tests/test_dispatch_session_id.py
+++ b/tests/test_dispatch_session_id.py
@@ -1,0 +1,75 @@
+"""Tests that handle_function_call forwards session_id into registry.dispatch."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+
+def _make_registry(captured: dict):
+    """Return a mock registry whose dispatch records the kwargs it receives."""
+    registry = MagicMock()
+
+    def _dispatch(name, args, **kwargs):
+        captured.update(kwargs)
+        return json.dumps({"result": "ok"})
+
+    registry.dispatch.side_effect = _dispatch
+    return registry
+
+
+class TestSessionIdForwarding:
+
+    def test_standard_path_forwards_session_id(self):
+        """registry.dispatch receives session_id on the normal tool path."""
+        captured = {}
+        with patch("model_tools.registry", _make_registry(captured)):
+            from model_tools import handle_function_call
+            handle_function_call(
+                "web_search",
+                {"query": "test"},
+                task_id="t1",
+                session_id="sess-abc",
+                skip_pre_tool_call_hook=True,
+            )
+        assert captured.get("session_id") == "sess-abc"
+
+    def test_execute_code_path_forwards_session_id(self):
+        """registry.dispatch receives session_id on the execute_code path."""
+        captured = {}
+        with patch("model_tools.registry", _make_registry(captured)):
+            from model_tools import handle_function_call
+            handle_function_call(
+                "execute_code",
+                {"code": "print(1)"},
+                task_id="t1",
+                session_id="sess-xyz",
+                skip_pre_tool_call_hook=True,
+            )
+        assert captured.get("session_id") == "sess-xyz"
+
+    def test_session_id_default_is_none(self):
+        """When session_id is omitted, dispatch receives None."""
+        captured = {}
+        with patch("model_tools.registry", _make_registry(captured)):
+            from model_tools import handle_function_call
+            handle_function_call(
+                "web_search",
+                {"query": "test"},
+                task_id="t1",
+                skip_pre_tool_call_hook=True,
+            )
+        assert "session_id" in captured
+        assert captured["session_id"] is None
+
+    def test_task_id_still_forwarded(self):
+        """Existing task_id forwarding is not broken by this change."""
+        captured = {}
+        with patch("model_tools.registry", _make_registry(captured)):
+            from model_tools import handle_function_call
+            handle_function_call(
+                "web_search",
+                {"query": "test"},
+                task_id="task-999",
+                session_id="sess-1",
+                skip_pre_tool_call_hook=True,
+            )
+        assert captured.get("task_id") == "task-999"


### PR DESCRIPTION
## Problem

`handle_function_call` receives `session_id` as a parameter (line 746) and already passes `task_id` into `registry.dispatch`, but `session_id` is silently dropped at the two dispatch call sites (lines 836 and 842). Plugins and dispatch-layer hooks that need to correlate calls with the active session receive `""` for every invocation.

The gap is visible by comparing the two kwargs blocks:

```python
# line 836 — execute_code path
result = registry.dispatch(
    function_name, function_args,
    task_id=task_id,          # ✓ forwarded
    enabled_tools=sandbox_enabled,
    # session_id missing
)

# line 842 — standard path
result = registry.dispatch(
    function_name, function_args,
    task_id=task_id,          # ✓ forwarded
    user_task=user_task,
    # session_id missing
)
```

`session_id` is already forwarded correctly to the `pre_tool_call` and `post_tool_call` plugin hooks (lines 791–792, 856–857, 877–878), so this is an inconsistency in the dispatch path specifically.

## Fix

Pass `session_id=session_id` in both dispatch call sites, matching the pattern already used for `task_id`.

## Compatibility

`registry.dispatch` accepts `**kwargs` and forwards them to handlers. No existing handler reads `session_id`; nothing breaks. Any plugin or dispatch-layer hook that needs session context will now receive it.