### PR TITLE
feat(linear): resolve labels and assignees on create

### DIFF
--- a/skills/productivity/linear/SKILL.md
+++ b/skills/productivity/linear/SKILL.md
@@ -190,6 +190,11 @@ curl -s -X POST https://api.linear.app/graphql \
   }' | python3 -m json.tool
 ```
 
+The script’s `create-issue` command also resolves `--label` and `--assignee`
+values before mutation:
+`--label` is matched against label `name` and sent as `labelIds`; `--assignee`
+is matched against user `name` or `email` and sent as `assigneeId`.
+
 ### Update issue status
 First get the target state UUID from the workflow states query above, then:
 ```bash

--- a/skills/productivity/linear/scripts/linear_api.py
+++ b/skills/productivity/linear/scripts/linear_api.py
@@ -131,6 +131,28 @@ def _resolve_team_id(key_or_name: str) -> str | None:
     return None
 
 
+def _resolve_label_id(name: str) -> str | None:
+    """Map a label name to UUID."""
+    q = "query { issueLabels(first: 200) { nodes { id name } } }"
+    labels = gql(q).get("issueLabels", {}).get("nodes", [])
+    nl = name.lower()
+    for label in labels:
+        if label["name"].lower() == nl:
+            return label["id"]
+    return None
+
+
+def _resolve_assignee_id(name_or_email: str) -> str | None:
+    """Map assignee name or email to UUID."""
+    q = "query { users(first: 200) { nodes { id name email } } }"
+    users = gql(q).get("users", {}).get("nodes", [])
+    nl = name_or_email.lower()
+    for user in users:
+        if user["name"].lower() == nl or (user.get("email", "") or "").lower() == nl:
+            return user["id"]
+    return None
+
+
 def cmd_list_projects(args: argparse.Namespace) -> None:
     if args.team:
         tid = _resolve_team_id(args.team)
@@ -229,7 +251,18 @@ def cmd_create_issue(args: argparse.Namespace) -> None:
         inp["priority"] = args.priority
     if args.parent:
         inp["parentId"] = args.parent
-    # TODO: label + assignee name->id lookup (omitted for v1 brevity)
+    if args.label:
+        label_id = _resolve_label_id(args.label)
+        if not label_id:
+            sys.stderr.write(f"Label not found: {args.label}\n")
+            sys.exit(1)
+        inp["labelIds"] = [label_id]
+    if args.assignee:
+        assignee_id = _resolve_assignee_id(args.assignee)
+        if not assignee_id:
+            sys.stderr.write(f"Assignee not found: {args.assignee}\n")
+            sys.exit(1)
+        inp["assigneeId"] = assignee_id
 
     q = """mutation($input: IssueCreateInput!) {
       issueCreate(input: $input) {

--- a/tests/skills/test_linear_api.py
+++ b/tests/skills/test_linear_api.py
@@ -1,0 +1,127 @@
+"""Tests for Linear script helpers."""
+
+import importlib.util
+import io
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+SKILL_API = (
+    Path(__file__).resolve().parents[2]
+    / "skills/productivity/linear/scripts/linear_api.py"
+)
+
+
+def _load_linear_api_module():
+    spec = importlib.util.spec_from_file_location("linear_api_test", SKILL_API)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_response(payload: dict) -> MagicMock:
+    resp = MagicMock()
+    resp.read.return_value = json.dumps(payload).encode("utf-8")
+    resp.__enter__.return_value = resp
+    resp.__exit__.return_value = False
+    return resp
+
+
+def _mock_urlopen(payloads: list[dict], captured_calls: list[dict]):
+    iterator = iter(payloads)
+
+    def _fake_urlopen(request, **_):
+        captured_calls.append(json.loads(request.data.decode("utf-8")))
+        return _make_response(next(iterator))
+
+    return _fake_urlopen
+
+
+@pytest.fixture
+def linear_api_module(monkeypatch):
+    monkeypatch.setenv("LINEAR_API_KEY", "lin_api_test")
+    return _load_linear_api_module()
+
+
+def test_create_issue_resolves_label_and_assignee(linear_api_module):
+    calls: list[dict] = []
+
+    payloads = [
+        {"data": {"teams": {"nodes": [{"id": "team-id", "key": "ENG", "name": "Engineers"}]}}},
+        {"data": {"issueLabels": {"nodes": [{"id": "label-id", "name": "bug"}]}}},
+        {"data": {"users": {"nodes": [{"id": "user-id", "name": "Alice", "email": "alice@example.com"}]}}},
+        {"data": {"issueCreate": {"success": True, "issue": {"identifier": "ENG-1"}}}},
+    ]
+
+    with patch("urllib.request.urlopen", side_effect=_mock_urlopen(payloads, calls)):
+        linear_api_module.main([
+            "create-issue",
+            "--title",
+            "Fix login",
+            "--team",
+            "ENG",
+            "--label",
+            "Bug",
+            "--assignee",
+            "alice@example.com",
+        ])
+
+    assert calls[0]["query"].startswith("query")
+    assert "issueLabels" in calls[1]["query"]
+    assert "users" in calls[2]["query"]
+    assert "issueCreate" in calls[3]["query"]
+    mutation_input = calls[3]["variables"]["input"]
+    assert mutation_input["teamId"] == "team-id"
+    assert mutation_input["labelIds"] == ["label-id"]
+    assert mutation_input["assigneeId"] == "user-id"
+
+
+@pytest.mark.parametrize("field_name", ["label", "assignee"])
+def test_create_issue_not_found_exits(linear_api_module, field_name):
+    err = io.StringIO()
+    calls: list[dict] = []
+
+    if field_name == "label":
+        payloads = [
+            {"data": {"teams": {"nodes": [{"id": "team-id", "key": "ENG", "name": "Engineers"}]}}},
+            {"data": {"issueLabels": {"nodes": [{"id": "other-label", "name": "feature"}]}}},
+        ]
+        args = [
+            "create-issue",
+            "--title",
+            "Fix login",
+            "--team",
+            "ENG",
+            "--label",
+            "Bug",
+        ]
+        expected_message = "Label not found: Bug"
+    else:
+        payloads = [
+            {"data": {"teams": {"nodes": [{"id": "team-id", "key": "ENG", "name": "Engineers"}]}}},
+            {"data": {"users": {"nodes": [{"id": "user-id", "name": "Alice", "email": "alice@example.com"}]}}},
+        ]
+        args = [
+            "create-issue",
+            "--title",
+            "Fix login",
+            "--team",
+            "ENG",
+            "--assignee",
+            "Missing Person",
+        ]
+        expected_message = "Assignee not found: Missing Person"
+
+    with patch.object(linear_api_module.sys, "stderr", err), patch(
+        "urllib.request.urlopen", side_effect=_mock_urlopen(payloads, calls)
+    ):
+        with pytest.raises(SystemExit) as exc:
+            linear_api_module.main(args)
+
+    assert exc.value.code == 1
+    assert expected_message in err.getvalue()
+    assert "issueCreate" not in calls[-1]["query"]

--- a/website/docs/user-guide/skills/bundled/productivity/productivity-linear.md
+++ b/website/docs/user-guide/skills/bundled/productivity/productivity-linear.md
@@ -205,6 +205,11 @@ curl -s -X POST https://api.linear.app/graphql \
   }' | python3 -m json.tool
 ```
 
+The script’s `create-issue` command also resolves `--label` and `--assignee`
+values before mutation:
+`--label` is matched against label `name` and sent as `labelIds`; `--assignee`
+is matched against user `name` or `email` and sent as `assigneeId`.
+
 ### Update issue status
 First get the target state UUID from the workflow states query above, then:
 ```bash


### PR DESCRIPTION
## Summary\n- implement Linear create-issue --label name -> labelIds resolution\n- implement --assignee name/email -> assigneeId resolution\n- add mocked stdlib tests for success and not-found paths\n- update Linear skill docs and generated bundled docs\n\n## Test plan\n- ./scripts/run_tests.sh tests/skills/test_linear_api.py -q\n- python -m py_compile skills/productivity/linear/scripts/linear_api.py\n- git diff --check