### PR TITLE
fix(tui): termux-gate scrollback/history copy QoL

### DIFF
--- a/ui-tui/src/__tests__/statusBarTicker.test.ts
+++ b/ui-tui/src/__tests__/statusBarTicker.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { padVerb, VERB_PAD_LEN } from '../components/appChrome.js'
+import { DURATION_PAD_LEN, padTickerDuration, padVerb, VERB_PAD_LEN } from '../components/appChrome.js'
 import { VERBS } from '../content/verbs.js'
 
 describe('FaceTicker verb padding', () => {
@@ -14,5 +14,14 @@ describe('FaceTicker verb padding', () => {
     for (const verb of VERBS) {
       expect(padVerb(verb).startsWith(`${verb}…`)).toBe(true)
     }
+  })
+})
+
+describe('FaceTicker duration padding', () => {
+  it('keeps elapsed segment width stable across second/minute boundaries', () => {
+    const samples = [9000, 10000, 59000, 60000, 61000, 3599000]
+    const lens = samples.map(ms => padTickerDuration(ms).length)
+
+    expect(new Set(lens)).toEqual(new Set([DURATION_PAD_LEN]))
   })
 })

--- a/ui-tui/src/__tests__/termux.test.ts
+++ b/ui-tui/src/__tests__/termux.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { isTermuxEnv, isTermuxTuiMode } from '../lib/termux.js'
+
+describe('isTermuxEnv', () => {
+  it('detects TERMUX_VERSION marker', () => {
+    expect(isTermuxEnv({ TERMUX_VERSION: '0.118.0' } as NodeJS.ProcessEnv)).toBe(true)
+  })
+
+  it('detects Termux PREFIX path marker', () => {
+    expect(
+      isTermuxEnv({ PREFIX: '/data/data/com.termux/files/usr' } as NodeJS.ProcessEnv)
+    ).toBe(true)
+  })
+
+  it('returns false for generic Linux envs', () => {
+    expect(isTermuxEnv({ PREFIX: '/usr' } as NodeJS.ProcessEnv)).toBe(false)
+  })
+})
+
+describe('isTermuxTuiMode', () => {
+  it('defaults to true inside Termux', () => {
+    expect(isTermuxTuiMode({ TERMUX_VERSION: '0.118.0' } as NodeJS.ProcessEnv)).toBe(true)
+  })
+
+  it('allows explicit opt-out override', () => {
+    expect(
+      isTermuxTuiMode({ TERMUX_VERSION: '0.118.0', HERMES_TUI_TERMUX_MODE: '0' } as NodeJS.ProcessEnv)
+    ).toBe(false)
+  })
+
+  it('stays false outside Termux even if override is set', () => {
+    expect(isTermuxTuiMode({ HERMES_TUI_TERMUX_MODE: '1', PREFIX: '/usr' } as NodeJS.ProcessEnv)).toBe(false)
+  })
+})

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -2,7 +2,7 @@ import { useApp, useHasSelection, useSelection, useStdout, useTerminalTitle, typ
 import { useStore } from '@nanostores/react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
-import { STARTUP_RESUME_ID } from '../config/env.js'
+import { STARTUP_RESUME_ID, TERMUX_HISTORY_MAX, TERMUX_TUI_MODE } from '../config/env.js'
 import { FULL_RENDER_TAIL_ITEMS, MAX_HISTORY, WHEEL_SCROLL_STEP } from '../config/limits.js'
 import { SECTION_NAMES, sectionMode } from '../domain/details.js'
 import { attachedImageNotice, imageTokenMeta } from '../domain/messages.js'
@@ -46,12 +46,12 @@ const BRACKET_PASTE_ON = '\x1b[?2004h'
 const BRACKET_PASTE_OFF = '\x1b[?2004l'
 const MAX_HEIGHT_CACHE_BUCKETS = 12
 
-const capHistory = (items: Msg[]): Msg[] => {
-  if (items.length <= MAX_HISTORY) {
+const capHistory = (items: Msg[], maxHistory: number): Msg[] => {
+  if (items.length <= maxHistory) {
     return items
   }
 
-  return items[0]?.kind === 'intro' ? [items[0]!, ...items.slice(-(MAX_HISTORY - 1))] : items.slice(-MAX_HISTORY)
+  return items[0]?.kind === 'intro' ? [items[0]!, ...items.slice(-(maxHistory - 1))] : items.slice(-maxHistory)
 }
 
 const statusColorOf = (status: string, t: { error: string; muted: string; ok: string; warn: string }) => {
@@ -74,6 +74,7 @@ export function useMainApp(gw: GatewayClient) {
   const { exit } = useApp()
   const { stdout } = useStdout()
   const [cols, setCols] = useState(stdout?.columns ?? 80)
+  const maxHistory = TERMUX_TUI_MODE ? TERMUX_HISTORY_MAX : MAX_HISTORY
 
   useEffect(() => {
     if (!stdout) {
@@ -307,8 +308,8 @@ export function useMainApp(gw: GatewayClient) {
   )
 
   const appendMessage = useCallback(
-    (msg: Msg) => setHistoryItems(prev => capHistory(appendTranscriptMessage(prev, msg))),
-    []
+    (msg: Msg) => setHistoryItems(prev => capHistory(appendTranscriptMessage(prev, msg), maxHistory)),
+    [maxHistory]
   )
 
   const sys = useCallback((text: string) => appendMessage({ role: 'system', text }), [appendMessage])
@@ -819,7 +820,7 @@ export function useMainApp(gw: GatewayClient) {
 
   const appStatus = useMemo(
     () => ({
-      cwdLabel: fmtCwdBranch(cwd, gitBranch),
+      cwdLabel: fmtCwdBranch(cwd, gitBranch, TERMUX_TUI_MODE ? Math.max(16, Math.min(30, Math.floor(cols * 0.42))) : 40),
       goodVibesTick,
       sessionStartedAt: ui.sid ? sessionStartedAt : null,
       showStickyPrompt: !!stickyPrompt,
@@ -831,6 +832,7 @@ export function useMainApp(gw: GatewayClient) {
       voiceLabel: voiceRecording ? '● REC' : voiceProcessing ? '◉ STT' : `voice ${voiceEnabled ? 'on' : 'off'}`
     }),
     [
+      cols,
       cwd,
       gitBranch,
       goodVibesTick,

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -7,6 +7,7 @@ import { $delegationState } from '../app/delegationStore.js'
 import type { IndicatorStyle } from '../app/interfaces.js'
 import { useTurnSelector } from '../app/turnStore.js'
 import { $uiState } from '../app/uiStore.js'
+import { TERMUX_TUI_MODE } from '../config/env.js'
 import { FACES } from '../content/faces.js'
 import { VERBS } from '../content/verbs.js'
 import { fmtDuration } from '../domain/messages.js'
@@ -24,6 +25,8 @@ const HEART_COLORS = ['#ff5fa2', '#ff4d6d']
 // jitter when the ticker rotates between short/long verbs.
 export const VERB_PAD_LEN = VERBS.reduce((max, v) => Math.max(max, v.length), 0) + 1 // + ellipsis
 export const padVerb = (verb: string) => `${verb}…`.padEnd(VERB_PAD_LEN, ' ')
+export const DURATION_PAD_LEN = 7 // e.g. "9s", "1m 05s", "59m 59s"
+export const padTickerDuration = (ms: number) => fmtDuration(ms).padStart(DURATION_PAD_LEN, ' ')
 
 // Compact alternates for the `emoji` and `ascii` indicator styles.
 // Each entry is a fixed-width (display-width) glyph.
@@ -112,7 +115,9 @@ function FaceTicker({ color, startedAt }: { color: string; startedAt?: null | nu
   // verb segment is hidden (e.g. `unicode` spinner style).  When the verb
   // IS shown, its trailing padding already provides the gap, so the extra
   // space is harmless.
-  const durationSegment = startedAt ? ` · ${fmtDuration(now - startedAt)}` : ''
+  const durationSegment = startedAt
+    ? ` · ${TERMUX_TUI_MODE ? padTickerDuration(now - startedAt) : fmtDuration(now - startedAt)}`
+    : ''
 
   return (
     <Text color={color}>

--- a/ui-tui/src/config/env.ts
+++ b/ui-tui/src/config/env.ts
@@ -1,16 +1,61 @@
+import { isTermuxTuiMode } from '../lib/termux.js'
+
 const truthy = (v?: string) => /^(?:1|true|yes|on)$/i.test((v ?? '').trim())
+const falsy = (v?: string) => /^(?:0|false|no|off)$/i.test((v ?? '').trim())
+
+const parseToggle = (v?: string): boolean | null => {
+  const raw = (v ?? '').trim()
+
+  if (!raw) {
+    return null
+  }
+
+  if (truthy(raw)) {
+    return true
+  }
+
+  if (falsy(raw)) {
+    return false
+  }
+
+  return null
+}
+
+const parsePositiveInt = (v?: string): null | number => {
+  const n = Number.parseInt((v ?? '').trim(), 10)
+
+  return Number.isFinite(n) && n > 0 ? n : null
+}
+
+export const TERMUX_TUI_MODE = isTermuxTuiMode()
 
 export const STARTUP_RESUME_ID = (process.env.HERMES_TUI_RESUME ?? '').trim()
 export const STARTUP_QUERY = (process.env.HERMES_TUI_QUERY ?? '').trim()
 export const STARTUP_IMAGE = (process.env.HERMES_TUI_IMAGE ?? '').trim()
-export const MOUSE_TRACKING = !truthy(process.env.HERMES_TUI_DISABLE_MOUSE)
+
+const mouseTrackingOverride = parseToggle(process.env.HERMES_TUI_MOUSE_TRACKING)
+const mouseTrackingDisabledLegacy = truthy(process.env.HERMES_TUI_DISABLE_MOUSE)
+// Mobile selection UX: on Termux default mouse tracking OFF so touch selection
+// is less likely to be intercepted by terminal mouse protocols. Desktop keeps
+// prior behavior unless explicitly overridden.
+export const MOUSE_TRACKING =
+  mouseTrackingOverride ?? (TERMUX_TUI_MODE ? false : !mouseTrackingDisabledLegacy)
+
 export const NO_CONFIRM_DESTRUCTIVE = truthy(process.env.HERMES_TUI_NO_CONFIRM)
+
+const inlineOverride = parseToggle(process.env.HERMES_TUI_INLINE)
 
 // Skip AlternateScreen — TUI renders into the primary buffer so the host
 // terminal's native scrollback captures whatever scrolls off the top.
-// Experiment gate: lets us measure native scroll vs our virtualization on
-// the same pipeline.
-export const INLINE_MODE = truthy(process.env.HERMES_TUI_INLINE)
+//
+// On Termux we default this on: users often background/foreground the app,
+// and primary-buffer rendering makes long-thread review and copy/paste much
+// less fragile. Override explicitly with HERMES_TUI_INLINE=0/1.
+export const INLINE_MODE = inlineOverride ?? TERMUX_TUI_MODE
+
+// Keep a deeper in-memory transcript on Termux before UI-level pruning so
+// long mobile sessions remain reviewable/copyable in one run.
+export const TERMUX_HISTORY_MAX = parsePositiveInt(process.env.HERMES_TUI_TERMUX_HISTORY_MAX) ?? 4000
 
 // Live FPS counter overlay, fed by ink's onFrame (real render rate, not a
 // synthetic timer).

--- a/ui-tui/src/entry.tsx
+++ b/ui-tui/src/entry.tsx
@@ -5,6 +5,7 @@ import './lib/forceTruecolor.js'
 
 import type { FrameEvent } from '@hermes/ink'
 
+import { TERMUX_TUI_MODE } from './config/env.js'
 import { GatewayClient } from './gatewayClient.js'
 import { setupGracefulExit } from './lib/gracefulExit.js'
 import { formatBytes, type HeapDumpResult, performHeapDump } from './lib/memory.js'
@@ -21,11 +22,14 @@ if (!process.stdin.isTTY) {
 // terminal tab can still have mouse/focus/paste modes enabled.
 resetTerminalModes()
 
-// Clear visible screen + scrollback buffer. Without this, tmux may retain
-// stale TUI output in its scrollback buffer from the previous session,
-// which is visible when the user scrolls up or briefly before AlternateScreen
-// takes over on restart. See entry.tsx → AlternateScreen flow.
-process.stdout.write('\x1b[2J\x1b[H\x1b[3J')
+// Desktop terminals benefit from a clean startup slate because the TUI usually
+// runs in AlternateScreen. On Termux we keep prior output intact so users can
+// review/copy earlier assistant replies after reopening the app.
+if (TERMUX_TUI_MODE) {
+  process.stdout.write('\n')
+} else {
+  process.stdout.write('\x1b[2J\x1b[H\x1b[3J')
+}
 
 const gw = new GatewayClient()
 

--- a/ui-tui/src/lib/termux.ts
+++ b/ui-tui/src/lib/termux.ts
@@ -1,0 +1,29 @@
+const TERMUX_PREFIX = '/data/data/com.termux/files/usr'
+
+const truthy = (value?: string) => /^(?:1|true|yes|on)$/i.test(String(value ?? '').trim())
+
+export const isTermuxEnv = (env: NodeJS.ProcessEnv = process.env): boolean => {
+  const prefix = String(env.PREFIX ?? '')
+
+  return Boolean(env.TERMUX_VERSION) || prefix.includes(TERMUX_PREFIX)
+}
+
+/**
+ * Return true when Hermes should enable Termux-focused TUI defaults.
+ *
+ * Defaults to on in Termux, with an explicit opt-out for debugging:
+ *   HERMES_TUI_TERMUX_MODE=0
+ */
+export const isTermuxTuiMode = (env: NodeJS.ProcessEnv = process.env): boolean => {
+  if (!isTermuxEnv(env)) {
+    return false
+  }
+
+  const override = String(env.HERMES_TUI_TERMUX_MODE ?? '').trim().toLowerCase()
+
+  if (override) {
+    return truthy(override)
+  }
+
+  return true
+}


### PR DESCRIPTION
## What does this PR do?

This PR delivers a Termux-focused TUI quality-of-life fix bundle that addresses mobile UX pain points without changing behavior on desktop platforms.

Primary goals:
- Preserve scrollback/history visibility when reopening Termux sessions.
- Make copying assistant replies easier on mobile.
- Reduce long-thread message loss in active TUI sessions.
- Improve right-edge/status-line stability on narrow mobile terminals.

All behavior changes are gated behind Termux detection (`TERMUX_VERSION` or Termux `PREFIX`) so non-Termux platforms keep existing defaults.

## Related Issue

N/A (user-reported Termux TUI UX regressions; no upstream issue number attached yet)

## Type of Change

- [x] ðŸ› Bug fix (non-breaking change that fixes an issue)
- [ ] âœ¨ New feature (non-breaking change that adds functionality)
- [ ] ðŸ”’ Security fix
- [ ] ðŸ“ Documentation update
- [x] âœ… Tests (adding or improving test coverage)
- [ ] â™»ï¸ Refactor (no behavior change)
- [ ] ðŸŽ¯ New skill (bundled or hub)

## Changes Made

- Added Termux runtime detection helper:
  - `ui-tui/src/lib/termux.ts`
    - `isTermuxEnv()`
    - `isTermuxTuiMode()` with opt-out `HERMES_TUI_TERMUX_MODE=0`

- Updated TUI env defaults to be Termux-aware:
  - `ui-tui/src/config/env.ts`
    - Added `TERMUX_TUI_MODE`
    - `INLINE_MODE` defaults to `true` on Termux (override with `HERMES_TUI_INLINE=0/1`)
    - Added `TERMUX_HISTORY_MAX` (default `4000`, override `HERMES_TUI_TERMUX_HISTORY_MAX`)
    - `MOUSE_TRACKING` now supports explicit `HERMES_TUI_MOUSE_TRACKING=0/1`
    - On Termux, mouse tracking defaults off to improve touch selection/copy UX
    - Preserved legacy `HERMES_TUI_DISABLE_MOUSE` behavior for non-Termux

- Increased active-session transcript retention on Termux:
  - `ui-tui/src/app/useMainApp.ts`
    - `capHistory()` now accepts dynamic max
    - Uses `TERMUX_HISTORY_MAX` on Termux, `MAX_HISTORY` elsewhere

- Improved right-edge stability for narrow/mobile terminals:
  - `ui-tui/src/app/useMainApp.ts`
    - Termux-gated tighter `cwdLabel` width budget in status line
  - `ui-tui/src/components/appChrome.tsx`
    - Added duration padding helper (`padTickerDuration`) and applied it only in Termux mode
    - Prevents elapsed-time width jitter from pushing status content at the far right

- Preserved scrollback on Termux startup/reopen:
  - `ui-tui/src/entry.tsx`
    - Non-Termux keeps existing full clear (`2J/H/3J`)
    - Termux skips destructive clear and prints newline instead, preserving prior terminal transcript for review/copy

## How to Test

1. Run targeted tests for this change:

```bash
cd ui-tui
npm test -- src/__tests__/termux.test.ts src/__tests__/statusBarTicker.test.ts src/__tests__/createGatewayEventHandler.test.ts src/__tests__/useSessionLifecycle.test.ts
npm run type-check
```

2. Manual Termux behavior check:

```bash
# In Termux env
hermes --tui
```

- Confirm long threads retain more visible messages before pruning.
- Confirm touch selection/copy of assistant replies is easier.
- Confirm status-line right edge is more stable on narrow width.
- Exit and relaunch `hermes --tui`; confirm previous terminal output remains in scrollback.

3. Non-Termux sanity:
- Existing desktop defaults remain unchanged (alternate-screen clear path retained).

## Validation Notes

Executed:
- `npm run type-check` âœ…
- Targeted vitest suites listed above âœ…

Observed upstream baseline failure (pre-existing, not introduced by this PR):
- Full `npm test` currently fails on `origin/main` with `TypeError: wrapAnsi is not a function` in:
  - `src/__tests__/textInputWrap.test.ts`
  - `src/__tests__/cursorDriftRegression.test.ts`
  - `src/__tests__/textInputFastEcho.test.ts`
- Reproduced after stashing this PRâ€™s changes to confirm baseline status.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Termux (Android)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) â€” or N/A (N/A)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys â€” or N/A (N/A)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows â€” or N/A (N/A)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) â€” or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior â€” or N/A (N/A)

## Screenshots / Logs

Useful command outputs (available from local run):
- `npm run type-check` passed
- Targeted `vitest` suites passed
- Baseline full-suite failures reproduced on clean `origin/main` in text input wrap tests (`wrapAnsi is not a function`)