### PR TITLE
fix(kanban): inherit default_workdir from the connected board

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -383,6 +383,47 @@ def board_metadata_path(board: Optional[str] = None) -> Path:
     return board_dir(slug) / "board.json"
 
 
+def _board_from_connection(conn: sqlite3.Connection) -> Optional[str]:
+    """Best-effort board slug inference from an open SQLite connection.
+
+    ``create_task()`` uses this to inherit the connected board's
+    ``default_workdir`` when the caller omitted ``board=`` but already opened
+    ``connect(board="...")``. If the DB path lives outside the normal kanban
+    layout, inference falls back to ``None`` and callers keep the legacy
+    current-board resolution chain.
+    """
+    try:
+        rows = conn.execute("PRAGMA database_list").fetchall()
+    except sqlite3.Error:
+        return None
+    db_file = None
+    for row in rows:
+        name = row["name"] if isinstance(row, sqlite3.Row) else row[1]
+        if name == "main":
+            db_file = row["file"] if isinstance(row, sqlite3.Row) else row[2]
+            break
+    if not db_file:
+        return None
+    try:
+        resolved = Path(str(db_file)).expanduser().resolve()
+        default_db = (kanban_home() / "kanban.db").resolve()
+        boards = boards_root().resolve()
+    except OSError:
+        return None
+    if resolved == default_db:
+        return DEFAULT_BOARD
+    try:
+        rel = resolved.relative_to(boards)
+    except ValueError:
+        return None
+    if len(rel.parts) != 2 or rel.parts[1] != "kanban.db":
+        return None
+    try:
+        return _normalize_board_slug(rel.parts[0])
+    except ValueError:
+        return None
+
+
 def _default_board_display_name(slug: str) -> str:
     """Turn a slug into a reasonable default display name.
 
@@ -1459,7 +1500,7 @@ def create_task(
     # Resolve workspace_path from board-level default_workdir when the
     # caller did not specify one explicitly.
     if workspace_path is None:
-        board_slug = board if board else get_current_board()
+        board_slug = board or _board_from_connection(conn) or get_current_board()
         board_meta = read_board_metadata(board_slug)
         board_default = board_meta.get("default_workdir")
         if board_default:

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2350,6 +2350,19 @@ def test_create_task_without_workspace_inherits_board_default_workdir(kanban_hom
     assert t.workspace_path == default_wd
 
 
+def test_create_task_uses_connected_board_default_workdir_when_current_board_differs(kanban_home):
+    """Connected board should win even when the current-board pointer differs."""
+    kb.write_board_metadata("default", default_workdir="/board/default")
+    kb.create_board("other", default_workdir="/board/other")
+    kb.set_current_board("default")
+
+    with kb.connect(board="other") as conn:
+        tid = kb.create_task(conn, title="inherits-connected-board-default")
+        t = kb.get_task(conn, tid)
+    assert t is not None
+    assert t.workspace_path == "/board/other"
+
+
 def test_create_task_without_workspace_no_default_stays_none(kanban_home):
     """Board without default_workdir → create_task without workspace_path → stays None."""
     kb.create_board("empty-board")


### PR DESCRIPTION
## Summary

Fix Kanban task creation so board-level `default_workdir` is inherited from the board backing the current SQLite connection, even when the caller omits `board=`.

Before this change, `create_task()` fell back to `get_current_board()` when resolving `default_workdir`. That meant a caller could open `connect(board="other")`, create a task on that board, and still inherit the active/current board's default workspace path instead of `other`'s.

## Root Cause

`hermes_cli.kanban_db.create_task()` resolved the board for `default_workdir` like this:

- explicit `board` arg, else
- `get_current_board()`

That works only when the caller also passes `board=...` into `create_task()`. Direct DB-layer callers that already had a board-specific connection but omitted `board=` could silently pick up the wrong board metadata.

## What Changed

- Added a small helper that infers the board slug from the open SQLite connection's `main` database path.
- Updated `create_task()` to resolve `default_workdir` in this order:
  1. explicit `board=`
  2. inferred board from the open connection
  3. legacy `get_current_board()` fallback

This keeps existing behavior for unusual pinned DB paths, while fixing the normal multi-board case.

## Tests

Added a regression test covering the failing scenario:

- current board pointer set to `default`
- connection opened with `connect(board="other")`
- `create_task(conn, ...)` called without `board=`
- task now correctly inherits `other`'s `default_workdir`

## Verification

Passed locally with:

```powershell
uv run python -m pytest tests\hermes_cli\test_kanban_db.py -k "default_workdir" -q

2 passed in 3.63s
