### PR TITLE
fix(telegram): respect reply_to_mode=off in slash-confirm DM topic follow-ups

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -3050,18 +3050,24 @@ class TelegramAdapter(BasePlatformAdapter):
                             str(getattr(ChatType.PRIVATE, "value", ChatType.PRIVATE)).lower(),
                         }
                         if thread_id is not None and is_private_chat and prompt_message_id is not None:
-                            reply_to_id = int(prompt_message_id)
+                            dm_topic_metadata = {
+                                "thread_id": str(thread_id),
+                                "telegram_dm_topic_reply_fallback": True,
+                                "telegram_reply_to_message_id": str(prompt_message_id),
+                            }
+                            reply_to_id = self._reply_to_message_id_for_send(
+                                None,
+                                dm_topic_metadata,
+                                reply_to_mode=self._reply_to_mode,
+                            )
                             send_kwargs["reply_to_message_id"] = reply_to_id
                             send_kwargs.update(
                                 self._thread_kwargs_for_send(
                                     str(query.message.chat_id),
                                     str(thread_id),
-                                    {
-                                        "thread_id": str(thread_id),
-                                        "telegram_dm_topic_reply_fallback": True,
-                                    },
+                                    dm_topic_metadata,
                                     reply_to_message_id=reply_to_id,
-                                    reply_to_mode=self._reply_to_mode
+                                    reply_to_mode=self._reply_to_mode,
                                 )
                             )
                         elif thread_id is not None:

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -998,6 +998,49 @@ async def test_slash_confirm_private_topic_callback_followup_sends_thread_and_re
 
 
 @pytest.mark.asyncio
+async def test_slash_confirm_private_topic_callback_followup_respects_reply_mode_off(monkeypatch):
+    adapter = _make_adapter()
+    adapter._reply_to_mode = "off"
+    adapter._slash_confirm_state = {"confirm-1": "session-1"}
+    adapter._is_callback_user_authorized = lambda *args, **kwargs: True
+    call_log = []
+
+    async def mock_send_message(**kwargs):
+        call_log.append(dict(kwargs))
+        return SimpleNamespace(message_id=9001)
+
+    async def resolve(_session_key, _confirm_id, _choice):
+        return "done"
+
+    from tools import slash_confirm
+
+    monkeypatch.setattr(slash_confirm, "resolve", resolve)
+    adapter._bot = SimpleNamespace(send_message=mock_send_message)
+
+    class Query:
+        data = "sc:once:confirm-1"
+        from_user = SimpleNamespace(id=42, first_name="Alice")
+        message = SimpleNamespace(
+            chat_id=12345,
+            chat=SimpleNamespace(type=_fake_telegram_constants.ChatType.PRIVATE),
+            message_thread_id=20197,
+            message_id=462,
+        )
+
+        async def answer(self, **kwargs):
+            return None
+
+        async def edit_message_text(self, **kwargs):
+            return None
+
+    await adapter._handle_callback_query(SimpleNamespace(callback_query=Query()), SimpleNamespace())
+
+    assert call_log
+    assert call_log[0]["message_thread_id"] == 20197
+    assert call_log[0]["reply_to_message_id"] is None
+
+
+@pytest.mark.asyncio
 async def test_slash_confirm_forum_callback_followup_keeps_existing_thread_behavior(monkeypatch):
     adapter = _make_adapter()
     adapter._slash_confirm_state = {"confirm-1": "session-1"}


### PR DESCRIPTION

**Description**
Private DM-topic slash-confirm follow-up messages were always setting `reply_to_message_id` directly, which bypassed `telegram.reply_to_mode=off` and still produced quote bubbles.

This change routes the callback follow-up through the existing Telegram DM-topic reply helpers so it matches normal `send()` behavior:
- `reply_to_mode=off` keeps `message_thread_id` but suppresses the reply anchor
- `reply_to_mode=first/all` preserves the existing quoted follow-up behavior

Also adds a regression test covering the private-topic slash-confirm callback path when `reply_to_mode` is `off`.

**Validation**
- `pytest tests/gateway/test_telegram_thread_fallback.py -k "slash_confirm" -q`
  - `3 passed in 3.15s`
- `pytest tests/gateway/test_telegram_reply_mode.py -q`
  - `40 passed in 3.96s`

