### PR TITLE
test(kanban): align _safe_int tests to renamed _to_epoch helper

### DIFF
--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2207,8 +2207,10 @@ def test_resolve_hermes_argv_module_actually_runs():
 # and turn ``GET /api/plugins/kanban/board`` into a 500 because the dashboard
 # calls ``task_age`` unguarded for every task in the response.
 #
-# After the fix, ``_safe_int`` returns ``None`` on bad input and ``task_age``
-# degrades gracefully (per-field ``None`` rather than a hard crash).
+# After the fix, ``_to_epoch`` returns ``None`` on bad input and ``task_age``
+# degrades gracefully (per-field ``None`` rather than a hard crash). The helper
+# was renamed from ``_safe_int`` and extended to accept ISO-8601 timestamps in
+# ``d8ad431de`` ("fix(kanban): task_age() tolerates ISO-8601 timestamps").
 # ---------------------------------------------------------------------------
 
 
@@ -2235,26 +2237,35 @@ def _make_task(**overrides) -> "kb.Task":
     return kb.Task(**defaults)
 
 
-def test_safe_int_accepts_int_and_int_string():
+def test_to_epoch_accepts_int_and_int_string():
     """Sanity: well-typed values pass through."""
-    assert kb._safe_int(0) == 0
-    assert kb._safe_int(1700000000) == 1700000000
-    assert kb._safe_int("1700000000") == 1700000000
+    assert kb._to_epoch(0) == 0
+    assert kb._to_epoch(1700000000) == 1700000000
+    assert kb._to_epoch("1700000000") == 1700000000
 
 
-def test_safe_int_returns_none_on_corrupt_inputs():
+def test_to_epoch_accepts_iso8601_string():
+    """ISO-8601 timestamps normalize to unix epoch seconds (d8ad431de)."""
+    # 2026-05-10T15:00:00Z == 1778425200 (UTC)
+    assert kb._to_epoch("2026-05-10T15:00:00Z") == 1778425200
+    # Offset suffix accepted (datetime.fromisoformat handles +HH:MM directly)
+    assert kb._to_epoch("2026-05-10T15:00:00+00:00") == 1778425200
+
+
+def test_to_epoch_returns_none_on_corrupt_inputs():
     """All the failure modes that used to crash task_age."""
     # None — common when the column was never written
-    assert kb._safe_int(None) is None
-    # Unsubstituted format string — the literal case the PR title cites
-    assert kb._safe_int("%s") is None
-    # Arbitrary non-numeric strings
-    assert kb._safe_int("abc") is None
-    assert kb._safe_int("") is None
-    # Float-ish strings: int("1.5") raises ValueError too — caller wants None.
-    assert kb._safe_int("1.5") is None
-    # Random object — covered by TypeError branch
-    assert kb._safe_int(object()) is None
+    assert kb._to_epoch(None) is None
+    # Unsubstituted format string — the literal case the original PR cited
+    assert kb._to_epoch("%s") is None
+    # Arbitrary non-numeric / non-ISO strings
+    assert kb._to_epoch("abc") is None
+    assert kb._to_epoch("") is None
+    # Float-ish strings: int("1.5") raises ValueError and fromisoformat rejects
+    # it too — caller wants None.
+    assert kb._to_epoch("1.5") is None
+    # Random object — str(object()) is non-numeric and non-ISO → None
+    assert kb._to_epoch(object()) is None
 
 
 def test_task_age_handles_corrupt_created_at():
@@ -2267,7 +2278,7 @@ def test_task_age_handles_corrupt_created_at():
 
 
 def test_task_age_handles_corrupt_started_and_completed():
-    """All three timestamp fields share the same _safe_int treatment."""
+    """All three timestamp fields share the same _to_epoch treatment."""
     t = _make_task(
         created_at=1700000000,
         started_at="garbage",


### PR DESCRIPTION
## What does this PR do?

The two probe tests in `tests/hermes_cli/test_kanban_db.py` still reference `kb._safe_int`, which was renamed to `kb._to_epoch` in d8ad431de ("fix(kanban): task_age() tolerates ISO-8601 timestamps", merged ~24h ago) and extended to accept ISO-8601 strings in addition to ints and numeric strings. The probes now fail under collection on every CI run:

```
AttributeError: module 'hermes_cli.kanban_db' has no attribute '_safe_int'
```

This shows up in the `test` job on every open PR (visible across briandevans's currently-open queue and on plain `origin/main`), so it also obscures real regression signal on unrelated PRs.

This PR aligns the two probe tests to `_to_epoch` (all eight existing assertions remain valid against the renamed helper — `_to_epoch` is a strict superset of `_safe_int`'s contract) and adds one new test covering the ISO-8601 branch added in d8ad431de.

## Related Issue

_N/A_ — direct test-fixture alignment to the recent main commit d8ad431de.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tests/hermes_cli/test_kanban_db.py` — rename `test_safe_int_*` → `test_to_epoch_*`, point assertions at `kb._to_epoch`, update the section-header comment + one docstring, add `test_to_epoch_accepts_iso8601_string` (covers both `Z`-suffix and explicit `+00:00` offset cases).

## How to Test

Reproduce on clean `origin/main`:

```
uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest \
  tests/hermes_cli/test_kanban_db.py::test_safe_int_accepts_int_and_int_string \
  tests/hermes_cli/test_kanban_db.py::test_safe_int_returns_none_on_corrupt_inputs -v
# 2 failed: AttributeError: module 'hermes_cli.kanban_db' has no attribute '_safe_int'
```

After this PR:

```
uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest \
  tests/hermes_cli/test_kanban_db.py::test_to_epoch_accepts_int_and_int_string \
  tests/hermes_cli/test_kanban_db.py::test_to_epoch_accepts_iso8601_string \
  tests/hermes_cli/test_kanban_db.py::test_to_epoch_returns_none_on_corrupt_inputs \
  tests/hermes_cli/test_kanban_db.py::test_task_age_handles_corrupt_created_at \
  tests/hermes_cli/test_kanban_db.py::test_task_age_handles_corrupt_started_and_completed \
  tests/hermes_cli/test_kanban_db.py::test_task_age_well_formed_task -v
# 6 passed
```

Full file run locally: 156 passed, 1 unrelated pre-existing baseline failure (`test_resolve_hermes_argv_module_actually_runs` — TimeoutError, also fails on plain `origin/main` and is not touched by this PR).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`test(kanban):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — no open PR touches `_safe_int` / `_to_epoch` / `test_kanban_db` for this rename
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (one new ISO-8601 case)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (test-only, comment updated in-file)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (pure Python timestamps)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

Direct follow-up to d8ad431de — pure test-fixture alignment, ≤50 LOC. The renamed helper is the same module-private symbol `_safe_int` was; the new test name keeps the helper-name convention so a future rename remains greppable.

> Audited siblings: searched `rg "_safe_int"` across the tree — remaining hits are (a) `agent/rate_limit_tracker.py` which defines its own unrelated local `_safe_int(value, default=0) -> int` for header parsing (different signature, different module, not the kanban helper), and (b) historical-context comments in `tests/plugins/test_kanban_dashboard_plugin.py` (lines 1396, 1401, 1428, 1430) that reference the old name but don't call it — purely cosmetic, not test-fixture issues. No widening needed.