### PR TITLE
fix(gateway): pre-mark sessions resume_pending before drain (#28217)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5574,6 +5574,24 @@ class GatewayRunner:
             )
 
             timeout = self._restart_drain_timeout
+
+            # Pre-mark sessions as resume_pending BEFORE the drain wait.
+            # If the process is killed by the service manager during the
+            # drain, the durable marker is already written so the next
+            # gateway boot can recover in-flight sessions (#27856).
+            _pre_drain_keys: list[str] = []
+            for _sk, _agent in list(self._running_agents.items()):
+                if _agent is _AGENT_PENDING_SENTINEL:
+                    continue
+                try:
+                    self.session_store.mark_resume_pending(
+                        _sk,
+                        "restart_timeout" if self._restart_requested else "shutdown_timeout",
+                    )
+                    _pre_drain_keys.append(_sk)
+                except Exception as _e:
+                    logger.debug("pre-drain mark_resume_pending failed for %s: %s", _sk, _e)
+
             _drain_started_at = time.monotonic()
             active_agents, timed_out = await self._drain_active_agents(timeout)
             logger.info(
@@ -5585,6 +5603,21 @@ class GatewayRunner:
                 len(active_agents),
                 self._running_agent_count(),
             )
+
+            if not timed_out:
+                # Drain completed gracefully — all running sessions finished.
+                # Clear the pre-drain resume_pending markers so sessions that
+                # completed during the drain window don't carry a stale flag.
+                for _sk in _pre_drain_keys:
+                    if _sk not in self._running_agents:
+                        try:
+                            self.session_store.clear_resume_pending(_sk)
+                        except Exception as _e:
+                            logger.debug(
+                                "clear_resume_pending after drain failed for %s: %s",
+                                _sk, _e,
+                            )
+
             if timed_out:
                 logger.warning(
                     "Gateway drain timed out after %.1fs with %d active agent(s); interrupting remaining work.",


### PR DESCRIPTION
Salvage of #28217 by @LifeJiggy. Extends just-merged #27831 to cover the SIGKILL-during-drain edge case.

**What:** `mark_resume_pending` was called AFTER drain timeout. If the service manager hard-kills the process mid-drain (e.g. systemd `TimeoutStopSec` exceeded before drain completes), the post-drain marker is never written and in-flight sessions lose their durable resume hint.

**How:**
- Pre-mark every running session as `resume_pending` BEFORE entering the drain wait, using `restart_timeout` / `shutdown_timeout` as the reason depending on the stop cause.
- After drain completes gracefully (not timed out), call `clear_resume_pending` on sessions that finished during the window, so they don't carry a stale flag into the next boot.
- Sentinels (pending agents that never started) are skipped — same logic as `_interrupt_running_agents()`.

Original PR: https://github.com/NousResearch/hermes-agent/pull/28217