### PR TITLE
fix(gateway): treat /model status as info subcommand, not model switch

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9847,6 +9847,12 @@ class GatewayRunner:
         # Parse --provider and --global flags
         model_input, explicit_provider, persist_global = parse_model_flags(raw_args)
 
+        # Intercept reserved subcommands that should show status/info
+        # instead of switching to a model literally named "status" etc.
+        _MODEL_INFO_SUBCOMMANDS = {"status", "info"}
+        if model_input.lower() in _MODEL_INFO_SUBCOMMANDS and not explicit_provider:
+            model_input = ""  # Treat as no-args → show status/picker
+
         # Read current model/provider from config
         current_model = ""
         current_provider = "openrouter"

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -684,6 +684,7 @@ AUTHOR_MAP = {
     "juan.ovalle@mistral.ai": "jjovalle99",
     "julien.talbot@ergonomia.re": "Julientalbot",
     "kagura.chen28@gmail.com": "kagura-agent",
+    "kagura.agent.ai@gmail.com": "kagura-agent",
     "1342088860@qq.com": "youngDoo",
     "kamil@gwozdz.me": "kamil-gwozdz",
     "skmishra1991@gmail.com": "bugkill3r",

--- a/tests/gateway/test_model_status_subcommand.py
+++ b/tests/gateway/test_model_status_subcommand.py
@@ -1,0 +1,96 @@
+"""Regression test: /model status should show current model, not switch to 'status'."""
+
+import yaml
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+def _make_runner():
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner._voice_mode = {}
+    runner._session_model_overrides = {}
+    return runner
+
+
+def _make_event(text="/model status"):
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_model_status_shows_info_instead_of_switching(tmp_path, monkeypatch):
+    """'/model status' should display current model info, not switch to a model named 'status'."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "model": {
+                    "default": "gemini-3.1-pro-preview",
+                    "provider": "custom",
+                    "base_url": "http://127.0.0.1:8317/v1",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    import gateway.run as gateway_run
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+
+    runner = _make_runner()
+    result = await runner._handle_model_command(_make_event("/model status"))
+
+    # Should return status text (not None which means picker was sent)
+    # and should NOT have stored a session override for "status"
+    session_key = runner._session_key_for_source(
+        SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm")
+    )
+    override = runner._session_model_overrides.get(session_key, {})
+    assert override.get("model") != "status", (
+        "/model status should not switch to a model named 'status'"
+    )
+
+
+@pytest.mark.asyncio
+async def test_model_info_shows_info_instead_of_switching(tmp_path, monkeypatch):
+    """'/model info' should display current model info, not switch to a model named 'info'."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "model": {
+                    "default": "gpt-5.4",
+                    "provider": "openrouter",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    import gateway.run as gateway_run
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+
+    runner = _make_runner()
+    result = await runner._handle_model_command(_make_event("/model info"))
+
+    session_key = runner._session_key_for_source(
+        SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm")
+    )
+    override = runner._session_model_overrides.get(session_key, {})
+    assert override.get("model") != "info", (
+        "/model info should not switch to a model named 'info'"
+    )


### PR DESCRIPTION
## Summary

Fixes #28489.

`/model status` was treated as switching to a literal model named `status`. The invalid override was stored in `_session_model_overrides` and persisted across sessions, causing later API calls with `model: status` → HTTP 502 → retry exhaustion → fallback.

## Changes

**`gateway/run.py`**: Added a reserved-subcommand guard in `_handle_model_command()`. When `model_input` is `status` or `info` (case-insensitive) and no `--provider` flag is given, the input is cleared so the command falls through to the no-args status/picker path instead of `switch_model()`.

## Why this approach

The root cause is that `parse_model_flags('status')` returns `model_input='status'`, which bypasses the no-args check and goes straight to `switch_model()`. On custom providers, there's no catalog validation, so any string is accepted as a model name.

Rather than adding model validation in `switch_model()` (which would need API probing and could break legitimate custom model names), this intercepts the two most common info-seeking subcommands at the command handler level — minimal change, no new dependencies, no risk to the switch pipeline.

## Testing

- Added `tests/gateway/test_model_status_subcommand.py` with two tests:
  - `/model status` → does not create a session override for model \status\
  - `/model info` → same guard
- All 16 existing model command tests pass
- New tests: 2 passed