### PR TITLE
feat(gateway): add display.show_background_review_in_chat flag

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1434,6 +1434,7 @@ class GatewayRunner:
         self._reasoning_config = self._load_reasoning_config()
         self._service_tier = self._load_service_tier()
         self._show_background_review_in_chat = self._load_show_background_review_in_chat()
+        self._show_auxiliary_warnings_in_chat = self._load_show_auxiliary_warnings_in_chat()
         self._show_reasoning = self._load_show_reasoning()
         self._busy_input_mode = self._load_busy_input_mode()
         self._restart_drain_timeout = self._load_restart_drain_timeout()
@@ -2709,6 +2710,30 @@ class GatewayRunner:
                 with open(cfg_path, encoding="utf-8") as _f:
                     cfg = _y.safe_load(_f) or {}
                 raw = cfg_get(cfg, "display", "show_background_review_in_chat")
+                if raw is True:
+                    return True
+        except Exception:
+            pass
+        return False
+
+    @staticmethod
+    def _load_show_auxiliary_warnings_in_chat() -> bool:
+        """Load show_auxiliary_warnings_in_chat from config.yaml display section.
+
+        Controls whether the gateway forwards auxiliary failure warnings
+        (e.g. "⚠ Auxiliary title generation failed: Request timed out.") to the
+        subject's chat. Defaults to False — these are internal degraded-path
+        signals not intended for subject-facing messaging platforms.
+
+        Set ``display.show_auxiliary_warnings_in_chat: true`` to opt in.
+        """
+        try:
+            import yaml as _y
+            cfg_path = _hermes_home / "config.yaml"
+            if cfg_path.exists():
+                with open(cfg_path, encoding="utf-8") as _f:
+                    cfg = _y.safe_load(_f) or {}
+                raw = cfg_get(cfg, "display", "show_auxiliary_warnings_in_chat")
                 if raw is True:
                     return True
         except Exception:
@@ -16073,6 +16098,8 @@ class GatewayRunner:
 
         def _status_callback_sync(event_type: str, message: str) -> None:
             if not _status_adapter or not _run_still_current():
+                return
+            if event_type == "warn" and not self._show_auxiliary_warnings_in_chat:
                 return
             prepared_message = _prepare_gateway_status_message(
                 source.platform,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1433,6 +1433,7 @@ class GatewayRunner:
         self._ephemeral_system_prompt = self._load_ephemeral_system_prompt()
         self._reasoning_config = self._load_reasoning_config()
         self._service_tier = self._load_service_tier()
+        self._show_background_review_in_chat = self._load_show_background_review_in_chat()
         self._show_reasoning = self._load_show_reasoning()
         self._busy_input_mode = self._load_busy_input_mode()
         self._restart_drain_timeout = self._load_restart_drain_timeout()
@@ -2689,6 +2690,30 @@ class GatewayRunner:
             return "priority"
         logger.warning("Unknown service_tier '%s', ignoring", raw)
         return None
+
+    @staticmethod
+    def _load_show_background_review_in_chat() -> bool:
+        """Load show_background_review_in_chat from config.yaml display section.
+
+        Controls whether the gateway forwards background self-improvement review
+        messages (e.g. "💾 Self-improvement review: User profile updated") to the
+        subject's chat. Defaults to False — this is a TUI debug signal that leaks
+        internal state to end users on messaging platforms (Telegram, Signal, etc.).
+
+        Set ``display.show_background_review_in_chat: true`` to opt in.
+        """
+        try:
+            import yaml as _y
+            cfg_path = _hermes_home / "config.yaml"
+            if cfg_path.exists():
+                with open(cfg_path, encoding="utf-8") as _f:
+                    cfg = _y.safe_load(_f) or {}
+                raw = cfg_get(cfg, "display", "show_background_review_in_chat")
+                if raw is True:
+                    return True
+        except Exception:
+            pass
+        return False
 
     @staticmethod
     def _load_show_reasoning() -> bool:
@@ -16365,7 +16390,8 @@ class GatewayRunner:
                             return
                 _deliver_bg_review_message(message)
 
-            agent.background_review_callback = _bg_review_send
+            if self._show_background_review_in_chat:
+                agent.background_review_callback = _bg_review_send
             # Register the release hook on the adapter so base.py's finally
             # block can fire it after delivering the main response.
             if _status_adapter and session_key:


### PR DESCRIPTION
## Problem

When using Hermes gateway with messaging platforms (Telegram, Signal, WhatsApp, etc.), the `background_review_callback` unconditionally forwards internal self-improvement review messages — e.g. `💾 Self-improvement review: User profile updated` — to the subject's chat after every turn.

This is a TUI debug signal that leaks internal system state to end users, breaking the illusion of a natural conversation.

**Root cause:** `gateway/run.py` always assigns `agent.background_review_callback = _bg_review_send`, which routes to `_status_adapter.send(source.chat_id, ...)` — the subject-facing chat.

## Fix

New boolean flag `display.show_background_review_in_chat` in `config.yaml` (default `false`). The callback is only wired when explicitly opted in.

```yaml
display:
  show_background_review_in_chat: true  # opt-in, default false
```

The `tui_gateway/server.py` path is intentionally left unchanged — the operator console always shows review output.

## Changes

- `GatewayRunner._load_show_background_review_in_chat()` — reads flag from `config.yaml display` section, defaults `false`
- `GatewayRunner.__init__` — loads flag into `self._show_background_review_in_chat`
- `_step()` / turn handler — guards `agent.background_review_callback = _bg_review_send` behind the flag

## Testing

Tested on Telegram: with flag absent (default), no review messages appear in subject chat. With `show_background_review_in_chat: true`, behaviour is restored.