### PR TITLE
feat(honcho): surface pinPeerName in setup and status (#28283)

### DIFF
--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -425,6 +425,22 @@ def cmd_setup(args) -> None:
     if new_peer:
         hermes_host["peerName"] = new_peer
 
+    current_pin = hermes_host.get("pinPeerName")
+    if current_pin is None:
+        current_pin = cfg.get("pinPeerName")
+    current_pin = current_pin is True
+    print("\n  Pin peerName across front-ends:")
+    print("    y -- keep the configured user peer for one human across Telegram/CLI/etc.")
+    print("    n -- let gateway user IDs scope memory per user (default for multi-user bots)")
+    new_pin = _prompt(
+        "Pin peerName across front-ends? (single user, multi-instance)",
+        default="y" if current_pin else "n",
+    ).strip().lower()
+    if new_pin in ("y", "yes", "true", "1", "on"):
+        hermes_host["pinPeerName"] = True
+    elif new_pin in ("n", "no", "false", "0", "off"):
+        hermes_host["pinPeerName"] = False
+
     current_ai = hermes_host.get("aiPeer") or cfg.get("aiPeer", "hermes")
     new_ai = _prompt("AI peer name", default=current_ai)
     if new_ai:
@@ -681,6 +697,7 @@ def cmd_status(args) -> None:
 
     print(f"  AI peer:        {hcfg.ai_peer}")
     print(f"  User peer:      {hcfg.peer_name or 'not set'}")
+    print(f"  Pin peer name:  {hcfg.pin_peer_name}")
     print(f"  Session key:    {hcfg.resolve_session_name()}")
     print(f"  Session strat:  {hcfg.session_strategy}")
     print(f"  Recall mode:    {hcfg.recall_mode}")

--- a/tests/honcho_plugin/test_cli.py
+++ b/tests/honcho_plugin/test_cli.py
@@ -115,6 +115,7 @@ class TestCmdStatus:
             base_url = None
             ai_peer = "hermes"
             peer_name = "eri"
+            pin_peer_name = False
             recall_mode = "hybrid"
             user_observe_me = True
             user_observe_others = False
@@ -154,3 +155,122 @@ class TestCmdStatus:
         out = capsys.readouterr().out
         assert "FAILED (Invalid API key)" in out
         assert "Connection... OK" not in out
+
+    def test_surfaces_pin_peer_name_in_status(self, monkeypatch, capsys, tmp_path):
+        import plugins.memory.honcho.cli as honcho_cli
+
+        cfg_path = tmp_path / "honcho.json"
+        cfg_path.write_text("{}")
+
+        class FakeConfig:
+            enabled = True
+            api_key = "root-key"
+            workspace_id = "hermes"
+            host = "hermes"
+            base_url = None
+            ai_peer = "hermes"
+            peer_name = "eri"
+            pin_peer_name = True
+            recall_mode = "hybrid"
+            user_observe_me = True
+            user_observe_others = False
+            ai_observe_me = False
+            ai_observe_others = True
+            write_frequency = "async"
+            session_strategy = "per-session"
+            context_tokens = 800
+            dialectic_reasoning_level = "low"
+            reasoning_level_cap = "high"
+            reasoning_heuristic = True
+            raw = {}
+            raw = {}
+
+            def resolve_session_name(self):
+                return "hermes"
+
+        monkeypatch.setattr(honcho_cli, "_read_config", lambda: {"apiKey": "***"})
+        monkeypatch.setattr(honcho_cli, "_config_path", lambda: cfg_path)
+        monkeypatch.setattr(honcho_cli, "_local_config_path", lambda: cfg_path)
+        monkeypatch.setattr(honcho_cli, "_active_profile_name", lambda: "default")
+        monkeypatch.setattr(
+            "plugins.memory.honcho.client.HonchoClientConfig.from_global_config",
+            lambda host=None: FakeConfig(),
+        )
+        monkeypatch.setattr(
+            "plugins.memory.honcho.client.get_honcho_client",
+            lambda cfg: object(),
+        )
+        monkeypatch.setattr(honcho_cli, "_show_peer_cards", lambda hcfg, client: None)
+        monkeypatch.setitem(__import__("sys").modules, "honcho", SimpleNamespace())
+
+        honcho_cli.cmd_status(SimpleNamespace(all=False))
+
+        out = capsys.readouterr().out
+        assert "Pin peer name:  True" in out
+
+
+class TestCmdSetup:
+    def test_wizard_persists_pin_peer_name_choice(self, monkeypatch, tmp_path):
+        import plugins.memory.honcho.cli as honcho_cli
+
+        cfg_path = tmp_path / "honcho.json"
+        written = {}
+        prompts = iter([
+            "cloud",
+            "",
+            "alice",
+            "y",
+            "hermes",
+            "shared-workspace",
+            "directional",
+            "async",
+            "hybrid",
+            "uncapped",
+            "2",
+            "low",
+            "per-session",
+        ])
+
+        class FakeConfig:
+            workspace_id = "shared-workspace"
+            peer_name = "alice"
+            ai_peer = "hermes"
+            observation_mode = "directional"
+            write_frequency = "async"
+            recall_mode = "hybrid"
+            session_strategy = "per-session"
+
+            def resolve_session_name(self):
+                return "hermes"
+
+        monkeypatch.setattr(honcho_cli, "_read_config", lambda: {"apiKey": "root-key", "hosts": {}})
+        monkeypatch.setattr(honcho_cli, "_config_path", lambda: cfg_path)
+        monkeypatch.setattr(honcho_cli, "_local_config_path", lambda: cfg_path)
+        monkeypatch.setattr(honcho_cli, "_ensure_sdk_installed", lambda: True)
+        monkeypatch.setattr(honcho_cli, "_host_key", lambda: "hermes")
+        monkeypatch.setattr(honcho_cli, "_prompt", lambda *args, **kwargs: next(prompts))
+        monkeypatch.setattr(honcho_cli, "_write_config", lambda cfg, path=None: written.setdefault("cfg", cfg))
+        monkeypatch.setattr(
+            "plugins.memory.honcho.client.reset_honcho_client",
+            lambda: None,
+        )
+        monkeypatch.setattr(
+            "plugins.memory.honcho.client.HonchoClientConfig.from_global_config",
+            lambda host=None: FakeConfig(),
+        )
+        monkeypatch.setattr(
+            "plugins.memory.honcho.client.get_honcho_client",
+            lambda cfg: object(),
+        )
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {},
+        )
+        monkeypatch.setattr(
+            "hermes_cli.config.save_config",
+            lambda cfg: None,
+        )
+
+        honcho_cli.cmd_setup(SimpleNamespace())
+
+        assert written["cfg"]["hosts"]["hermes"]["pinPeerName"] is True


### PR DESCRIPTION
## What does this PR do?

This PR makes the existing `pinPeerName` setting visible at the two places where users most need it: initial setup and status inspection.

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- introduce the smallest surface needed for the new capability in the touched subsystem
- preserve existing behavior and defaults outside the new entry point or configuration path
- cover the new path with focused validation before asking for review

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

Fixes #28283

<details>
<summary>Original body</summary>

## Summary

This PR makes the existing `pinPeerName` setting visible at the two places where users most need it: initial setup and status inspection.

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

This PR makes the existing `pinPeerName` setting visible at the two places where users most need it: initial setup and status inspection.

The underlying `pinPeerName` fix already exists and solves a real multi-instance Honcho problem: a single human using Hermes across multiple front-ends can otherwise get split into multiple Honcho peers.

What is missing today is discoverability:
- `hermes memory setup` does not surface the setting when the user is configuring Honcho
- `hermes honcho status` does not show the effective value, which makes diagnosis harder when memory appears fragmented across devices

This change is intentionally a discoverability + diagnostics improvement around an already-correct runtime capability (no runtime identity rule changes, no default flips).

## Solution Sketch

- introduce the smallest surface needed for the new capability in the touched subsystem
- preserve existing behavior and defaults outside the new entry point or configuration path
- cover the new path with focused validation before asking for review

## Related Issue

Fixes #28283

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- added a setup-wizard prompt that explains when `pinPeerName` should be enabled (`plugins/memory/honcho/cli.py`)
- persisted that choice into the active Honcho host config (`plugins/memory/honcho/cli.py`)
- surfaced the effective `pinPeerName` value in `hermes honcho status` (`plugins/memory/honcho/cli.py`)
- added regression coverage for the setup+status surface area (`tests/honcho_plugin/test_cli.py`)

## How to Test

1. Run `python -m pytest tests/honcho_plugin/test_cli.py -q -n 4`.
2. Run `hermes memory setup` and confirm the prompt surfaces `pinPeerName` with a clear explanation.
3. Run `hermes honcho status` and confirm it prints the effective `pinPeerName` value.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A (CLI change). If needed, I can attach a `hermes memory setup` capture and a `hermes honcho status` output snippet.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_