### PR TITLE
api-server: document and test outbound messaging opt-in

### DIFF
--- a/tests/gateway/test_api_server_toolset.py
+++ b/tests/gateway/test_api_server_toolset.py
@@ -55,6 +55,27 @@ class TestHermesApiServerToolset:
         tools = resolve_toolset("hermes-api-server")
         assert "send_message" not in tools
 
+    def test_messaging_toolset_can_opt_in_send_message(self, monkeypatch):
+        """API deployments can opt in to outbound messaging explicitly."""
+        from hermes_cli.tools_config import _get_platform_tools
+        from model_tools import get_tool_definitions
+        from tools.registry import invalidate_check_fn_cache
+
+        config = {
+            "platform_toolsets": {
+                "api_server": ["hermes-api-server", "messaging"],
+            }
+        }
+
+        toolsets = _get_platform_tools(config, "api_server")
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "api_server")
+        invalidate_check_fn_cache()
+        tools = get_tool_definitions(enabled_toolsets=toolsets, quiet_mode=True)
+        tool_names = {tool["function"]["name"] for tool in tools}
+
+        assert "messaging" in toolsets
+        assert "send_message" in tool_names
+
     def test_toolset_excludes_text_to_speech(self):
         tools = resolve_toolset("hermes-api-server")
         assert "text_to_speech" not in tools
@@ -127,3 +148,31 @@ class TestApiServerAdapterToolset:
             call_kwargs = mock_agent_cls.call_args
             toolsets = call_kwargs.kwargs.get("enabled_toolsets")
             assert sorted(toolsets) == ["terminal", "web"]
+
+    @patch("gateway.platforms.api_server.AIOHTTP_AVAILABLE", True)
+    def test_create_agent_allows_explicit_messaging_opt_in(self):
+        """send_message reaches API-created agents only when messaging is configured."""
+        from gateway.platforms.api_server import APIServerAdapter
+        from gateway.config import PlatformConfig
+
+        adapter = APIServerAdapter(PlatformConfig())
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs") as mock_kwargs, \
+             patch("gateway.run._resolve_gateway_model") as mock_model, \
+             patch("gateway.run._load_gateway_config") as mock_config, \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+
+            mock_kwargs.return_value = {"api_key": "test-key", "base_url": None,
+                                        "provider": None, "api_mode": None,
+                                        "command": None, "args": []}
+            mock_model.return_value = "test/model"
+            mock_config.return_value = {
+                "platform_toolsets": {"api_server": ["hermes-api-server", "messaging"]}
+            }
+            mock_agent_cls.return_value = MagicMock()
+
+            adapter._create_agent()
+
+            mock_agent_cls.assert_called_once()
+            toolsets = mock_agent_cls.call_args.kwargs.get("enabled_toolsets")
+            assert "messaging" in toolsets

--- a/website/docs/reference/toolsets-reference.md
+++ b/website/docs/reference/toolsets-reference.md
@@ -93,7 +93,7 @@ Platform toolsets define the complete tool configuration for a deployment target
 |---------|-------------------------------|
 | `hermes-cli` | Full toolset — the default for interactive CLI sessions. Includes file, terminal, web, browser, memory, skills, vision, image_gen, todo, tts, delegation, code_execution, cronjob, session_search, clarify, and `safe` (read-only) bundles plus the standard messaging tools. |
 | `hermes-acp` | Drops `clarify`, `cronjob`, `image_generate`, `send_message`, `text_to_speech`, and all four Home Assistant tools. Focused on coding tasks in IDE context. |
-| `hermes-api-server` | Drops `clarify`, `send_message`, and `text_to_speech`. Keeps everything else — suitable for programmatic access where user interaction isn't possible. |
+| `hermes-api-server` | Drops `clarify`, `send_message`, and `text_to_speech`. Keeps everything else — suitable for programmatic access where user interaction isn't possible. Add the `messaging` toolset to `platform_toolsets.api_server` to opt in to outbound `send_message`. |
 | `hermes-cron` | Same as `hermes-cli`. |
 | `hermes-telegram` | Same as `hermes-cli`. |
 | `hermes-discord` | Adds `discord` and `discord_admin` on top of `hermes-cli`. |

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -328,6 +328,21 @@ The API server gives full access to hermes-agent's toolset, **including terminal
 The default bind address (`127.0.0.1`) is for local-only use. Browser access is disabled by default; enable it only for explicit trusted origins.
 :::
 
+## Tool Access
+
+API-created agents use the `hermes-api-server` toolset by default. That toolset keeps normal non-interactive tools such as web, files, terminal, memory, browser automation, delegation, and cron, but it intentionally leaves out interactive or outbound user-contact tools such as `clarify`, `text_to_speech`, and `send_message`.
+
+If you run a trusted API deployment that should be able to send messages through Hermes's connected gateway platforms, opt in explicitly with `platform_toolsets.api_server`:
+
+```yaml
+platform_toolsets:
+  api_server:
+    - hermes-api-server
+    - messaging
+```
+
+Treat this as a real security boundary. Any client with API access can then cause an API-created agent to call `send_message`, subject to the normal gateway configuration and target checks.
+
 ## Configuration
 
 ### Environment Variables
@@ -344,8 +359,11 @@ The default bind address (`127.0.0.1`) is for local-only use. Browser access is 
 ### config.yaml
 
 ```yaml
-# Not yet supported — use environment variables.
-# config.yaml support coming in a future release.
+# API server network/auth/model settings use API_SERVER_* environment variables.
+# Shared agent settings such as platform_toolsets still live in config.yaml.
+platform_toolsets:
+  api_server:
+    - hermes-api-server
 ```
 
 ## Security Headers

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -440,7 +440,7 @@ Each platform has its own toolset:
 | QQBot | `hermes-qqbot` | Full tools including terminal |
 | Yuanbao | `hermes-yuanbao` | Full tools including terminal |
 | Microsoft Teams | `hermes-teams` | Full tools including terminal |
-| API Server | `hermes-api-server` | Full tools (drops `clarify`, `send_message`, `text_to_speech` — programmatic access doesn't have an interactive user) |
+| API Server | `hermes-api-server` | Full tools (drops `clarify`, `send_message`, `text_to_speech` by default; add `messaging` to `platform_toolsets.api_server` to opt in to outbound messages) |
 | Webhooks | `hermes-webhook` | Full tools including terminal |
 
 ## Operating a multi-platform gateway


### PR DESCRIPTION
## What changed

Documents and tests the supported opt-in path for API-created agents to use outbound messaging via `platform_toolsets.api_server`:

```yaml
platform_toolsets:
  api_server:
    - hermes-api-server
    - messaging
```

Adds focused tests that verify:

- the default `hermes-api-server` toolset still excludes `send_message`
- adding `messaging` exposes `send_message` to API-created agents
- `APIServerAdapter._create_agent()` passes the configured API server toolsets through to `AIAgent`

## Why

The API server default intentionally avoids interactive/outbound user-contact tools such as `clarify`, `text_to_speech`, and `send_message`. Trusted API deployments may still need API-originated agent sessions to contact configured Hermes messaging targets.

This came from an operator need where API-created sessions needed `send_message`. The first assumption was that a source patch was required, but the correct path is the existing `platform_toolsets.api_server` composition mechanism. This PR makes that opt-in path discoverable and tested so operators do not patch the default API toolset to expose outbound messaging.

## Security considerations

This keeps `send_message` disabled by default for API-created sessions. Operators must explicitly add `messaging` to `platform_toolsets.api_server`. The docs call this out as a security boundary because any client with API access can then cause an API-created agent to invoke `send_message`, subject to normal gateway configuration and target checks.

## Verification

- `scripts/run_tests.sh tests/gateway/test_api_server_toolset.py -v` -> `14 passed`
- `python3 -m py_compile toolsets.py gateway/platforms/api_server.py` -> passed
- `codex review --base origin/main` -> no discrete bug found
- Independent read-only review -> no blocking findings; upstream-ready
- Runtime smoke on macOS profile deployment:
  - deployed stock upstream Hermes with `platform_toolsets.api_server: [hermes-api-server, messaging]`
  - restarted two profile gateways
  - `GET /health` returned 200 for both API servers
  - two API-originated runs invoked `send_message(action="list")` successfully
  - one earlier API-originated run sent a Telegram message through `send_message` successfully

## AI assistance disclosure

Prepared with OpenAI Codex. I reviewed the diff, ran the tests and smoke checks above, and understand the submitted changes.
