### PR TITLE
fix(doctor): use compatible models URL for Alibaba coding plan

### DIFF
--- a/plugins/model-providers/alibaba-coding-plan/__init__.py
+++ b/plugins/model-providers/alibaba-coding-plan/__init__.py
@@ -15,6 +15,7 @@ alibaba_coding_plan = ProviderProfile(
     signup_url="https://help.aliyun.com/zh/model-studio/",
     env_vars=("ALIBABA_CODING_PLAN_API_KEY", "DASHSCOPE_API_KEY", "ALIBABA_CODING_PLAN_BASE_URL"),
     base_url="https://coding-intl.dashscope.aliyuncs.com/v1",
+    models_url="https://coding-intl.dashscope.aliyuncs.com/compatible-mode/v1/models",
     auth_type="api_key",
 )
 

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -761,6 +761,59 @@ def test_run_doctor_dashscope_retries_china_endpoint_after_intl_unauthorized(mon
     )
 
 
+def test_run_doctor_alibaba_coding_plan_uses_compatible_models_url(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+    (home / ".env").write_text("ALIBABA_CODING_PLAN_API_KEY=sk-test\n", encoding="utf-8")
+    project = tmp_path / "project"
+    project.mkdir(exist_ok=True)
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    monkeypatch.setenv("ALIBABA_CODING_PLAN_API_KEY", "sk-test")
+    monkeypatch.delenv("ALIBABA_CODING_PLAN_BASE_URL", raising=False)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
+    except ImportError:
+        pass
+
+    calls = []
+
+    def fake_get(url, headers=None, timeout=None):
+        calls.append((url, headers, timeout))
+        return types.SimpleNamespace(status_code=200)
+
+    import httpx
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    out = buf.getvalue()
+
+    assert "Alibaba Cloud (Coding Plan)" in out
+    assert any(
+        url == "https://coding-intl.dashscope.aliyuncs.com/compatible-mode/v1/models"
+        for url, _, _ in calls
+    )
+    assert not any(
+        url == "https://coding-intl.dashscope.aliyuncs.com/v1/models"
+        for url, _, _ in calls
+    )
+
+
 @pytest.mark.parametrize("base_url", [None, "https://opencode.ai/zen/go/v1"])
 def test_run_doctor_opencode_go_skips_invalid_models_probe(monkeypatch, tmp_path, base_url):
     home = tmp_path / ".hermes"


### PR DESCRIPTION
## Summary

The Alibaba coding-plan provider profile inherits the default `/models` probe from its chat base URL, but that host serves its model catalog from the compatible-mode endpoint instead. That makes `hermes doctor` probe `.../v1/models` and get a 404.

Closes #28273.

## Changes

- add an explicit `models_url` to the `alibaba-coding-plan` provider profile
- add a doctor regression test asserting the compatible-mode models URL is used instead of `.../v1/models`

## Testing

- `uv run --extra dev pytest tests/hermes_cli/test_doctor.py -k 'alibaba_coding_plan or dashscope_retries_china' -q`
