### PR TITLE
fix(web-dashboard): i18n types + reverse-proxy host allowlist

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -165,6 +165,10 @@ def _is_accepted_host(host_header: str, bound_host: str) -> bool:
     Accepts:
     - Exact bound host (with or without port suffix)
     - Loopback aliases when bound to loopback
+    - Any host listed in the ``HERMES_DASHBOARD_ALLOWED_HOSTS`` env var
+      (comma-separated, case-insensitive) — opt-in extension for
+      reverse-proxy or VPN-fronted access where the proxied request
+      arrives on loopback but the browser sends a public hostname
     - Any host when bound to 0.0.0.0 (explicit opt-in to non-loopback,
       no protection possible at this layer)
     """
@@ -187,6 +191,20 @@ def _is_accepted_host(host_header: str, bound_host: str) -> bool:
     else:
         host_only = h.rsplit(":", 1)[0] if ":" in h else h
     host_only = host_only.lower()
+
+    # Env-var allowlist for reverse-proxied or VPN-fronted access. When the
+    # dashboard is bound to loopback but reached via a reverse proxy (Caddy,
+    # nginx, Tailscale Serve, ngrok, etc.), the proxied request arrives on
+    # the loopback interface but the browser sends Host: <public hostname>.
+    # Without an opt-in allowlist the only escape is --insecure, which
+    # disables the DNS-rebinding defence entirely. This env hook keeps the
+    # defence on by default while letting operators name the proxy hosts
+    # they trust.
+    _extra = os.environ.get("HERMES_DASHBOARD_ALLOWED_HOSTS", "")
+    if _extra:
+        _allow = {h.strip().lower() for h in _extra.split(",") if h.strip()}
+        if host_only in _allow:
+            return True
 
     # 0.0.0.0 bind means operator explicitly opted into all-interfaces
     # (requires --insecure per web_server.start_server). No Host-layer

--- a/web/src/i18n/types.ts
+++ b/web/src/i18n/types.ts
@@ -666,6 +666,7 @@ export interface Translations {
     columnLabels: {
       triage: string;
       todo: string;
+      scheduled?: string;
       ready: string;
       running: string;
       blocked: string;
@@ -675,6 +676,7 @@ export interface Translations {
     columnHelp: {
       triage: string;
       todo: string;
+      scheduled?: string;
       ready: string;
       running: string;
       blocked: string;

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -185,6 +185,18 @@ Browse, search, and toggle skills and toolsets. Skills are loaded from `~/.herme
 The web dashboard reads and writes your `.env` file, which contains API keys and secrets. It binds to `127.0.0.1` by default — only accessible from your local machine. If you bind to `0.0.0.0`, anyone on your network can view and modify your credentials. The dashboard has no authentication of its own.
 :::
 
+### Reverse-proxy / VPN host allowlist
+
+The dashboard validates the incoming `Host` header against the bound interface to block DNS-rebinding attacks. When you front it with a reverse proxy (Caddy, nginx, Tailscale Serve, ngrok, etc.) the proxied request arrives on loopback but the browser sends a public hostname, which the validator rejects with HTTP 400.
+
+Set `HERMES_DASHBOARD_ALLOWED_HOSTS` to a comma-separated list of hostnames to allow alongside the bound interface. The DNS-rebinding defence stays on for all other hosts.
+
+```bash
+HERMES_DASHBOARD_ALLOWED_HOSTS=dashboard.example.com,dashboard.internal hermes web
+```
+
+Leave it unset (default) for direct-browser-to-loopback use.
+
 ## `/reload` Slash Command
 
 The dashboard PR also adds a `/reload` slash command to the interactive CLI. After changing API keys via the web dashboard (or by editing `.env` directly), use `/reload` in an active CLI session to pick up the changes without restarting:


### PR DESCRIPTION
## Summary

Two small, independent web-dashboard fixes:

1. **`web/src/i18n/types.ts`** — declare the new `scheduled` kanban column key as optional so `tsc -b` accepts `en.ts` without forcing a 15-locale translation pass.
2. **`hermes_cli/web_server.py`** — add an opt-in env var `HERMES_DASHBOARD_ALLOWED_HOSTS` so the DNS-rebinding Host-header defence can be paired with a reverse proxy or VPN-fronted tunnel without falling back to `--insecure`.

Each fix is its own commit; docs blurb is a third commit. The env var defaults to unset, so behaviour is unchanged for existing users.

## Bug 1 — i18n types missing the `scheduled` key

`web/src/i18n/en.ts` adds a `scheduled` entry to both `columnLabels` (line 661) and `columnHelp` (line 671), but `web/src/i18n/types.ts` (lines 666-683) wasn't updated. `tsc -b` fails:

```
src/i18n/en.ts(661,7): error TS2353: Object literal may only specify
known properties, and 'scheduled' does not exist in type
'{ triage: string; todo: string; ready: string; running: string;
   blocked: string; done: string; archived: string; }'.
src/i18n/en.ts(671,7): error TS2353: Object literal may only specify
known properties, and 'scheduled' does not exist in type ...
```

Declaring the key as **optional** (`scheduled?: string;`) is the minimum-diff fix: `en.ts` now type-checks, and the 15 other locale files (`af.ts`, `de.ts`, `es.ts`, `fr.ts`, `ga.ts`, `hu.ts`, `it.ts`, `ja.ts`, `ko.ts`, `pt.ts`, `ru.ts`, `tr.ts`, `uk.ts`, `zh-hant.ts`, `zh.ts`) remain valid without a coordinated translation pass. They fall back to the English label, matching the existing i18n behaviour for missing keys.

## Bug 2 — Host header rejects reverse-proxied access

### Repro

1. Start the dashboard bound to loopback (the default): `hermes web`.
2. Front it with a reverse proxy on a different host (e.g. an internal hostname `dashboard.internal` terminating at the loopback bind).
3. Open `https://dashboard.internal/` in a browser.

The browser sends `Host: dashboard.internal`. `_is_accepted_host` only accepts `localhost`, `127.0.0.1`, `::1` when bound to loopback, so the request is rejected with HTTP 400:

```
{"detail":"Invalid Host header. Dashboard requests must use the
 hostname the server was bound to."}
```

### Why `--insecure` isn't a real workaround

`--insecure` requires `--host 0.0.0.0`, which:

- **Disables the DNS-rebinding defence entirely** — every Host header is accepted on every interface. The whole point of the validator is gone.
- **Pushes trust to the network layer** — every interface is now reachable, so firewall / segmentation rules become the only barrier. That's a strictly worse posture than "loopback-only plus one named proxy host".

### Fix

Add an env var `HERMES_DASHBOARD_ALLOWED_HOSTS` (comma-separated, case-insensitive) checked inside `_is_accepted_host` right after the host is normalised. Default unset → no change. When set, the named hosts are accepted in addition to the bound interface; all other hosts are still rejected.

```bash
HERMES_DASHBOARD_ALLOWED_HOSTS=dashboard.example.com,dashboard.internal hermes web
```

The bind stays on loopback, the DNS-rebinding defence stays on for every host except the operator-named ones, and the reverse proxy / tunnel works.

### Backward compatibility

`HERMES_DASHBOARD_ALLOWED_HOSTS` unset → behaviour identical to today. No existing deployment is affected.

## Test plan

- [x] `npx tsc -b` in `web/` passes after the `types.ts` change (failed before).
- [x] `_is_accepted_host("localhost", "127.0.0.1")` still returns `True` (loopback alias path unchanged).
- [x] `_is_accepted_host("example.com", "127.0.0.1")` returns `False` when env is unset (rebinding defence intact).
- [x] `_is_accepted_host("example.com", "127.0.0.1")` returns `True` when `HERMES_DASHBOARD_ALLOWED_HOSTS=example.com` is exported.
- [x] `_is_accepted_host("evil.test", "127.0.0.1")` returns `False` even with `HERMES_DASHBOARD_ALLOWED_HOSTS=example.com` set (only listed hosts are allowed).
- [x] Case-insensitive: `HERMES_DASHBOARD_ALLOWED_HOSTS=Example.COM` matches `Host: example.com`.
- [x] Port stripping still works on the allowlist path (`Host: example.com:8443` matches `example.com`).
- [x] Empty / whitespace entries in the env var (`a,,  ,b`) don't accidentally allow empty Host headers.
- [x] Docs page renders the new subsection in the expected place (under the Security warning, above `/reload`).
