### PR TITLE
fix(tui): surface reasoning-only model output as assistant reply

### DIFF
--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -633,6 +633,16 @@ class TurnController {
 
     if (finalText) {
       finalMessages.push({ role: 'assistant', text: finalText })
+    } else if (split.reasoning.trim()) {
+      // Entire model output wrapped in reasoning tags (e.g. kimi-k2.6).
+      // Surface reasoning as the answer so the thread doesn't go silent.
+      finalMessages.push({ role: 'assistant', text: split.reasoning.trim() })
+      // Avoid rendering the same reasoning twice — once as the assistant
+      // message above and once in the thinking/details panel.
+      if (finalDetails.thinking) {
+        finalDetails.thinking = undefined
+        finalDetails.thinkingTokens = undefined
+      }
     }
 
     const wasInterrupted = this.interrupted


### PR DESCRIPTION
## Problem

When a model wraps its entire output in reasoning tags (e.g. kimi-k2.6), `recordMessageComplete` in `turnController.ts` finds no `finalText` and the assistant reply renders as empty/silent.

Closes #28755

## Fix

Add an `else if` branch after the `finalText` check to surface `split.reasoning` as the assistant message when `finalText` is empty but reasoning content exists. On this fallback path, also clear `finalDetails.thinking` to avoid rendering the same reasoning twice (once as assistant text, once in the thinking panel).

```ts
} else if (split.reasoning.trim()) {
  // Entire model output wrapped in reasoning tags (e.g. kimi-k2.6).
  // Surface reasoning as the answer so the thread doesn't go silent.
  finalMessages.push({ role: 'assistant', text: split.reasoning.trim() })
  // Avoid rendering the same reasoning twice — once as the assistant
  // message above and once in the thinking/details panel.
  if (finalDetails.thinking) {
    finalDetails.thinking = undefined
    finalDetails.thinkingTokens = undefined
  }
}
```

## Deduplication

Per the sweeper review: when there is no streamed reasoning segment, `savedReasoning` would previously land in `finalDetails.thinking`. The fallback path now clears `finalDetails.thinking` so reasoning appears only once — as the assistant message text, not also in a duplicate thinking panel.

## Testing

- Verified with kimi-k2.6 which emits reasoning-only output
- Thread no longer goes silent; reasoning text surfaces as the assistant reply
- Regression test needed: `message.complete` payload with reasoning-only content should produce exactly one visible assistant message