### PR TITLE
fix(achievements): persist lifetime counters to prevent regression after prune

### DIFF
--- a/plugins/hermes-achievements/dashboard/plugin_api.py
+++ b/plugins/hermes-achievements/dashboard/plugin_api.py
@@ -795,6 +795,23 @@ def _compute_from_scan(scan: Dict[str, Any], *, is_partial: bool = False) -> Dic
     aggregate = scan.get("aggregate", {})
     state = load_state() if not is_partial else {"unlocks": {}}
     unlocks = state.setdefault("unlocks", {})
+
+    # Merge scanned counters with persisted lifetime counters using max().
+    # This ensures session pruning cannot reduce lifetime achievement progress
+    # (issue #28661). Once a counter reaches a value, it never goes backward.
+    if not is_partial:
+        persisted_counters = state.get("lifetime_counters", {})
+        merged = {}
+        all_keys = set(aggregate.keys()) | set(persisted_counters.keys())
+        for key in all_keys:
+            scanned_val = aggregate.get(key, 0)
+            persisted_val = persisted_counters.get(key, 0)
+            try:
+                merged[key] = max(int(scanned_val or 0), int(persisted_val or 0))
+            except (TypeError, ValueError):
+                merged[key] = scanned_val
+        aggregate = merged
+        state["lifetime_counters"] = aggregate
     now = int(time.time())
     evaluated = []
     for definition in ACHIEVEMENTS:

--- a/tests/plugins/test_achievements_plugin.py
+++ b/tests/plugins/test_achievements_plugin.py
@@ -375,3 +375,37 @@ def test_partial_snapshots_do_not_persist_unlock_timestamps(plugin_api):
         "partial scans must not record unlock timestamps — a later session "
         "could change whether the badge deserves to be unlocked yet"
     )
+
+
+def test_full_scans_persist_lifetime_counters_monotonically(plugin_api):
+    """Lifetime achievement progress must not regress when old sessions are pruned."""
+    plugin_api.save_state({"unlocks": {}})
+
+    high_scan = {
+        "sessions": [{"session_id": "old", "title": "old", "tool_call_count": 5000}],
+        "aggregate": {
+            "session_count": 500,
+            "total_tool_calls": 5000,
+            "max_tool_calls_in_session": 200,
+        },
+        "scan_meta": {"mode": "full"},
+    }
+    high = plugin_api._compute_from_scan(high_scan, is_partial=False)
+
+    assert high["aggregate"]["total_tool_calls"] == 5000
+    assert plugin_api.load_state()["lifetime_counters"]["total_tool_calls"] == 5000
+
+    low_scan = {
+        "sessions": [{"session_id": "new", "title": "new", "tool_call_count": 1}],
+        "aggregate": {
+            "session_count": 1,
+            "total_tool_calls": 1,
+            "max_tool_calls_in_session": 1,
+        },
+        "scan_meta": {"mode": "full"},
+    }
+    low = plugin_api._compute_from_scan(low_scan, is_partial=False)
+
+    assert low["aggregate"]["total_tool_calls"] == 5000
+    assert low["aggregate"]["session_count"] == 500
+    assert plugin_api.load_state()["lifetime_counters"]["total_tool_calls"] == 5000


### PR DESCRIPTION
## Problem

When `sessions.auto_prune` deletes old rows from state.db, achievement lifetime counters regress because they are recomputed only from remaining sessions (issue #28661).

## Fix

Merge scanned aggregate counters with persisted `lifetime_counters` in state.json using `max()`. Once a counter reaches a value it never goes backward — pruning state.db cannot reduce lifetime achievements.

Fixes #28661