### PR TITLE
feat: show user-modified skill names in bundled skill sync summary (#28206)

### DIFF
--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -423,7 +423,12 @@ if __name__ == "__main__":
         f"{result['skipped']} unchanged",
     ]
     if result["user_modified"]:
-        parts.append(f"{len(result['user_modified'])} user-modified (kept)")
+        names = result["user_modified"]
+        MAX_SHOW = 5
+        shown = ", ".join(names[:MAX_SHOW])
+        if len(names) > MAX_SHOW:
+            shown += f", +{len(names) - MAX_SHOW} more"
+        parts.append(f"{len(names)} user-modified (kept): {shown}")
     if result["cleaned"]:
         parts.append(f"{len(result['cleaned'])} cleaned from manifest")
     print(f"\nDone: {', '.join(parts)}. {result['total_bundled']} total bundled.")


### PR DESCRIPTION
Salvage of #28206 by @zccyman.

**What:** `hermes update`'s bundled-skill sync summary showed only a count of user-modified skills (`3 user-modified (kept)`), not WHICH ones. After the update finished users had to grep their skill directory to figure out what still needed manual triage.

**How:** Append the skill names to the summary line in `tools/skills_sync.py`, capped at MAX_SHOW=5 with a `, +N more` suffix for long lists. 6-line diff. Tests pass (45/45 in `tests/tools/test_skills_sync.py`).

Output shape:
```
Done: 12 new, 3 updated, 7 unchanged, 3 user-modified (kept): hermes-agent, debugging-hermes-tui-commands, system-health. 25 total bundled.
```

Original PR: https://github.com/NousResearch/hermes-agent/pull/28206
Fixes #28121.