### PR TITLE
feat(cli): add PowerShell completion generation

### DIFF
--- a/hermes_cli/completion.py
+++ b/hermes_cli/completion.py
@@ -3,7 +3,7 @@
 Walks the live argparse parser tree to generate accurate, always-up-to-date
 completion scripts — no hardcoded subcommand lists, no extra dependencies.
 
-Supports bash, zsh, and fish.
+Supports bash, zsh, fish, and PowerShell.
 """
 
 from __future__ import annotations
@@ -239,6 +239,113 @@ _hermes() {{
 }}
 
 compdef _hermes hermes
+"""
+
+
+
+# ---------------------------------------------------------------------------
+# PowerShell
+# ---------------------------------------------------------------------------
+def _ps_quote(value: str) -> str:
+    """Single-quote a value for PowerShell source."""
+    return "'" + value.replace("'", "''") + "'"
+
+
+def generate_powershell(parser: argparse.ArgumentParser) -> str:
+    """Generate a PowerShell argument completer script."""
+    tree = _walk(parser)
+    top_cmds = sorted(tree["subcommands"])
+    top_cmds_str = ", ".join(_ps_quote(cmd) for cmd in top_cmds)
+
+    sub_lines: list[str] = []
+    help_lines: list[str] = []
+    for cmd in top_cmds:
+        info = tree["subcommands"][cmd]
+        help_text = _clean(info.get("help", ""))
+        help_lines.append(f"    {_ps_quote(cmd)} = {_ps_quote(help_text)}")
+        if info["subcommands"]:
+            values = ", ".join(_ps_quote(sc) for sc in sorted(info["subcommands"]))
+            sub_lines.append(f"    {_ps_quote(cmd)} = @({values})")
+    subcommands_str = "\n".join(sub_lines)
+    help_str = "\n".join(help_lines)
+
+    return f"""# Hermes Agent PowerShell completion
+# Add to your PowerShell profile:
+#   hermes completion powershell | Out-String | Invoke-Expression
+
+function __HermesProfiles {{
+    'default'
+    $profilesDir = Join-Path $HOME '.hermes/profiles'
+    if (Test-Path -LiteralPath $profilesDir -PathType Container) {{
+        Get-ChildItem -LiteralPath $profilesDir -Directory -ErrorAction SilentlyContinue |
+            ForEach-Object {{ $_.Name }}
+    }}
+}}
+
+$script:HermesTopCommands = @({top_cmds_str})
+$script:HermesSubcommands = @{{
+{subcommands_str}
+}}
+$script:HermesCommandHelp = @{{
+{help_str}
+}}
+$script:HermesProfileNameActions = @('use', 'delete', 'show', 'alias', 'rename', 'export')
+
+Register-ArgumentCompleter -Native -CommandName hermes -ScriptBlock {{
+    param($wordToComplete, $commandAst, $cursorPosition)
+
+    $tokens = @($commandAst.CommandElements | ForEach-Object {{ $_.Extent.Text }})
+    $args = @($tokens | Select-Object -Skip 1)
+    $current = if ($null -ne $wordToComplete) {{ $wordToComplete }} else {{ '' }}
+
+    if ($args.Count -ge 2) {{
+        $previous = $args[$args.Count - 2]
+        if ($previous -eq '-p' -or $previous -eq '--profile') {{
+            __HermesProfiles |
+                Where-Object {{ $_ -like "$current*" }} |
+                ForEach-Object {{ [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', 'Profile name') }}
+            return
+        }}
+    }}
+
+    $command = $null
+    foreach ($arg in $args) {{
+        if ($script:HermesTopCommands -contains $arg) {{
+            $command = $arg
+            break
+        }}
+    }}
+
+    if ($command -eq 'profile') {{
+        $profileAction = $null
+        foreach ($arg in $args) {{
+            if ($script:HermesProfileNameActions -contains $arg) {{
+                $profileAction = $arg
+                break
+            }}
+        }}
+        if ($null -ne $profileAction) {{
+            __HermesProfiles |
+                Where-Object {{ $_ -like "$current*" }} |
+                ForEach-Object {{ [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', 'Profile name') }}
+            return
+        }}
+    }}
+
+    if ($null -ne $command -and $script:HermesSubcommands.ContainsKey($command)) {{
+        $script:HermesSubcommands[$command] |
+            Where-Object {{ $_ -like "$current*" }} |
+            ForEach-Object {{ [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', "$command command") }}
+        return
+    }}
+
+    $script:HermesTopCommands |
+        Where-Object {{ $_ -like "$current*" }} |
+        ForEach-Object {{
+            $help = $script:HermesCommandHelp[$_]
+            [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $help)
+        }}
+}}
 """
 
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9978,13 +9978,20 @@ def cmd_dashboard(args):
 
 def cmd_completion(args, parser=None):
     """Print shell completion script."""
-    from hermes_cli.completion import generate_bash, generate_zsh, generate_fish
+    from hermes_cli.completion import (
+        generate_bash,
+        generate_fish,
+        generate_powershell,
+        generate_zsh,
+    )
 
     shell = getattr(args, "shell", "bash")
     if shell == "zsh":
         print(generate_zsh(parser))
     elif shell == "fish":
         print(generate_fish(parser))
+    elif shell in {"powershell", "pwsh"}:
+        print(generate_powershell(parser))
     else:
         print(generate_bash(parser))
 
@@ -12631,13 +12638,13 @@ Examples:
     # =========================================================================
     completion_parser = subparsers.add_parser(
         "completion",
-        help="Print shell completion script (bash, zsh, or fish)",
+        help="Print shell completion script (bash, zsh, fish, or PowerShell)",
     )
     completion_parser.add_argument(
         "shell",
         nargs="?",
         default="bash",
-        choices=["bash", "zsh", "fish"],
+        choices=["bash", "zsh", "fish", "powershell", "pwsh"],
         help="Shell type (default: bash)",
     )
     completion_parser.set_defaults(func=lambda args: cmd_completion(args, parser))

--- a/tests/hermes_cli/test_completion.py
+++ b/tests/hermes_cli/test_completion.py
@@ -9,7 +9,13 @@ import tempfile
 
 import pytest
 
-from hermes_cli.completion import _walk, generate_bash, generate_zsh, generate_fish
+from hermes_cli.completion import (
+    _walk,
+    generate_bash,
+    generate_fish,
+    generate_powershell,
+    generate_zsh,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -223,7 +229,51 @@ class TestGenerateFish:
 
 
 # ---------------------------------------------------------------------------
-# 5. Subcommand drift prevention
+# 5. PowerShell output
+# ---------------------------------------------------------------------------
+
+class TestGeneratePowerShell:
+    def test_registers_native_argument_completer(self):
+        out = generate_powershell(_make_parser())
+        assert "Register-ArgumentCompleter -Native -CommandName hermes" in out
+
+    def test_top_level_commands_present(self):
+        out = generate_powershell(_make_parser())
+        for cmd in ("chat", "gateway", "sessions", "version"):
+            assert f"'{cmd}'" in out
+
+    def test_nested_subcommands_present(self):
+        out = generate_powershell(_make_parser())
+        assert "'gateway' = @('run', 'start', 'status', 'stop')" in out
+
+    def test_profile_helpers_present(self):
+        out = generate_powershell(_make_parser())
+        assert "function __HermesProfiles" in out
+        assert "$script:HermesProfileNameActions" in out
+        assert "'-p'" in out
+        assert "'--profile'" in out
+
+    def test_valid_powershell_syntax_when_available(self):
+        pwsh = shutil.which("pwsh") or shutil.which("powershell")
+        if not pwsh:
+            pytest.skip("PowerShell not installed")
+        out = generate_powershell(_make_parser())
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".ps1", delete=False) as f:
+            f.write(out)
+            path = f.name
+        try:
+            result = subprocess.run(
+                [pwsh, "-NoProfile", "-NonInteractive", "-File", path],
+                capture_output=True,
+                text=True,
+            )
+            assert result.returncode == 0, result.stderr
+        finally:
+            os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# 6. Subcommand drift prevention
 # ---------------------------------------------------------------------------
 
 class TestSubcommandDrift:
@@ -250,7 +300,7 @@ class TestSubcommandDrift:
 
 
 # ---------------------------------------------------------------------------
-# 6. Profile completion (regression prevention)
+# 7. Profile completion (regression prevention)
 # ---------------------------------------------------------------------------
 
 class TestProfileCompletion:
@@ -317,3 +367,20 @@ class TestProfileCompletion:
         count = out.count("(__hermes_profiles)")
         # At least the -p flag + the profile action completions
         assert count >= 2, f"Expected >=2 profile completion entries, got {count}"
+
+    def test_powershell_has_profiles_helper(self):
+        out = generate_powershell(_make_parser())
+        assert "function __HermesProfiles" in out
+        assert "Join-Path $HOME '.hermes/profiles'" in out
+
+    def test_powershell_has_profile_flag_completion(self):
+        out = generate_powershell(_make_parser())
+        assert "'-p'" in out
+        assert "'--profile'" in out
+        assert "__HermesProfiles" in out
+
+    def test_powershell_profile_actions_complete_names(self):
+        out = generate_powershell(_make_parser())
+        assert "$script:HermesProfileNameActions" in out
+        for action in ("use", "delete", "show", "alias", "rename", "export"):
+            assert f"'{action}'" in out


### PR DESCRIPTION
## Summary

- Adds `hermes completion powershell` plus the `pwsh` alias.
- Generates a native PowerShell `Register-ArgumentCompleter` script from the live argparse parser tree.
- Preserves profile-name completions for `-p/--profile` and `hermes profile` actions.

## Test Plan

- `python -m pytest tests/hermes_cli/test_completion.py -q`
- `python -m hermes_cli.main completion powershell >/tmp/hermes-powershell-completion.ps1`
- `python -m hermes_cli.main completion pwsh >/tmp/hermes-pwsh-completion.ps1`
- `grep -q 'Register-ArgumentCompleter -Native -CommandName hermes' /tmp/hermes-powershell-completion.ps1`
- `cmp -s /tmp/hermes-powershell-completion.ps1 /tmp/hermes-pwsh-completion.ps1`
- `python -m py_compile hermes_cli/completion.py hermes_cli/main.py`
- `python -m ruff check hermes_cli/completion.py hermes_cli/main.py tests/hermes_cli/test_completion.py`
