### PR TITLE
fix(kanban): preserve task-specific skills during review dispatch

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4855,12 +4855,17 @@ def dispatch_once(
             continue
         # Persist the resolved workspace path so the worker can cd there.
         set_workspace_path(conn, claimed.id, str(workspace))
-        # Force-load sdlc-review skill for review agents.  The
-        # _default_spawn function already auto-loads kanban-worker, and
-        # appends task.skills via --skills.  Setting task.skills here
-        # means the review agent gets both kanban-worker (lifecycle)
-        # and sdlc-review (review logic: AC verification, merge, etc.).
-        claimed.skills = ["sdlc-review"]
+        # Force-load sdlc-review skill for review agents without
+        # dropping any task-level specialist skills already pinned on
+        # the task (e.g. translation, security-review). `_default_spawn`
+        # already auto-loads kanban-worker separately.
+        merged_skills: list[str] = []
+        for sk in (claimed.skills or []):
+            if sk and sk not in merged_skills:
+                merged_skills.append(sk)
+        if "sdlc-review" not in merged_skills:
+            merged_skills.append("sdlc-review")
+        claimed.skills = merged_skills
         _spawn = spawn_fn if spawn_fn is not None else _default_spawn
         try:
             import inspect

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2512,7 +2512,7 @@ def test_dispatch_review_dry_run(kanban_home, all_assignees_spawnable):
 def test_dispatch_review_spawns_with_correct_skills(
     kanban_home, all_assignees_spawnable,
 ):
-    """Review tasks get sdlc-review skill set before spawning."""
+    """Review dispatch preserves task skills and adds sdlc-review."""
     spawned_tasks = []
 
     def capture_spawn(task, workspace, board=None):
@@ -2520,12 +2520,17 @@ def test_dispatch_review_spawns_with_correct_skills(
         return 42  # fake PID
 
     with kb.connect() as conn:
-        t = kb.create_task(conn, title="review me", assignee="alice")
+        t = kb.create_task(
+            conn,
+            title="review me",
+            assignee="alice",
+            skills=["translation"],
+        )
         _set_task_status(conn, t, "review")
         res = kb.dispatch_once(conn, spawn_fn=capture_spawn)
     assert len(res.spawned) == 1
     assert len(spawned_tasks) == 1
-    assert spawned_tasks[0].skills == ["sdlc-review"]
+    assert spawned_tasks[0].skills == ["translation", "sdlc-review"]
 
 
 def test_dispatch_review_skips_unassigned(kanban_home):


### PR DESCRIPTION
## Summary

Review dispatch was overwriting `task.skills` with `["sdlc-review"]`, which dropped any task-specific skills pinned when the task was created.

This change preserves existing task skills and adds `sdlc-review` additively during review dispatch, matching the documented per-task skill behavior and the `_default_spawn()` contract.

## Changes

- Preserve existing `task.skills` during review dispatch
- Append `sdlc-review` only if it is not already present
- Add a regression test covering review dispatch with a pre-pinned task skill

## Tests

```bash
uv run pytest tests/hermes_cli/test_kanban_db.py -k review -v
14 passed