### PR TITLE
fix(gateway): make restart --all atomic on macOS

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5240,16 +5240,29 @@ def _gateway_command_inner(args):
 
         if restart_all:
             # --all: stop every gateway process across all profiles, then start fresh
+            if is_macos() and get_launchd_plist_path().exists():
+                # `launchd_stop` calls `launchctl bootout`, which unloads the
+                # service definition. If this CLI is interrupted before
+                # `launchd_start` re-bootstraps the plist, the gateway stays
+                # dead — KeepAlive cannot revive an unloaded service. Use
+                # `launchd_restart` (`launchctl kickstart -k`) instead: it
+                # cycles the running process atomically without unload.
+                try:
+                    from gateway.status import get_running_pid
+                    current_pid = get_running_pid(cleanup_stale=False)
+                except Exception:
+                    current_pid = None
+                exclude = {current_pid} if current_pid else set()
+                killed = kill_gateway_processes(exclude_pids=exclude, all_profiles=True)
+                if killed:
+                    print(f"✓ Stopped {killed} gateway process(es) from other profiles")
+                launchd_restart()
+                return
+
             service_stopped = False
             if supports_systemd_services() and (get_systemd_unit_path(system=False).exists() or get_systemd_unit_path(system=True).exists()):
                 try:
                     systemd_stop(system=system)
-                    service_stopped = True
-                except subprocess.CalledProcessError:
-                    pass
-            elif is_macos() and get_launchd_plist_path().exists():
-                try:
-                    launchd_stop()
                     service_stopped = True
                 except subprocess.CalledProcessError:
                     pass
@@ -5271,8 +5284,6 @@ def _gateway_command_inner(args):
             print("Starting gateway...")
             if supports_systemd_services() and (get_systemd_unit_path(system=False).exists() or get_systemd_unit_path(system=True).exists()):
                 systemd_start(system=system)
-            elif is_macos() and get_launchd_plist_path().exists():
-                launchd_start()
             elif is_windows():
                 from hermes_cli import gateway_windows
                 # On Windows, even without a registered Scheduled Task / Startup


### PR DESCRIPTION
## What does this PR do?

Fixes a non-atomic restart path. `hermes gateway restart --all` on macOS calls `launchd_stop()` (`launchctl bootout` → unloads the service) and only later calls `launchd_start()` (`bootstrap`). If the CLI dies between the two — closed pane, Ctrl+C, SIGHUP — the launchd service stays unloaded and the gateway can't be revived by KeepAlive.

This PR replaces that path with `launchd_restart()` (`launchctl kickstart -k`), which cycles the process atomically under the same launchd job. Other-profile processes are still swept via `kill_gateway_processes`, with the current PID excluded.

## Related Issue

Fixes #28632

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `hermes_cli/gateway.py:5234-5287` (`_gateway_command_inner`, `restart --all`): macOS branch now uses `launchd_restart()`; systemd/Windows untouched.

## How to Test

**Repro (without fix):**
1. `hermes gateway start`; confirm in `launchctl list`.
2. `hermes gateway restart --all` from a closable pane.
3. Close the pane immediately.
4. `launchctl list | grep ai.hermes.gateway` → empty.

**Verify (with fix):**
1–3 as above. Step 4 → service still loaded with a new PID.

**Sanity:** `scripts/run_tests.sh tests/hermes_cli/test_gateway_service.py tests/hermes_cli/test_update_gateway_restart.py tests/hermes_cli/test_gateway.py` — 202 pass, 1 skipped, 6 pre-existing systemd-on-macOS env failures that also fail on `origin/main` (no D-Bus session).

## Checklist

- [x] Contributing Guide read
- [x] Conventional Commits
- [x] No duplicate PR
- [x] Single focused change
- [x] Tests pass (gateway-related, on macOS; systemd failures are pre-existing env mismatches)
- [ ] Tests added — happy to add a subprocess-mocked test asserting `kickstart -k` is used instead of `bootout`+`bootstrap`; reviewer's call
- [x] Tested on macOS 15.4 (Darwin 25.4.0, arm64)
- [x] Docs / config / cross-platform considered — N/A or unchanged

## Logs

```
12:13:10.159  bootout initiated by: launchctl<-python3.11<-zsh<-zellij
12:13:11.088  removing service: ai.hermes.gateway
(no subsequent bootstrap)
```
