### PR TITLE
feat(web_search): add configurable fallback chain

### DIFF
--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -384,9 +384,10 @@ class TestBackendSelection:
             assert _get_backend() == "firecrawl"
 
     def test_fallback_no_keys_defaults_to_firecrawl(self):
-        """No keys, no config → 'firecrawl' (will fail at client init)."""
+        """No keys, no config → 'firecrawl' when no optional free backend is installed."""
         from tools.web_tools import _get_backend
-        with patch("tools.web_tools._load_web_config", return_value={}):
+        with patch("tools.web_tools._load_web_config", return_value={}), \
+             patch("tools.web_tools._ddgs_package_importable", return_value=False):
             assert _get_backend() == "firecrawl"
 
     def test_invalid_config_falls_through_to_fallback(self):
@@ -508,6 +509,90 @@ class TestWebSearchSchema:
         assert result == {"success": True, "data": {"web": []}}
         fake_search.assert_called_once_with("docs", 100)
 
+    def test_get_search_fallback_backends_normalizes_list_and_dedupes(self):
+        import tools.web_tools
+
+        with patch("tools.web_tools._load_web_config", return_value={
+            "search_fallbacks": ["ddgs", "tavily", "ddgs", "bad-backend", "  brave-free  "]
+        }):
+            result = tools.web_tools._get_search_fallback_backends("ddgs")
+
+        assert result == ["tavily", "brave-free"]
+
+    def test_web_search_uses_configured_fallback_when_primary_returns_failure(self):
+        import tools.web_tools
+
+        primary_provider = MagicMock(name="DDGSWebSearchProvider")
+        primary_provider.name = "ddgs"
+        primary_provider.supports_search.return_value = True
+        primary_provider.search.return_value = {"success": False, "error": "rate limited"}
+
+        fallback_provider = MagicMock(name="TavilyWebSearchProvider")
+        fallback_provider.name = "tavily"
+        fallback_provider.supports_search.return_value = True
+        fallback_provider.search.return_value = {
+            "success": True,
+            "data": {"web": [{"title": "OpenAI", "url": "https://openai.com", "description": "", "position": 1}]},
+        }
+
+        providers = {"ddgs": primary_provider, "tavily": fallback_provider}
+
+        with patch("tools.web_tools._get_search_backend", return_value="ddgs"), \
+             patch("tools.web_tools._get_search_fallback_backends", return_value=["tavily"]), \
+             patch("agent.web_search_registry.get_provider", side_effect=lambda name: providers.get(name)), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch.object(tools.web_tools._debug, "log_call"), \
+             patch.object(tools.web_tools._debug, "save"):
+            result = json.loads(tools.web_tools.web_search_tool("docs", limit=5))
+
+        assert result["success"] is True
+        assert result["data"]["web"][0]["url"] == "https://openai.com"
+        primary_provider.search.assert_called_once_with("docs", 5)
+        fallback_provider.search.assert_called_once_with("docs", 5)
+
+    def test_web_search_uses_brave_free_as_explicit_fallback_after_ddgs_failure(self):
+        import tools.web_tools
+
+        primary_provider = MagicMock(name="DDGSWebSearchProvider")
+        primary_provider.name = "ddgs"
+        primary_provider.supports_search.return_value = True
+        primary_provider.search.return_value = {
+            "success": False,
+            "error": "forced ddgs failure for brave fallback",
+        }
+
+        fallback_provider = MagicMock(name="BraveFreeWebSearchProvider")
+        fallback_provider.name = "brave-free"
+        fallback_provider.supports_search.return_value = True
+        fallback_provider.search.return_value = {
+            "success": True,
+            "data": {
+                "web": [
+                    {
+                        "title": "OpenAI | Research & Deployment",
+                        "url": "https://openai.com/",
+                        "description": "",
+                        "position": 1,
+                    }
+                ]
+            },
+        }
+
+        providers = {"ddgs": primary_provider, "brave-free": fallback_provider}
+
+        with patch("tools.web_tools._get_search_backend", return_value="ddgs"), \
+             patch("tools.web_tools._get_search_fallback_backends", return_value=["brave-free", "tavily"]), \
+             patch("agent.web_search_registry.get_provider", side_effect=lambda name: providers.get(name)), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch.object(tools.web_tools._debug, "log_call"), \
+             patch.object(tools.web_tools._debug, "save"):
+            result = json.loads(tools.web_tools.web_search_tool("OpenAI official website", limit=3))
+
+        assert result["success"] is True
+        assert result["data"]["web"][0]["url"] == "https://openai.com/"
+        primary_provider.search.assert_called_once_with("OpenAI official website", 3)
+        fallback_provider.search.assert_called_once_with("OpenAI official website", 3)
+
 
 class TestWebSearchErrorHandling:
     """Test suite for web_search_tool() error responses."""
@@ -602,8 +687,9 @@ class TestCheckWebApiKey:
             assert check_web_api_key() is True
 
     def test_no_keys_returns_false(self):
-        from tools.web_tools import check_web_api_key
-        assert check_web_api_key() is False
+        with patch("tools.web_tools._ddgs_package_importable", return_value=False):
+            from tools.web_tools import check_web_api_key
+            assert check_web_api_key() is False
 
     def test_both_keys_returns_true(self):
         with patch.dict(os.environ, {

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -118,6 +118,17 @@ import sys
 logger = logging.getLogger(__name__)
 
 
+_VALID_WEB_BACKENDS = {
+    "parallel",
+    "firecrawl",
+    "tavily",
+    "exa",
+    "searxng",
+    "brave-free",
+    "ddgs",
+}
+
+
 # ─── Backend Selection ────────────────────────────────────────────────────────
 
 def _has_env(name: str) -> bool:
@@ -140,7 +151,7 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs"}:
+    if configured in _VALID_WEB_BACKENDS:
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -176,6 +187,32 @@ def _get_search_backend() -> str:
     (e.g. SearXNG for search + Firecrawl for extract).
     """
     return _get_capability_backend("search")
+
+
+def _get_search_fallback_backends(primary_backend: str) -> List[str]:
+    """Return configured fallback backends for ``web_search``.
+
+    Accepts either a YAML list or a comma-separated string in
+    ``web.search_fallbacks``. Returns normalized, de-duplicated backend names
+    and excludes the active primary backend.
+    """
+    cfg = _load_web_config()
+    raw = cfg.get("search_fallbacks", [])
+    if isinstance(raw, str):
+        candidates = [part.strip().lower() for part in raw.split(",")]
+    elif isinstance(raw, list):
+        candidates = [str(part).strip().lower() for part in raw]
+    else:
+        return []
+
+    backends: List[str] = []
+    seen = {primary_backend}
+    for backend in candidates:
+        if not backend or backend in seen or backend not in _VALID_WEB_BACKENDS:
+            continue
+        seen.add(backend)
+        backends.append(backend)
+    return backends
 
 
 def _get_extract_backend() -> str:
@@ -805,8 +842,28 @@ def web_search_tool(query: str, limit: int = 5) -> str:
             # configured backend isn't a registered search provider (typo,
             # uninstalled plugin, or capability mismatch).
             provider = get_active_search_provider()
+            backend = provider.name if provider is not None else backend
 
-        if provider is None:
+        fallback_backends = _get_search_fallback_backends(backend)
+        candidates: List[tuple[str, Any]] = []
+        seen_candidate_names = set()
+
+        if provider is not None and provider.supports_search():
+            candidates.append((backend or provider.name, provider))
+            seen_candidate_names.add(provider.name)
+
+        for fallback_backend in fallback_backends:
+            fallback_provider = _wsp_get_provider(fallback_backend)
+            if (
+                fallback_provider is None
+                or not fallback_provider.supports_search()
+                or fallback_provider.name in seen_candidate_names
+            ):
+                continue
+            candidates.append((fallback_backend, fallback_provider))
+            seen_candidate_names.add(fallback_provider.name)
+
+        if not candidates:
             response_data = {
                 "success": False,
                 "error": (
@@ -815,11 +872,50 @@ def web_search_tool(query: str, limit: int = 5) -> str:
                 ),
             }
         else:
-            logger.info(
-                "Web search via %s: '%s' (limit: %d)",
-                provider.name, query, limit,
-            )
-            response_data = provider.search(query, limit)
+            backend_errors: List[str] = []
+            response_data = None
+            for index, (_candidate_backend, candidate_provider) in enumerate(candidates):
+                logger.info(
+                    "Web search via %s: '%s' (limit: %d)",
+                    candidate_provider.name, query, limit,
+                )
+                try:
+                    candidate_response = candidate_provider.search(query, limit)
+                except Exception as exc:
+                    if len(candidates) == 1:
+                        raise
+                    error_text = f"{candidate_provider.name}: {exc}"
+                    backend_errors.append(error_text)
+                    logger.warning("web_search backend failed: %s", error_text)
+                    continue
+
+                if candidate_response.get("success") is True:
+                    response_data = candidate_response
+                    if index > 0:
+                        logger.info(
+                            "Web search fallback succeeded via %s (primary=%s)",
+                            candidate_provider.name,
+                            candidates[0][1].name,
+                        )
+                    break
+
+                if len(candidates) == 1:
+                    response_data = candidate_response
+                    break
+
+                error_text = str(candidate_response.get("error") or "search failed")
+                backend_errors.append(f"{candidate_provider.name}: {error_text}")
+                logger.warning(
+                    "web_search backend failed: %s: %s",
+                    candidate_provider.name,
+                    error_text,
+                )
+
+            if response_data is None:
+                response_data = {
+                    "success": False,
+                    "error": "Web search failed across backends: " + "; ".join(backend_errors[:3]),
+                }
 
         debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
         result_json = json.dumps(response_data, indent=2, ensure_ascii=False)


### PR DESCRIPTION
## Summary
- add configurable `web.search_fallbacks` handling for `web_search`
- support YAML-list or comma-separated fallback config values
- normalize, deduplicate, skip the active primary backend, and try fallback providers in order
- return aggregated backend error context when all configured candidates fail
- add tests covering `ddgs -> brave-free` fallback behavior and fallback selection rules

## Test Plan
- `python -m pytest -o addopts='' tests/tools/test_web_tools_config.py -q -k 'fallback_backends or configured_fallback or brave_free or no_keys_defaults_to_firecrawl or no_keys_returns_false'`

## Notes
Split from #27751 per maintainer request to isolate configurable web-search fallback routing from the unrelated Telegram send-path fix.
