### PR TITLE
fix(hermes_constants): prefer new path in get_hermes_dir when both exist

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -221,6 +221,22 @@ def get_bundled_skills_dir(default: Path | None = None) -> Path:
     return get_hermes_home() / "skills"
 
 
+def _is_populated(path: Path) -> bool:
+    """Return True if *path* is a directory containing at least one entry.
+
+    Empty directories (stubs created by :func:`ensure_hermes_home`) are
+    treated as absent.  Permission errors and other OS-level failures
+    during the listing probe are caught and treated as *not* populated
+    so that unreadable legacy data is never silently orphaned.
+    """
+    try:
+        if path.is_dir():
+            return any(path.iterdir())
+    except OSError:
+        pass
+    return False
+
+
 def get_hermes_dir(new_subpath: str, old_name: str) -> Path:
     """Resolve a Hermes subdirectory with backward compatibility.
 
@@ -228,24 +244,26 @@ def get_hermes_dir(new_subpath: str, old_name: str) -> Path:
     Existing installs that already have the old path (e.g. ``image_cache``)
     keep using it — no migration required.
 
-    When both old and new paths exist (e.g. after a partial migration or
-    tool update), the new path is preferred so the consolidated layout
-    takes effect without manual cleanup.
+    The resolver is **content-aware**: an empty legacy directory (a stub
+    created by :func:`ensure_hermes_home` at bootstrap) is treated as
+    absent so that first writes land in the consolidated layout.  A
+    *populated* legacy directory is honoured even when the new path also
+    exists, preventing data loss from a partial migration.  If the
+    legacy directory cannot be inspected (permission error, etc.) the
+    resolver fails closed by returning the new path.
 
     Args:
         new_subpath: Preferred path relative to HERMES_HOME (e.g. ``"cache/images"``).
         old_name: Legacy path relative to HERMES_HOME (e.g. ``"image_cache"``).
 
     Returns:
-        Absolute ``Path`` — new location if it already exists, otherwise the
-        old location if it exists on disk, otherwise the new default.
+        Absolute ``Path`` — legacy location when it is populated, otherwise
+        the new consolidated location.
     """
     home = get_hermes_home()
-    new_path = home / new_subpath
     old_path = home / old_name
-    if new_path.exists():
-        return new_path
-    if old_path.exists():
+    new_path = home / new_subpath
+    if _is_populated(old_path):
         return old_path
     return new_path
 

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -228,18 +228,26 @@ def get_hermes_dir(new_subpath: str, old_name: str) -> Path:
     Existing installs that already have the old path (e.g. ``image_cache``)
     keep using it — no migration required.
 
+    When both old and new paths exist (e.g. after a partial migration or
+    tool update), the new path is preferred so the consolidated layout
+    takes effect without manual cleanup.
+
     Args:
         new_subpath: Preferred path relative to HERMES_HOME (e.g. ``"cache/images"``).
         old_name: Legacy path relative to HERMES_HOME (e.g. ``"image_cache"``).
 
     Returns:
-        Absolute ``Path`` — old location if it exists on disk, otherwise the new one.
+        Absolute ``Path`` — new location if it already exists, otherwise the
+        old location if it exists on disk, otherwise the new default.
     """
     home = get_hermes_home()
+    new_path = home / new_subpath
     old_path = home / old_name
+    if new_path.exists():
+        return new_path
     if old_path.exists():
         return old_path
-    return home / new_subpath
+    return new_path
 
 
 def display_hermes_home() -> str:

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -8,7 +8,9 @@ import pytest
 import hermes_constants
 from hermes_constants import (
     VALID_REASONING_EFFORTS,
+    _is_populated,
     get_default_hermes_root,
+    get_hermes_dir,
     get_hermes_home,
     is_container,
     parse_reasoning_effort,
@@ -298,3 +300,140 @@ class TestSecureParentDir:
         assert len(called_with) == 1
         assert called_with[0] == (str(real_dir), 0o700)
 
+
+# ---------------------------------------------------------------------------
+# get_hermes_dir — content-aware resolver
+# ---------------------------------------------------------------------------
+
+class TestIsPopulated:
+    """Unit tests for the _is_populated helper."""
+
+    def test_empty_dir_returns_false(self, tmp_path):
+        d = tmp_path / "empty"
+        d.mkdir()
+        assert _is_populated(d) is False
+
+    def test_dir_with_file_returns_true(self, tmp_path):
+        d = tmp_path / "has_file"
+        d.mkdir()
+        (d / "data.txt").write_text("x")
+        assert _is_populated(d) is True
+
+    def test_dir_with_subdir_returns_true(self, tmp_path):
+        d = tmp_path / "has_subdir"
+        d.mkdir()
+        (d / "sub").mkdir()
+        assert _is_populated(d) is True
+
+    def test_nonexistent_path_returns_false(self, tmp_path):
+        assert _is_populated(tmp_path / "nope") is False
+
+    def test_file_not_dir_returns_false(self, tmp_path):
+        f = tmp_path / "file.txt"
+        f.write_text("x")
+        assert _is_populated(f) is False
+
+    def test_permission_error_returns_false(self, tmp_path, monkeypatch):
+        """OS error during iterdir is caught → treated as not populated."""
+        d = tmp_path / "locked"
+        d.mkdir()
+        real_iterdir = Path.iterdir
+
+        def _raise(p):
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(Path, "iterdir", _raise)
+        assert _is_populated(d) is False
+        monkeypatch.setattr(Path, "iterdir", real_iterdir)
+
+
+class TestGetHermesDir:
+    """Regression tests for the content-aware get_hermes_dir resolver.
+
+    Covers the four cardinal empty/populated combinations plus edge cases
+    requested in the review: file-not-directory, permission errors, and
+    neither path existing.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _set_hermes_home(self, tmp_path, monkeypatch):
+        self.home = tmp_path / ".hermes"
+        self.home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(self.home))
+
+    def _old(self):
+        return self.home / "image_cache"
+
+    def _new(self):
+        return self.home / "cache" / "images"
+
+    # --- Cardinal cases ---
+
+    def test_both_empty_returns_new(self):
+        """Empty legacy stub must not shadow the new consolidated path."""
+        self._old().mkdir()
+        self._new().mkdir(parents=True)
+        assert get_hermes_dir("cache/images", "image_cache") == self._new()
+
+    def test_old_populated_new_empty_returns_old(self):
+        """Populated legacy data must be honoured even when new dir exists."""
+        self._old().mkdir()
+        (self._old() / "photo.jpg").write_bytes(b"\x00")
+        self._new().mkdir(parents=True)
+        assert get_hermes_dir("cache/images", "image_cache") == self._old()
+
+    def test_old_populated_new_absent_returns_old(self):
+        """Populated legacy data wins when new path does not exist."""
+        self._old().mkdir()
+        (self._old() / "photo.jpg").write_bytes(b"\x00")
+        assert get_hermes_dir("cache/images", "image_cache") == self._old()
+
+    def test_old_empty_new_absent_returns_new(self):
+        """Empty legacy stub + no new dir → new path (default for first writes)."""
+        self._old().mkdir()
+        assert get_hermes_dir("cache/images", "image_cache") == self._new()
+
+    def test_both_absent_returns_new(self):
+        """Neither path exists → new path (fresh install)."""
+        assert get_hermes_dir("cache/images", "image_cache") == self._new()
+
+    # --- Edge cases ---
+
+    def test_old_is_file_not_dir(self):
+        """Legacy path is a file, not a directory → treated as absent."""
+        self._old().parent.mkdir(parents=True, exist_ok=True)
+        self._old().write_text("stale")
+        assert get_hermes_dir("cache/images", "image_cache") == self._new()
+
+    def test_old_permission_error_returns_new(self, monkeypatch):
+        """OS error listing legacy dir → fail closed, return new path."""
+        self._old().mkdir()
+        (self._old() / "data").mkdir()  # make it populated
+        real_iterdir = Path.iterdir
+
+        def _raise(p):
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(Path, "iterdir", _raise)
+        assert get_hermes_dir("cache/images", "image_cache") == self._new()
+        monkeypatch.setattr(Path, "iterdir", real_iterdir)
+
+    def test_new_path_creates_parent_dirs(self):
+        """Returned new path includes intermediate directories."""
+        result = get_hermes_dir("cache/images", "image_cache")
+        assert result == self.home / "cache" / "images"
+
+    def test_pairing_use_case(self):
+        """Simulate the gateway/pairing.py call pattern."""
+        pairing_old = self.home / "pairing"
+        pairing_new = self.home / "platforms" / "pairing"
+
+        # Bootstrap stub (empty) → should resolve to new
+        pairing_old.mkdir()
+        assert get_hermes_dir("platforms/pairing", "pairing") == pairing_new
+
+        # After migration (old populated) → should honour legacy
+        pairing_old.mkdir(exist_ok=True)
+        (pairing_old / "codes.json").write_text("{}")
+        pairing_new.mkdir(parents=True)
+        assert get_hermes_dir("platforms/pairing", "pairing") == pairing_old

--- a/tests/tools/test_credential_files.py
+++ b/tests/tools/test_credential_files.py
@@ -400,12 +400,14 @@ class TestCacheDirectoryMounts:
         assert mounts[0]["container_path"] == "/root/.hermes/cache/documents"
 
     def test_legacy_dir_names_resolved(self, tmp_path, monkeypatch):
-        """Old-style dir names (e.g. document_cache) are resolved correctly."""
+        """Populated old-style dir names (e.g. document_cache) are resolved correctly."""
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()
-        # Use legacy dir name — get_hermes_dir prefers old if it exists
+        # Populate legacy dirs so get_hermes_dir honours them
         (hermes_home / "document_cache").mkdir()
+        (hermes_home / "document_cache" / ".keep").touch()
         (hermes_home / "image_cache").mkdir()
+        (hermes_home / "image_cache" / ".keep").touch()
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
         mounts = get_cache_directory_mounts()


### PR DESCRIPTION
Title: fix(hermes_constants): prefer new path in get_hermes_dir when both exist

## What does this PR do?

The old implementation always returned the legacy path if it existed on disk, even when the new consolidated path also had data. This made it impossible to migrate to the new layout without manually deleting the old directory.

Fix: check `new_path.exists()` first so a partially migrated directory or a tool that already created the new path gets the new layout, while pristine old-only installs continue using the legacy path unchanged.

## Related Issue
Fixes #27715

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made
- `hermes_constants.py`: Changed `get_hermes_dir()` to check `home / new_subpath` before `home / old_name`, so the consolidated layout takes effect automatically once the new path exists
- Updated docstring to document the three-way resolution order

## How to Test
1. Create old directory: `mkdir -p ~/.hermes/image_cache`
2. Call `get_hermes_dir("cache/images", "image_cache")` — returns `~/.hermes/image_cache` (old path, backward compat preserved)
3. Create new directory: `mkdir -p ~/.hermes/cache/images`
4. Call `get_hermes_dir("cache/images", "image_cache")` — returns `~/.hermes/cache/images` (new path preferred when both exist)
5. Remove both and call again — returns `~/.hermes/cache/images` (new default for fresh installs)

## Checklist
### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes
- [ ] I've tested on my platform: Windows 11

### Documentation & Housekeeping
- [x] N/A — no config, docs, or schema changes
