### PR TITLE
fix(api-server): preserve Unicode in OpenAI-compatible SSE tool-call payloads (#28646)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1381,7 +1381,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "created": created, "model": model,
                 "choices": [{"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}],
             }
-            await response.write(f"data: {json.dumps(role_chunk)}\n\n".encode())
+            await response.write(f"data: {json.dumps(role_chunk, ensure_ascii=False)}\n\n".encode())
             last_activity = time.monotonic()
 
             # Helper — route a queue item to the correct SSE event.
@@ -1396,7 +1396,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 #16588 for the ``toolCallId``/``status`` lifecycle fields.
                 """
                 if isinstance(item, tuple) and len(item) == 2 and item[0] == "__tool_progress__":
-                    event_data = json.dumps(item[1])
+                    event_data = json.dumps(item[1], ensure_ascii=False)
                     await response.write(
                         f"event: hermes.tool.progress\ndata: {event_data}\n\n".encode()
                     )
@@ -1406,7 +1406,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         "created": created, "model": model,
                         "choices": [{"index": 0, "delta": {"content": item}, "finish_reason": None}],
                     }
-                    await response.write(f"data: {json.dumps(content_chunk)}\n\n".encode())
+                    await response.write(f"data: {json.dumps(content_chunk, ensure_ascii=False)}\n\n".encode())
                 return time.monotonic()
 
             # Stream content chunks as they arrive from the agent
@@ -1455,7 +1455,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     "total_tokens": usage.get("total_tokens", 0),
                 },
             }
-            await response.write(f"data: {json.dumps(finish_chunk)}\n\n".encode())
+            await response.write(f"data: {json.dumps(finish_chunk, ensure_ascii=False)}\n\n".encode())
             await response.write(b"data: [DONE]\n\n")
         except (ConnectionResetError, ConnectionAbortedError, BrokenPipeError, OSError):
             # Client disconnected mid-stream.  Interrupt the agent so it
@@ -1486,7 +1486,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     "created": created, "model": model,
                     "choices": [{"index": 0, "delta": {}, "finish_reason": "error"}],
                 }
-                await response.write(f"data: {json.dumps(error_chunk)}\n\n".encode())
+                await response.write(f"data: {json.dumps(error_chunk, ensure_ascii=False)}\n\n".encode())
                 await response.write(b"data: [DONE]\n\n")
             except Exception:
                 pass
@@ -1584,7 +1584,10 @@ class APIServerAdapter(BasePlatformAdapter):
             if "sequence_number" not in data:
                 data["sequence_number"] = sequence_number
             sequence_number += 1
-            payload = f"event: {event_type}\ndata: {json.dumps(data)}\n\n"
+            # ``ensure_ascii=False`` preserves non-ASCII characters in
+            # text deltas / item payloads so OpenAI-compatible web UIs
+            # don't re-render them as ``\uXXXX`` escape sequences (#28646).
+            payload = f"event: {event_type}\ndata: {json.dumps(data, ensure_ascii=False)}\n\n"
             await response.write(payload.encode())
 
         def _envelope(status: str) -> Dict[str, Any]:
@@ -3225,7 +3228,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     # Run finished — send final SSE comment and close
                     await response.write(b": stream closed\n\n")
                     break
-                payload = f"data: {json.dumps(event)}\n\n"
+                payload = f"data: {json.dumps(event, ensure_ascii=False)}\n\n"
                 await response.write(payload.encode())
         except Exception as exc:
             logger.debug("[api_server] SSE stream error for run %s: %s", run_id, exc)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1713,7 +1713,15 @@ class APIServerAdapter(BasePlatformAdapter):
                 call_id = payload.get("tool_call_id") or f"call_{response_id[5:]}_{call_counter}"
                 args = payload.get("arguments", {})
                 if isinstance(args, dict):
-                    arguments_str = json.dumps(args)
+                    # ``ensure_ascii=False`` keeps non-ASCII characters
+                    # (CJK, accented Latin, emoji, …) as native Unicode in
+                    # the ``arguments`` JSON string that OpenAI-compatible
+                    # clients display verbatim.  Without this, ``echo "无
+                    # kanban 目录"`` round-trips through Python's default
+                    # ``json.dumps`` as ``echo "\u65e0 kanban \u76ee\u5f55"``
+                    # — exactly the mojibake reported in #28646 by web UIs
+                    # that don't second-parse the arguments string.
+                    arguments_str = json.dumps(args, ensure_ascii=False)
                 else:
                     arguments_str = str(args)
                 item = {
@@ -1779,7 +1787,11 @@ class APIServerAdapter(BasePlatformAdapter):
                 })
 
                 # function_call_output added (result)
-                result_str = result if isinstance(result, str) else json.dumps(result)
+                # ``ensure_ascii=False`` so non-ASCII tool output (CJK,
+                # accented Latin, emoji, …) reaches the client as native
+                # Unicode instead of ``\uXXXX`` escape sequences — same
+                # mojibake class as the arguments path (#28646).
+                result_str = result if isinstance(result, str) else json.dumps(result, ensure_ascii=False)
                 output_parts = [{"type": "input_text", "text": result_str}]
                 output_item = {
                     "id": f"fco_{uuid.uuid4().hex[:24]}",
@@ -1959,7 +1971,11 @@ class APIServerAdapter(BasePlatformAdapter):
                             for _k in ("content", "query", "pattern", "old_string", "new_string"):
                                 if isinstance(_args.get(_k), str) and len(_args[_k]) > 500:
                                     _args[_k] = "[" + str(len(_args[_k])) + " chars — truncated for response.completed]"
-                            _item["arguments"] = json.dumps(_args)
+                            # Match the encoding used by ``_emit_tool_started``
+                            # so the trimmed copy in ``response.completed``
+                            # doesn't reintroduce the ``\uXXXX`` mojibake
+                            # fixed for the streaming path (#28646).
+                            _item["arguments"] = json.dumps(_args, ensure_ascii=False)
                     except Exception:
                         pass
                 elif _item.get("type") == "function_call_output":

--- a/tests/gateway/test_api_server_cjk_unicode.py
+++ b/tests/gateway/test_api_server_cjk_unicode.py
@@ -1,0 +1,296 @@
+"""Regression coverage for the OpenAI-compatible API server's Unicode
+handling, reported as #28646 (Hermes-web-ui showed ``\\u65e0 kanban
+\\u76ee\\u5f55`` in tool-call rendering instead of ``无 kanban 目录``).
+
+Background
+----------
+The API server emits multiple JSON payloads to the wire:
+
+* ``function_call.arguments`` — a JSON-encoded *string* embedded in
+  larger SSE event payloads. OpenAI-compatible web UIs frequently
+  display this string verbatim instead of parsing it again, so any
+  ``\\uXXXX`` escape sequences inside reach the user as literal text.
+* ``function_call_output.output[0].text`` — same shape for tool
+  results.
+* ``response.completed`` — re-serializes the trimmed arguments map.
+* ``data:`` chunks of ``/v1/chat/completions`` SSE and ``event:`` /
+  ``data:`` envelopes of ``/v1/responses`` SSE.
+
+Python's ``json.dumps`` defaults to ``ensure_ascii=True``, which
+encodes every non-ASCII codepoint as a ``\\uXXXX`` escape — the root
+cause of the mojibake. These tests pin ``ensure_ascii=False`` on
+every wire-facing serialization in ``gateway/platforms/api_server.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+# Reuse the helper that constructs an APIServerAdapter with the same
+# config the rest of the suite uses. Importing as a module-level helper
+# instead of a fixture keeps each test self-contained and easy to read.
+from tests.gateway.test_api_server import _create_app, _make_adapter  # noqa: E402
+from aiohttp.test_utils import TestClient, TestServer  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Sample CJK fragments
+# ---------------------------------------------------------------------------
+#
+# ``无`` (U+65E0, "no / none") and ``目录`` (U+76EE U+5F55, "directory")
+# are the exact characters from the issue's screenshot. We also throw
+# in an accented Latin character and an emoji so the regression covers
+# the whole non-ASCII surface, not just CJK.
+
+CJK_COMMAND = 'echo "无 kanban 目录"'           # 无 + 目录 — issue #28646
+LATIN_DIACRITIC = "café"                       # U+00E9
+EMOJI = "🚀"                                    # U+1F680
+
+
+# ---------------------------------------------------------------------------
+# /v1/responses streaming path — function_call.arguments
+# ---------------------------------------------------------------------------
+
+
+class TestFunctionCallArgumentsUnicode:
+    """``_emit_tool_started`` JSON-encodes the ``arguments`` dict into a
+    string that web UIs render directly. ``ensure_ascii=False`` is the
+    only fix that lets them render CJK natively."""
+
+    @pytest.mark.asyncio
+    async def test_arguments_string_contains_native_cjk_chars(self):
+        """The exact mojibake from issue #28646 must not reappear.
+
+        Pre-fix: the SSE body contained ``"echo \\\"\\u65e0 kanban
+        \\u76ee\\u5f55\\\""`` — six ASCII characters per CJK codepoint.
+        Post-fix: the body carries the native ``无`` and ``目录``
+        bytes, which is what the issue's screenshot reporter expected.
+        """
+        adapter = _make_adapter()
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                start_cb = kwargs.get("tool_start_callback")
+                complete_cb = kwargs.get("tool_complete_callback")
+                if start_cb:
+                    start_cb("call_cjk", "terminal", {"command": CJK_COMMAND})
+                if complete_cb:
+                    complete_cb("call_cjk", "terminal", {"command": CJK_COMMAND}, "ok")
+                return (
+                    {"final_response": "done", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={"model": "hermes-agent", "input": "ls", "stream": True},
+                )
+                assert resp.status == 200
+                body = await resp.text()
+
+        # Positive: the native CJK chars survive end-to-end.
+        assert "无" in body
+        assert "目录" in body
+        # Negative: the escape-sequence form (the user-visible mojibake)
+        # must not appear anywhere in the stream.
+        assert "\\u65e0" not in body
+        assert "\\u76ee" not in body
+        assert "\\u5f55" not in body
+
+    @pytest.mark.asyncio
+    async def test_arguments_string_is_still_valid_inner_json(self):
+        """The fix mustn't break round-tripping: clients that *do*
+        ``JSON.parse`` the inner ``arguments`` string still need a
+        valid JSON object back.
+        """
+        adapter = _make_adapter()
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                start_cb = kwargs.get("tool_start_callback")
+                complete_cb = kwargs.get("tool_complete_callback")
+                if start_cb:
+                    start_cb("call_cjk", "terminal", {"command": CJK_COMMAND})
+                if complete_cb:
+                    complete_cb("call_cjk", "terminal", {"command": CJK_COMMAND}, "ok")
+                return (
+                    {"final_response": "done", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={"model": "hermes-agent", "input": "ls", "stream": True},
+                )
+                body = await resp.text()
+
+        # Find an output_item.added event for function_call and re-parse
+        # its inner arguments string the way a smart client would.
+        parsed_inner_args = None
+        for line in body.splitlines():
+            if not line.startswith("data: "):
+                continue
+            try:
+                payload = json.loads(line[len("data: "):])
+            except json.JSONDecodeError:
+                continue
+            item = payload.get("item") or {}
+            if item.get("type") == "function_call" and item.get("name") == "terminal":
+                parsed_inner_args = json.loads(item["arguments"])
+                break
+        assert parsed_inner_args is not None, "no function_call event found in SSE body"
+        assert parsed_inner_args == {"command": CJK_COMMAND}
+
+
+# ---------------------------------------------------------------------------
+# /v1/responses streaming path — function_call_output text
+# ---------------------------------------------------------------------------
+
+
+class TestFunctionCallOutputUnicode:
+    @pytest.mark.asyncio
+    async def test_tool_result_dict_preserves_cjk(self):
+        """When the tool returns a *dict*, ``_emit_tool_completed``
+        JSON-encodes it. CJK characters in the result map must reach
+        the client as native Unicode."""
+        adapter = _make_adapter()
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                start_cb = kwargs.get("tool_start_callback")
+                complete_cb = kwargs.get("tool_complete_callback")
+                if start_cb:
+                    start_cb("call_a", "kanban_show", {"id": "work"})
+                if complete_cb:
+                    # ``result`` is a dict here (not a string), so it goes
+                    # through ``json.dumps`` inside the API server.
+                    complete_cb(
+                        "call_a", "kanban_show", {"id": "work"},
+                        {"title": "目录", "note": "café 🚀"},
+                    )
+                return (
+                    {"final_response": "ok", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={"model": "hermes-agent", "input": "show", "stream": True},
+                )
+                body = await resp.text()
+
+        assert "目录" in body
+        assert "café" in body
+        assert "🚀" in body
+        assert "\\u76ee" not in body
+        assert "\\u00e9" not in body
+
+
+# ---------------------------------------------------------------------------
+# response.completed envelope — re-serialized trimmed arguments
+# ---------------------------------------------------------------------------
+
+
+class TestResponseCompletedTrimmingUnicode:
+    @pytest.mark.asyncio
+    async def test_completed_envelope_carries_native_cjk_arguments(self):
+        """``response.completed`` re-runs ``json.dumps`` on trimmed
+        tool-call arguments. Without ``ensure_ascii=False`` it would
+        silently reintroduce the mojibake fixed for the streaming
+        path."""
+        adapter = _make_adapter()
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                start_cb = kwargs.get("tool_start_callback")
+                complete_cb = kwargs.get("tool_complete_callback")
+                if start_cb:
+                    start_cb("call_cjk", "terminal", {"command": CJK_COMMAND})
+                if complete_cb:
+                    complete_cb("call_cjk", "terminal", {"command": CJK_COMMAND}, "ok")
+                return (
+                    {"final_response": "done", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={"model": "hermes-agent", "input": "ls", "stream": True},
+                )
+                body = await resp.text()
+
+        completed_arguments = None
+        for line in body.splitlines():
+            if not line.startswith("data: "):
+                continue
+            try:
+                payload = json.loads(line[len("data: "):])
+            except json.JSONDecodeError:
+                continue
+            if payload.get("type") != "response.completed":
+                continue
+            for item in payload.get("response", {}).get("output", []):
+                if item.get("type") == "function_call":
+                    completed_arguments = item["arguments"]
+                    break
+            break
+
+        assert completed_arguments is not None, "no terminal function_call in response.completed envelope"
+        # The string sent over the wire is native UTF-8…
+        assert "无" in completed_arguments
+        assert "目录" in completed_arguments
+        # …and still re-parses back into a structured dict.
+        assert json.loads(completed_arguments) == {"command": CJK_COMMAND}
+
+
+# ---------------------------------------------------------------------------
+# /v1/chat/completions delta.content envelope
+# ---------------------------------------------------------------------------
+
+
+class TestChatCompletionsDeltaUnicode:
+    @pytest.mark.asyncio
+    async def test_streamed_chat_completion_delivers_native_cjk_in_delta(self):
+        """OpenAI Chat Completions SSE wraps each token in
+        ``choices[0].delta.content``. Smart clients ``JSON.parse`` the
+        chunk and recover Unicode either way, but naive log inspectors
+        and dumps care about the literal wire bytes — keep CJK native
+        to avoid stack traces that surface as ``\\u65e0`` in support
+        threads."""
+        adapter = _make_adapter()
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                cb = kwargs.get("stream_delta_callback")
+                if cb:
+                    cb("你好,café 🚀")
+                    cb(None)
+                return (
+                    {"final_response": "你好,café 🚀", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "hermes-agent",
+                        "messages": [{"role": "user", "content": "hi"}],
+                        "stream": True,
+                    },
+                )
+                body = await resp.text()
+
+        assert "你好" in body
+        assert "café" in body
+        assert "🚀" in body
+        assert "\\u4f60" not in body  # 你
+        assert "\\u597d" not in body  # 好
+        assert "\\u00e9" not in body  # é


### PR DESCRIPTION
## What does this PR do?

Hermes-web-ui — and every other OpenAI-compatible client that displays the `function_call.arguments` field verbatim — was rendering CJK / non-ASCII characters in tool-call payloads as their literal `\uXXXX` escape sequences. The issue reporter's screenshot in #28646 shows the agent's `terminal` tool being announced with:

```
[Calling tool: terminal with arguments: {"command":
 "... || echo \"\u65e0 kanban \u76ee\u5f55\""}]
```

…where the model actually emitted `echo "无 kanban 目录"` (Chinese for "no kanban directory"). The Latin em-dash inside the same payload renders correctly because the model sent it as a literal `U+2014`, but Python's `json.dumps` rewrites every CJK codepoint into the six-byte `\u65e0` form whenever its default `ensure_ascii=True` is in effect.

Three `json.dumps` call sites in `gateway/platforms/api_server.py` produce the JSON-encoded strings that web UIs display directly — they all defaulted to `ensure_ascii=True`. Plus seven SSE-envelope encoders that wrap those strings re-escaped any literal non-ASCII bytes back into `\uXXXX` form before sending to the wire.

The fix is the smallest correct one: pass `ensure_ascii=False` to every wire-facing `json.dumps` in the file. The inner JSON object still round-trips through `json.loads`, so clients that *do* parse the arguments string keep getting the same dict back. The internal SQLite response store (`json.dumps(data, default=str)` at line 383) is left alone — it round-trips symmetrically and the encoding choice has no observable effect.

## Related Issue

Fixes #28646

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `gateway/platforms/api_server.py`
  - `_emit_tool_started` — JSON-encode the `arguments` dict with `ensure_ascii=False` so the OpenAI-spec `function_call.arguments` *string* carries native Unicode.
  - `_emit_tool_completed` — same encoding for tool results returned as dicts (`kanban_show`, search responses, etc.).
  - The trimmed-arguments re-serialisation before `response.completed` — keeps the terminal envelope consistent with the streaming events.
  - All SSE envelope encoders (`/v1/chat/completions` role / content / finish / error / `hermes.tool.progress` chunks; `/v1/responses` `_write_event`; runs SSE payload) — `ensure_ascii=False` for defense in depth.
- `tests/gateway/test_api_server_cjk_unicode.py` *(new file, 5 tests)*
  - `TestFunctionCallArgumentsUnicode` — pins the exact mojibake from the screenshot (`无 kanban 目录`) + round-trips the inner arguments JSON.
  - `TestFunctionCallOutputUnicode` — covers dict-shaped tool results with CJK + Latin diacritic + emoji.
  - `TestResponseCompletedTrimmingUnicode` — guards the re-serialisation pass that produces the terminal envelope.
  - `TestChatCompletionsDeltaUnicode` — `/v1/chat/completions` `delta.content` with CJK + accented Latin + emoji.

## How to Test

1. **Regression suite** (this PR's coverage):

   ```bash
   pytest tests/gateway/test_api_server_cjk_unicode.py -q
   ```

   Expected: `5 passed`.

2. **No regression in the existing API-server suite:**

   ```bash
   pytest tests/gateway/test_api_server.py tests/gateway/test_api_server_cjk_unicode.py -q
   ```

   Expected: `154 passed`.

3. **End-to-end reproduction of #28646** (requires an agent that emits CJK in tool calls — the easiest path is hermes-web-ui pointed at `hermes serve` with a Chinese-language session):

   ```bash
   # Pre-fix
   curl -sN http://localhost:8000/v1/responses \
     -H "Content-Type: application/json" \
     -d '{"model":"hermes-agent","input":"hermes kanban show work","stream":true}' \
     | grep -E '"arguments"' | head -1
   # → arguments contains "\u65e0 kanban \u76ee\u5f55"
   #   (web UI displays this verbatim)

   # Post-fix
   #   arguments contains "无 kanban 目录"
   #   (web UI renders the actual Chinese characters)
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the relevant test suites locally and all pass (`154 passed` across `test_api_server.py` + `test_api_server_cjk_unicode.py`)
- [x] I've added tests for my changes (5 regression tests, 4 of which fail on `upstream/main` without this PR)
- [x] I've tested on my platform: macOS 15 (darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — inline comments at all three function-level call sites explain the *why* and reference #28646
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — pure-Python `json` encoding, no platform branches
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (transport-only change, no tool surface affected)

## Screenshots / Logs

```
$ pytest tests/gateway/test_api_server_cjk_unicode.py -v
tests/gateway/test_api_server_cjk_unicode.py::TestFunctionCallArgumentsUnicode::test_arguments_string_contains_native_cjk_chars PASSED
tests/gateway/test_api_server_cjk_unicode.py::TestFunctionCallArgumentsUnicode::test_arguments_string_is_still_valid_inner_json PASSED
tests/gateway/test_api_server_cjk_unicode.py::TestFunctionCallOutputUnicode::test_tool_result_dict_preserves_cjk PASSED
tests/gateway/test_api_server_cjk_unicode.py::TestResponseCompletedTrimmingUnicode::test_completed_envelope_carries_native_cjk_arguments PASSED
tests/gateway/test_api_server_cjk_unicode.py::TestChatCompletionsDeltaUnicode::test_streamed_chat_completion_delivers_native_cjk_in_delta PASSED
5 passed in 1.76s
```

Reverting the fix on `upstream/main` and re-running the new suite:

```
FAILED tests/gateway/test_api_server_cjk_unicode.py::TestFunctionCallOutputUnicode::test_tool_result_dict_preserves_cjk
FAILED tests/gateway/test_api_server_cjk_unicode.py::TestFunctionCallArgumentsUnicode::test_arguments_string_contains_native_cjk_chars
FAILED tests/gateway/test_api_server_cjk_unicode.py::TestResponseCompletedTrimmingUnicode::test_completed_envelope_carries_native_cjk_arguments
FAILED tests/gateway/test_api_server_cjk_unicode.py::TestChatCompletionsDeltaUnicode::test_streamed_chat_completion_delivers_native_cjk_in_delta
4 failed, 1 passed
```

The one passing test (`test_arguments_string_is_still_valid_inner_json`) checks the JSON.parse round-trip — that invariant holds under both encodings and exists specifically to confirm the fix doesn't break smart clients.
