### PR TITLE
fix(kanban): remove duplicate idx_tasks_session_id from SCHEMA_SQL

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -865,8 +865,6 @@ CREATE TABLE IF NOT EXISTS tasks (
     session_id           TEXT
 );
 
-CREATE INDEX IF NOT EXISTS idx_tasks_session_id ON tasks(session_id);
-
 CREATE TABLE IF NOT EXISTS task_links (
     parent_id  TEXT NOT NULL,
     child_id   TEXT NOT NULL,


### PR DESCRIPTION
## Fix: Remove duplicate `idx_tasks_session_id` from `SCHEMA_SQL`

**Issue:** #28617

### Root Cause

When the kanban schema gains a new indexed column (`session_id` in the `tasks` table), the `CREATE INDEX IF NOT EXISTS` statement inside `SCHEMA_SQL` references the new column — but on existing databases, that column doesn't exist yet. SQLite throws `OperationalError: no such column: session_id` during `conn.executescript(SCHEMA_SQL)` in `connect()`, **before** `_migrate_add_optional_columns()` gets a chance to add the column.

`IF NOT EXISTS` only skips if the **index** exists — SQLite still validates the column reference. On an existing DB without `session_id`, this fails before the migration code runs.

### Fix

Remove the `CREATE INDEX IF NOT EXISTS idx_tasks_session_id ON tasks(session_id);` from `SCHEMA_SQL`. The migration function `_migrate_add_optional_columns()` already adds both the column and the index correctly for legacy databases.

This is consistent with how `run_id` on `task_events` is handled — the `idx_events_run` index lives only in the migration function, not in `SCHEMA_SQL`.

### Verification

- `idx_tasks_session_id` now only appears once, in `_migrate_add_optional_columns()` (line ~1176)
- `idx_tasks_session_id` no longer appears in `SCHEMA_SQL`
- Fresh installs: unaffected (migration runs, creates the index)
- Legacy installs: migration now runs successfully without crashing
