### PR TITLE
fix(dashboard): hide tab for plugins without a built entry (#28609)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4084,6 +4084,14 @@ def _discover_dashboard_plugins() -> list:
                 # ``override`` to replace a built-in route, and ``hidden`` to
                 # register the plugin component/slots without adding a tab
                 # (useful for slot-only plugins like a header-crest injector).
+                entry = data.get("entry", "dist/index.js")
+                entry_path = child / "dashboard" / entry
+                entry_exists = entry_path.exists()
+                if not entry_exists:
+                    _log.debug(
+                        "Dashboard plugin %s has no built entry %s; hiding tab",
+                        name, entry_path,
+                    )
                 raw_tab = data.get("tab", {}) if isinstance(data.get("tab"), dict) else {}
                 tab_info = {
                     "path": raw_tab.get("path", f"/{name}"),
@@ -4092,7 +4100,7 @@ def _discover_dashboard_plugins() -> list:
                 override_path = raw_tab.get("override")
                 if isinstance(override_path, str) and override_path.startswith("/"):
                     tab_info["override"] = override_path
-                if bool(raw_tab.get("hidden")):
+                if bool(raw_tab.get("hidden")) or not entry_exists:
                     tab_info["hidden"] = True
                 # Slots: list of named slot locations this plugin populates.
                 # The frontend exposes ``registerSlot(pluginName, slotName, Component)``
@@ -4109,7 +4117,7 @@ def _discover_dashboard_plugins() -> list:
                     "version": data.get("version", "0.0.0"),
                     "tab": tab_info,
                     "slots": slots,
-                    "entry": data.get("entry", "dist/index.js"),
+                    "entry": entry if entry_exists else None,
                     "css": data.get("css"),
                     "has_api": bool(data.get("api")),
                     "source": source,

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1941,12 +1941,47 @@ class TestDashboardPluginManifestExtensions:
     """Tests for the extended plugin manifest fields (tab.override,
     tab.hidden, slots) read by _discover_dashboard_plugins()."""
 
-    def _write_plugin(self, tmp_path, name, manifest):
+    def _write_plugin(self, tmp_path, name, manifest, *, write_entry=True):
         import json
         plug_dir = tmp_path / "plugins" / name / "dashboard"
         plug_dir.mkdir(parents=True)
         (plug_dir / "manifest.json").write_text(json.dumps(manifest))
+        if write_entry:
+            entry = manifest.get("entry", "dist/index.js")
+            entry_path = plug_dir / entry
+            entry_path.parent.mkdir(parents=True, exist_ok=True)
+            entry_path.write_text("// stub\n")
         return plug_dir
+
+    def test_missing_entry_hides_tab(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._write_plugin(tmp_path, "unbuilt", {
+            "name": "unbuilt",
+            "label": "Unbuilt",
+            "tab": {"path": "/unbuilt"},
+            "entry": "dist/index.js",
+        }, write_entry=False)
+        from hermes_cli import web_server
+        web_server._dashboard_plugins_cache = None
+        plugins = web_server._get_dashboard_plugins(force_rescan=True)
+        entry = next(p for p in plugins if p["name"] == "unbuilt")
+        assert entry["tab"]["hidden"] is True
+        assert entry["entry"] is None
+
+    def test_present_entry_shows_tab(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._write_plugin(tmp_path, "built", {
+            "name": "built",
+            "label": "Built",
+            "tab": {"path": "/built"},
+            "entry": "dist/index.js",
+        })
+        from hermes_cli import web_server
+        web_server._dashboard_plugins_cache = None
+        plugins = web_server._get_dashboard_plugins(force_rescan=True)
+        entry = next(p for p in plugins if p["name"] == "built")
+        assert entry["tab"].get("hidden", False) is False
+        assert entry["entry"] == "dist/index.js"
 
     def test_override_and_hidden_carried_through(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))


### PR DESCRIPTION
## Summary

Fixes #28609.

The bundled `plugins/example-dashboard` plugin ships a `dashboard/manifest.json` but no built `dist/index.js`. `_discover_dashboard_plugins()` registers it anyway, so every fresh `hermes` install shows a broken "Example" tab in the dashboard sidebar with the banner _"无法加载此插件的脚本"_ and a 404 on `GET /dashboard-plugins/example/dist/index.js`.

We can't simply skip the plugin from discovery — `tests/hermes_cli/test_web_server.py::TestPluginAPIAuth::test_plugin_route_allows_auth` hits `/api/plugins/example/hello`, which depends on the example plugin's `plugin_api.py` being registered. So the fix targets only the UI surface.

## Change

In `_discover_dashboard_plugins()` (`hermes_cli/web_server.py`), resolve the manifest's `entry` against the plugin's `dashboard/` directory and check whether the file exists. When it doesn't:

- force `tab.hidden = True` (in addition to honoring an explicit manifest `hidden`)
- set the returned `entry` to `None` so the frontend treats it as "no script to fetch"
- emit a `_log.debug(...)` so operators can grep for the cause

API routes and slot registration are untouched, so the example plugin's auth coverage test still passes.

## Tests

- Extended `_write_plugin` helper in `tests/hermes_cli/test_web_server.py` to also write a stub `dist/index.js` by default (opt-out via `write_entry=False`) so existing manifest-extension tests keep exercising the "entry present" path.
- New `test_missing_entry_hides_tab`: manifest without an `entry` file → plugin still discovered, but `tab.hidden is True` and `entry is None`.
- New `test_present_entry_shows_tab`: manifest with stubbed entry → `tab.hidden` falsy, `entry == "dist/index.js"`.

`pytest tests/hermes_cli/test_web_server.py` — 147 passed locally.

## Risk

- Minimal surface change inside one function; no behavior change for plugins whose entry is built.
- The hidden flag is a tab-level signal that the frontend already understands (`tab.hidden` is a documented manifest field), so no frontend change is required to drop the broken tab.
- `entry: null` is a new value the frontend hasn't seen before; even without a frontend-side guard the broken behavior degrades to "no tab" rather than "tab + 404", which is strictly better than today.
