### PR TITLE
fix(delegate): handle list tool message content in _run_single_child (#28639)

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1653,7 +1653,9 @@ def _run_single_child(
                         if tc_id:
                             trace_by_id[tc_id] = entry_t
                 elif msg.get("role") == "tool":
-                    content = msg.get("content", "")
+                    content = msg.get("content") or ""
+                    if not isinstance(content, str):
+                        content = str(content)
                     is_error = _looks_like_error_output(content)
                     result_meta = {
                         "result_bytes": len(content),


### PR DESCRIPTION
## Summary

Fix a crash in `_run_single_child` when tool message `content` is a list
(e.g., OpenAI multimodal format). `_looks_like_error_output()` expects a
string and calls `.lstrip()` on it.

## Problem

When `delegate_task(tasks=[...])` is called and subagents produce tool
messages with `content` as a list (e.g. `[{"type": "text", "text": "..."}]`),
`_run_single_child` crashes with:

```
AttributeError: 'list' object has no attribute 'lstrip'
```

Root cause: `msg.get("content", "")` returns the list when the key exists,
not the default empty string. The same `_build_tool_trace` function already
had this guard (lines 262-264) but `_run_single_child` (lines 1656) did not.

## Solution

Add the same type guard that already exists in `_build_tool_trace`:
- Use `msg.get("content") or ""` so falsy/empty values get the string default
- Convert non-string content to `str(content)` before passing to
  `_looks_like_error_output()`

## Files Changed

| File | Change |
|------|--------|
| `tools/delegate_tool.py` | +3/-1 — add type guard in _run_single_child |

## Test Results

```
135 passed in 22.93s
```

## Design Decisions

Pattern consistency: the exact same guard (isinstance check + str() fallback)
was already used in `_build_tool_trace()` at L262-264. This fix copies the
proven pattern rather than inventing a new one.

Closes #28639