### PR TITLE
chore(release): alias @xxxigm noreply form for #27986 salvage

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -794,6 +794,7 @@ AUTHOR_MAP = {
     "xiayh17@gmail.com": "xiayh0107",
     "zhujianxyz@gmail.com": "opriz",
     "tuancanhnguyen706@gmail.com": "xxxigm",
+    "54813621+xxxigm@users.noreply.github.com": "xxxigm",
     "asurla@nvidia.com": "anniesurla",
     "kchantharuan@nvidia.com": "nv-kasikritc",
     "limkuan24@gmail.com": "WideLee",


### PR DESCRIPTION
1-line AUTHOR_MAP add — alias `54813621+xxxigm@users.noreply.github.com` to `xxxigm` ahead of the codex-doctor PR salvage. Plain email was already mapped.