### PR TITLE
fix(kanban): move session_id index creation from SCHEMA_SQL to migration

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -865,8 +865,6 @@ CREATE TABLE IF NOT EXISTS tasks (
     session_id           TEXT
 );
 
-CREATE INDEX IF NOT EXISTS idx_tasks_session_id ON tasks(session_id);
-
 CREATE TABLE IF NOT EXISTS task_links (
     parent_id  TEXT NOT NULL,
     child_id   TEXT NOT NULL,


### PR DESCRIPTION
## Problem

When upgrading from an older Hermes version to v0.14.0, existing kanban.db files lack the `session_id` column. `SCHEMA_SQL` includes:

```sql
CREATE TABLE IF NOT EXISTS tasks (...);
CREATE INDEX IF NOT EXISTS idx_tasks_session_id ON tasks(session_id);  -- 💥
```

`CREATE TABLE IF NOT EXISTS` is a no-op on existing tables (old schema, no `session_id`). But the `CREATE INDEX` on the next line references `session_id` before `_migrate_add_optional_columns()` gets a chance to add it via `ALTER TABLE`. Crash.

## Fix

Remove the premature `CREATE INDEX` from `SCHEMA_SQL`. The index creation is already handled correctly inside `_migrate_add_optional_columns()` (line 1166–1178), where `ALTER TABLE ADD COLUMN` runs first.

One line deleted, no logic changed — the index still gets created, just at the right time.

## Verification

- Fresh install: `SCHEMA_SQL` creates table + all columns → migration is a no-op → index created during migration ✓
- Upgrade from old DB: `SCHEMA_SQL` no-ops on existing table → migration adds `session_id` column → migration creates index ✓

Fixes #28554