### PR TITLE
fix(delegate): resolve Portal model aliases before delegating to upstream API

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2342,6 +2342,72 @@ def _resolve_child_credential_pool(effective_provider: Optional[str], parent_age
     return None
 
 
+def _resolve_model_alias(model: Optional[str]) -> Optional[str]:
+    """Try to resolve a Portal/model-picker alias to a real API model ID.
+
+    Portal free-tier recommendations (e.g. ``nemotron-free``, ``llama70b-free``)
+    and short aliases (e.g. ``sonnet``, ``opus``) are convenient for display
+    but are NOT valid model IDs for upstream API calls.  When such an alias
+    lands in ``delegation.model`` (or is resolved from a runtime provider
+    default), the delegation call fails with a 400 from the upstream API.
+
+    This function attempts to resolve the alias via the static model catalog
+    and the same alias-resolution logic used by ``/model`` switching.  Returns
+    the resolved model ID on success, or the original string unchanged when
+    resolution is not possible (the caller decides whether to proceed or
+    error).
+
+    See #28023.
+    """
+    if not model or "/" in model:
+        # Already a fully-qualified model ID (e.g. "nvidia/nemotron-3-super-120b-a12b")
+        # or empty — nothing to resolve.
+        return model
+
+    try:
+        from hermes_cli.models import detect_static_provider_for_model
+        resolved = detect_static_provider_for_model(model, "openrouter")
+        if resolved:
+            _provider, resolved_id = resolved
+            logger.info(
+                "Resolved delegation model alias %r → %r",
+                model, resolved_id,
+            )
+            return resolved_id
+    except Exception:
+        pass
+
+    # Attempt suffix-stripping: "nemotron-free" → "nemotron"
+    # Some Portal aliases append "-free" to a short name.
+    stripped = model
+    for suffix in ("-free", "_free"):
+        if stripped.endswith(suffix):
+            stripped = stripped[: -len(suffix)]
+            break
+    if stripped != model:
+        try:
+            from hermes_cli.models import detect_static_provider_for_model
+            resolved = detect_static_provider_for_model(stripped, "openrouter")
+            if resolved:
+                _provider, resolved_id = resolved
+                logger.info(
+                    "Resolved delegation model alias %r (stripped %r) → %r",
+                    model, stripped, resolved_id,
+                )
+                return resolved_id
+        except Exception:
+            pass
+
+    # Could not resolve — return as-is and let the upstream API
+    # reject it with a clear error if it's invalid.
+    logger.warning(
+        "Could not resolve delegation model alias %r — "
+        "passing through to upstream API as-is",
+        model,
+    )
+    return model
+
+
 def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     """Resolve credentials for subagent delegation.
 
@@ -2407,8 +2473,9 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
         if configured_api_mode in {"chat_completions", "codex_responses", "anthropic_messages"}:
             api_mode = configured_api_mode
 
+        _resolved_model = _resolve_model_alias(configured_model)
         return {
-            "model": configured_model,
+            "model": _resolved_model,
             "provider": provider,
             "base_url": configured_base_url,
             "api_key": api_key,
@@ -2416,9 +2483,10 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
         }
 
     if not configured_provider:
+        _resolved_model = _resolve_model_alias(configured_model)
         # No provider override — child inherits everything from parent
         return {
-            "model": configured_model,
+            "model": _resolved_model,
             "provider": None,
             "base_url": None,
             "api_key": None,
@@ -2446,7 +2514,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
         )
 
     return {
-        "model": configured_model or runtime.get("model") or None,
+        "model": _resolve_model_alias(configured_model or runtime.get("model") or None),
         "provider": configured_provider if runtime.get("provider") == _RUNTIME_PROVIDER_CUSTOM else runtime.get("provider"),
         "base_url": runtime.get("base_url"),
         "api_key": api_key,


### PR DESCRIPTION
## Summary

Fixes #28023

Portal free-tier recommendations (e.g. `nemotron-free`, `llama70b-free`) and short aliases (e.g. `sonnet`, `opus`) are convenient for display but are NOT valid model IDs for upstream API calls. When such an alias lands in `delegation.model` (or is resolved from a runtime provider default), the delegation call fails with a **400 Bad Request** from the upstream API.

### Root Cause

`_resolve_delegation_credentials()` passes the configured model string through verbatim to the child agent. When the model is a Portal alias like `nemotron-free`, OpenRouter rejects it with:

```
{"error":{"message":"nemotron-free is not a valid model ID","code":400}}
```

### Changes

Added `_resolve_model_alias()` in `tools/delegate_tool.py` which:

1. **Pass-through** for fully-qualified model IDs (containing `/`) — no resolution needed
2. **Static catalog resolution** via `detect_static_provider_for_model()` — reuses the same alias logic as `/model` switching
3. **Suffix stripping** — removes `-free`/`_free` suffixes and retries (handles Portal aliases like `nemotron-free` → `nemotron` → `nvidia/nemotron-3-super-120b-a12b`)
4. **Graceful fallback** — returns the original string with a warning log if resolution fails

Applied at all three return points in `_resolve_delegation_credentials()`:
- `delegation.base_url` path
- No-provider path (child inherits from parent)
- Provider-resolved path (via `resolve_runtime_provider`)

### Testing

- Syntax validation: `ast.parse()` passes
- The resolution logic reuses existing `detect_static_provider_for_model()` which has its own test coverage

### Files Changed

- `tools/delegate_tool.py` — +71 lines (`_resolve_model_alias` + 3 call sites)