### PR TITLE
chore: add tinker atropos submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "tinker-atropos"]
+	path = tinker-atropos
+	url = https://github.com/nousresearch/tinker-atropos
+	branch = main


### PR DESCRIPTION
## Summary
- Adds `tinker-atropos` as a Git submodule pointing to https://github.com/nousresearch/tinker-atropos
- Tracks the current main commit `65f084ee8054a5d02aeac76e24ed60388511c82b`

## Validation
- `git diff --cached --check` passed before commit
- `git submodule status` verified the submodule pointer

Note: direct push to `NousResearch/hermes-agent` was denied for this token, so this PR is from the fork.