### PR TITLE
fix(telegram): resume typing indicator after inline approval click (#27853)

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2814,6 +2814,15 @@ class TelegramAdapter(BasePlatformAdapter):
                     )
                 except Exception as exc:
                     logger.error("Failed to resolve gateway approval from Telegram button: %s", exc)
+                    count = 0
+
+                # Resume the typing indicator — paused when the approval was
+                # sent (gateway/run.py).  The text /approve and /deny paths
+                # call resume_typing_for_chat here too; without it, typing
+                # stays paused for the rest of the turn after an inline
+                # button click.
+                if count and query_chat_id is not None:
+                    self.resume_typing_for_chat(str(query_chat_id))
             return
 
         # --- Slash-confirm callbacks (sc:choice:confirm_id) ---

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -272,6 +272,67 @@ class TestTelegramApprovalCallback:
         assert 1 not in adapter._approval_state
 
     @pytest.mark.asyncio
+    async def test_resume_typing_after_inline_approval(self):
+        """Clicking an inline approval button must un-pause the chat's typing.
+
+        Regression for #27853: the text /approve path resumed typing, but the
+        ea: callback path did not, so the typing indicator stayed gone for the
+        rest of a long-running turn after a button click.
+        """
+        adapter = _make_adapter()
+        adapter._approval_state[5] = "agent:main:telegram:group:12345:99"
+        adapter.pause_typing_for_chat("12345")
+        assert "12345" in adapter._typing_paused
+
+        query = AsyncMock()
+        query.data = "ea:once:5"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.from_user = MagicMock()
+        query.from_user.first_name = "Norbert"
+        query.from_user.id = "12345"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            with patch("tools.approval.resolve_gateway_approval", return_value=1):
+                await adapter._handle_callback_query(update, context)
+
+        assert "12345" not in adapter._typing_paused
+
+    @pytest.mark.asyncio
+    async def test_typing_stays_paused_when_resolve_returns_zero(self):
+        """If resolve_gateway_approval reports 0 resolves, the agent thread
+        was never unblocked, so typing should NOT be force-resumed."""
+        adapter = _make_adapter()
+        adapter._approval_state[6] = "agent:main:telegram:group:12345:99"
+        adapter.pause_typing_for_chat("12345")
+
+        query = AsyncMock()
+        query.data = "ea:once:6"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.from_user = MagicMock()
+        query.from_user.first_name = "Norbert"
+        query.from_user.id = "12345"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            with patch("tools.approval.resolve_gateway_approval", return_value=0):
+                await adapter._handle_callback_query(update, context)
+
+        assert "12345" in adapter._typing_paused
+
+    @pytest.mark.asyncio
     async def test_approval_callback_escapes_dynamic_user_name(self):
         adapter = _make_adapter()
         adapter._approval_state[3] = "agent:main:telegram:group:12345:99"


### PR DESCRIPTION
Salvage of #27874 (@briandevans). Clicking a Telegram inline approval/deny button (`ea:*` callback) left the typing indicator paused for the rest of a long-running turn. Text `/approve` and `/deny` already resumed typing; this aligns the inline-button path.

Authorship preserved via cherry-pick. One pre-existing test flake (`.update_response` file-not-found) reproduces on plain main, not caused by this PR.