### PR TITLE
fix(gateway): allow exec-type quick commands to bypass draining guard

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7312,10 +7312,45 @@ class GatewayRunner:
         if canonical == "voice":
             return await self._handle_voice_command(event)
 
+        # Exec-type quick commands bypass the draining guard — they are pure
+        # shell subprocesses that do not depend on the agent loop or LLM backend.
+        # This ensures ops commands remain available when the system is unhealthy.
+        if command:
+            if isinstance(self.config, dict):
+                _quick_cmds = self.config.get("quick_commands", {}) or {}
+            else:
+                _quick_cmds = getattr(self.config, "quick_commands", {}) or {}
+            if isinstance(_quick_cmds, dict) and command in _quick_cmds:
+                _qcmd = _quick_cmds[command]
+                if _qcmd.get("type") == "exec":
+                    _exec_cmd = _qcmd.get("command", "")
+                    if _exec_cmd:
+                        try:
+                            from tools.environments.local import _sanitize_subprocess_env
+                            sanitized_env = _sanitize_subprocess_env(os.environ.copy())
+                            proc = await asyncio.create_subprocess_shell(
+                                _exec_cmd,
+                                stdout=asyncio.subprocess.PIPE,
+                                stderr=asyncio.subprocess.PIPE,
+                                env=sanitized_env,
+                            )
+                            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
+                            output = (stdout or stderr).decode().strip()
+                            if output:
+                                from agent.redact import redact_sensitive_text
+                                output = redact_sensitive_text(output)
+                            return output if output else "Command returned no output."
+                        except asyncio.TimeoutError:
+                            return "Quick command timed out (30s)."
+                        except Exception as e:
+                            return f"Quick command error: {e}"
+                    else:
+                        return f"Quick command '/{command}' has no command defined."
+
         if self._draining:
             return f"⏳ Gateway is {self._status_action_gerund()} and is not accepting new work right now."
 
-        # User-defined quick commands (bypass agent loop, no LLM call)
+        # User-defined quick commands (alias-type and fallback; exec-type handled above)
         if command:
             if isinstance(self.config, dict):
                 quick_commands = self.config.get("quick_commands", {}) or {}
@@ -7326,12 +7361,11 @@ class GatewayRunner:
             if command in quick_commands:
                 qcmd = quick_commands[command]
                 if qcmd.get("type") == "exec":
+                    # Already handled above (pre-draining bypass); unreachable
+                    # but kept as defensive fallback.
                     exec_cmd = qcmd.get("command", "")
                     if exec_cmd:
                         try:
-                            # Sanitize env to prevent credential leakage —
-                            # quick commands run in the gateway process which
-                            # has all API keys in os.environ.
                             from tools.environments.local import _sanitize_subprocess_env
                             sanitized_env = _sanitize_subprocess_env(os.environ.copy())
                             proc = await asyncio.create_subprocess_shell(
@@ -7342,7 +7376,6 @@ class GatewayRunner:
                             )
                             stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
                             output = (stdout or stderr).decode().strip()
-                            # Redact any remaining sensitive patterns in output
                             if output:
                                 from agent.redact import redact_sensitive_text
                                 output = redact_sensitive_text(output)

--- a/tests/gateway/test_exec_quick_command_draining.py
+++ b/tests/gateway/test_exec_quick_command_draining.py
@@ -1,0 +1,139 @@
+"""Tests for exec-type quick commands bypassing the draining guard.
+
+When the gateway is in draining state (e.g. after SIGTERM or repeated LLM
+failures), exec-type quick commands (those using ``asyncio.create_subprocess_shell``)
+should still execute because they do not depend on the agent loop or LLM backend.
+
+See https://github.com/NousResearch/hermes-agent/issues/28663
+"""
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource
+from tests.gateway.restart_test_helpers import RestartTestAdapter, make_restart_runner, make_restart_source
+
+
+def _make_quick_command_event(command_name: str = "syscheck") -> MessageEvent:
+    """Create a MessageEvent for a quick command."""
+    return MessageEvent(
+        text=f"/{command_name}",
+        message_type=MessageType.TEXT,
+        source=make_restart_source(),
+        message_id="m-qc1",
+    )
+
+
+def _configure_exec_quick_command(runner, command_name: str = "syscheck", shell_cmd: str = "echo OK"):
+    """Set up a quick command with type: exec on the runner's config."""
+    runner.config.quick_commands = {
+        command_name: {
+            "type": "exec",
+            "command": shell_cmd,
+        },
+    }
+
+
+def _add_runner_mocks(runner):
+    """Add common mocks that _handle_message expects on the runner."""
+    runner._session_db = None
+
+
+@pytest.mark.asyncio
+async def test_exec_quick_command_runs_while_draining():
+    """Exec-type quick commands bypass the _draining guard and execute successfully."""
+    runner, _adapter = make_restart_runner()
+    _add_runner_mocks(runner)
+    runner._draining = True
+    runner._restart_requested = True
+
+    _configure_exec_quick_command(runner, "syscheck", "echo health-ok")
+    event = _make_quick_command_event("syscheck")
+
+    result = await runner._handle_message(event)
+
+    assert result == "health-ok"
+
+
+@pytest.mark.asyncio
+async def test_exec_quick_command_timeout_while_draining():
+    """Exec-type quick commands still respect the 30s timeout during draining."""
+    runner, _adapter = make_restart_runner()
+    _add_runner_mocks(runner)
+    runner._draining = True
+
+    _configure_exec_quick_command(runner, "slowcmd", "sleep 60")
+    event = _make_quick_command_event("slowcmd")
+
+    with patch("asyncio.wait_for", side_effect=asyncio.TimeoutError()):
+        result = await runner._handle_message(event)
+
+    assert "timed out" in result
+
+
+@pytest.mark.asyncio
+async def test_exec_quick_command_error_while_draining():
+    """Exec-type quick commands still report errors during draining."""
+    runner, _adapter = make_restart_runner()
+    _add_runner_mocks(runner)
+    runner._draining = True
+
+    _configure_exec_quick_command(runner, "failcmd", "nonexistent_command_xyz_12345")
+    event = _make_quick_command_event("failcmd")
+
+    result = await runner._handle_message(event)
+    # Should NOT be the draining message — the exec command ran (and produced output)
+    assert "not accepting new work" not in result
+
+
+@pytest.mark.asyncio
+async def test_exec_quick_command_with_empty_command_returns_error():
+    """Exec quick command with empty 'command' field returns an error, even while draining."""
+    runner, _adapter = make_restart_runner()
+    _add_runner_mocks(runner)
+    runner._draining = True
+
+    _configure_exec_quick_command(runner, "emptycmd", "")
+    event = _make_quick_command_event("emptycmd")
+
+    result = await runner._handle_message(event)
+
+    assert "no command defined" in result
+
+
+@pytest.mark.asyncio
+async def test_exec_quick_command_works_when_not_draining():
+    """Exec-type quick commands work normally when not draining (regression check)."""
+    runner, _adapter = make_restart_runner()
+    _add_runner_mocks(runner)
+    runner._draining = False
+
+    _configure_exec_quick_command(runner, "uptimechk", "echo uptime-ok")
+    event = _make_quick_command_event("uptimechk")
+
+    result = await runner._handle_message(event)
+
+    assert result == "uptime-ok"
+
+
+@pytest.mark.asyncio
+async def test_unknown_command_blocked_while_draining():
+    """Unknown slash commands (not quick commands, not built-in) are blocked during draining."""
+    runner, _adapter = make_restart_runner()
+    _add_runner_mocks(runner)
+    runner._draining = True
+    runner._restart_requested = True
+
+    event = MessageEvent(
+        text="/xyz-nonexistent-cmd-abc",
+        message_type=MessageType.TEXT,
+        source=make_restart_source(),
+        message_id="m-unknown",
+    )
+
+    result = await runner._handle_message(event)
+
+    assert "not accepting new work" in result


### PR DESCRIPTION
## Summary

Exec-type quick commands (`quick_commands.<name>.type: exec`) now bypass the `_draining` guard in `GatewayRunner._handle_message()`, ensuring they remain available when the gateway is shutting down or restarting.

These commands run pure shell subprocesses via `asyncio.create_subprocess_shell` and do not depend on the agent loop or LLM backend — there is no reason to block them during draining. In practice, this means ops commands (health checks, service status, etc.) are accessible when the system is most unhealthy and you need them the most.

## Changes

- **gateway/run.py**: Added exec-type quick command dispatch before the `_draining` guard. The original dispatch block after the guard is kept as a defensive fallback with a comment. Alias-type quick commands and regular slash commands remain blocked during draining as they may require the agent loop.
- **tests/gateway/test_exec_quick_command_draining.py**: 6 new tests covering exec commands while draining, timeout handling, error reporting, empty command, non-draining regression, and unknown command blocking.

## Testing

- 6/6 new tests pass
- 16/16 existing `test_restart_drain.py` tests pass (no regression)
- 18/18 existing `test_quick_commands.py` tests pass (no regression)

## Complementary with PR #25804

PR #25804 fixes exec quick commands being blocked when the agent is mid-turn (`_handle_active_session_busy_message` path). This PR fixes the same class of issue but for the draining trigger condition in `_handle_message`. Both fixes are complementary — one handles mid-turn, the other handles draining.

Closes #28663
