### PR TITLE
fix(cli): warn before resetting with active work (#28547)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9630,6 +9630,43 @@ class HermesCLI:
         Returns ``"once"``, ``"always"``, or ``None`` (cancelled).  Callers
         proceed with the destructive action when the result is non-None.
         """
+        active_children = 0
+        active_background_tasks = 0
+        try:
+            bg_tasks = getattr(self, "_background_tasks", None)
+            if bg_tasks:
+                active_background_tasks = len(bg_tasks)
+        except Exception:
+            active_background_tasks = 0
+
+        agent = getattr(self, "agent", None)
+        if agent is not None:
+            try:
+                lock = getattr(agent, "_active_children_lock", None)
+                children = getattr(agent, "_active_children", None)
+                if lock is not None and children is not None:
+                    with lock:
+                        active_children = len(children)
+                elif children:
+                    active_children = len(children)
+            except Exception:
+                active_children = 0
+
+        if active_children or active_background_tasks:
+            active_lines = []
+            if active_children:
+                label = "subagent" if active_children == 1 else "subagents"
+                active_lines.append(f"- {active_children} delegated {label} still running")
+            if active_background_tasks:
+                label = "task" if active_background_tasks == 1 else "tasks"
+                active_lines.append(f"- {active_background_tasks} background {label} still running")
+            detail = (
+                f"{detail.rstrip()}\n\n"
+                "Active work is still running:\n"
+                f"{chr(10).join(active_lines)}\n\n"
+                "Starting a fresh session now may detach that work from the current conversation."
+            )
+
         # Gate check — respects prior "Always Approve" clicks.
         try:
             cfg = load_cli_config()
@@ -9640,7 +9677,7 @@ class HermesCLI:
         except Exception:
             confirm_required = True
 
-        if not confirm_required:
+        if not confirm_required and not (active_children or active_background_tasks):
             return "once"
 
         # Render a prompt_toolkit-native confirmation panel.  This keeps option

--- a/tests/cli/test_destructive_slash_confirm.py
+++ b/tests/cli/test_destructive_slash_confirm.py
@@ -11,19 +11,41 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 
+def _import_cli():
+    """Import the real cli module from the checkout under test."""
+    import cli as cli_mod
+
+    return cli_mod
+
+
 def _bound(fn, instance):
     """Bind an unbound method to a stand-in instance."""
     return fn.__get__(instance, type(instance))
 
 
-def _make_self(prompt_response):
+def _make_self(
+    prompt_response,
+    *,
+    agent=None,
+    background_tasks=None,
+    capture=None,
+    cli_mod=None,
+):
     """Build a minimal stand-in 'self' for _confirm_destructive_slash."""
-    from cli import HermesCLI
+    cli_mod = cli_mod or _import_cli()
+    HermesCLI = cli_mod.HermesCLI
+
+    def _modal(**kwargs):
+        if capture is not None:
+            capture.append(kwargs)
+        return prompt_response
 
     self_ = SimpleNamespace(
         _app=None,
+        agent=agent,
+        _background_tasks=background_tasks or {},
         _prompt_text_input=lambda _prompt: prompt_response,
-        _prompt_text_input_modal=lambda **_kw: prompt_response,
+        _prompt_text_input_modal=_modal,
     )
     self_._normalize_slash_confirm_choice = _bound(
         HermesCLI._normalize_slash_confirm_choice, self_,
@@ -34,12 +56,13 @@ def _make_self(prompt_response):
 def test_gate_off_returns_once_without_prompting():
     """When approvals.destructive_slash_confirm is False, return 'once'
     immediately (caller proceeds without showing a prompt)."""
-    from cli import HermesCLI
+    cli_mod = _import_cli()
+    HermesCLI = cli_mod.HermesCLI
+    self_ = _make_self(prompt_response="should not be called", cli_mod=cli_mod)
 
-    self_ = _make_self(prompt_response="should not be called")
-
-    with patch(
-        "cli.load_cli_config",
+    with patch.object(
+        cli_mod,
+        "load_cli_config",
         return_value={"approvals": {"destructive_slash_confirm": False}},
     ):
         result = _bound(HermesCLI._confirm_destructive_slash, self_)(
@@ -51,12 +74,13 @@ def test_gate_off_returns_once_without_prompting():
 
 def test_gate_on_choice_once_returns_once():
     """When the gate is on and the user picks '1', return 'once'."""
-    from cli import HermesCLI
+    cli_mod = _import_cli()
+    HermesCLI = cli_mod.HermesCLI
+    self_ = _make_self(prompt_response="1", cli_mod=cli_mod)
 
-    self_ = _make_self(prompt_response="1")
-
-    with patch(
-        "cli.load_cli_config",
+    with patch.object(
+        cli_mod,
+        "load_cli_config",
         return_value={"approvals": {"destructive_slash_confirm": True}},
     ):
         result = _bound(HermesCLI._confirm_destructive_slash, self_)(
@@ -68,12 +92,13 @@ def test_gate_on_choice_once_returns_once():
 
 def test_gate_on_choice_cancel_returns_none():
     """When the user picks '3' (cancel), return None — caller must abort."""
-    from cli import HermesCLI
+    cli_mod = _import_cli()
+    HermesCLI = cli_mod.HermesCLI
+    self_ = _make_self(prompt_response="3", cli_mod=cli_mod)
 
-    self_ = _make_self(prompt_response="3")
-
-    with patch(
-        "cli.load_cli_config",
+    with patch.object(
+        cli_mod,
+        "load_cli_config",
         return_value={"approvals": {"destructive_slash_confirm": True}},
     ):
         result = _bound(HermesCLI._confirm_destructive_slash, self_)(
@@ -85,12 +110,13 @@ def test_gate_on_choice_cancel_returns_none():
 
 def test_gate_on_no_input_returns_none():
     """No input (None / EOF / Ctrl-C) treated as cancel."""
-    from cli import HermesCLI
+    cli_mod = _import_cli()
+    HermesCLI = cli_mod.HermesCLI
+    self_ = _make_self(prompt_response=None, cli_mod=cli_mod)
 
-    self_ = _make_self(prompt_response=None)
-
-    with patch(
-        "cli.load_cli_config",
+    with patch.object(
+        cli_mod,
+        "load_cli_config",
         return_value={"approvals": {"destructive_slash_confirm": True}},
     ):
         result = _bound(HermesCLI._confirm_destructive_slash, self_)(
@@ -102,12 +128,13 @@ def test_gate_on_no_input_returns_none():
 
 def test_gate_on_unknown_choice_returns_none():
     """Garbage input is treated as cancel — fail safe, don't destroy state."""
-    from cli import HermesCLI
+    cli_mod = _import_cli()
+    HermesCLI = cli_mod.HermesCLI
+    self_ = _make_self(prompt_response="maybe", cli_mod=cli_mod)
 
-    self_ = _make_self(prompt_response="maybe")
-
-    with patch(
-        "cli.load_cli_config",
+    with patch.object(
+        cli_mod,
+        "load_cli_config",
         return_value={"approvals": {"destructive_slash_confirm": True}},
     ):
         result = _bound(HermesCLI._confirm_destructive_slash, self_)(
@@ -120,19 +147,20 @@ def test_gate_on_unknown_choice_returns_none():
 def test_gate_on_choice_always_persists_and_returns_always():
     """User picks 'always' → returns 'always' AND
     save_config_value('approvals.destructive_slash_confirm', False) was called."""
-    from cli import HermesCLI
-
-    self_ = _make_self(prompt_response="2")
+    cli_mod = _import_cli()
+    HermesCLI = cli_mod.HermesCLI
+    self_ = _make_self(prompt_response="2", cli_mod=cli_mod)
 
     saves = []
     def _fake_save(key, value):
         saves.append((key, value))
         return True
 
-    with patch(
-        "cli.load_cli_config",
+    with patch.object(
+        cli_mod,
+        "load_cli_config",
         return_value={"approvals": {"destructive_slash_confirm": True}},
-    ), patch("cli.save_config_value", _fake_save):
+    ), patch.object(cli_mod, "save_config_value", _fake_save):
         result = _bound(HermesCLI._confirm_destructive_slash, self_)(
             "clear", "detail",
         )
@@ -144,11 +172,11 @@ def test_gate_on_choice_always_persists_and_returns_always():
 def test_gate_default_true_when_config_missing():
     """If load_cli_config raises or returns malformed data, treat as
     'gate on' (default safe) — must prompt."""
-    from cli import HermesCLI
+    cli_mod = _import_cli()
+    HermesCLI = cli_mod.HermesCLI
+    self_ = _make_self(prompt_response="3", cli_mod=cli_mod)  # cancel
 
-    self_ = _make_self(prompt_response="3")  # cancel
-
-    with patch("cli.load_cli_config", side_effect=Exception("boom")):
+    with patch.object(cli_mod, "load_cli_config", side_effect=Exception("boom")):
         result = _bound(HermesCLI._confirm_destructive_slash, self_)(
             "clear", "detail",
         )
@@ -159,9 +187,42 @@ def test_gate_default_true_when_config_missing():
     assert result is None
 
 
+def test_gate_off_still_prompts_when_active_work_exists():
+    """Active delegated/background work must force a confirmation prompt even
+    when the global destructive-slash gate is disabled."""
+    cli_mod = _import_cli()
+    HermesCLI = cli_mod.HermesCLI
+
+    captures = []
+    agent = SimpleNamespace(_active_children=[object(), object()])
+    self_ = _make_self(
+        prompt_response="1",
+        agent=agent,
+        background_tasks={"bg-1": object()},
+        capture=captures,
+        cli_mod=cli_mod,
+    )
+
+    with patch.object(
+        cli_mod,
+        "load_cli_config",
+        return_value={"approvals": {"destructive_slash_confirm": False}},
+    ):
+        result = _bound(HermesCLI._confirm_destructive_slash, self_)(
+            "new", "This starts a fresh session.",
+        )
+
+    assert result == "once"
+    assert captures, "active work should force the prompt modal to open"
+    rendered_detail = captures[0]["detail"]
+    assert "Active work is still running" in rendered_detail
+    assert "2 delegated subagents still running" in rendered_detail
+    assert "1 background task still running" in rendered_detail
+
+
 def test_slash_confirm_modal_number_selection_submits_without_raw_input():
     """Pressing 2 in the TUI modal should resolve to Always Approve directly."""
-    from cli import HermesCLI
+    HermesCLI = _import_cli().HermesCLI
 
     q = queue.Queue()
     self_ = SimpleNamespace(
@@ -187,7 +248,7 @@ def test_slash_confirm_modal_number_selection_submits_without_raw_input():
 
 def test_slash_confirm_display_fragments_include_choice_mapping():
     """The modal itself must show what 1/2/3 mean, not only 'Choice [1/2/3]'."""
-    from cli import HermesCLI
+    HermesCLI = _import_cli().HermesCLI
 
     self_ = SimpleNamespace(
         _slash_confirm_state={


### PR DESCRIPTION
## What does this PR do?

When `/new` or `/reset` is about to discard the current conversation while delegated subagents or background tasks are still running, Hermes now keeps the confirmation prompt on screen even if the user previously disabled the global destructive-slash confirmation gate.

## Root cause

Right now it is easy to start a fresh session while work from the current one is still in flight.

That creates an awkward failure mode:
- delegated subagents keep running
- background terminal jobs keep running
- the user loses the immediate connection between the old conversation and the work that is still producing results

The existing confirmation gate helps in the general case, but once a user opts out of that prompt entirely, there is no last checkpoint when active work is still attached to the current session.

## Fix

- counts active delegated children before destructive slash commands proceed
- counts active background tasks tracked by the CLI
- augments the confirmation detail with a short active-work summary
- forces the prompt to stay enabled whenever active work is present, even if the global destructive-slash confirmation setting is off

This keeps the existing UX for normal idle-session resets, while adding a sharper warning exactly in the cases that can detach ongoing work from the conversation the user was watching.

## Why this shape

I kept this as a narrow CLI-side follow-up instead of adding a larger workflow branch.

That lets Hermes reuse the existing destructive-slash confirmation flow, preserves the current opt-out behavior for ordinary resets, and only introduces the extra friction when there is active work that could be abandoned accidentally.

## Tests

- `python -m pytest tests/cli/test_destructive_slash_confirm.py -q -n 4`
- `python -m pytest tests/cli/test_cli_new_session.py -q -n 4`

Fixes #28547.

## Related PRs / issues

Fixes #28547.

<details>
<summary>Original body</summary>

## What does this PR do?

## Summary
This adds an active-work guardrail to destructive session commands in the CLI.

When `/new` or `/reset` is about to discard the current conversation while delegated subagents or background tasks are still running, Hermes now keeps the confirmation prompt on screen even if the user previously disabled the global destructive-slash confirmation gate.

## Problem
Right now it is easy to start a fresh session while work from the current one is still in flight.

That creates an awkward failure mode:
- delegated subagents keep running
- background terminal jobs keep running
- the user loses the immediate connection between the old conversation and the work that is still producing results

The existing confirmation gate helps in the general case, but once a user opts out of that prompt entirely, there is no last checkpoint when active work is still attached to the current session.

## What this changes
- counts active delegated children before destructive slash commands proceed
- counts active background tasks tracked by the CLI
- augments the confirmation detail with a short active-work summary
- forces the prompt to stay enabled whenever active work is present, even if the global destructive-slash confirmation setting is off

This keeps the existing UX for normal idle-session resets, while adding a sharper warning exactly in the cases that can detach ongoing work from the conversation the user was watching.

## Why this shape
I kept this as a narrow CLI-side follow-up instead of adding a larger workflow branch.

That lets Hermes reuse the existing destructive-slash confirmation flow, preserves the current opt-out behavior for ordinary resets, and only introduces the extra friction when there is active work that could be abandoned accidentally.

## Tests
- `python -m pytest tests/cli/test_destructive_slash_confirm.py -q -n 4`
- `python -m pytest tests/cli/test_cli_new_session.py -q -n 4`

Fixes #28547.

## Solution Sketch

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Related Issue

Fixes #28547.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_