### PR TITLE
fix(kanban): ensure decompose child tasks inherit board default_workdir

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -427,6 +427,59 @@ def read_board_metadata(board: Optional[str] = None) -> dict:
     return meta
 
 
+def _board_slug_for_conn(conn: sqlite3.Connection) -> Optional[str]:
+    """Best-effort board slug for an already-open connection."""
+    try:
+        rows = conn.execute("PRAGMA database_list").fetchall()
+    except sqlite3.Error:
+        return None
+
+    main_file: Optional[str] = None
+    for row in rows:
+        name = row["name"] if isinstance(row, sqlite3.Row) else row[1]
+        if name == "main":
+            main_file = row["file"] if isinstance(row, sqlite3.Row) else row[2]
+            break
+    if not main_file:
+        return None
+
+    try:
+        main_path = Path(main_file).resolve()
+    except OSError:
+        return None
+
+    try:
+        if main_path == kanban_db_path(DEFAULT_BOARD).resolve():
+            return DEFAULT_BOARD
+    except OSError:
+        pass
+
+    try:
+        if (
+            main_path.name == "kanban.db"
+            and main_path.parent.parent.resolve() == boards_root().resolve()
+        ):
+            return _normalize_board_slug(main_path.parent.name)
+    except (OSError, ValueError):
+        return None
+    return None
+
+
+def _resolve_board_default_workspace_path(
+    conn: sqlite3.Connection,
+    *,
+    board: Optional[str] = None,
+) -> Optional[str]:
+    """Return the board's default_workdir for this call context, if any."""
+    board_slug = _normalize_board_slug(board)
+    if board_slug is None:
+        board_slug = _board_slug_for_conn(conn) or get_current_board()
+    board_default = read_board_metadata(board_slug).get("default_workdir")
+    if not board_default:
+        return None
+    return str(board_default)
+
+
 def write_board_metadata(
     board: Optional[str],
     *,
@@ -1459,11 +1512,7 @@ def create_task(
     # Resolve workspace_path from board-level default_workdir when the
     # caller did not specify one explicitly.
     if workspace_path is None:
-        board_slug = board if board else get_current_board()
-        board_meta = read_board_metadata(board_slug)
-        board_default = board_meta.get("default_workdir")
-        if board_default:
-            workspace_path = str(board_default)
+        workspace_path = _resolve_board_default_workspace_path(conn, board=board)
 
     # Retry once on the extremely unlikely id collision.
     for attempt in range(2):
@@ -3205,6 +3254,7 @@ def decompose_triage_task(
     # write_txn pitfalls. Instead we inline the INSERTs and
     # _append_event calls.
     now = int(time.time())
+    board_workspace_path = _resolve_board_default_workspace_path(conn)
     child_ids: list[str] = []
     with write_txn(conn):
         root_row = conn.execute(
@@ -3228,13 +3278,14 @@ def decompose_triage_task(
             conn.execute(
                 "INSERT INTO tasks "
                 "(id, title, body, assignee, status, workspace_kind, "
-                " tenant, created_at, created_by) "
-                "VALUES (?, ?, ?, ?, 'todo', 'scratch', ?, ?, ?)",
+                " workspace_path, tenant, created_at, created_by) "
+                "VALUES (?, ?, ?, ?, 'todo', 'scratch', ?, ?, ?, ?)",
                 (
                     new_id,
                     title,
                     body if isinstance(body, str) else None,
                     assignee,
+                    board_workspace_path,
                     tenant,
                     now,
                     (author or "decomposer"),

--- a/tests/hermes_cli/test_kanban_decompose_db.py
+++ b/tests/hermes_cli/test_kanban_decompose_db.py
@@ -166,3 +166,25 @@ def test_decompose_records_audit_comment_and_event(kanban_home):
 
     assert any("Decomposed into" in (c.body or "") for c in comments)
     assert any(ev.kind == "decomposed" for ev in events)
+
+
+def test_decompose_children_inherit_board_default_workdir_without_current_board_switch(
+    kanban_home,
+):
+    kb.create_board("proj", default_workdir="/repo/project")
+
+    with kb.connect(board="proj") as conn:
+        tid = _create_triage(conn, title="board-scoped triage")
+        child_ids = kb.decompose_triage_task(
+            conn,
+            tid,
+            root_assignee="orch",
+            children=[{"title": "child", "assignee": "worker"}],
+            author="alice",
+        )
+        child = kb.get_task(conn, child_ids[0] if child_ids else "")
+
+    assert child_ids is not None
+    assert child is not None
+    assert child.workspace_kind == "scratch"
+    assert child.workspace_path == "/repo/project"


### PR DESCRIPTION
## Summary
Fix `decompose_triage_task()` so child tasks inherit the board's `default_workdir`, matching normal `create_task()` behavior.

## Why
Decomposed child tasks were being inserted with `workspace_kind='scratch'` and no `workspace_path`, which caused them to run in per-task scratch workspaces instead of the board's configured project directory.

## Validation
- Added a regression test covering decompose on a non-current board with `default_workdir`
- Passed:
  - `pytest tests/hermes_cli/test_kanban_decompose_db.py -q`
  - `pytest tests/hermes_cli/test_kanban_db.py -q -k default_workdir`