### PR TITLE
fix(telegram): reset sticky fallback IP on connect failure

### DIFF
--- a/gateway/platforms/telegram_network.py
+++ b/gateway/platforms/telegram_network.py
@@ -76,6 +76,8 @@ class TelegramFallbackTransport(httpx.AsyncBaseTransport):
 
         sticky_ip = self._sticky_ip
         attempt_order: list[Optional[str]] = [sticky_ip] if sticky_ip else [None]
+        if sticky_ip:
+            attempt_order.append(None)  # retry primary DNS after sticky failure
         for ip in self._fallback_ips:
             if ip != sticky_ip:
                 attempt_order.append(ip)
@@ -99,6 +101,14 @@ class TelegramFallbackTransport(httpx.AsyncBaseTransport):
                 last_error = exc
                 if not _is_retryable_connect_error(exc):
                     raise
+                if ip is not None and ip == self._sticky_ip:
+                    async with self._sticky_lock:
+                        if self._sticky_ip == ip:
+                            self._sticky_ip = None
+                            logger.warning(
+                                "[Telegram] Sticky fallback IP %s failed; resetting to primary DNS path",
+                                ip,
+                            )
                 if ip is None:
                     logger.warning(
                         "[Telegram] Primary api.telegram.org connection failed (%s); trying fallback IPs %s",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -169,6 +169,7 @@ AUTHOR_MAP = {
     "erhanyasarx@gmail.com": "erhnysr",  # PR #25198 salvage (tool-progress flood-control)
     "cryptobyz.airdrop@gmail.com": "CryptoByz",  # PR #25630 salvage (polling conflict Stage 1+2)
     "fabioxxx@gmail.com": "fabiosiqueira",  # PR #27212 salvage (bg-process notif anchor)
+    "lordfalcon.exe@gmail.com": "falconexe",  # PR #24511 salvage (sticky-IP reset)
     "androidhtml@yandex.com": "hllqkb",
     "25840394+Bongulielmi@users.noreply.github.com": "Bongulielmi",
     "jonathan.troyer@overmatch.com": "JTroyerOvermatch",

--- a/tests/gateway/test_telegram_network.py
+++ b/tests/gateway/test_telegram_network.py
@@ -252,8 +252,10 @@ class TestFallbackTransport:
 
         resp = await transport.handle_async_request(_telegram_request())
         assert resp.status_code == 200
-        # Tried sticky (.220) first, then fell through to .221
-        assert [c["url_host"] for c in calls] == ["149.154.167.220", "149.154.167.221"]
+        # After #24511: when sticky fails the transport also resets and
+        # re-tries the primary DNS path before falling through to other IPs.
+        # Path: sticky (.220) → primary (api.telegram.org) → .221
+        assert [c["url_host"] for c in calls] == ["149.154.167.220", "api.telegram.org", "149.154.167.221"]
         assert transport._sticky_ip == "149.154.167.221"
 
 


### PR DESCRIPTION
Salvage of #24511 (@falconexe).

When a sticky fallback IP (from DoH discovery) becomes unreachable, the transport got stuck trying only the dead IP, leaving the gateway unable to recover until restart. Fix: when the sticky IP fails, reset and re-try the primary DNS path before falling through to other discovered IPs.

## Validation
- `scripts/run_tests.sh tests/gateway/test_telegram_network.py -q` → 46/46 passing.

Follow-up commit updates `test_sticky_ip_tried_first_but_falls_through_if_stale` to expect the new three-step path (sticky → primary DNS → next fallback).

Authorship preserved via cherry-pick. AUTHOR_MAP entry added in follow-up.