### PR TITLE
fix(auxiliary): pass original base_url to _wrap_if_needed for Anthropic-proxy detection

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3307,7 +3307,10 @@ def resolve_provider_client(
                 except Exception:
                     pass
             client = OpenAI(api_key=custom_key, base_url=_clean_base, **extra)
-            client = _wrap_if_needed(client, final_model, custom_base, custom_key)
+            # Pass the ORIGINAL explicit_base_url (not custom_base which has
+            # /anthropic rewritten to /v1) so _wrap_if_needed can correctly
+            # detect Anthropic-wire endpoints and wrap with AnthropicAuxiliaryClient.
+            client = _wrap_if_needed(client, final_model, explicit_base_url or custom_base, custom_key)
             return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                     else (client, final_model))
         # Try custom first, then API-key providers (Codex excluded here:


### PR DESCRIPTION
## Problem

When `auxiliary.<task>` is configured with a custom Anthropic-format proxy
(e.g. `base_url: http://localhost:6655/anthropic/`), the auxiliary client
returns HTTP 404 on every title generation / compression / session_search call.

### Root cause

In `resolve_provider_client()`, the `custom` branch (line ~3130) calls
`_to_openai_base_url(explicit_base_url)` which rewrites `/anthropic` → `/v1`,
storing the result in `custom_base`. The same rewritten URL is then passed to
`_wrap_if_needed()`:

```python
client = OpenAI(api_key=custom_key, base_url=_clean_base, **extra)
client = _wrap_if_needed(client, final_model, custom_base, custom_key)  # ← bug
```

Inside `_wrap_if_needed`, `_endpoint_speaks_anthropic_messages()` checks whether
the URL ends in `/anthropic` — but it receives the already-rewritten `/v1` URL,
so the check fails. The client is left as a plain `OpenAI` client, which sends
requests to `/v1/chat/completions`. The proxy only exposes `/anthropic/v1/messages`,
so every request returns 404.

The user sees:
```
⚠ Auxiliary title generation failed: HTTP 404: 404 page not found
```

This affects all auxiliary tasks (`title_generation`, `compression`,
`session_search`, `skills_hub`) when the main provider is an Anthropic-format
proxy configured via `auxiliary.<task>.base_url`.

## Fix

Pass `explicit_base_url` (the original config value) to `_wrap_if_needed()`
instead of `custom_base` (the already-rewritten value). The `OpenAI` client
still connects to the correct rewritten `_clean_base`; only the Anthropic-wire
detection heuristic receives the original URL.

```python
# Before
client = _wrap_if_needed(client, final_model, custom_base, custom_key)

# After
client = _wrap_if_needed(client, final_model, explicit_base_url or custom_base, custom_key)
```

## Reproduction

1. Configure a custom Anthropic-format proxy:
   ```yaml
   # config.yaml
   base_url: http://localhost:6655/anthropic/
   ```
2. Set per-task auxiliary override:
   ```bash
   hermes config set auxiliary.title_generation.provider custom
   hermes config set auxiliary.title_generation.base_url http://localhost:6655/anthropic/
   hermes config set auxiliary.title_generation.api_key <key>
   ```
3. Start a new session — every conversation title generation fails with 404.

## Testing

Existing test coverage for `_wrap_if_needed` and `_endpoint_speaks_anthropic_messages`
in `tests/agent/test_auxiliary_client.py` should cover this path. No new behaviour
is introduced — only the URL passed to the detection function is corrected.