### PR TITLE
docs(skills/darwinian-evolver): add pickle security note to SKILL.md

### DIFF
--- a/optional-skills/research/darwinian-evolver/SKILL.md
+++ b/optional-skills/research/darwinian-evolver/SKILL.md
@@ -189,7 +189,13 @@ ls "$DE_DIR/darwinian_evolver/lineage_visualizer.html" >/dev/null && \
 cd "$DE_DIR" && uv run darwinian_evolver --help >/dev/null && \
 echo "darwinian-evolver: OK"
 ```
+## Security
 
+⚠️ **Pickle deserialization risk.** Snapshots produced by `darwinian_evolver` are Python pickle files. Loading a pickle from an untrusted source can execute arbitrary code on your machine.
+
+- Only load snapshots you generated yourself, or that come from a source you fully trust.
+- Never load snapshots shared over chat, email, or unverified Git repos without inspecting them first.
+- If you need to distribute snapshots, prefer signing them (e.g. with `gpg --detach-sign`) and verifying signatures before load.
 ## References
 
 - [Imbue research post](https://imbue.com/research/2026-02-27-darwinian-evolver/)


### PR DESCRIPTION
## What does this PR do?

Small follow-up to #26760. Adds an explicit security note to `SKILL.md` about the pickle deserialization risk for snapshots produced by `darwinian_evolver`.

The Pitfalls section in the merged version mentions nested-pickle snapshots as a structural quirk, but doesn't flag the underlying arbitrary-code-execution risk. This PR makes that explicit so users know not to load snapshots from untrusted sources.

Raised by @123mikeyd in Discord — credit to them for the catch.

## Related Issue

Follow-up to #26760 (no separate issue).

## Type of Change

- [x] 📝 Documentation update
- [x] 🔒 Security fix

## Changes Made

- `optional-skills/research/darwinian-evolver/SKILL.md`: added a new `## Security` section warning users about pickle deserialization risk and recommending they only load snapshots from trusted sources.

## How to Test

Docs-only change, no runtime behavior affected.

1. Open `optional-skills/research/darwinian-evolver/SKILL.md`
2. Verify the new `## Security` section renders correctly and the warning is clear.

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`docs(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A (docs-only)
- [ ] I've added tests for my changes — N/A (docs-only)
- [x] I've tested on my platform: docs-only, no platform-specific code

### Documentation & Housekeeping
- [x] I've updated relevant documentation (this PR is the documentation update)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (docs-only)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

N/A — docs-only change.