### PR TITLE
fix(profile): preserve custom HERMES_HOME in wrappers

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9618,11 +9618,11 @@ def cmd_profile(args):
             if collision:
                 print(f"Error: {collision}")
                 sys.exit(1)
-            wrapper_path = create_wrapper_script(alias_name)
+            wrapper_path = create_wrapper_script(
+                alias_name,
+                target_profile=name if custom_name else None,
+            )
             if wrapper_path:
-                # If custom name, write the profile name into the wrapper
-                if custom_name:
-                    wrapper_path.write_text(f'#!/bin/sh\nexec hermes -p {name} "$@"\n')
                 print(f"✓ Alias created: {wrapper_path}")
                 if not _is_wrapper_dir_in_path():
                     print(f"⚠ {_get_wrapper_dir()} is not in your PATH.")

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -22,6 +22,7 @@ Usage::
 import json
 import os
 import re
+import shlex
 import shutil
 import stat
 import subprocess
@@ -354,7 +355,19 @@ def _is_wrapper_dir_in_path() -> bool:
     return wrapper_dir in os.environ.get("PATH", "").split(os.pathsep)
 
 
-def create_wrapper_script(name: str) -> Optional[Path]:
+def _build_wrapper_script(profile_name: str) -> str:
+    """Return wrapper contents for a profile-aware shell launcher."""
+    canon = normalize_profile_name(profile_name)
+    current_root = _get_default_hermes_home()
+    native_root = Path.home() / ".hermes"
+    lines = ["#!/bin/sh"]
+    if current_root.resolve() != native_root.resolve():
+        lines.append(f"export HERMES_HOME={shlex.quote(str(current_root))}")
+    lines.append(f'exec hermes -p {canon} "$@"')
+    return "\n".join(lines) + "\n"
+
+
+def create_wrapper_script(name: str, target_profile: Optional[str] = None) -> Optional[Path]:
     """Create a shell wrapper script at ~/.local/bin/<name>.
 
     Returns the path to the created wrapper, or None if creation failed.
@@ -369,7 +382,7 @@ def create_wrapper_script(name: str) -> Optional[Path]:
 
     wrapper_path = wrapper_dir / canon
     try:
-        wrapper_path.write_text(f'#!/bin/sh\nexec hermes -p {canon} "$@"\n')
+        wrapper_path.write_text(_build_wrapper_script(target_profile or canon))
         wrapper_path.chmod(wrapper_path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
         return wrapper_path
     except OSError as e:

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -18,6 +18,7 @@ from hermes_cli.profiles import (
     normalize_profile_name,
     validate_profile_name,
     get_profile_dir,
+    create_wrapper_script,
     create_profile,
     delete_profile,
     list_profiles,
@@ -1093,6 +1094,25 @@ class TestInternalHelpers:
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         monkeypatch.setenv("HERMES_HOME", str(profile))
         assert get_active_profile_name() == "orchestrator"
+
+
+class TestWrapperScripts:
+    def test_wrapper_uses_plain_profile_exec_for_default_root(self, profile_env):
+        wrapper = create_wrapper_script("coder")
+        assert wrapper is not None
+        assert wrapper.read_text() == '#!/bin/sh\nexec hermes -p coder "$@"\n'
+
+    def test_wrapper_preserves_custom_hermes_home_root(self, tmp_path, monkeypatch):
+        custom_root = tmp_path / "opt" / "data"
+        custom_root.mkdir(parents=True)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(custom_root))
+
+        wrapper = create_wrapper_script("coder")
+        assert wrapper is not None
+        content = wrapper.read_text()
+        assert f"export HERMES_HOME={custom_root}" in content
+        assert 'exec hermes -p coder "$@"' in content
 
 
 # ===================================================================


### PR DESCRIPTION
## Summary

Profile wrapper scripts currently assume the standard `~/.hermes` root. When a profile is imported or managed under a custom Hermes root, the generated wrapper resolves `hermes -p <name>` against the wrong location unless the caller manually re-exports `HERMES_HOME` first.

Closes #28292.

## Changes

- centralize wrapper-script generation in `hermes_cli.profiles`
- preserve the active custom Hermes root in generated wrappers when it differs from the native `~/.hermes` root
- reuse the same helper for custom alias names so aliases and import-created wrappers behave consistently
- add regression tests for default-root wrappers and custom-root wrappers

## Testing

- `uv run --extra dev pytest tests/hermes_cli/test_profiles.py::TestWrapperScripts tests/hermes_cli/test_backup.py::TestProfileRestoration::test_import_creates_profile_wrappers -q`
