### PR TITLE
fix(web): add scheduled column to i18n type definitions

### DIFF
--- a/web/src/i18n/types.ts
+++ b/web/src/i18n/types.ts
@@ -666,6 +666,7 @@ export interface Translations {
     columnLabels: {
       triage: string;
       todo: string;
+      scheduled?: string;
       ready: string;
       running: string;
       blocked: string;
@@ -675,6 +676,7 @@ export interface Translations {
     columnHelp: {
       triage: string;
       todo: string;
+      scheduled?: string;
       ready: string;
       running: string;
       blocked: string;


### PR DESCRIPTION
## Summary
- `en.ts` added `scheduled` to `columnLabels` and `columnHelp` but the `Translations` interface in `types.ts` didn't declare it, causing a TypeScript build failure in the Nix derivation.
- Added `scheduled?: string` (optional) to both type objects since only `en.ts` provides it currently.

## Test plan
- [x] `nix build .#web` passes
- [x] `nix build .#default` passes
- [x] `nixos-rebuild switch` succeeds on NixOS host