### PR TITLE
fix(discord): suppress implicit reply-ping to break agent thread loops

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -114,15 +114,14 @@ def check_discord_requirements() -> bool:
     return True
 
 
-def _build_allowed_mentions():
+def _build_allowed_mentions(replied_user: Optional[bool] = None):
     """Build Discord ``AllowedMentions`` with safe defaults, overridable via env.
 
     Discord bots default to parsing ``@everyone``, ``@here``, role pings, and
     user pings when ``allowed_mentions`` is unset on the client — any LLM
     output or echoed user content that contains ``@everyone`` would therefore
     ping the whole server. We explicitly deny ``@everyone`` and role pings
-    by default and keep user / replied-user pings enabled so normal
-    conversation still works.
+    by default and keep user pings enabled so normal conversation still works.
 
     Override via environment variables (or ``discord.allow_mentions.*`` in
     config.yaml):
@@ -131,6 +130,14 @@ def _build_allowed_mentions():
         DISCORD_ALLOW_MENTION_ROLES         default false  — @role pings
         DISCORD_ALLOW_MENTION_USERS         default true   — @user pings
         DISCORD_ALLOW_MENTION_REPLIED_USER  default true   — reply-ping author
+
+    ``replied_user`` argument: when ``None`` (the default) the value comes
+    from ``DISCORD_ALLOW_MENTION_REPLIED_USER`` — this governs the
+    client-wide default used for non-reply sends. When an explicit bool is
+    passed it overrides the env entirely; the reply send path uses this to
+    suppress the implicit reply-ping by default (see ``send`` /
+    ``mention_replied_user``), which otherwise pings the author of every
+    message replied to and causes agent-to-agent loops in shared threads.
     """
     if not DISCORD_AVAILABLE:
         return None
@@ -145,7 +152,11 @@ def _build_allowed_mentions():
         everyone=_b("DISCORD_ALLOW_MENTION_EVERYONE", False),
         roles=_b("DISCORD_ALLOW_MENTION_ROLES", False),
         users=_b("DISCORD_ALLOW_MENTION_USERS", True),
-        replied_user=_b("DISCORD_ALLOW_MENTION_REPLIED_USER", True),
+        replied_user=(
+            replied_user
+            if replied_user is not None
+            else _b("DISCORD_ALLOW_MENTION_REPLIED_USER", True)
+        ),
     )
 
 
@@ -1372,7 +1383,8 @@ class DiscordAdapter(BasePlatformAdapter):
         chat_id: str,
         content: str,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None
+        metadata: Optional[Dict[str, Any]] = None,
+        mention_replied_user: bool = False,
     ) -> SendResult:
         """Send a message to a Discord channel or thread.
 
@@ -1381,6 +1393,17 @@ class DiscordAdapter(BasePlatformAdapter):
 
         Forum channels (type 15) reject direct messages — a thread post is
         created automatically.
+
+        ``mention_replied_user`` controls the implicit reply-ping. When a
+        message is sent as a reply (``reply_to`` set, ``reply_to_mode`` not
+        "off"), Discord pings the author of the replied-to message unless
+        ``allowed_mentions.replied_user`` is False. This defaults to False
+        here: the implicit ping is what causes agent-to-agent loops in
+        shared threads (agent A replies, B is pinged and wakes, B replies,
+        A is pinged...). Pass ``mention_replied_user=True`` to opt back in
+        when a ping is genuinely wanted. Note this is a behavior change for
+        agent threads — to intentionally ping someone, put an explicit
+        ``<@id>`` in the message body (still honored via ``users=True``).
         """
         if not self._client:
             return SendResult(success=False, error="Not connected")
@@ -1417,6 +1440,14 @@ class DiscordAdapter(BasePlatformAdapter):
             message_ids = []
             reference = None
 
+            # Suppress the implicit reply-ping by default. A reply otherwise
+            # pings the replied-to author (allowed_mentions.replied_user),
+            # which causes agent-to-agent loops in shared threads. Explicit
+            # <@id> mentions in the body still ping via users=True.
+            reply_allowed_mentions = _build_allowed_mentions(
+                replied_user=mention_replied_user
+            )
+
             if reply_to and self._reply_to_mode != "off":
                 try:
                     ref_msg = await channel.fetch_message(int(reply_to))
@@ -1436,6 +1467,7 @@ class DiscordAdapter(BasePlatformAdapter):
                     msg = await channel.send(
                         content=chunk,
                         reference=chunk_reference,
+                        allowed_mentions=reply_allowed_mentions,
                     )
                 except Exception as e:
                     err_text = str(e)
@@ -1458,6 +1490,7 @@ class DiscordAdapter(BasePlatformAdapter):
                         msg = await channel.send(
                             content=chunk,
                             reference=None,
+                            allowed_mentions=reply_allowed_mentions,
                         )
                     else:
                         raise

--- a/tests/gateway/conftest.py
+++ b/tests/gateway/conftest.py
@@ -129,6 +129,18 @@ def _ensure_discord_mock() -> None:
             return self
     discord_mod.Embed = _FakeEmbed
 
+    # AllowedMentions: store kwargs as real attributes so tests can assert
+    # on .replied_user / .users etc. A bare MagicMock makes every attribute
+    # a truthy MagicMock, which silently passes `is False` assertions.
+    class _FakeAllowedMentions:
+        def __init__(self, *, everyone=False, roles=False, users=True,
+                     replied_user=True):
+            self.everyone = everyone
+            self.roles = roles
+            self.users = users
+            self.replied_user = replied_user
+    discord_mod.AllowedMentions = _FakeAllowedMentions
+
     # ui.View / ui.Select / ui.Button: real classes (not MagicMock) so
     # tests that subclass ModelPickerView / iterate .children / clear
     # items work.

--- a/tests/gateway/test_discord_reply_mode.py
+++ b/tests/gateway/test_discord_reply_mode.py
@@ -460,3 +460,56 @@ class TestYamlConfigLoading:
         load_gateway_config()
 
         assert os.environ.get("DISCORD_REPLY_TO_MODE") == "all"
+
+
+class TestRepliedUserMention:
+    """Tests for the implicit reply-ping (allowed_mentions.replied_user).
+
+    A Discord reply pings the author of the replied-to message unless
+    allowed_mentions.replied_user is False. The send() path suppresses this
+    by default to avoid agent-to-agent loops in shared threads; callers can
+    opt back in with mention_replied_user=True.
+    """
+
+    @pytest.mark.asyncio
+    async def test_reply_does_not_ping_replied_user_by_default(self):
+        adapter, channel, ref_msg = _make_discord_adapter("first")
+        adapter.truncate_message = lambda content, max_len, **kw: ["chunk1", "chunk2"]
+
+        await adapter.send("12345", "test content", reply_to="999")
+
+        calls = channel.send.call_args_list
+        assert len(calls) == 2
+        for call in calls:
+            am = call.kwargs.get("allowed_mentions")
+            assert am is not None, "reply send must pass explicit allowed_mentions"
+            assert am.replied_user is False
+
+    @pytest.mark.asyncio
+    async def test_reply_pings_replied_user_when_opted_in(self):
+        adapter, channel, ref_msg = _make_discord_adapter("first")
+        adapter.truncate_message = lambda content, max_len, **kw: ["chunk1", "chunk2"]
+
+        await adapter.send(
+            "12345", "test content", reply_to="999", mention_replied_user=True
+        )
+
+        calls = channel.send.call_args_list
+        assert len(calls) == 2
+        for call in calls:
+            am = call.kwargs.get("allowed_mentions")
+            assert am is not None
+            assert am.replied_user is True
+
+    @pytest.mark.asyncio
+    async def test_replied_user_default_false_overrides_env(self, monkeypatch):
+        """The mention_replied_user default wins over DISCORD_ALLOW_MENTION_REPLIED_USER."""
+        monkeypatch.setenv("DISCORD_ALLOW_MENTION_REPLIED_USER", "true")
+        adapter, channel, ref_msg = _make_discord_adapter("first")
+        adapter.truncate_message = lambda content, max_len, **kw: ["chunk1"]
+
+        await adapter.send("12345", "test content", reply_to="999")
+
+        am = channel.send.call_args_list[0].kwargs.get("allowed_mentions")
+        assert am is not None
+        assert am.replied_user is False

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -54,7 +54,7 @@ async def test_send_retries_without_reference_when_reply_target_is_system_messag
     sent_msg = SimpleNamespace(id=1234)
     send_calls = []
 
-    async def fake_send(*, content, reference=None):
+    async def fake_send(*, content, reference=None, allowed_mentions=None):
         send_calls.append({"content": content, "reference": reference})
         if len(send_calls) == 1:
             raise RuntimeError(
@@ -92,7 +92,7 @@ async def test_send_retries_without_reference_when_reply_target_is_deleted():
     sent_msgs = [SimpleNamespace(id=1001), SimpleNamespace(id=1002)]
     send_calls = []
 
-    async def fake_send(*, content, reference=None):
+    async def fake_send(*, content, reference=None, allowed_mentions=None):
         send_calls.append({"content": content, "reference": reference})
         if len(send_calls) == 1:
             raise RuntimeError(
@@ -135,7 +135,7 @@ async def test_send_does_not_retry_on_unrelated_errors():
     ref_msg = SimpleNamespace(id=99, to_reference=MagicMock(return_value=reference_obj))
     send_calls = []
 
-    async def fake_send(*, content, reference=None):
+    async def fake_send(*, content, reference=None, allowed_mentions=None):
         send_calls.append({"content": content, "reference": reference})
         raise RuntimeError(
             "403 Forbidden (error code: 50013): Missing Permissions"


### PR DESCRIPTION
The reply send path inherited the client-default allowed_mentions (replied_user=True), so every reply pinged the author of the replied-to message. In shared threads this caused agent-to-agent loops: agent A posts a threaded reply, Discord pings agent B, B's gateway wakes and replies, which pings A, and so on.

- send() now passes explicit allowed_mentions on the reply path, with replied_user driven by a new mention_replied_user param (default False). Pass mention_replied_user=True to opt back in.
- _build_allowed_mentions() takes an optional replied_user override; the client-wide default for non-reply sends is unchanged (still env-driven via DISCORD_ALLOW_MENTION_REPLIED_USER).
- Explicit <@id> mentions in the message body still ping normally (users=True) — that is the intentional way to ping in agent threads.

Discord-only; Telegram, Slack and other adapters are untouched.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

