### PR TITLE
feat(gateway): capture inbound email leads for CRM intake

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -16,7 +16,9 @@ Environment variables:
 """
 
 import asyncio
+import base64
 import email as email_lib
+import json
 import imaplib
 import logging
 import os
@@ -25,6 +27,7 @@ import smtplib
 import ssl
 import uuid
 from email.header import decode_header
+from email.utils import getaddresses
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.mime.base import MIMEBase
@@ -46,9 +49,19 @@ from gateway.config import Platform, PlatformConfig
 logger = logging.getLogger(__name__)
 # Automated sender patterns — emails from these are silently ignored
 _NOREPLY_PATTERNS = (
-    "noreply", "no-reply", "no_reply", "donotreply", "do-not-reply",
-    "mailer-daemon", "postmaster", "bounce", "notifications@",
-    "automated@", "auto-confirm", "auto-reply", "automailer",
+    "noreply",
+    "no-reply",
+    "no_reply",
+    "donotreply",
+    "do-not-reply",
+    "mailer-daemon",
+    "postmaster",
+    "bounce",
+    "notifications@",
+    "automated@",
+    "auto-confirm",
+    "auto-reply",
+    "automailer",
 )
 
 # RFC headers that indicate bulk/automated mail
@@ -64,6 +77,7 @@ MAX_MESSAGE_LENGTH = 50_000
 
 # Supported image extensions for inline detection
 _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".gif", ".webp"}
+
 
 def _send_imap_id(imap: "imaplib.IMAP4") -> None:
     """Send RFC 2971 IMAP ID command identifying this client.
@@ -98,14 +112,25 @@ def _is_automated_sender(address: str, headers: dict) -> bool:
         if value and check(value):
             return True
     return False
-    
+
+
 def check_email_requirements() -> bool:
     """Check if email platform dependencies are available."""
     addr = os.getenv("EMAIL_ADDRESS")
     pwd = os.getenv("EMAIL_PASSWORD")
     imap = os.getenv("EMAIL_IMAP_HOST")
     smtp = os.getenv("EMAIL_SMTP_HOST")
-    if not all([addr, pwd, imap, smtp]):
+    auth_mode = os.getenv("EMAIL_AUTH_MODE", "password").strip().lower()
+    if not all([addr, imap, smtp]):
+        return False
+    if auth_mode == "google_oauth":
+        try:
+            from hermes_constants import get_hermes_home
+
+            return (get_hermes_home() / "google_token.json").exists()
+        except Exception:
+            return False
+    if not pwd:
         return False
     return True
 
@@ -182,6 +207,52 @@ def _extract_email_address(raw: str) -> str:
     return raw.strip().lower()
 
 
+def _extract_email_addresses(raw: str) -> List[str]:
+    """Extract all bare email addresses from an RFC 5322 address header."""
+    if not raw:
+        return []
+    return [addr.strip().lower() for _name, addr in getaddresses([raw]) if addr.strip()]
+
+
+def _parse_bool(value: Any, default: bool = False) -> bool:
+    """Parse common bool-ish config/env values."""
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _google_oauth_access_token() -> str:
+    """Return a fresh Google OAuth access token from Hermes' Workspace token."""
+    try:
+        from hermes_constants import get_hermes_home
+        from google.auth.transport.requests import Request
+        from google.oauth2.credentials import Credentials
+    except Exception as e:  # noqa: BLE001 — auth dependency may not be installed
+        raise RuntimeError(f"Google OAuth dependencies unavailable: {e}") from e
+
+    token_path = get_hermes_home() / "google_token.json"
+    if not token_path.exists():
+        raise RuntimeError(f"Google OAuth token not found at {token_path}")
+
+    token_data = json.loads(token_path.read_text())
+    scopes = token_data.get("scopes") or None
+    creds = Credentials.from_authorized_user_file(str(token_path), scopes=scopes)
+    if not creds.valid:
+        if creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+            token_path.write_text(creds.to_json())
+        else:
+            raise RuntimeError("Google OAuth token is invalid and cannot be refreshed")
+    return creds.token
+
+
+def _xoauth2_string(address: str, access_token: str) -> str:
+    """Build the SASL XOAUTH2 auth string used by Gmail IMAP/SMTP."""
+    return f"user={address}\x01auth=Bearer {access_token}\x01\x01"
+
+
 def _extract_attachments(
     msg: email_lib.message.Message,
     skip_attachments: bool = False,
@@ -197,13 +268,18 @@ def _extract_attachments(
 
     for part in msg.walk():
         disposition = str(part.get("Content-Disposition", ""))
-        if skip_attachments and ("attachment" in disposition or "inline" in disposition):
+        if skip_attachments and (
+            "attachment" in disposition or "inline" in disposition
+        ):
             continue
         if "attachment" not in disposition and "inline" not in disposition:
             continue
         # Skip text/plain and text/html body parts
         content_type = part.get_content_type()
-        if content_type in {"text/plain", "text/html"} and "attachment" not in disposition:
+        if (
+            content_type in {"text/plain", "text/html"}
+            and "attachment" not in disposition
+        ):
             continue
 
         filename = part.get_filename()
@@ -222,7 +298,9 @@ def _extract_attachments(
             try:
                 cached_path = cache_image_from_bytes(payload, ext)
             except ValueError:
-                logger.debug("Skipping non-image attachment %s (invalid magic bytes)", filename)
+                logger.debug(
+                    "Skipping non-image attachment %s (invalid magic bytes)", filename
+                )
                 continue
             attachments.append({
                 "path": cached_path,
@@ -250,6 +328,7 @@ class EmailAdapter(BasePlatformAdapter):
 
         self._address = os.getenv("EMAIL_ADDRESS", "")
         self._password = os.getenv("EMAIL_PASSWORD", "")
+        self._auth_mode = os.getenv("EMAIL_AUTH_MODE", "password").strip().lower()
         self._imap_host = os.getenv("EMAIL_IMAP_HOST", "")
         self._imap_port = int(os.getenv("EMAIL_IMAP_PORT", "993"))
         self._smtp_host = os.getenv("EMAIL_SMTP_HOST", "")
@@ -262,16 +341,108 @@ class EmailAdapter(BasePlatformAdapter):
         #       skip_attachments: true
         extra = config.extra or {}
         self._skip_attachments = extra.get("skip_attachments", False)
+        self._assistant_mode = _parse_bool(
+            os.getenv("EMAIL_ASSISTANT_MODE", extra.get("assistant_mode")),
+            default=False,
+        )
+        self._require_mention_when_not_direct = _parse_bool(
+            os.getenv(
+                "EMAIL_REQUIRE_MENTION_WHEN_NOT_DIRECT",
+                extra.get("require_mention_when_not_direct"),
+            ),
+            default=True,
+        )
+        wake_raw = os.getenv("EMAIL_WAKE_PHRASES") or extra.get("wake_phrases")
+        if isinstance(wake_raw, list):
+            wake_phrases = wake_raw
+        elif wake_raw:
+            wake_phrases = [p.strip() for p in str(wake_raw).split(",")]
+        else:
+            wake_phrases = ["lila,", "@lila", "lila please", "lila:", "[lila]"]
+        self._wake_phrases = [p.lower() for p in wake_phrases if p]
 
         # Track message IDs we've already processed to avoid duplicates
         self._seen_uids: set = set()
-        self._seen_uids_max: int = 2000   # cap to prevent unbounded memory growth
+        self._seen_uids_max: int = 2000  # cap to prevent unbounded memory growth
         self._poll_task: Optional[asyncio.Task] = None
 
         # Map chat_id (sender email) -> last subject + message-id for threading
         self._thread_context: Dict[str, Dict[str, str]] = {}
 
         logger.info("[Email] Adapter initialized for %s", self._address)
+
+    def _is_explicitly_invoked(self, subject: str, body: str) -> bool:
+        """Return True when the message explicitly invokes the assistant."""
+        text = f"{subject}\n{body}".lower()
+        if any(phrase in text for phrase in self._wake_phrases):
+            return True
+
+        # Common assistant-name invocations should work even when wake phrases
+        # came from a comma-delimited env var that cannot faithfully encode
+        # punctuation-bearing phrases like "lila,".
+        if re.search(r"\blila\s*[:,]", text) or re.search(
+            r"\blila\s*,?\s+please\b", text
+        ):
+            return True
+
+        local_part = self._address.split("@", 1)[0].lower()
+        if local_part:
+            patterns = (
+                rf"(^|\b){re.escape(local_part)}\s*[:,]",
+                rf"@{re.escape(local_part)}\b",
+                rf"\[{re.escape(local_part)}\]",
+            )
+            return any(re.search(pattern, text) for pattern in patterns)
+
+        return False
+
+    def _should_dispatch_assistant_message(self, msg_data: Dict[str, Any]) -> bool:
+        """Apply assistant-address rules before routing an email into Hermes."""
+        if not self._assistant_mode:
+            return True
+
+        subject = msg_data.get("subject", "")
+        body = msg_data.get("body", "")
+        if self._is_explicitly_invoked(subject, body):
+            return True
+
+        if not self._require_mention_when_not_direct:
+            return True
+
+        agent_addr = self._address.lower()
+        to_addrs = [addr.lower() for addr in msg_data.get("to_addrs", [])]
+        cc_addrs = [addr.lower() for addr in msg_data.get("cc_addrs", [])]
+        all_recipients = set(to_addrs + cc_addrs)
+
+        # Backwards compatibility for tests/odd providers: if we do not have
+        # recipient headers, treat the message like a direct DM.
+        if not all_recipients:
+            return True
+
+        # A one-to-one email directly to the assistant is intentional. Being
+        # cc'd or addressed alongside others is passive unless explicitly asked.
+        return to_addrs == [agent_addr] and not cc_addrs
+
+    def _imap_authenticate(self, imap: "imaplib.IMAP4") -> None:
+        """Authenticate to IMAP using password or Gmail XOAUTH2."""
+        if self._auth_mode == "google_oauth":
+            token = _google_oauth_access_token()
+            auth_string = _xoauth2_string(self._address, token)
+            imap.authenticate("XOAUTH2", lambda _challenge: auth_string.encode("utf-8"))
+            return
+        imap.login(self._address, self._password)
+
+    def _smtp_authenticate(self, smtp: "smtplib.SMTP") -> None:
+        """Authenticate to SMTP using password or Gmail XOAUTH2."""
+        if self._auth_mode == "google_oauth":
+            token = _google_oauth_access_token()
+            auth_string = _xoauth2_string(self._address, token)
+            encoded = base64.b64encode(auth_string.encode("utf-8")).decode("ascii")
+            code, response = smtp.docmd("AUTH", "XOAUTH2 " + encoded)
+            if code != 235:
+                raise smtplib.SMTPAuthenticationError(code, response)
+            return
+        smtp.login(self._address, self._password)
 
     def _trim_seen_uids(self) -> None:
         """Keep only the most recent UIDs to prevent unbounded memory growth.
@@ -288,17 +459,19 @@ class EmailAdapter(BasePlatformAdapter):
             sorted_uids = sorted(self._seen_uids, key=lambda u: int(u))
             keep = self._seen_uids_max // 2
             self._seen_uids = set(sorted_uids[-keep:])
-            logger.debug("[Email] Trimmed seen UIDs to %d entries", len(self._seen_uids))
+            logger.debug(
+                "[Email] Trimmed seen UIDs to %d entries", len(self._seen_uids)
+            )
         except (ValueError, TypeError):
             # Fallback: just clear old entries if sort fails
-            self._seen_uids = set(list(self._seen_uids)[-self._seen_uids_max // 2:])
+            self._seen_uids = set(list(self._seen_uids)[-self._seen_uids_max // 2 :])
 
     async def connect(self) -> bool:
         """Connect to the IMAP server and start polling for new messages."""
         try:
             # Test IMAP connection
             imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
-            imap.login(self._address, self._password)
+            self._imap_authenticate(imap)
             _send_imap_id(imap)
             # Mark all existing messages as seen so we only process new ones
             imap.select("INBOX")
@@ -309,7 +482,10 @@ class EmailAdapter(BasePlatformAdapter):
             # Keep only the most recent UIDs to prevent unbounded growth
             self._trim_seen_uids()
             imap.logout()
-            logger.info("[Email] IMAP connection test passed. %d existing messages skipped.", len(self._seen_uids))
+            logger.info(
+                "[Email] IMAP connection test passed. %d existing messages skipped.",
+                len(self._seen_uids),
+            )
         except Exception as e:
             logger.error("[Email] IMAP connection failed: %s", e)
             return False
@@ -318,7 +494,7 @@ class EmailAdapter(BasePlatformAdapter):
             # Test SMTP connection
             smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
             smtp.starttls(context=ssl.create_default_context())
-            smtp.login(self._address, self._password)
+            self._smtp_authenticate(smtp)
             smtp.quit()
             logger.info("[Email] SMTP connection test passed.")
         except Exception as e:
@@ -367,7 +543,7 @@ class EmailAdapter(BasePlatformAdapter):
         try:
             imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
             try:
-                imap.login(self._address, self._password)
+                self._imap_authenticate(imap)
                 _send_imap_id(imap)
                 imap.select("INBOX")
 
@@ -398,21 +574,29 @@ class EmailAdapter(BasePlatformAdapter):
                         sender_name = sender_name.split("<")[0].strip().strip('"')
 
                     subject = _decode_header_value(msg.get("Subject", "(no subject)"))
+                    to_addrs = _extract_email_addresses(msg.get("To", ""))
+                    cc_addrs = _extract_email_addresses(msg.get("Cc", ""))
                     message_id = msg.get("Message-ID", "")
                     in_reply_to = msg.get("In-Reply-To", "")
                     # Skip automated/noreply senders before any processing
                     msg_headers = dict(msg.items())
                     if _is_automated_sender(sender_addr, msg_headers):
-                        logger.debug("[Email] Skipping automated sender: %s", sender_addr)
+                        logger.debug(
+                            "[Email] Skipping automated sender: %s", sender_addr
+                        )
                         continue
                     body = _extract_text_body(msg)
-                    attachments = _extract_attachments(msg, skip_attachments=self._skip_attachments)
+                    attachments = _extract_attachments(
+                        msg, skip_attachments=self._skip_attachments
+                    )
 
                     results.append({
                         "uid": uid,
                         "sender_addr": sender_addr,
                         "sender_name": sender_name,
                         "subject": subject,
+                        "to_addrs": to_addrs,
+                        "cc_addrs": cc_addrs,
                         "message_id": message_id,
                         "in_reply_to": in_reply_to,
                         "body": body,
@@ -438,7 +622,9 @@ class EmailAdapter(BasePlatformAdapter):
 
         # Never reply to automated senders
         if _is_automated_sender(sender_addr, {}):
-            logger.debug("[Email] Dropping automated sender at dispatch: %s", sender_addr)
+            logger.debug(
+                "[Email] Dropping automated sender at dispatch: %s", sender_addr
+            )
             return
 
         # Skip senders not in EMAIL_ALLOWED_USERS — prevents the adapter
@@ -448,10 +634,23 @@ class EmailAdapter(BasePlatformAdapter):
         # sending a reply even though the handler returned None.
         allowed_raw = os.getenv("EMAIL_ALLOWED_USERS", "").strip()
         if allowed_raw:
-            allowed = {addr.strip().lower() for addr in allowed_raw.split(",") if addr.strip()}
+            allowed = {
+                addr.strip().lower() for addr in allowed_raw.split(",") if addr.strip()
+            }
             if sender_addr.lower() not in allowed:
-                logger.debug("[Email] Dropping non-allowlisted sender at dispatch: %s", sender_addr)
+                logger.debug(
+                    "[Email] Dropping non-allowlisted sender at dispatch: %s",
+                    sender_addr,
+                )
                 return
+
+        if not self._should_dispatch_assistant_message(msg_data):
+            logger.info(
+                "[Email] Assistant mode ignored passive email from %s: %s",
+                sender_addr,
+                msg_data.get("subject", ""),
+            )
+            return
 
         subject = msg_data["subject"]
         body = msg_data["body"].strip()
@@ -551,7 +750,7 @@ class EmailAdapter(BasePlatformAdapter):
         smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
         try:
             smtp.starttls(context=ssl.create_default_context())
-            smtp.login(self._address, self._password)
+            self._smtp_authenticate(smtp)
             smtp.send_message(msg)
         finally:
             try:
@@ -562,7 +761,9 @@ class EmailAdapter(BasePlatformAdapter):
         logger.info("[Email] Sent reply to %s (subject: %s)", to_addr, subject)
         return msg_id
 
-    async def send_typing(self, chat_id: str, metadata: Optional[Dict[str, Any]] = None) -> None:
+    async def send_typing(
+        self, chat_id: str, metadata: Optional[Dict[str, Any]] = None
+    ) -> None:
         """Email has no typing indicator — no-op."""
 
     async def send_image(
@@ -626,7 +827,9 @@ class EmailAdapter(BasePlatformAdapter):
                 local_paths,
             )
         except Exception as e:
-            logger.error("[Email] Multi-image send failed, falling back: %s", e, exc_info=True)
+            logger.error(
+                "[Email] Multi-image send failed, falling back: %s", e, exc_info=True
+            )
             await super().send_multiple_images(chat_id, images, metadata, human_delay)
 
     def _send_email_with_attachments(
@@ -665,7 +868,9 @@ class EmailAdapter(BasePlatformAdapter):
                     part = MIMEBase("application", "octet-stream")
                     part.set_payload(f.read())
                     encoders.encode_base64(part)
-                    part.add_header("Content-Disposition", f"attachment; filename={p.name}")
+                    part.add_header(
+                        "Content-Disposition", f"attachment; filename={p.name}"
+                    )
                     msg.attach(part)
             except Exception as e:
                 logger.warning("[Email] Failed to attach %s: %s", file_path, e)
@@ -673,7 +878,7 @@ class EmailAdapter(BasePlatformAdapter):
         smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
         try:
             smtp.starttls(context=ssl.create_default_context())
-            smtp.login(self._address, self._password)
+            self._smtp_authenticate(smtp)
             smtp.send_message(msg)
         finally:
             try:
@@ -681,7 +886,11 @@ class EmailAdapter(BasePlatformAdapter):
             except Exception:
                 smtp.close()
 
-        logger.info("[Email] Sent multi-attachment email to %s (%d files)", to_addr, len(file_paths))
+        logger.info(
+            "[Email] Sent multi-attachment email to %s (%d files)",
+            to_addr,
+            len(file_paths),
+        )
         return msg_id
 
     async def send_document(
@@ -752,7 +961,7 @@ class EmailAdapter(BasePlatformAdapter):
         smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
         try:
             smtp.starttls(context=ssl.create_default_context())
-            smtp.login(self._address, self._password)
+            self._smtp_authenticate(smtp)
             smtp.send_message(msg)
         finally:
             try:

--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -223,6 +223,94 @@ def _parse_bool(value: Any, default: bool = False) -> bool:
     return str(value).strip().lower() in {"1", "true", "yes", "y", "on"}
 
 
+_EMAIL_RE = re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.IGNORECASE)
+_PHONE_RE = re.compile(
+    r"(?<!\w)(?:\+?1[\s.-]?)?(?:\(?\d{3}\)?[\s.-]?)\d{3}[\s.-]?\d{4}(?!\w)"
+)
+_URL_RE = re.compile(r"https?://[^\s<>()]+", re.IGNORECASE)
+_LEAD_INTENT_KEYWORDS = {
+    "pricing": ("price", "pricing", "quote", "proposal", "budget", "cost", "rate"),
+    "scheduling": (
+        "schedule",
+        "calendar",
+        "book",
+        "call",
+        "demo",
+        "meeting",
+        "available",
+    ),
+    "buying_intent": (
+        "interested",
+        "need",
+        "looking for",
+        "evaluate",
+        "trial",
+        "pilot",
+    ),
+    "support": ("help", "issue", "problem", "broken", "error", "support"),
+    "partnership": ("partner", "partnership", "collaborate", "reseller", "affiliate"),
+}
+
+
+def _compact_text(text: str) -> str:
+    """Normalize whitespace for storage in local no-send lead records."""
+    return re.sub(r"\s+", " ", text or "").strip()
+
+
+def _detect_lead_intents(subject: str, body: str) -> List[str]:
+    """Return deterministic intent labels for an inbound email."""
+    text = f"{subject}\n{body}".lower()
+    intents = [
+        intent
+        for intent, keywords in _LEAD_INTENT_KEYWORDS.items()
+        if any(keyword in text for keyword in keywords)
+    ]
+    return intents or ["inbound_email"]
+
+
+def _build_inbound_lead_record(msg_data: Dict[str, Any]) -> Dict[str, Any]:
+    """Build a no-send, CRM-ready record from a fetched inbound email."""
+    subject = msg_data.get("subject", "")
+    body = msg_data.get("body", "")
+    body_excerpt = _compact_text(body)[:1000]
+    text = f"{subject}\n{body}"
+    contact_emails = sorted({
+        email.lower()
+        for email in _EMAIL_RE.findall(text)
+        if email.lower() != msg_data.get("sender_addr", "").lower()
+    })
+    return {
+        "schema": "hermes.email_inbound_lead.v1",
+        "no_send": True,
+        "human_review_required": True,
+        "source": "email_gateway",
+        "sender_email": msg_data.get("sender_addr", ""),
+        "sender_name": msg_data.get("sender_name", ""),
+        "subject": subject,
+        "date": msg_data.get("date", ""),
+        "message_id": msg_data.get("message_id", ""),
+        "in_reply_to": msg_data.get("in_reply_to", ""),
+        "to_addrs": msg_data.get("to_addrs", []),
+        "cc_addrs": msg_data.get("cc_addrs", []),
+        "intent_tags": _detect_lead_intents(subject, body),
+        "contact_paths": {
+            "emails": contact_emails,
+            "phones": sorted(set(_PHONE_RE.findall(text))),
+            "urls": sorted({url.rstrip(".,)") for url in _URL_RE.findall(text)}),
+        },
+        "body_excerpt": body_excerpt,
+        "body_truncated": len(_compact_text(body)) > len(body_excerpt),
+        "attachment_count": len(msg_data.get("attachments", [])),
+    }
+
+
+def _append_jsonl(path: Path, record: Dict[str, Any]) -> None:
+    """Append one JSON record to a local JSONL file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n")
+
+
 def _google_oauth_access_token() -> str:
     """Return a fresh Google OAuth access token from Hermes' Workspace token."""
     try:
@@ -360,6 +448,12 @@ class EmailAdapter(BasePlatformAdapter):
         else:
             wake_phrases = ["lila,", "@lila", "lila please", "lila:", "[lila]"]
         self._wake_phrases = [p.lower() for p in wake_phrases if p]
+        lead_capture_raw = os.getenv("EMAIL_LEAD_CAPTURE_PATH") or extra.get(
+            "lead_capture_path"
+        )
+        self._lead_capture_path = (
+            Path(lead_capture_raw).expanduser() if lead_capture_raw else None
+        )
 
         # Track message IDs we've already processed to avoid duplicates
         self._seen_uids: set = set()
@@ -422,6 +516,21 @@ class EmailAdapter(BasePlatformAdapter):
         # A one-to-one email directly to the assistant is intentional. Being
         # cc'd or addressed alongside others is passive unless explicitly asked.
         return to_addrs == [agent_addr] and not cc_addrs
+
+    def _capture_inbound_lead(self, msg_data: Dict[str, Any]) -> None:
+        """Optionally append a no-send inbound lead record for CRM review."""
+        if not self._lead_capture_path:
+            return
+        try:
+            record = _build_inbound_lead_record(msg_data)
+            _append_jsonl(self._lead_capture_path, record)
+            logger.info(
+                "[Email] Captured no-send inbound lead record from %s at %s",
+                record["sender_email"],
+                self._lead_capture_path,
+            )
+        except Exception as e:  # noqa: BLE001 — capture must not block replies
+            logger.warning("[Email] Lead capture failed: %s", e)
 
     def _imap_authenticate(self, imap: "imaplib.IMAP4") -> None:
         """Authenticate to IMAP using password or Gmail XOAUTH2."""
@@ -651,6 +760,8 @@ class EmailAdapter(BasePlatformAdapter):
                 msg_data.get("subject", ""),
             )
             return
+
+        self._capture_inbound_lead(msg_data)
 
         subject = msg_data["subject"]
         body = msg_data["body"].strip()

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -28,29 +28,45 @@ from gateway.platforms.base import SendResult
 class TestConfigEnvOverrides(unittest.TestCase):
     """Verify email config is loaded from environment variables."""
 
-    @patch.dict(os.environ, {
-        "EMAIL_ADDRESS": "hermes@test.com",
-        "EMAIL_PASSWORD": "secret",
-        "EMAIL_IMAP_HOST": "imap.test.com",
-        "EMAIL_SMTP_HOST": "smtp.test.com",
-    }, clear=False)
+    @patch.dict(
+        os.environ,
+        {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_AUTH_MODE": "password",
+            "EMAIL_ALLOWED_USERS": "",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+        },
+        clear=False,
+    )
     def test_email_config_loaded_from_env(self):
         from gateway.config import GatewayConfig, Platform, _apply_env_overrides
+
         config = GatewayConfig()
         _apply_env_overrides(config)
         self.assertIn(Platform.EMAIL, config.platforms)
         self.assertTrue(config.platforms[Platform.EMAIL].enabled)
-        self.assertEqual(config.platforms[Platform.EMAIL].extra["address"], "hermes@test.com")
+        self.assertEqual(
+            config.platforms[Platform.EMAIL].extra["address"], "hermes@test.com"
+        )
 
-    @patch.dict(os.environ, {
-        "EMAIL_ADDRESS": "hermes@test.com",
-        "EMAIL_PASSWORD": "secret",
-        "EMAIL_IMAP_HOST": "imap.test.com",
-        "EMAIL_SMTP_HOST": "smtp.test.com",
-        "EMAIL_HOME_ADDRESS": "user@test.com",
-    }, clear=False)
+    @patch.dict(
+        os.environ,
+        {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_AUTH_MODE": "password",
+            "EMAIL_ALLOWED_USERS": "",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+            "EMAIL_HOME_ADDRESS": "user@test.com",
+        },
+        clear=False,
+    )
     def test_email_home_channel_loaded(self):
         from gateway.config import GatewayConfig, Platform, _apply_env_overrides
+
         config = GatewayConfig()
         _apply_env_overrides(config)
         home = config.platforms[Platform.EMAIL].home_channel
@@ -60,34 +76,87 @@ class TestConfigEnvOverrides(unittest.TestCase):
     @patch.dict(os.environ, {}, clear=True)
     def test_email_not_loaded_without_env(self):
         from gateway.config import GatewayConfig, Platform, _apply_env_overrides
+
         config = GatewayConfig()
         _apply_env_overrides(config)
         self.assertNotIn(Platform.EMAIL, config.platforms)
 
+
 class TestCheckRequirements(unittest.TestCase):
     """Verify check_email_requirements function."""
 
-    @patch.dict(os.environ, {
-        "EMAIL_ADDRESS": "a@b.com",
-        "EMAIL_PASSWORD": "pw",
-        "EMAIL_IMAP_HOST": "imap.b.com",
-        "EMAIL_SMTP_HOST": "smtp.b.com",
-    }, clear=False)
+    @patch.dict(
+        os.environ,
+        {
+            "EMAIL_ADDRESS": "a@b.com",
+            "EMAIL_PASSWORD": "pw",
+            "EMAIL_AUTH_MODE": "password",
+            "EMAIL_ALLOWED_USERS": "",
+            "EMAIL_IMAP_HOST": "imap.b.com",
+            "EMAIL_SMTP_HOST": "smtp.b.com",
+        },
+        clear=False,
+    )
     def test_requirements_met(self):
         from gateway.platforms.email import check_email_requirements
+
         self.assertTrue(check_email_requirements())
 
-    @patch.dict(os.environ, {
-        "EMAIL_ADDRESS": "a@b.com",
-    }, clear=True)
+    @patch.dict(
+        os.environ,
+        {
+            "EMAIL_ADDRESS": "a@b.com",
+        },
+        clear=True,
+    )
     def test_requirements_not_met(self):
         from gateway.platforms.email import check_email_requirements
+
         self.assertFalse(check_email_requirements())
 
     @patch.dict(os.environ, {}, clear=True)
     def test_requirements_empty_env(self):
         from gateway.platforms.email import check_email_requirements
+
         self.assertFalse(check_email_requirements())
+
+    @patch.dict(
+        os.environ,
+        {
+            "EMAIL_ADDRESS": "a@gmail.com",
+            "EMAIL_AUTH_MODE": "google_oauth",
+            "EMAIL_IMAP_HOST": "imap.gmail.com",
+            "EMAIL_SMTP_HOST": "smtp.gmail.com",
+        },
+        clear=True,
+    )
+    def test_requirements_met_with_google_oauth_token(self):
+        from gateway.platforms.email import check_email_requirements
+
+        with patch(
+            "hermes_constants.get_hermes_home", return_value=Path("/tmp/hermes")
+        ):
+            with patch.object(Path, "exists", return_value=True):
+                self.assertTrue(check_email_requirements())
+
+    @patch.dict(
+        os.environ,
+        {
+            "EMAIL_ADDRESS": "a@gmail.com",
+            "EMAIL_AUTH_MODE": "google_oauth",
+            "EMAIL_IMAP_HOST": "imap.gmail.com",
+            "EMAIL_SMTP_HOST": "smtp.gmail.com",
+        },
+        clear=True,
+    )
+    def test_requirements_fail_with_google_oauth_missing_token(self):
+        from gateway.platforms.email import check_email_requirements
+
+        with patch(
+            "hermes_constants.get_hermes_home", return_value=Path("/tmp/hermes")
+        ):
+            with patch.object(Path, "exists", return_value=False):
+                self.assertFalse(check_email_requirements())
 
 
 class TestHelperFunctions(unittest.TestCase):
@@ -95,10 +164,12 @@ class TestHelperFunctions(unittest.TestCase):
 
     def test_decode_header_plain(self):
         from gateway.platforms.email import _decode_header_value
+
         self.assertEqual(_decode_header_value("Hello World"), "Hello World")
 
     def test_decode_header_encoded(self):
         from gateway.platforms.email import _decode_header_value
+
         # RFC 2047 encoded subject
         encoded = "=?utf-8?B?TWVyaGFiYQ==?="  # "Merhaba" in base64
         result = _decode_header_value(encoded)
@@ -106,27 +177,24 @@ class TestHelperFunctions(unittest.TestCase):
 
     def test_extract_email_address_with_name(self):
         from gateway.platforms.email import _extract_email_address
+
         self.assertEqual(
-            _extract_email_address("John Doe <john@example.com>"),
-            "john@example.com"
+            _extract_email_address("John Doe <john@example.com>"), "john@example.com"
         )
 
     def test_extract_email_address_bare(self):
         from gateway.platforms.email import _extract_email_address
-        self.assertEqual(
-            _extract_email_address("john@example.com"),
-            "john@example.com"
-        )
+
+        self.assertEqual(_extract_email_address("john@example.com"), "john@example.com")
 
     def test_extract_email_address_uppercase(self):
         from gateway.platforms.email import _extract_email_address
-        self.assertEqual(
-            _extract_email_address("John@Example.COM"),
-            "john@example.com"
-        )
+
+        self.assertEqual(_extract_email_address("John@Example.COM"), "john@example.com")
 
     def test_strip_html_basic(self):
         from gateway.platforms.email import _strip_html
+
         html = "<p>Hello <b>world</b></p>"
         result = _strip_html(html)
         self.assertIn("Hello", result)
@@ -136,6 +204,7 @@ class TestHelperFunctions(unittest.TestCase):
 
     def test_strip_html_br_tags(self):
         from gateway.platforms.email import _strip_html
+
         html = "Line 1<br>Line 2<br/>Line 3"
         result = _strip_html(html)
         self.assertIn("Line 1", result)
@@ -143,6 +212,7 @@ class TestHelperFunctions(unittest.TestCase):
 
     def test_strip_html_entities(self):
         from gateway.platforms.email import _strip_html
+
         html = "a &amp; b &lt; c &gt; d"
         result = _strip_html(html)
         self.assertIn("a & b", result)
@@ -153,12 +223,14 @@ class TestExtractTextBody(unittest.TestCase):
 
     def test_plain_text_body(self):
         from gateway.platforms.email import _extract_text_body
+
         msg = MIMEText("Hello, this is a test.", "plain", "utf-8")
         result = _extract_text_body(msg)
         self.assertEqual(result, "Hello, this is a test.")
 
     def test_html_body_fallback(self):
         from gateway.platforms.email import _extract_text_body
+
         msg = MIMEText("<p>Hello from HTML</p>", "html", "utf-8")
         result = _extract_text_body(msg)
         self.assertIn("Hello from HTML", result)
@@ -166,6 +238,7 @@ class TestExtractTextBody(unittest.TestCase):
 
     def test_multipart_prefers_plain(self):
         from gateway.platforms.email import _extract_text_body
+
         msg = MIMEMultipart("alternative")
         msg.attach(MIMEText("<p>HTML version</p>", "html", "utf-8"))
         msg.attach(MIMEText("Plain version", "plain", "utf-8"))
@@ -174,6 +247,7 @@ class TestExtractTextBody(unittest.TestCase):
 
     def test_multipart_html_only(self):
         from gateway.platforms.email import _extract_text_body
+
         msg = MIMEMultipart("alternative")
         msg.attach(MIMEText("<p>Only HTML</p>", "html", "utf-8"))
         result = _extract_text_body(msg)
@@ -181,6 +255,7 @@ class TestExtractTextBody(unittest.TestCase):
 
     def test_empty_body(self):
         from gateway.platforms.email import _extract_text_body
+
         msg = MIMEText("", "plain", "utf-8")
         result = _extract_text_body(msg)
         self.assertEqual(result, "")
@@ -191,6 +266,7 @@ class TestExtractAttachments(unittest.TestCase):
 
     def test_no_attachments(self):
         from gateway.platforms.email import _extract_attachments
+
         msg = MIMEText("No attachments here.", "plain", "utf-8")
         result = _extract_attachments(msg)
         self.assertEqual(result, [])
@@ -198,6 +274,7 @@ class TestExtractAttachments(unittest.TestCase):
     @patch("gateway.platforms.email.cache_document_from_bytes")
     def test_document_attachment(self, mock_cache):
         from gateway.platforms.email import _extract_attachments
+
         mock_cache.return_value = "/tmp/cached_doc.pdf"
 
         msg = MIMEMultipart()
@@ -218,6 +295,7 @@ class TestExtractAttachments(unittest.TestCase):
     @patch("gateway.platforms.email.cache_image_from_bytes")
     def test_image_attachment(self, mock_cache):
         from gateway.platforms.email import _extract_attachments
+
         mock_cache.return_value = "/tmp/cached_img.jpg"
 
         msg = MIMEMultipart()
@@ -241,22 +319,30 @@ class TestDispatchMessage(unittest.TestCase):
     def _make_adapter(self):
         """Create an EmailAdapter with mocked env vars."""
         from gateway.config import PlatformConfig
-        with patch.dict(os.environ, {
-            "EMAIL_ADDRESS": "hermes@test.com",
-            "EMAIL_PASSWORD": "secret",
-            "EMAIL_IMAP_HOST": "imap.test.com",
-            "EMAIL_IMAP_PORT": "993",
-            "EMAIL_SMTP_HOST": "smtp.test.com",
-            "EMAIL_SMTP_PORT": "587",
-            "EMAIL_POLL_INTERVAL": "15",
-        }):
+
+        with patch.dict(
+            os.environ,
+            {
+                "EMAIL_ADDRESS": "hermes@test.com",
+                "EMAIL_PASSWORD": "secret",
+                "EMAIL_AUTH_MODE": "password",
+                "EMAIL_ALLOWED_USERS": "",
+                "EMAIL_IMAP_HOST": "imap.test.com",
+                "EMAIL_IMAP_PORT": "993",
+                "EMAIL_SMTP_HOST": "smtp.test.com",
+                "EMAIL_SMTP_PORT": "587",
+                "EMAIL_POLL_INTERVAL": "15",
+            },
+        ):
             from gateway.platforms.email import EmailAdapter
+
             adapter = EmailAdapter(PlatformConfig(enabled=True))
         return adapter
 
     def test_self_message_filtered(self):
         """Messages from the agent's own address should be skipped."""
         import asyncio
+
         adapter = self._make_adapter()
         adapter._message_handler = MagicMock()
 
@@ -278,6 +364,7 @@ class TestDispatchMessage(unittest.TestCase):
     def test_subject_included_in_text(self):
         """Subject should be prepended to body for non-reply emails."""
         import asyncio
+
         adapter = self._make_adapter()
         captured_events = []
 
@@ -314,6 +401,7 @@ class TestDispatchMessage(unittest.TestCase):
     def test_reply_subject_not_duplicated(self):
         """Re: subjects should not be prepended to body."""
         import asyncio
+
         adapter = self._make_adapter()
         captured_events = []
 
@@ -342,6 +430,7 @@ class TestDispatchMessage(unittest.TestCase):
     def test_empty_body_handled(self):
         """Email with no body should dispatch '(empty email)'."""
         import asyncio
+
         adapter = self._make_adapter()
         captured_events = []
 
@@ -370,6 +459,7 @@ class TestDispatchMessage(unittest.TestCase):
         """Email with image attachment should set message type to PHOTO."""
         import asyncio
         from gateway.platforms.base import MessageType
+
         adapter = self._make_adapter()
         captured_events = []
 
@@ -386,7 +476,14 @@ class TestDispatchMessage(unittest.TestCase):
             "message_id": "<msg5@test.com>",
             "in_reply_to": "",
             "body": "Check this photo",
-            "attachments": [{"path": "/tmp/img.jpg", "filename": "img.jpg", "type": "image", "media_type": "image/jpeg"}],
+            "attachments": [
+                {
+                    "path": "/tmp/img.jpg",
+                    "filename": "img.jpg",
+                    "type": "image",
+                    "media_type": "image/jpeg",
+                }
+            ],
             "date": "",
         }
 
@@ -398,6 +495,7 @@ class TestDispatchMessage(unittest.TestCase):
     def test_source_built_correctly(self):
         """Session source should have correct chat_id and user info."""
         import asyncio
+
         adapter = self._make_adapter()
         captured_events = []
 
@@ -428,9 +526,13 @@ class TestDispatchMessage(unittest.TestCase):
     def test_non_allowlisted_sender_dropped(self):
         """Senders not in EMAIL_ALLOWED_USERS should be dropped before dispatch."""
         import asyncio
-        with patch.dict(os.environ, {
-            "EMAIL_ALLOWED_USERS": "hermes@test.com,admin@test.com",
-        }):
+
+        with patch.dict(
+            os.environ,
+            {
+                "EMAIL_ALLOWED_USERS": "hermes@test.com,admin@test.com",
+            },
+        ):
             adapter = self._make_adapter()
             adapter._message_handler = MagicMock()
 
@@ -455,9 +557,13 @@ class TestDispatchMessage(unittest.TestCase):
     def test_allowlisted_sender_proceeds(self):
         """Senders in EMAIL_ALLOWED_USERS should proceed to dispatch normally."""
         import asyncio
-        with patch.dict(os.environ, {
-            "EMAIL_ALLOWED_USERS": "hermes@test.com,admin@test.com",
-        }):
+
+        with patch.dict(
+            os.environ,
+            {
+                "EMAIL_ALLOWED_USERS": "hermes@test.com,admin@test.com",
+            },
+        ):
             adapter = self._make_adapter()
             captured_events = []
 
@@ -486,6 +592,7 @@ class TestDispatchMessage(unittest.TestCase):
     def test_empty_allowlist_allows_all(self):
         """When EMAIL_ALLOWED_USERS is not set, all senders should proceed."""
         import asyncio
+
         with patch.dict(os.environ, {}, clear=False):
             # Ensure EMAIL_ALLOWED_USERS is not in the env
             if "EMAIL_ALLOWED_USERS" in os.environ:
@@ -510,25 +617,109 @@ class TestDispatchMessage(unittest.TestCase):
             # Handler should be called when no allowlist is configured
             adapter._message_handler.assert_called()
 
+    def test_assistant_mode_ignores_passive_cc(self):
+        """Assistant mode should ignore passive cc'd emails without invocation."""
+        import asyncio
+
+        adapter = self._make_adapter()
+        adapter._assistant_mode = True
+        adapter.handle_message = AsyncMock()
+
+        msg_data = {
+            "uid": b"102",
+            "sender_addr": "nick@test.com",
+            "sender_name": "Nick",
+            "subject": "Project update",
+            "to_addrs": ["client@test.com"],
+            "cc_addrs": ["hermes@test.com"],
+            "message_id": "<passive@test.com>",
+            "in_reply_to": "",
+            "body": "Looping in Hermes for visibility.",
+            "attachments": [],
+            "date": "",
+        }
+
+        asyncio.run(adapter._dispatch_message(msg_data))
+        adapter.handle_message.assert_not_called()
+        self.assertNotIn("nick@test.com", adapter._thread_context)
+
+    def test_assistant_mode_dispatches_cc_with_invocation(self):
+        """Assistant mode should process cc'd emails that explicitly ask the assistant."""
+        import asyncio
+
+        adapter = self._make_adapter()
+        adapter._assistant_mode = True
+        adapter.handle_message = AsyncMock()
+
+        msg_data = {
+            "uid": b"103",
+            "sender_addr": "nick@test.com",
+            "sender_name": "Nick",
+            "subject": "Scheduling",
+            "to_addrs": ["client@test.com"],
+            "cc_addrs": ["hermes@test.com"],
+            "message_id": "<invoke@test.com>",
+            "in_reply_to": "",
+            "body": "Lila, please coordinate a time with us next week.",
+            "attachments": [],
+            "date": "",
+        }
+
+        asyncio.run(adapter._dispatch_message(msg_data))
+        adapter.handle_message.assert_called_once()
+
+    def test_assistant_mode_dispatches_direct_one_to_one(self):
+        """A one-to-one email directly to the assistant is intentional."""
+        import asyncio
+
+        adapter = self._make_adapter()
+        adapter._assistant_mode = True
+        adapter.handle_message = AsyncMock()
+
+        msg_data = {
+            "uid": b"104",
+            "sender_addr": "nick@test.com",
+            "sender_name": "Nick",
+            "subject": "Help",
+            "to_addrs": ["hermes@test.com"],
+            "cc_addrs": [],
+            "message_id": "<direct@test.com>",
+            "in_reply_to": "",
+            "body": "Can you check my calendar?",
+            "attachments": [],
+            "date": "",
+        }
+
+        asyncio.run(adapter._dispatch_message(msg_data))
+        adapter.handle_message.assert_called_once()
+
 
 class TestThreadContext(unittest.TestCase):
     """Test email reply threading logic."""
 
     def _make_adapter(self):
         from gateway.config import PlatformConfig
-        with patch.dict(os.environ, {
-            "EMAIL_ADDRESS": "hermes@test.com",
-            "EMAIL_PASSWORD": "secret",
-            "EMAIL_IMAP_HOST": "imap.test.com",
-            "EMAIL_SMTP_HOST": "smtp.test.com",
-        }):
+
+        with patch.dict(
+            os.environ,
+            {
+                "EMAIL_ADDRESS": "hermes@test.com",
+                "EMAIL_PASSWORD": "secret",
+                "EMAIL_AUTH_MODE": "password",
+                "EMAIL_ALLOWED_USERS": "",
+                "EMAIL_IMAP_HOST": "imap.test.com",
+                "EMAIL_SMTP_HOST": "smtp.test.com",
+            },
+        ):
             from gateway.platforms.email import EmailAdapter
+
             adapter = EmailAdapter(PlatformConfig(enabled=True))
         return adapter
 
     def test_thread_context_stored_after_dispatch(self):
         """After dispatching a message, thread context should be stored."""
         import asyncio
+
         adapter = self._make_adapter()
 
         async def noop_handle(event):
@@ -613,28 +804,34 @@ class TestSendMethods(unittest.TestCase):
 
     def _make_adapter(self):
         from gateway.config import PlatformConfig
-        with patch.dict(os.environ, {
-            "EMAIL_ADDRESS": "hermes@test.com",
-            "EMAIL_PASSWORD": "secret",
-            "EMAIL_IMAP_HOST": "imap.test.com",
-            "EMAIL_SMTP_HOST": "smtp.test.com",
-        }):
+
+        with patch.dict(
+            os.environ,
+            {
+                "EMAIL_ADDRESS": "hermes@test.com",
+                "EMAIL_PASSWORD": "secret",
+                "EMAIL_AUTH_MODE": "password",
+                "EMAIL_ALLOWED_USERS": "",
+                "EMAIL_IMAP_HOST": "imap.test.com",
+                "EMAIL_SMTP_HOST": "smtp.test.com",
+            },
+        ):
             from gateway.platforms.email import EmailAdapter
+
             adapter = EmailAdapter(PlatformConfig(enabled=True))
         return adapter
 
     def test_send_calls_smtp(self):
         """send() should use SMTP to deliver email."""
         import asyncio
+
         adapter = self._make_adapter()
 
         with patch("smtplib.SMTP") as mock_smtp:
             mock_server = MagicMock()
             mock_smtp.return_value = mock_server
 
-            result = asyncio.run(
-                adapter.send("user@test.com", "Hello from Hermes!")
-            )
+            result = asyncio.run(adapter.send("user@test.com", "Hello from Hermes!"))
 
             self.assertTrue(result.success)
             mock_server.starttls.assert_called_once()
@@ -645,14 +842,13 @@ class TestSendMethods(unittest.TestCase):
     def test_send_failure_returns_error(self):
         """SMTP failure should return SendResult with error."""
         import asyncio
+
         adapter = self._make_adapter()
 
         with patch("smtplib.SMTP") as mock_smtp:
             mock_smtp.side_effect = Exception("Connection refused")
 
-            result = asyncio.run(
-                adapter.send("user@test.com", "Hello")
-            )
+            result = asyncio.run(adapter.send("user@test.com", "Hello"))
 
             self.assertFalse(result.success)
             self.assertIn("Connection refused", result.error)
@@ -661,6 +857,7 @@ class TestSendMethods(unittest.TestCase):
         """send_image should include image URL in email body."""
         import asyncio
         from unittest.mock import AsyncMock
+
         adapter = self._make_adapter()
 
         adapter.send = AsyncMock(return_value=SendResult(success=True))
@@ -678,6 +875,7 @@ class TestSendMethods(unittest.TestCase):
         """send_document should send email with file attachment."""
         import asyncio
         import tempfile
+
         adapter = self._make_adapter()
 
         with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
@@ -699,8 +897,7 @@ class TestSendMethods(unittest.TestCase):
                 # Should be multipart with attachment
                 parts = list(sent_msg.walk())
                 has_attachment = any(
-                    "attachment" in str(p.get("Content-Disposition", ""))
-                    for p in parts
+                    "attachment" in str(p.get("Content-Disposition", "")) for p in parts
                 )
                 self.assertTrue(has_attachment)
         finally:
@@ -709,6 +906,7 @@ class TestSendMethods(unittest.TestCase):
     def test_send_typing_is_noop(self):
         """send_typing should do nothing for email."""
         import asyncio
+
         adapter = self._make_adapter()
         # Should not raise
         asyncio.run(adapter.send_typing("user@test.com"))
@@ -716,12 +914,14 @@ class TestSendMethods(unittest.TestCase):
     def test_get_chat_info(self):
         """get_chat_info should return email address as chat info."""
         import asyncio
-        adapter = self._make_adapter()
-        adapter._thread_context["user@test.com"] = {"subject": "Test", "message_id": "<m@t>"}
 
-        info = asyncio.run(
-            adapter.get_chat_info("user@test.com")
-        )
+        adapter = self._make_adapter()
+        adapter._thread_context["user@test.com"] = {
+            "subject": "Test",
+            "message_id": "<m@t>",
+        }
+
+        info = asyncio.run(adapter.get_chat_info("user@test.com"))
 
         self.assertEqual(info["name"], "user@test.com")
         self.assertEqual(info["type"], "dm")
@@ -733,26 +933,36 @@ class TestConnectDisconnect(unittest.TestCase):
 
     def _make_adapter(self):
         from gateway.config import PlatformConfig
-        with patch.dict(os.environ, {
-            "EMAIL_ADDRESS": "hermes@test.com",
-            "EMAIL_PASSWORD": "secret",
-            "EMAIL_IMAP_HOST": "imap.test.com",
-            "EMAIL_SMTP_HOST": "smtp.test.com",
-        }):
+
+        with patch.dict(
+            os.environ,
+            {
+                "EMAIL_ADDRESS": "hermes@test.com",
+                "EMAIL_PASSWORD": "secret",
+                "EMAIL_AUTH_MODE": "password",
+                "EMAIL_ALLOWED_USERS": "",
+                "EMAIL_IMAP_HOST": "imap.test.com",
+                "EMAIL_SMTP_HOST": "smtp.test.com",
+            },
+        ):
             from gateway.platforms.email import EmailAdapter
+
             adapter = EmailAdapter(PlatformConfig(enabled=True))
         return adapter
 
     def test_connect_success(self):
         """Successful IMAP + SMTP connection returns True."""
         import asyncio
+
         adapter = self._make_adapter()
 
         mock_imap = MagicMock()
         mock_imap.uid.return_value = ("OK", [b"1 2 3"])
 
-        with patch("imaplib.IMAP4_SSL", return_value=mock_imap), \
-             patch("smtplib.SMTP") as mock_smtp:
+        with (
+            patch("imaplib.IMAP4_SSL", return_value=mock_imap),
+            patch("smtplib.SMTP") as mock_smtp,
+        ):
             mock_server = MagicMock()
             mock_smtp.return_value = mock_server
 
@@ -770,6 +980,7 @@ class TestConnectDisconnect(unittest.TestCase):
     def test_connect_imap_failure(self):
         """IMAP connection failure returns False."""
         import asyncio
+
         adapter = self._make_adapter()
 
         with patch("imaplib.IMAP4_SSL", side_effect=Exception("IMAP down")):
@@ -780,19 +991,23 @@ class TestConnectDisconnect(unittest.TestCase):
     def test_connect_smtp_failure(self):
         """SMTP connection failure returns False."""
         import asyncio
+
         adapter = self._make_adapter()
 
         mock_imap = MagicMock()
         mock_imap.uid.return_value = ("OK", [b""])
 
-        with patch("imaplib.IMAP4_SSL", return_value=mock_imap), \
-             patch("smtplib.SMTP", side_effect=Exception("SMTP down")):
+        with (
+            patch("imaplib.IMAP4_SSL", return_value=mock_imap),
+            patch("smtplib.SMTP", side_effect=Exception("SMTP down")),
+        ):
             result = asyncio.run(adapter.connect())
             self.assertFalse(result)
 
     def test_disconnect_cancels_poll(self):
         """disconnect() should cancel the polling task."""
         import asyncio
+
         adapter = self._make_adapter()
         adapter._running = True
 
@@ -811,13 +1026,20 @@ class TestFetchNewMessages(unittest.TestCase):
 
     def _make_adapter(self):
         from gateway.config import PlatformConfig
-        with patch.dict(os.environ, {
-            "EMAIL_ADDRESS": "hermes@test.com",
-            "EMAIL_PASSWORD": "secret",
-            "EMAIL_IMAP_HOST": "imap.test.com",
-            "EMAIL_SMTP_HOST": "smtp.test.com",
-        }):
+
+        with patch.dict(
+            os.environ,
+            {
+                "EMAIL_ADDRESS": "hermes@test.com",
+                "EMAIL_PASSWORD": "secret",
+                "EMAIL_AUTH_MODE": "password",
+                "EMAIL_ALLOWED_USERS": "",
+                "EMAIL_IMAP_HOST": "imap.test.com",
+                "EMAIL_SMTP_HOST": "smtp.test.com",
+            },
+        ):
             from gateway.platforms.email import EmailAdapter
+
             adapter = EmailAdapter(PlatformConfig(enabled=True))
         return adapter
 
@@ -904,20 +1126,28 @@ class TestPollLoop(unittest.TestCase):
 
     def _make_adapter(self):
         from gateway.config import PlatformConfig
-        with patch.dict(os.environ, {
-            "EMAIL_ADDRESS": "hermes@test.com",
-            "EMAIL_PASSWORD": "secret",
-            "EMAIL_IMAP_HOST": "imap.test.com",
-            "EMAIL_SMTP_HOST": "smtp.test.com",
-            "EMAIL_POLL_INTERVAL": "1",
-        }):
+
+        with patch.dict(
+            os.environ,
+            {
+                "EMAIL_ADDRESS": "hermes@test.com",
+                "EMAIL_PASSWORD": "secret",
+                "EMAIL_AUTH_MODE": "password",
+                "EMAIL_ALLOWED_USERS": "",
+                "EMAIL_IMAP_HOST": "imap.test.com",
+                "EMAIL_SMTP_HOST": "smtp.test.com",
+                "EMAIL_POLL_INTERVAL": "1",
+            },
+        ):
             from gateway.platforms.email import EmailAdapter
+
             adapter = EmailAdapter(PlatformConfig(enabled=True))
         return adapter
 
     def test_check_inbox_dispatches_messages(self):
         """_check_inbox should fetch and dispatch new messages."""
         import asyncio
+
         adapter = self._make_adapter()
         dispatched = []
 
@@ -952,12 +1182,17 @@ class TestPollLoop(unittest.TestCase):
 class TestSendEmailStandalone(unittest.TestCase):
     """Test the standalone _send_email function in send_message_tool."""
 
-    @patch.dict(os.environ, {
-        "EMAIL_ADDRESS": "hermes@test.com",
-        "EMAIL_PASSWORD": "secret",
-        "EMAIL_SMTP_HOST": "smtp.test.com",
-        "EMAIL_SMTP_PORT": "587",
-    })
+    @patch.dict(
+        os.environ,
+        {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_AUTH_MODE": "password",
+            "EMAIL_ALLOWED_USERS": "",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+            "EMAIL_SMTP_PORT": "587",
+        },
+    )
     def test_send_email_tool_success(self):
         """_send_email should use verified STARTTLS when sending."""
         import asyncio
@@ -969,7 +1204,11 @@ class TestSendEmailStandalone(unittest.TestCase):
             mock_smtp.return_value = mock_server
 
             result = asyncio.run(
-                _send_email({"address": "hermes@test.com", "smtp_host": "smtp.test.com"}, "user@test.com", "Hello")
+                _send_email(
+                    {"address": "hermes@test.com", "smtp_host": "smtp.test.com"},
+                    "user@test.com",
+                    "Hello",
+                )
             )
 
             self.assertTrue(result["success"])
@@ -982,11 +1221,16 @@ class TestSendEmailStandalone(unittest.TestCase):
             self.assertEqual(send_call["To"], "user@test.com")
             self.assertEqual(send_call["From"], "hermes@test.com")
 
-    @patch.dict(os.environ, {
-        "EMAIL_ADDRESS": "hermes@test.com",
-        "EMAIL_PASSWORD": "secret",
-        "EMAIL_SMTP_HOST": "smtp.test.com",
-    })
+    @patch.dict(
+        os.environ,
+        {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_AUTH_MODE": "password",
+            "EMAIL_ALLOWED_USERS": "",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+        },
+    )
     def test_send_email_tool_failure(self):
         """SMTP failure should return error dict."""
         import asyncio
@@ -994,7 +1238,11 @@ class TestSendEmailStandalone(unittest.TestCase):
 
         with patch("smtplib.SMTP", side_effect=Exception("SMTP error")):
             result = asyncio.run(
-                _send_email({"address": "hermes@test.com", "smtp_host": "smtp.test.com"}, "user@test.com", "Hello")
+                _send_email(
+                    {"address": "hermes@test.com", "smtp_host": "smtp.test.com"},
+                    "user@test.com",
+                    "Hello",
+                )
             )
 
             self.assertIn("error", result)
@@ -1006,9 +1254,7 @@ class TestSendEmailStandalone(unittest.TestCase):
         import asyncio
         from tools.send_message_tool import _send_email
 
-        result = asyncio.run(
-            _send_email({}, "user@test.com", "Hello")
-        )
+        result = asyncio.run(_send_email({}, "user@test.com", "Hello"))
 
         self.assertIn("error", result)
         self.assertIn("not configured", result["error"])
@@ -1017,25 +1263,38 @@ class TestSendEmailStandalone(unittest.TestCase):
 class TestSmtpConnectionCleanup(unittest.TestCase):
     """Verify SMTP connections are closed even when send_message raises."""
 
-    @patch.dict(os.environ, {
-        "EMAIL_ADDRESS": "hermes@test.com",
-        "EMAIL_PASSWORD": "secret",
-        "EMAIL_IMAP_HOST": "imap.test.com",
-        "EMAIL_SMTP_HOST": "smtp.test.com",
-        "EMAIL_SMTP_PORT": "587",
-    }, clear=False)
+    @patch.dict(
+        os.environ,
+        {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_AUTH_MODE": "password",
+            "EMAIL_ALLOWED_USERS": "",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+            "EMAIL_SMTP_PORT": "587",
+        },
+        clear=False,
+    )
     def _make_adapter(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.email import EmailAdapter
+
         return EmailAdapter(PlatformConfig(enabled=True))
 
-    @patch.dict(os.environ, {
-        "EMAIL_ADDRESS": "hermes@test.com",
-        "EMAIL_PASSWORD": "secret",
-        "EMAIL_IMAP_HOST": "imap.test.com",
-        "EMAIL_SMTP_HOST": "smtp.test.com",
-        "EMAIL_SMTP_PORT": "587",
-    }, clear=False)
+    @patch.dict(
+        os.environ,
+        {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_AUTH_MODE": "password",
+            "EMAIL_ALLOWED_USERS": "",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+            "EMAIL_SMTP_PORT": "587",
+        },
+        clear=False,
+    )
     def test_smtp_quit_called_on_send_message_failure(self):
         """SMTP quit() must be called even when send_message() raises."""
         adapter = self._make_adapter()
@@ -1048,13 +1307,19 @@ class TestSmtpConnectionCleanup(unittest.TestCase):
 
         mock_smtp.quit.assert_called_once()
 
-    @patch.dict(os.environ, {
-        "EMAIL_ADDRESS": "hermes@test.com",
-        "EMAIL_PASSWORD": "secret",
-        "EMAIL_IMAP_HOST": "imap.test.com",
-        "EMAIL_SMTP_HOST": "smtp.test.com",
-        "EMAIL_SMTP_PORT": "587",
-    }, clear=False)
+    @patch.dict(
+        os.environ,
+        {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_AUTH_MODE": "password",
+            "EMAIL_ALLOWED_USERS": "",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+            "EMAIL_SMTP_PORT": "587",
+        },
+        clear=False,
+    )
     def test_smtp_close_called_when_quit_also_fails(self):
         """If both send_message() and quit() fail, close() is the fallback."""
         adapter = self._make_adapter()
@@ -1072,25 +1337,38 @@ class TestSmtpConnectionCleanup(unittest.TestCase):
 class TestImapConnectionCleanup(unittest.TestCase):
     """Verify IMAP connections are closed even when fetch raises."""
 
-    @patch.dict(os.environ, {
-        "EMAIL_ADDRESS": "hermes@test.com",
-        "EMAIL_PASSWORD": "secret",
-        "EMAIL_IMAP_HOST": "imap.test.com",
-        "EMAIL_IMAP_PORT": "993",
-        "EMAIL_SMTP_HOST": "smtp.test.com",
-    }, clear=False)
+    @patch.dict(
+        os.environ,
+        {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_AUTH_MODE": "password",
+            "EMAIL_ALLOWED_USERS": "",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_IMAP_PORT": "993",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+        },
+        clear=False,
+    )
     def _make_adapter(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.email import EmailAdapter
+
         return EmailAdapter(PlatformConfig(enabled=True))
 
-    @patch.dict(os.environ, {
-        "EMAIL_ADDRESS": "hermes@test.com",
-        "EMAIL_PASSWORD": "secret",
-        "EMAIL_IMAP_HOST": "imap.test.com",
-        "EMAIL_IMAP_PORT": "993",
-        "EMAIL_SMTP_HOST": "smtp.test.com",
-    }, clear=False)
+    @patch.dict(
+        os.environ,
+        {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_AUTH_MODE": "password",
+            "EMAIL_ALLOWED_USERS": "",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_IMAP_PORT": "993",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+        },
+        clear=False,
+    )
     def test_imap_logout_called_on_uid_fetch_failure(self):
         """IMAP logout() must be called even when uid fetch raises."""
         adapter = self._make_adapter()
@@ -1111,13 +1389,19 @@ class TestImapConnectionCleanup(unittest.TestCase):
         self.assertEqual(results, [])
         mock_imap.logout.assert_called_once()
 
-    @patch.dict(os.environ, {
-        "EMAIL_ADDRESS": "hermes@test.com",
-        "EMAIL_PASSWORD": "secret",
-        "EMAIL_IMAP_HOST": "imap.test.com",
-        "EMAIL_IMAP_PORT": "993",
-        "EMAIL_SMTP_HOST": "smtp.test.com",
-    }, clear=False)
+    @patch.dict(
+        os.environ,
+        {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_AUTH_MODE": "password",
+            "EMAIL_ALLOWED_USERS": "",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_IMAP_PORT": "993",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+        },
+        clear=False,
+    )
     def test_imap_logout_called_on_early_return(self):
         """IMAP logout() must be called even when returning early (no unseen)."""
         adapter = self._make_adapter()
@@ -1140,33 +1424,45 @@ class TestImapIdExtensionForNetEase(unittest.TestCase):
 
     def _make_adapter(self):
         from gateway.config import PlatformConfig
-        with patch.dict(os.environ, {
-            "EMAIL_ADDRESS": "hermes@163.com",
-            "EMAIL_PASSWORD": "secret",
-            "EMAIL_IMAP_HOST": "imap.163.com",
-            "EMAIL_SMTP_HOST": "smtp.163.com",
-        }):
+
+        with patch.dict(
+            os.environ,
+            {
+                "EMAIL_ADDRESS": "hermes@163.com",
+                "EMAIL_PASSWORD": "secret",
+                "EMAIL_AUTH_MODE": "password",
+                "EMAIL_ALLOWED_USERS": "",
+                "EMAIL_IMAP_HOST": "imap.163.com",
+                "EMAIL_SMTP_HOST": "smtp.163.com",
+            },
+        ):
             from gateway.platforms.email import EmailAdapter
+
             adapter = EmailAdapter(PlatformConfig(enabled=True))
         return adapter
 
     def test_connect_sends_imap_id_after_login(self):
         """connect() must call xatom('ID', ...) after LOGIN for 163 support."""
         import asyncio
+
         adapter = self._make_adapter()
 
         mock_imap = MagicMock()
         mock_imap.uid.return_value = ("OK", [b""])
 
-        with patch("imaplib.IMAP4_SSL", return_value=mock_imap), \
-             patch("smtplib.SMTP") as mock_smtp:
+        with (
+            patch("imaplib.IMAP4_SSL", return_value=mock_imap),
+            patch("smtplib.SMTP") as mock_smtp,
+        ):
             mock_smtp.return_value = MagicMock()
             asyncio.run(adapter.connect())
             adapter._running = False
             if adapter._poll_task:
                 adapter._poll_task.cancel()
 
-        id_calls = [c for c in mock_imap.xatom.call_args_list if c.args and c.args[0] == "ID"]
+        id_calls = [
+            c for c in mock_imap.xatom.call_args_list if c.args and c.args[0] == "ID"
+        ]
         self.assertTrue(
             id_calls,
             "EmailAdapter.connect() must call imap.xatom('ID', ...) after "
@@ -1188,7 +1484,9 @@ class TestImapIdExtensionForNetEase(unittest.TestCase):
         with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
             adapter._fetch_new_messages()
 
-        id_calls = [c for c in mock_imap.xatom.call_args_list if c.args and c.args[0] == "ID"]
+        id_calls = [
+            c for c in mock_imap.xatom.call_args_list if c.args and c.args[0] == "ID"
+        ]
         self.assertTrue(
             id_calls,
             "_fetch_new_messages() must call imap.xatom('ID', ...) after "

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -12,7 +12,9 @@ Covers:
 9. Message dispatch and threading
 """
 
+import json
 import os
+import tempfile
 import unittest
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
@@ -216,6 +218,48 @@ class TestHelperFunctions(unittest.TestCase):
         html = "a &amp; b &lt; c &gt; d"
         result = _strip_html(html)
         self.assertIn("a & b", result)
+
+    def test_build_inbound_lead_record_extracts_crm_fields(self):
+        from gateway.platforms.email import _build_inbound_lead_record
+
+        msg_data = {
+            "sender_addr": "founder@example.com",
+            "sender_name": "Founder",
+            "subject": "Need pricing for an AI receptionist pilot",
+            "message_id": "<lead@example.com>",
+            "in_reply_to": "",
+            "to_addrs": ["hermes@test.com"],
+            "cc_addrs": [],
+            "body": (
+                "Can we schedule a demo? Call me at (555) 123-4567 or see "
+                "https://example.com/intake. Ops can be reached at ops@example.com."
+            ),
+            "attachments": [{"filename": "brief.pdf"}],
+            "date": "Tue, 19 May 2026 01:15:00 -0400",
+        }
+
+        record = _build_inbound_lead_record(msg_data)
+
+        self.assertTrue(record["no_send"])
+        self.assertTrue(record["human_review_required"])
+        self.assertEqual(record["sender_email"], "founder@example.com")
+        self.assertIn("pricing", record["intent_tags"])
+        self.assertIn("scheduling", record["intent_tags"])
+        self.assertIn("buying_intent", record["intent_tags"])
+        self.assertEqual(record["contact_paths"]["emails"], ["ops@example.com"])
+        self.assertEqual(record["contact_paths"]["phones"], ["(555) 123-4567"])
+        self.assertEqual(
+            record["contact_paths"]["urls"], ["https://example.com/intake"]
+        )
+        self.assertEqual(record["attachment_count"], 1)
+
+    def test_build_inbound_lead_record_truncates_body_excerpt(self):
+        from gateway.platforms.email import _build_inbound_lead_record
+
+        record = _build_inbound_lead_record({"body": "x" * 1200})
+
+        self.assertEqual(len(record["body_excerpt"]), 1000)
+        self.assertTrue(record["body_truncated"])
 
 
 class TestExtractTextBody(unittest.TestCase):
@@ -522,6 +566,74 @@ class TestDispatchMessage(unittest.TestCase):
         self.assertEqual(event.source.user_id, "john@example.com")
         self.assertEqual(event.source.user_name, "John Doe")
         self.assertEqual(event.source.chat_type, "dm")
+
+    def test_lead_capture_disabled_by_default(self):
+        """Dispatch should not create lead records unless configured."""
+        import asyncio
+
+        adapter = self._make_adapter()
+        captured_events = []
+
+        async def capture_handle(event):
+            captured_events.append(event)
+
+        adapter.handle_message = capture_handle
+        with tempfile.TemporaryDirectory() as tmpdir:
+            capture_path = Path(tmpdir) / "leads.jsonl"
+            adapter._lead_capture_path = None
+            msg_data = {
+                "uid": b"7",
+                "sender_addr": "buyer@example.com",
+                "sender_name": "Buyer",
+                "subject": "Pricing",
+                "message_id": "<lead7@test.com>",
+                "in_reply_to": "",
+                "body": "Can we schedule a pricing call?",
+                "attachments": [],
+                "date": "",
+            }
+
+            asyncio.run(adapter._dispatch_message(msg_data))
+            self.assertEqual(len(captured_events), 1)
+            self.assertFalse(capture_path.exists())
+
+    def test_lead_capture_appends_jsonl_before_dispatch(self):
+        """Configured lead capture should append no-send JSONL records."""
+        import asyncio
+
+        adapter = self._make_adapter()
+        captured_events = []
+
+        async def capture_handle(event):
+            captured_events.append(event)
+
+        adapter.handle_message = capture_handle
+        with tempfile.TemporaryDirectory() as tmpdir:
+            capture_path = Path(tmpdir) / "nested" / "leads.jsonl"
+            adapter._lead_capture_path = capture_path
+            msg_data = {
+                "uid": b"8",
+                "sender_addr": "buyer@example.com",
+                "sender_name": "Buyer",
+                "subject": "Need a quote",
+                "message_id": "<lead8@test.com>",
+                "in_reply_to": "",
+                "body": "Interested in a pilot. Please call 555-111-2222.",
+                "attachments": [],
+                "date": "Tue, 19 May 2026 01:30:00 -0400",
+            }
+
+            asyncio.run(adapter._dispatch_message(msg_data))
+            self.assertEqual(len(captured_events), 1)
+            records = [
+                json.loads(line) for line in capture_path.read_text().splitlines()
+            ]
+            self.assertEqual(len(records), 1)
+            self.assertTrue(records[0]["no_send"])
+            self.assertEqual(records[0]["sender_email"], "buyer@example.com")
+            self.assertIn("pricing", records[0]["intent_tags"])
+            self.assertIn("buying_intent", records[0]["intent_tags"])
+            self.assertEqual(records[0]["contact_paths"]["phones"], ["555-111-2222"])
 
     def test_non_allowlisted_sender_dropped(self):
         """Senders not in EMAIL_ALLOWED_USERS should be dropped before dispatch."""

--- a/website/docs/user-guide/messaging/email.md
+++ b/website/docs/user-guide/messaging/email.md
@@ -72,6 +72,11 @@ EMAIL_IMAP_PORT=993                    # Default: 993 (IMAP SSL)
 EMAIL_SMTP_PORT=587                    # Default: 587 (SMTP STARTTLS)
 EMAIL_POLL_INTERVAL=15                 # Seconds between inbox checks (default: 15)
 EMAIL_HOME_ADDRESS=your@email.com      # Default delivery target for cron jobs
+
+# Assistant address mode: useful when the agent is cc'd on normal email threads
+EMAIL_ASSISTANT_MODE=true
+EMAIL_REQUIRE_MENTION_WHEN_NOT_DIRECT=true
+EMAIL_WAKE_PHRASES=@lila,lila please,lila:,[lila]
 ```
 
 ---
@@ -105,6 +110,20 @@ The adapter polls the IMAP inbox for UNSEEN messages at a configurable interval 
 - **HTML-only emails** have tags stripped for plain text extraction
 - **Self-messages** are filtered out to prevent reply loops
 - **Automated/noreply senders** are silently ignored — `noreply@`, `mailer-daemon@`, `bounce@`, `no-reply@`, and emails with `Auto-Submitted`, `Precedence: bulk`, or `List-Unsubscribe` headers
+
+### Assistant Address Mode
+
+When `EMAIL_ASSISTANT_MODE=true`, the email adapter can safely use an assistant address that gets cc'd on normal threads:
+
+- One-to-one emails directly to the assistant are processed.
+- Emails where the assistant is cc'd, or included alongside other recipients, are ignored unless explicitly invoked.
+- Explicit invocation is detected in the subject or body with wake phrases such as `Lila,`, `@lila`, `Lila please`, `Lila:`, or `[Lila]`.
+
+This is useful for workflows like:
+
+> Lila, please coordinate a time with everyone on this thread and send a calendar invite.
+
+Configure wake phrases with `EMAIL_WAKE_PHRASES` as a comma-separated list. Keep `EMAIL_ALLOWED_USERS` restricted while testing.
 
 ### Sending Replies
 
@@ -188,3 +207,6 @@ Email access follows the same pattern as all other Hermes platforms:
 | `EMAIL_ALLOWED_USERS` | No | — | Comma-separated allowed sender addresses |
 | `EMAIL_HOME_ADDRESS` | No | — | Default delivery target for cron jobs |
 | `EMAIL_ALLOW_ALL_USERS` | No | `false` | Allow all senders (not recommended) |
+| `EMAIL_ASSISTANT_MODE` | No | `false` | Ignore passive cc/group emails unless explicitly invoked |
+| `EMAIL_REQUIRE_MENTION_WHEN_NOT_DIRECT` | No | `true` | In assistant mode, require a wake phrase unless the email is one-to-one directly to the agent |
+| `EMAIL_WAKE_PHRASES` | No | `@lila,lila please,lila:,[lila]` | Comma-separated invocation phrases; `Lila,` / `Lila:` style local-part mentions are also detected automatically |

--- a/website/docs/user-guide/messaging/email.md
+++ b/website/docs/user-guide/messaging/email.md
@@ -77,6 +77,9 @@ EMAIL_HOME_ADDRESS=your@email.com      # Default delivery target for cron jobs
 EMAIL_ASSISTANT_MODE=true
 EMAIL_REQUIRE_MENTION_WHEN_NOT_DIRECT=true
 EMAIL_WAKE_PHRASES=@lila,lila please,lila:,[lila]
+
+# Optional no-send CRM intake: append human-review inbound lead records as JSONL
+EMAIL_LEAD_CAPTURE_PATH=~/.hermes/email-leads/inbound.jsonl
 ```
 
 ---
@@ -124,6 +127,24 @@ This is useful for workflows like:
 > Lila, please coordinate a time with everyone on this thread and send a calendar invite.
 
 Configure wake phrases with `EMAIL_WAKE_PHRASES` as a comma-separated list. Keep `EMAIL_ALLOWED_USERS` restricted while testing.
+
+### No-send CRM Intake
+
+Set `EMAIL_LEAD_CAPTURE_PATH` to append each processed inbound email to a local JSONL file before the agent replies:
+
+```bash
+EMAIL_LEAD_CAPTURE_PATH=~/.hermes/email-leads/inbound.jsonl
+```
+
+Each record is marked `no_send: true` and `human_review_required: true`, and includes the sender, subject, message IDs, a 1,000-character body excerpt, attachment count, detected contact paths (emails, phone numbers, URLs), and deterministic intent tags such as `pricing`, `scheduling`, `buying_intent`, `support`, or `partnership`. This is meant for CRM review/import workflows only; it does not send outbound email or call any CRM API.
+
+You can also configure the path in `config.yaml`:
+
+```yaml
+platforms:
+  email:
+    lead_capture_path: ~/.hermes/email-leads/inbound.jsonl
+```
 
 ### Sending Replies
 
@@ -210,3 +231,4 @@ Email access follows the same pattern as all other Hermes platforms:
 | `EMAIL_ASSISTANT_MODE` | No | `false` | Ignore passive cc/group emails unless explicitly invoked |
 | `EMAIL_REQUIRE_MENTION_WHEN_NOT_DIRECT` | No | `true` | In assistant mode, require a wake phrase unless the email is one-to-one directly to the agent |
 | `EMAIL_WAKE_PHRASES` | No | `@lila,lila please,lila:,[lila]` | Comma-separated invocation phrases; `Lila,` / `Lila:` style local-part mentions are also detected automatically |
+| `EMAIL_LEAD_CAPTURE_PATH` | No | — | Append processed inbound emails as no-send, human-review JSONL lead records for CRM intake |


### PR DESCRIPTION
## Linear
- Closes VIS-149
- Stacked on PR #28440 / VIS-148 (`feat/vis-148-safe-gmail-assistant-workflows`); if GitHub cannot target the fork-only base branch, review after #28440 merges or compare against that branch locally.

## Summary
- Adds optional no-send inbound lead capture for the email gateway via `EMAIL_LEAD_CAPTURE_PATH` or `platforms.email.lead_capture_path`.
- Appends CRM-ready JSONL records only for processed human emails, before the agent replies.
- Captures sender, subject, message IDs, body excerpt, attachment count, contact paths, and deterministic intent tags without calling a CRM or sending outbound mail.
- Documents the setup and human-review/no-send guardrail.

## Test plan
- [x] `scripts/run_tests.sh tests/gateway/test_email.py` — 69 passed.
- [x] `venv/bin/python -m ruff check gateway/platforms/email.py tests/gateway/test_email.py website/docs/user-guide/messaging/email.md` — All checks passed.
- [x] `venv/bin/python -m ruff format --check gateway/platforms/email.py tests/gateway/test_email.py` — passed after formatting.
- [x] `git diff --check` — passed.

## Review notes
- The capture path is opt-in. Disabled mode remains the default.
- The records are explicitly `no_send: true` and `human_review_required: true` for safe CRM import/review workflows.
- Intent labels are deterministic keyword heuristics, not LLM scoring.

## Scope control
In scope:
- Local JSONL capture for inbound email lead review.
- Tests and docs for the opt-in behavior.

Out of scope / follow-up Linear issues:
- Direct CRM API writes.
- Automated outbound/reply sequences.
- LLM lead scoring or enrichment.
