### PR TITLE
fix(cron): tolerate deliver=null in jobs.json for hermes cron list

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -67,7 +67,7 @@ def cron_list(show_all: bool = False):
         repeat_completed = repeat_info.get("completed", 0)
         repeat_str = f"{repeat_completed}/{repeat_times}" if repeat_times else "∞"
 
-        deliver = job.get("deliver", ["local"])
+        deliver = job.get("deliver") or ["local"]
         if isinstance(deliver, str):
             deliver = [deliver]
         deliver_str = ", ".join(deliver)


### PR DESCRIPTION
## Summary

`hermes cron list` crashes with `TypeError: can only join an iterable` whenever any entry in `~/.hermes/cron/jobs.json` has its `deliver` field explicitly set to `null`. Reproduces immediately on any machine whose scheduler ever stored a job without an explicit deliver target.

## Root cause

`hermes_cli/cron.py::cron_list()` reads the field via `job.get(\"deliver\", [\"local\"])`. \`dict.get(key, default)\` only returns the default when the key is **missing**, not when the key is present with a \`None\` value. \`jobs.json\` written by the scheduler regularly contains \`\"deliver\": null\`, so the \`None\` is then passed straight into \`\", \".join(deliver)\` two lines later and explodes.

## Fix

\`\`\`diff
-        deliver = job.get(\"deliver\", [\"local\"])
+        deliver = job.get(\"deliver\") or [\"local\"]
\`\`\`

\`or [\"local\"]\` keeps the existing \"empty means local\" intent and additionally handles the \`None\` / empty-string / empty-list cases. This matches how other Hermes call sites treat \`deliver\` (e.g. delivery routing in \`gateway/run.py\` already collapses falsy values into \`local\`).

## Reproducer

\`\`\`bash
python3 -c \"
import json, pathlib
p = pathlib.Path.home() / '.hermes/cron/jobs.json'
d = json.loads(p.read_text())
d['jobs'].append({'id': 'demo', 'name': 'demo', 'enabled': True, 'deliver': None, 'schedule': {'display': '0 * * * *'}})
p.write_text(json.dumps(d))
\"
hermes cron list
# TypeError: can only join an iterable
\`\`\`

After the patch \`hermes cron list\` prints \`Deliver:   local\` for that entry as documented.

## Test plan

- [ ] \`hermes cron list\` on a jobs.json containing \`deliver: null\` returns 0 and shows \`Deliver: local\`.
- [ ] \`hermes cron list\` on a jobs.json containing \`deliver: \"telegram\"\` still shows \`Deliver: telegram\`.
- [ ] \`hermes cron list\` on a jobs.json missing the \`deliver\` key entirely still shows \`Deliver: local\` (regression coverage for the original \`get(..., default)\` path).

Made with [Cursor](https://cursor.com)