### PR TITLE
fix(gateway): keep tool-progress edits alive after Telegram flood control (closes #25188)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15463,14 +15463,15 @@ class GatewayRunner:
                         if not result.success:
                             _err = (getattr(result, "error", "") or "").lower()
                             if "flood" in _err or "retry after" in _err:
-                                # Flood control hit — disable further edits,
-                                # switch to sending new messages only for
-                                # important updates.  Don't block 23s.
+                                # Flood control hit — backoff but keep editing.
+                                # Only disable edits for non-recoverable errors.
                                 logger.info(
-                                    "[%s] Progress edits disabled due to flood control",
+                                    "[%s] Progress edit flood control, backing off",
                                     adapter.name,
                                 )
-                            can_edit = False
+                                _last_edit_ts = time.monotonic()
+                            else:
+                                can_edit = False
                             _flood_result = await adapter.send(
                                 chat_id=source.chat_id,
                                 content=msg,

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -166,7 +166,7 @@ AUTHOR_MAP = {
     "ysfalweshcan@gmail.com": "Junass1",
     "bartokmagic@proton.me": "Bartok9",
     "bartok9@users.noreply.github.com": "Bartok9",
-    "pepelax@users.noreply.github.com": "pepelax",  # PR #25419 salvage (send_message TELEGRAM_PROXY)
+    "erhanyasarx@gmail.com": "erhnysr",  # PR #25198 salvage (tool-progress flood-control)
     "androidhtml@yandex.com": "hllqkb",
     "25840394+Bongulielmi@users.noreply.github.com": "Bongulielmi",
     "jonathan.troyer@overmatch.com": "JTroyerOvermatch",


### PR DESCRIPTION
Salvage of #25198 (@erhnysr).

## Summary
When a tool-progress edit hits Telegram flood control (`RetryAfter`), `can_edit` was unconditionally set to `False`, permanently disabling progress message coalescing for the rest of the run. All subsequent tool updates were posted as separate new messages instead of updating the existing progress bubble.

## Fix
Only set `can_edit = False` for non-recoverable edit errors. On flood control, back off by resetting `_last_edit_ts` so the existing throttle interval is respected before the next edit attempt. Coalescing resumes automatically after the backoff window.

## Changes
- `gateway/run.py::send_progress_messages`: scope `can_edit = False` to non-flood errors.

## Validation
- `scripts/run_tests.sh tests/gateway/test_run_progress_topics.py tests/gateway/test_run_progress_interrupt.py -q` → 28/28 passing.

Authorship preserved via cherry-pick. AUTHOR_MAP entry added in follow-up commit.