### PR TITLE
fix(telegram): handle channel post updates

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -4478,8 +4478,8 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         if not self._should_process_message(msg, is_command=True):
             return
-        await self._ensure_forum_commands(update.message)
-        
+        await self._ensure_forum_commands(msg)
+
         event = self._build_message_event(msg, MessageType.COMMAND, update_id=update.update_id)
         await self.handle_message(event)
 

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -4443,6 +4443,16 @@ class TelegramAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.warning("[%s] Forum command lazy-registration failed: %s", self.name, e)
 
+    def _effective_update_message(self, update: Update) -> Optional[Message]:
+        """Return the message-like payload for normal messages and channel posts.
+
+        Telegram exposes channel broadcasts as ``update.channel_post`` rather
+        than ``update.message``.  MessageHandler filters can still dispatch
+        those updates, so handlers must use ``effective_message`` to avoid
+        consuming channel posts without ever building a gateway event.
+        """
+        return getattr(update, "effective_message", None) or getattr(update, "message", None)
+
     async def _handle_text_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming text messages.
 
@@ -4450,35 +4460,37 @@ class TelegramAdapter(BasePlatformAdapter):
         rapid successive text messages from the same user/chat and aggregate
         them into a single MessageEvent before dispatching.
         """
-        if not update.message or not update.message.text:
+        msg = self._effective_update_message(update)
+        if not msg or not msg.text:
             return
-        if not self._should_process_message(update.message):
+        if not self._should_process_message(msg):
             return
         await self._ensure_forum_commands(update.message)
 
-        event = self._build_message_event(update.message, MessageType.TEXT, update_id=update.update_id)
+        event = self._build_message_event(msg, MessageType.TEXT, update_id=update.update_id)
         event.text = self._clean_bot_trigger_text(event.text)
         self._enqueue_text_event(event)
 
     async def _handle_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming command messages."""
-        if not update.message or not update.message.text:
+        msg = self._effective_update_message(update)
+        if not msg or not msg.text:
             return
-        if not self._should_process_message(update.message, is_command=True):
+        if not self._should_process_message(msg, is_command=True):
             return
         await self._ensure_forum_commands(update.message)
         
-        event = self._build_message_event(update.message, MessageType.COMMAND, update_id=update.update_id)
+        event = self._build_message_event(msg, MessageType.COMMAND, update_id=update.update_id)
         await self.handle_message(event)
 
     async def _handle_location_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming location/venue pin messages."""
-        if not update.message:
+        msg = self._effective_update_message(update)
+        if not msg:
             return
-        if not self._should_process_message(update.message):
+        if not self._should_process_message(msg):
             return
 
-        msg = update.message
         venue = getattr(msg, "venue", None)
         location = getattr(venue, "location", None) if venue else getattr(msg, "location", None)
 
@@ -5116,11 +5128,14 @@ class TelegramAdapter(BasePlatformAdapter):
         chat = message.chat
         user = message.from_user
         
-        # Determine chat type
+        # Determine chat type.  Normalize through ``str`` so tests/mocks and
+        # python-telegram-bot enum values both work (``ChatType.CHANNEL`` is
+        # string-like, but mocks often provide plain strings).
+        telegram_chat_type = str(getattr(chat, "type", "")).split(".")[-1].lower()
         chat_type = "dm"
-        if chat.type in {ChatType.GROUP, ChatType.SUPERGROUP}:
+        if telegram_chat_type in {"group", "supergroup"}:
             chat_type = "group"
-        elif chat.type == ChatType.CHANNEL:
+        elif telegram_chat_type == "channel":
             chat_type = "channel"
 
         # Resolve Telegram topic name and skill binding.
@@ -5181,8 +5196,20 @@ class TelegramAdapter(BasePlatformAdapter):
             chat_id=str(chat.id),
             chat_name=chat.title or (chat.full_name if hasattr(chat, "full_name") else None),
             chat_type=chat_type,
-            user_id=str(user.id) if user else (str(chat.id) if chat_type == "dm" else None),
-            user_name=user.full_name if user else (chat.full_name if hasattr(chat, "full_name") and chat_type == "dm" else None),
+            user_id=(
+                str(user.id)
+                if user
+                else (str(chat.id) if chat_type in {"dm", "channel"} else None)
+            ),
+            user_name=(
+                user.full_name
+                if user
+                else (
+                    chat.full_name
+                    if hasattr(chat, "full_name") and chat_type == "dm"
+                    else (chat.title if chat_type == "channel" else None)
+                )
+            ),
             thread_id=thread_id_str,
             chat_topic=chat_topic,
             message_id=str(message.message_id),

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -187,6 +187,7 @@ AUTHOR_MAP = {
     "psikonetik@gmail.com": "el-analista",  # PR #25368 salvage (cron topic fallback report)
     "75435655+khungate@users.noreply.github.com": "khungate",  # PR #25829 salvage (gmail-triage gt: callbacks)
     "stevehq26-bot@users.noreply.github.com": "stevehq26-bot",  # PR #28015 salvage (quick-command-only menus)
+    "seaverb@icloud.com": "brndnsvr",  # PR #25327 salvage (channel post updates)
     "282919977+eliteworkstation94-ai@users.noreply.github.com": "eliteworkstation94-ai",  # PR #28157 salvage (group reply session splits)
     "androidhtml@yandex.com": "hllqkb",
     "25840394+Bongulielmi@users.noreply.github.com": "Bongulielmi",

--- a/tests/gateway/test_telegram_channel_posts.py
+++ b/tests/gateway/test_telegram_channel_posts.py
@@ -90,7 +90,12 @@ def telegram_adapter_cls(monkeypatch):
 
 
 def _make_adapter(telegram_adapter_cls):
-    return telegram_adapter_cls(PlatformConfig(enabled=True, token="***", extra={}))
+    a = telegram_adapter_cls(PlatformConfig(enabled=True, token="***", extra={}))
+    # Channel posts have from_user=None.  After PR #28494's fail-closed
+    # auth, the empty-allowlist adapter rejects all messages including
+    # channel posts.  These tests focus on routing, not auth gating.
+    a._is_callback_user_authorized = lambda user_id, **_kw: True
+    return a
 
 
 def _make_channel_message(text="channel id test @hermes_bot"):

--- a/tests/gateway/test_telegram_channel_posts.py
+++ b/tests/gateway/test_telegram_channel_posts.py
@@ -1,0 +1,102 @@
+"""Regression tests for Telegram channel_post updates.
+
+Telegram channel broadcasts are delivered as ``Update.channel_post`` rather than
+``Update.message``.  The adapter should use ``effective_message`` so channel
+posts are converted into Hermes gateway events instead of being silently
+ignored.
+"""
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import MessageType
+
+
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+
+    telegram_mod = MagicMock()
+    telegram_mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    telegram_mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    telegram_mod.constants.ChatType.GROUP = "group"
+    telegram_mod.constants.ChatType.SUPERGROUP = "supergroup"
+    telegram_mod.constants.ChatType.CHANNEL = "channel"
+    telegram_mod.constants.ChatType.PRIVATE = "private"
+
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, telegram_mod)
+
+
+_ensure_telegram_mock()
+
+from gateway.platforms.telegram import TelegramAdapter  # noqa: E402
+
+
+def _make_adapter():
+    return TelegramAdapter(PlatformConfig(enabled=True, token="***", extra={}))
+
+
+def _make_channel_message(text="channel id test @hermes_bot"):
+    chat = SimpleNamespace(
+        id=-1003950368353,
+        type="channel",
+        title="wzrd",
+        full_name=None,
+        is_forum=False,
+    )
+    return SimpleNamespace(
+        chat=chat,
+        from_user=None,
+        text=text,
+        caption=None,
+        entities=[],
+        caption_entities=[],
+        message_thread_id=None,
+        is_topic_message=False,
+        message_id=11,
+        reply_to_message=None,
+        quote=None,
+        date=None,
+        forum_topic_created=None,
+    )
+
+
+def test_build_message_event_uses_channel_identity_for_channel_posts():
+    adapter = _make_adapter()
+    msg = _make_channel_message()
+
+    event = adapter._build_message_event(msg, MessageType.TEXT, update_id=12345)
+
+    assert event.source.chat_type == "channel"
+    assert event.source.chat_id == "-1003950368353"
+    # Channel posts often have no from_user.  Preserve an identity so the
+    # gateway authorization layer can allowlist the channel by numeric ID.
+    assert event.source.user_id == "-1003950368353"
+    assert event.source.user_name == "wzrd"
+    assert event.platform_update_id == 12345
+
+
+@pytest.mark.asyncio
+async def test_text_handler_uses_effective_message_for_channel_post():
+    adapter = _make_adapter()
+    msg = _make_channel_message()
+    update = SimpleNamespace(
+        update_id=12345,
+        message=None,
+        channel_post=msg,
+        effective_message=msg,
+    )
+    adapter._enqueue_text_event = MagicMock()
+
+    await adapter._handle_text_message(update, MagicMock())
+
+    adapter._enqueue_text_event.assert_called_once()
+    event = adapter._enqueue_text_event.call_args.args[0]
+    assert event.text == "channel id test @hermes_bot"
+    assert event.source.chat_type == "channel"
+    assert event.source.chat_id == "-1003950368353"

--- a/tests/gateway/test_telegram_channel_posts.py
+++ b/tests/gateway/test_telegram_channel_posts.py
@@ -6,9 +6,12 @@ posts are converted into Hermes gateway events instead of being silently
 ignored.
 """
 
+import importlib
+import importlib.util
 import sys
+import types
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -16,29 +19,78 @@ from gateway.config import PlatformConfig
 from gateway.platforms.base import MessageType
 
 
-def _ensure_telegram_mock():
-    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+def _build_telegram_stubs():
+    telegram_mod = types.ModuleType("telegram")
+    telegram_mod.Update = object
+    telegram_mod.Bot = object
+    telegram_mod.Message = object
+    telegram_mod.InlineKeyboardButton = object
+    telegram_mod.InlineKeyboardMarkup = object
+    telegram_mod.LinkPreviewOptions = object
+
+    telegram_ext_mod = types.ModuleType("telegram.ext")
+    telegram_ext_mod.Application = object
+    telegram_ext_mod.CommandHandler = object
+    telegram_ext_mod.CallbackQueryHandler = object
+    telegram_ext_mod.MessageHandler = object
+    telegram_ext_mod.ContextTypes = SimpleNamespace(DEFAULT_TYPE=type(None))
+    telegram_ext_mod.filters = SimpleNamespace()
+
+    telegram_constants_mod = types.ModuleType("telegram.constants")
+    telegram_constants_mod.ParseMode = SimpleNamespace(MARKDOWN_V2="MarkdownV2")
+    telegram_constants_mod.ChatType = SimpleNamespace(
+        GROUP="group",
+        SUPERGROUP="supergroup",
+        CHANNEL="channel",
+        PRIVATE="private",
+    )
+
+    telegram_request_mod = types.ModuleType("telegram.request")
+    telegram_request_mod.HTTPXRequest = object
+
+    telegram_mod.ext = telegram_ext_mod
+    telegram_mod.constants = telegram_constants_mod
+    telegram_mod.request = telegram_request_mod
+
+    return {
+        "telegram": telegram_mod,
+        "telegram.ext": telegram_ext_mod,
+        "telegram.constants": telegram_constants_mod,
+        "telegram.request": telegram_request_mod,
+    }
+
+
+@pytest.fixture
+def telegram_adapter_cls(monkeypatch):
+    """Import TelegramAdapter without leaking temporary telegram stubs."""
+    module_name = "gateway.platforms.telegram"
+    existing_module = sys.modules.get(module_name)
+    if existing_module is not None:
+        yield existing_module.TelegramAdapter
         return
 
-    telegram_mod = MagicMock()
-    telegram_mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
-    telegram_mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
-    telegram_mod.constants.ChatType.GROUP = "group"
-    telegram_mod.constants.ChatType.SUPERGROUP = "supergroup"
-    telegram_mod.constants.ChatType.CHANNEL = "channel"
-    telegram_mod.constants.ChatType.PRIVATE = "private"
+    telegram_pkg = sys.modules.get("telegram")
+    installed = isinstance(getattr(telegram_pkg, "__file__", None), str)
+    if telegram_pkg is None:
+        try:
+            installed = importlib.util.find_spec("telegram") is not None
+        except ValueError:
+            installed = False
 
-    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
-        sys.modules.setdefault(name, telegram_mod)
+    if not installed:
+        for name, module in _build_telegram_stubs().items():
+            monkeypatch.setitem(sys.modules, name, module)
+
+    module = importlib.import_module(module_name)
+    try:
+        yield module.TelegramAdapter
+    finally:
+        if not installed:
+            sys.modules.pop(module_name, None)
 
 
-_ensure_telegram_mock()
-
-from gateway.platforms.telegram import TelegramAdapter  # noqa: E402
-
-
-def _make_adapter():
-    return TelegramAdapter(PlatformConfig(enabled=True, token="***", extra={}))
+def _make_adapter(telegram_adapter_cls):
+    return telegram_adapter_cls(PlatformConfig(enabled=True, token="***", extra={}))
 
 
 def _make_channel_message(text="channel id test @hermes_bot"):
@@ -66,8 +118,17 @@ def _make_channel_message(text="channel id test @hermes_bot"):
     )
 
 
-def test_build_message_event_uses_channel_identity_for_channel_posts():
-    adapter = _make_adapter()
+def _make_channel_update(msg):
+    return SimpleNamespace(
+        update_id=12345,
+        message=None,
+        channel_post=msg,
+        effective_message=msg,
+    )
+
+
+def test_build_message_event_uses_channel_identity_for_channel_posts(telegram_adapter_cls):
+    adapter = _make_adapter(telegram_adapter_cls)
     msg = _make_channel_message()
 
     event = adapter._build_message_event(msg, MessageType.TEXT, update_id=12345)
@@ -82,15 +143,10 @@ def test_build_message_event_uses_channel_identity_for_channel_posts():
 
 
 @pytest.mark.asyncio
-async def test_text_handler_uses_effective_message_for_channel_post():
-    adapter = _make_adapter()
+async def test_text_handler_uses_effective_message_for_channel_post(telegram_adapter_cls):
+    adapter = _make_adapter(telegram_adapter_cls)
     msg = _make_channel_message()
-    update = SimpleNamespace(
-        update_id=12345,
-        message=None,
-        channel_post=msg,
-        effective_message=msg,
-    )
+    update = _make_channel_update(msg)
     adapter._enqueue_text_event = MagicMock()
 
     await adapter._handle_text_message(update, MagicMock())
@@ -98,5 +154,23 @@ async def test_text_handler_uses_effective_message_for_channel_post():
     adapter._enqueue_text_event.assert_called_once()
     event = adapter._enqueue_text_event.call_args.args[0]
     assert event.text == "channel id test @hermes_bot"
+    assert event.message_type == MessageType.TEXT
+    assert event.source.chat_type == "channel"
+    assert event.source.chat_id == "-1003950368353"
+
+
+@pytest.mark.asyncio
+async def test_command_handler_uses_effective_message_for_channel_post(telegram_adapter_cls):
+    adapter = _make_adapter(telegram_adapter_cls)
+    msg = _make_channel_message(text="/status")
+    update = _make_channel_update(msg)
+    adapter.handle_message = AsyncMock()
+
+    await adapter._handle_command(update, MagicMock())
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "/status"
+    assert event.message_type == MessageType.COMMAND
     assert event.source.chat_type == "channel"
     assert event.source.chat_id == "-1003950368353"


### PR DESCRIPTION
Salvage of #25327 (@brndnsvr). Routes Telegram handlers through `effective_message` so `channel_post` updates build gateway events instead of being silently ignored. Preserves channel identity for channel posts without `from_user` so operators can allowlist by chat id.

Conflict resolution: combined with #28503 (#27014 forum-commands) — both add new methods on TelegramAdapter; kept both.

Authorship preserved across 2 commits via cherry-pick. 3/3 channel-post tests passing. Follow-up commit stubs auth in the test fixture (channel posts have `from_user=None` and were getting rejected by #28494's fail-closed gate).