### PR TITLE
fix(telegram): defense-in-depth — enforce TELEGRAM_ALLOWED_USERS at adapter level (#23778)

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -4055,11 +4055,12 @@ class TelegramAdapter(BasePlatformAdapter):
         return cleaned or text
 
     def _should_process_message(self, message: Message, *, is_command: bool = False) -> bool:
-        """Apply Telegram group trigger rules.
+        """Apply Telegram group trigger rules and user allowlist.
 
-        DMs remain unrestricted. Group/supergroup messages are accepted when:
-        - the chat passes the ``allowed_chats`` whitelist (when set), or
-          ``guest_mode`` is enabled and the bot is explicitly mentioned
+        DMs and group messages are both subject to TELEGRAM_ALLOWED_USERS
+        allowlist check. The chat also passes the ``allowed_chats`` whitelist
+        (when set), or ``guest_mode`` is enabled and the bot is explicitly
+        mentioned. Group/supergroup messages are additionally accepted when:
         - the chat is explicitly allowlisted in ``free_response_chats``
         - ``require_mention`` is disabled
         - the message replies to the bot
@@ -4076,6 +4077,18 @@ class TelegramAdapter(BasePlatformAdapter):
         mentioning the bot (``@botname /command``), both of which are
         recognised as mentions by :meth:`_message_mentions_bot`.
         """
+        # Enforce TELEGRAM_ALLOWED_USERS allowlist for ALL message types
+        # (DMs and groups). Previously only callback actions were gated,
+        # leaving inbound messages unblocked (issue #23778).
+        _user = getattr(message, "from_user", None)
+        _user_id = str(getattr(_user, "id", "")) if _user else ""
+        if not self._is_callback_user_authorized(_user_id):
+            logger.warning(
+                "[%s] Unauthorized user %s — message dropped",
+                self.name, _user_id,
+            )
+            return False
+
         if not self._is_group_chat(message):
             return True
 


### PR DESCRIPTION
Salvage of #23795 (@ygd58).

## Summary
Defense-in-depth fix for #23778. The gateway runner's `_is_user_authorized` already gates inbound messages, but the platform adapter's `_should_process_message` (the earliest gate per message) did NOT check the allowlist — only callbacks did. This adds a uniform check at the adapter level so unauthorized messages are dropped before they even enter the gateway-runner dispatch flow.

This pairs with the (still-pending) #24468 salvage which fixes the fail-OPEN default in `_is_callback_user_authorized` when `TELEGRAM_ALLOWED_USERS` is empty.

## Changes
- `gateway/platforms/telegram.py::_should_process_message`: check `_is_callback_user_authorized` for the sender; drop with warning if unauthorized.

## Validation
- `scripts/run_tests.sh tests/gateway/test_telegram_group_gating.py tests/gateway/test_telegram_mention_boundaries.py -q` → 36/36 passing.

Authorship preserved via cherry-pick.