### PR TITLE
fix(kanban): move session_id index creation from SCHEMA_SQL to migration

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -865,8 +865,6 @@ CREATE TABLE IF NOT EXISTS tasks (
     session_id           TEXT
 );
 
-CREATE INDEX IF NOT EXISTS idx_tasks_session_id ON tasks(session_id);
-
 CREATE TABLE IF NOT EXISTS task_links (
     parent_id  TEXT NOT NULL,
     child_id   TEXT NOT NULL,
@@ -1174,10 +1172,13 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         _add_column_if_missing(
             conn, "tasks", "session_id", "session_id TEXT"
         )
-        conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_tasks_session_id "
-            "ON tasks(session_id)"
-        )
+    # Create index unconditionally: on new DBs the column already exists from
+    # SCHEMA_SQL but the index still needs to be created; on legacy DBs this
+    # runs after the ALTER TABLE ADD COLUMN above. IF NOT EXISTS makes it safe.
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_tasks_session_id "
+        "ON tasks(session_id)"
+    )
 
     # task_events gained a run_id column; back-fill it as NULL for
     # historical events (they predate runs and can't be attributed).


### PR DESCRIPTION
## What
Remove the `CREATE INDEX IF NOT EXISTS idx_tasks_session_id ON tasks(session_id)` statement from `SCHEMA_SQL` in `hermes_cli/kanban_db.py`, and move the index creation into the existing `_migrate_add_optional_columns()` migration function.

## Why
When the kanban schema introduced the `session_id` column on the `tasks` table, the `CREATE INDEX` statement was placed inside `SCHEMA_SQL` (line 868). On **existing** databases that predate this column, `conn.executescript(SCHEMA_SQL)` fails before the column migration code runs:

```
sqlite3.OperationalError: no such column: session_id
```

The `_migrate_add_optional_columns` function already contains the correct logic — it adds the column with `ALTER TABLE` and then creates the index. However, it is unreachable because `conn.executescript(SCHEMA_SQL)` crashes first (line 1012 vs line 1013).

Fixes #28617.

## How & Tested
1. `pytest tests/hermes_cli/test_kanban_db.py -v` — 157 passed, 0 failed.
2. Verified the `test_session_id_index_exists` test asserts the index is present on a **fresh** DB (since the index is now created unconditionally by the migration function).
3. Verified the `test_session_id_filters_listings` and `test_session_id_compose_with_tenant_filter` tests continue to pass (column + index round-tripped through list queries).

## Platforms
Tested on Fedora 44 (x86_64), SQLite 3.49.2. The change is SQLite-only, no platform-specific code.

## Checklist
- [x] Bug fix (top priority per CONTRIBUTING)
- [x] Tests pass
- [x] One logical change per PR
- [x] Conventional commit message
- [x] Closes #28617
