### PR TITLE
fix(codex): recover auxiliary auth with fresh pool tokens

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6808,6 +6808,17 @@ def call_llm(
                     "Auxiliary %s: recovered %s via credential-pool rotation after %s",
                     task or "call", pool_provider, type(recovery_err).__name__,
                 )
+                # Provider-level eviction cannot remove a client cached under
+                # the "auto" route. Drop the actual failed instance so retry
+                # rebuilds it with the recovered pool credential. Eviction is
+                # best-effort: successful credential recovery must still retry.
+                try:
+                    _evict_cached_client_instance(client)
+                except Exception:
+                    logger.debug(
+                        "Auxiliary: cache eviction after pool recovery failed",
+                        exc_info=True,
+                    )
                 try:
                     return _retry_same_provider_sync(
                         task=task,
@@ -7351,6 +7362,17 @@ async def async_call_llm(
                     "Auxiliary %s (async): recovered %s via credential-pool rotation after %s",
                     task or "call", pool_provider, type(recovery_err).__name__,
                 )
+                # Provider-level eviction cannot remove a client cached under
+                # the "auto" route. Drop the actual failed instance so retry
+                # rebuilds it with the recovered pool credential. Eviction is
+                # best-effort: successful credential recovery must still retry.
+                try:
+                    _evict_cached_client_instance(client)
+                except Exception:
+                    logger.debug(
+                        "Auxiliary: cache eviction after pool recovery failed",
+                        exc_info=True,
+                    )
                 try:
                     return await _retry_same_provider_async(
                         task=task,

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3730,6 +3730,54 @@ class TestAuxiliaryPoolRotationRetry:
         assert pool.rotate_calls[0]["status_code"] == 429
         mock_fallback.assert_not_called()
 
+    def test_call_llm_rebuilds_auto_cached_client_after_pool_recovery(self):
+        stale_client = MagicMock()
+        stale_client.base_url = "https://chatgpt.com/backend-api/codex"
+        stale_client.chat.completions.create.side_effect = _AuxAuth401("stale pooled token")
+
+        fresh_client = MagicMock()
+        fresh_client.base_url = "https://chatgpt.com/backend-api/codex"
+        fresh_client.chat.completions.create.return_value = _DummyResponse("recovered-auto-sync")
+
+        class _Pool:
+            def has_credentials(self):
+                return True
+
+            def try_refresh_current(self):
+                return SimpleNamespace(id="cred-refreshed")
+
+            def mark_exhausted_and_rotate(self, **_kwargs):
+                raise AssertionError("refresh recovery should not exhaust another credential")
+
+        cache_key = ("auto", False, None, None, None)
+        cache = {cache_key: (stale_client, "gpt-5.4", None)}
+
+        def get_cached_client(*_args, **_kwargs):
+            entry = cache.get(cache_key)
+            if entry is not None:
+                return entry[0], entry[1]
+            cache[cache_key] = (fresh_client, "gpt-5.4", None)
+            return fresh_client, "gpt-5.4"
+
+        with (
+            patch("agent.auxiliary_client._client_cache", cache),
+            patch("agent.auxiliary_client._resolve_task_provider_model", return_value=("auto", "gpt-5.4", None, None, None)),
+            patch("agent.auxiliary_client._get_cached_client", side_effect=get_cached_client),
+            patch("agent.auxiliary_client._refresh_provider_credentials", return_value=False),
+            patch("agent.auxiliary_client.load_pool", return_value=_Pool()),
+            patch("agent.auxiliary_client._try_payment_fallback") as mock_fallback,
+        ):
+            resp = call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        assert resp.choices[0].message.content == "recovered-auto-sync"
+        assert cache[cache_key][0] is fresh_client
+        assert stale_client.chat.completions.create.call_count == 1
+        assert fresh_client.chat.completions.create.call_count == 1
+        mock_fallback.assert_not_called()
+
     @pytest.mark.asyncio
     async def test_async_call_llm_rotates_explicit_codex_pool_on_429(self):
         rate_err = Exception("usage limit reached")
@@ -3778,6 +3826,59 @@ class TestAuxiliaryPoolRotationRetry:
         assert fresh_client.chat.completions.create.await_count == 1
         assert len(pool.rotate_calls) == 1
         assert pool.rotate_calls[0]["status_code"] == 429
+        mock_fallback.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_async_call_llm_rebuilds_auto_cached_client_after_pool_recovery(self):
+        stale_client = MagicMock()
+        stale_client.base_url = "https://chatgpt.com/backend-api/codex"
+        stale_client.chat.completions.create = AsyncMock(
+            side_effect=_AuxAuth401("stale pooled token")
+        )
+
+        fresh_client = MagicMock()
+        fresh_client.base_url = "https://chatgpt.com/backend-api/codex"
+        fresh_client.chat.completions.create = AsyncMock(
+            return_value=_DummyResponse("recovered-auto-async")
+        )
+
+        class _Pool:
+            def has_credentials(self):
+                return True
+
+            def try_refresh_current(self):
+                return SimpleNamespace(id="cred-refreshed")
+
+            def mark_exhausted_and_rotate(self, **_kwargs):
+                raise AssertionError("refresh recovery should not exhaust another credential")
+
+        cache_key = ("auto", True, None, None, None)
+        cache = {cache_key: (stale_client, "gpt-5.4", None)}
+
+        def get_cached_client(*_args, **_kwargs):
+            entry = cache.get(cache_key)
+            if entry is not None:
+                return entry[0], entry[1]
+            cache[cache_key] = (fresh_client, "gpt-5.4", None)
+            return fresh_client, "gpt-5.4"
+
+        with (
+            patch("agent.auxiliary_client._client_cache", cache),
+            patch("agent.auxiliary_client._resolve_task_provider_model", return_value=("auto", "gpt-5.4", None, None, None)),
+            patch("agent.auxiliary_client._get_cached_client", side_effect=get_cached_client),
+            patch("agent.auxiliary_client._refresh_provider_credentials", return_value=False),
+            patch("agent.auxiliary_client.load_pool", return_value=_Pool()),
+            patch("agent.auxiliary_client._try_payment_fallback") as mock_fallback,
+        ):
+            resp = await async_call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        assert resp.choices[0].message.content == "recovered-auto-async"
+        assert cache[cache_key][0] is fresh_client
+        assert stale_client.chat.completions.create.await_count == 1
+        assert fresh_client.chat.completions.create.await_count == 1
         mock_fallback.assert_not_called()
 
 


### PR DESCRIPTION
## Summary
- evict the exact failed auxiliary client instance after credential-pool recovery so an `auto`-cached route cannot reuse stale credentials
- apply the recovery behavior consistently to synchronous and asynchronous auxiliary calls
- add paired sync/async regressions that exercise an auto-resolved Codex client, pool recovery, cache eviction, and reconstruction with fresh credentials
- rebase the PR onto current `main`; the original `credential_pool.py` changes were dropped because current `main` already provides locked pre-refresh synchronization and post-failure token adoption

## Test Plan
- `uv run pytest tests/agent/test_auxiliary_client.py::TestAuxiliaryAuthRefreshRetry tests/agent/test_auxiliary_client.py::TestAuxiliaryPoolRotationRetry tests/agent/test_auxiliary_client.py::TestAuxiliaryClientPoisonedCacheEviction -q -o 'addopts='`
- `uv run ruff check agent/auxiliary_client.py tests/agent/test_auxiliary_client.py`
- `uv run python -m compileall -q agent/auxiliary_client.py tests/agent/test_auxiliary_client.py`
- `git diff --check`

## Context
Current `main` already handles cross-process Codex token refresh races in the credential pool. The remaining gap is auxiliary cache recovery: provider-level eviction targets the concrete backend, but the failed client can be cached under the `auto` route. After successful pool recovery, retrying without evicting that exact instance can reuse the stale token. This patch closes that gap for both sync and async callers.