### PR TITLE
refactor: replace _ra() lazy-import pattern with explicit dependency injection

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -62,14 +62,6 @@ from utils import base_url_host_matches
 logger = logging.getLogger("run_agent")
 
 
-def _ra():
-    """Lazy reference to ``run_agent`` so callers can patch
-    ``run_agent.OpenAI`` / ``run_agent.cleanup_vm`` / ... and have those
-    patches reach this code path.
-    """
-    import run_agent
-    return run_agent
-
 
 def init_agent(
     agent,
@@ -137,6 +129,7 @@ def init_agent(
     checkpoint_max_total_size_mb: int = 500,
     checkpoint_max_file_size_mb: int = 10,
     pass_session_id: bool = False,
+    run_agent_deps: Dict[str, Any] | None = None,
 ):
     """
     Initialize the AI Agent.
@@ -187,6 +180,29 @@ def init_agent(
             remain skipped.
     """
     _install_safe_stdio()
+
+    deps = run_agent_deps or {}
+    run_agent_logger = deps.get("logger", logger)
+    openrouter_prewarm_done = deps.get("openrouter_prewarm_done")
+    hermes_home = deps.get("hermes_home")
+    routermint_headers = deps.get("routermint_headers")
+    qwen_portal_headers = deps.get("qwen_portal_headers")
+    get_tool_definitions_dep = deps.get("get_tool_definitions")
+    check_toolset_requirements_dep = deps.get("check_toolset_requirements")
+    missing_deps = [
+        name
+        for name, value in {
+            "openrouter_prewarm_done": openrouter_prewarm_done,
+            "hermes_home": hermes_home,
+            "routermint_headers": routermint_headers,
+            "qwen_portal_headers": qwen_portal_headers,
+            "get_tool_definitions": get_tool_definitions_dep,
+            "check_toolset_requirements": check_toolset_requirements_dep,
+        }.items()
+        if value is None
+    ]
+    if missing_deps:
+        raise TypeError(f"init_agent missing run_agent_deps: {', '.join(missing_deps)}")
 
     agent.model = model
     agent.max_iterations = max_iterations
@@ -316,8 +332,8 @@ def init_agent(
     # each message leaks one OS thread and the process eventually exhausts
     # the system thread limit (RuntimeError: can't start new thread).
     if (agent.provider == "openrouter" or agent._is_openrouter_url()) and \
-            not _ra()._openrouter_prewarm_done.is_set():
-        _ra()._openrouter_prewarm_done.set()
+            not openrouter_prewarm_done.is_set():
+        openrouter_prewarm_done.set()
         threading.Thread(
             target=fetch_model_metadata,
             daemon=True,
@@ -451,11 +467,11 @@ def init_agent(
     # both live under ~/.hermes/logs/.  Idempotent, so gateway mode
     # (which creates a new AIAgent per message) won't duplicate handlers.
     from hermes_logging import setup_logging, setup_verbose_logging
-    setup_logging(hermes_home=_ra()._hermes_home)
+    setup_logging(hermes_home=hermes_home)
 
     if agent.verbose_logging:
         setup_verbose_logging()
-        _ra().logger.info("Verbose logging enabled (third-party library logs suppressed)")
+        run_agent_logger.info("Verbose logging enabled (third-party library logs suppressed)")
     elif agent.quiet_mode:
         # In quiet mode (CLI default), keep console output clean —
         # but DO NOT raise per-logger levels. Doing so prevents the
@@ -630,7 +646,7 @@ def init_agent(
                 from agent.auxiliary_client import build_nvidia_nim_headers
                 client_kwargs["default_headers"] = build_nvidia_nim_headers(effective_base)
             elif base_url_host_matches(effective_base, "api.routermint.com"):
-                client_kwargs["default_headers"] = _ra()._routermint_headers()
+                client_kwargs["default_headers"] = routermint_headers()
             elif base_url_host_matches(effective_base, "api.githubcopilot.com"):
                 from hermes_cli.models import copilot_default_headers
 
@@ -640,7 +656,7 @@ def init_agent(
                     "User-Agent": "claude-code/0.1.0",
                 }
             elif base_url_host_matches(effective_base, "portal.qwen.ai"):
-                client_kwargs["default_headers"] = _ra()._qwen_portal_headers()
+                client_kwargs["default_headers"] = qwen_portal_headers()
             elif base_url_host_matches(effective_base, "chatgpt.com"):
                 from agent.auxiliary_client import _codex_cloudflare_headers
                 client_kwargs["default_headers"] = _codex_cloudflare_headers(api_key)
@@ -815,7 +831,7 @@ def init_agent(
                   " → ".join(f"{f['model']} ({f['provider']})" for f in agent._fallback_chain))
 
     # Get available tools with filtering
-    agent.tools = _ra().get_tool_definitions(
+    agent.tools = get_tool_definitions_dep(
         enabled_toolsets=enabled_toolsets,
         disabled_toolsets=disabled_toolsets,
         quiet_mode=agent.quiet_mode,
@@ -839,7 +855,7 @@ def init_agent(
     
     # Check tool requirements
     if agent.tools and not agent.quiet_mode:
-        requirements = _ra().check_toolset_requirements()
+        requirements = check_toolset_requirements_dep()
         missing_reqs = [name for name, available in requirements.items() if not available]
         if missing_reqs:
             print(f"⚠️  Some tools may not work due to missing requirements: {missing_reqs}")
@@ -938,7 +954,7 @@ def init_agent(
             )
         )
     except Exception as _tlg_err:
-        _ra().logger.warning("Tool loop guardrail config ignored: %s", _tlg_err)
+        run_agent_logger.warning("Tool loop guardrail config ignored: %s", _tlg_err)
     # Cache only the derived auxiliary compression context override that is
     # needed later by the startup feasibility check.  Avoid exposing a
     # broad pseudo-public config object on the agent instance.
@@ -1024,18 +1040,18 @@ def init_agent(
                     except Exception:
                         pass
                     agent._memory_manager.initialize_all(**_init_kwargs)
-                    _ra().logger.info("Memory provider '%s' activated", _mem_provider_name)
+                    run_agent_logger.info("Memory provider '%s' activated", _mem_provider_name)
                 else:
-                    _ra().logger.debug("Memory provider '%s' not found or not available", _mem_provider_name)
+                    run_agent_logger.debug("Memory provider '%s' not found or not available", _mem_provider_name)
                     agent._memory_manager = None
         except Exception as _mpe:
-            _ra().logger.warning("Memory provider plugin init failed: %s", _mpe)
+            run_agent_logger.warning("Memory provider plugin init failed: %s", _mpe)
             agent._memory_manager = None
 
     # Inject memory provider tool schemas into the tool surface.
     # Skip tools whose names already exist (plugins may register the
     # same tools via ctx.register_tool(), which lands in agent.tools
-    # through _ra().get_tool_definitions()).  Duplicate function names cause
+    # through get_tool_definitions_dep()).  Duplicate function names cause
     # 400 errors on providers that enforce unique names (e.g. Xiaomi
     # MiMo via Nous Portal).
     if agent._memory_manager and agent.tools is not None:
@@ -1138,7 +1154,7 @@ def init_agent(
                     raise ValueError
                 agent.max_tokens = _parsed_max_tokens
             except (TypeError, ValueError):
-                _ra().logger.warning(
+                run_agent_logger.warning(
                     "Invalid model.max_tokens in config.yaml: %r — "
                     "must be a positive integer (e.g. 4096). "
                     "Falling back to provider default.",
@@ -1161,7 +1177,7 @@ def init_agent(
         try:
             _config_context_length = int(_config_context_length)
         except (TypeError, ValueError):
-            _ra().logger.warning(
+            run_agent_logger.warning(
                 "Invalid model.context_length in config.yaml: %r — "
                 "must be a plain integer (e.g. 256000, not '256K'). "
                 "Falling back to auto-detection.",
@@ -1223,7 +1239,7 @@ def init_agent(
                                     if _parsed <= 0:
                                         raise ValueError
                                 except (TypeError, ValueError):
-                                    _ra().logger.warning(
+                                    run_agent_logger.warning(
                                         "Invalid context_length for model %r in "
                                         "custom_providers: %r — must be a positive "
                                         "integer (e.g. 256000, not '256K'). "
@@ -1265,7 +1281,7 @@ def init_agent(
             from plugins.context_engine import load_context_engine
             _selected_engine = load_context_engine(_engine_name)
         except Exception as _ce_load_err:
-            _ra().logger.debug("Context engine load from plugins/context_engine/: %s", _ce_load_err)
+            run_agent_logger.debug("Context engine load from plugins/context_engine/: %s", _ce_load_err)
 
         # Try general plugin system as fallback
         if _selected_engine is None:
@@ -1278,7 +1294,7 @@ def init_agent(
                 pass
 
         if _selected_engine is None:
-            _ra().logger.warning(
+            run_agent_logger.warning(
                 "Context engine '%s' not found — falling back to built-in compressor",
                 _engine_name,
             )
@@ -1304,7 +1320,7 @@ def init_agent(
             provider=agent.provider,
         )
         if not agent.quiet_mode:
-            _ra().logger.info("Using context engine: %s", _selected_engine.name)
+            run_agent_logger.info("Using context engine: %s", _selected_engine.name)
     else:
         agent.context_compressor = ContextCompressor(
             model=agent.model,
@@ -1336,7 +1352,7 @@ def init_agent(
         )
 
     # Inject context engine tool schemas (e.g. lcm_grep, lcm_describe, lcm_expand).
-    # Skip names that are already present — the _ra().get_tool_definitions()
+    # Skip names that are already present — the get_tool_definitions_dep()
     # quiet_mode cache returned a shared list pre-#17335, so a stray
     # mutation here would poison subsequent agent inits in the same
     # Gateway process and trip provider-side 'duplicate tool name'
@@ -1372,7 +1388,7 @@ def init_agent(
                 context_length=getattr(agent.context_compressor, "context_length", 0),
             )
         except Exception as _ce_err:
-            _ra().logger.debug("Context engine on_session_start: %s", _ce_err)
+            run_agent_logger.debug("Context engine on_session_start: %s", _ce_err)
 
     agent._subdirectory_hints = SubdirectoryHintTracker(
         working_dir=os.getenv("TERMINAL_CWD") or None,
@@ -1408,7 +1424,7 @@ def init_agent(
         try:
             agent._ollama_num_ctx = int(_ollama_num_ctx_override)
         except (TypeError, ValueError):
-            _ra().logger.debug("Invalid ollama_num_ctx config value: %r", _ollama_num_ctx_override)
+            run_agent_logger.debug("Invalid ollama_num_ctx config value: %r", _ollama_num_ctx_override)
     if agent._ollama_num_ctx is None and agent.base_url and is_local_endpoint(agent.base_url):
         try:
             # ``agent.api_key`` may be a callable (Entra token provider).
@@ -1420,7 +1436,7 @@ def init_agent(
             if _detected and _detected > 0:
                 agent._ollama_num_ctx = _detected
         except Exception as exc:
-            _ra().logger.debug("Ollama num_ctx detection failed: %s", exc)
+            run_agent_logger.debug("Ollama num_ctx detection failed: %s", exc)
     # Cap auto-detected ollama_num_ctx to the user's explicit context_length.
     # Without this, GGUF metadata can advertise 256K+ which Ollama honours
     # by allocating that much VRAM — blowing up small GPUs even though the
@@ -1431,13 +1447,13 @@ def init_agent(
         and _ollama_num_ctx_override is None  # don't override explicit ollama_num_ctx
         and agent._ollama_num_ctx > _config_context_length
     ):
-        _ra().logger.info(
+        run_agent_logger.info(
             "Ollama num_ctx capped: %d -> %d (model.context_length override)",
             agent._ollama_num_ctx, _config_context_length,
         )
         agent._ollama_num_ctx = _config_context_length
     if agent._ollama_num_ctx and not agent.quiet_mode:
-        _ra().logger.info(
+        run_agent_logger.info(
             "Ollama num_ctx: will request %d tokens (model max from /api/show)",
             agent._ollama_num_ctx,
         )

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -44,14 +44,64 @@ from agent.trajectory import convert_scratchpad_to_think
 from agent.error_classifier import classify_api_error, FailoverReason
 from utils import base_url_host_matches, base_url_hostname, env_var_enabled, atomic_json_write
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("run_agent")
 
 
-def _ra():
-    """Lazy ``run_agent`` reference for test-patch routing."""
-    import run_agent
-    return run_agent
 
+_TOOL_CALL_ARGUMENTS_CORRUPTION_MARKER = (
+    "[hermes-agent: tool call arguments were corrupted in this session and "
+    "have been dropped to keep the conversation alive. See issue #15236.]"
+)
+_VALID_API_ROLES = frozenset({"system", "user", "assistant", "tool", "function", "developer"})
+
+
+def _get_tool_call_id_static(tc) -> str:
+    if isinstance(tc, dict):
+        return tc.get("call_id", "") or tc.get("id", "") or ""
+    return getattr(tc, "call_id", "") or getattr(tc, "id", "") or ""
+
+
+def _get_tool_call_name_static(tc) -> str:
+    if isinstance(tc, dict):
+        fn = tc.get("function")
+        if isinstance(fn, dict):
+            return fn.get("name", "") or ""
+        return ""
+    fn = getattr(tc, "function", None)
+    return getattr(fn, "name", "") or ""
+
+
+def _is_thinking_only_assistant(msg: Dict[str, Any]) -> bool:
+    if not isinstance(msg, dict) or msg.get("role") != "assistant":
+        return False
+    if msg.get("tool_calls"):
+        return False
+    content = msg.get("content")
+    if isinstance(content, str):
+        if content.strip():
+            return False
+    elif isinstance(content, list):
+        for block in content:
+            if not isinstance(block, dict):
+                if block:
+                    return False
+                continue
+            btype = block.get("type")
+            if btype in {"thinking", "redacted_thinking"}:
+                continue
+            if btype == "text":
+                text = block.get("text", "")
+                if isinstance(text, str) and text.strip():
+                    return False
+                continue
+            return False
+    elif content is not None and content != "":
+        return False
+    reasoning = msg.get("reasoning_content") or msg.get("reasoning")
+    if isinstance(reasoning, str) and reasoning.strip():
+        return True
+    rd = msg.get("reasoning_details")
+    return isinstance(rd, list) and bool(rd)
 
 
 def convert_to_trajectory_format(agent, messages: List[Dict[str, Any]], user_query: str, completed: bool) -> List[Dict[str, Any]]:
@@ -230,6 +280,7 @@ def sanitize_tool_call_arguments(
     *,
     logger=None,
     session_id: str = None,
+    corruption_marker: str = _TOOL_CALL_ARGUMENTS_CORRUPTION_MARKER,
 ) -> int:
     """Repair corrupted assistant tool-call argument JSON in-place."""
     log = logger or logging.getLogger(__name__)
@@ -237,7 +288,7 @@ def sanitize_tool_call_arguments(
         return 0
 
     repaired = 0
-    marker = _ra().AIAgent._TOOL_CALL_ARGUMENTS_CORRUPTION_MARKER
+    marker = corruption_marker
 
     def _prepend_marker(tool_msg: dict) -> None:
         existing = tool_msg.get("content")
@@ -573,7 +624,7 @@ def recover_with_credential_pool(
         rotate_status = status_code if status_code is not None else 402
         next_entry = pool.mark_exhausted_and_rotate(status_code=rotate_status, error_context=error_context)
         if next_entry is not None:
-            _ra().logger.info(
+            logger.info(
                 "Credential %s (billing) — rotated to pool entry %s",
                 rotate_status,
                 getattr(next_entry, "id", "?"),
@@ -596,7 +647,7 @@ def recover_with_credential_pool(
         rotate_status = status_code if status_code is not None else 429
         next_entry = pool.mark_exhausted_and_rotate(status_code=rotate_status, error_context=error_context)
         if next_entry is not None:
-            _ra().logger.info(
+            logger.info(
                 "Credential %s (rate limit) — rotated to pool entry %s",
                 rotate_status,
                 getattr(next_entry, "id", "?"),
@@ -607,7 +658,7 @@ def recover_with_credential_pool(
 
     if effective_reason == FailoverReason.auth:
         if agent._is_entitlement_failure(error_context, status_code):
-            _ra().logger.info(
+            logger.info(
                 "Credential %s — entitlement-shaped 403 from %s; "
                 "skipping pool refresh (account lacks subscription, "
                 "not a transient auth failure).",
@@ -617,7 +668,7 @@ def recover_with_credential_pool(
             return False, has_retried_429
         refreshed = pool.try_refresh_current()
         if refreshed is not None:
-            _ra().logger.info(f"Credential auth failure — refreshed pool entry {getattr(refreshed, 'id', '?')}")
+            logger.info(f"Credential auth failure — refreshed pool entry {getattr(refreshed, 'id', '?')}")
             agent._swap_credential(refreshed)
             return True, has_retried_429
         # Refresh failed — rotate to next credential instead of giving up.
@@ -625,7 +676,7 @@ def recover_with_credential_pool(
         rotate_status = status_code if status_code is not None else 401
         next_entry = pool.mark_exhausted_and_rotate(status_code=rotate_status, error_context=error_context)
         if next_entry is not None:
-            _ra().logger.info(
+            logger.info(
                 "Credential %s (auth refresh failed) — rotated to pool entry %s",
                 rotate_status,
                 getattr(next_entry, "id", "?"),
@@ -723,6 +774,8 @@ def try_recover_primary_transport(
 
 def drop_thinking_only_and_merge_users(
     messages: List[Dict[str, Any]],
+    *,
+    is_thinking_only_assistant: callable = _is_thinking_only_assistant,
 ) -> List[Dict[str, Any]]:
     """Drop thinking-only assistant turns; merge any adjacent user messages left behind.
 
@@ -744,7 +797,7 @@ def drop_thinking_only_and_merge_users(
         return messages
 
     # Pass 1: drop thinking-only assistant turns.
-    kept = [m for m in messages if not _ra().AIAgent._is_thinking_only_assistant(m)]
+    kept = [m for m in messages if not is_thinking_only_assistant(m)]
     dropped = len(messages) - len(kept)
     if dropped == 0:
         return messages
@@ -797,7 +850,7 @@ def drop_thinking_only_and_merge_users(
         else:
             merged.append(m)
 
-    _ra().logger.debug(
+    logger.debug(
         "Pre-call sanitizer: dropped %d thinking-only assistant turn(s), "
         "merged %d adjacent user message(s)",
         dropped,
@@ -1007,7 +1060,7 @@ def dump_api_request_debug(
         try:
             api_key = getattr(agent.client, "api_key", None)
         except Exception as e:
-            _ra().logger.debug("Could not extract API key for debug dump: %s", e)
+            logger.debug("Could not extract API key for debug dump: %s", e)
 
         dump_payload: Dict[str, Any] = {
             "timestamp": datetime.now().isoformat(),
@@ -1044,7 +1097,7 @@ def dump_api_request_debug(
                     error_info["response_status"] = getattr(response_obj, "status_code", None)
                     error_info["response_text"] = response_obj.text
                 except Exception as e:
-                    _ra().logger.debug("Could not extract error response details: %s", e)
+                    logger.debug("Could not extract error response details: %s", e)
 
             dump_payload["error"] = error_info
 
@@ -1174,7 +1227,14 @@ def anthropic_prompt_cache_policy(
 
 
 
-def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: bool) -> Any:
+def create_openai_client(
+    agent,
+    client_kwargs: dict,
+    *,
+    reason: str,
+    shared: bool,
+    openai_client_cls: callable,
+) -> Any:
     from agent.auxiliary_client import _validate_base_url, _validate_proxy_env_urls
     # Treat client_kwargs as read-only. Callers pass agent._client_kwargs (or shallow
     # copies of it) in; any in-place mutation leaks back into the stored dict and is
@@ -1191,7 +1251,7 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
         from agent.copilot_acp_client import CopilotACPClient
 
         client = CopilotACPClient(**client_kwargs)
-        _ra().logger.info(
+        logger.info(
             "Copilot ACP client created (%s, shared=%s) %s",
             reason,
             shared,
@@ -1207,7 +1267,7 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
             if k in {"api_key", "base_url", "default_headers", "project_id", "timeout"}
         }
         client = GeminiCloudCodeClient(**safe_kwargs)
-        _ra().logger.info(
+        logger.info(
             "Gemini Cloud Code Assist client created (%s, shared=%s) %s",
             reason,
             shared,
@@ -1228,7 +1288,7 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
                 if keepalive_http is not None:
                     safe_kwargs["http_client"] = keepalive_http
             client = GeminiNativeClient(**safe_kwargs)
-            _ra().logger.info(
+            logger.info(
                 "Gemini native client created (%s, shared=%s) %s",
                 reason,
                 shared,
@@ -1258,8 +1318,8 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
             client_kwargs["http_client"] = keepalive_http
     # Uses the module-level `OpenAI` name, resolved lazily on first
     # access via __getattr__ below. Tests patch via `run_agent.OpenAI`.
-    client = _ra().OpenAI(**client_kwargs)
-    _ra().logger.info(
+    client = openai_client_cls(**client_kwargs)
+    logger.info(
         "OpenAI client created (%s, shared=%s) %s",
         reason,
         shared,
@@ -1470,9 +1530,17 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
 
 
 
-def invoke_tool(agent, function_name: str, function_args: dict, effective_task_id: str,
-                 tool_call_id: Optional[str] = None, messages: list = None,
-                 pre_tool_block_checked: bool = False) -> str:
+def invoke_tool(
+    agent,
+    function_name: str,
+    function_args: dict,
+    effective_task_id: str,
+    tool_call_id: Optional[str] = None,
+    messages: list = None,
+    pre_tool_block_checked: bool = False,
+    *,
+    handle_function_call: callable,
+) -> str:
     """Invoke a single tool and return the result string. No display logic.
 
     Handles both agent-level tools (todo, memory, etc.) and registry-dispatched
@@ -1553,7 +1621,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
     elif function_name == "delegate_task":
         return agent._dispatch_delegate_task(function_args)
     else:
-        return _ra().handle_function_call(
+        return handle_function_call(
             function_name, function_args, effective_task_id,
             tool_call_id=tool_call_id,
             session_id=agent.session_id or "",
@@ -1637,7 +1705,13 @@ def repair_tool_call(agent, tool_name: str) -> str | None:
 
 
 
-def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+def sanitize_api_messages(
+    messages: List[Dict[str, Any]],
+    *,
+    valid_api_roles: frozenset[str] = _VALID_API_ROLES,
+    get_tool_call_id_static: callable = _get_tool_call_id_static,
+    get_tool_call_name_static: callable = _get_tool_call_name_static,
+) -> List[Dict[str, Any]]:
     """Fix orphaned tool_call / tool_result pairs before every LLM call.
 
     Runs unconditionally — not gated on whether the context compressor
@@ -1648,8 +1722,8 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
     filtered = []
     for msg in messages:
         role = msg.get("role")
-        if role not in _ra().AIAgent._VALID_API_ROLES:
-            _ra().logger.debug(
+        if role not in valid_api_roles:
+            logger.debug(
                 "Pre-call sanitizer: dropping message with invalid role %r",
                 role,
             )
@@ -1661,7 +1735,7 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
     for msg in messages:
         if msg.get("role") == "assistant":
             for tc in msg.get("tool_calls") or []:
-                cid = _ra().AIAgent._get_tool_call_id_static(tc)
+                cid = get_tool_call_id_static(tc)
                 if cid:
                     surviving_call_ids.add(cid)
 
@@ -1679,7 +1753,7 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
             m for m in messages
             if not (m.get("role") == "tool" and m.get("tool_call_id") in orphaned_results)
         ]
-        _ra().logger.debug(
+        logger.debug(
             "Pre-call sanitizer: removed %d orphaned tool result(s)",
             len(orphaned_results),
         )
@@ -1692,16 +1766,16 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
             patched.append(msg)
             if msg.get("role") == "assistant":
                 for tc in msg.get("tool_calls") or []:
-                    cid = _ra().AIAgent._get_tool_call_id_static(tc)
+                    cid = get_tool_call_id_static(tc)
                     if cid in missing_results:
                         patched.append({
                             "role": "tool",
-                            "name": _ra().AIAgent._get_tool_call_name_static(tc),
+                            "name": get_tool_call_name_static(tc),
                             "content": "[Result unavailable — see context summary above]",
                             "tool_call_id": cid,
                         })
         messages = patched
-        _ra().logger.debug(
+        logger.debug(
             "Pre-call sanitizer: added %d stub tool result(s)",
             len(missing_results),
         )
@@ -1915,14 +1989,14 @@ def cleanup_dead_connections(agent) -> bool:
                 except OSError:
                     pass
         if dead_count > 0:
-            _ra().logger.warning(
+            logger.warning(
                 "Found %d dead connection(s) in client pool — rebuilding client",
                 dead_count,
             )
             agent._replace_primary_openai_client(reason="dead_connection_cleanup")
             return True
     except Exception as exc:
-        _ra().logger.debug("Dead connection check error: %s", exc)
+        logger.debug("Dead connection check error: %s", exc)
     return False
 
 
@@ -2050,7 +2124,7 @@ def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: in
             messages[target_idx]["content"] = f"{existing_content}{marker}"
     else:
         messages[target_idx]["content"] = existing_content + marker
-    _ra().logger.info(
+    logger.info(
         "Delivered /steer to agent after tool batch (%d chars): %s",
         len(steer_text),
         steer_text[:120] + ("..." if len(steer_text) > 120 else ""),
@@ -2113,7 +2187,7 @@ def force_close_tcp_sockets(client: Any) -> int:
                 pass
             closed += 1
     except Exception as exc:
-        _ra().logger.debug("Force-close TCP sockets sweep error: %s", exc)
+        logger.debug("Force-close TCP sockets sweep error: %s", exc)
     return closed
 
 

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -9,8 +9,8 @@ Each function takes the parent ``AIAgent`` as its first argument
 (``agent``).  :class:`AIAgent` keeps thin forwarder methods so call
 sites unchanged.  Symbols that tests patch on ``run_agent`` (e.g.
 ``cleanup_vm`` / ``cleanup_browser`` in
-``test_zombie_process_cleanup.py``) are resolved through
-:func:`_ra` so the patch contract is preserved.
+``test_zombie_process_cleanup.py``) are passed in explicitly by
+``run_agent.AIAgent`` so the patch contract is preserved.
 """
 
 from __future__ import annotations
@@ -63,16 +63,6 @@ from utils import base_url_host_matches, base_url_hostname
 
 logger = logging.getLogger(__name__)
 
-
-def _ra():
-    """Lazy ``run_agent`` reference.
-
-    Used to honor test patches like
-    ``patch("run_agent.cleanup_vm")`` / ``patch("run_agent.cleanup_browser")``
-    that target symbols imported into ``run_agent``'s namespace.
-    """
-    import run_agent
-    return run_agent
 
 
 
@@ -1118,7 +1108,13 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
 
 
 
-def cleanup_task_resources(agent, task_id: str) -> None:
+def cleanup_task_resources(
+    agent,
+    task_id: str,
+    *,
+    cleanup_vm: callable,
+    cleanup_browser: callable,
+) -> None:
     """Clean up VM and browser resources for a given task.
 
     Skips ``cleanup_vm`` when the active terminal environment is marked
@@ -1137,12 +1133,12 @@ def cleanup_task_resources(agent, task_id: str) -> None:
                     f"idle reaper will handle it."
                 )
         else:
-            _ra().cleanup_vm(task_id)
+            cleanup_vm(task_id)
     except Exception as e:
         if agent.verbose_logging:
             logging.warning(f"Failed to cleanup VM for task {task_id}: {e}")
     try:
-        _ra().cleanup_browser(task_id)
+        cleanup_browser(task_id)
     except Exception as e:
         if agent.verbose_logging:
             logging.warning(f"Failed to cleanup browser for task {task_id}: {e}")

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -7,11 +7,12 @@ compression, post-turn hooks, background memory/skill review nudges).
 
 The function takes the parent ``AIAgent`` instance as its first
 argument (``agent``) and accesses its state via attribute lookup.
-``_ra().AIAgent.run_conversation`` is now a thin forwarder.
+``run_agent.AIAgent.run_conversation`` is now a thin forwarder.
 
 Symbols that production code or tests patch on ``run_agent`` directly
-(``handle_function_call``, ``_set_interrupt``, ``OpenAI``, ...) are
-resolved through :func:`_ra` so those patches keep working.
+(``handle_function_call``, ``_set_interrupt``, static tool-call helpers) are
+passed in explicitly by ``run_agent.AIAgent.run_conversation`` so those
+patches keep working without a lazy import back-edge.
 """
 
 from __future__ import annotations
@@ -72,14 +73,6 @@ from utils import base_url_host_matches, env_var_enabled
 
 logger = logging.getLogger(__name__)
 
-
-def _ra():
-    """Lazy reference to ``run_agent`` so callers can patch
-    ``run_agent.handle_function_call`` / ``run_agent._set_interrupt`` /
-    ``run_agent.OpenAI`` and have those patches reach this code path.
-    """
-    import run_agent
-    return run_agent
 
 
 def _restore_or_build_system_prompt(agent, system_message, conversation_history):
@@ -192,6 +185,10 @@ def run_conversation(
     task_id: str = None,
     stream_callback: Optional[callable] = None,
     persist_user_message: Optional[str] = None,
+    *,
+    set_interrupt: callable,
+    handle_function_call: callable,
+    get_tool_call_name_static: callable,
 ) -> Dict[str, Any]:
     """
     Run a complete conversation with tool calling until completion.
@@ -550,9 +547,9 @@ def run_conversation(
     # Always clear stale per-thread state from a previous turn. If an
     # interrupt arrived before startup finished, preserve it and bind it
     # to this execution thread now instead of dropping it on the floor.
-    _ra()._set_interrupt(False, agent._execution_thread_id)
+    set_interrupt(False, agent._execution_thread_id)
     if agent._interrupt_requested:
-        _ra()._set_interrupt(True, agent._execution_thread_id)
+        set_interrupt(True, agent._execution_thread_id)
         agent._interrupt_thread_signal_pending = False
     else:
         agent._interrupt_message = None
@@ -3777,7 +3774,7 @@ def run_conversation(
                         if tc["id"] not in answered_ids:
                             err_msg = {
                                 "role": "tool",
-                                "name": _ra().AIAgent._get_tool_call_name_static(tc),
+                                "name": get_tool_call_name_static(tc),
                                 "tool_call_id": tc["id"],
                                 "content": f"Error executing tool: {error_msg}",
                             }
@@ -3826,7 +3823,7 @@ def run_conversation(
         _kanban_task = os.environ.get("HERMES_KANBAN_TASK")
         if _kanban_task:
             try:
-                _ra().handle_function_call(
+                handle_function_call(
                     "kanban_block",
                     {
                         "task_id": _kanban_task,

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -42,22 +42,18 @@ from agent.prompt_builder import (
 )
 
 
-def _ra():
-    """Lazy reference to the ``run_agent`` module.
 
-    Helpers like ``load_soul_md``, ``build_environment_hints``,
-    ``build_context_files_prompt``, ``build_nous_subscription_prompt``,
-    ``build_skills_system_prompt`` and ``get_toolset_for_tool`` are
-    imported into ``run_agent``'s namespace.  Many tests
-    ``patch("run_agent.load_soul_md", ...)``; if we imported them
-    directly here those patches would not reach us.  Looking them up
-    through ``run_agent`` on every call preserves the patch contract.
-    """
-    import run_agent
-    return run_agent
-
-
-def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) -> Dict[str, str]:
+def build_system_prompt_parts(
+    agent: Any,
+    system_message: Optional[str] = None,
+    *,
+    load_soul_md: callable,
+    build_nous_subscription_prompt: callable,
+    get_toolset_for_tool: callable,
+    build_skills_system_prompt: callable,
+    build_environment_hints: callable,
+    build_context_files_prompt: callable,
+) -> Dict[str, str]:
     """Assemble the system prompt as three ordered parts.
 
     Returns a dict with three keys:
@@ -75,11 +71,6 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     session — that's the only way to keep upstream prompt caches
     warm across turns.
     """
-    # Local import to avoid pulling model_tools at module load.  Tests
-    # patch ``run_agent.get_toolset_for_tool`` and similar helpers, so
-    # we resolve through ``_ra()`` to honor those patches.
-    _r = _ra()
-
     # ── Stable tier ────────────────────────────────────────────────
     stable_parts: List[str] = []
 
@@ -88,7 +79,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # cwd project instructions disabled.
     _soul_loaded = False
     if agent.load_soul_identity or not agent.skip_context_files:
-        _soul_content = _r.load_soul_md()
+        _soul_content = load_soul_md()
         if _soul_content:
             stable_parts.append(_soul_content)
             _soul_loaded = True
@@ -123,7 +114,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         from agent.prompt_builder import COMPUTER_USE_GUIDANCE
         stable_parts.append(COMPUTER_USE_GUIDANCE)
 
-    nous_subscription_prompt = _r.build_nous_subscription_prompt(agent.valid_tool_names)
+    nous_subscription_prompt = build_nous_subscription_prompt(agent.valid_tool_names)
     if nous_subscription_prompt:
         stable_parts.append(nous_subscription_prompt)
     # Tool-use enforcement: tells the model to actually call tools instead
@@ -167,11 +158,11 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         avail_toolsets = {
             toolset
             for toolset in (
-                _r.get_toolset_for_tool(tool_name) for tool_name in agent.valid_tool_names
+                get_toolset_for_tool(tool_name) for tool_name in agent.valid_tool_names
             )
             if toolset
         }
-        skills_prompt = _r.build_skills_system_prompt(
+        skills_prompt = build_skills_system_prompt(
             available_tools=agent.valid_tool_names,
             available_toolsets=avail_toolsets,
         )
@@ -197,7 +188,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # Environment hints (WSL, Termux, etc.) — tell the agent about the
     # execution environment so it can translate paths and adapt behavior.
     # Stable for the lifetime of the process.
-    _env_hints = _r.build_environment_hints()
+    _env_hints = build_environment_hints()
     if _env_hints:
         stable_parts.append(_env_hints)
 
@@ -228,7 +219,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         # dir, so os.getcwd() would pick up the repo's AGENTS.md and
         # other dev files — inflating token usage by ~10k for no benefit.
         _context_cwd = os.getenv("TERMINAL_CWD") or None
-        context_files_prompt = _r.build_context_files_prompt(
+        context_files_prompt = build_context_files_prompt(
             cwd=_context_cwd, skip_soul=_soul_loaded)
         if context_files_prompt:
             context_parts.append(context_files_prompt)
@@ -280,7 +271,11 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     }
 
 
-def build_system_prompt(agent: Any, system_message: Optional[str] = None) -> str:
+def build_system_prompt(
+    agent: Any,
+    system_message: Optional[str] = None,
+    **prompt_deps: Any,
+) -> str:
     """Assemble the full system prompt from all layers.
 
     Called once per session (cached on ``agent._cached_system_prompt``) and
@@ -295,7 +290,7 @@ def build_system_prompt(agent: Any, system_message: Optional[str] = None) -> str
     mid-session, which is the only way to keep upstream prompt caches
     warm across turns.
     """
-    parts = build_system_prompt_parts(agent, system_message=system_message)
+    parts = build_system_prompt_parts(agent, system_message=system_message, **prompt_deps)
     return "\n\n".join(p for p in (parts["stable"], parts["context"], parts["volatile"]) if p)
 
 

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -5,9 +5,8 @@ Both AIAgent methods (``_execute_tool_calls_sequential`` and
 functions that take the parent ``AIAgent`` as their first argument.
 
 ``run_agent`` keeps thin wrappers so existing call sites work; tests
-that patch ``run_agent._set_interrupt`` are honored because the
-extracted functions reach back through the ``run_agent`` module via
-``_ra()`` for that symbol.
+that patch ``run_agent._set_interrupt`` / ``run_agent.handle_function_call``
+are honored because ``run_agent.AIAgent`` passes those callables explicitly.
 """
 
 from __future__ import annotations
@@ -55,13 +54,17 @@ logger = logging.getLogger(__name__)
 _MAX_TOOL_WORKERS = 8
 
 
-def _ra():
-    """Lazy reference to ``run_agent`` so patches like ``run_agent._set_interrupt`` work."""
-    import run_agent
-    return run_agent
 
-
-def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:
+def execute_tool_calls_concurrent(
+    agent,
+    assistant_message,
+    messages: list,
+    effective_task_id: str,
+    api_call_count: int = 0,
+    *,
+    set_interrupt: callable,
+    handle_function_call: callable,
+) -> None:
     """Execute multiple tool calls concurrently using a thread pool.
 
     Results are collected in the original tool-call order and appended to
@@ -208,7 +211,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         # the tool returns True on the next poll.
         if agent._interrupt_requested:
             try:
-                _ra()._set_interrupt(True, _worker_tid)
+                set_interrupt(True, _worker_tid)
             except Exception:
                 pass
         # Set the activity callback on THIS worker thread so
@@ -258,7 +261,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         with agent._tool_worker_threads_lock:
             agent._tool_worker_threads.discard(_worker_tid)
         try:
-            _ra()._set_interrupt(False, _worker_tid)
+            set_interrupt(False, _worker_tid)
         except Exception:
             pass
         # Clear thread-local callbacks so a recycled worker thread
@@ -471,7 +474,15 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
 
 
 
-def execute_tool_calls_sequential(agent, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:
+def execute_tool_calls_sequential(
+    agent,
+    assistant_message,
+    messages: list,
+    effective_task_id: str,
+    api_call_count: int = 0,
+    *,
+    handle_function_call: callable,
+) -> None:
     """Execute tool calls sequentially (original behavior). Used for single calls or interactive tools."""
     for i, tool_call in enumerate(assistant_message.tool_calls, 1):
         # SAFETY: check interrupt BEFORE starting each tool.
@@ -751,7 +762,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 spinner.start()
             _spinner_result = None
             try:
-                function_result = _ra().handle_function_call(
+                function_result = handle_function_call(
                     function_name, function_args, effective_task_id,
                     tool_call_id=tool_call.id,
                     session_id=agent.session_id or "",
@@ -771,7 +782,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     agent._vprint(f"  {cute_msg}")
         else:
             try:
-                function_result = _ra().handle_function_call(
+                function_result = handle_function_call(
                     function_name, function_args, effective_task_id,
                     tool_call_id=tool_call.id,
                     session_id=agent.session_id or "",

--- a/run_agent.py
+++ b/run_agent.py
@@ -481,6 +481,15 @@ class AIAgent:
             checkpoint_max_total_size_mb=checkpoint_max_total_size_mb,
             checkpoint_max_file_size_mb=checkpoint_max_file_size_mb,
             pass_session_id=pass_session_id,
+            run_agent_deps={
+                "logger": logger,
+                "openrouter_prewarm_done": _openrouter_prewarm_done,
+                "hermes_home": _hermes_home,
+                "routermint_headers": _routermint_headers,
+                "qwen_portal_headers": _qwen_portal_headers,
+                "get_tool_definitions": get_tool_definitions,
+                "check_toolset_requirements": check_toolset_requirements,
+            },
         )
 
     def _get_session_db_for_recall(self):
@@ -1080,7 +1089,12 @@ class AIAgent:
     def _cleanup_task_resources(self, task_id: str) -> None:
         """Forwarder — see ``agent.chat_completion_helpers.cleanup_task_resources``."""
         from agent.chat_completion_helpers import cleanup_task_resources
-        return cleanup_task_resources(self, task_id)
+        return cleanup_task_resources(
+            self,
+            task_id,
+            cleanup_vm=cleanup_vm,
+            cleanup_browser=cleanup_browser,
+        )
 
     # ------------------------------------------------------------------
     # Background memory/skill review — prompts live in agent.background_review
@@ -2151,12 +2165,30 @@ class AIAgent:
     def _build_system_prompt_parts(self, system_message: str = None) -> Dict[str, str]:
         """Forwarder — see ``agent.system_prompt.build_system_prompt_parts``."""
         from agent.system_prompt import build_system_prompt_parts
-        return build_system_prompt_parts(self, system_message=system_message)
+        return build_system_prompt_parts(
+            self,
+            system_message=system_message,
+            load_soul_md=load_soul_md,
+            build_nous_subscription_prompt=build_nous_subscription_prompt,
+            get_toolset_for_tool=get_toolset_for_tool,
+            build_skills_system_prompt=build_skills_system_prompt,
+            build_environment_hints=build_environment_hints,
+            build_context_files_prompt=build_context_files_prompt,
+        )
 
     def _build_system_prompt(self, system_message: str = None) -> str:
         """Forwarder — see ``agent.system_prompt.build_system_prompt``."""
         from agent.system_prompt import build_system_prompt
-        return build_system_prompt(self, system_message=system_message)
+        return build_system_prompt(
+            self,
+            system_message=system_message,
+            load_soul_md=load_soul_md,
+            build_nous_subscription_prompt=build_nous_subscription_prompt,
+            get_toolset_for_tool=get_toolset_for_tool,
+            build_skills_system_prompt=build_skills_system_prompt,
+            build_environment_hints=build_environment_hints,
+            build_context_files_prompt=build_context_files_prompt,
+        )
 
     @staticmethod
     def _get_tool_call_id_static(tc) -> str:
@@ -2188,7 +2220,12 @@ class AIAgent:
     def _sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """Forwarder — see ``agent.agent_runtime_helpers.sanitize_api_messages``."""
         from agent.agent_runtime_helpers import sanitize_api_messages
-        return sanitize_api_messages(messages)
+        return sanitize_api_messages(
+            messages,
+            valid_api_roles=AIAgent._VALID_API_ROLES,
+            get_tool_call_id_static=AIAgent._get_tool_call_id_static,
+            get_tool_call_name_static=AIAgent._get_tool_call_name_static,
+        )
 
     @staticmethod
     def _is_thinking_only_assistant(msg: Dict[str, Any]) -> bool:
@@ -2250,7 +2287,10 @@ class AIAgent:
     ) -> List[Dict[str, Any]]:
         """Forwarder — see ``agent.agent_runtime_helpers.drop_thinking_only_and_merge_users``."""
         from agent.agent_runtime_helpers import drop_thinking_only_and_merge_users
-        return drop_thinking_only_and_merge_users(messages)
+        return drop_thinking_only_and_merge_users(
+            messages,
+            is_thinking_only_assistant=AIAgent._is_thinking_only_assistant,
+        )
 
     @staticmethod
     def _cap_delegate_task_calls(tool_calls: list) -> list:
@@ -2412,7 +2452,13 @@ class AIAgent:
     def _create_openai_client(self, client_kwargs: dict, *, reason: str, shared: bool) -> Any:
         """Forwarder — see ``agent.agent_runtime_helpers.create_openai_client``."""
         from agent.agent_runtime_helpers import create_openai_client
-        return create_openai_client(self, client_kwargs, reason=reason, shared=shared)
+        return create_openai_client(
+            self,
+            client_kwargs,
+            reason=reason,
+            shared=shared,
+            openai_client_cls=OpenAI,
+        )
 
     @staticmethod
     def _force_close_tcp_sockets(client: Any) -> int:
@@ -3699,7 +3745,12 @@ class AIAgent:
     ) -> int:
         """Forwarder — see ``agent.agent_runtime_helpers.sanitize_tool_call_arguments``."""
         from agent.agent_runtime_helpers import sanitize_tool_call_arguments
-        return sanitize_tool_call_arguments(messages, logger=logger, session_id=session_id)
+        return sanitize_tool_call_arguments(
+            messages,
+            logger=logger,
+            session_id=session_id,
+            corruption_marker=AIAgent._TOOL_CALL_ARGUMENTS_CORRUPTION_MARKER,
+        )
 
     def _should_sanitize_tool_calls(self) -> bool:
         """Determine if tool_calls need sanitization for strict APIs.
@@ -3814,7 +3865,16 @@ class AIAgent:
                      pre_tool_block_checked: bool = False) -> str:
         """Forwarder — see ``agent.agent_runtime_helpers.invoke_tool``."""
         from agent.agent_runtime_helpers import invoke_tool
-        return invoke_tool(self, function_name, function_args, effective_task_id, tool_call_id, messages, pre_tool_block_checked)
+        return invoke_tool(
+            self,
+            function_name,
+            function_args,
+            effective_task_id,
+            tool_call_id,
+            messages,
+            pre_tool_block_checked,
+            handle_function_call=handle_function_call,
+        )
 
     @staticmethod
     def _wrap_verbose(label: str, text: str, indent: str = "     ") -> str:
@@ -3844,12 +3904,27 @@ class AIAgent:
     def _execute_tool_calls_concurrent(self, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:
         """Forwarder — see ``agent.tool_executor.execute_tool_calls_concurrent``."""
         from agent.tool_executor import execute_tool_calls_concurrent
-        return execute_tool_calls_concurrent(self, assistant_message, messages, effective_task_id, api_call_count)
+        return execute_tool_calls_concurrent(
+            self,
+            assistant_message,
+            messages,
+            effective_task_id,
+            api_call_count,
+            set_interrupt=_set_interrupt,
+            handle_function_call=handle_function_call,
+        )
 
     def _execute_tool_calls_sequential(self, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:
         """Forwarder — see ``agent.tool_executor.execute_tool_calls_sequential``."""
         from agent.tool_executor import execute_tool_calls_sequential
-        return execute_tool_calls_sequential(self, assistant_message, messages, effective_task_id, api_call_count)
+        return execute_tool_calls_sequential(
+            self,
+            assistant_message,
+            messages,
+            effective_task_id,
+            api_call_count,
+            handle_function_call=handle_function_call,
+        )
 
     def _handle_max_iterations(self, messages: list, api_call_count: int) -> str:
         """Forwarder — see ``agent.chat_completion_helpers.handle_max_iterations``."""
@@ -3867,7 +3942,18 @@ class AIAgent:
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.conversation_loop.run_conversation``."""
         from agent.conversation_loop import run_conversation
-        return run_conversation(self, user_message, system_message, conversation_history, task_id, stream_callback, persist_user_message)
+        return run_conversation(
+            self,
+            user_message,
+            system_message,
+            conversation_history,
+            task_id,
+            stream_callback,
+            persist_user_message,
+            set_interrupt=_set_interrupt,
+            handle_function_call=handle_function_call,
+            get_tool_call_name_static=AIAgent._get_tool_call_name_static,
+        )
 
     def chat(self, message: str, stream_callback: Optional[callable] = None) -> str:
         """


### PR DESCRIPTION
## Problem
Five+ modules in `agent/` use this pattern to reach back into `run_agent`:
```python
def _ra():
    import run_agent
    return run_agent
```
This means the extraction into `agent/` didn't actually decouple anything — every extracted module still has a runtime dependency on the god module. Any refactor of `run_agent` silently breaks all of them.

## Solution
For each file using `_ra()`:
1. Identified which symbols from `run_agent` are actually used
2. Changed extracted functions to accept those as explicit parameters
3. `run_agent.py` passes them when calling the extracted functions
4. Removed all `_ra()` functions

Affected files: `agent/conversation_loop.py`, `agent/agent_init.py`, `agent/tool_executor.py`, `agent/agent_runtime_helpers.py`, and others.

Test patches like `patch("run_agent.handle_function_call", ...)` continue to work because the patched version flows through the explicit parameter.

## Testing
- 719 tests pass in run-agent/auxiliary coverage
- All existing tests pass (4695 passed)
- `ruff check .` clean

Co-Authored-By: Oz <oz-agent@warp.dev>