### PR TITLE
feat: per-provider max_tokens via custom_providers models.<model>.max_tokens

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1165,6 +1165,23 @@ def init_agent(
                 )
     agent._session_init_model_config["max_tokens"] = agent.max_tokens
 
+    # If max_tokens is still unset, check custom_providers for a per-provider
+    # override (e.g. custom_providers[].models.<model>.max_tokens).
+    # This allows provider-scoped output-token caps without the global
+    # model.max_tokens affecting fallback providers.
+    if agent.max_tokens is None:
+        try:
+            from hermes_cli.config import get_compatible_custom_providers, get_custom_provider_max_tokens
+            _cp_max_tokens = get_custom_provider_max_tokens(
+                model=agent.model,
+                base_url=agent.base_url,
+                custom_providers=get_compatible_custom_providers(_agent_cfg),
+            )
+            if _cp_max_tokens is not None:
+                agent.max_tokens = int(_cp_max_tokens)
+        except Exception:
+            pass
+
     # Read explicit context_length override from model config
     if isinstance(_model_cfg, dict):
         _config_context_length = _model_cfg.get("context_length")

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3000,7 +3000,7 @@ def _normalize_custom_provider_entry(
     _KNOWN_KEYS = {
         "name", "api", "url", "base_url", "api_key", "key_env", "api_key_env",
         "api_mode", "transport", "model", "default_model", "models",
-        "context_length", "rate_limit_delay",
+        "context_length", "max_tokens", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
         "discover_models",
     }
@@ -3226,6 +3226,66 @@ def get_custom_provider_context_length(
             continue
         if ctx > 0:
             return ctx
+    return None
+
+
+def get_custom_provider_max_tokens(
+    model: str,
+    base_url: str,
+    custom_providers: Optional[List[Dict[str, Any]]] = None,
+    config: Optional[Dict[str, Any]] = None,
+) -> Optional[int]:
+    """Look up a per-model ``max_tokens`` override from ``custom_providers``.
+
+    Matches any entry whose ``base_url`` equals ``base_url`` (trailing-slash
+    insensitive) and returns ``custom_providers[i].models.<model>.max_tokens``
+    if present and valid.  Returns ``None`` when no override applies.
+
+    Mirrors ``get_custom_provider_context_length`` — the same pattern for
+    output-token caps that already exists for context windows.
+
+    Used by:
+      * ``AIAgent.__init__`` (startup resolution, after the global
+        ``model.max_tokens`` fallback)
+    """
+    if not model or not base_url:
+        return None
+    if custom_providers is None:
+        try:
+            custom_providers = get_compatible_custom_providers(config)
+        except Exception:
+            if config is None:
+                return None
+            raw = config.get("custom_providers")
+            custom_providers = raw if isinstance(raw, list) else []
+    if not isinstance(custom_providers, list):
+        return None
+
+    target_url = (base_url or "").rstrip("/")
+    if not target_url:
+        return None
+
+    for entry in custom_providers:
+        if not isinstance(entry, dict):
+            continue
+        entry_url = (entry.get("base_url") or "").rstrip("/")
+        if not entry_url or entry_url != target_url:
+            continue
+        models = entry.get("models")
+        if not isinstance(models, dict):
+            continue
+        model_cfg = models.get(model)
+        if not isinstance(model_cfg, dict):
+            continue
+        raw_mt = model_cfg.get("max_tokens")
+        if raw_mt is None:
+            continue
+        try:
+            mt = int(raw_mt)
+        except (TypeError, ValueError):
+            continue
+        if mt > 0:
+            return mt
     return None
 
 


### PR DESCRIPTION
## Summary

Adds per-provider `max_tokens` support to `custom_providers`, mirroring the existing `context_length` pattern. This allows users to set a provider-scoped output-token cap without affecting fallback providers.

## Problem

`model.max_tokens` in `config.yaml` is **global** — it applies to all providers including fallbacks. There is no way to scope `max_tokens` to a specific provider, unlike `context_length` which already supports per-provider overrides.

## Changes

### `hermes_cli/config.py`
- Adds `get_custom_provider_max_tokens()` — mirrors `get_custom_provider_context_length()` exactly. Matches by `base_url` + `model` name, returns `models.<model>.max_tokens` if present and valid.
- Adds `"max_tokens"` to `_KNOWN_KEYS` in `_normalize_custom_provider_entry` so the top-level key is not flagged as unknown (defensive, for users who had it at top level).

### `agent/agent_init.py`
- After the global `model.max_tokens` fallback (and before context_length resolution), adds a second fallback that checks `custom_providers` for a per-provider `max_tokens` when `agent.max_tokens` is still `None`.

## Usage

```yaml
custom_providers:
  - name: My Provider
    base_url: https://example.com/v1
    api_key: ...
    model: my-model
    api_mode: chat_completions
    models:
      my-model:
        context_length: 1000000
        max_tokens: 131072       # ← new per-provider field
```

## Related

Closes #28782
