### PR TITLE
fix(tts): OGG/Opus not delivered on Telegram when voice.auto_tts is true

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3198,9 +3198,17 @@ class BasePlatformAdapter(ABC):
                             speech_text = self.prepare_tts_text(text_content)
                             if not speech_text:
                                 raise ValueError("Empty text after markdown cleanup")
-                            tts_result_str = await asyncio.to_thread(
-                                text_to_speech_tool, text=speech_text
-                            )
+                            # The session contextvar HERMES_SESSION_PLATFORM may be
+                            # cleared by the time adapter.send() runs (the gateway
+                            # handler clears it in its finally block before calling
+                            # send).  Re-inject the platform so text_to_speech_tool
+                            # picks the correct output format (OGG on Telegram).
+                            _tts_platform_val = self.platform.value
+                            def _tts_with_platform(_text=speech_text, _plat=_tts_platform_val):
+                                from gateway.session_context import set_session_vars as _ssv
+                                _ssv(platform=_plat)
+                                return text_to_speech_tool(text=_text)
+                            tts_result_str = await asyncio.to_thread(_tts_with_platform)
                             tts_data = _json.loads(tts_result_str)
                             _tts_path = tts_data.get("file_path")
                     except Exception as tts_err:

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1662,12 +1662,12 @@ def text_to_speech_tool(
         text = text[:max_len]
 
     # Detect platform from gateway env var to choose the best output format.
-    # Telegram voice bubbles require Opus (.ogg); OpenAI and ElevenLabs can
-    # produce Opus natively (no ffmpeg needed).  Edge TTS always outputs MP3
-    # and needs ffmpeg for conversion.
+    # Telegram and WhatsApp voice messages require Opus (.ogg); OpenAI and
+    # ElevenLabs can produce Opus natively (no ffmpeg needed).  Edge TTS
+    # always outputs MP3 and needs ffmpeg for conversion.
     from gateway.session_context import get_session_env
     platform = get_session_env("HERMES_SESSION_PLATFORM", "").lower()
-    want_opus = (platform == "telegram")
+    want_opus = platform in {"telegram", "whatsapp"}
 
     # Determine output path
     if output_path:

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1679,6 +1679,11 @@ def text_to_speech_tool(
             file_path = _configured_command_tts_output_path(
                 file_path, command_provider_config
             )
+        elif want_opus and provider in {"openai", "elevenlabs", "mistral", "gemini"}:
+            # Caller may have passed a .mp3 path (e.g. auto-TTS in run.py), but
+            # these providers can produce native Opus — override the extension so
+            # the provider generates OGG directly instead of MP3.
+            file_path = file_path.with_suffix(".ogg")
     else:
         timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
         out_dir = Path(DEFAULT_OUTPUT_DIR)


### PR DESCRIPTION
## Summary

- **Root cause**: `_clear_session_env()` is called in the `finally` block of the gateway message handler before `adapter.send()` runs. The base adapter's auto-TTS fires *during* `send()`, at which point `HERMES_SESSION_PLATFORM` is already `""`. `text_to_speech_tool` reads this contextvar to set `want_opus`; with `want_opus=False`, ElevenLabs/OpenAI generate MP3 and the ffmpeg conversion for Edge TTS is also skipped — so Telegram and WhatsApp receive an audio file instead of a voice bubble.
- **Fix in `gateway/platforms/base.py`**: wrap the `asyncio.to_thread(text_to_speech_tool, ...)` call in a closure that re-injects `self.platform.value` into the session contextvar before the tool runs.
- **Fix in `tools/tts_tool.py`** (two changes):
  - Handle the case where the caller (e.g. `_send_voice_reply` in `run.py`) passes an explicit `.mp3` output path — override the extension to `.ogg` when `want_opus=True` and the provider supports native Opus.
  - Extend `want_opus` to cover WhatsApp (`platform in {"telegram", "whatsapp"}`), which also requires OGG/Opus for voice bubbles.

## Affected users

- All **Telegram** users with `voice.auto_tts: true` in `config.yaml` who send voice messages.
- All **WhatsApp** users with `voice.auto_tts: true` who send voice messages.

The base adapter auto-TTS path (`event.message_type == MessageType.VOICE`) is the only path triggered by this config, and it always ran after the contextvar was cleared.

## Test plan

- [ ] Configure `tts.provider: elevenlabs` (or `openai`) and `voice.auto_tts: true`
- [ ] Send a voice message from Telegram → reply arrives as voice bubble (OGG), not audio attachment (MP3)
- [ ] Send a voice message from WhatsApp → same result
- [ ] Confirm `tts.provider: edge` works too (ffmpeg conversion path via `_convert_to_opus`)
- [ ] Confirm non-Telegram/WhatsApp platforms are unaffected (`want_opus` remains False)

🤖 Generated with [Claude Code](https://claude.com/claude-code)