### PR TITLE
fix(tools/kanban): sync kanban_unblock response status with DB state

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -1013,6 +1013,40 @@ def test_unblock_happy_path(monkeypatch, worker_env):
         conn.close()
 
 
+def test_unblock_with_pending_parents_returns_todo(monkeypatch, tmp_path):
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "orchestrator")
+    from pathlib import Path as _Path
+    monkeypatch.setattr(_Path, "home", lambda: tmp_path)
+
+    from hermes_cli import kanban_db as kb
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        parent = kb.create_task(conn, title="parent", assignee="worker")
+        child = kb.create_task(conn, title="child", assignee="worker", parents=[parent])
+        conn.execute("UPDATE tasks SET status='blocked' WHERE id=?", (child,))
+        conn.commit()
+    finally:
+        conn.close()
+
+    from tools import kanban_tools as kt
+    out = kt._handle_unblock({"task_id": child})
+    d = json.loads(out)
+    assert d["ok"] is True
+    assert d["status"] == "todo"
+
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, child).status == "todo"
+    finally:
+        conn.close()
+
+
 def test_unblock_rejects_non_blocked_task(monkeypatch, worker_env):
     monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
     from tools import kanban_tools as kt

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -721,7 +721,7 @@ def _handle_create(args: dict, **kw) -> str:
 
 
 def _handle_unblock(args: dict, **kw) -> str:
-    """Transition a blocked task back to ready."""
+    """Transition a blocked task back to its actual post-unblock status."""
     guard = _require_orchestrator_tool("kanban_unblock")
     if guard:
         return guard
@@ -738,7 +738,8 @@ def _handle_unblock(args: dict, **kw) -> str:
             ok = kb.unblock_task(conn, str(tid))
             if not ok:
                 return tool_error(f"could not unblock {tid} (not blocked or unknown)")
-            return _ok(task_id=str(tid), status="ready")
+            task = kb.get_task(conn, str(tid))
+            return _ok(task_id=str(tid), status=task.status if task else None)
         finally:
             conn.close()
     except ValueError as e:


### PR DESCRIPTION
## Summary
- return the actual task status from `kanban_unblock` instead of always reporting `ready`
- add a regression test covering blocked child tasks with unfinished parents

## Why
`kanban_unblock` could report `ready` even when the DB correctly re-gated the task to `todo`, which made the tool response inconsistent with actual board state.

## Testing
- `scripts/run_tests.sh tests/tools/test_kanban_tools.py -k unblock`

```text
  
============================== 5 passed in 3.41s ==============================