### PR TITLE
fix: catch UnicodeDecodeError in _read_json_file for corrupted gateway_state.json

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -227,7 +227,7 @@ def _read_json_file(path: Path) -> Optional[dict[str, Any]]:
         return None
     try:
         raw = path.read_text(encoding="utf-8").strip()
-    except OSError:
+    except (OSError, UnicodeDecodeError):
         return None
     if not raw:
         return None

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -941,3 +941,32 @@ class TestReadProcessCmdlinePsFallback:
         )
         result = status._read_process_cmdline(12345)
         assert "hermes_cli/main.py" in result
+
+
+class TestReadJsonFile:
+    """Tests for _read_json_file UnicodeDecodeError handling."""
+
+    def test_read_json_file_returns_none_on_unicode_decode_error(self, tmp_path):
+        """Corrupted file with non-UTF-8 bytes is treated as missing."""
+        corrupted = tmp_path / "gateway_state.json"
+        # Valid JSON followed by TLS record garbage
+        corrupted.write_bytes(b'{"gateway_state": "running"}\n\x17\x03\x03\x00\x13')
+
+        result = status._read_json_file(corrupted)
+        assert result is None
+
+    def test_read_json_file_parses_valid_json(self, tmp_path):
+        """Valid JSON is parsed correctly."""
+        valid = tmp_path / "state.json"
+        valid.write_text('{"key": "value", "n": 42}', encoding="utf-8")
+
+        result = status._read_json_file(valid)
+        assert result == {"key": "value", "n": 42}
+
+    def test_read_json_file_returns_none_on_empty_file(self, tmp_path):
+        """Empty file is treated as missing."""
+        empty = tmp_path / "empty.json"
+        empty.write_text("", encoding="utf-8")
+
+        result = status._read_json_file(empty)
+        assert result is None


### PR DESCRIPTION
## Summary

Fixes a bug where `_read_json_file()` in `gateway/status.py` only caught `OSError` when reading JSON files, but not `UnicodeDecodeError`. When `gateway_state.json` contains non-UTF-8 bytes (e.g. TLS record data accidentally appended via a file descriptor leak), the `read_text(encoding="utf-8")` call raises `UnicodeDecodeError` which is NOT a subclass of `OSError`, escaping the `except` block and propagating as a persistent warning.

## Root Cause

```python
# gateway/status.py L229-231
try:
    raw = path.read_text(encoding="utf-8").strip()
except OSError:      # UnicodeDecodeError is a subclass of ValueError, NOT OSError!
    return None
```

`UnicodeDecodeError` inherits from `ValueError`, so when a corrupted file is read, the error propagates to `_write_runtime_status_safe()` which logs a warning but skips the write — leaving the corrupted file permanently in place.

## Fix

```python
except (OSError, UnicodeDecodeError):
```

When the file is treated as missing (return `None`), the next `write_runtime_status()` call will rebuild it cleanly via `_build_runtime_status_record()`.

## Changes

| File | Change |
|------|--------|
| `gateway/status.py` | `except OSError` → `except (OSError, UnicodeDecodeError)` |
| `tests/gateway/test_status.py` | +3 unit tests for `_read_json_file` |

## Test Results

```
tests/gateway/test_status.py — 53 passed (including 3 new)
```

Closes #28579
