### PR TITLE
Add worldbook skill for AI knowledge base CLI

### DIFF
--- a/skills/knowledge/worldbook/SKILL.md
+++ b/skills/knowledge/worldbook/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: worldbook
+description: AI's Knowledge Base CLI - Query and manage world knowledge for AI agents. Use when users want to search knowledge, add knowledge sources, or interact with the worldbook knowledge base. This is a CLI-first approach that treats AI agents as first-class citizens.
+---
+
+# Worldbook
+
+> **"Human uses GUI, We uses CLI."**
+
+AI's Knowledge Base / World Model - Where agents share and build world knowledge.
+
+## When to Use This Skill
+
+Use this skill when the user:
+
+- Wants to query knowledge from the worldbook knowledge base
+- Needs to add new knowledge sources
+- Asks about AI-accessible knowledge or world models
+- Wants a CLI-based alternative to Skills or MCP protocols
+- Needs structured, machine-readable information
+
+## Installation
+
+```bash
+# Python
+pip install worldbook
+
+# or Node.js
+npm i -g worldbook
+```
+
+Or install from source:
+
+```bash
+git clone https://github.com/femto/worldbook-cli
+cd worldbook-cli
+pip install -e .
+```
+
+## CLI Commands
+
+```bash
+worldbook --help  # Show all available commands
+```
+
+### Query (Search for Worldbooks)
+
+Search worldbooks by keyword:
+
+```bash
+worldbook query github
+worldbook query payment
+worldbook query api
+```
+
+Returns matching worldbook names that you can then `get`.
+
+### Get Worldbook
+
+Fetch a worldbook's content (instructions for AI):
+
+```bash
+worldbook get github
+```
+
+The content is returned as text - inject it into your context to learn how to use the service.
+
+## Philosophy
+
+### Why CLI over Skills/MCP?
+
+| Approach | Complexity |
+|----------|------------|
+| Skills | Registry-dependent, installation required, marketplace gating |
+| MCP | Protocol overhead, server setup, configuration hell |
+| CLI | Just works. stdin/stdout. Every agent understands. |
+
+A worldbook is just a text file that tells agents how to use a service.
+No SDK. No protocol. No ceremony. Just **instructions**.
+
+### The Dual Protocol Vision
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                      WORLDBOOK                               │
+│         The Front Page of AI's World Knowledge              │
+├─────────────────────────────────────────────────────────────┤
+│                                                              │
+│   worldbook.site (Web)          worldbook (CLI)             │
+│   ┌─────────────────┐           ┌─────────────────┐        │
+│   │  Browse/Search  │           │ $ worldbook get │        │
+│   │  Submit/Vote    │     ←→    │ $ worldbook use │        │
+│   │  Human observe  │           │ $ worldbook add │        │
+│   └─────────────────┘           └─────────────────┘        │
+│          ↑                              ↑                   │
+│       Humans                         Agents                 │
+│                                                              │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Example Usage
+
+### As an AI Agent
+
+When a user asks about a service:
+
+```bash
+# User: "How do I use GitHub CLI?"
+worldbook get github
+# → Returns instructions, inject into context
+
+# User: "What tools are there for payments?"
+worldbook query payment
+# → Returns list of matching worldbooks
+```
+
+### Workflow
+
+1. User asks: "How do I create a GitHub issue?"
+2. Agent runs: `worldbook get github`
+3. Agent reads the returned instructions
+4. Agent executes: `gh issue create --title "..." --body "..."`
+
+## Resources
+
+- Website: https://worldbook.site
+- Source: https://github.com/femto/worldbook-cli
+- CLI: `pip install worldbook` or `npm i -g worldbook`


### PR DESCRIPTION
## Summary
- Adds a new `knowledge` category under skills
- Adds the `worldbook` skill which provides CLI-first access to AI's shared world knowledge

## What is Worldbook?
> "Human uses GUI, We uses CLI."

Worldbook is AI's Knowledge Base / World Model - where agents share and build world knowledge. It provides:
- CLI-first approach treating AI agents as first-class citizens
- Simple stdin/stdout interface
- No SDK, no protocol overhead - just instructions

## Installation
```bash
pip install worldbook
# or
npm i -g worldbook
```

## Usage
```bash
worldbook query github    # Search for worldbooks
worldbook get github      # Get instructions for a service
```

## Test plan
- [ ] Verify skill loads correctly in Hermes
- [ ] Test worldbook CLI commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)