### PR TITLE
fix(kanban): migrate session_id before indexing

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -865,8 +865,6 @@ CREATE TABLE IF NOT EXISTS tasks (
     session_id           TEXT
 );
 
-CREATE INDEX IF NOT EXISTS idx_tasks_session_id ON tasks(session_id);
-
 CREATE TABLE IF NOT EXISTS task_links (
     parent_id  TEXT NOT NULL,
     child_id   TEXT NOT NULL,
@@ -1170,14 +1168,18 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         # created from within an agent loop that propagated
         # ``HERMES_SESSION_ID`` (e.g. ACP). NULL on legacy rows and on any
         # creation path that doesn't set the env var (CLI, dashboard).
-        # Index keeps per-session list queries cheap.
         _add_column_if_missing(
             conn, "tasks", "session_id", "session_id TEXT"
         )
-        conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_tasks_session_id "
-            "ON tasks(session_id)"
-        )
+    # Keep this out of SCHEMA_SQL: on legacy DBs, CREATE TABLE IF NOT EXISTS
+    # leaves tasks unchanged, so an index on a newly-added column must be
+    # created only after the additive migration has guaranteed the column
+    # exists. Run unconditionally so fresh DBs and partially-migrated DBs
+    # both get the index.
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_tasks_session_id "
+        "ON tasks(session_id)"
+    )
 
     # task_events gained a run_id column; back-fill it as NULL for
     # historical events (they predate runs and can't be attributed).
@@ -5656,6 +5658,15 @@ def _to_epoch(val) -> Optional[int]:
         return int(dt.timestamp())
     except (ValueError, OSError):
         return None
+
+
+def _safe_int(val) -> Optional[int]:
+    """Backward-compatible timestamp integer normalizer used by tests/plugins.
+
+    `_to_epoch` grew ISO-8601 support, but callers still import the older
+    helper name when they only need safe int-or-None behavior.
+    """
+    return _to_epoch(val)
 
 
 def task_age(task: Task) -> dict:

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -34,6 +34,16 @@ from hermes_cli.kanban import run_slash
 def kanban_home(tmp_path, monkeypatch):
     home = tmp_path / ".hermes"
     home.mkdir()
+    # Mirror the real default Hermes home enough for dispatcher spawn tests:
+    # bundled kanban workers should preload the kanban-worker skill when it is
+    # resolvable.  Tests that need an absent skill can remove this stub or
+    # monkeypatch _kanban_worker_skill_available directly.
+    skill_dir = home / "skills" / "devops" / "kanban-worker"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: kanban-worker\n---\n# Kanban worker\n",
+        encoding="utf-8",
+    )
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     kb.init_db()
@@ -3141,6 +3151,76 @@ def test_legacy_db_without_skills_column_migrates(tmp_path):
     conn.close()
 
 
+def test_connect_migrates_legacy_db_without_session_id_before_indexing(tmp_path):
+    """connect() must add tasks.session_id before creating its index.
+
+    Regression coverage for legacy boards created before session_id existed:
+    SCHEMA_SQL runs before the additive migrator, and CREATE TABLE IF NOT
+    EXISTS leaves the old tasks table untouched. Keeping idx_tasks_session_id
+    in SCHEMA_SQL made connect() fail with ``no such column: session_id``.
+    """
+    import sqlite3
+
+    db_path = tmp_path / "legacy-no-session-id.db"
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute("""
+            CREATE TABLE tasks (
+                id TEXT PRIMARY KEY,
+                title TEXT NOT NULL,
+                body TEXT,
+                assignee TEXT,
+                status TEXT NOT NULL,
+                priority INTEGER DEFAULT 0,
+                created_by TEXT,
+                created_at INTEGER NOT NULL,
+                started_at INTEGER,
+                completed_at INTEGER,
+                workspace_kind TEXT NOT NULL DEFAULT 'scratch',
+                workspace_path TEXT,
+                branch_name TEXT,
+                claim_lock TEXT,
+                claim_expires INTEGER,
+                tenant TEXT,
+                result TEXT,
+                idempotency_key TEXT,
+                consecutive_failures INTEGER NOT NULL DEFAULT 0,
+                worker_pid INTEGER,
+                last_failure_error TEXT,
+                max_runtime_seconds INTEGER,
+                last_heartbeat_at INTEGER,
+                current_run_id INTEGER,
+                workflow_template_id TEXT,
+                current_step_key TEXT,
+                skills TEXT,
+                model_override TEXT,
+                max_retries INTEGER
+            )
+        """)
+        conn.execute(
+            "INSERT INTO tasks (id, title, status, created_at) "
+            "VALUES ('legacy', 'old task', 'ready', 1)"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    migrated = kb.connect(db_path)
+    try:
+        cols = {r[1] for r in migrated.execute("PRAGMA table_info(tasks)")}
+        assert "session_id" in cols
+        idx = migrated.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type = 'index' AND name = 'idx_tasks_session_id'"
+        ).fetchone()
+        assert idx is not None
+        assert migrated.execute(
+            "SELECT session_id FROM tasks WHERE id = 'legacy'"
+        ).fetchone()[0] is None
+    finally:
+        migrated.close()
+
+
 def test_legacy_spawn_failure_columns_are_copied_not_renamed(tmp_path):
     """Legacy failure counters survive migration without fragile column renames."""
     import sqlite3
@@ -3618,6 +3698,7 @@ def test_gateway_dispatcher_disables_corrupt_board_without_traceback(
             "kanban": {
                 "dispatch_in_gateway": True,
                 "dispatch_interval_seconds": 1,
+                "auto_decompose": False,
             }
         },
     )


### PR DESCRIPTION
## Summary
- Move `idx_tasks_session_id` creation out of the initial schema script so legacy Kanban boards add the nullable `session_id` column before indexing it.
- Add regression coverage for pre-`session_id` Kanban databases.
- Keep `kanban-worker` spawn tests aligned with resolvable bundled skill behavior.

## Test Plan
- `python -m pytest tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_core_functionality.py -q`