### PR TITLE
fix(discord): define UI component views lazily for lazy-install compa…

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -4888,6 +4888,8 @@ class DiscordAdapter(BasePlatformAdapter):
 # module-level ``if DISCORD_AVAILABLE:`` gate would miss the class defs
 # when initial import fails and DISCORD_AVAILABLE flips to True later.
 
+_DISCORD_UI_COMPONENTS_DEFINED = False
+
 
 def _define_discord_ui_components():
     """Define discord-dependent UI components.
@@ -4898,8 +4900,8 @@ def _define_discord_ui_components():
     """
     if not DISCORD_AVAILABLE:
         return
-    global _component_check_auth, ExecApprovalView, SlashConfirmView, UpdatePromptView, ModelPickerView, ClarifyChoiceView
-    if '_component_check_auth' in globals() and 'ExecApprovalView' in globals():
+    global _DISCORD_UI_COMPONENTS_DEFINED, _component_check_auth, ExecApprovalView, SlashConfirmView, UpdatePromptView, ModelPickerView, ClarifyChoiceView
+    if _DISCORD_UI_COMPONENTS_DEFINED:
         return
 
     def _component_check_auth(
@@ -5660,6 +5662,8 @@ def _define_discord_ui_components():
             self.resolved = True
             for child in self.children:
                 child.disabled = True
+
+    _DISCORD_UI_COMPONENTS_DEFINED = True
 
 
 # Module-level call so component views are available immediately, both at

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -111,7 +111,7 @@ def check_discord_requirements() -> bool:
     Intents = _Intents
     commands = _commands
     DISCORD_AVAILABLE = True
-    _define_discord_ui_components()
+    _define_discord_views()
     return True
 
 
@@ -4883,86 +4883,90 @@ class DiscordAdapter(BasePlatformAdapter):
 # ---------------------------------------------------------------------------
 # Discord UI Components (outside the adapter class)
 # ---------------------------------------------------------------------------
-# Defined via _define_discord_ui_components() so they work even after
-# discord.py is lazy-installed via check_discord_requirements() -- the
-# module-level ``if DISCORD_AVAILABLE:`` gate would miss the class defs
-# when initial import fails and DISCORD_AVAILABLE flips to True later.
-
-_DISCORD_UI_COMPONENTS_DEFINED = False
+# Module-level placeholders — overwritten by _define_discord_views()
+# when discord.py is available.  Prevents NameError on lazy-install.
+# See https://github.com/NousResearch/hermes-agent/issues/26958
 
 
-def _define_discord_ui_components():
-    """Define discord-dependent UI components.
+def _component_check_auth(
+    interaction,
+    allowed_user_ids: Optional[set],
+    allowed_role_ids: Optional[set],
+) -> bool:
+    """Shared user-or-role OR semantics for component view button clicks.
 
-    Safe to call multiple times (idempotent).  Called at module load time
-    AND at the end of ``check_discord_requirements()`` so the views are
-    available even when discord.py is lazy-installed after initial import.
+    Mirrors ``DiscordAdapter._is_allowed_user`` / the slash and on_message
+    gates so every Discord interaction surface honors the same trust
+    boundary. Component views (ExecApprovalView, SlashConfirmView,
+    UpdatePromptView, ModelPickerView) used to receive only
+    ``allowed_user_ids``: in role-only deployments
+    (DISCORD_ALLOWED_ROLES set, DISCORD_ALLOWED_USERS empty) the user
+    set was empty and the legacy "no allowlist = allow everyone" branch
+    let any guild member click the buttons -- approving exec commands,
+    cancelling slash confirmations, switching the model.
+
+    Behavior:
+
+      - both allowlists empty -> allow (preserves existing no-allowlist
+        deployments, no regression)
+      - user is in user allowlist -> allow
+      - role allowlist set + user has a role in it -> allow
+      - role allowlist set + interaction.user has no resolvable
+        ``roles`` attribute (e.g. DM context with a role policy active)
+        -> reject (fail closed)
+      - otherwise -> reject
     """
-    if not DISCORD_AVAILABLE:
-        return
-    global _DISCORD_UI_COMPONENTS_DEFINED, _component_check_auth, ExecApprovalView, SlashConfirmView, UpdatePromptView, ModelPickerView, ClarifyChoiceView
-    if _DISCORD_UI_COMPONENTS_DEFINED:
-        return
+    user_set = allowed_user_ids or set()
+    role_set = allowed_role_ids or set()
+    has_users = bool(user_set)
+    has_roles = bool(role_set)
+    if not has_users and not has_roles:
+        return True
 
-    def _component_check_auth(
-        interaction,
-        allowed_user_ids: Optional[set],
-        allowed_role_ids: Optional[set],
-    ) -> bool:
-        """Shared user-or-role OR semantics for component view button clicks.
+    user = getattr(interaction, "user", None)
+    if user is None:
+        return False
 
-        Mirrors ``DiscordAdapter._is_allowed_user`` / the slash and on_message
-        gates so every Discord interaction surface honors the same trust
-        boundary. Component views (ExecApprovalView, SlashConfirmView,
-        UpdatePromptView, ModelPickerView) used to receive only
-        ``allowed_user_ids``: in role-only deployments
-        (DISCORD_ALLOWED_ROLES set, DISCORD_ALLOWED_USERS empty) the user
-        set was empty and the legacy "no allowlist = allow everyone" branch
-        let any guild member click the buttons -- approving exec commands,
-        cancelling slash confirmations, switching the model.
-
-        Behavior:
-
-          - both allowlists empty -> allow (preserves existing no-allowlist
-            deployments, no regression)
-          - user is in user allowlist -> allow
-          - role allowlist set + user has a role in it -> allow
-          - role allowlist set + interaction.user has no resolvable
-            ``roles`` attribute (e.g. DM context with a role policy active)
-            -> reject (fail closed)
-          - otherwise -> reject
-        """
-        user_set = allowed_user_ids or set()
-        role_set = allowed_role_ids or set()
-        has_users = bool(user_set)
-        has_roles = bool(role_set)
-        if not has_users and not has_roles:
+    if has_users:
+        try:
+            uid = str(user.id)
+        except AttributeError:
+            uid = ""
+        if uid and uid in user_set:
             return True
 
-        user = getattr(interaction, "user", None)
-        if user is None:
+    if has_roles:
+        roles_attr = getattr(user, "roles", None)
+        if roles_attr is None:
             return False
+        try:
+            user_role_ids = {getattr(r, "id", None) for r in roles_attr}
+        except TypeError:
+            return False
+        if user_role_ids & role_set:
+            return True
 
-        if has_users:
-            try:
-                uid = str(user.id)
-            except AttributeError:
-                uid = ""
-            if uid and uid in user_set:
-                return True
+    return False
 
-        if has_roles:
-            roles_attr = getattr(user, "roles", None)
-            if roles_attr is None:
-                return False
-            try:
-                user_role_ids = {getattr(r, "id", None) for r in roles_attr}
-            except TypeError:
-                return False
-            if user_role_ids & role_set:
-                return True
 
-        return False
+ExecApprovalView = None
+SlashConfirmView = None
+UpdatePromptView = None
+ModelPickerView = None
+ClarifyChoiceView = None
+
+
+def _define_discord_views():
+    """Define Discord View classes available after lazy-install.
+
+    Called at module load time and again from
+    ``check_discord_requirements()`` so the classes exist regardless
+    of when discord.py becomes available.
+    """
+    global ExecApprovalView, SlashConfirmView, UpdatePromptView
+    global ModelPickerView, ClarifyChoiceView
+    if not DISCORD_AVAILABLE or discord is None:
+        return
 
     class ExecApprovalView(discord.ui.View):
         """
@@ -5663,10 +5667,9 @@ def _define_discord_ui_components():
             for child in self.children:
                 child.disabled = True
 
-    _DISCORD_UI_COMPONENTS_DEFINED = True
 
 
-# Module-level call so component views are available immediately, both at
-# module load time AND after check_discord_requirements() lazy-installs
-# discord.py (which flips DISCORD_AVAILABLE from False to True).
-_define_discord_ui_components()
+# Define View classes at module load if discord.py is pre-installed.
+# When discord.py is lazily installed, check_discord_requirements()
+# calls _define_discord_views() again to define them post-install.
+_define_discord_views()

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -111,6 +111,7 @@ def check_discord_requirements() -> bool:
     Intents = _Intents
     commands = _commands
     DISCORD_AVAILABLE = True
+    _define_discord_ui_components()
     return True
 
 
@@ -4882,74 +4883,84 @@ class DiscordAdapter(BasePlatformAdapter):
 # ---------------------------------------------------------------------------
 # Discord UI Components (outside the adapter class)
 # ---------------------------------------------------------------------------
+# Defined via _define_discord_ui_components() so they work even after
+# discord.py is lazy-installed via check_discord_requirements() -- the
+# module-level ``if DISCORD_AVAILABLE:`` gate would miss the class defs
+# when initial import fails and DISCORD_AVAILABLE flips to True later.
 
 
-def _component_check_auth(
-    interaction,
-    allowed_user_ids: Optional[set],
-    allowed_role_ids: Optional[set],
-) -> bool:
-    """Shared user-or-role OR semantics for component view button clicks.
+def _define_discord_ui_components():
+    """Define discord-dependent UI components.
 
-    Mirrors ``DiscordAdapter._is_allowed_user`` / the slash and on_message
-    gates so every Discord interaction surface honors the same trust
-    boundary. Component views (ExecApprovalView, SlashConfirmView,
-    UpdatePromptView, ModelPickerView) used to receive only
-    ``allowed_user_ids``: in role-only deployments
-    (DISCORD_ALLOWED_ROLES set, DISCORD_ALLOWED_USERS empty) the user
-    set was empty and the legacy "no allowlist = allow everyone" branch
-    let any guild member click the buttons -- approving exec commands,
-    cancelling slash confirmations, switching the model.
-
-    Behavior:
-
-      - both allowlists empty -> allow (preserves existing no-allowlist
-        deployments, no regression)
-      - user is in user allowlist -> allow
-      - role allowlist set + user has a role in it -> allow
-      - role allowlist set + interaction.user has no resolvable
-        ``roles`` attribute (e.g. DM context with a role policy active)
-        -> reject (fail closed)
-      - otherwise -> reject
+    Safe to call multiple times (idempotent).  Called at module load time
+    AND at the end of ``check_discord_requirements()`` so the views are
+    available even when discord.py is lazy-installed after initial import.
     """
-    user_set = allowed_user_ids or set()
-    role_set = allowed_role_ids or set()
-    has_users = bool(user_set)
-    has_roles = bool(role_set)
-    if not has_users and not has_roles:
-        return True
+    if not DISCORD_AVAILABLE:
+        return
+    global _component_check_auth, ExecApprovalView, SlashConfirmView, UpdatePromptView, ModelPickerView, ClarifyChoiceView
+    if '_component_check_auth' in globals() and 'ExecApprovalView' in globals():
+        return
 
-    user = getattr(interaction, "user", None)
-    if user is None:
+    def _component_check_auth(
+        interaction,
+        allowed_user_ids: Optional[set],
+        allowed_role_ids: Optional[set],
+    ) -> bool:
+        """Shared user-or-role OR semantics for component view button clicks.
+
+        Mirrors ``DiscordAdapter._is_allowed_user`` / the slash and on_message
+        gates so every Discord interaction surface honors the same trust
+        boundary. Component views (ExecApprovalView, SlashConfirmView,
+        UpdatePromptView, ModelPickerView) used to receive only
+        ``allowed_user_ids``: in role-only deployments
+        (DISCORD_ALLOWED_ROLES set, DISCORD_ALLOWED_USERS empty) the user
+        set was empty and the legacy "no allowlist = allow everyone" branch
+        let any guild member click the buttons -- approving exec commands,
+        cancelling slash confirmations, switching the model.
+
+        Behavior:
+
+          - both allowlists empty -> allow (preserves existing no-allowlist
+            deployments, no regression)
+          - user is in user allowlist -> allow
+          - role allowlist set + user has a role in it -> allow
+          - role allowlist set + interaction.user has no resolvable
+            ``roles`` attribute (e.g. DM context with a role policy active)
+            -> reject (fail closed)
+          - otherwise -> reject
+        """
+        user_set = allowed_user_ids or set()
+        role_set = allowed_role_ids or set()
+        has_users = bool(user_set)
+        has_roles = bool(role_set)
+        if not has_users and not has_roles:
+            return True
+
+        user = getattr(interaction, "user", None)
+        if user is None:
+            return False
+
+        if has_users:
+            try:
+                uid = str(user.id)
+            except AttributeError:
+                uid = ""
+            if uid and uid in user_set:
+                return True
+
+        if has_roles:
+            roles_attr = getattr(user, "roles", None)
+            if roles_attr is None:
+                return False
+            try:
+                user_role_ids = {getattr(r, "id", None) for r in roles_attr}
+            except TypeError:
+                return False
+            if user_role_ids & role_set:
+                return True
+
         return False
-
-    if has_users:
-        try:
-            uid = str(user.id)
-        except AttributeError:
-            uid = ""
-        if uid and uid in user_set:
-            return True
-
-    if has_roles:
-        roles_attr = getattr(user, "roles", None)
-        if roles_attr is None:
-            # Role policy is configured but the interaction doesn't
-            # carry role data (DM-context Member, raw User payload).
-            # Fail closed: a user without a resolvable role list cannot
-            # satisfy a role allowlist.
-            return False
-        try:
-            user_role_ids = {getattr(r, "id", None) for r in roles_attr}
-        except TypeError:
-            return False
-        if user_role_ids & role_set:
-            return True
-
-    return False
-
-
-if DISCORD_AVAILABLE:
 
     class ExecApprovalView(discord.ui.View):
         """
@@ -5649,3 +5660,9 @@ if DISCORD_AVAILABLE:
             self.resolved = True
             for child in self.children:
                 child.disabled = True
+
+
+# Module-level call so component views are available immediately, both at
+# module load time AND after check_discord_requirements() lazy-installs
+# discord.py (which flips DISCORD_AVAILABLE from False to True).
+_define_discord_ui_components()


### PR DESCRIPTION
## What does this PR do?

When discord.py is not initially installed, `DISCORD_AVAILABLE` is `False` at module load time and the module-level `if DISCORD_AVAILABLE:` gate skips `ExecApprovalView` and other UI component classes entirely. When `check_discord_requirements()` later lazy-installs discord.py and flips `DISCORD_AVAILABLE` to `True`, those classes were never defined — causing a `NameError` when `send_exec_approval` tries to instantiate `ExecApprovalView`.

Fix: wrap the component view definitions in `_define_discord_ui_components()`, called both at module load time AND at the end of `check_discord_requirements()` after successful lazy install.

## Related Issue
Fixes #28045

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made
- `gateway/platforms/discord.py`: Replaced the module-level `_component_check_auth` function + `if DISCORD_AVAILABLE:` gate with a `_define_discord_ui_components()` function that defines both at runtime
- This function is called at module load time (via `_define_discord_ui_components()` at end of file) AND at the end of `check_discord_requirements()` after a successful lazy install
- Added idempotency guard (`'_component_check_auth' in globals()`) so the function is safe to call multiple times

## How to Test
1. Set up environment where `discord.py` is NOT installed initially (e.g. `pip uninstall discord.py`)
2. Run gateway with Discord platform configured — the lazy-install path in `check_discord_requirements()` will install discord.py and call `_define_discord_ui_components()`
3. Trigger an exec-approval flow (e.g. attempt a terminal command that needs approval)
4. Verify the `ExecApprovalView` buttons render in Discord without a `NameError`

## Checklist
### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes
- [ ] I've tested on my platform: Windows 11

### Documentation & Housekeeping
- [x] N/A — no config, docs, or schema changes