### PR TITLE
feat(anthropic-adapter): add HERMES_PREFER_API_KEY env to prefer Console API key over Claude Code OAuth

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -946,6 +946,12 @@ def resolve_anthropic_token() -> Optional[str]:
     """Resolve an Anthropic token from all available sources.
 
     Priority:
+      0. ANTHROPIC_API_KEY env var — only when HERMES_PREFER_API_KEY is set to
+         a truthy value (1/true/yes/on) AND the key has the real-API-key
+         prefix `sk-ant-api`. Opt-in override for users who run hermes on the
+         same machine as Claude Code but want hermes to bill a different
+         (Console / API-key) account than the one Claude Code is signed in
+         to. Without this opt-in the default order applies.
       1. ANTHROPIC_TOKEN env var (OAuth/setup token saved by Hermes)
       2. CLAUDE_CODE_OAUTH_TOKEN env var
       3. Claude Code credentials (~/.claude.json or ~/.claude/.credentials.json)
@@ -954,6 +960,12 @@ def resolve_anthropic_token() -> Optional[str]:
 
     Returns the token string or None.
     """
+    # 0. Opt-in API-key-first override.
+    if os.getenv("HERMES_PREFER_API_KEY", "").strip().lower() in ("1", "true", "yes", "on"):
+        early_api_key = os.getenv("ANTHROPIC_API_KEY", "").strip()
+        if early_api_key.startswith("sk-ant-api"):
+            return early_api_key
+
     creds = read_claude_code_credentials()
 
     # 1. Hermes-managed OAuth/setup token env var


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in `HERMES_PREFER_API_KEY` env var that makes `resolve_anthropic_token()` return `ANTHROPIC_API_KEY` ahead of the Claude Code OAuth credential discovery chain — only when the env var is truthy AND the configured key has the real-API-key prefix `sk-ant-api`.

**Use case**: I hit this on a dev machine where Claude Code is signed in to one Anthropic account (a work account, currently in billing timeout), but I want hermes-agent and its cron jobs to bill a *different* account whose API key is configured in `~/.hermes/.env`. The current 4-tier resolution order in `resolve_anthropic_token()` picks up Claude Code's local OAuth credentials at step 3 (from `~/.claude/.credentials.json`), so step 4 (`ANTHROPIC_API_KEY`) never runs. Every Hermes Claude API call fails with:

```
400 invalid_request_error: Third-party apps now draw from your extra usage,
not your plan limits. Add more at claude.ai/settings/usage and keep going.
```

Existing workarounds are invasive:

- Move `~/.claude/.credentials.json` aside → logs the user out of Claude Code
- Switch Claude Code accounts → defeats the point of having two accounts
- Patch hermes-agent locally → diff drifts on `git pull`

This PR adds a clean opt-in escape hatch.

## Related Issue

No existing issue — happy to open one if you'd prefer the discussion there before reviewing the code.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

(Could argue feature — adds an env var — but the primary purpose is fixing a real-world auth-resolution mismatch, so bug-fix feels right.)

## Changes Made

- `agent/anthropic_adapter.py`:
  - New step 0 in `resolve_anthropic_token()` priority: if `HERMES_PREFER_API_KEY` is truthy (`1` / `true` / `yes` / `on`) AND `ANTHROPIC_API_KEY` starts with `sk-ant-api`, return it immediately.
  - Docstring updated to document the new step 0 and call out that it's opt-in.
  - 12 lines added, no existing logic touched.

## Why this design

| Decision | Reason |
|---|---|
| **Env-var-gated, not always-on** | Preserves existing behaviour for users who rely on the OAuth-first ordering. No surprises on `git pull`. |
| **`sk-ant-api` prefix check** | Console API keys always start with `sk-ant-api`. OAuth tokens start with `sk-ant-oat`. Guarantees we never accidentally route an OAuth token through the wrong code path even if the env var is set. |
| **Step 0 (before everything)** | The whole point is to win over `~/.claude/.credentials.json`. Inserting after Claude Code creds would defeat the purpose. |
| **Multiple truthy spellings** | `1` / `true` / `yes` / `on` (case-insensitive). Matches the casual usage I see in `.env` files. |

## Backward compatibility

- Default behaviour unchanged: env var unset → identical to today.
- Existing `ANTHROPIC_API_KEY`-only users (no Claude Code, no `ANTHROPIC_TOKEN`) reach step 4 as before; the new step 0 just additionally lets them opt into a no-OAuth-fallback path.
- No new dependencies, no schema changes, no migration.

## Testing

Tested locally on a real Hermes install (Ubuntu 24.04, hermes-gateway as a systemd user service) with a dual-account setup:

- Before: planner cron job → 400 "extra usage" error every run.
- After (with `HERMES_PREFER_API_KEY=1` in `~/.hermes/.env`): planner runs cleanly, returns to `last_status: ok` and posts the analysis to Telegram as configured.

Happy to add a unit test for `resolve_anthropic_token()` with mocked env if useful — wanted to keep the diff minimal for first review.