### PR TITLE
feat(gateway): add LINE group/room mention-only and trigger-prefix gating

### DIFF
--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -424,6 +424,42 @@ def _allowed_for_source(
     return False
 
 
+def _group_message_triggers_reply(
+    *,
+    message: Dict[str, Any],
+    bot_user_id: Optional[str],
+    trigger_prefixes: Tuple[str, ...],
+) -> bool:
+    """Decide whether a group/room message should be replied to in
+    mention-only mode.
+
+    Returns ``True`` when the message is text and either:
+
+    - the bot is ``@mentioned`` (``message.mention.mentionees`` contains
+      an entry whose ``userId`` matches ``bot_user_id``), or
+    - the stripped text starts with one of ``trigger_prefixes``
+      (case-insensitive).
+
+    Non-text events (image, sticker, file, location) cannot address the
+    bot so they always return ``False`` here. DM (source type ``user``)
+    should never be passed in — the caller is responsible for
+    short-circuiting on DM before invoking this helper.
+
+    Both gates are useful together because LINE rarely surfaces bots in
+    the in-app ``@`` suggestion list, so a text prefix is often the
+    only reliable trigger in practice.
+    """
+    if (message or {}).get("type") != "text":
+        return False
+    text = ((message or {}).get("text") or "").strip()
+    mentionees = ((message or {}).get("mention") or {}).get("mentionees") or []
+    if bot_user_id and any(m.get("userId") == bot_user_id for m in mentionees):
+        return True
+    if trigger_prefixes and text.lower().startswith(trigger_prefixes):
+        return True
+    return False
+
+
 # ---------------------------------------------------------------------------
 # LINE Reply / Push HTTP client
 # ---------------------------------------------------------------------------
@@ -675,6 +711,22 @@ class LineAdapter(BasePlatformAdapter):
             os.getenv("LINE_ALLOWED_ROOMS", "")
         ) | set(extra.get("allowed_rooms", []))
 
+        # Group/room mention-only mode: only reply in group/room chats when
+        # the bot is @mentioned in the text. DMs are unaffected.
+        self.group_mention_only = _truthy_env(
+            "LINE_GROUP_MENTION_ONLY",
+            bool(extra.get("group_mention_only", False)),
+        )
+        # Group/room trigger prefixes (CSV, case-insensitive). When set,
+        # a message whose text starts with any of these prefixes also
+        # triggers a reply in mention-only mode — useful because LINE
+        # rarely surfaces bots in the @ suggestion list.
+        self.group_trigger_prefixes = tuple(
+            p.lower() for p in _csv_set(
+                os.getenv("LINE_GROUP_TRIGGER_PREFIXES", "")
+            )
+        )
+
         # Slow-LLM postback button threshold
         try:
             self.slow_response_threshold = float(
@@ -905,6 +957,26 @@ class LineAdapter(BasePlatformAdapter):
         ):
             logger.info("LINE: rejecting unauthorized source %s", source)
             return
+
+        # Mention-only gate for groups/rooms.
+        if (
+            self.group_mention_only
+            and event_type == "message"
+            and source.get("type") in {"group", "room"}
+        ):
+            msg = event.get("message") or {}
+            if not _group_message_triggers_reply(
+                message=msg,
+                bot_user_id=self._bot_user_id,
+                trigger_prefixes=self.group_trigger_prefixes,
+            ):
+                logger.info(
+                    "LINE: group/room message dropped in mention-only mode "
+                    "(msg_type=%s, source=%s)",
+                    msg.get("type"),
+                    source,
+                )
+                return
 
         if event_type == "message":
             await self._handle_message_event(event)

--- a/tests/gateway/test_line_plugin.py
+++ b/tests/gateway/test_line_plugin.py
@@ -36,6 +36,7 @@ split_for_line = _line.split_for_line
 build_postback_button_message = _line.build_postback_button_message
 _resolve_chat = _line._resolve_chat
 _allowed_for_source = _line._allowed_for_source
+_group_message_triggers_reply = _line._group_message_triggers_reply
 _is_system_bypass = _line._is_system_bypass
 RequestCache = _line.RequestCache
 State = _line.State
@@ -150,6 +151,125 @@ class TestAllowlist:
     def test_unknown_type_rejected(self):
         src = {"type": "weird"}
         assert not _allowed_for_source(src, allow_all=False, user_ids=set(), group_ids=set(), room_ids=set())
+
+
+# ---------------------------------------------------------------------------
+# 3b. Mention-only gate for group/room chats
+# ---------------------------------------------------------------------------
+
+class TestGroupMentionGate:
+    """Pure-function tests for ``_group_message_triggers_reply``.
+
+    The helper is only invoked for source types ``group`` and ``room``
+    when ``LINE_GROUP_MENTION_ONLY=true``. DM messages bypass the gate
+    in the dispatcher, so we don't test DM behavior here.
+    """
+
+    BOT = "Ubot1234567890abcdef1234567890abcd"
+
+    def _text(self, text, mentionees=None):
+        msg = {"type": "text", "text": text}
+        if mentionees is not None:
+            msg["mention"] = {"mentionees": mentionees}
+        return msg
+
+    # --- mention path --------------------------------------------------
+
+    def test_mention_matches(self):
+        msg = self._text("hi", mentionees=[{"index": 0, "length": 3, "userId": self.BOT}])
+        assert _group_message_triggers_reply(
+            message=msg, bot_user_id=self.BOT, trigger_prefixes=()
+        )
+
+    def test_mention_other_user_does_not_match(self):
+        msg = self._text("hi", mentionees=[{"userId": "Uother"}])
+        assert not _group_message_triggers_reply(
+            message=msg, bot_user_id=self.BOT, trigger_prefixes=()
+        )
+
+    def test_mention_without_bot_user_id_known(self):
+        # If we never learned the bot's own user id, mention path can't fire.
+        msg = self._text("hi", mentionees=[{"userId": self.BOT}])
+        assert not _group_message_triggers_reply(
+            message=msg, bot_user_id=None, trigger_prefixes=()
+        )
+
+    # --- prefix path ---------------------------------------------------
+
+    def test_prefix_at_start_matches(self):
+        msg = self._text("emma what's up")
+        assert _group_message_triggers_reply(
+            message=msg, bot_user_id=None, trigger_prefixes=("emma",)
+        )
+
+    def test_prefix_case_insensitive(self):
+        for text in ("Emma hi", "EMMA hi", "eMmA hi"):
+            msg = self._text(text)
+            assert _group_message_triggers_reply(
+                message=msg, bot_user_id=None, trigger_prefixes=("emma",)
+            ), text
+
+    def test_prefix_must_be_at_start(self):
+        msg = self._text("hey emma")
+        assert not _group_message_triggers_reply(
+            message=msg, bot_user_id=None, trigger_prefixes=("emma",)
+        )
+
+    def test_prefix_strips_leading_whitespace(self):
+        msg = self._text("   emma hi")
+        assert _group_message_triggers_reply(
+            message=msg, bot_user_id=None, trigger_prefixes=("emma",)
+        )
+
+    def test_any_of_multiple_prefixes_matches(self):
+        prefixes = ("emma", "/h", "!bot")
+        for text in ("emma hi", "/h hi", "!bot do something"):
+            assert _group_message_triggers_reply(
+                message=self._text(text), bot_user_id=None, trigger_prefixes=prefixes
+            ), text
+
+    def test_empty_prefixes_tuple_means_no_prefix_gate(self):
+        msg = self._text("emma hi")
+        assert not _group_message_triggers_reply(
+            message=msg, bot_user_id=None, trigger_prefixes=()
+        )
+
+    # --- combined / fallthrough ----------------------------------------
+
+    def test_mention_or_prefix_either_passes(self):
+        msg = self._text("emma hi", mentionees=[{"userId": "Uother"}])
+        assert _group_message_triggers_reply(
+            message=msg, bot_user_id=self.BOT, trigger_prefixes=("emma",)
+        )
+
+    def test_neither_mention_nor_prefix_rejected(self):
+        msg = self._text("hi", mentionees=[{"userId": "Uother"}])
+        assert not _group_message_triggers_reply(
+            message=msg, bot_user_id=self.BOT, trigger_prefixes=("emma",)
+        )
+
+    # --- non-text -----------------------------------------------------
+
+    def test_non_text_message_rejected(self):
+        for msg_type in ("image", "sticker", "video", "audio", "file", "location"):
+            msg = {"type": msg_type}
+            assert not _group_message_triggers_reply(
+                message=msg, bot_user_id=self.BOT, trigger_prefixes=("emma",)
+            ), msg_type
+
+    def test_missing_text_treated_as_empty(self):
+        # message of type text but no "text" field — defensive handling
+        msg = {"type": "text"}
+        assert not _group_message_triggers_reply(
+            message=msg, bot_user_id=None, trigger_prefixes=("emma",)
+        )
+
+    def test_none_message_rejected(self):
+        # The dispatcher uses ``event.get("message") or {}`` but make
+        # sure the helper is also robust to falsy inputs.
+        assert not _group_message_triggers_reply(
+            message={}, bot_user_id=None, trigger_prefixes=("emma",)
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/website/docs/user-guide/messaging/line.md
+++ b/website/docs/user-guide/messaging/line.md
@@ -15,8 +15,8 @@ LINE is the dominant messaging app in Japan, Taiwan, and Thailand. If your users
 | Context | Behavior |
 |---------|----------|
 | **1:1 chat** (`U` IDs) | Responds to every message |
-| **Group chat** (`C` IDs) | Responds when the group is on the allowlist |
-| **Multi-user room** (`R` IDs) | Responds when the room is on the allowlist |
+| **Group chat** (`C` IDs) | Responds when the group is on the allowlist. Optionally [restrict to @mention / trigger prefix](#quieting-groups-mention-only-mode). |
+| **Multi-user room** (`R` IDs) | Responds when the room is on the allowlist. Same optional gate as groups. |
 
 Inbound text, images, audio, video, files, stickers, and locations are all handled. Outbound text uses the **free reply token first** (single-use, ~60s window) and falls back to the metered Push API when the token has expired.
 
@@ -154,6 +154,38 @@ Cron jobs with `deliver: line` route to `LINE_HOME_CHANNEL`. The adapter ships a
 
 ---
 
+## Quieting groups: mention-only mode
+
+By default the bot replies to every message in any allowlisted group or room — which is the right behavior for a bot dedicated to one chat, but quickly becomes noise in a busy team channel. Set `LINE_GROUP_MENTION_ONLY=true` and the bot only replies in groups/rooms when:
+
+- the bot is **@mentioned** (`message.mention.mentionees` contains the bot's own user ID), **or**
+- the message text **starts with one of `LINE_GROUP_TRIGGER_PREFIXES`** (CSV, case-insensitive, matched after stripping leading whitespace).
+
+1:1 DMs are unaffected — the gate is only consulted when `source.type` is `group` or `room`.
+
+```env
+LINE_GROUP_MENTION_ONLY=true
+LINE_GROUP_TRIGGER_PREFIXES=emma,/h,!bot
+```
+
+With the example above:
+
+| In group, message | Result |
+|---|---|
+| `emma what's the weather?` | replies (prefix `emma`) |
+| `Emma 你好` | replies (case-insensitive) |
+| `/h help` | replies (prefix `/h`) |
+| `@Emma hi` (if LINE produced a real mention event) | replies (mention path) |
+| `hey emma` | dropped (prefix only matches at message start) |
+| `hello team` | dropped |
+| anything in DM | replies (DM bypasses the gate) |
+
+**Why prefixes matter even when LINE supports `@`.** LINE's in-app `@` typing suggestion list rarely surfaces bots — many users will not find your bot in the dropdown even when it is a group member. A text prefix (`emma`, `/h`, etc.) is the only reliable trigger in practice. The mention path is kept for clients that do produce mention events.
+
+Non-text events (image, sticker, file, location) in mention-only mode are always dropped in groups/rooms — there is no place to address the bot. Send them to the bot in DM instead.
+
+---
+
 ## Environment variable reference
 
 | Variable | Required | Default | Description |
@@ -167,6 +199,8 @@ Cron jobs with `deliver: line` route to `LINE_HOME_CHANNEL`. The adapter ships a
 | `LINE_ALLOWED_GROUPS` | one of | — | Comma-separated group IDs (C-prefixed) |
 | `LINE_ALLOWED_ROOMS` | one of | — | Comma-separated room IDs (R-prefixed) |
 | `LINE_ALLOW_ALL_USERS` | dev only | `false` | Skip allowlist entirely |
+| `LINE_GROUP_MENTION_ONLY` | no | `false` | In groups/rooms, only reply when @mentioned or a trigger prefix matches. DMs unaffected. See [Quieting groups](#quieting-groups-mention-only-mode). |
+| `LINE_GROUP_TRIGGER_PREFIXES` | no | — | CSV of case-insensitive prefixes; a group/room message whose stripped text starts with any of them triggers a reply in mention-only mode |
 | `LINE_HOME_CHANNEL` | no | — | Default cron / notification delivery target |
 | `LINE_SLOW_RESPONSE_THRESHOLD` | no | `45` | Seconds before the postback button fires (`0` = disabled) |
 | `LINE_PENDING_TEXT` | no | "🤔 Still thinking…" | Bubble text shown alongside the postback button |
@@ -181,6 +215,8 @@ Cron jobs with `deliver: line` route to `LINE_HOME_CHANNEL`. The adapter ships a
 **"invalid signature" on webhook verify.** The `Channel secret` was copied wrong, or your tunnel rewrote the request body. Verify with `curl -i https://<tunnel>/line/webhook/health` first — that should return `{"status":"ok","platform":"line"}`.
 
 **Bot receives nothing in groups.** Check `LINE_ALLOWED_GROUPS` includes the `C...` group ID. To find a group ID, send a test message and grep `~/.hermes/logs/gateway.log` for `LINE: rejecting unauthorized source` — the rejected source dict has the IDs.
+
+**Bot is in the group but never replies to anything.** If `LINE_GROUP_MENTION_ONLY=true` is set, the bot intentionally drops group messages that aren't addressed to it. Grep `gateway.log` for `dropped in mention-only mode` — if you see those, configure `LINE_GROUP_TRIGGER_PREFIXES` so users have a way to invoke the bot (e.g. `LINE_GROUP_TRIGGER_PREFIXES=emma`). LINE's `@` suggestion list rarely shows bots, so a prefix is usually the only reliable trigger.
 
 **`send_image` fails with "LINE_PUBLIC_URL must be set".** LINE's Messaging API does not accept binary uploads — images, audio, and video must be reachable HTTPS URLs. Set `LINE_PUBLIC_URL` to the tunnel's public hostname and the adapter will serve files from `/line/media/<token>/<filename>` automatically.
 


### PR DESCRIPTION
## What

Add two opt-in env vars for the LINE platform plugin so that bots in shared group/room chats can stay quiet until addressed:

- **`LINE_GROUP_MENTION_ONLY`** (bool, default `false`) — when on, group/room messages are dropped unless the bot is addressed. DMs are unaffected.
- **`LINE_GROUP_TRIGGER_PREFIXES`** (CSV, case-insensitive) — text prefixes that count as "addressing the bot" alongside LINE's native `@mention` event.

A group/room message triggers a reply when either:
- the bot's user id appears in `message.mention.mentionees`, **or**
- the stripped text starts with one of the configured prefixes (matched case-insensitive on `lower()`).

## Why

The existing three-list allowlist (`LINE_ALLOWED_USERS/GROUPS/ROOMS`) is binary at the chat level — once a group is on the list, the bot replies to every message in it. That's fine for a bot dedicated to one chat, but quickly becomes noise in any shared team channel.

The prefix path is necessary in addition to mention because **LINE's in-app `@` suggestion dropdown rarely surfaces bots**, even when the bot is a group member with `Allow bot to join group chats` enabled. I hit this on the LINE iOS app talking to my own channel — typing `@` shows real users but not the bot — and the LINE Developers community has long-running threads about it. A text prefix (`emma`, `/h`, `!bot`, …) is the only reliable trigger in practice. The mention path is kept so the bot still works in any client that does produce a real mention event.

Non-text events (image, sticker, file, location) in mention-only mode are always dropped in groups/rooms — there is no place to address the bot. Users send those in DM instead.

## How it's implemented

- **Pure decision helper** `_group_message_triggers_reply` at module scope, mirroring the `_allowed_for_source` pattern (module-level, keyword-only args, no adapter state) — keeps the dispatcher slim and the logic unit-testable in isolation.
- **`_dispatch_event`** consults the helper after the allowlist gate but before routing to `_handle_message_event`. A single info log records drops with both the message type and full source dict, so operators can grep for `dropped in mention-only mode` to debug "why isn't the bot replying" cases.
- **DMs short-circuit** before reaching the helper (the gate only triggers when `source.type in {"group", "room"}`), so 1:1 chat behavior is preserved bit-for-bit.

## Tests

New `TestGroupMentionGate` class in `tests/gateway/test_line_plugin.py` covering 14 cases:

- **mention path**: matches own id; rejects other users' ids; rejects when bot id is unknown
- **prefix path**: matches at start; case-insensitive (`Emma` / `EMMA` / `eMmA`); rejects mid-string (`hey emma`); strips leading whitespace; matches any of multiple CSV prefixes; empty tuple disables the prefix gate
- **combined**: either path alone passes; both failing is rejected
- **non-text**: image/sticker/video/audio/file/location all dropped
- **defensive**: missing `text` field, empty `message` dict

```
$ pytest tests/gateway/test_line_plugin.py
============================== 87 passed in 1.97s ==============================
```

All 73 existing LINE tests still pass — no regressions.

## Docs

`website/docs/user-guide/messaging/line.md`:
- New **"Quieting groups: mention-only mode"** section with a worked example and a behavior table
- Two rows added to the env var reference
- New troubleshooting entry for "bot is in the group but never replies", pointing at the `dropped in mention-only mode` log line

The existing "How the bot responds" table now links to the new section from the group/room rows.

## Manual testing

Tested end-to-end on **WSL2 Ubuntu 24.04** against a real LINE Messaging API channel, fronted by a Microsoft devtunnel:

| Scenario | Result |
|---|---|
| 1:1 DM, any text | Reply (no behavior change) |
| Group with `emma 你好` | Reply (prefix `emma` matched) |
| Group with `Emma hi` | Reply (case-insensitive) |
| Group with `hey emma` | Dropped, log: `dropped in mention-only mode` |
| Group with `hello team` | Dropped |
| Group with sticker (no text) | Dropped (non-text in mention-only) |
| With `LINE_GROUP_MENTION_ONLY=false` | Bot replies to everything in group (default behavior preserved) |

## Backwards compatibility

Both env vars default to off — existing deployments are unaffected. The `_group_message_triggers_reply` helper is only consulted when `group_mention_only` is true, so the hot path for users who don't opt in adds one boolean check per inbound event.

## Notes for reviewers

- Numbering in the test file: inserted as **section 3b** between TestAllowlist (3) and TestDedup (4) to avoid renumbering downstream sections.
- No new dependencies. No config schema changes. No migration needed.
- `extra.get("group_mention_only", ...)` / `extra.get("group_trigger_prefixes", ...)` paths are kept for symmetry with the existing allowlist init, in case someone wires this through `config.yaml` instead of env vars later.
