### PR TITLE
fix(gateway): explain stale runtime lock failures (#28561)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18007,9 +18007,18 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         )
         return False
     if not acquire_gateway_runtime_lock():
-        logger.error(
-            "Gateway runtime lock is already held by another instance. Exiting."
-        )
+        stale_lock_pid = get_running_pid(cleanup_stale=False)
+        if stale_lock_pid is None:
+            logger.error(
+                "Gateway runtime lock could not be acquired and no live gateway PID was found. "
+                "The runtime lock may be stale. Try `hermes gateway run --replace` or remove %s and %s.",
+                get_hermes_home() / "gateway.lock",
+                get_hermes_home() / "gateway.pid",
+            )
+        else:
+            logger.error(
+                "Gateway runtime lock is already held by another instance. Exiting."
+            )
         return False
     try:
         write_pid_file()

--- a/tests/gateway/test_runner_startup_failures.py
+++ b/tests/gateway/test_runner_startup_failures.py
@@ -349,6 +349,35 @@ async def test_start_gateway_replace_clears_marker_on_permission_denied(
 
 
 @pytest.mark.asyncio
+async def test_start_gateway_reports_stale_runtime_lock_guidance(monkeypatch, tmp_path, caplog):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    calls = []
+
+    def _mock_get_running_pid(*, cleanup_stale=True):
+        calls.append(cleanup_stale)
+        return None
+
+    monkeypatch.setattr("gateway.status.get_running_pid", _mock_get_running_pid)
+    monkeypatch.setattr("gateway.status.acquire_gateway_runtime_lock", lambda: False)
+    monkeypatch.setattr("tools.skills_sync.sync_skills", lambda quiet=True: None)
+    monkeypatch.setattr("hermes_logging.setup_logging", lambda hermes_home, mode: tmp_path)
+    monkeypatch.setattr("hermes_logging._add_rotating_handler", lambda *args, **kwargs: None)
+
+    from gateway.run import start_gateway
+
+    with caplog.at_level("ERROR"):
+        ok = await start_gateway(config=GatewayConfig(), replace=False, verbosity=None)
+
+    assert ok is False
+    assert calls[-1] is False
+    assert any(flag is True for flag in calls[:-1])
+    assert "runtime lock may be stale" in caplog.text
+    assert "gateway.lock" in caplog.text
+    assert "--replace" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_runner_degrades_gracefully_when_all_adapters_missing(monkeypatch, tmp_path, caplog):
     """When all enabled platforms have no adapter (missing library or credentials),
     the gateway should NOT return failure — it should warn and continue running for


### PR DESCRIPTION
## What does this PR do?

This PR improves gateway startup diagnostics around runtime-lock acquisition.

When Hermes cannot acquire `gateway.lock` and also cannot identify a live gateway PID, it now reports the failure as a likely stale-lock case and points the user to the supported recovery path (`hermes gateway run --replace`) instead of implying that another live gateway instance definitely exists.

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- Keep the existing competing-instance message when a live gateway PID is still present.
- Add a narrower stale-lock diagnostic when the lock is held but the recorded PID no longer points to a live gateway process.
- Include the concrete `gateway.lock` and `gateway.pid` paths in the error so users can inspect the runtime state quickly.
- Keep recovery conservative by pointing to the existing `--replace` path instead of force-killing or auto-removing lock files.
- Add focused regression coverage for this startup branch.

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

The original PR body below contains the previous validation notes, commands, or test plan.
No code changes are introduced by this formatting update itself.

## Related PRs / issues

Fixes #28561

<details>
<summary>Original body</summary>

## What does this PR do?

This PR improves gateway startup diagnostics around runtime-lock acquisition.

When Hermes cannot acquire `gateway.lock` and also cannot identify a live gateway PID, it now reports the failure as a likely stale-lock case and points the user to the supported recovery path (`hermes gateway run --replace`) instead of implying that another live gateway instance definitely exists.

## Solution Sketch

- Keep the existing competing-instance message when a live gateway PID is still present.
- Add a narrower stale-lock diagnostic when the lock is held but the recorded PID no longer points to a live gateway process.
- Include the concrete `gateway.lock` and `gateway.pid` paths in the error so users can inspect the runtime state quickly.
- Keep recovery conservative by pointing to the existing `--replace` path instead of force-killing or auto-removing lock files.
- Add focused regression coverage for this startup branch.

## Related Issue

Fixes #28561

## Related / Overlap Check

- Related active PR: #22483 (`fix(gateway): auto-recover stale runtime lock after Windows sleep/wake`).
- Difference in scope: #22483 attempts active auto-recovery/heartbeat handling, while this PR only improves diagnostics and points users to the existing explicit `--replace` recovery path.
- If maintainers prefer one combined stale-lock solution, this PR can be treated as the conservative diagnostic slice or folded into the broader auto-recovery work.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- re-checks for a live gateway PID after runtime-lock acquisition fails
- keeps the existing message when a live competing PID is present
- emits a more specific stale-lock message when no live PID can be found
- includes the concrete `gateway.lock` and `gateway.pid` paths plus the supported recovery path
- adds regression coverage for the stale-lock startup branch

## How to Test

1. Run `python -m pytest tests/gateway/test_runner_startup_failures.py::test_start_gateway_reports_stale_runtime_lock_guidance tests/gateway/test_runner_startup_failures.py::test_start_gateway_replace_clears_marker_on_permission_denied tests/gateway/test_runner_startup_failures.py::test_start_gateway_verbosity_imports_redacting_formatter -q -n 4`.
2. Confirm the stale-lock path now gives targeted recovery guidance.
3. Confirm the live-PID path still keeps the existing competing-instance message.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: focused gateway startup regression tests

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Focused validation: `python -m pytest tests/gateway/test_runner_startup_failures.py::test_start_gateway_reports_stale_runtime_lock_guidance tests/gateway/test_runner_startup_failures.py::test_start_gateway_replace_clears_marker_on_permission_denied tests/gateway/test_runner_startup_failures.py::test_start_gateway_verbosity_imports_redacting_formatter -q -n 4`.
- Result: `3 passed in 15.33s` on Windows.
- CI note: the broad `test` workflow is currently failing in unrelated gateway/kanban/tools tests; the touched focused startup tests are listed above.

</details>

---

_Generated by Hermes Turbo_