### PR TITLE
fix(cli): render markdown tables with visible column borders (#28714)

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -985,6 +985,26 @@ display:
   # Show [HH:MM] timestamps on user input and assistant response labels.
   # timestamps: false
 
+  # How the CLI presents the *final* assistant reply.
+  #   render: Run the text through Rich's Markdown renderer (headings,
+  #           tables, code blocks).  Best paired with `streaming: false`
+  #           since Rich expects the full document.
+  #   strip:  Strip the loudest markdown markers (default — prose-y).
+  #   raw:    Print the raw bytes (good for debugging).
+  # final_response_markdown: strip
+
+  # Box style for tables drawn by `final_response_markdown: render`.
+  # Upstream Rich defaults to a borderless table that's hard to read on
+  # multi-column data (#28714).  Any rich.box constant name is
+  # accepted; the useful subset on terminals is:
+  #   heavy_head: Heavy header rule + light cell borders (default).
+  #   square:     Uniform light-line box (┌─┬─┐ │ │ │ ├─┼─┤ └─┴─┘).
+  #   heavy:      Uniform heavy box (loud but very readable).
+  #   ascii:      ASCII-only (+ - |) for legacy terminals.
+  #   simple:     Legacy borderless — only a header underline.
+  # Unknown / blank values fall back to heavy_head.
+  # markdown_table_box_style: heavy_head
+
   # ───────────────────────────────────────────────────────────────────────────
   # Skin / Theme
   # ───────────────────────────────────────────────────────────────────────────

--- a/cli.py
+++ b/cli.py
@@ -1636,9 +1636,103 @@ def _terminal_width_for_streaming() -> int:
     return max(20, cols - len(_STREAM_PAD) - 2)
 
 
+_DEFAULT_MARKDOWN_TABLE_BOX = "heavy_head"
+
+# Rich's ``box`` module exposes ~19 named ``Box`` constants.  We accept any
+# of them as a value for ``display.markdown_table_box_style`` — sanitised
+# below by case-insensitive name lookup against this allowlist.  Centralised
+# so the config validator and the renderer agree on what's legal (#28714).
+_RICH_MARKDOWN_TABLE_BOX_NAMES = frozenset({
+    "ascii", "ascii2", "ascii_double_head",
+    "double", "double_edge",
+    "heavy", "heavy_edge", "heavy_head",
+    "horizontals", "markdown",
+    "minimal", "minimal_double_head", "minimal_heavy_head",
+    "rounded",
+    "simple", "simple_head", "simple_heavy",
+    "square", "square_double_head",
+})
+
+
+def _resolve_markdown_table_box():
+    """Resolve ``display.markdown_table_box_style`` to a ``rich.box.Box``.
+
+    Read at render time — *not* cached on the Markdown subclass — so a
+    live config reload (`/reload-config` and test monkeypatches) picks up
+    the new value without rebuilding the class.  Unknown / non-string
+    values fall back to the documented default (#28714).
+    """
+    from rich import box
+
+    raw = CLI_CONFIG.get("display", {}).get(
+        "markdown_table_box_style", _DEFAULT_MARKDOWN_TABLE_BOX,
+    )
+    name = str(raw or _DEFAULT_MARKDOWN_TABLE_BOX).strip().lower()
+    if name in _RICH_MARKDOWN_TABLE_BOX_NAMES:
+        resolved = getattr(box, name.upper(), None)
+        if resolved is not None:
+            return resolved
+    return box.HEAVY_HEAD
+
+
+_HERMES_BORDERED_MARKDOWN_CLS = None
+
+
+def _get_hermes_bordered_markdown_cls():
+    """Lazy-build (and cache) a ``rich.markdown.Markdown`` subclass that
+    renders tables with visible column borders (#28714).
+
+    Upstream Rich 14.x hardcodes ``box=box.SIMPLE`` inside
+    ``TableElement.__rich_console__`` — which omits vertical dividers
+    entirely and makes multi-column tables effectively unreadable
+    (`final_response_markdown: render` users had to manually edit the
+    vendored Rich source to recover sane output).
+
+    The fix mirrors Rich's own ``TableElement`` body line-for-line so
+    we stay forward-compatible across Rich versions; the only delta is
+    the ``box=`` argument, which is now operator-configurable.
+    """
+    global _HERMES_BORDERED_MARKDOWN_CLS
+    if _HERMES_BORDERED_MARKDOWN_CLS is not None:
+        return _HERMES_BORDERED_MARKDOWN_CLS
+
+    from rich.markdown import Markdown, TableElement
+    from rich.table import Table
+
+    class _HermesBorderedTableElement(TableElement):
+        """Rich ``TableElement`` with the box style read from config."""
+
+        def __rich_console__(self, console, options):
+            table = Table(
+                box=_resolve_markdown_table_box(),
+                pad_edge=False,
+                style="markdown.table.border",
+                show_edge=True,
+                collapse_padding=True,
+            )
+            if self.header is not None and self.header.row is not None:
+                for column in self.header.row.cells:
+                    heading = column.content.copy()
+                    heading.stylize("markdown.table.header")
+                    table.add_column(heading)
+            if self.body is not None:
+                for row in self.body.rows:
+                    row_content = [element.content for element in row.cells]
+                    table.add_row(*row_content)
+            yield table
+
+    class _HermesBorderedMarkdown(Markdown):
+        """Drop-in ``Markdown`` subclass.  Identical to upstream except
+        for the ``"table_open"`` element binding."""
+
+        elements = {**Markdown.elements, "table_open": _HermesBorderedTableElement}
+
+    _HERMES_BORDERED_MARKDOWN_CLS = _HermesBorderedMarkdown
+    return _HERMES_BORDERED_MARKDOWN_CLS
+
+
 def _render_final_assistant_content(text: str, mode: str = "render"):
     """Render final assistant content as markdown, stripped text, or raw text."""
-    from rich.markdown import Markdown
 
     # Estimate the cells available to the rendered table.  The Panel
     # used by the background-task / final-response path has 4 cells of
@@ -1671,7 +1765,7 @@ def _render_final_assistant_content(text: str, mode: str = "render"):
     plain = _rich_text_from_ansi(text or "").plain
     plain = _preserve_windows_dot_segments_for_markdown(plain)
     plain = realign_markdown_tables(plain, panel_width)
-    return Markdown(plain)
+    return _get_hermes_bordered_markdown_cls()(plain)
 
 
 _OUTPUT_HISTORY_ENABLED = True

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1019,6 +1019,15 @@ DEFAULT_CONFIG = {
         "streaming": False,
         "timestamps": False,      # Show [HH:MM] on user and assistant labels
         "final_response_markdown": "strip",  # render | strip | raw
+        # Box style for tables rendered when final_response_markdown is
+        # "render".  Rich ships ~19 box constants — see rich.box — but
+        # the useful subset for terminals is: heavy_head (default,
+        # vertical borders + heavy header rule), square (light box),
+        # heavy (loud box), simple (legacy: no vertical borders), or
+        # ascii (for terminals without box-drawing glyphs).  Fixes
+        # #28714 where the upstream rich.markdown default omits vertical
+        # column dividers and tables become hard to read.
+        "markdown_table_box_style": "heavy_head",
         # Preserve recent classic CLI output across Ctrl+L, /redraw, and
         # terminal resize full-screen clears. Disable if a terminal emulator
         # behaves badly with replayed scrollback.

--- a/tests/cli/test_cli_markdown_rendering.py
+++ b/tests/cli/test_cli_markdown_rendering.py
@@ -1,15 +1,47 @@
 from io import StringIO
 
+import pytest
 from rich.console import Console
 from rich.markdown import Markdown
 
-from cli import _render_final_assistant_content
+import cli
+from cli import (
+    _render_final_assistant_content,
+    _resolve_markdown_table_box,
+    _get_hermes_bordered_markdown_cls,
+)
 
 
-def _render_to_text(renderable) -> str:
+def _render_to_text(renderable, width: int = 80) -> str:
     buf = StringIO()
-    Console(file=buf, width=80, force_terminal=False, color_system=None).print(renderable)
+    Console(file=buf, width=width, force_terminal=False, color_system=None).print(renderable)
     return buf.getvalue()
+
+
+@pytest.fixture(autouse=True)
+def _reset_bordered_markdown_cache():
+    """The bordered ``Markdown`` subclass is built lazily once per
+    process, but tests mutate ``CLI_CONFIG['display']`` (via the
+    fixture below) to exercise different box styles.  The class itself
+    caches nothing config-dependent, but resetting between tests
+    documents the contract and protects against future regressions
+    where someone adds class-level caching by accident."""
+    yield
+    # No reset required — the cache holds the class identity, not the
+    # box style.  Box style is re-read at render time.
+
+
+@pytest.fixture
+def display_config(monkeypatch: pytest.MonkeyPatch):
+    """Hand back a mutable ``display`` config dict bound to the live
+    ``CLI_CONFIG``.  Use ``display_config['markdown_table_box_style']
+    = 'simple'`` to override per test; the fixture restores the prior
+    value on teardown.
+    """
+    original = dict(cli.CLI_CONFIG.get("display", {}))
+    yield cli.CLI_CONFIG.setdefault("display", {})
+    cli.CLI_CONFIG["display"].clear()
+    cli.CLI_CONFIG["display"].update(original)
 
 
 def test_final_assistant_content_uses_markdown_renderable():
@@ -191,3 +223,178 @@ def test_strip_mode_still_strips_boundary_underscore_emphasis():
 
     output = _render_to_text(renderable)
     assert "say hi and bold now" in output
+
+
+# ---------------------------------------------------------------------------
+# Bordered Markdown table renderer (#28714)
+# ---------------------------------------------------------------------------
+#
+# Upstream Rich draws ``rich.markdown.Markdown`` tables with
+# ``box=box.SIMPLE`` — i.e. only a single horizontal rule under the
+# header, no vertical column dividers.  These tests pin down the fix:
+#
+# * ``render`` mode now uses a Hermes-side subclass that draws visible
+#   column dividers by default.
+# * The default behaviour, the ``simple`` opt-out, and unknown-value
+#   fallback are all wired through ``display.markdown_table_box_style``.
+# * The new subclass remains an instance of ``rich.markdown.Markdown``
+#   so downstream code (`/render`, panels, snapshot tests) keeps working.
+
+
+_TABLE_SAMPLE = (
+    "| Module    | Status | Priority |\n"
+    "|-----------|--------|----------|\n"
+    "| User Mgmt | Done   | P0       |\n"
+    "| Role Mgmt | Done   | P0       |\n"
+)
+
+
+def _count_vertical_borders(text: str) -> int:
+    """Count the box-drawing column-divider glyphs that Rich emits.
+    Rich uses light (│), heavy (┃) or double (║) verticals depending
+    on the box style; any of them counts."""
+    return sum(text.count(ch) for ch in ("│", "┃", "║"))
+
+
+class TestBorderedTableRendering:
+    """Regression coverage for #28714 — render-mode tables must show
+    visible column dividers, not just a header underline."""
+
+    def test_render_mode_returns_a_rich_markdown_instance(self):
+        # Subclass identity must be preserved so existing isinstance
+        # checks and panel-layout code paths continue to work.
+        renderable = _render_final_assistant_content(_TABLE_SAMPLE, mode="render")
+        assert isinstance(renderable, Markdown)
+
+    def test_render_mode_draws_vertical_column_dividers_by_default(self):
+        """The default config (``markdown_table_box_style: heavy_head``)
+        must emit at least one vertical divider — anything else means
+        we regressed back to upstream Rich's borderless SIMPLE box."""
+        renderable = _render_final_assistant_content(_TABLE_SAMPLE, mode="render")
+        output = _render_to_text(renderable, width=80)
+        assert _count_vertical_borders(output) > 0, (
+            "Default markdown_table_box_style must add vertical "
+            "column dividers (#28714). Rendered output was:\n" + output
+        )
+
+    def test_simple_opt_out_restores_pre_28714_behaviour(self, display_config):
+        """Operators who liked the old borderless look can set
+        ``markdown_table_box_style: simple`` to get the legacy
+        behaviour back — verifying this explicitly keeps the
+        backward-compat path covered."""
+        display_config["markdown_table_box_style"] = "simple"
+
+        renderable = _render_final_assistant_content(_TABLE_SAMPLE, mode="render")
+        output = _render_to_text(renderable, width=80)
+        assert _count_vertical_borders(output) == 0, (
+            "simple box style must restore the pre-#28714 borderless "
+            "rendering.  Output:\n" + output
+        )
+
+    def test_unknown_box_style_falls_back_to_default(self, display_config):
+        """A typo'd config value must not crash rendering and must not
+        silently degrade to the borderless SIMPLE style."""
+        display_config["markdown_table_box_style"] = "definitely-not-a-real-style"
+
+        renderable = _render_final_assistant_content(_TABLE_SAMPLE, mode="render")
+        output = _render_to_text(renderable, width=80)
+        assert _count_vertical_borders(output) > 0, (
+            "Unknown box style must fall back to a bordered default, "
+            "not silently disable column dividers."
+        )
+
+    def test_empty_config_value_uses_documented_default(self, display_config):
+        """``None`` / empty string in config must resolve to the
+        documented ``heavy_head`` default — protects users whose YAML
+        sets the key but leaves the value blank."""
+        display_config["markdown_table_box_style"] = ""
+        assert _resolve_markdown_table_box() is not None
+
+        display_config["markdown_table_box_style"] = None
+        assert _resolve_markdown_table_box() is not None
+
+    def test_table_cell_contents_are_preserved(self):
+        """A borderless table that hides cell content would be useless;
+        regardless of the box style, the actual data must survive."""
+        renderable = _render_final_assistant_content(_TABLE_SAMPLE, mode="render")
+        output = _render_to_text(renderable, width=80)
+        for needle in ("Module", "Status", "Priority", "User Mgmt", "Role Mgmt"):
+            assert needle in output, f"Cell text {needle!r} missing from:\n{output}"
+
+    @pytest.mark.parametrize(
+        "box_name",
+        ["heavy", "heavy_head", "square", "rounded", "double"],
+    )
+    def test_each_bordered_style_emits_dividers(
+        self, display_config, box_name: str
+    ):
+        """The user-facing allowlist promises that any of these named
+        styles produce column dividers.  Lock that in so a future
+        refactor of ``_resolve_markdown_table_box`` can't quietly
+        narrow the supported set."""
+        display_config["markdown_table_box_style"] = box_name
+
+        renderable = _render_final_assistant_content(_TABLE_SAMPLE, mode="render")
+        output = _render_to_text(renderable, width=80)
+        assert _count_vertical_borders(output) > 0, (
+            f"box style {box_name!r} should emit vertical dividers but "
+            f"output had none:\n{output}"
+        )
+
+
+class TestResolveMarkdownTableBox:
+    """Direct unit tests for the box-resolver helper — kept separate
+    so renderer changes don't drown out config-validation regressions."""
+
+    def test_default_resolves_to_heavy_head(self, display_config):
+        # Make sure the documented default is what gets used when the
+        # key is absent from config.
+        display_config.pop("markdown_table_box_style", None)
+
+        from rich import box
+        assert _resolve_markdown_table_box() is box.HEAVY_HEAD
+
+    def test_case_insensitive(self, display_config):
+        from rich import box
+        display_config["markdown_table_box_style"] = "HEAVY"
+        assert _resolve_markdown_table_box() is box.HEAVY
+        display_config["markdown_table_box_style"] = "Square"
+        assert _resolve_markdown_table_box() is box.SQUARE
+
+    def test_whitespace_tolerated(self, display_config):
+        from rich import box
+        display_config["markdown_table_box_style"] = "  simple  "
+        assert _resolve_markdown_table_box() is box.SIMPLE
+
+    def test_non_string_falls_back_to_default(self, display_config):
+        from rich import box
+        display_config["markdown_table_box_style"] = 12345
+        assert _resolve_markdown_table_box() is box.HEAVY_HEAD
+
+
+class TestGetHermesBorderedMarkdownCls:
+    def test_returns_a_markdown_subclass(self):
+        cls = _get_hermes_bordered_markdown_cls()
+        assert issubclass(cls, Markdown)
+
+    def test_caches_the_class_across_calls(self):
+        # Same class identity = caching works; rebuilding on every
+        # render would create a hot allocation path for a long-lived
+        # CLI session.
+        assert _get_hermes_bordered_markdown_cls() is _get_hermes_bordered_markdown_cls()
+
+    def test_subclass_overrides_only_table_open(self):
+        """We deliberately do not replace any other element handler —
+        protects future Rich upgrades that add new element types from
+        silently regressing because our ``elements`` mapping was a
+        full copy frozen at PR time."""
+        cls = _get_hermes_bordered_markdown_cls()
+        upstream_keys = set(Markdown.elements.keys())
+        # All upstream keys are still present (no accidental drops).
+        assert upstream_keys.issubset(cls.elements.keys())
+        # Only "table_open" was customised.
+        diverged = [
+            k for k in upstream_keys
+            if cls.elements[k] is not Markdown.elements[k]
+        ]
+        assert diverged == ["table_open"]

--- a/website/docs/user-guide/cli.md
+++ b/website/docs/user-guide/cli.md
@@ -110,6 +110,8 @@ When resuming a previous session (`hermes -c` or `hermes --resume <id>`), a "Pre
 
 **Markdown stripping in final responses.** The CLI strips the most verbose markdown fences and `**bold**` / `*italic*` wrappers from *final* agent replies so they render as readable terminal prose rather than raw source. Code blocks and lists are preserved. This does not affect gateway platforms or tool results — they keep their markdown for native rendering.
 
+**Markdown table borders.** With `display.final_response_markdown: render` the CLI delegates table layout to Rich's Markdown renderer, which historically drew tables without vertical column dividers. Hermes now renders them with visible borders by default (`display.markdown_table_box_style: heavy_head`). Any [Rich box style](https://rich.readthedocs.io/en/latest/appendix/box.html) name is accepted — common choices are `heavy_head` (default: heavy header rule + light cell borders), `square` (uniform light box), `heavy` (uniform heavy box), `ascii` (no Unicode glyphs, safe on legacy terminals), or `simple` (legacy: header underline only, no column dividers). Unknown values fall back to the default.
+
 ## Slash Commands
 
 Type `/` to see the autocomplete dropdown. Hermes supports a large set of CLI slash commands, dynamic skill commands, and user-defined quick commands.


### PR DESCRIPTION
## What does this PR do?

Upstream `rich.markdown.Markdown` (v14.x) hard-codes `box=box.SIMPLE` inside `TableElement.__rich_console__`, so when `display.final_response_markdown: render` is enabled, Hermes draws markdown tables with **only a header underline — no vertical column dividers**. On any multi-column data this collapses into an unreadable wall of text, forcing users to hand-edit the vendored Rich source inside `~/.hermes/.../venv/lib/python3.11/site-packages/rich/markdown.py` to recover sane output (a hack that gets blown away on every upgrade or venv rebuild).

This PR fixes that without touching the third-party library:

- Subclass `rich.markdown.Markdown` with a `TableElement` whose `box=` argument is resolved from `display.markdown_table_box_style` **at render time** (so `/reload-config` and tests pick up changes without rebuilding the class).
- Default to `heavy_head` — heavy header rule + light cell borders. This adds the missing vertical dividers while preserving the visual hierarchy of the old SIMPLE style.
- Accept any [Rich box constant](https://rich.readthedocs.io/en/latest/appendix/box.html) name (case-insensitive, whitespace-tolerated). Unknown / blank / non-string values fall back to the default rather than silently regressing to borderless output.
- Setting `markdown_table_box_style: simple` restores the pre-PR borderless behaviour for operators who prefer it.

## Related Issue

Fixes #28714

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cli.py` — Introduce `_resolve_markdown_table_box()`, `_get_hermes_bordered_markdown_cls()` (lazy, cached), and a `_HermesBorderedTableElement` / `_HermesBorderedMarkdown` pair that mirror upstream Rich line-for-line except for the configurable `box=` argument. Switch `_render_final_assistant_content()` to use the new class.
- `hermes_cli/config.py` — Register `display.markdown_table_box_style: heavy_head` as the new default.
- `cli-config.yaml.example` — Document the new key (and the long-undocumented `final_response_markdown` neighbour) so operators find it via the canonical commented example.
- `website/docs/user-guide/cli.md` — Add a one-paragraph user-guide note next to the existing "markdown stripping" guidance.
- `tests/cli/test_cli_markdown_rendering.py` — 18 new tests covering: default-bordered rendering, the `simple` opt-out, unknown-value fallback, empty/None values, case-insensitive box name lookup, the documented bordered-style allowlist (`heavy`, `heavy_head`, `square`, `rounded`, `double`), Markdown subclass identity, lazy caching, and the contract that only `table_open` is overridden (so future Rich element additions aren't silently shadowed).

## How to Test

1. Set in `~/.hermes/config.yaml`:
   ```yaml
   display:
     streaming: false
     final_response_markdown: render
   ```
2. Restart Hermes CLI.
3. Ask the agent to output a markdown table, e.g. *"Show me a table with columns Module/Status/Priority"*.
4. Observe vertical column dividers between every cell (`┃` under the header, `│` elsewhere). Previously this would render as a single header rule with no column dividers.
5. To verify the opt-out: add `display.markdown_table_box_style: simple`, restart, repeat — the legacy borderless layout returns.
6. To verify unknown-value safety: set `display.markdown_table_box_style: not-a-real-style` — the CLI must not crash, and tables must still render with dividers.

Automated coverage:

```
scripts/run_tests.sh tests/cli/test_cli_markdown_rendering.py -q
# 32 passed (14 existing + 18 new) in 1.5s
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(cli):`, `test(cli):`, `docs(cli):`, `docs(config):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the relevant test suite locally and it passes
- [x] I've added tests for my changes (18 new regression tests)
- [x] Tested on my platform: macOS 15.2 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/user-guide/cli.md`)
- [x] I've updated `cli-config.yaml.example` with the new config key
- [x] N/A — no architecture or workflow changes
- [x] N/A — pure terminal-output change, identical on every platform
- [x] N/A — no tool descriptions / schemas changed

## Screenshots / Logs

**Before** (default config, `final_response_markdown: render`):

```
           ──────────────────────
   Module     Status     Priority
           ──────────────────────
  User Mgmt    Done        P0
  Role Mgmt    Done        P0
```

**After** (default config, same input):

```
┏━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━┓
┃ Module    ┃ Status ┃ Priority ┃
┡━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━┩
│ User Mgmt │ Done   │ P0       │
│ Role Mgmt │ Done   │ P0       │
└───────────┴────────┴──────────┘
```

**Opt out** (`display.markdown_table_box_style: simple`) — legacy behaviour preserved verbatim.
