### PR TITLE
fix(cli): exit prompt_toolkit cleanly on SIGTERM instead of raising KeyboardInterrupt

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -13907,7 +13907,31 @@ class HermesCLI:
                         time.sleep(_grace)
             except Exception:
                 pass  # never block signal handling
-            raise KeyboardInterrupt()
+            # Prefer a clean prompt_toolkit exit over `raise KeyboardInterrupt()`.
+            # Raising KBI from a signal handler unwinds into whatever Python
+            # frame the interpreter happens to be running — typically an
+            # `await asyncio.sleep()` inside prompt_toolkit's
+            # `_poll_output_size` coroutine.  The KBI becomes a Task
+            # exception, prompt_toolkit's `_handle_exception` prints
+            # "Unhandled exception in event loop" + the full traceback, and
+            # parks the terminal on "Press ENTER to continue..." (#13710
+            # variant — same root cause, different surface).
+            #
+            # `app.exit()` scheduled via `call_soon_threadsafe` lets the
+            # event loop unwind normally; `app.run()` returns and our
+            # existing `except (EOFError, KeyboardInterrupt, BrokenPipeError)`
+            # block at the bottom of the input loop handles the rest.
+            try:
+                from prompt_toolkit.application.current import get_app_or_none
+                _app = get_app_or_none()
+                if _app is not None:
+                    _loop = getattr(_app, "loop", None)
+                    if _loop is not None:
+                        _loop.call_soon_threadsafe(_app.exit)
+                        return  # clean unwind — no traceback, no ENTER pause
+            except Exception:
+                pass
+            raise KeyboardInterrupt()  # fallback for non-prompt_toolkit contexts
         
         try:
             import signal as _signal


### PR DESCRIPTION
## Summary
SIGTERM (or SIGHUP) while the CLI is at the prompt or mid-tool-call now exits cleanly with no traceback. Previously it dumped an asyncio traceback and parked the terminal on "Press ENTER to continue...".

## Root cause
`_signal_handler` ended with `raise KeyboardInterrupt()`. Python delivers signals between bytecodes on the main thread, so the KBI typically landed inside prompt_toolkit's `_poll_output_size` coroutine's `await asyncio.sleep()`. The Task captured the BaseException, prompt_toolkit's `_handle_exception` printed the full traceback and paused for ENTER.

Same root cause as #13710, different surface.

## Changes
- `cli.py` `_signal_handler`: after the agent-interrupt + grace window, try `get_app_or_none()` and schedule `app.exit()` via `call_soon_threadsafe`. Fall back to `raise KeyboardInterrupt()` only if no active prompt_toolkit app (e.g. `-q` one-shot mode).

## Validation
| | Before | After |
|---|---|---|
| External SIGTERM at prompt | Traceback dump + "Press ENTER" pause | Clean exit |
| External SIGTERM mid-tool-call | Same traceback dump | Clean exit |
| Targeted tests (test_suppress_eio_on_interrupt + test_update_hangup_protection) | 31/31 | 31/31 |

Live-tested with `kill <pid>` against a real CLI session under PTY: no "Unhandled exception in event loop", no "Press ENTER to continue...", no `Traceback` in output.