### PR TITLE
fix(cli): persist --global through model picker

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6838,7 +6838,16 @@ class HermesCLI:
         lines.append(('class:approval-border', '╰' + ('─' * box_width) + '╯\n'))
         return lines
 
-    def _open_model_picker(self, providers: list, current_model: str, current_provider: str, user_provs=None, custom_provs=None) -> None:
+    def _open_model_picker(
+        self,
+        providers: list,
+        current_model: str,
+        current_provider: str,
+        *,
+        persist_global: bool = False,
+        user_provs=None,
+        custom_provs=None,
+    ) -> None:
         """Open prompt_toolkit-native /model picker modal."""
         self._capture_modal_input_snapshot()
         default_idx = next((i for i, p in enumerate(providers) if p.get("is_current")), 0)
@@ -6848,6 +6857,7 @@ class HermesCLI:
             "selected": default_idx,
             "current_model": current_model,
             "current_provider": current_provider,
+            "persist_global": persist_global,
             "user_provs": user_provs,
             "custom_provs": custom_provs,
         }
@@ -6970,10 +6980,12 @@ class HermesCLI:
         else:
             _cprint("    (session only — add --global to persist)")
 
-    def _handle_model_picker_selection(self, persist_global: bool = False) -> None:
+    def _handle_model_picker_selection(self, persist_global: bool | None = None) -> None:
         state = self._model_picker_state
         if not state:
             return
+        if persist_global is None:
+            persist_global = bool(state.get("persist_global"))
         selected = state.get("selected", 0)
         stage = state.get("stage")
         if stage == "provider":
@@ -7096,6 +7108,7 @@ class HermesCLI:
                 providers,
                 model_display,
                 provider_display,
+                persist_global=persist_global,
                 user_provs=user_provs,
                 custom_provs=custom_provs,
             )

--- a/tests/hermes_cli/test_model_picker_global_persistence.py
+++ b/tests/hermes_cli/test_model_picker_global_persistence.py
@@ -1,0 +1,78 @@
+"""Regression tests for interactive `/model --global` picker persistence."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+
+class _StubCLI:
+    provider = "openai"
+    model = "gpt-5.5"
+    base_url = ""
+    api_key = ""
+
+    def __init__(self) -> None:
+        self._model_picker_state = None
+        self.closed = False
+        self.applied = None
+
+    def _capture_modal_input_snapshot(self) -> None:
+        pass
+
+    def _restore_modal_input_snapshot(self) -> None:
+        pass
+
+    def _invalidate(self, min_interval: float = 0.0) -> None:
+        _ = min_interval
+
+    def _close_model_picker(self) -> None:
+        self.closed = True
+        self._model_picker_state = None
+
+    def _apply_model_switch_result(self, result, persist_global: bool) -> None:
+        self.applied = (result, persist_global)
+
+
+def test_open_model_picker_stores_persist_global_flag():
+    import cli as cli_mod
+
+    stub = _StubCLI()
+    cli_mod.HermesCLI._open_model_picker(
+        stub,
+        [{"slug": "openai", "models": ["gpt-5.5"], "is_current": True}],
+        "gpt-5.5",
+        "OpenAI",
+        persist_global=True,
+    )
+
+    assert stub._model_picker_state is not None
+    assert stub._model_picker_state["persist_global"] is True
+
+
+def test_picker_selection_uses_stored_persist_global_flag(monkeypatch):
+    import cli as cli_mod
+
+    stub = _StubCLI()
+    stub._model_picker_state = {
+        "stage": "model",
+        "selected": 0,
+        "persist_global": True,
+        "provider_data": {"slug": "openai"},
+        "model_list": ["gpt-5.5"],
+        "user_provs": None,
+        "custom_provs": None,
+    }
+
+    calls = {}
+
+    def fake_switch_model(**kwargs):
+        calls.update(kwargs)
+        return object()
+
+    with patch("hermes_cli.model_switch.switch_model", side_effect=fake_switch_model):
+        cli_mod.HermesCLI._handle_model_picker_selection(stub)
+
+    assert calls["is_global"] is True
+    assert stub.closed is True
+    assert stub.applied is not None
+    assert stub.applied[1] is True


### PR DESCRIPTION
## Summary

The interactive `/model` picker dropped `--global` on the Enter-key path, so the selected model changed for the current session but was not written to `config.yaml`.

Closes #28034.

## Changes

- store the picker invocation's `persist_global` flag in `_model_picker_state`
- let `_handle_model_picker_selection()` fall back to the stored flag when called from the Enter-key handler
- thread `persist_global` through the picker open path in `_handle_model_switch()`
- add focused regression tests for the stored flag and the final `switch_model(..., is_global=True)` call

## Testing

- `uv run --extra dev pytest tests/hermes_cli/test_model_picker_global_persistence.py -q`
