### PR TITLE
feat(gateway): accept rar and 7z document uploads

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1034,6 +1034,8 @@ SUPPORTED_DOCUMENT_TYPES = {
     ".ini": "text/plain",
     ".cfg": "text/plain",
     ".zip": "application/zip",
+    ".rar": "application/vnd.rar",
+    ".7z": "application/x-7z-compressed",
     ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
     ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",

--- a/tests/gateway/test_document_cache.py
+++ b/tests/gateway/test_document_cache.py
@@ -151,7 +151,17 @@ class TestSupportedDocumentTypes:
 
     @pytest.mark.parametrize(
         "ext",
-        [".pdf", ".md", ".txt", ".zip", ".docx", ".xlsx", ".pptx"],
+        [
+            ".pdf",
+            ".md",
+            ".txt",
+            ".zip",
+            ".rar",
+            ".7z",
+            ".docx",
+            ".xlsx",
+            ".pptx",
+        ],
     )
     def test_expected_extensions_present(self, ext):
         assert ext in SUPPORTED_DOCUMENT_TYPES

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -263,6 +263,34 @@ class TestDocumentDownloadBlock:
         assert event.media_types == ["application/zip"]
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("filename", "mime_type", "expected_mime"),
+        [
+            ("assets.rar", "application/vnd.rar", "application/vnd.rar"),
+            ("assets.7z", "application/x-7z-compressed", "application/x-7z-compressed"),
+        ],
+    )
+    async def test_archive_document_cached(self, adapter, filename, mime_type, expected_mime):
+        """RAR/7z uploads should be cached like zip archives for CLI inspection."""
+        archive_bytes = b"archive-bytes"
+        file_obj = _make_file_obj(archive_bytes)
+        doc = _make_document(
+            file_name=filename,
+            mime_type=mime_type,
+            file_size=len(archive_bytes),
+            file_obj=file_obj,
+        )
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+        assert event.media_urls and event.media_urls[0].endswith(filename)
+        assert os.path.exists(event.media_urls[0])
+        assert event.media_types == [expected_mime]
+        assert event.text == ""
+
+    @pytest.mark.asyncio
     async def test_png_document_is_routed_as_image(self, adapter):
         """Telegram documents that are really PNGs should use the image path."""
         file_obj = _make_file_obj(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)


### PR DESCRIPTION
## Summary

- accept `.rar` and `.7z` as supported gateway document attachments
- keep archive uploads cached as documents so the agent can inspect them with existing terminal/file workflows
- add Telegram and shared document-cache regressions for the new archive types

Closes #28791.

## Notes

This intentionally does not add archive extraction behavior or bundle extractor binaries. It only lets the gateway cache the uploaded archive and pass the local path to the agent, matching existing `.zip` behavior from #4846.

## Test Plan

- [x] RED: `/usr/local/lib/hermes-agent/venv/bin/python -m pytest tests/gateway/test_document_cache.py::TestSupportedDocumentTypes::test_expected_extensions_present tests/gateway/test_telegram_documents.py::TestDocumentDownloadBlock::test_archive_document_cached -q` failed for missing `.rar`/`.7z`
- [x] GREEN: `/usr/local/lib/hermes-agent/venv/bin/python -m pytest tests/gateway/test_document_cache.py::TestSupportedDocumentTypes::test_expected_extensions_present tests/gateway/test_telegram_documents.py::TestDocumentDownloadBlock::test_archive_document_cached -q`
- [x] `/usr/local/lib/hermes-agent/venv/bin/python -m pytest tests/gateway/test_document_cache.py tests/gateway/test_telegram_documents.py -q`
- [x] `git diff --check`
