### PR TITLE
fix(telegram): recover control prompts when DM topic reply anchors go stale

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2241,9 +2241,12 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self._bot:
             raise RuntimeError("Not connected")
 
-        message_thread_id = kwargs.get("message_thread_id")
+        helper_metadata = kwargs.pop("_hermes_thread_metadata", None)
+        send_kwargs = dict(kwargs)
+        message_thread_id = send_kwargs.get("message_thread_id")
+        reply_to_message_id = send_kwargs.get("reply_to_message_id")
         try:
-            return await self._bot.send_message(**kwargs)
+            return await self._bot.send_message(**send_kwargs)
         except Exception as send_err:
             if (
                 message_thread_id is not None
@@ -2255,8 +2258,24 @@ class TelegramAdapter(BasePlatformAdapter):
                     self.name,
                     message_thread_id,
                 )
-                retry_kwargs = dict(kwargs)
+                retry_kwargs = dict(send_kwargs)
                 retry_kwargs.pop("message_thread_id", None)
+                return await self._bot.send_message(**retry_kwargs)
+            if (
+                reply_to_message_id is not None
+                and self._is_bad_request_error(send_err)
+                and "message to be replied not found" in str(send_err).lower()
+            ):
+                logger.warning(
+                    "[%s] Reply target deleted for control message, retrying without reply/topic anchor: %s",
+                    self.name,
+                    send_err,
+                )
+                retry_kwargs = dict(send_kwargs)
+                retry_kwargs["reply_to_message_id"] = None
+                if helper_metadata and helper_metadata.get("telegram_dm_topic_reply_fallback"):
+                    retry_kwargs.pop("message_thread_id", None)
+                    retry_kwargs.pop("direct_messages_topic_id", None)
                 return await self._bot.send_message(**retry_kwargs)
             raise
 
@@ -2289,6 +2308,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 parse_mode=ParseMode.MARKDOWN_V2,
                 reply_markup=keyboard,
                 reply_to_message_id=reply_to_id,
+                _hermes_thread_metadata=metadata,
                 **self._thread_kwargs_for_send(
                     chat_id,
                     thread_id,
@@ -2355,6 +2375,7 @@ class TelegramAdapter(BasePlatformAdapter):
             }
             reply_to_id = self._reply_to_message_id_for_send(None, metadata, reply_to_mode=self._reply_to_mode)
             kwargs["reply_to_message_id"] = reply_to_id
+            kwargs["_hermes_thread_metadata"] = metadata
             kwargs.update(
                 self._thread_kwargs_for_send(
                     chat_id,
@@ -2406,6 +2427,7 @@ class TelegramAdapter(BasePlatformAdapter):
             }
             reply_to_id = self._reply_to_message_id_for_send(None, metadata, reply_to_mode=self._reply_to_mode)
             kwargs["reply_to_message_id"] = reply_to_id
+            kwargs["_hermes_thread_metadata"] = metadata
             kwargs.update(
                 self._thread_kwargs_for_send(
                     chat_id,
@@ -2489,6 +2511,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
             reply_to_id = self._reply_to_message_id_for_send(None, metadata)
             kwargs["reply_to_message_id"] = reply_to_id
+            kwargs["_hermes_thread_metadata"] = metadata
             kwargs.update(
                 self._thread_kwargs_for_send(
                     chat_id,
@@ -2564,6 +2587,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 parse_mode=ParseMode.MARKDOWN_V2,
                 reply_markup=keyboard,
                 reply_to_message_id=reply_to_id,
+                _hermes_thread_metadata=metadata,
                 **self._thread_kwargs_for_send(
                     chat_id,
                     thread_id,
@@ -2984,6 +3008,10 @@ class TelegramAdapter(BasePlatformAdapter):
                         if thread_id is not None and is_private_chat and prompt_message_id is not None:
                             reply_to_id = int(prompt_message_id)
                             send_kwargs["reply_to_message_id"] = reply_to_id
+                            send_kwargs["_hermes_thread_metadata"] = {
+                                "thread_id": str(thread_id),
+                                "telegram_dm_topic_reply_fallback": True,
+                            }
                             send_kwargs.update(
                                 self._thread_kwargs_for_send(
                                     str(query.message.chat_id),

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -130,6 +130,10 @@ def _make_adapter():
     adapter._polling_conflict_count = 0
     adapter._polling_network_error_count = 0
     adapter._polling_error_callback_ref = None
+    adapter._model_picker_state = {}
+    adapter._approval_state = {}
+    adapter._slash_confirm_state = {}
+    adapter._clarify_state = {}
     adapter.platform = Platform.TELEGRAM
     return adapter
 
@@ -614,6 +618,39 @@ async def test_send_model_picker_uses_metadata_reply_fallback_for_dm_topics():
 
 
 @pytest.mark.asyncio
+async def test_send_exec_approval_dm_topic_reply_not_found_retry_drops_topic_anchor():
+    """Control prompts should recover when a DM-topic reply anchor is deleted."""
+    adapter = _make_adapter()
+    call_log = []
+
+    async def mock_send_message(**kwargs):
+        call_log.append(dict(kwargs))
+        if len(call_log) == 1:
+            raise FakeBadRequest("Message to be replied not found")
+        return SimpleNamespace(message_id=780)
+
+    adapter._bot = SimpleNamespace(send_message=mock_send_message)
+
+    result = await adapter.send_exec_approval(
+        chat_id="123",
+        command="echo test",
+        session_key="telegram:123:20197",
+        metadata={
+            "thread_id": "20197",
+            "telegram_dm_topic_reply_fallback": True,
+            "telegram_reply_to_message_id": "462",
+        },
+    )
+
+    assert result.success is True
+    assert call_log[0]["reply_to_message_id"] == 462
+    assert call_log[0]["message_thread_id"] == 20197
+    assert call_log[1]["reply_to_message_id"] is None
+    assert "message_thread_id" not in call_log[1]
+    assert "direct_messages_topic_id" not in call_log[1]
+
+
+@pytest.mark.asyncio
 async def test_send_dm_topic_fallback_without_anchor_does_not_crash():
     """DM-topic fallback without an anchor uses direct topic routing."""
     adapter = _make_adapter()
@@ -922,6 +959,53 @@ async def test_slash_confirm_private_topic_callback_followup_sends_thread_and_re
     assert call_log
     assert call_log[0]["message_thread_id"] == 20197
     assert call_log[0]["reply_to_message_id"] == 462
+
+
+@pytest.mark.asyncio
+async def test_slash_confirm_private_topic_callback_retry_drops_topic_anchor(monkeypatch):
+    adapter = _make_adapter()
+    adapter._slash_confirm_state = {"confirm-1": "session-1"}
+    adapter._is_callback_user_authorized = lambda *args, **kwargs: True
+    call_log = []
+
+    async def mock_send_message(**kwargs):
+        call_log.append(dict(kwargs))
+        if len(call_log) == 1:
+            raise FakeBadRequest("Message to be replied not found")
+        return SimpleNamespace(message_id=9002)
+
+    async def resolve(_session_key, _confirm_id, _choice):
+        return "done"
+
+    from tools import slash_confirm
+
+    monkeypatch.setattr(slash_confirm, "resolve", resolve)
+    adapter._bot = SimpleNamespace(send_message=mock_send_message)
+
+    class Query:
+        data = "sc:once:confirm-1"
+        from_user = SimpleNamespace(id=42, first_name="Alice")
+        message = SimpleNamespace(
+            chat_id=12345,
+            chat=SimpleNamespace(type=_fake_telegram_constants.ChatType.PRIVATE),
+            message_thread_id=20197,
+            message_id=462,
+        )
+
+        async def answer(self, **kwargs):
+            return None
+
+        async def edit_message_text(self, **kwargs):
+            return None
+
+    await adapter._handle_callback_query(SimpleNamespace(callback_query=Query()), SimpleNamespace())
+
+    assert len(call_log) == 2
+    assert call_log[0]["message_thread_id"] == 20197
+    assert call_log[0]["reply_to_message_id"] == 462
+    assert call_log[1]["reply_to_message_id"] is None
+    assert "message_thread_id" not in call_log[1]
+    assert "direct_messages_topic_id" not in call_log[1]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fix Telegram control-message retries for Hermes-created DM topic lanes.

When Telegram returns `Message to be replied not found` for control-style sends
such as exec approvals, slash confirms, update prompts, or model pickers, the
adapter now retries once without the stale reply/topic anchor instead of failing
the send outright.

## What changed

- taught `_send_message_with_thread_fallback()` to recover from stale reply anchors
- passed DM-topic fallback metadata through control-message send paths
- covered the same retry behavior for slash-confirm callback follow-up sends
- aligned the Telegram thread-fallback test helper with the adapter's runtime state

## Why

Streaming and media sends already handled stale DM-topic reply anchors, but
control prompts did not. That left approval and confirmation prompts able to
hard-fail in private topic lanes after the quoted message disappeared.

## Testing

- `pytest tests/gateway/test_telegram_thread_fallback.py -q`
- result: `41 passed`