### PR TITLE
[auto-fix] webhook ignored event response lacks actionable hint

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -403,7 +403,12 @@ class WebhookAdapter(BasePlatformAdapter):
                 allowed_events,
             )
             return web.json_response(
-                {"status": "ignored", "event": event_type}
+                {
+                    "status": "ignored",
+                    "event": event_type,
+                    "allowed_events": allowed_events,
+                    "hint": "Add this event to the subscription's events list if this should be accepted.",
+                }
             )
 
         # Format prompt from template

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -282,6 +282,9 @@ class TestEventFilter:
             assert resp.status == 200
             data = await resp.json()
             assert data["status"] == "ignored"
+            assert data["event"] == "push"
+            assert data["allowed_events"] == ["pull_request"]
+            assert "Add this event" in data["hint"]
 
     @pytest.mark.asyncio
     async def test_event_filter_empty_allows_all(self):


### PR DESCRIPTION
## 원인 (Root Cause)
Webhook adapter가 허용되지 않은 이벤트를 받았을 때 202 응답만 반환하고, 어떤 이벤트가 허용되는지/다음 조치가 무엇인지에 대한 진단 정보가 부족했습니다.

## 수정 내용 (Fix)
- `gateway/platforms/webhook.py`: ignored-event 응답에 actionable diagnostics(allowed events, hint) 포함.
- `tests/gateway/test_webhook_adapter.py`: ignored-event 진단 필드 검증 테스트 보강.

## 테스트 결과 (Test Results)
- ✅ `python -m pytest tests/gateway/test_webhook_adapter.py -o 'addopts=' -q -n 0`
  - `54 passed in 0.83s`
- ⚠️ `python -m pytest tests/ -o 'addopts=' -q -n 0`
  - 저장소 전체 baseline에 다수의 기존 실패/에러 존재(이번 수정 범위 외).
