### PR TITLE
fix(xai-oauth): strip service_tier and add safety-net sanitization for slash enums

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -820,6 +820,18 @@ def _preflight_codex_api_kwargs(
     elif "stream" in api_kwargs:
         raise ValueError("Codex Responses stream flag is only allowed in fallback streaming requests.")
 
+    # Safety-net sanitization for xAI: even if the caller skipped
+    # sanitization in ``build_api_kwargs``, strip slash-containing
+    # ``enum`` values from tool schemas here to prevent xAI Responses
+    # API from rejecting the request with HTTP 400 ``Invalid arguments
+    # passed to the model``.
+    if normalized.get("tools"):
+        try:
+            from tools.schema_sanitizer import strip_slash_enum
+            normalized["tools"], _ = strip_slash_enum(normalized["tools"])
+        except Exception:
+            pass  # Best-effort — the caller-level sanitization should have handled it
+
     unexpected = sorted(key for key in api_kwargs if key not in allowed_keys)
     if unexpected:
         raise ValueError(

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -146,6 +146,12 @@ class ResponsesApiTransport(ProviderTransport):
         if request_overrides:
             kwargs.update(request_overrides)
 
+        # xAI Responses API rejects ``service_tier`` (HTTP 400 "Argument not
+        # supported: service_tier"). Strip it from request overrides when
+        # targeting xAI. See #XXXXX.
+        if is_xai_responses:
+            kwargs.pop("service_tier", None)
+
         if is_codex_backend:
             prompt_cache_key = kwargs.get("prompt_cache_key")
             cache_scope_id = str(prompt_cache_key or session_id or "").strip()


### PR DESCRIPTION
## What changed

Strip `service_tier` from xAI Responses API requests and add a safety-net `strip_slash_enum` call in the preflight path.

## Why

xAI's `/v1/responses` endpoint rejects two request shapes with HTTP 400:

1. **`service_tier`** — `"Argument not supported: service_tier"` (hit when `/fast` mode is active)
2. **Tool schema `enum` values containing `/`** — `"Invalid arguments passed to the model"` (HuggingFace model IDs like `Qwen/Qwen3.5-0.8B` from MCP servers). The existing `strip_slash_enum` sanitizer in `build_api_kwargs` is bypassed in some code paths, so this adds a safety-net call in the preflight function.

## How to test

Run Hermes with xai-oauth provider (SuperGrok):
```bash
hermes model  # → pick xAI Grok OAuth (SuperGrok Subscription)
hermes        # → chat normally
```

## Platforms tested

- macOS (direct API testing with 23 request variants against api.x.ai/v1/responses + end-to-end Hermes agent runs)

## Tests

- `tests/agent/transports/test_codex_transport.py` — 39 passed
- `tests/run_agent/test_run_agent_codex_responses.py` — 63 passed
- `scripts/check-windows-footguns.py` — clean