### PR TITLE
fix(kanban): move session_id index out of SCHEMA_SQL to avoid legacy DB crash

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -865,8 +865,6 @@ CREATE TABLE IF NOT EXISTS tasks (
     session_id           TEXT
 );
 
-CREATE INDEX IF NOT EXISTS idx_tasks_session_id ON tasks(session_id);
-
 CREATE TABLE IF NOT EXISTS task_links (
     parent_id  TEXT NOT NULL,
     child_id   TEXT NOT NULL,


### PR DESCRIPTION
## Summary

Fixes a bug where the kanban dispatcher crashes every tick on legacy
kanban.dbs with:

    sqlite3.OperationalError: no such column: session_id

## Root Cause

Commit 31fe22903 added the `session_id` column to the `tasks` table and
created an index on it. The column was correctly added via
`_migrate_add_optional_columns()`, but the index
(`idx_tasks_session_id`) was placed inside `SCHEMA_SQL`.

When `connect()` opens a legacy DB:

1. `executescript(SCHEMA_SQL)` runs `CREATE TABLE IF NOT EXISTS tasks(...)`
   — does **nothing** because the table already exists (SQLite does not add
   missing columns via `IF NOT EXISTS`).
2. Next in the script: `CREATE INDEX IF NOT EXISTS idx_tasks_session_id ON tasks(session_id)`
   — **crashes** because the column does not exist yet.
3. `_migrate_add_optional_columns()` never runs, so the migration
   never self-heals.

## Fix

Move `CREATE INDEX idx_tasks_session_id` from `SCHEMA_SQL` into
`_migrate_add_optional_columns()` alongside the existing
`ALTER TABLE ... ADD COLUMN session_id` call.

This ensures the column is created before the index.

## Testing

- Verified with `python3 -c ...` that `executescript` crashes on a legacy
  table missing the column, and succeeds when the index is deferred until
  after the column is added.
- Manually applied same fix to a live kanban.db that had been failing every
  minute since commit 31fe22903 landed.

## Related

- Introduced in commit 31fe22903
- Closes any issue where kanban dispatcher fails with `no such column: session_id`