### PR TITLE
Fix kanban dashboard home-channel ownership isolation

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5708,14 +5708,23 @@ def add_notify_sub(
 
 
 def list_notify_subs(
-    conn: sqlite3.Connection, task_id: Optional[str] = None,
+    conn: sqlite3.Connection,
+    task_id: Optional[str] = None,
+    *,
+    notifier_profile: Optional[str] = None,
 ) -> list[dict]:
+    q = "SELECT * FROM kanban_notify_subs"
+    clauses: list[str] = []
+    params: list[Any] = []
     if task_id is not None:
-        rows = conn.execute(
-            "SELECT * FROM kanban_notify_subs WHERE task_id = ?", (task_id,),
-        ).fetchall()
-    else:
-        rows = conn.execute("SELECT * FROM kanban_notify_subs").fetchall()
+        clauses.append("task_id = ?")
+        params.append(task_id)
+    if notifier_profile is not None:
+        clauses.append("notifier_profile = ?")
+        params.append(notifier_profile)
+    if clauses:
+        q += " WHERE " + " AND ".join(clauses)
+    rows = conn.execute(q, params).fetchall()
     return [dict(r) for r in rows]
 
 
@@ -5726,13 +5735,18 @@ def remove_notify_sub(
     platform: str,
     chat_id: str,
     thread_id: Optional[str] = None,
+    notifier_profile: Optional[str] = None,
 ) -> bool:
+    q = (
+        "DELETE FROM kanban_notify_subs WHERE task_id = ? "
+        "AND platform = ? AND chat_id = ? AND thread_id = ?"
+    )
+    params: list[Any] = [task_id, platform, chat_id, thread_id or ""]
+    if notifier_profile is not None:
+        q += " AND notifier_profile = ?"
+        params.append(notifier_profile)
     with write_txn(conn):
-        cur = conn.execute(
-            "DELETE FROM kanban_notify_subs WHERE task_id = ? "
-            "AND platform = ? AND chat_id = ? AND thread_id = ?",
-            (task_id, platform, chat_id, thread_id or ""),
-        )
+        cur = conn.execute(q, params)
     return cur.rowcount > 0
 
 

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -1551,10 +1551,15 @@ def get_home_channels(
     homes = _configured_home_channels()
     subscribed_homes: set[tuple[str, str, str]] = set()
     if task_id:
+        active_profile = _active_profile_name()
         board = _resolve_board(board)
         conn = _conn(board=board)
         try:
-            subs = kanban_db.list_notify_subs(conn, task_id)
+            subs = kanban_db.list_notify_subs(
+                conn,
+                task_id,
+                notifier_profile=active_profile,
+            )
         finally:
             conn.close()
         for sub in subs:
@@ -1625,6 +1630,7 @@ def unsubscribe_home(task_id: str, platform: str, board: Optional[str] = Query(N
             platform=platform,
             chat_id=home["chat_id"],
             thread_id=home["thread_id"] or None,
+            notifier_profile=_active_profile_name(),
         )
         return {"ok": True, "task_id": task_id, "home_channel": home}
     finally:

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -1563,6 +1563,35 @@ def test_home_subscribe_flips_subscribed_flag_in_subsequent_get(client, with_hom
     assert flags == {"telegram": True, "discord": False}
 
 
+def test_home_channels_ignore_foreign_profile_subscription(
+    client, with_home_channels, monkeypatch,
+):
+    """GET /home-channels should only reflect rows owned by the active profile."""
+    t = client.post("/api/plugins/kanban/tasks", json={"title": "x"}).json()["task"]
+
+    conn = kb.connect()
+    try:
+        kb.add_notify_sub(
+            conn,
+            task_id=t["id"],
+            platform="telegram",
+            chat_id="1234567",
+            thread_id="42",
+            notifier_profile="other-profile",
+        )
+    finally:
+        conn.close()
+
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_active_profile_name",
+        lambda: "default",
+    )
+
+    r = client.get(f"/api/plugins/kanban/home-channels?task_id={t['id']}")
+    flags = {h["platform"]: h["subscribed"] for h in r.json()["home_channels"]}
+    assert flags == {"telegram": False, "discord": False}
+
+
 def test_home_subscribe_is_idempotent(client, with_home_channels):
     """Re-subscribing keeps a single row at the DB layer."""
     from hermes_cli import kanban_db as kb
@@ -1633,6 +1662,42 @@ def test_home_unsubscribe_removes_notify_sub_row(client, with_home_channels):
         assert kb.list_notify_subs(conn, t["id"]) == []
     finally:
         conn.close()
+
+
+def test_home_unsubscribe_preserves_foreign_profile_subscription(
+    client, with_home_channels, monkeypatch,
+):
+    """DELETE should not remove a matching home subscription owned elsewhere."""
+    t = client.post("/api/plugins/kanban/tasks", json={"title": "x"}).json()["task"]
+
+    conn = kb.connect()
+    try:
+        kb.add_notify_sub(
+            conn,
+            task_id=t["id"],
+            platform="telegram",
+            chat_id="1234567",
+            thread_id="42",
+            notifier_profile="other-profile",
+        )
+    finally:
+        conn.close()
+
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_active_profile_name",
+        lambda: "default",
+    )
+
+    r = client.delete(f"/api/plugins/kanban/tasks/{t['id']}/home-subscribe/telegram")
+    assert r.status_code == 200
+
+    conn = kb.connect()
+    try:
+        subs = kb.list_notify_subs(conn, t["id"])
+    finally:
+        conn.close()
+    assert len(subs) == 1
+    assert subs[0]["notifier_profile"] == "other-profile"
 
 
 def test_home_subscribe_multiple_platforms_independent(client, with_home_channels):


### PR DESCRIPTION
## Summary

This fixes a cross-profile ownership bug in the kanban dashboard's home-channel
notification toggles.

The dashboard already writes `notifier_profile` when creating home subscriptions,
but its read and delete paths were still ownership-agnostic. That meant a shared
board could:

- show another profile's home subscription as if it belonged to the active profile
- let one profile remove another profile's home notification subscription

This change makes the dashboard consistently respect `notifier_profile` for both
subscription state and unsubscribe behavior.

## What changed

- added optional `notifier_profile` filtering to kanban notify-sub DB helpers
- scoped `GET /home-channels` subscription state to the active profile
- scoped `DELETE /home-subscribe/{platform}` to only remove rows owned by the active profile
- added regression tests covering cross-profile read and delete isolation

## Why this is the right fix

The ownership model already exists in the schema and is used by the notifier path.
This patch brings the dashboard endpoints in line with that existing design instead
of introducing new state or special-case behavior.

It also keeps legacy/ownerless-row behavior unchanged outside the dashboard paths:
the fix only prevents the dashboard from reading or deleting foreign owned rows.

## Testing

Passed:

`uv run pytest tests/plugins/test_kanban_dashboard_plugin.py -k "home_" -v`

Result:

- `13 passed in 6.25s`

Covered behavior includes:

- home channel listing
- subscribe / unsubscribe flows
- idempotent subscribe behavior
- legacy owner backfill path
- multiple platform independence
- cross-profile isolation for home subscriptions