### PR TITLE
fix(kanban): stop board context leakage in specify/decompose flows

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5289,59 +5289,47 @@ class GatewayRunner:
                 slug = b.get("slug") or _kb.DEFAULT_BOARD
                 if attempted >= auto_decompose_per_tick:
                     break
-                # Pin this board for the duration of the call — same
-                # pattern as the dashboard specify endpoint. The
-                # decomposer module connects with no board kwarg and
-                # relies on the env var.
-                prev_env = os.environ.get("HERMES_KANBAN_BOARD")
                 try:
-                    os.environ["HERMES_KANBAN_BOARD"] = slug
+                    triage_ids = _decomp.list_triage_ids(board=slug)
+                except Exception as exc:
+                    logger.debug(
+                        "kanban auto-decompose: list_triage_ids failed on board %s (%s)",
+                        slug, exc,
+                    )
+                    triage_ids = []
+                for tid in triage_ids:
+                    if attempted >= auto_decompose_per_tick:
+                        break
+                    attempted += 1
                     try:
-                        triage_ids = _decomp.list_triage_ids()
-                    except Exception as exc:
-                        logger.debug(
-                            "kanban auto-decompose: list_triage_ids failed on board %s (%s)",
-                            slug, exc,
+                        outcome = _decomp.decompose_task(
+                            tid, author="auto-decomposer", board=slug,
                         )
-                        triage_ids = []
-                    for tid in triage_ids:
-                        if attempted >= auto_decompose_per_tick:
-                            break
-                        attempted += 1
-                        try:
-                            outcome = _decomp.decompose_task(
-                                tid, author="auto-decomposer",
+                    except Exception:
+                        logger.exception(
+                            "kanban auto-decompose: decompose_task crashed on %s",
+                            tid,
+                        )
+                        continue
+                    if outcome.ok:
+                        successes += 1
+                        if outcome.fanout and outcome.child_ids:
+                            logger.info(
+                                "kanban auto-decompose [%s]: %s → %d children",
+                                slug, tid, len(outcome.child_ids),
                             )
-                        except Exception:
-                            logger.exception(
-                                "kanban auto-decompose: decompose_task crashed on %s",
-                                tid,
-                            )
-                            continue
-                        if outcome.ok:
-                            successes += 1
-                            if outcome.fanout and outcome.child_ids:
-                                logger.info(
-                                    "kanban auto-decompose [%s]: %s → %d children",
-                                    slug, tid, len(outcome.child_ids),
-                                )
-                            else:
-                                logger.info(
-                                    "kanban auto-decompose [%s]: %s → single task (no fanout)",
-                                    slug, tid,
-                                )
                         else:
-                            # Common no-op reasons (no aux client configured) shouldn't
-                            # spam logs every tick. Log at debug.
-                            logger.debug(
-                                "kanban auto-decompose [%s]: %s skipped: %s",
-                                slug, tid, outcome.reason,
+                            logger.info(
+                                "kanban auto-decompose [%s]: %s → single task (no fanout)",
+                                slug, tid,
                             )
-                finally:
-                    if prev_env is None:
-                        os.environ.pop("HERMES_KANBAN_BOARD", None)
                     else:
-                        os.environ["HERMES_KANBAN_BOARD"] = prev_env
+                        # Common no-op reasons (no aux client configured) shouldn't
+                        # spam logs every tick. Log at debug.
+                        logger.debug(
+                            "kanban auto-decompose [%s]: %s skipped: %s",
+                            slug, tid, outcome.reason,
+                        )
             return successes
 
         logger.info(

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2386,6 +2386,7 @@ def _cmd_specify(args: argparse.Namespace) -> int:
     tenant = getattr(args, "tenant", None)
     author = getattr(args, "author", None) or _profile_author()
     want_json = bool(getattr(args, "json", False))
+    board = getattr(args, "board", None)
 
     if args.task_id and all_flag:
         print(
@@ -2395,7 +2396,7 @@ def _cmd_specify(args: argparse.Namespace) -> int:
         return 2
 
     if all_flag:
-        ids = spec.list_triage_ids(tenant=tenant)
+        ids = spec.list_triage_ids(tenant=tenant, board=board)
         if not ids:
             msg = (
                 "No triage tasks"
@@ -2419,7 +2420,7 @@ def _cmd_specify(args: argparse.Namespace) -> int:
     ok_count = 0
     fail_count = 0
     for tid in ids:
-        outcome = spec.specify_task(tid, author=author)
+        outcome = spec.specify_task(tid, author=author, board=board)
         if outcome.ok:
             ok_count += 1
         else:
@@ -2460,6 +2461,7 @@ def _cmd_decompose(args: argparse.Namespace) -> int:
     tenant = getattr(args, "tenant", None)
     author = getattr(args, "author", None) or _profile_author()
     want_json = bool(getattr(args, "json", False))
+    board = getattr(args, "board", None)
 
     if args.task_id and all_flag:
         print(
@@ -2469,7 +2471,7 @@ def _cmd_decompose(args: argparse.Namespace) -> int:
         return 2
 
     if all_flag:
-        ids = decomp.list_triage_ids(tenant=tenant)
+        ids = decomp.list_triage_ids(tenant=tenant, board=board)
         if not ids:
             msg = (
                 "No triage tasks"
@@ -2492,7 +2494,7 @@ def _cmd_decompose(args: argparse.Namespace) -> int:
 
     ok_count = 0
     for tid in ids:
-        outcome = decomp.decompose_task(tid, author=author)
+        outcome = decomp.decompose_task(tid, author=author, board=board)
         if outcome.ok:
             ok_count += 1
         if want_json:

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -273,6 +273,7 @@ def decompose_task(
     *,
     author: Optional[str] = None,
     timeout: Optional[int] = None,
+    board: Optional[str] = None,
 ) -> DecomposeOutcome:
     """Decompose a triage task into a graph of child tasks.
 
@@ -281,7 +282,7 @@ def decompose_task(
     configured, API error, malformed response, decomposer returned
     fanout=true with empty task list) — those surface via ``ok=False``.
     """
-    with kb.connect() as conn:
+    with kb.connect(board=board) as conn:
         task = kb.get_task(conn, task_id)
     if task is None:
         return DecomposeOutcome(task_id, False, "unknown task id")
@@ -370,7 +371,7 @@ def decompose_task(
             return DecomposeOutcome(
                 task_id, False, "decomposer returned fanout=false with no title/body",
             )
-        with kb.connect() as conn:
+        with kb.connect(board=board) as conn:
             ok = kb.specify_triage_task(
                 conn,
                 task_id,
@@ -439,7 +440,7 @@ def decompose_task(
         })
 
     try:
-        with kb.connect() as conn:
+        with kb.connect(board=board) as conn:
             child_ids = kb.decompose_triage_task(
                 conn,
                 task_id,
@@ -465,9 +466,13 @@ def decompose_task(
     )
 
 
-def list_triage_ids(*, tenant: Optional[str] = None) -> list[str]:
+def list_triage_ids(
+    *,
+    tenant: Optional[str] = None,
+    board: Optional[str] = None,
+) -> list[str]:
     """Return task ids currently in the triage column."""
-    with kb.connect() as conn:
+    with kb.connect(board=board) as conn:
         rows = kb.list_tasks(
             conn,
             status="triage",

--- a/hermes_cli/kanban_specify.py
+++ b/hermes_cli/kanban_specify.py
@@ -142,6 +142,7 @@ def specify_task(
     *,
     author: Optional[str] = None,
     timeout: Optional[int] = None,
+    board: Optional[str] = None,
 ) -> SpecifyOutcome:
     """Specify a single triage task and promote it to ``todo``.
 
@@ -150,7 +151,7 @@ def specify_task(
     error, malformed response) — those surface via ``ok=False`` so the
     ``--all`` sweep can continue past individual failures.
     """
-    with kb.connect() as conn:
+    with kb.connect(board=board) as conn:
         task = kb.get_task(conn, task_id)
     if task is None:
         return SpecifyOutcome(task_id, False, "unknown task id")
@@ -239,7 +240,7 @@ def specify_task(
                 task_id, False, "LLM response missing title and body"
             )
 
-    with kb.connect() as conn:
+    with kb.connect(board=board) as conn:
         ok = kb.specify_triage_task(
             conn,
             task_id,
@@ -256,12 +257,16 @@ def specify_task(
     return SpecifyOutcome(task_id, True, "specified", new_title=new_title)
 
 
-def list_triage_ids(*, tenant: Optional[str] = None) -> list[str]:
+def list_triage_ids(
+    *,
+    tenant: Optional[str] = None,
+    board: Optional[str] = None,
+) -> list[str]:
     """Return task ids currently in the triage column.
 
     ``tenant`` narrows the sweep; ``None`` returns every triage task.
     """
-    with kb.connect() as conn:
+    with kb.connect(board=board) as conn:
         tasks = kb.list_tasks(
             conn,
             status="triage",

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -1376,24 +1376,15 @@ def specify_task_endpoint(
     ``async def`` without an explicit ``run_in_executor``.
     """
     board = _resolve_board(board)
-    # Pin the board for the duration of this call so the specifier module
-    # (which calls ``kb.connect()`` with no args) hits the right DB.
-    prev_env = os.environ.get("HERMES_KANBAN_BOARD")
-    try:
-        os.environ["HERMES_KANBAN_BOARD"] = board or kanban_db.DEFAULT_BOARD
-        # Import lazily so a missing auxiliary client at import time
-        # doesn't break plugin load.
-        from hermes_cli import kanban_specify  # noqa: WPS433 (intentional)
+    # Import lazily so a missing auxiliary client at import time
+    # doesn't break plugin load.
+    from hermes_cli import kanban_specify  # noqa: WPS433 (intentional)
 
-        outcome = kanban_specify.specify_task(
-            task_id,
-            author=(payload.author or None),
-        )
-    finally:
-        if prev_env is None:
-            os.environ.pop("HERMES_KANBAN_BOARD", None)
-        else:
-            os.environ["HERMES_KANBAN_BOARD"] = prev_env
+    outcome = kanban_specify.specify_task(
+        task_id,
+        author=(payload.author or None),
+        board=board,
+    )
 
     return {
         "ok": bool(outcome.ok),
@@ -1990,19 +1981,12 @@ def decompose_task_endpoint(
     can take minutes on reasoning models.
     """
     board = _resolve_board(board)
-    prev_env = os.environ.get("HERMES_KANBAN_BOARD")
-    try:
-        os.environ["HERMES_KANBAN_BOARD"] = board or kanban_db.DEFAULT_BOARD
-        from hermes_cli import kanban_decompose  # noqa: WPS433 (intentional)
-        outcome = kanban_decompose.decompose_task(
-            task_id,
-            author=(payload.author or None),
-        )
-    finally:
-        if prev_env is None:
-            os.environ.pop("HERMES_KANBAN_BOARD", None)
-        else:
-            os.environ["HERMES_KANBAN_BOARD"] = prev_env
+    from hermes_cli import kanban_decompose  # noqa: WPS433 (intentional)
+    outcome = kanban_decompose.decompose_task(
+        task_id,
+        author=(payload.author or None),
+        board=board,
+    )
 
     return {
         "ok": bool(outcome.ok),

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -347,3 +347,37 @@ def test_decompose_no_aux_client_configured(kanban_home):
 
     assert outcome.ok is False
     assert "no auxiliary client" in outcome.reason
+
+
+def test_decompose_task_respects_explicit_board_over_env(kanban_home, monkeypatch):
+    kb.create_board("alpha")
+    kb.create_board("beta")
+    with kb.connect(board="alpha") as conn:
+        tid = kb.create_task(conn, title="alpha root", triage=True)
+
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "rationale": "test split",
+        "tasks": [
+            {"title": "alpha child", "body": "do it", "assignee": "engineer", "parents": []},
+        ],
+    })
+
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "beta")
+    patches = _patch_list_profiles(["orchestrator", "engineer"])
+    for p in patches:
+        p.start()
+    try:
+        with _patch_aux_client(llm_payload), _patch_extra_body():
+            outcome = decomp.decompose_task(tid, author="me", board="alpha")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert outcome.ok is True, outcome.reason
+    assert outcome.child_ids and len(outcome.child_ids) == 1
+    with kb.connect(board="alpha") as conn:
+        root = kb.get_task(conn, tid)
+        child = kb.get_task(conn, outcome.child_ids[0])
+    assert root is not None and root.status == "todo"
+    assert child is not None and child.assignee == "engineer"

--- a/tests/hermes_cli/test_kanban_specify.py
+++ b/tests/hermes_cli/test_kanban_specify.py
@@ -214,6 +214,29 @@ def test_list_triage_ids(kanban_home):
     assert ids_tenant == [b]
 
 
+def test_specify_task_respects_explicit_board_over_env(kanban_home, monkeypatch):
+    kb.create_board("alpha")
+    kb.create_board("beta")
+    with kb.connect(board="alpha") as conn:
+        tid = kb.create_task(conn, title="alpha rough", triage=True)
+
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "beta")
+    content = jsonlib.dumps({
+        "title": "Alpha refined",
+        "body": "**Goal**\nScoped to alpha.",
+    })
+    p, _ = _patch_aux_client(content)
+    with p:
+        outcome = spec.specify_task(tid, author="ace", board="alpha")
+
+    assert outcome.ok is True
+    with kb.connect(board="alpha") as conn:
+        task = kb.get_task(conn, tid)
+    assert task is not None
+    assert task.status == "ready"
+    assert task.title == "Alpha refined"
+
+
 # ---------------------------------------------------------------------------
 # CLI wiring — argparse + _cmd_specify
 # ---------------------------------------------------------------------------

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -12,6 +12,7 @@ import os
 import sys
 import time
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from fastapi import FastAPI
@@ -1672,6 +1673,69 @@ def test_home_channels_empty_when_no_homes_configured(client, monkeypatch):
     r = client.get("/api/plugins/kanban/home-channels")
     assert r.status_code == 200
     assert r.json()["home_channels"] == []
+
+
+def test_specify_endpoint_passes_board_without_mutating_env(client, monkeypatch):
+    kb.create_board("alpha")
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "sticky-board")
+    seen: dict[str, object] = {}
+
+    def _fake_specify(task_id, *, author=None, timeout=None, board=None):
+        seen["task_id"] = task_id
+        seen["author"] = author
+        seen["board"] = board
+        seen["env_board"] = os.environ.get("HERMES_KANBAN_BOARD")
+        return SimpleNamespace(ok=True, task_id=task_id, reason="ok", new_title="retitled")
+
+    monkeypatch.setattr("hermes_cli.kanban_specify.specify_task", _fake_specify)
+
+    r = client.post(
+        "/api/plugins/kanban/tasks/t_alpha/specify?board=alpha",
+        json={"author": "dash"},
+    )
+    assert r.status_code == 200
+    assert seen == {
+        "task_id": "t_alpha",
+        "author": "dash",
+        "board": "alpha",
+        "env_board": "sticky-board",
+    }
+    assert os.environ.get("HERMES_KANBAN_BOARD") == "sticky-board"
+
+
+def test_decompose_endpoint_passes_board_without_mutating_env(client, monkeypatch):
+    kb.create_board("alpha")
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "sticky-board")
+    seen: dict[str, object] = {}
+
+    def _fake_decompose(task_id, *, author=None, timeout=None, board=None):
+        seen["task_id"] = task_id
+        seen["author"] = author
+        seen["board"] = board
+        seen["env_board"] = os.environ.get("HERMES_KANBAN_BOARD")
+        return SimpleNamespace(
+            ok=True,
+            task_id=task_id,
+            reason="ok",
+            fanout=True,
+            child_ids=["t_child"],
+            new_title=None,
+        )
+
+    monkeypatch.setattr("hermes_cli.kanban_decompose.decompose_task", _fake_decompose)
+
+    r = client.post(
+        "/api/plugins/kanban/tasks/t_alpha/decompose?board=alpha",
+        json={"author": "dash"},
+    )
+    assert r.status_code == 200
+    assert seen == {
+        "task_id": "t_alpha",
+        "author": "dash",
+        "board": "alpha",
+        "env_board": "sticky-board",
+    }
+    assert os.environ.get("HERMES_KANBAN_BOARD") == "sticky-board"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This fixes a cross-board context leak in the kanban specify/decompose paths.

`kanban_specify` and `kanban_decompose` were relying on temporary
process-global `HERMES_KANBAN_BOARD` mutation to resolve the active board.
That made dashboard requests and gateway auto-decompose runs vulnerable to
cross-board races in the same process.

This change switches those flows to explicit board propagation instead.

## What changed

- Added an explicit `board` parameter to:
  - `hermes_cli.kanban_specify.specify_task`
  - `hermes_cli.kanban_specify.list_triage_ids`
  - `hermes_cli.kanban_decompose.decompose_task`
  - `hermes_cli.kanban_decompose.list_triage_ids`
- Updated the CLI wrappers to forward `--board` into those helpers.
- Updated dashboard specify/decompose endpoints to pass `board` directly
  instead of mutating `HERMES_KANBAN_BOARD`.
- Updated gateway auto-decompose to use explicit board routing as well.
- Added regression coverage for explicit-board behavior and dashboard
  endpoint forwarding.

## Why

Before this patch, two concurrent board-scoped operations in the same process
could overwrite each other’s board context via `os.environ`, causing lookups
or writes to hit the wrong kanban board.

## Testing

- Targeted kanban specify/decompose regression tests pass.
- Added dashboard endpoint tests to verify board forwarding without env mutation.

