### PR TITLE
fix: move audio_file_paths init before conditional to avoid UnboundLocalError

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7254,10 +7254,10 @@ class GatewayRunner:
         if getattr(event, "channel_context", None):
             message_text = f"{event.channel_context}\n\n[New message]\n{message_text}"
 
+        audio_file_paths: list[str] = []  # audio file attachments — not for STT
         if event.media_urls:
             image_paths = []
             audio_paths = []
-            audio_file_paths: list[str] = []  # audio file attachments — not for STT
             for i, path in enumerate(event.media_urls):
                 mtype = event.media_types[i] if i < len(event.media_types) else ""
                 if mtype.startswith("image/") or event.message_type == MessageType.PHOTO:


### PR DESCRIPTION
The `audio_file_paths` variable is initialized inside the `if event.media_urls:` block but accessed outside it at line 7334. When a message has no `media_urls`, the variable is never bound, causing:

```
UnboundLocalError: cannot access local variable "audio_file_paths"
where it is not associated with a value
```

This moves the initialization one line up, before the conditional block, so it is always bound regardless of whether `event.media_urls` is set.