### PR TITLE
fix(agent): accept union types in Moonshot schema sanitizer

### DIFF
--- a/agent/moonshot_schema.py
+++ b/agent/moonshot_schema.py
@@ -144,7 +144,7 @@ def _repair_schema(node: Any, is_schema: bool = True) -> Any:
     # empty, drop it entirely.
     if "enum" in repaired and isinstance(repaired["enum"], list):
         node_type = repaired.get("type")
-        if node_type in {"string", "integer", "number", "boolean"}:
+        if isinstance(node_type, str) and node_type in {"string", "integer", "number", "boolean"}:
             cleaned = [v for v in repaired["enum"]
                        if v is not None and v != ""]
             if cleaned:
@@ -166,8 +166,12 @@ def _repair_schema(node: Any, is_schema: bool = True) -> Any:
 
 def _fill_missing_type(node: Dict[str, Any]) -> Dict[str, Any]:
     """Infer a reasonable ``type`` if this schema node has none."""
-    if "type" in node and node["type"] not in {None, ""}:
-        return node
+    if "type" in node:
+        node_type = node["type"]
+        if isinstance(node_type, list):
+            return node
+        if node_type not in {None, ""}:
+            return node
 
     # Heuristic: presence of ``properties`` → object, ``items`` → array, ``enum``
     # → type of first enum value, else fall back to ``string`` (safest scalar).

--- a/tests/agent/test_moonshot_schema.py
+++ b/tests/agent/test_moonshot_schema.py
@@ -106,6 +106,19 @@ class TestMissingTypeFilled:
         out = sanitize_moonshot_tool_parameters(params)
         assert out["properties"]["tags"]["items"]["type"] == "string"
 
+    def test_union_type_list_is_left_intact(self):
+        params = {
+            "type": "object",
+            "properties": {
+                "time_from": {
+                    "type": ["number", "string"],
+                    "description": "Optional timestamp",
+                },
+            },
+        }
+        out = sanitize_moonshot_tool_parameters(params)
+        assert out["properties"]["time_from"]["type"] == ["number", "string"]
+
     def test_ref_node_is_not_given_synthetic_type(self):
         """$ref nodes should NOT get a synthetic type — the referenced
         definition supplies it, and Moonshot would reject the conflict."""


### PR DESCRIPTION
## Summary

`sanitize_moonshot_tools()` crashes on valid JSON Schema union types like `"type": ["number", "string"]` because the sanitizer assumes every `type` value is hashable.

Closes #28291.

## Changes

- treat list-valued `type` declarations as already-valid in `_fill_missing_type()`
- guard enum cleanup so it only runs for scalar string `type` values
- add a regression test covering a property that uses a JSON Schema union type list

## Testing

- `uv run --extra dev pytest tests/agent/test_moonshot_schema.py -q`
