### PR TITLE
feat(optional-skills): add daily-diary skill

### DIFF
--- a/optional-skills/productivity/daily-diary/README.md
+++ b/optional-skills/productivity/daily-diary/README.md
@@ -1,0 +1,80 @@
+# 📔 Daily Diary — Hermes Agent Skill
+
+A configurable markdown diary system for [Hermes Agent](https://hermes-agent.nousresearch.com).
+
+Write entries via `#diary-start` / `#diary-end`, store as ISO-week-organised markdown files, set an optional smart cron reminder that only fires when you haven't written yet.
+
+## Features
+
+- **`#diary-start` / `#diary-end`** — record entries with text and images
+- **ISO-week storage** — `2026-W21/2026-05-18.md`, one file per day
+- **Obsidian-ready** — relative image paths, markdown format, works with any vault
+- **Smart cron reminder** — only reminds if no entry exists for today
+- **Configurable** — storage directory, reminder time, command aliases
+- **First-run wizard** — interactive setup via Hermes Agent
+- **Image support** — `images/` subdirectory with relative references
+- **Weather annotation** — optional, configurable default location
+- **Progressive disclosure** — core SKILL.md is lightweight (2.7 KB); detailed references load on demand
+
+## Installation
+
+| Method | Command | Status |
+|---|---|---|
+| **PR merged → Official source** | `hermes skills install daily-diary` | ⏳ Awaiting [PR #28363](https://github.com/NousResearch/hermes-agent/pull/28363) merge |
+| **From GitHub (current)** | `hermes skills install https://github.com/liubao210/hermes-skill-daily-diary` | ✅ Works now |
+| **Manual clone** | `cd ~/.hermes/skills/productivity && git clone https://github.com/liubao210/hermes-skill-daily-diary.git daily-diary` | ✅ Works now |
+
+Once [PR #28363](https://github.com/NousResearch/hermes-agent/pull/28363) is merged into the main Hermes Agent repo, users can also run `hermes skills install --source official daily-diary` or simply `hermes skills install daily-diary`.
+
+## First Run
+
+After installation, just say:
+> Set up my diary
+
+The agent walks through storage directory, reminder time, and creates a cron job.
+
+## Usage
+
+| Command | What it does |
+|---|---|
+| `#diary-start` | Begin recording an entry. |
+| `#diary-end` | Stop recording. |
+| `#view-diary` | Read back today's entries. |
+| "Change my diary settings" | Update path, time, or commands. |
+| "Remove diary" | Delete cron job and config (files stay on disk). |
+
+## Structure
+
+```
+~/Documents/Diary/
+├── 2026-W21/
+│   ├── 2026-05-18.md
+│   └── images/
+│       ├── 2026-05-18-001.jpg
+│       └── 2026-05-18-002.jpg
+```
+
+## Progressive Loading
+
+This skill uses progressive disclosure to keep the agent's context lean:
+
+| File | Size | When loaded |
+|---|---|---|
+| `SKILL.md` | ~2.7 KB | **Always** — core logic, flow, triggers |
+| `references/setup.md` | ~2.3 KB | First run setup wizard |
+| `references/reconfiguration.md` | ~1.2 KB | Changing settings after setup |
+| `references/format.md` | ~1.4 KB | Entry formatting details |
+| `references/cron-reminder.md` | ~0.9 KB | Reminder behaviour deep-dive |
+| `references/pitfalls.md` | ~1.7 KB | Common pitfalls + verification |
+
+The agent loads `SKILL.md` on every session. Reference files are loaded via `skill_view('daily-diary', file_path='references/...')` only when the relevant scenario arises.
+
+## Requirements
+
+- [Hermes Agent](https://hermes-agent.nousresearch.com) (any version with skill support)
+- macOS or Linux
+- Optional: [Obsidian](https://obsidian.md) for rich reading on mobile/desktop
+
+## License
+
+MIT

--- a/optional-skills/productivity/daily-diary/SKILL.md
+++ b/optional-skills/productivity/daily-diary/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: daily-diary
+description: >-
+  Daily diary system — record entries via #diary-start / #diary-end commands,
+  store by ISO week in markdown files, optional cron reminder that skips if
+  already written. First-run setup wizard walks through directory and
+  reminder time.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [macos, linux]
+metadata:
+  hermes:
+    tags: [Diary, Journal, Note-Taking, Cron, Productivity]
+    related_skills: [obsidian]
+    requires_toolsets: [terminal, file]
+    category: productivity
+---
+
+# Daily Diary — Markdown Journal
+
+> **This skill is read by the AI agent (Hermes), not by the human user.**
+> Write instructions in the imperative, targeting the agent.
+
+## When This Skill Activates
+
+When the user says **any** of these, load this skill and respond accordingly:
+
+| User says (examples) | Your task |
+|---|---|
+| `#diary-start` | Begin recording a diary entry. |
+| `#diary-end` | Stop recording, confirm save. |
+| `#view-diary` | Read back today's entry. |
+| "set up my diary" / "帮我设置日记" / "init diary" | Run the first-time setup wizard. |
+| "change diary" / "reconfigure diary" / "改提醒" | Run reconfiguration workflow. |
+| "remove diary" / "delete diary" / "移除日记" | Remove cron job + clear config from memory. |
+
+If the user says `#diary-start` but memory has no `diary_storage_dir`, run the
+setup wizard first instead of trying to write.
+
+## How to Load Reference Files
+
+When a scenario requires detail beyond this core file, load the reference:
+
+```
+skill_view('daily-diary', file_path='references/setup.md')
+```
+
+Available references:
+
+| Scenario | Load this |
+|---|---|
+| User wants first-time setup (no config in memory) | `references/setup.md` |
+| User wants to change path, time, or remove diary | `references/reconfiguration.md` |
+| You need to know the exact markdown format or image layout | `references/format.md` |
+| You need the cron job's smart-skip logic details | `references/cron-reminder.md` |
+| You hit an error — check common pitfalls | `references/pitfalls.md` |
+
+## Daily Mode (diary_storage_dir is set in memory)
+
+### Starting an entry (`#diary-start`)
+
+1. Read `diary_storage_dir` from your memory block (format: `diary_storage_dir=/path/to/dir`)
+2. Determine today's ISO week: run `date +%V` → yields `Www` (e.g. `W21`)
+3. Build directory: `{diary_storage_dir}/{YYYY-Www}/`
+4. Build file: `{diary_storage_dir}/{YYYY-Www}/{YYYY-MM-DD}.md`
+5. If this date already has a `# YYYY-MM-DD` heading in the file → append a new `## HH:MM` section
+6. If new day → write the full header (`# YYYY-MM-DD DayOfWeek`, weather blockquote, `## HH:MM`)
+7. Optionally fetch weather via `curl -s wttr.in/{location}?format=3` (default: Beijing, configurable via memory `diary_default_location`)
+8. Save images to `{diary_storage_dir}/{YYYY-Www}/images/` with filename `{YYYY-MM-DD}-NNN.jpg`
+9. Tell the user: "Diary started. Send me your entry."
+
+### Receiving content during an entry
+
+- **Text** → append under the current `## HH:MM` section
+- **Image** → save to `images/` dir, reference as `![caption](images/YYYY-MM-DD-NNN.jpg)` in markdown
+- **No vision model** → save the image file but note: "Image saved — I can't see its contents with this model."
+
+### Ending an entry (`#diary-end`)
+
+Confirm the file path and entry count, then close the recording session.
+
+### Viewing entries (`#view-diary`)
+
+Read `{diary_storage_dir}/{YYYY-Www}/{YYYY-MM-DD}.md` and return its content.
+
+## Memory Format
+
+All diary config is stored in your persistent memory block as key-value pairs
+separated by semicolons:
+
+```
+diary_storage_dir=/path/to/dir; diary_reminder_time=21:00;
+diary_reminder_job_id=abc123; diary_start_command=#diary-start;
+diary_end_command=#diary-end; diary_initialized=true;
+diary_default_location=Beijing
+```
+
+When reading, split by `;` then by `=`. When writing, use the `=;` format.

--- a/optional-skills/productivity/daily-diary/references/cron-reminder.md
+++ b/optional-skills/productivity/daily-diary/references/cron-reminder.md
@@ -1,0 +1,28 @@
+# Cron Reminder Logic
+
+cronjob 的完整行为规范。
+（此文件通过 `skill_view('daily-diary', file_path='references/cron-reminder.md')` 加载）
+
+## 触发逻辑
+
+```
+每天 reminder_time：
+  1. 获取今天 → YYYY-MM-DD
+  2. 获取 ISO 周 → Www
+  3. 检查 {storage_dir}/{YYYY-Www}/{YYYY-MM-DD}.md：
+     ├─ 文件不存在 → 发送提醒
+     ├─ 文件存在，但 grep "# YYYY-MM-DD" 无结果 → 发送提醒（当天没写）
+     └─ 文件存在且包含当天标题 → 静默退出，不发任何消息
+```
+
+## 提醒消息
+
+> 📝 该写日记啦
+
+简短一句即可。不要加图片、MEDIA、长文。
+
+## 条款
+
+- cronjob 的 `deliver` 用 `"origin"` 自动适配创建时的对话
+- cronjob 绑定 `skills: ["daily-diary"]` 确保 cron agent 知道如何检查
+- 如果用户更换平台，需要更新 cronjob 的 deliver target

--- a/optional-skills/productivity/daily-diary/references/format.md
+++ b/optional-skills/productivity/daily-diary/references/format.md
@@ -1,0 +1,55 @@
+# Diary Format
+
+日记格式规范和排版规则。
+（此文件通过 `skill_view('daily-diary', file_path='references/format.md')` 加载）
+
+## 存储结构
+
+```
+{STORAGE_DIR}/
+├── 2026-W21/
+│   ├── 2026-05-18.md
+│   └── images/
+│       ├── 2026-05-18-001.jpg
+│       └── 2026-05-18-002.jpg
+├── 2026-W22/
+│   └── …
+```
+
+- 根目录：`{STORAGE_DIR}`（可配置）
+- 内部：ISO 周目录 `YYYY-Www`
+- 每周目录内：每天一个 `.md` 文件 + `images/` 子目录
+
+## 条目格式
+
+```markdown
+# 2026-05-18 Monday
+
+> ☀️ 21°C · Beijing
+
+## 08:34
+
+正文内容在前。
+
+![描述](images/2026-05-18-001.jpg)
+
+## 20:15
+
+追加内容。
+```
+
+### 规则
+
+- **H1:** `# YYYY-MM-DD DayOfWeek` — 每天只出现一次
+- **引用行:** `> <emoji> <天气> · <地点>` — 默认地点可配置（memory key: `diary_default_location`）
+- **H2:** `## HH:MM` — 每次追加的时间戳
+- **正文:** 文字在前，图片在后
+- **图片引用:** `![描述](images/YYYY-MM-DD-NNN.jpg)` — 相对路径
+- **同一天追加:** 追加到同一文件，不加重复 H1
+- **新一天:** 创建新文件，写完整头
+
+## 天气获取
+
+尝试 `curl -s wttr.in/{location}?format=3`，失败则跳过天气行。
+
+默认地点：`Beijing`（可从 memory `diary_default_location` 覆盖）。

--- a/optional-skills/productivity/daily-diary/references/pitfalls.md
+++ b/optional-skills/productivity/daily-diary/references/pitfalls.md
@@ -1,0 +1,31 @@
+# Pitfalls & Verification
+
+（此文件通过 `skill_view('daily-diary', file_path='references/pitfalls.md')` 加载）
+
+## Common Pitfalls
+
+1. **iCloud 同步延迟** — 文件写入本地后 iCloud 可能需要数分钟才在其他设备可见。告知用户：已保存本地，同步需要时间。
+
+2. **模型不支持 vision** — DeepSeek 等模型不能看图片。保存图片文件，但说明"图片已保存，但这个模型看不到内容"。
+
+3. **用户变更存储目录后 cronjob 未更新** — cron prompt 里 hardcode 了路径。必须：删旧 job → 更新路径 → 重建 job。三步缺一不可。
+
+4. **cron 在周末边界上的 ISO 周编号** — `date +%V` 在跨年边界也正确。但注意 Www 不含年份，跨年时 `2025-W01` 和 `2026-W01` 是不同的目录。
+
+5. **图片相对路径** — `images/YYYY-MM-DD-NNN.jpg` 是相对路径，在 Obsidian 中正常显示，但文件被移出目录树后不可用（这是设计，不是 bug）。
+
+6. **天气获取失败** — `curl wttr.in` 可能需要网络。失败时直接跳过天气行，不要报错中断。
+
+## Verification Checklist
+
+- [ ] `#diary-start` 创建目录和文件（如果不存在）
+- [ ] 同一天追加不重复 H1
+- [ ] 新一天创建新文件，写完整 H1
+- [ ] 图片保存到 `images/` 并用相对路径引用
+- [ ] `#diary-end` 确认并结束会话
+- [ ] `#view-diary` 读取当天内容返回
+- [ ] Setup wizard 第一次运行创建 cronjob
+- [ ] Setup wizard 第二次运行提示"已设置"，询问是否重配
+- [ ] 重配时删除旧 cronjob 再建新
+- [ ] 移除时删除 cronjob + 清 memory
+- [ ] cron 提醒在已有日记时静默退出

--- a/optional-skills/productivity/daily-diary/references/reconfiguration.md
+++ b/optional-skills/productivity/daily-diary/references/reconfiguration.md
@@ -1,0 +1,31 @@
+# Reconfiguration & Removal
+
+当用户已设置过日记，希望改配置或移除时加载。
+（此文件通过 `skill_view('daily-diary', file_path='references/reconfiguration.md')` 加载）
+
+## 变更存储目录
+
+1. 从 memory 读取 `diary_reminder_job_id`
+2. 如果 cronjob 存在 → **先删除**（cron prompt 里 hardcode 了路径）
+3. 询问新目录
+4. 如果之前设过提醒时间 → **重新创建** cronjob（见 setup.md Step 5）
+5. 用 `memory(action='replace', old_text='diary_storage_dir', new_content='...')` 更新
+
+## 变更提醒时间
+
+1. 从 memory 读取 `diary_reminder_job_id`
+2. 如果存在 → `cronjob(action='remove', job_id=...)`
+3. 询问新时间
+4. 用新 schedule 创建 cronjob
+5. 更新 `diary_reminder_time` 和 `diary_reminder_job_id`
+
+## 变更命令别名
+
+1. 询问新的 start/end 命令（如 `#dstart` / `#dend`）
+2. 更新 `diary_start_command` / `diary_end_command`
+
+## 移除日记系统
+
+1. 如果 `diary_reminder_job_id` 存在 → `cronjob(action='remove', job_id=...)`
+2. 移除所有 `diary_*` key（`memory(action='remove', old_text='diary_')`）
+3. 确认：日记系统已移除，日记文件仍保留在磁盘上

--- a/optional-skills/productivity/daily-diary/references/setup.md
+++ b/optional-skills/productivity/daily-diary/references/setup.md
@@ -1,0 +1,82 @@
+# Setup Wizard — First Run
+
+> **Target: AI agent.** These are instructions for Hermes, not for the human user.
+> Load this file via `skill_view('daily-diary', file_path='references/setup.md')` when:
+> - User says "set up diary" / "帮我设置日记" / similar, **AND**
+> - Memory does NOT contain `diary_storage_dir`
+
+## Pre-check (MANDATORY)
+
+Before running any step below, **always check your memory block first**:
+
+1. Scan your memory for `diary_storage_dir`
+2. If found → do NOT run the wizard. Tell the user: "Diary is already set up. Do you want to change settings instead?"
+3. If not found → proceed with Step 1 below.
+
+## Step-by-step Wizard
+
+### Step 1: Explain
+
+Tell the user:
+
+> I'll set up a daily diary. You'll use `#diary-start` and `#diary-end` to write entries, stored as markdown files.
+
+### Step 2: Ask for storage directory
+
+> Where should I save your diary files?
+> (Press enter for default: `~/Documents/Diary/`)
+
+Decision tree for suggesting a default:
+
+- User says "Obsidian" → suggest `~/Documents/Obsidian Vault/Diary/`
+- User says "iCloud" → suggest `~/Library/Mobile Documents/com~apple~CloudDocs/Diary/`
+- Otherwise → suggest `~/Documents/Diary/`
+
+Accept any absolute path. If the parent directory doesn't exist, tell the user: "I'll create it on first write."
+
+### Step 3: Ask for reminder time
+
+> Would you like a daily reminder to write? What time? (e.g. `21:00` for 9 PM, or "no" to skip)
+
+Accept: `21:00`, `9 PM`, `2100`, `no`, `skip`, `none`.
+Convert to cron: `21:00` → `"0 21 * * *"`, `8:30` → `"30 8 * * *"`.
+
+### Step 4: Explain smart reminder
+
+> The reminder is smart — if you've already written a diary entry that day, I won't send a notification. Only empty days get a nudge.
+
+### Step 5: Create the cron job
+
+Use the `cronjob` tool with these exact parameters (substitute `{STORAGE_DIR}` with the user's confirmed path):
+
+```json
+{
+  "action": "create",
+  "name": "diary-reminder",
+  "schedule": "0 21 * * *",
+  "prompt": "Check if today ({YYYY-MM-DD}) has a diary entry.\n\nSteps:\n1. Determine ISO week: `date +\\%V`\n2. Build path: {STORAGE_DIR}/{YYYY-Www}/{YYYY-MM-DD}.md\n3. If file contains \"# {YYYY-MM-DD}\" as a heading → already written. Say NOTHING.\n4. Otherwise → send: \"📝 该写日记啦\"\n\nDiary path: {STORAGE_DIR}\n\nCritical: If entry exists, SILENT exit — do not send any message.",
+  "deliver": "origin",
+  "skills": ["daily-diary"]
+}
+```
+
+⚠️ **Important:** Substitute `{STORAGE_DIR}` with the actual path. Do not send the literal placeholder.
+
+If user said "no" to reminders, skip this step entirely.
+
+### Step 6: Save config to memory
+
+Add these entries to your persistent memory. Use the exact key=value format:
+
+```
+diary_storage_dir=/path/to/dir; diary_reminder_time=21:00;
+diary_reminder_job_id=abc123; diary_start_command=#diary-start;
+diary_end_command=#diary-end; diary_initialized=true;
+diary_default_location=Beijing
+```
+
+Use `memory(action='add', target='memory', content='...')` with all keys in one string, semicolon-separated.
+
+### Step 7: Confirm
+
+> ✅ Diary is set up! Try `#diary-start` to write your first entry.


### PR DESCRIPTION
## Summary

Add a configurable markdown diary system as an optional skill under the productivity category.

## Features

- `#diary-start` / `#diary-end` commands for recording entries
- ISO-week directory organisation with single-file-per-day
- Configurable storage directory (local, iCloud, Obsidian)
- First-run setup wizard with interactive prompts
- Smart cron reminder (skips if diary already written that day)
- Reconfiguration support (change path, time, remove)
- Image support with relative paths for Obsidian compatibility
- Progressive disclosure — references/*.md load on demand