### PR TITLE
feat(security): release-age gate on hermes update (opt-in)

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -357,6 +357,14 @@ terminal:
 #   tirith_path: "tirith"       # Path to tirith binary (supports ~ expansion)
 #   tirith_timeout: 5           # Scan timeout in seconds
 #   tirith_fail_open: true      # Allow commands if tirith unavailable
+#
+#   # Release-age gate on `hermes update`. When > 0 and `uv` is installed,
+#   # passes --exclude-newer <today-N> so PyPI artifacts uploaded within
+#   # the last N days are refused. Defends against short-window supply-chain
+#   # compromises (mistralai 2.4.6 was live ~15 min; node-ipc 9.1.6 / 9.2.3 /
+#   # 12.0.1 lived hours-to-days). 3 days matches pnpm's minimumReleaseAge:
+#   # 4320 heuristic. Default 0 (off, opt-in).
+#   minimum_release_age_days: 3
 
 # =============================================================================
 # Browser Tool Configuration

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2746,6 +2746,19 @@ DEFAULT_CONFIG = {
         # for restricted networks, audited environments, or air-gapped
         # systems where any runtime install is unacceptable.
         "allow_lazy_installs": True,
+        # Refuse to resolve package versions published less than this many
+        # days ago. Defends against supply-chain compromise windows where a
+        # malicious release is detected and pulled within days — examples:
+        # mistralai 2.4.6 (PyPI, 2026-05-12, Mini Shai-Hulud — ~15-minute
+        # exposure window before quarantine); node-ipc 9.1.6/9.2.3/12.0.1
+        # (npm, 2026-05-14, load-time IIFE credential theft — hours-to-days
+        # before detection). A 3-day gate matches pnpm's minimumReleaseAge:
+        # 4320 default and would have refused both incidents on resolution.
+        # Requires ``uv`` (uses its --exclude-newer flag); falls through with
+        # a warning when only ``pip`` is available. Set to 0 to disable.
+        # Default 0 (opt-in) so existing installs see no behavior change;
+        # set to 3 (or higher) to enable.
+        "minimum_release_age_days": 0,
     },
 
     "cron": {

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6400,6 +6400,23 @@ def _update_via_zip(args):
                     extracted = candidate
                     break
 
+        # Release-age gate preflight: the live tree is untouched until the
+        # copy loop below, so a confirmed gate rejection of the incoming
+        # core deps can still defer the whole update cleanly (tmp_dir is
+        # removed in the finally). Fail-open contract lives in
+        # _release_age_preflight_blocked.
+        zip_cutoff = _exclude_newer_date(_get_min_release_age_days())
+        if zip_cutoff:
+            incoming_pyproject = os.path.join(extracted, "pyproject.toml")
+            blocked = None
+            if os.path.isfile(incoming_pyproject):
+                with open(incoming_pyproject, encoding="utf-8") as f:
+                    blocked = _release_age_preflight_blocked(f.read(), zip_cutoff)
+            if blocked:
+                _print_release_age_deferral(blocked, zip_cutoff)
+                # EX_TEMPFAIL: a deferred update must not read as applied.
+                sys.exit(75)
+
         # Copy updated files over existing installation, preserving venv/node_modules/.git
         preserve = {"venv", "node_modules", ".git", ".env"}
         update_count = 0
@@ -6901,7 +6918,7 @@ def _sync_fork_with_upstream(git_cmd: list[str], cwd: Path) -> bool:
         return False
 
 
-def _sync_with_upstream_if_needed(git_cmd: list[str], cwd: Path) -> None:
+def _sync_with_upstream_if_needed(git_cmd: list[str], cwd: Path) -> bool:
     """Check if fork is behind upstream and sync if safe.
 
     This implements the fork upstream sync logic:
@@ -6909,6 +6926,9 @@ def _sync_with_upstream_if_needed(git_cmd: list[str], cwd: Path) -> None:
     - Compare origin/main with upstream/main
     - If origin/main is strictly behind upstream/main, pull from upstream
     - Try to sync fork back to origin if possible
+
+    Returns True when the sync was deferred by the release-age gate (the
+    caller should report EX_TEMPFAIL rather than success); falsy otherwise.
     """
     has_upstream = _has_upstream_remote(git_cmd, cwd)
 
@@ -6990,14 +7010,47 @@ def _sync_with_upstream_if_needed(git_cmd: list[str], cwd: Path) -> None:
     # origin/main is strictly behind upstream/main (can fast-forward)
     print()
     print(f"→ Fork is {upstream_ahead} commit(s) behind upstream")
+
+    # Release-age preflight of the actual sync target: the main update
+    # preflight only sees origin/main, but this fast-forward advances the
+    # live tree from upstream/main. Pin the merge to the preflighted SHA
+    # (a pull would re-fetch and could land on a newer, unvalidated tip).
+    sync_cutoff = _exclude_newer_date(_get_min_release_age_days())
+    upstream_sha: str | None = None
+    if sync_cutoff:
+        sha_result = subprocess.run(
+            git_cmd + ["rev-parse", "upstream/main"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+        )
+        upstream_sha = (
+            sha_result.stdout.strip() if sha_result.returncode == 0 else None
+        )
+        if upstream_sha:
+            blocked = _release_age_preflight_git_ref(
+                git_cmd, upstream_sha, sync_cutoff, cwd
+            )
+            if blocked:
+                _print_release_age_deferral(blocked, sync_cutoff)
+                print("  Skipping upstream sync; your fork remains as-is.")
+                return True
+
     print("→ Pulling from upstream...")
 
     try:
-        subprocess.run(
-            git_cmd + ["pull", "--ff-only", "upstream", "main"],
-            cwd=cwd,
-            check=True,
-        )
+        if upstream_sha:
+            subprocess.run(
+                git_cmd + ["merge", "--ff-only", upstream_sha],
+                cwd=cwd,
+                check=True,
+            )
+        else:
+            subprocess.run(
+                git_cmd + ["pull", "--ff-only", "upstream", "main"],
+                cwd=cwd,
+                check=True,
+            )
     except subprocess.CalledProcessError:
         print(
             "  ✗ Failed to pull from upstream. You may need to resolve conflicts manually."
@@ -7741,12 +7794,32 @@ def _refresh_active_lazy_features() -> None:
     # can't be threaded through its API without coupling it to the CLI.
     # uv reads UV_EXCLUDE_NEWER as the env equivalent of --exclude-newer;
     # scope it to this refresh so gated updates can't pull brand-new
-    # artifacts through the lazy path. The pip fallback tier ignores the
-    # variable, matching the gate's uv-only behavior elsewhere.
+    # artifacts through the lazy path. lazy_deps fails closed on the pip
+    # fallback while the variable is set, so also make the managed uv
+    # (installed at $HERMES_HOME/bin, deliberately off PATH) discoverable
+    # for the same scope — otherwise every gated refresh on a standard
+    # managed install would fail despite a usable uv.
     cutoff = _exclude_newer_date(_get_min_release_age_days())
     saved_exclude_newer = os.environ.get("UV_EXCLUDE_NEWER")
+    saved_path = os.environ.get("PATH")
     if cutoff:
         os.environ["UV_EXCLUDE_NEWER"] = cutoff
+        # Always prefer the managed uv while the gate scopes the env var —
+        # a stale system uv on PATH that predates UV_EXCLUDE_NEWER would
+        # silently ignore it and install ungated.
+        try:
+            from hermes_cli.managed_uv import ensure_uv
+
+            managed_uv = ensure_uv()
+        except Exception:
+            managed_uv = None
+        if managed_uv:
+            managed_dir = os.path.dirname(managed_uv)
+            os.environ["PATH"] = (
+                managed_dir + os.pathsep + saved_path
+                if saved_path
+                else managed_dir
+            )
     try:
         results = lazy_deps.refresh_active_features(prompt=False)
     except Exception as exc:
@@ -7756,6 +7829,10 @@ def _refresh_active_lazy_features() -> None:
         return
     finally:
         if cutoff:
+            if saved_path is None:
+                os.environ.pop("PATH", None)
+            else:
+                os.environ["PATH"] = saved_path
             if saved_exclude_newer is None:
                 os.environ.pop("UV_EXCLUDE_NEWER", None)
             else:
@@ -7806,7 +7883,7 @@ def _get_min_release_age_days() -> int:
         if val is None:
             return 0
         try:
-            return max(0, int(val))
+            days = int(val)
         except (TypeError, ValueError):
             logger.warning(
                 "security.minimum_release_age_days has non-integer value %r; "
@@ -7814,6 +7891,16 @@ def _get_min_release_age_days() -> int:
                 val,
             )
             return 0
+        if days > 36500:
+            # ~100 years — anything larger is a typo and would overflow the
+            # datetime subtraction in _exclude_newer_date, crashing updates.
+            logger.warning(
+                "security.minimum_release_age_days=%r is out of range; "
+                "clamping to 36500",
+                val,
+            )
+            days = 36500
+        return max(0, days)
     except Exception as exc:
         logger.debug("release-age gate config read failed: %s", exc)
         return 0
@@ -7858,13 +7945,15 @@ def _print_release_age_status(
     ``cli-config.yaml.example``. When the gate is on, prints either a
     confirmation with the active cutoff (uv available) or a warning that
     the current updater path cannot apply it (pipx has no
-    ``--exclude-newer`` equivalent; plain pip requires uv). Suppressed
-    entirely in gateway mode (no human terminal).
+    ``--exclude-newer`` equivalent; plain pip requires uv). Gateway mode
+    suppresses only the informational confirmation — gateway output is
+    streamed back to the messaging user, so a *bypassed* gate must still
+    warn there.
     """
-    if gateway_mode:
-        return
     days = _get_min_release_age_days()
     if days <= 0:
+        return
+    if gateway_mode and uv_available:
         return
     if uv_available:
         cutoff = _exclude_newer_date(days)
@@ -7883,6 +7972,204 @@ def _print_release_age_status(
             f"  ⚠ release-age gate configured (minimum_release_age_days={days}) "
             f"but requires `uv`; falling through without gating"
         )
+
+
+def _release_age_preflight_blocked(pyproject_text: str, cutoff: str) -> str | None:
+    """Return uv's resolver error when the incoming core dependency set is
+    blocked *solely* by the release-age gate, else None.
+
+    Called with the **incoming** (not yet checked out) pyproject.toml so the
+    update can be deferred before source advances — a gated install failure
+    after the pull would strand new code with stale deps until the offending
+    pin ages past the cutoff.
+
+    Resolves ``[project.dependencies]`` only: optional extras are already
+    tolerated-to-fail by the install fallback flow, so a gate-refused extra
+    doesn't warrant deferring the whole update.
+
+    Fail-open by design: any machinery error (no uv, unparsable pyproject,
+    network failure, timeout) returns None so the preflight can never block
+    an update on its own. Only a confirmed gate rejection — gated resolution
+    fails while ungated resolution succeeds — defers.
+    """
+    try:
+        import tempfile
+        import tomllib
+
+        from hermes_cli.managed_uv import ensure_uv
+
+        uv = ensure_uv()
+        if not uv:
+            # Without uv nothing downstream is gated either; don't defer.
+            return None
+
+        # Capability probe: an older uv whose `pip compile` lacks any of the
+        # options used below would fail the gated runs with a usage error
+        # while the ungated control succeeds — indistinguishable from a real
+        # gate rejection and would falsely defer updates forever (before the
+        # install phase ever gets to run update_managed_uv()). Fail open on
+        # such a uv; the install-phase gate handles it from there.
+        help_probe = subprocess.run(
+            [uv, "pip", "compile", "--help"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if help_probe.returncode != 0 or any(
+            flag not in help_probe.stdout
+            for flag in ("--exclude-newer", "--no-build", "--offline")
+        ):
+            return None
+
+        parsed = tomllib.loads(pyproject_text)
+        deps = list(parsed.get("project", {}).get("dependencies", []) or [])
+        # The gated editable install also resolves the build backend, so a
+        # too-new [build-system].requires pin would strand the update the
+        # same way a runtime dep would. Preflight them together.
+        deps += list(parsed.get("build-system", {}).get("requires", []) or [])
+        if not deps:
+            return None
+
+        # Resolve for the interpreter the update will actually install into
+        # (PROJECT_ROOT/venv on the git/ZIP paths) — the uv on PATH may be
+        # bound to a different Python, skewing marker evaluation and wheel
+        # tags. Missing venv python → uv's default interpreter (fail-open
+        # spirit: a skewed resolution is still better than none).
+        venv_python = (
+            PROJECT_ROOT
+            / "venv"
+            / ("Scripts" if _is_windows() else "bin")
+            / ("python.exe" if _is_windows() else "python")
+        )
+        python_args = (
+            ["--python", str(venv_python)] if venv_python.exists() else []
+        )
+
+        # Ambient age gates (e.g. a stray UV_EXCLUDE_NEWER exported in the
+        # shell) would silently gate the "ungated" control below, masking a
+        # real rejection as broken-regardless → fail open → stranding. All
+        # resolves run with them scrubbed; the gated ones pass the flag
+        # explicitly.
+        resolve_env = {
+            k: v
+            for k, v in os.environ.items()
+            if k not in {"UV_EXCLUDE_NEWER", "UV_EXCLUDE_NEWER_PACKAGE"}
+        }
+
+        with tempfile.TemporaryDirectory() as tmp:
+            reqs = Path(tmp) / "requirements.in"
+            reqs.write_text("\n".join(deps) + "\n", encoding="utf-8")
+
+            def _resolve(extra_args: list[str], *, no_build: bool = True):
+                # --no-build: resolution must never execute a candidate's
+                # PEP 517 backend — the ungated control would otherwise run
+                # code from the very artifact the gate exists to quarantine.
+                # An sdist-only dep fails the control instead → fail open,
+                # and the real (gated) install handles it normally.
+                return subprocess.run(
+                    [
+                        uv,
+                        "pip",
+                        "compile",
+                        str(reqs),
+                        "--no-header",
+                        *(["--no-build"] if no_build else []),
+                        *python_args,
+                        *extra_args,
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=180,
+                    cwd=tmp,
+                    env=resolve_env,
+                )
+
+            # uv's refusal text does not name the exclusion (it reads as
+            # "there is no version of X"), so the gate is confirmed
+            # structurally instead: the ungated control must succeed online
+            # (proves resolvability and warms uv's metadata cache), then the
+            # gated resolve must fail BOTH --offline (pure cache — network
+            # cannot be the cause) and online (rules out a cache miss).
+            # Any other combination fails open.
+            ungated = _resolve([])
+            if ungated.returncode != 0:
+                # The wheels-only control failed — typically an sdist-only
+                # dependency (common on Termux/Android). An ungated build
+                # is off the table (it would execute a possibly brand-new
+                # artifact's PEP 517 backend), but a GATED build is safe:
+                # only aged, gate-passing artifacts are candidates. If it
+                # resolves, the real install will too; if it doesn't,
+                # defer conservatively — advancing source would strand the
+                # install whether the cause is the gate or broken deps.
+                gated_build = _resolve(
+                    ["--exclude-newer", cutoff], no_build=False
+                )
+                if gated_build.returncode == 0:
+                    return None
+                detail = (gated_build.stderr or "").strip() or (
+                    "resolution failed under --exclude-newer"
+                )
+                return (
+                    "the incoming dependencies could not be resolved under "
+                    "the release-age gate (this may also indicate a "
+                    "resolution problem unrelated to the gate — see the "
+                    "resolver output):\n" + detail
+                )
+            gated_offline = _resolve(["--offline", "--exclude-newer", cutoff])
+            if gated_offline.returncode == 0:
+                return None
+            gated_online = _resolve(["--exclude-newer", cutoff])
+            if gated_online.returncode == 0:
+                return None
+            # Final check before deferring: the gated failures above ran
+            # with --no-build, which can't fall back to an *aged, allowed*
+            # sdist when only the newer wheel is refused. The real install
+            # does build, so confirm with builds permitted — safe here,
+            # because --exclude-newer means only gate-passing artifacts are
+            # candidates for building.
+            gated_build = _resolve(["--exclude-newer", cutoff], no_build=False)
+            if gated_build.returncode == 0:
+                return None
+            return (gated_build.stderr or gated_online.stderr or "").strip() or (
+                "resolution refused by --exclude-newer"
+            )
+    except Exception as exc:
+        logger.debug("release-age preflight skipped: %s", exc)
+        return None
+
+
+def _release_age_preflight_git_ref(
+    git_cmd: list[str], ref: str, cutoff: str, cwd: Path
+) -> str | None:
+    """Preflight the pyproject.toml at a git ref (not yet checked out).
+
+    Returns the block reason when that revision's dependency set is refused
+    solely by the release-age gate, else None (including when the ref has no
+    readable pyproject — fail open, per _release_age_preflight_blocked).
+    """
+    show = subprocess.run(
+        git_cmd + ["show", f"{ref}:pyproject.toml"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+    if show.returncode != 0 or not show.stdout.strip():
+        return None
+    return _release_age_preflight_blocked(show.stdout, cutoff)
+
+
+def _print_release_age_deferral(blocked: str, cutoff: str) -> None:
+    """Explain a preflight deferral: what refused, and how to proceed."""
+    print("✗ Update deferred by the release-age gate:")
+    for line in blocked.splitlines()[-6:]:
+        print(f"    {line}")
+    print(
+        f"  The incoming version requires a dependency published after the "
+        f"cutoff ({cutoff}, minimum_release_age_days="
+        f"{_get_min_release_age_days()})."
+    )
+    print("  Your install is unchanged. Retry once the dependency ages past the")
+    print("  gate, or temporarily set security.minimum_release_age_days: 0.")
 
 
 def _uv_exclude_newer_args(
@@ -10142,6 +10429,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # minutes on a non-single-branch checkout. Fetch only what we update
         # against.
         branch = _resolve_update_branch(args)
+        # Set when the fork's upstream sync is deferred by the release-age
+        # gate after the origin update already applied; the success path
+        # still exits EX_TEMPFAIL so automation retries once the pin ages.
+        upstream_sync_deferred_late = False
 
         print("→ Fetching updates...")
         fetch_result = subprocess.run(
@@ -10176,6 +10467,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
             check=True,
         )
         current_branch = result.stdout.strip()
+        # For detached HEAD "current_branch" is the literal "HEAD"; capture
+        # the commit so a deferred update can restore the exact checkout.
+        original_head_sha = _capture_head_sha(git_cmd, PROJECT_ROOT)
 
         # If user is on a different branch than the update target, switch
         # to the target. When the target is "main" this is the historical
@@ -10191,6 +10485,44 @@ def _cmd_update_impl(args, gateway_mode: bool):
             print(f"  ⚠ Currently on {label} — switching to {branch} for update...")
             # Stash before checkout so uncommitted work isn't lost
             auto_stash_ref = _stash_local_changes_if_needed(git_cmd, PROJECT_ROOT)
+            # Release-age preflight before switching: a successful checkout
+            # advances the tree (real for detached HEAD), after which a
+            # zero-commit early return would skip the main preflight. The
+            # checked ref is the *fetched* tip — the update's true
+            # destination — not the possibly-stale local branch tip, which
+            # the flow only passes through transiently.
+            switch_cutoff = _exclude_newer_date(_get_min_release_age_days())
+            if switch_cutoff:
+                fetched_tip = subprocess.run(
+                    git_cmd + ["rev-parse", "--verify", f"origin/{branch}"],
+                    cwd=PROJECT_ROOT,
+                    capture_output=True,
+                    text=True,
+                )
+                target_sha = (
+                    fetched_tip.stdout.strip()
+                    if fetched_tip.returncode == 0
+                    else None
+                )
+                if target_sha and target_sha != original_head_sha:
+                    blocked = _release_age_preflight_git_ref(
+                        git_cmd, target_sha, switch_cutoff, PROJECT_ROOT
+                    )
+                    if blocked:
+                        _print_release_age_deferral(blocked, switch_cutoff)
+                        # Checkout hasn't run — the stash restores in place.
+                        if auto_stash_ref is not None:
+                            _restore_stashed_changes(
+                                git_cmd,
+                                PROJECT_ROOT,
+                                auto_stash_ref,
+                                prompt_user=False,
+                                input_fn=gw_input_fn,
+                            )
+                        _resume_windows_gateways_after_update(
+                            _windows_gateway_resume
+                        )
+                        sys.exit(75)  # EX_TEMPFAIL
             checkout_result = subprocess.run(
                 git_cmd + ["checkout", branch],
                 cwd=PROJECT_ROOT,
@@ -10202,6 +10534,33 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 # it up as a tracking branch of origin/<branch>. This is
                 # the common case when the requested branch exists upstream
                 # but was never checked out locally.
+                #
+                # Release-age preflight first: ``checkout -B`` jumps the
+                # live tree straight to the fetched revision, after which
+                # the zero-commit early return skips the main preflight.
+                switch_cutoff = _exclude_newer_date(_get_min_release_age_days())
+                if switch_cutoff:
+                    blocked = _release_age_preflight_git_ref(
+                        git_cmd, f"origin/{branch}", switch_cutoff, PROJECT_ROOT
+                    )
+                    if blocked:
+                        _print_release_age_deferral(blocked, switch_cutoff)
+                        # Still on the original branch (checkout failed), so
+                        # the stash restores where it was taken.
+                        if auto_stash_ref is not None:
+                            _restore_stashed_changes(
+                                git_cmd,
+                                PROJECT_ROOT,
+                                auto_stash_ref,
+                                prompt_user=False,
+                                input_fn=gw_input_fn,
+                            )
+                        _resume_windows_gateways_after_update(
+                            _windows_gateway_resume
+                        )
+                        # EX_TEMPFAIL: automation and the gateway watcher
+                        # must not report a deferred update as applied.
+                        sys.exit(75)
                 track_result = subprocess.run(
                     git_cmd + ["checkout", "-B", branch, f"origin/{branch}"],
                     cwd=PROJECT_ROOT,
@@ -10246,8 +10605,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
             _invalidate_update_cache()
 
             # Even if origin is up to date, the fork may be behind upstream
+            upstream_sync_deferred = False
             if is_fork and branch == "main":
-                _sync_with_upstream_if_needed(git_cmd, PROJECT_ROOT)
+                upstream_sync_deferred = bool(
+                    _sync_with_upstream_if_needed(git_cmd, PROJECT_ROOT)
+                )
 
             # Restore stash and switch back to original branch if we moved
             if auto_stash_ref is not None:
@@ -10266,6 +10628,12 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     text=True,
                     check=False,
                 )
+
+            if upstream_sync_deferred:
+                # The pending upstream update was deferred by the release-age
+                # gate — automation must not read this as "update applied".
+                _resume_windows_gateways_after_update(_windows_gateway_resume)
+                sys.exit(75)  # EX_TEMPFAIL
 
             # A current checkout does NOT imply a healthy install: a previous
             # dependency sync may have failed partway (classic on Windows,
@@ -10326,6 +10694,67 @@ def _cmd_update_impl(args, gateway_mode: bool):
 
         print(f"→ Found {commit_count} new commit(s)")
 
+        # Release-age gate preflight: resolve the *incoming* core dependency
+        # set (already fetched, not yet checked out) against the gate before
+        # the pull advances source. A confirmed gate rejection defers the
+        # whole update with the install unchanged; see
+        # _release_age_preflight_blocked for the fail-open contract.
+        #
+        # The preflighted revision is pinned: `git pull` re-fetches and the
+        # ref can move between our check and the merge, so when the gate is
+        # active the update below fast-forwards to exactly this SHA instead
+        # of whatever origin/<branch> means by then.
+        preflighted_sha: str | None = None
+        preflight_cutoff = _exclude_newer_date(_get_min_release_age_days())
+        if preflight_cutoff:
+            sha_result = subprocess.run(
+                git_cmd + ["rev-parse", f"origin/{branch}"],
+                cwd=PROJECT_ROOT,
+                capture_output=True,
+                text=True,
+            )
+            sha = sha_result.stdout.strip() if sha_result.returncode == 0 else ""
+            blocked = (
+                _release_age_preflight_git_ref(
+                    git_cmd, sha, preflight_cutoff, PROJECT_ROOT
+                )
+                if sha
+                else None
+            )
+            if blocked:
+                _print_release_age_deferral(blocked, preflight_cutoff)
+                # Return to the user's checkout BEFORE restoring their stash —
+                # applying it onto the update target branch could conflict
+                # and strand the edits in the stash. Detached HEAD goes back
+                # to the exact commit it was on.
+                restore_target = None
+                if current_branch == "HEAD":
+                    restore_target = original_head_sha
+                elif current_branch != branch:
+                    restore_target = current_branch
+                if restore_target:
+                    subprocess.run(
+                        git_cmd + ["checkout", restore_target],
+                        cwd=PROJECT_ROOT,
+                        capture_output=True,
+                        text=True,
+                        check=False,
+                    )
+                if auto_stash_ref is not None:
+                    _restore_stashed_changes(
+                        git_cmd,
+                        PROJECT_ROOT,
+                        auto_stash_ref,
+                        prompt_user=prompt_for_restore,
+                        input_fn=gw_input_fn,
+                    )
+                _resume_windows_gateways_after_update(_windows_gateway_resume)
+                # EX_TEMPFAIL: automation and the gateway watcher must not
+                # report a deferred update as applied.
+                sys.exit(75)
+            if sha:
+                preflighted_sha = sha
+
         print("→ Pulling updates...")
         update_succeeded = False
         # Capture the pre-pull SHA so we can auto-roll-back if the new code
@@ -10335,12 +10764,24 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # the bad commit and the fix landing).
         pre_pull_sha = _capture_head_sha(git_cmd, PROJECT_ROOT)
         try:
-            pull_result = subprocess.run(
-                git_cmd + ["pull", "--ff-only", "origin", branch],
-                cwd=PROJECT_ROOT,
-                capture_output=True,
-                text=True,
-            )
+            if preflighted_sha:
+                # Gate active: advance to exactly the revision the preflight
+                # validated (`git pull` would re-fetch and could land on a
+                # newer commit whose deps were never preflighted). The
+                # objects are already local from the fetch above.
+                pull_result = subprocess.run(
+                    git_cmd + ["merge", "--ff-only", preflighted_sha],
+                    cwd=PROJECT_ROOT,
+                    capture_output=True,
+                    text=True,
+                )
+            else:
+                pull_result = subprocess.run(
+                    git_cmd + ["pull", "--ff-only", "origin", branch],
+                    cwd=PROJECT_ROOT,
+                    capture_output=True,
+                    text=True,
+                )
             if pull_result.returncode != 0:
                 # ff-only failed — local and remote have diverged (e.g. upstream
                 # force-pushed or rebase).  Since local changes are already
@@ -10349,7 +10790,8 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     "  ⚠ Fast-forward not possible (history diverged), resetting to match remote..."
                 )
                 reset_result = subprocess.run(
-                    git_cmd + ["reset", "--hard", f"origin/{branch}"],
+                    git_cmd
+                    + ["reset", "--hard", preflighted_sha or f"origin/{branch}"],
                     cwd=PROJECT_ROOT,
                     capture_output=True,
                     text=True,
@@ -10445,7 +10887,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
 
         # Fork upstream sync logic (only for main branch on forks)
         if is_fork and branch == "main":
-            _sync_with_upstream_if_needed(git_cmd, PROJECT_ROOT)
+            upstream_sync_deferred_late = bool(
+                _sync_with_upstream_if_needed(git_cmd, PROJECT_ROOT)
+            )
 
         # Reinstall Python dependencies. Prefer .[all], but if one optional extra
         # breaks on this machine, keep base deps and reinstall the remaining extras
@@ -11632,6 +12076,12 @@ def _cmd_update_impl(args, gateway_mode: bool):
         print()
         print("Tip: You can now select a provider and model:")
         print("  hermes model              # Select provider and model")
+
+        if upstream_sync_deferred_late:
+            # Origin's commits and dependencies applied fine, but the
+            # upstream portion of this fork update was deferred by the
+            # release-age gate — EX_TEMPFAIL so automation retries later.
+            sys.exit(75)
 
     except subprocess.CalledProcessError as e:
         if sys.platform == "win32":

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6446,12 +6446,16 @@ def _update_via_zip(args):
     pip_cmd = [sys.executable, "-m", "pip"]
     if not uv_bin:
         uv_bin = _ensure_uv_for_termux(pip_cmd)
+    cutoff = _exclude_newer_date(_get_min_release_age_days())
+    _print_release_age_status(uv_available=bool(uv_bin))
     if uv_bin:
         uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
         if _is_termux_env(uv_env):
             uv_env.pop("PYTHONPATH", None)
             uv_env.pop("PYTHONHOME", None)
-        _install_python_dependencies_with_optional_fallback([uv_bin, "pip"], env=uv_env)
+        _install_python_dependencies_with_optional_fallback(
+            [uv_bin, "pip"], env=uv_env, exclude_newer=cutoff
+        )
     else:
         # Use sys.executable to explicitly call the venv's pip module,
         # avoiding PEP 668 'externally-managed-environment' errors on Debian/Ubuntu.
@@ -6470,7 +6474,7 @@ def _update_via_zip(args):
                 cwd=PROJECT_ROOT,
                 check=True,
             )
-        _install_python_dependencies_with_optional_fallback(pip_cmd)
+        _install_python_dependencies_with_optional_fallback(pip_cmd, exclude_newer=cutoff)
 
     node_failures = _update_node_dependencies()
     _build_web_ui(PROJECT_ROOT / "web")
@@ -7239,6 +7243,7 @@ def _recover_from_interrupted_install() -> None:
                 logger.debug("ensurepip during install recovery failed: %s", exc)
 
             uv_bin = ensure_uv()
+            _print_release_age_status(uv_available=bool(uv_bin))
             if uv_bin:
                 uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
                 if _is_termux_env(uv_env):
@@ -7248,6 +7253,7 @@ def _recover_from_interrupted_install() -> None:
                     [uv_bin, "pip"],
                     env=uv_env,
                     group="termux-all" if _is_termux_env(uv_env) else "all",
+                    exclude_newer=_exclude_newer_date(_get_min_release_age_days()),
                 )
             else:
                 _install_python_dependencies_with_optional_fallback(
@@ -7731,6 +7737,16 @@ def _refresh_active_lazy_features() -> None:
     print()
     print(f"→ Refreshing {len(active)} active lazy backend(s)...")
 
+    # Release-age gate: lazy_deps builds its own uv commands, so the flag
+    # can't be threaded through its API without coupling it to the CLI.
+    # uv reads UV_EXCLUDE_NEWER as the env equivalent of --exclude-newer;
+    # scope it to this refresh so gated updates can't pull brand-new
+    # artifacts through the lazy path. The pip fallback tier ignores the
+    # variable, matching the gate's uv-only behavior elsewhere.
+    cutoff = _exclude_newer_date(_get_min_release_age_days())
+    saved_exclude_newer = os.environ.get("UV_EXCLUDE_NEWER")
+    if cutoff:
+        os.environ["UV_EXCLUDE_NEWER"] = cutoff
     try:
         results = lazy_deps.refresh_active_features(prompt=False)
     except Exception as exc:
@@ -7738,6 +7754,12 @@ def _refresh_active_lazy_features() -> None:
         # the update flow against future regressions.
         print(f"  ⚠ Lazy refresh failed unexpectedly: {exc}")
         return
+    finally:
+        if cutoff:
+            if saved_exclude_newer is None:
+                os.environ.pop("UV_EXCLUDE_NEWER", None)
+            else:
+                os.environ["UV_EXCLUDE_NEWER"] = saved_exclude_newer
 
     refreshed = [f for f, s in results.items() if s == "refreshed"]
     current = [f for f, s in results.items() if s == "current"]
@@ -7765,16 +7787,137 @@ def _refresh_active_lazy_features() -> None:
         print("  `hermes update` once the upstream issue is resolved.")
 
 
+def _get_min_release_age_days() -> int:
+    """Read ``security.minimum_release_age_days`` from the active config.
+
+    Returns 0 (disabled) on any error — the gate is additive, so failing
+    closed here would block all updates, which is the wrong default for a
+    config-read error. Persistent misconfiguration (e.g. a typo'd key) is
+    surfaced via a one-line debug log rather than silent fallthrough so an
+    operator who *thinks* the gate is on can see why it isn't firing.
+    Returns int >= 0.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        sec = cfg.get("security", {}) if isinstance(cfg, dict) else {}
+        val = sec.get("minimum_release_age_days", 0)
+        if val is None:
+            return 0
+        try:
+            return max(0, int(val))
+        except (TypeError, ValueError):
+            logger.warning(
+                "security.minimum_release_age_days has non-integer value %r; "
+                "treating as 0 (gate disabled)",
+                val,
+            )
+            return 0
+    except Exception as exc:
+        logger.debug("release-age gate config read failed: %s", exc)
+        return 0
+
+
+def _exclude_newer_date(min_age_days: int, *, _now_utc=None) -> str | None:
+    """Compute the RFC 3339 timestamp for ``uv pip install --exclude-newer``.
+
+    Returns ``now (UTC) - min_age_days`` as ``YYYY-MM-DDTHH:MM:SSZ``, or
+    ``None`` when the gate is disabled (``min_age_days <= 0``). uv refuses
+    any artifact whose upload time is after the cutoff — so a package
+    published now is refused until exactly ``min_age_days``×24h have
+    elapsed. A bare date would be interpreted by uv as midnight in the
+    host's *local* timezone, admitting packages hours early (or late)
+    depending on where the machine sits; the explicit UTC timestamp makes
+    the window exact everywhere.
+
+    ``_now_utc`` is a test-only seam — pass a ``datetime`` to fix "now" for
+    deterministic regression tests against known incident dates.
+    """
+    if min_age_days <= 0:
+        return None
+    from datetime import datetime, timedelta, timezone
+
+    now = _now_utc if _now_utc is not None else datetime.now(timezone.utc)
+    cutoff = now - timedelta(days=min_age_days)
+    if cutoff.tzinfo is not None:
+        cutoff = cutoff.astimezone(timezone.utc)
+    return cutoff.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _print_release_age_status(
+    uv_available: bool,
+    *,
+    gateway_mode: bool = False,
+    update_mode: str | None = None,
+) -> None:
+    """Surface the release-age gate's state to the operator during update.
+
+    Silent when the gate is off (matches the wider "silent-when-clean"
+    pattern in ``security_advisories.py``); discoverability lives in
+    ``cli-config.yaml.example``. When the gate is on, prints either a
+    confirmation with the active cutoff (uv available) or a warning that
+    the current updater path cannot apply it (pipx has no
+    ``--exclude-newer`` equivalent; plain pip requires uv). Suppressed
+    entirely in gateway mode (no human terminal).
+    """
+    if gateway_mode:
+        return
+    days = _get_min_release_age_days()
+    if days <= 0:
+        return
+    if uv_available:
+        cutoff = _exclude_newer_date(days)
+        print(
+            f"  ↳ release-age gate active: refusing PyPI versions newer than "
+            f"{cutoff} (minimum_release_age_days={days})"
+        )
+    elif update_mode == "pipx":
+        print(
+            f"  ⚠ release-age gate configured (minimum_release_age_days={days}) "
+            f"but `pipx upgrade` has no --exclude-newer equivalent; "
+            f"proceeding without gating"
+        )
+    else:
+        print(
+            f"  ⚠ release-age gate configured (minimum_release_age_days={days}) "
+            f"but requires `uv`; falling through without gating"
+        )
+
+
+def _uv_exclude_newer_args(
+    install_cmd_prefix: list[str], exclude_newer: str | None
+) -> list[str]:
+    """Return ``["--exclude-newer", <date>]`` when the command is uv, else [].
+
+    uv accepts --exclude-newer; plain pip does not. Exact-match the binary
+    name (with optional .exe suffix on Windows) — substring matching would
+    false-positive on `pyuv`, `uvloop`-named wrappers, etc.
+    """
+    if exclude_newer and install_cmd_prefix:
+        head = os.path.basename(install_cmd_prefix[0]).lower()
+        if head in {"uv", "uv.exe"}:
+            return ["--exclude-newer", exclude_newer]
+    return []
+
+
 def _install_python_dependencies_with_optional_fallback(
     install_cmd_prefix: list[str],
     *,
     env: dict[str, str] | None = None,
     group: str = "all",
+    exclude_newer: str | None = None,
 ) -> None:
     """Install base deps plus as many optional extras as the environment supports.
 
     By default this targets ``.[all]``; Termux callers can pass
     ``group='termux-all'`` to use the curated Android-compatible profile.
+
+    When ``exclude_newer`` is a non-empty ISO date string and the install
+    command is a uv invocation (``["uv", "pip"]``-style), the date is
+    appended as ``--exclude-newer <date>`` to refuse PyPI artifacts
+    uploaded after that date. Plain ``pip`` invocations ignore the flag
+    (logged once by the caller via ``_print_release_age_status``).
 
     On Windows, pre-renames live ``hermes.exe`` / ``hermes-gateway.exe`` shims
     in the venv Scripts dir before each install attempt so uv can write fresh
@@ -7782,22 +7925,39 @@ def _install_python_dependencies_with_optional_fallback(
     ``_quarantine_running_hermes_exe`` for the rationale.
     """
     scripts_dir = _venv_scripts_dir() if _is_windows() else None
+    extra_args = _uv_exclude_newer_args(install_cmd_prefix, exclude_newer)
 
     def _install(args: list[str]) -> None:
         _run_quarantined_install(
-            install_cmd_prefix + args, env=env, scripts_dir=scripts_dir
+            install_cmd_prefix + args + extra_args, env=env, scripts_dir=scripts_dir
         )
 
     try:
         _install(["install", "-e", f".[{group}]"])
-        _verify_console_scripts_installed(install_cmd_prefix, env=env)
+        _verify_console_scripts_installed(
+            install_cmd_prefix, env=env, exclude_newer=exclude_newer
+        )
         return
     except subprocess.CalledProcessError:
         print(
             "  ⚠ Optional extras failed, reinstalling base dependencies and retrying extras individually..."
         )
 
-    _install(["install", "-e", "."])
+    try:
+        _install(["install", "-e", "."])
+    except subprocess.CalledProcessError:
+        if extra_args:
+            # The source tree has already been updated at this point, so a
+            # gate-refused core pin would otherwise strand the install with a
+            # cryptic resolver error until the pin ages past the cutoff.
+            print(
+                f"  ⚠ Base install failed with the release-age gate active "
+                f"(--exclude-newer {exclude_newer}). If a required dependency "
+                f"was released after that date, either wait for it to age past "
+                f"the gate or temporarily set security.minimum_release_age_days "
+                f"to 0 and rerun `hermes update`."
+            )
+        raise
 
     failed_extras: list[str] = []
     installed_extras: list[str] = []
@@ -7827,8 +7987,12 @@ def _install_python_dependencies_with_optional_fallback(
     # stage. Reinstall with --reinstall to force resolution if anything is
     # missing, then re-verify so the failure surfaces here instead of
     # downstream.
-    _verify_core_dependencies_installed(install_cmd_prefix, env=env, group=group)
-    _verify_console_scripts_installed(install_cmd_prefix, env=env)
+    _verify_core_dependencies_installed(
+        install_cmd_prefix, env=env, group=group, exclude_newer=exclude_newer
+    )
+    _verify_console_scripts_installed(
+        install_cmd_prefix, env=env, exclude_newer=exclude_newer
+    )
 
 
 def _load_console_script_names() -> list[str]:
@@ -7856,6 +8020,7 @@ def _verify_console_scripts_installed(
     install_cmd_prefix: list[str],
     *,
     env: dict[str, str] | None = None,
+    exclude_newer: str | None = None,
 ) -> None:
     """Ensure every declared console_script shim exists on disk after install.
 
@@ -7899,7 +8064,9 @@ def _verify_console_scripts_installed(
 
     try:
         _run_quarantined_install(
-            install_cmd_prefix + ["install", "--reinstall", "-e", "."],
+            install_cmd_prefix
+            + ["install", "--reinstall", "-e", "."]
+            + _uv_exclude_newer_args(install_cmd_prefix, exclude_newer),
             env=env,
             scripts_dir=scripts_dir,
         )
@@ -7926,6 +8093,7 @@ def _verify_core_dependencies_installed(
     *,
     env: dict[str, str] | None = None,
     group: str = "all",
+    exclude_newer: str | None = None,
 ) -> None:
     """Check that every base dep from pyproject.toml is importable; if not, retry.
 
@@ -8050,7 +8218,9 @@ def _verify_core_dependencies_installed(
     # rewrites the entry-point shims, and on Windows pip can't overwrite the
     # live launcher, which would leave ``hermes`` off PATH.
     scripts_dir = _venv_scripts_dir() if _is_windows() else None
-    repair_args = ["install", "--reinstall", "-e", "."]
+    repair_args = ["install", "--reinstall", "-e", "."] + _uv_exclude_newer_args(
+        install_cmd_prefix, exclude_newer
+    )
     try:
         _run_quarantined_install(
             install_cmd_prefix + repair_args, env=env, scripts_dir=scripts_dir
@@ -8084,7 +8254,10 @@ def _verify_core_dependencies_installed(
     )
     try:
         _run_install_with_heartbeat(
-            install_cmd_prefix + ["install", "--reinstall", *specs], env=env
+            install_cmd_prefix
+            + ["install", "--reinstall", *specs]
+            + _uv_exclude_newer_args(install_cmd_prefix, exclude_newer),
+            env=env,
         )
     except subprocess.CalledProcessError as e:
         logger.warning("dep verification: per-package repair failed: %s", e)
@@ -8144,6 +8317,7 @@ def _install_psutil_android_compat(
     install_cmd_prefix: list[str],
     *,
     env: dict[str, str] | None = None,
+    exclude_newer: str | None = None,
 ) -> None:
     """Install psutil on Android by patching upstream platform detection.
 
@@ -8162,7 +8336,23 @@ def _install_psutil_android_compat(
     """
     import tempfile
     import urllib.request
-    from hermes_cli.psutil_android import PSUTIL_URL, prepare_patched_psutil_sdist
+    from hermes_cli.psutil_android import (
+        PSUTIL_UPLOAD_TIME,
+        PSUTIL_URL,
+        prepare_patched_psutil_sdist,
+    )
+
+    # This direct sdist download bypasses uv's --exclude-newer, so enforce
+    # the release-age gate against the pin's recorded upload time. Skipping
+    # here is consistent: the subsequent gated editable install resolves
+    # psutil itself and refuses a too-new pin the same way.
+    if exclude_newer and PSUTIL_UPLOAD_TIME > exclude_newer:
+        print(
+            f"  ⚠ release-age gate: pinned psutil sdist was uploaded "
+            f"{PSUTIL_UPLOAD_TIME}, newer than the cutoff {exclude_newer}; "
+            f"skipping the Android compat preinstall."
+        )
+        return
 
     with tempfile.TemporaryDirectory() as tmp:
         tmp_path = Path(tmp)
@@ -9742,18 +9932,33 @@ def _cmd_update_pip(args):
     # set it for them.
     export_virtualenv = False
 
+    # Release-age gate: both uv paths (`uv tool upgrade` and `uv pip
+    # install`) accept ``--exclude-newer``; pipx and plain pip do not, so
+    # those paths proceed ungated with an explicit warning from
+    # ``_print_release_age_status``.
+    cutoff = _exclude_newer_date(_get_min_release_age_days())
+    gate_applied = False
+    update_mode = None
+
     if is_uv_tool_install():
         if not uv:
             print("✗ Detected a uv-tool install but managed uv install failed.")
             print("  Install uv manually: https://docs.astral.sh/uv/getting-started/installation/")
             sys.exit(1)
         cmd = [uv, "tool", "upgrade", "hermes-agent"]
+        if cutoff:
+            cmd.extend(["--exclude-newer", cutoff])
+        gate_applied = True
     elif pipx_managed and pipx:
         # pipx owns its own venv; ``pipx upgrade`` is the only correct path.
         # Matches scripts/auto-update.sh, which already uses pipx upgrade.
         cmd = [pipx, "upgrade", "hermes-agent"]
+        update_mode = "pipx"
     elif uv:
         cmd = [uv, "pip", "install", "--upgrade", "hermes-agent"]
+        if cutoff:
+            cmd.extend(["--exclude-newer", cutoff])
+        gate_applied = True
         if in_venv:
             # Launcher shim runs the venv interpreter but doesn't export
             # VIRTUAL_ENV; without it uv errors "No virtual environment found".
@@ -9764,6 +9969,7 @@ def _cmd_update_pip(args):
             cmd.insert(3, "--system")
     else:
         cmd = [sys.executable, "-m", "pip", "install", "--upgrade", "hermes-agent"]
+    _print_release_age_status(uv_available=gate_applied, update_mode=update_mode)
 
     print(f"→ Running: {' '.join(cmd)}")
     run_kwargs = {}
@@ -10093,10 +10299,14 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         cwd=PROJECT_ROOT,
                         check=False,
                     )
+                _print_release_age_status(uv_available=bool(repair_uv))
                 if repair_uv:
                     repair_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
                     _install_python_dependencies_with_optional_fallback(
-                        [repair_uv, "pip"], env=repair_env, group="all"
+                        [repair_uv, "pip"],
+                        env=repair_env,
+                        group="all",
+                        exclude_newer=_exclude_newer_date(_get_min_release_age_days()),
                     )
                 else:
                     _install_python_dependencies_with_optional_fallback(
@@ -10259,6 +10469,8 @@ def _cmd_update_impl(args, gateway_mode: bool):
         if not uv_bin:
             uv_bin = _ensure_uv_for_termux(pip_cmd)
         install_group = "all"
+        cutoff = _exclude_newer_date(_get_min_release_age_days())
+        _print_release_age_status(uv_available=bool(uv_bin), gateway_mode=gateway_mode)
 
         if uv_bin:
             uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
@@ -10269,9 +10481,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 print("  → Termux detected: using uv + curated termux-all optional profile...")
             if _is_termux_env(uv_env) and _is_android_python():
                 print("  → Termux/Android detected: prebuilding psutil with Linux source path compatibility...")
-                _install_psutil_android_compat([uv_bin, "pip"], env=uv_env)
+                _install_psutil_android_compat(
+                    [uv_bin, "pip"], env=uv_env, exclude_newer=cutoff
+                )
             _install_python_dependencies_with_optional_fallback(
-                [uv_bin, "pip"], env=uv_env, group=install_group
+                [uv_bin, "pip"], env=uv_env, group=install_group, exclude_newer=cutoff
             )
         else:
             # Use sys.executable to explicitly call the venv's pip module,
@@ -10297,8 +10511,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 print("  → Termux detected: using curated termux-all optional profile...")
             if _is_termux_env() and _is_android_python():
                 print("  → Termux/Android detected: prebuilding psutil with Linux source path compatibility...")
+                # No exclude_newer: this whole plain-pip branch is ungated
+                # (warned above) — skipping only the psutil preinstall would
+                # break Termux while pip installs everything else ungated.
                 _install_psutil_android_compat(pip_cmd)
-            _install_python_dependencies_with_optional_fallback(pip_cmd, group=install_group)
+            _install_python_dependencies_with_optional_fallback(pip_cmd, group=install_group, exclude_newer=cutoff)
 
         # Core Python deps installed AND verified (the fallback helper runs
         # _verify_core_dependencies_installed). Clear the interrupted-install

--- a/hermes_cli/psutil_android.py
+++ b/hermes_cli/psutil_android.py
@@ -14,6 +14,11 @@ PSUTIL_URL = (
     "psutil-7.2.2.tar.gz"
 )
 
+# PyPI upload time of the pinned sdist above (urls[].upload_time_iso_8601).
+# The release-age gate compares this against its cutoff since this direct
+# download bypasses uv's --exclude-newer. Update together with PSUTIL_URL.
+PSUTIL_UPLOAD_TIME = "2026-01-28T18:14:54Z"
+
 MARKER = 'LINUX = sys.platform.startswith("linux")'
 REPLACEMENT = 'LINUX = sys.platform.startswith(("linux", "android"))'
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -2050,6 +2050,7 @@ LEGACY_AUTHOR_MAP = {
     "1torhan@protonmail.com": "uzaylisak",  # PR #29988 salvage (detect_local_server_type process-lifetime cache)
     "zhchl@hermes-agent.local": "8294",  # PR #50572 salvage (honor config context_length on banner)
     "yansh2017@gmail.com": "ya-nsh",  # PR #26790 salvage (normalize local terminal relative cwd; #26783)
+    "jrcrittenden@gmail.com": "jrcrittenden",  # PR #28749 (release-age gate on hermes update)
 }
 
 

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -428,7 +428,9 @@ class TestCmdUpdateBranchFallback:
             hm,
             "_get_origin_url",
             return_value="https://github.com/example/hermes-agent.git",
-        ), patch.object(hm, "_sync_with_upstream_if_needed") as sync_mock:
+        ), patch.object(
+            hm, "_sync_with_upstream_if_needed", return_value=False
+        ) as sync_mock:
             cmd_update(mock_args)
 
         expected_git_cmd = (

--- a/tests/hermes_cli/test_release_age_gate.py
+++ b/tests/hermes_cli/test_release_age_gate.py
@@ -522,3 +522,414 @@ class TestGateCoverageOfInternalInstallers:
         )
         assert len(installed) == 1
         assert "--no-build-isolation" in installed[0]
+
+
+class TestReleaseAgePreflight:
+    """Option-A preflight: defer the update BEFORE source advances when the
+    incoming core dependency set is blocked solely by the gate."""
+
+    _PYPROJECT = '[project]\nname = "x"\nversion = "0"\ndependencies = ["foo==1.2.3"]\n'
+
+    def _run(
+        self,
+        monkeypatch,
+        *,
+        ungated_rc,
+        gated_offline_rc=0,
+        gated_online_rc=0,
+        gated_build_rc=0,
+        uv="/usr/bin/uv",
+    ):
+        calls: list[list[str]] = []
+        envs: list[dict | None] = []
+
+        def fake_run(cmd, **kw):
+            from types import SimpleNamespace
+
+            if "--help" in cmd:
+                # Capability probe: report a uv that supports all gate flags.
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout="--exclude-newer --no-build --offline",
+                    stderr="",
+                )
+            calls.append(list(cmd))
+            envs.append(kw.get("env"))
+            if "--exclude-newer" not in cmd:
+                rc = ungated_rc
+            elif "--offline" in cmd:
+                rc = gated_offline_rc
+            elif "--no-build" in cmd:
+                rc = gated_online_rc
+            else:
+                rc = gated_build_rc
+
+            return SimpleNamespace(
+                returncode=rc,
+                stdout="",
+                stderr="refused: only releases before cutoff allowed" if rc else "",
+            )
+
+        monkeypatch.setattr(cli_main.subprocess, "run", fake_run)
+        monkeypatch.setattr("hermes_cli.managed_uv.ensure_uv", lambda: uv)
+        result = cli_main._release_age_preflight_blocked(
+            self._PYPROJECT, "2026-05-10T00:00:00Z"
+        )
+        return result, calls, envs
+
+    def test_defers_when_only_the_gate_blocks_resolution(self, monkeypatch):
+        """Ungated succeeds; gated fails offline, online, AND with builds
+        permitted → confirmed rejection."""
+        blocked, calls, _ = self._run(
+            monkeypatch,
+            ungated_rc=0,
+            gated_offline_rc=1,
+            gated_online_rc=1,
+            gated_build_rc=1,
+        )
+        assert blocked is not None and "refused" in blocked
+        assert len(calls) == 4
+        assert "--exclude-newer" not in calls[0]
+        assert "--offline" in calls[1]
+        assert "--offline" not in calls[2] and "--exclude-newer" in calls[2]
+        # The resolves that can encounter ungated candidates must never
+        # execute a PEP 517 backend; only the final gate-confirmed check
+        # permits builds (its candidates are all gate-passing artifacts).
+        assert all("--no-build" in c for c in calls[:3])
+        assert "--no-build" not in calls[3] and "--exclude-newer" in calls[3]
+
+    def test_no_deferral_when_aged_sdist_satisfies_gated_build(self, monkeypatch):
+        """Wheel newer than cutoff + aged sdist: the --no-build gated runs
+        fail, but the build-permitted gated confirm succeeds (the real
+        install builds) → fail open."""
+        blocked, calls, _ = self._run(
+            monkeypatch,
+            ungated_rc=0,
+            gated_offline_rc=1,
+            gated_online_rc=1,
+            gated_build_rc=0,
+        )
+        assert blocked is None
+        assert len(calls) == 4
+
+    def test_ambient_uv_exclude_newer_is_scrubbed(self, monkeypatch):
+        """A stray UV_EXCLUDE_NEWER in the environment would silently gate
+        the 'ungated' control, masking real rejections as broken-regardless."""
+        monkeypatch.setenv("UV_EXCLUDE_NEWER", "2020-01-01T00:00:00Z")
+        blocked, calls, envs = self._run(monkeypatch, ungated_rc=0)
+        assert blocked is None
+        assert envs and all(e is not None for e in envs)
+        assert all("UV_EXCLUDE_NEWER" not in e for e in envs)
+
+    def test_preflight_includes_build_system_requires(self, monkeypatch):
+        """A too-new [build-system].requires pin strands the update the same
+        way a runtime dep does — it must be part of the resolved set."""
+        seen_reqs: dict[str, str] = {}
+
+        def fake_run(cmd, **kw):
+            from pathlib import Path
+            from types import SimpleNamespace
+
+            if "--help" in cmd:
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout="--exclude-newer --no-build --offline",
+                    stderr="",
+                )
+            reqs_path = next(a for a in cmd if str(a).endswith("requirements.in"))
+            seen_reqs["content"] = Path(reqs_path).read_text(encoding="utf-8")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(cli_main.subprocess, "run", fake_run)
+        monkeypatch.setattr("hermes_cli.managed_uv.ensure_uv", lambda: "/usr/bin/uv")
+
+        pyproject = (
+            '[build-system]\nrequires = ["setuptools==80.0.0"]\n'
+            '[project]\nname = "x"\nversion = "0"\ndependencies = ["foo==1.2.3"]\n'
+        )
+        assert (
+            cli_main._release_age_preflight_blocked(pyproject, "2026-05-10T00:00:00Z")
+            is None
+        )
+        assert "foo==1.2.3" in seen_reqs["content"]
+        assert "setuptools==80.0.0" in seen_reqs["content"]
+
+    def test_sdist_only_falls_back_to_gated_build_and_proceeds(self, monkeypatch):
+        """Wheels-only control fails (sdist-only dep, e.g. Termux) but the
+        gated build-permitted resolve succeeds → the real install will too."""
+        blocked, calls, _ = self._run(
+            monkeypatch, ungated_rc=1, gated_build_rc=0
+        )
+        assert blocked is None
+        assert len(calls) == 2
+        # The fallback resolve is gated (never an ungated build) so it can
+        # only execute backends of aged, gate-passing artifacts.
+        assert "--exclude-newer" in calls[1] and "--no-build" not in calls[1]
+
+    def test_sdist_only_defers_conservatively_when_gated_build_fails(
+        self, monkeypatch
+    ):
+        """If even the gated build can't resolve, advancing source would
+        strand the install whether the cause is the gate or broken deps —
+        defer, with wording that doesn't overclaim gate causality."""
+        blocked, calls, _ = self._run(
+            monkeypatch, ungated_rc=1, gated_build_rc=1
+        )
+        assert blocked is not None
+        assert "may also indicate a resolution problem" in blocked
+        assert len(calls) == 2
+
+    def test_no_deferral_when_gated_resolution_succeeds(self, monkeypatch):
+        blocked, calls, _ = self._run(monkeypatch, ungated_rc=0, gated_offline_rc=0)
+        assert blocked is None
+        assert len(calls) == 2  # ungated + gated --offline; online confirm not needed
+
+    def test_no_deferral_when_offline_fails_but_online_succeeds(self, monkeypatch):
+        """A cache miss can fail the --offline run; the online confirmation
+        succeeding proves the gate is not the cause → fail open."""
+        blocked, calls, _ = self._run(
+            monkeypatch, ungated_rc=0, gated_offline_rc=1, gated_online_rc=0
+        )
+        assert blocked is None
+        assert len(calls) == 3
+
+    def test_fails_open_without_uv(self, monkeypatch):
+        blocked, calls, _ = self._run(
+            monkeypatch, ungated_rc=0, gated_offline_rc=1, gated_online_rc=1, uv=None
+        )
+        assert blocked is None
+        assert calls == []
+
+    def test_fails_open_on_unparsable_pyproject(self, monkeypatch):
+        monkeypatch.setattr("hermes_cli.managed_uv.ensure_uv", lambda: "/usr/bin/uv")
+
+        def boom(cmd, **kw):
+            raise AssertionError("must not resolve an unparsable pyproject")
+
+        monkeypatch.setattr(cli_main.subprocess, "run", boom)
+        assert (
+            cli_main._release_age_preflight_blocked("not [ toml", "2026-05-10T00:00:00Z")
+            is None
+        )
+
+    def test_deferral_message_names_cutoff_and_override(self, monkeypatch, capsys):
+        monkeypatch.setattr(cli_main, "_get_min_release_age_days", lambda: 3)
+        cli_main._print_release_age_deferral(
+            "refused: foo too new", "2026-05-10T00:00:00Z"
+        )
+        out = capsys.readouterr().out
+        assert "Update deferred" in out
+        assert "2026-05-10T00:00:00Z" in out
+        assert "minimum_release_age_days" in out
+        assert "unchanged" in out
+
+    def test_lazy_refresh_makes_managed_uv_discoverable(self, monkeypatch):
+        """On managed installs uv lives off PATH; while the gate scopes
+        UV_EXCLUDE_NEWER (which makes lazy_deps fail closed without uv), the
+        managed uv's dir must be prepended to PATH — and restored after."""
+        import os
+
+        seen: dict[str, str | None] = {}
+
+        class _FakeLazyDeps:
+            @staticmethod
+            def active_features():
+                return ["voice"]
+
+            @staticmethod
+            def refresh_active_features(prompt=False):
+                seen["path"] = os.environ.get("PATH")
+                return {"voice": "current"}
+
+        original_path = os.environ.get("PATH", "")
+        monkeypatch.delenv("UV_EXCLUDE_NEWER", raising=False)
+        monkeypatch.setattr(cli_main, "_get_min_release_age_days", lambda: 3)
+        monkeypatch.setattr(
+            cli_main, "_exclude_newer_date", lambda days, **kw: "2026-05-10T00:00:00Z"
+        )
+        monkeypatch.setattr(cli_main.shutil, "which", lambda name: None)
+        monkeypatch.setattr(
+            "hermes_cli.managed_uv.ensure_uv", lambda: "/fake/hermes-home/bin/uv"
+        )
+        import sys as _sys
+
+        monkeypatch.setitem(_sys.modules, "tools.lazy_deps", _FakeLazyDeps())
+        import tools
+
+        monkeypatch.setattr(tools, "lazy_deps", _FakeLazyDeps(), raising=False)
+        cli_main._refresh_active_lazy_features()
+
+        assert seen["path"].startswith("/fake/hermes-home/bin" + os.pathsep)
+        assert os.environ.get("PATH", "") == original_path
+
+    def test_git_ref_preflight_fails_open_when_ref_has_no_pyproject(self, monkeypatch):
+        from pathlib import Path
+        from types import SimpleNamespace
+
+        monkeypatch.setattr(
+            cli_main.subprocess,
+            "run",
+            lambda cmd, **kw: SimpleNamespace(returncode=128, stdout="", stderr="bad ref"),
+        )
+        assert (
+            cli_main._release_age_preflight_git_ref(
+                ["git"], "origin/xyz", "2026-05-10T00:00:00Z", Path("/tmp")
+            )
+            is None
+        )
+
+    def test_git_ref_preflight_delegates_pyproject_to_blocked_check(self, monkeypatch):
+        from pathlib import Path
+        from types import SimpleNamespace
+
+        monkeypatch.setattr(
+            cli_main.subprocess,
+            "run",
+            lambda cmd, **kw: SimpleNamespace(
+                returncode=0, stdout='[project]\nname="x"\n', stderr=""
+            ),
+        )
+        captured = {}
+
+        def fake_blocked(text, cutoff):
+            captured["text"] = text
+            captured["cutoff"] = cutoff
+            return "blocked-reason"
+
+        monkeypatch.setattr(cli_main, "_release_age_preflight_blocked", fake_blocked)
+        assert (
+            cli_main._release_age_preflight_git_ref(
+                ["git"], "abc123", "2026-05-10T00:00:00Z", Path("/tmp")
+            )
+            == "blocked-reason"
+        )
+        assert captured["cutoff"] == "2026-05-10T00:00:00Z"
+
+    def test_fails_open_when_uv_lacks_gate_flags(self, monkeypatch):
+        """An older uv without --exclude-newer would fail the gated runs with
+        a usage error while the ungated control succeeds — indistinguishable
+        from a real rejection. The capability probe must fail open instead."""
+        from types import SimpleNamespace
+
+        compile_calls: list[list[str]] = []
+
+        def fake_run(cmd, **kw):
+            if "--help" in cmd:
+                return SimpleNamespace(
+                    returncode=0, stdout="an old uv with no such flags", stderr=""
+                )
+            compile_calls.append(list(cmd))
+            return SimpleNamespace(returncode=2, stdout="", stderr="unexpected argument")
+
+        monkeypatch.setattr(cli_main.subprocess, "run", fake_run)
+        monkeypatch.setattr("hermes_cli.managed_uv.ensure_uv", lambda: "/usr/bin/uv")
+
+        assert (
+            cli_main._release_age_preflight_blocked(
+                self._PYPROJECT, "2026-05-10T00:00:00Z"
+            )
+            is None
+        )
+        assert compile_calls == []  # probe failed → no resolution attempted
+
+    def test_resolves_against_target_venv_python(self, monkeypatch, tmp_path):
+        """Resolution must use the interpreter the update installs into —
+        the uv on PATH may be bound to a different Python, skewing marker
+        evaluation and wheel tags."""
+        from types import SimpleNamespace
+
+        venv_bin = tmp_path / "venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        (venv_bin / "python").write_text("")
+        monkeypatch.setattr(cli_main, "PROJECT_ROOT", tmp_path)
+        monkeypatch.setattr(cli_main, "_is_windows", lambda: False)
+
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, **kw):
+            if "--help" in cmd:
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout="--exclude-newer --no-build --offline",
+                    stderr="",
+                )
+            calls.append(list(cmd))
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(cli_main.subprocess, "run", fake_run)
+        monkeypatch.setattr("hermes_cli.managed_uv.ensure_uv", lambda: "/usr/bin/uv")
+
+        cli_main._release_age_preflight_blocked(
+            self._PYPROJECT, "2026-05-10T00:00:00Z"
+        )
+        assert calls, "expected at least one resolve"
+        assert all(
+            "--python" in c and str(venv_bin / "python") in c for c in calls
+        )
+
+
+class TestGatewayModeStatus:
+    """Gateway output is streamed to the messaging user: informational
+    confirmations stay quiet, but a bypassed gate must still warn."""
+
+    def test_gateway_mode_suppresses_active_confirmation(self, monkeypatch, capsys):
+        monkeypatch.setattr(cli_main, "_get_min_release_age_days", lambda: 3)
+        cli_main._print_release_age_status(uv_available=True, gateway_mode=True)
+        assert capsys.readouterr().out == ""
+
+    def test_gateway_mode_still_warns_when_gate_bypassed(self, monkeypatch, capsys):
+        monkeypatch.setattr(cli_main, "_get_min_release_age_days", lambda: 3)
+        cli_main._print_release_age_status(uv_available=False, gateway_mode=True)
+        out = capsys.readouterr().out
+        assert "release-age gate configured" in out
+
+
+class TestReleaseAgeDaysClamp:
+    def test_huge_value_clamped_instead_of_overflowing(self, monkeypatch):
+        """A typo'd huge day count must not crash the datetime subtraction
+        (OverflowError) and brick every update."""
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"security": {"minimum_release_age_days": 10**9}},
+        ):
+            days = cli_main._get_min_release_age_days()
+        assert days == 36500
+        # And the cutoff computation stays representable.
+        assert cli_main._exclude_newer_date(days) is not None
+
+    def test_lazy_refresh_prefers_managed_uv_over_system_uv(self, monkeypatch):
+        """A stale system uv that predates UV_EXCLUDE_NEWER would ignore the
+        gate env var — the managed uv dir must shadow it while gated."""
+        import os
+
+        seen: dict[str, str | None] = {}
+
+        class _FakeLazyDeps:
+            @staticmethod
+            def active_features():
+                return ["voice"]
+
+            @staticmethod
+            def refresh_active_features(prompt=False):
+                seen["path"] = os.environ.get("PATH")
+                return {"voice": "current"}
+
+        monkeypatch.delenv("UV_EXCLUDE_NEWER", raising=False)
+        monkeypatch.setattr(cli_main, "_get_min_release_age_days", lambda: 3)
+        monkeypatch.setattr(
+            cli_main, "_exclude_newer_date", lambda days, **kw: "2026-05-10T00:00:00Z"
+        )
+        # System uv IS discoverable — managed must still shadow it.
+        monkeypatch.setattr(cli_main.shutil, "which", lambda name: "/usr/bin/uv")
+        monkeypatch.setattr(
+            "hermes_cli.managed_uv.ensure_uv", lambda: "/fake/hermes-home/bin/uv"
+        )
+        import sys as _sys
+
+        monkeypatch.setitem(_sys.modules, "tools.lazy_deps", _FakeLazyDeps())
+        import tools
+
+        monkeypatch.setattr(tools, "lazy_deps", _FakeLazyDeps(), raising=False)
+        cli_main._refresh_active_lazy_features()
+
+        assert seen["path"].startswith("/fake/hermes-home/bin" + os.pathsep)

--- a/tests/hermes_cli/test_release_age_gate.py
+++ b/tests/hermes_cli/test_release_age_gate.py
@@ -1,0 +1,524 @@
+"""Tests for the release-age gate on ``hermes update``.
+
+The gate refuses to resolve PyPI versions published less than
+``security.minimum_release_age_days`` ago by passing ``--exclude-newer``
+to ``uv pip install``. This defends against supply-chain compromise
+windows where a malicious release is detected and pulled within days.
+
+The two live incidents that motivated this gate:
+
+- **mistralai 2.4.6** (PyPI, 2026-05-12, Mini Shai-Hulud campaign):
+  malicious release was live for ~15 minutes before PyPI quarantine.
+- **node-ipc 9.1.6 / 9.2.3 / 12.0.1** (npm, 2026-05-14): malicious
+  versions live for hours-to-days before detection-driven removal.
+
+A 3-day gate would have refused both classes outright. These tests
+exercise the helpers in isolation (no real PyPI, no real subprocess
+calls).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli import main as cli_main
+
+
+# ---------------------------------------------------------------------------
+# _exclude_newer_date — pure date arithmetic
+# ---------------------------------------------------------------------------
+
+
+class TestExcludeNewerDate:
+    def test_disabled_returns_none(self):
+        assert cli_main._exclude_newer_date(0) is None
+
+    def test_negative_returns_none(self):
+        assert cli_main._exclude_newer_date(-1) is None
+        assert cli_main._exclude_newer_date(-30) is None
+
+    # Mid-day fixed clock so the tests prove exact N×24h arithmetic, not
+    # just date truncation.
+    _FIXED_NOW = datetime(2026, 5, 13, 12, 30, 45, tzinfo=timezone.utc)
+
+    def test_one_day(self):
+        cutoff = cli_main._exclude_newer_date(1, _now_utc=self._FIXED_NOW)
+        assert cutoff == "2026-05-12T12:30:45Z"
+
+    def test_three_days_matches_nanoclaw_default(self):
+        # NanoClaw's pnpm minimumReleaseAge: 4320 (3 days)
+        cutoff = cli_main._exclude_newer_date(3, _now_utc=self._FIXED_NOW)
+        assert cutoff == "2026-05-10T12:30:45Z"
+
+    def test_seven_days(self):
+        cutoff = cli_main._exclude_newer_date(7, _now_utc=self._FIXED_NOW)
+        assert cutoff == "2026-05-06T12:30:45Z"
+
+    def test_rfc3339_format(self):
+        """Output must be an RFC 3339 UTC timestamp (exact-window enforcement;
+        uv would read a bare date as local midnight)."""
+        cutoff = cli_main._exclude_newer_date(1)
+        assert cutoff is not None
+        assert cutoff.endswith("Z")
+        # Parse round-trip — raises if not valid ISO 8601
+        datetime.fromisoformat(cutoff)
+
+    def test_non_utc_aware_clock_is_normalized(self):
+        """An aware non-UTC "now" must still produce a UTC cutoff."""
+        plus_two = timezone(timedelta(hours=2))
+        now = datetime(2026, 5, 13, 14, 30, 45, tzinfo=plus_two)  # == 12:30:45Z
+        cutoff = cli_main._exclude_newer_date(1, _now_utc=now)
+        assert cutoff == "2026-05-12T12:30:45Z"
+
+
+# ---------------------------------------------------------------------------
+# _get_min_release_age_days — config read with safe default
+# ---------------------------------------------------------------------------
+
+
+class TestGetMinReleaseAgeDays:
+    def test_default_when_config_missing_key(self):
+        with patch("hermes_cli.config.load_config", return_value={"security": {}}):
+            assert cli_main._get_min_release_age_days() == 0
+
+    def test_default_when_security_block_missing(self):
+        with patch("hermes_cli.config.load_config", return_value={}):
+            assert cli_main._get_min_release_age_days() == 0
+
+    def test_default_when_config_load_raises(self):
+        # Failing closed (blocking the gate) would be wrong — it would
+        # block all updates for any config error.
+        with patch("hermes_cli.config.load_config", side_effect=RuntimeError("boom")):
+            assert cli_main._get_min_release_age_days() == 0
+
+    def test_reads_configured_value(self):
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"security": {"minimum_release_age_days": 3}},
+        ):
+            assert cli_main._get_min_release_age_days() == 3
+
+    def test_coerces_str_int(self):
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"security": {"minimum_release_age_days": "7"}},
+        ):
+            assert cli_main._get_min_release_age_days() == 7
+
+    def test_none_treated_as_zero(self):
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"security": {"minimum_release_age_days": None}},
+        ):
+            assert cli_main._get_min_release_age_days() == 0
+
+
+# ---------------------------------------------------------------------------
+# _install_python_dependencies_with_optional_fallback — flag injection
+# ---------------------------------------------------------------------------
+
+
+class TestExcludeNewerInjection:
+    """Verify the install function actually passes --exclude-newer to uv.
+
+    These tests assert the *behavior* of the install path with a fixture
+    around `_run_install_with_heartbeat` — they catch regressions where
+    `extra_args` is silently dropped or `exclude_newer` is forgotten by
+    a future refactor.
+    """
+
+    def test_uv_command_gets_exclude_newer_when_provided(self, monkeypatch):
+        """A uv-prefixed install command receives --exclude-newer <date>."""
+        captured_args: list[list[str]] = []
+
+        def fake_run(args, env=None):
+            captured_args.append(list(args))
+
+        monkeypatch.setattr(cli_main, "_run_install_with_heartbeat", fake_run)
+        monkeypatch.setattr(cli_main, "_is_windows", lambda: False)
+
+        cli_main._install_python_dependencies_with_optional_fallback(
+            ["uv", "pip"], group="all", exclude_newer="2026-05-10"
+        )
+
+        assert len(captured_args) == 1
+        assert captured_args[0] == [
+            "uv", "pip", "install", "-e", ".[all]", "--exclude-newer", "2026-05-10"
+        ]
+
+    def test_uv_command_no_flag_when_none(self, monkeypatch):
+        """When exclude_newer is None (gate disabled), no flag is added."""
+        captured_args: list[list[str]] = []
+
+        def fake_run(args, env=None):
+            captured_args.append(list(args))
+
+        monkeypatch.setattr(cli_main, "_run_install_with_heartbeat", fake_run)
+        monkeypatch.setattr(cli_main, "_is_windows", lambda: False)
+
+        cli_main._install_python_dependencies_with_optional_fallback(
+            ["uv", "pip"], group="all", exclude_newer=None
+        )
+
+        assert "--exclude-newer" not in captured_args[0]
+
+    def test_pip_command_ignores_exclude_newer(self, monkeypatch):
+        """Plain pip does not support --exclude-newer; flag is suppressed."""
+        captured_args: list[list[str]] = []
+
+        def fake_run(args, env=None):
+            captured_args.append(list(args))
+
+        monkeypatch.setattr(cli_main, "_run_install_with_heartbeat", fake_run)
+        monkeypatch.setattr(cli_main, "_is_windows", lambda: False)
+
+        cli_main._install_python_dependencies_with_optional_fallback(
+            ["/usr/bin/python", "-m", "pip"], group="all", exclude_newer="2026-05-10"
+        )
+
+        assert "--exclude-newer" not in captured_args[0]
+
+    @pytest.mark.parametrize("name", ["pyuv", "uvloop-wrapper", "python-uv-shim", "uvicorn"])
+    def test_uv_substring_does_not_false_positive(self, monkeypatch, name):
+        """Binary basenames containing 'uv' but not equal to 'uv' / 'uv.exe'
+        must not get the flag — they're not uv and would crash on unknown args."""
+        captured_args: list[list[str]] = []
+
+        def fake_run(args, env=None):
+            captured_args.append(list(args))
+
+        monkeypatch.setattr(cli_main, "_run_install_with_heartbeat", fake_run)
+        monkeypatch.setattr(cli_main, "_is_windows", lambda: False)
+
+        cli_main._install_python_dependencies_with_optional_fallback(
+            [f"/some/path/{name}", "pip"], group="all", exclude_newer="2026-05-10"
+        )
+
+        assert "--exclude-newer" not in captured_args[0]
+
+    def test_uv_exe_on_windows(self, monkeypatch):
+        """Exact match also accepts the Windows ``uv.exe`` form."""
+        captured_args: list[list[str]] = []
+
+        def fake_run(args, env=None):
+            captured_args.append(list(args))
+
+        monkeypatch.setattr(cli_main, "_run_install_with_heartbeat", fake_run)
+        monkeypatch.setattr(cli_main, "_is_windows", lambda: False)
+
+        cli_main._install_python_dependencies_with_optional_fallback(
+            ["C:/Users/x/uv.exe", "pip"], group="all", exclude_newer="2026-05-10"
+        )
+
+        assert "--exclude-newer" in captured_args[0]
+
+
+# ---------------------------------------------------------------------------
+# Regression scenarios — the two live incidents that motivated this gate
+# ---------------------------------------------------------------------------
+
+
+class TestRealIncidentScenarios:
+    """Verify the install path would have refused real malicious releases.
+
+    These tests freeze "now" via the ``_now_utc`` test seam on
+    ``_exclude_newer_date``, then call the actual install function with a
+    captured-arg fake for ``_run_install_with_heartbeat``. They assert the
+    *exact* ``--exclude-newer <cutoff>`` value lands in the install argv —
+    so removing the ``extra_args`` injection in production would fail these
+    tests, not just the synthetic injection tests above.
+
+    The asserted cutoff values are computed from each scenario's frozen
+    "today" minus the gate window. uv's documented behavior is to refuse
+    any artifact whose upload time is after ``--exclude-newer``, so when
+    cutoff < release_date, the malicious version is refused.
+    """
+
+    @staticmethod
+    def _run_with_frozen_clock(
+        monkeypatch, today_iso: str, gate_days: int
+    ) -> list[list[str]]:
+        """Run the install path with frozen clock + captured argv; return
+        the list of argv lists passed to ``_run_install_with_heartbeat``."""
+        today = datetime.fromisoformat(today_iso).replace(tzinfo=timezone.utc)
+        captured: list[list[str]] = []
+
+        def fake_run(args, env=None):
+            captured.append(list(args))
+
+        monkeypatch.setattr(cli_main, "_run_install_with_heartbeat", fake_run)
+        monkeypatch.setattr(cli_main, "_is_windows", lambda: False)
+
+        cutoff = cli_main._exclude_newer_date(gate_days, _now_utc=today)
+        cli_main._install_python_dependencies_with_optional_fallback(
+            ["uv", "pip"], group="all", exclude_newer=cutoff
+        )
+        return captured
+
+    def test_mistralai_2_4_6_refused_by_3_day_gate(self, monkeypatch):
+        """mistralai 2.4.6 was published 2026-05-12.
+
+        On 2026-05-13 with a 3-day gate, cutoff is 2026-05-10 — uv would
+        refuse 2026-05-12 (>2026-05-10). The install argv must contain
+        the exact flag/value pair so uv applies it.
+        """
+        argv = self._run_with_frozen_clock(monkeypatch, "2026-05-13", gate_days=3)
+        assert len(argv) == 1
+        assert "--exclude-newer" in argv[0]
+        idx = argv[0].index("--exclude-newer")
+        cutoff = argv[0][idx + 1]
+        assert cutoff == "2026-05-10T00:00:00Z"
+        # The actual refusal condition: cutoff < malicious-release date
+        assert cutoff < "2026-05-12"
+
+    def test_mistralai_2_4_6_still_refused_a_day_later(self, monkeypatch):
+        """On 2026-05-14, cutoff = 2026-05-11; still < 2026-05-12 → refused."""
+        argv = self._run_with_frozen_clock(monkeypatch, "2026-05-14", gate_days=3)
+        idx = argv[0].index("--exclude-newer")
+        cutoff = argv[0][idx + 1]
+        assert cutoff == "2026-05-11T00:00:00Z"
+        assert cutoff < "2026-05-12"
+
+    def test_mistralai_2_4_6_allowed_after_window_expires(self, monkeypatch):
+        """On 2026-05-16, cutoff = 2026-05-13 — no longer < 2026-05-12.
+        In practice by this point the ecosystem has pulled the package so
+        upstream resolution fails anyway; the gate's job is the early
+        window, not perpetual protection."""
+        argv = self._run_with_frozen_clock(monkeypatch, "2026-05-16", gate_days=3)
+        idx = argv[0].index("--exclude-newer")
+        cutoff = argv[0][idx + 1]
+        assert cutoff == "2026-05-13T00:00:00Z"
+        assert cutoff >= "2026-05-12"  # gate no longer refuses
+
+    def test_node_ipc_9_1_6_refused_by_3_day_gate(self, monkeypatch):
+        """node-ipc 9.1.6 was published 2026-05-14. On 2026-05-15 with a
+        3-day gate, cutoff = 2026-05-12 — refused. Hermes doesn't pull
+        node-ipc from PyPI (it's npm) but the gate's mechanism is
+        ecosystem-agnostic; the test validates the same upload-date logic
+        the npm ecosystem analog would use."""
+        argv = self._run_with_frozen_clock(monkeypatch, "2026-05-15", gate_days=3)
+        idx = argv[0].index("--exclude-newer")
+        cutoff = argv[0][idx + 1]
+        assert cutoff == "2026-05-12T00:00:00Z"
+        assert cutoff < "2026-05-14"
+
+    def test_no_gate_emits_no_flag(self, monkeypatch):
+        """With gate disabled, --exclude-newer must be absent from argv —
+        the install proceeds with normal resolver behavior."""
+        argv = self._run_with_frozen_clock(monkeypatch, "2026-05-13", gate_days=0)
+        assert "--exclude-newer" not in argv[0]
+
+    def test_long_gate_window_for_audited_environments(self, monkeypatch):
+        """30-day gate (audited/regulated environments). On 2026-06-01 with
+        a 30-day gate, cutoff = 2026-05-02 — refuses anything from the
+        past month, including the 2026-05-12 incident."""
+        argv = self._run_with_frozen_clock(monkeypatch, "2026-06-01", gate_days=30)
+        idx = argv[0].index("--exclude-newer")
+        cutoff = argv[0][idx + 1]
+        assert cutoff == "2026-05-02T00:00:00Z"
+        assert cutoff < "2026-05-12"
+
+
+class TestGateCoverageOfInternalInstallers:
+    """The gate must also reach installs that run *inside* the update flow:
+    the core-dep verifier's repair reinstall and the lazy-backend refresh."""
+
+    def test_uv_exclude_newer_args_helper(self):
+        assert cli_main._uv_exclude_newer_args(["/usr/bin/uv", "pip"], "2026-05-10") == [
+            "--exclude-newer", "2026-05-10",
+        ]
+        # Plain pip never receives the uv-only flag.
+        assert cli_main._uv_exclude_newer_args(["/usr/bin/python", "-m", "pip"], "2026-05-10") == []
+        assert cli_main._uv_exclude_newer_args(["/usr/bin/uv", "pip"], None) == []
+
+    def test_verifier_repair_command_carries_exclude_newer(self, monkeypatch):
+        """When the verifier detects missing core deps and reinstalls, the
+        repair command must carry the same cutoff as the original install."""
+        from pathlib import Path
+        from types import SimpleNamespace
+
+        repaired: list[list[str]] = []
+
+        # First dep-check reports one missing dep (triggers repair), second
+        # reports none (repair "worked").
+        checks = iter(["somepkg\n", ""])
+
+        def _fake_run(cmd, **kw):
+            return SimpleNamespace(returncode=0, stdout=next(checks), stderr="")
+
+        monkeypatch.setattr(cli_main.subprocess, "run", _fake_run)
+        monkeypatch.setattr(
+            cli_main, "_resolve_install_target_python", lambda *a, **kw: Path("/x/python")
+        )
+        monkeypatch.setattr(
+            cli_main,
+            "_run_quarantined_install",
+            lambda cmd, **kw: repaired.append(list(cmd)),
+        )
+
+        cli_main._verify_core_dependencies_installed(
+            ["/usr/bin/uv", "pip"], exclude_newer="2026-05-10"
+        )
+
+        assert len(repaired) == 1
+        assert repaired[0][-2:] == ["--exclude-newer", "2026-05-10"]
+        assert "--reinstall" in repaired[0]
+
+    def test_lazy_refresh_scopes_uv_exclude_newer_env(self, monkeypatch):
+        """UV_EXCLUDE_NEWER must be set for the duration of the lazy refresh
+        (uv's env equivalent of --exclude-newer) and restored afterwards."""
+        import os
+
+        seen: dict[str, str | None] = {}
+
+        class _FakeLazyDeps:
+            @staticmethod
+            def active_features():
+                return ["voice"]
+
+            @staticmethod
+            def refresh_active_features(prompt=False):
+                seen["during"] = os.environ.get("UV_EXCLUDE_NEWER")
+                return {"voice": "current"}
+
+        monkeypatch.delenv("UV_EXCLUDE_NEWER", raising=False)
+        monkeypatch.setattr(cli_main, "_get_min_release_age_days", lambda: 3)
+        monkeypatch.setattr(
+            cli_main, "_exclude_newer_date", lambda days, **kw: "2026-05-10"
+        )
+        import sys as _sys
+
+        monkeypatch.setitem(_sys.modules, "tools.lazy_deps", _FakeLazyDeps())
+        import tools
+
+        monkeypatch.setattr(tools, "lazy_deps", _FakeLazyDeps(), raising=False)
+        cli_main._refresh_active_lazy_features()
+
+        assert seen["during"] == "2026-05-10"
+        assert "UV_EXCLUDE_NEWER" not in os.environ
+
+    def test_lazy_refresh_leaves_env_untouched_when_gate_off(self, monkeypatch):
+        import os
+
+        seen: dict[str, str | None] = {}
+
+        class _FakeLazyDeps:
+            @staticmethod
+            def active_features():
+                return ["voice"]
+
+            @staticmethod
+            def refresh_active_features(prompt=False):
+                seen["during"] = os.environ.get("UV_EXCLUDE_NEWER")
+                return {"voice": "current"}
+
+        monkeypatch.delenv("UV_EXCLUDE_NEWER", raising=False)
+        monkeypatch.setattr(cli_main, "_get_min_release_age_days", lambda: 0)
+        import sys as _sys
+
+        monkeypatch.setitem(_sys.modules, "tools.lazy_deps", _FakeLazyDeps())
+        import tools
+
+        monkeypatch.setattr(tools, "lazy_deps", _FakeLazyDeps(), raising=False)
+        cli_main._refresh_active_lazy_features()
+
+        assert seen["during"] is None
+        assert "UV_EXCLUDE_NEWER" not in os.environ
+
+    def test_verifier_per_package_fallback_carries_exclude_newer(self, monkeypatch):
+        """The last-ditch per-package force-install must stay gated too —
+        ranged requirements could otherwise resolve past the cutoff."""
+        from pathlib import Path
+        from types import SimpleNamespace
+
+        heartbeat_cmds: list[list[str]] = []
+
+        # check1: missing → full repair; check2: still missing → per-package
+        # force-install; check3: resolved.
+        checks = iter(["somepkg\n", "somepkg\n", ""])
+
+        def _fake_run(cmd, **kw):
+            return SimpleNamespace(returncode=0, stdout=next(checks), stderr="")
+
+        monkeypatch.setattr(cli_main.subprocess, "run", _fake_run)
+        monkeypatch.setattr(
+            cli_main, "_resolve_install_target_python", lambda *a, **kw: Path("/x/python")
+        )
+        monkeypatch.setattr(
+            cli_main, "_run_quarantined_install", lambda cmd, **kw: None
+        )
+        monkeypatch.setattr(
+            cli_main,
+            "_run_install_with_heartbeat",
+            lambda cmd, **kw: heartbeat_cmds.append(list(cmd)),
+        )
+
+        cli_main._verify_core_dependencies_installed(
+            ["/usr/bin/uv", "pip"], exclude_newer="2026-05-10"
+        )
+
+        assert len(heartbeat_cmds) == 1
+        assert heartbeat_cmds[0][-2:] == ["--exclude-newer", "2026-05-10"]
+
+    def test_lazy_install_fails_closed_instead_of_ungated_pip_fallback(self, monkeypatch):
+        """With UV_EXCLUDE_NEWER set, _venv_pip_install must not fall back to
+        plain pip (which ignores the cutoff): it fails closed so the backend
+        keeps its previously-installed version."""
+        from tools import lazy_deps
+
+        monkeypatch.setenv("UV_EXCLUDE_NEWER", "2026-05-10")
+        # uv absent → tier 1 skipped entirely.
+        monkeypatch.setattr(lazy_deps.shutil, "which", lambda name: None)
+
+        def _no_subprocess(*a, **kw):
+            raise AssertionError("pip fallback must not run while gate env is set")
+
+        monkeypatch.setattr(lazy_deps.subprocess, "run", _no_subprocess)
+
+        result = lazy_deps._venv_pip_install(("somepkg==1.0",))
+        assert result.success is False
+        assert "release-age" in result.stderr
+
+    def test_android_psutil_preinstall_respects_gate(self, monkeypatch, capsys):
+        """The Termux psutil sdist is fetched directly (no uv resolution), so
+        the gate compares the pin's recorded upload time to the cutoff."""
+        installed: list[list[str]] = []
+        monkeypatch.setattr(
+            cli_main, "_run_install_with_heartbeat", lambda cmd, **kw: installed.append(cmd)
+        )
+        monkeypatch.setattr(
+            "hermes_cli.psutil_android.PSUTIL_UPLOAD_TIME", "2026-05-12T09:00:00Z"
+        )
+
+        # Cutoff older than the pin's upload → refused, nothing downloaded.
+        cli_main._install_psutil_android_compat(
+            ["uv", "pip"], exclude_newer="2026-05-10T00:00:00Z"
+        )
+        assert installed == []
+        assert "release-age gate" in capsys.readouterr().out
+
+    def test_android_psutil_preinstall_proceeds_when_pin_old_enough(self, monkeypatch):
+        installed: list[list[str]] = []
+        monkeypatch.setattr(
+            cli_main, "_run_install_with_heartbeat", lambda cmd, **kw: installed.append(cmd)
+        )
+        monkeypatch.setattr(
+            "hermes_cli.psutil_android.PSUTIL_UPLOAD_TIME", "2026-01-28T18:14:54Z"
+        )
+        monkeypatch.setattr(
+            "urllib.request.urlretrieve", lambda url, dst: Path(dst).write_bytes(b"")
+        )
+        monkeypatch.setattr(
+            "hermes_cli.psutil_android.prepare_patched_psutil_sdist",
+            lambda archive, tmp: tmp / "psutil-src",
+        )
+        from pathlib import Path
+
+        cli_main._install_psutil_android_compat(
+            ["uv", "pip"], exclude_newer="2026-05-10T00:00:00Z"
+        )
+        assert len(installed) == 1
+        assert "--no-build-isolation" in installed[0]

--- a/tests/hermes_cli/test_uv_tool_update.py
+++ b/tests/hermes_cli/test_uv_tool_update.py
@@ -340,3 +340,139 @@ class TestCmdUpdatePipInstallLayouts:
         assert "--system" not in cmd
         assert cmd == ["/usr/bin/uv", "pip", "install", "--upgrade", "hermes-agent"]
         assert mock_run.call_args.kwargs["env"]["VIRTUAL_ENV"] == "/home/u/.hermes/hermes-agent/venv"
+
+
+# ---------------------------------------------------------------------------
+# release-age gate across the install-layout matrix (PR #28749)
+# ---------------------------------------------------------------------------
+
+
+class TestCmdUpdatePipReleaseAgeGate:
+    """``--exclude-newer`` composition per layout:
+
+    - uv tool upgrade      -> flag applied (uv-native)
+    - uv pip (venv)        -> flag applied, VIRTUAL_ENV overlay preserved
+    - uv pip (--system)    -> flag applied alongside ``--system``
+    - pipx upgrade         -> no equivalent flag; explicit warning, proceeds
+    - plain pip            -> no flag; explicit warning, proceeds
+    - gate off (days == 0) -> no flag anywhere, no gate output
+    """
+
+    def _gate(self, hm, days, cutoff="2026-05-10"):
+        return (
+            patch.object(hm, "_get_min_release_age_days", return_value=days),
+            patch.object(hm, "_exclude_newer_date", return_value=cutoff if days else None),
+        )
+
+    @patch("subprocess.run")
+    def test_uv_tool_upgrade_applies_exclude_newer(self, mock_run, monkeypatch):
+        from hermes_cli import main as hm
+
+        mock_run.return_value = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        gate_days, gate_cutoff = self._gate(hm, 3)
+        with patch("shutil.which", return_value="/usr/local/bin/uv"), \
+             patch("hermes_cli.config.is_uv_tool_install", return_value=True), \
+             gate_days, gate_cutoff:
+            hm._cmd_update_pip(SimpleNamespace())
+
+        assert mock_run.call_args[0][0] == [
+            "/usr/local/bin/uv", "tool", "upgrade", "hermes-agent",
+            "--exclude-newer", "2026-05-10",
+        ]
+
+    @patch("subprocess.run")
+    def test_uv_pip_venv_applies_exclude_newer(self, mock_run, monkeypatch):
+        from hermes_cli import main as hm
+
+        mock_run.return_value = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+        monkeypatch.setattr(hm.sys, "prefix", "/home/u/.hermes/hermes-agent/venv")
+        monkeypatch.setattr(hm.sys, "base_prefix", "/usr")
+        gate_days, gate_cutoff = self._gate(hm, 3)
+        with patch("shutil.which", return_value="/usr/bin/uv"), \
+             patch("hermes_cli.config.is_uv_tool_install", return_value=False), \
+             gate_days, gate_cutoff:
+            hm._cmd_update_pip(SimpleNamespace())
+
+        cmd = mock_run.call_args[0][0]
+        assert "--system" not in cmd
+        assert cmd == [
+            "/usr/bin/uv", "pip", "install", "--upgrade", "hermes-agent",
+            "--exclude-newer", "2026-05-10",
+        ]
+        assert mock_run.call_args.kwargs["env"]["VIRTUAL_ENV"] == "/home/u/.hermes/hermes-agent/venv"
+
+    @patch("subprocess.run")
+    def test_uv_pip_system_applies_exclude_newer(self, mock_run, monkeypatch):
+        from hermes_cli import main as hm
+
+        mock_run.return_value = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        monkeypatch.setattr(hm.sys, "prefix", "/usr")
+        monkeypatch.setattr(hm.sys, "base_prefix", "/usr")
+        gate_days, gate_cutoff = self._gate(hm, 3)
+        with patch("shutil.which", return_value="/usr/bin/uv"), \
+             patch("hermes_cli.config.is_uv_tool_install", return_value=False), \
+             gate_days, gate_cutoff:
+            hm._cmd_update_pip(SimpleNamespace())
+
+        assert mock_run.call_args[0][0] == [
+            "/usr/bin/uv", "pip", "install", "--system", "--upgrade", "hermes-agent",
+            "--exclude-newer", "2026-05-10",
+        ]
+
+    @patch("subprocess.run")
+    def test_pipx_upgrade_warns_and_proceeds_ungated(self, mock_run, monkeypatch, capsys):
+        from hermes_cli import main as hm
+
+        mock_run.return_value = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        monkeypatch.setattr(hm.sys, "prefix", "/home/u/.local/pipx/venvs/hermes-agent")
+        monkeypatch.setattr(hm.sys, "base_prefix", "/usr")
+
+        def _which(name):
+            return {"uv": "/usr/bin/uv", "pipx": "/usr/bin/pipx"}.get(name)
+
+        gate_days, gate_cutoff = self._gate(hm, 3)
+        with patch("shutil.which", side_effect=_which), \
+             patch("hermes_cli.config.is_uv_tool_install", return_value=False), \
+             gate_days, gate_cutoff:
+            hm._cmd_update_pip(SimpleNamespace())
+
+        cmd = mock_run.call_args[0][0]
+        assert cmd == ["/usr/bin/pipx", "upgrade", "hermes-agent"]
+        assert "--exclude-newer" not in cmd
+        out = capsys.readouterr().out
+        assert "release-age gate configured" in out
+        assert "pipx" in out
+
+    @patch("subprocess.run")
+    def test_plain_pip_warns_and_proceeds_ungated(self, mock_run, monkeypatch, capsys):
+        from hermes_cli import main as hm
+
+        mock_run.return_value = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        gate_days, gate_cutoff = self._gate(hm, 3)
+        with patch("shutil.which", return_value=None), \
+             patch("hermes_cli.config.is_uv_tool_install", return_value=False), \
+             gate_days, gate_cutoff:
+            hm._cmd_update_pip(SimpleNamespace())
+
+        cmd = mock_run.call_args[0][0]
+        assert "--exclude-newer" not in cmd
+        assert cmd[1:] == ["-m", "pip", "install", "--upgrade", "hermes-agent"]
+        out = capsys.readouterr().out
+        assert "requires `uv`" in out
+
+    @patch("subprocess.run")
+    def test_gate_off_adds_no_flag_and_no_output(self, mock_run, monkeypatch, capsys):
+        from hermes_cli import main as hm
+
+        mock_run.return_value = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        gate_days, gate_cutoff = self._gate(hm, 0)
+        with patch("shutil.which", return_value="/usr/local/bin/uv"), \
+             patch("hermes_cli.config.is_uv_tool_install", return_value=True), \
+             gate_days, gate_cutoff:
+            hm._cmd_update_pip(SimpleNamespace())
+
+        assert mock_run.call_args[0][0] == [
+            "/usr/local/bin/uv", "tool", "upgrade", "hermes-agent",
+        ]
+        assert "release-age" not in capsys.readouterr().out

--- a/tests/hermes_cli/test_verify_console_scripts.py
+++ b/tests/hermes_cli/test_verify_console_scripts.py
@@ -72,6 +72,26 @@ class TestVerifyConsoleScriptsInstalled:
         assert "-e" in args and "." in args
         assert mock_install.call_args[1]["scripts_dir"] == fake_scripts_dir
 
+    def test_reinstall_carries_exclude_newer_when_gated(
+        self, temp_pyproject, fake_scripts_dir
+    ):
+        """The entry-point repair re-resolves deps, so it must stay inside
+        the release-age gate when one is configured (PR #28749)."""
+        (fake_scripts_dir / "hermes-agent.exe").write_bytes(b"fake")
+        (fake_scripts_dir / "hermes-acp.exe").write_bytes(b"fake")
+
+        with patch("hermes_cli.main._is_windows", return_value=True), \
+             patch("hermes_cli.main._venv_scripts_dir", return_value=fake_scripts_dir), \
+             patch("hermes_cli.main._run_quarantined_install") as mock_install:
+            from hermes_cli.main import _verify_console_scripts_installed
+
+            _verify_console_scripts_installed(
+                ["uv", "pip"], env={}, exclude_newer="2026-05-10T00:00:00Z"
+            )
+
+        args = mock_install.call_args[0][0]
+        assert args[-2:] == ["--exclude-newer", "2026-05-10T00:00:00Z"]
+
     def test_skips_off_windows(self, temp_pyproject, fake_scripts_dir):
         with patch("hermes_cli.main._is_windows", return_value=False), \
              patch("hermes_cli.main._run_quarantined_install") as mock_install:
@@ -102,7 +122,9 @@ class TestVerifyConsoleScriptsInstalled:
             env={"VIRTUAL_ENV": "x"},
             scripts_dir=None,
         )
-        mock_verify.assert_called_once_with(["uv", "pip"], env={"VIRTUAL_ENV": "x"})
+        mock_verify.assert_called_once_with(
+            ["uv", "pip"], env={"VIRTUAL_ENV": "x"}, exclude_newer=None
+        )
 
     def test_quarantine_shims_include_declared_console_scripts(
         self, temp_pyproject, fake_scripts_dir

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -677,6 +677,18 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
             except (subprocess.TimeoutExpired, FileNotFoundError) as e:
                 logger.debug("uv invocation failed: %s", e)
 
+        # Release-age gate: when UV_EXCLUDE_NEWER is set (hermes update scopes
+        # it around the lazy refresh), pip cannot honor the cutoff, so falling
+        # back would silently bypass the gate the operator configured. Fail
+        # closed instead — the caller keeps the previously-installed version.
+        if os.environ.get("UV_EXCLUDE_NEWER"):
+            return _InstallResult(
+                False,
+                "",
+                "uv unavailable or refused the install and the release-age gate "
+                "(UV_EXCLUDE_NEWER) forbids the ungated pip fallback",
+            )
+
         # Tier 2: python -m pip (with ensurepip bootstrap if needed)
         pip_cmd = [sys.executable, "-m", "pip"]
         try:


### PR DESCRIPTION
## What does this PR do?

Adds `security.minimum_release_age_days` (default `0` — off) to refuse PyPI artifacts uploaded within the last N days during `hermes update`. The gate computes an RFC 3339 UTC cutoff (`now − N days`, exact N×24h window regardless of host timezone) and passes it to uv via `--exclude-newer` / `UV_EXCLUDE_NEWER` — leveraging uv's native support rather than a custom resolver.

Complements `security_advisories.py` (#24220). PR #24220 is the **reactive** layer (detect-after-install); this PR is the **preventive** layer: most package-compromise incidents are detected and yanked within days of publication, so delaying adoption of brand-new releases gives the ecosystem time to catch and reverse an attack before it reaches your machine.

Motivated by two incidents whose exposure windows were short enough that a small delay would have refused them outright:

- **`mistralai 2.4.6`** (PyPI, 2026-05-12, Mini Shai-Hulud campaign): malicious release live ~15 minutes before PyPI quarantine. Hermes's `[all]` / `[mistral]` extras were a vector.
- **`node-ipc 9.1.6 / 9.2.3 / 12.0.1`** (npm, 2026-05-14): malicious versions live hours-to-days before removal. Different ecosystem; identical defense pattern.

3 days matches pnpm's `minimumReleaseAge: 4320` heuristic. `CONTRIBUTING.md` already cites Mini Shai-Hulud for upper-bound pinning; this adds the upload-date gate as a peer control.

## Coverage across the current update matrix

Rebased onto current main; the gate composes with the post-#29700 install-layout dispatch in `_cmd_update_pip`:

| Path | Behavior with gate on |
|---|---|
| `uv tool upgrade` | `--exclude-newer <cutoff>` applied (flag verified supported; managed uv is kept current by `update_managed_uv()`) |
| `uv pip install` (venv, with `VIRTUAL_ENV` overlay) | gated |
| `uv pip install --system` (bare interpreter) | gated |
| `pipx upgrade` | no `--exclude-newer` equivalent — proceeds with an explicit per-mode warning |
| plain `pip` | proceeds with the existing "requires uv" warning |

Update-internal installers are gated too, so the gate can't be bypassed by a fallback path:

- git-pull dependency step, ZIP-fallback (Windows-without-git), interrupted-install recovery, and venv-repair installs all pass the cutoff.
- The core-dep verifier's `--reinstall` repair and its per-package force-install carry the cutoff.
- The Windows console-script (entry-point) repair carries the cutoff.
- The lazy-backend refresh is scoped under `UV_EXCLUDE_NEWER`, and `tools/lazy_deps._venv_pip_install` **fails closed** instead of falling back to ungated pip while the gate env is set (backends keep their previously-installed version).
- The Termux/Android psutil sdist preinstall (direct `urlretrieve`, no uv resolution) is gated against the pin's recorded PyPI upload time (`PSUTIL_UPLOAD_TIME`, updated together with `PSUTIL_URL`).

Ungated-by-design paths always say so: `_print_release_age_status` prints the active cutoff, or an explicit per-mode warning (pipx / plain-pip fallbacks, including the recovery/repair paths) — the gate never silently degrades.

## Source-advance preflight

A second commit closes the stranding gap the first commit left open: if an incoming update pins a required dependency younger than the configured window, the gated install used to fail only *after* the source tree had advanced. Now every source-advancing path preflights the incoming dependency set (`[project.dependencies]` + `[build-system].requires`) **before** anything moves, and defers the whole update (exit 75, EX_TEMPFAIL — automation retries once the pin ages) with the install fully unchanged:

- **main pull** — preflights the fetched SHA and then fast-forwards to exactly that revision (a plain `git pull` re-fetches and could land on an unvalidated tip)
- **`--branch` switches** (both checkout forms) — preflights the fetched destination tip before the tree moves; detached HEAD is restored to its exact commit on deferral
- **fork upstream sync** — preflights and pins `upstream/main` before the fast-forward
- **ZIP path** — preflights the extracted-to-tmp pyproject before any file is copied over the live tree

Resolution mechanics (all fail-open on machinery errors — the preflight can never block an update by itself):

- `uv pip compile --no-build --python <target venv>` with ambient `UV_EXCLUDE_NEWER*` scrubbed and a capability probe for older uv binaries
- a gate rejection is confirmed structurally (uv's refusal text doesn't name the exclusion): ungated control succeeds online → gated resolve must fail `--offline` (network can't be the cause) AND online (rules out cache miss) AND with builds permitted (an aged, allowed sdist may satisfy what a too-new wheel can't) — only then defer
- resolution never executes a PEP 517 backend except under `--exclude-newer`, where every build candidate is a gate-passing artifact; sdist-only dependency sets (Termux) use that gated build as the control and defer conservatively when it fails

## Changes Made

- `hermes_cli/config.py` — `security.minimum_release_age_days: 0` with threat-model comment block.
- `hermes_cli/main.py` — helpers `_get_min_release_age_days()`, `_exclude_newer_date()` (RFC 3339 UTC, test seam), `_print_release_age_status()` (per-mode messaging), `_uv_exclude_newer_args()` (shared uv-exact-match flag builder); gate wiring across `_cmd_update_pip`, `_cmd_update_impl`, recovery/repair paths, both verifiers, lazy refresh, and the Android psutil preinstall.
- `tools/lazy_deps.py` — fail-closed guard: no ungated pip fallback while `UV_EXCLUDE_NEWER` is set.
- `hermes_cli/psutil_android.py` — `PSUTIL_UPLOAD_TIME` pinned beside `PSUTIL_URL`.
- `cli-config.yaml.example` — commented entry alongside the `tirith` stanza.
- `tests/` — 60+ gate tests (`test_release_age_gate.py`: helper math, config reads, flag injection incl. `uv.exe`/substring false-positives, frozen-clock incident regressions, internal-installer coverage), 6 layout-matrix gate tests appended to the existing `test_uv_tool_update.py`, console-script repair gating in `test_verify_console_scripts.py`.
- `scripts/release.py` — AUTHOR_MAP entry per contributor-check.yml.

## How to Test

```bash
pytest tests/hermes_cli/test_release_age_gate.py tests/hermes_cli/test_uv_tool_update.py -v
```

Full serial run of `tests/hermes_cli/` + `tests/tools/test_lazy_deps*.py` passes (337 tests across the update flow; some unrelated web-server tests are flaky under xdist parallelism).

With `security.minimum_release_age_days: 3` configured:

```
→ Checking PyPI for updates...
  ↳ release-age gate active: refusing PyPI versions newer than 2026-07-16T09:14:02Z (minimum_release_age_days=3)
→ Running: uv tool upgrade hermes-agent --exclude-newer 2026-07-16T09:14:02Z
```

Default off: no behavior change, no output (matches the `security_advisories.py` silent-when-clean posture).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)

## Checklist

- [x] I've read the Contributing Guide
- [x] Conventional Commits
- [x] Not a duplicate
- [x] Only changes related to this feature
- [x] `pytest tests/hermes_cli/` — relevant suites pass in serial
- [x] Tests added
- [x] Tested on Ubuntu 24.04
- [x] Docs: inline comment block in `config.py` + `cli-config.yaml.example`
- [x] Cross-platform considered: uv flag passthrough is platform-neutral; Windows entry-point repair and ZIP-fallback paths are wired; Termux/Android preinstall gated via static upload time
