### PR TITLE
revert: 4 Telegram salvages flagged as broken or risky by post-merge audit

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1074,7 +1074,7 @@ def load_gateway_config() -> GatewayConfig:
                     if isinstance(group_allowed_chats, list):
                         group_allowed_chats = ",".join(str(v) for v in group_allowed_chats)
                     os.environ["TELEGRAM_GROUP_ALLOWED_CHATS"] = str(group_allowed_chats)
-                for _telegram_extra_key in ("guest_mode", "disable_link_previews", "command_menu"):
+                for _telegram_extra_key in ("guest_mode", "disable_link_previews"):
                     if _telegram_extra_key in telegram_cfg:
                         plat_data = platforms_data.setdefault(Platform.TELEGRAM.value, {})
                         if not isinstance(plat_data, dict):

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -5432,25 +5432,16 @@ class TelegramAdapter(BasePlatformAdapter):
             return False
 
     async def on_processing_start(self, event: MessageEvent) -> None:
-        """Add an in-progress reaction and pin the message when processing begins."""
+        """Add an in-progress reaction when message processing begins."""
+        if not self._reactions_enabled():
+            return
         chat_id = getattr(event.source, "chat_id", None)
         message_id = getattr(event, "message_id", None)
         if chat_id and message_id:
-            if self._reactions_enabled():
-                await self._set_reaction(chat_id, message_id, "\U0001f440")
-            # Pin the incoming message for the duration of the turn
-            if self._bot:
-                try:
-                    await self._bot.pin_chat_message(
-                        chat_id=int(chat_id),
-                        message_id=int(message_id),
-                        disable_notification=True,
-                    )
-                except Exception:
-                    logger.debug("[Telegram] Failed to pin message %s in chat %s", message_id, chat_id)
+            await self._set_reaction(chat_id, message_id, "\U0001f440")
 
     async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
-        """Swap the in-progress reaction for a final success/failure reaction and unpin.
+        """Swap the in-progress reaction for a final success/failure reaction.
 
         Unlike Discord (additive reactions), Telegram's set_message_reaction
         replaces all existing reactions in one call — no remove step needed.
@@ -5462,25 +5453,17 @@ class TelegramAdapter(BasePlatformAdapter):
         another agent run to swap it to 👍/👎 — which never happens if the
         cancellation was the last activity in the chat.
         """
+        if not self._reactions_enabled():
+            return
         chat_id = getattr(event.source, "chat_id", None)
         message_id = getattr(event, "message_id", None)
         if not (chat_id and message_id):
             return
-        if self._reactions_enabled():
-            if outcome == ProcessingOutcome.CANCELLED:
-                await self._clear_reactions(chat_id, message_id)
-            else:
-                await self._set_reaction(
-                    chat_id,
-                    message_id,
-                    "\U0001f44d" if outcome == ProcessingOutcome.SUCCESS else "\U0001f44e",
-                )
-        # Unpin the message when processing is complete
-        if self._bot:
-            try:
-                await self._bot.unpin_chat_message(
-                    chat_id=int(chat_id),
-                    message_id=int(message_id),
-                )
-            except Exception:
-                logger.debug("[Telegram] Failed to unpin message %s in chat %s", message_id, chat_id)
+        if outcome == ProcessingOutcome.CANCELLED:
+            await self._clear_reactions(chat_id, message_id)
+        else:
+            await self._set_reaction(
+                chat_id,
+                message_id,
+                "\U0001f44d" if outcome == ProcessingOutcome.SUCCESS else "\U0001f44e",
+            )

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -4432,12 +4432,11 @@ class TelegramAdapter(BasePlatformAdapter):
         return cleaned or text
 
     def _should_process_message(self, message: Message, *, is_command: bool = False) -> bool:
-        """Apply Telegram group trigger rules and user allowlist.
+        """Apply Telegram group trigger rules.
 
-        DMs and group messages are both subject to TELEGRAM_ALLOWED_USERS
-        allowlist check. The chat also passes the ``allowed_chats`` whitelist
-        (when set), or ``guest_mode`` is enabled and the bot is explicitly
-        mentioned. Group/supergroup messages are additionally accepted when:
+        DMs remain unrestricted. Group/supergroup messages are accepted when:
+        - the chat passes the ``allowed_chats`` whitelist (when set), or
+          ``guest_mode`` is enabled and the bot is explicitly mentioned
         - the chat is explicitly allowlisted in ``free_response_chats``
         - ``require_mention`` is disabled
         - the message replies to the bot
@@ -4454,18 +4453,6 @@ class TelegramAdapter(BasePlatformAdapter):
         mentioning the bot (``@botname /command``), both of which are
         recognised as mentions by :meth:`_message_mentions_bot`.
         """
-        # Enforce TELEGRAM_ALLOWED_USERS allowlist for ALL message types
-        # (DMs and groups). Previously only callback actions were gated,
-        # leaving inbound messages unblocked (issue #23778).
-        _user = getattr(message, "from_user", None)
-        _user_id = str(getattr(_user, "id", "")) if _user else ""
-        if not self._is_callback_user_authorized(_user_id):
-            logger.warning(
-                "[%s] Unauthorized user %s — message dropped",
-                self.name, _user_id,
-            )
-            return False
-
         if not self._is_group_chat(message):
             return True
 

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1527,28 +1527,11 @@ class TelegramAdapter(BasePlatformAdapter):
                     BotCommandScopeDefault,
                     BotCommandScopeChat,
                 )
-                from hermes_cli.commands import (
-                    telegram_menu_commands,
-                    telegram_quick_menu_commands,
-                )
+                from hermes_cli.commands import telegram_menu_commands
                 # Telegram allows up to 100 commands but has an undocumented
                 # payload size limit (~4KB total).  Limit to 30 core commands
                 # to stay well under the threshold while covering all categories.
-                if self.config.extra.get("command_menu") == "quick_commands_only":
-                    # Fetch quick_commands via the gateway runner reference if
-                    # available; otherwise fall back to PlatformConfig.extra.
-                    _qc = self.config.extra.get("quick_commands")
-                    if not isinstance(_qc, dict) or not _qc:
-                        _runner_ref = getattr(self, "_runner_ref", None)
-                        _runner = _runner_ref() if callable(_runner_ref) else None
-                        _gw_cfg = getattr(_runner, "config", None) if _runner else None
-                        _qc = getattr(_gw_cfg, "quick_commands", {}) or {}
-                    menu_commands, hidden_count = telegram_quick_menu_commands(
-                        _qc,
-                        max_commands=MAX_COMMANDS_PER_SCOPE,
-                    )
-                else:
-                    menu_commands, hidden_count = telegram_menu_commands(max_commands=MAX_COMMANDS_PER_SCOPE)
+                menu_commands, hidden_count = telegram_menu_commands(max_commands=MAX_COMMANDS_PER_SCOPE)
                 bot_commands = [BotCommand(name, desc) for name, desc in menu_commands]
                 # Register for all scopes independently — Telegram picks the
                 # narrowest matching scope per chat type (forum topics fall

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -740,42 +740,6 @@ def telegram_menu_commands(max_commands: int = 100) -> tuple[list[tuple[str, str
     return all_commands[:max_commands], hidden_count
 
 
-def telegram_quick_menu_commands(
-    quick_commands: Mapping[str, Any] | None,
-    max_commands: int = 100,
-) -> tuple[list[tuple[str, str]], int]:
-    """Return Telegram BotCommands for profile-defined quick commands only.
-
-    Specialist Telegram bots often use ``quick_commands`` as their whole
-    user-facing interface.  This helper lets a profile opt into a focused
-    Telegram slash menu without exposing every generic Hermes command.
-
-    ``show_in_telegram_menu: false`` hides a quick command from the native
-    menu while leaving gateway dispatch unchanged.
-    """
-    if not isinstance(quick_commands, Mapping):
-        return [], 0
-
-    menu: list[tuple[str, str]] = []
-    seen: set[str] = set()
-    for raw_name, raw_config in quick_commands.items():
-        if not isinstance(raw_name, str) or not isinstance(raw_config, Mapping):
-            continue
-        if raw_config.get("show_in_telegram_menu") is False:
-            continue
-        name = _sanitize_telegram_name(raw_name)
-        if not name or name in seen:
-            continue
-        desc = str(raw_config.get("description") or f"Run /{raw_name}")
-        if len(desc) > 40:
-            desc = desc[:37] + "..."
-        menu.append((name, desc))
-        seen.add(name)
-
-    hidden_count = max(0, len(menu) - max_commands)
-    return menu[:max_commands], hidden_count
-
-
 def discord_skill_commands(
     max_slots: int,
     reserved_names: set[str],

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -270,25 +270,6 @@ class TestLoadGatewayConfig:
 
         assert config.quick_commands == {"limits": {"type": "exec", "command": "echo ok"}}
 
-    def test_bridges_telegram_command_menu_from_config_yaml(self, tmp_path, monkeypatch):
-        hermes_home = tmp_path / ".hermes"
-        hermes_home.mkdir()
-        config_path = hermes_home / "config.yaml"
-        config_path.write_text(
-            "telegram:\n"
-            "  command_menu: quick_commands_only\n",
-            encoding="utf-8",
-        )
-
-        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
-
-        config = load_gateway_config()
-
-        assert (
-            config.platforms[Platform.TELEGRAM].extra["command_menu"]
-            == "quick_commands_only"
-        )
-
     def test_bridges_group_sessions_per_user_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -26,7 +26,6 @@ from hermes_cli.commands import (
     slack_subcommand_map,
     telegram_bot_commands,
     telegram_menu_commands,
-    telegram_quick_menu_commands,
 )
 
 
@@ -1153,47 +1152,6 @@ class TestTelegramMenuCommands:
         assert "valid_skill" in menu_names
         # No empty string in menu names
         assert "" not in menu_names
-
-    def test_quick_menu_commands_include_profile_quick_commands_only(self):
-        menu, hidden = telegram_quick_menu_commands(
-            {
-                "agent-health": {
-                    "type": "exec",
-                    "command": "echo ok",
-                    "description": "Show agent health",
-                },
-                "hidden": {
-                    "type": "exec",
-                    "command": "echo hidden",
-                    "description": "Hidden command",
-                    "show_in_telegram_menu": False,
-                },
-            }
-        )
-
-        assert hidden == 0
-        assert menu == [("agent_health", "Show agent health")]
-
-    def test_quick_menu_commands_sanitize_dedupe_and_trim_descriptions(self):
-        menu, hidden = telegram_quick_menu_commands(
-            {
-                "agent-health": {
-                    "description": "A" * 80,
-                },
-                "agent_health": {
-                    "description": "Duplicate after sanitization",
-                },
-                "+++": {
-                    "description": "Sanitizes to empty",
-                },
-            },
-            max_commands=1,
-        )
-
-        assert hidden == 0
-        assert len(menu) == 1
-        assert menu[0][0] == "agent_health"
-        assert menu[0][1] == ("A" * 37) + "..."
 
 
 # ---------------------------------------------------------------------------

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -804,7 +804,7 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
     instead, bypassing MarkdownV2 conversion.
     """
     try:
-        from telegram import Bot, MessageEntity
+        from telegram import Bot
         from telegram.constants import ParseMode
 
         # Auto-detect HTML tags — if present, skip MarkdownV2 and send as HTML.
@@ -824,14 +824,6 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                 # Fallback: send as-is if formatting unavailable
                 formatted = message
             send_parse_mode = ParseMode.MARKDOWN_V2
-
-        # Detect @username patterns and create mention entities so
-        # require_mention on the receiving bot's Gateway can trigger.
-        _MENTION_RE = re.compile(r'@([a-zA-Z][a-zA-Z0-9_]{4,31})')
-        _entities = [
-            MessageEntity(type="mention", offset=m.start(), length=len(m.group()))
-            for m in _MENTION_RE.finditer(formatted)
-        ]
 
         # Honour a configured proxy (telegram.proxy_url in config.yaml, exported
         # as TELEGRAM_PROXY env var by load_gateway_config). Without this, the
@@ -897,7 +889,7 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                 last_msg = await _send_telegram_message_with_retry(
                     bot,
                     chat_id=int_chat_id, text=formatted,
-                    parse_mode=send_parse_mode, entities=_entities, **text_kwargs
+                    parse_mode=send_parse_mode, **text_kwargs
                 )
             except Exception as md_error:
                 # Thread not found — retry without message_thread_id so the
@@ -931,7 +923,7 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                     last_msg = await _send_telegram_message_with_retry(
                         bot,
                         chat_id=int_chat_id, text=plain,
-                        parse_mode=None, entities=_entities, **text_kwargs
+                        parse_mode=None, **text_kwargs
                     )
                 else:
                     raise

--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -143,11 +143,6 @@ quick_commands:
 
 Then type `/status`, `/deploy`, or `/inbox` in the CLI or a messaging platform. Quick commands are resolved at dispatch time and may not appear in every built-in autocomplete/help table.
 
-For specialist Telegram bots, set `telegram.command_menu: quick_commands_only`
-to make Telegram's native slash menu show only profile-defined quick commands.
-Set `show_in_telegram_menu: false` on a quick command to keep it callable but
-hide it from the Telegram menu.
-
 String-only prompt shortcuts are not supported as quick commands. Put longer reusable prompts in a skill, or use `type: alias` to point at an existing slash command.
 
 ### Custom model aliases

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1433,28 +1433,6 @@ Usage: type `/status`, `/disk`, `/update`, `/gpu`, or `/restart` in the CLI or a
 - **Type** — supported types are `exec` and `alias`; other types show an error
 - **Works everywhere** — CLI, Telegram, Discord, Slack, WhatsApp, Signal, Email, Home Assistant
 
-Telegram profiles can opt into a focused BotCommand menu that shows only
-profile-defined quick commands:
-
-```yaml
-telegram:
-  command_menu: quick_commands_only
-
-quick_commands:
-  health:
-    type: exec
-    command: scripts/health.sh
-    description: Show service health
-  internal-debug:
-    type: exec
-    command: scripts/debug.sh
-    description: Internal debug helper
-    show_in_telegram_menu: false
-```
-
-`show_in_telegram_menu: false` hides a quick command from Telegram's native
-slash menu while leaving the command callable.
-
 String-only prompt shortcuts are not valid quick commands. For reusable prompt workflows, create a skill or alias to an existing slash command.
 
 ## Human Delay


### PR DESCRIPTION
Post-merge audit (parallel subagent fan-out across 9 clusters) flagged 4 of the 44 Telegram salvages as broken or unsafe. Reverting them.

## Reverts (newest-first to minimize conflicts)

### 1. Revert #26636 "pin incoming user message for duration of agent turn" (a724c3b9c)

**Issue:** Pin/unpin enabled UNCONDITIONALLY with no opt-out flag.

- Pinning every user message is a default-on UX-invasive behavior change affecting ALL Telegram users globally.
- Group chats: requires `Pin Messages` admin permission; without it every message logs a debug-level failure (silent noise).
- Forum topics: pin semantics differ per-topic; behavior may be confusing.
- No tests added.
- Original PR's commit message mentions `session_context.py` and `run.py` edits, but the actual diff only touches `telegram.py`.

Unpin DOES fire reliably on cancel/exception (`on_processing_complete` invoked in both paths), so that aspect was correct — the issue is the default-on policy without an opt-in flag.

**Path forward:** Re-merge gated behind `extra.pin_user_messages: true` with tests.

### 2. Revert #28015 "support quick-command-only menus" (b1acf80e1)

**Issue:** Feature is non-functional. The salvage references `self._runner_ref`, but no code in the repo ever assigns `_runner_ref` to a `TelegramAdapter` instance. Verified:

```
$ grep -rn '_runner_ref' gateway/
gateway/platforms/telegram.py:1542:    _runner_ref = getattr(self, "_runner_ref", None)
gateway/platforms/telegram.py:1543:    _runner = _runner_ref() if callable(_runner_ref) else None
gateway/run.py:1266:_gateway_runner_ref: _weakref.ref = lambda: None       # ← MODULE-LEVEL, different name
gateway/run.py:1391:    global _gateway_runner_ref
gateway/run.py:1395:    _gateway_runner_ref = _weakref.ref(self)
```

The fallback path `getattr(self, '_runner_ref', None)` returns None, the top-level `quick_commands` is never reached, and `set_my_commands([])` registers an empty menu when users set `telegram.command_menu: quick_commands_only` with their quick_commands defined at the top level.

Nothing populates `PlatformConfig.extra.quick_commands` anywhere in the codebase, so the only working code path requires users to manually duplicate `quick_commands` into `platforms.telegram.extra.quick_commands` — undocumented.

**Path forward:** Re-merge after either (a) wiring an actual runner ref on the adapter at attach-time, or (b) bridging `gateway.quick_commands` → `platforms.telegram.extra.quick_commands` at config-load time.

### 3. Revert #27865 "auto-detect @username mentions and create Telegram entities" (cf814c96f)

**Issue:** Three bugs, no tests:

1. **Email false-positives.** The regex `r'@([a-zA-Z][a-zA-Z0-9_]{4,31})'` matches `@example` inside `user@example.com`:

```python
>>> _MENTION_RE.findall("Send to user@example.com")
['example']    # ← creates a spurious 'mention' entity on email addresses
```

2. **`parse_mode` + `entities` are mutually exclusive per Telegram Bot API.** Bot API docs: "can be specified instead of parse_mode". Passing both alongside `ParseMode.MARKDOWN_V2` may cause Bot API to reject or silently ignore parse_mode.

3. **Offset miscalculation.** Offsets are computed against the MarkdownV2-escaped `formatted` string. `\@` escape bytes shift offsets relative to plain text; entity boundaries may mis-align in rendered output.

**Path forward:** Re-merge with (a) stricter regex (negative-lookbehind for `[^a-zA-Z0-9._-]`), (b) drop `entities=` when `parse_mode` is set, (c) compute offsets against unescaped text.

Conflict resolution: kept #27098's `**text_kwargs` split (thread-not-found retry) while removing only the `entities=_entities` argument.

### 4. Revert #23795 "enforce TELEGRAM_ALLOWED_USERS allowlist on inbound messages" (db50af910)

**Issue:** P0 claim is incorrect, and salvage introduces three concrete regressions.

The PR claims `TELEGRAM_ALLOWED_USERS was only checked for callback/inline-button actions but not for inbound messages`. False — the gateway runner's `_is_user_authorized` at `gateway/run.py:6025` already fail-closed inbound messages BEFORE this salvage. Default is deny.

Regressions introduced by adding the adapter-level user_id check:

1. **Channel posts dropped.** `message.from_user` is `None` for channel broadcasts, so `_user_id=""` short-circuits to deny BEFORE the runner sees the message. This required a follow-up test fixture stub (`f1cefad8c test+release: stub auth in channel_posts fixture`) just to keep the #25327 channel-post tests green — proving the salvage broke real channel post routing.

2. **Anonymous-admin / sender_chat traffic dropped.** PR #27806 (later-merged `fix(gateway): allow chat-scoped telegram auth without sender user_id`) explicitly aims to support this — but the adapter-level user_id requirement neuters it because `_should_process_message` returns False BEFORE the runner-level chat-scoped fallback can authorize.

3. **First-time DM users see silence.** The runner's pairing-flow onboarding UX in `_handle_message` is skipped because the adapter drops the message first.

The salvage ships **zero tests** despite the P0 label, and its docstring claim "Empty TELEGRAM_ALLOWED_USERS continues to allow all users" contradicts the actual code path it goes through after #24468 made the env fallback fail-closed.

Net: only real gain over pre-existing behavior is an earlier log line, paid for with three concrete user-facing regressions.

#24468 (the fail-closed env fallback, separate PR) is correctly KEPT — it only changes a rarely-reached fallback path. #27806's chat-scoped auth is correctly KEPT (the runner-level part), and reverting #23795 unblocks it functionally.

**Path forward:** If we want defense-in-depth at the adapter level, do it as a parity check (only refuse when runner would also refuse), not as a hard pre-runner gate.

## Audit methodology

Parallel subagent fan-out across 9 clusters (44 PRs total):
- Auth & gating (5)
- DM topic routing (9)
- Tool progress & streaming (5)
- Audio & TTS (5)
- Network resilience (3)
- UX features + Windows (8)
- Document/media routing (3)
- send_message tool (2)
- Errors & noise (4)

Each PR audited on: bug reality (does parent code have the bug?), fix correctness, test coverage (would new tests fail against parent?), side effects (silent default changes?), interaction with other recent salvages.

**Verdict counts:** KEEP 33 · KEEP-WITH-FOLLOWUP 7 · REVERT 4 (this PR).

Follow-up issues to file (not in this PR):
- #27806 unblocked by reverting #23795 — verify chat-scoped anonymous-admin path works end-to-end.
- #25327 still requires `*_ALLOW_ALL_USERS` env or runner-level fix to extend chat-scoped auth to `chat_type == 'channel'`.
- #24014 `_GATEWAY_PROVIDER_ERROR_RE` over-broad — could rewrite legitimate assistant prose mentioning HTTP status codes. Telegram-only scope limits blast radius; tightening regex is the follow-up.
- #25368 1s asyncio.sleep added to every thread-not-found path; make it configurable or remove.
- #26609 deliberate cross-topic Reply gets auto-redirected to user's last-active binding; consider opt-out.
- #27937 if Bot API rejects `direct_messages_topic_id`, no retry path; broaden `_should_retry_without_dm_topic_reply_anchor`.
- #24815 dead code — superseded by earlier `bd0c54d17 fix: route Telegram image documents through photo handling`.

## Validation
- `scripts/run_tests.sh tests/gateway/test_telegram_group_gating.py tests/gateway/test_telegram_mention_boundaries.py tests/gateway/test_telegram_callback_auth_fail_closed.py tests/gateway/test_telegram_channel_posts.py tests/gateway/test_telegram_documents.py tests/gateway/test_unauthorized_dm_behavior.py tests/tools/test_send_message_tool.py tests/tools/test_send_message_telegram_proxy.py -q` → 245/246 passing (1 pre-existing slack-parse flake unrelated)
- `scripts/run_tests.sh tests/gateway/test_telegram_thread_fallback.py -q` → 41/41 passing in isolation

The 3 test-pollution failures observed when running the full telegram test set together also reproduce on plain main without the reverts — pre-existing issue not introduced here.