### PR TITLE
feat(send_message): auto-detect @username mentions and create Telegram entities

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -170,6 +170,7 @@ AUTHOR_MAP = {
     "cryptobyz.airdrop@gmail.com": "CryptoByz",  # PR #25630 salvage (polling conflict Stage 1+2)
     "fabioxxx@gmail.com": "fabiosiqueira",  # PR #27212 salvage (bg-process notif anchor)
     "lordfalcon.exe@gmail.com": "falconexe",  # PR #24511 salvage (sticky-IP reset)
+    "fonhal@gmail.com": "fonhal",  # PR #27865/#27861 salvage (mention entities / typing fallback)
     "androidhtml@yandex.com": "hllqkb",
     "25840394+Bongulielmi@users.noreply.github.com": "Bongulielmi",
     "jonathan.troyer@overmatch.com": "JTroyerOvermatch",

--- a/tests/tools/test_send_message_telegram_proxy.py
+++ b/tests/tools/test_send_message_telegram_proxy.py
@@ -37,8 +37,11 @@ def _install_telegram_mock_with_request(
     parse_mode = SimpleNamespace(MARKDOWN_V2="MarkdownV2", HTML="HTML")
     constants_mod = SimpleNamespace(ParseMode=parse_mode)
     request_mod = SimpleNamespace(HTTPXRequest=httpx_request_factory)
+    # MessageEntity needed by #27865 mention-detection path.
+    _MessageEntity = lambda **_kw: SimpleNamespace(**_kw)
     telegram_mod = SimpleNamespace(
         Bot=bot_factory,
+        MessageEntity=_MessageEntity,
         constants=constants_mod,
         request=request_mod,
     )

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -48,7 +48,10 @@ def _make_config():
 def _install_telegram_mock(monkeypatch, bot):
     parse_mode = SimpleNamespace(MARKDOWN_V2="MarkdownV2", HTML="HTML")
     constants_mod = SimpleNamespace(ParseMode=parse_mode)
-    telegram_mod = SimpleNamespace(Bot=lambda token: bot, constants=constants_mod)
+    # MessageEntity needed by #27865 mention-detection path; tests don't
+    # inspect it but the import must succeed.
+    _MessageEntity = lambda **_kw: SimpleNamespace(**_kw)
+    telegram_mod = SimpleNamespace(Bot=lambda token: bot, MessageEntity=_MessageEntity, constants=constants_mod)
     monkeypatch.setitem(sys.modules, "telegram", telegram_mod)
     monkeypatch.setitem(sys.modules, "telegram.constants", constants_mod)
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -795,7 +795,7 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
     instead, bypassing MarkdownV2 conversion.
     """
     try:
-        from telegram import Bot
+        from telegram import Bot, MessageEntity
         from telegram.constants import ParseMode
 
         # Auto-detect HTML tags — if present, skip MarkdownV2 and send as HTML.
@@ -815,6 +815,14 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                 # Fallback: send as-is if formatting unavailable
                 formatted = message
             send_parse_mode = ParseMode.MARKDOWN_V2
+
+        # Detect @username patterns and create mention entities so
+        # require_mention on the receiving bot's Gateway can trigger.
+        _MENTION_RE = re.compile(r'@([a-zA-Z][a-zA-Z0-9_]{4,31})')
+        _entities = [
+            MessageEntity(type="mention", offset=m.start(), length=len(m.group()))
+            for m in _MENTION_RE.finditer(formatted)
+        ]
 
         # Honour a configured proxy (telegram.proxy_url in config.yaml, exported
         # as TELEGRAM_PROXY env var by load_gateway_config). Without this, the
@@ -876,7 +884,7 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                 last_msg = await _send_telegram_message_with_retry(
                     bot,
                     chat_id=int_chat_id, text=formatted,
-                    parse_mode=send_parse_mode, **thread_kwargs
+                    parse_mode=send_parse_mode, entities=_entities, **thread_kwargs
                 )
             except Exception as md_error:
                 # Parse failed, fall back to plain text
@@ -897,7 +905,7 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                     last_msg = await _send_telegram_message_with_retry(
                         bot,
                         chat_id=int_chat_id, text=plain,
-                        parse_mode=None, **thread_kwargs
+                        parse_mode=None, entities=_entities, **thread_kwargs
                     )
                 else:
                     raise


### PR DESCRIPTION
Salvage of #27865 (@fonhal). When bots send messages containing `@username` to each other via `send_message`, the text didn't generate a Telegram `MessageEntity(type='mention')`. This auto-detects username patterns and attaches mention entities so `require_mention` on the receiving bot's gateway triggers correctly.

Conflict resolution: combined with the just-merged #25419 (TELEGRAM_PROXY in send_message_tool). Test mocks updated to expose `MessageEntity` symbol.

Validation: targeted send_message tests pass (one pre-existing slack-parse test failure unrelated).