### PR TITLE
feat(gateway): add Nox worker live steer ledger

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -35,6 +35,15 @@ _GLOBAL_DEFAULTS: dict[str, Any] = {
     "show_reasoning": False,
     "tool_preview_length": 0,
     "streaming": None,  # None = follow top-level streaming config
+    # Lifecycle/status bubbles emitted by the agent itself (preflight
+    # compression, retry notices, auxiliary warnings).  Keep on by default for
+    # backwards compatibility, but allow chat platforms/topics that are meant
+    # to be clean control surfaces to disable them independently from tool
+    # progress.
+    "status_messages": True,
+    # Natural mid-turn assistant commentary.  Historically this was a global
+    # display flag; include it here so platforms/topics can opt out.
+    "interim_assistant_messages": True,
     # When true, delete tool-progress / "Still working..." / status bubbles
     # after the final response lands on platforms that support message
     # deletion (e.g. Telegram). Off by default — progress is still shown
@@ -190,7 +199,7 @@ def _normalise(setting: str, value: Any) -> Any:
         if value is True:
             return "all"
         return str(value).lower()
-    if setting in {"show_reasoning", "streaming"}:
+    if setting in {"show_reasoning", "streaming", "status_messages", "interim_assistant_messages"}:
         if isinstance(value, str):
             return value.lower() in {"true", "1", "yes", "on"}
         return bool(value)

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1637,6 +1637,40 @@ class TelegramAdapter(BasePlatformAdapter):
         else:  # "first" (default)
             return chunk_index == 0
 
+    def _creative_lab_quick_actions_markup(
+        self,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[Any]:
+        """Attach Creative Lab inline action buttons only inside that topic.
+
+        Do not infer this from message text: normal DM/status replies often
+        mention "Creative Lab" while discussing the feature, and attaching the
+        product cockpit globally pollutes every Telegram response.
+        """
+        metadata = metadata or {}
+        topic = str(
+            metadata.get("chat_topic")
+            or metadata.get("topic")
+            or metadata.get("thread_name")
+            or ""
+        ).strip().lower()
+        if topic != "creative lab":
+            return None
+        try:
+            return InlineKeyboardMarkup([
+                [
+                    InlineKeyboardButton("🔥 Winners", callback_data="crl:winners"),
+                    InlineKeyboardButton("🎨 Variants", callback_data="crl:variants"),
+                ],
+                [
+                    InlineKeyboardButton("📊 Stats", callback_data="crl:stats"),
+                    InlineKeyboardButton("🧪 Run lab", callback_data="crl:run"),
+                ],
+            ])
+        except Exception:
+            return None
+
     async def send(
         self,
         chat_id: str,
@@ -1687,6 +1721,8 @@ class TelegramAdapter(BasePlatformAdapter):
             except (ImportError, AttributeError):
                 _TimedOut = None  # type: ignore[assignment,misc]
 
+            creative_lab_keyboard = self._creative_lab_quick_actions_markup(content, metadata)
+
             for i, chunk in enumerate(chunks):
                 retried_thread_not_found = False
                 metadata_reply_to = self._metadata_reply_to_message_id(metadata)
@@ -1724,6 +1760,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                 text=chunk,
                                 parse_mode=ParseMode.MARKDOWN_V2,
                                 reply_to_message_id=reply_to_id,
+                                reply_markup=creative_lab_keyboard if i == len(chunks) - 1 else None,
                                 **thread_kwargs,
                                 **self._link_preview_kwargs(),
                                 **self._notification_kwargs(metadata),
@@ -1738,6 +1775,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                     text=plain_chunk,
                                     parse_mode=None,
                                     reply_to_message_id=reply_to_id,
+                                    reply_markup=creative_lab_keyboard if i == len(chunks) - 1 else None,
                                     **thread_kwargs,
                                     **self._link_preview_kwargs(),
                                     **self._notification_kwargs(metadata),
@@ -2890,6 +2928,81 @@ class TelegramAdapter(BasePlatformAdapter):
             )
             return
 
+        # --- Creative Lab quick-action callbacks (crl:action) ---
+        # Lightweight, product-specific buttons for Даня's Creative Lab Telegram
+        # topic. They turn a button click into a normal Hermes text event in the
+        # same chat/topic, so the existing agent loop does the actual work.
+        if data.startswith("crl:"):
+            action = data.split(":", 1)[1].strip().lower()
+            caller_id = str(getattr(query.from_user, "id", ""))
+            if not self._is_callback_user_authorized(
+                caller_id,
+                chat_id=query_chat_id,
+                chat_type=str(query_chat_type) if query_chat_type is not None else None,
+                thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                user_name=query_user_name,
+            ):
+                await query.answer(text="⛔ You are not authorized to use this button.")
+                return
+
+            prompt_map = {
+                "winners": "Creative Lab: найди текущие winner-креативы MetaAuto по последней доступной статистике ExzyPo. Только ExzyPo, не all users. Покажи source cards с preview/provenance и не генерируй варианты до выбора source.",
+                "variants": "Creative Lab: если в текущем сообщении/топике есть выбранный или загруженный source creative, сделай source analysis и generation plan. Если source не выбран/не доказан — сначала покажи winners/source cards и спроси выбор. Не генерируй из all users и не отправляй визуалы ниже self-grade 4/5.",
+                "stats": "Creative Lab: проверь последнюю статистику MetaAuto/ExzyPo и покажи, какие креативы реально лидируют. Только ExzyPo; обязательно proof/source scope.",
+                "run": "Creative Lab: запусти gated цикл lab — ExzyPo winners → source preview/provenance → source selection → analysis → variants. Без запуска рекламы и трат; без генерации, если source не доказан.",
+            }
+            label_map = {
+                "winners": "🔥 Найти winners",
+                "variants": "🎨 Сделать variants",
+                "stats": "📊 Проверить статистику",
+                "run": "🧪 Запустить lab",
+            }
+            prompt = prompt_map.get(action)
+            if not prompt or not query.message:
+                await query.answer(text="Unknown Creative Lab action.")
+                return
+
+            label = label_map.get(action, action)
+            await query.answer(text=f"Запускаю: {label}")
+            try:
+                await query.message.reply_text(
+                    f"{label} — принято, запускаю через Nox…",
+                    reply_to_message_id=getattr(query.message, "message_id", None),
+                )
+            except Exception:
+                pass
+
+            qmsg = query.message
+            chat = getattr(qmsg, "chat", None)
+            chat_type_value = getattr(chat, "type", None)
+            chat_type_str = str(getattr(chat_type_value, "value", chat_type_value)).lower()
+            normalized_chat_type = "dm"
+            if chat_type_str in {"group", "supergroup"}:
+                normalized_chat_type = "group"
+            elif chat_type_str == "channel":
+                normalized_chat_type = "channel"
+
+            thread_id = getattr(qmsg, "message_thread_id", None)
+            source = self.build_source(
+                chat_id=str(getattr(chat, "id", query_chat_id)),
+                chat_name=getattr(chat, "title", None) or getattr(chat, "full_name", None),
+                chat_type=normalized_chat_type,
+                user_id=str(getattr(query.from_user, "id", "")) or None,
+                user_name=getattr(query.from_user, "full_name", None) or getattr(query.from_user, "first_name", None),
+                thread_id=str(thread_id) if thread_id is not None else None,
+                chat_topic="Creative Lab" if thread_id is not None else None,
+                message_id=str(getattr(qmsg, "message_id", "")) or None,
+            )
+            event = MessageEvent(
+                text=prompt,
+                message_type=MessageType.TEXT,
+                source=source,
+                raw_message=qmsg,
+                message_id=str(getattr(qmsg, "message_id", "")) or None,
+            )
+            await self.handle_message(event)
+            return
+
         # --- Exec approval callbacks (ea:choice:id) ---
         if data.startswith("ea:"):
             parts = data.split(":", 2)
@@ -3585,6 +3698,10 @@ class TelegramAdapter(BasePlatformAdapter):
                 reply_to_message_id=reply_to_id,
                 reply_to_mode=self._reply_to_mode
             )
+            creative_lab_keyboard = self._creative_lab_quick_actions_markup(
+                f"{caption or ''}\n{image_path}",
+                metadata,
+            )
             with open(image_path, "rb") as image_file:
                 msg = await self._send_with_dm_topic_reply_anchor_retry(
                     self._bot.send_photo,
@@ -3593,6 +3710,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         "photo": image_file,
                         "caption": caption[:1024] if caption else None,
                         "reply_to_message_id": reply_to_id,
+                        "reply_markup": creative_lab_keyboard,
                         **thread_kwargs,
                         **self._notification_kwargs(metadata),
                     },

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -857,6 +857,38 @@ _NOX_PROJECT_ALIASES: Dict[str, tuple[str, ...]] = {
     ),
 }
 
+# Cross-project / agent-platform work belongs to the Nox OS employee lane when
+# no concrete product project is named.  Keep these out of _NOX_PROJECT_ALIASES:
+# broad words like "skills" or "agents" must not create a multi-project conflict
+# when the same message explicitly says "MetaAuto" or "Ryadom".
+_NOX_SYSTEM_SCOPE_MARKERS: tuple[str, ...] = (
+    "all projects",
+    "cross project",
+    "cross-project",
+    "все проекты",
+    "всех проектов",
+    "по всем проектам",
+    "всем проектам",
+    "all agents",
+    "agent platform",
+    "agents",
+    "агенты",
+    "агентов",
+    "все агенты",
+    "всех агентов",
+    "сами агенты",
+    "самих агентов",
+    "любой агент",
+    "любого агента",
+    "skills",
+    "skill",
+    "skill hub",
+    "hermes skills",
+    "скиллы",
+    "скилл",
+    "навыки",
+)
+
 # Soft, project-specific vocabulary used only when Башня receives a substantial
 # follow-up without an explicit project name.  This keeps long project work out
 # of the control tower while avoiding broad aliases like "приложение" that would
@@ -935,6 +967,14 @@ _NOX_PROJECT_HEAVY_MARKERS: tuple[str, ...] = (
     "implement",
     "реализ",
     "сделай",
+    "поставь",
+    "поставить",
+    "установи",
+    "установить",
+    "инсталл",
+    "install",
+    "внедри",
+    "внедр",
     "доделай",
     "почини",
     "исправ",
@@ -2437,6 +2477,12 @@ class GatewayRunner:
                 "reason": "multiple_projects",
             }
 
+        system_scope_hits = [
+            marker
+            for marker in _NOX_SYSTEM_SCOPE_MARKERS
+            if self._nox_bashnya_has_phrase(normalized, marker)
+        ]
+
         has_blocker = any(
             self._nox_bashnya_has_phrase(normalized, marker)
             for marker in _NOX_PROJECT_BLOCKER_MARKERS
@@ -2461,6 +2507,14 @@ class GatewayRunner:
         project_key = unique_matches[0] if unique_matches else None
         inference: Optional[Dict[str, Any]] = None
         active_projects: list[str] = []
+        if not project_key and system_scope_hits and substantial:
+            project_key = "nox-system"
+            inference = {
+                "project": "nox-system",
+                "reason": "system_scope_marker",
+                "score": len(system_scope_hits),
+                "hits": system_scope_hits[:5],
+            }
         if not project_key and substantial:
             inference, active_runs = self._nox_infer_project_from_active_context(normalized, source)
             active_projects = list(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -553,8 +553,23 @@ def _reload_runtime_env_preserving_config_authority() -> None:
         return
 
     agent_cfg = cfg.get("agent", {})
-    if isinstance(agent_cfg, dict) and "max_turns" in agent_cfg:
-        os.environ["HERMES_MAX_ITERATIONS"] = str(agent_cfg["max_turns"])
+    if isinstance(agent_cfg, dict):
+        # Keep all runtime-budget env bridges in sync on every turn, not only
+        # at module import. Gateway processes are long-lived and users often
+        # change config.yaml while the daemon keeps running; a stale env value
+        # must not resurrect raw "Still working... iteration x/y" notices or
+        # old timeout budgets after config says otherwise.
+        _runtime_env_map = {
+            "max_turns": "HERMES_MAX_ITERATIONS",
+            "gateway_timeout": "HERMES_AGENT_TIMEOUT",
+            "gateway_timeout_warning": "HERMES_AGENT_TIMEOUT_WARNING",
+            "gateway_notify_interval": "HERMES_AGENT_NOTIFY_INTERVAL",
+            "restart_drain_timeout": "HERMES_RESTART_DRAIN_TIMEOUT",
+            "gateway_auto_continue_freshness": "HERMES_AUTO_CONTINUE_FRESHNESS",
+        }
+        for _cfg_key, _env_name in _runtime_env_map.items():
+            if _cfg_key in agent_cfg:
+                os.environ[_env_name] = str(agent_cfg[_cfg_key])
 
 
 _DOCKER_VOLUME_SPEC_RE = re.compile(r"^(?P<host>.+):(?P<container>/[^:]+?)(?::(?P<options>[^:]+))?$")
@@ -808,6 +823,150 @@ logger = logging.getLogger(__name__)
 # session from bypassing the "already running" guard during the async gap
 # between the guard check and actual agent creation.
 _AGENT_PENDING_SENTINEL = object()
+
+# Nox v2 / Башня runtime router.  This is deliberately hard-gated to the
+# nox-v2 profile and one Telegram group topic so the default production profile
+# and token paths remain untouched.
+_NOX_BASHNYA_PROFILE = "nox-v2"
+_NOX_BASHNYA_CHAT_ID = "-1003889439571"
+_NOX_BASHNYA_THREAD_ID = "25"
+_NOX_PROJECT_EMPLOYEE_ROUTES_PATH = Path(
+    "/Users/exz/nox-os/state/war-room/project-employees.json"
+)
+_NOX_PHASE_RUNS_PATH = Path("/Users/exz/nox-os/state/war-room/phase-runs.json")
+_NOX_BASHNYA_FAST_MAX_TURNS_DEFAULT = 8
+_NOX_WORKER_PLAN_MAX_TURNS_DEFAULT = 10
+_NOX_WORKER_PHASE_MAX_TURNS_DEFAULT = 30
+
+_NOX_PROJECT_ALIASES: Dict[str, tuple[str, ...]] = {
+    "ryadom": ("ryadom", "рядом"),
+    "metaauto": ("metaauto", "meta auto", "метаавто", "мета авто"),
+    "planner": ("planner", "планнер", "планер", "планировщик"),
+    "creative-lab": ("creative lab", "creative", "креатив", "креативная лаборатория"),
+    "nox-system": (
+        "nox os",
+        "nox",
+        "nox v2",
+        "hermes",
+        "гермес",
+        "gateway",
+        "гейтвей",
+        "war room",
+        "башня",
+        "nox os hermes",
+    ),
+}
+
+_NOX_PROJECT_RUN_MARKERS: tuple[str, ...] = (
+    "запусти",
+    "прогони",
+    "run ",
+    "pytest",
+    "тесты",
+    "тест",
+    "deploy",
+    "release",
+    "миграц",
+    "пересобери",
+)
+
+_NOX_PROJECT_HEAVY_MARKERS: tuple[str, ...] = (
+    "implement",
+    "реализ",
+    "сделай",
+    "доделай",
+    "почини",
+    "исправ",
+    "fix",
+    "debug",
+    "investigate",
+    "разберись",
+    "диагност",
+    "добавь",
+    "создай",
+    "настрой",
+    "обнови",
+    "patch",
+    "код",
+    "router",
+    "routing",
+    "runtime",
+    "worker",
+    "сотрудник",
+    "проект",
+    "project",
+    "run ",
+    "pytest",
+)
+
+_NOX_PROJECT_BLOCKER_MARKERS: tuple[str, ...] = (
+    "rm -rf",
+    "удали прод",
+    "удали production",
+    "перезапусти gateway",
+    "restart gateway",
+    "deploy production",
+    "продакшен деплой",
+    "оплати",
+    "купи",
+)
+
+# Nox PM can approve safe worker phases without Danya.  These markers are the
+# conservative escape hatch: if they appear in the original task, worker plan,
+# or worker proof, the run stops on a human gate instead of auto-advancing.
+_NOX_HUMAN_APPROVAL_MARKERS: tuple[str, ...] = _NOX_PROJECT_BLOCKER_MARKERS + (
+    "sudo",
+    "git reset --hard",
+    "reset --hard",
+    "force push",
+    "push --force",
+    "drop database",
+    "drop table",
+    "truncate database",
+    "truncate table",
+    "delete database",
+    "delete prod",
+    "delete production",
+    "удали базу",
+    "дропни базу",
+    "сотри базу",
+    "миграция в прод",
+    "прод миграция",
+    "production migration",
+    "prod migration",
+    "деплой в прод",
+    "deploy prod",
+    "deploy production",
+    "production deploy",
+    "release prod",
+    "release production",
+    "перезапусти прод",
+    "перезапусти production",
+    "restart prod",
+    "restart production",
+    "нужен даня",
+    "нужна даня",
+    "нужно подтвердить у дани",
+    "требуется подтверждение дани",
+    "requires danya",
+    "requires human approval",
+    "approval required",
+    "нужен доступ",
+    "нужны доступы",
+    "нужен логин",
+    "нужен пароль",
+    "нужна 2fa",
+    "нужны секреты",
+    "api key needed",
+    "purchase",
+    "payment",
+    "card",
+    "credit card",
+    "массовая отправка",
+    "отправь всем",
+    "send to all",
+    "mass message",
+)
 
 
 def _resolve_runtime_agent_kwargs() -> dict:
@@ -2053,6 +2212,1132 @@ class GatewayRunner:
                 return None
         return None
 
+    def _nox_bashnya_normalize_text(self, text: str) -> str:
+        """Normalize Russian/English task text for the narrow Nox router."""
+        normalized = (text or "").lower().replace("ё", "е")
+        normalized = re.sub(r"[\u2010-\u2015_\-]+", " ", normalized)
+        normalized = re.sub(r"\s+", " ", normalized)
+        return normalized.strip()
+
+    def _nox_bashnya_has_phrase(self, normalized_text: str, phrase: str) -> bool:
+        phrase_norm = self._nox_bashnya_normalize_text(phrase)
+        if not phrase_norm:
+            return False
+        # Word-ish boundary matching avoids routing on substrings such as
+        # "planning" -> "planner" while still supporting multi-word aliases.
+        return re.search(
+            rf"(?<![\w]){re.escape(phrase_norm)}(?![\w])",
+            normalized_text,
+            flags=re.IGNORECASE,
+        ) is not None
+
+    def _is_nox_bashnya_source(self, source: Optional[SessionSource]) -> bool:
+        """Return True only for nox-v2's `01 Башня управления` topic."""
+        if source is None or source.platform != Platform.TELEGRAM:
+            return False
+        if str(source.chat_id or "") != _NOX_BASHNYA_CHAT_ID:
+            return False
+        if str(source.thread_id or "") != _NOX_BASHNYA_THREAD_ID:
+            return False
+        try:
+            profile = self._active_profile_name()
+        except Exception:
+            profile = "default"
+        return str(profile or "default") == _NOX_BASHNYA_PROFILE
+
+    def _nox_bashnya_classify_task(self, message_text: str) -> Dict[str, Any]:
+        """Classify obvious FAST vs project-heavy Nox Bashnya messages.
+
+        This is intentionally deterministic and conservative: unknown project
+        or ambiguous/light messages stay on the normal direct path; only a
+        known project plus explicit heavy/run markers is routed away.
+        """
+        raw_text = message_text or ""
+        normalized = self._nox_bashnya_normalize_text(raw_text)
+        if not normalized:
+            return {"weight": "FAST", "project": None, "reason": "empty"}
+
+        matches: list[str] = []
+        for project_key, aliases in _NOX_PROJECT_ALIASES.items():
+            if any(self._nox_bashnya_has_phrase(normalized, alias) for alias in aliases):
+                matches.append(project_key)
+
+        unique_matches = list(dict.fromkeys(matches))
+        if len(unique_matches) > 1:
+            return {
+                "weight": "BLOCKER",
+                "project": None,
+                "projects": unique_matches,
+                "reason": "multiple_projects",
+            }
+
+        project_key = unique_matches[0] if unique_matches else None
+        if not project_key:
+            return {"weight": "FAST", "project": None, "reason": "no_known_project"}
+
+        has_blocker = any(
+            self._nox_bashnya_has_phrase(normalized, marker)
+            for marker in _NOX_PROJECT_BLOCKER_MARKERS
+        )
+        if has_blocker:
+            return {
+                "weight": "BLOCKER",
+                "project": project_key,
+                "reason": "approval_required",
+            }
+
+        has_run = any(
+            self._nox_bashnya_has_phrase(normalized, marker)
+            for marker in _NOX_PROJECT_RUN_MARKERS
+        )
+        has_heavy_marker = any(
+            self._nox_bashnya_has_phrase(normalized, marker)
+            for marker in _NOX_PROJECT_HEAVY_MARKERS
+        )
+        looks_like_brief = len(raw_text.strip()) <= 220 and "\n" not in raw_text
+        if has_run:
+            return {"weight": "RUN", "project": project_key, "reason": "run_marker"}
+        if has_heavy_marker or not looks_like_brief:
+            return {"weight": "PROJECT", "project": project_key, "reason": "heavy_marker"}
+        return {"weight": "FAST", "project": project_key, "reason": "brief_project_question"}
+
+    def _load_nox_project_employee_routes(self) -> Dict[str, Dict[str, Any]]:
+        """Load `<Project> · Сотрудник` route map from the Nox control-plane."""
+        raw_path = os.getenv(
+            "NOX_PROJECT_EMPLOYEE_ROUTING_PATH",
+            str(_NOX_PROJECT_EMPLOYEE_ROUTES_PATH),
+        )
+        path = Path(raw_path).expanduser()
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            logger.warning("Nox Bashnya router: cannot read project routes at %s: %s", path, exc)
+            return {}
+        projects = data.get("projects") if isinstance(data, dict) else None
+        if not isinstance(projects, dict):
+            return {}
+        routes: Dict[str, Dict[str, Any]] = {}
+        for key, route in projects.items():
+            if not isinstance(route, dict):
+                continue
+            chat_id = str(route.get("chat_id") or "").strip()
+            thread_id = route.get("message_thread_id")
+            if not chat_id or thread_id is None:
+                continue
+            routes[str(key).lower()] = {
+                "project": str(route.get("project") or key),
+                "display": str(route.get("display") or key),
+                "topic_name": str(route.get("topic_name") or f"{route.get('display') or key} · Сотрудник"),
+                "chat_id": chat_id,
+                "message_thread_id": str(thread_id),
+            }
+        return routes
+
+    def _nox_now_iso(self) -> str:
+        return datetime.now().isoformat(timespec="seconds")
+
+    def _nox_phase_runs_path(self) -> Path:
+        raw_path = os.getenv("NOX_PHASE_RUNS_PATH", str(_NOX_PHASE_RUNS_PATH))
+        return Path(raw_path).expanduser()
+
+    def _load_nox_phase_runs(self) -> Dict[str, Dict[str, Any]]:
+        """Load durable Nox worker phase-run state.
+
+        Stored outside Hermes sessions so the visible War Room state survives
+        gateway restarts.  The default path is profile-specific Nox OS state,
+        and tests can override it with NOX_PHASE_RUNS_PATH.
+        """
+        path = self._nox_phase_runs_path()
+        try:
+            if not path.exists():
+                return {}
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            logger.warning("Nox phase runner: cannot read state at %s: %s", path, exc)
+            return {}
+        runs = data.get("runs") if isinstance(data, dict) else None
+        # Backward/hand-edit tolerance: a bare {run_id: state} dict is also OK.
+        if runs is None and isinstance(data, dict):
+            runs = data
+        if not isinstance(runs, dict):
+            return {}
+        return {
+            str(run_id): dict(state)
+            for run_id, state in runs.items()
+            if isinstance(state, dict)
+        }
+
+    def _save_nox_phase_runs(self, runs: Dict[str, Dict[str, Any]]) -> None:
+        path = self._nox_phase_runs_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "updated_at": self._nox_now_iso(),
+            "runs": runs,
+        }
+        tmp_path = path.with_name(f".{path.name}.tmp")
+        tmp_path.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
+        os.replace(tmp_path, path)
+
+    def _upsert_nox_phase_run(self, run_id: str, **updates: Any) -> Dict[str, Any]:
+        runs = self._load_nox_phase_runs()
+        state = dict(runs.get(run_id) or {})
+        state.update({k: v for k, v in updates.items() if v is not None})
+        state["run_id"] = run_id
+        state["updated_at"] = self._nox_now_iso()
+        runs[run_id] = state
+        self._save_nox_phase_runs(runs)
+        return state
+
+    def _redact_nox_goal_for_state(self, text: str) -> str:
+        goal = (text or "").strip()
+        try:
+            from agent.redact import redact_sensitive_text
+            goal = redact_sensitive_text(goal)
+        except Exception:
+            pass
+        if len(goal) > 4000:
+            goal = goal[:4000].rstrip() + "…"
+        return goal
+
+    def _build_nox_phase_state(
+        self,
+        *,
+        event: MessageEvent,
+        message_text: str,
+        classification: Dict[str, Any],
+        route: Dict[str, Any],
+        run_id: str,
+        packet_message_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        source = event.source
+        now = self._nox_now_iso()
+        goal_text = getattr(event, "text", "") or message_text
+        return {
+            "run_id": run_id,
+            "status": "planning",
+            "mode": str(classification.get("weight") or "PROJECT"),
+            "project": str(route.get("project") or classification.get("project") or ""),
+            "display": str(route.get("display") or route.get("project") or "Project"),
+            "topic_name": str(route.get("topic_name") or "Project · Сотрудник"),
+            "goal": self._redact_nox_goal_for_state(goal_text),
+            "source_message_id": str(event.message_id or ""),
+            "packet_message_id": str(packet_message_id or ""),
+            "bashnya_chat_id": str(source.chat_id or ""),
+            "bashnya_thread_id": str(source.thread_id or ""),
+            "employee_chat_id": str(route.get("chat_id") or ""),
+            "employee_thread_id": str(route.get("message_thread_id") or ""),
+            "source_user_id": str(source.user_id or ""),
+            "source_user_name": str(source.user_name or ""),
+            "phase_index": 0,
+            "phase_count": 0,
+            "created_at": now,
+            "updated_at": now,
+        }
+
+    def _nox_route_from_phase_state(self, state: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "project": state.get("project") or "",
+            "display": state.get("display") or state.get("project") or "Project",
+            "topic_name": state.get("topic_name") or "Project · Сотрудник",
+            "chat_id": str(state.get("employee_chat_id") or ""),
+            "message_thread_id": str(state.get("employee_thread_id") or ""),
+        }
+
+    def _nox_worker_source_from_state(self, state: Dict[str, Any]) -> SessionSource:
+        return SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id=str(state.get("employee_chat_id") or ""),
+            chat_name=str(state.get("topic_name") or "Project · Сотрудник"),
+            chat_type="supergroup",
+            user_id=str(state.get("source_user_id") or "8756671470"),
+            user_name=str(state.get("source_user_name") or "Danya"),
+            thread_id=str(state.get("employee_thread_id") or ""),
+        )
+
+    def _extract_nox_plan_phase_count(self, plan_text: str) -> int:
+        text = plan_text or ""
+        numbers: list[int] = []
+        patterns = (
+            r"(?im)^\s*(?:[-*]\s*)?(?:фаза|phase)\s*([0-9]{1,2})\b",
+            r"(?im)^\s*(?:[-*]\s*)?([0-9]{1,2})[\).\s:-]+(?:фаза|phase)\b",
+        )
+        for pattern in patterns:
+            for match in re.finditer(pattern, text):
+                try:
+                    numbers.append(int(match.group(1)))
+                except (TypeError, ValueError):
+                    continue
+        try:
+            max_phases = int(os.getenv("NOX_WORKER_MAX_PHASES", "7"))
+        except (TypeError, ValueError):
+            max_phases = 7
+        max_phases = max(1, min(max_phases, 20))
+        if not numbers:
+            return 1
+        return max(1, min(max(numbers), max_phases))
+
+    def _nox_pm_auto_approve_safe_phases_enabled(self) -> bool:
+        raw = os.getenv("NOX_PM_AUTO_APPROVE_SAFE_PHASES", "1")
+        return str(raw).strip().lower() not in {"0", "false", "no", "off"}
+
+    def _nox_human_approval_reason(self, *texts: str) -> Optional[str]:
+        """Return a conservative human-gate reason, or None for Nox PM auto-approval."""
+        if not self._nox_pm_auto_approve_safe_phases_enabled():
+            return "auto_approval_disabled"
+        combined = "\n".join(str(text or "") for text in texts if text)
+        normalized = self._nox_bashnya_normalize_text(combined)
+        if not normalized:
+            return None
+        for marker in _NOX_HUMAN_APPROVAL_MARKERS:
+            if self._nox_bashnya_has_phrase(normalized, marker):
+                return marker
+        return None
+
+    def _nox_worker_output_human_gate_reason(self, output: str) -> Optional[str]:
+        """Worker proof can discover a blocker even when the original task was safe."""
+        blocker_reason = self._nox_human_approval_reason(output)
+        if blocker_reason:
+            return blocker_reason
+        normalized = self._nox_bashnya_normalize_text(output)
+        soft_blockers = (
+            "не могу продолжить без дани",
+            "cannot continue without danya",
+            "waiting for human",
+            "жду человека",
+            "жду подтверждение",
+            "жду подтверждения",
+            "нужно решение",
+            "нужно product решение",
+            "нужно бизнес решение",
+        )
+        for marker in soft_blockers:
+            if self._nox_bashnya_has_phrase(normalized, marker):
+                return marker
+        return None
+
+    def _approve_and_start_nox_next_phase(
+        self,
+        *,
+        run_id: str,
+        state: Dict[str, Any],
+        approved_by: str,
+        approval_mode: str,
+        approval_reason: str,
+    ) -> tuple[int, str, Dict[str, Any]]:
+        phase_count = int(state.get("phase_count") or 1)
+        phase_index = int(state.get("phase_index") or 0)
+        next_phase = phase_index + 1
+        if next_phase > phase_count:
+            updated = self._upsert_nox_phase_run(run_id, status="completed")
+            return next_phase, "", updated
+        updated = self._upsert_nox_phase_run(
+            run_id,
+            status="running_phase",
+            phase_index=next_phase,
+            approved_at=self._nox_now_iso(),
+            approved_by=approved_by,
+            approval_mode=approval_mode,
+            approval_reason=approval_reason,
+        )
+        route = self._nox_route_from_phase_state(updated)
+        task_id = self._start_nox_worker_phase_runner(
+            run_id=run_id,
+            route=route,
+            state=updated,
+        )
+        updated = self._upsert_nox_phase_run(run_id, phase_task_id=task_id)
+        return next_phase, task_id, updated
+
+    def _build_nox_worker_plan_prompt(self, state: Dict[str, Any]) -> str:
+        return (
+            "Ты работаешь как Nox project employee lane, НЕ как Башня управления.\n"
+            "Сейчас нужен только ТЗ/план, без выполнения фаз.\n\n"
+            f"run_id: {state.get('run_id')}\n"
+            f"Проект: {state.get('display')}\n"
+            f"Исходная задача:\n{state.get('goal')}\n\n"
+            "Сделай короткий рабочий план в формате:\n"
+            "1. Цель и критерий готовности.\n"
+            "2. Scope / ограничения / риски.\n"
+            "3. Фазы, строго строками `Фаза 1: ...`, `Фаза 2: ...`.\n"
+            "4. Human gate: `none`, если всё safe; иначе самый маленький вопрос/риск для Дани.\n\n"
+            "Правила:\n"
+            "- Не делай destructive/high-risk действия.\n"
+            "- Не выполняй фазу 1 сейчас.\n"
+            "- Не проси Даню утверждать safe-план: Nox PM сам review/approve.\n"
+            "- Заверши строкой: `План готов для Nox PM review`.")
+
+    def _build_nox_worker_phase_prompt(self, state: Dict[str, Any], phase_number: int) -> str:
+        return (
+            "Ты работаешь в project employee lane. Выполни только одну утверждённую фазу.\n\n"
+            f"run_id: {state.get('run_id')}\n"
+            f"Проект: {state.get('display')}\n"
+            f"Фаза к выполнению: {phase_number}\n\n"
+            f"Исходная задача:\n{state.get('goal')}\n\n"
+            f"Утверждённый план:\n{state.get('plan') or '(план не сохранён)'}\n\n"
+            "Правила выполнения:\n"
+            "- Выполни только эту фазу, не переходи к следующей сам.\n"
+            "- Safe scoped edits/checks allowed; destructive/high-risk только если явно уже утверждено Даней.\n"
+            "- В конце дай proof: файлы/логи/команды/проверки и риски.\n"
+            "- Если нужен Даня, остановись и явно напиши `Нужен Даня:` + blocker.\n"
+            "- Если всё safe, не проси `утвердить`: Nox PM сам решит продолжать ли следующую фазу.")
+
+    async def _send_nox_phase_state_message(
+        self,
+        state: Dict[str, Any],
+        *,
+        target: str,
+        content: str,
+    ) -> Optional[str]:
+        adapter = self.adapters.get(Platform.TELEGRAM) if getattr(self, "adapters", None) else None
+        if adapter is None:
+            return None
+        if target == "bashnya":
+            chat_id = str(state.get("bashnya_chat_id") or "")
+            thread_id = str(state.get("bashnya_thread_id") or "")
+        else:
+            chat_id = str(state.get("employee_chat_id") or "")
+            thread_id = str(state.get("employee_thread_id") or "")
+        if not chat_id:
+            return None
+        metadata = {"thread_id": thread_id} if thread_id else None
+        result = await adapter.send(chat_id, content, metadata=metadata)
+        if getattr(result, "success", False):
+            return getattr(result, "message_id", None)
+        return None
+
+    async def _run_nox_worker_agent_once(
+        self,
+        *,
+        prompt: str,
+        source: SessionSource,
+        task_id: str,
+        max_iterations: int,
+    ) -> str:
+        """Run one hidden worker agent turn and return its final text."""
+        from run_agent import AIAgent
+
+        user_config = _load_gateway_config()
+        model, runtime_kwargs = self._resolve_session_agent_runtime(
+            source=source,
+            user_config=user_config,
+        )
+        if not runtime_kwargs.get("api_key"):
+            return "❌ Worker failed: no provider credentials configured."
+
+        platform_key = _platform_config_key(source.platform)
+        from hermes_cli.tools_config import _get_platform_tools
+        enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
+        agent_cfg = user_config.get("agent") or {}
+        disabled_toolsets = agent_cfg.get("disabled_toolsets") or None
+        pr = self._provider_routing
+        reasoning_config = self._resolve_session_reasoning_config(source=source)
+        service_tier = self._load_service_tier()
+        turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs)
+
+        def run_sync():
+            agent = AIAgent(
+                model=turn_route["model"],
+                **turn_route["runtime"],
+                max_iterations=max_iterations,
+                quiet_mode=True,
+                verbose_logging=False,
+                enabled_toolsets=enabled_toolsets,
+                disabled_toolsets=disabled_toolsets,
+                reasoning_config=reasoning_config,
+                service_tier=service_tier,
+                request_overrides=turn_route.get("request_overrides"),
+                providers_allowed=pr.get("only"),
+                providers_ignored=pr.get("ignore"),
+                providers_order=pr.get("order"),
+                provider_sort=pr.get("sort"),
+                provider_require_parameters=pr.get("require_parameters", False),
+                provider_data_collection=pr.get("data_collection"),
+                session_id=task_id,
+                platform=platform_key,
+                user_id=source.user_id,
+                user_name=source.user_name,
+                chat_id=source.chat_id,
+                chat_name=source.chat_name,
+                chat_type=source.chat_type,
+                thread_id=source.thread_id,
+                session_db=self._session_db,
+                fallback_model=self._fallback_model,
+            )
+            try:
+                result = agent.run_conversation(user_message=prompt, task_id=task_id)
+                response = result.get("final_response", "") if result else ""
+                if not response and result and result.get("error"):
+                    response = f"Error: {result['error']}"
+                return response or "(No response generated)"
+            finally:
+                self._cleanup_agent_resources(agent)
+
+        return await self._run_in_executor_with_context(run_sync)
+
+    def _start_nox_background_task(self, coro: Any) -> None:
+        task = asyncio.create_task(coro)
+        if not hasattr(self, "_background_tasks"):
+            self._background_tasks = set()
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+
+    def _start_nox_worker_plan_runner(
+        self,
+        *,
+        run_id: str,
+        route: Dict[str, Any],
+        state: Dict[str, Any],
+    ) -> str:
+        task_id = f"nox_plan_{datetime.now().strftime('%H%M%S')}_{os.urandom(3).hex()}"
+        self._start_nox_background_task(self._run_nox_worker_plan(run_id, route, state, task_id))
+        return task_id
+
+    def _start_nox_worker_phase_runner(
+        self,
+        *,
+        run_id: str,
+        route: Dict[str, Any],
+        state: Dict[str, Any],
+    ) -> str:
+        phase_number = int(state.get("phase_index") or 1)
+        task_id = f"nox_phase{phase_number}_{datetime.now().strftime('%H%M%S')}_{os.urandom(3).hex()}"
+        self._start_nox_background_task(self._run_nox_worker_phase(run_id, route, state, task_id))
+        return task_id
+
+    async def _run_nox_worker_plan(
+        self,
+        run_id: str,
+        route: Dict[str, Any],
+        state: Dict[str, Any],
+        task_id: str,
+    ) -> None:
+        del route  # route is captured for monkeypatch/test symmetry; state is source of truth.
+        try:
+            try:
+                max_turns = int(os.getenv("NOX_WORKER_PLAN_MAX_TURNS", str(_NOX_WORKER_PLAN_MAX_TURNS_DEFAULT)))
+            except (TypeError, ValueError):
+                max_turns = _NOX_WORKER_PLAN_MAX_TURNS_DEFAULT
+            prompt = self._build_nox_worker_plan_prompt(state)
+            source = self._nox_worker_source_from_state(state)
+            plan = await self._run_nox_worker_agent_once(
+                prompt=prompt,
+                source=source,
+                task_id=task_id,
+                max_iterations=max(1, max_turns),
+            )
+            phase_count = self._extract_nox_plan_phase_count(plan)
+            human_reason = self._nox_human_approval_reason(state.get("goal", ""), plan)
+            approval_mode = "human" if human_reason else "nox_pm_auto"
+            status = "awaiting_approval" if human_reason else "awaiting_nox_pm_approval"
+            state = self._upsert_nox_phase_run(
+                run_id,
+                status=status,
+                plan=plan,
+                phase_count=phase_count,
+                phase_index=0,
+                plan_task_id=task_id,
+                plan_completed_at=self._nox_now_iso(),
+                approval_mode=approval_mode,
+                approval_reason=human_reason or "safe_plan",
+            )
+            if human_reason:
+                employee_suffix = (
+                    f"Gate: Нужен Даня перед Фазой 1 — reason: `{human_reason}`. "
+                    "Напиши `утвердить`, если это разрешено."
+                )
+                bashnya_suffix = (
+                    f"Нужен Даня: план требует human gate (`{human_reason}`). "
+                    f"Жду `утвердить` в {state.get('topic_name')}."
+                )
+            else:
+                employee_suffix = "Nox PM: safe-план auto-approved; запускаю Фазу 1."
+                bashnya_suffix = "Nox PM: safe-план auto-approved; Фаза 1 запускается без Дани."
+            await self._send_nox_phase_state_message(
+                state,
+                target="employee",
+                content=(
+                    "🧭 ТЗ/план готов\n"
+                    f"run_id: `{run_id}`\n"
+                    f"Фаз найдено: {phase_count}\n"
+                    f"Approval: {approval_mode}\n\n"
+                    f"{plan}\n\n"
+                    f"{employee_suffix}"
+                ),
+            )
+            await self._send_nox_phase_state_message(
+                state,
+                target="bashnya",
+                content=(
+                    "Статус worker: план готов\n"
+                    f"Проект: {state.get('display')}\n"
+                    f"run_id: `{run_id}`\n"
+                    f"Фаз: {phase_count}\n"
+                    f"{bashnya_suffix}"
+                ),
+            )
+            if not human_reason:
+                try:
+                    next_phase, phase_task_id, _started = self._approve_and_start_nox_next_phase(
+                        run_id=run_id,
+                        state=state,
+                        approved_by="nox_pm",
+                        approval_mode="nox_pm_auto",
+                        approval_reason="safe_plan",
+                    )
+                    if phase_task_id:
+                        await self._send_nox_phase_state_message(
+                            _started,
+                            target="employee",
+                            content=(
+                                f"▶️ Nox PM запустил Фазу {next_phase}\n"
+                                f"run_id: `{run_id}`\n"
+                                f"task_id: `{phase_task_id}`"
+                            ),
+                        )
+                except Exception as exc:
+                    logger.exception("Nox PM auto-approval failed for %s", run_id)
+                    state = self._upsert_nox_phase_run(run_id, status="blocked", error=str(exc))
+                    await self._send_nox_phase_state_message(
+                        state,
+                        target="employee",
+                        content=f"❌ Nox PM auto-approval failed\nrun_id: `{run_id}`\nerror: {exc}",
+                    )
+        except Exception as exc:
+            logger.exception("Nox worker plan runner failed for %s", run_id)
+            state = self._upsert_nox_phase_run(
+                run_id,
+                status="blocked",
+                error=str(exc),
+                plan_task_id=task_id,
+            )
+            await self._send_nox_phase_state_message(
+                state,
+                target="employee",
+                content=f"❌ Worker plan failed\nrun_id: `{run_id}`\nerror: {exc}",
+            )
+
+    async def _run_nox_worker_phase(
+        self,
+        run_id: str,
+        route: Dict[str, Any],
+        state: Dict[str, Any],
+        task_id: str,
+    ) -> None:
+        del route
+        phase_number = int(state.get("phase_index") or 1)
+        try:
+            try:
+                max_turns = int(os.getenv("NOX_WORKER_PHASE_MAX_TURNS", str(_NOX_WORKER_PHASE_MAX_TURNS_DEFAULT)))
+            except (TypeError, ValueError):
+                max_turns = _NOX_WORKER_PHASE_MAX_TURNS_DEFAULT
+            prompt = self._build_nox_worker_phase_prompt(state, phase_number)
+            source = self._nox_worker_source_from_state(state)
+            result = await self._run_nox_worker_agent_once(
+                prompt=prompt,
+                source=source,
+                task_id=task_id,
+                max_iterations=max(1, max_turns),
+            )
+            phase_count = int(state.get("phase_count") or 1)
+            next_phase = phase_number + 1
+            run_policy_human_reason = None
+            if str(state.get("approval_mode") or "") == "human":
+                run_policy_human_reason = str(state.get("approval_reason") or "human_gate")
+            phase_blocker_reason = self._nox_worker_output_human_gate_reason(result)
+            human_reason = phase_blocker_reason or run_policy_human_reason
+            if next_phase > phase_count:
+                status = "completed"
+            elif human_reason:
+                status = "awaiting_approval"
+            else:
+                status = "awaiting_nox_pm_approval"
+            updated = self._upsert_nox_phase_run(
+                run_id,
+                status=status,
+                phase_index=phase_number,
+                last_phase_task_id=task_id,
+                last_phase_result=result,
+                last_phase_completed_at=self._nox_now_iso(),
+                approval_mode=("human" if human_reason else "nox_pm_auto"),
+                approval_reason=(human_reason or "safe_continuation"),
+            )
+            if status == "awaiting_approval":
+                suffix = (
+                    f"\n\nGate: Нужен Даня перед Фазой {next_phase} — reason: `{human_reason}`. "
+                    "Напиши `утвердить`, если это разрешено."
+                )
+            elif status == "awaiting_nox_pm_approval":
+                suffix = f"\n\nNox PM: safe proof accepted; запускаю Фазу {next_phase}."
+            else:
+                suffix = "\n\nСтатус: все запланированные фазы завершены."
+            await self._send_nox_phase_state_message(
+                updated,
+                target="employee",
+                content=(
+                    f"✅ Фаза {phase_number} завершена\n"
+                    f"run_id: `{run_id}`\n"
+                    f"Approval: {status}\n\n"
+                    f"{result}{suffix}"
+                ),
+            )
+            await self._send_nox_phase_state_message(
+                updated,
+                target="bashnya",
+                content=(
+                    f"Worker proof: Фаза {phase_number} завершена\n"
+                    f"Проект: {updated.get('display')}\n"
+                    f"run_id: `{run_id}`\n"
+                    f"Статус: {status}"
+                ),
+            )
+            if status == "awaiting_nox_pm_approval":
+                try:
+                    started_phase, phase_task_id, started_state = self._approve_and_start_nox_next_phase(
+                        run_id=run_id,
+                        state=updated,
+                        approved_by="nox_pm",
+                        approval_mode="nox_pm_auto",
+                        approval_reason="safe_continuation",
+                    )
+                    if phase_task_id:
+                        await self._send_nox_phase_state_message(
+                            started_state,
+                            target="employee",
+                            content=(
+                                f"▶️ Nox PM запустил Фазу {started_phase}\n"
+                                f"run_id: `{run_id}`\n"
+                                f"task_id: `{phase_task_id}`"
+                            ),
+                        )
+                except Exception as exc:
+                    logger.exception("Nox PM continuation failed for %s", run_id)
+                    blocked = self._upsert_nox_phase_run(run_id, status="blocked", error=str(exc))
+                    await self._send_nox_phase_state_message(
+                        blocked,
+                        target="employee",
+                        content=f"❌ Nox PM continuation failed\nrun_id: `{run_id}`\nerror: {exc}",
+                    )
+        except Exception as exc:
+            logger.exception("Nox worker phase runner failed for %s", run_id)
+            updated = self._upsert_nox_phase_run(
+                run_id,
+                status="blocked",
+                error=str(exc),
+                last_phase_task_id=task_id,
+            )
+            await self._send_nox_phase_state_message(
+                updated,
+                target="employee",
+                content=f"❌ Worker phase failed\nrun_id: `{run_id}`\nФаза: {phase_number}\nerror: {exc}",
+            )
+
+    def _strip_nox_gateway_author_prefix(self, message_text: str) -> str:
+        """Remove the Telegram gateway's human-readable `[User] ` prefix.
+
+        `_prepare_inbound_message_text()` may turn a raw topic message like
+        `утвердить` into `[Exzy] утвердить` before deterministic gateway hooks
+        see it.  Approval parsing must use the command text, not that display
+        prefix, while still rejecting phrases like `утвердить не запускай`.
+        """
+        raw_text = (message_text or "").strip()
+        return re.sub(r"^\[[^\]\n]{1,80}\]\s*", "", raw_text).strip()
+
+    def _is_nox_worker_approval_candidate(self, message_text: str) -> bool:
+        raw_text = (message_text or "").strip()
+        raw_lower = raw_text.lower()
+        normalized = self._nox_bashnya_normalize_text(raw_text)
+        if not normalized:
+            return False
+        strong_exact = {
+            "утвердить",
+            "утверждаю",
+            "подтверждаю",
+            "approve",
+            "approved",
+            "confirm",
+        }
+        if normalized in strong_exact:
+            return True
+        return re.match(
+            r"^\s*(?:утвердить|approve)\s+`?bashnya-[a-z0-9-]+`?\s*$",
+            raw_lower,
+        ) is not None
+
+    def _nox_worker_approval_command_text(self, *texts: str) -> Optional[str]:
+        """Return the exact approval command after display-prefix cleanup.
+
+        Multiple texts are accepted so the hook can prefer the raw platform
+        event text when available and fall back to the prepared agent message.
+        """
+        seen: set[str] = set()
+        for text in texts:
+            raw_text = (text or "").strip()
+            if not raw_text:
+                continue
+            candidates = (raw_text, self._strip_nox_gateway_author_prefix(raw_text))
+            for candidate in candidates:
+                if not candidate or candidate in seen:
+                    continue
+                seen.add(candidate)
+                if self._is_nox_worker_approval_candidate(candidate):
+                    return candidate
+        return None
+
+    def _is_nox_worker_approval_text(self, message_text: str) -> bool:
+        return self._nox_worker_approval_command_text(message_text) is not None
+
+    def _nox_phase_state_matches_source(
+        self,
+        state: Dict[str, Any],
+        source: SessionSource,
+    ) -> bool:
+        chat_id = str(source.chat_id or "")
+        thread_id = str(source.thread_id or "")
+        employee_match = (
+            chat_id == str(state.get("employee_chat_id") or "")
+            and thread_id == str(state.get("employee_thread_id") or "")
+        )
+        bashnya_match = (
+            chat_id == str(state.get("bashnya_chat_id") or "")
+            and thread_id == str(state.get("bashnya_thread_id") or "")
+        )
+        return employee_match or bashnya_match
+
+    def _nox_project_employee_route_for_source(
+        self,
+        source: Optional[SessionSource],
+    ) -> Optional[Dict[str, Any]]:
+        if source is None or source.platform != Platform.TELEGRAM:
+            return None
+        chat_id = str(source.chat_id or "")
+        thread_id = str(source.thread_id or "")
+        if not chat_id or not thread_id:
+            return None
+        for route in self._load_nox_project_employee_routes().values():
+            if (
+                chat_id == str(route.get("chat_id") or "")
+                and thread_id == str(route.get("message_thread_id") or "")
+            ):
+                return route
+        return None
+
+    def _is_nox_project_employee_source(self, source: Optional[SessionSource]) -> bool:
+        return self._nox_project_employee_route_for_source(source) is not None
+
+    def _find_nox_approval_run(
+        self,
+        *,
+        source: SessionSource,
+        message_text: str,
+    ) -> tuple[Optional[str], Optional[Dict[str, Any]], Optional[str]]:
+        runs = self._load_nox_phase_runs()
+        if not runs:
+            return None, None, None
+        normalized = self._nox_bashnya_normalize_text(message_text)
+        raw_lower = (message_text or "").lower()
+        explicit_run_id = None
+        for run_id in runs:
+            run_id_text = str(run_id or "")
+            if not run_id_text:
+                continue
+            if (
+                run_id_text.lower() in raw_lower
+                or self._nox_bashnya_normalize_text(run_id_text) in normalized.lower()
+            ):
+                explicit_run_id = run_id_text
+                break
+        candidates: list[tuple[str, Dict[str, Any]]] = []
+        for run_id, state in runs.items():
+            if str(state.get("status") or "") != "awaiting_approval":
+                continue
+            if explicit_run_id and run_id != explicit_run_id:
+                continue
+            if self._nox_phase_state_matches_source(state, source):
+                candidates.append((run_id, state))
+        if not candidates:
+            return None, None, None
+        if len(candidates) > 1 and not explicit_run_id:
+            ids = ", ".join(run_id for run_id, _ in candidates[:5])
+            return None, None, f"Нужен run_id: в этом топике несколько фаз ждут утверждения ({ids})."
+        candidates.sort(key=lambda item: str(item[1].get("updated_at") or ""), reverse=True)
+        run_id, state = candidates[0]
+        return run_id, state, None
+
+    async def _maybe_handle_nox_worker_approval(
+        self,
+        event: MessageEvent,
+        message_text: str,
+    ) -> Optional[str]:
+        source = getattr(event, "source", None)
+        if source is None or source.platform != Platform.TELEGRAM:
+            return None
+        try:
+            profile = self._active_profile_name()
+        except Exception:
+            profile = "default"
+        if str(profile or "default") != _NOX_BASHNYA_PROFILE:
+            return None
+        command_text = self._nox_worker_approval_command_text(
+            str(getattr(event, "text", "") or ""),
+            message_text,
+        )
+        if not command_text:
+            return None
+        run_id, state, error = self._find_nox_approval_run(source=source, message_text=command_text)
+        if error:
+            return f"Нужен Даня: {error}"
+        if not run_id or not state:
+            employee_route = self._nox_project_employee_route_for_source(source)
+            if self._is_nox_bashnya_source(source) or employee_route:
+                topic_name = "этом топике"
+                if employee_route:
+                    topic_name = str(employee_route.get("topic_name") or topic_name)
+                return f"Нет worker-фазы, которая сейчас ждёт `утвердить` в {topic_name}."
+            return None
+        phase_count = int(state.get("phase_count") or 1)
+        phase_index = int(state.get("phase_index") or 0)
+        next_phase = phase_index + 1
+        if next_phase > phase_count:
+            self._upsert_nox_phase_run(run_id, status="completed")
+            return f"Готово: run_id `{run_id}` уже прошёл все {phase_count} фаз."
+        next_phase, task_id, updated = self._approve_and_start_nox_next_phase(
+            run_id=run_id,
+            state=state,
+            approved_by=str(source.user_id or "danya"),
+            approval_mode="human",
+            approval_reason=str(state.get("approval_reason") or "manual_danya_approval"),
+        )
+        return (
+            f"Фаза {next_phase} запущена\n"
+            f"run_id: `{run_id}`\n"
+            f"Куда: {updated.get('topic_name')}\n"
+            f"task_id: `{task_id}`\n"
+            "Gate: дальше Nox PM продолжит safe-фазы сам; Даню спрошу только при риске."
+        )
+
+    def _build_nox_project_employee_packet(
+        self,
+        *,
+        event: MessageEvent,
+        message_text: str,
+        classification: Dict[str, Any],
+        route: Dict[str, Any],
+        run_id: str,
+    ) -> str:
+        """Build a compact visible packet for a project employee topic."""
+        goal = (message_text or "").strip()
+        try:
+            from agent.redact import redact_sensitive_text
+            goal = redact_sensitive_text(goal)
+        except Exception:
+            pass
+        if len(goal) > 1600:
+            goal = goal[:1600].rstrip() + "…"
+        source = event.source
+        source_ref = f"telegram:{source.chat_id}:{source.thread_id}"
+        if event.message_id:
+            source_ref += f" msg_id={event.message_id}"
+        weight = classification.get("weight") or "PROJECT"
+        return (
+            "PROJECT EMPLOYEE TASK\n"
+            f"run_id: {run_id}\n"
+            f"Project: {route['display']}\n"
+            f"Employee lane: {route['topic_name']}\n"
+            f"Mode: {weight}\n"
+            f"Source: {source_ref}\n"
+            "Goal:\n"
+            f"{goal}\n\n"
+            "Scope: execute outside `01 Башня управления`; keep work in this project lane.\n"
+            "Allowed actions: inspect project files/docs/logs, make safe scoped edits, run targeted checks/tests.\n"
+            "Forbidden without approval: destructive ops, credential exposure, purchases, production deploys/restarts.\n"
+            "Expected proof: changed files, commands/tests run, logs/docs inspected, report/proof pointer if created.\n"
+            "Return format:\n"
+            "- result\n"
+            "- proof\n"
+            "- inspected files/logs/docs\n"
+            "- commands/checks run\n"
+            "- risks\n"
+            "- blocker if any"
+        )
+
+    def _build_nox_bashnya_ack(
+        self,
+        *,
+        classification: Dict[str, Any],
+        route: Dict[str, Any],
+        run_id: str,
+        packet_message_id: Optional[str] = None,
+        plan_task_id: Optional[str] = None,
+    ) -> str:
+        proof_hint = "Reports / Proof + сообщение сотрудника"
+        if packet_message_id:
+            proof_hint = f"сообщение сотрудника `{packet_message_id}` + report/proof при завершении"
+        planner_hint = "Планер: запущен"
+        if plan_task_id:
+            planner_hint += f" (`{plan_task_id}`)"
+        return (
+            "Статус: взял в работу\n"
+            f"Режим: {classification.get('weight') or 'PROJECT'}\n"
+            f"Проект: {route['display']}\n"
+            f"Куда ушло: {route['topic_name']}\n"
+            f"run_id: `{run_id}`\n"
+            f"{planner_hint}\n"
+            f"Proof будет: {proof_hint}\n"
+            "Дальше: worker даст ТЗ/план; Nox PM auto-approve safe phases. Даню спрошу только при риске."
+        )
+
+    async def _maybe_route_nox_bashnya_task(
+        self,
+        event: MessageEvent,
+        message_text: str,
+    ) -> Optional[str]:
+        """Runtime-enforce Nox v2 Bashnya coordinator routing before main agent."""
+        source = getattr(event, "source", None)
+        if not self._is_nox_bashnya_source(source):
+            return None
+        if event.get_command():
+            return None
+
+        classification = self._nox_bashnya_classify_task(message_text)
+        weight = str(classification.get("weight") or "FAST").upper()
+        if weight == "FAST":
+            return None
+        if weight == "BLOCKER":
+            projects = classification.get("projects") or []
+            if projects:
+                return (
+                    "Нужен Даня: вижу несколько проектов "
+                    f"({', '.join(projects)}). Уточни один проект или скажи, что это cross-project run."
+                )
+            return (
+                "Нужен Даня: задача выглядит рискованной/деструктивной. "
+                "Подтверди разрешение и точный scope — пока не запускаю main run в Башне."
+            )
+        if weight not in {"PROJECT", "RUN"}:
+            return None
+
+        project_key = classification.get("project")
+        if not project_key:
+            return None
+        routes = self._load_nox_project_employee_routes()
+        route = routes.get(str(project_key).lower())
+        if not route:
+            return (
+                "⚠️ Роутер Башни остановил main run, но не нашёл mapped employee topic "
+                f"для проекта `{project_key}` в `{_NOX_PROJECT_EMPLOYEE_ROUTES_PATH}`."
+            )
+
+        adapter = self.adapters.get(source.platform) if getattr(self, "adapters", None) else None
+        if adapter is None:
+            return (
+                "⚠️ Роутер Башни остановил main run, но Telegram adapter недоступен — "
+                "packet сотруднику не отправлен."
+            )
+
+        run_id = f"bashnya-{datetime.now().strftime('%Y%m%d-%H%M%S')}-{os.urandom(2).hex()}"
+        packet = self._build_nox_project_employee_packet(
+            event=event,
+            message_text=message_text,
+            classification=classification,
+            route=route,
+            run_id=run_id,
+        )
+        state = self._build_nox_phase_state(
+            event=event,
+            message_text=message_text,
+            classification=classification,
+            route=route,
+            run_id=run_id,
+        )
+        try:
+            state = self._upsert_nox_phase_run(
+                run_id,
+                **{k: v for k, v in state.items() if k != "run_id"},
+            )
+        except Exception as exc:
+            logger.warning("Nox Bashnya router state persist failed before send: %s", exc)
+            return (
+                "⚠️ Роутер Башни остановил main run, но не смог сохранить durable state — "
+                "packet сотруднику не отправлен: "
+                f"{exc}"
+            )
+        try:
+            result = await adapter.send(
+                route["chat_id"],
+                packet,
+                metadata={"thread_id": route["message_thread_id"]},
+            )
+        except Exception as exc:
+            logger.warning("Nox Bashnya router send failed: %s", exc)
+            self._upsert_nox_phase_run(
+                run_id,
+                status="blocked",
+                error=f"employee packet send failed: {exc}",
+            )
+            return (
+                "⚠️ Роутер Башни остановил main run, но отправка packet сотруднику упала: "
+                f"{exc}\nrun_id: `{run_id}`"
+            )
+        if not getattr(result, "success", False):
+            err = getattr(result, "error", None) or "unknown send error"
+            self._upsert_nox_phase_run(
+                run_id,
+                status="blocked",
+                error=f"employee packet send failed: {err}",
+            )
+            return (
+                "⚠️ Роутер Башни остановил main run, но Telegram не принял packet сотруднику: "
+                f"{err}\nrun_id: `{run_id}`"
+            )
+
+        packet_message_id = getattr(result, "message_id", None)
+        state = self._upsert_nox_phase_run(run_id, packet_message_id=str(packet_message_id or ""))
+        try:
+            plan_task_id = self._start_nox_worker_plan_runner(
+                run_id=run_id,
+                route=route,
+                state=state,
+            )
+            self._upsert_nox_phase_run(run_id, plan_task_id=plan_task_id)
+        except Exception as exc:
+            logger.exception("Nox worker plan start failed for %s", run_id)
+            self._upsert_nox_phase_run(run_id, status="blocked", error=str(exc))
+            return (
+                "⚠️ Роутер Башни отправил packet сотруднику, но не смог запустить worker-plan: "
+                f"{exc}\nrun_id: `{run_id}`"
+            )
+
+        return self._build_nox_bashnya_ack(
+            classification=classification,
+            route=route,
+            run_id=run_id,
+            packet_message_id=packet_message_id,
+            plan_task_id=plan_task_id,
+        )
+
+    def _maybe_cap_nox_bashnya_fast_iterations(
+        self,
+        source: SessionSource,
+        message_text: str,
+        max_iterations: int,
+    ) -> int:
+        """Apply a small turn cap for direct FAST answers in Башня when safe."""
+        if not self._is_nox_bashnya_source(source):
+            return max_iterations
+        classification = self._nox_bashnya_classify_task(message_text)
+        if str(classification.get("weight") or "").upper() != "FAST":
+            return max_iterations
+        try:
+            cap = int(os.getenv("NOX_BASHNYA_FAST_MAX_TURNS", str(_NOX_BASHNYA_FAST_MAX_TURNS_DEFAULT)))
+        except (TypeError, ValueError):
+            cap = _NOX_BASHNYA_FAST_MAX_TURNS_DEFAULT
+        if cap <= 0:
+            return max_iterations
+        return min(max_iterations, cap)
+
     def _resolve_session_agent_runtime(
         self,
         *,
@@ -2916,9 +4201,26 @@ class GatewayRunner:
 
         self._busy_ack_ts[session_key] = now
 
-        # Build a status-rich acknowledgment
+        # Build a status-rich acknowledgment. On clean control surfaces
+        # (display.platforms.<platform>.status_messages: false), keep the ack
+        # human and omit raw internals like "iteration 0/90" / "running: tool".
+        status_details_enabled = True
+        try:
+            from gateway.display_config import resolve_display_setting as _resolve_display_setting
+            _busy_user_config = _load_gateway_config()
+            status_details_enabled = bool(
+                _resolve_display_setting(
+                    _busy_user_config,
+                    _platform_config_key(event.source.platform),
+                    "status_messages",
+                    True,
+                )
+            )
+        except Exception:
+            status_details_enabled = True
+
         status_parts = []
-        if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
+        if status_details_enabled and running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
             try:
                 summary = running_agent.get_activity_summary()
                 iteration = summary.get("api_call_count", 0)
@@ -2957,28 +4259,29 @@ class GatewayRunner:
         # while the agent is busy, append a one-time hint explaining the
         # queue/interrupt knob.  Flag is persisted to config.yaml so it never
         # fires again on this install.
-        try:
-            from agent.onboarding import (
-                BUSY_INPUT_FLAG,
-                busy_input_hint_gateway,
-                is_seen,
-                mark_seen,
-            )
-            _user_cfg = _load_gateway_config()
-            if not is_seen(_user_cfg, BUSY_INPUT_FLAG):
-                if is_steer_mode:
-                    _hint_mode = "steer"
-                elif is_queue_mode:
-                    _hint_mode = "queue"
-                else:
-                    _hint_mode = "interrupt"
-                message = (
-                    f"{message}\n\n"
-                    f"{busy_input_hint_gateway(_hint_mode)}"
+        if status_details_enabled:
+            try:
+                from agent.onboarding import (
+                    BUSY_INPUT_FLAG,
+                    busy_input_hint_gateway,
+                    is_seen,
+                    mark_seen,
                 )
-                mark_seen(_hermes_home / "config.yaml", BUSY_INPUT_FLAG)
-        except Exception as _onb_err:
-            logger.debug("Failed to apply busy-input onboarding hint: %s", _onb_err)
+                _user_cfg = _load_gateway_config()
+                if not is_seen(_user_cfg, BUSY_INPUT_FLAG):
+                    if is_steer_mode:
+                        _hint_mode = "steer"
+                    elif is_queue_mode:
+                        _hint_mode = "queue"
+                    else:
+                        _hint_mode = "interrupt"
+                    message = (
+                        f"{message}\n\n"
+                        f"{busy_input_hint_gateway(_hint_mode)}"
+                    )
+                    mark_seen(_hermes_home / "config.yaml", BUSY_INPUT_FLAG)
+            except Exception as _onb_err:
+                logger.debug("Failed to apply busy-input onboarding hint: %s", _onb_err)
 
         reply_anchor = self._reply_anchor_for_event(event)
         thread_meta = self._thread_metadata_for_source(event.source, reply_anchor)
@@ -8368,6 +9671,21 @@ class GatewayRunner:
         )
         if message_text is None:
             return
+
+        # Nox v2 worker phase runner: approvals are handled deterministically
+        # before the main agent loop, so employee topics do not need to rely on
+        # the bot receiving its own outgoing messages as new updates.
+        _nox_worker_approval = await self._maybe_handle_nox_worker_approval(event, message_text)
+        if _nox_worker_approval is not None:
+            return _nox_worker_approval
+
+        # Nox v2 Башня coordinator router: known heavy project tasks must be
+        # packeted to the mapped `<Project> · Сотрудник` topic before the
+        # main agent loop starts. This keeps the control topic lightweight and
+        # prevents project work from consuming the coordinator lane.
+        _nox_bashnya_ack = await self._maybe_route_nox_bashnya_task(event, message_text)
+        if _nox_bashnya_ack is not None:
+            return _nox_bashnya_ack
 
         # Bind this gateway run generation to the adapter's active-session
         # event so deferred post-delivery callbacks can be released by the
@@ -15459,15 +16777,21 @@ class GatewayRunner:
         # so each progress line would be sent as a separate message.
         from gateway.config import Platform
         tool_progress_enabled = progress_mode != "off" and source.platform != Platform.WEBHOOK
+        # Agent lifecycle/status bubbles (preflight compression, retry notices,
+        # auxiliary warnings) are intentionally configurable independently from
+        # tool progress. Control-room topics can keep the user-facing surface
+        # clean while CLI/team channels may still opt into diagnostic breadcrumbs.
+        status_messages_enabled = (
+            source.platform != Platform.WEBHOOK
+            and bool(resolve_display_setting(user_config, platform_key, "status_messages", True))
+        )
+
         # Natural assistant status messages are intentionally independent from
         # tool progress and token streaming. Users can keep tool_progress quiet
         # in chat platforms while opting into concise mid-turn updates.
         interim_assistant_messages_enabled = (
             source.platform != Platform.WEBHOOK
-            and is_truthy_value(
-                display_config.get("interim_assistant_messages"),
-                default=True,
-            )
+            and bool(resolve_display_setting(user_config, platform_key, "interim_assistant_messages", True))
         )
         
         # Queue for progress messages (thread-safe)
@@ -16014,6 +17338,8 @@ class GatewayRunner:
             _status_thread_metadata = self._thread_metadata_for_source(source, event_message_id) if _progress_thread_id else None
 
         def _status_callback_sync(event_type: str, message: str) -> None:
+            if not status_messages_enabled:
+                return
             if not _status_adapter or not _run_still_current():
                 return
             prepared_message = _prepare_gateway_status_message(
@@ -16065,8 +17391,20 @@ class GatewayRunner:
             # (concurrency-safe). Keep os.environ as fallback for CLI/cron.
             os.environ["HERMES_SESSION_KEY"] = session_key or ""
 
-            # Read from env var or use default (same as CLI)
+            # Re-read .env and config for fresh credentials (gateway is long-lived,
+            # keys may change without restart). Keep config.yaml authoritative for
+            # runtime budget settings bridged into env vars BEFORE reading the
+            # local per-turn max_iterations value.
+            _reload_runtime_env_preserving_config_authority()
+
+            # Read from env var or use default (same as CLI), then apply the
+            # Nox v2 Башня light-lane cap for FAST/direct coordinator turns.
             max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
+            max_iterations = self._maybe_cap_nox_bashnya_fast_iterations(
+                source,
+                message,
+                max_iterations,
+            )
             
             # Map platform enum to the platform hint key the agent understands.
             # Platform.LOCAL ("local") maps to "cli"; others pass through as-is.
@@ -16080,11 +17418,6 @@ class GatewayRunner:
                 combined_ephemeral = (combined_ephemeral + "\n\n" + event_channel_prompt).strip()
             if self._ephemeral_system_prompt:
                 combined_ephemeral = (combined_ephemeral + "\n\n" + self._ephemeral_system_prompt).strip()
-
-            # Re-read .env and config for fresh credentials (gateway is long-lived,
-            # keys may change without restart). Keep config.yaml authoritative for
-            # runtime budget settings bridged into env vars.
-            _reload_runtime_env_preserving_config_authority()
 
             try:
                 model, runtime_kwargs = self._resolve_session_agent_runtime(
@@ -16284,13 +17617,18 @@ class GatewayRunner:
                         self._enforce_agent_cache_cap()
                 logger.debug("Created new agent for session %s (sig=%s)", session_key, _sig)
 
+            # Runtime budget is per turn. Cached agents preserve constructor-time
+            # fields, so refresh max_iterations after cache lookup; run_conversation()
+            # rebuilds IterationBudget from this value at turn start.
+            agent.max_iterations = max_iterations
+
             # Per-message state — callbacks and reasoning config change every
             # turn and must not be baked into the cached agent constructor.
             agent.tool_progress_callback = progress_callback if tool_progress_enabled else None
             agent.step_callback = _step_callback_sync if _hooks_ref.loaded_hooks else None
             agent.stream_delta_callback = _stream_delta_cb
             agent.interim_assistant_callback = _interim_assistant_cb if _want_interim_messages else None
-            agent.status_callback = _status_callback_sync
+            agent.status_callback = _status_callback_sync if status_messages_enabled else None
             agent.reasoning_config = reasoning_config
             agent.service_tier = self._service_tier
             agent.request_overrides = turn_route.get("request_overrides") or {}
@@ -17023,8 +18361,19 @@ class GatewayRunner:
         # Config: agent.gateway_notify_interval in config.yaml, or
         # HERMES_AGENT_NOTIFY_INTERVAL env var.  Default 180s (3 min).
         # 0 = disable notifications.
-        _NOTIFY_INTERVAL_RAW = _float_env("HERMES_AGENT_NOTIFY_INTERVAL", 180)
-        _NOTIFY_INTERVAL = _NOTIFY_INTERVAL_RAW if _NOTIFY_INTERVAL_RAW > 0 else None
+        _agent_notify_cfg = user_config.get("agent", {}) if isinstance(user_config, dict) else {}
+        if isinstance(_agent_notify_cfg, dict) and "gateway_notify_interval" in _agent_notify_cfg:
+            try:
+                _NOTIFY_INTERVAL_RAW = float(_agent_notify_cfg.get("gateway_notify_interval") or 0)
+            except (TypeError, ValueError):
+                _NOTIFY_INTERVAL_RAW = _float_env("HERMES_AGENT_NOTIFY_INTERVAL", 180)
+        else:
+            _NOTIFY_INTERVAL_RAW = _float_env("HERMES_AGENT_NOTIFY_INTERVAL", 180)
+        _NOTIFY_INTERVAL = (
+            _NOTIFY_INTERVAL_RAW
+            if status_messages_enabled and _NOTIFY_INTERVAL_RAW > 0
+            else None
+        )
         _notify_start = time.time()
 
         async def _notify_long_running():

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -857,6 +857,67 @@ _NOX_PROJECT_ALIASES: Dict[str, tuple[str, ...]] = {
     ),
 }
 
+# Soft, project-specific vocabulary used only when Башня receives a substantial
+# follow-up without an explicit project name.  This keeps long project work out
+# of the control tower while avoiding broad aliases like "приложение" that would
+# steal unrelated tasks.
+_NOX_PROJECT_CONTEXT_ALIASES: Dict[str, tuple[str, ...]] = {
+    "ryadom": (
+        "лендинг",
+        "лендинга",
+        "лендингу",
+        "лендингом",
+        "лендинги",
+        "landing",
+        "hero",
+        "хуки",
+        "хуков",
+        "hook",
+        "воронка",
+        "воронки",
+        "воронкам",
+        "воронок",
+        "ценник",
+        "отзывы",
+        "макет",
+        "макеты",
+        "макетов",
+        "анимации",
+        "урок",
+        "уроки",
+        "озвучка",
+        "озвучку",
+        "tts",
+        "кнопки",
+        "checkout",
+        "pwa",
+    ),
+    "metaauto": (
+        "facebook",
+        "fb",
+        "ads",
+        "adspower",
+        "реклама",
+        "рекламный",
+        "кабинет",
+        "кампания",
+        "кампании",
+        "creative lab",
+        "exzypo",
+        "токен",
+        "токены",
+        "railway",
+    ),
+    "creative-lab": ("creative lab", "exzypo", "креативы", "варианты", "winner", "source"),
+}
+
+_NOX_ACTIVE_PHASE_STATUSES = {
+    "planning",
+    "running_phase",
+    "awaiting_approval",
+    "awaiting_nox_pm_approval",
+}
+
 _NOX_PROJECT_RUN_MARKERS: tuple[str, ...] = (
     "запусти",
     "прогони",
@@ -884,6 +945,8 @@ _NOX_PROJECT_HEAVY_MARKERS: tuple[str, ...] = (
     "диагност",
     "добавь",
     "создай",
+    "собери",
+    "собрать",
     "настрой",
     "обнови",
     "patch",
@@ -2245,12 +2308,115 @@ class GatewayRunner:
             profile = "default"
         return str(profile or "default") == _NOX_BASHNYA_PROFILE
 
-    def _nox_bashnya_classify_task(self, message_text: str) -> Dict[str, Any]:
-        """Classify obvious FAST vs project-heavy Nox Bashnya messages.
+    def _nox_active_phase_states_for_bashnya(
+        self,
+        source: Optional[SessionSource],
+    ) -> List[tuple[str, Dict[str, Any]]]:
+        """Return active project runs that originated from this Башня topic."""
+        if source is None:
+            return []
+        chat_id = str(source.chat_id or "")
+        thread_id = str(source.thread_id or "")
+        if not chat_id or not thread_id:
+            return []
+        states: List[tuple[str, Dict[str, Any]]] = []
+        for run_id, state in self._load_nox_phase_runs().items():
+            status = str(state.get("status") or "")
+            if status not in _NOX_ACTIVE_PHASE_STATUSES:
+                continue
+            if str(state.get("bashnya_chat_id") or "") != chat_id:
+                continue
+            if str(state.get("bashnya_thread_id") or "") != thread_id:
+                continue
+            project = str(state.get("project") or "").strip().lower()
+            if not project:
+                continue
+            states.append((str(run_id), state))
+        states.sort(
+            key=lambda item: str(item[1].get("updated_at") or item[1].get("created_at") or ""),
+            reverse=True,
+        )
+        return states
 
-        This is intentionally deterministic and conservative: unknown project
-        or ambiguous/light messages stay on the normal direct path; only a
-        known project plus explicit heavy/run markers is routed away.
+    def _nox_infer_project_from_active_context(
+        self,
+        normalized_text: str,
+        source: Optional[SessionSource],
+    ) -> tuple[Optional[Dict[str, Any]], List[tuple[str, Dict[str, Any]]]]:
+        """Infer project for a substantial unqualified Башня follow-up.
+
+        Used only as a guardrail after explicit project aliases fail.  If it
+        cannot infer one project confidently, the caller blocks and asks for a
+        project instead of letting the main control-tower session continue.
+        """
+        active = self._nox_active_phase_states_for_bashnya(source)
+        if not active:
+            return None, []
+
+        scored: list[tuple[int, str, str, list[str], Dict[str, Any]]] = []
+        for run_id, state in active:
+            project_key = str(state.get("project") or "").strip().lower()
+            hits = [
+                alias
+                for alias in _NOX_PROJECT_CONTEXT_ALIASES.get(project_key, ())
+                if self._nox_bashnya_has_phrase(normalized_text, alias)
+            ]
+            if hits:
+                scored.append((len(hits), project_key, run_id, hits, state))
+
+        if scored:
+            scored.sort(
+                key=lambda item: (
+                    item[0],
+                    str(item[4].get("updated_at") or item[4].get("created_at") or ""),
+                ),
+                reverse=True,
+            )
+            if len(scored) == 1 or scored[0][0] > scored[1][0]:
+                score, project_key, run_id, hits, _state = scored[0]
+                return (
+                    {
+                        "project": project_key,
+                        "reason": "active_context_alias",
+                        "run_id": run_id,
+                        "score": score,
+                        "hits": hits,
+                    },
+                    active,
+                )
+            return None, active
+
+        unique_projects = list(
+            dict.fromkeys(
+                str(state.get("project") or "").strip().lower()
+                for _run_id, state in active
+                if str(state.get("project") or "").strip()
+            )
+        )
+        if len(unique_projects) == 1:
+            return (
+                {
+                    "project": unique_projects[0],
+                    "reason": "single_active_context",
+                    "run_id": active[0][0],
+                    "score": 1,
+                    "hits": [],
+                },
+                active,
+            )
+        return None, active
+
+    def _nox_bashnya_classify_task(
+        self,
+        message_text: str,
+        source: Optional[SessionSource] = None,
+    ) -> Dict[str, Any]:
+        """Classify FAST vs project-heavy Nox Bashnya messages.
+
+        Conservative rule: substantial project-like messages must not fall
+        through into the main Башня session.  They need an explicit project, a
+        confident active-context inference, or a BLOCKER asking Danya to name
+        the project.
         """
         raw_text = message_text or ""
         normalized = self._nox_bashnya_normalize_text(raw_text)
@@ -2271,21 +2437,10 @@ class GatewayRunner:
                 "reason": "multiple_projects",
             }
 
-        project_key = unique_matches[0] if unique_matches else None
-        if not project_key:
-            return {"weight": "FAST", "project": None, "reason": "no_known_project"}
-
         has_blocker = any(
             self._nox_bashnya_has_phrase(normalized, marker)
             for marker in _NOX_PROJECT_BLOCKER_MARKERS
         )
-        if has_blocker:
-            return {
-                "weight": "BLOCKER",
-                "project": project_key,
-                "reason": "approval_required",
-            }
-
         has_run = any(
             self._nox_bashnya_has_phrase(normalized, marker)
             for marker in _NOX_PROJECT_RUN_MARKERS
@@ -2295,10 +2450,52 @@ class GatewayRunner:
             for marker in _NOX_PROJECT_HEAVY_MARKERS
         )
         looks_like_brief = len(raw_text.strip()) <= 220 and "\n" not in raw_text
+        substantial = (
+            has_run
+            or has_heavy_marker
+            or has_blocker
+            or not looks_like_brief
+            or "the user sent a voice message" in normalized
+        )
+
+        project_key = unique_matches[0] if unique_matches else None
+        inference: Optional[Dict[str, Any]] = None
+        active_projects: list[str] = []
+        if not project_key and substantial:
+            inference, active_runs = self._nox_infer_project_from_active_context(normalized, source)
+            active_projects = list(
+                dict.fromkeys(
+                    str(state.get("project") or "").strip().lower()
+                    for _run_id, state in active_runs
+                    if str(state.get("project") or "").strip()
+                )
+            )
+            if inference:
+                project_key = str(inference.get("project") or "").strip().lower()
+            else:
+                return {
+                    "weight": "BLOCKER",
+                    "project": None,
+                    "projects": active_projects,
+                    "reason": "missing_project_for_substantial_task",
+                }
+
+        if not project_key:
+            return {"weight": "FAST", "project": None, "reason": "no_known_project"}
+
+        if has_blocker:
+            return {
+                "weight": "BLOCKER",
+                "project": project_key,
+                "reason": "approval_required",
+            }
+
+        reason = str(inference.get("reason")) if inference else ""
+        extra: Dict[str, Any] = {"inferred_from": inference} if inference else {}
         if has_run:
-            return {"weight": "RUN", "project": project_key, "reason": "run_marker"}
-        if has_heavy_marker or not looks_like_brief:
-            return {"weight": "PROJECT", "project": project_key, "reason": "heavy_marker"}
+            return {"weight": "RUN", "project": project_key, "reason": reason or "run_marker", **extra}
+        if inference or has_heavy_marker or not looks_like_brief:
+            return {"weight": "PROJECT", "project": project_key, "reason": reason or "heavy_marker", **extra}
         return {"weight": "FAST", "project": project_key, "reason": "brief_project_question"}
 
     def _load_nox_project_employee_routes(self) -> Dict[str, Dict[str, Any]]:
@@ -3201,12 +3398,22 @@ class GatewayRunner:
         if event.get_command():
             return None
 
-        classification = self._nox_bashnya_classify_task(message_text)
+        classification = self._nox_bashnya_classify_task(message_text, source=source)
         weight = str(classification.get("weight") or "FAST").upper()
         if weight == "FAST":
             return None
         if weight == "BLOCKER":
             projects = classification.get("projects") or []
+            reason = str(classification.get("reason") or "")
+            if reason == "missing_project_for_substantial_task":
+                active = f" Активные проекты сейчас: {', '.join(projects)}." if projects else ""
+                return (
+                    "Нужен Даня: это похоже на проектную задачу/длинный бриф, "
+                    "но проект не указан."
+                    f"{active} Напиши проект одним словом (например `Ryadom`) "
+                    "или отправь задачу прямо в `<Project> · Сотрудник`. "
+                    "Main run в Башне не запускаю."
+                )
             if projects:
                 return (
                     "Нужен Даня: вижу несколько проектов "
@@ -3327,7 +3534,7 @@ class GatewayRunner:
         """Apply a small turn cap for direct FAST answers in Башня when safe."""
         if not self._is_nox_bashnya_source(source):
             return max_iterations
-        classification = self._nox_bashnya_classify_task(message_text)
+        classification = self._nox_bashnya_classify_task(message_text, source=source)
         if str(classification.get("weight") or "").upper() != "FAST":
             return max_iterations
         try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3149,6 +3149,7 @@ class GatewayRunner:
         if not normalized:
             return False
         strong_exact = {
+            "+",
             "утвердить",
             "утверждаю",
             "подтверждаю",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -949,6 +949,9 @@ _NOX_ACTIVE_PHASE_STATUSES = {
     "awaiting_approval",
     "awaiting_nox_pm_approval",
 }
+# Plain text in a project employee topic while a run is active/parked should
+# steer or amend that run, not start an unrelated main chat in the worker topic.
+_NOX_LIVE_WORKER_STATUSES = set(_NOX_ACTIVE_PHASE_STATUSES)
 
 _NOX_PROJECT_RUN_MARKERS: tuple[str, ...] = (
     "запусти",
@@ -1728,6 +1731,12 @@ class GatewayRunner:
         import threading as _threading
         self._agent_cache: "OrderedDict[str, tuple]" = OrderedDict()
         self._agent_cache_lock = _threading.Lock()
+        # Hidden Nox project-worker agents keyed by durable run/task id.
+        # These worker turns are spawned outside the normal gateway session
+        # loop, so `_running_agents` cannot be used for live steer.
+        self._nox_worker_agents_by_run_id: Dict[str, Any] = {}
+        self._nox_worker_agents_by_task_id: Dict[str, Any] = {}
+        self._nox_worker_agents_lock = _threading.RLock()
 
         # Per-session model overrides from /model command.
         # Key: session_key, Value: dict with model/provider/api_key/base_url/api_mode
@@ -2642,6 +2651,223 @@ class GatewayRunner:
         self._save_nox_phase_runs(runs)
         return state
 
+    def _refresh_nox_phase_state(self, run_id: str, state: Dict[str, Any]) -> Dict[str, Any]:
+        """Reload durable run state before building worker prompts.
+
+        Background plan/phase tasks are scheduled with a state snapshot. Live
+        amendments can arrive after scheduling but before the worker builds its
+        prompt, so refresh from disk and preserve any newer fields.
+        """
+        try:
+            fresh = self._load_nox_phase_runs().get(str(run_id))
+        except Exception:
+            fresh = None
+        if isinstance(fresh, dict):
+            merged = dict(state or {})
+            merged.update(fresh)
+            return merged
+        return dict(state or {})
+
+    def _ensure_nox_worker_agent_registry(self) -> None:
+        if not isinstance(getattr(self, "_nox_worker_agents_by_run_id", None), dict):
+            self._nox_worker_agents_by_run_id = {}
+        if not isinstance(getattr(self, "_nox_worker_agents_by_task_id", None), dict):
+            self._nox_worker_agents_by_task_id = {}
+        if getattr(self, "_nox_worker_agents_lock", None) is None:
+            self._nox_worker_agents_lock = threading.RLock()
+
+    def _register_nox_worker_agent(
+        self,
+        *,
+        run_id: Optional[str],
+        task_id: str,
+        agent: Any,
+    ) -> None:
+        self._ensure_nox_worker_agent_registry()
+        lock = self._nox_worker_agents_lock
+        with lock:
+            if run_id:
+                self._nox_worker_agents_by_run_id[str(run_id)] = agent
+            if task_id:
+                self._nox_worker_agents_by_task_id[str(task_id)] = agent
+
+    def _release_nox_worker_agent(
+        self,
+        *,
+        run_id: Optional[str],
+        task_id: str,
+        agent: Any,
+    ) -> None:
+        self._ensure_nox_worker_agent_registry()
+        lock = self._nox_worker_agents_lock
+        with lock:
+            if run_id and self._nox_worker_agents_by_run_id.get(str(run_id)) is agent:
+                self._nox_worker_agents_by_run_id.pop(str(run_id), None)
+            if task_id and self._nox_worker_agents_by_task_id.get(str(task_id)) is agent:
+                self._nox_worker_agents_by_task_id.pop(str(task_id), None)
+
+    def _nox_worker_agent_for_run(self, run_id: str) -> Optional[Any]:
+        self._ensure_nox_worker_agent_registry()
+        lock = self._nox_worker_agents_lock
+        with lock:
+            return self._nox_worker_agents_by_run_id.get(str(run_id))
+
+    def _nox_live_steer_text(self, event: MessageEvent, message_text: str) -> str:
+        text = str(getattr(event, "text", "") or "").strip()
+        if not text:
+            text = self._strip_nox_gateway_author_prefix(message_text)
+        text = (text or "").strip()
+        try:
+            from agent.redact import redact_sensitive_text
+            text = redact_sensitive_text(text)
+        except Exception:
+            pass
+        if len(text) > 3000:
+            text = text[:3000].rstrip() + "…"
+        return text
+
+    def _nox_live_steer_payload(
+        self,
+        *,
+        run_id: str,
+        state: Dict[str, Any],
+        amendment: Dict[str, Any],
+    ) -> str:
+        return (
+            "LIVE STEER / USER AMENDMENT\n"
+            f"run_id: {run_id}\n"
+            f"project: {state.get('display') or state.get('project') or ''}\n"
+            f"phase_index: {state.get('phase_index') or 0}\n"
+            f"message_id: {amendment.get('message_id') or ''}\n"
+            "Instruction from Danya; incorporate immediately if still relevant:\n"
+            f"{amendment.get('text') or ''}"
+        )
+
+    def _find_nox_live_worker_run(
+        self,
+        *,
+        source: SessionSource,
+        message_text: str,
+    ) -> tuple[Optional[str], Optional[Dict[str, Any]], Optional[str]]:
+        runs = self._load_nox_phase_runs()
+        if not runs:
+            return None, None, None
+        raw_lower = (message_text or "").lower()
+        normalized = self._nox_bashnya_normalize_text(message_text)
+        explicit_run_id = None
+        for run_id in runs:
+            run_id_text = str(run_id or "")
+            if not run_id_text:
+                continue
+            if run_id_text.lower() in raw_lower or self._nox_bashnya_normalize_text(run_id_text) in normalized:
+                explicit_run_id = run_id_text
+                break
+        chat_id = str(source.chat_id or "")
+        thread_id = str(source.thread_id or "")
+        candidates: list[tuple[str, Dict[str, Any]]] = []
+        for run_id, state in runs.items():
+            if str(state.get("status") or "") not in _NOX_LIVE_WORKER_STATUSES:
+                continue
+            if explicit_run_id and str(run_id) != explicit_run_id:
+                continue
+            employee_match = (
+                chat_id == str(state.get("employee_chat_id") or "")
+                and thread_id == str(state.get("employee_thread_id") or "")
+            )
+            if employee_match:
+                candidates.append((str(run_id), state))
+        if not candidates:
+            return None, None, None
+        if len(candidates) > 1 and not explicit_run_id:
+            ids = ", ".join(run_id for run_id, _ in candidates[:5])
+            return None, None, f"Нужен run_id: в этом worker-топике несколько активных runs ({ids})."
+        candidates.sort(key=lambda item: str(item[1].get("updated_at") or ""), reverse=True)
+        return candidates[0][0], candidates[0][1], None
+
+    def _append_nox_live_amendment(
+        self,
+        *,
+        run_id: str,
+        state: Dict[str, Any],
+        event: MessageEvent,
+        text: str,
+        delivery: str,
+        delivery_error: Optional[str] = None,
+    ) -> tuple[Dict[str, Any], Dict[str, Any]]:
+        now = self._nox_now_iso()
+        amendment_id = f"amend-{datetime.now().strftime('%Y%m%d-%H%M%S')}-{os.urandom(2).hex()}"
+        amendment: Dict[str, Any] = {
+            "id": amendment_id,
+            "created_at": now,
+            "source": "telegram",
+            "chat_id": str(getattr(event.source, "chat_id", "") or ""),
+            "thread_id": str(getattr(event.source, "thread_id", "") or ""),
+            "message_id": str(getattr(event, "message_id", "") or ""),
+            "user_id": str(getattr(event.source, "user_id", "") or ""),
+            "user_name": str(getattr(event.source, "user_name", "") or ""),
+            "text": text,
+            "delivery": delivery,
+        }
+        if delivery_error:
+            amendment["delivery_error"] = delivery_error
+        runs = self._load_nox_phase_runs()
+        current = dict(runs.get(run_id) or state or {})
+        amendments = current.get("amendments")
+        if not isinstance(amendments, list):
+            amendments = []
+        amendments.append(amendment)
+        current["amendments"] = amendments
+        current["last_amendment_at"] = now
+        current["run_id"] = run_id
+        current["updated_at"] = now
+        runs[run_id] = current
+        self._save_nox_phase_runs(runs)
+        return current, amendment
+
+    def _update_nox_live_amendment_delivery(
+        self,
+        *,
+        run_id: str,
+        amendment_id: str,
+        delivery: str,
+        delivery_error: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        runs = self._load_nox_phase_runs()
+        state = dict(runs.get(run_id) or {})
+        amendments = state.get("amendments")
+        if isinstance(amendments, list):
+            for item in amendments:
+                if isinstance(item, dict) and item.get("id") == amendment_id:
+                    item["delivery"] = delivery
+                    item["delivered_at"] = self._nox_now_iso()
+                    if delivery_error:
+                        item["delivery_error"] = delivery_error
+                    else:
+                        item.pop("delivery_error", None)
+                    break
+        state["updated_at"] = self._nox_now_iso()
+        runs[run_id] = state
+        self._save_nox_phase_runs(runs)
+        return state
+
+    def _render_nox_live_amendments(self, state: Dict[str, Any]) -> str:
+        amendments = state.get("amendments")
+        if not isinstance(amendments, list) or not amendments:
+            return ""
+        lines = ["Live amendments / user steering:"]
+        for item in amendments[-12:]:
+            if not isinstance(item, dict):
+                continue
+            text = str(item.get("text") or "").strip()
+            if not text:
+                continue
+            if len(text) > 1200:
+                text = text[:1200].rstrip() + "…"
+            stamp = str(item.get("created_at") or "")
+            delivery = str(item.get("delivery") or "saved")
+            lines.append(f"- [{stamp}] ({delivery}) {text}")
+        return "\n".join(lines) if len(lines) > 1 else ""
+
     def _redact_nox_goal_for_state(self, text: str) -> str:
         goal = (text or "").strip()
         try:
@@ -2803,12 +3029,15 @@ class GatewayRunner:
         return next_phase, task_id, updated
 
     def _build_nox_worker_plan_prompt(self, state: Dict[str, Any]) -> str:
+        amendments = self._render_nox_live_amendments(state)
+        amendments_block = f"\n{amendments}\n\n" if amendments else ""
         return (
             "Ты работаешь как Nox project employee lane, НЕ как Башня управления.\n"
             "Сейчас нужен только ТЗ/план, без выполнения фаз.\n\n"
             f"run_id: {state.get('run_id')}\n"
             f"Проект: {state.get('display')}\n"
             f"Исходная задача:\n{state.get('goal')}\n\n"
+            f"{amendments_block}"
             "Сделай короткий рабочий план в формате:\n"
             "1. Цель и критерий готовности.\n"
             "2. Scope / ограничения / риски.\n"
@@ -2821,6 +3050,8 @@ class GatewayRunner:
             "- Заверши строкой: `План готов для Nox PM review`.")
 
     def _build_nox_worker_phase_prompt(self, state: Dict[str, Any], phase_number: int) -> str:
+        amendments = self._render_nox_live_amendments(state)
+        amendments_block = f"\n{amendments}\n\n" if amendments else ""
         return (
             "Ты работаешь в project employee lane. Выполни только одну утверждённую фазу.\n\n"
             f"run_id: {state.get('run_id')}\n"
@@ -2828,6 +3059,7 @@ class GatewayRunner:
             f"Фаза к выполнению: {phase_number}\n\n"
             f"Исходная задача:\n{state.get('goal')}\n\n"
             f"Утверждённый план:\n{state.get('plan') or '(план не сохранён)'}\n\n"
+            f"{amendments_block}"
             "Правила выполнения:\n"
             "- Выполни только эту фазу, не переходи к следующей сам.\n"
             "- Safe scoped edits/checks allowed; destructive/high-risk только если явно уже утверждено Даней.\n"
@@ -2866,6 +3098,7 @@ class GatewayRunner:
         source: SessionSource,
         task_id: str,
         max_iterations: int,
+        run_id: Optional[str] = None,
     ) -> str:
         """Run one hidden worker agent turn and return its final text."""
         from run_agent import AIAgent
@@ -2917,6 +3150,7 @@ class GatewayRunner:
                 session_db=self._session_db,
                 fallback_model=self._fallback_model,
             )
+            self._register_nox_worker_agent(run_id=run_id, task_id=task_id, agent=agent)
             try:
                 result = agent.run_conversation(user_message=prompt, task_id=task_id)
                 response = result.get("final_response", "") if result else ""
@@ -2924,6 +3158,7 @@ class GatewayRunner:
                     response = f"Error: {result['error']}"
                 return response or "(No response generated)"
             finally:
+                self._release_nox_worker_agent(run_id=run_id, task_id=task_id, agent=agent)
                 self._cleanup_agent_resources(agent)
 
         return await self._run_in_executor_with_context(run_sync)
@@ -2967,6 +3202,7 @@ class GatewayRunner:
     ) -> None:
         del route  # route is captured for monkeypatch/test symmetry; state is source of truth.
         try:
+            state = self._refresh_nox_phase_state(run_id, state)
             try:
                 max_turns = int(os.getenv("NOX_WORKER_PLAN_MAX_TURNS", str(_NOX_WORKER_PLAN_MAX_TURNS_DEFAULT)))
             except (TypeError, ValueError):
@@ -2978,6 +3214,7 @@ class GatewayRunner:
                 source=source,
                 task_id=task_id,
                 max_iterations=max(1, max_turns),
+                run_id=run_id,
             )
             phase_count = self._extract_nox_plan_phase_count(plan)
             human_reason = self._nox_human_approval_reason(state.get("goal", ""), plan)
@@ -3080,6 +3317,8 @@ class GatewayRunner:
         del route
         phase_number = int(state.get("phase_index") or 1)
         try:
+            state = self._refresh_nox_phase_state(run_id, state)
+            phase_number = int(state.get("phase_index") or 1)
             try:
                 max_turns = int(os.getenv("NOX_WORKER_PHASE_MAX_TURNS", str(_NOX_WORKER_PHASE_MAX_TURNS_DEFAULT)))
             except (TypeError, ValueError):
@@ -3091,6 +3330,7 @@ class GatewayRunner:
                 source=source,
                 task_id=task_id,
                 max_iterations=max(1, max_turns),
+                run_id=run_id,
             )
             phase_count = int(state.get("phase_count") or 1)
             next_phase = phase_number + 1
@@ -3368,6 +3608,86 @@ class GatewayRunner:
             f"Куда: {updated.get('topic_name')}\n"
             f"task_id: `{task_id}`\n"
             "Gate: дальше Nox PM продолжит safe-фазы сам; Даню спрошу только при риске."
+        )
+
+    async def _maybe_handle_nox_worker_live_steer(
+        self,
+        event: MessageEvent,
+        message_text: str,
+    ) -> Optional[str]:
+        """Persist/steer plain project-employee follow-ups into the active worker run.
+
+        This is the Telegram-topic equivalent of `/steer`: while a hidden
+        project worker is planning/running (or parked on a gate), Danya's
+        follow-up in the employee topic amends that run instead of starting a
+        fresh main LLM session in the same topic.
+        """
+        source = getattr(event, "source", None)
+        if source is None or source.platform != Platform.TELEGRAM:
+            return None
+        try:
+            profile = self._active_profile_name()
+        except Exception:
+            profile = "default"
+        if str(profile or "default") != _NOX_BASHNYA_PROFILE:
+            return None
+        if event.get_command():
+            return None
+        if not self._nox_project_employee_route_for_source(source):
+            return None
+        # Approval commands are handled by _maybe_handle_nox_worker_approval
+        # just before this hook.  Keep this guard for direct unit calls too.
+        if self._nox_worker_approval_command_text(str(getattr(event, "text", "") or ""), message_text):
+            return None
+        steer_text = self._nox_live_steer_text(event, message_text)
+        if not steer_text:
+            return None
+        run_id, state, error = self._find_nox_live_worker_run(source=source, message_text=steer_text)
+        if error:
+            return f"Нужен Даня: {error}"
+        if not run_id or not state:
+            return None
+        state, amendment = self._append_nox_live_amendment(
+            run_id=run_id,
+            state=state,
+            event=event,
+            text=steer_text,
+            delivery="saved_for_worker",
+        )
+        delivery = "saved_for_worker"
+        agent = self._nox_worker_agent_for_run(run_id)
+        if agent is not None and hasattr(agent, "steer"):
+            payload = self._nox_live_steer_payload(run_id=run_id, state=state, amendment=amendment)
+            try:
+                accepted = bool(agent.steer(payload))
+            except Exception as exc:
+                delivery = "saved_for_worker"
+                state = self._update_nox_live_amendment_delivery(
+                    run_id=run_id,
+                    amendment_id=str(amendment.get("id") or ""),
+                    delivery=delivery,
+                    delivery_error=str(exc),
+                )
+                logger.warning("Nox live steer failed for %s: %s", run_id, exc)
+            else:
+                if accepted:
+                    delivery = "delivered_live"
+                    state = self._update_nox_live_amendment_delivery(
+                        run_id=run_id,
+                        amendment_id=str(amendment.get("id") or ""),
+                        delivery=delivery,
+                    )
+        if delivery == "delivered_live":
+            return (
+                "Усвоил прямо сейчас: live steer доставлен worker'у\n"
+                f"run_id: `{run_id}`\n"
+                f"Куда: {state.get('topic_name') or 'project employee lane'}"
+            )
+        return (
+            "Принял: сохранил amendment для текущего worker-run\n"
+            f"run_id: `{run_id}`\n"
+            f"Куда: {state.get('topic_name') or 'project employee lane'}\n"
+            "Доставка: worker подхватит из durable ledger на следующем шаге/после рестарта."
         )
 
     def _build_nox_project_employee_packet(
@@ -9940,6 +10260,10 @@ class GatewayRunner:
         _nox_worker_approval = await self._maybe_handle_nox_worker_approval(event, message_text)
         if _nox_worker_approval is not None:
             return _nox_worker_approval
+
+        _nox_worker_live_steer = await self._maybe_handle_nox_worker_live_steer(event, message_text)
+        if _nox_worker_live_steer is not None:
+            return _nox_worker_live_steer
 
         # Nox v2 Башня coordinator router: known heavy project tasks must be
         # packeted to the mapped `<Project> · Сотрудник` topic before the

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2869,12 +2869,36 @@ def launchd_plist_is_current() -> bool:
     return _normalize_launchd_plist_for_comparison(installed) == _normalize_launchd_plist_for_comparison(expected)
 
 
+def _called_from_running_gateway_process() -> bool:
+    """Return True when this CLI process is a child of the live gateway.
+
+    Gateway tool calls execute as subprocesses below the gateway PID.  If one
+    of those subprocesses runs a command that bootouts the launchd job, launchd
+    kills the gateway *and the subprocess doing the bootstrap*, leaving the job
+    unloaded.  Detect that ancestry so self-repair paths can avoid unloading
+    their own parent process.
+    """
+    try:
+        from gateway.status import get_running_pid
+
+        pid = get_running_pid(cleanup_stale=False)
+    except Exception:
+        return False
+    return bool(pid and _is_pid_ancestor_of_current_process(pid))
+
+
 def refresh_launchd_plist_if_needed() -> bool:
     """Rewrite the installed launchd plist when the generated definition has changed.
 
     Unlike systemd, launchd picks up plist changes on the next ``launchctl kill``/
-    ``launchctl kickstart`` cycle — no daemon-reload is needed. We still bootout/
-    bootstrap to make launchd re-read the updated plist immediately.
+    ``launchctl kickstart`` cycle — no daemon-reload is needed.
+
+    Important macOS footgun: when this function is invoked from a gateway tool
+    call, the current CLI is a child process of the launchd-managed gateway.  A
+    synchronous ``launchctl bootout`` kills both the gateway and this child
+    before the following ``bootstrap`` can run, leaving the Telegram gateway
+    unloaded.  In that self-repair case we only update the plist on disk and let
+    an external restart (or the next launchd load) pick it up.
     """
     plist_path = get_launchd_plist_path()
     if not plist_path.exists() or launchd_plist_is_current():
@@ -2882,7 +2906,14 @@ def refresh_launchd_plist_if_needed() -> bool:
 
     plist_path.write_text(generate_launchd_plist(), encoding="utf-8")
     label = get_launchd_label()
-    # Bootout/bootstrap so launchd picks up the new definition
+    if _called_from_running_gateway_process():
+        print(
+            "↻ Updated gateway launchd service definition on disk "
+            "(reload deferred to avoid unloading the running gateway from its own tool call)"
+        )
+        return True
+
+    # Bootout/bootstrap so launchd picks up the new definition immediately.
     subprocess.run(["launchctl", "bootout", f"{_launchd_domain()}/{label}"], check=False, timeout=90)
     subprocess.run(["launchctl", "bootstrap", _launchd_domain(), str(plist_path)], check=False, timeout=30)
     print("↻ Updated gateway launchd service definition to match the current Hermes install")

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -349,8 +349,11 @@ class TestBusySessionAck:
         assert adapter._send_with_retry.call_count == 2
 
     @pytest.mark.asyncio
-    async def test_includes_status_detail(self):
+    async def test_includes_status_detail(self, monkeypatch):
         """Ack message should include iteration and tool info when available."""
+        import gateway.run as _gr
+        monkeypatch.setattr(_gr, "_load_gateway_config", lambda: {})
+
         runner, sentinel = _make_runner()
         runner._busy_input_mode = "interrupt"
         adapter = _make_adapter()
@@ -378,6 +381,47 @@ class TestBusySessionAck:
         assert "21/60" in content  # iteration
         assert "terminal" in content  # current tool
         assert "10 min" in content  # elapsed
+
+    @pytest.mark.asyncio
+    async def test_status_messages_off_hides_raw_busy_ack_details(self, monkeypatch):
+        """Clean Telegram control lanes should not expose raw agent internals
+        like `Still working... iteration 0/90` or current tool names in the
+        busy acknowledgment."""
+        import gateway.run as _gr
+        monkeypatch.setattr(
+            _gr,
+            "_load_gateway_config",
+            lambda: {"display": {"platforms": {"telegram": {"status_messages": False}}}},
+        )
+
+        runner, sentinel = _make_runner()
+        runner._busy_input_mode = "queue"
+        adapter = _make_adapter()
+
+        event = _make_event(text="yo")
+        sk = build_session_key(event.source)
+
+        agent = MagicMock()
+        agent.get_activity_summary.return_value = {
+            "api_call_count": 21,
+            "max_iterations": 60,
+            "current_tool": "terminal",
+            "last_activity_ts": time.time(),
+            "last_activity_desc": "terminal",
+            "seconds_since_activity": 0.5,
+        }
+        runner._running_agents[sk] = agent
+        runner._running_agents_ts[sk] = time.time() - 600
+        runner.adapters[event.source.platform] = adapter
+
+        with patch("gateway.run.merge_pending_message_event"):
+            await runner._handle_active_session_busy_message(event, sk)
+
+        content = adapter._send_with_retry.call_args.kwargs.get("content", "")
+        assert "Queued for the next turn" in content
+        assert "21/60" not in content
+        assert "terminal" not in content
+        assert "First-time tip" not in content
 
     @pytest.mark.asyncio
     async def test_draining_still_works(self):

--- a/tests/gateway/test_config_env_bridge_authority.py
+++ b/tests/gateway/test_config_env_bridge_authority.py
@@ -44,6 +44,7 @@ def _run_gateway_import(hermes_home: Path, initial_env: dict[str, str]) -> dict[
             "HERMES_MAX_ITERATIONS",
             "HERMES_AGENT_TIMEOUT",
             "HERMES_AGENT_TIMEOUT_WARNING",
+            "HERMES_AGENT_NOTIFY_INTERVAL",
             "HERMES_GATEWAY_BUSY_INPUT_MODE",
             "HERMES_TIMEZONE",
         ):
@@ -132,6 +133,50 @@ def test_config_gateway_timeout_wins_over_stale_env(hermes_home: Path) -> None:
 
     assert env.get("HERMES_AGENT_TIMEOUT") == "1800"
     assert env.get("HERMES_AGENT_TIMEOUT_WARNING") == "900"
+
+
+def test_config_gateway_notify_interval_wins_over_stale_env(hermes_home: Path) -> None:
+    """Regression: config agent.gateway_notify_interval=0 must disable
+    periodic `Still working... iteration x/y` even if .env still has an old
+    notify interval value."""
+    _write_config(hermes_home, agent_cfg={"gateway_notify_interval": 0})
+    _write_env(hermes_home, {"HERMES_AGENT_NOTIFY_INTERVAL": "180"})
+
+    env = _run_gateway_import(hermes_home, initial_env={})
+
+    assert env.get("HERMES_AGENT_NOTIFY_INTERVAL") == "0"
+
+
+def test_runtime_reload_gateway_notify_interval_wins_over_stale_env(hermes_home: Path) -> None:
+    """Long-lived gateways reload .env before each turn; config.yaml must
+    still keep notify interval disabled after that reload."""
+    _write_config(hermes_home, agent_cfg={"gateway_notify_interval": 0})
+    _write_env(hermes_home, {"HERMES_AGENT_NOTIFY_INTERVAL": "180"})
+
+    script = textwrap.dedent(
+        f"""
+        import os, sys
+        sys.path.insert(0, {str(PROJECT_ROOT)!r})
+        from gateway import run
+        os.environ["HERMES_AGENT_NOTIFY_INTERVAL"] = "180"
+        run._reload_runtime_env_preserving_config_authority()
+        print("HERMES_AGENT_NOTIFY_INTERVAL=" + os.environ.get("HERMES_AGENT_NOTIFY_INTERVAL", ""))
+        """
+    )
+    env = {"HERMES_HOME": str(hermes_home)}
+    for k in ("PATH", "PYTHONPATH", "VIRTUAL_ENV", "HOME"):
+        if k in os.environ:
+            env[k] = os.environ[k]
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if result.returncode != 0:
+        pytest.fail(f"runtime reload check failed\nstderr:\n{result.stderr}\nstdout:\n{result.stdout}")
+    assert "HERMES_AGENT_NOTIFY_INTERVAL=0" in result.stdout
 
 
 def test_config_display_busy_input_mode_wins_over_stale_env(hermes_home: Path) -> None:

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -164,6 +164,20 @@ class TestYAMLNormalisation:
         config = {"display": {"platforms": {"slack": {"tool_preview_length": "80"}}}}
         assert resolve_display_setting(config, "slack", "tool_preview_length") == 80
 
+    def test_status_messages_platform_false(self):
+        """Per-platform status_messages can silence lifecycle bubbles."""
+        from gateway.display_config import resolve_display_setting
+
+        config = {"display": {"platforms": {"telegram": {"status_messages": "false"}}}}
+        assert resolve_display_setting(config, "telegram", "status_messages") is False
+
+    def test_interim_assistant_messages_platform_false(self):
+        """Per-platform interim assistant messages can be disabled."""
+        from gateway.display_config import resolve_display_setting
+
+        config = {"display": {"platforms": {"telegram": {"interim_assistant_messages": False}}}}
+        assert resolve_display_setting(config, "telegram", "interim_assistant_messages") is False
+
     def test_platform_override_false_tool_progress(self):
         """Per-platform bare off → normalised."""
         from gateway.display_config import resolve_display_setting

--- a/tests/gateway/test_nox_bashnya_router.py
+++ b/tests/gateway/test_nox_bashnya_router.py
@@ -111,6 +111,13 @@ def bashnya_routes_path(tmp_path, monkeypatch):
                         "chat_id": BASHNYA_CHAT_ID,
                         "message_thread_id": "32",
                     },
+                    "nox-system": {
+                        "project": "nox-system",
+                        "display": "Nox OS",
+                        "topic_name": "Nox OS · Сотрудник",
+                        "chat_id": BASHNYA_CHAT_ID,
+                        "message_thread_id": "33",
+                    },
                 }
             }
         ),
@@ -221,6 +228,68 @@ async def test_bashnya_project_task_routes_to_employee_lane_before_agent(monkeyp
     assert "Project: MetaAuto" in packet["content"]
     assert "Mode: RUN" in packet["content"]
     assert "почини metaauto coordinator routing" in packet["content"]
+
+
+@pytest.mark.asyncio
+async def test_bashnya_cross_project_skill_task_routes_to_nox_system_lane_before_agent(bashnya_routes_path):
+    """Cross-project skills/agents work belongs to Nox OS, not the main Башня session."""
+    event = _make_bashnya_event(
+        "внедри UI/design skills для всех проектов и самих агентов, "
+        "чтобы любой агент мог ими пользоваться"
+    )
+    adapter = CaptureAdapter()
+    runner = _make_runner(event.source, adapter)
+
+    async def fail_if_agent_runs(**_kwargs):  # pragma: no cover - should not be called
+        raise AssertionError("cross-project agent task must be routed before _run_agent")
+
+    runner._run_agent = fail_if_agent_runs
+
+    ack = await runner._handle_message_with_agent(
+        event,
+        event.source,
+        build_session_key(event.source),
+        run_generation=1,
+    )
+
+    assert "Статус: взял в работу" in ack
+    assert "Куда ушло: Nox OS · Сотрудник" in ack
+    assert "run_id:" in ack
+
+    assert len(adapter.sent) == 1
+    packet = adapter.sent[0]
+    assert packet["chat_id"] == BASHNYA_CHAT_ID
+    assert packet["metadata"] == {"thread_id": "33"}
+    assert "PROJECT EMPLOYEE TASK" in packet["content"]
+    assert "Project: Nox OS" in packet["content"]
+    assert "Mode: PROJECT" in packet["content"]
+    assert "UI/design skills" in packet["content"]
+
+
+@pytest.mark.asyncio
+async def test_bashnya_explicit_project_wins_over_system_skill_markers(bashnya_routes_path):
+    """System-scope vocabulary must not steal an explicitly named product project."""
+    event = _make_bashnya_event("внедри skills в metaauto агенте и прогони тесты")
+    adapter = CaptureAdapter()
+    runner = _make_runner(event.source, adapter)
+
+    async def fail_if_agent_runs(**_kwargs):  # pragma: no cover - should not be called
+        raise AssertionError("explicit project task must be routed before _run_agent")
+
+    runner._run_agent = fail_if_agent_runs
+
+    ack = await runner._handle_message_with_agent(
+        event,
+        event.source,
+        build_session_key(event.source),
+        run_generation=1,
+    )
+
+    assert "Статус: взял в работу" in ack
+    assert "Куда ушло: MetaAuto · Сотрудник" in ack
+    assert len(adapter.sent) == 1
+    assert adapter.sent[0]["metadata"] == {"thread_id": "31"}
+    assert "Project: MetaAuto" in adapter.sent[0]["content"]
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_nox_bashnya_router.py
+++ b/tests/gateway/test_nox_bashnya_router.py
@@ -1,0 +1,615 @@
+"""Regression coverage for the Nox v2 / Башня Telegram coordinator router.
+
+The coordinator topic must not run heavy project tasks in the main Башня
+session. Known project work is packeted to the matching `<Project> · Сотрудник`
+topic and the main topic only receives a compact acknowledgment.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType, SendResult
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource, build_session_key
+
+
+BASHNYA_CHAT_ID = "-1003889439571"
+BASHNYA_THREAD_ID = "25"
+
+
+class CaptureAdapter:
+    def __init__(self) -> None:
+        self.sent: list[dict] = []
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        self.sent.append(
+            {
+                "chat_id": str(chat_id),
+                "content": content,
+                "reply_to": reply_to,
+                "metadata": metadata or {},
+            }
+        )
+        return SendResult(success=True, message_id=f"sent-{len(self.sent)}")
+
+    async def stop_typing(self, chat_id):
+        return None
+
+
+class StateCheckingAdapter(CaptureAdapter):
+    def __init__(self, phase_path) -> None:
+        super().__init__()
+        self.phase_path = phase_path
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        if "PROJECT EMPLOYEE TASK" in content:
+            match = re.search(r"^run_id: (\S+)$", content, flags=re.MULTILINE)
+            assert match, "employee packet must include run_id before send"
+            run_id = match.group(1)
+            payload = json.loads(self.phase_path.read_text(encoding="utf-8"))
+            assert payload["runs"][run_id]["status"] == "planning"
+            assert payload["runs"][run_id]["packet_message_id"] == ""
+        return await super().send(chat_id, content, reply_to=reply_to, metadata=metadata)
+
+
+class FakeSessionStore:
+    def __init__(self, source: SessionSource) -> None:
+        self.entry = SimpleNamespace(
+            session_id="sess-bashnya",
+            session_key=build_session_key(source),
+            created_at=1,
+            updated_at=2,
+            was_auto_reset=False,
+            is_fresh_reset=False,
+            last_prompt_tokens=0,
+        )
+        self.config = SimpleNamespace(
+            get_reset_policy=lambda **_kwargs: SimpleNamespace(
+                notify=False,
+                notify_exclude_platforms=[],
+                idle_minutes=0,
+                at_hour=0,
+            )
+        )
+
+    def get_or_create_session(self, _source):
+        return self.entry
+
+    def load_transcript(self, _session_id):
+        return []
+
+    def has_any_sessions(self):
+        return True
+
+
+@pytest.fixture
+def bashnya_routes_path(tmp_path, monkeypatch):
+    path = tmp_path / "project-employees.json"
+    path.write_text(
+        json.dumps(
+            {
+                "projects": {
+                    "metaauto": {
+                        "project": "metaauto",
+                        "display": "MetaAuto",
+                        "topic_name": "MetaAuto · Сотрудник",
+                        "chat_id": BASHNYA_CHAT_ID,
+                        "message_thread_id": "31",
+                    },
+                    "ryadom": {
+                        "project": "ryadom",
+                        "display": "Ryadom",
+                        "topic_name": "Ryadom · Сотрудник",
+                        "chat_id": BASHNYA_CHAT_ID,
+                        "message_thread_id": "32",
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    phase_path = tmp_path / "phase-runs.json"
+    monkeypatch.setenv("NOX_PROJECT_EMPLOYEE_ROUTING_PATH", str(path))
+    monkeypatch.setenv("NOX_PHASE_RUNS_PATH", str(phase_path))
+    monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", BASHNYA_CHAT_ID)
+    return path
+
+
+@pytest.fixture
+def nox_phase_runs_path(bashnya_routes_path):
+    return bashnya_routes_path.with_name("phase-runs.json")
+
+
+def _make_bashnya_event(text: str) -> MessageEvent:
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id=BASHNYA_CHAT_ID,
+        thread_id=BASHNYA_THREAD_ID,
+        chat_type="supergroup",
+        user_id="8756671470",
+        user_name="Danya",
+    )
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="source-msg-1",
+    )
+
+
+def _make_runner(source: SessionSource, adapter: CaptureAdapter) -> Any:
+    runner: Any = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")},
+        group_sessions_per_user=False,
+        thread_sessions_per_user=False,
+        stt_enabled=False,
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner.session_store = FakeSessionStore(source)
+    runner._session_db = None
+    runner._voice_mode = {}
+    runner._pending_native_image_paths_by_session = {}
+    runner._session_model_overrides = {}
+    runner._pending_model_notes = {}
+    runner._session_run_generation = {}
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._busy_ack_ts = {}
+    runner._prefill_messages = []
+    runner._ephemeral_system_prompt = ""
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._reasoning_config = None
+    runner._service_tier = None
+    runner._background_tasks = set()
+    runner._active_profile_name = lambda: "nox-v2"
+    runner._is_telegram_topic_lane = lambda _source: False
+    runner._set_session_env = lambda _context: []
+    runner._clear_session_env = lambda _tokens: None
+    runner._bind_adapter_run_generation = lambda *_args, **_kwargs: None
+    runner._reply_anchor_for_event = lambda _event: _event.message_id
+    runner._thread_metadata_for_source = lambda source, reply_anchor=None: {
+        "thread_id": source.thread_id,
+        "reply_to_message_id": reply_anchor,
+    }
+    runner._resolve_session_reasoning_config = lambda **_kwargs: None
+    runner._load_service_tier = lambda: None
+    runner._is_session_run_current = lambda *_args, **_kwargs: True
+    runner._start_nox_worker_plan_runner = lambda **_kwargs: "plan-task-id"
+    runner._start_nox_worker_phase_runner = lambda **_kwargs: "phase-task-id"
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_bashnya_project_task_routes_to_employee_lane_before_agent(monkeypatch, bashnya_routes_path):
+    """Known heavy project task in Башня is packeted to employee lane, not run in main lane."""
+    event = _make_bashnya_event("почини metaauto coordinator routing и прогони тесты")
+    adapter = CaptureAdapter()
+    runner = _make_runner(event.source, adapter)
+
+    async def fail_if_agent_runs(**_kwargs):  # pragma: no cover - should not be called
+        raise AssertionError("project task must be routed before _run_agent")
+
+    runner._run_agent = fail_if_agent_runs
+
+    ack = await runner._handle_message_with_agent(
+        event,
+        event.source,
+        build_session_key(event.source),
+        run_generation=1,
+    )
+
+    assert "Статус: взял в работу" in ack
+    assert "Куда ушло: MetaAuto · Сотрудник" in ack
+    assert "run_id:" in ack
+
+    assert len(adapter.sent) == 1
+    packet = adapter.sent[0]
+    assert packet["chat_id"] == BASHNYA_CHAT_ID
+    assert packet["metadata"] == {"thread_id": "31"}
+    assert "PROJECT EMPLOYEE TASK" in packet["content"]
+    assert "Project: MetaAuto" in packet["content"]
+    assert "Mode: RUN" in packet["content"]
+    assert "почини metaauto coordinator routing" in packet["content"]
+
+
+@pytest.mark.asyncio
+async def test_bashnya_fast_question_stays_direct_and_can_be_capped(bashnya_routes_path):
+    """Brief/non-project Башня messages are not packeted away and use the light turn cap."""
+    event = _make_bashnya_event("почему так долго?")
+    adapter = CaptureAdapter()
+    runner = _make_runner(event.source, adapter)
+
+    routed = await runner._maybe_route_nox_bashnya_task(event, event.text)
+
+    assert routed is None
+    assert adapter.sent == []
+    assert runner._maybe_cap_nox_bashnya_fast_iterations(event.source, event.text, 90) == 8
+
+
+def _make_employee_event(text: str) -> MessageEvent:
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id=BASHNYA_CHAT_ID,
+        thread_id="31",
+        chat_type="supergroup",
+        user_id="8756671470",
+        user_name="Danya",
+    )
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="employee-msg-1",
+    )
+
+
+def _make_ryadom_employee_event(text: str) -> MessageEvent:
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id=BASHNYA_CHAT_ID,
+        thread_id="32",
+        chat_type="supergroup",
+        user_id="8756671470",
+        user_name="Danya",
+    )
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="ryadom-employee-msg-1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_bashnya_project_task_starts_worker_plan_runner(monkeypatch, bashnya_routes_path):
+    """Routing a project task should start a plan-only worker run, not just post a packet."""
+    event = _make_bashnya_event("почини metaauto импорты и разбей работу на фазы")
+    adapter = CaptureAdapter()
+    runner = _make_runner(event.source, adapter)
+    started: list[dict] = []
+
+    def fake_start_plan_runner(*, run_id, route, state):
+        started.append({"run_id": run_id, "route": route, "state": state})
+        return "plan-task-id"
+
+    runner._start_nox_worker_plan_runner = fake_start_plan_runner
+
+    ack = await runner._handle_message_with_agent(
+        event,
+        event.source,
+        build_session_key(event.source),
+        run_generation=1,
+    )
+
+    assert "Режим: PROJECT" in ack
+    assert "Планер: запущен" in ack
+    assert started, "plan runner must start after routing"
+    run_id = started[0]["run_id"]
+    runs = runner._load_nox_phase_runs()
+    assert runs[run_id]["status"] == "planning"
+    assert runs[run_id]["goal"] == event.text
+    assert runs[run_id]["employee_thread_id"] == "31"
+
+
+@pytest.mark.asyncio
+async def test_employee_approval_starts_next_phase(monkeypatch, bashnya_routes_path):
+    """After the worker plan is ready, 'утвердить' in the employee topic starts phase 1 only."""
+    event = _make_employee_event("утвердить")
+    adapter = CaptureAdapter()
+    runner = _make_runner(event.source, adapter)
+    runner._save_nox_phase_runs(
+        {
+            "run-1": {
+                "run_id": "run-1",
+                "status": "awaiting_approval",
+                "project": "metaauto",
+                "display": "MetaAuto",
+                "goal": "почини metaauto импорты",
+                "plan": "Фаза 1: диагностика\nФаза 2: фикс и тесты",
+                "phase_index": 0,
+                "phase_count": 2,
+                "bashnya_chat_id": BASHNYA_CHAT_ID,
+                "bashnya_thread_id": BASHNYA_THREAD_ID,
+                "employee_chat_id": BASHNYA_CHAT_ID,
+                "employee_thread_id": "31",
+                "topic_name": "MetaAuto · Сотрудник",
+            }
+        }
+    )
+    started: list[dict] = []
+
+    def fake_start_phase_runner(*, run_id, route, state):
+        started.append({"run_id": run_id, "route": route, "state": dict(state)})
+        return "phase-task-id"
+
+    runner._start_nox_worker_phase_runner = fake_start_phase_runner
+
+    reply = await runner._maybe_handle_nox_worker_approval(event, event.text)
+
+    assert "Фаза 1" in reply
+    assert "запущена" in reply
+    assert started, "phase runner must start only after approval"
+    runs = runner._load_nox_phase_runs()
+    assert runs["run-1"]["status"] == "running_phase"
+    assert runs["run-1"]["phase_index"] == 1
+    assert started[0]["state"]["phase_index"] == 1
+
+
+@pytest.mark.asyncio
+async def test_prefixed_employee_approval_is_bound_to_exact_project_thread(bashnya_routes_path):
+    """Gateway-prepared '[User] утвердить' must approve only the run waiting in this topic."""
+    event = _make_ryadom_employee_event("утвердить")
+    adapter = CaptureAdapter()
+    runner = _make_runner(event.source, adapter)
+    base_state = {
+        "status": "awaiting_approval",
+        "goal": "safe next phase",
+        "plan": "Фаза 1: диагностика",
+        "phase_index": 0,
+        "phase_count": 1,
+        "bashnya_chat_id": BASHNYA_CHAT_ID,
+        "bashnya_thread_id": BASHNYA_THREAD_ID,
+    }
+    runner._save_nox_phase_runs(
+        {
+            "meta-run": {
+                "run_id": "meta-run",
+                "project": "metaauto",
+                "display": "MetaAuto",
+                "employee_chat_id": BASHNYA_CHAT_ID,
+                "employee_thread_id": "31",
+                "topic_name": "MetaAuto · Сотрудник",
+                **base_state,
+            },
+            "ryadom-run": {
+                "run_id": "ryadom-run",
+                "project": "ryadom",
+                "display": "Ryadom",
+                "employee_chat_id": BASHNYA_CHAT_ID,
+                "employee_thread_id": "32",
+                "topic_name": "Ryadom · Сотрудник",
+                **base_state,
+            },
+        }
+    )
+    started: list[dict] = []
+
+    def fake_start_phase_runner(*, run_id, route, state):
+        started.append({"run_id": run_id, "route": route, "state": dict(state)})
+        return "phase-task-id"
+
+    runner._start_nox_worker_phase_runner = fake_start_phase_runner
+
+    reply = await runner._maybe_handle_nox_worker_approval(event, "[Exzy] утвердить")
+
+    assert "Ryadom · Сотрудник" in reply
+    assert started[0]["run_id"] == "ryadom-run"
+    runs = runner._load_nox_phase_runs()
+    assert runs["meta-run"]["status"] == "awaiting_approval"
+    assert runs["ryadom-run"]["status"] == "running_phase"
+
+
+@pytest.mark.asyncio
+async def test_project_employee_approval_without_matching_run_stops_before_agent(bashnya_routes_path):
+    """An approval word in a project employee topic must not fall through to the LLM."""
+    event = _make_ryadom_employee_event("утвердить")
+    runner = _make_runner(event.source, CaptureAdapter())
+    runner._save_nox_phase_runs(
+        {
+            "meta-run": {
+                "run_id": "meta-run",
+                "status": "awaiting_approval",
+                "project": "metaauto",
+                "display": "MetaAuto",
+                "goal": "safe next phase",
+                "plan": "Фаза 1: диагностика",
+                "phase_index": 0,
+                "phase_count": 1,
+                "bashnya_chat_id": BASHNYA_CHAT_ID,
+                "bashnya_thread_id": BASHNYA_THREAD_ID,
+                "employee_chat_id": BASHNYA_CHAT_ID,
+                "employee_thread_id": "31",
+                "topic_name": "MetaAuto · Сотрудник",
+            }
+        }
+    )
+
+    reply = await runner._maybe_handle_nox_worker_approval(event, "[Exzy] утвердить")
+
+    assert reply is not None
+    assert "Нет worker-фазы" in reply
+    assert "Ryadom · Сотрудник" in reply
+    assert runner._load_nox_phase_runs()["meta-run"]["status"] == "awaiting_approval"
+
+
+@pytest.mark.asyncio
+async def test_worker_plan_safe_scope_is_auto_approved_by_nox_pm(monkeypatch, bashnya_routes_path):
+    """Safe worker plans should not bounce back to Danya for phase approval."""
+    event = _make_bashnya_event("почини metaauto импорты и прогони тесты")
+    adapter = CaptureAdapter()
+    runner = _make_runner(event.source, adapter)
+    run_id = "run-safe"
+    state = {
+        "run_id": run_id,
+        "status": "planning",
+        "project": "metaauto",
+        "display": "MetaAuto",
+        "goal": event.text,
+        "phase_index": 0,
+        "phase_count": 0,
+        "bashnya_chat_id": BASHNYA_CHAT_ID,
+        "bashnya_thread_id": BASHNYA_THREAD_ID,
+        "employee_chat_id": BASHNYA_CHAT_ID,
+        "employee_thread_id": "31",
+        "topic_name": "MetaAuto · Сотрудник",
+        "source_user_id": "8756671470",
+        "source_user_name": "Danya",
+    }
+
+    async def fake_worker_plan(**_kwargs):
+        return "Цель: safe fix\nФаза 1: диагностика\nФаза 2: фикс и targeted tests\nHuman gate: none"
+
+    started: list[dict] = []
+
+    def fake_start_phase_runner(*, run_id, route, state):
+        started.append({"run_id": run_id, "route": route, "state": dict(state)})
+        return "phase-task-id"
+
+    runner._run_nox_worker_agent_once = fake_worker_plan
+    runner._start_nox_worker_phase_runner = fake_start_phase_runner
+    runner._save_nox_phase_runs({run_id: state})
+
+    await runner._run_nox_worker_plan(run_id, {}, state, "plan-task-id")
+
+    assert started, "Nox PM must start phase 1 without Danya for safe plans"
+    assert started[0]["state"]["phase_index"] == 1
+    runs = runner._load_nox_phase_runs()
+    assert runs[run_id]["status"] == "running_phase"
+    assert runs[run_id]["phase_index"] == 1
+    assert runs[run_id]["approval_mode"] == "nox_pm_auto"
+    assert any("auto-approved" in item["content"] for item in adapter.sent)
+
+
+@pytest.mark.asyncio
+async def test_worker_plan_high_risk_keeps_human_gate(monkeypatch, bashnya_routes_path):
+    """High-risk plans still require Danya even when Nox PM auto-approval is enabled."""
+    event = _make_bashnya_event("подготовь metaauto deploy production")
+    adapter = CaptureAdapter()
+    runner = _make_runner(event.source, adapter)
+    run_id = "run-risk"
+    state = {
+        "run_id": run_id,
+        "status": "planning",
+        "project": "metaauto",
+        "display": "MetaAuto",
+        "goal": event.text,
+        "phase_index": 0,
+        "phase_count": 0,
+        "bashnya_chat_id": BASHNYA_CHAT_ID,
+        "bashnya_thread_id": BASHNYA_THREAD_ID,
+        "employee_chat_id": BASHNYA_CHAT_ID,
+        "employee_thread_id": "31",
+        "topic_name": "MetaAuto · Сотрудник",
+        "source_user_id": "8756671470",
+        "source_user_name": "Danya",
+    }
+
+    async def fake_worker_plan(**_kwargs):
+        return "Цель: release\nФаза 1: проверить diff\nФаза 2: deploy production\nHuman gate: deploy production"
+
+    started: list[dict] = []
+    runner._run_nox_worker_agent_once = fake_worker_plan
+    runner._start_nox_worker_phase_runner = lambda **kwargs: started.append(kwargs) or "phase-task-id"
+    runner._save_nox_phase_runs({run_id: state})
+
+    await runner._run_nox_worker_plan(run_id, {}, state, "plan-task-id")
+
+    assert started == []
+    runs = runner._load_nox_phase_runs()
+    assert runs[run_id]["status"] == "awaiting_approval"
+    assert runs[run_id]["approval_mode"] == "human"
+    assert "deploy production" in runs[run_id]["approval_reason"]
+    assert any("Нужен Даня" in item["content"] for item in adapter.sent)
+
+
+@pytest.mark.asyncio
+async def test_employee_packet_send_happens_after_durable_state(monkeypatch, nox_phase_runs_path):
+    """A visible employee packet must not exist without durable run state for restart recovery."""
+    event = _make_bashnya_event("почини metaauto импорты и разбей работу на фазы")
+    adapter = StateCheckingAdapter(nox_phase_runs_path)
+    runner = _make_runner(event.source, adapter)
+
+    ack = await runner._handle_message_with_agent(
+        event,
+        event.source,
+        build_session_key(event.source),
+        run_generation=1,
+    )
+
+    assert "Статус: взял в работу" in ack
+    match = re.search(r"run_id: `([^`]+)`", ack)
+    assert match
+    run_id = match.group(1)
+    runs = runner._load_nox_phase_runs()
+    assert runs[run_id]["packet_message_id"] == "sent-1"
+    assert runs[run_id]["status"] == "planning"
+
+
+@pytest.mark.asyncio
+async def test_unrelated_topic_approval_text_falls_through(bashnya_routes_path):
+    """Exact approval words in unrelated Telegram topics must not be hijacked by the Nox gate."""
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id=BASHNYA_CHAT_ID,
+        thread_id="99",
+        chat_type="supergroup",
+        user_id="8756671470",
+        user_name="Danya",
+    )
+    event = MessageEvent(
+        text="утвердить",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="other-topic-msg-1",
+    )
+    runner = _make_runner(source, CaptureAdapter())
+
+    assert await runner._maybe_handle_nox_worker_approval(event, event.text) is None
+
+
+@pytest.mark.asyncio
+async def test_approval_requires_exact_command_and_supports_hyphenated_run_id(bashnya_routes_path):
+    """Safety gate accepts exact approve/run_id commands, not ambiguous negated phrases."""
+    event = _make_employee_event("утвердить не запускай")
+    adapter = CaptureAdapter()
+    runner = _make_runner(event.source, adapter)
+    base_state = {
+        "status": "awaiting_approval",
+        "project": "metaauto",
+        "display": "MetaAuto",
+        "goal": "почини metaauto импорты",
+        "plan": "Фаза 1: диагностика",
+        "phase_index": 0,
+        "phase_count": 1,
+        "bashnya_chat_id": BASHNYA_CHAT_ID,
+        "bashnya_thread_id": BASHNYA_THREAD_ID,
+        "employee_chat_id": BASHNYA_CHAT_ID,
+        "employee_thread_id": "31",
+        "topic_name": "MetaAuto · Сотрудник",
+    }
+    runner._save_nox_phase_runs(
+        {
+            "bashnya-20260518-111111-aaaa": {"run_id": "bashnya-20260518-111111-aaaa", **base_state},
+            "bashnya-20260518-222222-bbbb": {"run_id": "bashnya-20260518-222222-bbbb", **base_state},
+        }
+    )
+    started: list[dict] = []
+
+    def fake_start_phase_runner(*, run_id, route, state):
+        started.append({"run_id": run_id, "route": route, "state": dict(state)})
+        return "phase-task-id"
+
+    runner._start_nox_worker_phase_runner = fake_start_phase_runner
+
+    assert await runner._maybe_handle_nox_worker_approval(event, event.text) is None
+    assert started == []
+
+    event.text = "утвердить bashnya-20260518-222222-bbbb"
+    reply = await runner._maybe_handle_nox_worker_approval(event, event.text)
+
+    assert "Фаза 1" in reply
+    assert started[0]["run_id"] == "bashnya-20260518-222222-bbbb"
+    runs = runner._load_nox_phase_runs()
+    assert runs["bashnya-20260518-111111-aaaa"]["status"] == "awaiting_approval"
+    assert runs["bashnya-20260518-222222-bbbb"]["status"] == "running_phase"

--- a/tests/gateway/test_nox_bashnya_router.py
+++ b/tests/gateway/test_nox_bashnya_router.py
@@ -224,6 +224,117 @@ async def test_bashnya_project_task_routes_to_employee_lane_before_agent(monkeyp
 
 
 @pytest.mark.asyncio
+async def test_bashnya_unqualified_landing_followup_infers_ryadom_active_context(bashnya_routes_path):
+    """Long landing follow-up in Башня must route to Ryadom, not continue main control chat."""
+    event = _make_bashnya_event(
+        "[The user sent a voice message~ Here's what they said: "
+        "\"Что не хватает нашему лендингу, чтобы он был максимально продающим? "
+        "Нужны хуки, вау hero, отзывы, ценник и макеты до кода.\"]"
+    )
+    adapter = CaptureAdapter()
+    runner = _make_runner(event.source, adapter)
+    runner._save_nox_phase_runs(
+        {
+            "meta-run": {
+                "run_id": "meta-run",
+                "status": "awaiting_approval",
+                "project": "metaauto",
+                "display": "MetaAuto",
+                "bashnya_chat_id": BASHNYA_CHAT_ID,
+                "bashnya_thread_id": BASHNYA_THREAD_ID,
+                "employee_chat_id": BASHNYA_CHAT_ID,
+                "employee_thread_id": "31",
+                "topic_name": "MetaAuto · Сотрудник",
+                "updated_at": "2026-05-18T19:43:31",
+            },
+            "ryadom-run": {
+                "run_id": "ryadom-run",
+                "status": "awaiting_approval",
+                "project": "ryadom",
+                "display": "Ryadom",
+                "bashnya_chat_id": BASHNYA_CHAT_ID,
+                "bashnya_thread_id": BASHNYA_THREAD_ID,
+                "employee_chat_id": BASHNYA_CHAT_ID,
+                "employee_thread_id": "32",
+                "topic_name": "Ryadom · Сотрудник",
+                "updated_at": "2026-05-18T23:37:03",
+            },
+        }
+    )
+
+    async def fail_if_agent_runs(**_kwargs):  # pragma: no cover - should not be called
+        raise AssertionError("unqualified project follow-up must not run in Башня")
+
+    runner._run_agent = fail_if_agent_runs
+
+    ack = await runner._handle_message_with_agent(
+        event,
+        event.source,
+        build_session_key(event.source),
+        run_generation=1,
+    )
+
+    assert "Статус: взял в работу" in ack
+    assert "Куда ушло: Ryadom · Сотрудник" in ack
+    assert adapter.sent[0]["metadata"] == {"thread_id": "32"}
+    assert "Project: Ryadom" in adapter.sent[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_bashnya_substantial_unqualified_task_blocks_instead_of_main_agent(bashnya_routes_path):
+    """If project cannot be inferred, Башня asks for project and does not run the main agent."""
+    event = _make_bashnya_event(
+        "Собери максимально сильный рабочий план: сначала аудит, потом варианты, "
+        "потом список рисков. Ничего не коммить и не пушить, "
+        "просто разложи по фазам и покажи мне proof в правильном месте."
+    )
+    adapter = CaptureAdapter()
+    runner = _make_runner(event.source, adapter)
+    runner._save_nox_phase_runs(
+        {
+            "meta-run": {
+                "run_id": "meta-run",
+                "status": "awaiting_approval",
+                "project": "metaauto",
+                "bashnya_chat_id": BASHNYA_CHAT_ID,
+                "bashnya_thread_id": BASHNYA_THREAD_ID,
+                "employee_chat_id": BASHNYA_CHAT_ID,
+                "employee_thread_id": "31",
+                "topic_name": "MetaAuto · Сотрудник",
+                "updated_at": "2026-05-18T19:43:31",
+            },
+            "ryadom-run": {
+                "run_id": "ryadom-run",
+                "status": "awaiting_approval",
+                "project": "ryadom",
+                "bashnya_chat_id": BASHNYA_CHAT_ID,
+                "bashnya_thread_id": BASHNYA_THREAD_ID,
+                "employee_chat_id": BASHNYA_CHAT_ID,
+                "employee_thread_id": "32",
+                "topic_name": "Ryadom · Сотрудник",
+                "updated_at": "2026-05-18T23:37:03",
+            },
+        }
+    )
+
+    async def fail_if_agent_runs(**_kwargs):  # pragma: no cover - should not be called
+        raise AssertionError("ambiguous project task must block before _run_agent")
+
+    runner._run_agent = fail_if_agent_runs
+
+    reply = await runner._handle_message_with_agent(
+        event,
+        event.source,
+        build_session_key(event.source),
+        run_generation=1,
+    )
+
+    assert "проект не указан" in reply
+    assert "Main run в Башне не запускаю" in reply
+    assert adapter.sent == []
+
+
+@pytest.mark.asyncio
 async def test_bashnya_fast_question_stays_direct_and_can_be_capped(bashnya_routes_path):
     """Brief/non-project Башня messages are not packeted away and use the light turn cap."""
     event = _make_bashnya_event("почему так долго?")

--- a/tests/gateway/test_nox_bashnya_router.py
+++ b/tests/gateway/test_nox_bashnya_router.py
@@ -458,6 +458,124 @@ async def test_employee_approval_starts_next_phase(monkeypatch, bashnya_routes_p
 
 
 @pytest.mark.asyncio
+async def test_bare_plus_approval_in_employee_topic_starts_matching_phase(bashnya_routes_path):
+    """Bare '+' is allowed only as a deterministic gate approval in the current worker topic."""
+    event = _make_employee_event("+")
+    adapter = CaptureAdapter()
+    runner = _make_runner(event.source, adapter)
+    runner._save_nox_phase_runs(
+        {
+            "run-plus": {
+                "run_id": "run-plus",
+                "status": "awaiting_approval",
+                "project": "metaauto",
+                "display": "MetaAuto",
+                "goal": "safe next phase",
+                "plan": "Фаза 1: диагностика",
+                "phase_index": 0,
+                "phase_count": 1,
+                "bashnya_chat_id": BASHNYA_CHAT_ID,
+                "bashnya_thread_id": BASHNYA_THREAD_ID,
+                "employee_chat_id": BASHNYA_CHAT_ID,
+                "employee_thread_id": "31",
+                "topic_name": "MetaAuto · Сотрудник",
+            }
+        }
+    )
+    started: list[dict] = []
+
+    def fake_start_phase_runner(*, run_id, route, state):
+        started.append({"run_id": run_id, "route": route, "state": dict(state)})
+        return "phase-task-id"
+
+    runner._start_nox_worker_phase_runner = fake_start_phase_runner
+
+    reply = await runner._maybe_handle_nox_worker_approval(event, "[Exzy] +")
+
+    assert "Фаза 1" in reply
+    assert started[0]["run_id"] == "run-plus"
+    assert runner._load_nox_phase_runs()["run-plus"]["status"] == "running_phase"
+
+
+@pytest.mark.asyncio
+async def test_bare_plus_in_bashnya_without_waiting_gate_stops_before_agent(bashnya_routes_path):
+    """Bare '+' in Башня must not fall through to the LLM and continue stale context."""
+    event = _make_bashnya_event("+")
+    adapter = CaptureAdapter()
+    runner = _make_runner(event.source, adapter)
+
+    async def fail_if_agent_runs(**_kwargs):  # pragma: no cover - should not be called
+        raise AssertionError("bare plus must be handled deterministically before _run_agent")
+
+    runner._run_agent = fail_if_agent_runs
+
+    reply = await runner._handle_message_with_agent(
+        event,
+        event.source,
+        build_session_key(event.source),
+        run_generation=1,
+    )
+
+    assert "Нет worker-фазы" in reply
+    assert adapter.sent == []
+
+
+@pytest.mark.asyncio
+async def test_bare_plus_in_bashnya_requires_run_id_when_multiple_gates(bashnya_routes_path):
+    """Bare '+' in Башня is rejected if more than one active gate could match."""
+    event = _make_bashnya_event("+")
+    adapter = CaptureAdapter()
+    runner = _make_runner(event.source, adapter)
+    base_state = {
+        "status": "awaiting_approval",
+        "goal": "safe next phase",
+        "plan": "Фаза 1: диагностика",
+        "phase_index": 0,
+        "phase_count": 1,
+        "bashnya_chat_id": BASHNYA_CHAT_ID,
+        "bashnya_thread_id": BASHNYA_THREAD_ID,
+    }
+    runner._save_nox_phase_runs(
+        {
+            "meta-run": {
+                "run_id": "meta-run",
+                "project": "metaauto",
+                "display": "MetaAuto",
+                "employee_chat_id": BASHNYA_CHAT_ID,
+                "employee_thread_id": "31",
+                "topic_name": "MetaAuto · Сотрудник",
+                **base_state,
+            },
+            "ryadom-run": {
+                "run_id": "ryadom-run",
+                "project": "ryadom",
+                "display": "Ryadom",
+                "employee_chat_id": BASHNYA_CHAT_ID,
+                "employee_thread_id": "32",
+                "topic_name": "Ryadom · Сотрудник",
+                **base_state,
+            },
+        }
+    )
+
+    async def fail_if_agent_runs(**_kwargs):  # pragma: no cover - should not be called
+        raise AssertionError("ambiguous plus must be handled before _run_agent")
+
+    runner._run_agent = fail_if_agent_runs
+
+    reply = await runner._handle_message_with_agent(
+        event,
+        event.source,
+        build_session_key(event.source),
+        run_generation=1,
+    )
+
+    assert "Нужен run_id" in reply
+    assert "meta-run" in reply and "ryadom-run" in reply
+    assert adapter.sent == []
+
+
+@pytest.mark.asyncio
 async def test_prefixed_employee_approval_is_bound_to_exact_project_thread(bashnya_routes_path):
     """Gateway-prepared '[User] утвердить' must approve only the run waiting in this topic."""
     event = _make_ryadom_employee_event("утвердить")

--- a/tests/gateway/test_nox_bashnya_router.py
+++ b/tests/gateway/test_nox_bashnya_router.py
@@ -178,6 +178,8 @@ def _make_runner(source: SessionSource, adapter: CaptureAdapter) -> Any:
     runner._reasoning_config = None
     runner._service_tier = None
     runner._background_tasks = set()
+    runner._nox_worker_agents_by_run_id = {}
+    runner._nox_worker_agents_by_task_id = {}
     runner._active_profile_name = lambda: "nox-v2"
     runner._is_telegram_topic_lane = lambda _source: False
     runner._set_session_env = lambda _context: []
@@ -729,6 +731,176 @@ async def test_project_employee_approval_without_matching_run_stops_before_agent
     assert "Нет worker-фазы" in reply
     assert "Ryadom · Сотрудник" in reply
     assert runner._load_nox_phase_runs()["meta-run"]["status"] == "awaiting_approval"
+
+
+class FakeSteerAgent:
+    def __init__(self) -> None:
+        self.steers: list[str] = []
+
+    def steer(self, text: str) -> bool:
+        self.steers.append(text)
+        return True
+
+
+@pytest.mark.asyncio
+async def test_employee_live_steer_delivers_to_running_worker_agent_and_persists_amendment(bashnya_routes_path):
+    """Plain text in `<Project> · Сотрудник` during an active worker run is live-steered, not run as a new chat."""
+    event = _make_employee_event("усвой прямо сейчас: не коммить, только покажи report")
+    runner = _make_runner(event.source, CaptureAdapter())
+    runner._save_nox_phase_runs(
+        {
+            "run-live": {
+                "run_id": "run-live",
+                "status": "running_phase",
+                "project": "metaauto",
+                "display": "MetaAuto",
+                "goal": "почини metaauto импорты",
+                "plan": "Фаза 1: диагностика",
+                "phase_index": 1,
+                "phase_count": 1,
+                "phase_task_id": "phase-task-id",
+                "bashnya_chat_id": BASHNYA_CHAT_ID,
+                "bashnya_thread_id": BASHNYA_THREAD_ID,
+                "employee_chat_id": BASHNYA_CHAT_ID,
+                "employee_thread_id": "31",
+                "topic_name": "MetaAuto · Сотрудник",
+            }
+        }
+    )
+    fake_agent = FakeSteerAgent()
+    runner._nox_worker_agents_by_run_id = {"run-live": fake_agent}
+
+    reply = await runner._maybe_handle_nox_worker_live_steer(event, "[Danya] " + event.text)
+
+    assert "Усвоил прямо сейчас" in reply
+    assert "run-live" in reply
+    assert fake_agent.steers, "active worker agent must receive a live steer"
+    assert "не коммить" in fake_agent.steers[0]
+    assert "run_id: run-live" in fake_agent.steers[0]
+    runs = runner._load_nox_phase_runs()
+    amendment = runs["run-live"]["amendments"][-1]
+    assert amendment["delivery"] == "delivered_live"
+    assert amendment["message_id"] == "employee-msg-1"
+    assert "только покажи report" in amendment["text"]
+
+
+@pytest.mark.asyncio
+async def test_employee_live_steer_without_registered_worker_is_saved_and_blocks_main_agent(bashnya_routes_path):
+    """If the hidden worker is starting/restarted, employee follow-up is still stored as run amendment and does not hit the main LLM."""
+    event = _make_employee_event("добавь ограничение: без production deploy")
+    adapter = CaptureAdapter()
+    runner = _make_runner(event.source, adapter)
+    runner._save_nox_phase_runs(
+        {
+            "run-planning": {
+                "run_id": "run-planning",
+                "status": "planning",
+                "project": "metaauto",
+                "display": "MetaAuto",
+                "goal": "почини metaauto импорты",
+                "phase_index": 0,
+                "phase_count": 0,
+                "bashnya_chat_id": BASHNYA_CHAT_ID,
+                "bashnya_thread_id": BASHNYA_THREAD_ID,
+                "employee_chat_id": BASHNYA_CHAT_ID,
+                "employee_thread_id": "31",
+                "topic_name": "MetaAuto · Сотрудник",
+            }
+        }
+    )
+
+    async def fail_if_agent_runs(**_kwargs):  # pragma: no cover - should not be called
+        raise AssertionError("employee live steer must be handled before _run_agent")
+
+    runner._run_agent = fail_if_agent_runs
+
+    reply = await runner._handle_message_with_agent(
+        event,
+        event.source,
+        build_session_key(event.source),
+        run_generation=1,
+    )
+
+    assert "сохранил amendment" in reply
+    assert "run-planning" in reply
+    runs = runner._load_nox_phase_runs()
+    assert runs["run-planning"]["amendments"][-1]["delivery"] == "saved_for_worker"
+    assert "без production deploy" in runs["run-planning"]["amendments"][-1]["text"]
+    assert adapter.sent == []
+
+
+@pytest.mark.asyncio
+async def test_employee_live_steer_multiple_active_runs_requires_explicit_run_id(bashnya_routes_path):
+    """Ambiguous employee-topic amendments stop until Danya names the target run_id."""
+    event = _make_employee_event("добавь это ограничение в текущую фазу")
+    runner = _make_runner(event.source, CaptureAdapter())
+    base_state = {
+        "status": "running_phase",
+        "project": "metaauto",
+        "display": "MetaAuto",
+        "goal": "почини metaauto импорты",
+        "phase_index": 1,
+        "phase_count": 2,
+        "bashnya_chat_id": BASHNYA_CHAT_ID,
+        "bashnya_thread_id": BASHNYA_THREAD_ID,
+        "employee_chat_id": BASHNYA_CHAT_ID,
+        "employee_thread_id": "31",
+        "topic_name": "MetaAuto · Сотрудник",
+    }
+    runner._save_nox_phase_runs(
+        {
+            "run-a": {**base_state, "run_id": "run-a", "updated_at": "2026-05-19T12:00:00"},
+            "run-b": {**base_state, "run_id": "run-b", "updated_at": "2026-05-19T12:01:00"},
+        }
+    )
+
+    ambiguous_reply = await runner._maybe_handle_nox_worker_live_steer(event, "[Danya] " + event.text)
+
+    assert "Нужен Даня" in ambiguous_reply
+    assert "несколько активных runs" in ambiguous_reply
+    runs = runner._load_nox_phase_runs()
+    assert "amendments" not in runs["run-a"]
+    assert "amendments" not in runs["run-b"]
+
+    explicit_event = _make_employee_event("run-a: применяй только к первой фазе")
+    explicit_reply = await runner._maybe_handle_nox_worker_live_steer(
+        explicit_event,
+        "[Danya] " + explicit_event.text,
+    )
+
+    assert "сохранил amendment" in explicit_reply
+    runs = runner._load_nox_phase_runs()
+    assert runs["run-a"]["amendments"][-1]["text"] == "run-a: применяй только к первой фазе"
+    assert "amendments" not in runs["run-b"]
+
+
+def test_worker_phase_prompt_includes_saved_live_amendments(bashnya_routes_path):
+    """Saved live-steer amendments are injected into later worker prompts after restarts/gates."""
+    event = _make_employee_event("placeholder")
+    runner = _make_runner(event.source, CaptureAdapter())
+    state = {
+        "run_id": "run-with-amendment",
+        "status": "running_phase",
+        "project": "metaauto",
+        "display": "MetaAuto",
+        "goal": "почини metaauto импорты",
+        "plan": "Фаза 1: диагностика",
+        "phase_index": 1,
+        "phase_count": 1,
+        "amendments": [
+            {
+                "id": "a1",
+                "created_at": "2026-05-19T12:00:00",
+                "text": "не коммить; только report",
+                "delivery": "saved_for_worker",
+            }
+        ],
+    }
+
+    prompt = runner._build_nox_worker_phase_prompt(state, 1)
+
+    assert "Live amendments / user steering" in prompt
+    assert "не коммить; только report" in prompt
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_run_cleanup_progress.py
+++ b/tests/gateway/test_run_cleanup_progress.py
@@ -131,6 +131,22 @@ class FailingAgent:
         }
 
 
+class StatusAgent:
+    """Emits an agent lifecycle status message and returns normally."""
+
+    def __init__(self, **kwargs):
+        self.status_callback = kwargs.get("status_callback")
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        cb = getattr(self, "status_callback", None)
+        if cb is not None:
+            cb("lifecycle", "📦 Preflight compression: test status")
+            time.sleep(0.05)
+        return {"final_response": "done", "messages": [], "api_calls": 1}
+
+
 def _make_runner(adapter):
     gateway_run = importlib.import_module("gateway.run")
     GatewayRunner = gateway_run.GatewayRunner
@@ -154,7 +170,7 @@ def _make_runner(adapter):
     return runner
 
 
-def _install_fakes(monkeypatch, agent_cls, *, cleanup_on: bool):
+def _install_fakes(monkeypatch, agent_cls, *, cleanup_on: bool, platform_overrides=None):
     """Wire up the module stubs every _run_agent test needs."""
     monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
 
@@ -170,15 +186,18 @@ def _install_fakes(monkeypatch, agent_cls, *, cleanup_on: bool):
     gateway_run = importlib.import_module("gateway.run")
     monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"})
 
-    # Wire the per-platform cleanup_progress flag via the config loader the
-    # gateway actually reads (``_load_gateway_config`` returns user config).
+    # Wire per-platform display flags via the config loader the gateway
+    # actually reads (``_load_gateway_config`` returns user config).
+    platform_cfg = {"cleanup_progress": True} if cleanup_on else {}
+    if platform_overrides:
+        platform_cfg.update(platform_overrides)
     cfg = {
         "display": {
             "platforms": {
-                "telegram": {"cleanup_progress": True},
+                "telegram": platform_cfg,
             }
         }
-    } if cleanup_on else {}
+    } if platform_cfg else {}
     monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: cfg)
     return gateway_run
 
@@ -219,6 +238,34 @@ async def test_cleanup_off_by_default_leaves_bubbles(monkeypatch, tmp_path):
         for _ in range(10):
             await asyncio.sleep(0.01)
     assert adapter.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_status_messages_platform_off_suppresses_lifecycle_bubbles(monkeypatch, tmp_path):
+    """display.platforms.<plat>.status_messages=false prevents agent
+    lifecycle/status callbacks from sending user-visible Telegram messages."""
+    adapter = CleanupCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = _install_fakes(
+        monkeypatch,
+        StatusAgent,
+        cleanup_on=False,
+        platform_overrides={"status_messages": False},
+    )
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="-1001")
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-status-off",
+        session_key="agent:main:telegram:group:-1001",
+    )
+
+    assert result["final_response"] == "done"
+    assert not any("Preflight compression" in entry["content"] for entry in adapter.sent)
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -76,6 +76,32 @@ class _AuthRunner:
 
 
 # ===========================================================================
+# Creative Lab quick-action buttons
+# ===========================================================================
+
+class TestTelegramCreativeLabQuickActions:
+    """Creative Lab product buttons must stay scoped to the topic."""
+
+    def test_does_not_attach_buttons_from_message_text_only(self):
+        adapter = _make_adapter()
+
+        markup = adapter._creative_lab_quick_actions_markup(
+            "Для Creative Lab конкретно: source first", metadata={}
+        )
+
+        assert markup is None
+
+    def test_attaches_buttons_inside_creative_lab_topic(self):
+        adapter = _make_adapter()
+
+        markup = adapter._creative_lab_quick_actions_markup(
+            "Короткий ответ", metadata={"chat_topic": "Creative Lab"}
+        )
+
+        assert markup is not None
+
+
+# ===========================================================================
 # send_exec_approval — inline keyboard buttons
 # ===========================================================================
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -65,6 +65,7 @@ class TestSystemdServiceRefresh:
         unit_path = tmp_path / "hermes-gateway.service"
         unit_path.write_text("old unit\n", encoding="utf-8")
 
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda *args, **kwargs: None)
         monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
         monkeypatch.setattr(gateway_cli, "generate_systemd_unit", lambda system=False, run_as_user=None: "new unit\n")
 
@@ -88,6 +89,7 @@ class TestSystemdServiceRefresh:
         unit_path = tmp_path / "hermes-gateway.service"
         unit_path.write_text("old unit\n", encoding="utf-8")
 
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda *args, **kwargs: None)
         monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
         monkeypatch.setattr(gateway_cli, "generate_systemd_unit", lambda system=False, run_as_user=None: "new unit\n")
 
@@ -499,6 +501,26 @@ class TestLaunchdServiceRecovery:
             ["launchctl", "bootstrap", domain, str(plist_path)],
         ]
 
+    def test_launchd_plist_refresh_from_gateway_tool_call_defers_bootout(self, tmp_path, monkeypatch, capsys):
+        """A gateway child must not bootout its own launchd parent before bootstrap."""
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text("<plist>old content</plist>", encoding="utf-8")
+
+        calls = []
+
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "_called_from_running_gateway_process", lambda: True)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        assert gateway_cli.refresh_launchd_plist_if_needed() is True
+        assert "--replace" in plist_path.read_text(encoding="utf-8")
+        assert calls == []
+        assert "reload deferred" in capsys.readouterr().out
+
     def test_launchd_start_reloads_unloaded_job_and_retries(self, tmp_path, monkeypatch):
         plist_path = tmp_path / "ai.hermes.gateway.plist"
         plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
@@ -741,6 +763,7 @@ class TestGatewaySystemServiceRouting:
         calls = []
 
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda *args, **kwargs: None)
         monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: calls.append(("refresh", system)))
         monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
@@ -786,6 +809,7 @@ class TestGatewaySystemServiceRouting:
         calls = []
 
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda *args, **kwargs: None)
         monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: None)
         monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 10.0)
@@ -845,6 +869,7 @@ class TestGatewaySystemServiceRouting:
         calls = []
 
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda *args, **kwargs: None)
         monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: None)
         monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
@@ -875,6 +900,7 @@ class TestGatewaySystemServiceRouting:
 
     def test_systemd_restart_recovers_failed_planned_restart(self, monkeypatch, capsys):
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda *args, **kwargs: None)
         monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: None)
         monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- Add Nox project-worker live steer handling for plain text in `<Project> · Сотрудник` topics.
- Persist user amendments into the durable phase-run ledger and inject them into worker prompts.
- Register hidden worker agents by run/task id so active runs can receive live `steer()` payloads.
- Add regression coverage for live delivery, saved amendments, prompt injection, and ambiguous multiple-run routing.

## Test plan
- `pytest tests/gateway/test_nox_bashnya_router.py -q` → 22 passed
- `python -m py_compile gateway/run.py tests/gateway/test_nox_bashnya_router.py`
- `git diff --check`
- static added-line security scan: no findings
- independent reviewer worker: passed
