### PR TITLE
fix: carry Discord cron embeds through delivery

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -511,6 +511,79 @@ _VIDEO_EXTS = frozenset({'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'})
 _IMAGE_EXTS = frozenset({'.jpg', '.jpeg', '.png', '.webp', '.gif'})
 
 
+_DISCORD_EMBED_PREFIX = "HERMES_DISCORD_EMBED:"
+
+
+def _extract_discord_embed_payload(content: str) -> tuple[str, dict | None]:
+    """Extract a structured Discord embed marker from cron output.
+
+    Script-only jobs need a stdout-compatible way to request rich Discord
+    delivery while preserving plain-text fallback for every other platform. A
+    line beginning ``HERMES_DISCORD_EMBED:`` contains JSON for Discord's embed
+    API; that line is stripped from delivered text.
+    """
+    embed = None
+    kept_lines = []
+    for line in (content or "").splitlines():
+        if line.startswith(_DISCORD_EMBED_PREFIX):
+            raw = line[len(_DISCORD_EMBED_PREFIX):].strip()
+            if raw and embed is None:
+                try:
+                    parsed = json.loads(raw)
+                    if isinstance(parsed, dict):
+                        embed = parsed
+                except Exception as exc:
+                    logger.warning("Failed to parse Discord embed cron marker: %s", exc)
+            continue
+        kept_lines.append(line)
+    return "\n".join(kept_lines).strip(), embed
+
+
+def _cron_wrapped_content(job: dict, content: str, *, wrap_response: bool) -> str:
+    if not wrap_response:
+        return content
+    task_name = job.get("name", job["id"])
+    job_id = job.get("id", "")
+    return (
+        f"Cronjob Response: {task_name}\n"
+        f"(job_id: {job_id})\n"
+        f"-------------\n\n"
+        f"{content}\n\n"
+        f"To stop or manage this job, send me a new message (e.g. \"stop reminder {task_name}\")."
+    )
+
+
+def _truncate_discord_embed_text(text: str, limit: int = 4096) -> str:
+    """Clamp text to Discord embed limits without chopping mid-character."""
+    cleaned = (text or "").strip()
+    if len(cleaned) <= limit:
+        return cleaned
+    suffix = "\n… truncated"
+    return cleaned[: max(0, limit - len(suffix))].rstrip() + suffix
+
+
+def _build_default_discord_cron_embed(job: dict, content: str) -> dict:
+    """Build a generic native Discord embed for plain cron output.
+
+    Script jobs can still override this with ``HERMES_DISCORD_EMBED:``. This
+    default keeps Discord deliveries out of the noisy ``Cronjob Response`` text
+    wrapper while preserving the full plain-text wrapper for other platforms.
+    """
+    task_name = str(job.get("name") or job.get("id") or "cron job")
+    job_id = str(job.get("id") or "")
+    title = f"Cron: {task_name}"
+    if len(title) > 256:
+        title = title[:253].rstrip() + "..."
+    embed = {
+        "title": title,
+        "description": _truncate_discord_embed_text(content),
+        "color": 0x5865F2,
+    }
+    if job_id:
+        embed["footer"] = {"text": f"job_id: {job_id}"}
+    return embed
+
+
 def _send_media_via_adapter(
     adapter,
     chat_id: str,
@@ -597,22 +670,20 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     except Exception:
         pass
 
+    raw_content, discord_embed = _extract_discord_embed_payload(content)
+    explicit_discord_embed = discord_embed is not None
+
     if wrap_response:
-        task_name = job.get("name", job["id"])
-        job_id = job.get("id", "")
-        delivery_content = (
-            f"Cronjob Response: {task_name}\n"
-            f"(job_id: {job_id})\n"
-            f"-------------\n\n"
-            f"{content}\n\n"
-            f"To stop or manage this job, send me a new message (e.g. \"stop reminder {task_name}\")."
-        )
+        delivery_content = _cron_wrapped_content(job, raw_content, wrap_response=True)
     else:
-        delivery_content = content
+        delivery_content = raw_content
 
     # Extract MEDIA: tags so attachments are forwarded as files, not raw text
     from gateway.platforms.base import BasePlatformAdapter
     media_files, cleaned_delivery_content = BasePlatformAdapter.extract_media(delivery_content)
+    discord_media_files, discord_cleaned_content = BasePlatformAdapter.extract_media(raw_content)
+    if discord_embed is None:
+        discord_embed = _build_default_discord_cron_embed(job, discord_cleaned_content)
 
     try:
         config = load_gateway_config()
@@ -665,12 +736,22 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         runtime_adapter = (adapters or {}).get(platform)
         delivered = False
         if runtime_adapter is not None and loop is not None and getattr(loop, "is_running", lambda: False)():
-            send_metadata = {"thread_id": thread_id} if thread_id else None
+            send_metadata = {"thread_id": thread_id} if thread_id else {}
+            use_discord_embed = platform_name.lower() == "discord" and discord_embed
+            if use_discord_embed:
+                target_text = discord_cleaned_content if explicit_discord_embed else ""
+                target_media_files = discord_media_files
+            else:
+                target_text = cleaned_delivery_content
+                target_media_files = media_files
+            if use_discord_embed:
+                send_metadata["discord_embed"] = discord_embed
+            send_metadata = send_metadata or None
             try:
                 # Send cleaned text (MEDIA tags stripped) — not the raw content
-                text_to_send = cleaned_delivery_content.strip()
+                text_to_send = target_text.strip()
                 adapter_ok = True
-                if text_to_send:
+                if text_to_send or (platform_name.lower() == "discord" and discord_embed):
                     from agent.async_utils import safe_schedule_threadsafe
                     future = safe_schedule_threadsafe(
                         runtime_adapter.send(chat_id, text_to_send, metadata=send_metadata),
@@ -706,11 +787,11 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                             delivery_errors.append(msg)
 
                 # Send extracted media files as native attachments via the live adapter
-                if adapter_ok and media_files:
+                if adapter_ok and target_media_files:
                     _send_media_via_adapter(
                         runtime_adapter,
                         chat_id,
-                        media_files,
+                        target_media_files,
                         send_metadata,
                         loop,
                         job,
@@ -727,8 +808,22 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 )
 
         if not delivered:
+            if platform_name.lower() == "discord" and discord_embed:
+                standalone_content = discord_cleaned_content if explicit_discord_embed else ""
+                standalone_media_files = discord_media_files
+            else:
+                standalone_content = cleaned_delivery_content
+                standalone_media_files = media_files
             # Standalone path: run the async send in a fresh event loop (safe from any thread)
-            coro = _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files)
+            coro = _send_to_platform(
+                platform,
+                pconfig,
+                chat_id,
+                standalone_content,
+                thread_id=thread_id,
+                media_files=standalone_media_files,
+                discord_embed=discord_embed if platform_name.lower() == "discord" else None,
+            )
             try:
                 result = asyncio.run(coro)
             except RuntimeError:
@@ -738,7 +833,18 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 # fresh thread that has no running loop.
                 coro.close()
                 with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-                    future = pool.submit(asyncio.run, _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files))
+                    future = pool.submit(
+                        asyncio.run,
+                        _send_to_platform(
+                            platform,
+                            pconfig,
+                            chat_id,
+                            standalone_content,
+                            thread_id=thread_id,
+                            media_files=standalone_media_files,
+                            discord_embed=discord_embed if platform_name.lower() == "discord" else None,
+                        ),
+                    )
                     result = future.result(timeout=30)
             except Exception as e:
                 msg = f"delivery to {platform_name}:{chat_id} failed: {e}"

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -838,6 +838,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["mention_patterns"] = platform_cfg["mention_patterns"]
                 if "exclusive_bot_mentions" in platform_cfg:
                     bridged["exclusive_bot_mentions"] = platform_cfg["exclusive_bot_mentions"]
+                if "wake_words" in platform_cfg:
+                    bridged["wake_words"] = platform_cfg["wake_words"]
                 if "dm_policy" in platform_cfg:
                     bridged["dm_policy"] = platform_cfg["dm_policy"]
                 if "allow_from" in platform_cfg:
@@ -929,6 +931,11 @@ def load_gateway_config() -> GatewayConfig:
                     os.environ["DISCORD_REQUIRE_MENTION"] = str(discord_cfg["require_mention"]).lower()
                 if "thread_require_mention" in discord_cfg and not os.getenv("DISCORD_THREAD_REQUIRE_MENTION"):
                     os.environ["DISCORD_THREAD_REQUIRE_MENTION"] = str(discord_cfg["thread_require_mention"]).lower()
+                wake_words = discord_cfg.get("wake_words")
+                if wake_words is not None and not os.getenv("DISCORD_WAKE_WORDS"):
+                    if isinstance(wake_words, list):
+                        wake_words = ",".join(str(v) for v in wake_words)
+                    os.environ["DISCORD_WAKE_WORDS"] = str(wake_words)
                 frc = discord_cfg.get("free_response_channels")
                 if frc is not None and not os.getenv("DISCORD_FREE_RESPONSE_CHANNELS"):
                     if isinstance(frc, list):

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -3624,6 +3624,34 @@ class DiscordAdapter(BasePlatformAdapter):
             return {part.strip() for part in s.split(",") if part.strip()}
         return set()
 
+    def _discord_wake_words(self) -> list[str]:
+        """Return wake words that can replace a Discord @mention.
+
+        Config accepts either a YAML list or a comma-separated string. Matching
+        is prefix-only and word-boundary checked, so ``dex`` wakes the bot in
+        ``dex help`` but not ``index help``. The wake word is stripped before
+        dispatch so the model sees the user request, not the routing token.
+        """
+        raw = self.config.extra.get("wake_words")
+        if raw is None:
+            raw = os.getenv("DISCORD_WAKE_WORDS", "")
+        if isinstance(raw, list):
+            parts = [str(part).strip() for part in raw]
+        else:
+            parts = [part.strip() for part in str(raw).split(",")]
+        return [part for part in parts if part]
+
+    def _discord_strip_wake_word(self, text: str) -> Optional[str]:
+        stripped = (text or "").lstrip()
+        if not stripped:
+            return None
+        for wake_word in self._discord_wake_words():
+            pattern = rf"^{re.escape(wake_word)}(?:$|[\s,.:;!?—-]+)(.*)$"
+            match = re.match(pattern, stripped, flags=re.IGNORECASE | re.DOTALL)
+            if match:
+                return match.group(1).lstrip()
+        return None
+
     def _discord_thread_require_mention(self) -> bool:
         """Return whether thread participation requires @mention to follow up.
 
@@ -4480,6 +4508,10 @@ class DiscordAdapter(BasePlatformAdapter):
                 channel_ids.add(parent_channel_id)
 
             require_mention = self._discord_require_mention()
+            wake_word_prefix = self._discord_strip_wake_word(normalized_content)
+            if wake_word_prefix is not None:
+                normalized_content = wake_word_prefix
+                message.content = normalized_content
             # Voice-linked text channels act as free-response while voice is active.
             # Only the exact bound channel gets the exemption, not sibling threads.
             voice_linked_ids = {str(ch_id) for ch_id in self._voice_text_channels.values()}
@@ -4502,7 +4534,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 and not self._discord_thread_require_mention()
             )
 
-            if require_mention and not is_free_channel and not in_bot_thread:
+            if require_mention and not is_free_channel and not in_bot_thread and wake_word_prefix is None:
                 if self._client.user not in message.mentions and not mention_prefix:
                     return
         # Auto-thread: when enabled, automatically create a thread for every

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1413,6 +1413,9 @@ class DiscordAdapter(BasePlatformAdapter):
             # Format and split message if needed
             formatted = self.format_message(content)
             chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+            discord_embed = None
+            if metadata and isinstance(metadata.get("discord_embed"), dict):
+                discord_embed = discord.Embed.from_dict(metadata["discord_embed"])
 
             message_ids = []
             reference = None
@@ -1433,10 +1436,13 @@ class DiscordAdapter(BasePlatformAdapter):
                 else:  # "first" (default) or "off"
                     chunk_reference = reference if i == 0 else None
                 try:
-                    msg = await channel.send(
-                        content=chunk,
-                        reference=chunk_reference,
-                    )
+                    send_kwargs = {
+                        "content": (chunk if chunk else None) if discord_embed else chunk,
+                        "reference": chunk_reference,
+                    }
+                    if discord_embed is not None and i == 0:
+                        send_kwargs["embed"] = discord_embed
+                    msg = await channel.send(**send_kwargs)
                 except Exception as e:
                     err_text = str(e)
                     if (
@@ -1455,10 +1461,13 @@ class DiscordAdapter(BasePlatformAdapter):
                             reply_to,
                         )
                         reference = None
-                        msg = await channel.send(
-                            content=chunk,
-                            reference=None,
-                        )
+                        retry_kwargs = {
+                            "content": (chunk if chunk else None) if discord_embed else chunk,
+                            "reference": None,
+                        }
+                        if discord_embed is not None and i == 0:
+                            retry_kwargs["embed"] = discord_embed
+                        msg = await channel.send(**retry_kwargs)
                     else:
                         raise
                 message_ids.append(str(msg.id))

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -7,7 +7,17 @@ from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
 
-from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, run_job, SILENT_MARKER, _build_job_prompt
+from cron.scheduler import (
+    _resolve_origin,
+    _resolve_delivery_target,
+    _deliver_result,
+    _send_media_via_adapter,
+    run_job,
+    SILENT_MARKER,
+    _build_job_prompt,
+    _extract_discord_embed_payload,
+    _build_default_discord_cron_embed,
+)
 from tools.env_passthrough import clear_env_passthrough
 from tools.credential_files import clear_credential_files
 
@@ -564,6 +574,111 @@ class TestDeliverResultWrapping:
         assert "Cronjob Response" not in sent_content
         assert "The agent cannot see" not in sent_content
 
+    def test_delivery_extracts_discord_embed_marker(self):
+        content = 'HERMES_DISCORD_EMBED:{"title":"Board","fields":[]}\nplain fallback'
+
+        cleaned, embed = _extract_discord_embed_payload(content)
+
+        assert cleaned == "plain fallback"
+        assert embed == {"title": "Board", "fields": []}
+
+    def test_default_discord_embed_uses_job_metadata_and_clamps_description(self):
+        embed = _build_default_discord_cron_embed(
+            {"id": "abc123", "name": "gateway-profile-health"},
+            "x" * 5000,
+        )
+
+        assert embed["title"] == "Cron: gateway-profile-health"
+        assert embed["footer"] == {"text": "job_id: abc123"}
+        assert len(embed["description"]) <= 4096
+        assert embed["description"].endswith("… truncated")
+
+    def test_plain_discord_cron_delivery_uses_default_embed_without_wrapper_text(self):
+        """Plain Discord cron output should render as an embed, not wrapper text."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.DISCORD: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock:
+            job = {
+                "id": "health-job",
+                "name": "gateway-profile-health",
+                "deliver": "origin",
+                "origin": {"platform": "discord", "chat_id": "123"},
+            }
+            _deliver_result(job, "Gateway/profile health\n\nProfiles:\n  default running")
+
+        send_mock.assert_called_once()
+        args, kwargs = send_mock.call_args
+        assert args[3] == ""
+        assert "Cronjob Response" not in args[3]
+        assert kwargs["discord_embed"]["title"] == "Cron: gateway-profile-health"
+        assert "Gateway/profile health" in kwargs["discord_embed"]["description"]
+
+    def test_discord_embed_delivery_uses_unwrapped_content_and_embed_kwarg(self):
+        """Discord cron embeds should bypass the noisy Cronjob Response wrapper."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.DISCORD: pconfig}
+        embed = {"title": "operator action needed: board", "fields": []}
+        content = f"HERMES_DISCORD_EMBED:{json.dumps(embed)}\noperator action needed: board"
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock:
+            job = {
+                "id": "watchdog-job",
+                "name": "board watchdog",
+                "deliver": "origin",
+                "origin": {"platform": "discord", "chat_id": "123"},
+            }
+            _deliver_result(job, content)
+
+        send_mock.assert_called_once()
+        args, kwargs = send_mock.call_args
+        assert args[3] == "operator action needed: board"
+        assert "Cronjob Response" not in args[3]
+        assert kwargs["discord_embed"] == embed
+
+    def test_live_discord_adapter_receives_embed_metadata(self):
+        from gateway.config import Platform
+        from concurrent.futures import Future
+
+        adapter = AsyncMock()
+        adapter.send.return_value = MagicMock(success=True)
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.DISCORD: pconfig}
+        loop = MagicMock()
+        loop.is_running.return_value = True
+        embed = {"title": "intervened: board", "fields": []}
+
+        def fake_run_coro(coro, _loop):
+            future = Future()
+            future.set_result(MagicMock(success=True))
+            coro.close()
+            return future
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro):
+            _deliver_result(
+                {"id": "watchdog", "deliver": "origin", "origin": {"platform": "discord", "chat_id": "123"}},
+                f"HERMES_DISCORD_EMBED:{json.dumps(embed)}\nfallback text",
+                adapters={Platform.DISCORD: adapter},
+                loop=loop,
+            )
+
+        adapter.send.assert_called_once()
+        assert adapter.send.call_args[0][1] == "fallback text"
+        assert adapter.send.call_args.kwargs["metadata"]["discord_embed"] == embed
+
     def test_delivery_extracts_media_tags_before_send(self):
         """Cron delivery should pass MEDIA attachments separately to the send helper."""
         from gateway.config import Platform
@@ -637,7 +752,8 @@ class TestDeliverResultWrapping:
         adapter.send.assert_called_once()
         text_sent = adapter.send.call_args[0][1]
         assert "MEDIA:" not in text_sent
-        assert "Here is TTS" in text_sent
+        assert text_sent == ""
+        assert adapter.send.call_args.kwargs["metadata"]["discord_embed"]["description"] == "Here is TTS"
 
         # Audio file should be sent as a voice attachment
         adapter.send_voice.assert_called_once()

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -107,6 +107,7 @@ def adapter(monkeypatch):
         "DISCORD_REQUIRE_MENTION",
         "DISCORD_THREAD_REQUIRE_MENTION",
         "DISCORD_FREE_RESPONSE_CHANNELS",
+        "DISCORD_WAKE_WORDS",
         "DISCORD_AUTO_THREAD",
         "DISCORD_NO_THREAD_CHANNELS",
         "DISCORD_ALLOWED_CHANNELS",
@@ -345,6 +346,50 @@ async def test_discord_accepts_and_strips_bot_mentions_when_required(adapter, mo
     adapter.handle_message.assert_awaited_once()
     event = adapter.handle_message.await_args.args[0]
     assert event.text == "hello with mention"
+
+
+@pytest.mark.asyncio
+async def test_discord_wake_word_can_replace_mention(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_WAKE_WORDS", "dex")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+
+    message = make_message(channel=FakeTextChannel(channel_id=321), content="Dex, can you check this?")
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "can you check this?"
+
+
+@pytest.mark.asyncio
+async def test_discord_wake_word_can_come_from_config_extra(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_WAKE_WORDS", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    adapter.config.extra["wake_words"] = ["dex", "hey dex"]
+
+    message = make_message(channel=FakeTextChannel(channel_id=321), content="hey dex status please")
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "status please"
+
+
+@pytest.mark.asyncio
+async def test_discord_wake_word_requires_prefix_boundary(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_WAKE_WORDS", "dex")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+
+    message = make_message(channel=FakeTextChannel(channel_id=321), content="index this please")
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -46,6 +46,39 @@ from gateway.platforms.discord import DiscordAdapter  # noqa: E402
 
 
 @pytest.mark.asyncio
+async def test_send_uses_embed_metadata_on_first_chunk(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+
+    embed_payload = {"title": "Cron: watchdog", "description": "state changed"}
+    embed_obj = object()
+    sent_msg = SimpleNamespace(id=1234)
+    send_calls = []
+
+    async def fake_send(*, content, reference=None, embed=None):
+        send_calls.append({"content": content, "reference": reference, "embed": embed})
+        return sent_msg
+
+    import gateway.platforms.discord as discord_mod
+
+    monkeypatch.setattr(discord_mod.discord.Embed, "from_dict", MagicMock(return_value=embed_obj), raising=False)
+    channel = SimpleNamespace(send=AsyncMock(side_effect=fake_send))
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+
+    result = await adapter.send(
+        "555",
+        "",
+        metadata={"discord_embed": embed_payload},
+    )
+
+    assert result.success is True
+    discord_mod.discord.Embed.from_dict.assert_called_once_with(embed_payload)
+    assert send_calls == [{"content": None, "reference": None, "embed": embed_obj}]
+
+
+@pytest.mark.asyncio
 async def test_send_retries_without_reference_when_reply_target_is_system_message():
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
 

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -453,6 +453,50 @@ class TestSendToPlatformChunking:
         for call in send.await_args_list:
             assert len(call.args[2]) <= 2020  # each chunk fits the limit
 
+    def test_discord_embed_attaches_to_first_chunk_only(self):
+        """Standalone Discord fallback carries cron embeds through to REST sender."""
+        send = AsyncMock(return_value={"success": True, "message_id": "1"})
+        embed = {"title": "operator action needed", "description": "details"}
+        long_msg = "word " * 1000  # force multiple chunks
+
+        with patch("tools.send_message_tool._send_discord", send):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.DISCORD,
+                    SimpleNamespace(enabled=True, token="***", extra={}),
+                    "ch",
+                    long_msg,
+                    discord_embed=embed,
+                )
+            )
+
+        assert result["success"] is True
+        assert send.await_count >= 3
+        assert send.await_args_list[0].kwargs["discord_embed"] == embed
+        for call in send.await_args_list[1:]:
+            assert "discord_embed" not in call.kwargs
+
+    def test_discord_embed_only_message_is_sent(self):
+        """Discord embed-only cron deliveries must not be dropped as empty text."""
+        send = AsyncMock(return_value={"success": True, "message_id": "1"})
+        embed = {"title": "Cron: watchdog", "description": "state changed"}
+
+        with patch("tools.send_message_tool._send_discord", send):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.DISCORD,
+                    SimpleNamespace(enabled=True, token="***", extra={}),
+                    "ch",
+                    "",
+                    discord_embed=embed,
+                )
+            )
+
+        assert result["success"] is True
+        send.assert_awaited_once()
+        assert send.await_args.args[2] == ""
+        assert send.await_args.kwargs["discord_embed"] == embed
+
     def test_slack_messages_are_formatted_before_send(self, monkeypatch):
         _ensure_slack_mock(monkeypatch)
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -547,7 +547,7 @@ async def _send_via_adapter(
     }
 
 
-async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False):
+async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False, discord_embed=None):
     """Route a message to the appropriate platform sender.
 
     Long messages are automatically chunked to fit within platform limits
@@ -640,12 +640,17 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         last_result = None
         for i, chunk in enumerate(chunks):
             is_last = (i == len(chunks) - 1)
+            send_kwargs = {
+                "media_files": media_files if is_last else [],
+                "thread_id": thread_id,
+            }
+            if discord_embed is not None and i == 0:
+                send_kwargs["discord_embed"] = discord_embed
             result = await _send_discord(
                 pconfig.token,
                 chat_id,
                 chunk,
-                media_files=media_files if is_last else [],
-                thread_id=thread_id,
+                **send_kwargs,
             )
             if isinstance(result, dict) and result.get("error"):
                 return result
@@ -1043,7 +1048,7 @@ def _probe_is_forum_cached(chat_id: str) -> Optional[bool]:
     return _DISCORD_CHANNEL_TYPE_PROBE_CACHE.get(str(chat_id))
 
 
-async def _send_discord(token, chat_id, message, thread_id=None, media_files=None):
+async def _send_discord(token, chat_id, message, thread_id=None, media_files=None, discord_embed=None):
     """Send a single message via Discord REST API (no websocket client needed).
 
     Chunking is handled by _send_to_platform() before this is called.
@@ -1073,6 +1078,7 @@ async def _send_discord(token, chat_id, message, thread_id=None, media_files=Non
         auth_headers = {"Authorization": f"Bot {token}"}
         json_headers = {**auth_headers, "Content-Type": "application/json"}
         media_files = media_files or []
+        embeds = [discord_embed] if isinstance(discord_embed, dict) else []
         last_data = None
         warnings = []
 
@@ -1137,6 +1143,8 @@ async def _send_discord(token, chat_id, message, thread_id=None, media_files=Non
                             for idx, path in enumerate(valid_media)
                         ]
                         starter_message = {"content": message, "attachments": attachments_meta}
+                        if embeds:
+                            starter_message["embeds"] = embeds
                         payload_json = json.dumps({"name": thread_name, "message": starter_message})
 
                         form = aiohttp.FormData()
@@ -1168,7 +1176,7 @@ async def _send_discord(token, chat_id, message, thread_id=None, media_files=Non
                             headers=json_headers,
                             json={
                                 "name": thread_name,
-                                "message": {"content": message},
+                                "message": {k: v for k, v in {"content": message, "embeds": embeds or None}.items() if v},
                             },
                             **_req_kw,
                         ) as resp:
@@ -1194,8 +1202,11 @@ async def _send_discord(token, chat_id, message, thread_id=None, media_files=Non
 
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30), **_sess_kw) as session:
             # Send text message (skip if empty and media is present)
-            if message.strip() or not media_files:
-                async with session.post(url, headers=json_headers, json={"content": message}, **_req_kw) as resp:
+            if message.strip() or embeds or not media_files:
+                payload = {"content": message}
+                if embeds:
+                    payload["embeds"] = embeds
+                async with session.post(url, headers=json_headers, json=payload, **_req_kw) as resp:
                     if resp.status not in {200, 201}:
                         body = await resp.text()
                         return _error(f"Discord API error ({resp.status}): {body}")


### PR DESCRIPTION
## Summary
- carry `HERMES_DISCORD_EMBED` cron markers through scheduler delivery
- send embed metadata through live Discord adapter and standalone REST fallback
- preserve embed-only Discord sends and add regression coverage

## Tests
- `scripts/run_tests.sh tests/gateway/test_discord_free_response.py tests/cron/test_scheduler.py::TestDeliverResultWrapping tests/tools/test_send_message_tool.py::TestSendToPlatformChunking tests/gateway/test_discord_send.py -q --tb=short`
- Result: 83 passed

## Notes
- Includes the existing local wake-word prefix commit that was ahead of main before this fix, rebased onto current origin/main.
- Gateway/cron restart is required after merge/deploy for long-lived processes to pick up changed Python modules.