### PR TITLE
fix(i18n): mark scheduled column key as
  optional in locale type

### DIFF
--- a/web/src/i18n/types.ts
+++ b/web/src/i18n/types.ts
@@ -666,6 +666,7 @@ export interface Translations {
     columnLabels: {
       triage: string;
       todo: string;
+      scheduled?: string;
       ready: string;
       running: string;
       blocked: string;
@@ -675,6 +676,7 @@ export interface Translations {
     columnHelp: {
       triage: string;
       todo: string;
+      scheduled?: string;
       ready: string;
       running: string;
       blocked: string;


### PR DESCRIPTION
Fixes TS2353 errors in en.ts by making the scheduled column key
  optional in columnLabels and columnHelp, matching how confirmScheduled? is already optional in the
  same interface. Unblocks npm run build for the web dashboard.