### PR TITLE
fix: respect mode filter in hermes memory status for Hindsight

### DIFF
--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -422,7 +422,16 @@ def cmd_status(args) -> None:
                         print(f"  Status:    not available ✗")
                         schema = p.get_config_schema() if hasattr(p, "get_config_schema") else []
                         # Check all fields that have env_var (both secret and non-secret)
-                        required_fields = [f for f in schema if f.get("env_var")]
+                        # Respect "when" conditions — skip fields not relevant to current mode
+                        current_mode = provider_config.get("mode", "cloud")
+                        required_fields = []
+                        for f in schema:
+                            if not f.get("env_var"):
+                                continue
+                            when = f.get("when", {})
+                            if when and "mode" in when and when["mode"] != current_mode:
+                                continue
+                            required_fields.append(f)
                         if required_fields:
                             print(f"  Missing:")
                             for f in required_fields:


### PR DESCRIPTION
## Problem

`hermes memory status` shows `✗ HINDSIGHT_API_KEY` as missing even when Hindsight is configured in `local_embedded` mode. This key is only required for cloud mode — local mode uses `HINDSIGHT_API_LLM_API_KEY` instead.

The schema in `get_config_schema()` correctly defines `"when": {"mode": "cloud"}` for the `api_key` field, but the status check at line 425 iterates ALL fields with `env_var` without respecting the `when` condition.

## Fix

Filter `required_fields` by the current mode before checking env vars. Fields with `"when": {"mode": "X"}` are skipped when the current mode is not X.

## Before vs After

| Mode | Field | Before | After |
|------|-------|--------|-------|
| `local_embedded` | `HINDSIGHT_API_KEY` | ✗ (wrongly flagged) | Skipped (correct) |
| `cloud` | `HINDSIGHT_API_KEY` | ✗ (correctly flagged) | ✗ (correctly flagged) |
| `local_embedded` | `HINDSIGHT_API_LLM_API_KEY` | ✓/✗ | ✓/✗ (unchanged) |

## Tests

Verified syntax with `py_compile.compile()`. The change is minimal (10 lines added, 1 removed) and only affects the status display path — no runtime behavior change.
