### PR TITLE
fix(matrix): accept bang-prefixed gateway commands

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -180,6 +180,33 @@ def _looks_like_matrix_image_filename(text: str) -> bool:
     return suffix in _MATRIX_IMAGE_FILENAME_EXTS
 
 
+def _normalize_matrix_bang_command(body: str) -> str:
+    """Map Matrix-friendly ``!command`` text to Hermes' canonical ``/command``.
+
+    Element/Matrix clients reserve leading ``/`` for client-side slash commands,
+    so a bare ``/yolo`` may never reach the bot.  Hermes' gateway dispatcher is
+    slash-based, though, so normalize a leading ``!`` only when it names a real
+    Hermes command/alias.  Unknown exclamations remain normal user text.
+    """
+    if not body.startswith("!"):
+        return body
+
+    head = body.split(maxsplit=1)[0][1:].lower()
+    if not head or "/" in head:
+        return body
+    if "@" in head:
+        head = head.split("@", 1)[0]
+
+    try:
+        from hermes_cli.commands import is_gateway_known_command
+    except Exception:
+        return body
+
+    if not is_gateway_known_command(head):
+        return body
+    return f"/{body[1:]}"
+
+
 def _create_matrix_session(proxy_url: str | None):
     """Create an ``aiohttp.ClientSession`` whose proxy applies to *all* requests.
 
@@ -1781,6 +1808,7 @@ class MatrixAdapter(BasePlatformAdapter):
         body = source_content.get("body", "") or ""
         if not body:
             return
+        body = _normalize_matrix_bang_command(body)
 
         ctx = await self._resolve_message_context(
             room_id,
@@ -1815,9 +1843,10 @@ class MatrixAdapter(BasePlatformAdapter):
                     past_fallback = True
                 stripped.append(line)
             body = "\n".join(stripped) if stripped else body
+            body = _normalize_matrix_bang_command(body)
 
         msg_type = MessageType.TEXT
-        if body.startswith(("!", "/")):
+        if body.startswith("/"):
             msg_type = MessageType.COMMAND
 
         msg_event = MessageEvent(

--- a/tests/gateway/test_matrix_bang_commands.py
+++ b/tests/gateway/test_matrix_bang_commands.py
@@ -1,0 +1,129 @@
+"""Matrix-specific command-prefix compatibility tests."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import MessageType
+from gateway.platforms.matrix import MatrixAdapter, _normalize_matrix_bang_command
+
+
+def _make_adapter() -> MatrixAdapter:
+    return MatrixAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="test-token",
+            extra={
+                "homeserver": "https://matrix.example.org",
+                "user_id": "@bot:example.org",
+            },
+        )
+    )
+
+
+class TestMatrixBangCommandNormalization:
+    def test_known_bang_command_maps_to_slash(self):
+        assert _normalize_matrix_bang_command("!yolo") == "/yolo"
+        assert _normalize_matrix_bang_command("!reasoning high") == "/reasoning high"
+
+    def test_alias_and_bot_suffix_map_to_slash(self):
+        assert _normalize_matrix_bang_command("!reset") == "/reset"
+        assert _normalize_matrix_bang_command("!yolo@HermesBot") == "/yolo@HermesBot"
+
+    def test_unknown_bang_text_stays_plain_text(self):
+        assert _normalize_matrix_bang_command("!not-a-hermes-command") == "!not-a-hermes-command"
+        assert _normalize_matrix_bang_command("!path/to/file.py") == "!path/to/file.py"
+        assert _normalize_matrix_bang_command("hello !yolo") == "hello !yolo"
+
+    def test_cli_only_command_stays_plain_text(self):
+        assert _normalize_matrix_bang_command("!history is useful") == "!history is useful"
+        assert _normalize_matrix_bang_command("!config should be yaml") == "!config should be yaml"
+        assert _normalize_matrix_bang_command("!tools are useful") == "!tools are useful"
+
+    @pytest.mark.asyncio
+    async def test_text_handler_emits_command_event_for_known_bang_command(self):
+        adapter = _make_adapter()
+        adapter._is_dm_room = AsyncMock(return_value=True)
+        adapter._get_display_name = AsyncMock(return_value="Alice")
+        adapter._text_batch_delay_seconds = 0
+
+        captured = None
+
+        async def capture(event):
+            nonlocal captured
+            captured = event
+
+        adapter.handle_message = capture
+
+        await adapter._handle_text_message(
+            "!room:example.org",
+            "@alice:example.org",
+            "$event1",
+            0.0,
+            {"msgtype": "m.text", "body": "!yolo"},
+            {},
+        )
+
+        assert captured is not None
+        assert captured.text == "/yolo"
+        assert captured.message_type == MessageType.COMMAND
+        assert captured.get_command() == "yolo"
+
+    @pytest.mark.asyncio
+    async def test_text_handler_keeps_unknown_bang_text_plain(self):
+        adapter = _make_adapter()
+        adapter._is_dm_room = AsyncMock(return_value=True)
+        adapter._get_display_name = AsyncMock(return_value="Alice")
+        adapter._text_batch_delay_seconds = 0
+
+        captured = None
+
+        async def capture(event):
+            nonlocal captured
+            captured = event
+
+        adapter.handle_message = capture
+
+        await adapter._handle_text_message(
+            "!room:example.org",
+            "@alice:example.org",
+            "$event2",
+            0.0,
+            {"msgtype": "m.text", "body": "!not-a-hermes-command"},
+            {},
+        )
+
+        assert captured is not None
+        assert captured.text == "!not-a-hermes-command"
+        assert captured.message_type == MessageType.TEXT
+        assert captured.get_command() is None
+
+    @pytest.mark.asyncio
+    async def test_text_handler_emits_command_event_after_reply_fallback(self):
+        adapter = _make_adapter()
+        adapter._is_dm_room = AsyncMock(return_value=True)
+        adapter._get_display_name = AsyncMock(return_value="Alice")
+        adapter._text_batch_delay_seconds = 0
+
+        captured = None
+
+        async def capture(event):
+            nonlocal captured
+            captured = event
+
+        adapter.handle_message = capture
+
+        await adapter._handle_text_message(
+            "!room:example.org",
+            "@alice:example.org",
+            "$event3",
+            0.0,
+            {"msgtype": "m.text", "body": "> <@bob:example.org> quoted\n\n!yolo"},
+            {"m.in_reply_to": {"event_id": "$parent"}},
+        )
+
+        assert captured is not None
+        assert captured.text == "/yolo"
+        assert captured.message_type == MessageType.COMMAND
+        assert captured.get_command() == "yolo"


### PR DESCRIPTION
## Summary
- adds a Matrix-friendly `!` command fallback for gateway slash commands, so `!yolo` is normalized to `/yolo` before dispatch
- limits normalization to gateway-dispatchable commands/aliases so normal exclamation text and CLI-only commands stay plain text
- covers direct messages and reply-fallback bodies with Matrix-specific tests

Fixes #12688

## Test Plan
- [x] `python -m pytest tests/gateway/test_matrix.py tests/gateway/test_matrix_bang_commands.py tests/gateway/test_command_bypass_active_session.py tests/e2e/test_platform_commands.py -q -o 'addopts='`
- [x] `git diff --check`
- [x] `python -m compileall -q gateway/platforms/matrix.py tests/gateway/test_matrix_bang_commands.py`

## Notes
Element clients reserve leading `/` for client-side slash commands, so `/yolo` may never be sent as a Matrix room message. This preserves existing `/` behavior for clients that do send it, and adds `!yolo`/`!help`/etc. as a Matrix-safe fallback.
