### PR TITLE
fix(aux): allow Kimi Coding vision tasks to use OpenAI chat.completions wire

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3018,6 +3018,14 @@ def resolve_provider_client(
             return CodexAuxiliaryClient(client_obj, final_model_str)
         # Anthropic-wire endpoints: rewrap plain OpenAI clients so
         # chat.completions.create() is translated to /v1/messages.
+        # EXCEPTION: vision tasks on Kimi Coding should stay on OpenAI wire
+        # because /v1/chat/completions supports image_url while the Anthropic
+        # Messages translation does not (#17076).
+        if is_vision and base_url_str and "api.kimi.com" in base_url_str and "/coding" in base_url_str:
+            logger.debug(
+                "resolve_provider_client: skipping Anthropic wrap for Kimi Coding "
+                "vision task (base_url=%s)", base_url_str[:60])
+            return client_obj
         return _maybe_wrap_anthropic(
             client_obj, final_model_str, api_key_str, base_url_str, api_mode,
         )
@@ -3645,6 +3653,7 @@ def resolve_vision_provider_client(
             explicit_base_url=resolved_base_url,
             explicit_api_key=resolved_api_key,
             api_mode=resolved_api_mode,
+            is_vision=True,
         )
         if client is None:
             return provider_for_base_override, None, None
@@ -4137,6 +4146,14 @@ def _resolve_task_provider_model(
     resolved_api_mode = cfg_api_mode
 
     if base_url:
+        # When base_url is passed explicitly but api_key is not, fall back to
+        # the task config so that vision tasks with explicit base_url still
+        # pick up the configured api_key (e.g. auxiliary.vision.api_key).
+        if api_key is None and task:
+            task_config = _get_auxiliary_task_config(task)
+            cfg_api_key = str(task_config.get("api_key", "")).strip() or None
+            if cfg_api_key:
+                api_key = cfg_api_key
         return "custom", resolved_model, base_url, api_key, resolved_api_mode
     if provider:
         return provider, resolved_model, base_url, api_key, resolved_api_mode


### PR DESCRIPTION
## Problem

When `auxiliary.vision.provider` is set to `kimi-coding`, vision requests fail with **404** because the auxiliary client wraps the OpenAI client in `AnthropicAuxiliaryClient`, which does not support OpenAI-style `image_url` multimodal content.

## Root Cause

Kimi Coding endpoint (`api.kimi.com/coding`) supports both Anthropic Messages and OpenAI `chat.completions`. Hermes unconditionally treats `api.kimi.com/coding` as an Anthropic-wire endpoint, but the Anthropic Messages translation does not handle `image_url` blocks.

Additionally, two related bugs were found:
1. `resolve_vision_provider_client` did not pass `is_vision=True` when calling `resolve_provider_client` with an explicit `base_url`.
2. `_resolve_task_provider_model` did not fall back to the task config `api_key` when `base_url` was passed explicitly but `api_key` was not.

## Changes

- Skip Anthropic wrapper for vision tasks on Kimi Coding endpoints
- Pass `is_vision=True` through `resolve_vision_provider_client`
- Fall back to task config `api_key` when `base_url` is explicit

## Testing

Verified that `vision_analyze` and `async_call_llm(task="vision")` now work with:
- Provider: `kimi-coding`
- Model: `kimi-for-coding`
- Base URL: `https://api.kimi.com/coding`

Fixes #17076