### PR TITLE
fix(web): allow mobile dashboard scrolling (#28051)

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -118,14 +118,7 @@ code, kbd, pre, samp, .font-mono, .font-mono-ui {
 }
 
 @media (max-width: 768px) {
-  html {
-    min-height: 100dvh;
-    height: auto;
-    max-height: none;
-    overflow-x: hidden;
-    overflow-y: auto;
-  }
-
+  html,
   body,
   #root {
     min-height: 100dvh;

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -117,6 +117,25 @@ code, kbd, pre, samp, .font-mono, .font-mono-ui {
   overflow: hidden;
 }
 
+@media (max-width: 768px) {
+  html {
+    min-height: 100dvh;
+    height: auto;
+    max-height: none;
+    overflow-x: hidden;
+    overflow-y: auto;
+  }
+
+  body,
+  #root {
+    min-height: 100dvh;
+    height: auto;
+    max-height: none;
+    overflow-x: hidden;
+    overflow-y: auto;
+  }
+}
+
 /* Nousnet's hermes-agent layout bumps `small` and `code` to readable
    dashboard sizes. Keep in sync. */
 small { font-size: 1.0625rem; }


### PR DESCRIPTION
## What does this PR do?

Fixes mobile dashboard usability by allowing the document root to scroll on small screens.

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- Add one mobile-only media query in `web/src/index.css`.
- Apply the same root overflow rule to `html`, `body`, and `#root` together.
- Preserve horizontal overflow clipping to avoid sideways drift.
- Avoid unrelated layout, component, or routing changes.

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

The original PR body below contains the previous validation notes, commands, or test plan.
No code changes are introduced by this formatting update itself.

## Related PRs / issues

Fixes #28051

<details>
<summary>Original body</summary>

﻿## What does this PR do?

Fixes mobile dashboard usability by allowing the document root to scroll on small screens.

The dashboard shell currently locks `html`, `body`, and `#root` to a fixed viewport and hides overflow. That works on desktop, but on mobile-sized screens it can trap dashboard content below the fold. This PR keeps the desktop lock intact and only relaxes the root scroll behavior inside the mobile breakpoint.

## Solution Sketch

- Add one mobile-only media query in `web/src/index.css`.
- Apply the same root overflow rule to `html`, `body`, and `#root` together.
- Preserve horizontal overflow clipping to avoid sideways drift.
- Avoid unrelated layout, component, or routing changes.

## Related Issue

Fixes #28051

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added a `max-width: 768px` rule for the dashboard root containers.
- Changed mobile root sizing to `height: auto`, `min-height: 100dvh`, and `max-height: none`.
- Enabled `overflow-y: auto` on mobile root containers.
- Kept `overflow-x: hidden` for the same containers.

## How to Test

1. Run `npm --prefix web run build`.
2. Start the web UI with `npm --prefix web run dev -- --host 127.0.0.1 --port 5177`.
3. Open `http://127.0.0.1:5177` in a mobile viewport such as `390x844`.
4. Confirm the dashboard can scroll vertically and does not introduce horizontal drift.
5. Confirm desktop viewport behavior remains unchanged.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, web dashboard mobile viewport smoke

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Build: `npm --prefix web run build` passed.
- Whitespace: `git diff --check HEAD -- web/src/index.css` passed.
- Mobile viewport smoke: `npx playwright screenshot --viewport-size=390,844 http://127.0.0.1:5177 evidence/pr-28577-mobile-390x844.png` passed.
- Note: the generated screenshot is intentionally kept out of the source diff.

</details>

---

_Generated by Hermes Turbo_