### PR TITLE
feat(optional-skills): add spot-advanced-swap-orders

### DIFF
--- a/optional-skills/blockchain/spot-advanced-swap-orders/SKILL.md
+++ b/optional-skills/blockchain/spot-advanced-swap-orders/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: spot-advanced-swap-orders
+description: Use for gasless non-custodial EVM market, limit, TWAP, stop-loss, take-profit, delayed-start swaps.
+version: 2.5.6
+author: Orbs Network
+license: MIT
+metadata:
+  hermes:
+    tags: [DeFi, EVM, swaps, limit-orders, TWAP, stop-loss, Ethereum, Polygon, Base, Arbitrum, Avalanche, BNB, crypto, Web3]
+    category: blockchain
+    related_skills: [evm]
+---
+
+# Spot Advanced Swap Orders
+
+Use this skill when the agent needs to turn user intent into a final Spot order payload on a supported EVM chain.
+It covers order-shape selection, param normalization, typed-data population, approval guidance, signing, submission, query, and cancellation.
+This bundle is instruction-only: build everything locally from the bundled markdown and JSON assets, then submit only the final signed payload.
+Execution remains decentralized, non-custodial, oracle-protected, immutable, audited, and battle-tested onchain.
+
+## Supported Chains
+
+1. Ethereum - `1` - adapter `0xC1bB4d5071Fe7109ae2D67AE05826A3fe9116cfc`
+2. BNB Chain - `56` - adapter `0x67Feba015c968c76cCB2EEabf197b4578640BE2C`
+3. Polygon - `137` - adapter `0x75A3d70Fa6d054d31C896b9Cf8AB06b1c1B829B8`
+4. Sonic - `146` - adapter `0xD87ee28806bc0060789C4789F123647f4Df25A6C`
+5. Base - `8453` - adapter `0xc64d6E64A713EfbbCcB14413479c56461F9c0b77`
+6. Arbitrum One - `42161` - adapter `0x6F1002141Fcb5d3A3aA8b12A49e6e7DCE5661ae9`
+7. Avalanche - `43114` - adapter `0xc64d6E64A713EfbbCcB14413479c56461F9c0b77`
+8. Linea - `59144` - adapter `0x55E4da2cd634729064bEb294EC682Dc94f5c3f24`
+
+## Relay
+
+1. Submit signed orders with `POST https://agents-sink.orbs.network/orders/new`.
+2. Query orders with `GET https://agents-sink.orbs.network/orders`; see [references/lifecycle.md](references/lifecycle.md) for filters, polling, and cancellation follow-up.
+
+## Workflow
+
+1. Read [references/quickstart.md](references/quickstart.md) for the minimum end-to-end flow.
+2. Use [references/params.md](references/params.md) to map user intent into params, defaults, validation, and order-shape fields.
+3. Use [references/sign.md](references/sign.md) to fill the template, handle approval, sign, and submit.
+4. Use [references/lifecycle.md](references/lifecycle.md) for relay query semantics, status polling, and cancellation.
+5. Use [references/examples.md](references/examples.md) only when the final relay payload shape is still unclear.
+6. Use [assets/token-addressbook.md](assets/token-addressbook.md) only for optional token alias lookup on supported chains.
+7. Use [assets/repermit.template.json](assets/repermit.template.json) as the canonical typed-data shape.
+8. Treat `## Supported Chains` as the authoritative source for chain support and per-chain adapters.
+9. Treat `## Relay` as the authoritative relay endpoint list.
+
+## Guardrails
+
+1. `## Supported Chains` is authoritative for chain support and per-chain adapters.
+2. `## Relay` is authoritative for relay endpoints.
+3. [assets/token-addressbook.md](assets/token-addressbook.md) is a convenience alias list only. It does not expand chain support or override explicit user-provided addresses.
+4. This skill is instruction-only. Do not fetch or execute external helper code.
+5. Normalize params with [references/params.md](references/params.md) before touching the template.
+6. Replace only the `<...>` placeholders in [assets/repermit.template.json](assets/repermit.template.json). Keep the fixed protocol fields already in the template unchanged.
+7. Default approval guidance is exact `approve(..., input.maxAmount)`. Standing `maxUint256` approval is opt-in convenience for repeat use, not the default suggestion.
+8. Submit only the final signed payload as described in [references/sign.md](references/sign.md).
+
+## Agent Contract
+
+1. Turn the user request into a params JSON object using [references/params.md](references/params.md).
+2. Normalize params locally, including defaults, rounding, and order-shape fields.
+3. Confirm `chainId` is listed in `## Supported Chains`, then populate [assets/repermit.template.json](assets/repermit.template.json) from the normalized params and replace `<ADAPTER>` with that chain's listed adapter.
+4. Handle approval, signing, and submission exactly as described in [references/sign.md](references/sign.md), and forward the returned signature unchanged.
+5. Query and cancel exactly as described in [references/lifecycle.md](references/lifecycle.md).

--- a/optional-skills/blockchain/spot-advanced-swap-orders/assets/repermit.template.json
+++ b/optional-skills/blockchain/spot-advanced-swap-orders/assets/repermit.template.json
@@ -1,0 +1,213 @@
+{
+    "domain": {
+        "name": "RePermit",
+        "version": "1",
+        "chainId": "<CHAIN_ID>",
+        "verifyingContract": "0x00002a9C4D9497df5Bd31768eC5d30eEf5405000"
+    },
+    "primaryType": "RePermitWitnessTransferFrom",
+    "types": {
+        "EIP712Domain": [
+            {
+                "name": "name",
+                "type": "string"
+            },
+            {
+                "name": "version",
+                "type": "string"
+            },
+            {
+                "name": "chainId",
+                "type": "uint256"
+            },
+            {
+                "name": "verifyingContract",
+                "type": "address"
+            }
+        ],
+        "RePermitWitnessTransferFrom": [
+            {
+                "name": "permitted",
+                "type": "TokenPermissions"
+            },
+            {
+                "name": "spender",
+                "type": "address"
+            },
+            {
+                "name": "nonce",
+                "type": "uint256"
+            },
+            {
+                "name": "deadline",
+                "type": "uint256"
+            },
+            {
+                "name": "witness",
+                "type": "Order"
+            }
+        ],
+        "Exchange": [
+            {
+                "name": "adapter",
+                "type": "address"
+            },
+            {
+                "name": "ref",
+                "type": "address"
+            },
+            {
+                "name": "share",
+                "type": "uint32"
+            },
+            {
+                "name": "data",
+                "type": "bytes"
+            }
+        ],
+        "Input": [
+            {
+                "name": "token",
+                "type": "address"
+            },
+            {
+                "name": "amount",
+                "type": "uint256"
+            },
+            {
+                "name": "maxAmount",
+                "type": "uint256"
+            }
+        ],
+        "Order": [
+            {
+                "name": "reactor",
+                "type": "address"
+            },
+            {
+                "name": "executor",
+                "type": "address"
+            },
+            {
+                "name": "exchange",
+                "type": "Exchange"
+            },
+            {
+                "name": "swapper",
+                "type": "address"
+            },
+            {
+                "name": "nonce",
+                "type": "uint256"
+            },
+            {
+                "name": "start",
+                "type": "uint256"
+            },
+            {
+                "name": "deadline",
+                "type": "uint256"
+            },
+            {
+                "name": "chainid",
+                "type": "uint256"
+            },
+            {
+                "name": "exclusivity",
+                "type": "uint32"
+            },
+            {
+                "name": "epoch",
+                "type": "uint32"
+            },
+            {
+                "name": "slippage",
+                "type": "uint32"
+            },
+            {
+                "name": "freshness",
+                "type": "uint32"
+            },
+            {
+                "name": "input",
+                "type": "Input"
+            },
+            {
+                "name": "output",
+                "type": "Output"
+            }
+        ],
+        "Output": [
+            {
+                "name": "token",
+                "type": "address"
+            },
+            {
+                "name": "limit",
+                "type": "uint256"
+            },
+            {
+                "name": "triggerLower",
+                "type": "uint256"
+            },
+            {
+                "name": "triggerUpper",
+                "type": "uint256"
+            },
+            {
+                "name": "recipient",
+                "type": "address"
+            }
+        ],
+        "TokenPermissions": [
+            {
+                "name": "token",
+                "type": "address"
+            },
+            {
+                "name": "amount",
+                "type": "uint256"
+            }
+        ]
+    },
+    "message": {
+        "permitted": {
+            "token": "<INPUT_TOKEN>",
+            "amount": "<INPUT_MAX_AMOUNT>"
+        },
+        "spender": "0x000000b33fE4fB9d999Dd684F79b110731c3d000",
+        "nonce": "<NONCE>",
+        "deadline": "<DEADLINE>",
+        "witness": {
+            "reactor": "0x000000b33fE4fB9d999Dd684F79b110731c3d000",
+            "executor": "0x000642A0966d9bd49870D9519f76b5cf823f3000",
+            "exchange": {
+                "adapter": "<ADAPTER>",
+                "ref": "0x0000000000000000000000000000000000000000",
+                "share": 0,
+                "data": "0x"
+            },
+            "swapper": "<SWAPPER>",
+            "nonce": "<NONCE>",
+            "start": "<START>",
+            "deadline": "<DEADLINE>",
+            "chainid": "<CHAIN_ID>",
+            "exclusivity": 0,
+            "epoch": "<EPOCH_SECONDS>",
+            "slippage": 500,
+            "freshness": 50,
+            "input": {
+                "token": "<INPUT_TOKEN>",
+                "amount": "<INPUT_AMOUNT>",
+                "maxAmount": "<INPUT_MAX_AMOUNT>"
+            },
+            "output": {
+                "token": "<OUTPUT_TOKEN>",
+                "limit": "<OUTPUT_LIMIT>",
+                "triggerLower": "<OUTPUT_TRIGGER_LOWER>",
+                "triggerUpper": "<OUTPUT_TRIGGER_UPPER>",
+                "recipient": "<OUTPUT_RECIPIENT>"
+            }
+        }
+    }
+}

--- a/optional-skills/blockchain/spot-advanced-swap-orders/assets/token-addressbook.md
+++ b/optional-skills/blockchain/spot-advanced-swap-orders/assets/token-addressbook.md
@@ -1,0 +1,99 @@
+# Common Token Addressbook
+
+Use this only as an optional alias helper for the supported chains listed in [../SKILL.md](../SKILL.md).
+The `## Supported Chains` section in [`SKILL.md`](../SKILL.md) is the authoritative support list; this file does not expand chain support.
+Token decimals below are verified onchain snapshots for convenience. Use them for the listed tokens, and check onchain only if you are unsure or working with an address that is not listed here.
+
+## Ethereum (`1`)
+
+| Symbol | Decimals | Address |
+|  --- | ---: | --- |
+| `weth` | `18` | `0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2` |
+| `wbtc` | `8` | `0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599` |
+| `usdc` | `6` | `0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48` |
+| `usdt` | `6` | `0xdAC17F958D2ee523a2206206994597C13D831ec7` |
+| `dai` | `18` | `0x6B175474E89094C44Da98b954EedeAC495271d0F` |
+| `lusd` | `18` | `0x5f98805A4E8be255a32880FDeC7F6728C6568bA0` |
+| `orbs` | `18` | `0xff56Cc6b1E6dEd347aA0B7676C85AB0B3D08B0FA` |
+
+## BNB Chain (`56`)
+
+| Symbol | Decimals | Address |
+| --- | ---: | --- |
+| `wbnb` | `18` | `0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c` |
+| `btcb` | `18` | `0x7130d2A12B9BCbFAe4f2634d864A1Ee1Ce3Ead9c` |
+| `wbtc` | `8` | `0x0555e30da8f98308edb960aa94c0db47230d2b9c` |
+| `usdc` | `18` | `0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d` |
+| `usdt` | `18` | `0x55d398326f99059fF775485246999027B3197955` |
+| `usd1` | `18` | `0x8d0d000ee44948fc98c9b98a4fa4921476f08b0d` |
+| `dai` | `18` | `0x1AF3F329e8BE154074D8769D1FFa4eE058B1DBc3` |
+| `busd` | `18` | `0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56` |
+| `weth` | `18` | `0x2170Ed0880ac9A755fd29B2688956BD959F933F8` |
+| `orbs` | `18` | `0x43a8cab15D06d3a5fE5854D714C37E7E9246F170` |
+
+## Polygon (`137`)
+
+| Symbol | Decimals | Address |
+| --- | ---: | --- |
+| `wmatic` | `18` | `0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270` |
+| `wbtc` | `8` | `0x1BFD67037B42Cf73acF2047067bd4F2C47D9BfD6` |
+| `usdc` | `6` | `0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359` |
+| `usdc.e` | `6` | `0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174` |
+| `usdt` | `6` | `0xc2132D05D31c914a87C6611C10748AEb04B58e8F` |
+| `dai` | `18` | `0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063` |
+| `weth` | `18` | `0x7ceb23fd6bc0add59e62ac25578270cff1b9f619` |
+| `orbs` | `18` | `0x614389EaAE0A6821DC49062D56BDA3d9d45Fa2ff` |
+
+## Arbitrum One (`42161`)
+
+| Symbol | Decimals | Address |
+| --- | ---: | --- |
+| `weth` | `18` | `0x82af49447d8a07e3bd95bd0d56f35241523fbab1` |
+| `wbtc` | `8` | `0x2f2a2543b76a4166549f7aab2e75bef0aefc5b0f` |
+| `usdc` | `6` | `0xaf88d065e77c8cC2239327C5EDb3A432268e5831` |
+| `usdt` | `6` | `0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9` |
+| `dai` | `18` | `0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1` |
+| `arb` | `18` | `0x912CE59144191C1204E64559FE8253a0e49E6548` |
+| `orbs` | `18` | `0xf3C091ed43de9c270593445163a41A876A0bb3dd` |
+
+## Avalanche (`43114`)
+
+| Symbol | Decimals | Address |
+| --- | ---: | --- |
+| `wavax` | `18` | `0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7` |
+| `wbtc` | `8` | `0x50b7545627a5162F82A992c33b87aDc75187B218` |
+| `usdc` | `6` | `0xA7D7079b0FEaD91F3e65f86E8915Cb59c1a4C664` |
+| `usdt` | `6` | `0xc7198437980c041c805A1EDcbA50c1Ce5db95118` |
+| `dai` | `18` | `0xd586E7F844cEa2F87f50152665BCbc2C279D8d70` |
+| `weth` | `18` | `0x49D5c2BdFfac6CE2BFdB6640F4F80f226bc10bAB` |
+| `orbs` | `18` | `0x340fE1D898ECCAad394e2ba0fC1F93d27c7b717A` |
+
+## Base (`8453`)
+
+| Symbol | Decimals | Address |
+| --- | ---: | --- |
+| `weth` | `18` | `0x4200000000000000000000000000000000000006` |
+| `usdc` | `6` | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` |
+| `dai` | `18` | `0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb` |
+| `cbbtc` | `8` | `0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf` |
+
+## Linea (`59144`)
+
+| Symbol | Decimals | Address |
+| --- | ---: | --- |
+| `weth` | `18` | `0xe5D7C2a44FfDDf6b295A15c148167daaAf5Cf34f` |
+| `wbtc` | `8` | `0x3aAB2285ddcDdaD8edf438C1bAB47e1a9D05a9b4` |
+| `usdc` | `6` | `0x176211869cA2b568f2A7D4EE941E073a821EE1ff` |
+| `usdt` | `6` | `0xA219439258ca9da29E9Cc4cE5596924745e12B93` |
+| `dai` | `18` | `0x4AF15ec2A0BD43Db75dd04E62FAA3B8EF36b00d5` |
+
+## Sonic (`146`)
+
+| Symbol | Decimals | Address |
+| --- | ---: | --- |
+| `ws` | `18` | `0x039e2fB66102314Ce7b64Ce5Ce3E5183bc94aD38` |
+| `wbtc` | `8` | `0x0555E30da8f98308EdB960aa94C0Db47230d2B9c` |
+| `weth` | `18` | `0x50c42dEAcD8Fc9773493ED674b675bE577f2634b` |
+| `usdc` | `6` | `0x29219dd400f2Bf60E5a23d13Be72B486D4038894` |
+| `usdt` | `6` | `0x6047828dc181963ba44974801FF68e538dA5eaF9` |
+| `sfc` | `18` | `0xFC00FACE00000000000000000000000000000000` |

--- a/optional-skills/blockchain/spot-advanced-swap-orders/references/examples.md
+++ b/optional-skills/blockchain/spot-advanced-swap-orders/references/examples.md
@@ -1,0 +1,151 @@
+# Examples
+
+These are mock final relay payloads.
+Copy the nearest shape, then replace addresses, amounts, timing, and signature.
+Mix limit, trigger, and delay fields as needed.
+
+## Limit Order
+
+```json
+{
+  "order": {
+    "permitted": {
+      "token": "0x1111111111111111111111111111111111111111",
+      "amount": "1000000"
+    },
+    "spender": "0x000000b33fE4fB9d999Dd684F79b110731c3d000",
+    "nonce": "1712345601",
+    "deadline": "1712345901",
+    "witness": {
+      "reactor": "0x000000b33fE4fB9d999Dd684F79b110731c3d000",
+      "executor": "0x000642A0966d9bd49870D9519f76b5cf823f3000",
+      "exchange": {
+        "adapter": "0x9999999999999999999999999999999999999999",
+        "ref": "0x0000000000000000000000000000000000000000",
+        "share": 0,
+        "data": "0x"
+      },
+      "swapper": "0x2222222222222222222222222222222222222222",
+      "nonce": "1712345601",
+      "start": "1712345601",
+      "deadline": "1712345901",
+      "chainid": 42161,
+      "exclusivity": 0,
+      "epoch": 0,
+      "slippage": 500,
+      "freshness": 50,
+      "input": {
+        "token": "0x1111111111111111111111111111111111111111",
+        "amount": "1000000",
+        "maxAmount": "1000000"
+      },
+      "output": {
+        "token": "0x3333333333333333333333333333333333333333",
+        "limit": "250000000000000",
+        "triggerLower": "0",
+        "triggerUpper": "0",
+        "recipient": "0x2222222222222222222222222222222222222222"
+      }
+    }
+  },
+  "signature": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb1b"
+}
+```
+
+## Stop-Loss Order
+
+```json
+{
+  "order": {
+    "permitted": {
+      "token": "0x4444444444444444444444444444444444444444",
+      "amount": "5000000000000000000"
+    },
+    "spender": "0x000000b33fE4fB9d999Dd684F79b110731c3d000",
+    "nonce": "1712346602",
+    "deadline": "1712347202",
+    "witness": {
+      "reactor": "0x000000b33fE4fB9d999Dd684F79b110731c3d000",
+      "executor": "0x000642A0966d9bd49870D9519f76b5cf823f3000",
+      "exchange": {
+        "adapter": "0x9999999999999999999999999999999999999999",
+        "ref": "0x0000000000000000000000000000000000000000",
+        "share": 0,
+        "data": "0x"
+      },
+      "swapper": "0x5555555555555555555555555555555555555555",
+      "nonce": "1712346602",
+      "start": "1712346602",
+      "deadline": "1712347202",
+      "chainid": 1,
+      "exclusivity": 0,
+      "epoch": 0,
+      "slippage": 500,
+      "freshness": 50,
+      "input": {
+        "token": "0x4444444444444444444444444444444444444444",
+        "amount": "5000000000000000000",
+        "maxAmount": "5000000000000000000"
+      },
+      "output": {
+        "token": "0x6666666666666666666666666666666666666666",
+        "limit": "0",
+        "triggerLower": "9000000000000",
+        "triggerUpper": "0",
+        "recipient": "0x5555555555555555555555555555555555555555"
+      }
+    }
+  },
+  "signature": "0xccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd1c"
+}
+```
+
+## TWAP Order
+
+```json
+{
+  "order": {
+    "permitted": {
+      "token": "0x7777777777777777777777777777777777777777",
+      "amount": "12000000"
+    },
+    "spender": "0x000000b33fE4fB9d999Dd684F79b110731c3d000",
+    "nonce": "1712347603",
+    "deadline": "1712348503",
+    "witness": {
+      "reactor": "0x000000b33fE4fB9d999Dd684F79b110731c3d000",
+      "executor": "0x000642A0966d9bd49870D9519f76b5cf823f3000",
+      "exchange": {
+        "adapter": "0x9999999999999999999999999999999999999999",
+        "ref": "0x0000000000000000000000000000000000000000",
+        "share": 0,
+        "data": "0x"
+      },
+      "swapper": "0x8888888888888888888888888888888888888888",
+      "nonce": "1712347603",
+      "start": "1712347603",
+      "deadline": "1712348503",
+      "chainid": 8453,
+      "exclusivity": 0,
+      "epoch": 300,
+      "slippage": 500,
+      "freshness": 50,
+      "input": {
+        "token": "0x7777777777777777777777777777777777777777",
+        "amount": "3000000",
+        "maxAmount": "12000000"
+      },
+      "output": {
+        "token": "0x9999999999999999999999999999999999999999",
+        "limit": "0",
+        "triggerLower": "0",
+        "triggerUpper": "0",
+        "recipient": "0x8888888888888888888888888888888888888888"
+      }
+    }
+  },
+  "signature": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff1b"
+}
+```
+
+If a signer returns `{ "r": "...", "s": "...", "v": "..." }` instead of one full signature string, send that object unchanged in the same `signature` field.

--- a/optional-skills/blockchain/spot-advanced-swap-orders/references/lifecycle.md
+++ b/optional-skills/blockchain/spot-advanced-swap-orders/references/lifecycle.md
@@ -1,0 +1,57 @@
+# Lifecycle
+
+Use this file for relay query semantics, status polling, and exact-match cancellation.
+
+## Query
+
+1. Primary query path: `GET https://agents-sink.orbs.network/orders?hash=<orderHash>`.
+2. Canonical response shape is a top-level object with an `orders` array. When you query by `hash`, use the first element of `orders`.
+3. Canonical order status field is `.orders[0].metadata.status`. If it is absent, fall back to `.orders[0].status`.
+4. Canonical chunk status field is `.orders[0].metadata.chunks[].status` when `metadata.chunks` exists.
+5. Known non-terminal statuses are `pending` and `eligible`.
+6. Known terminal statuses are `filled`, `completed`, `partially_completed`, `cancelled`, `expired`, `failed`, and `rejected`.
+7. Cancellation can surface as `cancelled`, or `failed` with cancellation text, depending on relay normalization. Treat them as terminal outcomes after you have confirmed the onchain cancel transaction.
+8. `partially_completed` means at least one chunk reached a successful final state and at least one chunk did not. Treat it as terminal for polling and report the chunk statuses.
+9. Poll every 5 seconds until the order reaches a terminal status.
+10. Canonical CLI query path:
+
+```sh
+curl -fsS "https://agents-sink.orbs.network/orders?hash=$order_hash" \
+  | jq -r '.orders[0] | (.metadata.status // .status // "pending")'
+```
+
+11. Canonical CLI chunk-status path:
+
+```sh
+curl -fsS "https://agents-sink.orbs.network/orders?hash=$order_hash" \
+  | jq -r '.orders[0].metadata.chunks[]?.status'
+```
+
+12. Secondary recovery path: `GET https://agents-sink.orbs.network/orders?swapper=<swapper>`. Use it only when you do not have `orderHash` yet or need to recover from an ambiguous submit response.
+13. If you query by `swapper` and receive multiple orders, disambiguate by `hash` before polling or reporting status.
+
+## Cancel
+
+1. Cancellation is exact-match and onchain. It invalidates only the digest you pass, not every order by the same `swapper`.
+2. Always keep the exact populated `typedData` used for signing and submission. The cancellation digest must be derived from that same populated payload.
+3. Compute the EIP-712 digest for that exact populated `typedData`, then call `cancel(bytes32[] digests)` on `typedData.domain.verifyingContract` from `swapper` with `[digest]`.
+4. Canonical CLI cancel call once you already have the digest:
+
+```sh
+cast send "$typed_data_domain_verifying_contract" 'cancel(bytes32[])' "[$order_digest]"
+```
+
+5. Canonical JavaScript cancel path with `ethers` once you already have the digest:
+
+```js
+import { Contract } from "ethers";
+
+const repermit = new Contract(typedData.domain.verifyingContract, ["function cancel(bytes32[] digests)"], signer);
+
+const tx = await repermit.cancel([orderDigest]);
+await tx.wait();
+```
+
+6. In both examples, the contract address is the exact `typedData.domain.verifyingContract` value from the submitted order.
+7. Use the same signer that created the order. The caller must equal `swapper`.
+8. After the cancel transaction is confirmed, keep polling the relay query endpoint until the order reaches a terminal status.

--- a/optional-skills/blockchain/spot-advanced-swap-orders/references/params.md
+++ b/optional-skills/blockchain/spot-advanced-swap-orders/references/params.md
@@ -1,0 +1,26 @@
+# Params
+
+Use this file for field semantics, order-shape mapping, defaults, validation, and local normalization.
+
+1. Required: `chainId`, `swapper`, `input.token`, `input.amount`, `output.token`.
+2. Optional: `input.maxAmount`, `nonce`, `start`, `deadline`, `epoch`, `freshness`, `slippage`, `output.limit`, `output.triggerLower`, `output.triggerUpper`, `output.recipient`.
+3. Common order-shape fields: market = `output.limit = 0`; limit = `output.limit > 0`; stop-loss = `output.triggerLower > 0`; take-profit = `output.triggerUpper > 0`; delayed-start = future `start`; chunked or TWAP = `input.amount < input.maxAmount`; recurring chunked = `epoch > 0`; back to native output = `output.token = 0x0000000000000000000000000000000000000000`.
+4. `input.amount` is the fixed per-chunk size. `input.maxAmount` is the total requested size. If omitted, it defaults to `input.amount`. If it is not divisible by `input.amount`, round it down to a whole number of chunks before building `typedData`.
+5. `output.limit`, `output.triggerLower`, and `output.triggerUpper` are output-token amounts per chunk, encoded in the output token's smallest unit. When `output.token` is an ERC-20, encode them in that token's decimals. When `output.token = 0x0000000000000000000000000000000000000000`, encode them in native `wei` with 18 decimals.
+6. Input and output units are independent. Always encode `input.amount` and `input.maxAmount` in `input.token` decimals, even for back-to-native orders; encode `output.limit`, `output.triggerLower`, and `output.triggerUpper` in `output.token` units. For example, USDC-to-native uses USDC decimals for input amounts and native `wei` for output triggers.
+7. Future `start` delays the first fill. `epoch` is the delay between chunks, but it is not exact: each chunk can fill anywhere inside its epoch window, only once. Large `epoch` is not a delayed order by itself.
+8. Chunked orders should use `epoch > 0`; with `epoch = 0`, only the first chunk can fill.
+9. Defaults:
+   `input.maxAmount = input.amount`, `nonce = now`, `start = now`, `epoch = 0` for single orders, `epoch = 60` for chunked orders, `freshness = 50`, `deadline = start + 300 + chunkCount * epoch`, `slippage = 500`, `output.limit = 0`, `output.triggerLower = 0`, `output.triggerUpper = 0`, `output.recipient = swapper`. When replacing `<EPOCH_SECONDS>` for a recurring order, choose a value greater than `freshness`.
+10. Validation:
+   `start != 0`, `input.amount != 0`, `input.amount <= input.maxAmount`, `input.token != output.token`, `output.triggerLower <= output.triggerUpper` when `triggerUpper != 0`, `slippage <= 5000`, `freshness != 0`, `freshness < epoch` when `epoch != 0`, and non-zero `epoch >= 60`.
+11. Higher slippage is still protected by oracle pricing and offchain executors.
+12. `output.recipient` is dangerous to change away from `swapper`.
+13. Native input is not supported. Wrap to WNATIVE first. Native output, including back-to-native orders, is supported directly with `output.token = 0x0000000000000000000000000000000000000000`.
+14. Derived execution values:
+    `chunkCount = floor(input.maxAmount / input.amount)` after any rounding down.
+15. JSON typing:
+    keep addresses and byte strings as `0x` strings,
+    keep large integer fields as decimal strings,
+    use JSON numbers for `domain.chainId`, `message.witness.chainid`, `message.witness.exclusivity`, `message.witness.epoch`, `message.witness.slippage`, `message.witness.freshness`, and `message.witness.exchange.share`.
+16. For full mock relay payloads, see [examples.md](examples.md).

--- a/optional-skills/blockchain/spot-advanced-swap-orders/references/quickstart.md
+++ b/optional-skills/blockchain/spot-advanced-swap-orders/references/quickstart.md
@@ -1,0 +1,11 @@
+# Quickstart
+
+1. Required fields: `chainId`, `swapper`, `input.token`, `input.amount`, `output.token`.
+2. Choose the intended order shape before populating JSON: market, limit, stop-loss, take-profit, delayed-start, or chunked/TWAP. Shapes can be mixed in one order.
+3. Build and normalize a params JSON object using [params.md](params.md).
+4. Fill the remaining `<...>` placeholders in [../assets/repermit.template.json](../assets/repermit.template.json), leaving the fixed template fields unchanged.
+5. If approval is needed, follow [sign.md](sign.md).
+6. Sign `typedData` as the `swapper`.
+7. Submit according to [sign.md](sign.md).
+8. Query or cancel according to [lifecycle.md](lifecycle.md).
+9. Use [examples.md](examples.md) only if you still need a full mock relay payload as a reference.

--- a/optional-skills/blockchain/spot-advanced-swap-orders/references/sign.md
+++ b/optional-skills/blockchain/spot-advanced-swap-orders/references/sign.md
@@ -1,0 +1,78 @@
+# Template, Sign, And Submit
+
+1. Load [../assets/repermit.template.json](../assets/repermit.template.json) and the normalized params. Respect the JSON typing rules from [params.md](params.md).
+2. Confirm `chainId` is listed in `## Supported Chains` in [../SKILL.md](../SKILL.md), replace `<ADAPTER>` with that chain's listed adapter, then replace the remaining `<...>` placeholders. Keep the fixed protocol fields already present in the template unchanged.
+3. If allowance for `input.token` to `typedData.domain.verifyingContract` is lower than `input.maxAmount`, the default suggestion is a standard ERC-20 `approve(typedData.domain.verifyingContract, input.maxAmount)` transaction first.
+4. If you explicitly want a standing approval instead, `maxUint256` is often more convenient for repeat orders, but keep it opt-in rather than the default suggestion.
+5. Sign `typedData` with any EIP-712-capable wallet or library. The signer must equal `swapper`.
+6. Canonical CLI signing path with Foundry `cast`:
+
+```sh
+cast wallet sign --data --from-file ./typed-data.json
+```
+
+7. Canonical browser-wallet signing path:
+
+```js
+const signature = await ethereum.request({
+  method: "eth_signTypedData_v4",
+  params: [swapper, JSON.stringify(typedData)],
+});
+```
+
+8. Submit this exact relay payload to `https://agents-sink.orbs.network/orders/new`:
+
+```json
+{
+  "order": "<typedData.message>",
+  "signature": "<full signature or { r, s, v }>",
+  "status": "pending"
+}
+```
+
+9. Relay accepts either one full signature hex string or the exact `{ "r": "...", "s": "...", "v": "..." }` object returned by the signer.
+10. Send the signature exactly as returned. Do not split, normalize, or rewrite it.
+11. Canonical CLI submit path:
+
+```sh
+sig=$(cast wallet sign --data --from-file ./typed-data.json --interactive)
+jq -n --slurpfile typed ./typed-data.json --arg sig "$sig" \
+  '{order: $typed[0].message, signature: $sig, status: "pending"}' \
+  > ./relay-payload.json
+
+curl -fsS -X POST 'https://agents-sink.orbs.network/orders/new' \
+  -H 'content-type: application/json' \
+  --data @./relay-payload.json
+```
+
+12. Canonical JavaScript submit path with `ethers` plus standard `fetch`:
+
+```js
+const relayPayload = {
+  order: typedData.message,
+  signature,
+  status: "pending",
+};
+
+const response = await fetch("https://agents-sink.orbs.network/orders/new", {
+  method: "POST",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify(relayPayload),
+});
+
+const body = await response.json();
+const orderHash = body.orderHash ?? body.signedOrder?.hash ?? "";
+```
+
+13. Capture `orderHash` from the submit response when available. Canonical extraction:
+
+```sh
+curl -fsS -X POST 'https://agents-sink.orbs.network/orders/new' \
+  -H 'content-type: application/json' \
+  --data @./relay-payload.json \
+  | jq -r '.orderHash // .signedOrder.hash // empty'
+```
+
+14. After an ambiguous relay failure such as a timeout or `5xx`, persist and reuse the exact populated `typedData` and signature for any retry. Do not rebuild the order from fresh balances or refreshed prices until you have resolved whether the previous submit created an order.
+15. See [lifecycle.md](lifecycle.md) for follow-up query and cancellation flow.
+16. See [examples.md](examples.md) for full payload examples.


### PR DESCRIPTION
## What does this PR do?

Adds the **Spot Advanced Swap Orders** skill to `optional-skills/blockchain/`.

Spot is an audited, non-custodial DeFi protocol that enables AI agents to construct and submit advanced EVM swap orders — limit, TWAP, stop-loss, take-profit, delayed-start, and market — across 8 EVM chains without holding custody of user funds.

The skill is instruction-only: the agent builds and signs order payloads locally from bundled reference docs, then submits only the final signed payload to the Orbs relay.

## Related Issue

N/A

## Type of Change

- [x] 🎯 New skill (bundled or hub)

## Changes Made

- Added `optional-skills/blockchain/spot-advanced-swap-orders/SKILL.md` — main skill with frontmatter, supported chains, workflow, guardrails, and agent contract
- Added `optional-skills/blockchain/spot-advanced-swap-orders/assets/repermit.template.json` — canonical EIP-712 typed-data template
- Added `optional-skills/blockchain/spot-advanced-swap-orders/assets/token-addressbook.md` — token alias lookup across supported chains
- Added `optional-skills/blockchain/spot-advanced-swap-orders/references/quickstart.md` — minimum end-to-end flow
- Added `optional-skills/blockchain/spot-advanced-swap-orders/references/params.md` — param normalization, defaults, validation
- Added `optional-skills/blockchain/spot-advanced-swap-orders/references/sign.md` — approval, signing, and submission
- Added `optional-skills/blockchain/spot-advanced-swap-orders/references/lifecycle.md` — relay query, polling, cancellation
- Added `optional-skills/blockchain/spot-advanced-swap-orders/references/examples.md` — example relay payloads

## How to Test

1. `hermes skills install optional/blockchain/spot-advanced-swap-orders`
2. `/spot-advanced-swap-orders`
3. Ask: "Place a limit order to swap 100 USDC for ETH on Base with a minimum output of 0.03 ETH"
4. Verify the agent constructs a valid order payload and requests wallet signing

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(optional-skills):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [x] I've run `pytest tests/ -q` and all tests pass — N/A (skill only, no Python code changes)
- [x] I've added tests for my changes — N/A (skill only)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — skill is platform-agnostic (no shell commands, no OS-specific tools)
- [x] I've updated tool descriptions/schemas — N/A

## For New Skills

- [x] This skill goes in `optional-skills/` — useful for DeFi/crypto users, not universally needed (per [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled))
- [x] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) — frontmatter with `name`, `description`, `version`, `author`, `license`, `metadata.hermes.tags`, `category`, `related_skills`; includes When to Use, Workflow, Guardrails, Verification sections
- [x] No external dependencies — instruction-only skill, no CLI tools, no pip installs, no shell commands required
- [x] Skill tested end-to-end

## Screenshots / Logs

Upstream source: https://github.com/orbs-network/spot/tree/master/skill
Security audit: https://github.com/orbs-network/spot/blob/master/Audit-AstraSec.pdf