### PR TITLE
fix(signal): use cached recipient UUID to resolve bot @mentions when number omitted

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -539,14 +539,27 @@ class SignalAdapter(BasePlatformAdapter):
         # Mention filter: in groups, only process messages that @mention the bot account
         if is_group and self.require_mention:
             account_norm = self._account_normalized
-            # Check rendered mention tags OR raw mention metadata
+            # Signal senders with phone privacy enabled emit UUID-only mention
+            # metadata (no "number" field). Look up the bot's own cached UUID so
+            # those @mentions are not silently dropped.
+            _own_uuid = self._recipient_uuid_by_number.get(account_norm)
+            raw_mentions = data_message.get("mentions") or []
             mentioned_in_text = account_norm and (
                 f"@{account_norm}" in (text or "")
             )
             mentioned_in_metadata = any(
-                m.get("number") == account_norm or m.get("uuid") == account_norm
-                for m in (data_message.get("mentions") or [])
+                m.get("number") == account_norm
+                or m.get("uuid") == account_norm
+                or (_own_uuid and m.get("uuid") == _own_uuid)
+                for m in raw_mentions
             )
+            # Opportunistically cache bot's own UUID from phone-number-matched
+            # mentions so subsequent UUID-only @mentions resolve correctly.
+            if not _own_uuid:
+                for _m in raw_mentions:
+                    if _m.get("number") == account_norm and _m.get("uuid"):
+                        self._remember_recipient_identifiers(account_norm, _m["uuid"])
+                        break
             if not mentioned_in_text and not mentioned_in_metadata:
                 logger.debug(
                     "Signal: ignoring group message (require_mention=true, bot not mentioned)"

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -1953,3 +1953,138 @@ class TestSignalGroupV2Routing:
 
         assert len(captured) == 1
         assert captured[0].source.chat_type == "dm"
+
+
+# ---------------------------------------------------------------------------
+# require_mention UUID lookup
+# ---------------------------------------------------------------------------
+
+class TestSignalRequireMentionUuidLookup:
+    """require_mention=true must accept @mentions that carry only a UUID,
+    no phone number, in the mention metadata (Signal phone-privacy mode).
+
+    Regression for the case where m.get("uuid") was compared against
+    _account_normalized (a phone number) — a comparison that always fails.
+    """
+
+    BOT_ACCOUNT = "+15550000001"
+    BOT_UUID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    SENDER = "+15559998888"
+    SENDER_UUID = "11111111-2222-3333-4444-555555555555"
+    GROUP_ID = "testgroup=="
+
+    def _group_envelope(self, data_message: dict) -> dict:
+        return {
+            "envelope": {
+                "sourceNumber": self.SENDER,
+                "sourceUuid": self.SENDER_UUID,
+                "sourceName": "Alice",
+                "timestamp": 1700000001000,
+                "dataMessage": {"groupV2": {"id": self.GROUP_ID}, **data_message},
+            }
+        }
+
+    @pytest.mark.asyncio
+    async def test_uuid_only_mention_passes_when_uuid_cached(self, monkeypatch):
+        """A mention with UUID only (no number field) is accepted when the
+        bot's own UUID is already in _recipient_uuid_by_number."""
+        adapter = _make_signal_adapter(
+            monkeypatch, account=self.BOT_ACCOUNT,
+            group_allowed="*", require_mention=True,
+        )
+        adapter._recipient_uuid_by_number[self.BOT_ACCOUNT] = self.BOT_UUID
+        captured = []
+
+        async def _capture(event):
+            captured.append(event)
+
+        adapter.handle_message = _capture
+
+        env = self._group_envelope({
+            "message": "￼ hello",
+            "mentions": [{"uuid": self.BOT_UUID, "start": 0, "length": 1}],
+        })
+        await adapter._handle_envelope(env)
+
+        assert len(captured) == 1, "UUID-only mention should pass when bot UUID is cached"
+
+    @pytest.mark.asyncio
+    async def test_uuid_only_mention_dropped_when_uuid_not_cached(self, monkeypatch):
+        """Before any phone-number mention caches the bot UUID, a UUID-only
+        mention for a different UUID is dropped."""
+        adapter = _make_signal_adapter(
+            monkeypatch, account=self.BOT_ACCOUNT,
+            group_allowed="*", require_mention=True,
+        )
+        captured = []
+
+        async def _capture(event):
+            captured.append(event)
+
+        adapter.handle_message = _capture
+
+        env = self._group_envelope({
+            "message": "￼ hello",
+            "mentions": [{"uuid": "unknown-uuid-0000-0000-000000000000", "start": 0, "length": 1}],
+        })
+        await adapter._handle_envelope(env)
+
+        assert len(captured) == 0, "UUID for an unknown bot should be dropped"
+
+    @pytest.mark.asyncio
+    async def test_phone_mention_caches_bot_uuid(self, monkeypatch):
+        """A mention that includes both number and uuid must cache the bot's
+        UUID so future UUID-only @mentions resolve correctly."""
+        adapter = _make_signal_adapter(
+            monkeypatch, account=self.BOT_ACCOUNT,
+            group_allowed="*", require_mention=True,
+        )
+        assert self.BOT_ACCOUNT not in adapter._recipient_uuid_by_number
+        captured = []
+
+        async def _capture(event):
+            captured.append(event)
+
+        adapter.handle_message = _capture
+
+        env = self._group_envelope({
+            "message": "￼ hello",
+            "mentions": [
+                {"number": self.BOT_ACCOUNT, "uuid": self.BOT_UUID, "start": 0, "length": 1}
+            ],
+        })
+        await adapter._handle_envelope(env)
+
+        assert len(captured) == 1
+        assert adapter._recipient_uuid_by_number.get(self.BOT_ACCOUNT) == self.BOT_UUID
+
+    @pytest.mark.asyncio
+    async def test_uuid_only_mention_passes_after_phone_mention_cached_uuid(self, monkeypatch):
+        """End-to-end: first @mention (phone+uuid) caches the UUID; second
+        @mention (uuid only, phone-privacy sender) still reaches the handler."""
+        adapter = _make_signal_adapter(
+            monkeypatch, account=self.BOT_ACCOUNT,
+            group_allowed="*", require_mention=True,
+        )
+        captured = []
+
+        async def _capture(event):
+            captured.append(event)
+
+        adapter.handle_message = _capture
+
+        # First message: phone+uuid mention caches bot UUID
+        await adapter._handle_envelope(self._group_envelope({
+            "message": "￼ hi",
+            "mentions": [
+                {"number": self.BOT_ACCOUNT, "uuid": self.BOT_UUID, "start": 0, "length": 1}
+            ],
+        }))
+        assert len(captured) == 1
+
+        # Second message: UUID-only mention (privacy-enabled sender)
+        await adapter._handle_envelope(self._group_envelope({
+            "message": "￼ follow-up",
+            "mentions": [{"uuid": self.BOT_UUID, "start": 0, "length": 1}],
+        }))
+        assert len(captured) == 2, "UUID-only mention should pass after UUID was cached"


### PR DESCRIPTION
## Summary

Signal senders with phone privacy enabled send mention metadata with a UUID
but no `number` field. When `require_mention: true` is configured, the adapter
compared `m.get("uuid")` against `_account_normalized` (a phone number) — a
comparison that always fails — causing all such @mentions to be silently dropped.

- **Root cause**: `mentioned_in_metadata` checked `m.get("uuid") == account_norm`
  where `account_norm` is always a phone number (`+E.164`), so the UUID branch
  was dead code.
- **Fix**: look up the bot's own UUID via `_recipient_uuid_by_number.get(account_norm)`
  before evaluating mention metadata. When a mention carries both `number` and
  `uuid`, the UUID is cached opportunistically so subsequent UUID-only @mentions
  from privacy-enabled senders resolve correctly.
- **No behaviour change** when `number` is present in mention data (the common path).
- The adapter already maintains `_recipient_uuid_by_number` / `_recipient_number_by_uuid`
  for outbound routing; this fix reuses that infrastructure for inbound mention gating.

Closes #13478

## Test plan

- [ ] `test_uuid_only_mention_passes_when_uuid_cached` — UUID already in cache → message accepted
- [ ] `test_uuid_only_mention_dropped_when_uuid_not_cached` — unknown UUID → message dropped
- [ ] `test_phone_mention_caches_bot_uuid` — phone+uuid mention populates the cache
- [ ] `test_uuid_only_mention_passes_after_phone_mention_cached_uuid` — end-to-end: first phone mention caches UUID, second UUID-only mention passes
- [ ] All 113 existing `tests/gateway/test_signal.py` tests pass (verified locally)