### PR TITLE
fix(kanban): allow dashboard task updates to move cards into review

### DIFF
--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -678,7 +678,7 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                     status_code=400,
                     detail="Cannot set status to 'running' directly; use the dispatcher/claim path",
                 )
-            elif s in ("todo", "triage", "scheduled"):
+            elif s in ("todo", "triage", "review", "scheduled"):
                 ok = _set_status_direct(conn, task_id, s)
             else:
                 raise HTTPException(status_code=400, detail=f"unknown status: {s}")
@@ -1022,7 +1022,7 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                         continue
                     elif s == "scheduled":
                         ok = kanban_db.schedule_task(conn, tid)
-                    elif s in {"todo", "triage"}:
+                    elif s in {"todo", "triage", "review"}:
                         ok = _set_status_direct(conn, tid, s)
                     else:
                         entry.update(ok=False, error=f"unknown status {s!r}")

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -387,6 +387,23 @@ def test_patch_drag_drop_move_todo_to_ready(client):
     assert child_after["status"] == "ready"
 
 
+def test_patch_status_review(client):
+    t = client.post("/api/plugins/kanban/tasks", json={"title": "needs review"}).json()["task"]
+
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{t['id']}",
+        json={"status": "review"},
+    )
+    assert r.status_code == 200
+    assert r.json()["task"]["status"] == "review"
+
+    review = next(
+        c for c in client.get("/api/plugins/kanban/board").json()["columns"]
+        if c["name"] == "review"
+    )
+    assert any(x["id"] == t["id"] for x in review["tasks"])
+
+
 def test_reopening_parent_demotes_ready_child(client):
     """Reopening a completed parent must invalidate ready children immediately.
 
@@ -909,6 +926,24 @@ def test_bulk_status_ready(client):
     ready = next(col for col in board["columns"] if col["name"] == "ready")
     ids = {t["id"] for t in ready["tasks"]}
     assert {a["id"], b["id"], c2["id"]}.issubset(ids)
+
+
+def test_bulk_status_review(client):
+    a = client.post("/api/plugins/kanban/tasks", json={"title": "a"}).json()["task"]
+    b = client.post("/api/plugins/kanban/tasks", json={"title": "b"}).json()["task"]
+
+    r = client.post(
+        "/api/plugins/kanban/tasks/bulk",
+        json={"ids": [a["id"], b["id"]], "status": "review"},
+    )
+    assert r.status_code == 200
+    results = r.json()["results"]
+    assert all(entry["ok"] for entry in results)
+
+    board = client.get("/api/plugins/kanban/board").json()
+    review = next(col for col in board["columns"] if col["name"] == "review")
+    ids = {t["id"] for t in review["tasks"]}
+    assert {a["id"], b["id"]}.issubset(ids)
 
 
 def test_bulk_status_done_forwards_completion_summary(client):


### PR DESCRIPTION
## Summary
Allow the Kanban dashboard API to move tasks into the `review` column.

## What changed
- Added `review` support to `PATCH /api/plugins/kanban/tasks/{id}`
- Added `review` support to `POST /api/plugins/kanban/tasks/bulk`
- Added regression tests for both single-task and bulk review transitions

## Why
The dashboard already exposes a `review` column and the kanban kernel treats `review` as a first-class status, but the dashboard status update endpoints rejected it as unknown. This made the review lane visible but unreachable from the dashboard UI.

## Testing
- `uv run pytest tests/plugins/test_kanban_dashboard_plugin.py -q -k status_review`
- Result: `2 passed`