### PR TITLE
fix: reject line-numbered read_file output in write_file to prevent silent file corruption

### DIFF
--- a/tests/tools/test_file_read_guards.py
+++ b/tests/tools/test_file_read_guards.py
@@ -25,6 +25,7 @@ from tools.file_tools import (
     _DEFAULT_MAX_READ_CHARS,
     _read_tracker,
     notify_other_tool_call,
+    _is_line_number_polluted,
 )
 
 
@@ -221,6 +222,83 @@ class TestFileDedup(unittest.TestCase):
         self.assertIn("error", result)
         self.assertIn("internal read_file status text", result["error"])
         fake.write_file.assert_not_called()
+
+    # -------------------------------------------------------------------------
+    # Line-number pollution guards
+    # -------------------------------------------------------------------------
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_write_rejects_line_number_polluted_content(self, mock_ops):
+        """write_file must reject content that is clearly read_file output."""
+        fake = MagicMock()
+        fake.write_file = MagicMock()
+        mock_ops.return_value = fake
+
+        polluted = "     1|setting: value\n     2|other: thing\n     3|third: item\n"
+        result = json.loads(write_file_tool(
+            self._tmpfile,
+            polluted,
+            task_id="guard",
+        ))
+
+        self.assertIn("error", result)
+        self.assertIn("line-numbered read_file output", result["error"])
+        fake.write_file.assert_not_called()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_write_rejects_partial_line_number_pollution(self, mock_ops):
+        """Mixed content with majority line-number prefixes is rejected."""
+        fake = MagicMock()
+        fake.write_file = MagicMock()
+        mock_ops.return_value = fake
+
+        # 3 polluted lines, 1 legitimate — 75% > 50% threshold
+        polluted = "     1|alpha\n     2|beta\n     3|gamma\nreal line without number\n"
+        result = json.loads(write_file_tool(
+            self._tmpfile,
+            polluted,
+            task_id="guard",
+        ))
+
+        self.assertIn("error", result)
+        fake.write_file.assert_not_called()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_write_allows_genuine_number_prefixed_content(self, mock_ops):
+        """Legitimate content with sparse number prefixes is allowed (>50% threshold)."""
+        fake = MagicMock()
+        write_mock = MagicMock(
+            to_dict=lambda: {"success": True, "path": self._tmpfile}
+        )
+        fake.write_file = lambda path, content: write_mock
+        mock_ops.return_value = fake
+
+        # Only 1 in 4 lines has number prefix — 25% < 50% threshold
+        genuine = "1|first item\n2|second item\nregular line\nfourth line\n"
+        result = json.loads(write_file_tool(
+            self._tmpfile,
+            genuine,
+            task_id="guard",
+        ))
+
+        self.assertNotIn("error", result)
+
+    # Unit tests for the helper directly
+    def test_is_line_number_polluted_true_on_typical_read_file_output(self):
+        content = "     1|foo\n     2|bar\n     3|baz\n"
+        self.assertTrue(_is_line_number_polluted(content))
+
+    def test_is_line_number_polluted_false_on_empty(self):
+        self.assertFalse(_is_line_number_polluted(""))
+        self.assertFalse(_is_line_number_polluted("   \n  \n"))
+
+    def test_is_line_number_polluted_false_on_single_line(self):
+        self.assertFalse(_is_line_number_polluted("no numbers here"))
+
+    def test_is_line_number_polluted_respects_threshold(self):
+        # Exactly 50% — not > 50%, so False
+        content = "     1|a\n     2|b\nthird\nfourth\n"
+        self.assertFalse(_is_line_number_polluted(content))
 
     @patch("tools.file_tools._get_file_ops")
     def test_write_allows_large_file_that_quotes_status_text(self, mock_ops):

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -302,6 +302,27 @@ def _is_internal_file_status_text(content: str) -> bool:
     return False
 
 
+def _is_line_number_polluted(content: str) -> bool:
+    """Return True when content appears to be line-numbered read_file output.
+
+    When the model echoes read_file output directly into write_file,
+    the ``LINE_NUM|CONTENT`` prefixes get written to disk.  Detect this
+    by looking for the characteristic ``{n:6d}|`` prefix on most lines.
+
+    Threshold: >50% of non-empty lines must match the pattern.
+    """
+    if not isinstance(content, str) or not content.strip():
+        return False
+    lines = content.split('\n')
+    non_empty = [l for l in lines if l.strip()]
+    if len(non_empty) < 2:
+        return False
+    import re
+    pattern = re.compile(r'^\s*\d{1,6}\|')
+    polluted = sum(1 for l in non_empty if pattern.match(l))
+    return polluted > 0 and polluted / len(non_empty) > 0.5
+
+
 def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
     """Get or create ShellFileOperations for a terminal environment.
 
@@ -799,6 +820,11 @@ def write_file_tool(path: str, content: str, task_id: str = "default") -> str:
         return tool_error(
             "Refusing to write internal read_file status text as file content. "
             "Re-read the file or reconstruct the intended file contents before writing."
+        )
+    if _is_line_number_polluted(content):
+        return tool_error(
+            "Refusing to write line-numbered read_file output as file content. "
+            "Strip the LINE_NUM| prefixes or reconstruct the file before writing."
         )
     try:
         # Resolve once for the registry lock + stale check.  Failures here


### PR DESCRIPTION
## Summary

Fixes silent file corruption when a model echoes `read_file` output (which includes `LINE_NUM|CONTENT` prefixes) directly into `write_file`.

## Problem

`read_file` unconditionally adds line-number prefixes (`{i:6d}|`) to every line. When a model echoes this output into `write_file`, the prefixes get persisted to disk — silently corrupting config files, `.env` files, source code, etc.

The existing guard only caught the "dedup status message" shape, but was completely unaware of the `LINE_NUM|CONTENT` pattern.

## Solution

Add `_is_line_number_polluted()` detection alongside the existing `_is_internal_file_status_text()` guard:

- **Heuristic**: if >50% of non-empty lines match `^\s*\d{1,6}\|` (the `{n:6d}|` prefix from `read_file`), reject with a clear error message
- **Threshold**: >50% avoids false positives on legitimate files that happen to start with similar-looking content
- **Minimal impact**: 100% additive — only adds new detection, changes nothing else

## Changes

| File | Change |
|------|--------|
| `tools/file_tools.py` | +1 guard call in `write_file_tool`; +1 helper `_is_line_number_polluted()` |
| `tests/tools/test_file_read_guards.py` | +6 tests: rejection cases, false-positive case, unit tests |

## Test Results

```
tests/tools/test_file_read_guards.py - 41 passed
```

Closes #19798
