### PR TITLE
feat(telegram): add ignore_root_dm config to drop messages without thread_id

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -435,6 +435,10 @@ class TelegramAdapter(BasePlatformAdapter):
         self._forum_lock = asyncio.Lock()
         # DM Topics config from extra.dm_topics
         self._dm_topics_config: List[Dict[str, Any]] = self.config.extra.get("dm_topics", [])
+        # Precomputed chat_ids that have DM topics configured (for O(1) root-DM ignore check)
+        self._dm_topic_chat_ids: Set[str] = {
+            str(e["chat_id"]) for e in self._dm_topics_config if "chat_id" in e
+        }
         # Interactive model picker state per chat
         self._model_picker_state: Dict[str, dict] = {}
         # Approval button state: message_id → session_key
@@ -4473,12 +4477,21 @@ class TelegramAdapter(BasePlatformAdapter):
             if topic_id not in allowed_topics:
                 return False
 
+        # Check ignored_threads first — applies to both groups and DM topics
         if thread_id is not None:
             try:
                 if int(thread_id) in self._telegram_ignored_threads():
                     return False
             except (TypeError, ValueError):
                 logger.warning("[%s] Ignoring non-numeric Telegram message_thread_id: %r", self.name, thread_id)
+
+        if not self._is_group_chat(message):
+            # Root DM (non-topic): ignore if ignore_root_dm is configured
+            if thread_id is None and self.config.extra.get("ignore_root_dm", False):
+                chat_id = str(getattr(getattr(message, "chat", None), "id", ""))
+                if not is_command and chat_id in self._dm_topic_chat_ids:
+                    return False
+            return True
 
         chat_id_str = str(getattr(getattr(message, "chat", None), "id", ""))
 
@@ -5133,10 +5146,17 @@ class TelegramAdapter(BasePlatformAdapter):
                 .get("dm_topics", [])
             )
             if not dm_topics:
+                # Clear both config and precomputed set when all topics are removed
+                self._dm_topics_config = []
+                self._dm_topic_chat_ids = set()
                 return
 
             # Update in-memory config and cache any new thread_ids
             self._dm_topics_config = dm_topics
+            # Rebuild the chat_id set for O(1) root-DM ignore lookup
+            self._dm_topic_chat_ids = {
+                str(chat_entry["chat_id"]) for chat_entry in dm_topics if "chat_id" in chat_entry
+            }
             for chat_entry in dm_topics:
                 cid = chat_entry.get("chat_id")
                 if not cid:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -190,6 +190,7 @@ AUTHOR_MAP = {
     "seaverb@icloud.com": "brndnsvr",  # PR #25327 salvage (channel post updates)
     "oracle@jarviss-mbp.home": "houenyang-momo",  # PR #24014 salvage (quiet noisy errors)
     "57119977+OCWC22@users.noreply.github.com": "OCWC22",  # PR #24581 salvage (multi-bot exclusive mentions)
+    "ai-hana-ai@users.noreply.github.com": "ai-hana-ai",  # PR #23928 salvage (ignore_root_dm)
     "282919977+eliteworkstation94-ai@users.noreply.github.com": "eliteworkstation94-ai",  # PR #28157 salvage (group reply session splits)
     "androidhtml@yandex.com": "hllqkb",
     "25840394+Bongulielmi@users.noreply.github.com": "Bongulielmi",

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -456,6 +456,28 @@ platforms:
 3. Each topic maps to an isolated session key: `agent:main:telegram:dm:{chat_id}:{thread_id}`
 4. Messages in each topic have their own conversation history, memory flush, and context window
 
+### Root DM handling
+
+By default, messages sent to the root DM (outside any topic) are processed
+normally. Set `ignore_root_dm: true` to turn the root DM into a lobby — normal
+messages are silently ignored for users who have DM topics configured, while
+system commands (`/start`, `/help`, `/status`, etc.) still work.
+
+```yaml
+platforms:
+  telegram:
+    extra:
+      ignore_root_dm: true
+      dm_topics:
+        - chat_id: 123456789
+          topics:
+            - name: General
+```
+
+The check is **per-chat**: only users with at least one entry in `dm_topics`
+will have their root DM affected. Users without configured topics are
+unaffected.
+
 ### Skill binding
 
 Topics with a `skill` field automatically load that skill when a new session starts in the topic. This works exactly like typing `/skill-name` at the start of a conversation — the skill content is injected into the first message, and subsequent messages see it in the conversation history.
@@ -490,7 +512,7 @@ Only authorized users (allowlist via `TELEGRAM_ALLOWED_USERS` / platform auth co
 | Who activates it | Operator, in `config.yaml` | End user, by sending `/topic` |
 | Topic list | Fixed set declared in config | User creates/deletes topics freely |
 | Topic names | Chosen by operator | Chosen by user; auto-renamed to match Hermes session title |
-| Root DM behavior | Unchanged — normal chat | Becomes a system lobby (non-command messages are rejected) |
+| Root DM behavior | Normal chat (lobby if `ignore_root_dm: true`) | Becomes a system lobby (non-command messages are rejected) |
 | Primary use case | Permanent workspaces with optional skill binding | Ad-hoc parallel sessions |
 | Persistence | `extra.dm_topics` in config | `telegram_dm_topic_mode` + `telegram_dm_topic_bindings` SQLite tables |
 


### PR DESCRIPTION
Salvage of #23928 (@ai-hana-ai). When `dm_topics` are configured, root DM messages without a `message_thread_id` cause split sessions and user confusion. New `telegram.ignore_root_dm` config drops these messages silently so all conversation flows through named topic threads.

Conflict resolution: combined with #28492's allowlist enforcement and #28503's allowed_topics gate. All gates run in sequence: auth → allowed_topics → ignore_root_dm → ignored_threads.

Authorship preserved across 2 commits via cherry-pick. 68/68 topic + group-gating tests passing.