### PR TITLE
fix(kanban): create additive indexes after migrations

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -865,8 +865,6 @@ CREATE TABLE IF NOT EXISTS tasks (
     session_id           TEXT
 );
 
-CREATE INDEX IF NOT EXISTS idx_tasks_session_id ON tasks(session_id);
-
 CREATE TABLE IF NOT EXISTS task_links (
     parent_id  TEXT NOT NULL,
     child_id   TEXT NOT NULL,
@@ -937,13 +935,10 @@ CREATE TABLE IF NOT EXISTS kanban_notify_subs (
 
 CREATE INDEX IF NOT EXISTS idx_tasks_assignee_status ON tasks(assignee, status);
 CREATE INDEX IF NOT EXISTS idx_tasks_status          ON tasks(status);
-CREATE INDEX IF NOT EXISTS idx_tasks_tenant          ON tasks(tenant);
-CREATE INDEX IF NOT EXISTS idx_tasks_idempotency     ON tasks(idempotency_key);
 CREATE INDEX IF NOT EXISTS idx_links_child           ON task_links(child_id);
 CREATE INDEX IF NOT EXISTS idx_links_parent          ON task_links(parent_id);
 CREATE INDEX IF NOT EXISTS idx_comments_task         ON task_comments(task_id, created_at);
 CREATE INDEX IF NOT EXISTS idx_events_task           ON task_events(task_id, created_at);
-CREATE INDEX IF NOT EXISTS idx_events_run            ON task_events(run_id, id);
 CREATE INDEX IF NOT EXISTS idx_runs_task             ON task_runs(task_id, started_at);
 CREATE INDEX IF NOT EXISTS idx_runs_status           ON task_runs(status);
 CREATE INDEX IF NOT EXISTS idx_notify_task           ON kanban_notify_subs(task_id);
@@ -1075,6 +1070,10 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     cols = {row["name"] for row in conn.execute("PRAGMA table_info(tasks)")}
     if "tenant" not in cols:
         _add_column_if_missing(conn, "tasks", "tenant", "tenant TEXT")
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_tasks_tenant "
+        "ON tasks(tenant)"
+    )
     if "result" not in cols:
         _add_column_if_missing(conn, "tasks", "result", "result TEXT")
     if "branch_name" not in cols:
@@ -1083,10 +1082,10 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         _add_column_if_missing(
             conn, "tasks", "idempotency_key", "idempotency_key TEXT"
         )
-        conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_tasks_idempotency "
-            "ON tasks(idempotency_key)"
-        )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_tasks_idempotency "
+        "ON tasks(idempotency_key)"
+    )
 
     # Refresh after early additive migrations above. Some existing DBs were
     # partially migrated in older releases and can already contain the later
@@ -1174,20 +1173,20 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         _add_column_if_missing(
             conn, "tasks", "session_id", "session_id TEXT"
         )
-        conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_tasks_session_id "
-            "ON tasks(session_id)"
-        )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_tasks_session_id "
+        "ON tasks(session_id)"
+    )
 
     # task_events gained a run_id column; back-fill it as NULL for
     # historical events (they predate runs and can't be attributed).
     ev_cols = {row["name"] for row in conn.execute("PRAGMA table_info(task_events)")}
     if "run_id" not in ev_cols:
         _add_column_if_missing(conn, "task_events", "run_id", "run_id INTEGER")
-        conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_events_run "
-            "ON task_events(run_id, id)"
-        )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_events_run "
+        "ON task_events(run_id, id)"
+    )
 
     notify_table_exists = conn.execute(
         "SELECT name FROM sqlite_master WHERE type='table' AND name='kanban_notify_subs'"

--- a/tests/hermes_cli/test_kanban_db_init.py
+++ b/tests/hermes_cli/test_kanban_db_init.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sqlite3
 import threading
 from pathlib import Path
 
@@ -36,3 +37,83 @@ def test_connect_initialization_is_thread_safe(tmp_path, monkeypatch):
     with kb.connect(board="default") as conn:
         cols = {row["name"] for row in conn.execute("PRAGMA table_info(tasks)")}
     assert "max_retries" in cols
+
+
+def test_connect_migrates_legacy_db_before_creating_additive_column_indexes(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    db_path = kb.kanban_db_path(board="default")
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Simulate a board DB created before these additive columns existed.
+    # SCHEMA_SQL uses CREATE TABLE IF NOT EXISTS, so it will not add missing
+    # columns to this table before running CREATE INDEX statements. Indexes on
+    # additive columns must therefore be created only after migrations run.
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE tasks (
+                id                   TEXT PRIMARY KEY,
+                title                TEXT NOT NULL,
+                body                 TEXT,
+                assignee             TEXT,
+                status               TEXT NOT NULL,
+                priority             INTEGER DEFAULT 0,
+                created_by           TEXT,
+                created_at           INTEGER NOT NULL,
+                started_at           INTEGER,
+                completed_at         INTEGER,
+                workspace_kind       TEXT NOT NULL DEFAULT 'scratch',
+                workspace_path       TEXT,
+                branch_name          TEXT,
+                claim_lock           TEXT,
+                claim_expires        INTEGER,
+                result               TEXT,
+                consecutive_failures INTEGER NOT NULL DEFAULT 0,
+                worker_pid           INTEGER,
+                last_failure_error   TEXT,
+                max_runtime_seconds  INTEGER,
+                last_heartbeat_at    INTEGER,
+                current_run_id       INTEGER,
+                workflow_template_id TEXT,
+                current_step_key     TEXT,
+                skills               TEXT,
+                model_override       TEXT,
+                max_retries          INTEGER
+            );
+            CREATE TABLE task_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                task_id TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                payload TEXT,
+                created_at TEXT NOT NULL
+            );
+            """
+        )
+
+    with kb.connect(board="default") as conn:
+        task_cols = {row["name"] for row in conn.execute("PRAGMA table_info(tasks)")}
+        event_cols = {
+            row["name"] for row in conn.execute("PRAGMA table_info(task_events)")
+        }
+        indexes = {
+            row["name"]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'index'"
+            )
+        }
+
+    assert {"tenant", "idempotency_key", "session_id"}.issubset(task_cols)
+    assert "run_id" in event_cols
+    assert {
+        "idx_tasks_tenant",
+        "idx_tasks_idempotency",
+        "idx_tasks_session_id",
+        "idx_events_run",
+    }.issubset(indexes)


### PR DESCRIPTION
## Summary

Fixes Kanban DB initialization for legacy boards whose existing `tasks` / `task_events` tables predate additive columns that now have indexes.

`connect()` runs `SCHEMA_SQL` before `_migrate_add_optional_columns()`. Because `CREATE TABLE IF NOT EXISTS` does not add missing columns to an existing table, any `CREATE INDEX` in `SCHEMA_SQL` that references an additive column can fail before the migration has a chance to add that column.

This moves all currently indexed additive-column indexes out of `SCHEMA_SQL` and creates them after the additive migration guarantees the columns exist:

- `tasks.tenant` / `idx_tasks_tenant`
- `tasks.idempotency_key` / `idx_tasks_idempotency`
- `tasks.session_id` / `idx_tasks_session_id`
- `task_events.run_id` / `idx_events_run`

## Relationship to #28461

This intentionally overlaps with #28461, which fixes the same ordering class for `session_id` and `run_id`. This PR covers the broader additive-index set (`tenant`, `idempotency_key`, `session_id`, and `run_id`) and adds a regression test with a legacy DB missing all four indexed additive columns.

If maintainers prefer #28461 as the landing path, this can be closed or used as supplemental regression coverage / patch guidance.

## Test Plan

- [x] `python -m py_compile hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_db_init.py`
- [x] `python -m pytest tests/hermes_cli/test_kanban_db_init.py -q -o addopts= --tb=short`
- [x] `git diff --check`
