### PR TITLE
fix(kanban): reset stranded_in_ready on dashboard status->ready moves

### DIFF
--- a/hermes_cli/kanban_diagnostics.py
+++ b/hermes_cli/kanban_diagnostics.py
@@ -839,13 +839,21 @@ def _rule_stranded_in_ready(task, events, runs, now, cfg) -> list[Diagnostic]:
     # Find the most recent event that put this task into ready.
     # ``created`` covers tasks born ready; ``promoted`` covers parent-
     # done auto-promotion; ``reclaimed`` covers TTL/crash recovery;
-    # ``unblocked`` covers human-driven resumes.
+    # ``unblocked`` covers human-driven resumes. The dashboard's
+    # drag-drop / patch path writes a generic ``status`` event with
+    # payload.status="ready" instead of a dedicated ready-transition
+    # kind, so count that too.
     READY_TRANSITION_KINDS = {
         "created", "promoted", "reclaimed", "unblocked",
     }
     last_ready_ts = 0
     for ev in events:
-        if _event_kind(ev) in READY_TRANSITION_KINDS:
+        kind = _event_kind(ev)
+        payload = _parse_payload(ev) if kind == "status" else {}
+        if (
+            kind in READY_TRANSITION_KINDS
+            or (kind == "status" and payload.get("status") == "ready")
+        ):
             t = _event_ts(ev)
             last_ready_ts = max(last_ready_ts, t)
 

--- a/tests/hermes_cli/test_kanban_diagnostics.py
+++ b/tests/hermes_cli/test_kanban_diagnostics.py
@@ -522,6 +522,19 @@ def test_stranded_in_ready_uses_latest_ready_transition():
     assert [d for d in diags if d.kind == "stranded_in_ready"] == []
 
 
+def test_stranded_in_ready_treats_dashboard_status_ready_as_transition():
+    """Dashboard drag-drop writes ``kind='status'`` with payload.status=ready.
+    That manual move must reset the stranded timer just like ``reclaimed``."""
+    now = 100_000
+    task = _task(status="ready", assignee="demo", created_at=now - 4 * 3600)
+    events = [
+        _event("created", ts=now - 4 * 3600),
+        _event("status", ts=now - 5 * 60, status="ready"),
+    ]
+    diags = kd.compute_task_diagnostics(task, events, [], now=now)
+    assert [d for d in diags if d.kind == "stranded_in_ready"] == []
+
+
 def test_stranded_in_ready_severity_escalates_with_age():
     """warning → error → critical at 2x and 6x threshold."""
     now = 100_000


### PR DESCRIPTION
## What
Fix `stranded_in_ready` so dashboard/manual moves to `ready` reset the ready-age timer.

## Why
The diagnostics rule only treated `created`, `promoted`, `reclaimed`, and `unblocked` as ready-entry events. The dashboard drag/drop path writes `kind="status"` with `payload.status="ready"`, so recently re-readied older tasks could be flagged immediately as stranded.

## How
- count `status` events with `payload.status == "ready"` as ready transitions
- add a regression test covering the dashboard/manual status-change path

## Validation
- `python -m pytest tests/hermes_cli/test_kanban_diagnostics.py -q -o addopts=`
- manual repro: old task + recent dashboard `status=ready` event no longer emits `stranded_in_ready`