### PR TITLE
fix: add platform formatting override note for non-CLI platforms

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -218,6 +218,24 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         except Exception:
             pass
 
+    # ── Override SOUL.md CLI-centric formatting for non-CLI platforms ─
+    #
+    # SOUL.md (loaded as Agent Persona at the top of the prompt) contains
+    # instructions written for the CLI/TUI: "prefer plain text", "avoid
+    # unnecessary markdown", mobile-terminal splitting logic, etc.  These
+    # are correct on the CLI but wrong on platforms like Telegram, Discord,
+    # Mattermost, Matrix, WebUI, and others that support rich formatting.
+    #
+    # The platform-specific hint above is the authoritative guidance for
+    # the current channel — it always takes precedence.
+    if platform_key and platform_key not in ("cli", "cron"):
+        stable_parts.append(
+            "Note: The platform-specific formatting guidance above overrides "
+            "any earlier instructions about 'preferring plain text' or "
+            "'avoiding unnecessary markdown.' Those instructions apply "
+            "to the CLI/TUI only."
+        )
+
     # ── Context tier (cwd-dependent, may change between sessions) ─
     context_parts: List[str] = []
 


### PR DESCRIPTION
## Problem

SOUL.md (`~/.hermes/SOUL.md`) is loaded as Layer 1 of the system prompt and contains CLI/TUI-centric formatting instructions ("prefer plain text", "avoid unnecessary markdown", mobile-terminal splitting logic). These are correct for the CLI but wrong for platforms that support rich formatting (Telegram, Discord, Mattermost, Matrix, WebUI, etc.).

The platform-specific hint (Layer 7) already has correct instructions per platform, but SOUL.md's earlier, more explicit "avoid markdown" instruction dominates and defeats the platform hint.

## Fix

In `build_system_prompt_parts()`, after platform hint injection, added a clarifying note when the platform is not `cli` or `cron` that the platform-specific guidance takes precedence over SOUL.md's CLI-centric formatting instructions.

## Verification

- 133 tests passed, 1 skipped
- CLI: no override (correct — SOUL.md instructions are correct for CLI)
- Telegram/Discord/Mattermost/Matrix/WebUI: override added (platform hint takes precedence)
- WhatsApp/Signal/SMS: override added (harmless — hints already say no markdown)
- No platform: no override (correct — no platform hint to conflict)