### PR TITLE
fix: wrap kanban columns instead of horizontal scroll

### DIFF
--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -64,17 +64,16 @@
 
 .hermes-kanban-columns {
   display: flex;
+  flex-wrap: wrap;
   gap: 0.75rem;
-  align-items: start;
-  overflow-x: auto;
-  scrollbar-width: none;
-}
-.hermes-kanban-columns::-webkit-scrollbar {
-  display: none;
+  align-items: flex-start;
+  overflow-x: visible;
 }
 
 .hermes-kanban-column {
-  flex: 0 0 280px;
+  flex: 1 1 280px;
+  min-width: 260px;
+  max-width: 360px;
   display: flex;
   flex-direction: column;
   background: color-mix(in srgb, var(--color-card) 85%, transparent);


### PR DESCRIPTION
## Summary
- make Kanban columns wrap onto additional rows instead of requiring horizontal scrolling
- keep columns responsive with a 260px minimum and 360px maximum width

## Context
On narrower screens or with all Kanban columns visible, the board currently uses a single horizontal flex row with hidden scrollbars. This makes completed/right-side columns hard to discover. Wrapping columns keeps every status visible without horizontal scrolling.

## Test Plan
- [x] CSS-only change; inspected generated diff for `.hermes-kanban-columns` and `.hermes-kanban-column`
