### PR TITLE
Fix scheduled status i18n build regression

### DIFF
--- a/web/src/i18n/af.ts
+++ b/web/src/i18n/af.ts
@@ -654,6 +654,7 @@ export const af: Translations = {
     columnLabels: {
       triage: "Triage",
       todo: "Te doen",
+      scheduled: "Scheduled",
       ready: "Gereed",
       running: "Aan die gang",
       blocked: "Geblokkeer",
@@ -663,6 +664,7 @@ export const af: Translations = {
     columnHelp: {
       triage: "Rou idees — 'n spesifiseerder sal die spesifikasie uitwerk",
       todo: "Wag op afhanklikhede of nie toegewys nie",
+      scheduled: "Waiting on a known time delay or scheduled follow-up",
       ready: "Afhanklikhede is bevredig; wys 'n profiel toe om te versend",
       running: "Deur 'n werker geëis — in vlug",
       blocked: "Werker het mensinvoer aangevra",

--- a/web/src/i18n/de.ts
+++ b/web/src/i18n/de.ts
@@ -653,6 +653,7 @@ export const de: Translations = {
     columnLabels: {
       triage: "Triage",
       todo: "Zu erledigen",
+      scheduled: "Scheduled",
       ready: "Bereit",
       running: "In Bearbeitung",
       blocked: "Blockiert",
@@ -662,6 +663,7 @@ export const de: Translations = {
     columnHelp: {
       triage: "Rohe Ideen — ein Specifier wird die Spezifikation ausarbeiten",
       todo: "Wartet auf Abhängigkeiten oder ist nicht zugewiesen",
+      scheduled: "Waiting on a known time delay or scheduled follow-up",
       ready: "Abhängigkeiten erfüllt; Profil zum Dispatch zuweisen",
       running: "Von einem Worker übernommen — in Bearbeitung",
       blocked: "Worker hat um menschliche Eingabe gebeten",

--- a/web/src/i18n/es.ts
+++ b/web/src/i18n/es.ts
@@ -653,6 +653,7 @@ export const es: Translations = {
     columnLabels: {
       triage: "Clasificación",
       todo: "Por hacer",
+      scheduled: "Scheduled",
       ready: "Listo",
       running: "En curso",
       blocked: "Bloqueado",
@@ -662,6 +663,7 @@ export const es: Translations = {
     columnHelp: {
       triage: "Ideas en bruto — un specifier desarrollará la especificación",
       todo: "Esperando dependencias o sin asignar",
+      scheduled: "Waiting on a known time delay or scheduled follow-up",
       ready: "Dependencias satisfechas; asigna un perfil para despachar",
       running: "Reclamado por un worker — en ejecución",
       blocked: "El worker pidió intervención humana",

--- a/web/src/i18n/fr.ts
+++ b/web/src/i18n/fr.ts
@@ -653,6 +653,7 @@ export const fr: Translations = {
     columnLabels: {
       triage: "Triage",
       todo: "À faire",
+      scheduled: "Scheduled",
       ready: "Prêt",
       running: "En cours",
       blocked: "Bloqué",
@@ -662,6 +663,7 @@ export const fr: Translations = {
     columnHelp: {
       triage: "Idées brutes — un specifier rédigera la spécification",
       todo: "En attente de dépendances ou non assigné",
+      scheduled: "Waiting on a known time delay or scheduled follow-up",
       ready: "Dépendances satisfaites ; assignez un profil pour dispatch",
       running: "Réclamé par un worker — en cours d'exécution",
       blocked: "Le worker a demandé une intervention humaine",

--- a/web/src/i18n/ga.ts
+++ b/web/src/i18n/ga.ts
@@ -654,6 +654,7 @@ export const ga: Translations = {
     columnLabels: {
       triage: "Triáiseáil",
       todo: "Le déanamh",
+      scheduled: "Scheduled",
       ready: "Réidh",
       running: "Ar siúl",
       blocked: "Bactha",
@@ -663,6 +664,7 @@ export const ga: Translations = {
     columnHelp: {
       triage: "Smaointe amha — déanfaidh specifier an spec a chur i bhfeidhm",
       todo: "Ag fanacht ar spleáchais nó gan sannadh",
+      scheduled: "Waiting on a known time delay or scheduled follow-up",
       ready: "Tá na spleáchais sásaithe; sann próifíl le dispatch a dhéanamh",
       running: "Éilithe ag worker — ar siúl",
       blocked: "D'iarr an worker ionchur duine",

--- a/web/src/i18n/hu.ts
+++ b/web/src/i18n/hu.ts
@@ -654,6 +654,7 @@ export const hu: Translations = {
     columnLabels: {
       triage: "Triázs",
       todo: "Tennivaló",
+      scheduled: "Scheduled",
       ready: "Indulásra kész",
       running: "Folyamatban",
       blocked: "Blokkolva",
@@ -663,6 +664,7 @@ export const hu: Translations = {
     columnHelp: {
       triage: "Nyers ötletek — egy specifier kidolgozza a specifikációt",
       todo: "Függőségekre vár vagy nincs felelőse",
+      scheduled: "Waiting on a known time delay or scheduled follow-up",
       ready: "A függőségek teljesültek; rendelj hozzá profilt az indításhoz",
       running: "Worker felvette — folyamatban",
       blocked: "A worker emberi beavatkozást kért",

--- a/web/src/i18n/it.ts
+++ b/web/src/i18n/it.ts
@@ -653,6 +653,7 @@ export const it: Translations = {
     columnLabels: {
       triage: "Triage",
       todo: "Da fare",
+      scheduled: "Scheduled",
       ready: "Pronto",
       running: "In corso",
       blocked: "Bloccato",
@@ -662,6 +663,7 @@ export const it: Translations = {
     columnHelp: {
       triage: "Idee grezze — un specifier elaborerà la specifica",
       todo: "In attesa di dipendenze o non assegnato",
+      scheduled: "Waiting on a known time delay or scheduled follow-up",
       ready: "Dipendenze soddisfatte; assegna un profilo per il dispatch",
       running: "Preso in carico da un worker — in esecuzione",
       blocked: "Il worker ha richiesto input umano",

--- a/web/src/i18n/ja.ts
+++ b/web/src/i18n/ja.ts
@@ -654,6 +654,7 @@ export const ja: Translations = {
     columnLabels: {
       triage: "トリアージ",
       todo: "ToDo",
+      scheduled: "Scheduled",
       ready: "準備完了",
       running: "進行中",
       blocked: "ブロック中",
@@ -663,6 +664,7 @@ export const ja: Translations = {
     columnHelp: {
       triage: "未整理のアイデア — スペシファイアが仕様を肉付けします",
       todo: "依存関係の待機中、または未割り当て",
+      scheduled: "Waiting on a known time delay or scheduled follow-up",
       ready: "依存関係は満たされています。ディスパッチするにはプロファイルを割り当ててください",
       running: "ワーカーが取得中 — 実行中",
       blocked: "ワーカーが人間の入力を求めています",

--- a/web/src/i18n/ko.ts
+++ b/web/src/i18n/ko.ts
@@ -654,6 +654,7 @@ export const ko: Translations = {
     columnLabels: {
       triage: "분류",
       todo: "할 일",
+      scheduled: "Scheduled",
       ready: "준비됨",
       running: "진행 중",
       blocked: "차단됨",
@@ -663,6 +664,7 @@ export const ko: Translations = {
     columnHelp: {
       triage: "원시 아이디어 — 스페시파이어가 사양을 구체화합니다",
       todo: "종속성 대기 중 또는 미지정",
+      scheduled: "Waiting on a known time delay or scheduled follow-up",
       ready: "종속성이 충족됨; 디스패치하려면 프로필을 지정하세요",
       running: "워커가 점유 중 — 실행 중",
       blocked: "워커가 사람의 입력을 요청함",

--- a/web/src/i18n/pt.ts
+++ b/web/src/i18n/pt.ts
@@ -654,6 +654,7 @@ export const pt: Translations = {
     columnLabels: {
       triage: "Triagem",
       todo: "A fazer",
+      scheduled: "Scheduled",
       ready: "Pronto",
       running: "Em curso",
       blocked: "Bloqueado",
@@ -663,6 +664,7 @@ export const pt: Translations = {
     columnHelp: {
       triage: "Ideias em bruto — um specifier vai detalhar a especificação",
       todo: "À espera de dependências ou sem atribuição",
+      scheduled: "Waiting on a known time delay or scheduled follow-up",
       ready: "Dependências satisfeitas; atribua um perfil para despachar",
       running: "Reivindicado por um worker — em execução",
       blocked: "O worker pediu intervenção humana",

--- a/web/src/i18n/ru.ts
+++ b/web/src/i18n/ru.ts
@@ -654,6 +654,7 @@ export const ru: Translations = {
     columnLabels: {
       triage: "Сортировка",
       todo: "К выполнению",
+      scheduled: "Scheduled",
       ready: "Готово к работе",
       running: "В работе",
       blocked: "Заблокировано",
@@ -663,6 +664,7 @@ export const ru: Translations = {
     columnHelp: {
       triage: "Сырые идеи — specifier подготовит спецификацию",
       todo: "Ожидает зависимостей или без исполнителя",
+      scheduled: "Waiting on a known time delay or scheduled follow-up",
       ready: "Зависимости выполнены; назначьте профиль для диспетчеризации",
       running: "Взято воркером — выполняется",
       blocked: "Воркер запросил вмешательство человека",

--- a/web/src/i18n/tr.ts
+++ b/web/src/i18n/tr.ts
@@ -654,6 +654,7 @@ export const tr: Translations = {
     columnLabels: {
       triage: "Triyaj",
       todo: "Yapılacak",
+      scheduled: "Scheduled",
       ready: "Hazır",
       running: "Sürüyor",
       blocked: "Engellendi",
@@ -663,6 +664,7 @@ export const tr: Translations = {
     columnHelp: {
       triage: "Ham fikirler — bir specifier şartnameyi detaylandıracak",
       todo: "Bağımlılıklar bekleniyor veya atanmamış",
+      scheduled: "Waiting on a known time delay or scheduled follow-up",
       ready: "Bağımlılıklar karşılandı; dispatch için bir profil atayın",
       running: "Bir worker tarafından alındı — yürütülüyor",
       blocked: "Worker insan girdisi istedi",

--- a/web/src/i18n/types.ts
+++ b/web/src/i18n/types.ts
@@ -666,6 +666,7 @@ export interface Translations {
     columnLabels: {
       triage: string;
       todo: string;
+      scheduled: string;
       ready: string;
       running: string;
       blocked: string;
@@ -675,6 +676,7 @@ export interface Translations {
     columnHelp: {
       triage: string;
       todo: string;
+      scheduled: string;
       ready: string;
       running: string;
       blocked: string;

--- a/web/src/i18n/uk.ts
+++ b/web/src/i18n/uk.ts
@@ -654,6 +654,7 @@ export const uk: Translations = {
     columnLabels: {
       triage: "Сортування",
       todo: "До виконання",
+      scheduled: "Scheduled",
       ready: "Готово",
       running: "У роботі",
       blocked: "Заблоковано",
@@ -663,6 +664,7 @@ export const uk: Translations = {
     columnHelp: {
       triage: "Сирі ідеї — специфікатор деталізує специфікацію",
       todo: "Очікує на залежності або не призначено",
+      scheduled: "Waiting on a known time delay or scheduled follow-up",
       ready: "Залежності задоволені; призначте профіль для диспетчеризації",
       running: "Захоплено воркером — у роботі",
       blocked: "Воркер запитав втручання людини",

--- a/web/src/i18n/zh-hant.ts
+++ b/web/src/i18n/zh-hant.ts
@@ -654,6 +654,7 @@ export const zhHant: Translations = {
     columnLabels: {
       triage: "待分類",
       todo: "待辦",
+      scheduled: "Scheduled",
       ready: "就緒",
       running: "進行中",
       blocked: "已封鎖",
@@ -663,6 +664,7 @@ export const zhHant: Translations = {
     columnHelp: {
       triage: "原始想法 — 規格制定者將完善規格",
       todo: "等待相依項目或尚未指派",
+      scheduled: "Waiting on a known time delay or scheduled follow-up",
       ready: "相依項目已滿足；指派設定檔以便排程",
       running: "已被工作者領取 — 執行中",
       blocked: "工作者請求人工輸入",

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -650,6 +650,7 @@ export const zh: Translations = {
     columnLabels: {
       triage: "待分类",
       todo: "待办",
+      scheduled: "Scheduled",
       ready: "就绪",
       running: "进行中",
       blocked: "阻塞",
@@ -659,6 +660,7 @@ export const zh: Translations = {
     columnHelp: {
       triage: "原始想法 — 规范制定者将完善规格",
       todo: "等待依赖项或未分配",
+      scheduled: "Waiting on a known time delay or scheduled follow-up",
       ready: "依赖项已满足；分配一个配置文件以便调度",
       running: "已被工作者认领 — 执行中",
       blocked: "工作者请求人工输入",


### PR DESCRIPTION
## Summary
- add the missing `scheduled` key to the board i18n type definition
- add English fallback `scheduled` entries to the remaining locale files so every translation matches the shared schema
- restore the Web UI build path that was broken by the scheduled status addition

Closes #28502

## Testing
- git diff --check
- env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy /opt/homebrew/bin/node /opt/homebrew/lib/node_modules/npm/bin/npm-cli.js ci
- env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy /opt/homebrew/bin/node /opt/homebrew/lib/node_modules/npm/bin/npm-cli.js run build