### PR TITLE
fix: restore telegram dm-topic typing indicator

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -3514,17 +3514,21 @@ class TelegramAdapter(BasePlatformAdapter):
         if self._bot:
             try:
                 _typing_thread = self._metadata_thread_id(metadata)
-                message_thread_id = self._message_thread_id_for_typing(_typing_thread)
-                # No retry-without-thread fallback here: _message_thread_id_for_typing
-                # already maps the forum General topic to None, so any non-None value
-                # reaching this call is a user-created topic. If Telegram rejects it
-                # (e.g. topic deleted mid-session), we swallow the failure rather than
-                # showing a typing indicator in the wrong chat/All Messages.
-                await self._bot.send_chat_action(
-                    chat_id=int(chat_id),
-                    action="typing",
-                    message_thread_id=message_thread_id,
-                )
+                direct_topic_id = self._metadata_direct_messages_topic_id(metadata)
+
+                chat_action_kwargs: Dict[str, Any] = {
+                    "chat_id": int(chat_id),
+                    "action": "typing",
+                }
+
+                # True Telegram DM topics route via direct_messages_topic_id.
+                # For forum/private topic lanes, keep message_thread_id behavior.
+                if direct_topic_id is not None:
+                    chat_action_kwargs["direct_messages_topic_id"] = int(direct_topic_id)
+                else:
+                    chat_action_kwargs["message_thread_id"] = self._message_thread_id_for_typing(_typing_thread)
+
+                await self._bot.send_chat_action(**chat_action_kwargs)
             except Exception as e:
                 # Typing failures are non-fatal; log at debug level only.
                 logger.debug(

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -267,6 +267,35 @@ async def test_send_typing_attempts_api_call_for_dm_topic_reply_fallback():
 
 
 @pytest.mark.asyncio
+async def test_send_typing_private_dm_topic_uses_direct_messages_topic_id():
+    """Typing in true Telegram DM topics must use direct_messages_topic_id.
+
+    Regression guard: when metadata carries direct_messages_topic_id, typing
+    must follow that lane (not message_thread_id), otherwise Telegram clients
+    can hide the typing bubble in topic mode.
+    """
+    adapter = _make_adapter()
+    call_log = []
+
+    async def mock_send_chat_action(**kwargs):
+        call_log.append(dict(kwargs))
+
+    adapter._bot = SimpleNamespace(send_chat_action=mock_send_chat_action)
+
+    await adapter.send_typing(
+        "12345",
+        metadata={
+            "thread_id": "20197",
+            "direct_messages_topic_id": "20197",
+        },
+    )
+
+    assert call_log == [
+        {"chat_id": 12345, "action": "typing", "direct_messages_topic_id": 20197},
+    ]
+
+
+@pytest.mark.asyncio
 async def test_send_retries_without_thread_on_thread_not_found():
     """When message_thread_id causes 'thread not found', retry without it."""
     adapter = _make_adapter()


### PR DESCRIPTION
## Summary
- restore Telegram typing indicator in DM topic mode by routing  with  when present
- keep existing  behavior for forum/private-thread flows
- add regression smoke test for private DM topic typing routing

## Validation
- bringing up nodes...
bringing up nodes...

...................................                                      [100%]
35 passed in 13.64s (35 passed)

## Notes
This fixes the missing "typing…" indicator observed in Telegram topic-mode DMs.