### PR TITLE
fix(gateway): recover from corrupt runtime state (#28579)

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -227,7 +227,7 @@ def _read_json_file(path: Path) -> Optional[dict[str, Any]]:
         return None
     try:
         raw = path.read_text(encoding="utf-8").strip()
-    except OSError:
+    except (OSError, UnicodeDecodeError):
         return None
     if not raw:
         return None

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -358,6 +358,19 @@ class TestGatewayRuntimeStatus:
         assert payload["platforms"]["discord"]["error_code"] is None
         assert payload["platforms"]["discord"]["error_message"] is None
 
+    def test_write_runtime_status_recovers_from_non_utf8_state_file(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        state_path = tmp_path / "gateway_state.json"
+        state_path.write_bytes(b'{"gateway_state":"running"}\x17\x03\x03\x00\x13')
+
+        status.write_runtime_status(gateway_state="connected", active_agents=2)
+
+        payload = status.read_runtime_status()
+        assert payload["gateway_state"] == "connected"
+        assert payload["active_agents"] == 2
+        assert payload["pid"] == os.getpid()
+
 
 class TestTerminatePid:
     def test_force_uses_taskkill_on_windows(self, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

## Summary
This teaches gateway runtime-state reads to treat non-UTF-8 corruption the same way they already treat missing or invalid JSON.

If `gateway_state.json` contains stray non-UTF-8 bytes, Hermes now falls back to rebuilding the runtime status payload instead of surfacing the decode error on every status write.

## Problem
The gateway status reader currently catches `OSError` and `JSONDecodeError`, but not `UnicodeDecodeError`.

That leaves one awkward recovery path open: when `gateway_state.json` is present but has trailing non-UTF-8 bytes, every runtime status update tries to read the file, fails during UTF-8 decoding, and bubbles the exception back to the platform writer. The write gets skipped, so the bad file never gets replaced with a healthy one.

## What this changes
- catches `UnicodeDecodeError` in `_read_json_file()`
- treats that corrupted file as unreadable state instead of a hard failure
- lets `write_runtime_status()` rebuild the payload and overwrite the corrupted file on the next write
- adds a regression test that writes raw non-UTF-8 bytes into `gateway_state.json` and verifies Hermes recovers cleanly

## Why this shape
This stays intentionally small.

The rest of the runtime status pipeline already knows how to rebuild a missing or invalid state file. The missing piece was simply classifying UTF-8 corruption as another unreadable-state case so the existing recovery path can do its job.

## Tests
- `python -m pytest tests/gateway/test_status.py -q -n 4`

Fixes #28579.

## Solution Sketch

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Related Issue

Fixes #28579.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.