### PR TITLE
fix(agent): normalize non-string tool content in delegate tool_trace (#28639)

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -582,6 +582,48 @@ class TestDelegateObservability(unittest.TestCase):
             trace = result["results"][0]["tool_trace"]
             self.assertEqual(trace[0]["status"], "error")
 
+    def test_tool_trace_handles_non_string_content(self):
+        """Tool messages with list content must not crash tool_trace build (#28639)."""
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.model = "claude-sonnet-4-6"
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            # Anthropic / OpenAI-style multi-part tool content: a list of blocks,
+            # not a plain string. Previously, _looks_like_error_output() called
+            # content.lstrip() which raised AttributeError on lists, crashing
+            # the whole subagent result assembly.
+            mock_child.run_conversation.return_value = {
+                "final_response": "done",
+                "completed": True,
+                "interrupted": False,
+                "api_calls": 1,
+                "messages": [
+                    {"role": "assistant", "tool_calls": [
+                        {"id": "tc_1", "function": {"name": "vision", "arguments": '{"path": "a.png"}'}}
+                    ]},
+                    {"role": "tool", "tool_call_id": "tc_1", "content": [
+                        {"type": "text", "text": "ok"},
+                        {"type": "image", "source": {"type": "base64", "data": "..."}},
+                    ]},
+                    {"role": "assistant", "content": "done"},
+                ],
+            }
+            MockAgent.return_value = mock_child
+
+            result = json.loads(delegate_task(goal="Test list content", parent_agent=parent))
+            entry = result["results"][0]
+            self.assertEqual(entry["exit_reason"], "completed")
+            trace = entry["tool_trace"]
+            self.assertEqual(len(trace), 1)
+            self.assertEqual(trace[0]["tool"], "vision")
+            self.assertIsInstance(trace[0]["result_bytes"], int)
+            self.assertGreaterEqual(trace[0]["result_bytes"], 0)
+            # List content does not match the conservative error detector.
+            self.assertEqual(trace[0]["status"], "ok")
+
     def test_parallel_tool_calls_paired_correctly(self):
         """Parallel tool calls should each get their own result via tool_call_id matching."""
         parent = _make_mock_parent(depth=0)

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -624,6 +624,43 @@ class TestDelegateObservability(unittest.TestCase):
             # List content does not match the conservative error detector.
             self.assertEqual(trace[0]["status"], "ok")
 
+    def test_tool_trace_dict_error_content_still_detected(self):
+        """Already-parsed dict content with an `error` key must still be flagged as error.
+
+        Regression guard for Copilot's review point on #28658: a naive
+        str(content) coercion would produce Python repr with single quotes,
+        which json.loads cannot parse, so _looks_like_error_output() would
+        silently miss the dict-error pattern. The normalize step must
+        preserve JSON structure (json.dumps) so the conservative error
+        detector continues to work on structured tool output.
+        """
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.model = "claude-sonnet-4-6"
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            mock_child.run_conversation.return_value = {
+                "final_response": "failed",
+                "completed": True,
+                "interrupted": False,
+                "api_calls": 1,
+                "messages": [
+                    {"role": "assistant", "tool_calls": [
+                        {"id": "tc_1", "function": {"name": "terminal", "arguments": '{"cmd": "x"}'}}
+                    ]},
+                    # Already-parsed dict (not a JSON string) with structured error.
+                    {"role": "tool", "tool_call_id": "tc_1", "content": {"error": "command not found"}},
+                ],
+            }
+            MockAgent.return_value = mock_child
+
+            result = json.loads(delegate_task(goal="Test dict error", parent_agent=parent))
+            trace = result["results"][0]["tool_trace"]
+            self.assertEqual(len(trace), 1)
+            self.assertEqual(trace[0]["status"], "error")
+
     def test_parallel_tool_calls_paired_correctly(self):
         """Parallel tool calls should each get their own result via tool_call_id matching."""
         parent = _make_mock_parent(depth=0)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1655,10 +1655,17 @@ def _run_single_child(
                 elif msg.get("role") == "tool":
                     content = msg.get("content", "")
                     if not isinstance(content, str):
-                        content = str(content)
+                        # Preserve JSON structure so _looks_like_error_output's
+                        # dict-error detection still works (str() on a dict
+                        # produces Python repr with single quotes, which
+                        # json.loads cannot parse).
+                        try:
+                            content = json.dumps(content)
+                        except (TypeError, ValueError):
+                            content = str(content)
                     is_error = _looks_like_error_output(content)
                     result_meta = {
-                        "result_bytes": len(content),
+                        "result_bytes": len(content.encode("utf-8", errors="replace")),
                         "status": "error" if is_error else "ok",
                     }
                     # Match by tool_call_id for parallel calls

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1654,6 +1654,8 @@ def _run_single_child(
                             trace_by_id[tc_id] = entry_t
                 elif msg.get("role") == "tool":
                     content = msg.get("content", "")
+                    if not isinstance(content, str):
+                        content = str(content)
                     is_error = _looks_like_error_output(content)
                     result_meta = {
                         "result_bytes": len(content),


### PR DESCRIPTION
## What does this PR do?

`tools/delegate_tool.py::_run_single_child` reads each tool message's
content with `msg.get("content", "")` and immediately calls
`_looks_like_error_output(content)`, which does `content.lstrip()`.
When a subagent produces Anthropic/OpenAI-style multi-part tool content
(a list of `{"type": "text", ...}` / image blocks), this raises
`AttributeError: 'list' object has no attribute 'lstrip'` and the entire
subagent result assembly crashes — even though the child task itself
ran to completion. The reporter (#28639) hit this from a Discord
gateway running a batch `delegate_task(tasks=[...])`, where all three
children failed with this single error.

This PR mirrors the canonical normalize-content pattern that already
exists at the sibling call site `_build_tool_trace_tail` (around line
262 of the same file): if `content` is not a string, coerce it with
`str(content)` before passing it to `_looks_like_error_output()` and
before measuring `len(content)`. After the guard the conservative error
detector runs on a safe string, and `result_bytes` becomes a usable
byte estimate instead of a parts count.

## Related Issue

Fixes #28639

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/delegate_tool.py` — In the tool-result branch of `_run_single_child`'s tool_trace builder, coerce non-string `content` to `str(content)` before invoking `_looks_like_error_output()` and `len(content)`. Two-line guard, mirrors the existing pattern at `_build_tool_trace_tail`.
- `tests/tools/test_delegate.py` — Add `test_tool_trace_handles_non_string_content` in `TestDelegateObservability` that exercises a tool message with list-typed content and asserts the child exits cleanly with a usable `tool_trace` entry. Reproduces the exact `AttributeError` from the issue when the fix is reverted.

## How to Test

1. From the repo root:
2. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/tools/test_delegate.py::TestDelegateObservability -v`
3. Expected: 6 passed including `test_tool_trace_handles_non_string_content`. Reverting the two-line guard in `_run_single_child` flips the new test to FAIL with the exact `AttributeError: 'list' object has no attribute 'lstrip'` traceback from the issue.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (no platform-specific code paths)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

> Audited siblings: `_build_tool_trace_tail` (the other `_looks_like_error_output` call site at line ~262) already normalizes non-string content with the same `str(content)` guard. No further widening needed inside this file. The fix is the missing half of an existing convention, not a new one.