### PR TITLE
fix(daytona): use unique sandbox names

### DIFF
--- a/tests/tools/test_daytona_environment.py
+++ b/tests/tools/test_daytona_environment.py
@@ -184,6 +184,23 @@ class TestPersistence:
         env._mock_client.list.assert_not_called()
         env._mock_client.create.assert_called_once()
 
+    def test_created_sandbox_name_is_unique_but_labels_keep_task_id(
+        self, make_env, daytona_sdk, monkeypatch
+    ):
+        daytona_sdk.CreateSandboxFromImageParams = lambda **kwargs: SimpleNamespace(
+            **kwargs
+        )
+        monkeypatch.setattr(
+            "tools.environments.daytona.uuid.uuid4",
+            lambda: SimpleNamespace(hex="deadbeefcafebabe"),
+        )
+
+        env = make_env(persistent=False, task_id="default")
+
+        created_params = env._mock_client.create.call_args.args[0]
+        assert created_params.name == "hermes-default-deadbeef"
+        assert created_params.labels == {"hermes_task_id": "default"}
+
 
 # ---------------------------------------------------------------------------
 # Cleanup

--- a/tools/environments/daytona.py
+++ b/tools/environments/daytona.py
@@ -10,6 +10,7 @@ import math
 import os
 import shlex
 import threading
+import uuid
 from pathlib import Path
 
 from tools.environments.base import (
@@ -84,11 +85,12 @@ class DaytonaEnvironment(BaseEnvironment):
         resources = Resources(cpu=cpu, memory=memory_gib, disk=disk_gib)
 
         labels = {"hermes_task_id": task_id}
-        sandbox_name = f"hermes-{task_id}"
+        legacy_sandbox_name = f"hermes-{task_id}"
+        sandbox_name = f"{legacy_sandbox_name}-{uuid.uuid4().hex[:8]}"
 
         if self._persistent:
             try:
-                self._sandbox = self._daytona.get(sandbox_name)
+                self._sandbox = self._daytona.get(legacy_sandbox_name)
                 self._sandbox.start()
                 logger.info("Daytona: resumed sandbox %s for task %s",
                             self._sandbox.id, task_id)


### PR DESCRIPTION
## Summary

The Daytona backend currently creates sandboxes with a deterministic `hermes-<task_id>` name. When multiple workers collapse to the same logical task id, concurrent sandbox creation collides at the Daytona API layer.

Closes #28299.

## Changes

- keep the existing `hermes_task_id` label for logical task lookup
- preserve the legacy deterministic name only for resume lookup
- create new Daytona sandboxes with a short random suffix so concurrent workers do not collide on name
- add a regression test covering the unique create-name plus stable task label pair

## Testing

- `uv run --extra dev pytest tests/tools/test_daytona_environment.py -q`
