### PR TITLE
fix(cli): preserve pre-subcommand flags across the chat subparser (#28780)

### DIFF
--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -122,7 +122,8 @@ def build_top_level_parser():
         default=None,
         help=(
             "Model override for this invocation (e.g. anthropic/claude-sonnet-4.6). "
-            "Applies to -z/--oneshot and --tui. Also settable via HERMES_INFERENCE_MODEL env var."
+            "May appear before or after the ``chat`` subcommand; also applies "
+            "to -z/--oneshot and --tui. Also settable via HERMES_INFERENCE_MODEL env var."
         ),
     )
     _inherited_flag(
@@ -131,7 +132,8 @@ def build_top_level_parser():
         default=None,
         help=(
             "Provider override for this invocation (e.g. openrouter, anthropic). "
-            "Applies to -z/--oneshot and --tui. The persistent provider lives in config.yaml "
+            "May appear before or after the ``chat`` subcommand; also applies "
+            "to -z/--oneshot and --tui. The persistent provider lives in config.yaml "
             "under model.provider — use `hermes setup` or edit the file to change it."
         ),
     )
@@ -139,7 +141,11 @@ def build_top_level_parser():
         "-t",
         "--toolsets",
         default=None,
-        help="Comma-separated toolsets to enable for this invocation. Applies to -z/--oneshot and --tui.",
+        help=(
+            "Comma-separated toolsets to enable for this invocation. May "
+            "appear before or after the ``chat`` subcommand; also applies "
+            "to -z/--oneshot and --tui."
+        ),
     )
     parser.add_argument(
         "--resume",
@@ -259,12 +265,25 @@ def build_top_level_parser():
     chat_parser.add_argument(
         "--image", help="Optional local image path to attach to a single query"
     )
+    # These five flags are mirrored from the top-level parser so they can
+    # appear *after* the ``chat`` subcommand name (e.g. ``hermes chat -t
+    # web``).  When the user puts them BEFORE ``chat`` they're consumed by
+    # the top-level parser and stored in ``args.<name>`` first; we MUST
+    # use ``argparse.SUPPRESS`` here so an absent post-subcommand
+    # occurrence doesn't silently overwrite that top-level value with the
+    # subparser's own default (``None`` / ``False``).  Without SUPPRESS
+    # ``hermes -t web chat`` would parse correctly at the top level and
+    # then immediately get clobbered to ``None`` — see #28780.
     _inherited_flag(
         chat_parser,
-        "-m", "--model", help="Model to use (e.g., anthropic/claude-sonnet-4)",
+        "-m", "--model",
+        default=argparse.SUPPRESS,
+        help="Model to use (e.g., anthropic/claude-sonnet-4)",
     )
     chat_parser.add_argument(
-        "-t", "--toolsets", help="Comma-separated toolsets to enable"
+        "-t", "--toolsets",
+        default=argparse.SUPPRESS,
+        help="Comma-separated toolsets to enable",
     )
     _inherited_flag(
         chat_parser,
@@ -281,7 +300,10 @@ def build_top_level_parser():
         # are also valid values, and runtime resolution (resolve_runtime_provider)
         # handles validation/error reporting consistently with the top-level
         # `--provider` flag.
-        default=None,
+        #
+        # ``default=argparse.SUPPRESS`` so a pre-subcommand ``hermes
+        # --provider X chat`` isn't clobbered to None (#28780).
+        default=argparse.SUPPRESS,
         help="Inference provider (default: auto). Built-in or a user-defined name from `providers:` in config.yaml.",
     )
     chat_parser.add_argument(
@@ -389,7 +411,10 @@ def build_top_level_parser():
         chat_parser,
         "--tui",
         action="store_true",
-        default=False,
+        # ``default=argparse.SUPPRESS`` so a pre-subcommand ``hermes
+        # --tui chat`` isn't reset back to False by the chat
+        # subparser (#28780).
+        default=argparse.SUPPRESS,
         help="Launch the modern TUI instead of the classic REPL",
     )
     _inherited_flag(
@@ -404,7 +429,7 @@ def build_top_level_parser():
         "--dev",
         dest="tui_dev",
         action="store_true",
-        default=False,
+        default=argparse.SUPPRESS,
         help="With --tui: run TypeScript sources via tsx (skip dist build)",
     )
 

--- a/tests/hermes_cli/test_pre_subcommand_flags.py
+++ b/tests/hermes_cli/test_pre_subcommand_flags.py
@@ -1,0 +1,263 @@
+"""Tests for top-level flags that appear BEFORE the ``chat`` subcommand.
+
+Regression coverage for #28780 — ``hermes -t web chat`` silently
+parsed identically to ``hermes chat`` because the ``chat`` subparser
+redefined ``-t/--toolsets`` with ``default=None`` and clobbered the
+value the top-level parser had already stashed in ``args.toolsets``.
+
+The same bug affected ``-m/--model``, ``--provider``, ``--tui``, and
+``--dev``. After the fix, all of these flags work in either position
+(before or after ``chat``), and an explicit post-subcommand
+occurrence still wins ("most specific override").
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Iterable
+
+import pytest
+
+from hermes_cli._parser import build_top_level_parser
+
+
+def _parse(argv: Iterable[str]):
+    """Parse ``argv`` through the real top-level parser.
+
+    Returns the populated ``argparse.Namespace``.  We use
+    ``parse_known_args`` (not ``parse_args``) so an unknown trailing
+    chat-prompt token doesn't cause a SystemExit during the test —
+    we're asserting on the parsed flag values, not on argv completeness.
+    """
+    parser, _subparsers, chat_parser = build_top_level_parser()
+    # cmd_chat is only attached inside main.py; for these tests we just
+    # need argparse to know that ``chat`` is a valid subcommand, which
+    # ``build_top_level_parser`` already wires up.
+    chat_parser.set_defaults(func=lambda _a: None)
+
+    real_argv = sys.argv
+    try:
+        sys.argv = ["hermes", *argv]
+        args, _unknown = parser.parse_known_args()
+    finally:
+        sys.argv = real_argv
+    return args
+
+
+class TestToolsetsFlagPosition:
+    """``-t/--toolsets`` must work in either position (#28780)."""
+
+    @pytest.mark.parametrize("toolset", ["web", "web,terminal", "*", "all"])
+    def test_pre_subcommand_toolsets_survives_chat(self, toolset):
+        # ``hermes -t web chat`` — the exact form from the bug report.
+        args = _parse(["-t", toolset, "chat"])
+        assert args.toolsets == toolset, (
+            "Pre-subcommand -t was silently dropped by the chat subparser. "
+            "This is the #28780 regression."
+        )
+
+    def test_post_subcommand_toolsets_still_works(self):
+        # The working form from the bug report — must keep working.
+        args = _parse(["chat", "-t", "web"])
+        assert args.toolsets == "web"
+
+    def test_post_subcommand_overrides_pre_subcommand(self):
+        # If a user passes ``-t`` on both sides, the more-specific
+        # (post-subcommand) value should win.  This matches argparse's
+        # "subparser is more specific" convention and the way
+        # ``hermes chat -t cli`` reads naturally.
+        args = _parse(["-t", "web", "chat", "-t", "cli"])
+        assert args.toolsets == "cli"
+
+    def test_no_toolsets_yields_none(self):
+        # Sanity: when neither position is used, the attribute is still
+        # present (top-level default) and is None — many callers rely on
+        # ``args.toolsets`` being addressable.
+        args = _parse(["chat"])
+        assert args.toolsets is None
+
+
+class TestModelFlagPosition:
+    """``-m/--model`` must also work in either position (same bug)."""
+
+    def test_pre_subcommand_model_survives_chat(self):
+        args = _parse(["-m", "gpt5", "chat"])
+        assert args.model == "gpt5"
+
+    def test_long_form_pre_subcommand(self):
+        # Long-form spelling must travel the same path as the short form.
+        args = _parse(["--model", "anthropic/claude-sonnet-4.6", "chat"])
+        assert args.model == "anthropic/claude-sonnet-4.6"
+
+    def test_post_subcommand_model_still_works(self):
+        args = _parse(["chat", "-m", "gpt5"])
+        assert args.model == "gpt5"
+
+    def test_post_subcommand_model_overrides_pre(self):
+        args = _parse(["-m", "gpt5", "chat", "-m", "claude"])
+        assert args.model == "claude"
+
+
+class TestProviderFlagPosition:
+    """``--provider`` must also work in either position (same bug)."""
+
+    def test_pre_subcommand_provider_survives_chat(self):
+        args = _parse(["--provider", "openai", "chat"])
+        assert getattr(args, "provider", None) == "openai"
+
+    def test_post_subcommand_provider_still_works(self):
+        args = _parse(["chat", "--provider", "openai"])
+        assert getattr(args, "provider", None) == "openai"
+
+    def test_post_subcommand_provider_overrides_pre(self):
+        args = _parse(["--provider", "openai", "chat", "--provider", "anthropic"])
+        assert getattr(args, "provider", None) == "anthropic"
+
+
+class TestTuiFlagPosition:
+    """``--tui`` must also work in either position (same bug)."""
+
+    def test_pre_subcommand_tui_survives_chat(self):
+        args = _parse(["--tui", "chat"])
+        assert getattr(args, "tui", False) is True
+
+    def test_post_subcommand_tui_still_works(self):
+        args = _parse(["chat", "--tui"])
+        assert getattr(args, "tui", False) is True
+
+    def test_no_tui_anywhere_defaults_false(self):
+        args = _parse(["chat"])
+        assert getattr(args, "tui", False) is False
+
+
+class TestDevFlagPosition:
+    """``--dev`` (dest ``tui_dev``) was the fifth clobbered flag (#28780).
+
+    Only the structural SUPPRESS contract covered it before; pin the actual
+    before/after-``chat`` parse behaviour so a future regression is caught at
+    runtime, not just by the contract test.
+    """
+
+    def test_pre_subcommand_dev_survives_chat(self):
+        args = _parse(["--dev", "chat"])
+        assert getattr(args, "tui_dev", False) is True
+
+    def test_post_subcommand_dev_still_works(self):
+        args = _parse(["chat", "--dev"])
+        assert getattr(args, "tui_dev", False) is True
+
+    def test_no_dev_anywhere_defaults_false(self):
+        args = _parse(["chat"])
+        assert getattr(args, "tui_dev", False) is False
+
+
+class TestMixedPreSubcommandFlags:
+    """All five inherited flags should compose freely (#28780)."""
+
+    def test_all_five_inherited_flags_pre_subcommand(self):
+        # Smoke: every fixed flag stacked in the pre-subcommand position.
+        args = _parse([
+            "-t", "web,terminal",
+            "-m", "gpt5",
+            "--provider", "openai",
+            "--tui",
+            "chat",
+        ])
+        assert args.toolsets == "web,terminal"
+        assert args.model == "gpt5"
+        assert getattr(args, "provider", None) == "openai"
+        assert getattr(args, "tui", False) is True
+
+    def test_mixed_pre_and_post_subcommand_positions(self):
+        # Realistic usage where the user has half their flags before
+        # ``chat`` (from a shell alias, perhaps) and adds more
+        # interactively after.
+        args = _parse([
+            "-t", "web",
+            "chat",
+            "-m", "gpt5",
+        ])
+        assert args.toolsets == "web"
+        assert args.model == "gpt5"
+
+
+class TestPreviouslyWorkingFlagsStillWork:
+    """Sanity: the flags that *weren't* broken (they already used
+    ``argparse.SUPPRESS``) must stay unaffected by the fix.  Lock
+    them down so a future refactor doesn't quietly regress them."""
+
+    def test_pre_subcommand_continue_with_name(self):
+        # Note: ``-c`` is ``nargs='?'`` (optional value).  With a bare
+        # ``hermes -c chat`` argparse greedily consumes ``chat`` as
+        # the optional value instead of the subcommand — a known
+        # argparse limitation acknowledged in main.py's
+        # ``_TOP_LEVEL_VALUE_FLAGS``.  The supported form is therefore
+        # ``-c <name> chat`` (this test) or ``-c`` alone with no
+        # following positional.  Neither path is affected by the
+        # #28780 fix; this test exists so future cleanup of ``-c``
+        # parsing doesn't accidentally re-break the supported form.
+        args = _parse(["-c", "my-session", "chat"])
+        assert args.continue_last == "my-session"
+
+    def test_pre_subcommand_resume_flag(self):
+        args = _parse(["-r", "abc123", "chat"])
+        assert args.resume == "abc123"
+
+    def test_pre_subcommand_worktree_flag(self):
+        args = _parse(["-w", "chat"])
+        assert args.worktree is True
+
+    def test_pre_subcommand_skills_flag(self):
+        args = _parse(["-s", "git-auth,hermes-agent-dev", "chat"])
+        assert args.skills == ["git-auth,hermes-agent-dev"]
+
+    def test_pre_subcommand_yolo_flag(self):
+        args = _parse(["--yolo", "chat"])
+        assert args.yolo is True
+
+    def test_pre_subcommand_ignore_user_config(self):
+        args = _parse(["--ignore-user-config", "chat"])
+        assert args.ignore_user_config is True
+
+
+class TestParserContract:
+    """Lock down the parser shape that the fix relies on.  If these
+    invariants drift, the runtime tests above might still pass
+    accidentally — the explicit contract makes intent clear and
+    surfaces regressions at the structural level."""
+
+    def test_chat_subparser_uses_suppress_for_inherited_flags(self):
+        """The five formerly-broken flags must use ``argparse.SUPPRESS``
+        on the chat subparser, otherwise an absent post-subcommand
+        occurrence will silently re-overwrite the top-level value."""
+        import argparse
+
+        _parser, _subs, chat = build_top_level_parser()
+        inherited = {"--model", "--toolsets", "--provider", "--tui", "--dev"}
+
+        for action in chat._actions:
+            if not action.option_strings:
+                continue
+            if any(opt in inherited for opt in action.option_strings):
+                assert action.default is argparse.SUPPRESS, (
+                    f"chat subparser action {action.option_strings!r} must "
+                    f"use argparse.SUPPRESS so pre-subcommand values "
+                    f"survive, got default={action.default!r} (#28780)."
+                )
+
+    def test_top_level_parser_still_defines_these_flags(self):
+        """The fix relies on the top-level parser providing real defaults
+        for these flags so ``args.toolsets`` etc. always exist on the
+        Namespace.  If someone removes a top-level definition, every
+        ``args.toolsets`` site in main.py would AttributeError."""
+        parser, _subs, _chat = build_top_level_parser()
+        top_level_option_strings: set[str] = set()
+        for action in parser._actions:
+            top_level_option_strings.update(action.option_strings)
+
+        for required in ("--toolsets", "--model", "--provider", "--tui"):
+            assert required in top_level_option_strings, (
+                f"Top-level parser must define {required!r} — the chat "
+                f"subparser uses argparse.SUPPRESS and relies on the "
+                f"top-level default to populate args."
+            )


### PR DESCRIPTION
## What does this PR do?

`hermes -t web chat` silently parses identically to `hermes chat` — all default toolsets are still enabled rather than just `web` — even though `hermes chat -t web` works correctly. The same silent clobber affects `-m/--model`, `--provider`, `--tui`, and `--dev` (e.g. `hermes -m gpt5 chat` ignores the model override).

**Root cause.** Those flags are defined on *both* the top-level parser (so they work with `-z/--oneshot` and `--tui`) and on the `chat` subparser (so the natural `hermes chat -t web` works). The chat subparser's defaults were `None` / `False`, which argparse applies **after** the top-level parse — overwriting `args.toolsets` (and friends) whenever the user put the flag *before* `chat`.

**Fix.** Set `default=argparse.SUPPRESS` on the five duplicated chat-subparser flags so an absent post-subcommand occurrence leaves the top-level value intact. Mirrors the pattern already used by `--resume`, `--continue`, `--yolo`, `--ignore-user-config`, etc., which were unaffected by the bug.

**Behaviour after the fix:**

| Invocation | Before | After |
|---|---|---|
| `hermes -t web chat` | `toolsets=None` ❌ | `toolsets="web"` ✅ |
| `hermes chat -t web` | `toolsets="web"` ✅ | `toolsets="web"` ✅ |
| `hermes -m gpt5 chat` | `model=None` ❌ | `model="gpt5"` ✅ |
| `hermes --provider openai chat` | `provider=None` ❌ | `provider="openai"` ✅ |
| `hermes --tui chat` | `tui=False` ❌ | `tui=True` ✅ |
| `hermes -t web chat -t cli` | `toolsets="cli"` ✅ | `toolsets="cli"` ✅ (post-subcommand still wins) |

## Related Issue

Fixes #28780

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update (help text)
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/_parser.py` — Set `default=argparse.SUPPRESS` on the chat subparser's `-m/--model`, `-t/--toolsets`, `--provider`, `--tui`, and `--dev` arguments so pre-subcommand values are no longer clobbered. Updated the top-level help text for `-m`, `--provider`, and `-t` to explicitly say they work before or after `chat`.
- `tests/hermes_cli/test_pre_subcommand_flags.py` — 27 new tests covering: each affected flag in both positions, post-overrides-pre semantics, composition of all five flags stacked pre-subcommand, regression coverage for the already-working SUPPRESS'd flags (`-r`, `-c`, `-w`, `-s`, `--yolo`, `--ignore-user-config`), and a structural contract test asserting the chat subparser uses `argparse.SUPPRESS` for these flags.

## How to Test

Reproduce the bug on `main`:

```bash
hermes -t web chat
# In the CLI:
/toolsets
# Expected (per issue): only 'web' is enabled.
# Actual on main:       every default toolset is enabled.
```

After this PR:

```bash
hermes -t web chat
/toolsets   # ← shows only the 'web' toolset enabled
exit

hermes -m gpt5 chat                            # model override works pre-subcommand
hermes --provider openai chat                  # provider override works pre-subcommand
hermes --tui chat                              # TUI launches pre-subcommand
hermes chat -t web                             # post-subcommand still works (unchanged)
hermes -t web chat -t cli                      # post wins ("cli") — explicit override
```

Automated coverage:

```
scripts/run_tests.sh tests/hermes_cli/test_pre_subcommand_flags.py -q
# 27 passed in 1.19s
```

The broader `tests/hermes_cli/` suite was also exercised — every failure observed (PTY/systemd/kanban-DB tests) is a pre-existing platform-incompatibility flake on macOS and also fails identically on `upstream/main` without this PR. The parser fix introduces zero new failures.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(cli):`, `test(cli):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant tests locally and they pass
- [x] I've added tests for my changes (27 new regression tests)
- [x] Tested on my platform: macOS 15.2 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] Updated relevant help text (`-m`, `--provider`, `-t` now explicitly mention they work before or after `chat`)
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow changes
- [x] N/A — argparse fix is platform-independent
- [x] N/A — no tool descriptions / schemas changed

## Screenshots / Logs

Direct argparse trace before the fix:

```python
>>> sys.argv = ['hermes', '-t', 'web', 'chat']
>>> args, _ = parser.parse_known_args()
>>> args.toolsets
None        # ← bug: top-level value silently dropped
```

After the fix:

```python
>>> sys.argv = ['hermes', '-t', 'web', 'chat']
>>> args, _ = parser.parse_known_args()
>>> args.toolsets
'web'       # ← top-level value preserved
```
