### PR TITLE
fix(agent-init): forward custom_headers on OpenAI-wire branch

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -655,6 +655,38 @@ def init_agent(
                         client_kwargs["default_headers"] = dict(_ph.default_headers)
                 except Exception:
                     pass
+            # Resolve custom_headers from custom_providers config for
+            # gateway auth (e.g. subscription keys for API-management proxies).
+            # The anthropic_messages branch above does the same lookup; without
+            # this mirror block on the OpenAI-wire path, APIM-style gateways
+            # that require a subscription key (e.g. AMD LLM Gateway's
+            # Ocp-Apim-Subscription-Key) are silently rejected with HTTP 401
+            # because the only outbound auth header is the Bearer token the
+            # gateway doesn't recognise. Also forward `verify: false` for
+            # gateways behind self-signed certs.
+            if "default_headers" not in client_kwargs:
+                try:
+                    from hermes_cli.config import load_config as _load_cp_cfg
+                    _cp_cfg = _load_cp_cfg()
+                    _cp_list = _cp_cfg.get("custom_providers", [])
+                    if isinstance(_cp_list, list):
+                        _my_base = (base_url or "").rstrip("/")
+                        for _cp in _cp_list:
+                            if not isinstance(_cp, dict):
+                                continue
+                            _cp_base = (_cp.get("base_url") or "").rstrip("/")
+                            if (_cp_base and _my_base
+                                    and _cp_base.lower() == _my_base.lower()
+                                    and _cp.get("custom_headers")):
+                                client_kwargs["default_headers"] = dict(
+                                    _cp["custom_headers"])
+                                if _cp.get("verify") is False:
+                                    import httpx as _httpx_local
+                                    client_kwargs["http_client"] = (
+                                        _httpx_local.Client(verify=False))
+                                break
+                except Exception:
+                    pass
         else:
             # No explicit creds — use the centralized provider router
             from agent.auxiliary_client import resolve_provider_client


### PR DESCRIPTION
## Summary

The `anthropic_messages` branch in `init_agent()` resolves `custom_headers` from `custom_providers` entries (matching by `base_url`) and forwards them to the Anthropic client as `default_headers`, so APIM-style gateways that require auth via a subscription header (e.g. `Ocp-Apim-Subscription-Key`) authenticate correctly.

The OpenAI-wire branch (`chat_completions` / `codex_responses`) never had this lookup. It only sets `default_headers` for a fixed list of providers (OpenRouter, NVIDIA NIM, Routermint, Copilot, Kimi, Qwen Portal, Codex Cloudflare) plus a `profile.default_headers` fallback. For any other `custom_providers` entry served over the OpenAI wire — including the AMD LLM Gateway, Azure OpenAI behind APIM, and similar enterprise proxies — the subscription header was silently dropped and the gateway rejected every request with `HTTP 401`:

> Access denied due to missing subscription key. Make sure to include subscription key when making requests to an API.

Because the fallback chain often cycles through several `custom_providers` entries that all share the same gateway, this manifests as **every fallback** failing with the same 401. Visible in `~/.hermes/sessions/request_dump_*.json` — outbound headers contain only `Authorization` and `Content-Type`, never the configured `custom_headers`.

## Fix

Mirror the existing `anthropic_messages` lookup on the OpenAI-wire branch:

1. Match `base_url` against `custom_providers` entries (case-insensitive, trailing slash normalized).
2. Copy `custom_headers` into `client_kwargs["default_headers"]`.
3. Forward `verify: false` via an explicit `httpx.Client(verify=False)` for gateways behind self-signed certs.

Guarded by `if "default_headers" not in client_kwargs` so it never overrides the existing per-host branches (OpenRouter, Copilot, etc.) or a `profile.default_headers` set earlier.

## Repro

`config.yaml`:

```yaml
model:
  provider: custom:my-gateway
  base_url: https://gateway.example.com/openai
  api_mode: chat_completions
  api_key: dummy

custom_providers:
- id: my-gateway
  name: My APIM Gateway
  api_mode: chat_completions
  base_url: https://gateway.example.com/openai
  api_key: dummy
  custom_headers:
    Ocp-Apim-Subscription-Key: <your-key>
  model: gpt-4o
```

Before this PR: every request returns HTTP 401 because `Ocp-Apim-Subscription-Key` is never sent.
After this PR: request succeeds, header is forwarded.

## Test Plan

- [x] Existing tests pass: `pytest tests/run_agent/test_provider_attribution_headers.py tests/run_agent/test_callable_api_key.py` — 26/26 passing.
- [x] Verified end-to-end against an APIM-fronted gateway across all three surfaces (Anthropic-wire, OpenAI-wire, OnPrem). All return HTTP 200.
- [x] Verified guard: when `default_headers` is already set by an earlier per-host branch (e.g. OpenRouter), the new block is a no-op.

## Notes

- This is the mirror of the lookup already present at lines 564–592 of `agent/agent_init.py` (the `anthropic_messages` branch).
- Symmetric with PRs #15033 / fc1b74a02 which originally added the lookup to the Anthropic branch — same rationale, same shape.
