### PR TITLE
fix(proxy): point Nous auth hint at auth add

### DIFF
--- a/hermes_cli/proxy/adapters/nous_portal.py
+++ b/hermes_cli/proxy/adapters/nous_portal.py
@@ -64,6 +64,10 @@ class NousPortalAdapter(UpstreamAdapter):
         return "Nous Portal"
 
     @property
+    def auth_hint(self) -> str:
+        return "hermes auth add nous --type oauth"
+
+    @property
     def allowed_paths(self) -> FrozenSet[str]:
         return _ALLOWED_PATHS
 
@@ -103,7 +107,7 @@ class NousPortalAdapter(UpstreamAdapter):
             state = self._read_state()
             if state is None:
                 raise RuntimeError(
-                    "Not logged into Nous Portal. Run `hermes login nous` first."
+                    "Not logged into Nous Portal. Run `hermes auth add nous --type oauth` first."
                 )
 
             try:
@@ -134,7 +138,7 @@ class NousPortalAdapter(UpstreamAdapter):
             if not agent_key:
                 raise RuntimeError(
                     "Nous Portal refresh did not return a usable agent_key. "
-                    "Try `hermes login nous` to re-authenticate."
+                    "Try `hermes auth add nous --type oauth` to re-authenticate."
                 )
 
             base_url = refreshed.get("base_url") or DEFAULT_NOUS_INFERENCE_URL

--- a/hermes_cli/proxy/cli.py
+++ b/hermes_cli/proxy/cli.py
@@ -44,7 +44,7 @@ def cmd_proxy_start(args: Any) -> int:
         return 2
 
     if not adapter.is_authenticated():
-        auth_hint = getattr(adapter, "auth_hint", f"hermes login {adapter.name}")
+        auth_hint = getattr(adapter, "auth_hint", f"hermes auth add {adapter.name}")
         print(
             f"Not logged into {adapter.display_name}. "
             f"Run `{auth_hint}` first.",

--- a/tests/hermes_cli/test_proxy.py
+++ b/tests/hermes_cli/test_proxy.py
@@ -207,7 +207,7 @@ def test_nous_adapter_retry_credential_skips_opaque_bearer(tmp_path, monkeypatch
 def test_nous_adapter_get_credential_raises_when_not_logged_in(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     adapter = NousPortalAdapter()
-    with pytest.raises(RuntimeError, match="hermes login nous"):
+    with pytest.raises(RuntimeError, match="hermes auth add nous --type oauth"):
         adapter.get_credential()
 
 
@@ -784,4 +784,4 @@ def test_cmd_proxy_start_refuses_when_unauthenticated(capsys, tmp_path, monkeypa
     rc = cmd_proxy_start(args)
     assert rc == 2
     err = capsys.readouterr().err
-    assert "hermes login nous" in err
+    assert "hermes auth add nous --type oauth" in err


### PR DESCRIPTION
## Summary

The proxy still points unauthenticated Nous users at `hermes login nous`, but the current auth flow is `hermes auth add nous --type oauth`.

Closes #28089.

## Changes

- switch the proxy CLI fallback hint from `hermes login <provider>` to `hermes auth add <provider>`
- add an explicit `auth_hint` for the Nous Portal adapter
- update Nous adapter error messages to match the current OAuth auth flow
- refresh the proxy regression tests to assert the new hint

## Testing

- `uv run --extra dev --extra messaging pytest tests/hermes_cli/test_proxy.py -q`
