### PR TITLE
feat(telegram): add pin_messages config option to disable auto-pinning

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -5439,7 +5439,7 @@ class TelegramAdapter(BasePlatformAdapter):
             if self._reactions_enabled():
                 await self._set_reaction(chat_id, message_id, "\U0001f440")
             # Pin the incoming message for the duration of the turn
-            if self._bot:
+            if self._bot and self.config.extra.get("pin_messages", True):
                 try:
                     await self._bot.pin_chat_message(
                         chat_id=int(chat_id),
@@ -5476,7 +5476,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     "\U0001f44d" if outcome == ProcessingOutcome.SUCCESS else "\U0001f44e",
                 )
         # Unpin the message when processing is complete
-        if self._bot:
+        if self._bot and self.config.extra.get("pin_messages", True):
             try:
                 await self._bot.unpin_chat_message(
                     chat_id=int(chat_id),

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -1097,6 +1097,21 @@ Unlike Discord (where reactions are additive), Telegram's Bot API replaces all b
 If the bot doesn't have permission to add reactions in a group, the reaction calls fail silently and message processing continues normally.
 :::
 
+## Message Pinning
+
+By default, Hermes pins your incoming message at the start of processing and unpins it when the turn completes. This gives a visual indicator that the message is being worked on, but it also creates a service message in the chat history ("Bot pinned a message" / "Bot unpinned a message").
+
+To disable this behavior, set `pin_messages: false` under `platforms.telegram.extra`:
+
+```yaml
+platforms:
+  telegram:
+    extra:
+      pin_messages: false
+```
+
+When disabled, reactions (if enabled) still work — only the pin/unpin step is skipped.
+
 ## Per-Channel Prompts
 
 Assign ephemeral system prompts to specific Telegram groups or forum topics. The prompt is injected at runtime on every turn — never persisted to transcript history — so changes take effect immediately.


### PR DESCRIPTION
By default, Hermes pins the incoming user message at the start of processing and unpins it when the turn completes. This creates service messages in the chat history ("Bot pinned a message" / "Bot unpinned a message") that some users find noisy.

This PR adds a new `platforms.telegram.extra.pin_messages` config option (default: true). When set to false, the pin/unpin step is skipped while reactions (if enabled) continue to work normally.

**Changes:**
- `gateway/platforms/telegram.py`: Gate `pinChatMessage` and `unpinChatMessage` on `self.config.extra.get('pin_messages', True)`.
- `website/docs/user-guide/messaging/telegram.md`: Document the new option in a new "Message Pinning" section.
