### PR TITLE
fix(gateway): extend follow-up grace to WeChat/WeCom + bump default to 5s (#28417)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2707,6 +2707,67 @@ class GatewayRunner:
             pass
         return False
 
+    # ---- Messaging follow-up grace (#28417) ---------------------------
+    #
+    # Platforms whose users commonly send rapid burst follow-ups (IME
+    # autocorrect on Chinese keyboards, mobile typo fixups, voice-to-text
+    # cleanups, telegram client-side splits).  Within the grace window
+    # below, the second message is merged into the active session's
+    # pending buffer instead of interrupting the running agent — which
+    # is what made one Q&A "break in the middle" on Telegram and WeChat
+    # before this fix.
+
+    _FOLLOWUP_GRACE_PLATFORMS: frozenset = frozenset({
+        Platform.TELEGRAM,
+        Platform.WEIXIN,
+        Platform.WECOM,
+        Platform.WECOM_CALLBACK,
+    })
+
+    @classmethod
+    def _platform_has_followup_grace(cls, platform: "Platform") -> bool:
+        """Return whether *platform* participates in the follow-up grace
+        window.  Centralised so the set is easy to extend (e.g. Feishu,
+        Slack) without scattering platform tuples through ``_handle_message``.
+        """
+        return platform in cls._FOLLOWUP_GRACE_PLATFORMS
+
+    @staticmethod
+    def _messaging_followup_grace_seconds() -> float:
+        """Read the follow-up grace window from env, in seconds.
+
+        Resolution order (first non-empty wins):
+
+        1. ``HERMES_GATEWAY_FOLLOWUP_GRACE_SECONDS`` — the generalised
+           knob covering every platform in ``_FOLLOWUP_GRACE_PLATFORMS``.
+        2. ``HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS`` — legacy
+           Telegram-only override; kept honoured so existing deployments
+           that tuned it don't see a value reset.
+        3. Default ``5.0`` seconds — slightly wider than the previous
+           Telegram-only ``3.0`` because the symptom in #28417 was that
+           3s did not cover normal mobile bursts; still tight enough
+           that genuine user-initiated interrupts work within ~5s.
+
+        Returns ``0.0`` (which disables the window) if a non-numeric
+        value is set, so a misconfigured deployment fails open to the
+        previous default-interrupt behaviour rather than crashing.
+        """
+        for env_var in (
+            "HERMES_GATEWAY_FOLLOWUP_GRACE_SECONDS",
+            "HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS",
+        ):
+            raw = os.getenv(env_var, "").strip()
+            if raw:
+                try:
+                    return max(0.0, float(raw))
+                except ValueError:
+                    logger.warning(
+                        "Invalid %s=%r — ignoring; using default 5.0s",
+                        env_var, raw,
+                    )
+                    return 5.0
+        return 5.0
+
     @staticmethod
     def _load_busy_input_mode() -> str:
         """Load gateway drain-time busy-input behavior from config/env."""
@@ -6969,19 +7030,26 @@ class GatewayRunner:
                     merge_pending_message_event(adapter._pending_messages, _quick_key, event)
                 return None
 
-            _telegram_followup_grace = float(
-                os.getenv("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", "3.0")
-            )
+            # Messaging follow-up grace window (#28417): mobile chat clients
+            # commonly split one logical message into rapid bursts (typo
+            # correction, IME segmentation, voice-to-text fixups).  Without
+            # a grace window the burst's second chunk hits the running
+            # session and triggers default ``interrupt`` mode, which aborts
+            # the in-flight answer mid-stream — the exact symptom users
+            # report on Telegram *and* WeChat.  Apply the grace to all
+            # platforms that exhibit this burst pattern.
+            _followup_grace = self._messaging_followup_grace_seconds()
             _started_at = self._running_agents_ts.get(_quick_key, 0)
             if (
-                source.platform == Platform.TELEGRAM
+                self._platform_has_followup_grace(source.platform)
                 and event.message_type == MessageType.TEXT
-                and _telegram_followup_grace > 0
+                and _followup_grace > 0
                 and _started_at
-                and (time.time() - _started_at) <= _telegram_followup_grace
+                and (time.time() - _started_at) <= _followup_grace
             ):
                 logger.debug(
-                    "Telegram follow-up arrived %.2fs after run start for %s — queueing without interrupt",
+                    "[%s] follow-up arrived %.2fs after run start for %s — queueing without interrupt",
+                    source.platform.value,
                     time.time() - _started_at,
                     _quick_key,
                 )

--- a/tests/gateway/test_messaging_followup_grace.py
+++ b/tests/gateway/test_messaging_followup_grace.py
@@ -1,0 +1,267 @@
+"""Tests for the messaging follow-up grace window (#28417).
+
+The grace window prevents rapid burst follow-ups (mobile typo fixups,
+Chinese IME segmentation, voice-to-text cleanup) from interrupting an
+in-flight agent turn — that asymmetry between Telegram (had 3s grace)
+and WeChat (had 0s) was the smoking gun behind a user-visible "the
+conversation breaks mid Q&A" bug on both platforms.
+
+These tests pin down:
+
+* The grace covers Telegram, Weixin, WeCom, and WeCom callback.
+* Platforms outside that set (e.g. Slack) fall through to the legacy
+  interrupt path so we don't accidentally widen the change.
+* ``HERMES_GATEWAY_FOLLOWUP_GRACE_SECONDS`` is the canonical knob.
+* ``HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS`` is honoured as a legacy
+  fallback so existing deployments don't regress.
+* A non-numeric env value fails open to the default (no crash).
+* Once the window has elapsed, the message no longer short-circuits and
+  flows on to the normal busy-session handling.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource, build_session_key
+
+
+class _PendingAdapter:
+    def __init__(self) -> None:
+        self._pending_messages: dict = {}
+
+
+def _make_runner(platform: Platform) -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={platform: PlatformConfig(enabled=True, token="***")}
+    )
+    runner.adapters = {platform: _PendingAdapter()}
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._voice_mode = {}
+    runner._draining = False
+    runner._busy_input_mode = "interrupt"
+    runner._is_user_authorized = lambda _source: True
+    return runner
+
+
+def _mark_running(runner: GatewayRunner, session_key: str, *, started_at: float | None = None) -> MagicMock:
+    """Pretend an agent is already running for ``session_key``.
+
+    ``get_activity_summary`` is wired up explicitly so the
+    stale-eviction code in ``_handle_message`` sees a healthy idle
+    figure (real ``float``, not a ``MagicMock``) and leaves our test
+    agent in place.  Without this the eviction would race with the
+    grace branch and wipe the running_agent state we just installed.
+    """
+    agent = MagicMock()
+    agent.get_activity_summary.return_value = {
+        "seconds_since_activity": 0.0,
+        "last_activity_desc": "test",
+        "api_call_count": 1,
+        "max_iterations": 10,
+    }
+    runner._running_agents[session_key] = agent
+    runner._running_agents_ts[session_key] = (
+        started_at if started_at is not None else time.time()
+    )
+    return agent
+
+
+def _make_text_event(source: SessionSource, text: str = "follow up") -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+
+
+# ----------------------------------------------------------------------
+# Platform coverage
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "platform",
+    [
+        Platform.TELEGRAM,
+        Platform.WEIXIN,
+        Platform.WECOM,
+        Platform.WECOM_CALLBACK,
+    ],
+)
+@pytest.mark.asyncio
+async def test_burst_followup_within_grace_is_merged_not_interrupted(
+    monkeypatch: pytest.MonkeyPatch, platform: Platform
+) -> None:
+    """Each of the four messaging platforms in scope must queue the
+    follow-up (instead of interrupting) when it arrives well inside the
+    grace window — that's the core regression from #28417."""
+    monkeypatch.delenv("HERMES_GATEWAY_FOLLOWUP_GRACE_SECONDS", raising=False)
+    monkeypatch.delenv("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", raising=False)
+
+    runner = _make_runner(platform)
+    source = SessionSource(platform=platform, chat_id="42", chat_type="dm", user_id="u")
+    session_key = build_session_key(source)
+    agent = _mark_running(runner, session_key)
+
+    event = _make_text_event(source, text="oops typo correction")
+    result = await runner._handle_message(event)
+
+    assert result is None
+    agent.interrupt.assert_not_called()
+    assert runner.adapters[platform]._pending_messages[session_key] is event
+
+
+@pytest.mark.asyncio
+async def test_platform_outside_grace_set_does_not_short_circuit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Slack is intentionally NOT in the grace set: Slack threads have
+    well-defined boundaries and rich-burst follow-ups are uncommon.  We
+    must NOT accidentally widen the grace by enumerating every platform."""
+    monkeypatch.delenv("HERMES_GATEWAY_FOLLOWUP_GRACE_SECONDS", raising=False)
+    monkeypatch.delenv("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", raising=False)
+
+    runner = _make_runner(Platform.SLACK)
+    source = SessionSource(platform=Platform.SLACK, chat_id="C1", chat_type="channel", user_id="U1")
+    session_key = build_session_key(source)
+    _mark_running(runner, session_key)
+
+    event = _make_text_event(source)
+    result = await runner._handle_message(event)
+
+    # When the grace short-circuit doesn't fire, the message flows on to
+    # the regular busy-session handling.  We just need to assert it was
+    # NOT queued via the grace path — exact downstream behaviour belongs
+    # to other tests, not this one.
+    pending = runner.adapters[Platform.SLACK]._pending_messages
+    assert pending.get(session_key) is not event or result is not None
+
+
+# ----------------------------------------------------------------------
+# Timing semantics
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_followup_outside_window_is_not_queued_via_grace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After the grace window elapses, the short-circuit must release
+    the message to the normal busy-session path so genuine ``interrupt``
+    semantics still work."""
+    monkeypatch.setenv("HERMES_GATEWAY_FOLLOWUP_GRACE_SECONDS", "5.0")
+    monkeypatch.delenv("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", raising=False)
+
+    runner = _make_runner(Platform.TELEGRAM)
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="1", chat_type="dm", user_id="u")
+    session_key = build_session_key(source)
+    # Mark the run as having started 60 seconds ago — well outside any
+    # plausible grace window.
+    _mark_running(runner, session_key, started_at=time.time() - 60.0)
+
+    event = _make_text_event(source)
+    await runner._handle_message(event)
+
+    pending = runner.adapters[Platform.TELEGRAM]._pending_messages
+    # The grace branch did NOT capture the event.
+    assert pending.get(session_key) is not event
+
+
+@pytest.mark.asyncio
+async def test_zero_grace_disables_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Setting the grace to ``0`` must completely disable the
+    short-circuit, restoring the pre-#28417 default-interrupt path."""
+    monkeypatch.setenv("HERMES_GATEWAY_FOLLOWUP_GRACE_SECONDS", "0")
+    monkeypatch.delenv("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", raising=False)
+
+    runner = _make_runner(Platform.WEIXIN)
+    source = SessionSource(platform=Platform.WEIXIN, chat_id="1", chat_type="dm", user_id="u")
+    session_key = build_session_key(source)
+    _mark_running(runner, session_key)
+
+    event = _make_text_event(source)
+    await runner._handle_message(event)
+
+    pending = runner.adapters[Platform.WEIXIN]._pending_messages
+    assert pending.get(session_key) is not event
+
+
+# ----------------------------------------------------------------------
+# Env var resolution
+# ----------------------------------------------------------------------
+
+
+def test_generalised_env_var_wins_over_legacy(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HERMES_GATEWAY_FOLLOWUP_GRACE_SECONDS", "12.5")
+    monkeypatch.setenv("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", "3.0")
+    assert GatewayRunner._messaging_followup_grace_seconds() == 12.5
+
+
+def test_legacy_env_var_is_honoured_when_generalised_is_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("HERMES_GATEWAY_FOLLOWUP_GRACE_SECONDS", raising=False)
+    monkeypatch.setenv("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", "7.0")
+    assert GatewayRunner._messaging_followup_grace_seconds() == 7.0
+
+
+def test_default_is_five_seconds_when_no_env_var_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    """5s is wide enough to cover normal mobile bursts (the gap that
+    3s left uncovered in #28417) without making real interrupts feel
+    laggy."""
+    monkeypatch.delenv("HERMES_GATEWAY_FOLLOWUP_GRACE_SECONDS", raising=False)
+    monkeypatch.delenv("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", raising=False)
+    assert GatewayRunner._messaging_followup_grace_seconds() == 5.0
+
+
+def test_invalid_env_value_does_not_crash(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A misconfigured env var must not break gateway startup or
+    request handling — fall back to the default value instead."""
+    monkeypatch.setenv("HERMES_GATEWAY_FOLLOWUP_GRACE_SECONDS", "not-a-number")
+    monkeypatch.delenv("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", raising=False)
+    assert GatewayRunner._messaging_followup_grace_seconds() == 5.0
+
+
+def test_negative_value_is_clamped_to_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Negative values would short-circuit the ``> 0`` guard but make no
+    semantic sense; clamp to zero so the window is simply disabled."""
+    monkeypatch.setenv("HERMES_GATEWAY_FOLLOWUP_GRACE_SECONDS", "-1")
+    monkeypatch.delenv("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", raising=False)
+    assert GatewayRunner._messaging_followup_grace_seconds() == 0.0
+
+
+# ----------------------------------------------------------------------
+# Platform set
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "platform,expected",
+    [
+        (Platform.TELEGRAM, True),
+        (Platform.WEIXIN, True),
+        (Platform.WECOM, True),
+        (Platform.WECOM_CALLBACK, True),
+        (Platform.SLACK, False),
+        (Platform.DISCORD, False),
+        (Platform.WHATSAPP, False),
+        (Platform.FEISHU, False),
+    ],
+)
+def test_platform_membership(platform: Platform, expected: bool) -> None:
+    """Pin down the platform set so future widening is an explicit
+    decision rather than an accidental drive-by edit."""
+    assert GatewayRunner._platform_has_followup_grace(platform) is expected

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -492,7 +492,8 @@ Advanced per-platform knobs for throttling the outbound message batcher. Most us
 | `HERMES_TELEGRAM_TEXT_BATCH_DELAY_SECONDS` | Grace window before flushing a queued Telegram text chunk (default: `0.6`). |
 | `HERMES_TELEGRAM_TEXT_BATCH_SPLIT_DELAY_SECONDS` | Delay between split chunks when a single Telegram message exceeds the length limit (default: `2.0`). |
 | `HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS` | Grace window before flushing queued Telegram media (default: `0.6`). |
-| `HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS` | Delay before sending a follow-up after the agent finishes, to avoid racing the last stream chunk. |
+| `HERMES_GATEWAY_FOLLOWUP_GRACE_SECONDS` | Within this many seconds of an agent turn starting, an inbound user follow-up is merged into the active session instead of triggering the default interrupt — covers Telegram, WeChat (Weixin), and WeCom (default: `5.0`, set to `0` to disable). Mitigates mid-Q&A breaks caused by mobile keyboards / IMEs / voice-to-text emitting bursts of short messages. See #28417. |
+| `HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS` | Legacy Telegram-only alias for `HERMES_GATEWAY_FOLLOWUP_GRACE_SECONDS`; honoured only as a fallback when the generalised variable is unset. New deployments should use the generalised name. |
 | `HERMES_TELEGRAM_HTTP_CONNECT_TIMEOUT` / `_READ_TIMEOUT` / `_WRITE_TIMEOUT` / `_POOL_TIMEOUT` | Override the underlying `python-telegram-bot` HTTP timeouts (seconds). |
 | `HERMES_TELEGRAM_HTTP_POOL_SIZE` | Max concurrent HTTP connections to the Telegram API. |
 | `HERMES_TELEGRAM_DISABLE_FALLBACK_IPS` | Disable the hard-coded Cloudflare fallback IPs used when DNS fails (`true`/`false`). |


### PR DESCRIPTION
## What does this PR do?

#28417 reports that on **Telegram and WeChat (微信)**, a single Q&A "自动自动中断" — auto-interrupts before the agent has finished its reply, takes a long time to recover, then breaks again on retry.

Root-cause walk-through (see `tests/gateway/test_messaging_followup_grace.py` for the contract pinned by this PR):

1. The runner's default `busy_input_mode` is `"interrupt"` (`gateway/run.py:1411`). Any second user text that arrives while an agent task is running for that `session_key` fires `interrupt_event.set()`, aborts the run, and the partial reply is suppressed via the stale-response path in `gateway/platforms/base.py:3143-3156`.
2. To stop normal user behavior (typo correction, IME segmentation, voice-to-text fixups) from tripping that interrupt, there's a 3-second "follow-up grace window" in `_handle_message` that merges the second message into the pending buffer instead.
3. **But that grace was Telegram-only** (`source.platform == Platform.TELEGRAM`). WeChat had no grace at all — every burst follow-up interrupted the run. That's the exact asymmetry that made #28417 hit WeChat just as hard as Telegram.
4. The 3-second default is also too short for normal mobile bursts: Chinese IMEs and voice-to-text often emit a second short text 2–4s after the first.

**Fix** (smallest defensible change):

- Generalize the grace window to a `_FOLLOWUP_GRACE_PLATFORMS` frozenset covering **Telegram, Weixin, WeCom, WeCom callback** — the four platforms in scope for the burst-follow-up pattern that triggered this bug. Slack/Discord/WhatsApp/Feishu intentionally stay on the legacy path; future widenings should be an explicit edit of the set, not a drive-by.
- New env var **`HERMES_GATEWAY_FOLLOWUP_GRACE_SECONDS`** is the canonical knob. The legacy `HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS` is still honoured as a fallback so existing deployments that tuned it don't see their value reset.
- Default bumped from **3.0 → 5.0 seconds**. Still well below "the user typed a fresh question" territory, but wide enough to swallow IME / voice-to-text bursts.
- Invalid env values **fail open** to the default instead of crashing request handling; negative values clamp to zero.
- Debug log now names the actual platform instead of always saying "Telegram", which had hidden the WeChat case in production logs.

The fix touches one branch in `_handle_message` plus two new static helpers — the rest of the busy-session machinery is unchanged.

## Related Issue

Fixes #28417

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)
- [x] 📝 Documentation update

## Changes Made

- **`gateway/run.py`** —
  - Replace the inlined Telegram-only branch in `_handle_message` with a call to two new static helpers: `_platform_has_followup_grace()` (checks the `_FOLLOWUP_GRACE_PLATFORMS` frozenset of TELEGRAM / WEIXIN / WECOM / WECOM_CALLBACK) and `_messaging_followup_grace_seconds()` (resolves env vars, fails open on bad input, clamps negative values to zero).
  - Update the debug log to include the actual platform name.
  - 75 added / 7 removed lines.
- **`tests/gateway/test_messaging_followup_grace.py`** — new 267-line test module with 20 tests over four axes:
  - **Platform coverage** — Telegram + Weixin + WeCom + WeCom callback all queue-without-interrupt within the window.
  - **Negative coverage** — Slack stays on the legacy path so this PR doesn't accidentally widen scope.
  - **Timing semantics** — outside the window, the grace branch defers to normal busy-session handling; `0` disables the window entirely.
  - **Env var resolution** — generalised wins over legacy, legacy still honoured, default `5.0`, malformed values fall back, negative values clamp.
  - Parametrised membership test over 8 platforms so future additions are an explicit fail-the-test diff.
- **`website/docs/reference/environment-variables.md`** —
  - Add a row for `HERMES_GATEWAY_FOLLOWUP_GRACE_SECONDS` linking to #28417.
  - Fix the existing `HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS` description, which incorrectly said the knob delayed _outbound_ messages "to avoid racing the last stream chunk" — it actually controls the _inbound_ follow-up merge window.

## How to Test

```bash
# New regression suite.
scripts/run_tests.sh tests/gateway/test_messaging_followup_grace.py -q
# Expected: 20 passed in ~1s.

# Adjacent suites that exercise the surrounding busy-session paths.
scripts/run_tests.sh \
  tests/gateway/test_telegram_photo_interrupts.py \
  tests/gateway/test_active_session_text_merge.py \
  tests/gateway/test_busy_session_ack.py \
  tests/gateway/test_command_bypass_active_session.py \
  -q
# Expected: 58 passed (no regressions).
```

Manual reproduction (Telegram or WeChat):

1. Start a long-running agent turn (e.g. ask for a multi-paragraph summary).
2. Within 3–5s of starting, send a short follow-up ("oops, in English please").
3. **Before this PR (WeChat):** the run is interrupted, the partial answer is suppressed, the bot starts over from scratch with the merged text — exactly the symptom in #28417.
4. **After this PR:** the follow-up is merged into pending and the in-flight run completes uninterrupted; the merged context is consumed on the next turn.

## Checklist

### Code

- [x] My commit messages follow Conventional Commits (`fix(gateway):`, `test(gateway):`, `docs(env):`)
- [x] I searched for existing PRs — no duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `scripts/run_tests.sh tests/gateway/test_messaging_followup_grace.py -q` (20 passed)
- [x] I've added regression tests covering the asymmetry that caused the bug
- [x] I've tested on my platform: macOS 15.x (darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/reference/environment-variables.md` — added the new knob, fixed the misleading existing description)
- [ ] N/A — no config.yaml schema changes (env-only knob, with documented config.yaml route via `display.busy_input_mode` already present)
- [ ] N/A — no architecture or workflow change requiring `CONTRIBUTING.md` / `AGENTS.md` updates
- [x] I've considered cross-platform impact — pure Python in a `_handle_message` branch, no platform-specific syscalls. The fix runs identically on Linux/macOS/Windows.
- [ ] N/A — no tool description/schema changes
