### PR TITLE
fix(kanban): prevent recompute_ready from unblocking parent-free blocked tasks

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2014,9 +2014,15 @@ def recompute_ready(conn: sqlite3.Connection) -> int:
                 "WHERE l.child_id = ?",
                 (task_id,),
             ).fetchall()
-            if all(p["status"] in ("done", "archived") for p in parents):
+            parents_satisfied = all(
+                p["status"] in ("done", "archived") for p in parents
+            )
+            # A parent-free blocked task was intentionally blocked by a
+            # worker or operator. Only dependency-gated blocked tasks
+            # should auto-promote here when their parents clear.
+            if parents_satisfied and (cur_status != "blocked" or parents):
                 # Blocked tasks also get their failure counters reset —
-                # this is effectively an auto-unblock.
+                # this is effectively an auto-unblock for dependency waits.
                 if cur_status == "blocked":
                     conn.execute(
                         "UPDATE tasks SET status = 'ready', "

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -192,6 +192,24 @@ def test_recompute_ready_promotes_blocked_with_done_parents(kanban_home):
         assert task.last_failure_error is None
 
 
+def test_recompute_ready_does_not_unblock_parent_free_manual_block(kanban_home):
+    """Parent-free blocked tasks must stay blocked until explicit unblock."""
+    with kb.connect() as conn:
+        blocked = kb.create_task(conn, title="blocked", assignee="a")
+        other = kb.create_task(conn, title="other", assignee="a")
+
+        kb.claim_task(conn, blocked)
+        assert kb.block_task(conn, blocked, reason="waiting on human")
+        assert kb.get_task(conn, blocked).status == "blocked"
+
+        # Unrelated board progress triggers recompute_ready internally.
+        kb.complete_task(conn, other, result="ok")
+
+        task = kb.get_task(conn, blocked)
+        assert task.status == "blocked"
+        assert task.consecutive_failures == 0
+
+
 def test_recompute_ready_fan_in_waits_for_all_parents(kanban_home):
     with kb.connect() as conn:
         a = kb.create_task(conn, title="a")


### PR DESCRIPTION
## Summary

`recompute_ready()` was treating every `blocked` task with no parents as eligible
for promotion because `all(...)` over an empty parent set returns `True`.

This meant an intentionally blocked task could jump back to `ready` whenever an
unrelated board action triggered a recompute pass.

## What changed

- only auto-promote `blocked` tasks when they are actually dependency-gated
- keep parent-free manual blocks in `blocked` until an explicit unblock
- add a regression test covering the parent-free manual block case

## Repro

1. Create a parent-free task
2. Move it to `blocked`
3. Complete some unrelated task on the board
4. Before this fix, the blocked task moved back to `ready`

## Validation

- `pytest tests/hermes_cli/test_kanban_db.py -k recompute_ready`
- Result : `6 passed`