### PR TITLE
fix(openviking): add on_session_switch to update cached session_id

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -583,6 +583,27 @@ class OpenVikingMemoryProvider(MemoryProvider):
         )
         self._sync_thread.start()
 
+    def on_session_switch(
+        self,
+        new_session_id: str,
+        *,
+        parent_session_id: str = "",
+        reset: bool = False,
+        **kwargs,
+    ) -> None:
+        """Update cached session state when the agent rotates session_id.
+
+        Without this hook, ``_session_id`` keeps pointing at the previous
+        session and subsequent ``sync_turn`` writes land in the old session.
+        """
+        if new_session_id and new_session_id != self._session_id:
+            logger.debug(
+                "OpenViking session switch: %s → %s (parent=%s reset=%s)",
+                self._session_id, new_session_id, parent_session_id, reset,
+            )
+            self._session_id = new_session_id
+            self._turn_count = 0
+
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
         """Commit the session to trigger memory extraction.
 

--- a/tests/plugins/test_openviking_session_switch.py
+++ b/tests/plugins/test_openviking_session_switch.py
@@ -1,0 +1,58 @@
+"""Tests for OpenVikingMemoryProvider.on_session_switch.
+
+Covers #28296: after /new, /branch, or context compression the provider's
+cached ``_session_id`` must be updated so subsequent sync_turn writes land
+in the correct session.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def provider():
+    """Create an OpenVikingMemoryProvider with faked config."""
+    with patch.dict(
+        "os.environ",
+        {"OPENVIKING_ENDPOINT": "http://localhost:9101", "OPENVIKING_API_KEY": "test"},
+    ):
+        from plugins.memory.openviking import OpenVikingMemoryProvider
+
+        p = OpenVikingMemoryProvider()
+        p._session_id = "old-session"
+        p._turn_count = 5
+        return p
+
+
+class TestOpenVikingSessionSwitch:
+    def test_updates_session_id(self, provider):
+        """on_session_switch should update _session_id to the new value."""
+        provider.on_session_switch("new-session")
+        assert provider._session_id == "new-session"
+
+    def test_resets_turn_count(self, provider):
+        """on_session_switch should reset _turn_count to 0."""
+        assert provider._turn_count == 5
+        provider.on_session_switch("new-session")
+        assert provider._turn_count == 0
+
+    def test_noop_when_same_session(self, provider):
+        """on_session_switch should be a no-op when session_id unchanged."""
+        provider.on_session_switch("old-session")
+        assert provider._session_id == "old-session"
+        assert provider._turn_count == 5
+
+    def test_noop_when_empty_new_session(self, provider):
+        """on_session_switch should be a no-op when new_session_id is empty."""
+        provider.on_session_switch("")
+        assert provider._session_id == "old-session"
+        assert provider._turn_count == 5
+
+    def test_passes_parent_and_reset_kwargs(self, provider):
+        """on_session_switch should accept parent_session_id and reset kwargs."""
+        provider.on_session_switch(
+            "branch-session", parent_session_id="old-session", reset=True
+        )
+        assert provider._session_id == "branch-session"
+        assert provider._turn_count == 0


### PR DESCRIPTION
## Problem

`OpenVikingMemoryProvider` caches `_session_id` in `initialize()` but does **not** override `on_session_switch()`. When the agent rotates its `session_id` mid-process (via `/new`, `/branch`, context compression), the provider's cached value stays at the old session — all subsequent `sync_turn` writes land in the old session's record and `on_session_end()` commits the old session repeatedly while the new session accumulates zero turns.

Other providers (e.g. Hindsight) already implement this hook. OpenViking is the only one missing it.

## Solution

Add `on_session_switch()` to `OpenVikingMemoryProvider`:

```python
def on_session_switch(self, new_session_id, *, parent_session_id="", reset=False, **kwargs):
    if new_session_id and new_session_id != self._session_id:
        self._session_id = new_session_id
        self._turn_count = 0
```

The guard `new_session_id and new_session_id != self._session_id` skips no-op switches (empty new id or same session).

## Testing

- 5 new unit tests covering: session_id update, turn_count reset, same-session noop, empty-session noop, and kwarg passthrough
- All 5 tests pass
- No network calls required (all mocked)

Fixes #28296
