### PR TITLE
feat(display): declarative tool-preview schema to eliminate per-tool hardcoding (#28621)

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -306,7 +306,7 @@ def _render_registered_preview(tool_name: str, args: dict) -> tuple[str | None, 
     safe_args = _SafePreviewArgs.from_args(args if isinstance(args, dict) else {})
     try:
         rendered = template.format_map(safe_args).strip()
-    except (IndexError, ValueError, KeyError) as exc:
+    except (IndexError, ValueError, KeyError, AttributeError, TypeError) as exc:
         # A bad template should never crash the agent spinner — log it
         # once at warning and let the caller fall through to the legacy
         # path so the bug is obvious in logs but the user gets *some*

--- a/agent/display.py
+++ b/agent/display.py
@@ -168,16 +168,183 @@ def _oneline(text: str) -> str:
     return " ".join(text.split())
 
 
+# -------------------------------------------------------------------------
+# Declarative tool-preview schema (#28621)
+# -------------------------------------------------------------------------
+#
+# Maps ``tool_name -> {field, templates, truncate}`` so new tools (and
+# plugins) can opt in to tool-progress previews without editing
+# ``build_tool_preview``'s if-elif chain.  Each entry is a mini DSL:
+#
+#   register_tool_preview(
+#       "fact_store",
+#       field="action",
+#       templates={
+#           "add":    "+ \"{content:.30}\"",
+#           "search": "search: \"{query:.25}\"",
+#           "*":      "{action}",
+#       },
+#       truncate=60,
+#   )
+#
+# * ``field`` selects the dispatch argument; omit when the tool has only
+#   one template.
+# * ``templates`` is consulted by exact field-value first, then ``"*"``.
+# * ``truncate`` overrides ``_tool_preview_max_len`` for this tool only.
+# * Per-field length limits use the standard ``str.format`` precision
+#   suffix, e.g. ``{content:.30}`` truncates ``args["content"]`` to 30
+#   characters before the template fills in.
+#
+# Missing keys render as empty strings (the registry never crashes a
+# spinner because of a partial tool call); list-valued args render as
+# comma-joined strings so e.g. ``{entities:.40}`` works on ``fact_store
+# reason``.
+
+_TOOL_PREVIEW_REGISTRY: dict[str, dict] = {}
+
+
+def register_tool_preview(
+    tool_name: str,
+    *,
+    templates: dict[str, str] | str,
+    field: str | None = None,
+    truncate: int | None = None,
+) -> None:
+    """Register a declarative preview template for ``tool_name`` (#28621).
+
+    Replaces hand-written if-elif branches in :func:`build_tool_preview`
+    so that plugins and third-party tools can ship preview support
+    alongside their schema definition instead of waiting for a core
+    code edit each time.
+
+    ``templates`` is either a single template string (no dispatch) or a
+    mapping keyed by the value of ``field``.  Use ``"*"`` for the
+    fallback bucket.  Templates use ``str.format_map`` semantics with
+    missing-key safety — partial tool calls degrade to empty fields,
+    they never raise.
+
+    Last-write-wins: re-registering the same ``tool_name`` overwrites
+    the previous schema, which keeps plugin reloads and test fixtures
+    predictable.
+    """
+    if isinstance(templates, str):
+        templates_map: dict[str, str] = {"*": templates}
+    else:
+        if not templates:
+            raise ValueError(
+                f"register_tool_preview({tool_name!r}): templates mapping must not be empty"
+            )
+        if field is None:
+            raise ValueError(
+                f"register_tool_preview({tool_name!r}): field= is required when "
+                "templates is a mapping"
+            )
+        templates_map = dict(templates)
+    _TOOL_PREVIEW_REGISTRY[tool_name] = {
+        "field": field,
+        "templates": templates_map,
+        "truncate": truncate,
+    }
+
+
+def _unregister_tool_preview(tool_name: str) -> None:
+    """Drop ``tool_name`` from the registry.  Test-only escape hatch."""
+    _TOOL_PREVIEW_REGISTRY.pop(tool_name, None)
+
+
+class _SafePreviewArgs(dict):
+    """``dict`` subclass that returns ``""`` for missing keys and
+    pre-normalises values for :meth:`str.format_map`.
+
+    String values get whitespace-collapsed (``\\n`` → space) so multi-line
+    inputs render on one progress-bubble line.  List / tuple values are
+    rendered as comma-joined strings so the same templates work for
+    array-valued args like ``entities`` on ``fact_store reason``.
+    ``None`` becomes ``""`` so ``{old_text}`` doesn't print ``None``.
+    """
+
+    def __missing__(self, key: str) -> str:
+        return ""
+
+    @classmethod
+    def from_args(cls, args: dict) -> "_SafePreviewArgs":
+        out = cls()
+        for k, v in args.items():
+            if v is None:
+                out[k] = ""
+            elif isinstance(v, str):
+                out[k] = _oneline(v)
+            elif isinstance(v, (list, tuple)):
+                out[k] = ", ".join(_oneline(str(x)) for x in v)
+            else:
+                out[k] = v
+        return out
+
+
+def _render_registered_preview(tool_name: str, args: dict) -> tuple[str | None, int | None]:
+    """Return ``(rendered_preview, per_tool_truncate)`` for a registered
+    tool, or ``(None, None)`` when there is no registration / no match.
+
+    Returning the truncate cap alongside the preview lets the caller
+    apply ``per_tool_truncate`` *after* it falls back to the global
+    ``_tool_preview_max_len`` — neither layer needs to know about the
+    other's existence.
+    """
+    schema = _TOOL_PREVIEW_REGISTRY.get(tool_name)
+    if schema is None:
+        return None, None
+    templates = schema["templates"]
+    field = schema["field"]
+    if field is None:
+        template = templates.get("*")
+    else:
+        value = args.get(field) if isinstance(args, dict) else None
+        key = str(value) if value is not None else ""
+        template = templates.get(key) or templates.get("*")
+    if template is None:
+        return None, schema.get("truncate")
+    safe_args = _SafePreviewArgs.from_args(args if isinstance(args, dict) else {})
+    try:
+        rendered = template.format_map(safe_args).strip()
+    except (IndexError, ValueError, KeyError) as exc:
+        # A bad template should never crash the agent spinner — log it
+        # once at warning and let the caller fall through to the legacy
+        # path so the bug is obvious in logs but the user gets *some*
+        # preview rather than a stack trace.
+        logger.warning(
+            "tool_preview template for %s failed (%s); falling back to legacy preview",
+            tool_name, exc,
+        )
+        return None, schema.get("truncate")
+    return (rendered or None), schema.get("truncate")
+
+
 def build_tool_preview(tool_name: str, args: dict, max_len: int | None = None) -> str | None:
     """Build a short preview of a tool call's primary argument for display.
 
     *max_len* controls truncation.  ``None`` (default) defers to the global
     ``_tool_preview_max_len`` set via config; ``0`` means unlimited.
+
+    Tools registered via :func:`register_tool_preview` (#28621) are
+    rendered from their declarative template first.  Anything not in
+    the registry falls back to the legacy hardcoded handlers below for
+    backward compatibility — migration is incremental, on a tool-by-tool
+    basis, with no flag-day.
     """
     if max_len is None:
         max_len = _tool_preview_max_len
     if not args:
         return None
+    if not isinstance(args, dict):
+        return None
+
+    rendered, per_tool_truncate = _render_registered_preview(tool_name, args)
+    if rendered is not None:
+        effective = per_tool_truncate if per_tool_truncate is not None else max_len
+        if effective and effective > 0 and len(rendered) > effective:
+            rendered = rendered[: effective - 3] + "..."
+        return rendered
+
     primary_args = {
         "terminal": "command", "web_search": "query", "web_extract": "urls",
         "read_file": "path", "write_file": "path", "patch": "path",

--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -90,6 +90,41 @@ FACT_FEEDBACK_SCHEMA = {
 }
 
 
+# Declarative tool-progress previews so Feishu / Telegram / CLI bubbles
+# always carry actionable context instead of falling back to the bare
+# tool name (#28621, fixes #28598).  ``register_tool_preview`` is the
+# documented plugin-developer entry point — co-locate the call with
+# the schema so reviewers see preview + schema together.
+from agent.display import register_tool_preview  # noqa: E402
+
+register_tool_preview(
+    "fact_store",
+    field="action",
+    templates={
+        "add":        '+ "{content:.30}"',
+        "search":     'search: "{query:.25}"',
+        "probe":      "probe: {entity:.25}",
+        "related":    "related: {entity:.25}",
+        "reason":     "reason: {entities:.30}",
+        "contradict": "contradict: {entity:.25}",
+        "update":     "update: #{fact_id}",
+        "remove":     "remove: #{fact_id}",
+        "list":       "list",
+        "*":          "{action}",
+    },
+)
+
+register_tool_preview(
+    "fact_feedback",
+    field="action",
+    templates={
+        "helpful":   "+1 #{fact_id}",
+        "unhelpful": "-1 #{fact_id}",
+        "*":         "{action} #{fact_id}",
+    },
+)
+
+
 # ---------------------------------------------------------------------------
 # Config
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_display.py
+++ b/tests/agent/test_display.py
@@ -10,9 +10,11 @@ from agent.display import (
     capture_local_edit_snapshot,
     extract_edit_diff,
     get_cute_tool_message,
+    register_tool_preview,
     set_tool_preview_max_len,
     _render_inline_unified_diff,
     _summarize_rendered_diff_sections,
+    _unregister_tool_preview,
     render_edit_diff_with_delta,
 )
 
@@ -110,6 +112,213 @@ class TestBuildToolPreview:
         assert build_tool_preview("terminal", 0) is None
         assert build_tool_preview("terminal", "") is None
         assert build_tool_preview("terminal", []) is None
+
+    def test_truthy_non_dict_args_returns_none(self):
+        """Truthy non-dict args (e.g. ``[1, 2]``) must not raise."""
+        assert build_tool_preview("terminal", [1, 2]) is None
+        assert build_tool_preview("terminal", "ls") is None
+
+
+# ----------------------------------------------------------------------
+# Declarative tool-preview schema (#28621)
+# ----------------------------------------------------------------------
+#
+# These tests exercise the registry primitive itself so that future
+# plugin-authored templates have a documented contract: dispatch field,
+# template format spec, missing-key safety, list-valued args, fallback
+# resolution, and graceful degradation on bad templates.
+
+
+class TestRegisterToolPreview:
+    """register_tool_preview / _render_registered_preview contract."""
+
+    def teardown_method(self) -> None:
+        for name in (
+            "_pytest_simple",
+            "_pytest_dispatch",
+            "_pytest_wildcard",
+            "_pytest_list_arg",
+            "_pytest_truncate",
+            "_pytest_bad",
+            "_pytest_collapse",
+            "_pytest_lastwins",
+        ):
+            _unregister_tool_preview(name)
+
+    def test_single_template_renders_args(self):
+        register_tool_preview("_pytest_simple", templates="hello {who}")
+        assert build_tool_preview("_pytest_simple", {"who": "world"}) == "hello world"
+
+    def test_field_dispatch_picks_template_by_value(self):
+        register_tool_preview(
+            "_pytest_dispatch",
+            field="action",
+            templates={
+                "add": "+ {content}",
+                "remove": "- #{fact_id}",
+            },
+        )
+        assert build_tool_preview(
+            "_pytest_dispatch", {"action": "add", "content": "pizza"}
+        ) == "+ pizza"
+        assert build_tool_preview(
+            "_pytest_dispatch", {"action": "remove", "fact_id": 7}
+        ) == "- #7"
+
+    def test_wildcard_fallback_used_when_value_not_listed(self):
+        register_tool_preview(
+            "_pytest_wildcard",
+            field="action",
+            templates={"add": "+ x", "*": "(other: {action})"},
+        )
+        assert build_tool_preview(
+            "_pytest_wildcard", {"action": "ponder"}
+        ) == "(other: ponder)"
+
+    def test_missing_field_returns_none_when_no_wildcard(self):
+        register_tool_preview(
+            "_pytest_dispatch",
+            field="action",
+            templates={"add": "+ x"},
+        )
+        assert build_tool_preview("_pytest_dispatch", {"other": "thing"}) is None
+
+    def test_missing_key_renders_as_empty_string(self):
+        register_tool_preview("_pytest_simple", templates="[{a}|{b}]")
+        assert build_tool_preview("_pytest_simple", {"a": "x"}) == "[x|]"
+
+    def test_list_arg_joins_with_commas(self):
+        register_tool_preview("_pytest_list_arg", templates="who: {entities}")
+        result = build_tool_preview(
+            "_pytest_list_arg", {"entities": ["alice", "bob", "carol"]}
+        )
+        assert result == "who: alice, bob, carol"
+
+    def test_per_field_precision_truncates_long_strings(self):
+        register_tool_preview("_pytest_simple", templates='"{content:.10}"')
+        result = build_tool_preview(
+            "_pytest_simple", {"content": "abcdefghij_TRUNCATED_TAIL"}
+        )
+        assert result == '"abcdefghij"'
+
+    def test_per_tool_truncate_overrides_global_limit(self):
+        register_tool_preview(
+            "_pytest_truncate",
+            templates="{content}",
+            truncate=15,
+        )
+        set_tool_preview_max_len(80)
+        result = build_tool_preview(
+            "_pytest_truncate", {"content": "x" * 50}
+        )
+        assert result.endswith("...")
+        assert len(result) == 15
+
+    def test_global_limit_applies_when_no_per_tool_truncate(self):
+        register_tool_preview("_pytest_simple", templates="{content}")
+        set_tool_preview_max_len(10)
+        result = build_tool_preview("_pytest_simple", {"content": "x" * 50})
+        assert result.endswith("...")
+        assert len(result) == 10
+
+    def test_string_args_get_whitespace_collapsed(self):
+        register_tool_preview("_pytest_collapse", templates="cmd: {command}")
+        result = build_tool_preview(
+            "_pytest_collapse", {"command": "echo  hello\nworld\t!"}
+        )
+        assert result == "cmd: echo hello world !"
+
+    def test_none_arg_renders_as_empty(self):
+        register_tool_preview("_pytest_simple", templates="[{value}]")
+        assert build_tool_preview("_pytest_simple", {"value": None}) == "[]"
+
+    def test_bad_template_falls_back_without_crashing(self, caplog):
+        # ``{not_a_number:d}`` against a string value raises ValueError —
+        # the registry should log and return None instead of bubbling.
+        register_tool_preview("_pytest_bad", templates="{value:d}")
+        with caplog.at_level("WARNING"):
+            result = build_tool_preview("_pytest_bad", {"value": "abc"})
+        assert result is None
+        assert any("_pytest_bad" in rec.getMessage() for rec in caplog.records)
+
+    def test_re_registration_overwrites_previous_schema(self):
+        register_tool_preview("_pytest_lastwins", templates="v1: {x}")
+        register_tool_preview("_pytest_lastwins", templates="v2: {x}")
+        assert build_tool_preview("_pytest_lastwins", {"x": "y"}) == "v2: y"
+
+    def test_registry_takes_priority_over_legacy_chain(self):
+        # ``terminal`` is in the legacy ``primary_args`` map — registry
+        # registration should win so plugins can override even built-ins.
+        try:
+            register_tool_preview(
+                "terminal", templates="overridden: {command}"
+            )
+            assert build_tool_preview(
+                "terminal", {"command": "ls"}
+            ) == "overridden: ls"
+        finally:
+            _unregister_tool_preview("terminal")
+        # Sanity: legacy path restored after teardown.
+        assert build_tool_preview("terminal", {"command": "ls"}) == "ls"
+
+    def test_empty_templates_mapping_rejected(self):
+        with pytest.raises(ValueError):
+            register_tool_preview("_pytest_dispatch", field="action", templates={})
+
+    def test_dispatch_mapping_without_field_rejected(self):
+        with pytest.raises(ValueError):
+            register_tool_preview(
+                "_pytest_dispatch", templates={"add": "+ x"}
+            )
+
+
+class TestFactStorePluginPreview:
+    """Smoke tests for the holographic-memory plugin registrations."""
+
+    def test_fact_store_add_shows_content(self):
+        # Importing the plugin triggers register_tool_preview() calls.
+        import plugins.memory.holographic  # noqa: F401
+        assert build_tool_preview(
+            "fact_store", {"action": "add", "content": "user prefers tabs"}
+        ) == '+ "user prefers tabs"'
+
+    def test_fact_store_search_shows_query(self):
+        import plugins.memory.holographic  # noqa: F401
+        assert build_tool_preview(
+            "fact_store", {"action": "search", "query": "editor config"}
+        ) == 'search: "editor config"'
+
+    def test_fact_store_reason_joins_entities(self):
+        import plugins.memory.holographic  # noqa: F401
+        result = build_tool_preview(
+            "fact_store",
+            {"action": "reason", "entities": ["alice", "redis"]},
+        )
+        assert result == "reason: alice, redis"
+
+    def test_fact_store_update_carries_fact_id(self):
+        import plugins.memory.holographic  # noqa: F401
+        assert build_tool_preview(
+            "fact_store", {"action": "update", "fact_id": 42}
+        ) == "update: #42"
+
+    def test_fact_store_unknown_action_falls_back_to_wildcard(self):
+        import plugins.memory.holographic  # noqa: F401
+        assert build_tool_preview(
+            "fact_store", {"action": "experimental"}
+        ) == "experimental"
+
+    def test_fact_feedback_helpful_shows_thumbs_up(self):
+        import plugins.memory.holographic  # noqa: F401
+        assert build_tool_preview(
+            "fact_feedback", {"action": "helpful", "fact_id": 9}
+        ) == "+1 #9"
+
+    def test_fact_feedback_unhelpful_shows_thumbs_down(self):
+        import plugins.memory.holographic  # noqa: F401
+        assert build_tool_preview(
+            "fact_feedback", {"action": "unhelpful", "fact_id": 9}
+        ) == "-1 #9"
 
 
 class TestCuteToolMessagePreviewLength:

--- a/tests/agent/test_display.py
+++ b/tests/agent/test_display.py
@@ -241,6 +241,17 @@ class TestRegisterToolPreview:
         assert result is None
         assert any("_pytest_bad" in rec.getMessage() for rec in caplog.records)
 
+    def test_attribute_access_template_falls_back_without_crashing(self, caplog):
+        # ``{value.foo}`` makes ``str.format_map`` do attribute access on the
+        # arg, which raises AttributeError — a different exception family than
+        # the numeric ``{value:d}`` ValueError above. The fallback must catch
+        # it too so a malformed plugin template never escapes to the spinner.
+        register_tool_preview("_pytest_attr", templates="{value.foo}")
+        with caplog.at_level("WARNING"):
+            result = build_tool_preview("_pytest_attr", {"value": "abc"})
+        assert result is None
+        assert any("_pytest_attr" in rec.getMessage() for rec in caplog.records)
+
     def test_re_registration_overwrites_previous_schema(self):
         register_tool_preview("_pytest_lastwins", templates="v1: {x}")
         register_tool_preview("_pytest_lastwins", templates="v2: {x}")

--- a/website/docs/developer-guide/adding-tools.md
+++ b/website/docs/developer-guide/adding-tools.md
@@ -200,6 +200,51 @@ OPTIONAL_ENV_VARS = {
 }
 ```
 
+## Optional: Tool Progress Previews
+
+Tool-progress bubbles in the CLI spinner, the Feishu/Telegram gateways,
+and any other display surface that calls `agent.display.build_tool_preview()`
+default to showing only the tool name when a tool isn't recognised.
+That looks like a stalled call (`⚙️ weather...`) instead of useful
+context (`weather: London`). Register a **declarative preview template**
+once, next to your schema, so every surface gets a meaningful one-liner:
+
+```python
+from agent.display import register_tool_preview
+
+register_tool_preview(
+    "weather",
+    templates="weather: {location}",
+)
+```
+
+For tools whose preview depends on an action / mode argument, dispatch
+on the field directly — no `if/elif` ladder required:
+
+```python
+register_tool_preview(
+    "fact_store",
+    field="action",
+    templates={
+        "add":    '+ "{content:.30}"',     # truncate content to 30 chars
+        "search": 'search: "{query:.25}"',
+        "remove": "remove: #{fact_id}",
+        "*":      "{action}",              # fallback for unlisted actions
+    },
+    truncate=60,                            # optional per-tool cap
+)
+```
+
+Templates use Python `str.format_map` semantics. Missing keys render as
+empty strings (partial tool calls never crash the spinner). String
+values are whitespace-collapsed and lists are joined with `, ` so the
+same template works for both scalar and array-valued args. Use the
+standard precision suffix (`{content:.30}`) to truncate a specific
+field, or pass `truncate=N` to cap the final rendered string.
+
+Re-registration is last-write-wins, so plugins can also override
+built-in previews.
+
 ## Checklist
 
 - [ ] Tool file created with handler, schema, check function, and registration
@@ -207,5 +252,6 @@ OPTIONAL_ENV_VARS = {
 - [ ] Confirmed this really should be a built-in/core tool and not a plugin
 - [ ] Handler returns JSON strings, errors returned as `{"error": "..."}`
 - [ ] Optional: API key added to `OPTIONAL_ENV_VARS` in `hermes_cli/config.py`
+- [ ] Optional: `register_tool_preview()` called so progress bubbles show useful context
 - [ ] Optional: Added to `toolset_distributions.py` for batch processing
 - [ ] Tested with `hermes chat -q "Use the weather tool for London"`


### PR DESCRIPTION
## What does this PR do?

Adds a **declarative tool-preview schema registry** to `agent/display.py` so new tools — including plugin/third-party tools — can ship a one-line progress preview alongside their schema definition, instead of editing the hardcoded `if-elif` chain in `build_tool_preview()` every time.

Before, tools without a manual entry fell back to `⚙️ tool_name...` on Feishu / Telegram bubbles and the CLI spinner. This is what prompted #28598 (`fact_store` / `fact_feedback` showing no useful context); #28621 generalises that observation: the if-elif chain is a **structural oversight generator**, and plugins have no path to preview support at all.

The new API is:

```python
from agent.display import register_tool_preview

register_tool_preview(
    "fact_store",
    field="action",
    templates={
        "add":    '+ "{content:.30}"',
        "search": 'search: "{query:.25}"',
        "remove": "remove: #{fact_id}",
        "*":      "{action}",          # wildcard fallback
    },
    truncate=60,                        # per-tool cap
)
```

Design choices:

- **Backward compatible** — registry is consulted *before* the legacy chain. Existing tools keep working; migration is incremental, no flag-day.
- **Plugin-friendly** — plugins call `register_tool_preview()` at import time, next to their schema definition. No core code edit required.
- **Safe by default** — missing keys render as `""` (a partial tool call never crashes the spinner), string values are whitespace-collapsed, lists are joined with `, `, bad templates degrade to `None` + a warning log instead of raising.
- **Per-tool override** — `truncate=N` takes priority over the global `_tool_preview_max_len`, useful for plugins that know their content is naturally short.
- **Last-write-wins** — plugins can override built-in previews if they need to.

## Related Issue

Fixes #28621
Also closes #28598 (the user-visible bug that prompted this proposal — `fact_store` and `fact_feedback` now render meaningful previews).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- **`agent/display.py`** — adds `register_tool_preview()`, `_unregister_tool_preview()`, the `_TOOL_PREVIEW_REGISTRY` module-level dict, `_SafePreviewArgs` (a `dict` subclass that returns `""` for missing keys and normalises values for `str.format_map`), and `_render_registered_preview()`. `build_tool_preview()` consults the registry first, applies the per-tool `truncate` (falling back to the global `_tool_preview_max_len`), and only then falls through to the existing hardcoded chain. Also hardens the legacy path against truthy non-dict `args`.
- **`plugins/memory/holographic/__init__.py`** — registers preview templates for `fact_store` (10 actions, including `add`, `search`, `probe`, `reason`, `update`, `remove`, plus a `*` fallback) and `fact_feedback` (`helpful` / `unhelpful` / `*`). The registration sits right next to `FACT_STORE_SCHEMA` / `FACT_FEEDBACK_SCHEMA` so reviewers see UX + schema together.
- **`tests/agent/test_display.py`** — adds `TestRegisterToolPreview` (15 unit tests covering single-template rendering, field dispatch with `*` fallback, missing-key safety, list-arg joining, per-field precision truncation, per-tool vs. global truncate precedence, whitespace collapsing, `None` → `""`, bad-template fallback with log assertion, last-write-wins re-registration, registry-over-legacy priority, and rejection of malformed registrations) plus `TestFactStorePluginPreview` (7 smoke tests for the holographic plugin registrations) and one extra defensive test for truthy non-dict args.
- **`website/docs/developer-guide/adding-tools.md`** — adds an "Optional: Tool Progress Previews" section showing the API and dispatch form, plus a checklist nudge so authors register a preview when relevant.

Memory and the other complex special cases (`process`, `todo`, `send_message`) are intentionally **left on the legacy path** in this PR — the issue's scope calls for 2–3 POC migrations with the rest deferred. `memory` in particular has a `"<missing old_text>"` sentinel that doesn't fit the minimal `field`/`templates`/`truncate` schema cleanly; if that's wanted, it should land in a follow-up PR (possibly extending the schema with an optional `defaults` mapping).

## How to Test

```bash
# Full registry coverage + smoke tests for the plugin migration.
scripts/run_tests.sh tests/agent/test_display.py -q
# Expected: 55 passed (31 existing + 24 new).

# Manual: with the holographic-memory plugin enabled, watch a tool
# progress bubble while issuing a fact_store call from chat.
# Before this PR:  ⚙️ fact_store...
# After this PR:   ⚙️ fact_store + "user prefers tabs"
```

## Checklist

### Code

- [x] My commit messages follow Conventional Commits (`feat(display):`, `feat(memory/holographic):`, `test(display)+docs:`)
- [x] I searched for existing PRs — no duplicate
- [x] My PR contains only changes related to this feature
- [x] I've run `scripts/run_tests.sh tests/agent/test_display.py -q` (55 passed, 0 failed)
- [x] I've added tests for my changes (22 new tests covering the registry contract + plugin smoke tests)
- [x] I've tested on my platform: macOS 15.x (darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/developer-guide/adding-tools.md`)
- [ ] N/A — no config keys changed (`cli-config.yaml.example`)
- [ ] N/A — no architecture / workflow change requiring `CONTRIBUTING.md` / `AGENTS.md` updates
- [x] I've considered cross-platform impact — pure Python, no platform-specific code paths
- [ ] N/A — no tool description/schema changes (preview registration is additive metadata)
