### PR TITLE
fix(gateway): clear stale agent slot after session_reset to prevent zombie thread

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7497,18 +7497,18 @@ class GatewayRunner:
                 logger.debug("goal continuation hook failed: %s", _goal_exc)
             return _agent_result
         finally:
-            # If _run_agent replaced the sentinel with a real agent and
-            # then cleaned it up, this is a no-op.  If we exited early
-            # (exception, command fallthrough, etc.) the sentinel must
-            # not linger or the session would be permanently locked out.
-            if self._running_agents.get(_quick_key) is _AGENT_PENDING_SENTINEL:
-                self._release_running_agent_state(_quick_key)
-            else:
-                # Agent path already cleaned _running_agents; make sure
-                # the paired metadata dicts are gone too.
-                self._running_agents_ts.pop(_quick_key, None)
-                if hasattr(self, "_busy_ack_ts"):
-                    self._busy_ack_ts.pop(_quick_key, None)
+            # Always release the running-agent slot for this turn.
+            # Normal path: _run_agent already released it, so this is a
+            # no-op (pop on an absent key is harmless).
+            # Zombie-prevention: when session_reset bumps the run-generation
+            # while the agent is active, the inner generation-guarded
+            # _release_running_agent_state returns False and leaves a stale
+            # dead-agent reference in _running_agents.  Without this
+            # unconditional pop, subsequent messages are silently dropped
+            # as "agent busy", requiring a gateway restart to recover.
+            # Safe: no new agent for this session_key can start while
+            # this outer frame is still unwinding.
+            self._release_running_agent_state(_quick_key)
 
     async def _prepare_inbound_message_text(
         self,
@@ -8959,6 +8959,11 @@ class GatewayRunner:
         # Get existing session key
         session_key = self._session_key_for_source(source)
         self._invalidate_session_run_generation(session_key, reason="session_reset")
+        # Force-clear any stale agent slot.  The generation bump above makes
+        # the in-flight run's generation-guarded cleanup a no-op, so without
+        # this the dead agent would linger in _running_agents and zombie the
+        # thread — every subsequent message would be silently dropped as busy.
+        self._release_running_agent_state(session_key)
 
         # Snapshot the old entry so on_session_finalize can report the
         # expiring session id before reset_session() rotates it.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1252,6 +1252,7 @@ AUTHOR_MAP = {
     "120500656+ooovenenoso@users.noreply.github.com": "ooovenenoso",  # PR #28256 salvage (tool loop recovery hints)
     "120500656+oooindefatigable@users.noreply.github.com": "ooovenenoso",
     "vanthinh6886@gmail.com": "vanthinh6886",  # PR #28018 salvage (yaml/flock/atomic write guards)
+    "qq237271823@gmail.com": "yifengingit",  # PR #28689 (session-zombie fix)
 }
 
 


### PR DESCRIPTION
Closes #28686

## Problem

When a `session_reset` skill fires while an agent turn is in-flight **and** the credential pool is simultaneously exhausted, the affected Telegram thread enters a permanent zombie state: every subsequent message is silently dropped as "agent busy", requiring a gateway restart to recover.

The root cause is a gap in the outer `_process_message_or_command` finally block: when the run-generation guard correctly blocks the inner `_release_running_agent_state` call (to protect a newer run), the outer `else` branch only clears the metadata dicts (`_running_agents_ts`, `_busy_ack_ts`) but leaves the dead agent reference in `_running_agents[session_key]`. The staleness-eviction path can't recover it either because `_running_agents_ts` was already popped.

See issue #28686 for the full step-by-step trace and log evidence.

## Changes

**`gateway/run.py` — Fix 1: outer finally in `_process_message_or_command`**

Replace the sentinel-conditional cleanup with an unconditional `_release_running_agent_state` call. This is safe because the method is idempotent (pop on an absent key is harmless) and no new agent for the same session key can start while the outer frame is unwinding.

**`gateway/run.py` — Fix 2: `_handle_reset_command`**

Add an explicit `_release_running_agent_state(session_key)` call immediately after `_invalidate_session_run_generation`. This makes the reset path self-contained: even if the outer finally doesn't run for this session key (e.g. the reset arrives from a different coroutine context), the slot is still cleared.

## Test plan

- [ ] `tests/gateway/test_pending_event_none.py` — existing tests still pass (guard for the related pending-event path)
- [ ] Manual: trigger `/cc` on a thread while an agent turn is in-flight with a depleted credential pool → thread continues accepting messages after the reset
- [ ] Manual: trigger `/new` while an agent turn is in-flight (normal path) → behavior unchanged
- [ ] No regressions on other threads during/after the reset