### PR TITLE
fix(tui): preserve Python dunder identifiers in markdown (#28146)

### DIFF
--- a/ui-tui/src/__tests__/markdown.test.ts
+++ b/ui-tui/src/__tests__/markdown.test.ts
@@ -46,7 +46,7 @@ const renderPlain = (node: React.ReactNode) => {
 describe('INLINE_RE emphasis', () => {
   it('matches word-boundary italic/bold', () => {
     expect(matches('say _hi_ there')).toEqual(['_hi_'])
-    expect(matches('very __bold__ move')).toEqual(['__bold__'])
+    expect(matches('very __bold move__ today')).toEqual(['__bold move__'])
     expect(matches('(_paren_) and [_bracket_]')).toEqual(['_paren_', '_bracket_'])
   })
 
@@ -56,6 +56,12 @@ describe('INLINE_RE emphasis', () => {
     expect(matches(path)).toEqual([])
     expect(matches('snake_case_var and MY_CONST')).toEqual([])
     expect(matches('foo__bar__baz')).toEqual([])
+  })
+
+  it('keeps Python dunder identifiers literal', () => {
+    expect(matches('if __name__ == "__main__":')).toEqual([])
+    expect(matches('def __init__(self):')).toEqual([])
+    expect(matches('print(__file__)')).toEqual([])
   })
 
   it('still matches asterisk emphasis intraword', () => {
@@ -93,7 +99,12 @@ describe('stripInlineMarkup', () => {
   it('strips word-boundary emphasis only', () => {
     expect(stripInlineMarkup('say _hi_ there')).toBe('say hi there')
     expect(stripInlineMarkup('browser_screenshot_ecc.png')).toBe('browser_screenshot_ecc.png')
-    expect(stripInlineMarkup('__bold__ and foo__bar__')).toBe('bold and foo__bar__')
+    expect(stripInlineMarkup('__bold move__ and foo__bar__')).toBe('bold move and foo__bar__')
+  })
+
+  it('preserves Python dunder identifiers', () => {
+    expect(stripInlineMarkup('if __name__ == "__main__":')).toBe('if __name__ == "__main__":')
+    expect(stripInlineMarkup('class X: def __init__(self): pass')).toBe('class X: def __init__(self): pass')
   })
 
   it('leaves ~!/~? kaomoji alone and still handles real subscript', () => {
@@ -215,6 +226,24 @@ describe('Md wrapping', () => {
     )
 
     expect(lines.some(line => line.startsWith(' hi  ok'))).toBe(true)
+  })
+
+  it('renders Python dunder identifiers literally outside code fences', () => {
+    const lines = renderPlain(
+      React.createElement(
+        Box,
+        { width: 80 },
+        React.createElement(Md, {
+          t: DEFAULT_THEME,
+          text: 'if __name__ == "__main__":\n    obj.__init__()'
+        })
+      )
+    )
+
+    const rendered = lines.join('\n')
+
+    expect(rendered).toContain('if __name__ == "__main__":')
+    expect(rendered).toContain('obj.__init__()')
   })
 })
 

--- a/ui-tui/src/components/markdown.tsx
+++ b/ui-tui/src/components/markdown.tsx
@@ -70,6 +70,12 @@ const NUMBERED_RE = /^(\s*)(\d+)[.)]\s+(.*)$/
 const QUOTE_RE = /^\s*(?:>\s*)+/
 const TABLE_DIVIDER_CELL_RE = /^:?-{3,}:?$/
 const MD_URL_RE = '((?:[^\\s()]|\\([^\\s()]*\\))+?)'
+const MD_IDENTIFIER_RE = '[A-Za-z_][A-Za-z0-9_]*'
+const MD_DUNDER_IDENTIFIER_RE = `(?:${MD_IDENTIFIER_RE}__(?!\\w))`
+const MD_UNDERSCORE_BOLD_RE = `(?<!\\w)__(?!${MD_DUNDER_IDENTIFIER_RE})(.+?)__(?!\\w)`
+const MD_UNDERSCORE_ITALIC_RE = `(?<![\\w_])_(?!_)(.+?)(?<!_)_(?![\\w_])`
+const STRIP_UNDERSCORE_BOLD_RE = new RegExp(MD_UNDERSCORE_BOLD_RE, 'g')
+const STRIP_UNDERSCORE_ITALIC_RE = new RegExp(MD_UNDERSCORE_ITALIC_RE, 'g')
 
 // Display math openers: `$$ ... $$` (TeX) and `\[ ... \]` (LaTeX). The
 // opener is matched only when `$$` / `\[` appears at the very start of the
@@ -107,9 +113,9 @@ export const INLINE_RE = new RegExp(
     `~~(.+?)~~`, // 6    strike
     `\`([^\\\`]+)\``, // 7    code
     `\\*\\*(.+?)\\*\\*`, // 8    bold *
-    `(?<!\\w)__(.+?)__(?!\\w)`, // 9    bold _
+    MD_UNDERSCORE_BOLD_RE, // 9    bold _
     `\\*(.+?)\\*`, // 10   italic *
-    `(?<!\\w)_(.+?)_(?!\\w)`, // 11   italic _
+    MD_UNDERSCORE_ITALIC_RE, // 11   italic _
     `==(.+?)==`, // 12   highlight
     `\\[\\^([^\\]]+)\\]`, // 13   footnote ref
     `\\^([^^\\s][^^]*?)\\^`, // 14   superscript
@@ -190,9 +196,9 @@ export const stripInlineMarkup = (v: string) =>
     .replace(/~~(.+?)~~/g, '$1')
     .replace(/`([^`]+)`/g, '$1')
     .replace(/\*\*(.+?)\*\*/g, '$1')
-    .replace(/(?<!\w)__(.+?)__(?!\w)/g, '$1')
+    .replace(STRIP_UNDERSCORE_BOLD_RE, '$1')
     .replace(/\*(.+?)\*/g, '$1')
-    .replace(/(?<!\w)_(.+?)_(?!\w)/g, '$1')
+    .replace(STRIP_UNDERSCORE_ITALIC_RE, '$1')
     .replace(/==(.+?)==/g, '$1')
     .replace(/\[\^([^\]]+)\]/g, '[$1]')
     .replace(/\^([^^\s][^^]*?)\^/g, '^$1')


### PR DESCRIPTION
Salvage of #28146 by @helix4u.

**What:** The Ink markdown renderer's emphasis regex matched `__name__`, `__main__`, `__init__`, `__file__` as bold-italic and stripped/transformed them. Python code in agent responses came out mangled.

**How:** Tighten `INLINE_RE` and `stripInlineMarkup` so they only match `__bold__`/`_emphasis_` when the inner text contains whitespace (i.e. real prose) or non-word boundaries. Pure underscore-wrapped identifiers like `__name__` pass through literal. Vitest cases cover the dunder set.

Original PR: https://github.com/NousResearch/hermes-agent/pull/28146