### PR TITLE
fix(kanban): add dispatcher preflight guards

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2529,13 +2529,17 @@ class GatewayRunner:
                 logger.debug("Failed interrupting agent during shutdown: %s", e)
 
     async def _notify_active_sessions_of_shutdown(self) -> None:
-        """Send shutdown/restart notifications to active chats and home channels.
+        """Send shutdown/restart notifications to active chats, with home fallback.
 
         Called at the very start of stop() — adapters are still connected so
         messages can be delivered. Best-effort: individual send failures are
-        logged and swallowed so they never block the shutdown sequence.
+        logged and swallowed so they never block the shutdown sequence. Home
+        channels are fallback-only: if any active session target is notified,
+        avoid duplicate lifecycle noise in the configured home channel.
         """
         active = self._snapshot_running_agents()
+        if not active:
+            return
 
         action = "restarting" if self._restart_requested else "shutting down"
         hint = (
@@ -2547,6 +2551,7 @@ class GatewayRunner:
         msg = f"⚠️ Gateway {action} — {hint}"
 
         notified: set[tuple[str, str, Optional[str]]] = set()
+        active_delivery_succeeded = False
         for session_key in active:
             source = None
             try:
@@ -2595,23 +2600,26 @@ class GatewayRunner:
                 result = await adapter.send(chat_id, msg, metadata=metadata)
                 if result is not None and getattr(result, "success", True) is False:
                     logger.debug(
-                        "Failed to send shutdown notification to %s:%s: %s",
+                        "Failed to send shutdown notification to active %s session: %s",
                         platform_str,
-                        chat_id,
                         getattr(result, "error", "send returned success=False"),
                     )
                     continue
 
                 notified.add(dedup_key)
+                active_delivery_succeeded = True
                 logger.info(
-                    "Sent shutdown notification to active chat %s:%s",
-                    platform_str, chat_id,
+                    "Sent shutdown notification to active %s session",
+                    platform_str,
                 )
             except Exception as e:
                 logger.debug(
-                    "Failed to send shutdown notification to %s:%s: %s",
-                    platform_str, chat_id, e,
+                    "Failed to send shutdown notification to active %s session: %s",
+                    platform_str, e,
                 )
+
+        if active_delivery_succeeded:
+            return
 
         for platform, adapter in self.adapters.items():
             home = self.config.get_home_channel(platform)
@@ -2630,24 +2638,21 @@ class GatewayRunner:
                     result = await adapter.send(str(home.chat_id), msg)
                 if result is not None and getattr(result, "success", True) is False:
                     logger.debug(
-                        "Failed to send shutdown notification to home channel %s:%s: %s",
+                        "Failed to send shutdown notification to %s home channel: %s",
                         platform.value,
-                        home.chat_id,
                         getattr(result, "error", "send returned success=False"),
                     )
                     continue
 
                 notified.add(dedup_key)
                 logger.info(
-                    "Sent shutdown notification to home channel %s:%s",
+                    "Sent shutdown notification to %s home channel",
                     platform.value,
-                    home.chat_id,
                 )
             except Exception as e:
                 logger.debug(
-                    "Failed to send shutdown notification to home channel %s:%s: %s",
+                    "Failed to send shutdown notification to %s home channel: %s",
                     platform.value,
-                    home.chat_id,
                     e,
                 )
 

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1268,6 +1268,7 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             "crashed": res.crashed,
             "timed_out": res.timed_out,
             "auto_blocked": res.auto_blocked,
+            "preflight_blocked": res.preflight_blocked,
             "promoted": res.promoted,
             "spawned": [
                 {"task_id": tid, "assignee": who, "workspace": ws}
@@ -1286,6 +1287,9 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
     print(f"Auto-blocked: {len(res.auto_blocked)}")
     if res.auto_blocked:
         print(f"  {', '.join(res.auto_blocked)}")
+    print(f"Preflight-blocked: {len(res.preflight_blocked)}")
+    if res.preflight_blocked:
+        print(f"  {', '.join(res.preflight_blocked)}")
     print(f"Promoted:     {res.promoted}")
     print(f"Spawned:      {len(res.spawned)}")
     for tid, who, ws in res.spawned:
@@ -1391,13 +1395,14 @@ def _cmd_daemon(args: argparse.Namespace) -> int:
             return
         did_work = (
             res.reclaimed or res.crashed or res.timed_out or res.promoted
-            or res.spawned or res.auto_blocked
+            or res.spawned or res.auto_blocked or res.preflight_blocked
         )
         if did_work:
             print(
                 f"[{_fmt_ts(int(time.time()))}] "
                 f"reclaimed={res.reclaimed} crashed={len(res.crashed)} "
                 f"timed_out={len(res.timed_out)} "
+                f"preflight_blocked={len(res.preflight_blocked)} "
                 f"promoted={res.promoted} spawned={len(res.spawned)} "
                 f"auto_blocked={len(res.auto_blocked)}",
                 flush=True,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2148,6 +2148,8 @@ class DispatchResult:
     spawned: list[tuple[str, str, str]] = field(default_factory=list)
     """List of ``(task_id, assignee, workspace_path)`` triples."""
     skipped_unassigned: list[str] = field(default_factory=list)
+    skipped_non_runnable: list[str] = field(default_factory=list)
+    """Human/approval tasks intentionally not auto-spawned."""
     crashed: list[str] = field(default_factory=list)
     """Task ids reclaimed because their worker PID disappeared."""
     auto_blocked: list[str] = field(default_factory=list)
@@ -2496,6 +2498,63 @@ def _clear_spawn_failures(conn: sqlite3.Connection, task_id: str) -> None:
         )
 
 
+def _configured_runnable_human_assignees() -> set[str]:
+    """Return human-like assignees explicitly allowed to auto-dispatch.
+
+    Human approval tasks are board coordination artifacts by default, not
+    runnable worker profiles. Operators can opt a specific human-like profile
+    back into dispatch with either:
+
+    * ``HERMES_KANBAN_RUNNABLE_HUMAN_ASSIGNEES=human-alice,human-bob``; or
+    * ``kanban.runnable_human_assignees`` in config.yaml.
+
+    ``*`` allows all human-like assignees for private installs that
+    intentionally name real worker profiles ``human-*``.
+    """
+    raw_items: list[str] = []
+    env = os.environ.get("HERMES_KANBAN_RUNNABLE_HUMAN_ASSIGNEES", "")
+    if env.strip():
+        raw_items.extend(env.split(","))
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        configured = (cfg.get("kanban") or {}).get("runnable_human_assignees")
+        if isinstance(configured, str):
+            raw_items.extend(configured.split(","))
+        elif isinstance(configured, (list, tuple, set)):
+            raw_items.extend(str(x) for x in configured)
+    except Exception:
+        pass
+    return {item.strip().lower() for item in raw_items if item and item.strip()}
+
+
+def _is_non_runnable_human_task(
+    *,
+    assignee: Optional[str],
+    title: Optional[str],
+    runnable_human_assignees: Optional[set[str]] = None,
+) -> bool:
+    """Return True when a ready task should not be auto-spawned.
+
+    ``human-*`` assignees and explicit ``[HUMAN]`` / ``[APPROVAL]`` title
+    markers represent human-in-the-loop work. Spawning ``hermes -p`` for
+    those tasks causes crash loops instead of closing the approval loop.
+    """
+    assignee_norm = (assignee or "").strip().lower()
+    title_norm = (title or "").strip().lower()
+    looks_human = (
+        assignee_norm.startswith("human-")
+        or "[human]" in title_norm
+        or "[approval]" in title_norm
+    )
+    if not looks_human:
+        return False
+    allowed = runnable_human_assignees
+    if allowed is None:
+        allowed = _configured_runnable_human_assignees()
+    return "*" not in allowed and assignee_norm not in allowed
+
+
 def dispatch_once(
     conn: sqlite3.Connection,
     *,
@@ -2531,8 +2590,9 @@ def dispatch_once(
     result.timed_out = enforce_max_runtime(conn)
     result.promoted = recompute_ready(conn)
 
+    runnable_humans = _configured_runnable_human_assignees()
     ready_rows = conn.execute(
-        "SELECT id, assignee FROM tasks "
+        "SELECT id, title, assignee FROM tasks "
         "WHERE status = 'ready' AND claim_lock IS NULL "
         "ORDER BY priority DESC, created_at ASC"
     ).fetchall()
@@ -2542,6 +2602,13 @@ def dispatch_once(
             break
         if not row["assignee"]:
             result.skipped_unassigned.append(row["id"])
+            continue
+        if _is_non_runnable_human_task(
+            assignee=row["assignee"],
+            title=row["title"],
+            runnable_human_assignees=runnable_humans,
+        ):
+            result.skipped_non_runnable.append(row["id"])
             continue
         if dry_run:
             result.spawned.append((row["id"], row["assignee"], ""))

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1729,7 +1729,7 @@ def claim_task(
                SET status        = 'running',
                    claim_lock    = ?,
                    claim_expires = ?,
-                   started_at    = COALESCE(started_at, ?)
+                   started_at    = ?
              WHERE id = ?
                AND status = 'ready'
                AND claim_lock IS NULL
@@ -2268,17 +2268,28 @@ def enforce_max_runtime(
     host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
 
     rows = conn.execute(
-        "SELECT id, worker_pid, started_at, max_runtime_seconds, claim_lock "
-        "FROM tasks "
-        "WHERE status = 'running' AND max_runtime_seconds IS NOT NULL "
-        "  AND started_at IS NOT NULL AND worker_pid IS NOT NULL"
+        """
+        SELECT t.id,
+               COALESCE(r.worker_pid, t.worker_pid) AS worker_pid,
+               COALESCE(r.started_at, t.started_at) AS run_started_at,
+               COALESCE(r.max_runtime_seconds, t.max_runtime_seconds) AS max_runtime_seconds,
+               COALESCE(r.claim_lock, t.claim_lock) AS claim_lock
+          FROM tasks t
+          LEFT JOIN task_runs r ON r.id = t.current_run_id
+         WHERE t.status = 'running'
+           AND COALESCE(r.max_runtime_seconds, t.max_runtime_seconds) IS NOT NULL
+           AND COALESCE(r.started_at, t.started_at) IS NOT NULL
+           AND COALESCE(r.worker_pid, t.worker_pid) IS NOT NULL
+           AND (t.current_run_id IS NULL OR r.status = 'running')
+        """
     ).fetchall()
     for row in rows:
         lock = row["claim_lock"] or ""
         if not lock.startswith(host_prefix):
             continue
-        elapsed = now - int(row["started_at"])
-        if elapsed < int(row["max_runtime_seconds"]):
+        elapsed = now - int(row["run_started_at"])
+        limit = int(row["max_runtime_seconds"])
+        if elapsed < limit:
             continue
 
         pid = int(row["worker_pid"])
@@ -2316,7 +2327,7 @@ def enforce_max_runtime(
                 (
                     f"ORCHESTRATOR_PROCESS_BLOCK: worker exceeded "
                     f"max_runtime_seconds ({int(elapsed)}s > "
-                    f"{int(row['max_runtime_seconds'])}s); inspect/recover "
+                    f"{limit}s); inspect/recover "
                     f"before retry",
                     tid,
                 ),
@@ -2325,13 +2336,13 @@ def enforce_max_runtime(
                 payload = {
                     "pid": pid,
                     "elapsed_seconds": int(elapsed),
-                    "limit_seconds": int(row["max_runtime_seconds"]),
+                    "limit_seconds": limit,
                     "sigkill": killed,
                 }
                 run_id = _end_run(
                     conn, tid,
                     outcome="timed_out", status="timed_out",
-                    error=f"elapsed {int(elapsed)}s > limit {int(row['max_runtime_seconds'])}s",
+                    error=f"elapsed {int(elapsed)}s > limit {limit}s",
                     metadata=payload,
                 )
                 _append_event(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1810,17 +1810,47 @@ def heartbeat_claim(
 def release_stale_claims(conn: sqlite3.Connection) -> int:
     """Reset any ``running`` task whose claim has expired.
 
-    Returns the number of stale claims reclaimed.  Safe to call often.
+    If the expired claim still has a live worker PID on this host, do not
+    reclaim it. Extend the claim instead. This prevents the dispatcher from
+    spawning a duplicate worker while the original process is still making
+    progress but failed to heartbeat from inside a long LLM/tool loop.
+
+    Returns the number of claims actually reclaimed. Safe to call often.
     """
     now = int(time.time())
     reclaimed = 0
     with write_txn(conn):
         stale = conn.execute(
-            "SELECT id, claim_lock FROM tasks "
+            "SELECT id, claim_lock, worker_pid FROM tasks "
             "WHERE status = 'running' AND claim_expires IS NOT NULL AND claim_expires < ?",
             (now,),
         ).fetchall()
         for row in stale:
+            pid = row["worker_pid"]
+            if pid and _pid_alive(pid):
+                # PID is host-local and still alive. Treat the expired lease
+                # as a missed heartbeat rather than a dead worker. This keeps
+                # exactly one worker attached to the task and avoids duplicate
+                # writes into shared workspaces.
+                new_expires = now + DEFAULT_CLAIM_TTL_SECONDS
+                conn.execute(
+                    "UPDATE tasks SET claim_expires = ?, last_heartbeat_at = ? "
+                    "WHERE id = ? AND status = 'running'",
+                    (new_expires, now, row["id"]),
+                )
+                run_id = _current_run_id(conn, row["id"])
+                if run_id is not None:
+                    conn.execute(
+                        "UPDATE task_runs SET claim_expires = ?, last_heartbeat_at = ? "
+                        "WHERE id = ?",
+                        (new_expires, now, run_id),
+                    )
+                _append_event(
+                    conn, row["id"], "heartbeat",
+                    {"note": "dispatcher lease extended for live worker after stale claim"},
+                    run_id=run_id,
+                )
+                continue
             conn.execute(
                 "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
                 "claim_expires = NULL, worker_pid = NULL "
@@ -2191,18 +2221,19 @@ def heartbeat_worker(
     """
     now = int(time.time())
     with write_txn(conn):
+        expires = now + DEFAULT_CLAIM_TTL_SECONDS
         cur = conn.execute(
-            "UPDATE tasks SET last_heartbeat_at = ? "
+            "UPDATE tasks SET last_heartbeat_at = ?, claim_expires = ? "
             "WHERE id = ? AND status = 'running'",
-            (now, task_id),
+            (now, expires, task_id),
         )
         if cur.rowcount != 1:
             return False
         run_id = _current_run_id(conn, task_id)
         if run_id is not None:
             conn.execute(
-                "UPDATE task_runs SET last_heartbeat_at = ? WHERE id = ?",
-                (now, run_id),
+                "UPDATE task_runs SET last_heartbeat_at = ?, claim_expires = ? WHERE id = ?",
+                (now, expires, run_id),
             )
         _append_event(
             conn, task_id, "heartbeat",
@@ -2220,10 +2251,10 @@ def enforce_max_runtime(
     """Terminate workers whose per-task ``max_runtime_seconds`` has elapsed.
 
     Sends SIGTERM, waits a short grace window, then SIGKILL. Emits a
-    ``timed_out`` event and drops the task back to ``ready`` so the next
-    dispatcher tick re-spawns it — unless the spawn-failure circuit
-    breaker has already given up, in which case the task stays blocked
-    where ``_record_spawn_failure`` parked it.
+    ``timed_out`` event and blocks the logical task instead of dropping it
+    back to ``ready``. A timeout usually means the task needs decomposition,
+    recovery, or an operator decision; automatic re-spawn can create an
+    infinite retry/start-ping loop.
 
     Runs host-local: only tasks claimed by this host are candidates
     (same reasoning as ``detect_crashed_workers``). ``signal_fn`` is a
@@ -2276,11 +2307,17 @@ def enforce_max_runtime(
 
         with write_txn(conn):
             cur = conn.execute(
-                "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
+                "UPDATE tasks SET status = 'blocked', claim_lock = NULL, "
                 "claim_expires = NULL, worker_pid = NULL, "
-                "last_heartbeat_at = NULL "
+                "last_heartbeat_at = NULL, result = ? "
                 "WHERE id = ? AND status = 'running'",
-                (tid,),
+                (
+                    f"ORCHESTRATOR_PROCESS_BLOCK: worker exceeded "
+                    f"max_runtime_seconds ({int(elapsed)}s > "
+                    f"{int(row['max_runtime_seconds'])}s); inspect/recover "
+                    f"before retry",
+                    tid,
+                ),
             )
             if cur.rowcount == 1:
                 payload = {

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2154,6 +2154,8 @@ class DispatchResult:
     """Task ids reclaimed because their worker PID disappeared."""
     auto_blocked: list[str] = field(default_factory=list)
     """Task ids auto-blocked by the spawn-failure circuit breaker."""
+    preflight_blocked: list[str] = field(default_factory=list)
+    """Task ids refused by pre-dispatch validation before worker spawn."""
     timed_out: list[str] = field(default_factory=list)
     """Task ids whose workers exceeded ``max_runtime_seconds``."""
 
@@ -2539,6 +2541,123 @@ def _configured_runnable_human_assignees() -> set[str]:
     return {item.strip().lower() for item in raw_items if item and item.strip()}
 
 
+def _strict_dispatch_preflight_enabled() -> bool:
+    """Return True when optional contract/workspace policy checks are enabled.
+
+    The profile-existence guard is always active for the real dispatcher.
+    These stricter checks are opt-in so existing lightweight boards that use
+    scratch tasks are not forced into the CAT-style task contract overnight.
+    """
+    env = os.environ.get("HERMES_KANBAN_STRICT_DISPATCH_PREFLIGHT", "").strip().lower()
+    if env in {"1", "true", "yes", "on"}:
+        return True
+    if env in {"0", "false", "no", "off"}:
+        return False
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        return bool((cfg.get("kanban") or {}).get("strict_dispatch_preflight", False))
+    except Exception:
+        return False
+
+
+def _selection_packet_must_not_spawn(task: Task) -> Optional[str]:
+    text = f"{task.title or ''}\n{task.body or ''}".lower()
+    if "selection packet" in text or "scheduler-visible selection packet" in text:
+        return "selection packet is a planning artifact and must not auto-dispatch"
+    if "[selection" in text or "[packet" in text:
+        return "selection/packet task marker is non-runnable"
+    return None
+
+
+def _validate_dispatch_contract(task: Task) -> Optional[str]:
+    """CAT-style task contract lint for strict dispatcher mode."""
+    text = f"{task.title or ''}\n{task.body or ''}".lower()
+    required_any = {
+        "workspace mode": ("workspace mode", "workspace_mode", "workspace:"),
+        "write authority": ("write authority", "write_authority"),
+        "mutation authority": (
+            "mutation authority", "kanban mutation", "cron mutation", "git mutation",
+        ),
+        "conflict boundary": ("conflict boundary", "max parallelism", "parallelism"),
+    }
+    missing = [label for label, needles in required_any.items() if not any(n in text for n in needles)]
+    if missing:
+        return "missing dispatch contract fields: " + ", ".join(missing)
+    return None
+
+
+def _validate_workspace_preflight(task: Task, workspace: Path) -> Optional[str]:
+    kind = task.workspace_kind or "scratch"
+    if kind in {"dir", "worktree"}:
+        if not Path(str(workspace)).is_absolute():
+            return f"workspace path is not absolute: {workspace}"
+    if kind == "dir" and not workspace.exists():
+        return f"dir workspace does not exist: {workspace}"
+    if kind == "worktree":
+        if not workspace.exists():
+            return f"worktree workspace does not exist: {workspace}"
+        if not (workspace / ".git").exists():
+            return f"worktree workspace is not a git worktree: {workspace}"
+        try:
+            import subprocess
+            top = subprocess.run(
+                ["git", "-C", str(workspace), "rev-parse", "--show-toplevel"],
+                capture_output=True, text=True, timeout=5,
+            )
+            if top.returncode != 0:
+                return f"worktree workspace is not inside a git checkout: {workspace}"
+        except Exception as exc:
+            return f"could not validate git worktree {workspace}: {exc}"
+    return None
+
+
+def _workspace_conflict_error(
+    conn: sqlite3.Connection, task: Task, workspace: Path,
+) -> Optional[str]:
+    rows = conn.execute(
+        "SELECT id, title FROM tasks "
+        "WHERE status = 'running' AND id != ? AND workspace_path = ? LIMIT 3",
+        (task.id, str(workspace)),
+    ).fetchall()
+    if rows:
+        ids = ", ".join(str(r["id"]) for r in rows)
+        return f"workspace already has running task(s): {ids}"
+    return None
+
+
+def _preflight_real_dispatch(
+    conn: sqlite3.Connection, task: Task, workspace: Path, *, strict: bool,
+) -> Optional[str]:
+    """Fail-closed guard run after claim but before worker spawn."""
+    if not task.assignee:
+        return f"task {task.id} has no assignee"
+    try:
+        from hermes_cli.profiles import normalize_profile_name, profile_exists
+        profile = normalize_profile_name(task.assignee)
+        if not profile_exists(profile):
+            return f"assignee profile does not exist: {profile}"
+    except Exception as exc:
+        return f"could not validate assignee profile {task.assignee!r}: {exc}"
+
+    selection_error = _selection_packet_must_not_spawn(task)
+    if selection_error:
+        return selection_error
+
+    conflict_error = _workspace_conflict_error(conn, task, workspace)
+    if conflict_error:
+        return conflict_error
+
+    if strict:
+        workspace_error = _validate_workspace_preflight(task, workspace)
+        if workspace_error:
+            return workspace_error
+        contract_error = _validate_dispatch_contract(task)
+        if contract_error:
+            return contract_error
+    return None
+
+
 def _is_non_runnable_human_task(
     *,
     assignee: Optional[str],
@@ -2602,6 +2721,7 @@ def dispatch_once(
     result.promoted = recompute_ready(conn)
 
     runnable_humans = _configured_runnable_human_assignees()
+    strict_preflight = _strict_dispatch_preflight_enabled()
     ready_rows = conn.execute(
         "SELECT id, title, assignee FROM tasks "
         "WHERE status = 'ready' AND claim_lock IS NULL "
@@ -2639,6 +2759,21 @@ def dispatch_once(
             continue
         # Persist the resolved workspace path so the worker can cd there.
         set_workspace_path(conn, claimed.id, str(workspace))
+        if spawn_fn is None:
+            preflight_error = _preflight_real_dispatch(
+                conn, claimed, workspace, strict=strict_preflight,
+            )
+            if preflight_error:
+                auto = _record_spawn_failure(
+                    conn,
+                    claimed.id,
+                    f"preflight: {preflight_error}",
+                    failure_limit=failure_limit,
+                )
+                result.preflight_blocked.append(claimed.id)
+                if auto:
+                    result.auto_blocked.append(claimed.id)
+                continue
         _spawn = spawn_fn if spawn_fn is not None else _default_spawn
         try:
             # Back-compat: older spawn_fn signatures accept only

--- a/run_agent.py
+++ b/run_agent.py
@@ -9415,6 +9415,23 @@ class AIAgent:
             )
 
     @staticmethod
+    def _kanban_complete_tool_succeeded(tool_name: str, tool_result: str) -> bool:
+        """Return True when kanban_complete reports a successful handoff.
+
+        Dispatcher-spawned workers must stop doing work immediately after a
+        successful completion write. Otherwise a model can keep issuing tool
+        calls after the board already says status=done, leaving post-complete
+        orphan work for the supervisor to kill.
+        """
+        if tool_name != "kanban_complete":
+            return False
+        try:
+            parsed = json.loads(tool_result)
+        except Exception:
+            return False
+        return bool(isinstance(parsed, dict) and parsed.get("ok") is True)
+
+    @staticmethod
     def _wrap_verbose(label: str, text: str, indent: str = "     ") -> str:
         """Word-wrap verbose tool output to fit the terminal width.
 
@@ -10190,6 +10207,29 @@ class AIAgent:
                 "tool_call_id": tool_call.id
             }
             messages.append(tool_msg)
+
+            if (
+                os.environ.get("HERMES_KANBAN_TASK")
+                and self._kanban_complete_tool_succeeded(function_name, function_result)
+            ):
+                # A completed Kanban worker has no authority to keep mutating
+                # the workspace/board. Synthesize skipped results for any
+                # remaining tool calls in this assistant turn so provider
+                # tool-call/result pairing stays valid, then return to the
+                # main loop where we emit a final response and exit.
+                for skipped_tc in assistant_message.tool_calls[i:]:
+                    skipped_name = skipped_tc.function.name
+                    messages.append({
+                        "role": "tool",
+                        "name": skipped_name,
+                        "content": (
+                            "[Tool execution skipped — kanban_complete "
+                            "succeeded; worker is exiting to prevent "
+                            "post-completion work]"
+                        ),
+                        "tool_call_id": skipped_tc.id,
+                    })
+                break
 
             # ── Per-tool /steer drain ───────────────────────────────────
             # Drain pending steer BETWEEN individual tool calls so the
@@ -13315,6 +13355,24 @@ class AIAgent:
                             pass
 
                     self._execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count)
+
+                    if os.environ.get("HERMES_KANBAN_TASK"):
+                        _tool_count = len(assistant_message.tool_calls or [])
+                        _recent_tool_msgs = messages[-_tool_count:] if _tool_count else []
+                        if any(
+                            isinstance(_msg, dict)
+                            and self._kanban_complete_tool_succeeded(
+                                _msg.get("name", ""),
+                                _msg.get("content", ""),
+                            )
+                            for _msg in _recent_tool_msgs
+                        ):
+                            final_response = (
+                                "Kanban task completed; worker exiting to "
+                                "prevent post-completion work."
+                            )
+                            messages.append({"role": "assistant", "content": final_response})
+                            break
 
                     if self._tool_guardrail_halt_decision is not None:
                         decision = self._tool_guardrail_halt_decision

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 import gateway.run as gateway_run
-from gateway.platforms.base import MessageEvent, MessageType
+from gateway.platforms.base import MessageEvent, MessageType, SendResult
 from gateway.restart import DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
 from gateway.session import SessionEntry, build_session_key
 from tests.gateway.restart_test_helpers import make_restart_runner, make_restart_source
@@ -283,3 +283,60 @@ async def test_shutdown_notification_uses_persisted_origin_for_colon_ids():
 
     assert adapter.send.await_count == 1
     assert adapter.send.await_args.args[0] == "!room123:example.org"
+
+
+@pytest.mark.asyncio
+async def test_shutdown_notification_threaded_active_session_skips_home_fallback():
+    """A successful threaded active-session notification should not also notify home."""
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[gateway_run.Platform.TELEGRAM].home_channel = gateway_run.HomeChannel(
+        platform=gateway_run.Platform.TELEGRAM,
+        chat_id="home-chat",
+        name="Home",
+    )
+    source = make_restart_source(chat_id="project-chat", chat_type="group", thread_id="topic-1")
+    session_key = build_session_key(source)
+    runner._running_agents[session_key] = MagicMock()
+    runner.session_store._entries = {
+        session_key: SessionEntry(
+            session_key=session_key,
+            session_id="sess-threaded",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            origin=source,
+            platform=source.platform,
+            chat_type=source.chat_type,
+        )
+    }
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    assert len(adapter.sent_calls) == 1
+    chat_id, _content, metadata = adapter.sent_calls[0]
+    assert chat_id == "project-chat"
+    assert metadata == {"thread_id": "topic-1"}
+
+
+@pytest.mark.asyncio
+async def test_shutdown_notification_uses_home_fallback_only_when_active_not_notified():
+    """Home fallback remains available when every active-session delivery fails."""
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[gateway_run.Platform.TELEGRAM].home_channel = gateway_run.HomeChannel(
+        platform=gateway_run.Platform.TELEGRAM,
+        chat_id="home-chat",
+        name="Home",
+    )
+    session_key = "agent:main:telegram:dm:active-chat"
+    runner._running_agents[session_key] = MagicMock()
+
+    async def fail_active_succeed_home(chat_id, content, reply_to=None, metadata=None):
+        adapter.sent_calls.append((chat_id, content, metadata))
+        if chat_id == "active-chat":
+            return SendResult(success=False, error="network error")
+        return SendResult(success=True, message_id="home-message")
+
+    adapter.send = fail_active_succeed_home
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    assert [call[0] for call in adapter.sent_calls] == ["active-chat", "home-chat"]

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -663,11 +663,17 @@ def test_max_runtime_terminates_overrun_worker(kanban_home):
             # Spawn by hand: claim + set pid + set started_at to the past.
             kb.claim_task(conn, tid)
             kb._set_worker_pid(conn, tid, os.getpid())   # any live pid works
-            # Backdate started_at so elapsed > limit.
+            # Backdate the active run so elapsed > limit.
             with kb.write_txn(conn):
+                run_id = kb._current_run_id(conn, tid)
+                assert run_id is not None
                 conn.execute(
                     "UPDATE tasks SET started_at = ? WHERE id = ?",
                     (int(time.time()) - 30, tid),
+                )
+                conn.execute(
+                    "UPDATE task_runs SET started_at = ? WHERE id = ?",
+                    (int(time.time()) - 30, run_id),
                 )
 
             timed_out = kb.enforce_max_runtime(conn, signal_fn=_signal_fn)
@@ -701,9 +707,15 @@ def test_max_runtime_none_means_no_cap(kanban_home):
         kb._set_worker_pid(conn, tid, os.getpid())
         # Backdate aggressively; no cap means we don't care.
         with kb.write_txn(conn):
+            run_id = kb._current_run_id(conn, tid)
+            assert run_id is not None
             conn.execute(
                 "UPDATE tasks SET started_at = ? WHERE id = ?",
                 (int(time.time()) - 100_000, tid),
+            )
+            conn.execute(
+                "UPDATE task_runs SET started_at = ? WHERE id = ?",
+                (int(time.time()) - 100_000, run_id),
             )
         timed_out = kb.enforce_max_runtime(conn)
         assert timed_out == []
@@ -748,9 +760,15 @@ def test_enforce_max_runtime_integrates_with_dispatch(kanban_home, monkeypatch):
         kb.claim_task(conn, tid)
         kb._set_worker_pid(conn, tid, os.getpid())
         with kb.write_txn(conn):
+            run_id = kb._current_run_id(conn, tid)
+            assert run_id is not None
             conn.execute(
                 "UPDATE tasks SET started_at = ? WHERE id = ?",
                 (int(time.time()) - 30, tid),
+            )
+            conn.execute(
+                "UPDATE task_runs SET started_at = ? WHERE id = ?",
+                (int(time.time()) - 30, run_id),
             )
         # Use enforce_max_runtime directly with our signal stub — dispatch_once
         # uses the default os.kill, but integration-wise calling
@@ -767,6 +785,70 @@ def test_enforce_max_runtime_integrates_with_dispatch(kanban_home, monkeypatch):
         task = kb.get_task(conn, tid)
         assert task.status == "blocked"
         assert res.spawned == []
+    finally:
+        conn.close()
+
+
+def test_max_runtime_uses_current_run_start_after_unblock(kanban_home, monkeypatch):
+    """A re-run must not time out against stale tasks.started_at from a
+    previous blocked attempt.
+
+    This reproduces the dispatcher-restart failure mode where a task with a
+    fresh task_runs.started_at was immediately blocked because the timeout
+    check used the logical task's old started_at value.
+    """
+    import hermes_cli.kanban_db as _kb
+
+    monkeypatch.setattr(_kb, "_pid_alive", lambda pid: False)
+    killed = []
+
+    def _signal(pid, sig):
+        killed.append((pid, sig))
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="rerun should use fresh run clock",
+            assignee="worker",
+            max_runtime_seconds=3600,
+        )
+
+        kb.claim_task(conn, tid)
+        stale_started_at = int(time.time()) - 28_000
+        with kb.write_txn(conn):
+            first_run_id = kb._current_run_id(conn, tid)
+            assert first_run_id is not None
+            conn.execute(
+                "UPDATE tasks SET started_at = ? WHERE id = ?",
+                (stale_started_at, tid),
+            )
+            conn.execute(
+                "UPDATE task_runs SET started_at = ? WHERE id = ?",
+                (stale_started_at, first_run_id),
+            )
+        assert kb.block_task(conn, tid, reason="operator recovery")
+        assert kb.unblock_task(conn, tid)
+
+        before_second_claim = int(time.time())
+        second = kb.claim_task(conn, tid)
+        assert second is not None
+        kb._set_worker_pid(conn, tid, os.getpid())
+
+        task = kb.get_task(conn, tid)
+        assert task.started_at >= before_second_claim
+        second_run_id = kb._current_run_id(conn, tid)
+        assert second_run_id is not None
+        second_run = conn.execute(
+            "SELECT started_at FROM task_runs WHERE id = ?",
+            (second_run_id,),
+        ).fetchone()
+        assert second_run["started_at"] >= before_second_claim
+
+        timed_out = kb.enforce_max_runtime(conn, signal_fn=_signal)
+        assert timed_out == []
+        assert killed == []
+        assert kb.get_task(conn, tid).status == "running"
     finally:
         conn.close()
 

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -24,12 +24,36 @@ from hermes_cli import kanban_db as kb
 from hermes_cli.kanban import run_slash
 
 
+_KANBAN_PATH_ENV_KEYS = (
+    "HERMES_KANBAN_TASK",
+    "HERMES_KANBAN_BOARD",
+    "HERMES_KANBAN_DB",
+    "HERMES_KANBAN_HOME",
+    "HERMES_KANBAN_WORKSPACES_ROOT",
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_kanban_path_env(monkeypatch):
+    """Keep tests isolated when pytest itself runs inside a Kanban worker."""
+    for key in _KANBAN_PATH_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
 
 @pytest.fixture
 def kanban_home(tmp_path, monkeypatch):
+    for key in (
+        "HERMES_KANBAN_TASK",
+        "HERMES_KANBAN_BOARD",
+        "HERMES_KANBAN_DB",
+        "HERMES_KANBAN_HOME",
+        "HERMES_KANBAN_WORKSPACES_ROOT",
+    ):
+        monkeypatch.delenv(key, raising=False)
     home = tmp_path / ".hermes"
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -619,7 +619,7 @@ def test_run_slash_every_verb_returns_sensible_output(kanban_home):
 
 def test_max_runtime_terminates_overrun_worker(kanban_home):
     """A running task whose elapsed time exceeds max_runtime_seconds gets
-    SIGTERM'd, emits a ``timed_out`` event, and goes back to ready."""
+    SIGTERM'd, emits a ``timed_out`` event, and is blocked for recovery."""
     killed = []
     def _signal_fn(pid, sig):
         killed.append((pid, sig))
@@ -651,9 +651,10 @@ def test_max_runtime_terminates_overrun_worker(kanban_home):
             assert killed and killed[0][0] == os.getpid()
 
             task = kb.get_task(conn, tid)
-            assert task.status == "ready",                 f"timed-out task should reset to ready, got {task.status}"
+            assert task.status == "blocked",                 f"timed-out task should block for recovery, got {task.status}"
             assert task.worker_pid is None
             assert task.last_heartbeat_at is None
+            assert task.result and task.result.startswith("ORCHESTRATOR_PROCESS_BLOCK")
 
             events = kb.list_events(conn, tid)
             assert any(e.kind == "timed_out" for e in events)
@@ -700,8 +701,7 @@ def test_create_task_persists_max_runtime(kanban_home):
 
 def test_enforce_max_runtime_integrates_with_dispatch(kanban_home, monkeypatch):
     """enforce_max_runtime + dispatch_once integrate cleanly — a timed-out
-    task goes through ``timed_out`` → ``ready`` and dispatch_once can then
-    re-spawn it without re-reporting the timeout."""
+    task is blocked for operator recovery and is not re-spawned in a retry loop."""
     import hermes_cli.kanban_db as _kb
     # Leave _pid_alive=True so the crash detector doesn't steal the task
     # before timeout enforcement runs. After SIGTERM in enforce_max_runtime,
@@ -737,12 +737,12 @@ def test_enforce_max_runtime_integrates_with_dispatch(kanban_home, monkeypatch):
         assert tid in before, "kernel enforce_max_runtime should catch the overrun"
 
         # Now a second dispatch_once run should be a no-op on this task
-        # (already released). Confirm the loop doesn't re-report it.
+        # (blocked for operator recovery). Confirm the dispatcher does not
+        # immediately re-spawn the same logical task.
         res = kb.dispatch_once(conn, spawn_fn=lambda t, ws: None)
         task = kb.get_task(conn, tid)
-        # After timeout, task is back in 'ready' and will be re-spawned
-        # by the same pass. That's the intended behaviour.
-        assert task.status in ("ready", "running")
+        assert task.status == "blocked"
+        assert res.spawned == []
     finally:
         conn.close()
 
@@ -760,6 +760,8 @@ def test_heartbeat_on_running_task(kanban_home):
         assert ok is True
         task = kb.get_task(conn, tid)
         assert task.last_heartbeat_at is not None
+        assert task.claim_expires is not None
+        assert task.claim_expires > int(time.time())
         events = kb.list_events(conn, tid)
         hb = [e for e in events if e.kind == "heartbeat"]
         assert len(hb) == 1

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -12,9 +12,33 @@ import pytest
 from hermes_cli import kanban_db as kb
 
 
+_KANBAN_PATH_ENV_KEYS = (
+    "HERMES_KANBAN_TASK",
+    "HERMES_KANBAN_BOARD",
+    "HERMES_KANBAN_DB",
+    "HERMES_KANBAN_HOME",
+    "HERMES_KANBAN_WORKSPACES_ROOT",
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_kanban_path_env(monkeypatch):
+    """Keep tests isolated when pytest itself runs inside a Kanban worker."""
+    for key in _KANBAN_PATH_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+
 @pytest.fixture
 def kanban_home(tmp_path, monkeypatch):
     """Isolated HERMES_HOME with an empty kanban DB."""
+    for key in (
+        "HERMES_KANBAN_TASK",
+        "HERMES_KANBAN_BOARD",
+        "HERMES_KANBAN_DB",
+        "HERMES_KANBAN_HOME",
+        "HERMES_KANBAN_WORKSPACES_ROOT",
+    ):
+        monkeypatch.delenv(key, raising=False)
     home = tmp_path / ".hermes"
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
@@ -365,6 +389,91 @@ def test_dispatch_skips_unassigned(kanban_home):
     assert not res.spawned
 
 
+def test_dispatch_skips_human_and_approval_tasks_by_default(kanban_home, monkeypatch):
+    """Human-in-the-loop tasks must not be claimed or spawned automatically."""
+    monkeypatch.delenv("HERMES_KANBAN_RUNNABLE_HUMAN_ASSIGNEES", raising=False)
+    spawns = []
+
+    def fake_spawn(task, workspace):
+        spawns.append(task.id)
+
+    with kb.connect() as conn:
+        human_assignee = kb.create_task(
+            conn,
+            title="Choose model/provider",
+            assignee="human-vladimir",
+        )
+        approval_marker = kb.create_task(
+            conn,
+            title="[APPROVAL][MODEL] Choose cheaper model/provider",
+            assignee="codex-test",
+        )
+        human_marker = kb.create_task(
+            conn,
+            title="[HUMAN] review security exception",
+            assignee="security-reviewer",
+        )
+        res = kb.dispatch_once(conn, spawn_fn=fake_spawn)
+
+        assert set(res.skipped_non_runnable) == {
+            human_assignee,
+            approval_marker,
+            human_marker,
+        }
+        assert spawns == []
+        for tid in (human_assignee, approval_marker, human_marker):
+            task = kb.get_task(conn, tid)
+            assert task.status == "ready"
+            assert task.claim_lock is None
+            assert task.current_run_id is None
+
+
+def test_dispatch_allows_explicitly_runnable_human_assignee(kanban_home, monkeypatch):
+    """Private installs can opt a human-* profile back into dispatch."""
+    monkeypatch.setenv("HERMES_KANBAN_RUNNABLE_HUMAN_ASSIGNEES", "human-vladimir")
+    spawns = []
+
+    def fake_spawn(task, workspace):
+        spawns.append(task.id)
+
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="real worker profile with legacy name",
+            assignee="human-vladimir",
+        )
+        res = kb.dispatch_once(conn, spawn_fn=fake_spawn)
+        task = kb.get_task(conn, tid)
+
+    assert res.skipped_non_runnable == []
+    assert spawns == [tid]
+    assert task.status == "running"
+
+
+def test_blocked_human_task_is_not_retried(kanban_home, monkeypatch):
+    """Blocked human approvals stay parked until a human unblocks them."""
+    monkeypatch.delenv("HERMES_KANBAN_RUNNABLE_HUMAN_ASSIGNEES", raising=False)
+    spawns = []
+
+    def fake_spawn(task, workspace):
+        spawns.append(task.id)
+
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="[APPROVAL] choose model",
+            assignee="human-vladimir",
+        )
+        assert kb.block_task(conn, tid, reason="needs human decision")
+        res = kb.dispatch_once(conn, spawn_fn=fake_spawn)
+        task = kb.get_task(conn, tid)
+
+    assert res.skipped_non_runnable == []
+    assert spawns == []
+    assert task.status == "blocked"
+    assert task.claim_lock is None
+
+
 def test_dispatch_promotes_ready_and_spawns(kanban_home):
     spawns = []
 
@@ -489,7 +598,14 @@ class TestSharedBoardPaths:
     def _set_home(self, monkeypatch, tmp_path, hermes_home):
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
-        monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
+        for key in (
+            "HERMES_KANBAN_TASK",
+            "HERMES_KANBAN_BOARD",
+            "HERMES_KANBAN_DB",
+            "HERMES_KANBAN_HOME",
+            "HERMES_KANBAN_WORKSPACES_ROOT",
+        ):
+            monkeypatch.delenv(key, raising=False)
 
     def test_default_install_anchors_at_home_dot_hermes(
         self, tmp_path, monkeypatch

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -182,6 +182,24 @@ def test_stale_claim_reclaimed(kanban_home):
         assert kb.get_task(conn, t).status == "ready"
 
 
+def test_stale_claim_with_live_worker_pid_is_extended_not_reclaimed(kanban_home):
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="a")
+        kb.claim_task(conn, t)
+        kb._set_worker_pid(conn, t, os.getpid())
+        conn.execute(
+            "UPDATE tasks SET claim_expires = ? WHERE id = ?",
+            (int(time.time()) - 3600, t),
+        )
+        reclaimed = kb.release_stale_claims(conn)
+        task = kb.get_task(conn, t)
+        assert reclaimed == 0
+        assert task.status == "running"
+        assert task.worker_pid == os.getpid()
+        assert task.claim_expires > int(time.time())
+        assert task.last_heartbeat_at is not None
+
+
 def test_heartbeat_extends_claim(kanban_home):
     with kb.connect() as conn:
         t = kb.create_task(conn, title="x", assignee="a")

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -507,6 +507,105 @@ def test_dispatch_spawn_failure_releases_claim(kanban_home):
         assert kb.get_task(conn, t).claim_lock is None
 
 
+def test_dispatch_preflight_blocks_missing_profile_before_spawn(kanban_home):
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="needs missing profile", assignee="ghost-profile")
+        res = kb.dispatch_once(conn, failure_limit=1)
+        task = kb.get_task(conn, t)
+
+    assert res.preflight_blocked == [t]
+    assert res.auto_blocked == [t]
+    assert res.spawned == []
+    assert task.status == "blocked"
+    assert "assignee profile does not exist" in task.last_spawn_error
+
+
+def test_dispatch_preflight_blocks_selection_packet_before_spawn(kanban_home):
+    with kb.connect() as conn:
+        t = kb.create_task(
+            conn,
+            title="Scheduler-visible selection packet",
+            body="Selection packet for future dispatcher; not executable.",
+            assignee="default",
+        )
+        res = kb.dispatch_once(conn, failure_limit=1)
+        task = kb.get_task(conn, t)
+
+    assert res.preflight_blocked == [t]
+    assert res.spawned == []
+    assert task.status == "blocked"
+    assert "selection packet" in task.last_spawn_error
+
+
+def test_strict_dispatch_preflight_requires_contract(kanban_home, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_STRICT_DISPATCH_PREFLIGHT", "1")
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="implementation without contract", assignee="default")
+        res = kb.dispatch_once(conn, failure_limit=1)
+        task = kb.get_task(conn, t)
+
+    assert res.preflight_blocked == [t]
+    assert res.spawned == []
+    assert task.status == "blocked"
+    assert "missing dispatch contract fields" in task.last_spawn_error
+
+
+def test_strict_dispatch_preflight_requires_existing_worktree(kanban_home, monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_KANBAN_STRICT_DISPATCH_PREFLIGHT", "1")
+    missing = tmp_path / ".worktrees" / "missing-task"
+    body = """
+    Workspace mode: worktree
+    Write authority: repo docs only
+    Kanban mutation authority: comments only
+    Max parallelism/conflict boundary: one writer
+    """
+    with kb.connect() as conn:
+        t = kb.create_task(
+            conn,
+            title="implementation with missing worktree",
+            body=body,
+            assignee="default",
+            workspace_kind="worktree",
+            workspace_path=str(missing),
+        )
+        res = kb.dispatch_once(conn, failure_limit=1)
+        task = kb.get_task(conn, t)
+
+    assert res.preflight_blocked == [t]
+    assert res.spawned == []
+    assert task.status == "blocked"
+    assert "worktree workspace does not exist" in task.last_spawn_error
+
+
+def test_dispatch_preflight_blocks_duplicate_running_workspace(kanban_home, tmp_path):
+    workspace = tmp_path / "shared"
+    workspace.mkdir()
+    with kb.connect() as conn:
+        running = kb.create_task(
+            conn,
+            title="first writer",
+            assignee="default",
+            workspace_kind="dir",
+            workspace_path=str(workspace),
+        )
+        assert kb.claim_task(conn, running) is not None
+        kb.set_workspace_path(conn, running, str(workspace))
+        contender = kb.create_task(
+            conn,
+            title="second writer",
+            assignee="default",
+            workspace_kind="dir",
+            workspace_path=str(workspace),
+        )
+        res = kb.dispatch_once(conn, failure_limit=1)
+        task = kb.get_task(conn, contender)
+
+    assert res.preflight_blocked == [contender]
+    assert res.spawned == []
+    assert task.status == "blocked"
+    assert "workspace already has running task" in task.last_spawn_error
+
+
 def test_dispatch_reclaims_stale_before_spawning(kanban_home):
     with kb.connect() as conn:
         t = kb.create_task(conn, title="x", assignee="alice")

--- a/tests/test_run_agent_kanban_completion.py
+++ b/tests/test_run_agent_kanban_completion.py
@@ -1,0 +1,103 @@
+"""Regression tests for Kanban worker completion cleanup."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import run_agent
+from run_agent import AIAgent
+
+
+class _AllowAllGuardrails:
+    def before_call(self, _name, _args):
+        return SimpleNamespace(allows_execution=True)
+
+
+class _NoSubdirHints:
+    def check_tool_call(self, _name, _args):
+        return ""
+
+
+def _tool_call(name: str, args: dict | None = None, call_id: str | None = None):
+    return SimpleNamespace(
+        id=call_id or f"call_{name}",
+        function=SimpleNamespace(
+            name=name,
+            arguments=json.dumps(args or {}),
+        ),
+    )
+
+
+def _minimal_agent():
+    agent = object.__new__(AIAgent)
+    agent._interrupt_requested = False
+    agent._tool_guardrails = _AllowAllGuardrails()
+    agent._turns_since_memory = 0
+    agent._iters_since_skill = 0
+    agent.quiet_mode = True
+    agent.verbose_logging = False
+    agent.log_prefix = ""
+    agent.log_prefix_chars = 120
+    agent.tool_progress_callback = None
+    agent.tool_start_callback = None
+    agent.tool_complete_callback = None
+    agent.tool_delay = 0
+    agent.session_id = "test-session"
+    agent.valid_tool_names = None
+    agent._checkpoint_mgr = SimpleNamespace(enabled=False)
+    agent._memory_manager = None
+    agent._context_engine_tool_names = set()
+    agent.context_compressor = None
+    agent._subdirectory_hints = _NoSubdirHints()
+    agent._current_tool = None
+    agent._append_guardrail_observation = lambda _n, _a, result, failed=False: result
+    agent._apply_pending_steer_to_tool_results = lambda _messages, _count: None
+    agent._touch_activity = lambda _note: None
+    agent._should_emit_quiet_tool_messages = lambda: False
+    agent._should_start_quiet_spinner = lambda: False
+    agent._vprint = lambda *args, **kwargs: None
+    agent._print_fn = lambda *args, **kwargs: None
+    return agent
+
+
+def test_kanban_complete_success_detection_is_exact():
+    assert AIAgent._kanban_complete_tool_succeeded(
+        "kanban_complete", '{"ok": true, "task_id": "t_1"}'
+    )
+    assert not AIAgent._kanban_complete_tool_succeeded(
+        "kanban_complete", '{"ok": false, "error": "blocked"}'
+    )
+    assert not AIAgent._kanban_complete_tool_succeeded("terminal", '{"ok": true}')
+    assert not AIAgent._kanban_complete_tool_succeeded("kanban_complete", "not-json")
+
+
+def test_kanban_worker_stops_after_successful_complete(monkeypatch):
+    """A dispatched worker must not execute tool calls after completion."""
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_done")
+    invoked: list[str] = []
+
+    def fake_handle_function_call(name, args, *unused_args, **unused_kwargs):
+        invoked.append(name)
+        if name == "kanban_complete":
+            return json.dumps({"ok": True, "task_id": "t_done"})
+        raise AssertionError(f"post-completion tool executed: {name}")
+
+    monkeypatch.setattr(run_agent, "handle_function_call", fake_handle_function_call)
+
+    agent = _minimal_agent()
+    messages: list[dict] = []
+    assistant_message = SimpleNamespace(
+        tool_calls=[
+            _tool_call("kanban_complete", {"summary": "done"}, "call_complete"),
+            _tool_call("terminal", {"command": "touch should_not_exist"}, "call_terminal"),
+        ]
+    )
+
+    agent._execute_tool_calls_sequential(assistant_message, messages, "task-id")
+
+    assert invoked == ["kanban_complete"]
+    assert [m["name"] for m in messages] == ["kanban_complete", "terminal"]
+    assert json.loads(messages[0]["content"])["ok"] is True
+    assert "skipped" in messages[1]["content"].lower()
+    assert "kanban_complete succeeded" in messages[1]["content"]


### PR DESCRIPTION
Adds real dispatcher preflight guards before worker spawn:

- refuse missing assignee profiles before subprocess spawn
- refuse selection-packet/planning artifacts
- refuse duplicate running workspace writers
- add optional strict mode (`HERMES_KANBAN_STRICT_DISPATCH_PREFLIGHT=1` or `kanban.strict_dispatch_preflight`) for workspace existence/worktree checks and CAT-style task contract fields
- expose `preflight_blocked` in `hermes kanban dispatch --json` and daemon logs

Verification:
- `python3 -m py_compile hermes_cli/kanban_db.py hermes_cli/kanban.py`
- `python3 -m pytest -q tests/hermes_cli/test_kanban_db.py -q`
- `python3 -m pytest -q tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_cli.py -q`
- CAT live read-only snapshot: dispatch preflight PASS with 0 runnable tasks
- CAT dispatch dry-run: no spawned tasks, no preflight blocks

Note: this branch is stacked on existing `fix/kanban-worker-race` work already present in the local checkout; this commit is the preflight guard increment.
