### PR TITLE
fix(gateway): extend launchd exit timeout

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2181,8 +2181,7 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
     # SIGKILL on the cgroup — otherwise bash/sleep tool-call children left
     # by a force-interrupted agent get reaped by systemd instead of us
     # (#8202). 30s of headroom covers the worst case we've observed.
-    _drain_timeout = int(_get_restart_drain_timeout() or 0)
-    restart_timeout = max(60, _drain_timeout) + 30
+    restart_timeout = _service_restart_exit_timeout()
 
     if system:
         username, group_name, home_dir = _system_service_identity(run_as_user)
@@ -2457,6 +2456,17 @@ def _get_restart_drain_timeout() -> float:
             )
         )
     return parse_restart_drain_timeout(raw)
+
+
+def _service_restart_exit_timeout() -> int:
+    """Return service-manager stop/exit timeout with cleanup headroom."""
+    # The gateway drain loop can legitimately run for the full configured
+    # restart timeout, then still needs a little time to clean up adapter
+    # connections, tool subprocesses, and the session DB. Service managers
+    # should therefore wait longer than ``agent.restart_drain_timeout`` before
+    # escalating to SIGKILL.
+    drain_timeout = int(_get_restart_drain_timeout() or 0)
+    return max(60, drain_timeout) + 30
 
 
 def systemd_install(
@@ -2809,6 +2819,7 @@ def generate_launchd_plist() -> str:
     log_dir = get_hermes_home() / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)
     label = get_launchd_label()
+    exit_timeout = _service_restart_exit_timeout()
     profile_arg = _profile_arg(hermes_home)
     # Build a sane PATH for the launchd plist.  launchd provides only a
     # minimal default (/usr/bin:/bin:/usr/sbin:/sbin) which misses Homebrew,
@@ -2878,6 +2889,9 @@ def generate_launchd_plist() -> str:
         <key>SuccessfulExit</key>
         <false/>
     </dict>
+
+    <key>ExitTimeOut</key>
+    <integer>{exit_timeout}</integer>
     
     <key>StandardOutPath</key>
     <string>{log_dir}/gateway.log</string>

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1,6 +1,7 @@
 """Tests for gateway service management helpers."""
 
 import os
+import plistlib
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
@@ -450,6 +451,26 @@ class TestGatewayStopCleanup:
 
 
 class TestLaunchdServiceRecovery:
+    def test_launchd_plist_uses_extended_exit_timeout(self, monkeypatch):
+        monkeypatch.setattr(
+            gateway_cli,
+            "_get_restart_drain_timeout",
+            lambda: DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
+        )
+
+        plist = plistlib.loads(gateway_cli.generate_launchd_plist().encode("utf-8"))
+
+        expected_timeout = int(max(60, DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT) + 30)
+        assert plist["ExitTimeOut"] == expected_timeout
+        assert plist["ExitTimeOut"] > DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
+
+    def test_launchd_plist_exit_timeout_tracks_custom_drain_timeout(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 240.0)
+
+        plist = plistlib.loads(gateway_cli.generate_launchd_plist().encode("utf-8"))
+
+        assert plist["ExitTimeOut"] == 270
+
     def test_get_restart_drain_timeout_prefers_env_then_config_then_default(self, monkeypatch):
         monkeypatch.delenv("HERMES_RESTART_DRAIN_TIMEOUT", raising=False)
         monkeypatch.setattr(gateway_cli, "read_raw_config", lambda: {})


### PR DESCRIPTION
## Summary
- Adds `ExitTimeOut` to the macOS launchd gateway plist so launchd waits longer than the configured gateway restart drain window before escalating shutdown.
- Reuses the same drain-timeout-plus-headroom calculation already used by systemd `TimeoutStopSec`.
- Adds launchd plist regression coverage for both the default drain timeout and a custom drain timeout.

## Why
When the gateway receives a service-manager shutdown signal while an agent is still active, it can spend the full `agent.restart_drain_timeout` draining before cleanup. Without an explicit launchd `ExitTimeOut`, macOS may use a short default budget and SIGKILL the gateway before adapter/session cleanup finishes.

## Test Plan
- RED: `python -m pytest tests/hermes_cli/test_gateway_service.py::TestLaunchdServiceRecovery::test_launchd_plist_uses_extended_exit_timeout tests/hermes_cli/test_gateway_service.py::TestLaunchdServiceRecovery::test_launchd_plist_exit_timeout_tracks_custom_drain_timeout -q` failed with `KeyError: 'ExitTimeOut'` before the fix.
- GREEN: `python -m pytest tests/hermes_cli/test_gateway_service.py::TestLaunchdServiceRecovery tests/hermes_cli/test_gateway_service.py::TestGeneratedSystemdUnits -q` → 18 passed.
- `python -m ruff check hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py`
- `git diff --check`
- Manual plist parse: generated launchd plist now includes `ExitTimeOut` with the drain-timeout + 30s headroom value.

## Note
- On this macOS dev host, the full `tests/hermes_cli/test_gateway_service.py -q` still has the same pre-existing systemd user D-Bus preflight failures on clean `origin/main`; the focused launchd/systemd generation tests above pass.