### PR TITLE
feat(gateway): add KimiClaw (Moonshot AI) platform plugin

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -762,6 +762,17 @@ platform_toolsets:
 #         priority:
 #           - my_plugin_command
 #
+# KimiClaw-specific settings (Moonshot AI's bot platform on kimi.com — distinct
+# from the kimi LLM provider). Top-level block, mapped to KIMI_* env vars by the
+# bundled plugin:
+#
+# kimiclaw:
+#   bot_token: ${KIMI_BOT_TOKEN}        # or km_b_prod_<your_token>
+#   home_channel: room:<uuid>           # optional cron / notification target
+#   allowed_users:
+#     - km_u_<uuid>                     # optional user allowlist
+#   allow_all_users: false              # dev only; bypasses allowlist when true
+
 # Discord-specific settings (config.yaml top-level, not under platforms:):
 #
 # discord:

--- a/plugins/platforms/kimiclaw/__init__.py
+++ b/plugins/platforms/kimiclaw/__init__.py
@@ -1,0 +1,3 @@
+from .adapter import register
+
+__all__ = ["register"]

--- a/plugins/platforms/kimiclaw/adapter.py
+++ b/plugins/platforms/kimiclaw/adapter.py
@@ -1,0 +1,4374 @@
+"""Kimi (kimi.com / Moonshot AI) platform adapter.
+
+Bridges two channels under one bot identity using a single `X-Kimi-Bot-Token`
+credential:
+
+- DM channel:    ``wss://www.kimi.com/api-claw/bots/agent-ws``
+  Kimi speaks Zed Agent Client Protocol (ACP) JSON-RPC over WebSocket. The
+  adapter responds to ACP handshake frames locally (``initialize``,
+  ``session/new``) and converts ``session/prompt`` frames into MessageEvent
+  for dispatch through the normal gateway pipeline.
+
+- Group channel: ``https://www.kimi.com/api-ws/``
+  Kimi exposes a Connect RPC (https://connectrpc.com) surface for group IM.
+  The adapter opens a server-streamed ``Subscribe`` call (one HTTP/1.1
+  long-poll POST per session; all-rooms firehose),
+  translates inbound ``ChatMessageEvent`` payloads into MessageEvent, and
+  sends outbound replies via unary ``SendMessage``. Both use
+  ``application/json`` / ``application/connect+json`` content types — no
+  protobuf bindings required on our side.
+
+The adapter owns no subprocess. Messages flow directly into
+``BasePlatformAdapter.handle_message`` via ``self._message_handler``.
+
+Group-room participation requires OpenClaw runtime metadata headers on the IM
+RPC path. Kimi Claw gathers these from ``openclaw --version``,
+``openclaw skills list --json``, and ``openclaw plugins list --json``; this
+adapter supplies conservative defaults and lets deployments override them via
+``config.extra``.
+
+References:
+    - Connect protocol spec: https://connectrpc.com/docs/protocol
+    - Zed ACP spec: https://github.com/zed-industries/agent-client-protocol
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import mimetypes
+import os
+import re
+import struct
+import time
+import uuid
+from collections import OrderedDict, deque
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, AsyncIterator, Dict, List, Optional, Set, Tuple
+
+try:
+    import aiohttp  # type: ignore
+    _AIOHTTP_AVAILABLE = True
+except ImportError:  # pragma: no cover - hermes core already depends on aiohttp
+    aiohttp = None  # type: ignore
+    _AIOHTTP_AVAILABLE = False
+
+try:
+    import websockets  # type: ignore
+    from websockets.exceptions import ConnectionClosed  # type: ignore
+    _WEBSOCKETS_AVAILABLE = True
+except ImportError:
+    websockets = None  # type: ignore
+    ConnectionClosed = Exception  # type: ignore
+    _WEBSOCKETS_AVAILABLE = False
+
+from gateway.config import Platform, PlatformConfig
+from gateway.session import build_session_key
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+)
+from hermes_constants import get_hermes_dir
+
+logger = logging.getLogger(__name__)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Constants
+# ──────────────────────────────────────────────────────────────────────────────
+
+_DEFAULT_BASE_URL = "https://www.kimi.com/api-ws"
+_DEFAULT_KIMIAPI_HOST = "https://www.kimi.com/api-claw"
+_DEFAULT_DM_WS_URL = "wss://www.kimi.com/api-claw/bots/agent-ws"
+_IM_SERVICE = "kimi.gateway.im.v1.IMService"
+
+# Connect protocol envelope flags (https://connectrpc.com/docs/protocol)
+_CONNECT_FLAG_COMPRESSED = 0x01
+_CONNECT_FLAG_END_STREAM = 0x02
+
+# Kimi's DM channel uses a single sentinel sessionId across all WS lifecycles
+_DM_SESSION_SENTINEL = "im:kimi:main"
+
+# Chat-id prefix scheme used inside MessageEvent.source.chat_id
+_CHATID_DM_PREFIX = "dm:"
+_CHATID_ROOM_PREFIX = "room:"
+
+# WS close codes that indicate permanent auth failure
+_PERMANENT_WS_CODES = {4001}  # kimi-claw's auth-failed sentinel
+
+# Group-gate header defaults. Kimi's IM service refuses group-room
+# participation unless these OpenClaw runtime headers meet the minimum CalVer
+# (2026.3.13). Defaults here unlock group access; cosmetic fields like
+# claw_id auto-generate a unique value per adapter instance.
+_GROUP_GATE_DEFAULTS = {
+    "claw_version": "0.25.0",
+    "openclaw_version": "2026.3.13",
+    "openclaw_plugins": [{"id": "kimi-claw", "version": "0.25.0"}],
+    "openclaw_skills": [],
+}
+
+_SLASH_COMMAND_RE = re.compile(r"^/[a-z0-9_-]+$", re.IGNORECASE)
+_DEFAULT_USER_MESSAGE_PREFIX = "User Message From Kimi:\n"
+
+# kimi-claw's prompt-adapter injects sender identity into the prompt text as
+# a `[sender_short_id: <short_id>]` line for group-routed-over-ACP messages
+# (see kimi-claw's user-message-prefix.js::withGroupRoomSenderShortId). The
+# structured session/prompt.params carries only sessionId + prompt by design.
+# We parse this prefix line so per-user routing works when Kimi routes a
+# group message through the DM WS instead of through Subscribe.
+_SENDER_SHORT_ID_LINE_RE = re.compile(
+    r"^\s*\[sender_short_id:\s*([^\]\s][^\]]*?)\s*\]\s*$",
+    re.MULTILINE,
+)
+
+# Kimi's WS frames are large but finite; 4MB matches the bridge setting.
+_WS_MAX_FRAME_SIZE = 4 * 1024 * 1024
+
+# DM outbound chunking — Kimi's UI renders progressively so split long replies.
+_DM_CHUNK_SIZE = 3500
+
+# Unary RPC default timeout (seconds).
+_RPC_TIMEOUT_S = 30.0
+
+# Reconnect backoff bounds.
+_RECONNECT_MIN_S = 2.0
+_RECONNECT_MAX_S_DEFAULT = 60.0
+
+# DM application-level keepalive interval. Kimi's server idle-closes the WS
+# at ~60s when no ACP frames flow; WS-protocol PING frames do NOT satisfy
+# its liveness check (observed code=1006 close at exactly 60s post-connect
+# during an idle window). We emit `$/ping` JSON-RPC notifications well under
+# the 60s window to reset the server's idle timer. `$/`-prefixed methods are
+# the LSP/JSON-RPC convention for implementation-specific notifications and
+# MUST be ignored by peers that don't recognize them.
+_DM_APP_KEEPALIVE_S_DEFAULT = 25.0
+
+# DM health tripwire: after this many seconds since first connect, log a
+# one-shot summary of DM prompt traffic. In live testing, Kimi routes what
+# users call "DMs" through the group Subscribe stream as room:<uuid>; the
+# ACP WS connects and keepalives but never receives session/prompt frames.
+# Zero traffic after an hour flags that the ACP WS path may be dead weight
+# — the operator can toggle config.extra.enable_dms=false to drop it.
+_DM_HEALTH_SUMMARY_S_DEFAULT = 3600.0
+
+# Dedup ring buffer size — covers Kimi's replay window on Subscribe reconnect.
+_DEDUP_MAXLEN = 2000
+
+# Default cap for per-room state dicts (``_rooms``, ``_last_message_id_per_
+# room``, ``_probe_msg_id_room_counts``). Bloom in production sees ~4-10 unique
+# rooms over weeks; 500 is two orders of magnitude above that, so the cap is
+# inert for normal operation. The point is to bound the worst case for
+# operators running this plugin at higher cardinality (Bloom-as-a-Service,
+# multi-org deployments) without forcing them to tune anything. Override via
+# ``config.extra["room_cache_max_entries"]``.
+_ROOM_CACHE_DEFAULT_MAX = 500
+
+# Phase 0 burst-drop instrumentation: arrival-time cache is bounded too,
+# but at a much higher ceiling than the other per-room dicts. Codex review
+# #58 noted that sharing the 500-entry cap with ``_rooms`` /
+# ``_last_message_id_per_room`` / ``_probe_msg_id_room_counts`` would
+# *silently neuter* the gap-candidate log under cardinality pressure: an
+# evicted arrival-time entry yields ``prev_arrival=None`` on the next
+# message → no INFO log fires regardless of actual delay. Since gap
+# detection is correctness-critical for observability (the very signal
+# Phase 0 ships to gather), this dict gets its own cap that's effectively
+# unbounded for any realistic Kimi deployment. 10000 entries × ~16 bytes
+# (room_id key + monotonic float) ≈ 160KB — negligible. Override via
+# ``config.extra["arrival_time_cache_max_entries"]`` on the rare deployment
+# that exceeds 10000 distinct rooms; consider Phase 1 recovery dispatch
+# at that point because 10000+ rooms is a different scale problem entirely.
+_ARRIVAL_TIME_CACHE_DEFAULT_MAX = 10000
+
+# Kimi file upload/download tuning.
+_FILE_UPLOAD_MAX_PATHS = 5
+_FILE_UPLOAD_TIMEOUT_S_DEFAULT = 120.0
+_KIMI_FILE_URI_RE = re.compile(r"^kimi-file://([^/?#\s]+)$")
+
+_CHAT_MESSAGE_COMPLETED_STATUSES = {"2", "COMPLETED", "STATUS_COMPLETED"}
+_CHAT_MESSAGE_INCOMPLETE_STATUSES = {
+    "0",
+    "1",
+    "UNSPECIFIED",
+    "GENERATING",
+    "STATUS_UNSPECIFIED",
+    "STATUS_GENERATING",
+}
+# NOTE: `role` classifies message CONTENT (USER/ASSISTANT/SYSTEM per OpenAI chat
+# semantics), not sender IDENTITY. A human using AI-drafting tools may emit
+# `role=ASSISTANT`; a bot may emit `role=USER`. Use `group_trusted_senders` for
+# authoritative sender-identity gating; this role axis is a best-effort content
+# signal only.
+_USER_MESSAGE_ROLES = {"USER", "ROLE_USER", "MESSAGE_ROLE_USER"}
+_NON_USER_MESSAGE_ROLES = {
+    "ASSISTANT",
+    "BOT",
+    "MODEL",
+    "SYSTEM",
+    "ROLE_ASSISTANT",
+    "ROLE_BOT",
+    "ROLE_MODEL",
+    "ROLE_SYSTEM",
+    "MESSAGE_ROLE_ASSISTANT",
+    "MESSAGE_ROLE_BOT",
+    "MESSAGE_ROLE_MODEL",
+    "MESSAGE_ROLE_SYSTEM",
+}
+
+MAX_MESSAGE_LENGTH = 8000  # Kimi UI handles long messages, but chunking is kinder
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Exceptions
+# ──────────────────────────────────────────────────────────────────────────────
+
+class KimiAdapterError(Exception):
+    """Base for all Kimi adapter errors."""
+
+
+class KimiAuthError(KimiAdapterError):
+    """Permanent authentication failure (HTTP 401/403, WS 4001)."""
+
+
+class KimiTransientError(KimiAdapterError):
+    """Transient error — caller should retry with backoff."""
+
+
+class KimiRpcError(KimiAdapterError):
+    """RPC returned a structured error (4xx with grpc-style body)."""
+
+
+class KimiProtocolError(KimiAdapterError):
+    """Malformed wire frame — treat as terminal for this connection."""
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Requirements check
+# ──────────────────────────────────────────────────────────────────────────────
+
+def check_kimi_requirements() -> bool:
+    """Return True if dependencies for the Kimi adapter are available.
+
+    Mirrors other platforms' ``check_*_requirements`` pattern. We require:
+    - ``websockets`` (for DM channel)
+    - ``aiohttp`` (for group Connect RPC channel)
+    Both ship via the ``hermes-agent[messaging]`` extra; this check exists
+    for defensive symmetry with other platforms and to fail fast with a
+    clear message if someone strips the runtime.
+    """
+    if not _WEBSOCKETS_AVAILABLE:
+        logger.error("Kimi adapter: websockets package not installed")
+        return False
+    if not _AIOHTTP_AVAILABLE:
+        logger.error("Kimi adapter: aiohttp package not installed")
+        return False
+    return True
+
+
+def _check_for_registry() -> bool:
+    """``check_fn`` for the platform-registry pass — stricter than the
+    deps-only :func:`check_kimi_requirements`.
+
+    ``gateway/config.py`` enables every plugin whose ``check_fn`` returns
+    True. This PR declares ``websockets`` in the ``[messaging]`` extra,
+    so a deps-only check would auto-enable KimiClaw on every install
+    that already has the ``[messaging]`` extra (Telegram, LINE, …) even
+    when ``KIMI_BOT_TOKEN`` is not set. Gate on credentials in addition
+    to deps so unconfigured users do not see the platform light up.
+    Mirrors the LINE / SimpleX / Google Chat precedent (e.g.
+    ``plugins/platforms/google_chat/adapter.py::_check_for_registry``).
+    """
+    if not check_kimi_requirements():
+        return False
+    if not os.getenv("KIMI_BOT_TOKEN"):
+        return False
+    return True
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _is_standalone_slash_command(text: str) -> bool:
+    return bool(_SLASH_COMMAND_RE.match(text.strip()))
+
+
+def _first_text_block(params: Any) -> Optional[Dict[str, Any]]:
+    """Return the first text block dict inside an ACP session/prompt params."""
+    if not isinstance(params, dict):
+        return None
+    prompt = params.get("prompt")
+    if not isinstance(prompt, list):
+        return None
+    for block in prompt:
+        if isinstance(block, dict) and block.get("type") == "text":
+            return block
+    return None
+
+
+def _extract_user_identity(params: Any) -> Tuple[Optional[str], Optional[str]]:
+    """Best-effort extract ``(user_id, user_name)`` from ACP ``session/prompt``.
+
+    Kimi's public ACP contract defines ``session/prompt.params`` as carrying
+    only ``sessionId`` and ``prompt`` — DMs are 1:1 so sender identity is
+    implicit in the WS session, and groups are normally delivered via the
+    Subscribe stream (which carries structured sender metadata). There is no
+    documented sender-identity field on ``params`` for either case.
+
+    Defensive probes we still run (for future schema additions and any
+    non-standard deployments):
+
+      - Nested ``params["sender"]`` / ``params["user"]`` / ``params["author"]``
+        with ``id`` / ``userId`` / ``name``
+      - Flat ``params["userId"]`` / ``params["user_id"]``
+
+    Returns ``(None, None)`` if none of these shapes are present. Callers
+    should then probe the prompt text for a ``[sender_short_id: X]`` prefix
+    via :func:`_extract_short_id_from_text` (kimi-claw's injection convention
+    for group-routed-over-ACP messages).
+    """
+    if not isinstance(params, dict):
+        return None, None
+    user_id: Optional[str] = None
+    user_name: Optional[str] = None
+    for key in ("sender", "user", "author"):
+        obj = params.get(key)
+        if isinstance(obj, dict):
+            user_id = user_id or (
+                obj.get("id") or obj.get("userId") or obj.get("user_id")
+            )
+            user_name = user_name or (
+                obj.get("name") or obj.get("display_name") or obj.get("displayName")
+            )
+    user_id = user_id or params.get("userId") or params.get("user_id")
+    return user_id, user_name
+
+
+def _extract_short_id_from_text(text: str) -> Optional[str]:
+    """Return the ``sender_short_id`` from kimi-claw's text prefix, if present.
+
+    kimi-claw's client injects a ``[sender_short_id: <short_id>]`` line into
+    the prompt text when forwarding a group-room message over the DM ACP WS
+    (see kimi-claw ``src/user-message-prefix.js::withGroupRoomSenderShortId``).
+    We treat this as the authoritative sender identity for that routing
+    mode. The structured `params` surface does not carry it.
+    """
+    if not isinstance(text, str) or not text:
+        return None
+    m = _SENDER_SHORT_ID_LINE_RE.search(text)
+    if not m:
+        return None
+    return m.group(1).strip() or None
+
+
+def _field(obj: Dict[str, Any], *names: str) -> Any:
+    """Return the first non-empty field value across camelCase/snake_case names."""
+    for name in names:
+        value = obj.get(name)
+        if value is not None and value != "":
+            return value
+    return None
+
+
+def _normalize_status(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped:
+            return stripped.upper()
+    return None
+
+
+def _chat_message_is_complete(value: Any) -> bool:
+    """Return whether a Kimi ChatMessageEvent should be dispatched.
+
+    Kimi's Connect JSON uses protobuf enum names (``STATUS_COMPLETED``), while
+    decoded generated-message tests may carry the numeric enum value (2). Legacy
+    hand-written fixtures often omit status entirely; keep those dispatchable.
+    """
+    status = _normalize_status(value)
+    if status is None:
+        return True
+    if status in _CHAT_MESSAGE_COMPLETED_STATUSES:
+        return True
+    if status in _CHAT_MESSAGE_INCOMPLETE_STATUSES:
+        return False
+    # Unknown future status: prefer visibility over silent drops.
+    return True
+
+
+def _chat_message_is_user_role(value: Any) -> bool:
+    """Return whether a Kimi ChatMessage role is dispatchable as user input."""
+    role = _normalize_status(value)
+    if role is None:
+        return True
+    if role in _USER_MESSAGE_ROLES:
+        return True
+    if role in _NON_USER_MESSAGE_ROLES:
+        return False
+    # Unknown future roles are not safe to treat as user prompts.
+    return False
+
+
+def _event_payload(event: Dict[str, Any]) -> Tuple[Optional[str], Dict[str, Any]]:
+    """Normalize Kimi IM event oneof shapes to ``(case, value)``.
+
+    On the wire, Connect/protobuf JSON uses top-level oneof field names like
+    ``{"chatMessage": {...}}``. Kimi's generated JS objects use
+    ``{"payload": {"case": "chatMessage", "value": {...}}}``. Older local
+    tests used ``{"message": {...}}``. Accept all three.
+    """
+    payload = event.get("payload")
+    if isinstance(payload, dict):
+        case = payload.get("case")
+        value = payload.get("value")
+        if isinstance(case, str) and isinstance(value, dict):
+            return case, value
+
+    for case in ("chatMessage", "chat_message", "message", "ping", "reconnect", "typing"):
+        value = event.get(case)
+        if isinstance(value, dict):
+            normalized = "chatMessage" if case in ("chat_message", "message") else case
+            return normalized, value
+
+    # Legacy tests sometimes pass the message fields at the top level.
+    if _field(event, "chatId", "chat_id") and _field(event, "messageId", "message_id"):
+        return "chatMessage", event
+
+    return None, {}
+
+
+def _redact_sender(short_id_or_id: Optional[str]) -> str:
+    """Redact a Kimi sender identifier for safe INFO-level logging.
+
+    Keeps the ``u_`` / ``b_`` type prefix plus the first 4 chars of the
+    body, and masks the rest. Enough signal for an operator to spot a
+    misconfigured ``group_trusted_senders`` (unique-ish prefix + known
+    peer list → identification by pattern) without bleeding full
+    short_ids into log aggregators.
+
+    Examples::
+
+        _redact_sender("u_gs5ri2l5dpytlap") -> "u_gs5r****"
+        _redact_sender("b_ipt7azbrrljvjsu") -> "b_ipt7****"
+        _redact_sender("kimi")              -> "kimi"  # <= 4 chars untouched
+        _redact_sender(None)                -> "<none>"
+    """
+    if not short_id_or_id:
+        return "<none>"
+    s = str(short_id_or_id)
+    if len(s) <= 4:
+        return s
+    # Preserve "u_" / "b_" prefix if present → "u_" + 4 chars + ****
+    if len(s) >= 6 and s[1] == "_":
+        return f"{s[:6]}****"
+    return f"{s[:4]}****"
+
+
+# Crockford base32 alphabet used by ULID (RFC: 0-9, A-Z minus I, L, O, U).
+_ULID_CROCKFORD = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+_ULID_CROCKFORD_INDEX = {c: i for i, c in enumerate(_ULID_CROCKFORD)}
+
+
+def _ulid_time_ms(ulid_str: Optional[str]) -> Optional[int]:
+    """Extract the 48-bit Crockford-base32 timestamp prefix from a ULID.
+
+    Returns None on malformed input. **Important production caveat:** Kimi's
+    actual message ids in production are UUID v6/v7/v8-shaped (36-char dashed
+    hex like ``19dc9c4f-1262-8c1b-8000-0a4a6c626bbb``), not Crockford base32
+    ULIDs. The first 48 bits of those UUIDs ARE time-monotonic but their
+    units are NOT unix-ms — captured deltas show ~16× the wall-clock seconds,
+    suggesting a Snowflake-style or otherwise non-standard epoch encoding.
+
+    For correctness, this decoder accepts only the canonical Crockford ULID
+    format. Production gap-detection should NOT rely on this — use wall-
+    clock ``time.time()`` arrival tracking instead (see
+    ``_last_arrival_time_per_room`` and the Phase 0 #18 gap-candidate logger).
+
+    Used by Probe-3 timing DEBUG log and the test suite. Returns None for
+    UUID-shaped input so callers must fall back to a different time source.
+    """
+    if not ulid_str or not isinstance(ulid_str, str) or len(ulid_str) < 10:
+        return None
+    prefix = ulid_str[:10].upper()
+    total = 0
+    for c in prefix:
+        v = _ULID_CROCKFORD_INDEX.get(c)
+        if v is None:
+            return None
+        total = total * 32 + v
+    return total
+
+
+def _block_text(block: Any) -> Optional[str]:
+    if not isinstance(block, dict):
+        return None
+
+    content = block.get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, dict):
+        case = content.get("case")
+        value = content.get("value")
+        if case == "text" and isinstance(value, dict):
+            text = _field(value, "content", "text")
+            return text if isinstance(text, str) else None
+        for key in ("text", "textBlock"):
+            nested = content.get(key)
+            if isinstance(nested, dict):
+                text = _field(nested, "content", "text")
+                return text if isinstance(text, str) else None
+
+    for key in ("text", "textBlock"):
+        nested = block.get(key)
+        if isinstance(nested, dict):
+            text = _field(nested, "content", "text")
+            return text if isinstance(text, str) else None
+        if isinstance(nested, str):
+            return nested
+
+    text = _field(block, "contentText", "content_text")
+    return text if isinstance(text, str) else None
+
+
+def _resource_link_uri(block: Any) -> Optional[str]:
+    if not isinstance(block, dict):
+        return None
+
+    candidates: List[Any] = []
+    content = block.get("content")
+    if isinstance(content, dict):
+        if content.get("case") == "resourceLink" and isinstance(content.get("value"), dict):
+            candidates.append(content["value"])
+        for key in ("resourceLink", "resource_link"):
+            nested = content.get(key)
+            if isinstance(nested, dict):
+                candidates.append(nested)
+
+    for key in ("resourceLink", "resource_link"):
+        nested = block.get(key)
+        if isinstance(nested, dict):
+            candidates.append(nested)
+
+    for candidate in candidates:
+        uri = _field(candidate, "uri", "url", "downloadUrl", "download_url")
+        if isinstance(uri, str) and uri:
+            return uri
+    return None
+
+
+def _extract_blocks_payload(msg: Dict[str, Any]) -> Tuple[str, List[str], List[str]]:
+    text_parts: List[str] = []
+    media_urls: List[str] = []
+    media_types: List[str] = []
+
+    # Probe (H-A): collect non-text block shapes for a post-loop DEBUG
+    # summary with envelope-length oracle fields. Observability-only —
+    # removable standalone.
+    non_text_blocks: List[Dict[str, Any]] = []
+
+    blocks = msg.get("blocks") if isinstance(msg.get("blocks"), list) else []
+    for block in blocks:
+        text = _block_text(block)
+        if text:
+            text_parts.append(text)
+        elif logger.isEnabledFor(logging.DEBUG):
+            block_info: Dict[str, Any] = {}
+            if isinstance(block, dict):
+                block_info["keys"] = sorted(block.keys())
+                content = block.get("content")
+                if isinstance(content, dict):
+                    block_info["content_case"] = content.get("case")
+                    block_info["content_keys"] = sorted(content.keys())
+                block_info["has_uri"] = _resource_link_uri(block) is not None
+            else:
+                block_info["type"] = type(block).__name__
+            logger.debug(
+                "Kimi groups: non-text block (no extracted text): %r",
+                block_info,
+            )
+            non_text_blocks.append(block_info)
+        uri = _resource_link_uri(block)
+        if uri:
+            media_urls.append(uri)
+            media_types.append("resource_link")
+
+    text = "\n".join(text_parts).strip()
+
+    # Probe (H-A) oracle: one summary line per message that had any
+    # non-text blocks, pairing the extracted length with the envelope
+    # preview lengths so operators can distinguish "legitimate image
+    # attachment" from "orphaned fragmented tail" without correlating
+    # against the sender's intent manually.
+    if non_text_blocks and logger.isEnabledFor(logging.DEBUG):
+        envelope_text = _field(msg, "text")
+        envelope_summary = _field(msg, "summary")
+        envelope_text_len = len(envelope_text) if isinstance(envelope_text, str) else 0
+        envelope_summary_len = (
+            len(envelope_summary) if isinstance(envelope_summary, str) else 0
+        )
+        extracted_len = sum(len(p) for p in text_parts)
+        logger.debug(
+            "Kimi groups: %d non-text block(s) — extracted_text=%d, envelope_text=%d, envelope_summary=%d, shapes=%r",
+            len(non_text_blocks), extracted_len, envelope_text_len,
+            envelope_summary_len, non_text_blocks,
+        )
+
+    return text, media_urls, media_types
+
+
+def _build_text_block(text: str) -> Dict[str, Any]:
+    """Build Kimi SendMessageRequest block JSON using protobuf JSON names."""
+    return {
+        "id": f"hermes_{uuid.uuid4().hex}",
+        "text": {"content": text},
+    }
+
+
+def _build_resource_link_block(resource: Dict[str, Any]) -> Dict[str, Any]:
+    uri = str(_field(resource, "uri", "url", "downloadUrl", "download_url") or "")
+    title = str(_field(resource, "title", "name", "fileName", "file_name") or uri)
+    return {
+        "id": f"hermes_{uuid.uuid4().hex}",
+        "resourceLink": {
+            "title": title,
+            "uri": uri,
+            "downloadUrl": str(_field(resource, "downloadUrl", "download_url") or uri),
+            "etag": str(_field(resource, "etag") or ""),
+            "sizeBytes": int(_field(resource, "sizeBytes", "size_bytes") or 0),
+        },
+    }
+
+
+def _infer_mime_type(path: str) -> str:
+    guessed, _ = mimetypes.guess_type(path)
+    return guessed or "application/octet-stream"
+
+
+def _sanitize_kimi_file_name(name: str) -> str:
+    base = Path(name).name.strip()
+    base = re.sub(r"[\x00-\x1f\x7f/\\]+", "_", base)
+    base = re.sub(r"[^A-Za-z0-9._-]+", "_", base)
+    base = re.sub(r"_+", "_", base).strip("._")
+    return (base[:120] or "file")
+
+
+def _parse_kimi_file_id(uri: str) -> Optional[str]:
+    match = _KIMI_FILE_URI_RE.match(uri.strip())
+    return match.group(1) if match else None
+
+
+def _origin_from_url(url: str, fallback: str = "https://www.kimi.com") -> str:
+    try:
+        from urllib.parse import urlparse
+        parsed = urlparse(url)
+        if parsed.scheme and parsed.netloc:
+            return f"{parsed.scheme}://{parsed.netloc}"
+    except Exception:
+        pass
+    return fallback.rstrip("/")
+
+
+def _upload_endpoint(kimiapi_host: str) -> str:
+    host = (kimiapi_host or _DEFAULT_KIMIAPI_HOST).strip().rstrip("/")
+    if host.endswith("/files:upload"):
+        return host
+    origin = _origin_from_url(host)
+    return f"{origin}/api-claw/files:upload"
+
+
+def _file_metadata_endpoint(kimiapi_host: str, file_id: str) -> str:
+    origin = _origin_from_url(kimiapi_host or _DEFAULT_KIMIAPI_HOST)
+    return f"{origin}/api-claw/files/{file_id}"
+
+
+async def _upload_kimi_file(
+    session: Any,
+    *,
+    path: str,
+    bot_token: str,
+    upload_url: str,
+    timeout_s: float,
+) -> Dict[str, Any]:
+    file_path = Path(path).expanduser()
+    if not file_path.is_file():
+        raise KimiProtocolError(f"Kimi upload path is not a readable file: {path}")
+
+    file_name = file_path.name
+    mime_type = _infer_mime_type(str(file_path))
+    form = aiohttp.FormData()
+    with file_path.open("rb") as handle:
+        form.add_field("file", handle, filename=file_name, content_type=mime_type)
+        async with session.post(
+            upload_url,
+            data=form,
+            headers={"X-Kimi-Bot-Token": bot_token},
+            timeout=aiohttp.ClientTimeout(total=timeout_s),
+        ) as resp:
+            raw = await resp.read()
+            if resp.status in (401, 403):
+                raise KimiAuthError(f"upload auth failed HTTP {resp.status}")
+            if resp.status >= 400:
+                retryable = resp.status >= 500 or resp.status == 429
+                exc = KimiTransientError if retryable else KimiRpcError
+                raise exc(f"upload failed HTTP {resp.status}: {raw[:200]!r}")
+            try:
+                data = json.loads(raw.decode("utf-8")) if raw else {}
+            except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+                raise KimiProtocolError(f"upload returned bad JSON: {exc}") from exc
+
+    file_obj = data.get("file") if isinstance(data, dict) else None
+    if not isinstance(file_obj, dict):
+        raise KimiProtocolError("upload response missing file object")
+    file_id = _field(file_obj, "id")
+    if not isinstance(file_id, str) or not file_id:
+        raise KimiProtocolError("upload response missing file.id")
+    meta = file_obj.get("meta") if isinstance(file_obj.get("meta"), dict) else {}
+    return {
+        "uri": f"kimi-file://{file_id}",
+        "name": _field(meta, "name") or file_name,
+        "mimeType": _field(meta, "contentType", "content_type") or mime_type,
+        "sizeBytes": file_path.stat().st_size,
+    }
+
+
+async def _upload_kimi_files(
+    session: Any,
+    *,
+    paths: List[str],
+    bot_token: str,
+    upload_url: str,
+    timeout_s: float,
+) -> List[Dict[str, Any]]:
+    if len(paths) > _FILE_UPLOAD_MAX_PATHS:
+        raise KimiProtocolError(
+            f"Kimi upload supports at most {_FILE_UPLOAD_MAX_PATHS} files per message"
+        )
+    uploaded: List[Dict[str, Any]] = []
+    for path in paths:
+        uploaded.append(await _upload_kimi_file(
+            session,
+            path=path,
+            bot_token=bot_token,
+            upload_url=upload_url,
+            timeout_s=timeout_s,
+        ))
+    return uploaded
+
+
+def _header_value(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    if isinstance(value, (list, dict)):
+        if not value:
+            return None
+        return json.dumps(value, ensure_ascii=True, separators=(",", ":"))
+    return str(value)
+
+
+def _resolve_env_template(value: Any) -> str:
+    """Resolve ``${VAR}`` template strings against the environment.
+
+    Defensive against Hermes config-loading paths that do not invoke
+    env-var substitution for external-plugin platforms.  In particular,
+    when ``platforms.kimi.token: ${KIMI_BOT_TOKEN}`` appears in
+    ``~/.hermes/config.yaml``, the kimi plugin (registered via
+    ``ctx.register_platform()``) receives the LITERAL string
+    ``"${KIMI_BOT_TOKEN}"`` rather than the resolved env value.  The
+    adapter's bot-token fallback chain previously short-circuited on
+    that truthy-but-bogus value, sending the template string to
+    kimi.com and getting 401 ``unauthenticated``.
+
+    Returns:
+        - For a ``"${NAME}"`` literal: the value of env var ``NAME``
+          (``""`` if unset).
+        - For any other string: the string unchanged.
+        - For ``None``: ``""``.
+        - For non-strings: ``str(value)``.
+    """
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        return str(value)
+    stripped = value.strip()
+    if (
+        stripped.startswith("${")
+        and stripped.endswith("}")
+        and len(stripped) >= 4  # at least ${X}
+    ):
+        var_name = stripped[2:-1].strip()
+        if var_name:
+            return os.getenv(var_name, "")
+    return value
+
+
+def _normalize_openclaw_plugins(value: Any, claw_version: Any) -> Any:
+    """Accept legacy string config while emitting Kimi Claw's JSON shape."""
+    if not isinstance(value, str):
+        return value
+    stripped = value.strip()
+    if not stripped or stripped[0] in "[{":
+        return value
+    return [{
+        "id": stripped,
+        "version": str(claw_version or _GROUP_GATE_DEFAULTS["claw_version"]),
+    }]
+
+
+def _normalize_openclaw_skills(value: Any) -> Any:
+    if not isinstance(value, str):
+        return value
+    stripped = value.strip()
+    if not stripped or stripped[0] in "[{":
+        return value
+    return [item.strip() for item in stripped.split(",") if item.strip()]
+
+
+def _runtime_headers(
+    *,
+    bot_token: Optional[str] = None,
+    claw_version: Any = None,
+    openclaw_version: Any = None,
+    claw_id: Any = None,
+    openclaw_plugins: Any = None,
+    openclaw_skills: Any = None,
+) -> Dict[str, str]:
+    headers: Dict[str, str] = {}
+    if bot_token:
+        headers["X-Kimi-Bot-Token"] = bot_token
+    plugins = _normalize_openclaw_plugins(openclaw_plugins, claw_version)
+    skills = _normalize_openclaw_skills(openclaw_skills)
+    for name, value in (
+        ("X-Kimi-Claw-Version", claw_version),
+        ("X-Kimi-OpenClaw-Version", openclaw_version),
+        ("X-Kimi-Claw-ID", claw_id),
+        ("X-Kimi-OpenClaw-Plugins", plugins),
+        ("X-Kimi-OpenClaw-Skills", skills),
+    ):
+        header = _header_value(value)
+        if header:
+            headers[name] = header
+    return headers
+
+
+def _split_for_streaming(text: str, chunk_size: int) -> List[str]:
+    """Split ``text`` for progressive DM streaming.
+
+    Prefer paragraph boundaries, fall back to line boundaries, fall back to
+    hard cuts. Avoids splitting mid-word where possible.
+    """
+    if len(text) <= chunk_size:
+        return [text]
+    chunks: List[str] = []
+    remaining = text
+    while len(remaining) > chunk_size:
+        # Try paragraph break first
+        split_at = remaining.rfind("\n\n", 0, chunk_size)
+        if split_at < chunk_size // 2:
+            # Too early — try single newline
+            split_at = remaining.rfind("\n", 0, chunk_size)
+        if split_at < chunk_size // 2:
+            # Fall back to last space in the window
+            split_at = remaining.rfind(" ", 0, chunk_size)
+        if split_at < chunk_size // 2:
+            split_at = chunk_size
+        chunks.append(remaining[:split_at])
+        remaining = remaining[split_at:].lstrip("\n").lstrip(" ")
+    if remaining:
+        chunks.append(remaining)
+    return chunks
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Internal state dataclasses
+# ──────────────────────────────────────────────────────────────────────────────
+
+@dataclass
+class _DMInflight:
+    """Tracks one in-flight DM session/prompt awaiting a final end_turn response."""
+    kimi_sid: str
+    req_id: Any
+    started_at: float = field(default_factory=time.time)
+
+
+@dataclass
+class _ChatInfoCache:
+    """Cached metadata for one Kimi room (TTL-refreshed on demand)."""
+    room_id: str
+    name: Optional[str] = None
+    members: List[Dict[str, Any]] = field(default_factory=list)
+    last_refresh_ts: float = 0.0
+
+
+class _BoundedLRU(OrderedDict):
+    """``OrderedDict`` with a hard size cap; oldest entry evicted on overflow.
+
+    Used for the adapter's per-room state dicts (``_rooms``,
+    ``_last_message_id_per_room``, ``_probe_msg_id_room_counts``, and
+    ``_last_arrival_time_per_room``) so the plugin stays bounded under
+    arbitrary room cardinality. Reads do **not** refresh order — only
+    writes. "Least recently used" → "least recently *updated*", which is
+    the right semantics for our consumers:
+
+    - ``_last_message_id_per_room`` is written every inbound group message,
+      so a busy room naturally refreshes its position; idle rooms drift
+      toward the LRU end. If reads refreshed too, the cap could never
+      bite a single chatty room (read every message + write every message
+      → permanent residency for *any* room with traffic).
+    - ``_rooms`` owns its own freshness via the 300s TTL re-fetch in
+      ``get_chat_info``; eviction recency is decoupled from that on
+      purpose. Update-LRU treats "least recently re-fetched" as the
+      eviction key, which is exactly what we want for a TTL-managed cache.
+    - ``_probe_msg_id_room_counts`` reads and writes at the same call site
+      (increment-then-store), so the read/write distinction is irrelevant.
+    - ``_last_arrival_time_per_room`` writes monotonic timestamps every
+      inbound chatMessage. The same write-on-message pattern as
+      ``_last_message_id_per_room`` keeps the access semantics symmetric.
+      **It uses its own larger cap** (``_ARRIVAL_TIME_CACHE_DEFAULT_MAX``,
+      default 10000) rather than the shared 500-entry cap because eviction
+      blinds the Phase 0 gap-candidate log — a re-cached room produces
+      ``prev_arrival=None`` and the gap log won't fire no matter how
+      large the actual delay was. Codex review #58 flagged this as a
+      contradiction with the "no load-bearing state" disclaimer below;
+      the separate cap resolves it.
+
+    None of these dicts hold *message-dispatch* correctness state — replay
+    dedup is owned by ``_processed_set``, which is independently bounded by
+    ``_DEDUP_MAXLEN``. So eviction never causes a duplicate or dropped
+    message at the agent layer. The arrival-time dict above is the lone
+    *observability*-critical user; it gets a higher cap to keep the
+    "bounded" promise meaningful in practice.
+
+    Eviction *does* have observable side effects under cardinality pressure
+    that we accept as the cost of bounded growth:
+
+    1. **Resumed-room ``first-seen`` DEBUG log.** ``_last_message_id_per_
+       room`` is hoisted out of the DEBUG gate (line ~2412) specifically
+       so toggling DEBUG on later doesn't produce a misleading
+       ``first-seen`` for an active room. Eviction of a quiet room
+       reintroduces a similar (but narrower) failure mode: the next
+       message from a resumed-after-eviction room logs ``first-seen``
+       instead of a delta. Misleading observability, not misleading
+       state. At the default cap (500) and Bloom's typical cardinality
+       (~10 rooms) this never fires.
+    2. **Probe sample-phase reset.** ``_probe_msg_id_room_counts`` keys
+       its sampling phase off the count modulo ``probe_msg_id_sample_
+       rate``. Eviction resets to count=1 so the first ``sample_rate-1``
+       resumed messages are skipped from the DEBUG sample. Same scale
+       gating as #1.
+    3. **``_rooms`` cold-resume + RPC failure.** ``get_chat_info`` re-
+       fetches a missing entry via ``GetRoom``/``ListMembers``; on
+       ``KimiAdapterError`` the fallback path returns
+       ``{"name": room_id, "type": "group"}`` with no members. Without
+       eviction, that fallback only runs for never-cached rooms; with
+       eviction, a transient RPC failure on a previously-cached room
+       can briefly degrade display name + members until the next
+       successful refresh. Real degradation, but bounded to one
+       inbound per failed re-fetch and recovered on next success.
+
+    None of these triggers at the default cap unless room cardinality
+    exceeds 500, and operators can raise ``room_cache_max_entries`` if
+    they routinely run more rooms than that. The README's "Bounded room
+    state" entry summarises this for users.
+    """
+
+    def __init__(self, *, maxsize: int):
+        super().__init__()
+        if maxsize < 1:
+            raise ValueError(f"maxsize must be ≥ 1, got {maxsize!r}")
+        self._maxsize = maxsize
+
+    def __setitem__(self, key: Any, value: Any) -> None:
+        # Update existing key in-place but move it to the most-recent end so
+        # the LRU ordering reflects the latest activity — important for
+        # ``_last_message_id_per_room``, which writes the same key on every
+        # inbound message in a busy room and must NOT count that room as
+        # stale just because it was first inserted long ago.
+        if key in self:
+            self.move_to_end(key, last=True)
+            super().__setitem__(key, value)
+            return
+        super().__setitem__(key, value)
+        # Evict from the oldest end until we're under cap. ``last=False``
+        # pops the *first*-inserted key (FIFO from the LRU end).
+        while len(self) > self._maxsize:
+            self.popitem(last=False)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Adapter
+# ──────────────────────────────────────────────────────────────────────────────
+
+class KimiAdapter(BasePlatformAdapter):
+    """Platform adapter for Kimi (kimi.com / Moonshot AI).
+
+    Architecture: two concurrent long-lived tasks under one ``connect()``:
+      - ``_dm_ws_loop``: maintains ACP WebSocket, synthesises handshake
+        responses, dispatches ``session/prompt`` frames as MessageEvents,
+        emits replies as ``agent_message_chunk`` updates.
+      - ``_group_subscribe_loop``: maintains ``Subscribe {}`` Connect stream,
+        translates inbound ChatMessageEvents into MessageEvents, routes
+        outbound ``send()`` to ``SendMessage`` unary RPC.
+
+    Both tasks reconnect independently with exponential backoff. A fatal
+    auth failure stops only the affected task — DM and groups degrade
+    independently.
+
+    Chat-id scheme in MessageEvent.source.chat_id:
+      - ``dm:im:kimi:main`` for the single DM channel (Kimi's sentinel
+        sessionId)
+      - ``room:<uuid>`` for group rooms. Inbound thread-like metadata is kept
+        on ``SessionSource.thread_id`` when present, but current Kimi
+        ``SendMessageRequest`` does not accept an outbound thread field.
+
+    Loop-affinity invariant (load-bearing — see ``_session_for_current_loop``
+    at the http-session helpers):
+        ``self._http_session`` is created in ``connect()`` and is therefore
+        bound to whichever event loop is running at connect time (the
+        gateway's main loop in normal deployment).  Hermes's
+        ``send_message_tool`` bridges back to async from a sync entry point
+        via a worker-thread loop (``model_tools._run_async`` →
+        ``worker_loop.run_until_complete``).  Calling ``self._http_session``
+        from that worker loop trips aiohttp's
+        ``current_task(loop=self._loop)`` guard and raises ``Timeout context
+        manager should be used inside a task``.  Every async helper that
+        touches the session goes through ``_session_for_current_loop()``,
+        which transparently yields an ephemeral session bound to the current
+        loop when the loops don't match.  Future maintainers: do not call
+        ``self._http_session.post(...)`` directly from any code path that
+        might be reached via the tool dispatcher.  Always go through the
+        helper.
+    """
+
+    MAX_MESSAGE_LENGTH = MAX_MESSAGE_LENGTH
+
+    # ──────────────────────────────────────────────────────────────────────
+    # Lifecycle
+    # ──────────────────────────────────────────────────────────────────────
+
+    def __init__(self, config: PlatformConfig) -> None:
+        # Platform("kimiclaw") creates a pseudo-member via Platform._missing_()
+        # once the registry has been populated by our register() call below.
+        # Identity-stable: Platform("kimiclaw") is Platform("kimiclaw"). See
+        # upstream gateway/config.py::Platform._missing_ for the mechanism.
+        super().__init__(config, Platform("kimiclaw"))
+
+        # Credentials — ``_resolve_env_template`` guards against the
+        # ``token: ${KIMI_BOT_TOKEN}`` config.yaml pattern arriving
+        # unsubstituted (Hermes does not run env-var substitution for
+        # external-plugin platform config).  Without it, the literal
+        # ``"${KIMI_BOT_TOKEN}"`` would short-circuit the ``or`` chain
+        # before the env-var fallback fires, and that template string
+        # would be sent to kimi.com as the bot token (HTTP 401).
+        self._bot_token: str = (
+            _resolve_env_template(config.token)
+            or _resolve_env_template(config.extra.get("bot_token", ""))
+            or os.getenv("KIMI_BOT_TOKEN", "")
+        )
+
+        # Endpoints
+        self._base_url: str = config.extra.get("base_url", _DEFAULT_BASE_URL).rstrip("/")
+        self._kimiapi_host: str = config.extra.get(
+            "kimiapi_host",
+            config.extra.get("kimiapiHost", _DEFAULT_KIMIAPI_HOST),
+        ).rstrip("/")
+        self._upload_url: str = config.extra.get(
+            "upload_url",
+            _upload_endpoint(self._kimiapi_host),
+        )
+        self._dm_ws_url: str = config.extra.get("dm_ws_url", _DEFAULT_DM_WS_URL)
+        self._file_timeout_s: float = float(
+            config.extra.get("file_timeout_s", _FILE_UPLOAD_TIMEOUT_S_DEFAULT)
+        )
+        self._file_download_dir: Path = Path(
+            config.extra.get(
+                "file_download_dir",
+                str(get_hermes_dir("cache/kimi_files", "kimi_file_cache")),
+            )
+        ).expanduser()
+
+        # Channel enable flags
+        self._enable_dms: bool = bool(config.extra.get("enable_dms", True))
+        self._enable_groups: bool = bool(config.extra.get("enable_groups", True))
+
+        # Group-gate runtime metadata headers (OpenClaw version, plugins,
+        # skills) — kimi.com gates group-room frames at OpenClaw v2026.3.13.
+        # See `website/docs/user-guide/messaging/kimiclaw.md` ("Deployment
+        # model") for the disclosure of why we send these without running
+        # an OpenClaw runtime locally.
+        self._claw_version: str = config.extra.get(
+            "claw_version", _GROUP_GATE_DEFAULTS["claw_version"]
+        )
+        self._openclaw_version: str = config.extra.get(
+            "openclaw_version", _GROUP_GATE_DEFAULTS["openclaw_version"]
+        )
+        self._claw_id: str = config.extra.get("claw_id") or (
+            f"hermes-kimi-{uuid.uuid4().hex[:16]}"
+        )
+        self._openclaw_plugins: Any = config.extra.get(
+            "openclaw_plugins", _GROUP_GATE_DEFAULTS["openclaw_plugins"]
+        )
+        self._openclaw_skills: Any = config.extra.get(
+            "openclaw_skills", _GROUP_GATE_DEFAULTS["openclaw_skills"]
+        )
+
+        # Message handling
+        self._user_message_prefix: str = config.extra.get(
+            "user_message_prefix", _DEFAULT_USER_MESSAGE_PREFIX
+        )
+        self._disable_prefix: bool = bool(config.extra.get("disable_prefix", False))
+        self._auto_skill: Optional[Any] = config.extra.get("auto_skill")
+        self._channel_prompt: Optional[str] = config.extra.get("channel_prompt")
+        self._group_require_mention: bool = bool(
+            config.extra.get("group_require_mention", False)
+        )
+
+        # Per-chat exemption from the mention gate. Mirrors the Matrix/DingTalk
+        # `free_response_chats` pattern: when `group_require_mention=True`, rooms
+        # listed here bypass the mention requirement and respond to every message.
+        # Necessary because Kimi has no wire-level distinction between 1:1 DM and
+        # group rooms — both are `room:<uuid>` — so a global mention requirement
+        # silently swallows DM traffic without an exempt list. Accepts both keys
+        # for cross-platform familiarity; `kimi_free_response_chats` is the
+        # documented name, the other is an alias.
+        #
+        # Wire shape note: `_on_group_event` reads `chatId` directly from the
+        # subscribe-stream envelope, where it arrives as a raw UUID with no
+        # `room:` prefix.  Gateway-side identifiers (KIMI_HOME_CHANNEL,
+        # /sethome output, `Session.chat_id` after handler enrichment) all
+        # carry the `room:` prefix.  Users naturally copy-paste the prefixed
+        # form from those surfaces.  We normalise the set entries to the raw
+        # UUID shape that the gate's `chat_id` actually carries, so a config
+        # of `room:<uuid>` and a wire frame with `chatId=<uuid>` correctly
+        # compare equal.  Both formats are accepted on input.
+        _exempt_raw = (
+            config.extra.get("kimi_free_response_chats")
+            or config.extra.get("group_require_mention_exempt_rooms")
+            or []
+        )
+
+        def _normalise_exempt_entry(value: object) -> Optional[str]:
+            if not isinstance(value, str) or not value:
+                return None
+            return value[len("room:"):] if value.startswith("room:") else value
+
+        self._group_require_mention_exempt_rooms: frozenset[str] = frozenset(
+            normalised
+            for normalised in (_normalise_exempt_entry(r) for r in _exempt_raw)
+            if normalised
+        )
+
+        # v2.2.0: room-distinguishability via list_group_members.  When True,
+        # the mention gate auto-bypasses rooms that the ListMembers RPC reports
+        # have exactly 2 members (bot + 1 user) — kimi.com delivers 1:1 DMs
+        # as ``room:<uuid>`` indistinguishable from groups at the envelope
+        # layer we consume, so without explicit classification a global
+        # ``group_require_mention=true`` swallows DM traffic.  The detector
+        # replaces use case 1 of ``kimi_free_response_chats`` (DM
+        # misdetection); use case 2 (explicit free-response groups via
+        # operator policy) is NOT auto-detectable and remains served by the
+        # exempt list.  See ``.review/b1-room-distinguishability-spike.md``
+        # for the cost analysis and race-window handling.
+        #
+        # Default OFF for v2.2.0 — opt-in until stabilization.  After
+        # validation in production, a future release may flip the default.
+        self._kimi_dm_autodetect: bool = bool(
+            config.extra.get("kimi_dm_autodetect", False)
+        )
+
+        # Short_id / id allowlist — authoritative identity-based bypass of role filter
+        trusted = config.extra.get("group_trusted_senders") or []
+        self._group_trusted_senders: frozenset[str] = frozenset(
+            str(s) for s in trusted if isinstance(s, (str, int))
+        )
+
+        # Policy for non-user-role senders: "off" | "trusted_only" | "mentions" | "all"
+        raw = config.extra.get("group_allow_bot_senders", "off")
+        if raw is True:
+            raw = "all"
+        elif raw is False:
+            raw = "off"
+        if raw not in ("off", "trusted_only", "mentions", "all"):
+            logger.warning(
+                "Kimi: invalid group_allow_bot_senders=%r, defaulting to 'off'", raw
+            )
+            raw = "off"
+        self._group_allow_bot_senders: str = raw
+
+        self._hydrate_missing_text: bool = bool(
+            config.extra.get("hydrate_missing_text", True)
+        )
+
+        # Reconnect tuning
+        self._reconnect_max_s: float = float(
+            config.extra.get("reconnect_max_s", _RECONNECT_MAX_S_DEFAULT)
+        )
+        # Subscribe (group) backoff state — instance-scoped so a successful
+        # stream (first processed frame post-connect) can reset it without
+        # driving bot-thrash: after reset, the next reconnect delay starts
+        # from the floor (not base), preventing oscillation hammering Kimi's
+        # infra when the stream flaps every ~30-60s.
+        self._group_subscribe_backoff_base: float = _RECONNECT_MIN_S
+        self._group_subscribe_backoff_floor: float = 10.0
+        self._group_subscribe_backoff: float = self._group_subscribe_backoff_base
+        self._group_subscribe_frame_since_connect: bool = False
+        # Monotonic counter of successful subscribe-stream reconnects,
+        # incremented at the first chatMessage post-connect. Phase 0 burst-
+        # drop instrumentation: operators correlate this against per-room
+        # gap-candidate INFOs in the same log to see whether drops cluster
+        # around reconnects (favours Phase 1 design) or appear mid-stream
+        # (favours Phase 2/3). Cold start counts as #1.
+        self._group_subscribe_reconnect_count: int = 0
+        # Wall-clock timestamp (``time.time()``) of the most recent
+        # increment, captured at the same line. Used by the gap-candidate
+        # INFO log to compute ``since_reconnect_s`` so the correlation
+        # operators want is in a single line rather than across two
+        # journalctl streams. ``-1`` sentinel = no reconnect observed yet.
+        self._group_subscribe_last_reconnect_ts: float = -1.0
+        self._ws_ping_interval: int = int(config.extra.get("ws_ping_interval", 15))
+        self._ws_ping_timeout: int = int(config.extra.get("ws_ping_timeout", 60))
+        self._dm_app_keepalive_s: float = float(
+            config.extra.get("dm_app_keepalive_s", _DM_APP_KEEPALIVE_S_DEFAULT)
+        )
+        self._startup_grace_s: float = float(config.extra.get("startup_grace_s", 30))
+        self._dm_health_summary_s: float = float(
+            config.extra.get("dm_health_summary_s", _DM_HEALTH_SUMMARY_S_DEFAULT)
+        )
+
+        # Session-key knobs hoisted out of the _dm_cancel_session hot path.
+        # These are semantically config flags — read once at __init__ so the
+        # session-cancel call site stays a straight function call, matching
+        # the pattern used by `_group_require_mention` et al.
+        self._group_sessions_per_user: bool = bool(
+            config.extra.get("group_sessions_per_user", True)
+        )
+        self._thread_sessions_per_user: bool = bool(
+            config.extra.get("thread_sessions_per_user", False)
+        )
+
+        # Runtime state
+        self._closing: bool = False
+        self._startup_ts: float = 0.0
+        self._dm_task: Optional[asyncio.Task] = None
+        self._group_task: Optional[asyncio.Task] = None
+        self._dm_health_task: Optional[asyncio.Task] = None
+        self._http_session: Optional[Any] = None  # aiohttp.ClientSession
+        # The event loop ``self._http_session`` was constructed on.  aiohttp
+        # binds ``ClientSession`` to ``asyncio.get_running_loop()`` at
+        # ``__init__`` time; using the session from a different loop later
+        # makes ``TimerContext`` raise ``RuntimeError("Timeout context
+        # manager should be used inside a task")`` because
+        # ``asyncio.current_task(loop=session._loop)`` returns ``None``.
+        # See ``_session_for_current_loop`` for the cross-loop workaround.
+        self._http_session_loop: Optional[asyncio.AbstractEventLoop] = None
+        self._ws: Optional[Any] = None  # active DM WS
+
+        # DM traffic observability — count successfully dispatched
+        # session/prompt frames. A one-shot summary fires
+        # `_dm_health_summary_s` after connect() to flag zero-traffic DMs
+        # (Kimi routing DMs via the group Subscribe path instead of ACP).
+        self._dm_prompt_count: int = 0
+
+        # Bot identity (populated by GetMe on connect)
+        self._me_id: Optional[str] = None
+        self._me_short_id: Optional[str] = None
+        self._me_name: Optional[str] = None
+
+        # DM state
+        # ACP synthetic session id (we generate; Kimi treats it as opaque)
+        self._dm_fake_session_id: Optional[str] = None
+        # In-flight DM prompts per sid (FIFO). Overlapping prompts are queued
+        # so end_turn responses match their originating req_id in order.
+        self._dm_inflight: Dict[str, "deque[_DMInflight]"] = {}
+        # Kimi's actual sessionId parameter, observed from inbound frames
+        self._dm_observed_kimi_sid: Optional[str] = None
+        # 409 "bot already connected" strike count — resets on successful connect.
+        # First strike sleeps 60s, subsequent strikes 300s to let Kimi's server-
+        # side routing clear any ghost WS state from prior thrash cycles.
+        self._dm_409_strikes: int = 0
+        # One-shot warning guard for the multi-user DM collapse limitation.
+        self._warned_dm_collapse: bool = False
+        # One-shot warning guards for outbound group surfaces that Kimi Claw
+        # v0.25.0's SendMessageRequest doesn't currently carry on the wire.
+        # Kept as simple bools because the warning is a one-per-process
+        # operator tripwire, not per-room metering.
+        self._warned_outbound_thread_drop: bool = False
+        self._warned_outbound_mentions_drop: bool = False
+
+        # Dedup of inbound events (keyed by (source_tag, message_id))
+        self._processed: deque = deque(maxlen=_DEDUP_MAXLEN)
+        self._processed_set: Set[Tuple[str, str]] = set()
+
+        # Bound the per-room state dicts so cardinality can't grow without
+        # ceiling on long-running deployments (see ``_ROOM_CACHE_DEFAULT_MAX``
+        # for rationale). All three dicts share the same key space (room_id)
+        # and the same eviction semantics, so a single cap is sufficient.
+        _raw_room_cap = config.extra.get(
+            "room_cache_max_entries", _ROOM_CACHE_DEFAULT_MAX
+        )
+        try:
+            _room_cap = max(1, int(_raw_room_cap))
+        except (TypeError, ValueError):
+            logger.warning(
+                "Kimi: invalid room_cache_max_entries=%r in config.extra — "
+                "expected positive integer, falling back to %d",
+                _raw_room_cap, _ROOM_CACHE_DEFAULT_MAX,
+            )
+            _room_cap = _ROOM_CACHE_DEFAULT_MAX
+
+        # Per-room cache
+        self._rooms: _BoundedLRU = _BoundedLRU(maxsize=_room_cap)
+
+        # Probe (H-C): per-room last-seen message_id, for DEBUG timing
+        # correlation against conductor wall-clock. Observability only —
+        # removable standalone with the Probe-3 log block.
+        self._last_message_id_per_room: _BoundedLRU = _BoundedLRU(maxsize=_room_cap)
+        # Probe (H-C) sample-rate knob: log 1-in-N per-room DEBUG records
+        # under busy groups so operators can cap log volume without flipping
+        # DEBUG off entirely. Default 1 (log every message — prior behavior).
+        # Tracker-update itself is NEVER sampled — every inbound populates
+        # _last_message_id_per_room so Fix A's invariant survives sampling.
+        _raw_sample_rate = config.extra.get("probe_msg_id_sample_rate", 1)
+        try:
+            self._probe_msg_id_sample_rate: int = max(1, int(_raw_sample_rate or 1))
+        except (TypeError, ValueError):
+            logger.warning(
+                "Kimi: invalid probe_msg_id_sample_rate=%r in config.extra — "
+                "expected positive integer, falling back to 1",
+                _raw_sample_rate,
+            )
+            self._probe_msg_id_sample_rate = 1
+        self._probe_msg_id_room_counts: _BoundedLRU = _BoundedLRU(maxsize=_room_cap)
+
+        # Phase 0 burst-drop instrumentation: per-room MONOTONIC arrival
+        # tracking + INFO threshold. Tracks ``time.monotonic()`` at the
+        # moment each chatMessage is processed in ``_on_group_event``;
+        # logs at INFO when the per-room delta meets the threshold.
+        # Monotonic (not wall-clock) because deltas need to be safe
+        # against NTP step / leap-second / VM-suspend resume — Codex and
+        # Kimi reviews #58 independently flagged that ``time.time()``-
+        # based deltas can produce false-positive gap logs when the
+        # system clock jumps. Operator correlation with journalctl
+        # timestamps still works via the log line's own leading ISO
+        # timestamp; the embedded delta describes "process-time since
+        # last delivery" which is the honest signal. Higher cap than
+        # the shared LRU (see ``_ARRIVAL_TIME_CACHE_DEFAULT_MAX``) to
+        # keep gap detection unblinded under cardinality pressure.
+        _raw_arrival_cap = config.extra.get(
+            "arrival_time_cache_max_entries", _ARRIVAL_TIME_CACHE_DEFAULT_MAX
+        )
+        try:
+            _arrival_cap = max(1, int(_raw_arrival_cap))
+        except (TypeError, ValueError):
+            logger.warning(
+                "Kimi: invalid arrival_time_cache_max_entries=%r in config.extra "
+                "— expected positive integer, falling back to %d",
+                _raw_arrival_cap, _ARRIVAL_TIME_CACHE_DEFAULT_MAX,
+            )
+            _arrival_cap = _ARRIVAL_TIME_CACHE_DEFAULT_MAX
+        self._last_arrival_time_per_room: _BoundedLRU = _BoundedLRU(maxsize=_arrival_cap)
+
+        # Threshold in seconds for emitting the gap-candidate INFO log. 0
+        # disables. Default 30 — well above conversational cadence (humans
+        # often reply within 1-5s), conservative enough that an idle room
+        # resuming after a coffee break naturally crosses it. False-positive
+        # rate is acceptable: the operator-facing premise is "look for
+        # CLUSTERS of these correlating against reconnects", not "any single
+        # one is a problem". Codex review #1 noted this risks flooding INFO
+        # in idle rooms — the wall-clock pivot keeps the signal honest;
+        # threshold tuning per-deployment is the operator's call.
+        _raw_gap_threshold = config.extra.get(
+            "burst_drop_gap_log_threshold_s", 30.0
+        )
+        try:
+            self._burst_drop_gap_log_threshold_s: float = max(0.0, float(_raw_gap_threshold))
+        except (TypeError, ValueError):
+            logger.warning(
+                "Kimi: invalid burst_drop_gap_log_threshold_s=%r in config.extra "
+                "— expected non-negative number, falling back to 30.0",
+                _raw_gap_threshold,
+            )
+            self._burst_drop_gap_log_threshold_s = 30.0
+
+        # ── Lift 3a: interrupt-and-drain queue improvements ───────────────
+        # Pending-slot TTL (seconds). ``None`` = never expire (default,
+        # matches Bloom's ``session_reset.mode: none`` — sessions are held
+        # indefinitely). When set, a queued pending message older than this
+        # many seconds is silently evicted and not dispatched to the agent,
+        # preventing stale follow-ups from re-entering the conversation after
+        # a long tool-call turn. Hakimi hard-codes 5 minutes; we make it
+        # configurable so operators tune to their session-lifetime preference.
+        _raw_ttl = config.extra.get("pending_message_ttl_seconds")
+        self._pending_message_ttl: Optional[float] = (
+            float(_raw_ttl) if _raw_ttl is not None else None
+        )
+        # Timestamps of when each pending message was *first* enqueued,
+        # keyed by session_key. Used for TTL eviction and drop-log metadata.
+        self._pending_enqueued_at: Dict[str, float] = {}
+
+        # ── Lift 3b: output_mode flag ─────────────────────────────────────
+        #
+        # Two-path architecture: Hermes routes outbound messages to Kimi via
+        # two distinct entry points, and ``output_mode`` controls only the
+        # first.
+        #
+        #   1. ``adapter.send()`` ← gateway run-loop calls this for each agent
+        #      prose chunk during a streaming turn. This is what generates
+        #      "the agent typing back to you in chat" UX. Gated by
+        #      ``output_mode``.
+        #
+        #   2. ``send_kimi_message()`` ← module-level helper at the bottom of
+        #      this file.  Registered via ``standalone_sender_fn=_standalone_send``
+        #      in ``register()``.  Invoked by Hermes's cron scheduler for
+        #      out-of-process delivery, and by ``send_message_tool`` as the
+        #      fallback path when no live adapter is in-process (per the
+        #      upstream contract at ``tools/send_message_tool.py::_send_via_adapter``,
+        #      which prefers the live ``adapter.send()`` when one exists).
+        #      Bypasses ``adapter.send()`` entirely → never gated by
+        #      ``output_mode``.
+        #
+        # Modes:
+        #   ``passthrough`` (default) — both paths emit. Agent prose streams
+        #     to Kimi as it's generated; explicit tool calls + cron deliveries
+        #     also work. Production-default; matches every other Hermes
+        #     platform adapter.
+        #   ``tool_only`` — path (1) is suppressed (``send()`` returns early
+        #     with success=True). The agent's prose still appears in Hermes
+        #     logs but is not relayed to Kimi. Path (2) is unaffected — tool-
+        #     driven sends and cron deliveries work normally. The user sees
+        #     output only when the agent explicitly invokes
+        #     ``send_message_tool``.
+        #
+        # When to use ``tool_only``:
+        #   • Group rooms where streaming prose would be noisy and the agent
+        #     should emit a single curated reply via the tool.
+        #   • Multi-step agents where intermediate "thinking out loud" is
+        #     undesirable platform-side but useful in logs.
+        #   • Cron-only or tool-only deployments (no interactive turns).
+        #
+        # When NOT to use ``tool_only``:
+        #   • 1:1 DMs where the user expects streaming response UX — silence
+        #     looks like the bot hung.
+        #   • Setups where the agent isn't reliably guided (system prompt or
+        #     skill nudge) to call ``send_message_tool``. Without that
+        #     guidance, the bot will appear mute on every turn.
+        #
+        # Background — this flag exists because the bridge's
+        # ``HIDE_TOOL_CALLS=1`` filter, the prior workaround, hung Hermes
+        # over stdio. The adapter's in-process coupling lets us suppress at
+        # the right layer without that deadlock.
+        _raw_mode = config.extra.get("output_mode", "passthrough")
+        if _raw_mode not in ("passthrough", "tool_only"):
+            logger.warning(
+                "Kimi: invalid output_mode=%r — expected 'passthrough' or "
+                "'tool_only'; defaulting to 'passthrough'",
+                _raw_mode,
+            )
+            _raw_mode = "passthrough"
+        self._output_mode: str = _raw_mode
+
+    async def connect(self) -> bool:
+        """Open HTTP session, fetch bot identity, spawn channel loops.
+
+        Returns ``True`` if at least one enabled channel is viable.
+        """
+        if not self._bot_token:
+            logger.error("Kimi: no bot_token configured (set config.token or KIMI_BOT_TOKEN)")
+            return False
+        if not check_kimi_requirements():
+            return False
+
+        if not self._acquire_platform_lock(
+            "kimi-bot-token", self._bot_token, "Kimi bot token"
+        ):
+            return False
+
+        self._closing = False
+        self._startup_ts = time.time()
+        # trust_env=True so that HTTP_PROXY / HTTPS_PROXY / ALL_PROXY env
+        # vars are honoured. aiohttp's default is False, which silently
+        # ignores them and breaks corporate-proxy deployments. Symmetric
+        # with the in-tree Yuanbao / WeCom / Weixin / Matrix adapters and
+        # with the SMS / Slack / Teams / Google-Chat sweep that landed
+        # upstream in commit c1ae18ee8.  Must be re-applied at EVERY
+        # ClientSession() construction site below; aiohttp does not pick
+        # this up from a module-level default.
+        self._http_session = aiohttp.ClientSession(trust_env=True)
+        self._http_session_loop = asyncio.get_running_loop()
+
+        # Belt-and-braces sweep of parallel TTL state at the start of
+        # every connect cycle. Standard teardown paths (disconnect,
+        # cancel_background_tasks) already clear this, but partial-init
+        # failures or future code paths that bypass them could leave
+        # stale entries from a prior session — and the gateway reuses
+        # this same adapter instance on reconnect. Clearing here
+        # guarantees every connect starts from a known-empty state.
+        self._pending_enqueued_at.clear()
+
+        # Fetch bot identity once — needed to filter self-authored group messages.
+        try:
+            me = await self._rpc_unary("GetMe", {})
+            self._me_id = me.get("id")
+            self._me_short_id = me.get("shortId")
+            self._me_name = me.get("name")
+            logger.info(
+                "Kimi: connected as %s (shortId=%s, id=%s)",
+                self._me_name, self._me_short_id, self._me_id,
+            )
+        except KimiAuthError as exc:
+            logger.error("Kimi: GetMe auth failed: %s", exc)
+            await self._cleanup_http()
+            self._release_platform_lock()
+            return False
+        except Exception as exc:
+            logger.warning("Kimi: GetMe failed (%s); continuing — loops will retry", exc)
+
+        if self._enable_dms:
+            self._dm_task = asyncio.create_task(self._dm_ws_loop(), name="kimi-dm")
+            # Arm the one-shot DM health tripwire in parallel. If disconnect()
+            # fires before _dm_health_summary_s elapses, the task is cancelled
+            # cleanly and never logs.
+            if self._dm_health_summary_s > 0:
+                self._dm_health_task = asyncio.create_task(
+                    self._log_dm_health_summary(), name="kimi-dm-health",
+                )
+        if self._enable_groups:
+            self._group_task = asyncio.create_task(
+                self._group_subscribe_loop(), name="kimi-group"
+            )
+
+        if not (self._dm_task or self._group_task):
+            logger.error("Kimi: both channels disabled — nothing to do")
+            await self._cleanup_http()
+            self._release_platform_lock()
+            return False
+
+        self._mark_connected()
+        return True
+
+    async def disconnect(self) -> None:
+        """Cancel both loops, close WS + HTTP session."""
+        self._closing = True
+        self._mark_disconnected()
+
+        tasks = [
+            t for t in (self._dm_task, self._group_task, self._dm_health_task)
+            if t is not None
+        ]
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        self._dm_health_task = None
+
+        if self._ws is not None:
+            try:
+                await self._ws.close()
+            except Exception:
+                pass
+            self._ws = None
+
+        await self._cleanup_http()
+        self._release_platform_lock()
+
+        # Defense-in-depth: clear our parallel TTL state. The gateway's
+        # standard shutdown path calls cancel_background_tasks() before
+        # disconnect() (gateway/run.py:2725-2729), and that override
+        # already clears _pending_enqueued_at via super(). But other
+        # call sites — gateway/run.py:_safe_adapter_disconnect at
+        # ~line 953 + line 1145, plus the error-recovery branch at
+        # ~line 1110-1112 in connect() — call disconnect() directly
+        # without a prior drain. Clearing here ensures
+        # _pending_enqueued_at never outlives the connection,
+        # regardless of teardown path.
+        #
+        # Known limitation (out of scope for this fix): direct-
+        # disconnect paths don't clear the base class's
+        # ``_pending_messages`` or ``_active_sessions`` either — those
+        # only get cleaned up via cancel_background_tasks(). If a
+        # future code path reuses an adapter after a direct disconnect
+        # with real pending messages, those would also need clearing.
+        # The pre-existing behaviour is unchanged by this commit.
+        self._pending_enqueued_at.clear()
+
+    async def cancel_background_tasks(self) -> None:
+        """Mirror base behaviour for our parallel TTL state.
+
+        BasePlatformAdapter.cancel_background_tasks (gateway/platforms/
+        base.py:2553-2554) clears ``_pending_messages`` and
+        ``_active_sessions`` at the end of its drain. Our subclass
+        maintains a parallel ``_pending_enqueued_at`` dict that is
+        only meaningful while the corresponding ``_pending_messages``
+        slot is live; once base clears its state, our timestamps are
+        orphaned. Without this override they leak across reconnects
+        (the gateway typically reuses the adapter instance).
+
+        Correctness note: a stale-only timestamp is benign — the TTL
+        guard in ``handle_message`` keys off ``_pending_messages.get
+        (session_key)`` first (see line ~1247) and bails if no slot
+        exists, so a phantom ``_pending_enqueued_at`` entry can't
+        evict a real later message. The leak is a memory-hygiene
+        issue, not a correctness one — relevant for long-running pi
+        deployments that reconnect repeatedly over weeks.
+
+        Order: ``super()`` first, then our ``clear()``. Reversed,
+        an in-flight handler whose ``finally`` block runs during the
+        drain's ``await asyncio.gather`` could re-insert a key after
+        our clear, leaving us with a single stray entry per drain.
+        With this order, the base awaits all such handlers to
+        completion (their ``finally`` blocks see ``_pending_messages``
+        empty and pop their own timestamp via the guard), so our
+        clear is a final sweep over a known-empty dict.
+
+        Other parallel dicts on this adapter (``_last_message_id_per_
+        room`` for replay dedup, ``_probe_msg_id_room_counts`` for
+        debug counters) intentionally persist across reconnects or
+        carry no semantic state — they're not in scope here.
+        """
+        await super().cancel_background_tasks()
+        self._pending_enqueued_at.clear()
+
+    @asynccontextmanager
+    async def _session_for_current_loop(self) -> AsyncIterator[Any]:
+        """Yield an ``aiohttp.ClientSession`` bound to the running event loop.
+
+        The cached ``self._http_session`` is bound to whichever loop ran
+        ``connect()`` (the gateway main loop).  Hermes's
+        ``send_message_tool`` dispatches ``adapter.send()`` from a
+        worker-thread loop via ``_run_async`` →
+        ``worker_loop.run_until_complete``, which crosses event loops with
+        the gateway-bound session.  aiohttp's ``TimerContext.__enter__``
+        then raises ``RuntimeError("Timeout context manager should be used
+        inside a task")`` because
+        ``asyncio.current_task(loop=session._loop)`` looks at the
+        gateway loop while we're on the worker loop.
+
+        Strategy:
+        - Same loop as the cached session → yield the cached session
+          (connection pool preserved for normal traffic).
+        - No cached session yet → create one on the current loop and cache
+          it for reuse.
+        - Different loop than the cached session → yield an ephemeral
+          session bound to the current loop, closed when the ``async
+          with`` block exits.  Single-connection cost on cross-loop calls
+          is acceptable; the alternative is the bug.
+
+        Counterpart upstream issue: ``send_message_tool`` should marshal
+        ``adapter.send()`` back to the gateway loop via
+        ``asyncio.run_coroutine_threadsafe`` rather than running the
+        coroutine on the worker loop.  Until then, this helper is the
+        plugin-side workaround.
+        """
+        current_loop = asyncio.get_running_loop()
+        cached = self._http_session
+        if cached is None:
+            # First-ever lazy creation — cache on the current loop.
+            # See ``connect()`` for the trust_env=True rationale.
+            self._http_session = aiohttp.ClientSession(trust_env=True)
+            self._http_session_loop = current_loop
+            yield self._http_session
+            return
+        if getattr(cached, "closed", False):
+            # Stale closed session — replace on the current loop.
+            self._http_session = aiohttp.ClientSession(trust_env=True)
+            self._http_session_loop = current_loop
+            yield self._http_session
+            return
+        if self._http_session_loop is None or self._http_session_loop is current_loop:
+            # Either same loop, or caller installed the session directly
+            # (e.g. a test fixture that bypassed ``connect()``).  Either
+            # way, trust it; cross-loop protection only kicks in when we
+            # have a known-bound loop that differs from the current one.
+            yield cached
+            return
+        # Cross-loop: ephemeral session scoped to this call.
+        async with aiohttp.ClientSession(trust_env=True) as ephemeral:
+            yield ephemeral
+
+    async def _cleanup_http(self) -> None:
+        if self._http_session is not None:
+            try:
+                await self._http_session.close()
+            except Exception:
+                pass
+            self._http_session = None
+            self._http_session_loop = None
+
+    # ──────────────────────────────────────────────────────────────────────
+    # ── Lift 3a: handle_message override ─────────────────────────────────
+
+    async def handle_message(self, event: MessageEvent) -> None:  # type: ignore[override]
+        """Augment base dispatch with pending-slot drop-logging and TTL eviction.
+
+        Hakimi's ``processMessage`` pattern (``chatRouter.ts:395-433``) uses a
+        single-slot pending buffer and silently drops messages when a second
+        follow-up arrives before the first processes. ``BasePlatformAdapter``
+        already implements the slot + interrupt-and-drain correctly (including
+        the error-path drain via ``finally``). This override adds two
+        improvements over hakimi:
+
+        1. **WARN on pending-slot overwrite** — when a new message overwrites
+           an existing pending slot (hakimi silently drops). Logs chat_id and
+           a 80-char redacted preview of the dropped message text.
+        2. **Configurable TTL** — if ``pending_message_ttl_seconds`` is set,
+           evict an expired pending message (too stale to be useful) before
+           queuing the new one. Hakimi hard-codes 5 minutes; default here is
+           ``None`` (no expiry) to match Bloom's indefinite session config.
+
+        The error-path drain fix (drain runs in ``finally``, not just in
+        ``try``) is already correct in ``BasePlatformAdapter`` via the
+        late-arrival drain in ``_process_message_background``.
+        """
+        from gateway.session import build_session_key as _bsk
+
+        session_key = _bsk(
+            event.source,
+            group_sessions_per_user=self._group_sessions_per_user,
+            thread_sessions_per_user=self._thread_sessions_per_user,
+        )
+
+        # Only intervene when there is already an active session — this is
+        # the exact condition under which the base class would overwrite the
+        # pending slot.
+        if session_key in self._active_sessions:
+            now = time.monotonic()
+
+            # ── TTL eviction ────────────────────────────────────────────────
+            existing = self._pending_messages.get(session_key)
+            if existing is not None and self._pending_message_ttl is not None:
+                enqueued_at = self._pending_enqueued_at.get(session_key)
+                if enqueued_at is not None:
+                    age = now - enqueued_at
+                    if age > self._pending_message_ttl:
+                        logger.info(
+                            "Kimi [%s]: evicting expired pending message "
+                            "(age=%.1fs > ttl=%.1fs) — slot freed for new message",
+                            session_key,
+                            age,
+                            self._pending_message_ttl,
+                        )
+                        self._pending_messages.pop(session_key, None)
+                        self._pending_enqueued_at.pop(session_key, None)
+                        existing = None
+
+            # ── Drop-log when overwriting a non-expired slot ────────────────
+            existing = self._pending_messages.get(session_key)
+            if existing is not None:
+                dropped_text = getattr(existing, "text", "") or ""
+                preview = dropped_text[:80].replace("\n", " ")
+                if len(dropped_text) > 80:
+                    preview += "..."
+                logger.warning(
+                    "Kimi [%s]: overwriting pending slot — dropping message "
+                    "(preview: %r). Latest message will be queued instead "
+                    "(last-wins semantics).",
+                    session_key,
+                    preview,
+                )
+                self._pending_enqueued_at.pop(session_key, None)
+
+            # Record enqueue timestamp for the new pending message.
+            # Set BEFORE calling super() so the slot timestamp is consistent
+            # with what super() puts in _pending_messages.
+            self._pending_enqueued_at[session_key] = now
+
+        try:
+            await super().handle_message(event)
+        finally:
+            # Clean up timestamp when the session finishes (slot consumed
+            # or not needed). Wrapped in finally so any unexpected
+            # exception from super() — most relevantly a CancelledError
+            # propagating up from base.handle_message itself — doesn't
+            # skip the cleanup and leak a timestamp into a future
+            # invocation. (Note: gateway/run.py's task-drain at
+            # cancel_background_tasks cancels ``_background_tasks`` —
+            # the spawned ``_process_message_background`` workers —
+            # not direct ``handle_message`` callers, so the
+            # cancellation pressure here is from other paths.)
+            #
+            # Why the guard is deterministic under cancellation: base
+            # writes to ``_pending_messages[session_key]`` happen
+            # synchronously with no ``await`` between the write and
+            # the function return (see gateway/platforms/base.py
+            # interrupt-queue path). So by the time our ``finally``
+            # observes ``_pending_messages``, the slot is in one of
+            # two known states: empty (no follow-up landed → safe to
+            # pop) or owned by a follow-up (write completed before
+            # our await unwound → preserve the fresh timestamp the
+            # follow-up's own pre-super block set).
+            if session_key not in self._pending_messages:
+                self._pending_enqueued_at.pop(session_key, None)
+
+    # Public send / platform-surface overrides
+    # ──────────────────────────────────────────────────────────────────────
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Route outbound message by chat_id prefix.
+
+        - ``dm:<sid>``   → emit ACP ``agent_message_chunk`` frames + end_turn
+        - ``room:<id>``  → POST ``SendMessage`` with Kimi text blocks
+
+        ``metadata`` keys:
+          - ``thread_id``: accepted for compatibility with the Hermes surface.
+            Kimi Claw v0.25.0's ``SendMessageRequest`` has no thread field, so
+            threaded sends currently collapse to the underlying room with a
+            one-shot WARNING log (see ``_send_group``).
+          - ``mentions``: list of member short_ids to @-mention. Currently
+            emits a one-shot WARNING and falls through to plain text; Kimi's
+            mention-block wire shape is not yet confirmed via the surface
+            check.
+        """
+        # ── Lift 3b: output_mode gate ─────────────────────────────────────
+        # In ``tool_only`` mode the agent's prose responses are suppressed.
+        #
+        # Known behaviour against current upstream Hermes (≤ 0.14.0):
+        # ``send_message_tool._send_via_adapter`` prefers the live adapter
+        # over ``standalone_sender_fn`` when both exist (this is the
+        # documented dispatch contract).  In ``tool_only`` mode, explicit
+        # tool sends therefore route through this method and are suppressed
+        # alongside streaming prose.  The dispatch contract itself is
+        # correct; the limitation is that this plugin doesn't currently
+        # differentiate prose vs explicit tool sends at the gate.  See
+        # README "tool_only and send_message_tool — known limitation" for
+        # the user-facing guidance + when each output_mode is appropriate.
+        #
+        # Default is ``passthrough`` so production behavior is unchanged.
+        if self._output_mode == "tool_only":
+            logger.debug(
+                "Kimi: output_mode=tool_only — suppressing prose send to %s",
+                chat_id,
+            )
+            # Bug fix: still need to close the inflight DM round-trip even when
+            # we suppress the prose send, otherwise Kimi's UI spinner hangs
+            # waiting for end_turn until WS reconnect. See _close_dm_inflight.
+            if chat_id.startswith(_CHATID_DM_PREFIX):
+                await self._close_dm_inflight(chat_id[len(_CHATID_DM_PREFIX):])
+            return SendResult(success=True)
+
+        if not content:
+            # Same fix as the tool_only path: empty content still needs to
+            # close any pending DM inflight round-trip.
+            if chat_id.startswith(_CHATID_DM_PREFIX):
+                await self._close_dm_inflight(chat_id[len(_CHATID_DM_PREFIX):])
+            return SendResult(success=True)
+
+        metadata = metadata or {}
+        formatted = self.format_message(content)
+
+        try:
+            if chat_id.startswith(_CHATID_DM_PREFIX):
+                kimi_sid = chat_id[len(_CHATID_DM_PREFIX):]
+                return await self._send_dm(kimi_sid, formatted, reply_to, metadata)
+            if chat_id.startswith(_CHATID_ROOM_PREFIX):
+                room_and_thread = chat_id[len(_CHATID_ROOM_PREFIX):]
+                if "/" in room_and_thread:
+                    room_id, thread_id = room_and_thread.split("/", 1)
+                else:
+                    room_id, thread_id = room_and_thread, metadata.get("thread_id")
+                return await self._send_group(
+                    room_id, formatted, reply_to, thread_id, metadata
+                )
+            return SendResult(
+                success=False,
+                error=f"Kimi: unknown chat_id format: {chat_id!r}",
+                retryable=False,
+            )
+        except KimiAuthError as exc:
+            # Send-path auth failure (token expired mid-session, revoked, etc.)
+            # — surface via runtime status so the gateway's per-platform
+            # circuit breaker (upstream commit 518f39557, May 2026) sees the
+            # platform as fatally broken and stops dispatching new sends
+            # against this adapter.  Symmetric with the connect-loop auth
+            # paths at _dm_ws_loop (≈L2269) and _group_subscribe_loop
+            # (≈L2680), which already call _set_fatal_error on permanent
+            # auth failure (rc==3).  Without this, the gateway would keep
+            # accepting send requests against a dead adapter — silent
+            # outage from the operator's perspective.
+            #
+            # retryable=True (not False) because a send-time auth failure
+            # is ambiguous: it might be a refreshable token expiry or a
+            # truly permanent revoke.  Let the reconnect machinery decide:
+            # the connect attempt either succeeds (transient was real) or
+            # hits the rc==3 path and re-fires _set_fatal_error with
+            # retryable=False for the permanent case.
+            logger.error(
+                "Kimi: send-time auth failure on %s — marking platform "
+                "fatal (retryable, reconnect will re-evaluate): %s",
+                chat_id, exc,
+            )
+            self._set_fatal_error(
+                "kimi_send_auth",
+                f"Kimi: send-time auth failure: {exc}",
+                retryable=True,
+            )
+            return SendResult(success=False, error=str(exc), retryable=False)
+        except asyncio.TimeoutError:
+            # Kimi.com server occasionally accepts a SendMessage POST internally
+            # but holds the HTTP response on that TCP connection, causing
+            # aiohttp.ClientTimeout(total=_RPC_TIMEOUT_S) to fire client-side at
+            # exactly 30 s.  Production capture 2026-05-17:  one SendMessage
+            # entered `_rpc_unary` at T+0 and never received RESPONSE_HEADERS,
+            # while a concurrent SendMessage on the same adapter / same session
+            # completed in 697 ms during the same window — proving the hang is
+            # per-connection, not per-pool.  The pre-timeout request is still
+            # processed server-side, so the previous policy of treating timeout
+            # as retryable delivered the message twice (user-visible duplicate).
+            # Mark non-retryable so the gateway does not double-send.  Genuine
+            # network failures still propagate as KimiTransientError below.
+            logger.warning(
+                "Kimi: SendMessage to %s timed out after %.1fs at the client; "
+                "kimi.com may still have accepted the message internally. "
+                "Marking non-retryable to avoid duplicate delivery.",
+                chat_id, _RPC_TIMEOUT_S,
+            )
+            return SendResult(
+                success=False,
+                error=(
+                    f"Kimi: send timed out after {_RPC_TIMEOUT_S:.0f}s "
+                    "(message may have been delivered server-side; not retrying)"
+                ),
+                retryable=False,
+            )
+        except KimiTransientError as exc:
+            return SendResult(success=False, error=str(exc), retryable=True)
+        except Exception as exc:
+            logger.exception("Kimi: send failed")
+            return SendResult(success=False, error=str(exc), retryable=False)
+
+    async def _is_dm_room(self, room_id: str) -> Optional[bool]:
+        """Classify a Kimi room as DM (2 members) or group (3+).
+
+        Returns:
+            ``True``  — 2 members (bot + 1 user); this is a 1:1 DM.
+            ``False`` — 3+ members; this is a group room.
+            ``None``  — classification failed (RPC error, etc.).  Callers
+                        must fall back to existing behaviour (treat as group).
+
+        Reads / populates ``self._rooms[room_id].members`` with the same 5
+        minute TTL as ``get_chat_info``.  First call per new room costs one
+        ``ListMembers`` RPC (≈50-200 ms over WAN to kimi.com); subsequent
+        calls are O(1) until TTL expiry.
+
+        Background: Kimi delivers 1:1 DMs as ``room:<uuid>`` indistinguishable
+        from group rooms at the wire envelope our adapter consumes — see the
+        v2.1.2 / v2.1.3 release notes for the original debugging episode that
+        produced the ``kimi_free_response_chats`` workaround.  This helper is
+        the v2.2.0 detector that lets us auto-bypass the mention gate for
+        rooms structurally identifiable as DMs without operator config.
+        """
+        cached = self._rooms.get(room_id)
+        if cached is not None and (time.time() - cached.last_refresh_ts) <= 300:
+            members = cached.members
+        else:
+            try:
+                members = await self.list_group_members(room_id)
+            except (KimiAdapterError, asyncio.TimeoutError) as exc:
+                logger.warning(
+                    "Kimi: DM-autodetect classification failed for %s — "
+                    "falling back to exempt-list behaviour: %s",
+                    room_id, exc,
+                )
+                return None
+            # Refresh the cache.  Preserve any existing name (separate RPC).
+            prior_name = cached.name if cached is not None else None
+            self._rooms[room_id] = _ChatInfoCache(
+                room_id=room_id,
+                name=prior_name,
+                members=members,
+                last_refresh_ts=time.time(),
+            )
+        n = len(members)
+        if n == 2:
+            return True
+        if n >= 3:
+            return False
+        # Degenerate (0 or 1 member) — shouldn't happen for a room that
+        # actually sent us a message.  Defensive: log + return None so the
+        # caller falls back to legacy behaviour rather than over-bypassing.
+        logger.warning(
+            "Kimi: room %s has %d members (expected ≥2) — cannot classify",
+            room_id, n,
+        )
+        return None
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        """Return ``{"name", "type", "chat_id", "members"?}``."""
+        if chat_id.startswith(_CHATID_DM_PREFIX):
+            return {
+                "chat_id": chat_id,
+                "name": "Kimi DM",
+                "type": "dm",
+            }
+        if chat_id.startswith(_CHATID_ROOM_PREFIX):
+            room_id = chat_id[len(_CHATID_ROOM_PREFIX):].split("/", 1)[0]
+            cached = self._rooms.get(room_id)
+            if cached is None or (time.time() - cached.last_refresh_ts) > 300:
+                try:
+                    room = await self.get_group(room_id)
+                    members = await self.list_group_members(room_id)
+                except KimiAdapterError:
+                    return {"chat_id": chat_id, "name": room_id, "type": "group"}
+                cached = _ChatInfoCache(
+                    room_id=room_id,
+                    name=room.get("name"),
+                    members=members,
+                    last_refresh_ts=time.time(),
+                )
+                self._rooms[room_id] = cached
+            return {
+                "chat_id": chat_id,
+                "name": cached.name or room_id,
+                "type": "group",
+                "members": cached.members,
+            }
+        return {"chat_id": chat_id, "name": chat_id, "type": "unknown"}
+
+    async def get_me(self) -> Dict[str, Any]:
+        """Return the current Kimi bot/user identity."""
+        return await self._rpc_unary("GetMe", {})
+
+    async def get_group(self, room_id: str) -> Dict[str, Any]:
+        """Return one Kimi room object using GetRoom."""
+        room_resp = await self._rpc_unary("GetRoom", {"roomId": room_id})
+        room = (
+            room_resp.get("room")
+            if isinstance(room_resp.get("room"), dict)
+            else room_resp
+        )
+        return room if isinstance(room, dict) else {}
+
+    async def list_group_members(
+        self,
+        room_id: str,
+        *,
+        page_size: int = 100,
+        max_pages: int = 5,
+    ) -> List[Dict[str, Any]]:
+        """Return room members using Kimi's ListMembers RPC."""
+        members: List[Dict[str, Any]] = []
+        page_token = ""
+        for _ in range(max_pages):
+            body: Dict[str, Any] = {
+                "roomId": room_id,
+                "pageSize": page_size,
+            }
+            if page_token:
+                body["pageToken"] = page_token
+            resp = await self._rpc_unary("ListMembers", body)
+            page_members = resp.get("members")
+            if isinstance(page_members, list):
+                members.extend(m for m in page_members if isinstance(m, dict))
+            page_token = str(resp.get("nextPageToken") or "")
+            if not page_token:
+                break
+        return members
+
+    async def list_group_messages(
+        self,
+        chat_id: str,
+        *,
+        limit: int = 20,
+        start_message_id: Optional[str] = None,
+        end_message_id: Optional[str] = None,
+        include_start_message: bool = True,
+        include_end_message: bool = True,
+        direction: str = "BACKWARD",
+        max_pages: int = 1,
+    ) -> List[Dict[str, Any]]:
+        """Return Kimi IM message wrappers for a group or thread chat.
+
+        Wraps ``kimi.gateway.im.v1.IMService.ListMessages`` (unary
+        Connect-RPC at ``https://www.kimi.com/api-ws/``).
+
+        ## Direction (anchor-relative)
+
+        - ``BACKWARD`` (default, wire enum value 2) — returns messages going
+          *older in time* from the anchor. With no ``startMessageId``, returns
+          the latest ``limit`` messages newest-first. With ``startMessageId``,
+          returns messages older than (or including, per
+          ``includeStartMessage``) that id. This is the "show me history" mode.
+          ``_fetch_group_message`` (below) relies on this.
+        - ``FORWARD`` — returns messages going *newer in time* from the
+          anchor (and including the anchor when ``includeStartMessage=True``).
+          Use this for catch-up / recovery patterns: pass the last message id
+          you saw to fetch what came after. **Probed live 2026-04-27** via
+          kimiim-cli: anchor of an oldest known id returned newer messages
+          (CreateTimes ascending forward in time) plus the anchor itself in
+          newest-first display order.
+
+        ## Pagination (max_pages)
+
+        The response carries ``nextPageToken``; echo it back as ``pageToken``
+        on the next request. Empty/missing token = end of stream. Tokens are
+        opaque server-issued cursors (NOT message ids — kimiim-cli treats
+        ``--start-id`` and ``--page-token`` as separate modes).
+
+        ``max_pages`` (default 1) caps the loop. Default keeps backward-
+        compatible single-page behaviour with every existing caller. Set
+        higher to recover gaps larger than ``limit`` messages; the cap
+        prevents runaway fetches if Kimi keeps issuing tokens.
+
+        Mirrors ``list_group_files`` (below) and ``list_group_members`` —
+        same ``pageToken`` round-trip pattern.
+
+        ## Wrapper schema (per item in returned list)
+
+        ::
+
+            {
+                "senderId": str,
+                "senderShortId": str,           # optional
+                "senderName": str,              # optional
+                "messageId": str,               # OPTIONAL at top level
+                "message": {                    # canonical Message object
+                    "id": str,                  # canonical message id lives HERE
+                    "blocks": [...],
+                    "threadId": str,            # optional
+                    ...
+                },
+            }
+
+        **Top-level ``messageId`` is sometimes absent** — the canonical id is
+        ``wrapper["message"]["id"]``. Use ``_field`` to walk both possibilities
+        safely (see ``_fetch_group_message`` for the precedent).
+
+        ## Edge cases
+
+        - Unknown ``chatId``: HTTP 400 → ``KimiRpcError``.
+        - Malformed/zero ``startMessageId``: HTTP 400 with body
+          ``"value does not match any of the specified id_kinds"`` (Kimi
+          validates against ``id_kind=uuidv8`` — confirms the production id
+          format). Treat as permanent error.
+        - Stale-but-shape-valid ``startMessageId``: behaviour unproven for
+          actual deleted/non-existent ids; recommend wrapping recovery calls
+          in ``try/except KimiRpcError`` and falling back to no-anchor.
+        - Empty room: returns ``[]`` after one RPC call.
+
+        Sources for the contract:
+        - kimiim-cli ``list-messages -h`` (definitive, since kimiim-cli is
+          Kimi's own binary for this RPC)
+        - mitm-captured request body for direction default
+        - existing wrapper consumers ``_fetch_group_message`` and the
+          hydration tests
+        """
+        if max_pages < 1:
+            raise ValueError(f"max_pages must be ≥ 1, got {max_pages!r}")
+        wrappers: List[Dict[str, Any]] = []
+        page_token = ""
+        for _ in range(max_pages):
+            body: Dict[str, Any] = {
+                "chatId": chat_id,
+                "pageSize": limit,
+                "direction": direction,
+                "includeStartMessage": include_start_message,
+                "includeEndMessage": include_end_message,
+            }
+            # ``pageToken`` and ``startMessageId``/``endMessageId`` are
+            # mutually-exclusive cursoring modes: on page 0 (no token yet)
+            # the anchors define the window; on page 1+ the server-issued
+            # ``pageToken`` encodes everything needed to continue.
+            # Echoing anchors alongside ``pageToken`` is what Kimi review
+            # #58 flagged as risking duplicate results / undefined ordering
+            # — and it's the precondition for ``_fetch_group_message``
+            # to safely raise ``max_pages`` above 1. Mirrors the conditional
+            # ``pageToken`` injection in ``list_group_files`` below.
+            if page_token:
+                body["pageToken"] = page_token
+            else:
+                if start_message_id:
+                    body["startMessageId"] = start_message_id
+                if end_message_id:
+                    body["endMessageId"] = end_message_id
+            resp = await self._rpc_unary("ListMessages", body)
+            messages = resp.get("messages")
+            if isinstance(messages, list):
+                wrappers.extend(m for m in messages if isinstance(m, dict))
+            page_token = str(resp.get("nextPageToken") or "")
+            if not page_token:
+                break
+        return wrappers
+
+    async def list_group_files(
+        self,
+        room_id: str,
+        *,
+        page_size: int = 100,
+        max_pages: int = 5,
+    ) -> List[Dict[str, Any]]:
+        """Return files shared in a Kimi room using ListRoomFiles."""
+        files: List[Dict[str, Any]] = []
+        page_token = ""
+        for _ in range(max_pages):
+            body: Dict[str, Any] = {"roomId": room_id, "pageSize": page_size}
+            if page_token:
+                body["pageToken"] = page_token
+            resp = await self._rpc_unary("ListRoomFiles", body)
+            page_files = resp.get("files")
+            if isinstance(page_files, list):
+                files.extend(f for f in page_files if isinstance(f, dict))
+            page_token = str(resp.get("nextPageToken") or "")
+            if not page_token:
+                break
+        return files
+
+    def format_message(self, content: str) -> str:
+        """Kimi renders markdown natively; pass through unchanged."""
+        return content
+
+    async def send_typing(
+        self, chat_id: str, metadata: Optional[Dict[str, Any]] = None
+    ) -> None:
+        """Kimi has no native typing indicator RPC. DMs already show a spinner
+        from the open ACP session/prompt; groups have no API surface. No-op."""
+        return None
+
+    async def send_image(
+        self,
+        chat_id: str,
+        image_url: str,
+        caption: Optional[str] = None,
+    ) -> SendResult:
+        """Send image URLs as Kimi resource-link blocks for groups.
+
+        Local images are handled by ``send_image_file`` through Kimi's upload
+        endpoint. DM image upload is not supported by Kimi's ACP chunk channel,
+        so DMs fall back to a text URL.
+        """
+        if chat_id.startswith(_CHATID_ROOM_PREFIX):
+            room_and_thread = chat_id[len(_CHATID_ROOM_PREFIX):]
+            room_id, thread_id = (
+                room_and_thread.split("/", 1)
+                if "/" in room_and_thread
+                else (room_and_thread, None)
+            )
+            return await self._send_group(
+                room_id,
+                caption or "",
+                reply_to=None,
+                thread_id=thread_id,
+                metadata={
+                    "attachments": [{
+                        "uri": image_url,
+                        "title": caption or image_url,
+                    }]
+                },
+            )
+        text = f"{caption}\n{image_url}" if caption else image_url
+        return await self.send(chat_id, text)
+
+    async def send_image_file(
+        self,
+        chat_id: str,
+        image_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        **kwargs: Any,
+    ) -> SendResult:
+        return await self._send_uploaded_file(
+            chat_id,
+            image_path,
+            caption=caption,
+            reply_to=reply_to,
+            metadata=kwargs.get("metadata"),
+        )
+
+    async def send_document(
+        self,
+        chat_id: str,
+        file_path: str,
+        caption: Optional[str] = None,
+        file_name: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        **kwargs: Any,
+    ) -> SendResult:
+        metadata = dict(kwargs.get("metadata") or {})
+        if file_name:
+            metadata["file_name"] = file_name
+        return await self._send_uploaded_file(
+            chat_id,
+            file_path,
+            caption=caption,
+            reply_to=reply_to,
+            metadata=metadata,
+        )
+
+    async def _send_uploaded_file(
+        self,
+        chat_id: str,
+        file_path: str,
+        *,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Upload a local file to Kimi and send it as a resource link."""
+        if not chat_id.startswith(_CHATID_ROOM_PREFIX):
+            return await self.send(
+                chat_id,
+                f"{caption + chr(10) if caption else ''}File: {file_path}",
+                reply_to=reply_to,
+                metadata=metadata,
+            )
+        try:
+            async with self._session_for_current_loop() as session:
+                uploaded = await _upload_kimi_files(
+                    session,
+                    paths=[file_path],
+                    bot_token=self._bot_token,
+                    upload_url=self._upload_url,
+                    timeout_s=self._file_timeout_s,
+                )
+        except KimiAuthError as exc:
+            return SendResult(success=False, error=str(exc), retryable=False)
+        except KimiTransientError as exc:
+            return SendResult(success=False, error=str(exc), retryable=True)
+        except Exception as exc:
+            return SendResult(success=False, error=str(exc), retryable=False)
+
+        if metadata and metadata.get("file_name") and uploaded:
+            uploaded[0]["name"] = metadata["file_name"]
+        room_and_thread = chat_id[len(_CHATID_ROOM_PREFIX):]
+        room_id, thread_id = (
+            room_and_thread.split("/", 1)
+            if "/" in room_and_thread
+            else (room_and_thread, None)
+        )
+        return await self._send_group(
+            room_id,
+            caption or "",
+            reply_to=reply_to,
+            thread_id=thread_id,
+            metadata={"attachments": uploaded},
+        )
+
+    # ──────────────────────────────────────────────────────────────────────
+    # DM WebSocket loop
+    # ──────────────────────────────────────────────────────────────────────
+
+    async def _log_dm_health_summary(self) -> None:
+        """One-shot observability tripwire for the DM ACP WS path.
+
+        After ``_dm_health_summary_s`` elapses since ``connect()``, log an
+        INFO summary of DM prompts processed. If the count is zero, log at
+        WARNING — Kimi may be routing what users call "DMs" through the
+        group Subscribe stream (we've seen this live) and the ACP WS path
+        is effectively dead weight that can be disabled via
+        ``config.extra.enable_dms = false``.
+
+        Cancellation-safe: if the adapter disconnects before the delay
+        elapses, the sleep raises ``CancelledError`` and we exit without
+        logging anything. No recurrence — this is a tripwire, not a
+        heartbeat.
+        """
+        try:
+            await asyncio.sleep(self._dm_health_summary_s)
+        except asyncio.CancelledError:
+            return
+        count = self._dm_prompt_count
+        if count > 0:
+            logger.info(
+                "Kimi DM: received %d prompts in first hour", count,
+            )
+        else:
+            logger.warning(
+                "Kimi DM: zero prompts in first hour since connect — Kimi "
+                "may be routing DMs via group Subscribe. Consider "
+                "config.extra.enable_dms: false to disable ACP path.",
+            )
+
+    async def _dm_ws_loop(self) -> None:
+        """Maintain the DM ACP WebSocket with exponential reconnect backoff."""
+        backoff = _RECONNECT_MIN_S
+        while not self._closing:
+            rc = await self._dm_ws_connect_once()
+            if self._closing or rc == 3:
+                # Permanent auth failure — surface it via runtime status so the
+                # gateway supervisor can stop retrying and alert the operator.
+                if rc == 3 and not self._closing:
+                    logger.error("Kimi DM: permanent auth failure, stopping loop")
+                    self._set_fatal_error(
+                        "kimi_dm_auth",
+                        "Kimi DM WebSocket permanent auth failure",
+                        retryable=False,
+                    )
+                return
+            if rc == 1:
+                # Other terminal error — stop trying but don't claim auth.
+                logger.error("Kimi DM: terminal error, stopping loop")
+                return
+            # rc == 0: transient — back off + retry.
+            logger.info("Kimi DM: reconnecting in %.1fs", backoff)
+            try:
+                await asyncio.sleep(backoff)
+            except asyncio.CancelledError:
+                return
+            backoff = min(backoff * 2, self._reconnect_max_s)
+
+    async def _dm_ws_connect_once(self) -> int:
+        """One WS connection attempt.
+
+        Return codes:
+          0 → transient (retry)
+          1 → other terminal error
+          3 → permanent auth failure (don't retry)
+        """
+        headers = self._ws_upgrade_headers()
+        logger.info("Kimi DM: dialing %s", self._dm_ws_url)
+        try:
+            async with websockets.connect(
+                self._dm_ws_url,
+                additional_headers=headers,
+                ping_interval=self._ws_ping_interval,
+                ping_timeout=self._ws_ping_timeout,
+                max_size=_WS_MAX_FRAME_SIZE,
+            ) as ws:
+                logger.info("Kimi DM: connected")
+                self._ws = ws
+                self._dm_fake_session_id = None
+                self._dm_observed_kimi_sid = None
+                self._dm_inflight.clear()
+                # Successful upgrade — clear any accumulated 409 cooldown strikes.
+                self._dm_409_strikes = 0
+                keepalive_task = asyncio.create_task(
+                    self._dm_app_keepalive(ws), name="kimi-dm-keepalive"
+                )
+                try:
+                    async for frame in ws:
+                        if isinstance(frame, bytes):
+                            logger.debug("Kimi DM: dropping %d-byte binary frame", len(frame))
+                            continue
+                        try:
+                            msg = json.loads(frame)
+                        except json.JSONDecodeError:
+                            logger.warning("Kimi DM: non-JSON frame: %.200r", frame)
+                            continue
+                        if isinstance(msg, dict):
+                            await self._dm_on_inbound_frame(msg)
+                finally:
+                    keepalive_task.cancel()
+                    try:
+                        await keepalive_task
+                    except asyncio.CancelledError:
+                        # Expected — we just cancelled the keepalive. Outer-scope
+                        # cancellation will propagate via the next await point.
+                        pass
+                    except Exception:
+                        logger.debug(
+                            "Kimi DM: keepalive task ended with exception",
+                            exc_info=True,
+                        )
+                    self._ws = None
+            return 0
+        except ConnectionClosed as exc:
+            code = getattr(exc, "code", None)
+            logger.info("Kimi DM: WS closed code=%s reason=%r", code, getattr(exc, "reason", None))
+            if code in _PERMANENT_WS_CODES:
+                return 3
+            return 0
+        except asyncio.CancelledError:
+            return 1
+        except Exception as exc:
+            status = (
+                getattr(exc, "status_code", None)
+                or getattr(getattr(exc, "response", None), "status_code", None)
+            )
+            if status == 401:
+                logger.error("Kimi DM: WS upgrade 401 — bot token rejected")
+                return 3
+            if status == 403:
+                logger.error("Kimi DM: WS upgrade 403 — bot forbidden")
+                return 3
+            if status == 409:
+                # "Bot already connected" — Kimi's single-WS-per-token constraint.
+                # Using the default 2s→60s exponential here produces reconnect
+                # thrash that Kimi's routing layer can interpret as misbehavior
+                # and silently throttle DM delivery to this bot for hours. Hard
+                # cooldown so any ghost WS on the server side ages out first.
+                self._dm_409_strikes += 1
+                cooldown = 60.0 if self._dm_409_strikes == 1 else 300.0
+                logger.warning(
+                    "Kimi DM: WS upgrade 409 (ghost WS, strike %d) — cooling "
+                    "off %.0fs before retry",
+                    self._dm_409_strikes, cooldown,
+                )
+                try:
+                    await asyncio.sleep(cooldown)
+                except asyncio.CancelledError:
+                    return 1
+                return 0
+            logger.warning("Kimi DM: connection error: %r", exc)
+            return 0
+
+    async def _dm_app_keepalive(self, ws: Any) -> None:
+        """Emit `$/ping` JSON-RPC notifications to prevent Kimi's 60s idle close.
+
+        Kimi's server idle-closes the WebSocket at ~60 seconds when no
+        application-level ACP frames flow; WS-protocol PING frames (handled
+        automatically by the `websockets` library) do NOT satisfy its
+        liveness check. This was confirmed by observing code=1006 closes at
+        exactly 60s post-connect during idle windows (no user messages, no
+        outbound session/update notifications).
+
+        `$/`-prefixed methods are the LSP / JSON-RPC convention for
+        implementation-specific notifications that peers MUST silently
+        ignore when unrecognized, so this is safe for any ACP-aware
+        counterparty.
+        """
+        try:
+            while True:
+                await asyncio.sleep(self._dm_app_keepalive_s)
+                try:
+                    await ws.send(json.dumps(
+                        {"jsonrpc": "2.0", "method": "$/ping", "params": {}},
+                        separators=(",", ":"),
+                    ))
+                    logger.debug("Kimi DM: $/ping keepalive sent")
+                except ConnectionClosed:
+                    return
+        except asyncio.CancelledError:
+            return
+
+    def _ws_upgrade_headers(self) -> Dict[str, str]:
+        """Build headers for the DM WS upgrade, including group-gate runtime metadata."""
+        return _runtime_headers(
+            bot_token=self._bot_token,
+            claw_version=self._claw_version,
+            openclaw_version=self._openclaw_version,
+            claw_id=self._claw_id,
+            openclaw_plugins=self._openclaw_plugins,
+            openclaw_skills=self._openclaw_skills,
+        )
+
+    async def _dm_on_inbound_frame(self, msg: Dict[str, Any]) -> None:
+        """Dispatch one ACP JSON-RPC frame from Kimi.
+
+        Kimi's client sends:
+          - ``initialize``          → respond with agent info
+          - ``session/new``         → respond with a synthetic sessionId
+          - ``session/prompt``      → convert to MessageEvent, dispatch
+          - ``session/cancel``      → cancel in-flight reply (best-effort)
+        """
+        method = msg.get("method")
+        req_id = msg.get("id")
+        params = msg.get("params") if isinstance(msg.get("params"), dict) else {}
+
+        # Observe Kimi's sessionId unconditionally — needed for outbound rewrites.
+        sid = params.get("sessionId") if isinstance(params, dict) else None
+        if isinstance(sid, str) and sid != self._dm_observed_kimi_sid:
+            self._dm_observed_kimi_sid = sid
+            logger.info("Kimi DM: observed sessionId=%s", sid)
+
+        if method == "initialize":
+            await self._dm_respond(req_id, {
+                "protocolVersion": 1,
+                "agentInfo": {"name": "hermes-agent", "version": "1.0"},
+            })
+            return
+
+        if method == "session/new":
+            self._dm_fake_session_id = str(uuid.uuid4())
+            await self._dm_respond(req_id, {"sessionId": self._dm_fake_session_id})
+            logger.info("Kimi DM: created synthetic session %s", self._dm_fake_session_id)
+            return
+
+        if method == "session/cancel":
+            logger.info("Kimi DM: session/cancel for sid=%s", sid)
+            await self._dm_cancel_session(sid if isinstance(sid, str) else None)
+            if req_id is not None:
+                await self._dm_respond(req_id, None)
+            return
+
+        if method == "session/prompt":
+            await self._dm_handle_prompt(msg)
+            return
+
+        # Unknown methods with ids: reply with method-not-found so the peer
+        # doesn't hang. Notifications (no id): silently ignore.
+        if req_id is not None:
+            await self._dm_respond_error(
+                req_id,
+                code=-32601,
+                message=f"method not found: {method}",
+            )
+        else:
+            logger.debug("Kimi DM: ignoring notification method=%s", method)
+
+    async def _dm_handle_prompt(self, msg: Dict[str, Any]) -> None:
+        """Convert a session/prompt into a MessageEvent and dispatch."""
+        req_id = msg.get("id")
+        params = msg.get("params") or {}
+        text_block = _first_text_block(params)
+        if text_block is None:
+            logger.warning("Kimi DM: session/prompt with no text block")
+            if req_id is not None:
+                await self._dm_respond(req_id, {"stopReason": "end_turn"})
+            return
+
+        text = text_block.get("text") if isinstance(text_block, dict) else ""
+        if not isinstance(text, str):
+            text = ""
+
+        # Apply user-message prefix unless it's a standalone slash command.
+        if (
+            not self._disable_prefix
+            and text
+            and not _is_standalone_slash_command(text)
+        ):
+            text = self._user_message_prefix + text
+
+        kimi_sid = self._dm_observed_kimi_sid or _DM_SESSION_SENTINEL
+        chat_id = f"{_CHATID_DM_PREFIX}{kimi_sid}"
+        message_id = str(req_id) if req_id is not None else f"dm-{uuid.uuid4().hex[:12]}"
+
+        # Queue req_id so overlapping prompts get FIFO end_turn responses
+        # instead of clobbering a previous in-flight (which would leave the
+        # original prompt's Kimi UI spinner hanging forever).
+        self._dm_inflight.setdefault(kimi_sid, deque()).append(
+            _DMInflight(kimi_sid=kimi_sid, req_id=req_id)
+        )
+
+        # Resolve a per-user identity. Kimi's ACP contract only carries
+        # sessionId + prompt on `params` by design; identity is implicit on
+        # 1:1 DMs. For group-routed-over-ACP messages kimi-claw injects a
+        # `[sender_short_id: X]` prefix into the prompt text, so we fall
+        # through to that surface before giving up and using a sid-derived id.
+        user_id, user_name = _extract_user_identity(params)
+        if not user_id:
+            short_id = _extract_short_id_from_text(text)
+            if short_id:
+                user_id = f"kimi:{short_id}"
+        if not user_id:
+            if not self._warned_dm_collapse:
+                logger.warning(
+                    "Kimi DM: session/prompt carries no user identity and "
+                    "prompt text has no [sender_short_id: X] prefix — this "
+                    "is expected for 1:1 DMs (single user). Multi-user "
+                    "bots reading this WS will collapse all users into "
+                    "one Hermes session; session state won't be isolated "
+                    "per user. See docs § Known limitations."
+                )
+                self._warned_dm_collapse = True
+            user_id = f"kimi:dm:{kimi_sid}"
+
+        event = self._build_message_event(
+            kind="dm",
+            text=text,
+            message_id=message_id,
+            chat_id=chat_id,
+            chat_name="Kimi DM",
+            user_id=user_id,
+            user_name=user_name,
+            raw=msg,
+        )
+        # Count before dispatch — semantically "the adapter processed one
+        # session/prompt frame from Kimi's WS". Not conditional on handler
+        # success; the signal we care about is Kimi-side routing behaviour.
+        self._dm_prompt_count += 1
+        await self.handle_message(event)
+
+    async def _dm_cancel_session(self, kimi_sid: Optional[str]) -> None:
+        """Cancel active Hermes processing for a Kimi DM ACP session."""
+        sid = kimi_sid or self._dm_observed_kimi_sid or _DM_SESSION_SENTINEL
+        chat_id = f"{_CHATID_DM_PREFIX}{sid}"
+        source = self.build_source(
+            chat_id=chat_id,
+            chat_name="Kimi DM",
+            chat_type="dm",
+            user_id=f"kimi:dm:{sid}",
+            user_name=None,
+        )
+        session_key = build_session_key(
+            source,
+            group_sessions_per_user=self._group_sessions_per_user,
+            thread_sessions_per_user=self._thread_sessions_per_user,
+        )
+        await self.cancel_session_processing(
+            session_key,
+            release_guard=True,
+            discard_pending=True,
+        )
+        self._dm_inflight.pop(sid, None)
+
+    async def _dm_respond(self, req_id: Any, result: Any) -> None:
+        """Send a JSON-RPC result back over the DM WS."""
+        if self._ws is None or req_id is None:
+            return
+        payload = {"jsonrpc": "2.0", "id": req_id, "result": result}
+        try:
+            await self._ws.send(json.dumps(payload, separators=(",", ":")))
+        except ConnectionClosed:
+            logger.info("Kimi DM: WS closed while sending response")
+
+    async def _dm_respond_error(self, req_id: Any, code: int, message: str) -> None:
+        if self._ws is None or req_id is None:
+            return
+        payload = {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "error": {"code": code, "message": message},
+        }
+        try:
+            await self._ws.send(json.dumps(payload, separators=(",", ":")))
+        except ConnectionClosed:
+            pass
+
+    async def _dm_emit_chunk(self, kimi_sid: str, text: str) -> None:
+        """Emit one ACP ``agent_message_chunk`` update over the WS."""
+        if self._ws is None:
+            return
+        payload = {
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": kimi_sid,
+                "update": {
+                    "sessionUpdate": "agent_message_chunk",
+                    "content": {"type": "text", "text": text},
+                },
+            },
+        }
+        try:
+            await self._ws.send(json.dumps(payload, separators=(",", ":")))
+        except ConnectionClosed:
+            logger.info("Kimi DM: WS closed while emitting chunk")
+
+    async def _send_dm(
+        self,
+        kimi_sid: str,
+        content: str,
+        reply_to: Optional[str],
+        metadata: Dict[str, Any],
+    ) -> SendResult:
+        """Emit streamed ``agent_message_chunk`` frames + end_turn response.
+
+        ``reply_to`` is not used on the DM channel (Kimi's ACP doesn't expose
+        reply-to semantics for DMs — the UI threads all responses to the
+        in-flight prompt). Ignored gracefully.
+        """
+        del reply_to, metadata  # unused on DM path
+        if self._ws is None:
+            return SendResult(success=False, error="Kimi DM: WS not connected", retryable=True)
+
+        chunks = _split_for_streaming(content, _DM_CHUNK_SIZE)
+        for chunk in chunks:
+            await self._dm_emit_chunk(kimi_sid, chunk)
+
+        # Pop the oldest in-flight prompt for this sid (FIFO) and close its
+        # round-trip via _close_dm_inflight (shared with send()'s short-
+        # circuit paths so tool_only / empty-content don't hang the spinner).
+        await self._close_dm_inflight(kimi_sid)
+
+        return SendResult(
+            success=True,
+            message_id=f"dm-{uuid.uuid4().hex[:12]}",
+        )
+
+    async def _close_dm_inflight(self, kimi_sid: str) -> None:
+        """Pop the oldest in-flight DM prompt and close its JSON-RPC round-trip.
+
+        Called both by ``_send_dm`` (after streaming the prose chunks) and by
+        ``send()``'s short-circuit paths (``output_mode='tool_only'`` and
+        empty-content). Without this in the short-circuits, the Kimi UI
+        spinner hangs waiting for ``end_turn`` until the next WS reconnect
+        clears ``_dm_inflight``.
+
+        Safe to call when no inflight prompt exists (no-op).
+        """
+        queue = self._dm_inflight.get(kimi_sid)
+        if not queue:
+            return
+        inflight = queue.popleft()
+        if not queue:
+            self._dm_inflight.pop(kimi_sid, None)
+        if inflight.req_id is not None:
+            await self._dm_respond(inflight.req_id, {"stopReason": "end_turn"})
+
+    # ──────────────────────────────────────────────────────────────────────
+    # Group Subscribe loop
+    # ──────────────────────────────────────────────────────────────────────
+
+    async def _group_subscribe_loop(self) -> None:
+        """Maintain the global ``Subscribe`` stream with reconnect backoff.
+
+        Backoff state lives on the adapter (``_group_subscribe_backoff``) so a
+        successful stream (first processed ``chatMessage`` frame post-connect)
+        can reset it. The reset is conditional on the current backoff already
+        exceeding the floor:
+
+        - Cold start (backoff == base == 2s) → no reset, no log.
+        - Grown state (e.g. 32s after churn) → clamps to floor (10s) and
+          emits ``"stream recovered after N.Ns backoff"`` once per cycle.
+
+        Only ``chatMessage`` events arm the hook — keepalive pings, typing,
+        and control events cannot reset backoff (a degraded stream emitting
+        only pings would otherwise thrash back to the floor every cycle).
+        The floor (10s) rather than the base (2s) stays oscillation-safe: a
+        flap-every-30s pattern would otherwise hammer Kimi's infra at
+        2→4→8→... on every cycle.
+        """
+        while not self._closing:
+            rc = await self._group_subscribe_once()
+            if self._closing or rc == 3:
+                if rc == 3 and not self._closing:
+                    logger.error("Kimi groups: permanent auth failure, stopping loop")
+                    self._set_fatal_error(
+                        "kimi_groups_auth",
+                        "Kimi Subscribe stream permanent auth failure",
+                        retryable=False,
+                    )
+                return
+            if rc == 1:
+                logger.error("Kimi groups: terminal error, stopping loop")
+                return
+            logger.info(
+                "Kimi groups: reconnecting in %.1fs", self._group_subscribe_backoff
+            )
+            try:
+                await asyncio.sleep(self._group_subscribe_backoff)
+            except asyncio.CancelledError:
+                return
+            self._group_subscribe_backoff = min(
+                self._group_subscribe_backoff * 2, self._reconnect_max_s
+            )
+
+    async def _group_subscribe_once(self) -> int:
+        """One Subscribe stream session.
+
+        Return codes match ``_dm_ws_connect_once``.
+        """
+        url = f"{self._base_url}/{_IM_SERVICE}/Subscribe"
+        headers = self._http_headers(streaming=True)
+        body = self._encode_envelope(b"{}")
+
+        try:
+            async with self._session_for_current_loop() as session, session.post(
+                url,
+                data=body,
+                headers=headers,
+                timeout=aiohttp.ClientTimeout(total=None, sock_read=None),
+            ) as resp:
+                if resp.status == 401 or resp.status == 403:
+                    logger.error("Kimi groups: Subscribe auth failure HTTP %s", resp.status)
+                    return 3
+                if resp.status != 200:
+                    logger.warning("Kimi groups: Subscribe HTTP %s", resp.status)
+                    return 0
+                # Fresh connection — arm the first-frame hook. Reset + log
+                # fire exactly once per reconnect cycle (see below).
+                self._group_subscribe_frame_since_connect = False
+                try:
+                    async for event in self._connect_envelope_parser(resp.content):
+                        # Classify BEFORE dispatch so ping/control/unsupported
+                        # events can't satisfy the first-frame hook.
+                        case, _ = _event_payload(event) if isinstance(event, dict) else (None, {})
+                        is_chat_message = case == "chatMessage"
+                        # Detect "first chatMessage of this cycle" BEFORE
+                        # dispatch so the gap-candidate log inside
+                        # ``_on_group_event`` reads the *correct* connect#
+                        # and ``last_reconnect_ts`` for in-line correlation.
+                        # Claude code-reviewer #58 + Codex challenge #58 both
+                        # flagged the prior post-dispatch ordering as an
+                        # off-by-one: gap log carrying ``connect#=N-1`` while
+                        # the subscribe-stream-live log emitted moments later
+                        # carried ``connect#=N`` for the same boundary
+                        # event — defeats the design goal of in-line
+                        # correlation without grepping two log streams.
+                        is_first_chat_post_connect = (
+                            is_chat_message
+                            and not self._group_subscribe_frame_since_connect
+                        )
+                        if is_first_chat_post_connect:
+                            # Counter + ts represent "stream received its
+                            # first non-control frame this cycle". That
+                            # fact is true even if the dispatch below
+                            # raises and the cycle ends — the subsequent
+                            # reconnect+first-frame produces another bump,
+                            # giving honest cycle counts. Frame gate flips
+                            # synchronously to prevent re-entry within the
+                            # same cycle if a second chatMessage arrives.
+                            self._group_subscribe_frame_since_connect = True
+                            self._group_subscribe_reconnect_count += 1
+                            self._group_subscribe_last_reconnect_ts = (
+                                time.monotonic()
+                            )
+                            prev_backoff = self._group_subscribe_backoff
+                        await self._on_group_event(event)
+                        # Subscribe-live log + backoff clamp run AFTER
+                        # dispatch. They gate on processing success
+                        # (a raise inside ``_on_group_event`` exits via
+                        # the except clauses below, skipping these). This
+                        # preserves the original semantic that operator-
+                        # facing "stream recovered" messages only fire on
+                        # genuine recovery — degraded streams emitting
+                        # only pings still won't reach this block because
+                        # the first-frame check above requires
+                        # ``is_chat_message``.
+                        if is_first_chat_post_connect:
+                            # Phase 0 burst-drop instrumentation: snapshot the
+                            # adapter's per-room state at the first chatMessage
+                            # post-connect. This is the candidate "Phase 1
+                            # recovery hook point" — operators reading
+                            # journalctl can correlate gap-candidate INFOs
+                            # against this line to see whether suspicious gaps
+                            # cluster around reconnects (favouring Phase 1
+                            # recovery design) or appear mid-stream (favouring
+                            # Phase 2 / 3). The counter is monotonic over the
+                            # adapter lifetime; a sudden cluster of increments
+                            # is itself signal.
+                            logger.info(
+                                "Kimi groups: subscribe stream live "
+                                "(connect#%d, rooms_tracked=%d, prev_backoff=%.1fs)",
+                                self._group_subscribe_reconnect_count,
+                                len(self._last_message_id_per_room),
+                                prev_backoff,
+                            )
+                            # Conditional reset: only clamp to the floor when
+                            # backoff actually grew beyond it. Cold start
+                            # (backoff=base=2s) stays at 2s with no spurious
+                            # "stream recovered" log on every process boot.
+                            # Grown state (e.g. 32s) clamps to floor (10s) —
+                            # never below, to stay oscillation-safe.
+                            if prev_backoff > self._group_subscribe_backoff_floor:
+                                self._group_subscribe_backoff = (
+                                    self._group_subscribe_backoff_floor
+                                )
+                                logger.info(
+                                    "Kimi groups: stream recovered after %.1fs backoff",
+                                    prev_backoff,
+                                )
+                except KimiAuthError as exc:
+                    logger.error("Kimi groups: %s", exc)
+                    return 3
+                except (KimiTransientError, KimiProtocolError, KimiRpcError) as exc:
+                    logger.warning("Kimi groups: stream error: %s", exc)
+                    return 0
+            return 0
+        except asyncio.CancelledError:
+            return 1
+        except aiohttp.ClientError as exc:
+            logger.warning("Kimi groups: HTTP client error: %r", exc)
+            return 0
+        except Exception:
+            logger.exception("Kimi groups: unexpected error in Subscribe")
+            return 0
+
+    def _is_mention_of_me(self, msg: Dict[str, Any]) -> bool:
+        """Check whether a ChatMessage event explicitly @-mentions this bot.
+
+        Reads the `mentions` array and `mentioned` field, matching against
+        self._me_id and self._me_short_id. Pure function — no side effects.
+
+        NOTE: `group_allow_bot_senders="mentions"` is EXPERIMENTAL. Kimi's
+        mention metadata may be client-provided rather than server-enriched
+        (unverified as of this commit). Until verified via probe, a malicious
+        sender could spoof mentions to bypass this gate. For production
+        authorization, prefer `trusted_only` with an explicit
+        `group_trusted_senders` allowlist.
+        """
+        if bool(_field(msg, "mentioned")):
+            return True
+        mentions = msg.get("mentions") or []
+        if not isinstance(mentions, list):
+            return False
+        for m in mentions:
+            if not isinstance(m, dict):
+                continue
+            for key in ("short_id", "shortId"):
+                v = m.get(key)
+                if v and self._me_short_id and str(v) == self._me_short_id:
+                    return True
+            v = m.get("id")
+            if v and self._me_id and str(v) == self._me_id:
+                return True
+        return False
+
+    async def _on_group_event(self, event: Dict[str, Any]) -> None:
+        """Handle one decoded envelope from the Subscribe firehose.
+
+        Events observed from kimi-claw:
+          - ``{"ping": {}}`` — keepalive, ignored
+          - ``{"chatMessage": {...}}`` — protobuf JSON oneof
+          - ``{"payload": {"case": "chatMessage", "value": {...}}}`` —
+            generated JS shape used by kimi-claw internals
+
+        ChatMessage fields are normalized across protobuf JSON names and older
+        local fixtures:
+          ``{
+            "chatId":        "<room-uuid>",
+            "messageId":     "<uuid>",
+            "status":        "STATUS_COMPLETED",
+            "senderId":      "<uuid>"?,
+            "senderShortId": "<short>"?,
+            "summary":       "...",
+            "blocks":        [{"text": {"content": "..."}}]?
+          }``
+
+        We tolerate schema drift — missing fields just drop details silently.
+        """
+        if not isinstance(event, dict):
+            return
+        case, msg = _event_payload(event)
+        if case == "ping":
+            logger.debug("Kimi groups: keepalive ping")
+            return
+        if case in ("reconnect", "typing"):
+            logger.debug("Kimi groups: ignoring %s event", case)
+            return
+        if case != "chatMessage" or not msg:
+            logger.info("Kimi groups: unsupported event shape, skipping: %.200r", event)
+            return
+
+        if not _chat_message_is_complete(_field(msg, "status")):
+            logger.info(
+                "Kimi groups: skipping incomplete chatMessage status=%r",
+                _field(msg, "status"),
+            )
+            return
+
+        chat_id = _field(msg, "chatId", "chat_id")
+        message_id = _field(msg, "messageId", "message_id")
+        if not (chat_id and message_id):
+            logger.info("Kimi groups: event missing chat_id/message_id, skipping: %.200r", msg)
+            return
+
+        # Probe (H-C): per-room message_id timing for post-hoc correlation
+        # against conductor wall-clock. Updated BEFORE the filter chain so
+        # self-drops, trust drops, and dedup still count as "what Kimi sent
+        # us" — burst drops would show up as gaps in this trace.
+        # Observability only — removable standalone.
+        #
+        # Tracker update is hoisted OUT of the DEBUG gate: if DEBUG is off at
+        # process start and toggled on later, we must not falsely report
+        # `first-seen` on the first post-toggle message (real bug fix).
+        room_key = str(chat_id)
+        this_id_str = str(message_id)
+        prev_id = self._last_message_id_per_room.get(room_key)
+        self._last_message_id_per_room[room_key] = this_id_str
+
+        # Phase 0 burst-drop instrumentation: track MONOTONIC arrival time
+        # per room, not the ULID-embedded timestamp. Two reasons: (1) Kimi's
+        # production message ids are UUID v8 with a non-standard epoch (their
+        # first 48 bits aren't unix-ms — captured deltas show ~16× the
+        # wall-clock interval), so id-derived deltas are nonsense in
+        # production. (2) ``time.monotonic()`` is the right primitive for
+        # "how long since last delivery": it never goes backward, never
+        # jumps on NTP sync or VM suspend/resume, and is immune to leap-
+        # second adjustments. Codex review #1 + Kimi review #2 (#58)
+        # independently flagged ``time.time()``-based deltas as a false-
+        # positive risk under clock skew. The log line's own leading ISO
+        # timestamp gives operators wall-clock correlation; the embedded
+        # delta is honestly "process-time since last delivery".
+        now_mono_s = time.monotonic()
+        prev_arrival = self._last_arrival_time_per_room.get(room_key)
+        self._last_arrival_time_per_room[room_key] = now_mono_s
+
+        arrival_delta_s: Optional[float] = None
+        if prev_arrival is not None:
+            arrival_delta_s = now_mono_s - prev_arrival
+            if (
+                self._burst_drop_gap_log_threshold_s > 0
+                and arrival_delta_s >= self._burst_drop_gap_log_threshold_s
+            ):
+                # Include since-last-reconnect so operators can correlate gap
+                # candidates against reconnect events without grepping two
+                # log streams. ``-1.0`` sentinel = "no reconnect observed
+                # yet this process" (cold start before first chatMessage).
+                # Both timestamps are monotonic so the subtraction is safe.
+                if self._group_subscribe_last_reconnect_ts > 0:
+                    since_reconnect_s = (
+                        now_mono_s - self._group_subscribe_last_reconnect_ts
+                    )
+                    correlation = f"since_reconnect_s={since_reconnect_s:.1f}"
+                else:
+                    correlation = "since_reconnect_s=N/A"
+                logger.info(
+                    "Kimi groups: gap candidate room=%s id=%s prev=%s "
+                    "delta_s=%.1f (>=%.1fs threshold) %s connect#=%d",
+                    chat_id, message_id, prev_id, arrival_delta_s,
+                    self._burst_drop_gap_log_threshold_s,
+                    correlation,
+                    self._group_subscribe_reconnect_count,
+                )
+
+        # Probe-3 DEBUG path uses ULID-decoded magnitudes for backward
+        # compatibility with the existing test fixtures. In production these
+        # consistently return None because Kimi sends UUIDs, so the DEBUG
+        # log path falls through to "first-seen" — that's expected and
+        # not the gap-candidate signal anyway.
+        if logger.isEnabledFor(logging.DEBUG):
+            # Sample-rate gate: only count + conditionally emit inside DEBUG,
+            # so INFO and above pay nothing for the per-room counter dict
+            # either.
+            count = self._probe_msg_id_room_counts.get(room_key, 0) + 1
+            self._probe_msg_id_room_counts[room_key] = count
+            if count % self._probe_msg_id_sample_rate == 0:
+                this_ts = _ulid_time_ms(this_id_str)
+                prev_ts = _ulid_time_ms(prev_id) if prev_id else None
+                if this_ts is not None and prev_ts is not None:
+                    legacy_delta_ms = this_ts - prev_ts
+                    logger.debug(
+                        "Kimi groups: message_id timing room=%s id=%s prev=%s delta_ms=%d",
+                        chat_id, message_id, prev_id, legacy_delta_ms,
+                    )
+                else:
+                    logger.debug(
+                        "Kimi groups: message_id first-seen room=%s id=%s",
+                        chat_id, message_id,
+                    )
+
+        sender = msg.get("sender") or {}
+        sender_id = (
+            sender.get("id") if isinstance(sender, dict) else None
+        ) or _field(msg, "senderId", "sender_id")
+        sender_short_id = (
+            sender.get("short_id") if isinstance(sender, dict) else None
+        ) or (
+            sender.get("shortId") if isinstance(sender, dict) else None
+        ) or _field(msg, "senderShortId", "sender_short_id")
+        sender_name = (
+            sender.get("name") if isinstance(sender, dict) else None
+        ) or _field(msg, "senderName", "sender_name")
+
+        # Self-message filter.
+        if sender_id and self._me_id and sender_id == self._me_id:
+            return
+        if sender_short_id and self._me_short_id and sender_short_id == self._me_short_id:
+            return
+
+        # Startup grace — ignore events older than startup_ts - grace.
+        sent_at = _field(msg, "sentAt", "sent_at", "createTime", "create_time")
+        if sent_at:
+            event_ts = _parse_iso8601(sent_at)
+            if event_ts and event_ts < (self._startup_ts - self._startup_grace_s):
+                logger.info(
+                    "Kimi groups: skipping stale event %s (sent_at=%s)",
+                    message_id,
+                    sent_at,
+                )
+                return
+
+        block_text, media_urls, media_types = _extract_blocks_payload(msg)
+        message_role = _field(msg, "role", "messageRole", "message_role")
+
+        # Resolve text in three stages:
+        #   1. inline body (blocks → text field) from the Subscribe event
+        #   2. hydration if inline body is empty (Subscribe sometimes ships
+        #      preview-only events for long messages — empty blocks/text and
+        #      a truncated `summary`)
+        #   3. summary as a last-resort fallback for graceful degradation
+        #
+        # H-B fix (2026-04-26): the prior fallback chain
+        #     text = block_text or text_field or summary or ""
+        # treated `summary` as equivalent to inline body, so a truthy
+        # 50-char preview bypassed the `if not text` hydration gate and
+        # the agent only ever saw the truncated server-side preview.
+        # We now gate hydration on inline body being empty regardless of
+        # summary, and only fall through to summary if hydration is
+        # unavailable or fails. Production confirmation: Probe 2 log at
+        # 2026-04-26 11:21:36 BST showed
+        #   blocks=0, text=0, summary=50, chose=summary, miss_candidate=none
+        # for a ~150-char inbound message, with the agent answering against
+        # the 50-char preview rather than the full body.
+        text_field = _field(msg, "text") or ""
+        if not isinstance(text_field, str):
+            text_field = ""
+        summary_field = _field(msg, "summary") or ""
+        if not isinstance(summary_field, str):
+            summary_field = ""
+        inline_text = block_text or text_field
+        text = inline_text
+
+        hydrated: Optional[Dict[str, Any]] = None
+        # `hydration_state` drives Probe 2's `hydrated=` field. Five values
+        # so operators can distinguish operationally distinct states when
+        # debugging "why didn't hydration fire / what did it produce":
+        #   skipped:inline   — inline body present, hydration not needed
+        #   skipped:disabled — _hydrate_missing_text=False (operator policy)
+        #   true             — hydration ran AND populated text non-empty
+        #   false            — hydration ran but raised, returned empty,
+        #                      or returned a payload that yielded no text
+        #
+        # `text_from_hydration` is the authoritative "did hydration provide
+        # the chosen text?" flag — Probe 2 uses it instead of string-equality
+        # against summary, so a hydrated body that happens to equal the
+        # summary preview verbatim is still correctly labeled `chose=hydrated`.
+        text_from_hydration = False
+        if inline_text:
+            hydration_state = "skipped:inline"
+        elif not self._hydrate_missing_text:
+            hydration_state = "skipped:disabled"
+        else:
+            hydration_state = "false"
+            try:
+                hydrated = await self._fetch_group_message(str(chat_id), str(message_id))
+            except KimiAdapterError as exc:
+                logger.debug(
+                    "Kimi groups: failed to hydrate message %s/%s: %s",
+                    chat_id,
+                    message_id,
+                    exc,
+                )
+            else:
+                if hydrated:
+                    hydrated_text, hydrated_urls, hydrated_types = _extract_blocks_payload(
+                        hydrated
+                    )
+                    new_text = hydrated_text or _field(hydrated, "text") or ""
+                    if new_text:
+                        text = new_text
+                        text_from_hydration = True
+                        hydration_state = "true"
+                    # else: hydrated payload was truthy but yielded no text
+                    # (e.g. wrapper-only). Keep hydration_state="false" so
+                    # Probe 2 doesn't claim a hydration win on an empty
+                    # payload (Codex MINOR #2 — Fix E).
+                    media_urls.extend(url for url in hydrated_urls if url not in media_urls)
+                    media_types.extend(hydrated_types)
+                    sender_id = sender_id or _field(hydrated, "senderId", "sender_id")
+                    sender_short_id = sender_short_id or _field(
+                        hydrated, "senderShortId", "sender_short_id"
+                    )
+                    sender_name = sender_name or _field(
+                        hydrated, "senderName", "sender_name"
+                    )
+                    message_role = message_role or _field(
+                        hydrated, "role", "messageRole", "message_role"
+                    )
+
+        # Final fallback: hydration unavailable, failed, or returned an
+        # empty body → use summary as better-than-nothing so the agent
+        # at least sees SOMETHING. Without this, a degraded Kimi backend
+        # would silently drop messages we could have shown a preview of.
+        # Annotate so the agent knows the body is truncated and can
+        # acknowledge rather than confidently answer against half a
+        # sentence (Fix B — same H-B failure mode as the original bug,
+        # just less frequent).
+        if not text and summary_field:
+            text = (
+                "[message truncated — full text unavailable, "
+                "preview only]\n"
+                + summary_field
+            )
+
+        # Probe (H-B): which source populated `text`, candidate lengths,
+        # and whether hydration ran. Logged after the full resolution
+        # cascade so the chosen source reflects the final outcome
+        # (blocks / text / hydrated / summary / none).
+        #
+        # `miss_candidate` flags non-chosen *raw-event* candidates whose
+        # length exceeds the chosen one — the precise hydration-miss
+        # signature. After the H-B fix this should never report
+        # `chose=summary, miss_candidate=none` for a long inbound; if it
+        # does, hydration was disabled or failed silently.
+        if logger.isEnabledFor(logging.DEBUG):
+            # Order matters: hydration check before block/text comparisons
+            # would mislabel a hydrated body that equals the inline candidate
+            # verbatim. Inline candidates win when they actually populated
+            # the chosen text (text_from_hydration is False in that case).
+            if text_from_hydration:
+                chosen = "hydrated"
+            elif block_text and text == block_text:
+                chosen = "blocks"
+            elif text_field and text == text_field:
+                chosen = "text"
+            elif summary_field and summary_field in (text or ""):
+                # Fix B prepends a truncation marker, so `text` is no
+                # longer == summary_field — use containment.
+                chosen = "summary"
+            else:
+                chosen = "none"
+            candidate_lens = {
+                "blocks": len(block_text or ""),
+                "text": len(text_field),
+                "summary": len(summary_field),
+            }
+            # Length oracle covers raw-event candidates only; `hydrated`
+            # is reported via the `hydrated=` field rather than length
+            # (the hydrated payload may itself be a wrapper of arbitrary
+            # shape and isn't directly comparable to inline candidates).
+            if chosen in candidate_lens:
+                chosen_len = candidate_lens[chosen]
+            else:
+                # `hydrated` or `none` — compare misses against the chosen
+                # text's length so a longer inline candidate still flags.
+                chosen_len = len(text or "")
+            miss_candidates = [
+                name for name, length in candidate_lens.items()
+                if name != chosen and length > chosen_len
+            ]
+            miss_str = ",".join(miss_candidates) if miss_candidates else "none"
+            logger.debug(
+                "Kimi groups: text source for %s/%s — blocks=%d, text=%d, summary=%d, chose=%s, hydrated=%s, miss_candidate=%s",
+                chat_id, message_id,
+                candidate_lens["blocks"], candidate_lens["text"],
+                candidate_lens["summary"], chosen, hydration_state, miss_str,
+            )
+
+        if sender_id and self._me_id and sender_id == self._me_id:
+            return
+        if sender_short_id and self._me_short_id and sender_short_id == self._me_short_id:
+            return
+
+        # Trusted-sender allowlist — authoritative bypass of role filter
+        is_trusted = False
+        if sender_short_id and sender_short_id in self._group_trusted_senders:
+            is_trusted = True
+        elif sender_id and sender_id in self._group_trusted_senders:
+            is_trusted = True
+
+        # Role filter — gated by allow_bot_senders policy
+        if not is_trusted and not _chat_message_is_user_role(message_role):
+            policy = self._group_allow_bot_senders
+            if policy == "off":
+                logger.info(
+                    "Kimi groups: dropping non-user message %s/%s role=%r (group_allow_bot_senders=off)",
+                    chat_id, message_id, message_role,
+                )
+                return
+            elif policy == "trusted_only":
+                # INFO with redacted sender: operators need a grep-able
+                # signal that messages are being dropped (e.g. after
+                # forgetting to add a new teammate to group_trusted_senders).
+                # Full short_ids at INFO would leak hundreds of user
+                # identifiers into log aggregators in a kimi-claw group
+                # where every user message has role='assistant', so we
+                # redact to prefix + 4 chars. Full identifiers are still
+                # available at DEBUG via the raw event dumps.
+                logger.info(
+                    "Kimi groups: dropping non-user message %s/%s role=%r sender=%s (not in group_trusted_senders)",
+                    chat_id, message_id, message_role,
+                    _redact_sender(sender_short_id or sender_id),
+                )
+                return
+            elif policy == "mentions":
+                if not self._is_mention_of_me(msg):
+                    logger.info(
+                        "Kimi groups: dropping non-user message %s/%s role=%r (group_allow_bot_senders=mentions, no @mention of us)",
+                        chat_id, message_id, message_role,
+                    )
+                    return
+                # falls through
+            elif policy == "all":
+                pass  # falls through
+
+        if not text and not media_urls:
+            logger.debug(
+                "Kimi groups: message %s/%s has no dispatchable content",
+                chat_id,
+                message_id,
+            )
+            return
+
+        # Dedup (chat_id, message_id) after hydration/content checks. If a
+        # lightweight event fails hydration, a later replay can still deliver
+        # the full message instead of being suppressed as already processed.
+        if self._dedup_is_duplicate("group", str(chat_id), str(message_id)):
+            return
+
+        thread_id = _field(msg, "threadId", "thread_id")
+        if not thread_id and hydrated:
+            thread_id = _field(hydrated, "threadId", "thread_id")
+        reply_to = msg.get("reply_to") or msg.get("replyTo") or {}
+        reply_to_message_id = reply_to.get("message_id") if isinstance(reply_to, dict) else None
+        reply_to_text = reply_to.get("text") if isinstance(reply_to, dict) else None
+
+        attachments = msg.get("attachments") or []
+        for att in attachments if isinstance(attachments, list) else []:
+            if not isinstance(att, dict):
+                continue
+            url = att.get("url")
+            if url:
+                media_urls.append(url)
+                media_types.append(att.get("type", "file"))
+
+        if media_urls:
+            media_urls, media_types = await self._resolve_kimi_file_media(
+                media_urls,
+                media_types,
+                message_id=str(message_id),
+            )
+
+        # Mention gate: if configured to require mentions and the message
+        # doesn't reference us, ignore.  Supports both numeric id and
+        # short_id.  Rooms in ``kimi_free_response_chats`` bypass this —
+        # historically used for two purposes:
+        #
+        #   1. Working around DM misdetection (Kimi delivers 1:1 DMs as
+        #      ``room:<uuid>`` indistinguishable from groups at the wire
+        #      envelope we consume).  v2.2.0 introduces the
+        #      ``kimi_dm_autodetect`` flag which auto-bypasses 2-member
+        #      rooms via ``_is_dm_room`` — operators no longer need to
+        #      list DM UUIDs manually when the flag is on.
+        #   2. Explicit operator policy ("this small trusted group room
+        #      should be free-response despite the global mention gate").
+        #      NOT auto-detectable; remains served by
+        #      ``kimi_free_response_chats``.
+        #
+        # The detector is the LAST bypass chance — only consulted if the
+        # other checks already decided to drop.  This preserves the fast
+        # path: messages headed to dispatch never incur the detector RPC,
+        # only messages about to be silenced.
+        if (
+            self._group_require_mention
+            and chat_id not in self._group_require_mention_exempt_rooms
+            and not self._is_mention_of_me(msg)
+        ):
+            if self._kimi_dm_autodetect:
+                is_dm = await self._is_dm_room(chat_id)
+                if is_dm is True:
+                    logger.debug(
+                        "Kimi groups: auto-detected DM, bypassing mention "
+                        "gate for %s/%s",
+                        chat_id, message_id,
+                    )
+                    # Fall through to dispatch.
+                else:
+                    # is_dm is False (group) or None (classification failed
+                    # — fail closed and let the legacy gate fire).
+                    logger.info(
+                        "Kimi groups: dropping message %s/%s "
+                        "(group_require_mention=true, no @mention, "
+                        "auto-detect=%s)",
+                        chat_id, message_id,
+                        "group" if is_dm is False else "unknown",
+                    )
+                    return
+            else:
+                logger.info(
+                    "Kimi groups: dropping message %s/%s "
+                    "(group_require_mention=true, no @mention of us)",
+                    chat_id, message_id,
+                )
+                return
+
+        # Preserve thread identity in the dispatched chat_id so the gateway's
+        # session routing keeps distinct threads inside one Kimi room in
+        # separate Hermes sessions. Without this, every thread in a busy room
+        # collapses to the same session key and threads crosstalk.
+        if thread_id:
+            chat_id_prefixed = f"{_CHATID_ROOM_PREFIX}{chat_id}/{thread_id}"
+        else:
+            chat_id_prefixed = f"{_CHATID_ROOM_PREFIX}{chat_id}"
+
+        event_obj = self._build_message_event(
+            kind="group",
+            text=str(text),
+            message_id=str(message_id),
+            chat_id=chat_id_prefixed,
+            chat_name=None,  # populated lazily via get_chat_info if needed
+            user_id=sender_id or (f"kimi:{sender_short_id}" if sender_short_id else None),
+            user_name=sender_name or sender_short_id,
+            thread_id=thread_id,
+            reply_to_message_id=reply_to_message_id,
+            reply_to_text=reply_to_text,
+            media_urls=media_urls,
+            media_types=media_types,
+            raw=msg,
+        )
+        await self.handle_message(event_obj)
+
+    async def _fetch_group_message(
+        self,
+        chat_id: str,
+        message_id: str,
+    ) -> Optional[Dict[str, Any]]:
+        """Fetch a full message wrapper when Subscribe only carries a summary.
+
+        Sets ``max_pages=2`` so that if Kimi paginates around a tight
+        ``start=end=message_id`` window (Codex impl #4 in #18), we still
+        find the message rather than silently returning ``None``. Safe
+        because ``list_group_messages`` no longer echoes the anchor on
+        follow-up pages (Kimi review #58 fix above) — page 1 follows the
+        opaque cursor only, so the second request has the same effective
+        scope without anchor/cursor ambiguity.
+        """
+        wrappers = await self.list_group_messages(
+            chat_id,
+            limit=20,
+            start_message_id=message_id,
+            end_message_id=message_id,
+            include_start_message=True,
+            include_end_message=True,
+            max_pages=2,
+        )
+        for wrapper in wrappers:
+            message = wrapper.get("message") if isinstance(wrapper.get("message"), dict) else {}
+            candidate_id = (
+                _field(message, "id", "messageId", "message_id")
+                or _field(wrapper, "messageId", "message_id")
+            )
+            if str(candidate_id) != str(message_id):
+                continue
+            merged = dict(message)
+            for source_key, target_key in (
+                ("senderId", "senderId"),
+                ("sender_id", "senderId"),
+                ("senderShortId", "senderShortId"),
+                ("sender_short_id", "senderShortId"),
+                ("senderName", "senderName"),
+                ("sender_name", "senderName"),
+            ):
+                value = wrapper.get(source_key)
+                if value is not None and target_key not in merged:
+                    merged[target_key] = value
+            return merged
+        return None
+
+    async def _resolve_kimi_file_media(
+        self,
+        media_urls: List[str],
+        media_types: List[str],
+        *,
+        message_id: str,
+    ) -> Tuple[List[str], List[str]]:
+        resolved_urls: List[str] = []
+        resolved_types: List[str] = []
+        for idx, uri in enumerate(media_urls):
+            media_type = media_types[idx] if idx < len(media_types) else ""
+            if isinstance(uri, str) and uri.startswith("kimi-file://"):
+                resolved = await self._resolve_kimi_file_uri(uri, message_id=message_id)
+                if resolved:
+                    resolved_urls.append(resolved["localPath"])
+                    resolved_types.append(
+                        resolved.get("contentType") or media_type or "application/octet-stream"
+                    )
+                    continue
+            resolved_urls.append(uri)
+            resolved_types.append(media_type)
+        return resolved_urls, resolved_types
+
+    async def _resolve_kimi_file_uri(
+        self,
+        uri: str,
+        *,
+        message_id: str,
+    ) -> Optional[Dict[str, Any]]:
+        file_id = _parse_kimi_file_id(uri)
+        if not file_id:
+            logger.warning("Kimi groups: invalid kimi-file URI in message %s: %s", message_id, uri)
+            return None
+
+        self._file_download_dir.mkdir(parents=True, exist_ok=True)
+        existing = self._find_cached_kimi_file(file_id)
+        if existing:
+            return existing
+        metadata_url = _file_metadata_endpoint(self._kimiapi_host, file_id)
+        try:
+            async with self._session_for_current_loop() as session, session.get(
+                metadata_url,
+                headers={"X-Kimi-Bot-Token": self._bot_token, "Accept": "application/json"},
+                timeout=aiohttp.ClientTimeout(total=self._file_timeout_s),
+            ) as resp:
+                raw = await resp.read()
+                if resp.status in (401, 403):
+                    raise KimiAuthError(f"kimi-file metadata auth failed HTTP {resp.status}")
+                if resp.status >= 400:
+                    logger.warning(
+                        "Kimi groups: kimi-file metadata failed file_id=%s HTTP %s",
+                        file_id,
+                        resp.status,
+                    )
+                    return None
+                metadata = json.loads(raw.decode("utf-8")) if raw else {}
+        except Exception as exc:
+            logger.warning("Kimi groups: kimi-file metadata failed file_id=%s: %s", file_id, exc)
+            return None
+
+        if not isinstance(metadata, dict):
+            return None
+        meta = metadata.get("meta") if isinstance(metadata.get("meta"), dict) else {}
+        name = str(_field(meta, "name") or file_id)
+        content_type = str(_field(meta, "contentType", "content_type") or "application/octet-stream")
+        blob = metadata.get("blob") if isinstance(metadata.get("blob"), dict) else {}
+        download_url = _field(blob, "signUrl", "sign_url") or self._preview_download_url(metadata)
+        if not isinstance(download_url, str) or not download_url:
+            logger.warning("Kimi groups: kimi-file metadata has no download URL file_id=%s", file_id)
+            return None
+
+        local_name = f"{file_id}_{_sanitize_kimi_file_name(name)}"
+        local_path = self._file_download_dir / local_name
+        try:
+            async with self._session_for_current_loop() as session, session.get(
+                download_url,
+                timeout=aiohttp.ClientTimeout(total=self._file_timeout_s),
+            ) as resp:
+                data = await resp.read()
+                if resp.status >= 400 or not data:
+                    logger.warning(
+                        "Kimi groups: kimi-file download failed file_id=%s HTTP %s",
+                        file_id,
+                        resp.status,
+                    )
+                    return None
+            local_path.write_bytes(data)
+        except Exception as exc:
+            logger.warning("Kimi groups: kimi-file download failed file_id=%s: %s", file_id, exc)
+            return None
+
+        return {
+            "fileId": file_id,
+            "name": name,
+            "contentType": content_type,
+            "localPath": str(local_path),
+        }
+
+    def _find_cached_kimi_file(self, file_id: str) -> Optional[Dict[str, Any]]:
+        prefix = f"{file_id}_"
+        try:
+            candidates = sorted(self._file_download_dir.iterdir(), key=lambda p: p.name)
+        except OSError:
+            return None
+        for path in candidates:
+            if path.is_file() and path.name.startswith(prefix) and path.stat().st_size > 0:
+                return {
+                    "fileId": file_id,
+                    "name": path.name[len(prefix):],
+                    "contentType": _infer_mime_type(str(path)),
+                    "localPath": str(path),
+                }
+        return None
+
+    def _preview_download_url(self, metadata: Dict[str, Any]) -> Optional[str]:
+        parse_job = metadata.get("parseJob") or metadata.get("parse_job")
+        if not isinstance(parse_job, dict):
+            return None
+        result = parse_job.get("result")
+        image = result.get("image") if isinstance(result, dict) else None
+        thumbnail = image.get("thumbnail") if isinstance(image, dict) else None
+        if isinstance(thumbnail, dict):
+            url = _field(thumbnail, "previewUrl", "preview_url")
+            return url if isinstance(url, str) else None
+        return None
+
+    async def _send_group(
+        self,
+        room_id: str,
+        content: str,
+        reply_to: Optional[str],
+        thread_id: Optional[str],
+        metadata: Dict[str, Any],
+    ) -> SendResult:
+        """POST unary ``SendMessage`` with text + optional attachments.
+
+        Kimi Claw v0.25.0's ``SendMessageRequest`` wire protocol exposes only
+        ``chatId`` and ``blocks``. Two caller-visible affordances therefore
+        don't round-trip today:
+
+        - ``thread_id`` (either from ``room:<uuid>/<tid>`` or
+          ``metadata["thread_id"]``): collapses to the underlying room. The
+          reply shows up at the room level instead of in the intended thread.
+        - ``metadata["mentions"]``: ignored. The call falls through to the
+          plain-text block, which means Kimi renders ``@u_foo`` as ordinary
+          characters rather than a mention pill — no notification, and
+          mention-gated bots won't see the reply.
+
+        Both were previously silently dropped. They now emit a one-shot
+        WARNING so operators can see the gap. Explicit wire support for
+        either will be added here when the Kimi Claw surface script confirms
+        the field shapes (thread_id on ``SendMessageRequest``; a mention
+        block variant alongside ``text`` / ``resourceLink``).
+        """
+        del reply_to  # SendMessageRequest has no reply-to field on the wire.
+        if thread_id and not self._warned_outbound_thread_drop:
+            logger.warning(
+                "Kimi groups: outbound thread_id=%r on room=%r is not "
+                "representable on SendMessageRequest (Kimi Claw v0.25.0 — "
+                "chatId + blocks only). Reply will target the underlying "
+                "room, not the thread. Further drops suppressed.",
+                thread_id, room_id,
+            )
+            self._warned_outbound_thread_drop = True
+
+        mentions = metadata.get("mentions") if metadata else None
+        if isinstance(mentions, list) and mentions and not self._warned_outbound_mentions_drop:
+            logger.warning(
+                "Kimi groups: metadata.mentions=%r on room=%r falls through "
+                "to plain text — Kimi Claw v0.25.0's block protobuf has no "
+                "confirmed mention variant yet. Reply renders @short_id as "
+                "text, producing no mention pill and no push notification. "
+                "Further drops suppressed.",
+                mentions, room_id,
+            )
+            self._warned_outbound_mentions_drop = True
+
+        blocks: List[Dict[str, Any]] = []
+        if content:
+            blocks.append(_build_text_block(content))
+        if metadata and "attachments" in metadata:
+            for attachment in metadata["attachments"]:
+                if not isinstance(attachment, dict):
+                    continue
+                uri = _field(attachment, "uri", "url", "downloadUrl", "download_url")
+                if isinstance(uri, str) and uri:
+                    blocks.append(_build_resource_link_block(attachment))
+
+        if not blocks:
+            return SendResult(
+                success=False,
+                error="Kimi: SendMessage requires text or attachments",
+                retryable=False,
+            )
+
+        body: Dict[str, Any] = {"chatId": room_id, "blocks": blocks}
+        resp = await self._rpc_unary("SendMessage", body)
+        return SendResult(
+            success=True,
+            message_id=resp.get("message_id") or resp.get("messageId"),
+            raw_response=resp,
+        )
+
+    # ──────────────────────────────────────────────────────────────────────
+    # Connect RPC — unary + envelope streaming
+    # ──────────────────────────────────────────────────────────────────────
+
+    async def _rpc_unary(
+        self,
+        method: str,
+        body: Dict[str, Any],
+        *,
+        timeout_s: float = _RPC_TIMEOUT_S,
+    ) -> Dict[str, Any]:
+        """POST ``/api-ws/{service}/{method}`` with JSON body, return response.
+
+        Raises:
+            KimiAuthError     on HTTP 401/403.
+            KimiTransientError on HTTP 429/5xx/network errors.
+            KimiRpcError      on other 4xx with JSON error body.
+        """
+        url = f"{self._base_url}/{_IM_SERVICE}/{method}"
+        headers = self._http_headers(streaming=False)
+        try:
+            async with self._session_for_current_loop() as session, session.post(
+                url,
+                data=json.dumps(body).encode("utf-8"),
+                headers=headers,
+                timeout=aiohttp.ClientTimeout(total=timeout_s),
+            ) as resp:
+                raw = await resp.read()
+                if resp.status in (401, 403):
+                    raise KimiAuthError(
+                        f"{method}: auth failed (HTTP {resp.status}): {raw[:200]!r}"
+                    )
+                if resp.status == 429 or 500 <= resp.status < 600:
+                    raise KimiTransientError(
+                        f"{method}: HTTP {resp.status}: {raw[:200]!r}"
+                    )
+                if resp.status >= 400:
+                    err_msg = raw.decode("utf-8", errors="replace")[:500]
+                    raise KimiRpcError(f"{method}: HTTP {resp.status}: {err_msg}")
+                try:
+                    return json.loads(raw.decode("utf-8")) if raw else {}
+                except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+                    raise KimiProtocolError(
+                        f"{method}: invalid JSON response: {exc}"
+                    )
+        except aiohttp.ClientError as exc:
+            raise KimiTransientError(f"{method}: network error: {exc}")
+
+    def _http_headers(self, *, streaming: bool) -> Dict[str, str]:
+        """Shared HTTP headers for all Connect RPCs."""
+        headers = {
+            "Content-Type": (
+                "application/connect+json" if streaming else "application/json"
+            ),
+            "Connect-Protocol-Version": "1",
+            "Accept-Encoding": "identity",
+            "User-Agent": "hermes-kimi-adapter/1.0",
+        }
+        if streaming:
+            headers["Accept"] = "application/connect+json"
+        headers.update(_runtime_headers(
+            bot_token=self._bot_token,
+            claw_version=self._claw_version,
+            openclaw_version=self._openclaw_version,
+            claw_id=self._claw_id,
+            openclaw_plugins=self._openclaw_plugins,
+            openclaw_skills=self._openclaw_skills,
+        ))
+        return headers
+
+    def _encode_envelope(self, payload: bytes, *, end_stream: bool = False) -> bytes:
+        """Encode one outbound Connect envelope: ``[flag:1B][len:4B BE][body]``."""
+        flag = _CONNECT_FLAG_END_STREAM if end_stream else 0
+        return bytes([flag]) + struct.pack(">I", len(payload)) + payload
+
+    async def _connect_envelope_parser(
+        self,
+        reader: Any,  # aiohttp.StreamReader
+    ) -> AsyncIterator[Dict[str, Any]]:
+        """Yield JSON dicts from a chunked Connect streaming body.
+
+        Handles:
+          - partial envelopes (readexactly blocks correctly)
+          - compressed flag bit (rejected — we negotiate uncompressed)
+          - end-stream frame with optional ``error`` payload (raises appropriate
+            KimiAuthError / KimiRpcError, or returns cleanly)
+        """
+        while True:
+            try:
+                header = await reader.readexactly(5)
+            except asyncio.IncompleteReadError:
+                # Stream closed mid-envelope — treat as transient.
+                raise KimiTransientError("Subscribe stream closed mid-envelope")
+            except aiohttp.ClientPayloadError as exc:
+                raise KimiTransientError(f"Subscribe payload error: {exc}")
+
+            flag = header[0]
+            length = struct.unpack(">I", header[1:5])[0]
+            # Defensive cap: the length prefix is 4 bytes big-endian (up to
+            # 4 GB). An unbounded readexactly here would OOM on a hostile or
+            # buggy upstream. Mirror the WS max-frame cap.
+            if length > _WS_MAX_FRAME_SIZE:
+                raise KimiProtocolError(
+                    f"envelope length {length} exceeds max frame size "
+                    f"{_WS_MAX_FRAME_SIZE}"
+                )
+            payload = b""
+            if length:
+                try:
+                    payload = await reader.readexactly(length)
+                except asyncio.IncompleteReadError:
+                    raise KimiTransientError("Subscribe truncated envelope body")
+                except aiohttp.ClientPayloadError as exc:
+                    raise KimiTransientError(f"Subscribe payload error: {exc}")
+
+            if flag & _CONNECT_FLAG_COMPRESSED:
+                raise KimiProtocolError("Kimi sent compressed frame (unsupported)")
+
+            try:
+                msg = json.loads(payload.decode("utf-8")) if payload else {}
+            except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+                raise KimiProtocolError(f"malformed envelope JSON: {exc}")
+
+            if flag & _CONNECT_FLAG_END_STREAM:
+                err = msg.get("error") if isinstance(msg, dict) else None
+                if err:
+                    code = err.get("code", "unknown")
+                    message = err.get("message") or err.get("details") or ""
+                    if code in ("unauthenticated", "permission_denied"):
+                        raise KimiAuthError(f"{code}: {message}")
+                    raise KimiRpcError(f"{code}: {message}")
+                return  # clean end-of-stream
+
+            if isinstance(msg, dict):
+                yield msg
+
+    # ──────────────────────────────────────────────────────────────────────
+    # MessageEvent synthesis + dedup
+    # ──────────────────────────────────────────────────────────────────────
+
+    def _build_message_event(
+        self,
+        *,
+        kind: str,  # "dm" | "group"
+        text: str,
+        message_id: str,
+        chat_id: str,
+        chat_name: Optional[str],
+        user_id: Optional[str],
+        user_name: Optional[str],
+        thread_id: Optional[str] = None,
+        reply_to_message_id: Optional[str] = None,
+        reply_to_text: Optional[str] = None,
+        media_urls: Optional[List[str]] = None,
+        media_types: Optional[List[str]] = None,
+        raw: Any = None,
+    ) -> MessageEvent:
+        msg_type = MessageType.TEXT
+        if text.strip().startswith("/"):
+            msg_type = MessageType.COMMAND
+        if media_urls:
+            # Best-effort mapping from MIME prefix to MessageType.
+            first = (media_types or [""])[0].lower()
+            if first.startswith("image"):
+                msg_type = MessageType.PHOTO
+            elif first.startswith("video"):
+                msg_type = MessageType.VIDEO
+            elif first.startswith("audio"):
+                msg_type = MessageType.AUDIO
+            else:
+                msg_type = MessageType.DOCUMENT
+
+        return MessageEvent(
+            text=text,
+            message_type=msg_type,
+            source=self.build_source(
+                chat_id=chat_id,
+                chat_name=chat_name,
+                chat_type=("dm" if kind == "dm" else "group"),
+                user_id=user_id,
+                user_name=user_name,
+                thread_id=thread_id,
+            ),
+            raw_message=raw,
+            message_id=message_id,
+            media_urls=list(media_urls or []),
+            media_types=list(media_types or []),
+            reply_to_message_id=reply_to_message_id,
+            reply_to_text=reply_to_text,
+            auto_skill=self._auto_skill,
+            channel_prompt=self._channel_prompt,
+            internal=False,
+        )
+
+    def _dedup_is_duplicate(self, kind: str, chat_id: str, message_id: str) -> bool:
+        key = (f"{kind}:{chat_id}", str(message_id))
+        if key in self._processed_set:
+            return True
+        # Evict oldest when full.
+        if len(self._processed) >= self._processed.maxlen:
+            old = self._processed[0]
+            self._processed_set.discard(old)
+        self._processed.append(key)
+        self._processed_set.add(key)
+        return False
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Module helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _parse_iso8601(text: str) -> Optional[float]:
+    """Parse an ISO-8601 timestamp to unix-seconds, or None on failure."""
+    if not isinstance(text, str) or not text:
+        return None
+    try:
+        from datetime import datetime
+        # Normalize 'Z' suffix to +00:00 for fromisoformat.
+        if text.endswith("Z"):
+            text = text[:-1] + "+00:00"
+        return datetime.fromisoformat(text).timestamp()
+    except Exception:
+        return None
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Standalone send helper (for send_message_tool / cron paths outside gateway)
+# ──────────────────────────────────────────────────────────────────────────────
+
+async def send_kimi_message(
+    config: PlatformConfig,
+    chat_id: str,
+    text: str,
+    *,
+    thread_id: Optional[str] = None,
+    media_paths: Optional[List[str]] = None,
+) -> SendResult:
+    """Send a message via Kimi without instantiating the full adapter.
+
+    Used by cron delivery and ``send_message_tool`` when a live gateway
+    adapter isn't available. Supports only group rooms (``room:<id>``) for
+    now — DM sends require an active WS session.
+    """
+    if not chat_id.startswith(_CHATID_ROOM_PREFIX):
+        return SendResult(
+            success=False,
+            error="Kimi: standalone send supports only group rooms",
+            retryable=False,
+        )
+    # Mirror the ``__init__`` chain so the standalone send path (used by
+    # cron delivery and ``send_message_tool`` when no live adapter exists)
+    # resolves ``${KIMI_BOT_TOKEN}`` literals the same way the live adapter
+    # does. Without this, a config.yaml of the form
+    # ``platforms.kimi.token: ${KIMI_BOT_TOKEN}`` would 401 silently on
+    # cron-driven kimi deliveries while the live bot path worked fine.
+    token = (
+        _resolve_env_template(config.token)
+        or _resolve_env_template(config.extra.get("bot_token", ""))
+        or os.getenv("KIMI_BOT_TOKEN", "")
+    )
+    if not token:
+        return SendResult(success=False, error="Kimi: no bot_token configured", retryable=False)
+    base_url = config.extra.get("base_url", _DEFAULT_BASE_URL).rstrip("/")
+    kimiapi_host = config.extra.get(
+        "kimiapi_host",
+        config.extra.get("kimiapiHost", _DEFAULT_KIMIAPI_HOST),
+    )
+    upload_url = config.extra.get("upload_url", _upload_endpoint(kimiapi_host))
+    file_timeout_s = float(config.extra.get("file_timeout_s", _FILE_UPLOAD_TIMEOUT_S_DEFAULT))
+    room_and_thread = chat_id[len(_CHATID_ROOM_PREFIX):]
+    if "/" in room_and_thread:
+        room_id, inline_thread = room_and_thread.split("/", 1)
+    else:
+        room_id, inline_thread = room_and_thread, None
+    effective_thread = thread_id or inline_thread
+    if effective_thread:
+        logger.warning(
+            "Kimi groups: standalone send_kimi_message thread_id=%r on "
+            "room=%r is not representable on SendMessageRequest (Kimi "
+            "Claw v0.25.0 — chatId + blocks only). Reply will target the "
+            "underlying room, not the thread.",
+            effective_thread, room_id,
+        )
+    media_paths = list(media_paths or [])
+    blocks: List[Dict[str, Any]] = []
+    if text:
+        blocks.append(_build_text_block(text))
+    url = f"{base_url}/{_IM_SERVICE}/SendMessage"
+    headers = {
+        "Content-Type": "application/json",
+        "Connect-Protocol-Version": "1",
+        "User-Agent": "hermes-kimi-adapter/1.0",
+    }
+    headers.update(_runtime_headers(
+        bot_token=token,
+        claw_version=config.extra.get("claw_version", _GROUP_GATE_DEFAULTS["claw_version"]),
+        openclaw_version=config.extra.get(
+            "openclaw_version", _GROUP_GATE_DEFAULTS["openclaw_version"]
+        ),
+        claw_id=config.extra.get("claw_id"),
+        openclaw_plugins=config.extra.get(
+            "openclaw_plugins", _GROUP_GATE_DEFAULTS["openclaw_plugins"]
+        ),
+        openclaw_skills=config.extra.get(
+            "openclaw_skills", _GROUP_GATE_DEFAULTS["openclaw_skills"]
+        ),
+    ))
+    try:
+        # trust_env=True: see KimiAdapter.connect() for rationale.
+        async with aiohttp.ClientSession(trust_env=True) as session:
+            if media_paths:
+                uploaded = await _upload_kimi_files(
+                    session,
+                    paths=media_paths,
+                    bot_token=token,
+                    upload_url=upload_url,
+                    timeout_s=file_timeout_s,
+                )
+                blocks.extend(_build_resource_link_block(item) for item in uploaded)
+            if not blocks:
+                return SendResult(
+                    success=False,
+                    error="Kimi: SendMessage requires text or attachments",
+                    retryable=False,
+                )
+            body: Dict[str, Any] = {"chatId": room_id, "blocks": blocks}
+            async with session.post(
+                url,
+                data=json.dumps(body).encode("utf-8"),
+                headers=headers,
+                timeout=aiohttp.ClientTimeout(total=_RPC_TIMEOUT_S),
+            ) as resp:
+                raw = await resp.read()
+                if resp.status == 401 or resp.status == 403:
+                    return SendResult(
+                        success=False,
+                        error=f"auth failed HTTP {resp.status}",
+                        retryable=False,
+                    )
+                if resp.status >= 400:
+                    return SendResult(
+                        success=False,
+                        error=f"HTTP {resp.status}: {raw[:200]!r}",
+                        retryable=(resp.status >= 500 or resp.status == 429),
+                    )
+                try:
+                    data = json.loads(raw.decode("utf-8")) if raw else {}
+                except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+                    return SendResult(success=False, error=f"bad JSON: {exc}", retryable=False)
+                return SendResult(
+                    success=True,
+                    message_id=data.get("message_id") or data.get("messageId"),
+                    raw_response=data,
+                )
+    except asyncio.TimeoutError:
+        # Mirrors the live-adapter v2.1.4 fix at line ~1807.  Standalone path
+        # also hits the kimi.com response-hang phenomenon (per-connection
+        # server-side response held past 30s while concurrent requests succeed
+        # in <1s).  Without this clause, bare asyncio.TimeoutError propagates
+        # uncaught through _standalone_send and any retry layer above can
+        # double-deliver — the same duplicate-send bug v2.1.4 fixed for the
+        # live arm.  Return retryable=False so cron / send_message_tool don't
+        # re-POST the same body.
+        logger.warning(
+            "Kimi: standalone SendMessage to %s timed out after %.1fs at the client; "
+            "kimi.com may still have accepted the message internally. "
+            "Marking non-retryable to avoid duplicate delivery.",
+            chat_id, _RPC_TIMEOUT_S,
+        )
+        return SendResult(
+            success=False,
+            error=(
+                f"Kimi: send timed out after {_RPC_TIMEOUT_S:.0f}s "
+                "(message may have been delivered server-side; not retrying)"
+            ),
+            retryable=False,
+        )
+    except aiohttp.ClientError as exc:
+        return SendResult(success=False, error=f"network error: {exc}", retryable=True)
+    except KimiAuthError as exc:
+        # Upload path raised: token revoked / expired. Mirror live
+        # _send_uploaded_file mapping (line ~2302) — non-retryable.
+        return SendResult(success=False, error=str(exc), retryable=False)
+    except KimiTransientError as exc:
+        # Upload path raised: 429 / 5xx from the upload endpoint.
+        return SendResult(success=False, error=str(exc), retryable=True)
+    except (KimiRpcError, KimiProtocolError) as exc:
+        # Upload path raised: 4xx from upload, or malformed response.
+        return SendResult(success=False, error=str(exc), retryable=False)
+
+
+async def _standalone_send(
+    pconfig: PlatformConfig,
+    chat_id: str,
+    message: str,
+    *,
+    thread_id: Optional[str] = None,
+    media_files: Optional[list] = None,
+    force_document: bool = False,
+) -> Dict[str, Any]:
+    """Registry wrapper for out-of-process ``send_message_tool`` / cron sends."""
+    _ = force_document  # Kimi has no document-vs-native attachment split.
+    # ``send_message_tool`` runs ``filter_media_delivery_paths()``, which yields
+    # ``(path, is_voice)`` tuples, before invoking ``standalone_sender_fn``.
+    # Normalize to bare paths; KimiClaw uploads every attachment generically and
+    # has no voice-note concept, so the flag is dropped (mirrors the discord
+    # adapter's ``for media_path, _is_voice in media_files``).
+    media_paths = [media_path for media_path, _is_voice in (media_files or [])]
+    result = await send_kimi_message(
+        pconfig,
+        chat_id,
+        message,
+        thread_id=thread_id,
+        media_paths=media_paths,
+    )
+    if result.success:
+        payload: Dict[str, Any] = {"success": True}
+        if result.message_id:
+            payload["message_id"] = result.message_id
+        return payload
+    return {
+        "error": result.error or "Kimi standalone send failed",
+        "retryable": result.retryable,
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Plugin registration helpers (upstream ctx.register_platform API)
+# Pattern reference: upstream plugins/platforms/simplex/adapter.py
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def validate_config(config: PlatformConfig) -> bool:
+    """Return True if a Kimi bot token is reachable.
+
+    Mirrors the three sources the adapter ``__init__`` consults
+    (see :class:`KimiAdapter`): env var ``KIMI_BOT_TOKEN``,
+    ``PlatformConfig.token``, or ``PlatformConfig.extra["bot_token"]``.
+    The registry calls this once during gateway setup-status display
+    and again before adapter instantiation; permissive on purpose so
+    env-only setups validate when the YAML/extra path is empty.
+
+    ``${VAR}`` template strings on ``token`` / ``extra["bot_token"]`` are
+    resolved against the environment before the truthiness check, so a
+    YAML entry like ``token: ${KIMI_BOT_TOKEN}`` with the env var unset
+    is reported as not-configured rather than as a false-positive truthy
+    literal that would later 401 at ``connect()``.
+    """
+    if os.getenv("KIMI_BOT_TOKEN"):
+        return True
+    if _resolve_env_template(getattr(config, "token", None)).strip():
+        return True
+    extra = getattr(config, "extra", {}) or {}
+    return bool(_resolve_env_template(extra.get("bot_token")).strip())
+
+
+def is_connected(config: PlatformConfig) -> bool:
+    """Return True if Kimi is configured (token present).
+
+    Used by GatewayConfig.get_connected_platforms() and the setup UI.
+    """
+    return validate_config(config)
+
+
+def _env_enablement() -> Optional[Dict[str, Any]]:
+    """Read KIMI_* env vars, return a PlatformConfig.extra seed dict.
+
+    Called during gateway startup BEFORE the adapter is constructed. Returning
+    a non-None dict marks Kimi as 'env-configured' in `hermes gateway status`
+    even when the adapter has not yet been instantiated.
+    """
+    token = os.getenv("KIMI_BOT_TOKEN")
+    if not token:
+        return None
+    extra: Dict[str, Any] = {"bot_token": token}
+    home = os.getenv("KIMI_HOME_CHANNEL")
+    if home:
+        extra["home_channel"] = {
+            "chat_id": home,
+            "name": os.getenv("KIMI_HOME_CHANNEL_NAME", "Home"),
+        }
+    return extra
+
+
+def _apply_yaml_config(
+    yaml_cfg: Dict[str, Any], platform_cfg: Dict[str, Any]
+) -> Optional[Dict[str, Any]]:
+    """Translate top-level ``kimiclaw:`` config.yaml keys into ``KIMI_*`` env vars.
+
+    Env precedence is preserved via ``not os.getenv(...)`` guards — if the env
+    var is already set (e.g. from ~/.hermes/.env), the YAML value is ignored.
+    Lets Mimi-style profile configs put a top-level ``kimiclaw:`` block (the
+    registered platform name; ``load_gateway_config()`` dispatches this hook
+    via ``yaml_cfg.get(entry.name)``) directly in their profile ``config.yaml``
+    instead of needing a per-profile .env.
+
+    Called from ``gateway.config.load_gateway_config()`` after the generic
+    shared-key loop and before ``_apply_env_overrides``. Returns ``None`` —
+    we mutate env directly so the rest of the gateway sees the values
+    through the standard env-var path.
+    """
+    if not isinstance(platform_cfg, dict):
+        return None
+    _yaml_to_env = {
+        "bot_token": "KIMI_BOT_TOKEN",
+        "home_channel": "KIMI_HOME_CHANNEL",
+        "allowed_users": "KIMI_ALLOWED_USERS",
+        "allow_all_users": "KIMI_ALLOW_ALL_USERS",
+    }
+    for yaml_key, env_key in _yaml_to_env.items():
+        if yaml_key not in platform_cfg or os.getenv(env_key):
+            continue
+        value = platform_cfg[yaml_key]
+        if isinstance(value, list):
+            value = ",".join(str(item) for item in value)
+        os.environ[env_key] = str(value)
+    return None
+
+
+def interactive_setup() -> None:
+    """Minimal stdin wizard for ``hermes gateway setup`` → Kimi.
+
+    Prompts for the bot token and optional allowlist / home channel. Writes
+    via ``hermes_cli.config`` so the values land in ``~/.hermes/.env``.
+    """
+    print()
+    print("Kimi platform setup")
+    print("-------------------")
+    print("Requirements:")
+    print("  1. A Kimi bot token (km_b_prod_*) — generate via kimi.com")
+    print("     'Link existing OpenClaw' flow.")
+    print("  2. Python packages: websockets, aiohttp (installed via the")
+    print("     hermes-agent[messaging] extra; the bundled kimiclaw plugin")
+    print("     declares websockets there).")
+    print()
+
+    try:
+        from hermes_cli.config import get_env_value, save_env_value
+    except ImportError:
+        print(
+            "hermes_cli.config not available; set KIMI_* vars manually in "
+            "~/.hermes/.env"
+        )
+        return
+
+    def _prompt(var: str, prompt_text: str, *, secret: bool = False) -> None:
+        existing = get_env_value(var) if callable(get_env_value) else None
+        suffix = " [keep current]" if existing else ""
+        try:
+            if secret:
+                import getpass
+                value = getpass.getpass(f"{prompt_text}{suffix}: ")
+            else:
+                value = input(f"{prompt_text}{suffix}: ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return
+        if value:
+            save_env_value(var, value)
+
+    _prompt("KIMI_BOT_TOKEN", "Kimi bot token (km_b_prod_*)", secret=True)
+    _prompt(
+        "KIMI_ALLOWED_USERS",
+        "Allowed user UUIDs (comma-separated; blank=skip)",
+    )
+    _prompt(
+        "KIMI_HOME_CHANNEL",
+        "Home channel for cron delivery (room:<uuid>; DM cron not supported)",
+    )
+    print("Done. Restart `hermes gateway` to apply.")
+
+
+# Inlined here rather than as a class attribute because the prompt builder
+# reads it via the registry, not from KimiAdapter directly.
+_PLATFORM_HINT = (
+    "You are chatting on Kimi (kimi.com / Moonshot AI). "
+    "Users may be on the kimi.com web app or mobile. "
+    "Direct messages arrive over a Zed ACP WebSocket — one sentinel session "
+    "per user with sessionId ``im:kimi:main``. Group rooms arrive with "
+    "chat_id ``room:<uuid>`` over a separate Connect RPC stream. User "
+    "identities are opaque UUIDs (``km_u_*``); display names may be absent. "
+    "Kimi supports standard markdown formatting. Be concise in group rooms; "
+    "verbose responses are fine in DMs."
+)
+
+_INSTALL_HINT = (
+    "Requires hermes-agent with the platform-registry API (commit 2e20f6ae2 "
+    "'plugin platform parity', merged ~Apr 11 2026). "
+    "Run: `uv tool upgrade 'hermes-agent[messaging]'` (or `pip install --upgrade "
+    "'hermes-agent[messaging]'`) — the `[messaging]` extra provides "
+    "`websockets` (DM ACP socket) and `aiohttp` (group-room Connect RPC stream)."
+)
+
+
+def register(ctx) -> None:
+    """Plugin entry point — called by the Hermes plugin system at startup.
+
+    Uses the upstream ``ctx.register_platform()`` API introduced by Teknium's
+    ``2e20f6ae2`` "plugin platform parity" commit. All canonical Kimi wiring
+    (env-var loading, auth env-maps, prompt hint, cron delivery, display)
+    that previously lived as in-tree patches on the fork branches now lives
+    as parameters on this single call.
+    """
+    ctx.register_platform(
+        name="kimiclaw",
+        label="KimiClaw",
+        adapter_factory=lambda cfg: KimiAdapter(cfg),
+        check_fn=_check_for_registry,
+        validate_config=validate_config,
+        is_connected=is_connected,
+        required_env=["KIMI_BOT_TOKEN"],
+        install_hint=_INSTALL_HINT,
+        setup_fn=interactive_setup,
+        # Env-driven auto-configuration: seeds PlatformConfig.extra so
+        # env-only setups appear in `hermes gateway status` without
+        # needing to instantiate the adapter.
+        env_enablement_fn=_env_enablement,
+        # YAML→env bridge for profile configs (e.g. Mimi) that prefer
+        # a top-level `kimiclaw:` block in config.yaml over per-profile
+        # .env. The block key matches the registered platform name
+        # (``entry.name``); see ``_apply_yaml_config`` for details.
+        apply_yaml_config_fn=_apply_yaml_config,
+        # Cron home-channel delivery — `deliver=kimi` cron jobs route to
+        # KIMI_HOME_CHANNEL when set.
+        cron_deliver_env_var="KIMI_HOME_CHANNEL",
+        # Out-of-process cron / send_message delivery for group rooms.
+        standalone_sender_fn=_standalone_send,
+        # Auth env vars for _is_user_authorized() integration.
+        allowed_users_env="KIMI_ALLOWED_USERS",
+        allow_all_env="KIMI_ALLOW_ALL_USERS",
+        # Kimi has no hard message-length cap; we chunk for readability.
+        max_message_length=MAX_MESSAGE_LENGTH,
+        # Display.
+        emoji="🌙",  # Moonshot AI
+        # Kimi uses opaque UUIDs only — no phone numbers, no emails.
+        pii_safe=True,
+        allow_update_command=True,
+        # LLM guidance.
+        platform_hint=_PLATFORM_HINT,
+    )

--- a/plugins/platforms/kimiclaw/adapter.py
+++ b/plugins/platforms/kimiclaw/adapter.py
@@ -1476,7 +1476,7 @@ class KimiAdapter(BasePlatformAdapter):
             _raw_mode = "passthrough"
         self._output_mode: str = _raw_mode
 
-    async def connect(self) -> bool:
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Open HTTP session, fetch bot identity, spawn channel loops.
 
         Returns ``True`` if at least one enabled channel is viable.

--- a/plugins/platforms/kimiclaw/plugin.yaml
+++ b/plugins/platforms/kimiclaw/plugin.yaml
@@ -1,0 +1,40 @@
+name: kimiclaw
+label: KimiClaw
+kind: platform
+version: 1.0.0
+description: >
+  KimiClaw (Moonshot AI's agentic bot platform on kimi.com) adapter for Hermes
+  Agent.  KimiClaw bridges direct messages and group rooms under one bot
+  identity: DM via Zed ACP over WebSocket (sentinel session ``im:kimi:main``),
+  group rooms via Connect RPC server-stream over HTTP/1.1 long-poll
+  (chat_id ``room:<uuid>``).
+  Distinct from Kimi-the-LLM-provider (see
+  ``plugins/model-providers/kimi-coding/`` for the ``kimi-for-coding`` profile;
+  aliases register through ``hermes_cli/providers.py``).
+  Registers via upstream's ``ctx.register_platform()`` API.
+author: linxule
+# ``requires_env`` / ``optional_env`` entries appear in the ``hermes config``
+# UI via the platform-plugin env var injector in ``hermes_cli/config.py``.
+requires_env:
+  - name: KIMI_BOT_TOKEN
+    description: "Kimi bot token (km_b_prod_*) — generate via kimi.com 'Link existing OpenClaw' flow"
+    prompt: "Kimi bot token"
+    url: "https://www.kimi.com/"
+    password: true
+optional_env:
+  - name: KIMI_ALLOWED_USERS
+    description: "Comma-separated Kimi user UUIDs (km_u_*) allowed to talk to the bot"
+    prompt: "Allowed user UUIDs (comma-separated)"
+    password: false
+  - name: KIMI_ALLOW_ALL_USERS
+    description: "Allow any user to talk to the bot (dev only — disables allowlist)"
+    prompt: "Allow all users? (true/false)"
+    password: false
+  - name: KIMI_HOME_CHANNEL
+    description: "Default ``room:<uuid>`` for cron / notification delivery (standalone DM cron is not supported — see kimiclaw.md Known limitations)"
+    prompt: "Home channel room ID (room:<uuid>, or empty)"
+    password: false
+  - name: KIMI_HOME_CHANNEL_NAME
+    description: "Display name for the home channel (default ``Home``); used by ``hermes gateway status`` and cron delivery"
+    prompt: "Home channel display name (blank for 'Home')"
+    password: false

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1729,6 +1729,7 @@ AUTHOR_MAP = {
     "steveonjava@gmail.com": "steveonjava",  # PR #29669 (redact secrets in kanban tool payloads)
     "afnlegion01@gmail.com": "Afnath-max",  # PR #49129 salvage (opencode-zen catalog refresh + uncapped/live-first picker)
     "sharma.priyanshu96@gmail.com": "ipriyaaanshu",  # PR #51488 salvage (clear stale base_url on gateway model switches; #25107)
+    "x@linxule.com": "linxule",  # PR #28704 (KimiClaw (Moonshot AI) bundled platform plugin)
 }
 
 

--- a/tests/gateway/test_kimiclaw_plugin.py
+++ b/tests/gateway/test_kimiclaw_plugin.py
@@ -5163,6 +5163,30 @@ class PendingEnqueuedAtCleanupTests(unittest.IsolatedAsyncioTestCase):
             "connect should clear stale TTL state at session start"
         )
 
+    async def test_connect_accepts_is_reconnect_kwarg(self):
+        """connect() must honour the BasePlatformAdapter contract
+        (hermes-agent >= 0.17.0), which the gateway calls as
+        ``connect(is_reconnect=...)`` from the reconnect watcher. The kwarg
+        is keyword-only with a default, so the cold-boot call site is
+        unaffected; KimiClaw holds no durable server-side queue to preserve,
+        so it accepts and ignores the flag — mirroring the in-tree
+        yuanbao/weixin adapters. Pins the signature so a future edit can't
+        silently drop it: cold-boot tests call connect() with no args, so
+        only this test exercises the reconnect call site."""
+        adapter = KimiAdapter(_cfg())
+        from kimi_adapter import KimiAuthError
+        with patch.object(adapter, "_acquire_platform_lock", return_value=True), \
+             patch.object(adapter, "_rpc_unary", new=AsyncMock(side_effect=KimiAuthError("test"))), \
+             patch.object(adapter, "_cleanup_http", new=AsyncMock()), \
+             patch.object(adapter, "_release_platform_lock"):
+            # Behaviour is identical to cold boot (flag ignored): short-circuits
+            # False at GetMe. The point is that the keyword is accepted at the
+            # real call site without a TypeError.
+            result = await adapter.connect(is_reconnect=True)
+            self.assertFalse(result, "connect(is_reconnect=True) must be accepted")
+        if adapter._http_session is not None and not adapter._http_session.closed:
+            await adapter._http_session.close()
+
     async def test_handle_message_cleanup_runs_on_cancellation(self):
         """try/finally ensures the post-super cleanup runs on CancelledError,
         so a per-task cancellation outside of full adapter teardown doesn't

--- a/tests/gateway/test_kimiclaw_plugin.py
+++ b/tests/gateway/test_kimiclaw_plugin.py
@@ -1,0 +1,5649 @@
+"""Unit tests for the Kimi platform adapter.
+
+Focus is on pure-function correctness: envelope codec, chat-id routing,
+dedup, MessageEvent synthesis, slash-command detection. Live-network tests
+(GetMe, Subscribe against real Kimi) are gated behind a
+``KIMI_INTEGRATION_TOKEN`` env var and skipped by default.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import struct
+import sys
+import tempfile
+import unittest
+import uuid
+from collections import deque
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from gateway.config import GatewayConfig, HomeChannel, Platform, PlatformConfig
+from gateway.platforms.base import MessageType, SendResult
+from tests.gateway._plugin_adapter_loader import load_plugin_adapter
+
+# Load plugins/platforms/kimi/adapter.py under plugin_adapter_kimi so it
+# cannot collide with sibling platform-plugin tests in the same xdist worker.
+_kimi = load_plugin_adapter("kimiclaw")
+# The source test still patches/imports kimi_adapter by name and asserts that
+# logger name, so provide a test-local alias to the isolated plugin module.
+sys.modules["kimi_adapter"] = _kimi
+_kimi.logger = logging.getLogger("kimi_adapter")
+
+_ARRIVAL_TIME_CACHE_DEFAULT_MAX = _kimi._ARRIVAL_TIME_CACHE_DEFAULT_MAX
+_CONNECT_FLAG_COMPRESSED = _kimi._CONNECT_FLAG_COMPRESSED
+_CONNECT_FLAG_END_STREAM = _kimi._CONNECT_FLAG_END_STREAM
+_DMInflight = _kimi._DMInflight
+_ROOM_CACHE_DEFAULT_MAX = _kimi._ROOM_CACHE_DEFAULT_MAX
+_WS_MAX_FRAME_SIZE = _kimi._WS_MAX_FRAME_SIZE
+KimiAdapter = _kimi.KimiAdapter
+KimiAuthError = _kimi.KimiAuthError
+KimiProtocolError = _kimi.KimiProtocolError
+KimiRpcError = _kimi.KimiRpcError
+KimiTransientError = _kimi.KimiTransientError
+_BoundedLRU = _kimi._BoundedLRU
+_extract_blocks_payload = _kimi._extract_blocks_payload
+_extract_short_id_from_text = _kimi._extract_short_id_from_text
+_resolve_env_template = _kimi._resolve_env_template
+_extract_user_identity = _kimi._extract_user_identity
+_is_standalone_slash_command = _kimi._is_standalone_slash_command
+_parse_iso8601 = _kimi._parse_iso8601
+_split_for_streaming = _kimi._split_for_streaming
+_ulid_time_ms = _kimi._ulid_time_ms
+_standalone_send = _kimi._standalone_send
+check_kimi_requirements = _kimi.check_kimi_requirements
+send_kimi_message = _kimi.send_kimi_message
+
+from gateway.session import SessionSource
+
+
+def setUpModule():
+    """Make ``Platform("kimiclaw")`` resolvable in tests by populating the registry.
+
+    The plugin's :func:`kimi_adapter.register` does this via
+    ``ctx.register_platform()`` in production, but tests don't go through
+    the plugin discovery flow.  Without this fixture, every test that
+    constructs ``KimiAdapter`` or compares platforms fails because
+    ``Platform._missing_`` returns ``None`` for unregistered names and
+    ``Platform("kimiclaw")`` raises ``ValueError``.
+
+    Skips silently in pre-v0.13.0 envs where ``gateway.platform_registry``
+    doesn't exist — tests that depend on the new API will then fail with
+    the same ``ImportError``/``ValueError`` they would at runtime, which
+    is the right diagnostic signal.
+    """
+    try:
+        from gateway.platform_registry import platform_registry, PlatformEntry
+    except ImportError:
+        return
+
+    if not platform_registry.is_registered("kimiclaw"):
+        platform_registry.register(PlatformEntry(
+            name="kimiclaw",
+            label="KimiClaw",
+            adapter_factory=lambda cfg: None,  # not invoked in unit tests
+            check_fn=lambda: True,
+        ))
+
+
+class _FakeWSStatusError(Exception):
+    """Mimic websockets 12+ upgrade-rejection exception shape."""
+    def __init__(self, status: int):
+        super().__init__(f"HTTP {status}")
+        self.status_code = status
+
+
+def _cfg(**extra) -> PlatformConfig:
+    """Test config factory."""
+    defaults = {"enable_dms": True, "enable_groups": True}
+    defaults.update(extra)
+    return PlatformConfig(
+        enabled=True,
+        token="km_b_prod_TEST_TOKEN",
+        extra=defaults,
+    )
+
+
+class HelpersTests(unittest.TestCase):
+    def test_is_standalone_slash_command(self):
+        self.assertTrue(_is_standalone_slash_command("/status"))
+        self.assertTrue(_is_standalone_slash_command("  /new  "))
+        self.assertTrue(_is_standalone_slash_command("/compact"))
+        self.assertFalse(_is_standalone_slash_command("/status please"))
+        self.assertFalse(_is_standalone_slash_command("hello /status"))
+        self.assertFalse(_is_standalone_slash_command("hi"))
+
+    def test_split_for_streaming_short(self):
+        self.assertEqual(_split_for_streaming("hi", 100), ["hi"])
+
+    def test_split_for_streaming_long(self):
+        text = "a" * 8000
+        chunks = _split_for_streaming(text, 3500)
+        # Rejoining should preserve length (minus stripped whitespace between).
+        self.assertGreater(len(chunks), 1)
+        self.assertTrue(all(len(c) <= 3500 for c in chunks))
+
+    def test_split_for_streaming_respects_size_and_preserves_content(self):
+        text = "para one.\n\npara two.\n\npara three.\n\n" + ("x" * 5000)
+        chunks = _split_for_streaming(text, 3500)
+        self.assertGreater(len(chunks), 1)
+        self.assertTrue(all(len(c) <= 3500 for c in chunks))
+        # Length preservation (minus leading whitespace stripped between chunks).
+        rejoined_len = sum(len(c) for c in chunks)
+        self.assertGreaterEqual(rejoined_len, len(text) - 4 * len(chunks))
+
+    def test_parse_iso8601(self):
+        self.assertIsNotNone(_parse_iso8601("2026-04-23T16:53:48Z"))
+        self.assertIsNotNone(_parse_iso8601("2026-04-23T16:53:48+00:00"))
+        self.assertIsNone(_parse_iso8601("not-a-date"))
+        self.assertIsNone(_parse_iso8601(""))
+
+
+class RequirementsTests(unittest.TestCase):
+    def test_dependencies_available(self):
+        # websockets + aiohttp ship via the hermes-agent[messaging] extra —
+        # the test env installs them, so this should always pass.
+        self.assertTrue(check_kimi_requirements())
+
+
+class CheckForRegistryTests(unittest.TestCase):
+    """Auto-enable gating: deps alone must NOT enable KimiClaw —
+    ``KIMI_BOT_TOKEN`` must also be set. Prevents the platform from
+    lighting up on installs that have the ``[messaging]`` extra now
+    that we declare ``websockets`` there. Mirrors LINE / SimpleX /
+    Google Chat precedent.
+    """
+
+    def test_registry_check_requires_bot_token(self):
+        from kimi_adapter import _check_for_registry
+        env_no_kimi = {k: v for k, v in os.environ.items()
+                       if not k.startswith("KIMI_")}
+        with patch.dict(os.environ, env_no_kimi, clear=True):
+            self.assertFalse(_check_for_registry())
+
+    def test_registry_check_passes_with_bot_token(self):
+        from kimi_adapter import _check_for_registry
+        with patch.dict(os.environ, {"KIMI_BOT_TOKEN": "km_b_prod_TEST"}, clear=False):
+            self.assertTrue(_check_for_registry())
+
+
+class EnvTemplateResolverTests(unittest.TestCase):
+    """Regression test for the 2026-05-16 token-substitution bug.
+
+    Hermes does not invoke ``${VAR}`` substitution for external-plugin
+    PlatformConfig fields, so ``token: ${KIMI_BOT_TOKEN}`` in config.yaml
+    used to arrive as a truthy literal and short-circuit the
+    ``or os.getenv(...)`` fallback chain in ``__init__``.  The adapter
+    then sent the template string to kimi.com as the bot token (HTTP 401).
+    """
+
+    def test_resolves_dollar_brace_to_env(self):
+        with patch.dict(os.environ, {"PROBE_VAR_A": "actual-secret-value"}, clear=False):
+            self.assertEqual(
+                _resolve_env_template("${PROBE_VAR_A}"), "actual-secret-value"
+            )
+
+    def test_unset_env_var_returns_empty(self):
+        # Ensure the variable is unset.
+        os.environ.pop("PROBE_VAR_UNSET_XYZ", None)
+        self.assertEqual(_resolve_env_template("${PROBE_VAR_UNSET_XYZ}"), "")
+
+    def test_plain_string_passthrough(self):
+        self.assertEqual(_resolve_env_template("km_b_prod_real_token"), "km_b_prod_real_token")
+
+    def test_none_returns_empty(self):
+        self.assertEqual(_resolve_env_template(None), "")
+
+    def test_partial_template_passthrough(self):
+        # Strings that *look* like templates but don't match the full
+        # ``${...}`` shape are passed through unchanged.
+        self.assertEqual(_resolve_env_template("${incomplete"), "${incomplete")
+        self.assertEqual(_resolve_env_template("trailing${VAR}"), "trailing${VAR}")
+        self.assertEqual(_resolve_env_template("${}"), "${}")
+
+    def test_whitespace_inside_template(self):
+        with patch.dict(os.environ, {"PROBE_VAR_B": "spaced-value"}, clear=False):
+            self.assertEqual(
+                _resolve_env_template("${ PROBE_VAR_B }"), "spaced-value"
+            )
+
+    def test_non_string_coerces(self):
+        self.assertEqual(_resolve_env_template(42), "42")
+        self.assertEqual(_resolve_env_template(True), "True")
+
+
+class AdapterTokenResolutionTests(unittest.TestCase):
+    """End-to-end: the adapter ``__init__`` resolves ``${KIMI_BOT_TOKEN}``
+    in ``config.token`` from the env, not literally."""
+
+    # The unique sentinel below is what the test SHOULD see if the resolver
+    # actually ran.  If we just asserted on a generic value like
+    # ``"km_b_prod_RESOLVED_TOKEN"`` and the dev's shell happened to export
+    # ``KIMI_BOT_TOKEN`` with that exact value, the assertion would pass
+    # even if ``_resolve_env_template`` were broken.  A UUID-derived
+    # sentinel makes that vanishingly unlikely.
+    _SENTINEL = "km_b_prod_TEST_SENTINEL_" + uuid.uuid4().hex
+
+    def test_template_in_config_token_resolves_from_env(self):
+        # Pop any pre-existing KIMI_BOT_TOKEN from the shell so the
+        # ``patch.dict(..., clear=False)`` block is what's actually
+        # being asserted against, not a leaky shell var.
+        prior = os.environ.pop("KIMI_BOT_TOKEN", None)
+        try:
+            cfg = PlatformConfig(
+                enabled=True,
+                token="${KIMI_BOT_TOKEN}",  # the bug pattern
+                extra={"enable_dms": True, "enable_groups": False},
+            )
+            with patch.dict(
+                os.environ, {"KIMI_BOT_TOKEN": self._SENTINEL}, clear=False
+            ):
+                adapter = KimiAdapter(cfg)
+            self.assertEqual(adapter._bot_token, self._SENTINEL)
+            self.assertNotIn("${", adapter._bot_token)
+        finally:
+            if prior is not None:
+                os.environ["KIMI_BOT_TOKEN"] = prior
+
+
+class StandaloneSendTokenResolutionTests(unittest.TestCase):
+    """Regression test for the 2026-05-16 v2.0.1 fix.
+
+    The standalone ``send_kimi_message`` helper (used by cron delivery and
+    ``send_message_tool`` when no live adapter is available) shares the
+    same bot-token resolution surface as ``KimiAdapter.__init__``.  The
+    v2.0.0 fix wrapped ``__init__`` only, so a ``token: ${KIMI_BOT_TOKEN}``
+    config.yaml line would 401 silently on every cron-driven kimi
+    delivery while the live bot path worked fine.  These tests verify the
+    helper now resolves the template before reaching ``_runtime_headers``.
+    """
+
+    _SENTINEL = "km_b_prod_STANDALONE_SENTINEL_" + uuid.uuid4().hex
+
+    def test_template_in_config_token_resolves_for_standalone_send(self):
+        prior = os.environ.pop("KIMI_BOT_TOKEN", None)
+        try:
+            cfg = PlatformConfig(
+                enabled=True,
+                token="${KIMI_BOT_TOKEN}",  # the bug pattern
+                extra={"enable_groups": True},
+            )
+            with patch.dict(
+                os.environ, {"KIMI_BOT_TOKEN": self._SENTINEL}, clear=False
+            ):
+                # Mock _runtime_headers to capture the bot_token it
+                # receives, then short-circuit the rest of the send by
+                # making the aiohttp POST raise — we don't care what
+                # happens after token resolution.
+                with patch("kimi_adapter._runtime_headers") as mock_headers:
+                    mock_headers.return_value = {}
+                    with patch("kimi_adapter.aiohttp.ClientSession") as mock_session:
+                        mock_session.side_effect = RuntimeError("short-circuit")
+                        try:
+                            asyncio.run(
+                                send_kimi_message(
+                                    cfg,
+                                    chat_id="room:test-room-id",
+                                    text="hello",
+                                )
+                            )
+                        except RuntimeError:
+                            pass  # expected
+            mock_headers.assert_called_once()
+            kwargs = mock_headers.call_args.kwargs
+            self.assertEqual(kwargs["bot_token"], self._SENTINEL)
+            self.assertNotIn("${", kwargs["bot_token"])
+        finally:
+            if prior is not None:
+                os.environ["KIMI_BOT_TOKEN"] = prior
+
+    def test_unresolved_template_yields_no_token_error(self):
+        # When KIMI_BOT_TOKEN is unset, the template resolves to empty
+        # string, and the empty-token guard should fire BEFORE any HTTP
+        # call. We must not send a literal "${KIMI_BOT_TOKEN}" to kimi.
+        prior = os.environ.pop("KIMI_BOT_TOKEN", None)
+        try:
+            cfg = PlatformConfig(
+                enabled=True,
+                token="${KIMI_BOT_TOKEN}",
+                extra={"enable_groups": True},
+            )
+            result = asyncio.run(
+                send_kimi_message(
+                    cfg,
+                    chat_id="room:test-room-id",
+                    text="hello",
+                )
+            )
+            self.assertFalse(result.success)
+            self.assertIn("no bot_token configured", result.error)
+            self.assertNotIn("${", result.error)  # nothing template-shaped leaked
+        finally:
+            if prior is not None:
+                os.environ["KIMI_BOT_TOKEN"] = prior
+
+
+class StandaloneSendRegistryWrapperTests(unittest.TestCase):
+    """The registered standalone_sender_fn wrapper matches upstream's contract.
+
+    ``send_message_tool`` applies ``filter_media_delivery_paths()`` before
+    invoking the wrapper, so ``media_files`` arrives as ``(path, is_voice)``
+    tuples; these tests assert that shape is normalized to bare upload paths.
+    """
+
+    def test_success_result_converts_to_send_message_tool_dict(self):
+        cfg = PlatformConfig(enabled=True, token="tok", extra={})
+        with patch(
+            "kimi_adapter.send_kimi_message",
+            new=AsyncMock(return_value=SendResult(success=True, message_id="msg-123")),
+        ) as mock_send:
+            result = asyncio.run(
+                _standalone_send(
+                    cfg,
+                    "room:abc",
+                    "hello",
+                    thread_id="thread-1",
+                    # Real registry contract: filter_media_delivery_paths()
+                    # yields (path, is_voice) tuples before standalone_sender_fn.
+                    media_files=[("/tmp/a.png", False)],
+                )
+            )
+
+        self.assertEqual(result, {"success": True, "message_id": "msg-123"})
+        mock_send.assert_awaited_once_with(
+            cfg,
+            "room:abc",
+            "hello",
+            thread_id="thread-1",
+            media_paths=["/tmp/a.png"],
+        )
+
+    def test_failure_result_converts_to_error_dict(self):
+        cfg = PlatformConfig(enabled=True, token="tok", extra={})
+        with patch(
+            "kimi_adapter.send_kimi_message",
+            new=AsyncMock(
+                return_value=SendResult(
+                    success=False,
+                    error="network error",
+                    retryable=True,
+                )
+            ),
+        ):
+            result = asyncio.run(_standalone_send(cfg, "room:abc", "hello"))
+
+        self.assertEqual(result, {"error": "network error", "retryable": True})
+
+    def test_force_document_is_accepted_but_ignored(self):
+        cfg = PlatformConfig(enabled=True, token="tok", extra={})
+        with patch(
+            "kimi_adapter.send_kimi_message",
+            new=AsyncMock(return_value=SendResult(success=True)),
+        ) as mock_send:
+            result = asyncio.run(
+                _standalone_send(
+                    cfg,
+                    "room:abc",
+                    "hello",
+                    media_files=[("/tmp/a.pdf", False)],
+                    force_document=True,
+                )
+            )
+
+        self.assertEqual(result, {"success": True})
+        mock_send.assert_awaited_once_with(
+            cfg,
+            "room:abc",
+            "hello",
+            thread_id=None,
+            media_paths=["/tmp/a.pdf"],
+        )
+
+    def test_media_files_empty_list_forwards_empty(self):
+        cfg = PlatformConfig(enabled=True, token="tok", extra={})
+        with patch(
+            "kimi_adapter.send_kimi_message",
+            new=AsyncMock(return_value=SendResult(success=True)),
+        ) as mock_send:
+            asyncio.run(_standalone_send(cfg, "room:abc", "hi", media_files=[]))
+        self.assertEqual(mock_send.await_args.kwargs["media_paths"], [])
+
+    def test_media_files_none_default_forwards_empty(self):
+        cfg = PlatformConfig(enabled=True, token="tok", extra={})
+        with patch(
+            "kimi_adapter.send_kimi_message",
+            new=AsyncMock(return_value=SendResult(success=True)),
+        ) as mock_send:
+            asyncio.run(_standalone_send(cfg, "room:abc", "hi"))
+        self.assertEqual(mock_send.await_args.kwargs["media_paths"], [])
+
+    def test_media_files_voice_tuple_keeps_path_drops_flag(self):
+        # A (path, True) voice tuple: KimiClaw uploads the file like any other
+        # attachment and discards the voice flag (no voice-note wire concept).
+        cfg = PlatformConfig(enabled=True, token="tok", extra={})
+        with patch(
+            "kimi_adapter.send_kimi_message",
+            new=AsyncMock(return_value=SendResult(success=True)),
+        ) as mock_send:
+            asyncio.run(
+                _standalone_send(
+                    cfg, "room:abc", "voice", media_files=[("/tmp/v.ogg", True)]
+                )
+            )
+        self.assertEqual(mock_send.await_args.kwargs["media_paths"], ["/tmp/v.ogg"])
+
+    def test_media_files_mixed_tuples_normalize_to_paths(self):
+        # Multiple attachments, mixed voice flags -> ordered list of bare paths.
+        cfg = PlatformConfig(enabled=True, token="tok", extra={})
+        with patch(
+            "kimi_adapter.send_kimi_message",
+            new=AsyncMock(return_value=SendResult(success=True)),
+        ) as mock_send:
+            asyncio.run(
+                _standalone_send(
+                    cfg,
+                    "room:abc",
+                    "both",
+                    media_files=[("/tmp/a.png", False), ("/tmp/v.ogg", True)],
+                )
+            )
+        self.assertEqual(
+            mock_send.await_args.kwargs["media_paths"],
+            ["/tmp/a.png", "/tmp/v.ogg"],
+        )
+
+
+class SendKimiMessageStandalonePolicyTests(unittest.IsolatedAsyncioTestCase):
+    """v2.1.5 regression coverage for the standalone send path's timeout policy.
+
+    v2.1.4 marked ``asyncio.TimeoutError`` non-retryable in the live
+    ``send()`` arm, but the standalone ``send_kimi_message`` helper (used by
+    cron delivery and by ``send_message_tool`` when no live adapter is
+    available) only caught ``aiohttp.ClientError``.  Bare TimeoutError
+    propagated uncaught, so cron-driven Kimi sends could still duplicate
+    via any retry layer that interpreted the absent ``retryable`` field as
+    "retry".  v2.1.5 adds ``except asyncio.TimeoutError`` ahead of the
+    existing ``except aiohttp.ClientError`` clause.
+    """
+
+    async def test_standalone_timeout_returns_non_retryable(self):
+        cfg = PlatformConfig(
+            enabled=True,
+            token="km_b_prod_STANDALONE_TIMEOUT_TEST",
+            extra={"enable_groups": True},
+        )
+
+        # Patch aiohttp.ClientSession so session.post(...) raises
+        # asyncio.TimeoutError — the exact failure mode the v2.1.5 except
+        # clause catches.
+        class _TimeoutPostCtx:
+            async def __aenter__(self_inner):
+                raise asyncio.TimeoutError()
+
+            async def __aexit__(self_inner, *exc):
+                return False
+
+        fake_session = MagicMock()
+        fake_session.post = MagicMock(return_value=_TimeoutPostCtx())
+
+        class _FakeSessionFactory:
+            async def __aenter__(self_inner):
+                return fake_session
+
+            async def __aexit__(self_inner, *exc):
+                return False
+
+        with patch(
+            "kimi_adapter.aiohttp.ClientSession",
+            return_value=_FakeSessionFactory(),
+        ):
+            with self.assertLogs("kimi_adapter", level="WARNING") as cm:
+                result = await send_kimi_message(
+                    cfg,
+                    chat_id="room:test-timeout-uuid",
+                    text="hello",
+                )
+
+        self.assertFalse(result.success)
+        self.assertFalse(result.retryable)
+        self.assertIn("timed out", result.error)
+        warning_text = "\n".join(cm.output)
+        self.assertIn("room:test-timeout-uuid", warning_text)
+        self.assertIn("Marking non-retryable", warning_text)
+        # Mirror the live-arm message phrasing for cross-arm consistency.
+        self.assertIn("standalone SendMessage", warning_text)
+
+    async def test_standalone_network_error_remains_retryable(self):
+        # ClientError (genuine network failure) should still be retryable —
+        # only TimeoutError gets the non-retryable treatment.
+        import aiohttp as _aiohttp  # local import; not in top-level test imports
+
+        cfg = PlatformConfig(
+            enabled=True,
+            token="km_b_prod_STANDALONE_NETERR_TEST",
+            extra={"enable_groups": True},
+        )
+
+        class _NetErrPostCtx:
+            async def __aenter__(self_inner):
+                raise _aiohttp.ClientError("simulated network drop")
+
+            async def __aexit__(self_inner, *exc):
+                return False
+
+        fake_session = MagicMock()
+        fake_session.post = MagicMock(return_value=_NetErrPostCtx())
+
+        class _FakeSessionFactory:
+            async def __aenter__(self_inner):
+                return fake_session
+
+            async def __aexit__(self_inner, *exc):
+                return False
+
+        with patch(
+            "kimi_adapter.aiohttp.ClientSession",
+            return_value=_FakeSessionFactory(),
+        ):
+            result = await send_kimi_message(
+                cfg,
+                chat_id="room:test-neterr-uuid",
+                text="hello",
+            )
+
+        self.assertFalse(result.success)
+        self.assertTrue(result.retryable)
+        self.assertIn("network error", result.error)
+
+
+class CrossLoopSessionTests(unittest.TestCase):
+    """Regression coverage for the cross-loop aiohttp ``ClientSession`` bug.
+
+    Hermes's ``send_message_tool`` dispatches ``adapter.send()`` from a
+    worker-thread event loop via ``_run_async`` →
+    ``worker_loop.run_until_complete``.  But ``adapter.connect()`` runs
+    on the gateway's main loop and creates ``self._http_session`` there;
+    aiohttp binds ``ClientSession`` to the running loop at ``__init__``.
+    Using the gateway-bound session from a worker loop later raises
+    ``RuntimeError("Timeout context manager should be used inside a
+    task")`` because ``asyncio.current_task(loop=session._loop)`` returns
+    ``None`` from the worker loop's perspective.
+
+    ``_session_for_current_loop`` is the plugin-side workaround.  An
+    upstream issue tracks the broader fix in
+    ``send_message_tool._send_via_adapter``.
+    """
+
+    def _make_adapter(self) -> KimiAdapter:
+        return KimiAdapter(_cfg())
+
+    def test_first_call_caches_session_on_current_loop(self):
+        adapter = self._make_adapter()
+        self.assertIsNone(adapter._http_session)
+        self.assertIsNone(adapter._http_session_loop)
+
+        async def scenario():
+            async with adapter._session_for_current_loop() as session:
+                self.assertIs(adapter._http_session, session)
+                self.assertIs(
+                    adapter._http_session_loop,
+                    asyncio.get_running_loop(),
+                )
+                return session
+
+        # Use new_event_loop + run_until_complete (not asyncio.run) so the
+        # loop stays alive long enough to close the cached session cleanly
+        # — otherwise the session is bound to a closed loop on teardown
+        # and aiohttp emits an "Unclosed client session" ResourceWarning.
+        loop = asyncio.new_event_loop()
+        try:
+            cached = loop.run_until_complete(scenario())
+            self.assertIs(adapter._http_session, cached)
+            self.assertFalse(cached.closed)
+        finally:
+            if adapter._http_session is not None and not adapter._http_session.closed:
+                loop.run_until_complete(adapter._http_session.close())
+            loop.close()
+
+    def test_same_loop_reuses_cached_session(self):
+        adapter = self._make_adapter()
+
+        async def scenario():
+            async with adapter._session_for_current_loop() as s1:
+                first = s1
+            async with adapter._session_for_current_loop() as s2:
+                second = s2
+            return first, second
+
+        loop = asyncio.new_event_loop()
+        try:
+            first, second = loop.run_until_complete(scenario())
+            self.assertIs(first, second, "Same loop must reuse the cached session")
+        finally:
+            if adapter._http_session is not None and not adapter._http_session.closed:
+                loop.run_until_complete(adapter._http_session.close())
+            loop.close()
+
+    def test_cross_loop_yields_ephemeral_session(self):
+        """The exact scenario send_message_tool exercises in production."""
+        adapter = self._make_adapter()
+
+        # Loop A: simulate connect() — populate _http_session and
+        # _http_session_loop. Keep the loop alive afterwards so the
+        # cached session stays bound to a live loop.
+        loop_a = asyncio.new_event_loop()
+        try:
+            async def seed_on_loop_a():
+                async with adapter._session_for_current_loop() as s:
+                    return s
+            cached = loop_a.run_until_complete(seed_on_loop_a())
+            self.assertIs(adapter._http_session, cached)
+            self.assertIs(adapter._http_session_loop, loop_a)
+
+            # Loop B: simulate send_message_tool's worker-thread dispatch.
+            loop_b = asyncio.new_event_loop()
+            try:
+                ephemerals = []
+                async def use_on_loop_b():
+                    async with adapter._session_for_current_loop() as s:
+                        ephemerals.append(s)
+                        self.assertIsNot(
+                            s, cached,
+                            "Cross-loop call must NOT yield the cached session",
+                        )
+                        self.assertFalse(
+                            s.closed,
+                            "Ephemeral session must be open inside the block",
+                        )
+                loop_b.run_until_complete(use_on_loop_b())
+                self.assertTrue(
+                    ephemerals[0].closed,
+                    "Ephemeral session must be closed after the block exits",
+                )
+                # Cache is untouched.
+                self.assertIs(adapter._http_session, cached)
+                self.assertIs(adapter._http_session_loop, loop_a)
+            finally:
+                loop_b.close()
+        finally:
+            # Close the cached session on its own loop before tearing down.
+            if adapter._http_session is not None:
+                try:
+                    loop_a.run_until_complete(adapter._http_session.close())
+                except Exception:
+                    pass
+            loop_a.close()
+
+    def test_cleanup_resets_session_loop_tracking(self):
+        adapter = self._make_adapter()
+
+        async def scenario():
+            async with adapter._session_for_current_loop():
+                pass
+            self.assertIsNotNone(adapter._http_session)
+            self.assertIsNotNone(adapter._http_session_loop)
+            await adapter._cleanup_http()
+            self.assertIsNone(adapter._http_session)
+            self.assertIsNone(adapter._http_session_loop)
+
+        asyncio.run(scenario())
+
+
+class ProxyTrustEnvTests(unittest.IsolatedAsyncioTestCase):
+    """Every ``aiohttp.ClientSession`` constructed by this plugin must set
+    ``trust_env=True`` so that ``HTTP_PROXY`` / ``HTTPS_PROXY`` / ``ALL_PROXY``
+    are honoured.  aiohttp's default is ``False``, which silently routes
+    traffic around the user's proxy and breaks corporate-network deployments.
+
+    Symmetric with the in-tree Yuanbao / WeCom / Weixin / Matrix adapters and
+    with upstream commit ``c1ae18ee8`` (the SMS / Slack / Teams / Google-Chat
+    sweep).  Tests intentionally cover all five construction sites so a
+    refactor cannot silently drop the flag at one of them.
+    """
+
+    def _assert_trust_env(self, mock_session_cls) -> None:
+        """All calls to the mock ClientSession ctor must include trust_env=True."""
+        self.assertTrue(
+            mock_session_cls.called,
+            "Expected aiohttp.ClientSession to be constructed at least once",
+        )
+        for call in mock_session_cls.call_args_list:
+            _args, kwargs = call
+            self.assertTrue(
+                kwargs.get("trust_env") is True,
+                f"ClientSession constructed without trust_env=True: {call!r}",
+            )
+
+    async def test_connect_persistent_session_sets_trust_env(self):
+        # Strategy: patch aiohttp.ClientSession to RAISE after recording the
+        # call. connect() will bail at the session-construction line, but the
+        # mock has already captured kwargs by then. Avoids having to mock the
+        # full WS/RPC stack.
+        adapter = KimiAdapter(_cfg())
+        adapter._bot_token = "test-token"
+        sentinel_exc = RuntimeError("test exit after session ctor")
+        with patch("kimi_adapter.aiohttp.ClientSession", side_effect=sentinel_exc) as mock_session_cls, \
+             patch.object(adapter, "_acquire_platform_lock", return_value=True), \
+             patch("kimi_adapter.check_kimi_requirements", return_value=True):
+            try:
+                await adapter.connect()
+            except RuntimeError as exc:
+                if exc is not sentinel_exc:
+                    raise
+            self._assert_trust_env(mock_session_cls)
+
+    async def test_session_for_current_loop_lazy_creation_sets_trust_env(self):
+        adapter = KimiAdapter(_cfg())
+        self.assertIsNone(adapter._http_session)
+        with patch("kimi_adapter.aiohttp.ClientSession") as mock_session_cls:
+            # Make the mock instance look like a live, unclosed session so
+            # the cross-loop branch doesn't try to close it on cleanup.
+            mock_session_cls.return_value.closed = False
+            mock_session_cls.return_value.close = AsyncMock()
+            async with adapter._session_for_current_loop():
+                pass
+            self._assert_trust_env(mock_session_cls)
+
+    async def test_session_for_current_loop_stale_closed_replacement_sets_trust_env(self):
+        adapter = KimiAdapter(_cfg())
+        # Seed a fake closed session bound to a different loop so the helper
+        # takes the "stale closed" branch.
+        stale = MagicMock()
+        stale.closed = True
+        adapter._http_session = stale
+        adapter._http_session_loop = None
+        with patch("kimi_adapter.aiohttp.ClientSession") as mock_session_cls:
+            mock_session_cls.return_value.closed = False
+            mock_session_cls.return_value.close = AsyncMock()
+            async with adapter._session_for_current_loop():
+                pass
+            self._assert_trust_env(mock_session_cls)
+
+    def test_session_for_current_loop_cross_loop_ephemeral_sets_trust_env(self):
+        # Cross-loop branch requires two real event loops, mirroring
+        # test_cross_loop_yields_ephemeral_session.
+        adapter = KimiAdapter(_cfg())
+        loop_a = asyncio.new_event_loop()
+        try:
+            # Seed a real session on loop_a so the cached-session check passes.
+            async def seed():
+                async with adapter._session_for_current_loop() as s:
+                    return s
+            loop_a.run_until_complete(seed())
+            self.assertIs(adapter._http_session_loop, loop_a)
+
+            # Now exercise loop_b with the constructor patched.
+            loop_b = asyncio.new_event_loop()
+            try:
+                with patch("kimi_adapter.aiohttp.ClientSession") as mock_session_cls:
+                    mock_session_cls.return_value.closed = False
+                    mock_session_cls.return_value.close = AsyncMock()
+                    mock_session_cls.return_value.__aenter__ = AsyncMock(
+                        return_value=mock_session_cls.return_value,
+                    )
+                    mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=None)
+                    async def use_on_loop_b():
+                        async with adapter._session_for_current_loop():
+                            pass
+                    loop_b.run_until_complete(use_on_loop_b())
+                    self._assert_trust_env(mock_session_cls)
+            finally:
+                loop_b.close()
+        finally:
+            if adapter._http_session is not None and not adapter._http_session.closed:
+                loop_a.run_until_complete(adapter._http_session.close())
+            loop_a.close()
+
+    async def test_standalone_send_kimi_message_session_sets_trust_env(self):
+        # Exercise the module-level send_kimi_message() helper used by cron
+        # and by send_message_tool fallbacks. Use the same _FakeSessionFactory
+        # pattern as SendKimiMessageStandalonePolicyTests so we don't depend
+        # on the real network or a specific response shape.
+        cfg = PlatformConfig(
+            enabled=True,
+            token="km_b_prod_TRUST_ENV_STANDALONE_TEST",
+            extra={"enable_groups": True},
+        )
+
+        class _BailPostCtx:
+            async def __aenter__(self_inner):
+                raise RuntimeError("test exit after post()")
+
+            async def __aexit__(self_inner, *exc):
+                return False
+
+        fake_session = MagicMock()
+        fake_session.post = MagicMock(return_value=_BailPostCtx())
+
+        class _FakeSessionFactory:
+            async def __aenter__(self_inner):
+                return fake_session
+
+            async def __aexit__(self_inner, *exc):
+                return False
+
+        with patch(
+            "kimi_adapter.aiohttp.ClientSession",
+            return_value=_FakeSessionFactory(),
+        ) as mock_session_cls:
+            try:
+                await send_kimi_message(
+                    cfg,
+                    chat_id="room:00000000-0000-0000-0000-000000000000",
+                    text="hello",
+                )
+            except Exception:
+                # post() raises by design; we only care that the
+                # ClientSession constructor recorded trust_env=True.
+                pass
+            self._assert_trust_env(mock_session_cls)
+
+
+class AdapterInitTests(unittest.TestCase):
+    def test_config_parsing(self):
+        cfg = _cfg(
+            enable_dms=True,
+            enable_groups=False,
+            openclaw_version="2026.5.1",
+            claw_id="custom-id-123",
+            group_require_mention=True,
+            user_message_prefix="FROM KIMI: ",
+        )
+        adapter = KimiAdapter(cfg)
+        self.assertEqual(adapter._bot_token, "km_b_prod_TEST_TOKEN")
+        self.assertTrue(adapter._enable_dms)
+        self.assertFalse(adapter._enable_groups)
+        self.assertEqual(adapter._openclaw_version, "2026.5.1")
+        self.assertEqual(adapter._claw_id, "custom-id-123")
+        self.assertTrue(adapter._group_require_mention)
+        self.assertEqual(adapter._user_message_prefix, "FROM KIMI: ")
+
+    def test_claw_id_auto_generated(self):
+        adapter = KimiAdapter(_cfg())
+        self.assertTrue(adapter._claw_id.startswith("hermes-kimi-"))
+        self.assertEqual(len(adapter._claw_id), len("hermes-kimi-") + 16)
+
+    def test_ws_upgrade_headers_include_runtime_metadata(self):
+        adapter = KimiAdapter(_cfg())
+        headers = adapter._ws_upgrade_headers()
+        self.assertEqual(headers["X-Kimi-Bot-Token"], "km_b_prod_TEST_TOKEN")
+        self.assertEqual(headers["X-Kimi-OpenClaw-Version"], "2026.3.13")
+        self.assertIn("X-Kimi-Claw-ID", headers)
+        self.assertIn("X-Kimi-OpenClaw-Plugins", headers)
+
+    def test_ws_upgrade_headers_omit_empty_runtime_metadata(self):
+        adapter = KimiAdapter(_cfg(openclaw_version="", openclaw_skills=""))
+        headers = adapter._ws_upgrade_headers()
+        self.assertNotIn("X-Kimi-OpenClaw-Version", headers)
+        # Skills default is empty — should not be included.
+        self.assertNotIn("X-Kimi-OpenClaw-Skills", headers)
+
+    def test_http_headers_unary_vs_streaming(self):
+        adapter = KimiAdapter(_cfg())
+        unary = adapter._http_headers(streaming=False)
+        streaming = adapter._http_headers(streaming=True)
+        self.assertEqual(unary["Content-Type"], "application/json")
+        self.assertEqual(streaming["Content-Type"], "application/connect+json")
+        self.assertEqual(streaming["Accept"], "application/connect+json")
+        self.assertEqual(unary["X-Kimi-Bot-Token"], "km_b_prod_TEST_TOKEN")
+        self.assertEqual(unary["X-Kimi-Claw-Version"], "0.25.0")
+        self.assertEqual(unary["X-Kimi-OpenClaw-Version"], "2026.3.13")
+        self.assertIn("X-Kimi-Claw-ID", unary)
+        self.assertEqual(
+            json.loads(unary["X-Kimi-OpenClaw-Plugins"]),
+            [{"id": "kimi-claw", "version": "0.25.0"}],
+        )
+        self.assertEqual(streaming["X-Kimi-OpenClaw-Plugins"], unary["X-Kimi-OpenClaw-Plugins"])
+
+    def test_legacy_inventory_header_strings_are_normalized_to_json(self):
+        adapter = KimiAdapter(_cfg(
+            openclaw_plugins="kimi-claw",
+            openclaw_skills="kimiim,worker-safety",
+        ))
+
+        headers = adapter._http_headers(streaming=False)
+
+        self.assertEqual(
+            json.loads(headers["X-Kimi-OpenClaw-Plugins"]),
+            [{"id": "kimi-claw", "version": "0.25.0"}],
+        )
+        self.assertEqual(
+            json.loads(headers["X-Kimi-OpenClaw-Skills"]),
+            ["kimiim", "worker-safety"],
+        )
+
+
+class EnvelopeCodecTests(unittest.TestCase):
+    def test_encode_envelope_data(self):
+        adapter = KimiAdapter(_cfg())
+        body = adapter._encode_envelope(b'{"hello": "world"}')
+        self.assertEqual(body[0], 0)  # data flag
+        length = struct.unpack(">I", body[1:5])[0]
+        self.assertEqual(length, len(b'{"hello": "world"}'))
+        self.assertEqual(body[5:], b'{"hello": "world"}')
+
+    def test_encode_envelope_end_stream(self):
+        adapter = KimiAdapter(_cfg())
+        body = adapter._encode_envelope(b"{}", end_stream=True)
+        self.assertEqual(body[0], _CONNECT_FLAG_END_STREAM)
+
+
+class EnvelopeParserTests(unittest.IsolatedAsyncioTestCase):
+    """Feed synthetic byte streams through the envelope parser."""
+
+    async def _collect(self, adapter: KimiAdapter, stream: bytes):
+        reader = _FakeStreamReader(stream)
+        out = []
+        async for msg in adapter._connect_envelope_parser(reader):
+            out.append(msg)
+        return out
+
+    async def test_single_data_frame_then_end_stream(self):
+        adapter = KimiAdapter(_cfg())
+        data = b'{"ping":{}}'
+        stream = (
+            bytes([0]) + struct.pack(">I", len(data)) + data
+            + bytes([_CONNECT_FLAG_END_STREAM]) + struct.pack(">I", 2) + b"{}"
+        )
+        msgs = await self._collect(adapter, stream)
+        self.assertEqual(msgs, [{"ping": {}}])
+
+    async def test_multiple_data_frames(self):
+        adapter = KimiAdapter(_cfg())
+        parts = [b'{"ping":{}}', b'{"message":{"id":"x"}}']
+        stream = b""
+        for p in parts:
+            stream += bytes([0]) + struct.pack(">I", len(p)) + p
+        stream += bytes([_CONNECT_FLAG_END_STREAM]) + struct.pack(">I", 2) + b"{}"
+        msgs = await self._collect(adapter, stream)
+        self.assertEqual(msgs, [{"ping": {}}, {"message": {"id": "x"}}])
+
+    async def test_end_stream_with_auth_error_raises(self):
+        adapter = KimiAdapter(_cfg())
+        err_body = json.dumps({
+            "error": {"code": "unauthenticated", "message": "token expired"}
+        }).encode()
+        stream = bytes([_CONNECT_FLAG_END_STREAM]) + struct.pack(">I", len(err_body)) + err_body
+        with self.assertRaises(KimiAuthError):
+            await self._collect(adapter, stream)
+
+    async def test_end_stream_with_rpc_error_raises(self):
+        adapter = KimiAdapter(_cfg())
+        err_body = json.dumps({"error": {"code": "invalid_argument", "message": "bad"}}).encode()
+        stream = bytes([_CONNECT_FLAG_END_STREAM]) + struct.pack(">I", len(err_body)) + err_body
+        with self.assertRaises(KimiRpcError):
+            await self._collect(adapter, stream)
+
+    async def test_compressed_frame_rejected(self):
+        adapter = KimiAdapter(_cfg())
+        stream = bytes([_CONNECT_FLAG_COMPRESSED]) + struct.pack(">I", 2) + b"{}"
+        with self.assertRaises(KimiProtocolError):
+            await self._collect(adapter, stream)
+
+    async def test_malformed_json_rejected(self):
+        adapter = KimiAdapter(_cfg())
+        bad = b"{not json"
+        stream = bytes([0]) + struct.pack(">I", len(bad)) + bad
+        with self.assertRaises(KimiProtocolError):
+            await self._collect(adapter, stream)
+
+
+class _FakeStreamReader:
+    """Minimal aiohttp.StreamReader stub for parser tests."""
+
+    def __init__(self, data: bytes):
+        self._data = data
+        self._pos = 0
+
+    async def readexactly(self, n: int) -> bytes:
+        if self._pos + n > len(self._data):
+            raise asyncio.IncompleteReadError(self._data[self._pos:], n)
+        chunk = self._data[self._pos:self._pos + n]
+        self._pos += n
+        return chunk
+
+
+class ChatIdRoutingTests(unittest.IsolatedAsyncioTestCase):
+    async def test_dm_prefix_routes_to_send_dm(self):
+        adapter = KimiAdapter(_cfg())
+        adapter._send_dm = AsyncMock(return_value=SendResult(success=True))
+        adapter._send_group = AsyncMock()
+        result = await adapter.send("dm:im:kimi:main", "hello")
+        self.assertTrue(result.success)
+        adapter._send_dm.assert_awaited_once()
+        adapter._send_group.assert_not_awaited()
+
+    async def test_room_prefix_routes_to_send_group(self):
+        adapter = KimiAdapter(_cfg())
+        adapter._send_dm = AsyncMock()
+        adapter._send_group = AsyncMock(return_value=SendResult(success=True))
+        result = await adapter.send("room:abc-def", "hello")
+        self.assertTrue(result.success)
+        adapter._send_group.assert_awaited_once()
+        call_args = adapter._send_group.call_args
+        self.assertEqual(call_args.args[0], "abc-def")  # room_id
+        # thread_id position (from metadata) should be None
+        self.assertIsNone(call_args.args[3])
+
+    async def test_room_thread_suffix_extracts_thread(self):
+        adapter = KimiAdapter(_cfg())
+        adapter._send_group = AsyncMock(return_value=SendResult(success=True))
+        await adapter.send("room:abc-def/thread-xyz", "hello")
+        call_args = adapter._send_group.call_args
+        self.assertEqual(call_args.args[0], "abc-def")
+        self.assertEqual(call_args.args[3], "thread-xyz")
+
+    async def test_thread_id_in_metadata(self):
+        adapter = KimiAdapter(_cfg())
+        adapter._send_group = AsyncMock(return_value=SendResult(success=True))
+        await adapter.send("room:abc-def", "hello", metadata={"thread_id": "t-1"})
+        call_args = adapter._send_group.call_args
+        self.assertEqual(call_args.args[3], "t-1")
+
+    async def test_unknown_prefix_fails_cleanly(self):
+        adapter = KimiAdapter(_cfg())
+        result = await adapter.send("weird:foo", "hello")
+        self.assertFalse(result.success)
+        self.assertFalse(result.retryable)
+        self.assertIn("unknown chat_id format", result.error)
+
+
+class SendArmExceptionPolicyTests(unittest.IsolatedAsyncioTestCase):
+    """`send()` translates exceptions into ``SendResult.retryable``.
+
+    Regression for v2.1.4 duplicate-send fix:  asyncio.TimeoutError used to
+    be grouped with KimiTransientError and returned ``retryable=True``,
+    which let the gateway's retry wrapper re-POST the same SendMessage on
+    a fresh TCP connection.  Kimi.com's server-side delivery would already
+    have succeeded by then, so the user saw the message twice.
+
+    The diagnostic capture at 2026-05-17 18:46:03-18:46:37 BST proved a
+    single client-side ``ClientTimeout(total=30)`` corresponds to a
+    server-side accepted delivery (a concurrent SendMessage on the same
+    adapter completed in 697 ms during the same 30 s hang window).  The
+    fix marks TimeoutError non-retryable; ``KimiTransientError`` keeps
+    its retryable=True contract for genuine network failures.
+    """
+
+    async def test_timeout_returns_non_retryable(self):
+        # asyncio.TimeoutError from _send_group → retryable=False, warning logged.
+        adapter = KimiAdapter(_cfg())
+        adapter._send_group = AsyncMock(side_effect=asyncio.TimeoutError())
+        with self.assertLogs("kimi_adapter", level="WARNING") as cm:
+            result = await adapter.send("room:abc-def", "hello")
+        self.assertFalse(result.success)
+        self.assertFalse(result.retryable)
+        self.assertIn("timed out", result.error)
+        # WARNING includes chat_id + the configured timeout for ops triage.
+        warning_text = "\n".join(cm.output)
+        self.assertIn("room:abc-def", warning_text)
+        self.assertIn("Marking non-retryable", warning_text)
+
+    async def test_transient_error_remains_retryable(self):
+        # KimiTransientError (genuine network failure) → retryable=True.
+        adapter = KimiAdapter(_cfg())
+        adapter._send_group = AsyncMock(
+            side_effect=KimiTransientError("simulated network error"),
+        )
+        result = await adapter.send("room:abc-def", "hello")
+        self.assertFalse(result.success)
+        self.assertTrue(result.retryable)
+        self.assertIn("simulated network error", result.error)
+
+    async def test_auth_error_remains_non_retryable(self):
+        from kimi_adapter import KimiAuthError
+        adapter = KimiAdapter(_cfg())
+        adapter._send_group = AsyncMock(
+            side_effect=KimiAuthError("simulated 401"),
+        )
+        result = await adapter.send("room:abc-def", "hello")
+        self.assertFalse(result.success)
+        self.assertFalse(result.retryable)
+
+    async def test_auth_error_surfaces_to_fatal_error_hook(self):
+        # v2.1.7: the send-path KimiAuthError handler must call
+        # ``_set_fatal_error`` so the gateway's per-platform circuit
+        # breaker (upstream commit 518f39557, May 2026) sees the
+        # platform as fatally broken and stops dispatching new sends.
+        # Without this, the gateway would keep accepting send requests
+        # against a dead adapter — silent outage from the operator's
+        # perspective.  retryable=True (not False) at this layer because
+        # send-time auth failures are ambiguous (transient token expiry
+        # vs permanent revoke); reconnect re-evaluates and the connect-
+        # loop fatal hook at ~L2269 / ~L2680 sets retryable=False if the
+        # new auth attempt also fails.
+        from kimi_adapter import KimiAuthError
+        adapter = KimiAdapter(_cfg())
+        adapter._send_group = AsyncMock(
+            side_effect=KimiAuthError("simulated 401 mid-send"),
+        )
+        fatal_calls: list[tuple] = []
+
+        def _record_fatal(code, message, *, retryable):
+            fatal_calls.append((code, message, retryable))
+
+        adapter._set_fatal_error = _record_fatal  # type: ignore[method-assign]
+
+        with self.assertLogs("kimi_adapter", level="ERROR") as cm:
+            result = await adapter.send("room:abc-def", "hello")
+
+        # SendResult contract unchanged: retryable=False so the gateway's
+        # send-retry wrapper does NOT re-attempt the dispatch (the failure
+        # is auth, not network; retry without reconnect would just 401 again).
+        self.assertFalse(result.success)
+        self.assertFalse(result.retryable)
+        self.assertIn("simulated 401 mid-send", result.error)
+
+        # Fatal-error hook was called exactly once with the documented contract.
+        self.assertEqual(len(fatal_calls), 1, fatal_calls)
+        code, message, retryable = fatal_calls[0]
+        self.assertEqual(code, "kimi_send_auth")
+        self.assertIn("simulated 401 mid-send", message)
+        self.assertTrue(retryable, "Send-path fatal must be retryable so reconnect re-evaluates")
+
+        # ERROR log carries the chat_id for operator triage.
+        log_text = "\n".join(cm.output)
+        self.assertIn("room:abc-def", log_text)
+        self.assertIn("marking platform", log_text.lower())
+
+    async def test_auth_error_on_dm_path_also_surfaces_to_fatal_hook(self):
+        # Dispatcher-level coverage: send()'s try/except wraps both
+        # _send_dm and _send_group, so a KimiAuthError from either arm
+        # must funnel through the same _set_fatal_error call.
+        from kimi_adapter import KimiAuthError
+        adapter = KimiAdapter(_cfg())
+        adapter._send_dm = AsyncMock(
+            side_effect=KimiAuthError("simulated 401 on dm arm"),
+        )
+        fatal_calls: list[tuple] = []
+        adapter._set_fatal_error = lambda code, message, *, retryable: fatal_calls.append(  # type: ignore[method-assign]
+            (code, message, retryable)
+        )
+
+        with self.assertLogs("kimi_adapter", level="ERROR"):
+            result = await adapter.send("dm:im:kimi:main", "hello")
+
+        self.assertFalse(result.retryable)
+        self.assertEqual(len(fatal_calls), 1)
+        self.assertEqual(fatal_calls[0][0], "kimi_send_auth")
+
+    async def test_dm_path_timeout_also_non_retryable(self):
+        # Dispatcher-level coverage: send()'s try/except at kimi_adapter.py:1809
+        # wraps BOTH the _send_dm and _send_group dispatch arms.  This test
+        # exercises the dm:* arm to prove a timeout from either arm collapses
+        # to the same non-retryable SendResult contract — i.e. the v2.1.4 fix
+        # lives at the dispatcher, not inside _send_group.  In production Kimi
+        # delivers user-bot 1:1 conversations as room:<uuid>, so the dm:
+        # prefix is rarely exercised live, but the contract guarantee must hold.
+        adapter = KimiAdapter(_cfg())
+        adapter._send_dm = AsyncMock(side_effect=asyncio.TimeoutError())
+        with self.assertLogs("kimi_adapter", level="WARNING"):
+            result = await adapter.send("dm:im:kimi:main", "hello")
+        self.assertFalse(result.success)
+        self.assertFalse(result.retryable)
+
+
+class DedupTests(unittest.TestCase):
+    def test_same_pair_deduped(self):
+        adapter = KimiAdapter(_cfg())
+        self.assertFalse(adapter._dedup_is_duplicate("group", "chat-1", "msg-1"))
+        self.assertTrue(adapter._dedup_is_duplicate("group", "chat-1", "msg-1"))
+
+    def test_different_kinds_not_deduped(self):
+        adapter = KimiAdapter(_cfg())
+        self.assertFalse(adapter._dedup_is_duplicate("group", "chat-1", "msg-1"))
+        self.assertFalse(adapter._dedup_is_duplicate("dm", "chat-1", "msg-1"))
+
+    def test_eviction_at_max(self):
+        adapter = KimiAdapter(_cfg())
+        maxlen = adapter._processed.maxlen
+        # Fill + one overflow
+        for i in range(maxlen + 1):
+            adapter._dedup_is_duplicate("group", "chat", f"msg-{i}")
+        # First key should be evicted now.
+        self.assertFalse(adapter._dedup_is_duplicate("group", "chat", "msg-0"))
+
+
+class MessageEventSynthesisTests(unittest.TestCase):
+    def test_text_event(self):
+        adapter = KimiAdapter(_cfg())
+        event = adapter._build_message_event(
+            kind="group",
+            text="hello",
+            message_id="mid-1",
+            chat_id="room:abc",
+            chat_name="Test Room",
+            user_id="u-1",
+            user_name="Alice",
+        )
+        self.assertEqual(event.text, "hello")
+        self.assertEqual(event.message_type, MessageType.TEXT)
+        self.assertEqual(event.source.platform, Platform("kimiclaw"))
+        self.assertEqual(event.source.chat_id, "room:abc")
+        self.assertEqual(event.source.chat_type, "group")
+        self.assertFalse(event.internal)
+
+    def test_command_event(self):
+        adapter = KimiAdapter(_cfg())
+        event = adapter._build_message_event(
+            kind="dm",
+            text="/reset",
+            message_id="mid-2",
+            chat_id="dm:im:kimi:main",
+            chat_name="Kimi DM",
+            user_id="u-2",
+            user_name=None,
+        )
+        self.assertEqual(event.message_type, MessageType.COMMAND)
+
+    def test_photo_event(self):
+        adapter = KimiAdapter(_cfg())
+        event = adapter._build_message_event(
+            kind="group",
+            text="look at this",
+            message_id="mid-3",
+            chat_id="room:abc",
+            chat_name=None,
+            user_id="u-3",
+            user_name=None,
+            media_urls=["https://example/img.jpg"],
+            media_types=["image/jpeg"],
+        )
+        self.assertEqual(event.message_type, MessageType.PHOTO)
+        self.assertEqual(event.media_urls, ["https://example/img.jpg"])
+
+    def test_auto_skill_passthrough(self):
+        adapter = KimiAdapter(_cfg(auto_skill="test-skill"))
+        event = adapter._build_message_event(
+            kind="group",
+            text="hello",
+            message_id="mid-4",
+            chat_id="room:abc",
+            chat_name=None,
+            user_id=None,
+            user_name=None,
+        )
+        self.assertEqual(event.auto_skill, "test-skill")
+
+
+class GroupEventParsingTests(unittest.IsolatedAsyncioTestCase):
+    """Kimi Subscribe protobuf-JSON events are converted into Hermes messages."""
+
+    async def test_protobuf_json_chat_message_event_dispatches_summary(self):
+        adapter = KimiAdapter(_cfg())
+        adapter.handle_message = AsyncMock()  # type: ignore
+        # Fix A: legacy summary-fallback test — disable hydration so the
+        # cascade lands on the summary path WITHOUT making a real
+        # _fetch_group_message → aiohttp call (Commit 6 made hydration
+        # the default; without this the test attempts a real network
+        # round-trip and only "passes" because the resulting transient
+        # error falls through to the same summary fallback).
+        adapter._hydrate_missing_text = False
+
+        await adapter._on_group_event({
+            "id": "evt-1",
+            "chatMessage": {
+                "chatId": "chat-1",
+                "messageId": "msg-1",
+                "status": "STATUS_COMPLETED",
+                "senderId": "user-1",
+                "senderShortId": "u1",
+                "roomId": "room-1",
+                "summary": "hello from kimi",
+            },
+        })
+
+        adapter.handle_message.assert_awaited_once()
+        event = adapter.handle_message.await_args.args[0]
+        # Fix B: summary-fallback path now prepends a truncation marker
+        # so the agent knows the body is a preview, not the full message.
+        self.assertTrue(
+            event.text.startswith("[message truncated"),
+            f"expected truncation marker prefix, got: {event.text!r}",
+        )
+        self.assertIn("hello from kimi", event.text)
+        self.assertEqual(event.source.chat_id, "room:chat-1")
+        self.assertEqual(event.source.user_id, "user-1")
+        self.assertEqual(event.source.user_name, "u1")
+
+    async def test_generated_payload_shape_extracts_text_block(self):
+        adapter = KimiAdapter(_cfg())
+        adapter.handle_message = AsyncMock()  # type: ignore
+
+        await adapter._on_group_event({
+            "id": "evt-2",
+            "payload": {
+                "case": "chatMessage",
+                "value": {
+                    "chatId": "chat-2",
+                    "messageId": "msg-2",
+                    "status": 2,
+                    "senderShortId": "u2",
+                    "blocks": [
+                        {
+                            "id": "b1",
+                            "content": {
+                                "case": "text",
+                                "value": {"content": "block text"},
+                            },
+                        }
+                    ],
+                },
+            },
+        })
+
+        adapter.handle_message.assert_awaited_once()
+        event = adapter.handle_message.await_args.args[0]
+        self.assertEqual(event.text, "block text")
+        self.assertEqual(event.source.user_id, "kimi:u2")
+
+    async def test_generating_status_is_not_dispatched(self):
+        adapter = KimiAdapter(_cfg())
+        adapter.handle_message = AsyncMock()  # type: ignore
+
+        await adapter._on_group_event({
+            "id": "evt-3",
+            "chatMessage": {
+                "chatId": "chat-3",
+                "messageId": "msg-3",
+                "status": "STATUS_GENERATING",
+                "summary": "partial",
+            },
+        })
+
+        adapter.handle_message.assert_not_awaited()
+
+
+class SendMessageShapeTests(unittest.IsolatedAsyncioTestCase):
+    async def test_group_send_uses_kimi_blocks_request_shape(self):
+        adapter = KimiAdapter(_cfg())
+        adapter._rpc_unary = AsyncMock(return_value={"messageId": "sent-1"})  # type: ignore
+
+        result = await adapter._send_group(
+            "chat-1",
+            "hello",
+            reply_to="ignored",
+            thread_id="ignored",
+            metadata={},
+        )
+
+        self.assertTrue(result.success)
+        adapter._rpc_unary.assert_awaited_once()
+        method, body = adapter._rpc_unary.await_args.args
+        self.assertEqual(method, "SendMessage")
+        self.assertEqual(body["chatId"], "chat-1")
+        self.assertEqual(body["blocks"][0]["text"]["content"], "hello")
+        self.assertNotIn("text", body)
+        self.assertNotIn("chat_id", body)
+
+    async def test_group_send_supports_attachment_only_resource_link(self):
+        adapter = KimiAdapter(_cfg())
+        adapter._rpc_unary = AsyncMock(return_value={"messageId": "sent-2"})  # type: ignore
+
+        result = await adapter._send_group(
+            "chat-1",
+            "",
+            reply_to=None,
+            thread_id=None,
+            metadata={"attachments": [{
+                "uri": "kimi-file://file-123",
+                "name": "report.pdf",
+                "mimeType": "application/pdf",
+                "sizeBytes": 42,
+            }]},
+        )
+
+        self.assertTrue(result.success)
+        _method, body = adapter._rpc_unary.await_args.args
+        self.assertEqual(len(body["blocks"]), 1)
+        resource = body["blocks"][0]["resourceLink"]
+        self.assertEqual(resource["uri"], "kimi-file://file-123")
+        self.assertEqual(resource["title"], "report.pdf")
+        self.assertNotIn("text", body["blocks"][0])
+
+    async def test_send_document_uploads_to_kimi_file_resource(self):
+        adapter = KimiAdapter(_cfg())
+        # closed=False so _session_for_current_loop yields the mock instead of
+        # falling into the "stale closed session — replace" branch and opening
+        # a real aiohttp.ClientSession that nothing closes.
+        adapter._http_session = MagicMock(closed=False)
+        adapter._send_group = AsyncMock(return_value=SendResult(success=True, message_id="sent-3"))  # type: ignore
+        uploaded = [{
+            "uri": "kimi-file://file-456",
+            "name": "notes.txt",
+            "mimeType": "text/plain",
+        }]
+
+        with patch("kimi_adapter._upload_kimi_files", new=AsyncMock(return_value=uploaded)) as upload_mock:
+            result = await adapter.send_document("room:chat-1", "/tmp/notes.txt", caption="see attached")
+
+        self.assertTrue(result.success)
+        upload_mock.assert_awaited_once()
+        adapter._send_group.assert_awaited_once()
+        args = adapter._send_group.await_args.args
+        self.assertEqual(args[0], "chat-1")
+        self.assertEqual(args[1], "see attached")
+        self.assertEqual(adapter._send_group.await_args.kwargs["metadata"]["attachments"], uploaded)
+
+    async def test_kimi_file_media_resolution_replaces_uri_with_local_path(self):
+        adapter = KimiAdapter(_cfg())
+        adapter._resolve_kimi_file_uri = AsyncMock(return_value={
+            "localPath": "/tmp/kimi-file/report.pdf",
+            "contentType": "application/pdf",
+        })  # type: ignore
+
+        urls, types = await adapter._resolve_kimi_file_media(
+            ["kimi-file://12345678-1234-1234-1234-123456789abc", "https://example/a.png"],
+            ["resource_link", "image/png"],
+            message_id="msg-1",
+        )
+
+        self.assertEqual(urls, ["/tmp/kimi-file/report.pdf", "https://example/a.png"])
+        self.assertEqual(types, ["application/pdf", "image/png"])
+
+
+class GroupRpcHelperTests(unittest.IsolatedAsyncioTestCase):
+    async def test_get_chat_info_fetches_room_and_members(self):
+        adapter = KimiAdapter(_cfg())
+        adapter._rpc_unary = AsyncMock(side_effect=[
+            {"room": {"id": "room-1", "name": "Research Room"}},
+            {"members": [{"id": "m1", "shortId": "alice"}]},
+        ])  # type: ignore
+
+        info = await adapter.get_chat_info("room:room-1")
+
+        self.assertEqual(info["name"], "Research Room")
+        self.assertEqual(info["members"], [{"id": "m1", "shortId": "alice"}])
+        self.assertEqual(
+            adapter._rpc_unary.await_args_list[0].args,
+            ("GetRoom", {"roomId": "room-1"}),
+        )
+        self.assertEqual(adapter._rpc_unary.await_args_list[1].args[0], "ListMembers")
+        self.assertEqual(adapter._rpc_unary.await_args_list[1].args[1]["roomId"], "room-1")
+
+    async def test_empty_subscribe_event_hydrates_from_list_messages(self):
+        adapter = KimiAdapter(_cfg())
+        adapter.handle_message = AsyncMock()  # type: ignore
+        adapter._rpc_unary = AsyncMock(return_value={
+            "messages": [
+                {
+                    "senderId": "user-9",
+                    "senderShortId": "u9",
+                    "message": {
+                        "id": "msg-9",
+                        "blocks": [
+                            {
+                                "content": {
+                                    "case": "text",
+                                    "value": {"content": "hydrated text"},
+                                },
+                            }
+                        ],
+                    },
+                }
+            ]
+        })  # type: ignore
+
+        await adapter._on_group_event({
+            "chatMessage": {
+                "chatId": "chat-9",
+                "messageId": "msg-9",
+                "status": "STATUS_COMPLETED",
+            },
+        })
+
+        adapter.handle_message.assert_awaited_once()
+        event = adapter.handle_message.await_args.args[0]
+        self.assertEqual(event.text, "hydrated text")
+        self.assertEqual(event.source.user_id, "user-9")
+        self.assertEqual(event.source.user_name, "u9")
+        method, body = adapter._rpc_unary.await_args.args
+        self.assertEqual(method, "ListMessages")
+        self.assertEqual(body["chatId"], "chat-9")
+        self.assertEqual(body["startMessageId"], "msg-9")
+
+    async def test_failed_hydration_does_not_dispatch_or_dedup_empty_event(self):
+        adapter = KimiAdapter(_cfg())
+        adapter.handle_message = AsyncMock()  # type: ignore
+        adapter._fetch_group_message = AsyncMock(side_effect=[
+            KimiRpcError("temporary bad cursor"),
+            {
+                "id": "msg-10",
+                "blocks": [
+                    {
+                        "content": {
+                            "case": "text",
+                            "value": {"content": "second replay text"},
+                        },
+                    }
+                ],
+            },
+        ])  # type: ignore
+        event = {
+            "chatMessage": {
+                "chatId": "chat-10",
+                "messageId": "msg-10",
+                "status": "STATUS_COMPLETED",
+            },
+        }
+
+        await adapter._on_group_event(event)
+        adapter.handle_message.assert_not_awaited()
+
+        await adapter._on_group_event(event)
+        adapter.handle_message.assert_awaited_once()
+        delivered = adapter.handle_message.await_args.args[0]
+        self.assertEqual(delivered.text, "second replay text")
+
+    async def test_hydrated_self_message_is_filtered(self):
+        adapter = KimiAdapter(_cfg())
+        adapter._me_id = "bot-self"
+        adapter.handle_message = AsyncMock()  # type: ignore
+        adapter._fetch_group_message = AsyncMock(return_value={
+            "id": "msg-self",
+            "senderId": "bot-self",
+            "blocks": [
+                {
+                    "content": {
+                        "case": "text",
+                        "value": {"content": "echo"},
+                    },
+                }
+            ],
+        })  # type: ignore
+
+        await adapter._on_group_event({
+            "chatMessage": {
+                "chatId": "chat-self",
+                "messageId": "msg-self",
+                "status": "STATUS_COMPLETED",
+            },
+        })
+
+        adapter.handle_message.assert_not_awaited()
+
+    async def test_non_user_group_message_role_is_not_dispatched(self):
+        adapter = KimiAdapter(_cfg())
+        adapter.handle_message = AsyncMock()  # type: ignore
+        # Fix A: summary-only event with hydration default-on would
+        # otherwise trigger a real _fetch_group_message → aiohttp call.
+        # Test asserts a role drop, not text content — disable hydration.
+        adapter._hydrate_missing_text = False
+
+        await adapter._on_group_event({
+            "chatMessage": {
+                "chatId": "chat-bot",
+                "messageId": "msg-bot",
+                "status": "STATUS_COMPLETED",
+                "role": "ROLE_ASSISTANT",
+                "senderId": "assistant-1",
+                "summary": "assistant echo",
+            },
+        })
+
+        adapter.handle_message.assert_not_awaited()
+
+    async def test_hydrated_non_user_group_message_role_is_not_dispatched(self):
+        adapter = KimiAdapter(_cfg())
+        adapter.handle_message = AsyncMock()  # type: ignore
+        adapter._fetch_group_message = AsyncMock(return_value={
+            "id": "msg-hydrated-bot",
+            "role": "ASSISTANT",
+            "senderId": "assistant-2",
+            "blocks": [
+                {
+                    "content": {
+                        "case": "text",
+                        "value": {"content": "hydrated assistant echo"},
+                    },
+                }
+            ],
+        })  # type: ignore
+
+        await adapter._on_group_event({
+            "chatMessage": {
+                "chatId": "chat-hydrated-bot",
+                "messageId": "msg-hydrated-bot",
+                "status": "STATUS_COMPLETED",
+            },
+        })
+
+        adapter.handle_message.assert_not_awaited()
+
+
+def _bot_msg(**overrides) -> dict:
+    """Build a minimal ROLE_ASSISTANT chatMessage event with a bot-role sender."""
+    base = {
+        "chatMessage": {
+            "chatId": "chat-bot",
+            "messageId": "msg-bot",
+            "status": "STATUS_COMPLETED",
+            "role": "ROLE_ASSISTANT",
+            "senderId": "assistant-1",
+            "senderShortId": "u_bot",
+            "summary": "hello from bot",
+        },
+    }
+    base["chatMessage"].update(overrides)
+    return base
+
+
+class GroupTrustedSenderTests(unittest.IsolatedAsyncioTestCase):
+    """group_trusted_senders is an authoritative short_id / id allowlist.
+
+    Fix A: ``_bot_msg()`` is summary-only (no inline blocks). With
+    hydration default-on these tests would attempt a real
+    ``_fetch_group_message`` → ``aiohttp`` call. Tests assert
+    trust/policy behavior, not text content — disable hydration on each
+    fixture.
+    """
+
+    async def test_group_trusted_sender_bypasses_role_filter(self):
+        adapter = KimiAdapter(_cfg(group_trusted_senders=["u_bot"]))
+        adapter.handle_message = AsyncMock()  # type: ignore
+        adapter._hydrate_missing_text = False  # Fix A — see class docstring
+
+        await adapter._on_group_event(_bot_msg())
+
+        adapter.handle_message.assert_awaited_once()
+
+    async def test_group_trusted_sender_by_id_also_matches(self):
+        adapter = KimiAdapter(_cfg(group_trusted_senders=["assistant-1"]))
+        adapter.handle_message = AsyncMock()  # type: ignore
+        adapter._hydrate_missing_text = False  # Fix A — see class docstring
+
+        # senderShortId not in allowlist; senderId IS — should still bypass.
+        await adapter._on_group_event(_bot_msg(senderShortId="u_somebody_else"))
+
+        adapter.handle_message.assert_awaited_once()
+
+
+class GroupAllowBotSendersPolicyTests(unittest.IsolatedAsyncioTestCase):
+    """group_allow_bot_senders policy: off | trusted_only | mentions | all.
+
+    Fix A: every test in this class feeds ``_bot_msg()`` (summary-only).
+    Disable hydration so the cascade doesn't attempt a real
+    ``_fetch_group_message`` → ``aiohttp`` call when policy allows
+    dispatch.
+    """
+
+    async def test_group_allow_bot_senders_off_drops_assistant(self):
+        adapter = KimiAdapter(_cfg(group_allow_bot_senders="off"))
+        adapter.handle_message = AsyncMock()  # type: ignore
+        adapter._hydrate_missing_text = False  # Fix A
+
+        await adapter._on_group_event(_bot_msg())
+
+        adapter.handle_message.assert_not_awaited()
+
+    async def test_group_allow_bot_senders_trusted_only_drops_untrusted_assistant(self):
+        adapter = KimiAdapter(_cfg(
+            group_allow_bot_senders="trusted_only",
+            group_trusted_senders=["u_other"],
+        ))
+        adapter.handle_message = AsyncMock()  # type: ignore
+        adapter._hydrate_missing_text = False  # Fix A
+
+        await adapter._on_group_event(_bot_msg())
+
+        adapter.handle_message.assert_not_awaited()
+
+    async def test_group_allow_bot_senders_trusted_only_allows_trusted_assistant(self):
+        adapter = KimiAdapter(_cfg(
+            group_allow_bot_senders="trusted_only",
+            group_trusted_senders=["u_bot"],
+        ))
+        adapter.handle_message = AsyncMock()  # type: ignore
+        adapter._hydrate_missing_text = False  # Fix A
+
+        await adapter._on_group_event(_bot_msg())
+
+        adapter.handle_message.assert_awaited_once()
+
+    async def test_group_allow_bot_senders_mentions_allows_with_mention(self):
+        adapter = KimiAdapter(_cfg(group_allow_bot_senders="mentions"))
+        adapter._me_short_id = "u_me"
+        adapter.handle_message = AsyncMock()  # type: ignore
+        adapter._hydrate_missing_text = False  # Fix A
+
+        await adapter._on_group_event(_bot_msg(
+            mentions=[{"short_id": "u_me"}],
+        ))
+
+        adapter.handle_message.assert_awaited_once()
+
+    async def test_group_allow_bot_senders_mentions_drops_without_mention(self):
+        adapter = KimiAdapter(_cfg(group_allow_bot_senders="mentions"))
+        adapter._me_short_id = "u_me"
+        adapter.handle_message = AsyncMock()  # type: ignore
+        adapter._hydrate_missing_text = False  # Fix A
+
+        await adapter._on_group_event(_bot_msg(
+            mentions=[{"short_id": "u_someone_else"}],
+        ))
+
+        adapter.handle_message.assert_not_awaited()
+
+    async def test_group_allow_bot_senders_all_allows_unconditionally(self):
+        adapter = KimiAdapter(_cfg(group_allow_bot_senders="all"))
+        adapter.handle_message = AsyncMock()  # type: ignore
+        adapter._hydrate_missing_text = False  # Fix A
+
+        await adapter._on_group_event(_bot_msg())
+
+        adapter.handle_message.assert_awaited_once()
+
+
+class IsMentionOfMeTests(unittest.TestCase):
+    """_is_mention_of_me: pure helper shared by policy + group_require_mention."""
+
+    def _adapter(self) -> KimiAdapter:
+        adapter = KimiAdapter(_cfg())
+        adapter._me_id = "bot-self-id"
+        adapter._me_short_id = "u_me"
+        return adapter
+
+    def test_is_mention_of_me_short_id_match(self):
+        adapter = self._adapter()
+        self.assertTrue(adapter._is_mention_of_me({
+            "mentions": [{"short_id": "u_me"}],
+        }))
+        # shortId variant
+        self.assertTrue(adapter._is_mention_of_me({
+            "mentions": [{"shortId": "u_me"}],
+        }))
+
+    def test_is_mention_of_me_id_match(self):
+        adapter = self._adapter()
+        self.assertTrue(adapter._is_mention_of_me({
+            "mentions": [{"id": "bot-self-id"}],
+        }))
+
+    def test_is_mention_of_me_mentioned_flag_fallback(self):
+        adapter = self._adapter()
+        # No mentions array, but `mentioned: true` → accept
+        self.assertTrue(adapter._is_mention_of_me({"mentioned": True}))
+
+    def test_is_mention_of_me_no_match(self):
+        adapter = self._adapter()
+        self.assertFalse(adapter._is_mention_of_me({}))
+        self.assertFalse(adapter._is_mention_of_me({
+            "mentions": [{"short_id": "u_someone_else"}],
+        }))
+        # Malformed inputs return False
+        self.assertFalse(adapter._is_mention_of_me({"mentions": "not-a-list"}))
+        self.assertFalse(adapter._is_mention_of_me({"mentions": ["not-a-dict"]}))
+
+
+class GroupPolicyLoggingTests(unittest.IsolatedAsyncioTestCase):
+    """Policy drops log at INFO, not DEBUG, for operator observability."""
+
+    async def test_policy_drops_log_at_info_level(self):
+        adapter = KimiAdapter(_cfg(group_allow_bot_senders="off"))
+        adapter.handle_message = AsyncMock()  # type: ignore
+        # Fix A: _bot_msg() is summary-only — disable hydration so the
+        # cascade doesn't make a real network call before the role drop.
+        adapter._hydrate_missing_text = False
+
+        with self.assertLogs("kimi_adapter", level=logging.INFO) as cm:
+            await adapter._on_group_event(_bot_msg())
+
+        adapter.handle_message.assert_not_awaited()
+        # Exactly one INFO record, and it's the policy-drop message.
+        info_records = [r for r in cm.records if r.levelno == logging.INFO]
+        self.assertTrue(
+            any("group_allow_bot_senders=off" in r.getMessage() for r in info_records),
+            f"expected INFO drop log, got: {[r.getMessage() for r in cm.records]}",
+        )
+
+
+class GroupInvalidPolicyTests(unittest.TestCase):
+    """Invalid group_allow_bot_senders values log WARNING and fall back to 'off'."""
+
+    def test_invalid_bot_sender_policy_defaults_to_off(self):
+        with self.assertLogs("kimi_adapter", level=logging.WARNING) as cm:
+            adapter = KimiAdapter(_cfg(group_allow_bot_senders="nonsense"))
+        self.assertEqual(adapter._group_allow_bot_senders, "off")
+        self.assertTrue(
+            any(
+                "invalid group_allow_bot_senders" in r.getMessage()
+                and r.levelno == logging.WARNING
+                for r in cm.records
+            ),
+            f"expected WARNING about invalid policy, got: {[r.getMessage() for r in cm.records]}",
+        )
+
+
+class GroupRequireMentionSharedHelperTests(unittest.IsolatedAsyncioTestCase):
+    """Existing group_require_mention path now delegates to _is_mention_of_me."""
+
+    async def test_group_require_mention_uses_shared_helper(self):
+        # USER-role message in a room — mention gate applies even to humans.
+        adapter = KimiAdapter(_cfg(group_require_mention=True))
+        adapter._me_short_id = "u_me"
+        adapter.handle_message = AsyncMock()  # type: ignore
+        # Fix A: events below are summary-only (no inline blocks). Disable
+        # hydration so the cascade doesn't make a real _fetch_group_message
+        # call before the mention filter runs.
+        adapter._hydrate_missing_text = False
+
+        # With a proper @-mention of us via the helper's matching logic → dispatched.
+        await adapter._on_group_event({
+            "chatMessage": {
+                "chatId": "chat-req",
+                "messageId": "msg-req",
+                "status": "STATUS_COMPLETED",
+                "role": "USER",
+                "senderId": "user-1",
+                "senderShortId": "u_user",
+                "summary": "hey @u_me",
+                "mentions": [{"short_id": "u_me"}],
+            },
+        })
+        adapter.handle_message.assert_awaited_once()
+
+        # Without a mention → dropped.
+        adapter.handle_message.reset_mock()
+        await adapter._on_group_event({
+            "chatMessage": {
+                "chatId": "chat-req",
+                "messageId": "msg-req-2",
+                "status": "STATUS_COMPLETED",
+                "role": "USER",
+                "senderId": "user-2",
+                "senderShortId": "u_user2",
+                "summary": "no mention here",
+            },
+        })
+        adapter.handle_message.assert_not_awaited()
+
+        # Bot-role sender who's in group_trusted_senders still has to mention us
+        # (require-mention gate runs AFTER role/policy filters). Confirm the
+        # shared helper is the authoritative source by flipping to assistant
+        # role with a mention + all policy.
+        adapter2 = KimiAdapter(_cfg(
+            group_require_mention=True,
+            group_allow_bot_senders="all",
+        ))
+        adapter2._me_short_id = "u_me"
+        adapter2.handle_message = AsyncMock()  # type: ignore
+        adapter2._hydrate_missing_text = False  # Fix A — _bot_msg is summary-only
+        await adapter2._on_group_event(_bot_msg(
+            mentions=[{"short_id": "u_me"}],
+        ))
+        adapter2.handle_message.assert_awaited_once()
+
+
+class MentionGateExemptionTests(unittest.IsolatedAsyncioTestCase):
+    """`kimi_free_response_chats` bypasses the mention gate per chat_id.
+
+    Necessary because Kimi delivers both 1:1 DMs and group rooms as
+    `room:<uuid>` with no wire-level distinction. A global
+    `group_require_mention=True` would otherwise swallow DM traffic.
+    """
+
+    def test_default_exempt_list_is_empty(self):
+        adapter = KimiAdapter(_cfg(group_require_mention=True))
+        self.assertEqual(adapter._group_require_mention_exempt_rooms, frozenset())
+
+    def test_exempt_list_loaded_from_config(self):
+        # Mixed prefixed + raw entries: both normalise to the raw UUID form
+        # so they can compare against `chatId` from the subscribe stream.
+        # Regression for v2.1.2 deploy bug: README documents the prefixed
+        # form (matching KIMI_HOME_CHANNEL convention), but `_on_group_event`
+        # extracts `chatId` from the wire envelope as a raw UUID — the v2.1.2
+        # gate silently never fired because the set held prefixed strings
+        # that never equalled the wire's raw form.
+        adapter = KimiAdapter(_cfg(
+            group_require_mention=True,
+            kimi_free_response_chats=["room:aaa", "bbb"],
+        ))
+        self.assertEqual(
+            adapter._group_require_mention_exempt_rooms,
+            frozenset({"aaa", "bbb"}),
+        )
+
+    def test_exempt_entries_strip_room_prefix(self):
+        # All-prefixed config (the README-documented form) must still match
+        # raw-UUID chat_ids from the wire after normalisation.
+        adapter = KimiAdapter(_cfg(
+            group_require_mention=True,
+            kimi_free_response_chats=[
+                "room:19e31a29-4722-8804-8000-094a7731741b",
+            ],
+        ))
+        self.assertEqual(
+            adapter._group_require_mention_exempt_rooms,
+            frozenset({"19e31a29-4722-8804-8000-094a7731741b"}),
+        )
+
+    def test_alias_key_recognized(self):
+        # group_require_mention_exempt_rooms is accepted as an alias for the
+        # documented kimi_free_response_chats key. Useful for users coming
+        # from the explicit name. Normalisation applies to the alias too.
+        adapter = KimiAdapter(_cfg(
+            group_require_mention=True,
+            group_require_mention_exempt_rooms=["room:zzz"],
+        ))
+        self.assertEqual(
+            adapter._group_require_mention_exempt_rooms,
+            frozenset({"zzz"}),
+        )
+
+    def test_non_string_entries_filtered(self):
+        # Be tolerant of YAML-side garbage (None, ints, empty strings).
+        # Normalisation runs after the type filter; survivors land prefix-free.
+        adapter = KimiAdapter(_cfg(
+            group_require_mention=True,
+            kimi_free_response_chats=["room:ok", "", None, 42, "also-ok"],
+        ))
+        self.assertEqual(
+            adapter._group_require_mention_exempt_rooms,
+            frozenset({"ok", "also-ok"}),
+        )
+
+    async def test_exempt_room_bypasses_mention_gate(self):
+        # Message in an exempt room, no @-mention → still dispatched.
+        # This is the DM-as-room case in production.
+        adapter = KimiAdapter(_cfg(
+            group_require_mention=True,
+            kimi_free_response_chats=["chat-dm"],
+        ))
+        adapter._me_short_id = "u_me"
+        adapter.handle_message = AsyncMock()  # type: ignore
+        adapter._hydrate_missing_text = False  # Fix A
+
+        await adapter._on_group_event({
+            "chatMessage": {
+                "chatId": "chat-dm",
+                "messageId": "msg-dm-1",
+                "status": "STATUS_COMPLETED",
+                "role": "USER",
+                "senderId": "user-1",
+                "senderShortId": "u_user",
+                "summary": "no mention here, just talking in DM",
+            },
+        })
+        adapter.handle_message.assert_awaited_once()
+
+    async def test_non_exempt_room_still_gated(self):
+        # Same adapter as above, different room, no mention → dropped.
+        # Confirms the exempt list is per-chat_id, not a global disable.
+        adapter = KimiAdapter(_cfg(
+            group_require_mention=True,
+            kimi_free_response_chats=["chat-dm"],
+        ))
+        adapter._me_short_id = "u_me"
+        adapter.handle_message = AsyncMock()  # type: ignore
+        adapter._hydrate_missing_text = False
+
+        await adapter._on_group_event({
+            "chatMessage": {
+                "chatId": "chat-other-group",
+                "messageId": "msg-grp-1",
+                "status": "STATUS_COMPLETED",
+                "role": "USER",
+                "senderId": "user-1",
+                "senderShortId": "u_user",
+                "summary": "no mention here either",
+            },
+        })
+        adapter.handle_message.assert_not_awaited()
+
+    async def test_exempt_room_with_mention_still_works(self):
+        # Sanity: mention gate ALSO bypassed if the message has a mention —
+        # exempt list is an additive bypass, not a replacement of the mention path.
+        adapter = KimiAdapter(_cfg(
+            group_require_mention=True,
+            kimi_free_response_chats=["chat-dm"],
+        ))
+        adapter._me_short_id = "u_me"
+        adapter.handle_message = AsyncMock()  # type: ignore
+        adapter._hydrate_missing_text = False
+
+        await adapter._on_group_event({
+            "chatMessage": {
+                "chatId": "chat-dm",
+                "messageId": "msg-dm-2",
+                "status": "STATUS_COMPLETED",
+                "role": "USER",
+                "senderId": "user-1",
+                "senderShortId": "u_user",
+                "summary": "hey @u_me",
+                "mentions": [{"short_id": "u_me"}],
+            },
+        })
+        adapter.handle_message.assert_awaited_once()
+
+
+class DmAutodetectTests(unittest.IsolatedAsyncioTestCase):
+    """v2.2.0 room-distinguishability detector + mention-gate integration.
+
+    Kimi delivers 1:1 DMs as ``room:<uuid>`` indistinguishable from groups
+    at the envelope layer the adapter consumes.  Before v2.2.0 the only
+    workaround was to add the DM's room UUID to ``kimi_free_response_chats``
+    manually.  The ``kimi_dm_autodetect`` flag (default OFF) makes the
+    adapter call ``list_group_members`` on rooms about to be dropped by
+    the mention gate; rooms with exactly 2 members (bot + 1 user) bypass
+    the gate without operator config.
+
+    Default OFF preserves v2.1.x behaviour exactly; the test grouping
+    below mirrors that guarantee.
+
+    The detector is the LAST bypass chance — only consulted when the
+    message is otherwise about to be dropped.  Messages that already
+    qualify for dispatch (no gate, or mentioned, or in the explicit
+    exempt list) never incur the detector RPC.
+
+    See ``.review/b1-room-distinguishability-spike.md`` for the design
+    document covering cost analysis, race-window handling, and the
+    dual-use-case justification for keeping ``kimi_free_response_chats``.
+    """
+
+    def _build_msg(self, chat_id: str, with_mention: bool = False) -> Dict[str, Any]:
+        msg: Dict[str, Any] = {
+            "chatMessage": {
+                "chatId": chat_id,
+                "messageId": f"msg-for-{chat_id}",
+                "status": "STATUS_COMPLETED",
+                "role": "USER",
+                "senderId": "user-1",
+                "senderShortId": "u_user",
+                "summary": "hello bot",
+            },
+        }
+        if with_mention:
+            msg["chatMessage"]["mentions"] = [{"short_id": "u_me"}]
+        return msg
+
+    # ── _is_dm_room helper ────────────────────────────────────────────────
+
+    async def test_helper_returns_true_for_2_member_room(self):
+        adapter = KimiAdapter(_cfg())
+        adapter.list_group_members = AsyncMock(  # type: ignore[method-assign]
+            return_value=[{"id": "bot"}, {"id": "user-1"}],
+        )
+        self.assertTrue(await adapter._is_dm_room("room-uuid-1"))
+
+    async def test_helper_returns_false_for_3plus_member_room(self):
+        adapter = KimiAdapter(_cfg())
+        adapter.list_group_members = AsyncMock(  # type: ignore[method-assign]
+            return_value=[{"id": "bot"}, {"id": "user-1"}, {"id": "user-2"}],
+        )
+        self.assertFalse(await adapter._is_dm_room("room-uuid-2"))
+
+    async def test_helper_returns_none_for_rpc_failure(self):
+        from kimi_adapter import KimiTransientError
+        adapter = KimiAdapter(_cfg())
+        adapter.list_group_members = AsyncMock(  # type: ignore[method-assign]
+            side_effect=KimiTransientError("simulated network drop"),
+        )
+        with self.assertLogs("kimi_adapter", level="WARNING") as cm:
+            result = await adapter._is_dm_room("room-uuid-3")
+        self.assertIsNone(result)
+        warning_text = "\n".join(cm.output)
+        self.assertIn("room-uuid-3", warning_text)
+        self.assertIn("DM-autodetect classification failed", warning_text)
+
+    async def test_helper_returns_none_for_timeout(self):
+        adapter = KimiAdapter(_cfg())
+        adapter.list_group_members = AsyncMock(  # type: ignore[method-assign]
+            side_effect=asyncio.TimeoutError(),
+        )
+        with self.assertLogs("kimi_adapter", level="WARNING"):
+            self.assertIsNone(await adapter._is_dm_room("room-uuid-4"))
+
+    async def test_helper_uses_cache_within_ttl(self):
+        # Second call within the 5-minute TTL must NOT issue a fresh RPC.
+        adapter = KimiAdapter(_cfg())
+        adapter.list_group_members = AsyncMock(  # type: ignore[method-assign]
+            return_value=[{"id": "bot"}, {"id": "user-1"}],
+        )
+        self.assertTrue(await adapter._is_dm_room("room-uuid-5"))
+        self.assertEqual(adapter.list_group_members.await_count, 1)
+        self.assertTrue(await adapter._is_dm_room("room-uuid-5"))
+        self.assertEqual(adapter.list_group_members.await_count, 1, "Cache hit must not re-RPC")
+
+    async def test_helper_returns_none_for_degenerate_membership(self):
+        # Defensive: 0 or 1 member shouldn't happen for a room that sent us
+        # a message.  Helper logs a warning and returns None so callers
+        # fall back to existing behaviour rather than over-bypassing.
+        adapter = KimiAdapter(_cfg())
+        adapter.list_group_members = AsyncMock(  # type: ignore[method-assign]
+            return_value=[{"id": "lonely"}],
+        )
+        with self.assertLogs("kimi_adapter", level="WARNING"):
+            self.assertIsNone(await adapter._is_dm_room("room-uuid-6"))
+
+    # ── Mention-gate integration ──────────────────────────────────────────
+
+    async def _make_gated_adapter(self, *, dm_autodetect: bool, members: List[Dict[str, Any]]) -> KimiAdapter:
+        adapter = KimiAdapter(_cfg(
+            group_require_mention=True,
+            kimi_dm_autodetect=dm_autodetect,
+        ))
+        adapter._me_short_id = "u_me"
+        adapter._me_id = "bot-self-id"
+        adapter.handle_message = AsyncMock()  # type: ignore[method-assign]
+        adapter._hydrate_missing_text = False
+        adapter.list_group_members = AsyncMock(return_value=members)  # type: ignore[method-assign]
+        return adapter
+
+    async def test_gate_default_off_unchanged_v21x_behaviour(self):
+        # With kimi_dm_autodetect=False (the v2.2.0 default), a 2-member
+        # room without @-mention is still dropped — proving v2.1.x
+        # semantics are preserved exactly when the flag is off.
+        adapter = await self._make_gated_adapter(
+            dm_autodetect=False,
+            members=[{"id": "bot"}, {"id": "user-1"}],
+        )
+        await adapter._on_group_event(self._build_msg("would-be-dm-room"))
+        adapter.handle_message.assert_not_awaited()
+        # Detector must NOT have been called.
+        adapter.list_group_members.assert_not_awaited()
+
+    async def test_gate_with_flag_on_bypasses_for_detected_dm(self):
+        adapter = await self._make_gated_adapter(
+            dm_autodetect=True,
+            members=[{"id": "bot"}, {"id": "user-1"}],  # 2 members → DM
+        )
+        await adapter._on_group_event(self._build_msg("dm-room-uuid"))
+        adapter.handle_message.assert_awaited_once()
+        adapter.list_group_members.assert_awaited_once_with("dm-room-uuid")
+
+    async def test_gate_with_flag_on_still_drops_for_detected_group(self):
+        adapter = await self._make_gated_adapter(
+            dm_autodetect=True,
+            members=[{"id": "bot"}, {"id": "user-1"}, {"id": "user-2"}],
+        )
+        with self.assertLogs("kimi_adapter", level="INFO") as cm:
+            await adapter._on_group_event(self._build_msg("real-group-uuid"))
+        adapter.handle_message.assert_not_awaited()
+        # The augmented drop log must carry the auto-detect annotation so
+        # operators can correlate drops with classification outcomes.
+        info_records = [r for r in cm.records if r.levelno == logging.INFO]
+        self.assertTrue(
+            any("auto-detect=group" in r.getMessage() for r in info_records),
+            f"expected auto-detect=group annotation, got: {[r.getMessage() for r in cm.records]}",
+        )
+
+    async def test_gate_with_flag_on_falls_back_when_classification_fails(self):
+        # Classifier returns None → log says auto-detect=unknown, message dropped.
+        # Fail-closed behaviour: matches v2.1.x when no explicit exempt exists.
+        from kimi_adapter import KimiTransientError
+        adapter = await self._make_gated_adapter(
+            dm_autodetect=True,
+            members=[],  # unused
+        )
+        adapter.list_group_members = AsyncMock(  # type: ignore[method-assign]
+            side_effect=KimiTransientError("rpc died"),
+        )
+        with self.assertLogs("kimi_adapter", level="INFO") as cm:
+            await adapter._on_group_event(self._build_msg("uncertain-room"))
+        adapter.handle_message.assert_not_awaited()
+        info_records = [r for r in cm.records if r.levelno == logging.INFO]
+        self.assertTrue(
+            any("auto-detect=unknown" in r.getMessage() for r in info_records),
+            f"expected auto-detect=unknown annotation, got: {[r.getMessage() for r in cm.records]}",
+        )
+
+    async def test_gate_with_flag_on_explicit_exempt_still_takes_precedence(self):
+        # An exempt-listed room must skip the detector entirely (fast path).
+        # Proves the detector is the LAST bypass, not a replacement.
+        adapter = KimiAdapter(_cfg(
+            group_require_mention=True,
+            kimi_dm_autodetect=True,
+            kimi_free_response_chats=["explicit-policy-group"],
+        ))
+        adapter._me_short_id = "u_me"
+        adapter.handle_message = AsyncMock()  # type: ignore[method-assign]
+        adapter._hydrate_missing_text = False
+        adapter.list_group_members = AsyncMock()  # type: ignore[method-assign]
+        await adapter._on_group_event(self._build_msg("explicit-policy-group"))
+        adapter.handle_message.assert_awaited_once()
+        # Detector was NOT consulted — the room is in the explicit exempt list.
+        adapter.list_group_members.assert_not_awaited()
+
+    async def test_gate_with_flag_on_mentioned_message_skips_detector(self):
+        # Sanity: mention path short-circuits before the detector.
+        # No RPC, no auto-detect annotation.
+        adapter = await self._make_gated_adapter(
+            dm_autodetect=True,
+            members=[{"id": "bot"}, {"id": "user-1"}],
+        )
+        await adapter._on_group_event(self._build_msg("any-room", with_mention=True))
+        adapter.handle_message.assert_awaited_once()
+        adapter.list_group_members.assert_not_awaited()
+
+
+class ThreadRoutingTests(unittest.IsolatedAsyncioTestCase):
+    """Inbound/outbound thread routing preserves thread identity.
+
+    Kimi Claw v0.25.0's ``SendMessageRequest`` has no thread field on the
+    wire. Inbound threaded messages are still tagged so gateway sessions
+    stay isolated per-thread; outbound sends to a threaded chat_id WARN
+    on first occurrence instead of silently collapsing.
+    """
+
+    async def test_inbound_thread_chat_id_preserved(self):
+        adapter = KimiAdapter(_cfg())
+        adapter.handle_message = AsyncMock()  # type: ignore
+        # Fix A: summary-only event — disable hydration so routing assertions
+        # don't depend on a real network call.
+        adapter._hydrate_missing_text = False
+
+        await adapter._on_group_event({
+            "chatMessage": {
+                "chatId": "chat-t1",
+                "messageId": "msg-t1",
+                "status": "STATUS_COMPLETED",
+                "senderId": "user-1",
+                "senderShortId": "u1",
+                "threadId": "thread-abc",
+                "summary": "hello in a thread",
+            },
+        })
+
+        adapter.handle_message.assert_awaited_once()
+        event = adapter.handle_message.await_args.args[0]
+        self.assertEqual(event.source.chat_id, "room:chat-t1/thread-abc")
+        # SessionSource also carries the raw thread_id for routing helpers.
+        self.assertEqual(event.source.thread_id, "thread-abc")
+
+    async def test_inbound_no_thread_chat_id_room_only(self):
+        adapter = KimiAdapter(_cfg())
+        adapter.handle_message = AsyncMock()  # type: ignore
+        # Fix A: summary-only event — disable hydration so routing assertions
+        # don't depend on a real network call.
+        adapter._hydrate_missing_text = False
+
+        await adapter._on_group_event({
+            "chatMessage": {
+                "chatId": "chat-t2",
+                "messageId": "msg-t2",
+                "status": "STATUS_COMPLETED",
+                "senderId": "user-2",
+                "senderShortId": "u2",
+                "summary": "no thread",
+            },
+        })
+
+        adapter.handle_message.assert_awaited_once()
+        event = adapter.handle_message.await_args.args[0]
+        # No slash — plain room id only.
+        self.assertEqual(event.source.chat_id, "room:chat-t2")
+        self.assertNotIn("/", event.source.chat_id)
+
+    async def test_inbound_hydrated_thread_id_preserved(self):
+        """Thread id on the hydrated wrapper is preserved when the Subscribe
+        event itself was a lightweight stub."""
+        adapter = KimiAdapter(_cfg())
+        adapter.handle_message = AsyncMock()  # type: ignore
+        adapter._fetch_group_message = AsyncMock(return_value={
+            "id": "msg-t3",
+            "senderId": "user-3",
+            "senderShortId": "u3",
+            "threadId": "thread-from-hydration",
+            "blocks": [
+                {"content": {"case": "text", "value": {"content": "hydrated text"}}},
+            ],
+        })  # type: ignore
+
+        await adapter._on_group_event({
+            "chatMessage": {
+                "chatId": "chat-t3",
+                "messageId": "msg-t3",
+                "status": "STATUS_COMPLETED",
+            },
+        })
+
+        adapter.handle_message.assert_awaited_once()
+        event = adapter.handle_message.await_args.args[0]
+        self.assertEqual(event.source.chat_id, "room:chat-t3/thread-from-hydration")
+
+    async def test_outbound_thread_suffix_parsed_not_dropped(self):
+        """Sending to ``room:<uuid>/<tid>`` warns about thread collapse on
+        first occurrence instead of silently targeting the plain room."""
+        adapter = KimiAdapter(_cfg())
+        adapter._rpc_unary = AsyncMock(return_value={"messageId": "sent-t1"})  # type: ignore
+
+        with self.assertLogs("kimi_adapter", level=logging.WARNING) as cm:
+            result = await adapter.send("room:chat-t4/thread-xyz", "hello thread")
+
+        self.assertTrue(result.success)
+        # WARNING fired exactly once, references the thread id and the room.
+        self.assertTrue(
+            any(
+                r.levelno == logging.WARNING
+                and "thread_id='thread-xyz'" in r.getMessage()
+                and "chat-t4" in r.getMessage()
+                for r in cm.records
+            ),
+            f"expected WARNING about thread drop, got: {[r.getMessage() for r in cm.records]}",
+        )
+        # Payload still hits Kimi at the room level.
+        _method, body = adapter._rpc_unary.await_args.args
+        self.assertEqual(body["chatId"], "chat-t4")
+
+    async def test_outbound_thread_warning_is_one_shot(self):
+        """Second threaded send to the same adapter instance does not re-warn."""
+        adapter = KimiAdapter(_cfg())
+        adapter._rpc_unary = AsyncMock(return_value={"messageId": "sent-t2"})  # type: ignore
+
+        # Prime: first send consumes the warning.
+        with self.assertLogs("kimi_adapter", level=logging.WARNING):
+            await adapter.send("room:chat-t5/tid1", "first")
+
+        # Second send: attach a record-capturing handler directly instead of
+        # assertLogs (which fails when zero records are emitted).
+        captured: list[logging.LogRecord] = []
+        handler = logging.Handler()
+        handler.emit = captured.append  # type: ignore[assignment]
+        kimi_logger = logging.getLogger("kimi_adapter")
+        kimi_logger.addHandler(handler)
+        try:
+            await adapter.send("room:chat-t5/tid2", "second")
+        finally:
+            kimi_logger.removeHandler(handler)
+        self.assertFalse(
+            any(
+                r.levelno >= logging.WARNING
+                and "thread_id=" in r.getMessage()
+                for r in captured
+            ),
+            f"thread drop WARNING should be one-shot, got: {[r.getMessage() for r in captured]}",
+        )
+
+
+class OutboundMentionRenderingTests(unittest.IsolatedAsyncioTestCase):
+    """Outbound ``metadata['mentions']`` is no longer silently dropped.
+
+    Kimi Claw v0.25.0 has no confirmed mention-block wire shape, so the
+    adapter emits a WARNING and falls through to plain text. When the
+    surface check confirms a variant, this path can serialize instead.
+    """
+
+    async def test_outbound_mentions_metadata_serialized(self):
+        adapter = KimiAdapter(_cfg())
+        adapter._rpc_unary = AsyncMock(return_value={"messageId": "sent-m1"})  # type: ignore
+
+        with self.assertLogs("kimi_adapter", level=logging.WARNING) as cm:
+            result = await adapter._send_group(
+                "chat-m1",
+                "hey @u_bob",
+                reply_to=None,
+                thread_id=None,
+                metadata={"mentions": ["u_bob"]},
+            )
+
+        self.assertTrue(result.success)
+        self.assertTrue(
+            any(
+                r.levelno == logging.WARNING
+                and "metadata.mentions" in r.getMessage()
+                and "u_bob" in r.getMessage()
+                for r in cm.records
+            ),
+            f"expected WARNING about mention fall-through, got: {[r.getMessage() for r in cm.records]}",
+        )
+        # Plain text block still goes out — existing send contract preserved.
+        _method, body = adapter._rpc_unary.await_args.args
+        self.assertEqual(body["chatId"], "chat-m1")
+        self.assertEqual(len(body["blocks"]), 1)
+        self.assertEqual(body["blocks"][0]["text"]["content"], "hey @u_bob")
+
+    async def test_outbound_mentions_empty_metadata_plain_text_only(self):
+        """No mentions → no WARNING, plain text path unchanged."""
+        adapter = KimiAdapter(_cfg())
+        adapter._rpc_unary = AsyncMock(return_value={"messageId": "sent-m2"})  # type: ignore
+
+        captured: list[logging.LogRecord] = []
+        handler = logging.Handler()
+        handler.emit = captured.append  # type: ignore[assignment]
+        kimi_logger = logging.getLogger("kimi_adapter")
+        kimi_logger.addHandler(handler)
+        try:
+            result = await adapter._send_group(
+                "chat-m2",
+                "hello",
+                reply_to=None,
+                thread_id=None,
+                metadata={},
+            )
+        finally:
+            kimi_logger.removeHandler(handler)
+
+        self.assertTrue(result.success)
+        self.assertFalse(
+            any(
+                "metadata.mentions" in r.getMessage()
+                for r in captured
+            ),
+            f"no mentions means no mention warning, got: {[r.getMessage() for r in captured]}",
+        )
+        # Also covers metadata=None via empty-dict default in the caller.
+        _method, body = adapter._rpc_unary.await_args.args
+        self.assertEqual(body["blocks"][0]["text"]["content"], "hello")
+
+    async def test_outbound_mentions_warning_is_one_shot(self):
+        adapter = KimiAdapter(_cfg())
+        adapter._rpc_unary = AsyncMock(return_value={"messageId": "sent-m3"})  # type: ignore
+
+        with self.assertLogs("kimi_adapter", level=logging.WARNING):
+            await adapter._send_group(
+                "chat-m3", "first", reply_to=None, thread_id=None,
+                metadata={"mentions": ["u_one"]},
+            )
+
+        captured: list[logging.LogRecord] = []
+        handler = logging.Handler()
+        handler.emit = captured.append  # type: ignore[assignment]
+        kimi_logger = logging.getLogger("kimi_adapter")
+        kimi_logger.addHandler(handler)
+        try:
+            await adapter._send_group(
+                "chat-m3", "second", reply_to=None, thread_id=None,
+                metadata={"mentions": ["u_two"]},
+            )
+        finally:
+            kimi_logger.removeHandler(handler)
+        self.assertFalse(
+            any(
+                r.levelno >= logging.WARNING
+                and "metadata.mentions" in r.getMessage()
+                for r in captured
+            ),
+            f"mention drop WARNING should be one-shot, got: {[r.getMessage() for r in captured]}",
+        )
+
+
+class ConfigIntegrationTests(unittest.TestCase):
+    """Plugin-side config bridge: env vars, YAML translation, validate_config.
+
+    Replaces the older Fork-only tests that exercised in-fork
+    ``_apply_env_overrides`` and the hardcoded ``Platform.KIMI`` auth env-maps
+    in ``gateway/run.py``.  Both of those layers are now plugin-owned via the
+    upstream ``PlatformEntry`` registry (see :func:`kimi_adapter.register`).
+    """
+
+    def test_platform_kimiclaw_resolves_via_registry(self):
+        """After ``setUpModule`` registration, ``Platform('kimiclaw')`` yields a stable pseudo-member."""
+        p = Platform("kimiclaw")
+        self.assertEqual(p.value, "kimiclaw")
+        self.assertIs(p, Platform("kimiclaw"))  # identity-stable
+
+    def test_validate_config_with_env_token(self):
+        from kimi_adapter import validate_config
+        with patch.dict(os.environ, {"KIMI_BOT_TOKEN": "km_b_prod_TEST"}, clear=False):
+            self.assertTrue(validate_config(_cfg()))
+
+    def test_validate_config_with_extra_token(self):
+        from kimi_adapter import validate_config
+        env_no_token = {k: v for k, v in os.environ.items() if k != "KIMI_BOT_TOKEN"}
+        with patch.dict(os.environ, env_no_token, clear=True):
+            cfg = PlatformConfig(enabled=True, extra={"bot_token": "km_b_prod_TEST"})
+            self.assertTrue(validate_config(cfg))
+
+    def test_validate_config_with_config_token(self):
+        """``PlatformConfig.token`` is the third token source the adapter
+        ``__init__`` consults; ``validate_config`` must agree."""
+        from kimi_adapter import validate_config
+        env_no_token = {k: v for k, v in os.environ.items() if k != "KIMI_BOT_TOKEN"}
+        with patch.dict(os.environ, env_no_token, clear=True):
+            cfg = PlatformConfig(enabled=True, token="km_b_prod_TEST")
+            self.assertTrue(validate_config(cfg))
+
+    def test_validate_config_missing_token(self):
+        from kimi_adapter import validate_config
+        env_no_kimi = {k: v for k, v in os.environ.items()
+                       if not k.startswith("KIMI_")}
+        with patch.dict(os.environ, env_no_kimi, clear=True):
+            cfg = PlatformConfig(enabled=True, extra={})
+            self.assertFalse(validate_config(cfg))
+
+    def test_validate_config_rejects_unresolved_env_template(self):
+        """``${KIMI_BOT_TOKEN}`` with the env var unset must resolve to empty
+        and report not-configured — not a truthy literal that 401s at connect.
+        """
+        from kimi_adapter import validate_config
+        env_no_kimi = {k: v for k, v in os.environ.items()
+                       if not k.startswith("KIMI_")}
+        with patch.dict(os.environ, env_no_kimi, clear=True):
+            cfg_token = PlatformConfig(enabled=True, token="${KIMI_BOT_TOKEN}")
+            self.assertFalse(validate_config(cfg_token))
+            cfg_extra = PlatformConfig(
+                enabled=True, extra={"bot_token": "${KIMI_BOT_TOKEN}"}
+            )
+            self.assertFalse(validate_config(cfg_extra))
+
+    def test_validate_config_accepts_resolved_env_template(self):
+        """A ``${VAR}`` template that resolves to a real value is accepted.
+
+        Uses a non-``KIMI_BOT_TOKEN`` template var so the env short-circuit
+        at the top of ``validate_config`` doesn't mask the template path.
+        """
+        from kimi_adapter import validate_config
+        env_no_kimi = {k: v for k, v in os.environ.items()
+                       if not k.startswith("KIMI_")}
+        env_with = {**env_no_kimi, "KIMI_ALT_TOKEN": "km_b_prod_RESOLVED"}
+        with patch.dict(os.environ, env_with, clear=True):
+            cfg_token = PlatformConfig(enabled=True, token="${KIMI_ALT_TOKEN}")
+            self.assertTrue(validate_config(cfg_token))
+
+    def test_env_enablement_returns_token_dict(self):
+        from kimi_adapter import _env_enablement
+        with patch.dict(os.environ, {"KIMI_BOT_TOKEN": "km_b_prod_TEST"}, clear=False):
+            result = _env_enablement()
+        self.assertIsNotNone(result)
+        self.assertEqual(result["bot_token"], "km_b_prod_TEST")
+
+    def test_env_enablement_returns_none_without_token(self):
+        from kimi_adapter import _env_enablement
+        env_no_token = {k: v for k, v in os.environ.items() if k != "KIMI_BOT_TOKEN"}
+        with patch.dict(os.environ, env_no_token, clear=True):
+            result = _env_enablement()
+        self.assertIsNone(result)
+
+    def test_env_enablement_includes_home_channel(self):
+        from kimi_adapter import _env_enablement
+        with patch.dict(os.environ, {
+            "KIMI_BOT_TOKEN": "tok",
+            "KIMI_HOME_CHANNEL": "im:kimi:main",
+            "KIMI_HOME_CHANNEL_NAME": "Kimi Home",
+        }, clear=False):
+            result = _env_enablement()
+        self.assertEqual(
+            result["home_channel"],
+            {"chat_id": "im:kimi:main", "name": "Kimi Home"},
+        )
+
+    def test_apply_yaml_config_populates_env(self):
+        from kimi_adapter import _apply_yaml_config
+        env_no_kimi = {k: v for k, v in os.environ.items()
+                       if not k.startswith("KIMI_")}
+        with patch.dict(os.environ, env_no_kimi, clear=True):
+            _apply_yaml_config({}, {
+                "bot_token": "km_b_prod_FROM_YAML",
+                "home_channel": "room:abc",
+                "allowed_users": ["u1", "u2"],
+            })
+            self.assertEqual(os.environ.get("KIMI_BOT_TOKEN"), "km_b_prod_FROM_YAML")
+            self.assertEqual(os.environ.get("KIMI_HOME_CHANNEL"), "room:abc")
+            self.assertEqual(os.environ.get("KIMI_ALLOWED_USERS"), "u1,u2")
+
+    def test_apply_yaml_config_respects_env_precedence(self):
+        from kimi_adapter import _apply_yaml_config
+        with patch.dict(os.environ, {"KIMI_BOT_TOKEN": "km_b_prod_ENV_WINS"}, clear=False):
+            _apply_yaml_config({}, {"bot_token": "km_b_prod_YAML_LOSES"})
+            self.assertEqual(os.environ["KIMI_BOT_TOKEN"], "km_b_prod_ENV_WINS")
+
+    def test_apply_yaml_config_ignores_non_dict(self):
+        from kimi_adapter import _apply_yaml_config
+        # platform_cfg can be None or a non-dict when the YAML key is absent
+        self.assertIsNone(_apply_yaml_config({}, None))
+        self.assertIsNone(_apply_yaml_config({}, "not a dict"))
+
+    def test_load_gateway_config_top_level_kimiclaw_yaml_bridge_seeds_env_and_extra(self):
+        from gateway.config import Platform, load_gateway_config
+        from gateway.platform_registry import PlatformEntry, platform_registry
+        from kimi_adapter import _apply_yaml_config, _env_enablement
+
+        previous = platform_registry.get("kimiclaw")
+        platform_registry.unregister("kimiclaw")
+        platform_registry.register(PlatformEntry(
+            name="kimiclaw",
+            label="KimiClaw",
+            adapter_factory=lambda cfg: None,
+            check_fn=lambda: bool(os.getenv("KIMI_BOT_TOKEN")),
+            source="plugin",
+            apply_yaml_config_fn=_apply_yaml_config,
+            env_enablement_fn=_env_enablement,
+        ))
+        old_home = os.environ.get("HERMES_HOME")
+        env_no_kimi = {k: v for k, v in os.environ.items() if not k.startswith("KIMI_")}
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                home = Path(tmp) / ".hermes"
+                home.mkdir()
+                (home / "config.yaml").write_text(
+                    "kimiclaw:\n"
+                    "  bot_token: km_b_prod_FROM_TOP_LEVEL\n"
+                    "  home_channel: room:home\n",
+                    encoding="utf-8",
+                )
+                with patch.dict(os.environ, env_no_kimi, clear=True):
+                    os.environ["HERMES_HOME"] = str(home)
+                    cfg = load_gateway_config()
+
+                    self.assertEqual(
+                        os.environ.get("KIMI_BOT_TOKEN"),
+                        "km_b_prod_FROM_TOP_LEVEL",
+                    )
+                    platform = Platform("kimiclaw")
+                    self.assertIn(platform, cfg.platforms)
+                    self.assertEqual(
+                        cfg.platforms[platform].extra.get("bot_token"),
+                        "km_b_prod_FROM_TOP_LEVEL",
+                    )
+                    self.assertIsNotNone(cfg.platforms[platform].home_channel)
+                    self.assertEqual(
+                        cfg.platforms[platform].home_channel.chat_id,
+                        "room:home",
+                    )
+        finally:
+            platform_registry.unregister("kimiclaw")
+            if previous is not None:
+                platform_registry.register(previous)
+            if old_home is None:
+                os.environ.pop("HERMES_HOME", None)
+            else:
+                os.environ["HERMES_HOME"] = old_home
+
+    def test_platforms_extra_template_resolves_in_upstream_config_and_runtime_paths(self):
+        from gateway.config import Platform, load_gateway_config
+        from gateway.platform_registry import PlatformEntry, platform_registry
+        from kimi_adapter import _apply_yaml_config, _env_enablement
+
+        previous = platform_registry.get("kimiclaw")
+        platform_registry.unregister("kimiclaw")
+        platform_registry.register(PlatformEntry(
+            name="kimiclaw",
+            label="KimiClaw",
+            adapter_factory=lambda cfg: None,
+            check_fn=lambda: True,
+            source="plugin",
+            apply_yaml_config_fn=_apply_yaml_config,
+            env_enablement_fn=_env_enablement,
+        ))
+        old_home = os.environ.get("HERMES_HOME")
+        sentinel = "km_b_prod_RAW_EXTRA_" + uuid.uuid4().hex
+        env_no_kimi = {k: v for k, v in os.environ.items() if not k.startswith("KIMI_")}
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                home = Path(tmp) / ".hermes"
+                home.mkdir()
+                (home / "config.yaml").write_text(
+                    "platforms:\n"
+                    "  kimiclaw:\n"
+                    "    enabled: true\n"
+                    "    extra:\n"
+                    "      bot_token: ${KIMI_BOT_TOKEN}\n",
+                    encoding="utf-8",
+                )
+                with patch.dict(os.environ, env_no_kimi, clear=True):
+                    os.environ["HERMES_HOME"] = str(home)
+                    os.environ["KIMI_BOT_TOKEN"] = sentinel
+                    cfg = load_gateway_config()
+
+                    platform = Platform("kimiclaw")
+                    pconfig = cfg.platforms[platform]
+                    self.assertEqual(pconfig.extra.get("bot_token"), sentinel)
+                    adapter = KimiAdapter(pconfig)
+                    self.assertEqual(adapter._bot_token, sentinel)
+                    with patch(
+                        "kimi_adapter.send_kimi_message",
+                        new=AsyncMock(return_value=SendResult(success=True)),
+                    ) as mock_send:
+                        result = asyncio.run(
+                            _standalone_send(pconfig, "room:abc", "hello")
+                        )
+
+                    self.assertEqual(result, {"success": True})
+                    forwarded_cfg = mock_send.await_args.args[0]
+                    self.assertEqual(
+                        _resolve_env_template(forwarded_cfg.extra["bot_token"]),
+                        sentinel,
+                    )
+        finally:
+            platform_registry.unregister("kimiclaw")
+            if previous is not None:
+                platform_registry.register(previous)
+            if old_home is None:
+                os.environ.pop("HERMES_HOME", None)
+            else:
+                os.environ["HERMES_HOME"] = old_home
+
+
+class UserIdentityExtractionTests(unittest.TestCase):
+    """_extract_user_identity probes several plausible Kimi wire shapes."""
+
+    def test_flat_userid(self):
+        uid, name = _extract_user_identity({"userId": "u-123"})
+        self.assertEqual(uid, "u-123")
+        self.assertIsNone(name)
+
+    def test_flat_user_id_snake(self):
+        uid, _ = _extract_user_identity({"user_id": "u-456"})
+        self.assertEqual(uid, "u-456")
+
+    def test_nested_sender(self):
+        uid, name = _extract_user_identity(
+            {"sender": {"id": "u-789", "name": "Alice"}}
+        )
+        self.assertEqual(uid, "u-789")
+        self.assertEqual(name, "Alice")
+
+    def test_nested_user_with_display_name(self):
+        uid, name = _extract_user_identity(
+            {"user": {"userId": "u-abc", "display_name": "Bob"}}
+        )
+        self.assertEqual(uid, "u-abc")
+        self.assertEqual(name, "Bob")
+
+    def test_no_identity(self):
+        uid, name = _extract_user_identity({"sessionId": "im:kimi:main"})
+        self.assertIsNone(uid)
+        self.assertIsNone(name)
+
+    def test_non_dict_input(self):
+        uid, name = _extract_user_identity(None)
+        self.assertIsNone(uid)
+        self.assertIsNone(name)
+        uid, name = _extract_user_identity("string")
+        self.assertIsNone(uid)
+        self.assertIsNone(name)
+
+
+class SenderShortIdPrefixTests(unittest.TestCase):
+    """kimi-claw's [sender_short_id: X] text prefix (group-routed-over-ACP)."""
+
+    def test_extracts_short_id_from_prefix_line(self):
+        text = (
+            "Message From Kimi Group Chat Room:\n"
+            "[sender_short_id: u_abc123]\n"
+            "hello there"
+        )
+        self.assertEqual(_extract_short_id_from_text(text), "u_abc123")
+
+    def test_extracts_short_id_anywhere_in_text(self):
+        # The kimi-claw injector places it after the group prefix; we accept
+        # any line-start match so we're robust to prompt-text transforms.
+        text = "prelude\n[sender_short_id: u_xyz]\nactual content"
+        self.assertEqual(_extract_short_id_from_text(text), "u_xyz")
+
+    def test_no_prefix_returns_none(self):
+        self.assertIsNone(_extract_short_id_from_text("plain message"))
+        self.assertIsNone(_extract_short_id_from_text(""))
+        self.assertIsNone(_extract_short_id_from_text(None))  # type: ignore
+
+    def test_empty_short_id_returns_none(self):
+        # Malformed: empty content between brackets.
+        self.assertIsNone(_extract_short_id_from_text("[sender_short_id: ]"))
+
+    def test_strips_surrounding_whitespace(self):
+        text = "[sender_short_id:   u_padded   ]"
+        self.assertEqual(_extract_short_id_from_text(text), "u_padded")
+
+
+class EnvelopeLengthCapTests(unittest.IsolatedAsyncioTestCase):
+    """Connect envelope parser refuses oversize frames (I4 DoS guard)."""
+
+    async def test_envelope_length_cap_rejects_oversize(self):
+        adapter = KimiAdapter(_cfg())
+        oversize = _WS_MAX_FRAME_SIZE + 1
+        header = bytes([0x00]) + struct.pack(">I", oversize)
+        reader = MagicMock()
+        reader.readexactly = AsyncMock(return_value=header)
+        with self.assertRaises(KimiProtocolError) as ctx:
+            async for _ in adapter._connect_envelope_parser(reader):
+                self.fail("should not yield")
+        self.assertIn("exceeds max frame size", str(ctx.exception))
+
+    async def test_envelope_length_at_cap_is_allowed(self):
+        adapter = KimiAdapter(_cfg())
+        body = b'{"ping":{}}'
+        header = bytes([0x00]) + struct.pack(">I", len(body))
+        reads = [header, body, b""]
+        reader = MagicMock()
+
+        async def _readexactly(n):
+            if not reads:
+                raise asyncio.IncompleteReadError(b"", n)
+            chunk = reads.pop(0)
+            if len(chunk) != n:
+                # Simulate end-of-stream for the empty tail read
+                raise asyncio.IncompleteReadError(chunk, n)
+            return chunk
+
+        reader.readexactly = _readexactly
+        yielded = []
+        with self.assertRaises(Exception):
+            async for msg in adapter._connect_envelope_parser(reader):
+                yielded.append(msg)
+        self.assertEqual(yielded, [{"ping": {}}])
+
+
+class DMInflightQueueTests(unittest.IsolatedAsyncioTestCase):
+    """Overlapping DM prompts get FIFO end_turn responses (I2)."""
+
+    async def test_send_dm_pops_oldest_inflight(self):
+        adapter = KimiAdapter(_cfg())
+        # Simulate two in-flight prompts on the same kimi_sid
+        sid = "im:kimi:main"
+        adapter._dm_inflight[sid] = deque([
+            _DMInflight(kimi_sid=sid, req_id=101),
+            _DMInflight(kimi_sid=sid, req_id=102),
+        ])
+
+        respond_mock = AsyncMock()
+        adapter._dm_respond = respond_mock  # type: ignore
+        adapter._dm_emit_chunk = AsyncMock()  # type: ignore
+        adapter._ws = MagicMock()  # non-None sentinel
+
+        # First reply should pop req_id=101
+        await adapter._send_dm(sid, "reply one", reply_to=None, metadata={})
+        self.assertEqual(respond_mock.await_args_list[0].args[0], 101)
+
+        # Second reply should pop req_id=102 and leave the queue empty
+        await adapter._send_dm(sid, "reply two", reply_to=None, metadata={})
+        self.assertEqual(respond_mock.await_args_list[1].args[0], 102)
+        self.assertNotIn(sid, adapter._dm_inflight)
+
+    async def test_send_dm_no_inflight_is_harmless(self):
+        adapter = KimiAdapter(_cfg())
+        adapter._dm_respond = AsyncMock()  # type: ignore
+        adapter._dm_emit_chunk = AsyncMock()  # type: ignore
+        adapter._ws = MagicMock()
+        result = await adapter._send_dm(
+            "im:kimi:main", "reply", reply_to=None, metadata={}
+        )
+        self.assertTrue(result.success)
+
+    async def test_session_cancel_cancels_active_processing_and_clears_inflight(self):
+        adapter = KimiAdapter(_cfg())
+        sid = "im:kimi:main"
+        adapter._dm_inflight[sid] = deque([
+            _DMInflight(kimi_sid=sid, req_id=101),
+        ])
+        adapter.cancel_session_processing = AsyncMock()  # type: ignore
+
+        await adapter._dm_cancel_session(sid)
+
+        adapter.cancel_session_processing.assert_awaited_once()
+        self.assertNotIn(sid, adapter._dm_inflight)
+        kwargs = adapter.cancel_session_processing.await_args.kwargs
+        self.assertTrue(kwargs["release_guard"])
+        self.assertTrue(kwargs["discard_pending"])
+
+
+class DMPromptCounterTests(unittest.IsolatedAsyncioTestCase):
+    """DM session/prompt traffic counter increments on real prompts only."""
+
+    async def test_dm_prompt_counter_increments_on_prompt(self):
+        adapter = KimiAdapter(_cfg())
+        adapter.handle_message = AsyncMock()  # type: ignore
+        self.assertEqual(adapter._dm_prompt_count, 0)
+
+        # Minimal session/prompt frame shape — one text block.
+        frame = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "session/prompt",
+            "params": {
+                "sessionId": "im:kimi:main",
+                "prompt": [{"type": "text", "text": "hello"}],
+            },
+        }
+        await adapter._dm_on_inbound_frame(frame)
+
+        self.assertEqual(adapter._dm_prompt_count, 1)
+        adapter.handle_message.assert_awaited_once()
+
+        # Two more — counter accumulates.
+        await adapter._dm_on_inbound_frame(frame)
+        await adapter._dm_on_inbound_frame(frame)
+        self.assertEqual(adapter._dm_prompt_count, 3)
+
+    async def test_dm_prompt_counter_unchanged_on_non_prompt(self):
+        """$/ping, initialize, session/new etc. are not user prompts."""
+        adapter = KimiAdapter(_cfg())
+        adapter._dm_respond = AsyncMock()  # type: ignore
+        adapter.handle_message = AsyncMock()  # type: ignore
+
+        await adapter._dm_on_inbound_frame({
+            "jsonrpc": "2.0", "method": "$/ping", "params": {},
+        })
+        await adapter._dm_on_inbound_frame({
+            "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {},
+        })
+        await adapter._dm_on_inbound_frame({
+            "jsonrpc": "2.0", "id": 2, "method": "session/new", "params": {},
+        })
+        # Frame with no text block — the prompt branch runs but returns early,
+        # so we DO NOT count it as a real prompt.
+        await adapter._dm_on_inbound_frame({
+            "jsonrpc": "2.0", "id": 3, "method": "session/prompt",
+            "params": {"sessionId": "im:kimi:main", "prompt": []},
+        })
+
+        self.assertEqual(adapter._dm_prompt_count, 0)
+
+    async def test_dm_prompt_counter_does_not_count_empty_prompt(self):
+        """Empty / malformed session/prompt frames short-circuit before counting."""
+        adapter = KimiAdapter(_cfg())
+        adapter._dm_respond = AsyncMock()  # type: ignore
+        adapter.handle_message = AsyncMock()  # type: ignore
+
+        await adapter._dm_on_inbound_frame({
+            "jsonrpc": "2.0", "id": 7, "method": "session/prompt",
+            "params": {"sessionId": "im:kimi:main"},
+        })
+        self.assertEqual(adapter._dm_prompt_count, 0)
+        adapter.handle_message.assert_not_awaited()
+
+
+class DMHealthSummaryTests(unittest.IsolatedAsyncioTestCase):
+    """One-shot DM traffic tripwire at _dm_health_summary_s."""
+
+    async def test_dm_health_summary_warns_on_zero_traffic(self):
+        adapter = KimiAdapter(_cfg(dm_health_summary_s=0.01))
+        self.assertEqual(adapter._dm_prompt_count, 0)
+
+        with self.assertLogs("kimi_adapter", level=logging.WARNING) as cm:
+            await adapter._log_dm_health_summary()
+
+        warnings = [r for r in cm.records if r.levelno == logging.WARNING]
+        self.assertEqual(len(warnings), 1)
+        msg = warnings[0].getMessage()
+        self.assertIn("zero prompts", msg)
+        self.assertIn("enable_dms", msg)
+
+    async def test_dm_health_summary_info_on_traffic(self):
+        adapter = KimiAdapter(_cfg(dm_health_summary_s=0.01))
+        adapter._dm_prompt_count = 7
+
+        with self.assertLogs("kimi_adapter", level=logging.INFO) as cm:
+            await adapter._log_dm_health_summary()
+
+        info = [r for r in cm.records if r.levelno == logging.INFO]
+        warnings = [r for r in cm.records if r.levelno == logging.WARNING]
+        self.assertEqual(len(warnings), 0)
+        self.assertTrue(any("received 7 prompts" in r.getMessage() for r in info))
+
+    async def test_dm_health_summary_cancellation_safe(self):
+        """Cancelling the task before the delay elapses logs nothing.
+
+        The coroutine catches CancelledError internally so the task finishes
+        cleanly (no unhandled exception noise in logs) — we assert no
+        summary record was emitted and the task result is consumed.
+        """
+        adapter = KimiAdapter(_cfg(dm_health_summary_s=60))  # long delay
+
+        # Collect any records that fire during the task's lifetime.
+        captured: list[logging.LogRecord] = []
+        handler = logging.Handler()
+        handler.emit = captured.append  # type: ignore[assignment]
+        kimi_logger = logging.getLogger("kimi_adapter")
+        kimi_logger.addHandler(handler)
+        try:
+            task = asyncio.create_task(adapter._log_dm_health_summary())
+            await asyncio.sleep(0)  # give it a chance to enter sleep()
+            task.cancel()
+            # The coroutine swallows CancelledError internally, so it
+            # returns normally (and awaiting it produces None).
+            await task
+        finally:
+            kimi_logger.removeHandler(handler)
+        health_records = [
+            r for r in captured
+            if "prompts in first hour" in r.getMessage()
+            or "zero prompts in first hour" in r.getMessage()
+        ]
+        self.assertEqual(health_records, [])
+
+    async def test_dm_health_summary_disabled_by_zero_setting(self):
+        """dm_health_summary_s=0 skips arming the task in connect()."""
+        adapter = KimiAdapter(_cfg(dm_health_summary_s=0))
+        self.assertEqual(adapter._dm_health_summary_s, 0)
+        # Task is only created inside connect() — this verifies the knob is
+        # read and typed correctly. Lifecycle scheduling is covered indirectly
+        # by the cancellation test above.
+
+
+class SessionKeyConfigHoistingTests(unittest.TestCase):
+    """session_key_* config reads live in __init__, not the hot cancel path."""
+
+    def test_session_key_attributes_hoisted_from_config(self):
+        adapter = KimiAdapter(_cfg(
+            group_sessions_per_user=False,
+            thread_sessions_per_user=True,
+        ))
+        self.assertFalse(adapter._group_sessions_per_user)
+        self.assertTrue(adapter._thread_sessions_per_user)
+
+    def test_session_key_attributes_defaults(self):
+        adapter = KimiAdapter(_cfg())
+        # Defaults match prior behavior (see _dm_cancel_session before hoist).
+        self.assertTrue(adapter._group_sessions_per_user)
+        self.assertFalse(adapter._thread_sessions_per_user)
+
+
+class WSUpgradeClassificationTests(unittest.IsolatedAsyncioTestCase):
+    """_dm_ws_connect_once special-cases 401/403/409 (C2)."""
+
+    async def test_403_returns_permanent(self):
+        adapter = KimiAdapter(_cfg())
+        with patch(
+            "kimi_adapter.websockets.connect",
+            side_effect=_FakeWSStatusError(403),
+        ):
+            rc = await adapter._dm_ws_connect_once()
+        self.assertEqual(rc, 3)
+
+    async def test_409_first_strike_cools_off_60s(self):
+        adapter = KimiAdapter(_cfg())
+        sleep_mock = AsyncMock()
+        with patch(
+            "kimi_adapter.websockets.connect",
+            side_effect=_FakeWSStatusError(409),
+        ), patch("kimi_adapter.asyncio.sleep", sleep_mock):
+            rc = await adapter._dm_ws_connect_once()
+        self.assertEqual(rc, 0)
+        self.assertEqual(adapter._dm_409_strikes, 1)
+        sleep_mock.assert_awaited_once_with(60.0)
+
+    async def test_409_second_strike_cools_off_300s(self):
+        adapter = KimiAdapter(_cfg())
+        adapter._dm_409_strikes = 1  # prior strike
+        sleep_mock = AsyncMock()
+        with patch(
+            "kimi_adapter.websockets.connect",
+            side_effect=_FakeWSStatusError(409),
+        ), patch("kimi_adapter.asyncio.sleep", sleep_mock):
+            rc = await adapter._dm_ws_connect_once()
+        self.assertEqual(rc, 0)
+        self.assertEqual(adapter._dm_409_strikes, 2)
+        sleep_mock.assert_awaited_once_with(300.0)
+
+    async def test_401_returns_permanent(self):
+        adapter = KimiAdapter(_cfg())
+        with patch(
+            "kimi_adapter.websockets.connect",
+            side_effect=_FakeWSStatusError(401),
+        ):
+            rc = await adapter._dm_ws_connect_once()
+        self.assertEqual(rc, 3)
+
+
+class LifecycleStatusTests(unittest.IsolatedAsyncioTestCase):
+    """connect/disconnect drive base-class status + permanent auth sets fatal."""
+
+    async def test_permanent_auth_triggers_fatal_error(self):
+        adapter = KimiAdapter(_cfg())
+        adapter._dm_ws_connect_once = AsyncMock(return_value=3)  # type: ignore
+        await adapter._dm_ws_loop()
+        self.assertEqual(adapter._fatal_error_code, "kimi_dm_auth")
+        self.assertFalse(adapter._fatal_error_retryable)
+
+    async def test_closing_shutdown_does_not_set_fatal(self):
+        """If _closing is already True (clean shutdown path), don't leak fatal."""
+        adapter = KimiAdapter(_cfg())
+        adapter._closing = True
+        adapter._dm_ws_connect_once = AsyncMock(return_value=3)  # type: ignore
+        await adapter._dm_ws_loop()
+        self.assertIsNone(adapter._fatal_error_code)
+
+    async def test_groups_permanent_auth_triggers_fatal_error(self):
+        adapter = KimiAdapter(_cfg())
+        adapter._group_subscribe_once = AsyncMock(return_value=3)  # type: ignore
+        await adapter._group_subscribe_loop()
+        self.assertEqual(adapter._fatal_error_code, "kimi_groups_auth")
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Wave-2 hardening (Commit 4)
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TrustedOnlyDropLogLevelTests(unittest.IsolatedAsyncioTestCase):
+    """trusted_only drops log at INFO with a redacted sender — balancing
+    operator visibility against PII hygiene.
+
+    The prior shape (INFO + full short_id) leaked identifiers into log
+    aggregators in kimi-claw groups where every user message has
+    role='assistant'. The DEBUG demote that followed removed the operator
+    tripwire for misconfigured ``group_trusted_senders``. Current shape:
+    INFO with sender redacted to ``prefix + 4 chars + ****`` — enough to
+    diagnose drops without bleeding full identities.
+    """
+
+    async def test_trusted_only_drop_emits_info_with_redacted_sender(self):
+        adapter = KimiAdapter(_cfg(
+            group_allow_bot_senders="trusted_only",
+            group_trusted_senders=["u_someone_else"],
+        ))
+        adapter.handle_message = AsyncMock()  # type: ignore
+        # Fix A: _bot_msg() is summary-only — disable hydration so the
+        # cascade doesn't hit the network before the redacted-drop log fires.
+        adapter._hydrate_missing_text = False
+
+        # Use a realistic-looking short_id so we can assert that the
+        # redaction preserves only the prefix + first 4 body chars.
+        msg = _bot_msg(senderShortId="u_gs5ri2l5dpytlap", senderId="assistant-long-id-xyz")
+
+        with self.assertLogs("kimi_adapter", level=logging.DEBUG) as cm:
+            await adapter._on_group_event(msg)
+
+        adapter.handle_message.assert_not_awaited()
+
+        drop_records = [
+            r for r in cm.records
+            if "not in group_trusted_senders" in r.getMessage()
+        ]
+        self.assertEqual(len(drop_records), 1, f"expected one drop log, got: {drop_records}")
+        # INFO, not DEBUG — operators need a grep-able signal.
+        self.assertEqual(drop_records[0].levelno, logging.INFO)
+        rendered = drop_records[0].getMessage()
+        # Redacted token present; full tail absent.
+        self.assertIn("u_gs5r****", rendered)
+        self.assertNotIn("gs5ri2l5dpytlap", rendered)
+
+    async def test_trusted_only_drop_redacts_sender_id_when_short_id_absent(self):
+        """If only sender_id is set (no short_id), that too must be redacted."""
+        adapter = KimiAdapter(_cfg(
+            group_allow_bot_senders="trusted_only",
+            group_trusted_senders=["u_someone_else"],
+        ))
+        adapter.handle_message = AsyncMock()  # type: ignore
+        # Fix A: _bot_msg() is summary-only — disable hydration.
+        adapter._hydrate_missing_text = False
+
+        msg = _bot_msg(senderShortId=None, senderId="assistant-long-id-xyz")
+
+        with self.assertLogs("kimi_adapter", level=logging.DEBUG) as cm:
+            await adapter._on_group_event(msg)
+
+        drop_records = [
+            r for r in cm.records
+            if "not in group_trusted_senders" in r.getMessage()
+        ]
+        self.assertEqual(len(drop_records), 1)
+        self.assertEqual(drop_records[0].levelno, logging.INFO)
+        rendered = drop_records[0].getMessage()
+        # "assistant-long-id-xyz" has no "u_"/"b_" prefix → first 4 + ****.
+        self.assertIn("assi****", rendered)
+        self.assertNotIn("assistant-long-id-xyz", rendered)
+
+
+class SubscribeBackoffStateTests(unittest.IsolatedAsyncioTestCase):
+    """Subscribe reconnect backoff is instance-scoped and resets to the
+    oscillation-safe floor (10s) on the first processed frame post-connect.
+
+    Pre-fix: backoff was a loop-local int that only grew monotonically.
+    After hitting the 60s cap it stayed at 60s forever — messages arriving
+    during reconnect windows silently lost.
+
+    The fix resets backoff to ``floor`` (not ``base``) so flap-every-30s
+    oscillation doesn't drive reconnect delay back to 2s every cycle,
+    which would hammer Kimi's infra.
+    """
+
+    def _make_parser(self, events):
+        """Return an async generator function that yields the given events."""
+        async def _gen(_content):
+            for ev in events:
+                yield ev
+        return _gen
+
+    def _install_fake_session(self, adapter):
+        """Replace _http_session.post() with a context manager yielding HTTP 200.
+
+        Also pins ``_http_session_loop`` to the currently running loop so
+        ``_session_for_current_loop`` treats the fixture as same-loop and
+        yields the mock as-is, instead of creating an ephemeral aiohttp
+        session that would bypass the mock.
+        """
+        resp = MagicMock()
+        resp.status = 200
+
+        class _AsyncCtx:
+            async def __aenter__(self_inner):
+                return resp
+
+            async def __aexit__(self_inner, *exc):
+                return False
+
+        session = MagicMock()
+        # MagicMock attributes are themselves MagicMocks (truthy by default),
+        # so ``cached.closed`` would always test as truthy in
+        # ``_session_for_current_loop``'s ``getattr(cached, "closed", False)``
+        # check, sending the helper into the "stale session, recreate" branch
+        # — which silently replaces this fixture with a real
+        # ``aiohttp.ClientSession()`` and dials kimi.com for real.  Pinning
+        # the attribute to ``False`` keeps the helper on the cached-yield
+        # path so tests actually exercise the mock they installed.  Real
+        # production aiohttp sessions expose ``.closed`` as a proper bool,
+        # so the helper's check is correct there.
+        session.closed = False
+        session.post = MagicMock(return_value=_AsyncCtx())
+        adapter._http_session = session
+        try:
+            adapter._http_session_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            # Called outside a running loop (sync setUp). The helper's
+            # ``_http_session_loop is None`` branch treats this as
+            # caller-installed and yields as-is, so leave it None.
+            pass
+
+    async def test_subscribe_backoff_resets_to_floor_after_first_frame(self):
+        adapter = KimiAdapter(_cfg())
+        self._install_fake_session(adapter)
+        # Pretend we've grown backoff to the cap from prior reconnect churn.
+        adapter._group_subscribe_backoff = 60.0
+        adapter._connect_envelope_parser = self._make_parser(  # type: ignore
+            [{"chatMessage": {"chatId": "c", "messageId": "m"}}]
+        )
+        adapter._on_group_event = AsyncMock()  # type: ignore
+
+        rc = await adapter._group_subscribe_once()
+
+        self.assertEqual(rc, 0)
+        # Reset lands at floor (10s) — NOT base (2s) and NOT the prior 60s.
+        self.assertEqual(adapter._group_subscribe_backoff, 10.0)
+        self.assertTrue(adapter._group_subscribe_frame_since_connect)
+
+    async def test_subscribe_backoff_respects_floor_under_oscillation(self):
+        """Once backoff has grown past the floor, reconnect recoveries must
+        clamp to the floor — never below — so a flap-every-30s oscillation
+        can't drive the reconnect delay back to the 2s base each cycle.
+
+        Seed at ``floor * 2`` to skip the cold-start no-reset window and
+        exercise the oscillation invariant directly.
+        """
+        adapter = KimiAdapter(_cfg())
+        self._install_fake_session(adapter)
+        adapter._on_group_event = AsyncMock()  # type: ignore
+        # Seed past the floor so every cycle genuinely hits the reset path.
+        adapter._group_subscribe_backoff = adapter._group_subscribe_backoff_floor * 2
+
+        observed_backoffs = []
+        for cycle in range(3):
+            adapter._connect_envelope_parser = self._make_parser(  # type: ignore
+                [{"chatMessage": {"chatId": f"c{cycle}", "messageId": f"m{cycle}"}}]
+            )
+            await adapter._group_subscribe_once()
+            observed_backoffs.append(adapter._group_subscribe_backoff)
+            # Simulate the loop's post-error grow step between cycles.
+            adapter._group_subscribe_backoff = min(
+                adapter._group_subscribe_backoff * 2, adapter._reconnect_max_s,
+            )
+
+        # Every post-reset value is at least the floor (10s). Without the
+        # floor, naive reset to base would yield 2s on every cycle → thrash.
+        for value in observed_backoffs:
+            self.assertGreaterEqual(value, adapter._group_subscribe_backoff_floor)
+
+    async def test_subscribe_emits_recovered_log_after_frame(self):
+        adapter = KimiAdapter(_cfg())
+        self._install_fake_session(adapter)
+        adapter._group_subscribe_backoff = 32.0  # mid-growth reconnect
+        adapter._connect_envelope_parser = self._make_parser(  # type: ignore
+            [{"chatMessage": {"chatId": "c", "messageId": "m"}}]
+        )
+        adapter._on_group_event = AsyncMock()  # type: ignore
+
+        with self.assertLogs("kimi_adapter", level=logging.INFO) as cm:
+            await adapter._group_subscribe_once()
+
+        recovered = [r for r in cm.records if "stream recovered" in r.getMessage()]
+        self.assertEqual(len(recovered), 1)
+        self.assertEqual(recovered[0].levelno, logging.INFO)
+        # Log carries the backoff that was in effect at the time of the
+        # reconnect — useful operator signal for "how long were we down".
+        self.assertIn("32.0s", recovered[0].getMessage())
+
+    async def test_subscribe_no_duplicate_recovered_log(self):
+        adapter = KimiAdapter(_cfg())
+        self._install_fake_session(adapter)
+        adapter._group_subscribe_backoff = 32.0  # past the floor → recovery will log
+        adapter._connect_envelope_parser = self._make_parser(  # type: ignore
+            [
+                {"chatMessage": {"chatId": "c", "messageId": "m1"}},
+                {"chatMessage": {"chatId": "c", "messageId": "m2"}},
+                {"chatMessage": {"chatId": "c", "messageId": "m3"}},
+            ]
+        )
+        adapter._on_group_event = AsyncMock()  # type: ignore
+
+        with self.assertLogs("kimi_adapter", level=logging.INFO) as cm:
+            await adapter._group_subscribe_once()
+
+        recovered = [r for r in cm.records if "stream recovered" in r.getMessage()]
+        self.assertEqual(len(recovered), 1, f"expected exactly one 'stream recovered', got: {len(recovered)}")
+
+    async def test_subscribe_backoff_not_reset_on_keepalive_ping(self):
+        """A degraded stream emitting only keepalive pings must NOT reset
+        backoff — otherwise a ping-only loop would thrash back to the floor
+        on every reconnect and hammer Kimi's infra.
+        """
+        adapter = KimiAdapter(_cfg())
+        self._install_fake_session(adapter)
+        adapter._group_subscribe_backoff = 32.0  # would be reset if ping counted
+        adapter._connect_envelope_parser = self._make_parser(  # type: ignore
+            [{"ping": {}}]
+        )
+        adapter._on_group_event = AsyncMock()  # type: ignore
+
+        records, teardown = _capture_kimi_log_records()
+        try:
+            await adapter._group_subscribe_once()
+        finally:
+            teardown()
+
+        # Backoff unchanged, hook not armed, no recovery log emitted.
+        self.assertEqual(adapter._group_subscribe_backoff, 32.0)
+        self.assertFalse(adapter._group_subscribe_frame_since_connect)
+        recovered = [r for r in records if "stream recovered" in r.getMessage()]
+        self.assertEqual(recovered, [])
+
+    async def test_subscribe_backoff_not_reset_on_empty_stream(self):
+        """Stream opens and closes cleanly with zero events — must NOT flip
+        state or emit the recovery log.
+        """
+        adapter = KimiAdapter(_cfg())
+        self._install_fake_session(adapter)
+        adapter._group_subscribe_backoff = 32.0
+        adapter._connect_envelope_parser = self._make_parser([])  # type: ignore
+        adapter._on_group_event = AsyncMock()  # type: ignore
+
+        records, teardown = _capture_kimi_log_records()
+        try:
+            rc = await adapter._group_subscribe_once()
+        finally:
+            teardown()
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(adapter._group_subscribe_backoff, 32.0)
+        self.assertFalse(adapter._group_subscribe_frame_since_connect)
+        recovered = [r for r in records if "stream recovered" in r.getMessage()]
+        self.assertEqual(recovered, [])
+
+    async def test_subscribe_backoff_not_reset_on_handler_exception(self):
+        """If _on_group_event raises on the first chatMessage, the
+        operator-facing recovery log must NOT fire — otherwise a
+        dispatch-error loop would masquerade as a healthy stream.
+        Backoff is untouched too.
+
+        Cumulative review #58 split the pre-dispatch state transitions
+        from the post-dispatch operator log: counter + ts + gate flip
+        happen synchronously with first-frame detection (so the gap
+        log inside dispatch reads consistent ``connect#`` values), but
+        the recovery LOG and backoff CLAMP still gate on processing
+        success. This test exercises that split — pre-dispatch state
+        moves forward; operator-visible "healthy stream" signals do
+        NOT fire on dispatch failure.
+
+        The exception still propagates as before (caught by the outer
+        handlers into return code 0 / transient retry; the next cycle
+        resets the gate at the top of ``_group_subscribe_once``).
+        """
+        adapter = KimiAdapter(_cfg())
+        self._install_fake_session(adapter)
+        adapter._group_subscribe_backoff = 32.0
+        adapter._connect_envelope_parser = self._make_parser(  # type: ignore
+            [{"chatMessage": {"chatId": "c", "messageId": "m"}}]
+        )
+        adapter._on_group_event = AsyncMock(  # type: ignore
+            side_effect=KimiTransientError("simulated handler failure")
+        )
+
+        records, teardown = _capture_kimi_log_records()
+        try:
+            rc = await adapter._group_subscribe_once()
+        finally:
+            teardown()
+
+        # Transient handler errors are swallowed to rc=0 (retry) by the
+        # outer except block, so the caller retries the reconnect.
+        self.assertEqual(rc, 0)
+        # Backoff: untouched (the clamp is post-dispatch, gated on success).
+        self.assertEqual(adapter._group_subscribe_backoff, 32.0)
+        # Pre-dispatch state IS now advanced (#58): the counter increments
+        # and the gate flips before _on_group_event runs. Their meaning is
+        # "WS layer delivered a real chatMessage this cycle", which is
+        # true regardless of processing outcome. Cycle-level reset on the
+        # next reconnect (line 2500) clears the gate cleanly.
+        self.assertTrue(adapter._group_subscribe_frame_since_connect)
+        self.assertEqual(adapter._group_subscribe_reconnect_count, 1)
+        # The actual operator-visible "healthy stream" signals must
+        # remain silent on dispatch failure — both the new "subscribe
+        # stream live" and the legacy "stream recovered" log lines.
+        live = [r for r in records if "subscribe stream live" in r.getMessage()]
+        self.assertEqual(live, [], "stream-live log must not fire on dispatch failure")
+        recovered = [r for r in records if "stream recovered" in r.getMessage()]
+        self.assertEqual(recovered, [])
+
+
+class HomeChannelNagGuardTests(unittest.IsolatedAsyncioTestCase):
+    """Home-channel nag suppresses when /sethome has persisted a channel.
+
+    Pre-fix: the guard at run.py:4415 checked ``os.getenv(env_key)`` only.
+    The /sethome handler (run.py:5952) persists to config.yaml via
+    ``HomeChannel`` wiring AND sets the env var, but a gateway restarted
+    after /sethome may lose env-var state before config reloads — and
+    the authoritative source is the config, not the environment.
+
+    The fix checks ``self.config.get_home_channel(platform)`` first, then
+    falls back to env for the true first-run case.
+
+    These tests exercise the guard condition directly because
+    ``_handle_message_with_agent`` spans 2000+ lines and requires the
+    entire GatewayRunner state graph to reach the nag block. The
+    condition itself is a 2-line expression — a focused unit test on
+    that expression gives higher signal than a flaky end-to-end.
+    """
+
+    def _evaluate_nag_condition(self, config, platform, env_key_present: bool) -> bool:
+        """Replicate the guard at gateway/run.py:4425-4438 exactly.
+
+        Returns True iff the nag SHOULD fire under the given config+env.
+        """
+        env_value = "some-chat-id" if env_key_present else None
+        home_channel = config.get_home_channel(platform)
+        # Guard from run.py: send nag if neither source has a value.
+        return not home_channel and not env_value
+
+    def test_home_channel_nag_suppressed_when_config_has_home_channel(self):
+        config = GatewayConfig(
+            platforms={
+                Platform("kimiclaw"): PlatformConfig(
+                    enabled=True,
+                    token="tok",
+                    home_channel=HomeChannel(
+                        platform=Platform("kimiclaw"),
+                        chat_id="room:abc",
+                        name="Home",
+                    ),
+                ),
+            },
+        )
+        # Config has a home channel; env is empty — nag must NOT fire.
+        self.assertFalse(self._evaluate_nag_condition(config, Platform("kimiclaw"), env_key_present=False))
+        # Sanity: the config API used by the fix returns the HomeChannel object.
+        self.assertIsNotNone(config.get_home_channel(Platform("kimiclaw")))
+
+    def test_home_channel_nag_fires_when_both_env_and_config_empty(self):
+        """True first-run: no env, no config → operator should be prompted."""
+        config = GatewayConfig(
+            platforms={Platform("kimiclaw"): PlatformConfig(enabled=True, token="tok")},
+        )
+        self.assertTrue(self._evaluate_nag_condition(config, Platform("kimiclaw"), env_key_present=False))
+        # Env-set first-run path still suppresses (preserved behavior).
+        self.assertFalse(self._evaluate_nag_condition(config, Platform("kimiclaw"), env_key_present=True))
+
+
+def _capture_kimi_log_records(level: int = logging.DEBUG):
+    """Attach a list-capturing handler to the kimi logger.
+
+    Module-level shared helper used by both ``SubscribeBackoffStateTests``
+    and the Probe* test classes. Unlike ``assertLogs``, does not require
+    at least one record — suitable for tests that expect *zero* logs
+    from a code path. Returns ``(records_list, teardown_callable)``.
+    """
+    records: list = []
+
+    class _ListHandler(logging.Handler):
+        def emit(self_inner, record):
+            records.append(record)
+
+    handler = _ListHandler(level=level)
+    kimi_logger = logging.getLogger("kimi_adapter")
+    prev_level = kimi_logger.level
+    kimi_logger.addHandler(handler)
+    kimi_logger.setLevel(level)
+
+    def _teardown():
+        kimi_logger.removeHandler(handler)
+        kimi_logger.setLevel(prev_level)
+
+    return records, _teardown
+
+
+class Probe1BlockCaseTypeTests(unittest.TestCase):
+    """Probe (H-A): DEBUG dump of non-text block shapes from
+    ``_extract_blocks_payload``. Discriminates fragmented long messages
+    from unknown block variants (resourceLink, mention, code, etc.)
+    without behavior change.
+    """
+
+    def test_block_probe_fires_for_unknown_block_type(self):
+        """resourceLink block with no text → per-block DEBUG log includes
+        content_case, and the aggregate summary reports envelope lengths.
+        """
+        msg = {
+            "text": "envelope preview text",
+            "summary": "envelope preview summary",
+            "blocks": [
+                {
+                    "id": "b1",
+                    "content": {
+                        "case": "resourceLink",
+                        "value": {"uri": "kimi://file/x", "title": "x"},
+                    },
+                }
+            ],
+        }
+        records, teardown = _capture_kimi_log_records()
+        try:
+            text, urls, types = _extract_blocks_payload(msg)
+        finally:
+            teardown()
+
+        # Behavior unchanged: no text, but URI still extracted.
+        self.assertEqual(text, "")
+        self.assertEqual(urls, ["kimi://file/x"])
+        self.assertEqual(types, ["resource_link"])
+
+        per_block = [
+            r for r in records
+            if "non-text block (no extracted text)" in r.getMessage()
+        ]
+        self.assertEqual(len(per_block), 1, f"expected one per-block log, got: {per_block}")
+        self.assertEqual(per_block[0].levelno, logging.DEBUG)
+        rendered = per_block[0].getMessage()
+        self.assertIn("'content_case': 'resourceLink'", rendered)
+        self.assertIn("'has_uri': True", rendered)
+
+        # Aggregate summary with envelope lengths (Fix D oracle).
+        summary_log = [
+            r for r in records
+            if "non-text block(s)" in r.getMessage()
+        ]
+        self.assertEqual(len(summary_log), 1)
+        rendered_sum = summary_log[0].getMessage()
+        self.assertIn("extracted_text=0", rendered_sum)
+        self.assertIn(f"envelope_text={len('envelope preview text')}", rendered_sum)
+        self.assertIn(f"envelope_summary={len('envelope preview summary')}", rendered_sum)
+
+    def test_block_probe_silent_for_text_blocks(self):
+        """Normal text-bearing block must emit no probe log (neither per-block
+        nor aggregate summary).
+        """
+        msg = {
+            "blocks": [
+                {
+                    "id": "b1",
+                    "content": {
+                        "case": "text",
+                        "value": {"content": "hello world"},
+                    },
+                }
+            ],
+        }
+        records, teardown = _capture_kimi_log_records()
+        try:
+            text, _, _ = _extract_blocks_payload(msg)
+        finally:
+            teardown()
+
+        self.assertEqual(text, "hello world")
+        per_block = [
+            r for r in records
+            if "non-text block (no extracted text)" in r.getMessage()
+        ]
+        self.assertEqual(per_block, [])
+        summary_log = [
+            r for r in records
+            if "non-text block(s)" in r.getMessage()
+        ]
+        self.assertEqual(summary_log, [])
+
+    def test_block_probe_silent_for_all_text_blocks(self):
+        """Negative-assertion: every block yields text → neither per-block
+        probe nor the aggregate summary fires (Fix E trigger invariant).
+        """
+        msg = {
+            "blocks": [
+                {"content": {"case": "text", "value": {"content": "alpha"}}},
+                {"content": {"case": "text", "value": {"content": "beta"}}},
+            ],
+        }
+        records, teardown = _capture_kimi_log_records()
+        try:
+            text, _, _ = _extract_blocks_payload(msg)
+        finally:
+            teardown()
+
+        self.assertEqual(text, "alpha\nbeta")
+        probe = [
+            r for r in records
+            if "non-text block" in r.getMessage()
+        ]
+        self.assertEqual(probe, [])
+
+    def test_block_probe_handles_non_dict_block(self):
+        """Malformed non-dict block → no crash; DEBUG log includes type name."""
+        msg = {"blocks": ["not a dict", 42]}
+        records, teardown = _capture_kimi_log_records()
+        try:
+            text, urls, types = _extract_blocks_payload(msg)
+        finally:
+            teardown()
+
+        self.assertEqual(text, "")
+        self.assertEqual(urls, [])
+        self.assertEqual(types, [])
+
+        per_block = [
+            r for r in records
+            if "non-text block (no extracted text)" in r.getMessage()
+        ]
+        self.assertEqual(len(per_block), 2)
+        rendered = " ".join(r.getMessage() for r in per_block)
+        self.assertIn("'type': 'str'", rendered)
+        self.assertIn("'type': 'int'", rendered)
+
+    def test_block_probe_logs_envelope_lengths(self):
+        """Fix D oracle: aggregate log reports envelope text/summary lengths
+        + extracted length, so operators can distinguish "legitimate media
+        attachment" from "orphaned fragmented tail".
+        """
+        msg = {
+            "text": "short envelope",
+            "summary": "much longer envelope preview than the extracted bit",
+            "blocks": [
+                {"content": {"case": "text", "value": {"content": "hi"}}},
+                {
+                    "id": "b2",
+                    "content": {
+                        "case": "resourceLink",
+                        "value": {"uri": "kimi://file/y"},
+                    },
+                },
+            ],
+        }
+        records, teardown = _capture_kimi_log_records()
+        try:
+            text, _, _ = _extract_blocks_payload(msg)
+        finally:
+            teardown()
+
+        self.assertEqual(text, "hi")
+        summary_log = [
+            r for r in records
+            if "non-text block(s)" in r.getMessage()
+        ]
+        self.assertEqual(len(summary_log), 1)
+        rendered = summary_log[0].getMessage()
+        self.assertIn("extracted_text=2", rendered)
+        self.assertIn(f"envelope_text={len('short envelope')}", rendered)
+        self.assertIn(
+            f"envelope_summary={len('much longer envelope preview than the extracted bit')}",
+            rendered,
+        )
+        # Oracle signature: envelope_summary > extracted_text → operator
+        # sees the mismatch immediately.
+        self.assertGreater(
+            len("much longer envelope preview than the extracted bit"),
+            2,
+        )
+
+
+class Probe2TextSourceTests(unittest.IsolatedAsyncioTestCase):
+    """Probe (H-B): DEBUG log reports which source populated ``text``
+    (blocks / text / summary / none) and the lengths of each candidate.
+    Reveals when a short summary silently wins over empty blocks and
+    bypasses the hydration gate.
+    """
+
+    def _adapter(self):
+        adapter = KimiAdapter(_cfg(group_allow_bot_senders="all"))
+        adapter.handle_message = AsyncMock()  # type: ignore
+        # Disable hydration so the probe log fires on the original text,
+        # not on the re-extracted hydrated payload.
+        adapter._hydrate_missing_text = False
+        return adapter
+
+    async def test_text_source_probe_chooses_blocks(self):
+        adapter = self._adapter()
+        msg = {
+            "chatMessage": {
+                "chatId": "room-a",
+                "messageId": "01HKCHF4FC4S0W7T3V74SG6AT6",
+                "status": "STATUS_COMPLETED",
+                "role": "ROLE_USER",
+                "senderId": "u1",
+                "senderShortId": "u_real",
+                "summary": "preview",
+                "blocks": [
+                    {"content": {"case": "text", "value": {"content": "body text"}}}
+                ],
+            }
+        }
+        records, teardown = _capture_kimi_log_records()
+        try:
+            await adapter._on_group_event(msg)
+        finally:
+            teardown()
+
+        probe = [r for r in records if "text source for" in r.getMessage()]
+        self.assertEqual(len(probe), 1, f"expected one probe log, got: {probe}")
+        rendered = probe[0].getMessage()
+        self.assertIn("chose=blocks", rendered)
+        self.assertIn("blocks=9", rendered)
+        # Inline body present → hydration check short-circuits to
+        # `skipped:inline` regardless of the _hydrate_missing_text flag
+        # (Fix C distinguishes "not needed" from "operator policy off").
+        self.assertIn("hydrated=skipped:inline", rendered)
+
+    async def test_text_source_probe_chooses_summary_when_blocks_empty(self):
+        adapter = self._adapter()
+        msg = {
+            "chatMessage": {
+                "chatId": "room-b",
+                "messageId": "01HKCHF4FC4S0W7T3V74SG6AT7",
+                "status": "STATUS_COMPLETED",
+                "role": "ROLE_USER",
+                "senderId": "u1",
+                "senderShortId": "u_real",
+                "summary": "preview-only",
+                "blocks": [],
+            }
+        }
+        records, teardown = _capture_kimi_log_records()
+        try:
+            await adapter._on_group_event(msg)
+        finally:
+            teardown()
+
+        probe = [r for r in records if "text source for" in r.getMessage()]
+        self.assertEqual(len(probe), 1)
+        rendered = probe[0].getMessage()
+        self.assertIn("chose=summary", rendered)
+        self.assertIn("blocks=0", rendered)
+        self.assertIn(f"summary={len('preview-only')}", rendered)
+        # Hydration disabled by fixture (`_hydrate_missing_text=False`) →
+        # `skipped:disabled` distinguishes operator policy from "inline
+        # body present, hydration not needed" (Fix C).
+        self.assertIn("hydrated=skipped:disabled", rendered)
+
+    async def test_text_source_probe_chooses_none_when_all_empty(self):
+        adapter = self._adapter()
+        msg = {
+            "chatMessage": {
+                "chatId": "room-c",
+                "messageId": "01HKCHF4FC4S0W7T3V74SG6AT8",
+                "status": "STATUS_COMPLETED",
+                "role": "ROLE_USER",
+                "senderId": "u1",
+                "senderShortId": "u_real",
+            }
+        }
+        records, teardown = _capture_kimi_log_records()
+        try:
+            await adapter._on_group_event(msg)
+        finally:
+            teardown()
+
+        probe = [r for r in records if "text source for" in r.getMessage()]
+        self.assertEqual(len(probe), 1)
+        rendered = probe[0].getMessage()
+        self.assertIn("chose=none", rendered)
+        self.assertIn("blocks=0", rendered)
+        self.assertIn("text=0", rendered)
+        self.assertIn("summary=0", rendered)
+        # No miss candidates when every source is empty.
+        self.assertIn("miss_candidate=none", rendered)
+        # Fix C: `skipped:disabled` (not generic `skipped`) when the
+        # hydration flag is off.
+        self.assertIn("hydrated=skipped:disabled", rendered)
+
+    async def test_text_source_probe_flags_miss_candidate_when_summary_longer(self):
+        """Fix C: when a non-chosen candidate is LONGER than the chosen one,
+        `miss_candidate=<name>` flags the hydration-miss signature directly
+        so operators don't have to eyeball per-field lengths.
+        """
+        adapter = self._adapter()
+        msg = {
+            "chatMessage": {
+                "chatId": "room-d",
+                "messageId": "01HKCHF4FC4S0W7T3V74SG6AT9",
+                "status": "STATUS_COMPLETED",
+                "role": "ROLE_USER",
+                "senderId": "u1",
+                "senderShortId": "u_real",
+                "text": "short",
+                "summary": "much longer preview",
+                "blocks": [],
+            }
+        }
+        records, teardown = _capture_kimi_log_records()
+        try:
+            await adapter._on_group_event(msg)
+        finally:
+            teardown()
+
+        probe = [r for r in records if "text source for" in r.getMessage()]
+        self.assertEqual(len(probe), 1)
+        rendered = probe[0].getMessage()
+        self.assertIn("chose=text", rendered)
+        self.assertIn("miss_candidate=summary", rendered)
+        # Inline body present (text=short) → `skipped:inline` (Fix C),
+        # not `skipped:disabled` — the flag is off in this fixture but
+        # the inline-present check short-circuits first.
+        self.assertIn("hydrated=skipped:inline", rendered)
+
+
+class HydrateWhenInlineBodyEmptyTests(unittest.IsolatedAsyncioTestCase):
+    """H-B fix (Commit 6): when Subscribe ships ``blocks=[]`` and no inline
+    ``text`` but a non-empty ``summary`` preview, hydrate from
+    ``ListMessages`` rather than dispatching the truncated preview to the
+    agent. Summary remains as a last-resort fallback if hydration fails.
+
+    Production trigger (2026-04-26 11:21:36 BST): Probe 2 captured
+    ``blocks=0, text=0, summary=50, chose=summary, miss_candidate=none``
+    for a ~150-char inbound; agent answered against the 50-char preview.
+    """
+
+    def _summary_only_event(self, *, chat_id="chat-hb", message_id="msg-hb",
+                            summary="this is a 50-char-ish truncated server-side preview"):
+        return {
+            "chatMessage": {
+                "chatId": chat_id,
+                "messageId": message_id,
+                "status": "STATUS_COMPLETED",
+                "role": "ROLE_USER",
+                "senderId": "u1",
+                "senderShortId": "u_real",
+                "summary": summary,
+                "blocks": [],
+            }
+        }
+
+    async def test_summary_only_event_triggers_hydration(self):
+        """Empty blocks + empty text + populated summary + hydration enabled
+        → ``_fetch_group_message`` called exactly once with the chat/message
+        ids from the event.
+        """
+        adapter = KimiAdapter(_cfg(group_allow_bot_senders="all"))
+        adapter.handle_message = AsyncMock()  # type: ignore
+        # Default is True; assert explicitly to make the contract visible.
+        self.assertTrue(adapter._hydrate_missing_text)
+        adapter._fetch_group_message = AsyncMock(return_value={
+            "id": "msg-hb",
+            "blocks": [
+                {"content": {"case": "text", "value": {"content": "full body"}}}
+            ],
+        })  # type: ignore
+
+        await adapter._on_group_event(self._summary_only_event())
+
+        adapter._fetch_group_message.assert_awaited_once_with("chat-hb", "msg-hb")
+
+    async def test_hydrated_body_wins_over_summary(self):
+        """Dispatched ``MessageEvent.text`` matches the hydrated body, not
+        the summary preview — the whole point of the H-B fix.
+        """
+        adapter = KimiAdapter(_cfg(group_allow_bot_senders="all"))
+        adapter.handle_message = AsyncMock()  # type: ignore
+        full_body = (
+            "please reply with the literal word pineapple so the operator "
+            "can verify full delivery (this is a ~150 char message)"
+        )
+        adapter._fetch_group_message = AsyncMock(return_value={
+            "id": "msg-hb",
+            "senderId": "u1",
+            "senderShortId": "u_real",
+            "blocks": [
+                {"content": {"case": "text", "value": {"content": full_body}}}
+            ],
+        })  # type: ignore
+
+        await adapter._on_group_event(
+            self._summary_only_event(summary="please reply with the literal word…")
+        )
+
+        adapter.handle_message.assert_awaited_once()
+        delivered = adapter.handle_message.await_args.args[0]
+        self.assertEqual(delivered.text, full_body)
+        self.assertNotIn("…", delivered.text)
+
+    async def test_hydration_failure_falls_back_to_summary(self):
+        """When hydration raises ``KimiAdapterError`` (transient infra blip)
+        we still dispatch with the summary text rather than dropping the
+        message entirely. Graceful degradation — better-than-nothing.
+
+        Fix B: summary fallback now prepends a truncation marker so the
+        agent can acknowledge the body is a preview rather than answer
+        confidently against half a sentence (same H-B failure mode as
+        the original bug, just less frequent).
+        """
+        adapter = KimiAdapter(_cfg(group_allow_bot_senders="all"))
+        adapter.handle_message = AsyncMock()  # type: ignore
+        summary = "preview-only fallback text"
+        adapter._fetch_group_message = AsyncMock(
+            side_effect=KimiRpcError("hydration failed")
+        )  # type: ignore
+
+        await adapter._on_group_event(self._summary_only_event(summary=summary))
+
+        adapter.handle_message.assert_awaited_once()
+        delivered = adapter.handle_message.await_args.args[0]
+        self.assertTrue(
+            delivered.text.startswith("[message truncated"),
+            f"expected truncation marker prefix, got: {delivered.text!r}",
+        )
+        self.assertTrue(
+            delivered.text.endswith(summary),
+            f"expected summary at tail, got: {delivered.text!r}",
+        )
+
+    async def test_hydration_skipped_when_inline_text_present(self):
+        """Happy path: inline blocks/text present → no hydration RPC even
+        if a summary also exists. Guards against re-introducing per-event
+        ``ListMessages`` overhead in the common case.
+        """
+        adapter = KimiAdapter(_cfg(group_allow_bot_senders="all"))
+        adapter.handle_message = AsyncMock()  # type: ignore
+        adapter._fetch_group_message = AsyncMock()  # type: ignore
+
+        await adapter._on_group_event({
+            "chatMessage": {
+                "chatId": "chat-happy",
+                "messageId": "msg-happy",
+                "status": "STATUS_COMPLETED",
+                "role": "ROLE_USER",
+                "senderId": "u1",
+                "senderShortId": "u_real",
+                "summary": "preview",
+                "blocks": [
+                    {"content": {"case": "text", "value": {"content": "inline body"}}}
+                ],
+            }
+        })
+
+        adapter._fetch_group_message.assert_not_awaited()
+        adapter.handle_message.assert_awaited_once()
+        delivered = adapter.handle_message.await_args.args[0]
+        self.assertEqual(delivered.text, "inline body")
+
+    async def test_probe2_logs_hydrated_field(self):
+        """Probe 2 reports ``hydrated=true`` and ``chose=hydrated`` when
+        a summary-only inbound is successfully hydrated. Confirms the
+        observability surface tracks the new control flow.
+        """
+        adapter = KimiAdapter(_cfg(group_allow_bot_senders="all"))
+        adapter.handle_message = AsyncMock()  # type: ignore
+        full_body = "the actual full body fetched via ListMessages"
+        adapter._fetch_group_message = AsyncMock(return_value={
+            "id": "msg-hb",
+            "blocks": [
+                {"content": {"case": "text", "value": {"content": full_body}}}
+            ],
+        })  # type: ignore
+
+        records, teardown = _capture_kimi_log_records()
+        try:
+            await adapter._on_group_event(
+                self._summary_only_event(summary="short preview")
+            )
+        finally:
+            teardown()
+
+        probe = [r for r in records if "text source for" in r.getMessage()]
+        self.assertEqual(len(probe), 1, f"expected one probe log, got: {probe}")
+        rendered = probe[0].getMessage()
+        self.assertIn("hydrated=true", rendered)
+        self.assertIn("chose=hydrated", rendered)
+        # Original raw-event candidates: blocks=0 text=0 summary>0.
+        self.assertIn("blocks=0", rendered)
+        self.assertIn("text=0", rendered)
+
+    async def test_summary_fallback_includes_truncation_marker(self):
+        """Fix B: hydration failure → summary fallback path prepends a
+        clear truncation marker so the agent knows the body is a preview
+        and can acknowledge rather than confidently answer against half
+        a sentence. Same H-B failure mode as the original bug — just less
+        frequent now that hydration is the primary path.
+        """
+        adapter = KimiAdapter(_cfg(group_allow_bot_senders="all"))
+        adapter.handle_message = AsyncMock()  # type: ignore
+        summary = "this is the 50-char-ish truncated server-side preview"
+        adapter._fetch_group_message = AsyncMock(
+            side_effect=KimiRpcError("hydration unavailable")
+        )  # type: ignore
+
+        await adapter._on_group_event(self._summary_only_event(summary=summary))
+
+        adapter.handle_message.assert_awaited_once()
+        delivered = adapter.handle_message.await_args.args[0]
+        self.assertTrue(
+            delivered.text.startswith("[message truncated"),
+            f"expected truncation marker prefix, got: {delivered.text!r}",
+        )
+        self.assertIn(summary, delivered.text)
+
+    async def test_probe2_logs_hydrated_skipped_disabled_when_flag_off(self):
+        """Fix C: ``_hydrate_missing_text=False`` → ``hydrated=skipped:disabled``
+        in Probe 2 (operator policy distinguishable from "inline body
+        present, hydration not needed").
+        """
+        adapter = KimiAdapter(_cfg(group_allow_bot_senders="all"))
+        adapter.handle_message = AsyncMock()  # type: ignore
+        adapter._hydrate_missing_text = False  # operator policy: no hydration
+        # _fetch_group_message intentionally NOT mocked: with the flag off
+        # it must never be invoked.
+
+        records, teardown = _capture_kimi_log_records()
+        try:
+            await adapter._on_group_event(
+                self._summary_only_event(summary="short preview")
+            )
+        finally:
+            teardown()
+
+        probe = [r for r in records if "text source for" in r.getMessage()]
+        self.assertEqual(len(probe), 1, f"expected one probe log, got: {probe}")
+        rendered = probe[0].getMessage()
+        self.assertIn("hydrated=skipped:disabled", rendered)
+        self.assertNotIn("hydrated=skipped:inline", rendered)
+
+    async def test_probe2_logs_hydrated_skipped_inline_when_inline_text_present(self):
+        """Fix C: inline body present (non-empty blocks/text) →
+        ``hydrated=skipped:inline``, regardless of the
+        ``_hydrate_missing_text`` flag. Distinguishes "happy path, no
+        hydration needed" from "operator turned hydration off".
+        """
+        adapter = KimiAdapter(_cfg(group_allow_bot_senders="all"))
+        adapter.handle_message = AsyncMock()  # type: ignore
+        adapter._fetch_group_message = AsyncMock()  # type: ignore
+
+        records, teardown = _capture_kimi_log_records()
+        try:
+            await adapter._on_group_event({
+                "chatMessage": {
+                    "chatId": "chat-inline",
+                    "messageId": "msg-inline",
+                    "status": "STATUS_COMPLETED",
+                    "role": "ROLE_USER",
+                    "senderId": "u1",
+                    "senderShortId": "u_real",
+                    "summary": "preview",
+                    "blocks": [
+                        {"content": {"case": "text", "value": {"content": "inline body"}}}
+                    ],
+                }
+            })
+        finally:
+            teardown()
+
+        adapter._fetch_group_message.assert_not_awaited()
+        probe = [r for r in records if "text source for" in r.getMessage()]
+        self.assertEqual(len(probe), 1, f"expected one probe log, got: {probe}")
+        rendered = probe[0].getMessage()
+        self.assertIn("hydrated=skipped:inline", rendered)
+        self.assertNotIn("hydrated=skipped:disabled", rendered)
+
+    async def test_probe2_logs_hydrated_false_when_hydration_returns_empty_payload(self):
+        """Fix E: hydration returns a truthy-but-empty payload (e.g. wrapper
+        with no blocks/text) → ``hydrated=false``, NOT ``hydrated=true``.
+        Prior shape set ``hydrated=true`` whenever the hydrated dict was
+        truthy, before checking whether ``_extract_blocks_payload`` actually
+        yielded text — Probe 2 then falsely claimed a hydration win on an
+        empty payload.
+
+        Falls through to summary fallback (Fix B annotated).
+        """
+        adapter = KimiAdapter(_cfg(group_allow_bot_senders="all"))
+        adapter.handle_message = AsyncMock()  # type: ignore
+        # Truthy but yields no text — wrapper-only payload.
+        adapter._fetch_group_message = AsyncMock(return_value={
+            "id": "msg-hb",
+            "blocks": [],
+        })  # type: ignore
+
+        records, teardown = _capture_kimi_log_records()
+        try:
+            await adapter._on_group_event(
+                self._summary_only_event(summary="short preview")
+            )
+        finally:
+            teardown()
+
+        probe = [r for r in records if "text source for" in r.getMessage()]
+        self.assertEqual(len(probe), 1, f"expected one probe log, got: {probe}")
+        rendered = probe[0].getMessage()
+        self.assertIn("hydrated=false", rendered)
+        self.assertNotIn("hydrated=true", rendered)
+        # Cascade then falls through to Fix B's annotated summary.
+        self.assertIn("chose=summary", rendered)
+
+
+class Probe3MessageIdTimingTests(unittest.IsolatedAsyncioTestCase):
+    """Probe (H-C): per-room message_id timing DEBUG log for post-hoc
+    burst-drop correlation. Updated BEFORE the filter chain so drops
+    still count as "what Kimi sent us" — gaps then map to burst losses.
+    """
+
+    def _adapter(self):
+        adapter = KimiAdapter(_cfg(group_allow_bot_senders="all"))
+        adapter.handle_message = AsyncMock()  # type: ignore
+        adapter._hydrate_missing_text = False
+        return adapter
+
+    def _msg(self, chat_id, message_id):
+        return {
+            "chatMessage": {
+                "chatId": chat_id,
+                "messageId": message_id,
+                "status": "STATUS_COMPLETED",
+                "role": "ROLE_USER",
+                "senderId": "u1",
+                "senderShortId": "u_real",
+                "blocks": [
+                    {"content": {"case": "text", "value": {"content": "hi"}}}
+                ],
+            }
+        }
+
+    async def test_message_id_probe_first_seen_for_new_room(self):
+        adapter = self._adapter()
+        records, teardown = _capture_kimi_log_records()
+        try:
+            await adapter._on_group_event(self._msg("room-X", "01HKCHF4FC4S0W7T3V74SG6AT6"))
+        finally:
+            teardown()
+
+        probe = [r for r in records if "message_id first-seen" in r.getMessage()]
+        self.assertEqual(len(probe), 1, f"expected one first-seen log, got: {probe}")
+        rendered = probe[0].getMessage()
+        self.assertIn("room=room-X", rendered)
+        self.assertIn("id=01HKCHF4FC4S0W7T3V74SG6AT6", rendered)
+
+    async def test_message_id_probe_emits_delta_for_second_message(self):
+        adapter = self._adapter()
+        # Bump char 10 (end of the 48-bit timestamp prefix) so the two ULIDs
+        # decode to different millisecond timestamps — the random tail has
+        # no effect on the delta.
+        first_id = "01HKCHF4FC4S0W7T3V74SG6AT6"
+        second_id = "01HKCHF4FD4S0W7T3V74SG6AT6"
+        # DEBUG enabled on both dispatches so the log emission fires; the
+        # tracker update itself is hoisted OUT of the DEBUG gate (Fix A)
+        # so it populates regardless of level.
+        records, teardown = _capture_kimi_log_records()
+        try:
+            await adapter._on_group_event(self._msg("room-Y", first_id))
+            first_records_len = len(records)
+            await adapter._on_group_event(self._msg("room-Y", second_id))
+        finally:
+            teardown()
+
+        # Only inspect records emitted during the second dispatch.
+        second_records = records[first_records_len:]
+        timing = [r for r in second_records if "message_id timing" in r.getMessage()]
+        self.assertEqual(len(timing), 1)
+        rendered = timing[0].getMessage()
+        self.assertIn("room=room-Y", rendered)
+        self.assertIn(f"prev={first_id}", rendered)
+        self.assertIn("delta_ms=", rendered)
+        # delta must equal the second - first timestamp diff.
+        expected_delta = _ulid_time_ms(second_id) - _ulid_time_ms(first_id)
+        self.assertIn(f"delta_ms={expected_delta}", rendered)
+        # Second dispatch must not emit a first-seen log.
+        first_seen = [r for r in second_records if "first-seen" in r.getMessage()]
+        self.assertEqual(first_seen, [])
+
+    async def test_message_id_probe_per_room_isolation(self):
+        adapter = self._adapter()
+        records, teardown = _capture_kimi_log_records()
+        try:
+            # Room A: two messages.
+            await adapter._on_group_event(self._msg("room-A", "01HKCHF4FC4S0W7T3V74SG6AT6"))
+            await adapter._on_group_event(self._msg("room-A", "01HKCHF4FD4S0W7T3V74SG6AT6"))
+            boundary = len(records)
+            # Room B: first message — must log first-seen, not a delta from A.
+            await adapter._on_group_event(self._msg("room-B", "01HKCHF4FE4S0W7T3V74SG6AT6"))
+        finally:
+            teardown()
+
+        b_records = records[boundary:]
+        first_seen = [r for r in b_records if "first-seen" in r.getMessage()]
+        timing = [r for r in b_records if "message_id timing" in r.getMessage()]
+        self.assertEqual(len(first_seen), 1, f"expected first-seen for room-B, got: {b_records}")
+        self.assertIn("room=room-B", first_seen[0].getMessage())
+        self.assertEqual(timing, [], "room-B must not emit a delta against room-A")
+
+    def test_ulid_time_ms_parses_known_ulid(self):
+        """Canonical ULID decode — cross-checked against python-ulid."""
+        # '01ARZ3NDEKTSV4RRFFQ69G5FAV' → 1469922850259 ms
+        # (2016-07-30T23:54:10.259+00:00 UTC), verified against python-ulid.
+        self.assertEqual(
+            _ulid_time_ms("01ARZ3NDEKTSV4RRFFQ69G5FAV"),
+            1469922850259,
+        )
+        # Case-insensitive.
+        self.assertEqual(
+            _ulid_time_ms("01arz3ndektsv4rrffq69g5fav"),
+            1469922850259,
+        )
+        # Monotonic across two close ULIDs — later ULID has larger prefix value.
+        earlier = _ulid_time_ms("01HKCHF4FC4S0W7T3V74SG6AT6")
+        later = _ulid_time_ms("01HKCHF4FD4S0W7T3V74SG6AT6")
+        self.assertIsNotNone(earlier)
+        self.assertIsNotNone(later)
+        self.assertGreater(later, earlier)
+
+    def test_ulid_time_ms_rejects_short_or_invalid(self):
+        """None / empty / short / non-crockford → None, not a crash."""
+        self.assertIsNone(_ulid_time_ms(None))
+        self.assertIsNone(_ulid_time_ms(""))
+        self.assertIsNone(_ulid_time_ms("01ARZ3NDE"))  # 9 chars, too short
+        # 'I', 'L', 'O', 'U' are NOT in Crockford base32 — must reject.
+        # (These IDs are 10 chars so they don't trip the UUID branch.)
+        self.assertIsNone(_ulid_time_ms("01IRZ3NDEK"))
+        self.assertIsNone(_ulid_time_ms("01LRZ3NDEK"))
+        self.assertIsNone(_ulid_time_ms("01ORZ3NDEK"))
+        self.assertIsNone(_ulid_time_ms("01URZ3NDEK"))
+        # Non-string input.
+        self.assertIsNone(_ulid_time_ms(12345))  # type: ignore[arg-type]
+
+    def test_ulid_time_ms_returns_none_for_uuid_v8_production_format(self):
+        """Real Kimi message ids are UUID v8 (per Kimi's own error message:
+        ``id_kind=uuidv8``). Their first 48 bits are NOT unix-ms — captured
+        deltas show ~16× wall-clock seconds, suggesting a non-standard epoch
+        encoding. ``_ulid_time_ms`` deliberately does NOT decode UUID format
+        because the resulting magnitudes can't be interpreted as
+        milliseconds. Production gap-detection uses wall-clock
+        ``time.time()`` arrival tracking instead — see
+        ``_last_arrival_time_per_room`` and the Phase 0 #18 gap-candidate
+        logger. This test guards against a future "fix" that re-introduces
+        UUID decoding without addressing the unit mismatch.
+        """
+        self.assertIsNone(_ulid_time_ms("19dc9c4f-1262-8c1b-8000-0a4a6c626bbb"))
+        self.assertIsNone(_ulid_time_ms("19dc9c4d-93c2-87b8-8000-0a4a0ecd76fe"))
+
+    async def test_message_id_probe_tracker_populates_at_info_level(self):
+        """Fix A / Fix E invariant: tracker-update is hoisted out of the
+        DEBUG gate, so toggling DEBUG on later does NOT falsely report
+        ``first-seen`` for a message that already arrived at INFO. No
+        probe-3 log is emitted under INFO either.
+        """
+        adapter = self._adapter()
+        # Capture at WARNING (drops DEBUG) to prove the probe is silent
+        # while the tracker still fills.
+        records, teardown = _capture_kimi_log_records(level=logging.WARNING)
+        try:
+            await adapter._on_group_event(
+                self._msg("room-K", "01HKCHF4FC4S0W7T3V74SG6AT6")
+            )
+        finally:
+            teardown()
+
+        # Tracker populated regardless of log level.
+        self.assertEqual(
+            adapter._last_message_id_per_room.get("room-K"),
+            "01HKCHF4FC4S0W7T3V74SG6AT6",
+        )
+        # No probe-3 log emitted at WARNING.
+        probe = [r for r in records if "message_id" in r.getMessage()]
+        self.assertEqual(probe, [])
+
+    async def test_probes_silent_under_warning_level(self):
+        """Fix E: all three probes are DEBUG-gated — at WARNING or above,
+        zero probe records are emitted (block, text-source, or message_id).
+        """
+        adapter = self._adapter()
+        msg = {
+            "chatMessage": {
+                "chatId": "room-W",
+                "messageId": "01HKCHF4FC4S0W7T3V74SG6AT6",
+                "status": "STATUS_COMPLETED",
+                "role": "ROLE_USER",
+                "senderId": "u1",
+                "senderShortId": "u_real",
+                "text": "envelope preview",
+                "summary": "envelope summary",
+                "blocks": [
+                    {
+                        "content": {
+                            "case": "resourceLink",
+                            "value": {"uri": "kimi://file/z"},
+                        }
+                    }
+                ],
+            }
+        }
+        records, teardown = _capture_kimi_log_records(level=logging.WARNING)
+        try:
+            await adapter._on_group_event(msg)
+        finally:
+            teardown()
+
+        probe_substrings = ("non-text block", "text source for", "message_id")
+        fired = [
+            r for r in records
+            if any(s in r.getMessage() for s in probe_substrings)
+        ]
+        self.assertEqual(fired, [], f"expected zero probe logs at WARNING, got: {fired}")
+
+    async def test_probe_msg_id_sample_rate_reduces_log_volume(self):
+        """Fix F: ``probe_msg_id_sample_rate=3`` → exactly one probe-3 log
+        every three inbound messages in the same room. Tracker still
+        updates on every inbound regardless of sampling.
+        """
+        adapter = KimiAdapter(_cfg(
+            group_allow_bot_senders="all",
+            probe_msg_id_sample_rate=3,
+        ))
+        adapter.handle_message = AsyncMock()  # type: ignore
+        adapter._hydrate_missing_text = False
+
+        ids = [
+            "01HKCHF4F14S0W7T3V74SG6AT6",
+            "01HKCHF4F24S0W7T3V74SG6AT6",
+            "01HKCHF4F34S0W7T3V74SG6AT6",
+            "01HKCHF4F44S0W7T3V74SG6AT6",
+            "01HKCHF4F54S0W7T3V74SG6AT6",
+            "01HKCHF4F64S0W7T3V74SG6AT6",
+            "01HKCHF4F74S0W7T3V74SG6AT6",
+            "01HKCHF4F84S0W7T3V74SG6AT6",
+            "01HKCHF4F94S0W7T3V74SG6AT6",
+        ]
+
+        records, teardown = _capture_kimi_log_records()
+        try:
+            for mid in ids:
+                await adapter._on_group_event(self._msg("room-S", mid))
+        finally:
+            teardown()
+
+        probe3 = [
+            r for r in records
+            if "message_id timing" in r.getMessage()
+            or "message_id first-seen" in r.getMessage()
+        ]
+        # 9 dispatches / sample_rate=3 → exactly 3 probe-3 logs.
+        self.assertEqual(
+            len(probe3), 3,
+            f"expected 3 probe-3 records at 1-in-3 sampling, got {len(probe3)}: "
+            f"{[r.getMessage() for r in probe3]}",
+        )
+        # Tracker reflects the LAST observed id, not the last SAMPLED id.
+        self.assertEqual(
+            adapter._last_message_id_per_room.get("room-S"),
+            ids[-1],
+        )
+
+    def test_probe_msg_id_sample_rate_falls_back_on_invalid_config(self):
+        """Fix-up (Codex P2): a non-numeric ``probe_msg_id_sample_rate``
+        in ``config.extra`` (e.g. operator typo ``"ten"``) must not crash
+        adapter init. Falls back to 1 with a WARNING log naming the bad
+        value.
+        """
+        records, teardown = _capture_kimi_log_records(level=logging.WARNING)
+        try:
+            adapter = KimiAdapter(_cfg(probe_msg_id_sample_rate="ten"))
+        finally:
+            teardown()
+
+        self.assertEqual(adapter._probe_msg_id_sample_rate, 1)
+        warnings = [
+            r for r in records
+            if r.levelno == logging.WARNING
+            and "probe_msg_id_sample_rate" in r.getMessage()
+        ]
+        self.assertEqual(
+            len(warnings), 1,
+            f"expected one WARNING naming the bad value, got: "
+            f"{[r.getMessage() for r in records]}",
+        )
+        self.assertIn("'ten'", warnings[0].getMessage())
+
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Lift 3a: interrupt-and-drain queue improvements (pending-slot drop-log + TTL)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def _make_message_event(text: str = "hello", chat_id: str = "dm:im:kimi:main") -> "MagicMock":
+    """Build a minimal MessageEvent-like object for testing handle_message."""
+    from gateway.platforms.base import MessageEvent, MessageType
+    from gateway.session import SessionSource
+    from gateway.config import Platform
+
+    source = SessionSource(
+        platform=Platform("kimiclaw"),
+        chat_id=chat_id,
+        chat_type="dm",
+        user_id="kimi:user:1",
+    )
+    event = MagicMock(spec=MessageEvent)
+    event.source = source
+    event.text = text
+    event.message_type = MessageType.TEXT
+    event.message_id = "msg-test"
+    return event
+
+
+def _compute_session_key(adapter: "KimiAdapter", event: "MagicMock") -> str:
+    """Compute the session key the adapter will derive for a given event."""
+    from gateway.session import build_session_key
+    return build_session_key(
+        event.source,
+        group_sessions_per_user=adapter._group_sessions_per_user,
+        thread_sessions_per_user=adapter._thread_sessions_per_user,
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Issue #18 Phase 0 instrumentation: gap-candidate INFO + reconnect counter +
+# ListMessages pagination.
+#
+# This is the EVIDENCE-GATHERING layer for the future burst-drop recovery work
+# (Phase 1+). It does not recover anything; it only surfaces signal that
+# operators can use to validate which design wins. Three independent pieces:
+#
+#   1. ``BurstDropGapLogTests`` — promote suspiciously-large per-room
+#      message_id timestamp deltas to INFO so they show up in journalctl
+#      regardless of DEBUG state.
+#   2. ``GroupSubscribeReconnectCounterTests`` — counter + snapshot log on
+#      the first chatMessage post-connect, the candidate Phase 1 hook point.
+#   3. ``ListGroupMessagesPaginationTests`` — wrapper now follows
+#      ``nextPageToken`` up to ``max_pages``. Required for any recovery
+#      design that fetches more than ``limit`` messages from a gap.
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class BurstDropGapLogTests(unittest.IsolatedAsyncioTestCase):
+    """Phase 0 (#18): suspicious wall-clock gaps logged at INFO.
+
+    Tests use ``time.monotonic`` patching to simulate per-room arrival
+    deltas deterministically. Cumulative review #58 switched gap-delta
+    tracking from ``time.time`` to ``time.monotonic`` (independent flags
+    from Codex and Kimi reviewers — wall-clock is unsafe for delta
+    computation under NTP step / leap-second / VM suspend-resume). Gap
+    detection is fundamentally about elapsed time between receives, which
+    monotonic answers directly without depending on wall-clock stability.
+
+    The message-ids in fixtures are UUID v8 to match Kimi's actual
+    production format — see ``test_ulid_time_ms_returns_none_for_uuid_v8_
+    production_format`` for the regression guard around id-derived timing.
+    """
+
+    def _adapter(self, **cfg):
+        adapter = KimiAdapter(_cfg(group_allow_bot_senders="all", **cfg))
+        adapter.handle_message = AsyncMock()  # type: ignore
+        adapter._hydrate_missing_text = False
+        return adapter
+
+    @staticmethod
+    def _msg(chat_id: str, message_id: str) -> "Dict[str, Any]":
+        return {
+            "chatMessage": {
+                "chatId": chat_id,
+                "messageId": message_id,
+                "status": "STATUS_COMPLETED",
+                "role": "ROLE_USER",
+                "senderId": "u1",
+                "senderShortId": "u_real",
+                "blocks": [
+                    {"content": {"case": "text", "value": {"content": "hi"}}}
+                ],
+            }
+        }
+
+    async def test_gap_below_threshold_no_info_log(self):
+        """Delta < threshold (in seconds) → no INFO log."""
+        adapter = self._adapter(burst_drop_gap_log_threshold_s=60.0)
+        records, teardown = _capture_kimi_log_records(level=logging.INFO)
+        # ``time.time`` is called multiple times per _on_group_event (gap
+        # tracking + base-class hooks), so use return_value + manual swap
+        # rather than a fixed-length side_effect.
+        with patch("kimi_adapter.time.monotonic") as mock_time:
+            mock_time.return_value = 1000.0
+            try:
+                await adapter._on_group_event(
+                    self._msg("room-X", "19dc9c4d-93c2-87b8-8000-0a4a0ecd76fe")
+                )
+                mock_time.return_value = 1001.0
+                await adapter._on_group_event(
+                    self._msg("room-X", "19dc9c4f-1262-8c1b-8000-0a4a6c626bbb")
+                )
+            finally:
+                teardown()
+        gap = [r for r in records if "gap candidate" in r.getMessage()]
+        self.assertEqual(gap, [], "small gap should not log gap candidate at INFO")
+
+    async def test_gap_above_threshold_emits_info_log(self):
+        """Delta >= threshold (seconds) → INFO log fires with delta_s, prev_id,
+        connect#, since_reconnect_s. Production UUID-shaped ids accepted —
+        the gap signal is wall-clock-driven so id format is irrelevant."""
+        adapter = self._adapter(burst_drop_gap_log_threshold_s=10.0)
+        records, teardown = _capture_kimi_log_records(level=logging.INFO)
+        with patch("kimi_adapter.time.monotonic") as mock_time:
+            mock_time.return_value = 2000.0
+            try:
+                await adapter._on_group_event(
+                    self._msg("room-Y", "19dc9c4d-93c2-87b8-8000-0a4a0ecd76fe")
+                )
+                mock_time.return_value = 2045.0  # 45s delta, > 10s threshold
+                await adapter._on_group_event(
+                    self._msg("room-Y", "19dc9c4f-1262-8c1b-8000-0a4a6c626bbb")
+                )
+            finally:
+                teardown()
+        gap = [r for r in records if "gap candidate" in r.getMessage()]
+        self.assertEqual(len(gap), 1, f"expected one gap-candidate INFO, got {gap}")
+        rendered = gap[0].getMessage()
+        self.assertIn("room=room-Y", rendered)
+        self.assertIn("prev=19dc9c4d-93c2-87b8-8000-0a4a0ecd76fe", rendered)
+        self.assertIn("delta_s=45.0", rendered)
+        self.assertIn(">=10.0s threshold", rendered)
+        self.assertIn("since_reconnect_s=N/A", rendered)
+        self.assertIn("connect#=0", rendered)
+        self.assertEqual(gap[0].levelno, logging.INFO)
+
+    async def test_gap_log_includes_since_reconnect_correlation(self):
+        """When reconnect timestamp is set, the log includes since_reconnect_s
+        for in-line correlation (Codex review #2 — operators shouldn't have to
+        grep two log streams to correlate)."""
+        adapter = self._adapter(burst_drop_gap_log_threshold_s=10.0)
+        adapter._group_subscribe_reconnect_count = 5
+        adapter._group_subscribe_last_reconnect_ts = 3000.0
+        records, teardown = _capture_kimi_log_records(level=logging.INFO)
+        with patch("kimi_adapter.time.monotonic") as mock_time:
+            mock_time.return_value = 3050.0
+            try:
+                await adapter._on_group_event(
+                    self._msg("room-Z", "19dc9c4d-93c2-87b8-8000-0a4a0ecd76fe")
+                )
+                mock_time.return_value = 3120.0  # 70s gap, 120s after reconnect
+                await adapter._on_group_event(
+                    self._msg("room-Z", "19dc9c4f-1262-8c1b-8000-0a4a6c626bbb")
+                )
+            finally:
+                teardown()
+        gap = [r for r in records if "gap candidate" in r.getMessage()]
+        self.assertEqual(len(gap), 1)
+        rendered = gap[0].getMessage()
+        self.assertIn("since_reconnect_s=120.0", rendered)
+        self.assertIn("connect#=5", rendered)
+
+    async def test_first_message_in_room_no_gap_log(self):
+        """First message has no prior arrival anchor; can't compute delta — no log."""
+        adapter = self._adapter(burst_drop_gap_log_threshold_s=0.001)
+        records, teardown = _capture_kimi_log_records(level=logging.INFO)
+        with patch("kimi_adapter.time.monotonic", return_value=4000.0):
+            try:
+                await adapter._on_group_event(
+                    self._msg("room-W", "19dc9c4f-1262-8c1b-8000-0a4a6c626bbb")
+                )
+            finally:
+                teardown()
+        gap = [r for r in records if "gap candidate" in r.getMessage()]
+        self.assertEqual(gap, [])
+
+    async def test_threshold_zero_disables_info_log(self):
+        """Threshold 0 disables the INFO log entirely."""
+        adapter = self._adapter(burst_drop_gap_log_threshold_s=0)
+        records, teardown = _capture_kimi_log_records(level=logging.INFO)
+        with patch("kimi_adapter.time.monotonic") as mock_time:
+            mock_time.return_value = 5000.0
+            try:
+                await adapter._on_group_event(
+                    self._msg("room-V", "19dc9c4d-93c2-87b8-8000-0a4a0ecd76fe")
+                )
+                mock_time.return_value = 5999.0
+                await adapter._on_group_event(
+                    self._msg("room-V", "19dc9c4f-1262-8c1b-8000-0a4a6c626bbb")
+                )
+            finally:
+                teardown()
+        gap = [r for r in records if "gap candidate" in r.getMessage()]
+        self.assertEqual(gap, [], "threshold=0 must suppress the INFO log")
+
+    async def test_invalid_threshold_falls_back_to_default(self):
+        """Garbage in config doesn't crash startup; default 30.0 applies."""
+        adapter = self._adapter(burst_drop_gap_log_threshold_s="not-a-number")
+        self.assertEqual(adapter._burst_drop_gap_log_threshold_s, 30.0)
+
+    async def test_negative_threshold_clamped_to_zero(self):
+        """Negative values clamp at 0 (which disables the INFO path)."""
+        adapter = self._adapter(burst_drop_gap_log_threshold_s=-5.0)
+        self.assertEqual(adapter._burst_drop_gap_log_threshold_s, 0.0)
+
+    async def test_monotonic_clock_immune_to_wall_clock_jump(self):
+        """Cumulative review #58: gap-delta uses ``time.monotonic`` — patching
+        ``time.time`` to simulate an NTP forward jump must NOT trigger a
+        spurious gap log if monotonic time hasn't advanced past the threshold.
+
+        This is the regression guard for the wall-clock-vs-monotonic pivot.
+        Before the fix, a Pi resuming from suspend (wall-clock catch-up) or
+        an NTP step would emit false-positive gap candidates; now only
+        true elapsed process-time matters.
+        """
+        adapter = self._adapter(burst_drop_gap_log_threshold_s=30.0)
+        records, teardown = _capture_kimi_log_records(level=logging.INFO)
+        try:
+            with patch("kimi_adapter.time.monotonic") as mock_mono:
+                # Simulate 1 second elapsed in monotonic time, but...
+                mock_mono.return_value = 100.0
+                await adapter._on_group_event(
+                    self._msg("room-Q", "19dc9c4d-93c2-87b8-8000-0a4a0ecd76fe")
+                )
+                # ...wall-clock would have jumped 60s (NTP / suspend resume).
+                # We only patch monotonic — wall-clock is irrelevant to the
+                # delta calc now that #58 fixed the timestamp source. If we
+                # ever regress to time.time() this test would fail because
+                # the test wouldn't be controlling the relevant clock.
+                mock_mono.return_value = 101.0  # 1s elapsed monotonic
+                await adapter._on_group_event(
+                    self._msg("room-Q", "19dc9c4f-1262-8c1b-8000-0a4a6c626bbb")
+                )
+        finally:
+            teardown()
+        gap = [r for r in records if "gap candidate" in r.getMessage()]
+        self.assertEqual(
+            gap, [],
+            "1s monotonic elapsed must not trigger 30s threshold even if "
+            "wall-clock jumped — proves time.monotonic is the timestamp source",
+        )
+
+
+class GroupSubscribeReconnectCounterTests(unittest.TestCase):
+    """Phase 0 (#18): reconnect counter starts at 0 and is exposed on adapter.
+
+    Cumulative review #58 (Claude code-reviewer + Codex challenge) flagged
+    an off-by-one in ``_group_subscribe_once``: the counter was incremented
+    AFTER ``_on_group_event`` was awaited, so the gap log inside dispatch
+    saw the prior cycle's count while the ``subscribe stream live`` log
+    emitted moments later carried the new count — defeating in-line
+    correlation. Fix: bump pre-dispatch. The end-to-end integration test
+    that drives ``_group_subscribe_once`` with mocked WS layers is tracked
+    as task #61; the unit invariant below documents the post-bump
+    behaviour any regression would fail.
+    """
+
+    def test_counter_initialised_to_zero(self):
+        adapter = KimiAdapter(_cfg())
+        self.assertEqual(adapter._group_subscribe_reconnect_count, 0)
+        # Sentinel for "no reconnect observed yet" — used by gap-log
+        # since_reconnect_s correlation. Monotonic time is always >= 0,
+        # so -1 is safely outside the legitimate value range.
+        self.assertEqual(adapter._group_subscribe_last_reconnect_ts, -1.0)
+
+    def test_counter_attribute_exists_for_log_format_consumers(self):
+        """Documents that the counter is a public-shape attribute used in the
+        ``Kimi groups: subscribe stream live`` INFO log. If anything renames
+        or removes this attribute, the log line breaks — operators correlating
+        gap-candidate INFOs against this would lose their anchor."""
+        adapter = KimiAdapter(_cfg())
+        self.assertIsInstance(adapter._group_subscribe_reconnect_count, int)
+
+
+class ConnectCounterOrderingInvariantTests(unittest.IsolatedAsyncioTestCase):
+    """Cumulative review #58: documents the post-bump invariant the
+    ``_group_subscribe_once`` fix must preserve.
+
+    The actual subscribe-loop integration test is deferred to #61 (heavy
+    WS mocks). This class instead asserts: GIVEN the counter is bumped
+    pre-dispatch (as the new code does), THEN ``_on_group_event``'s gap
+    log uses the bumped value. A regression that moves the bump back to
+    post-dispatch would still pass these tests; it would fail the deferred
+    integration test under #61, which is why the sequencing is documented
+    in the class docstring rather than spread across files.
+    """
+
+    def _adapter(self, **cfg):
+        adapter = KimiAdapter(_cfg(group_allow_bot_senders="all", **cfg))
+        adapter.handle_message = AsyncMock()  # type: ignore
+        adapter._hydrate_missing_text = False
+        return adapter
+
+    @staticmethod
+    def _msg(chat_id: str, message_id: str):
+        return {
+            "chatMessage": {
+                "chatId": chat_id,
+                "messageId": message_id,
+                "status": "STATUS_COMPLETED",
+                "role": "ROLE_USER",
+                "senderId": "u1",
+                "senderShortId": "u_real",
+                "blocks": [{"content": {"case": "text", "value": {"content": "hi"}}}],
+            }
+        }
+
+    async def test_gap_log_reads_post_bump_counter(self):
+        """If the counter is bumped before dispatch (mirroring the new
+        ``_group_subscribe_once`` ordering), the gap-candidate log inside
+        ``_on_group_event`` sees the bumped value. With the OLD ordering,
+        the log would carry connect#=0 while the ``subscribe stream live``
+        log emitted seconds later would carry connect#=1 for the same
+        first-frame event."""
+        adapter = self._adapter(burst_drop_gap_log_threshold_s=10.0)
+        # Simulate the new pre-dispatch bump exactly as
+        # _group_subscribe_once now does it.
+        adapter._group_subscribe_frame_since_connect = True
+        adapter._group_subscribe_reconnect_count += 1  # 0 -> 1
+        adapter._group_subscribe_last_reconnect_ts = 100.0  # monotonic
+
+        records, teardown = _capture_kimi_log_records(level=logging.INFO)
+        try:
+            with patch("kimi_adapter.time.monotonic") as mock_mono:
+                # Two arrivals 50s apart on monotonic clock → trips the
+                # 10s threshold and emits the gap-candidate INFO log.
+                mock_mono.return_value = 100.0
+                await adapter._on_group_event(
+                    self._msg("room-K", "19dc9c4d-93c2-87b8-8000-0a4a0ecd76fe")
+                )
+                mock_mono.return_value = 150.0
+                await adapter._on_group_event(
+                    self._msg("room-K", "19dc9c4f-1262-8c1b-8000-0a4a6c626bbb")
+                )
+        finally:
+            teardown()
+
+        gap = [r for r in records if "gap candidate" in r.getMessage()]
+        self.assertEqual(len(gap), 1)
+        rendered = gap[0].getMessage()
+        # Critical assertion: gap log saw the BUMPED counter, not 0.
+        self.assertIn(
+            "connect#=1", rendered,
+            "Gap log must reflect the post-bump counter — if this asserts "
+            "connect#=0 instead, the off-by-one regressed (#58)",
+        )
+        # since_reconnect_s = 50 (150 - 100) confirms the monotonic ts is
+        # also being read post-bump.
+        self.assertIn("since_reconnect_s=50.0", rendered)
+
+
+class ListGroupMessagesPaginationTests(unittest.IsolatedAsyncioTestCase):
+    """Phase 0 (#18): list_group_messages now follows nextPageToken up to
+    max_pages, with backward-compat default of single-page (max_pages=1).
+    """
+
+    def _adapter(self):
+        adapter = KimiAdapter(_cfg())
+        adapter._rpc_unary = AsyncMock()  # type: ignore
+        return adapter
+
+    async def test_default_single_page_backward_compat(self):
+        """Default ``max_pages=1`` — single RPC call, ``pageToken`` empty
+        in the request, ``nextPageToken`` in response is ignored."""
+        adapter = self._adapter()
+        adapter._rpc_unary.return_value = {
+            "messages": [{"messageId": "m1"}, {"messageId": "m2"}],
+            "nextPageToken": "page2",  # ignored in single-page mode
+        }
+        result = await adapter.list_group_messages("room-1", limit=20)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(adapter._rpc_unary.await_count, 1)
+        first_call_body = adapter._rpc_unary.await_args[0][1]
+        # First page omits pageToken entirely (cumulative review #58 fix —
+        # was previously sent as empty string; mirrors list_group_files).
+        self.assertNotIn("pageToken", first_call_body)
+
+    async def test_multi_page_follows_token(self):
+        """``max_pages>1`` follows ``nextPageToken`` until empty."""
+        adapter = self._adapter()
+        adapter._rpc_unary.side_effect = [
+            {"messages": [{"messageId": "m1"}], "nextPageToken": "tok2"},
+            {"messages": [{"messageId": "m2"}], "nextPageToken": "tok3"},
+            {"messages": [{"messageId": "m3"}], "nextPageToken": ""},
+        ]
+        result = await adapter.list_group_messages("room-1", max_pages=5)
+        self.assertEqual(len(result), 3)
+        self.assertEqual(adapter._rpc_unary.await_count, 3)
+        # Second call should have sent the first page's token.
+        second_body = adapter._rpc_unary.await_args_list[1][0][1]
+        self.assertEqual(second_body["pageToken"], "tok2")
+        third_body = adapter._rpc_unary.await_args_list[2][0][1]
+        self.assertEqual(third_body["pageToken"], "tok3")
+
+    async def test_max_pages_caps_runaway(self):
+        """If Kimi keeps returning a token, ``max_pages`` stops the loop."""
+        adapter = self._adapter()
+        adapter._rpc_unary.return_value = {
+            "messages": [{"messageId": "mX"}],
+            "nextPageToken": "always-more",
+        }
+        result = await adapter.list_group_messages("room-1", max_pages=3)
+        self.assertEqual(adapter._rpc_unary.await_count, 3)
+        self.assertEqual(len(result), 3)
+
+    async def test_empty_pagetoken_breaks_loop_early(self):
+        """First-page empty ``nextPageToken`` → stop after one call even with
+        ``max_pages=10``."""
+        adapter = self._adapter()
+        adapter._rpc_unary.return_value = {
+            "messages": [{"messageId": "only"}],
+            # No nextPageToken at all.
+        }
+        result = await adapter.list_group_messages("room-1", max_pages=10)
+        self.assertEqual(adapter._rpc_unary.await_count, 1)
+        self.assertEqual(len(result), 1)
+
+    async def test_max_pages_below_one_raises(self):
+        """``max_pages=0`` is a config bug — surface it as ValueError."""
+        adapter = self._adapter()
+        with self.assertRaises(ValueError):
+            await adapter.list_group_messages("room-1", max_pages=0)
+
+    async def test_anchor_only_on_first_page(self):
+        """Cumulative review #58 (Kimi review): anchor IDs (start_message_id /
+        end_message_id) must be sent ONLY on the first request. Once
+        ``pageToken`` is in play, the server-issued cursor encodes
+        everything; echoing anchors alongside the cursor risks duplicate
+        results or undefined ordering. Mirrors the conditional pageToken
+        injection in ``list_group_files``.
+        """
+        adapter = self._adapter()
+        adapter._rpc_unary.side_effect = [
+            {"messages": [{"messageId": "m1"}], "nextPageToken": "tok2"},
+            {"messages": [{"messageId": "m2"}], "nextPageToken": "tok3"},
+            {"messages": [{"messageId": "m3"}], "nextPageToken": ""},
+        ]
+        await adapter.list_group_messages(
+            "room-1",
+            max_pages=5,
+            start_message_id="anchor-start",
+            end_message_id="anchor-end",
+        )
+        # First call: anchors present, no pageToken.
+        first_body = adapter._rpc_unary.await_args_list[0][0][1]
+        self.assertEqual(first_body.get("startMessageId"), "anchor-start")
+        self.assertEqual(first_body.get("endMessageId"), "anchor-end")
+        self.assertNotIn("pageToken", first_body)
+        # Subsequent calls: pageToken present, anchors absent.
+        for idx in (1, 2):
+            body = adapter._rpc_unary.await_args_list[idx][0][1]
+            self.assertNotIn(
+                "startMessageId", body,
+                f"page {idx} must not echo startMessageId alongside pageToken",
+            )
+            self.assertNotIn(
+                "endMessageId", body,
+                f"page {idx} must not echo endMessageId alongside pageToken",
+            )
+            self.assertTrue(body.get("pageToken"), "page 2+ must carry cursor")
+
+
+class FetchGroupMessagePaginationTests(unittest.IsolatedAsyncioTestCase):
+    """#60 fold-in: ``_fetch_group_message`` raises max_pages=2 so a tight
+    ``start=end=message_id`` window that Kimi paginates around is still
+    found rather than silently returning None. Safe given the
+    anchor-only-on-first-page fix above (cumulative review #58)."""
+
+    def _adapter(self):
+        adapter = KimiAdapter(_cfg())
+        adapter._rpc_unary = AsyncMock()  # type: ignore
+        return adapter
+
+    async def test_fetch_passes_max_pages_2_to_list_group_messages(self):
+        """``_fetch_group_message`` must call ``list_group_messages`` with
+        ``max_pages=2`` so a single follow-up page is permitted."""
+        adapter = self._adapter()
+        adapter.list_group_messages = AsyncMock(return_value=[])  # type: ignore
+        await adapter._fetch_group_message("room-1", "msg-target")
+        adapter.list_group_messages.assert_awaited_once()
+        kwargs = adapter.list_group_messages.await_args.kwargs
+        self.assertEqual(kwargs.get("max_pages"), 2)
+        self.assertEqual(kwargs.get("start_message_id"), "msg-target")
+        self.assertEqual(kwargs.get("end_message_id"), "msg-target")
+
+    async def test_fetch_finds_message_on_second_page(self):
+        """If Kimi paginates the tight-range window such that the target
+        appears on page 2, ``_fetch_group_message`` returns it (not None)."""
+        adapter = self._adapter()
+        # Page 1: unrelated message + nextPageToken.
+        # Page 2: the target.
+        adapter._rpc_unary.side_effect = [
+            {
+                "messages": [{
+                    "messageId": "msg-other",
+                    "message": {"id": "msg-other", "blocks": []},
+                }],
+                "nextPageToken": "tok-page2",
+            },
+            {
+                "messages": [{
+                    "messageId": "msg-target",
+                    "senderId": "u1",
+                    "message": {"id": "msg-target", "blocks": []},
+                }],
+                "nextPageToken": "",
+            },
+        ]
+        result = await adapter._fetch_group_message("room-1", "msg-target")
+        self.assertIsNotNone(result)
+        # Two RPC calls confirm the second-page traversal.
+        self.assertEqual(adapter._rpc_unary.await_count, 2)
+
+
+class HakimiLift3aDropLogTests(unittest.IsolatedAsyncioTestCase):
+    """Lift 3a: WARN log when a pending-slot overwrite occurs."""
+
+    async def test_3a_1_drop_log_on_overwrite(self):
+        """3a.1 — overwriting an existing pending slot emits a WARNING with
+        chat_id and message preview."""
+        adapter = KimiAdapter(_cfg())
+
+        # Simulate a session in progress (active-session guard set).
+        first_event = _make_message_event("first pending message")
+        session_key = _compute_session_key(adapter, first_event)
+        guard = asyncio.Event()
+        adapter._active_sessions[session_key] = guard
+
+        # Put a first pending message in the slot.
+        adapter._pending_messages[session_key] = first_event
+        adapter._pending_enqueued_at[session_key] = 1.0  # arbitrary
+
+        # Now call handle_message with a SECOND message — this should overwrite.
+        second_event = _make_message_event("second message overwrites first")
+        # Patch super().handle_message to avoid real dispatch.
+        records, teardown = _capture_kimi_log_records(level=logging.WARNING)
+        try:
+            with patch.object(
+                adapter.__class__.__bases__[0], "handle_message", new=AsyncMock()
+            ):
+                await adapter.handle_message(second_event)
+        finally:
+            teardown()
+
+        warnings = [
+            r for r in records
+            if r.levelno == logging.WARNING and "overwriting pending slot" in r.getMessage()
+        ]
+        self.assertEqual(len(warnings), 1, f"Expected one overwrite WARNING, got: {[r.getMessage() for r in records]}")
+        msg = warnings[0].getMessage()
+        self.assertIn("first pending", msg)  # preview of the dropped message
+
+    async def test_3a_2_error_path_drain_preserved(self):
+        """3a.2 — when message_handler raises, the pending slot is still drained.
+
+        BasePlatformAdapter already handles this via the late-arrival drain in
+        _process_message_background's ``finally`` block. This test documents and
+        exercises the contract: after a handler exception, a message queued in
+        _pending_messages is NOT silently lost.
+
+        Implementation note: we test the base-class invariant via the KimiAdapter
+        since KimiAdapter.handle_message delegates to super().handle_message which
+        runs _process_message_background. The test checks that after an exception
+        during handler execution, _pending_messages is cleared (either consumed or
+        cleaned up).
+        """
+        adapter = KimiAdapter(_cfg())
+
+        first_event = _make_message_event("first message that will error")
+        session_key = _compute_session_key(adapter, first_event)
+
+        # Set up a message handler that raises on the first call, succeeds on second.
+        call_count = [0]
+
+        async def _handler(event):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise RuntimeError("synthetic processing error")
+            return "ok"
+
+        adapter.set_message_handler(_handler)
+
+        second_event = _make_message_event("second message — must not be lost")
+
+        # Queue second event in pending slot before first processes.
+        adapter._pending_messages[session_key] = second_event
+        adapter._pending_enqueued_at[session_key] = 0.0  # pre-enqueued
+
+        # Now simulate base._process_message_background having set the active guard.
+        guard = asyncio.Event()
+        guard.set()  # interrupt already signalled
+        adapter._active_sessions[session_key] = guard
+        adapter._session_tasks[session_key] = asyncio.current_task()
+
+        # Run _process_message_background which includes our exception + drain path.
+        try:
+            await adapter._process_message_background(first_event, session_key)
+        except Exception:
+            pass  # exception propagation details not under test
+
+        # After the whole run, _pending_messages for this session should be gone —
+        # the pending message was either dispatched (good) or cleaned up (acceptable).
+        # The key invariant: it is NOT still sitting unprocessed in the dict
+        # while the session is no longer active.
+        session_still_active = session_key in adapter._active_sessions
+        pending_still_queued = session_key in adapter._pending_messages
+        self.assertFalse(
+            session_still_active and pending_still_queued,
+            "Pending message stranded: session is inactive but pending slot not cleared.",
+        )
+
+    async def test_3a_3_ttl_disabled_by_default(self):
+        """3a.3 — with no TTL configured, pending slot never expires."""
+        adapter = KimiAdapter(_cfg())  # no pending_message_ttl_seconds
+
+        self.assertIsNone(adapter._pending_message_ttl)
+
+        # Simulate an arbitrarily old pending message.
+        old_event = _make_message_event("old pending message")
+        session_key = _compute_session_key(adapter, old_event)
+        guard = asyncio.Event()
+        adapter._active_sessions[session_key] = guard
+
+        adapter._pending_messages[session_key] = old_event
+        # Enqueued a long time ago (1000 seconds).
+        import time as _time
+        adapter._pending_enqueued_at[session_key] = _time.monotonic() - 1000.0
+
+        new_event = _make_message_event("newer message")
+        records, teardown = _capture_kimi_log_records(level=logging.INFO)
+        try:
+            with patch.object(
+                adapter.__class__.__bases__[0], "handle_message", new=AsyncMock()
+            ):
+                await adapter.handle_message(new_event)
+        finally:
+            teardown()
+
+        # No eviction log should appear.
+        eviction_logs = [
+            r for r in records
+            if "evicting expired" in r.getMessage()
+        ]
+        self.assertEqual(len(eviction_logs), 0, "TTL eviction should not fire when TTL is None")
+
+    async def test_3a_4_ttl_enabled_evicts_expired_pending(self):
+        """3a.4 — with TTL set, an expired pending slot is evicted and logged."""
+        import time as _time
+        adapter = KimiAdapter(_cfg(pending_message_ttl_seconds=5))
+
+        self.assertEqual(adapter._pending_message_ttl, 5.0)
+
+        old_event = _make_message_event("expired pending message")
+        session_key = _compute_session_key(adapter, old_event)
+        guard = asyncio.Event()
+        adapter._active_sessions[session_key] = guard
+
+        adapter._pending_messages[session_key] = old_event
+        # Enqueued well past the 5s TTL.
+        adapter._pending_enqueued_at[session_key] = _time.monotonic() - 60.0
+
+        new_event = _make_message_event("fresh message after expiry")
+        records, teardown = _capture_kimi_log_records(level=logging.INFO)
+        try:
+            with patch.object(
+                adapter.__class__.__bases__[0], "handle_message", new=AsyncMock()
+            ):
+                await adapter.handle_message(new_event)
+        finally:
+            teardown()
+
+        eviction_logs = [
+            r for r in records
+            if "evicting expired" in r.getMessage()
+        ]
+        self.assertEqual(
+            len(eviction_logs), 1,
+            f"Expected one eviction INFO log, got: {[r.getMessage() for r in records]}",
+        )
+        # After eviction of the old slot the new message is NOT double-logged as
+        # an "overwriting" drop (the slot was cleared before the drop-log check).
+        overwrite_warnings = [
+            r for r in records
+            if "overwriting pending slot" in r.getMessage()
+        ]
+        self.assertEqual(len(overwrite_warnings), 0, "Eviction should not also fire a drop warning")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Issue #33: _pending_enqueued_at cleanup across teardown paths
+#
+# The Kimi adapter maintains `_pending_enqueued_at` as a parallel TTL dict
+# alongside the base class's `_pending_messages` and `_active_sessions`. The
+# base clears the latter two during `cancel_background_tasks`; without parallel
+# clears in our subclass, the TTL dict leaks across reconnects (the gateway
+# reuses the adapter instance). The fix layers three guarantees: (1) the
+# `cancel_background_tasks` override mirrors the base's clear; (2) `disconnect`
+# also clears for direct-disconnect paths that bypass cancel_background_tasks
+# (gateway/run.py:_safe_adapter_disconnect, error-recovery in connect()); (3)
+# `handle_message`'s post-super cleanup is wrapped in `try/finally` so any
+# unexpected exception from super doesn't leak a stamped timestamp.
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class PendingEnqueuedAtCleanupTests(unittest.IsolatedAsyncioTestCase):
+    """Issue #33: _pending_enqueued_at must be cleared across teardown paths."""
+
+    async def test_cancel_background_tasks_clears_pending_enqueued_at(self):
+        """cancel_background_tasks override must mirror the base's clear()
+        behaviour for our parallel TTL state."""
+        adapter = KimiAdapter(_cfg())
+        adapter._pending_enqueued_at["dm:test:abc"] = 1.0
+        adapter._pending_enqueued_at["room:xyz"] = 2.0
+        # super().cancel_background_tasks() walks _background_tasks (empty
+        # on a fresh adapter) and clears the base's parallel dicts; our
+        # override should clear _pending_enqueued_at on top of that.
+        await adapter.cancel_background_tasks()
+        self.assertEqual(
+            adapter._pending_enqueued_at, {},
+            "cancel_background_tasks should clear _pending_enqueued_at"
+        )
+
+    async def test_disconnect_clears_pending_enqueued_at(self):
+        """disconnect() must clear _pending_enqueued_at as defense-in-depth
+        for direct-disconnect call sites that bypass cancel_background_tasks."""
+        adapter = KimiAdapter(_cfg())
+        adapter._pending_enqueued_at["dm:test:abc"] = 1.0
+        adapter._pending_enqueued_at["room:xyz"] = 2.0
+        # Patch out network/lock teardown — the test only cares about the
+        # parallel-state clear; the rest is unrelated infrastructure.
+        with patch.object(adapter, "_cleanup_http", new=AsyncMock()), \
+             patch.object(adapter, "_release_platform_lock"):
+            await adapter.disconnect()
+        self.assertEqual(
+            adapter._pending_enqueued_at, {},
+            "disconnect should clear _pending_enqueued_at"
+        )
+
+    async def test_connect_clears_pending_enqueued_at(self):
+        """connect() must clear stale TTL state as a belt-and-braces sweep
+        before establishing a new session — protects against any path that
+        reuses the adapter without going through disconnect first."""
+        adapter = KimiAdapter(_cfg())
+        adapter._pending_enqueued_at["dm:stale:xyz"] = 99.0  # leftover from prior session
+
+        # connect() reaches the clear() before any network IO. Make connect
+        # short-circuit at GetMe so we don't have to mock the whole WS stack.
+        from kimi_adapter import KimiAuthError
+        with patch.object(adapter, "_acquire_platform_lock", return_value=True), \
+             patch.object(adapter, "_rpc_unary", new=AsyncMock(side_effect=KimiAuthError("test"))), \
+             patch.object(adapter, "_cleanup_http", new=AsyncMock()), \
+             patch.object(adapter, "_release_platform_lock"):
+            # Returns False because GetMe raises; the clear() ran before that.
+            result = await adapter.connect()
+            self.assertFalse(result, "connect() should fail when GetMe raises")
+        # _cleanup_http was mocked out above so the aiohttp.ClientSession that
+        # connect() opened at session start never gets closed by the SUT.
+        # Close it here to keep the suite warning-clean.
+        if adapter._http_session is not None and not adapter._http_session.closed:
+            await adapter._http_session.close()
+        self.assertEqual(
+            adapter._pending_enqueued_at, {},
+            "connect should clear stale TTL state at session start"
+        )
+
+    async def test_handle_message_cleanup_runs_on_cancellation(self):
+        """try/finally ensures the post-super cleanup runs on CancelledError,
+        so a per-task cancellation outside of full adapter teardown doesn't
+        leak a stamped timestamp into the next handler invocation."""
+        adapter = KimiAdapter(_cfg())
+        event = _make_message_event("test message")
+        session_key = _compute_session_key(adapter, event)
+
+        # Simulate an active session so the override stamps _pending_enqueued_at.
+        adapter._active_sessions[session_key] = asyncio.Event()
+
+        # Patch super().handle_message to raise CancelledError mid-await, AFTER
+        # the override stamped its timestamp. _pending_messages is left empty
+        # (the mock does no enqueueing), so the cleanup guard's "if session_key
+        # not in _pending_messages" branch should fire.
+        with patch.object(
+            adapter.__class__.__bases__[0],
+            "handle_message",
+            new=AsyncMock(side_effect=asyncio.CancelledError),
+        ):
+            with self.assertRaises(asyncio.CancelledError):
+                await adapter.handle_message(event)
+
+        self.assertNotIn(
+            session_key,
+            adapter._pending_enqueued_at,
+            "try/finally should pop the timestamp on CancelledError when the "
+            "pending slot was never populated",
+        )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Issue #22: room-state eviction policy (bounded LRU on per-room dicts)
+#
+# The adapter has three dicts keyed on room_id that grew without ceiling on
+# long-running deployments: ``_rooms`` (cache), ``_last_message_id_per_room``
+# (DEBUG observability anchor), ``_probe_msg_id_room_counts`` (DEBUG counter).
+# All three are now backed by ``_BoundedLRU`` with a configurable cap. None of
+# them hold replay-dedup correctness state — that's ``_processed_set``, which
+# is bounded by ``_DEDUP_MAXLEN`` independently. Eviction is silent because
+# every consumer of these dicts handles a missing entry transparently
+# (re-fetch / first-seen path).
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class BoundedLRUTests(unittest.TestCase):
+    """Stand-alone behaviour of the _BoundedLRU primitive."""
+
+    def test_grows_up_to_cap(self):
+        """Inserts up to ``maxsize`` are kept; nothing evicted yet."""
+        d = _BoundedLRU(maxsize=3)
+        for i in range(3):
+            d[f"k{i}"] = i
+        self.assertEqual(len(d), 3)
+        self.assertEqual(list(d.keys()), ["k0", "k1", "k2"])
+
+    def test_evicts_oldest_when_over_cap(self):
+        """N+1th insert pops the first-inserted key (FIFO from LRU end)."""
+        d = _BoundedLRU(maxsize=3)
+        d["a"] = 1
+        d["b"] = 2
+        d["c"] = 3
+        d["d"] = 4  # cap exceeded → evict "a"
+        self.assertEqual(len(d), 3)
+        self.assertNotIn("a", d)
+        self.assertEqual(list(d.keys()), ["b", "c", "d"])
+
+    def test_update_moves_key_to_recent_end(self):
+        """Re-writing an existing key refreshes its LRU position so it's
+        not next to be evicted. This is what protects ``_last_message_id_
+        per_room`` for a busy room from being evicted just because the
+        room was first inserted long ago."""
+        d = _BoundedLRU(maxsize=3)
+        d["a"] = 1
+        d["b"] = 2
+        d["c"] = 3
+        d["a"] = 99  # touch "a" — it should now be the freshest
+        d["d"] = 4   # cap exceeded → evict "b" (oldest), NOT "a"
+        self.assertEqual(d["a"], 99)
+        self.assertNotIn("b", d)
+        self.assertEqual(list(d.keys()), ["c", "a", "d"])
+
+    def test_get_does_not_refresh_lru(self):
+        """Reads must not move the key to the recent end. We want
+        'least recently *updated*' semantics, not 'least recently
+        accessed' — for ``_last_message_id_per_room`` the read happens
+        every inbound message, so refreshing on read would defeat the
+        cap entirely."""
+        d = _BoundedLRU(maxsize=3)
+        d["a"] = 1
+        d["b"] = 2
+        d["c"] = 3
+        _ = d.get("a")     # read — must NOT touch ordering
+        _ = d["a"]         # subscript read — must NOT touch ordering
+        d["e"] = 5         # cap exceeded → evict "a" (still oldest)
+        self.assertNotIn("a", d)
+        self.assertEqual(list(d.keys()), ["b", "c", "e"])
+
+    def test_invalid_maxsize_rejected(self):
+        """Cap of 0 or negative is a config bug, not a runtime no-op."""
+        with self.assertRaises(ValueError):
+            _BoundedLRU(maxsize=0)
+        with self.assertRaises(ValueError):
+            _BoundedLRU(maxsize=-1)
+
+
+class RoomCacheCapIntegrationTests(unittest.TestCase):
+    """Adapter-level: per-room dicts honour the cap, config knob plumbed."""
+
+    def test_default_cap_applied(self):
+        """No config override → all three dicts use _ROOM_CACHE_DEFAULT_MAX."""
+        adapter = KimiAdapter(_cfg())
+        self.assertIsInstance(adapter._rooms, _BoundedLRU)
+        self.assertIsInstance(adapter._last_message_id_per_room, _BoundedLRU)
+        self.assertIsInstance(adapter._probe_msg_id_room_counts, _BoundedLRU)
+        self.assertEqual(adapter._rooms._maxsize, _ROOM_CACHE_DEFAULT_MAX)
+        self.assertEqual(
+            adapter._last_message_id_per_room._maxsize, _ROOM_CACHE_DEFAULT_MAX
+        )
+        self.assertEqual(
+            adapter._probe_msg_id_room_counts._maxsize, _ROOM_CACHE_DEFAULT_MAX
+        )
+
+    def test_config_override_applied(self):
+        """``room_cache_max_entries`` in config.extra propagates to all three."""
+        adapter = KimiAdapter(_cfg(room_cache_max_entries=10))
+        self.assertEqual(adapter._rooms._maxsize, 10)
+        self.assertEqual(adapter._last_message_id_per_room._maxsize, 10)
+        self.assertEqual(adapter._probe_msg_id_room_counts._maxsize, 10)
+
+    def test_invalid_config_falls_back_to_default(self):
+        """Garbage in config doesn't crash startup; default applies + warning."""
+        adapter = KimiAdapter(_cfg(room_cache_max_entries="not-an-int"))
+        self.assertEqual(adapter._rooms._maxsize, _ROOM_CACHE_DEFAULT_MAX)
+
+    def test_negative_or_zero_clamped_to_one(self):
+        """``max(1, int(...))`` floors any non-positive value at 1, matching
+        the same defensive pattern used by ``probe_msg_id_sample_rate``."""
+        adapter = KimiAdapter(_cfg(room_cache_max_entries=0))
+        self.assertEqual(adapter._rooms._maxsize, 1)
+        adapter2 = KimiAdapter(_cfg(room_cache_max_entries=-5))
+        self.assertEqual(adapter2._rooms._maxsize, 1)
+
+    def test_per_room_dict_evicts_under_pressure(self):
+        """Insert past the cap; oldest room_id is dropped silently."""
+        adapter = KimiAdapter(_cfg(room_cache_max_entries=3))
+        adapter._last_message_id_per_room["room-1"] = "msg-1"
+        adapter._last_message_id_per_room["room-2"] = "msg-2"
+        adapter._last_message_id_per_room["room-3"] = "msg-3"
+        adapter._last_message_id_per_room["room-4"] = "msg-4"  # evicts room-1
+        self.assertEqual(len(adapter._last_message_id_per_room), 3)
+        self.assertNotIn("room-1", adapter._last_message_id_per_room)
+        self.assertEqual(adapter._last_message_id_per_room["room-4"], "msg-4")
+
+    def test_busy_room_protected_from_eviction(self):
+        """A room receiving frequent updates moves to the recent end on each
+        write and is NOT evicted just because it was first inserted long ago.
+        This is the load-bearing case for ``_last_message_id_per_room`` —
+        a single chatty room should be the LAST to evict, not the first."""
+        adapter = KimiAdapter(_cfg(room_cache_max_entries=3))
+        # Insert busy + idle rooms.
+        adapter._last_message_id_per_room["busy"] = "msg-1"
+        adapter._last_message_id_per_room["idle-a"] = "msg-2"
+        adapter._last_message_id_per_room["idle-b"] = "msg-3"
+        # 100 more messages in "busy" — each write refreshes its LRU position.
+        for i in range(100):
+            adapter._last_message_id_per_room["busy"] = f"msg-{10+i}"
+        # Now insert a 4th distinct room. Eviction should hit "idle-a"
+        # (oldest among rooms that haven't been touched), NOT "busy".
+        adapter._last_message_id_per_room["new-room"] = "msg-fresh"
+        self.assertIn("busy", adapter._last_message_id_per_room)
+        self.assertNotIn("idle-a", adapter._last_message_id_per_room)
+
+
+class ArrivalTimeCacheCapTests(unittest.TestCase):
+    """Cumulative review #58 (Codex lead): ``_last_arrival_time_per_room``
+    is bounded INDEPENDENTLY of the shared ``room_cache_max_entries`` cap.
+
+    Sharing the 500-entry cap with the other per-room dicts would silently
+    blind the Phase 0 gap-candidate log under cardinality pressure: an
+    evicted arrival-time entry produces ``prev_arrival=None`` on the next
+    message, suppressing the INFO log regardless of actual delay. Codex
+    framed it as a contradiction with the ``_BoundedLRU`` "no load-bearing
+    state" promise — fixed here by giving arrival-time tracking its own
+    ceiling that's effectively unbounded for any realistic deployment
+    (10000 entries × ~16 bytes ≈ 160KB).
+    """
+
+    def test_default_arrival_cap_is_separate_and_larger(self):
+        """No config override → arrival dict at 10000, room dict at 500."""
+        adapter = KimiAdapter(_cfg())
+        self.assertIsInstance(adapter._last_arrival_time_per_room, _BoundedLRU)
+        self.assertEqual(
+            adapter._last_arrival_time_per_room._maxsize,
+            _ARRIVAL_TIME_CACHE_DEFAULT_MAX,
+        )
+        # Crucially: NOT the same as _ROOM_CACHE_DEFAULT_MAX.
+        self.assertNotEqual(
+            adapter._last_arrival_time_per_room._maxsize,
+            adapter._rooms._maxsize,
+            "arrival-time cap must be distinct from shared room cap — "
+            "Codex review #58 lead objection",
+        )
+        self.assertGreater(
+            adapter._last_arrival_time_per_room._maxsize,
+            adapter._rooms._maxsize,
+            "arrival-time cap must be larger so eviction is unreachable "
+            "in any realistic deployment",
+        )
+
+    def test_arrival_cap_config_override_independent(self):
+        """``arrival_time_cache_max_entries`` plumbs to the arrival dict
+        without affecting ``room_cache_max_entries``."""
+        adapter = KimiAdapter(_cfg(
+            room_cache_max_entries=42,
+            arrival_time_cache_max_entries=999,
+        ))
+        self.assertEqual(adapter._rooms._maxsize, 42)
+        self.assertEqual(adapter._last_message_id_per_room._maxsize, 42)
+        self.assertEqual(adapter._last_arrival_time_per_room._maxsize, 999)
+
+    def test_arrival_cap_invalid_falls_back_to_default(self):
+        """Garbage in config doesn't crash startup; default applies + warning."""
+        adapter = KimiAdapter(_cfg(arrival_time_cache_max_entries="not-an-int"))
+        self.assertEqual(
+            adapter._last_arrival_time_per_room._maxsize,
+            _ARRIVAL_TIME_CACHE_DEFAULT_MAX,
+        )
+
+    def test_arrival_cap_negative_or_zero_clamped_to_one(self):
+        """Same defensive ``max(1, int(...))`` floor as the room cap."""
+        a0 = KimiAdapter(_cfg(arrival_time_cache_max_entries=0))
+        self.assertEqual(a0._last_arrival_time_per_room._maxsize, 1)
+        a_neg = KimiAdapter(_cfg(arrival_time_cache_max_entries=-7))
+        self.assertEqual(a_neg._last_arrival_time_per_room._maxsize, 1)
+
+    def test_eviction_with_separate_caps_doesnt_cross_dicts(self):
+        """Inserting past one dict's cap evicts only from that dict —
+        proves the caps are truly independent, not aliased to a single
+        shared cap. Regression guard against an accidental refactor that
+        re-merges the caps."""
+        adapter = KimiAdapter(_cfg(
+            room_cache_max_entries=2,
+            arrival_time_cache_max_entries=4,
+        ))
+        # Push past the ROOM cap (2) but stay under the ARRIVAL cap (4).
+        for i in range(3):
+            adapter._rooms[f"room-{i}"] = object()
+            adapter._last_arrival_time_per_room[f"room-{i}"] = float(i)
+        self.assertEqual(len(adapter._rooms), 2)  # evicted room-0
+        self.assertEqual(len(adapter._last_arrival_time_per_room), 3)  # still has all
+        self.assertIn("room-0", adapter._last_arrival_time_per_room,
+                      "arrival-dict must NOT be evicted at the room-cap boundary")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Lift 3b: output_mode flag
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class HakimiLift3bOutputModeTests(unittest.IsolatedAsyncioTestCase):
+    """Lift 3b: output_mode: passthrough | tool_only."""
+
+    async def test_3b_1_passthrough_mode_delivers_prose(self):
+        """3b.1 — passthrough (default) — send() routes through normally."""
+        adapter = KimiAdapter(_cfg(output_mode="passthrough"))
+        self.assertEqual(adapter._output_mode, "passthrough")
+
+        # Patch the routing methods so we don't need a live WS/HTTP session.
+        adapter._send_dm = AsyncMock(return_value=SendResult(success=True))
+        adapter._send_group = AsyncMock(return_value=SendResult(success=True))
+
+        result = await adapter.send(
+            chat_id="dm:im:kimi:main", content="agent prose response"
+        )
+        self.assertTrue(result.success)
+        adapter._send_dm.assert_awaited_once()
+
+    async def test_3b_2_tool_only_mode_suppresses_prose(self):
+        """3b.2 — tool_only — send() is gated, nothing reaches the platform."""
+        adapter = KimiAdapter(_cfg(output_mode="tool_only"))
+        self.assertEqual(adapter._output_mode, "tool_only")
+
+        adapter._send_dm = AsyncMock(return_value=SendResult(success=True))
+        adapter._send_group = AsyncMock(return_value=SendResult(success=True))
+
+        result = await adapter.send(
+            chat_id="dm:im:kimi:main", content="agent prose that should be suppressed"
+        )
+        # Returns success=True (no error) but nothing was sent.
+        self.assertTrue(result.success)
+        adapter._send_dm.assert_not_awaited()
+        adapter._send_group.assert_not_awaited()
+
+    async def test_3b_3_tool_only_mode_suppresses_all_send_targets(self):
+        """3b.3 — tool_only suppresses prose to both DM and group targets."""
+        adapter = KimiAdapter(_cfg(output_mode="tool_only"))
+
+        adapter._send_dm = AsyncMock(return_value=SendResult(success=True))
+        adapter._send_group = AsyncMock(return_value=SendResult(success=True))
+
+        # DM target.
+        result_dm = await adapter.send(
+            chat_id="dm:im:kimi:main", content="thinking out loud"
+        )
+        # Group target.
+        result_group = await adapter.send(
+            chat_id="room:abc123", content="group prose also suppressed"
+        )
+        self.assertTrue(result_dm.success)
+        self.assertTrue(result_group.success)
+        adapter._send_dm.assert_not_awaited()
+        adapter._send_group.assert_not_awaited()
+
+    async def test_3b_4_tool_only_mode_still_closes_inflight_dm(self):
+        """3b.4 — tool_only DM suppression still pops inflight + responds end_turn.
+
+        Regression: without _close_dm_inflight in send()'s short-circuit, the
+        DM JSON-RPC reply never fires and Kimi's UI spinner hangs until WS
+        reconnect. The inflight deque also grows unbounded over WS lifetime.
+        """
+        adapter = KimiAdapter(_cfg(output_mode="tool_only"))
+        adapter._dm_respond = AsyncMock()
+        adapter._send_dm = AsyncMock(return_value=SendResult(success=True))
+
+        # Simulate an in-flight prompt as _dm_handle_prompt would.
+        sid = "user-xyz"
+        adapter._dm_inflight.setdefault(sid, deque()).append(
+            _DMInflight(kimi_sid=sid, req_id=42)
+        )
+
+        result = await adapter.send(
+            chat_id=f"dm:{sid}", content="agent prose to suppress"
+        )
+
+        # tool_only still short-circuits the prose
+        self.assertTrue(result.success)
+        adapter._send_dm.assert_not_awaited()
+        # …but the JSON-RPC end_turn reply fires so the UI spinner closes
+        adapter._dm_respond.assert_awaited_once_with(42, {"stopReason": "end_turn"})
+        # …and the inflight queue is fully drained (no leak)
+        self.assertNotIn(sid, adapter._dm_inflight)
+
+    async def test_3b_5_empty_content_still_closes_inflight_dm(self):
+        """3b.5 — empty content send() short-circuit also closes inflight DM."""
+        adapter = KimiAdapter(_cfg(output_mode="passthrough"))
+        adapter._dm_respond = AsyncMock()
+
+        sid = "user-empty"
+        adapter._dm_inflight.setdefault(sid, deque()).append(
+            _DMInflight(kimi_sid=sid, req_id=99)
+        )
+
+        result = await adapter.send(chat_id=f"dm:{sid}", content="")
+        self.assertTrue(result.success)
+        adapter._dm_respond.assert_awaited_once_with(99, {"stopReason": "end_turn"})
+        self.assertNotIn(sid, adapter._dm_inflight)
+
+
+class HakimiLift3bOutputModeInitTests(unittest.TestCase):
+    """Init-level validation for output_mode."""
+
+    def test_output_mode_default_is_passthrough(self):
+        adapter = KimiAdapter(_cfg())
+        self.assertEqual(adapter._output_mode, "passthrough")
+
+    def test_output_mode_tool_only_accepted(self):
+        adapter = KimiAdapter(_cfg(output_mode="tool_only"))
+        self.assertEqual(adapter._output_mode, "tool_only")
+
+    def test_output_mode_invalid_defaults_with_warning(self):
+        records, teardown = _capture_kimi_log_records(level=logging.WARNING)
+        try:
+            adapter = KimiAdapter(_cfg(output_mode="robot_only"))
+        finally:
+            teardown()
+        self.assertEqual(adapter._output_mode, "passthrough")
+        warnings = [
+            r for r in records
+            if r.levelno == logging.WARNING and "output_mode" in r.getMessage()
+        ]
+        self.assertEqual(len(warnings), 1)
+        self.assertIn("robot_only", warnings[0].getMessage())
+
+
+class PluginRegistrationTests(unittest.TestCase):
+    """Verify ``register()`` populates the expected ``PlatformEntry`` fields.
+
+    Replaces the older Fork-only ``AuthorizationIntegrationTests`` which
+    scraped ``gateway/run.py`` source for hardcoded ``Platform.KIMI`` map
+    entries.  All of that wiring is now plugin-owned via the upstream
+    ``ctx.register_platform()`` API — these tests assert the call's kwargs
+    instead of poking the gateway's source code.
+    """
+
+    def test_register_calls_ctx_with_expected_fields(self):
+        from kimi_adapter import register
+
+        ctx = MagicMock()
+        register(ctx)
+
+        ctx.register_platform.assert_called_once()
+        kwargs = ctx.register_platform.call_args.kwargs
+
+        # Identity
+        self.assertEqual(kwargs["name"], "kimiclaw")
+        self.assertEqual(kwargs["label"], "KimiClaw")
+
+        # Auth env-var mapping (replaces fork's gateway/run.py auth env-maps).
+        self.assertEqual(kwargs["allowed_users_env"], "KIMI_ALLOWED_USERS")
+        self.assertEqual(kwargs["allow_all_env"], "KIMI_ALLOW_ALL_USERS")
+
+        # Cron delivery (replaces fork's cron/scheduler.py wiring).
+        self.assertEqual(kwargs["cron_deliver_env_var"], "KIMI_HOME_CHANNEL")
+
+        # Required env
+        self.assertEqual(kwargs["required_env"], ["KIMI_BOT_TOKEN"])
+
+        # Display flags
+        self.assertEqual(kwargs["emoji"], "🌙")
+        self.assertTrue(kwargs["pii_safe"])
+        self.assertTrue(kwargs["allow_update_command"])
+
+        # Callable hooks must all be present + callable.
+        self.assertTrue(callable(kwargs["adapter_factory"]))
+        self.assertTrue(callable(kwargs["check_fn"]))
+        self.assertTrue(callable(kwargs["validate_config"]))
+        self.assertTrue(callable(kwargs["is_connected"]))
+        self.assertTrue(callable(kwargs["env_enablement_fn"]))
+        self.assertTrue(callable(kwargs["apply_yaml_config_fn"]))
+        self.assertTrue(callable(kwargs["standalone_sender_fn"]))
+        self.assertTrue(callable(kwargs["setup_fn"]))
+
+        # Platform hint mentions Kimi explicitly.
+        self.assertIn("Kimi", kwargs["platform_hint"])
+        self.assertIn("kimi.com", kwargs["platform_hint"])
+
+        # Install hint references the upstream commit so operators can find it.
+        self.assertIn("2e20f6ae2", kwargs["install_hint"])
+
+        # Message-length guidance present for smart-chunking.
+        self.assertGreater(kwargs["max_message_length"], 0)
+
+    def test_register_factory_constructs_adapter(self):
+        """The factory passed to ``register_platform`` actually constructs a KimiAdapter."""
+        from kimi_adapter import register
+
+        ctx = MagicMock()
+        register(ctx)
+        factory = ctx.register_platform.call_args.kwargs["adapter_factory"]
+        adapter = factory(_cfg())
+        self.assertIsInstance(adapter, KimiAdapter)
+
+    def test_register_check_fn_passes_in_dev_env(self):
+        """``check_fn`` returns True when deps are importable AND
+        ``KIMI_BOT_TOKEN`` is set. Mirrors the :class:`CheckForRegistryTests`
+        assertion; this variant exercises the actual function reference the
+        ``register()`` call hands to ``ctx.register_platform``.
+        """
+        from kimi_adapter import register
+
+        ctx = MagicMock()
+        register(ctx)
+        check_fn = ctx.register_platform.call_args.kwargs["check_fn"]
+        with patch.dict(os.environ, {"KIMI_BOT_TOKEN": "km_b_prod_TEST"}, clear=False):
+            self.assertTrue(check_fn())
+
+    def test_register_check_fn_fails_without_bot_token(self):
+        """``check_fn`` returns False when ``KIMI_BOT_TOKEN`` is unset, even
+        if deps are importable. Protects against KimiClaw auto-enabling on
+        every install that has the ``[messaging]`` extra now that we declare
+        ``websockets`` there.
+        """
+        from kimi_adapter import register
+
+        ctx = MagicMock()
+        register(ctx)
+        check_fn = ctx.register_platform.call_args.kwargs["check_fn"]
+        env_no_kimi = {k: v for k, v in os.environ.items()
+                       if not k.startswith("KIMI_")}
+        with patch.dict(os.environ, env_no_kimi, clear=True):
+            self.assertFalse(check_fn())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -660,6 +660,18 @@ The Microsoft Teams platform adapter (Bot Framework / Azure AD), distinct from t
 |----------|-------------|
 | `RAFT_PROFILE` | Raft agent profile slug — auto-enables the adapter when set. |
 
+### KimiClaw (Moonshot AI)
+
+Used by the bundled KimiClaw platform plugin (`plugins/platforms/kimiclaw/`). See [Messaging Gateway → KimiClaw](/user-guide/messaging/kimiclaw) for full setup. Env-var names are kept as `KIMI_*` because the credentials are issued by kimi.com itself.
+
+| Variable | Description |
+|----------|-------------|
+| `KIMI_BOT_TOKEN` | Bot token from kimi.com's *Kimi Claw → Add Claw → Link existing OpenClaw* flow (format `km_b_prod_*`). Required. |
+| `KIMI_ALLOWED_USERS` | Comma-separated Kimi user IDs (`km_u_*`) allowed to talk to the bot. |
+| `KIMI_ALLOW_ALL_USERS` | Dev-only escape hatch — accepts any source. Default: `false`. |
+| `KIMI_HOME_CHANNEL` | Default delivery target for cron / notification sends. Must be a `room:<uuid>` value; DM cron delivery is not supported through the standalone send path (see [Known limitations](/user-guide/messaging/kimiclaw#known-limitations)). |
+| `KIMI_HOME_CHANNEL_NAME` | Optional display name for the home channel. |
+
 ### Advanced Messaging Tuning
 
 Advanced per-platform knobs for throttling the outbound message batcher. Most users never need to touch these; defaults are set to respect each platform's rate limits without feeling sluggish.

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 1
 title: "Messaging Gateway"
-description: "Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Signal, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Yuanbao, Microsoft Teams, LINE, Raft, Webhooks, or any OpenAI-compatible frontend via the API server — architecture and setup overview"
+description: "Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Signal, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Yuanbao, Microsoft Teams, LINE, KimiClaw (kimi.com), Raft, Webhooks, or any OpenAI-compatible frontend via the API server — architecture and setup overview"
 ---
 
 # Messaging Gateway
 
-Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Signal, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Feishu/Lark, WeCom, Weixin, BlueBubbles (iMessage), QQ, Yuanbao, Microsoft Teams, LINE, ntfy, or your browser. The gateway is a single background process that connects to all your configured platforms, handles sessions, runs cron jobs, and delivers voice messages.
+Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Signal, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Feishu/Lark, WeCom, Weixin, BlueBubbles (iMessage), QQ, Yuanbao, KimiClaw (kimi.com), Microsoft Teams, LINE, ntfy, or your browser. The gateway is a single background process that connects to all your configured platforms, handles sessions, runs cron jobs, and delivers voice messages.
 
 For the full voice feature set — including CLI microphone mode, spoken replies in messaging, and Discord voice-channel conversations — see [Voice Mode](/user-guide/features/voice-mode) and [Use Voice Mode with Hermes](/guides/use-voice-mode-with-hermes).
 
@@ -37,6 +37,7 @@ Bots need both a model provider and tool providers (TTS, web). A [Nous Portal](/
 | BlueBubbles | — | ✅ | ✅ | — | ✅ | ✅ | — |
 | QQ | ✅ | ✅ | ✅ | — | — | ✅ | — |
 | Yuanbao | ✅ | ✅ | ✅ | — | — | ✅ | ✅ |
+| KimiClaw | — | ✅ | ✅ | ✅ | — | — | ✅ |
 | Microsoft Teams | — | ✅ | — | ✅ | — | ✅ | — |
 | LINE | — | ✅ | ✅ | — | — | ✅ | — |
 | ntfy | — | — | — | — | — | — | — |

--- a/website/docs/user-guide/messaging/kimiclaw.md
+++ b/website/docs/user-guide/messaging/kimiclaw.md
@@ -1,0 +1,119 @@
+---
+sidebar_position: 18
+title: "KimiClaw"
+description: "Set up Hermes Agent as a KimiClaw bot on Kimi (Moonshot AI's consumer chat platform)"
+---
+
+# KimiClaw Setup
+
+Run Hermes Agent as a [KimiClaw](https://www.kimi.com/) bot through the bundled `kimiclaw` platform plugin. KimiClaw is Moonshot AI's agentic bot system on kimi.com — distinct from the `kimi` LLM provider (which is the Moonshot inference API, configured under `providers:` not `platforms:`).
+
+The adapter lives under `plugins/platforms/kimiclaw/` and is discovered by the platform-plugin loader, so there is no `Platform.KIMICLAW` enum edit or gateway factory edit.
+
+KimiClaw bridges direct messages and group rooms under one bot identity. Direct messages use the Zed ACP path over a persistent WebSocket with sentinel session `im:kimi:main`; group rooms use the Connect RPC `Subscribe` server-stream over an HTTP/1.1 long-poll with `room:<uuid>` chat IDs.
+
+## How the bot responds
+
+| Context | Behavior |
+|---------|----------|
+| **Direct message** (`im:kimi:main`) | Uses the Zed ACP channel and responds as the bot user. |
+| **Group room** (`room:<uuid>`) | Uses the Connect RPC channel and follows the gateway mention / free-response policy. |
+| **Cron or notification delivery** | Routes through `KIMI_HOME_CHANNEL` when set. |
+| **Allowlisted users** (`km_u_*`) | `KIMI_ALLOWED_USERS` restricts who can talk to the bot unless `KIMI_ALLOW_ALL_USERS=true`. |
+
+Kimi user IDs use the `km_u_*` shape. Bot tokens use the `km_b_prod_*` shape. (Env-var names stay `KIMI_*` because the credentials are issued by Kimi.com itself.)
+
+---
+
+## Step 1: Create a KimiClaw bot and copy the token
+
+1. Open [kimi.com](https://www.kimi.com/) and sign in.
+2. Navigate **Kimi Claw → Add Claw → Link existing OpenClaw**. Kimi displays a one-shot install command of the form:
+
+   ```bash
+   bash <(curl -fsSL https://cdn.kimi.com/kimi-claw/claw-install.sh) --bot-token km_b_prod_<your_token>
+   ```
+
+3. **Copy the `km_b_prod_<your_token>` value.** That is the bot credential Hermes Agent needs. You do **not** need to run the install command itself — Hermes Agent connects to the KimiClaw wire protocol directly without a local OpenClaw runtime (see [Deployment model](#deployment-model) below). Keep the token private; Hermes sends it as `X-Kimi-Bot-Token` when connecting.
+4. After clicking **Done** in the Kimi UI to bind your bot identity to the token, you can proceed to Step 2.
+
+### Deployment model
+
+KimiClaw's official install flow expects you to run `claw-install.sh` to set up a local OpenClaw runtime that owns the wire connection. The Hermes adapter takes a different path: it speaks the KimiClaw wire protocol (DM ACP WebSocket and Connect-RPC long-poll) directly from Python, with no local OpenClaw process. The adapter does send the OpenClaw-shaped runtime-metadata headers that kimi.com gates group-room participation on — declaring the minimum protocol version (`X-Kimi-OpenClaw-Version: 2026.3.13`, matching kimi.com's documented "OpenClaw 3.13 or above" gate). Bot identity is attributed honestly: the `X-Kimi-Claw-ID` header (`hermes-kimi-<hex>`) is set on both the DM WebSocket upgrade and the group HTTP path, and the group HTTP path additionally sets `User-Agent: hermes-kimi-adapter/1.0` (the WebSocket upgrade does not carry a `User-Agent` header). All five OpenClaw headers are overridable via `config.extra` (`claw_version`, `openclaw_version`, `claw_id`, `openclaw_plugins`, `openclaw_skills`).
+
+---
+
+## Step 2: Configure Hermes
+
+Add to `~/.hermes/.env`:
+
+```env
+KIMI_BOT_TOKEN=km_b_prod_<your_token>
+
+# Optional allowlist. Use Kimi user IDs, comma-separated.
+KIMI_ALLOWED_USERS=km_u_<uuid>
+
+# Development only: bypass the allowlist.
+KIMI_ALLOW_ALL_USERS=false
+
+# Optional default delivery target for cron / notifications.
+# Must be a room:<uuid> — see "Known limitations" for why DM cron
+# is not supported through the standalone send path.
+KIMI_HOME_CHANNEL=room:<uuid>
+```
+
+Then enable the platform in `~/.hermes/config.yaml`:
+
+```yaml
+gateway:
+  platforms:
+    kimiclaw:
+      enabled: true
+```
+
+For profile-local configuration without a per-profile `.env`, the adapter also reads a top-level `kimiclaw:` block and maps it to the same `KIMI_*` environment values:
+
+```yaml
+kimiclaw:
+  bot_token: km_b_prod_<your_token>
+  home_channel: room:<uuid>
+  allowed_users:
+    - km_u_<uuid>
+  allow_all_users: false
+```
+
+`platforms.kimiclaw.extra` still works for raw adapter extras, but the top-level `kimiclaw:` block is the bridge that expands into the standard env-var path.
+
+---
+
+## Step 3: Run the gateway
+
+```bash
+hermes gateway start
+```
+
+On startup, the plugin loader discovers `plugins/platforms/kimiclaw/` and registers the `kimiclaw` platform. A healthy connection logs that KimiClaw connected as the bot identity.
+
+Send a message to the bot from Kimi. For group rooms, use the `room:<uuid>` value from the gateway inbound-message log when you need to set `KIMI_HOME_CHANNEL` or room-specific policy.
+
+---
+
+## Known limitations
+
+**`output_mode: tool_only` and `send_message_tool`.** Against current upstream Hermes, `send_message_tool._send_via_adapter` prefers a live in-process adapter over the standalone-sender fallback. In `tool_only` mode the adapter suppresses all `send()` calls (it cannot yet distinguish "streaming prose" from "explicit tool send" at the gate), so explicit tool sends from an in-process gateway are silently dropped alongside the prose. Stay on the default `passthrough` for interactive DMs; `tool_only` is safe only for cron-driven or out-of-process deployments where dispatch falls through to `standalone_sender_fn` (which is not gated by `output_mode`).
+
+**Cron home channel is group-rooms-only.** `KIMI_HOME_CHANNEL` accepts both `room:<uuid>` and `im:kimi:main` syntactically, but the standalone sender used by cron currently only delivers to `room:<uuid>` — DM cron delivery requires an active WebSocket session and falls through to the live adapter path. Configure `KIMI_HOME_CHANNEL` to a `room:<uuid>` for predictable cron delivery.
+
+**`validate_config` token sources.** `validate_config(config)` returns true when any of `KIMI_BOT_TOKEN` (env), `PlatformConfig.token` (`platforms.kimiclaw.token` YAML), or `PlatformConfig.extra["bot_token"]` resolves to a non-empty string — mirroring the three sources the adapter `__init__` consults. The `apply_yaml_config_fn` hook also bridges top-level `kimiclaw.bot_token` YAML into `extra`, so both the top-level and `platforms.kimiclaw.*` YAML layouts are honored.
+
+---
+
+## Troubleshooting
+
+**`KIMI_BOT_TOKEN` is missing or rejected.** Regenerate the token in Kimi and verify it starts with `km_b_prod_`. If you put the token in YAML, prefer the top-level `kimiclaw.bot_token` bridge or a real `KIMI_BOT_TOKEN` env var.
+
+**Cron delivery does not reach Kimi.** Set `KIMI_HOME_CHANNEL` to the target `room:<uuid>` (cron uses the standalone send path, which currently only supports group rooms — see [Known limitations](#known-limitations) for the DM caveat). If the bot token was regenerated, the old room can become stale because the bot identity changed; run `/sethome` again from the live target chat or update the env var manually.
+
+**The bot is silent for a user.** Add that user ID to `KIMI_ALLOWED_USERS`, or set `KIMI_ALLOW_ALL_USERS=true` only for a trusted development setup. User IDs have the `km_u_*` shape.
+
+**Confused with the `kimi` LLM provider?** They're separate integrations. The Moonshot `kimi-for-coding` LLM provider (profile in `plugins/model-providers/kimi-coding/`, with aliases registered in `hermes_cli/providers.py`) talks to Moonshot's inference API and supplies LLM completions. The `kimiclaw` platform (this plugin) talks to kimi.com's bot endpoints (DM via WebSocket, group rooms via Connect RPC over HTTP long-poll) and runs as a chat bot on the consumer Kimi product. You can use either, both, or neither independently.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -638,6 +638,7 @@ const sidebars: SidebarsConfig = {
             'user-guide/messaging/weixin',
             'user-guide/messaging/qqbot',
             'user-guide/messaging/yuanbao',
+            'user-guide/messaging/kimiclaw',
           ],
         },
         {


### PR DESCRIPTION
## What does this PR do?

Adds **KimiClaw** — Moonshot AI's agentic bot platform on kimi.com (launched Feb 2026) — as a bundled platform plugin under `plugins/platforms/kimiclaw/`, mirroring the LINE bundled-plugin pattern (PR #23197) and the more recent SimpleX precedent (#26232). **Distinct from the Moonshot LLM provider** — the `kimi-for-coding` profile lives at `plugins/model-providers/kimi-coding/` (with aliases registered in `hermes_cli/providers.py`); this PR adds a separate chat platform and does not touch that integration. No edits to `gateway/run.py`, `gateway/platform_registry.py`, `hermes_cli/*`, or the built-in `Platform` enum — the bundled-plugin scan in `gateway/config.py` auto-discovers `Platform("kimiclaw")` via dynamic `_missing_()`.

**Why bundle:**

1. **Bot-API access to Moonshot's consumer chat product.** Kimi (kimi.com) is Moonshot AI's globally-available consumer chat product; KimiClaw is its public, documented bot API and browser-native agent platform (`Kimi Claw → Add Claw`). Hermes already integrates with Moonshot at the LLM-provider layer (`kimi-for-coding`), so adding the platform-side integration completes the Moonshot-ecosystem story: an operator can run a Hermes agent that uses Kimi as both its inference provider and the consumer chat surface users interact with. Bundling lets operators set this up from a fresh install without manually cloning an external plugin repo.

2. **Dual-channel architecture exercises an API surface the existing bundled platforms don't.** LINE and Teams are webhook-based; Google Chat is unary-RPC; SimpleX uses a local-daemon WebSocket relay. KimiClaw is the first bundled platform to combine **Zed ACP JSON-RPC over a persistent WebSocket** (DM) with **Connect RPC server-streamed Subscribe over HTTP/1.1 long-poll** plus **unary Connect RPC `SendMessage`** (groups) — all wired via `ctx.register_platform()`. The adapter's `register()` call (`plugins/platforms/kimiclaw/adapter.py:4324`) exercises every behavioral hook the API offers: `validate_config`, `is_connected`, `setup_fn`, `env_enablement_fn`, `apply_yaml_config_fn`, `cron_deliver_env_var`, `standalone_sender_fn`, `allowed_users_env`, `allow_all_env`, `max_message_length`, `emoji`, `pii_safe`, `allow_update_command`, `platform_hint`.

3. **Production wear.** The same adapter code has run on one Raspberry Pi gateway under daily user traffic since 2026-04-27 (the "Bloom" deployment). The adapter previously shipped (and continues to ship) as an external plugin at `linxule/hermes-kimi-plugin`; this PR upstreams it at version `1.0.0` as a stable snapshot intentionally decoupled from the external repo's bleeding-edge stream.

### Deployment model (please read)

Moonshot's intended bot deployment uses the official OpenClaw runtime (`claw-install.sh`, V2026.4.5+) to own the wire connection. This plugin instead speaks the wire protocol directly from Python while sending the OpenClaw-shaped runtime-metadata headers kimi.com gates group-room participation on ("OpenClaw 3.13 or above"). Identity layers are honest:

- `User-Agent: hermes-kimi-adapter/1.0` on the group HTTP path (the DM WebSocket upgrade does not carry a `User-Agent` header)
- `X-Kimi-Claw-ID: hermes-kimi-<hex>` on both DM and group channels
- `X-Kimi-OpenClaw-Skills` is suppressed by default (matching kimi.com's UI message "Reading third-party OpenClaw Skills is not supported yet")
- `X-Kimi-OpenClaw-Version: 2026.3.13` is the documented group-gate floor — not a "real install" value
- `X-Kimi-OpenClaw-Plugins` names Moonshot's own `kimi-claw`

All five OpenClaw-shaped headers are overridable via `config.extra`. See `plugins/platforms/kimiclaw/adapter.py:23-28` (module docstring) and `:107-112` (`_GROUP_GATE_DEFAULTS`).

## Related Issue

N/A — bundled-platform addition (no upstream issue tracks this surface).

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/kimiclaw/adapter.py` (+4,358) — `KimiAdapter(BasePlatformAdapter)` — dual-channel: Zed ACP JSON-RPC over WebSocket for DM (sentinel session `im:kimi:main`), Connect RPC `application/connect+json` server-stream over HTTP/1.1 long-poll for group rooms (`room:<uuid>`). Includes dedup, reconnect, chunked-message reassembly, OpenClaw runtime metadata headers, env-template substitution for `${VAR}` config.yaml patterns, and the env-AND-deps `_check_for_registry()` gate so KimiClaw does not auto-enable on installs without `KIMI_BOT_TOKEN`.
- `plugins/platforms/kimiclaw/plugin.yaml` (+36) — Manifest with `KIMI_BOT_TOKEN` (required, with `url:` field), `KIMI_ALLOWED_USERS` / `KIMI_ALLOW_ALL_USERS` / `KIMI_HOME_CHANNEL` (optional). Version `1.0.0` — fresh start as a bundled plugin (the external `linxule/hermes-kimi-plugin` continues its own version stream). Env-var names kept as `KIMI_*` because credentials are issued by kimi.com.
- `plugins/platforms/kimiclaw/__init__.py` (+3) — LINE-pattern entry point.
- `tests/gateway/test_kimiclaw_plugin.py` (+5,560) — 259 tests across protocol framing, dedup, chat-id routing, slash-command detection, env-template substitution, YAML→env config bridge, `register()` metadata, `_standalone_send`, plus regression coverage for the `tool_only` DM-inflight closure path and the registry-gate (`_check_for_registry`) requiring `KIMI_BOT_TOKEN`. Loaded via `load_plugin_adapter("kimiclaw")` (same isolation pattern as `test_line_plugin.py`). All tests pure-function / mocked — no live-network calls.
- `website/docs/user-guide/messaging/kimiclaw.md` (+119) — Setup guide with concrete kimi.com flow (*Kimi Claw → Add Claw → Link existing OpenClaw*), Deployment-model note for the OpenClaw runtime-metadata headers, disambiguation vs the Moonshot LLM provider, and a Known-limitations section covering `tool_only`/`send_message_tool` interaction, `KIMI_HOME_CHANNEL` cron behaviour, and the `validate_config` token-resolution path.
- `website/docs/reference/environment-variables.md` (+12) — `KIMI_*` reference table under Messaging (LINE-section precedent).
- `website/docs/user-guide/messaging/index.md` (+3 / -2) — KimiClaw capability-table row + lead-paragraph + description-frontmatter mentions.
- `website/sidebars.ts` (+1) — Sidebar entry in the messaging category.
- `cli-config.yaml.example` (+11) — Commented-out top-level `kimiclaw:` block (YAML→env bridge).
- `scripts/release.py` (+1) — CI author attribution: `x@linxule.com → linxule` added to `AUTHOR_MAP` (LINE / SimpleX / Google Chat / Teams precedent).
- `pyproject.toml` (+1 / -1) — Adds `websockets==15.0.1` to the `[messaging]` extra (DM ACP socket dependency — previously satisfied only as a transitive of `daytona` / `elevenlabs` / `fal_client`; now declared explicitly so messaging-only installs receive it).
- `uv.lock` (+2) — Regenerated by `uv lock` after the `pyproject.toml [messaging]` change to record the `websockets ↔ messaging` extra mapping.

**Total: 10,107 insertions, 3 deletions across 12 files (net +10,104).**

## How to Test

```bash
# 1. Set the bot token (obtain via kimi.com → Kimi Claw → Add Claw → Link existing OpenClaw)
export KIMI_BOT_TOKEN=km_b_prod_<your_token>

# 2. Install messaging extras (provides websockets + aiohttp)
uv sync --extra messaging

# 3. Run the kimiclaw test suite (259 tests, mocked / pure-function — no live-network calls)
uv run --with pytest --with pytest-asyncio pytest tests/gateway/test_kimiclaw_plugin.py -q

# 4. Optional: confirm the platform shows up in `hermes gateway status`
hermes gateway status   # KimiClaw should appear with the bot token set
hermes gateway start    # connects to kimi.com over Zed ACP WS (DM) + Connect RPC long-poll (groups)
```

For a fresh install without `KIMI_BOT_TOKEN`, the platform should **not** auto-enable (the `_check_for_registry()` gate is env-AND-deps). Set the token and restart — the platform will enable and connect.

Production wear: the same adapter code runs daily on a Raspberry Pi gateway since 2026-04-27.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(gateway):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_kimiclaw_plugin.py -q` and all 259 tests pass; also warning-clean under `-W error::ResourceWarning`
- [x] I've added tests for my changes (259 tests, including regression coverage for the registry-gate, the `tool_only` DM-inflight closure path, `_standalone_send` exceptions, and 429 retryability)
- [x] I've tested on my platform: macOS 15 (development) + Raspberry Pi OS (production "Bloom" deployment since 2026-04-27)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/user-guide/messaging/kimiclaw.md`, `website/docs/reference/environment-variables.md`, `website/docs/user-guide/messaging/index.md`, `website/sidebars.ts`, plus a `Known limitations` section covering `tool_only`, `KIMI_HOME_CHANNEL` cron behaviour, and `validate_config` token-path)
- [x] I've updated `cli-config.yaml.example` (added the commented-out top-level `kimiclaw:` YAML→env bridge block)
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A (no architecture changes)
- [x] I've considered cross-platform impact (Windows, macOS) — adapter is pure asyncio + `aiohttp`/`websockets`; the Raspberry Pi production deployment exercises a Linux ARM path. No Windows-specific code paths.
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no tool changes)

## Screenshots / Logs

```
$ uv run --with pytest --with pytest-asyncio pytest tests/gateway/test_kimiclaw_plugin.py -q
259 passed in 5.81s

$ uv run --with pytest --with pytest-asyncio pytest tests/gateway/test_kimiclaw_plugin.py -q -W error::ResourceWarning
259 passed in 5.89s

$ git diff --stat upstream/main...HEAD
 12 files changed, 10107 insertions(+), 3 deletions(-)
$ uv lock --check
Resolved 217 packages
$ git diff --check upstream/main...HEAD
(clean)
```

---

**Notes for reviewers:**

- **Stable snapshot, not a tracking mirror.** This plugin lands at `1.0.0`. The external repo at `linxule/hermes-kimi-plugin` (currently `v2.2.x`) continues for bleeding-edge fixes; the bundled version is intentionally decoupled and resyncs happen opportunistically (bundled-affecting bug fix or wire-format change) rather than on a fixed cadence.
- **Maintainer.** Xule Lin (linxule, x@linxule.com). CI author attribution added in `scripts/release.py` (LINE / SimpleX / Google Chat / Teams precedent).
- **Dependency note.** `websockets==15.0.1` matches the exact-pin style used by all other entries in the `[messaging]` extra (`python-telegram-bot[webhooks]==22.6`, `discord.py[voice]==2.7.1`, `aiohttp==3.13.3`, `slack-bolt==1.27.0`, etc.). Happy to widen to `>=15.0.1,<16` if you prefer the policy form.
