### PR TITLE
fix(tools): keep cua-driver MCP session task-local

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import sys
+import types
 from typing import Any, Dict, List, Optional, Tuple
 from unittest.mock import MagicMock, patch
 
@@ -100,6 +102,38 @@ class TestRegistration:
 # ---------------------------------------------------------------------------
 
 class TestDispatch:
+    def test_backend_start_failure_does_not_poison_cached_backend(self):
+        from tools.computer_use import tool as cu_tool
+
+        class FlakyBackend:
+            starts = 0
+            stops = 0
+
+            def start(self):
+                type(self).starts += 1
+                if type(self).starts == 1:
+                    raise RuntimeError("startup failed")
+
+            def stop(self):
+                type(self).stops += 1
+
+            def is_available(self): return True
+            def list_apps(self): return []
+
+        cu_tool.reset_backend_for_tests()
+        with patch.dict(os.environ, {"HERMES_COMPUTER_USE_BACKEND": "cua"}, clear=False), \
+             patch("tools.computer_use.cua_backend.CuaDriverBackend", FlakyBackend):
+            with pytest.raises(RuntimeError, match="startup failed"):
+                cu_tool._get_backend()
+
+            assert cu_tool._backend is None
+            backend = cu_tool._get_backend()
+
+        assert isinstance(backend, FlakyBackend)
+        assert FlakyBackend.starts == 2
+        assert FlakyBackend.stops == 1
+        cu_tool.reset_backend_for_tests()
+
     def test_missing_action_returns_error(self):
         from tools.computer_use.tool import handle_computer_use
         out = handle_computer_use({})
@@ -286,6 +320,76 @@ class TestCaptureResponse:
         assert "#1" in text_part["text"]
         assert "AXButton" in text_part["text"]
         assert "AXTextField" in text_part["text"]
+
+
+# ---------------------------------------------------------------------------
+# Cua-driver session lifecycle
+# ---------------------------------------------------------------------------
+
+class TestCuaDriverSessionLifecycle:
+    def test_mcp_context_and_tool_calls_stay_on_one_asyncio_task(self, monkeypatch):
+        from tools.computer_use import cua_backend
+
+        task_ids = {}
+
+        class FakeStdioContext:
+            async def __aenter__(self):
+                task_ids["stdio_enter"] = id(asyncio.current_task())
+                return object(), object()
+
+            async def __aexit__(self, exc_type, exc, tb):
+                task_ids["stdio_exit"] = id(asyncio.current_task())
+
+        class FakeClientSession:
+            def __init__(self, read, write):
+                pass
+
+            async def __aenter__(self):
+                task_ids["session_enter"] = id(asyncio.current_task())
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                task_ids["session_exit"] = id(asyncio.current_task())
+
+            async def initialize(self):
+                task_ids["initialize"] = id(asyncio.current_task())
+
+            async def call_tool(self, name, args):
+                task_ids.setdefault("calls", []).append(id(asyncio.current_task()))
+                return types.SimpleNamespace(
+                    isError=False,
+                    structuredContent=None,
+                    content=[types.SimpleNamespace(type="text", text=json.dumps({"tool": name}))],
+                )
+
+        fake_mcp = types.ModuleType("mcp")
+        setattr(fake_mcp, "ClientSession", FakeClientSession)
+        setattr(fake_mcp, "StdioServerParameters", lambda **kwargs: kwargs)
+        fake_mcp_client = types.ModuleType("mcp.client")
+        fake_stdio = types.ModuleType("mcp.client.stdio")
+        setattr(fake_stdio, "stdio_client", lambda params: FakeStdioContext())
+
+        monkeypatch.setitem(sys.modules, "mcp", fake_mcp)
+        monkeypatch.setitem(sys.modules, "mcp.client", fake_mcp_client)
+        monkeypatch.setitem(sys.modules, "mcp.client.stdio", fake_stdio)
+        monkeypatch.setattr(cua_backend, "cua_driver_binary_available", lambda: True)
+
+        bridge = cua_backend._AsyncBridge()
+        session = cua_backend._CuaDriverSession(bridge)
+        try:
+            session.start()
+            assert session.call_tool("list_apps", {})["data"] == {"tool": "list_apps"}
+            assert session.call_tool("click", {"element_index": 1})["data"] == {"tool": "click"}
+            session.stop()
+        finally:
+            bridge.stop()
+
+        worker_task_id = task_ids["session_enter"]
+        assert task_ids["stdio_enter"] == worker_task_id
+        assert task_ids["initialize"] == worker_task_id
+        assert task_ids["calls"] == [worker_task_id, worker_task_id]
+        assert task_ids["session_exit"] == worker_task_id
+        assert task_ids["stdio_exit"] == worker_task_id
 
 
 # ---------------------------------------------------------------------------

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -207,68 +207,128 @@ class _AsyncBridge:
 # ---------------------------------------------------------------------------
 
 class _CuaDriverSession:
-    """Holds the mcp ClientSession. Spawned lazily; re-entered on drop."""
+    """Long-lived cua-driver MCP session owned by one asyncio task.
+
+    The MCP stdio transport uses AnyIO cancel scopes that must be exited by the
+    same task that entered them. Keep session creation, tool calls, and shutdown
+    inside one worker task instead of entering in one task and closing in
+    another. This also preserves cua-driver's per-session AX element cache
+    between capture and element-index actions.
+    """
 
     def __init__(self, bridge: _AsyncBridge) -> None:
         self._bridge = bridge
         self._session = None
-        self._exit_stack = None
         self._lock = threading.Lock()
         self._started = False
+        self._queue: Optional[asyncio.Queue] = None
+        self._worker_task: Optional[asyncio.Task] = None
+        self._ready_event: Optional[asyncio.Event] = None
+        self._startup_error: Optional[BaseException] = None
 
     def _require_started(self) -> None:
-        if not self._started:
+        if not self._started or self._queue is None:
             raise RuntimeError("cua-driver session not started")
 
-    async def _aenter(self) -> None:
+    async def _worker(self) -> None:
         from contextlib import AsyncExitStack
         from mcp import ClientSession, StdioServerParameters
         from mcp.client.stdio import stdio_client
 
-        if not cua_driver_binary_available():
-            raise RuntimeError(cua_driver_install_hint())
+        try:
+            if not cua_driver_binary_available():
+                raise RuntimeError(cua_driver_install_hint())
 
-        params = StdioServerParameters(
-            command=_CUA_DRIVER_CMD,
-            args=_CUA_DRIVER_ARGS,
-            env={**os.environ},
-        )
-        stack = AsyncExitStack()
-        read, write = await stack.enter_async_context(stdio_client(params))
-        session = await stack.enter_async_context(ClientSession(read, write))
-        await session.initialize()
-        self._exit_stack = stack
-        self._session = session
+            params = StdioServerParameters(
+                command=_CUA_DRIVER_CMD,
+                args=_CUA_DRIVER_ARGS,
+                env={**os.environ},
+            )
+            async with AsyncExitStack() as stack:
+                read, write = await stack.enter_async_context(stdio_client(params))
+                session = await stack.enter_async_context(ClientSession(read, write))
+                await session.initialize()
+                self._session = session
+                self._started = True
+                if self._ready_event is not None:
+                    self._ready_event.set()
 
-    async def _aexit(self) -> None:
-        if self._exit_stack is not None:
+                assert self._queue is not None
+                while True:
+                    item = await self._queue.get()
+                    if item is None:
+                        break
+                    name, args, fut = item
+                    if fut.cancelled():
+                        continue
+                    try:
+                        result = await session.call_tool(name, args)
+                        fut.set_result(_extract_tool_result(result))
+                    except Exception as e:
+                        fut.set_exception(e)
+        except BaseException as e:
+            self._startup_error = e
+            if self._ready_event is not None:
+                self._ready_event.set()
+            raise
+        finally:
+            self._session = None
+            self._started = False
+
+    async def _start_worker(self) -> None:
+        self._queue = asyncio.Queue()
+        self._ready_event = asyncio.Event()
+        self._startup_error = None
+        self._worker_task = asyncio.create_task(self._worker())
+        await self._ready_event.wait()
+        if self._startup_error is not None:
+            task = self._worker_task
+            self._worker_task = None
+            self._queue = None
+            self._ready_event = None
+            if task is not None and task.done():
+                try:
+                    task.result()
+                except BaseException:
+                    pass
+            raise self._startup_error
+
+    async def _stop_worker(self) -> None:
+        queue = self._queue
+        task = self._worker_task
+        self._queue = None
+        self._worker_task = None
+        self._ready_event = None
+        if queue is not None:
+            await queue.put(None)
+        if task is not None:
             try:
-                await self._exit_stack.aclose()
+                await asyncio.wait_for(task, timeout=5.0)
             except Exception as e:
                 logger.warning("cua-driver shutdown error: %s", e)
-        self._exit_stack = None
-        self._session = None
+                task.cancel()
+        self._started = False
 
     def start(self) -> None:
         with self._lock:
             if self._started:
                 return
             self._bridge.start()
-            self._bridge.run(self._aenter(), timeout=15.0)
-            self._started = True
+            self._bridge.run(self._start_worker(), timeout=15.0)
 
     def stop(self) -> None:
         with self._lock:
-            if not self._started:
+            if not self._started and self._worker_task is None:
                 return
-            try:
-                self._bridge.run(self._aexit(), timeout=5.0)
-            finally:
-                self._started = False
+            self._bridge.run(self._stop_worker(), timeout=6.0)
 
     async def _call_tool_async(self, name: str, args: Dict[str, Any]) -> Dict[str, Any]:
-        result = await self._session.call_tool(name, args)
-        return _extract_tool_result(result)
+        self._require_started()
+        assert self._queue is not None
+        loop = asyncio.get_running_loop()
+        fut = loop.create_future()
+        await self._queue.put((name, args, fut))
+        return await fut
 
     def call_tool(self, name: str, args: Dict[str, Any], timeout: float = 30.0) -> Dict[str, Any]:
         self._require_started()
@@ -409,6 +469,7 @@ class CuaDriverBackend(ComputerUseBackend):
             gws_out = self._session.call_tool(
                 "get_window_state",
                 {"pid": self._active_pid, "window_id": self._active_window_id},
+                timeout=120.0,
             )
             text = gws_out["data"] if isinstance(gws_out["data"], str) else ""
             summary, tree = _split_tree_text(text)

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -133,12 +133,21 @@ def _get_backend() -> ComputerUseBackend:
             backend_name = os.environ.get("HERMES_COMPUTER_USE_BACKEND", "cua").lower()
             if backend_name in {"cua", "cua-driver", ""}:
                 from tools.computer_use.cua_backend import CuaDriverBackend
-                _backend = CuaDriverBackend()
+                backend = CuaDriverBackend()
             elif backend_name == "noop":  # pragma: no cover
-                _backend = _NoopBackend()
+                backend = _NoopBackend()
             else:
                 raise RuntimeError(f"Unknown HERMES_COMPUTER_USE_BACKEND={backend_name!r}")
-            _backend.start()
+            try:
+                backend.start()
+            except Exception:
+                try:
+                    backend.stop()
+                except Exception:
+                    pass
+                _backend = None
+                raise
+            _backend = backend
         return _backend
 
 


### PR DESCRIPTION
## Summary
- keep the cua-driver MCP stdio session lifecycle inside one long-lived asyncio worker task
- route all cua-driver tool calls through that worker so capture/action calls share the same MCP session and AX cache
- avoid poisoning the cached computer_use backend when startup fails
- give `get_window_state` more time for heavy native app AX trees

## Motivation
The previous bridge entered the MCP stdio/ClientSession contexts in one task, then closed them from another. AnyIO cancel scopes used by the MCP stdio transport must be exited by the same task that entered them, which can produce shutdown errors and broken/stale session state. It also makes it easier for element-index actions to lose the cua-driver AX cache created during capture.

## Test plan
- `python -m pytest tests/tools/test_computer_use.py -q -o 'addopts='` — 49 passed
- `python -m ruff check tools/computer_use/cua_backend.py tools/computer_use/tool.py tests/tools/test_computer_use.py` — passed
- `python -m py_compile tools/computer_use/cua_backend.py tools/computer_use/tool.py tests/tools/test_computer_use.py` — passed
- manual macOS smoke test: started `CuaDriverBackend`, called `list_apps()`, captured Safari AX state successfully (`188` elements)

## Notes
A full `python -m pytest tests/ -q -o 'addopts='` run was attempted locally but failed broadly outside this change area after 7k+ passes; I did not treat that as validation for this PR because the failures were not isolated to computer_use. Targeted computer_use tests and lint pass.
