### PR TITLE
fix(cli): preserve -t/-m/--provider/--tui/--dev before chat subcommand

### DIFF
--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -250,10 +250,8 @@ def build_top_level_parser():
     # own default (`None`) would silently clobber the top-level value because
     # the subparser shares the same namespace and `dest`. SUPPRESS keeps the
     # subparser action a no-op unless the user actually passes the flag after
-    # the subcommand. Matches the pattern already used for `-s/--skills` and
-    # the relaunch-inherited flags `-r/--resume`, `-c/--continue`,
-    # `-w/--worktree`, `--yolo`, etc. (see tests/hermes_cli/
-    # test_argparse_flag_propagation.py).
+    # the subcommand. Matches the pattern already used for `-s/--skills`
+    # (see tests/hermes_cli/test_argparse_flag_propagation.py).
     _inherited_flag(
         chat_parser,
         "-m", "--model",

--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -243,12 +243,27 @@ def build_top_level_parser():
     chat_parser.add_argument(
         "--image", help="Optional local image path to attach to a single query"
     )
+    # `default=argparse.SUPPRESS` on flags that are ALSO declared on the
+    # top-level parser: when the user writes `hermes -m foo chat`, argparse
+    # first sets `args.model = "foo"` from the top-level parser, then
+    # dispatches to the chat subparser. Without SUPPRESS the chat subparser's
+    # own default (`None`) would silently clobber the top-level value because
+    # the subparser shares the same namespace and `dest`. SUPPRESS keeps the
+    # subparser action a no-op unless the user actually passes the flag after
+    # the subcommand. Matches the pattern already used for `-s/--skills` and
+    # the relaunch-inherited flags `-r/--resume`, `-c/--continue`,
+    # `-w/--worktree`, `--yolo`, etc. (see tests/hermes_cli/
+    # test_argparse_flag_propagation.py).
     _inherited_flag(
         chat_parser,
-        "-m", "--model", help="Model to use (e.g., anthropic/claude-sonnet-4)",
+        "-m", "--model",
+        default=argparse.SUPPRESS,
+        help="Model to use (e.g., anthropic/claude-sonnet-4)",
     )
     chat_parser.add_argument(
-        "-t", "--toolsets", help="Comma-separated toolsets to enable"
+        "-t", "--toolsets",
+        default=argparse.SUPPRESS,
+        help="Comma-separated toolsets to enable",
     )
     _inherited_flag(
         chat_parser,
@@ -265,7 +280,7 @@ def build_top_level_parser():
         # are also valid values, and runtime resolution (resolve_runtime_provider)
         # handles validation/error reporting consistently with the top-level
         # `--provider` flag.
-        default=None,
+        default=argparse.SUPPRESS,
         help="Inference provider (default: auto). Built-in or a user-defined name from `providers:` in config.yaml.",
     )
     chat_parser.add_argument(
@@ -366,7 +381,7 @@ def build_top_level_parser():
         chat_parser,
         "--tui",
         action="store_true",
-        default=False,
+        default=argparse.SUPPRESS,
         help="Launch the modern TUI instead of the classic REPL",
     )
     _inherited_flag(
@@ -374,7 +389,7 @@ def build_top_level_parser():
         "--dev",
         dest="tui_dev",
         action="store_true",
-        default=False,
+        default=argparse.SUPPRESS,
         help="With --tui: run TypeScript sources via tsx (skip dist build)",
     )
 

--- a/tests/hermes_cli/test_argparse_flag_propagation.py
+++ b/tests/hermes_cli/test_argparse_flag_propagation.py
@@ -182,3 +182,120 @@ class TestAcceptHooksOnAgentSubparsers:
             f"stderr: {result.stderr[:300]}"
         )
         assert "unrecognized arguments" not in result.stderr
+
+
+class TestChatSubparserInheritedValueFlags:
+    """Verify -t/--toolsets, -m/--model and --provider survive parent→chat
+    subparser dispatch.
+
+    Regression test for #28780: `hermes -t web chat` silently dropped the
+    toolset because the chat subparser re-declared `-t/--toolsets` with
+    `default=None`, which clobbered the top-level parser's value during
+    subparser dispatch.
+
+    Uses the real `hermes_cli._parser.build_top_level_parser()` rather than
+    the hand-rolled replica above so this also fails if the production
+    parser drifts back to `default=None` on these flags.
+    """
+
+    @pytest.fixture
+    def real_parser(self):
+        from hermes_cli._parser import build_top_level_parser
+        parser, _subparsers, _chat = build_top_level_parser()
+        return parser
+
+    @pytest.mark.parametrize("flag,attr,value", [
+        ("-t", "toolsets", "web"),
+        ("--toolsets", "toolsets", "web,terminal"),
+        ("-m", "model", "anthropic/claude-sonnet-4"),
+        ("--model", "model", "openai/gpt-4"),
+        ("--provider", "provider", "openrouter"),
+    ])
+    def test_flag_before_chat_is_preserved(self, real_parser, flag, attr, value):
+        args, _ = real_parser.parse_known_args([flag, value, "chat"])
+        assert getattr(args, attr, None) == value, (
+            f"`hermes {flag} {value} chat` lost the flag — got "
+            f"{getattr(args, attr, None)!r}, expected {value!r}"
+        )
+
+    @pytest.mark.parametrize("flag,attr,value", [
+        ("-t", "toolsets", "web"),
+        ("--toolsets", "toolsets", "web,terminal"),
+        ("-m", "model", "anthropic/claude-sonnet-4"),
+        ("--model", "model", "openai/gpt-4"),
+        ("--provider", "provider", "openrouter"),
+    ])
+    def test_flag_after_chat_still_works(self, real_parser, flag, attr, value):
+        args, _ = real_parser.parse_known_args(["chat", flag, value])
+        assert getattr(args, attr, None) == value
+
+    def test_no_flag_leaves_attrs_at_top_level_default(self, real_parser):
+        """When the user passes none of the inherited flags, the top-level
+        parser's `default=None` still seeds the namespace — the SUPPRESS on
+        the subparser must not remove existing attributes."""
+        args, _ = real_parser.parse_known_args(["chat"])
+        assert getattr(args, "toolsets", "MISSING") is None
+        assert getattr(args, "model", "MISSING") is None
+        assert getattr(args, "provider", "MISSING") is None
+
+    def test_all_three_flags_before_chat(self, real_parser):
+        """Issue #28780 reporter's case generalized: passing every inherited
+        value flag before `chat` must preserve all of them simultaneously."""
+        args, _ = real_parser.parse_known_args([
+            "-t", "web",
+            "-m", "anthropic/claude-sonnet-4",
+            "--provider", "openrouter",
+            "chat",
+        ])
+        assert args.toolsets == "web"
+        assert args.model == "anthropic/claude-sonnet-4"
+        assert args.provider == "openrouter"
+
+    @pytest.mark.parametrize("flag,attr", [
+        ("--tui", "tui"),
+        ("--dev", "tui_dev"),
+    ])
+    def test_store_true_flag_before_chat_is_preserved(
+        self, real_parser, flag, attr,
+    ):
+        """`--tui` / `--dev` are store_true flags inherited by chat; the same
+        SUPPRESS contract applies. Without it, the subparser's `default=False`
+        would clobber the parent's `True` when used as `hermes --tui chat`."""
+        args, _ = real_parser.parse_known_args([flag, "chat"])
+        assert getattr(args, attr, None) is True, (
+            f"`hermes {flag} chat` lost the flag — got "
+            f"{getattr(args, attr, None)!r}, expected True"
+        )
+
+    def test_chat_subparser_inherited_value_flags_use_suppress(self):
+        """Contract test for the underlying invariant.
+
+        Any chat-subparser flag whose `dest` also exists on the top-level
+        parser MUST declare `default=argparse.SUPPRESS`, otherwise the
+        subparser silently overwrites the top-level value with its own
+        default during dispatch. This is the structural class behind #28780.
+        """
+        from hermes_cli._parser import build_top_level_parser
+        parser, _subparsers, chat_parser = build_top_level_parser()
+
+        top_level_dests = {
+            a.dest for a in parser._actions
+            if a.option_strings and a.dest != "help"
+        }
+
+        offenders = []
+        for action in chat_parser._actions:
+            if not action.option_strings or action.dest == "help":
+                continue
+            if action.dest not in top_level_dests:
+                continue
+            if action.default is not argparse.SUPPRESS:
+                offenders.append((action.option_strings, action.dest, action.default))
+
+        assert not offenders, (
+            "Chat subparser redeclares these top-level flags without "
+            "default=argparse.SUPPRESS; they will silently clobber the "
+            "top-level value when used as `hermes <flag> <value> chat`:\n  "
+            + "\n  ".join(f"{opts} dest={dest} default={d!r}"
+                          for opts, dest, d in offenders)
+        )


### PR DESCRIPTION
## What does this PR do?

Fixes `hermes -t web chat` (and the sibling `-m`, `--provider`, `--tui`, `--dev` placements before the `chat` subcommand) silently dropping the flag value. Reported in #28780 for `-t/--toolsets`; the other four are sibling failures with the same root cause and are fixed in the same commit.

**Root cause.** The chat subparser re-declared these flags with `default=None` (or `default=False` for store_true) on top of the matching top-level parser flags. When argparse dispatches into the subparser it shares the namespace via `dest`, so the subparser's default overwrites whatever the top-level parser parsed before the subcommand. `-s/--skills`, `-r`/`-c`/`-w`, `--yolo`, and `--pass-session-id` already use `default=argparse.SUPPRESS` for exactly this reason — the chat-subparser action becomes a no-op unless the user explicitly passes the flag after `chat`, and the parent value survives. This PR extends the same fix to the remaining offenders.

Reproduction (origin/main, before fix):

```
>>> parser.parse_known_args(["-t", "web", "chat"]).toolsets
None
>>> parser.parse_known_args(["chat", "-t", "web"]).toolsets
'web'
```

After fix both calls return `'web'`.

> Audited siblings: contract test `test_chat_subparser_inherited_value_flags_use_suppress` scans every chat-subparser action whose `dest` is also on the top-level parser and asserts `default is argparse.SUPPRESS`. It fails on origin/main listing all five offenders (`-m/--model`, `-t/--toolsets`, `--provider`, `--tui`, `--dev`) and passes after this fix, so no widening needed.

## Related Issue

Fixes #28780

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `hermes_cli/_parser.py` — switched chat subparser's `-m/--model`, `-t/--toolsets`, `--provider`, `--tui`, `--dev` declarations from `default=None`/`default=False` to `default=argparse.SUPPRESS`, matching the pattern already used for `-s/--skills` and the relaunch-inherited flags. Added a comment block explaining the SUPPRESS rationale.
- `tests/hermes_cli/test_argparse_flag_propagation.py` — added `TestChatSubparserInheritedValueFlags` that imports the real `build_top_level_parser` (not the hand-rolled replica higher in the file) so future drift to `default=None` would re-fail. Covers: parametrized before-chat / after-chat cases for each value flag; negative case where no flag is passed; combined case with all three value flags; store_true cases for `--tui` and `--dev`; and a contract test asserting every shared-`dest` chat flag uses `SUPPRESS`.

## How to Test

1. Reproduce the bug on `origin/main`:
   ```bash
   uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/hermes_cli/test_argparse_flag_propagation.py::TestChatSubparserInheritedValueFlags -v
   ```
   On `origin/main` 9 of the 15 new tests fail (the 6 `after-chat` cases were already passing because the bug only affects the before-chat position). After the fix, all 15 pass.
2. Run the full file plus adjacent CLI suites — both clean:
   ```bash
   uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/hermes_cli/test_argparse_flag_propagation.py tests/hermes_cli/test_apply_profile_override.py tests/hermes_cli/test_ignore_user_config_flags.py tests/hermes_cli/test_tui_resume_flow.py tests/hermes_cli/test_setup_model_provider.py tests/hermes_cli/test_regression_16767.py tests/hermes_cli/test_tool_token_estimation.py tests/hermes_cli/test_tools_config.py tests/hermes_cli/test_setup_noninteractive.py tests/hermes_cli/test_banner.py tests/hermes_cli/test_gmi_provider.py tests/hermes_cli/test_config_drift.py tests/hermes_cli/test_tools_disable_enable.py
   ```
   29 + 67 + 156 = 252 tests pass locally on macOS 15 (Python 3.11.14).
3. Smoke-check the user's exact reported invocation — `hermes -t web chat` and verify `/toolsets` shows only `web` enabled.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (inline comment added in `_parser.py`)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys touched)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — argparse behavior is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A