### PR TITLE
fix(cron): tolerate null repeat in cron list

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -58,11 +58,27 @@ def cron_list(show_all: bool = False):
     for job in jobs:
         job_id = job.get("id", "?")
         name = job.get("name", "(unnamed)")
-        schedule = job.get("schedule_display", job.get("schedule", {}).get("value", "?"))
+        schedule = job.get("schedule_display")
+        if not schedule:
+            raw_schedule = job.get("schedule")
+            if isinstance(raw_schedule, dict):
+                schedule = (
+                    raw_schedule.get("display")
+                    or raw_schedule.get("value")
+                    or raw_schedule.get("expr")
+                    or raw_schedule.get("run_at")
+                    or "?"
+                )
+            elif raw_schedule is not None:
+                schedule = str(raw_schedule)
+            else:
+                schedule = "?"
         state = job.get("state", "scheduled" if job.get("enabled", True) else "paused")
         next_run = job.get("next_run_at", "?")
 
-        repeat_info = job.get("repeat", {})
+        repeat_info = job.get("repeat")
+        if not isinstance(repeat_info, dict):
+            repeat_info = {}
         repeat_times = repeat_info.get("times")
         repeat_completed = repeat_info.get("completed", 0)
         repeat_str = f"{repeat_completed}/{repeat_times}" if repeat_times else "∞"

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -5,7 +5,7 @@ from argparse import Namespace
 import pytest
 
 from cron.jobs import create_job, get_job, list_jobs
-from hermes_cli.cron import cron_command
+from hermes_cli.cron import cron_command, cron_list
 
 
 @pytest.fixture()
@@ -111,3 +111,26 @@ class TestCronCommandLifecycle:
         assert jobs[0]["skills"] == ["blogwatcher", "maps"]
         assert jobs[0]["name"] == "Skill combo"
         assert jobs[0]["profile"] == "default"
+
+    def test_list_tolerates_none_repeat_and_string_schedule(self, capsys, monkeypatch):
+        monkeypatch.setattr(
+            "cron.jobs.list_jobs",
+            lambda include_disabled=False: [
+                {
+                    "id": "job-1",
+                    "name": "Legacy job",
+                    "schedule": "every 60m",
+                    "repeat": None,
+                    "deliver": "local",
+                    "enabled": True,
+                }
+            ],
+        )
+        monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [1234])
+
+        cron_list()
+
+        out = capsys.readouterr().out
+        assert "Legacy job" in out
+        assert "every 60m" in out
+        assert "∞" in out


### PR DESCRIPTION
## Summary

`hermes cron list` assumes `repeat` is always a dict and that `schedule` is always dict-shaped when `schedule_display` is missing. MCP-created or hand-edited jobs can violate both assumptions and crash the list command.

Closes #28662.

## Changes

- make `cron_list()` handle `repeat=None` and other non-dict repeat values
- make `cron_list()` fall back cleanly when `schedule` is a plain string instead of a dict
- add a CLI regression test covering the mixed legacy/MCP-shaped job payload

## Testing

- `uv run --extra dev pytest tests/hermes_cli/test_cron.py -q`
