### PR TITLE
fix(kanban): refuse deleting running tasks with active workers

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3377,16 +3377,31 @@ def delete_task(conn: sqlite3.Connection, task_id: str) -> bool:
 
     Returns ``True`` if the task existed and was deleted, ``False``
     if the task was not found.
+
+    Refuses to delete a task with an active run or live claim. Operators
+    must reclaim or archive it first so the worker lifecycle stays visible
+    and the in-flight run is closed explicitly.
     """
     with write_txn(conn):
-        cur = conn.execute("DELETE FROM tasks WHERE id = ?", (task_id,))
-        if cur.rowcount != 1:
+        row = conn.execute(
+            "SELECT status, claim_lock, current_run_id FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if not row:
             return False
+        if row["status"] == "running" or row["claim_lock"] is not None or row["current_run_id"] is not None:
+            raise RuntimeError(
+                f"cannot delete {task_id}: task is currently running or has an active run. "
+                "Reclaim or archive it first."
+            )
         conn.execute("DELETE FROM task_links WHERE parent_id = ? OR child_id = ?", (task_id, task_id))
         conn.execute("DELETE FROM task_comments WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM task_events WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM task_runs WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM kanban_notify_subs WHERE task_id = ?", (task_id,))
+        cur = conn.execute("DELETE FROM tasks WHERE id = ?", (task_id,))
+        if cur.rowcount != 1:
+            return False
     recompute_ready(conn)
     return True
 

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -756,7 +756,10 @@ def delete_task(task_id: str, board: Optional[str] = Query(None)):
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
-        ok = kanban_db.delete_task(conn, task_id)
+        try:
+            ok = kanban_db.delete_task(conn, task_id)
+        except RuntimeError as e:
+            raise HTTPException(status_code=409, detail=str(e)) from e
         if not ok:
             raise HTTPException(status_code=404, detail=f"task {task_id} not found")
         return {"deleted": True, "task_id": task_id}

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -833,6 +833,20 @@ def test_delete_task_returns_false_for_missing_task(kanban_home):
         assert not kb.delete_task(conn, "t_nonexistent")
 
 
+def test_delete_task_refuses_running_task_with_active_run(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="still-running", assignee="worker")
+        kb.claim_task(conn, tid, claimer="host:worker")
+
+        with pytest.raises(RuntimeError, match="Reclaim or archive it first"):
+            kb.delete_task(conn, tid)
+
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "running"
+        assert kb.latest_run(conn, tid).ended_at is None
+
+
 def test_delete_task_cascades_links(kanban_home):
     with kb.connect() as conn:
         p = kb.create_task(conn, title="parent")

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -512,6 +512,22 @@ def test_delete_task_not_found(client):
     assert "not found" in r.json()["detail"]
 
 
+def test_delete_task_running_returns_409(client):
+    t = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "still-running", "assignee": "worker"},
+    ).json()["task"]
+    conn = kb.connect()
+    try:
+        kb.claim_task(conn, t["id"])
+    finally:
+        conn.close()
+
+    r = client.delete(f"/api/plugins/kanban/tasks/{t['id']}")
+    assert r.status_code == 409
+    assert "Reclaim or archive it first" in r.json()["detail"]
+
+
 # ---------------------------------------------------------------------------
 # Comments + Links
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Prevent hard-deleting Kanban tasks that are still running or still have an active claim/run.

Before this change, `delete_task()` could remove the task row and run history while the worker subprocess kept running in the background. That left an orphaned worker with no visible board state.

This change:
- makes `hermes_cli.kanban_db.delete_task()` refuse deletion when a task is still running or has an active claim/run
- returns `409 Conflict` from the dashboard delete endpoint for that case
- preserves the existing recovery flow: reclaim or archive first, then delete through the intended path

## Why

This enforces the same lifecycle invariant already used elsewhere in Kanban:
active work must be reclaimed or explicitly archived before it can disappear from operator-visible state.

## Tests

Passed:
- `tests/hermes_cli/test_kanban_db.py -k delete_task_refuses_running_task_with_active_run`
- `tests/plugins/test_kanban_dashboard_plugin.py -k delete_task_running_returns_409`

