### PR TITLE
fix: add Forge co-author trailer policy

### DIFF
--- a/tests/tools/test_forge_git_coauthor_policy.py
+++ b/tests/tools/test_forge_git_coauthor_policy.py
@@ -1,0 +1,172 @@
+"""Forge git co-author policy smoke tests."""
+
+import os
+import subprocess
+
+from tools.forge_git_coauthor import (
+    RAZ_COAUTHOR_TRAILER,
+    apply_forge_git_coauthor_policy,
+    forge_git_coauthor_prelude,
+    should_enable_forge_git_coauthor,
+)
+
+
+def _run(cmd: str, cwd, env=None) -> subprocess.CompletedProcess:
+    merged = os.environ.copy()
+    if env:
+        merged.update(env)
+    return subprocess.run(
+        ["bash", "-lc", cmd],
+        cwd=cwd,
+        env=merged,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=True,
+    )
+
+
+def test_policy_enabled_only_for_forge_kanban_worker(monkeypatch):
+    monkeypatch.setenv("HERMES_PROFILE", "forge")
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_example")
+    monkeypatch.delenv("HERMES_FORGE_COAUTHOR_DISABLED", raising=False)
+    assert should_enable_forge_git_coauthor()
+
+    monkeypatch.setenv("HERMES_FORGE_COAUTHOR_DISABLED", "1")
+    assert not should_enable_forge_git_coauthor()
+
+    monkeypatch.setenv("HERMES_FORGE_COAUTHOR_DISABLED", "0")
+    monkeypatch.setenv("HERMES_PROFILE", "default")
+    assert not should_enable_forge_git_coauthor()
+
+
+def test_terminal_tool_policy_application_is_scoped(monkeypatch):
+    command = "git commit -m 'feat: example'"
+
+    monkeypatch.setenv("HERMES_PROFILE", "forge")
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_example")
+    wrapped = apply_forge_git_coauthor_policy(command)
+    assert wrapped != command
+    assert RAZ_COAUTHOR_TRAILER in wrapped
+    assert wrapped.endswith(command)
+
+    monkeypatch.setenv("HERMES_FORGE_COAUTHOR_DISABLED", "1")
+    assert apply_forge_git_coauthor_policy(command) == command
+
+
+def test_forge_git_commit_gets_raz_trailer_exactly_once(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run("git init && git config user.name Forge && git config user.email forge@example.invalid", repo)
+    (repo / "file.txt").write_text("hello\n", encoding="utf-8")
+
+    env = {
+        "HERMES_PROFILE": "forge",
+        "HERMES_KANBAN_TASK": "t_example",
+    }
+    _run(f"{forge_git_coauthor_prelude()}\ngit add file.txt && git commit -m 'feat: add file'", repo, env)
+
+    message = _run("git log -1 --format=%B", repo).stdout
+    assert message.count(RAZ_COAUTHOR_TRAILER) == 1
+    assert message.rstrip().endswith(RAZ_COAUTHOR_TRAILER)
+
+
+def test_existing_commit_message_trailers_remain_valid_and_deduped(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run("git init && git config user.name Forge && git config user.email forge@example.invalid", repo)
+    (repo / "file.txt").write_text("hello\n", encoding="utf-8")
+
+    env = {
+        "HERMES_PROFILE": "forge",
+        "HERMES_KANBAN_TASK": "t_example",
+    }
+    other_coauthor = "Co-authored-by: Other Person <other@example.com>"
+    message_file = repo / "message.txt"
+    message_file.write_text(
+        "feat: add file\n\nBody line.\n\nRefs: #123\n"
+        f"{other_coauthor}\n"
+        f"{RAZ_COAUTHOR_TRAILER}\n"
+        f"{RAZ_COAUTHOR_TRAILER}\n",
+        encoding="utf-8",
+    )
+
+    _run(f"{forge_git_coauthor_prelude()}\ngit add file.txt && git commit -F message.txt", repo, env)
+
+    message = _run("git log -1 --format=%B", repo).stdout
+    assert message.count(RAZ_COAUTHOR_TRAILER) == 1
+    assert other_coauthor in message
+    assert "Refs: #123" in message
+    parsed = _run("git log -1 --format=%B | git interpret-trailers --parse", repo).stdout
+    assert RAZ_COAUTHOR_TRAILER in parsed
+    assert other_coauthor in parsed
+    assert message.rstrip().endswith(RAZ_COAUTHOR_TRAILER)
+
+
+def test_forge_git_push_guard_rejects_raz_line_outside_trailer_block(tmp_path):
+    remote = tmp_path / "remote.git"
+    repo = tmp_path / "repo"
+    _run(f"git init --bare {remote}", tmp_path)
+    _run(
+        f"git init {repo} && cd {repo} && git config user.name Forge && "
+        "git config user.email forge@example.invalid && git remote add origin "
+        f"{remote}",
+        tmp_path,
+    )
+    (repo / "file.txt").write_text("hello\n", encoding="utf-8")
+    message_file = repo / "message.txt"
+    message_file.write_text(
+        f"feat: body-only trailer\n\n{RAZ_COAUTHOR_TRAILER}\n\nMore body text after the line.\n",
+        encoding="utf-8",
+    )
+    _run("git add file.txt && git commit -F message.txt", repo)
+
+    env = {
+        "HERMES_PROFILE": "forge",
+        "HERMES_KANBAN_TASK": "t_example",
+    }
+    result = subprocess.run(
+        ["bash", "-lc", f"{forge_git_coauthor_prelude()}\ngit push -u origin HEAD"],
+        cwd=repo,
+        env={**os.environ, **env},
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "Forge commit policy blocked git push" in result.stdout
+    assert "missing Raz co-author trailer" in result.stdout
+
+
+def test_forge_git_push_guard_blocks_missing_trailer(tmp_path):
+    remote = tmp_path / "remote.git"
+    repo = tmp_path / "repo"
+    _run(f"git init --bare {remote}", tmp_path)
+    _run(
+        f"git init {repo} && cd {repo} && git config user.name Forge && "
+        "git config user.email forge@example.invalid && git remote add origin "
+        f"{remote}",
+        tmp_path,
+    )
+    (repo / "file.txt").write_text("hello\n", encoding="utf-8")
+    _run("git add file.txt && git commit -m 'feat: missing trailer'", repo)
+
+    env = {
+        "HERMES_PROFILE": "forge",
+        "HERMES_KANBAN_TASK": "t_example",
+    }
+    result = subprocess.run(
+        ["bash", "-lc", f"{forge_git_coauthor_prelude()}\ngit push -u origin HEAD"],
+        cwd=repo,
+        env={**os.environ, **env},
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "Forge commit policy blocked git push" in result.stdout
+    assert "missing Raz co-author trailer" in result.stdout

--- a/tools/forge_git_coauthor.py
+++ b/tools/forge_git_coauthor.py
@@ -1,0 +1,237 @@
+"""Forge-specific git co-author policy helpers.
+
+Forge remains the primary committer, but commits produced by Forge kanban
+workers should include Raz as a GitHub-recognized co-author.  This module keeps
+that policy at the terminal execution seam instead of relying on prompt wording
+or scattered ``git commit`` examples.
+
+Override for special cases: set ``HERMES_FORGE_COAUTHOR_DISABLED=1`` in the
+terminal command environment before committing/pushing.  This is intentionally
+explicit so attribution exceptions leave an audit trail in the command history.
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+
+RAZ_COAUTHOR_NAME = "Ryan McInteer"
+RAZ_COAUTHOR_EMAIL = "ryan.mcinteer@gmail.com"
+RAZ_COAUTHOR_TRAILER = f"Co-authored-by: {RAZ_COAUTHOR_NAME} <{RAZ_COAUTHOR_EMAIL}>"
+
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+
+
+def _active_profile_name() -> str:
+    """Return the current Hermes profile name, best-effort and side-effect free."""
+
+    for key in ("HERMES_PROFILE", "HERMES_PROFILE_NAME", "HERMES_AGENT_PROFILE"):
+        raw = os.environ.get(key, "").strip()
+        if raw:
+            return raw
+
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+
+        return get_active_profile_name()
+    except Exception:
+        return ""
+
+
+def should_enable_forge_git_coauthor() -> bool:
+    """Return True when the Forge kanban commit policy should be active."""
+
+    disabled = os.environ.get("HERMES_FORGE_COAUTHOR_DISABLED", "").strip().lower()
+    if disabled in _TRUE_VALUES:
+        return False
+
+    # Keep scope narrow: default chat sessions, other profiles, and non-kanban
+    # shells should not inherit Forge's commit attribution policy.
+    return _active_profile_name() == "forge" and bool(os.environ.get("HERMES_KANBAN_TASK"))
+
+
+def forge_git_coauthor_prelude() -> str:
+    """Return a bash prelude that wraps git for Forge commit attribution.
+
+    The wrapper:
+    * lets Forge remain the primary author/committer;
+    * amends successful ``git commit`` results to add Raz's co-author trailer;
+    * uses ``git interpret-trailers`` for valid trailer formatting/dedupe while
+      preserving other co-authors;
+    * blocks ``git push`` when outgoing commits are missing the trailer;
+    * can be disabled per-command via ``HERMES_FORGE_COAUTHOR_DISABLED=1``.
+    """
+
+    trailer = shlex.quote(RAZ_COAUTHOR_TRAILER)
+    return f"""
+# Hermes Forge git co-author policy. Override with HERMES_FORGE_COAUTHOR_DISABLED=1.
+__hermes_forge_raz_trailer={trailer}
+
+__hermes_forge_git_context=()
+__hermes_forge_git_subcommand_result=""
+__hermes_forge_git_subcommand_args=()
+
+__hermes_forge_capture_git_context() {{
+  __hermes_forge_git_context=()
+  __hermes_forge_git_subcommand_result=""
+  __hermes_forge_git_subcommand_args=()
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      -C|-c|--git-dir|--work-tree|--namespace)
+        [ "$#" -ge 2 ] || return 0
+        __hermes_forge_git_context+=("$1" "$2")
+        shift 2
+        ;;
+      --git-dir=*|--work-tree=*|--namespace=*)
+        __hermes_forge_git_context+=("$1")
+        shift
+        ;;
+      --*)
+        shift
+        ;;
+      *)
+        __hermes_forge_git_subcommand_result="$1"
+        __hermes_forge_git_subcommand_args=("$@")
+        return 0
+        ;;
+    esac
+  done
+}}
+
+__hermes_forge_git_subcommand() {{
+  __hermes_forge_capture_git_context "$@"
+  printf '%s' "$__hermes_forge_git_subcommand_result"
+}}
+
+__hermes_forge_append_raz_trailer() {{
+  command git "${{__hermes_forge_git_context[@]}}" rev-parse --verify HEAD >/dev/null 2>&1 || return 0
+  local msg new
+  msg=$(mktemp "${{TMPDIR:-/tmp}}/hermes-forge-commit-msg.XXXXXX") || return 1
+  new=$(mktemp "${{TMPDIR:-/tmp}}/hermes-forge-commit-msg-new.XXXXXX") || {{ rm -f "$msg"; return 1; }}
+  command git "${{__hermes_forge_git_context[@]}}" log -1 --format=%B | awk -v trailer="$__hermes_forge_raz_trailer" '
+    $0 == trailer {{ if (seen++) next }}
+    {{ print }}
+  ' > "$msg" || {{ rm -f "$msg" "$new"; return 1; }}
+  command git "${{__hermes_forge_git_context[@]}}" interpret-trailers --if-exists addIfDifferent --if-missing add \
+    --trailer "$__hermes_forge_raz_trailer" "$msg" > "$new" || {{ rm -f "$msg" "$new"; return 1; }}
+  command git "${{__hermes_forge_git_context[@]}}" commit --amend --no-verify -F "$new" >/dev/null || {{ rm -f "$msg" "$new"; return 1; }}
+  rm -f "$msg" "$new"
+}}
+
+__hermes_forge_push_base() {{
+  local upstream default_branch
+  upstream=$(command git "${{__hermes_forge_git_context[@]}}" rev-parse --abbrev-ref --symbolic-full-name @{{u}} 2>/dev/null) && {{ printf '%s' "$upstream"; return 0; }}
+  if command git "${{__hermes_forge_git_context[@]}}" rev-parse --verify origin/main >/dev/null 2>&1; then
+    printf '%s' origin/main
+    return 0
+  fi
+  default_branch=$(command git "${{__hermes_forge_git_context[@]}}" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##')
+  if [ -n "$default_branch" ] && command git "${{__hermes_forge_git_context[@]}}" rev-parse --verify "origin/$default_branch" >/dev/null 2>&1; then
+    printf '%s' "origin/$default_branch"
+  fi
+}}
+
+__hermes_forge_push_sources() {{
+  local seen_remote=0 all_branches=0 arg src
+  for arg in "$@"; do
+    [ "$arg" = "push" ] && continue
+    case "$arg" in
+      --all)
+        all_branches=1
+        ;;
+      --mirror)
+        all_branches=1
+        ;;
+      -u|--set-upstream|--force|--force-with-lease|--tags|--follow-tags|--dry-run|--porcelain)
+        ;;
+      --*)
+        ;;
+      *)
+        if [ "$seen_remote" -eq 0 ]; then
+          seen_remote=1
+          continue
+        fi
+        src="${{arg%%:*}}"
+        src="${{src#+}}"
+        [ -n "$src" ] && printf '%s\n' "$src"
+        ;;
+    esac
+  done
+  if [ "$all_branches" -eq 1 ]; then
+    command git "${{__hermes_forge_git_context[@]}}" for-each-ref refs/heads --format='%(refname:short)'
+    return 0
+  fi
+}}
+
+__hermes_forge_commit_has_raz_trailer() {{
+  command git "${{__hermes_forge_git_context[@]}}" log -1 --format=%B "$1" | command git interpret-trailers --parse | grep -Fqx "$__hermes_forge_raz_trailer"
+}}
+
+__hermes_forge_verify_outgoing_trailers() {{
+  local base range missing sha sources source
+  base=$(__hermes_forge_push_base)
+  sources=$(__hermes_forge_push_sources "$@")
+  [ -n "$sources" ] || sources="HEAD"
+  missing=""
+  while IFS= read -r source; do
+    [ -n "$source" ] || continue
+    if [ -n "$base" ]; then
+      range="$base..$source"
+    else
+      range="$source"
+    fi
+    while IFS= read -r sha; do
+      [ -n "$sha" ] || continue
+      if ! __hermes_forge_commit_has_raz_trailer "$sha"; then
+        missing="$missing ${{sha%% *}}"
+      fi
+    done <<EOF
+$(command git "${{__hermes_forge_git_context[@]}}" rev-list "$range" 2>/dev/null)
+EOF
+  done <<EOF
+$sources
+EOF
+  if [ -n "$missing" ]; then
+    printf '%s\n' "Forge commit policy blocked git push: outgoing commit(s)$missing missing Raz co-author trailer: $__hermes_forge_raz_trailer" >&2
+    printf '%s\n' "Set HERMES_FORGE_COAUTHOR_DISABLED=1 only for explicit special-case attribution overrides." >&2
+    return 1
+  fi
+}}
+
+git() {{
+  if [ "${{HERMES_FORGE_COAUTHOR_DISABLED:-}}" = "1" ]; then
+    command git "$@"
+    return $?
+  fi
+
+  local subcommand ec
+  subcommand=$(__hermes_forge_git_subcommand "$@")
+  case "$subcommand" in
+    commit)
+      command git "$@"
+      ec=$?
+      if [ "$ec" -eq 0 ]; then
+        __hermes_forge_append_raz_trailer || return $?
+      fi
+      return "$ec"
+      ;;
+    push)
+      __hermes_forge_verify_outgoing_trailers "${{__hermes_forge_git_subcommand_args[@]}}" || return $?
+      command git "$@"
+      return $?
+      ;;
+    *)
+      command git "$@"
+      return $?
+      ;;
+  esac
+}}
+""".strip()
+
+
+def apply_forge_git_coauthor_policy(command: str) -> str:
+    """Prepend the Forge git co-author wrapper when policy scope matches."""
+
+    if not should_enable_forge_git_coauthor():
+        return command
+    return f"{forge_git_coauthor_prelude()}\n{command}"

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1919,6 +1919,18 @@ def terminal_tool(
                 "EOF."
             )
 
+        # Forge kanban workers have a narrow git attribution policy: commits
+        # created through terminal commands keep Forge as primary committer but
+        # receive Raz's GitHub co-author trailer, with a pre-push guard.  Apply
+        # after approval/workdir/PTY checks so the injected wrapper does not
+        # change how the user's original command is classified or displayed.
+        try:
+            from tools.forge_git_coauthor import apply_forge_git_coauthor_policy
+
+            command = apply_forge_git_coauthor_policy(command)
+        except Exception:
+            logger.debug("Forge git co-author policy injection skipped", exc_info=True)
+
         if background:
             # Spawn a tracked background process via the process registry.
             # For local backends: uses subprocess.Popen with output buffering.

--- a/website/docs/user-guide/features/kanban-worker-lanes.md
+++ b/website/docs/user-guide/features/kanban-worker-lanes.md
@@ -84,6 +84,18 @@ The shape every kanban worker takes today: the assignee is a profile name, the d
 
 When you create profiles for your fleet, choose names that match the *role* you want the orchestrator to route to. The orchestrator (when there is one) discovers your profile names via `hermes profile list` — there's no fixed roster the system assumes (see the [`kanban-orchestrator`](https://github.com/NousResearch/hermes-agent/blob/main/skills/devops/kanban-orchestrator/SKILL.md) skill for the orchestrator side of the contract).
 
+#### Forge commit co-author policy
+
+The built-in `forge` profile lane has one additional attribution rule when it is running as a kanban worker (`HERMES_PROFILE=forge` and `HERMES_KANBAN_TASK` is set): terminal-tool `git commit` commands keep Forge as the primary author/committer, then amend the new commit message with Raz's GitHub co-author trailer exactly once:
+
+```text
+Co-authored-by: Ryan McInteer <ryan.mcinteer@gmail.com>
+```
+
+The same terminal seam guards `git push`: outgoing commits that do not contain that exact trailer are blocked before push where the local repo can determine the outgoing range. This is a future-behaviour policy only; it does not rewrite merged history or existing remote branches.
+
+To make an explicit special-case attribution override, run the command with `HERMES_FORGE_COAUTHOR_DISABLED=1`. Do not change the primary author to Raz unless a separate lane/config explicitly says Raz authored the work.
+
 ### Orchestrator profile lane
 
 A specialisation of the profile lane: an orchestrator is a Hermes profile whose toolset includes `kanban` but excludes `terminal` / `file` / `code` / `web` for implementation. Its job is decomposing a high-level goal into child tasks via `kanban_create` + `kanban_link` and stepping back. The orchestrator skill encodes the anti-temptation rules.


### PR DESCRIPTION
## Summary
- add a Forge kanban-worker scoped git wrapper at the terminal tool seam
- append Raz's GitHub co-author trailer exactly once after successful Forge commits
- add a pre-push outgoing-commit guard plus docs for override cases

## Test Plan
- python -m pytest tests/tools/test_terminal_none_command_guard.py tests/tools/test_forge_git_coauthor_policy.py -q -o 'addopts='
- git log -1 --format=%B shows exactly one Co-authored-by: Ryan McInteer <ryan.mcinteer@gmail.com> trailer