### PR TITLE
fix(agent+gateway): drain pending messages when interrupt arrives during context compaction

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -456,6 +456,7 @@ def run_conversation(
             # context windows (each pass summarises the middle N turns).
             for _pass in range(3):
                 _orig_len = len(messages)
+                _pre_compress_interrupted = agent._interrupt_requested
                 messages, active_system_prompt = agent._compress_context(
                     messages, system_message, approx_tokens=_preflight_tokens,
                     task_id=effective_task_id,
@@ -486,6 +487,16 @@ def run_conversation(
                 )
                 if _preflight_tokens < agent.context_compressor.threshold_tokens:
                     break  # Under threshold
+                # If an interrupt arrived during preflight compression,
+                # stop compressing and let the tool loop detect the
+                # interrupt on its first iteration.  See #28093.
+                if not _pre_compress_interrupted and agent._interrupt_requested:
+                    logger.info(
+                        "%sInterrupt arrived during preflight compression "
+                        "— aborting multi-pass compression to drain pending",
+                        agent.log_prefix,
+                    )
+                    break
 
     # Plugin hook: pre_llm_call
     # Fired once per turn before the tool-calling loop.  Plugins can
@@ -3399,6 +3410,15 @@ def run_conversation(
 
                 if agent.compression_enabled and _compressor.should_compress(_real_tokens):
                     agent._safe_print("  ⟳ compacting context…")
+                    # Snapshot interrupt state BEFORE compression. If an
+                    # interrupt arrives during _compress_context (which is
+                    # synchronous and long-running), the interrupt flag will
+                    # be set but won't be checked until the next loop
+                    # iteration.  Record the pre-compression message count
+                    # so the post-compression check can detect whether
+                    # the interrupt message should take priority over
+                    # continued tool calling.  See #28093.
+                    _pre_compress_interrupted = agent._interrupt_requested
                     messages, active_system_prompt = agent._compress_context(
                         messages, system_message,
                         approx_tokens=agent.context_compressor.last_prompt_tokens,
@@ -3408,6 +3428,18 @@ def run_conversation(
                     # _flush_messages_to_session_db writes compressed messages
                     # to the new session (see preflight compression comment).
                     conversation_history = None
+                    # If an interrupt arrived during compression, break out
+                    # immediately so the gateway can drain the pending
+                    # message without waiting for another tool-call round.
+                    if not _pre_compress_interrupted and agent._interrupt_requested:
+                        logger.info(
+                            "%sInterrupt arrived during compression — "
+                            "breaking out to drain pending message",
+                            agent.log_prefix,
+                        )
+                        interrupted = True
+                        _turn_exit_reason = "interrupted_by_user"
+                        break
                 
                 # Save session log incrementally (so progress is visible even if interrupted)
                 agent._session_messages = messages

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3558,9 +3558,35 @@ class BasePlatformAdapter(ABC):
                 # same session.
                 current_task = asyncio.current_task()
                 if current_task is not None and self._session_tasks.get(session_key) is current_task:
+                    # Defensive check (#28093): before releasing the guard,
+                    # verify no pending message arrived between the
+                    # late-arrival drain above and this cleanup.  Under
+                    # heavy load or during context compaction, a message
+                    # can slip through the timing gap.
+                    _orphan = self._pending_messages.pop(session_key, None)
+                    if _orphan is not None:
+                        logger.warning(
+                            "[%s] Orphaned pending message detected during "
+                            "cleanup for %s — re-spawning drain task to "
+                            "prevent silent drop",
+                            self.name, session_key,
+                        )
+                        _active = self._active_sessions.get(session_key)
+                        if _active is not None:
+                            _active.clear()
+                        drain_task = asyncio.create_task(
+                            self._process_message_background(_orphan, session_key)
+                        )
+                        self._session_tasks[session_key] = drain_task
+                        try:
+                            self._background_tasks.add(drain_task)
+                            drain_task.add_done_callback(self._background_tasks.discard)
+                        except TypeError:
+                            pass
+                        return  # drain task owns the session now
                     del self._session_tasks[session_key]
                     self._release_session_guard(session_key, guard=interrupt_event)
-    
+
     async def cancel_background_tasks(self) -> None:
         """Cancel any in-flight background message-processing tasks.
 


### PR DESCRIPTION
## Summary

Fixes #28093

When a user sends a message during active agent processing, and context compaction triggers on the agent's response turn, the user's message can be delayed while the agent continues making API calls and tool executions it no longer needs to make.

### Root Cause

`_compress_context()` is synchronous and long-running. When an interrupt arrives during compression, the interrupt flag is set via `agent.interrupt()` from the gateway's async monitor, but it is not checked until the next tool-loop iteration — which may involve another full API call + tool execution cycle before the loop condition evaluates `_interrupt_requested`.

This means the gateway's pending message sits in `_pending_messages` longer than necessary, and in edge cases (e.g. SSE listener reconnection, rapid message bursts), the timing gap can widen enough for the message to appear lost from the user's perspective.

### Changes

**Agent layer** (`agent/conversation_loop.py`):
- Snapshot interrupt state BEFORE each `_compress_context()` call (both preflight pass and mid-loop).
- After compression returns, check if an interrupt arrived during the compress. If so, break out of the tool loop immediately instead of continuing to the next iteration.
- This ensures the gateway can drain the pending message from `_pending_messages` as quickly as possible.

**Gateway layer** (`gateway/platforms/base.py`):
- Add an orphan-message safety net in `_process_message_background`'s finally block: before releasing the session guard, re-check `_pending_messages` one final time. If a message arrived between the late-arrival drain and cleanup, spawn a drain task instead of silently dropping it.
- This is a defensive last-resort guard that should never fire under normal operation but prevents silent data loss if timing gaps emerge.

### Testing

- Syntax validation: both files pass `ast.parse()`.
- The changes are additive (no existing code paths removed) — they add early-exit paths and a safety-net recheck.

### Files Changed

- `agent/conversation_loop.py` — +32 lines (interrupt detection around both compression sites)
- `gateway/platforms/base.py` — +27 lines (orphan-message safety net in finally block)