### PR TITLE
Cap Discord slash command registration and sync

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -30,6 +30,8 @@ _DISCORD_COMMAND_SYNC_STATE_SUBDIR = "gateway"
 _DISCORD_COMMAND_SYNC_STATE_FILENAME = "discord_command_sync_state.json"
 _DISCORD_COMMAND_SYNC_MUTATION_INTERVAL_SECONDS = 4.5
 _DISCORD_COMMAND_SYNC_MAX_RATE_LIMIT_SLEEP_SECONDS = 30.0
+_DISCORD_GLOBAL_COMMAND_LIMIT = 100
+_DISCORD_SKILL_COMMAND_NAME = "skill"
 
 try:
     import discord
@@ -1147,6 +1149,28 @@ class DiscordAdapter(BasePlatformAdapter):
             )
         return "safe"
 
+    def _discord_global_command_limit(self) -> int:
+        """Return the hard Discord global application-command budget.
+
+        Discord caps global application commands at 100 per app.  Keep an
+        env override for tests and emergency local mitigation, but never let
+        it exceed Discord's published limit.
+        """
+        raw = str(os.getenv("DISCORD_GLOBAL_COMMAND_LIMIT", "") or "").strip()
+        if not raw:
+            return _DISCORD_GLOBAL_COMMAND_LIMIT
+        try:
+            value = int(raw)
+        except ValueError:
+            logger.warning(
+                "[%s] Invalid DISCORD_GLOBAL_COMMAND_LIMIT=%r; using %d",
+                self.name,
+                raw,
+                _DISCORD_GLOBAL_COMMAND_LIMIT,
+            )
+            return _DISCORD_GLOBAL_COMMAND_LIMIT
+        return max(1, min(value, _DISCORD_GLOBAL_COMMAND_LIMIT))
+
     def _canonicalize_app_command_payload(self, payload: Dict[str, Any]) -> Dict[str, Any]:
         """Reduce command payloads to the semantic fields Hermes manages."""
         contexts = payload.get("contexts")
@@ -1255,7 +1279,34 @@ class DiscordAdapter(BasePlatformAdapter):
         if not app_id:
             raise RuntimeError("Discord application ID is unavailable for slash command sync")
 
-        desired_payloads = [command.to_dict(tree) for command in tree.get_commands()]
+        all_desired_payloads = [command.to_dict(tree) for command in tree.get_commands()]
+        desired_payloads = list(all_desired_payloads)
+        command_limit = self._discord_global_command_limit()
+        if len(desired_payloads) > command_limit:
+            logger.warning(
+                "[%s] Desired Discord slash command set has %d command(s), "
+                "above Discord's %d-command global limit; trimming overflow "
+                "before sync",
+                self.name,
+                len(desired_payloads),
+                command_limit,
+            )
+            desired_payloads = desired_payloads[:command_limit]
+            if not any(
+                str(payload.get("name", "") or "").lower() == _DISCORD_SKILL_COMMAND_NAME
+                for payload in desired_payloads
+            ):
+                skill_payload = next(
+                    (
+                        payload
+                        for payload in all_desired_payloads
+                        if str(payload.get("name", "") or "").lower()
+                        == _DISCORD_SKILL_COMMAND_NAME
+                    ),
+                    None,
+                )
+                if skill_payload is not None:
+                    desired_payloads[-1] = skill_payload
         desired_by_key = {
             (int(payload.get("type", 1) or 1), str(payload.get("name", "") or "").lower()): payload
             for payload in desired_payloads
@@ -1285,6 +1336,16 @@ class DiscordAdapter(BasePlatformAdapter):
             mutation_count += 1
             return result
 
+        # Delete obsolete commands before creating new ones.  If the app is
+        # already at Discord's 100-command cap, creating first can fail with
+        # error 30032 even when the final desired set is within budget.
+        for key, current in list(existing_by_key.items()):
+            if key in desired_by_key:
+                continue
+            await mutate(http.delete_global_command, app_id, current.id)
+            existing_by_key.pop(key, None)
+            deleted += 1
+
         for key, desired in desired_by_key.items():
             current = existing_by_key.pop(key, None)
             if current is None:
@@ -1307,10 +1368,6 @@ class DiscordAdapter(BasePlatformAdapter):
 
             await mutate(http.edit_global_command, app_id, current.id, desired)
             updated += 1
-
-        for current in existing_by_key.values():
-            await mutate(http.delete_global_command, app_id, current.id)
-            deleted += 1
 
         return {
             "total": len(desired_payloads),
@@ -3103,6 +3160,14 @@ class DiscordAdapter(BasePlatformAdapter):
                 pass
 
             config_overrides = _resolve_config_gates()
+            command_limit = self._discord_global_command_limit()
+            # Reserve one global command slot for the scalable /skill command.
+            # Top-level auto/plugin commands are optional UX sugar; /skill is
+            # the scalable access path for the much larger skill catalog.
+            optional_limit = command_limit
+            if _DISCORD_SKILL_COMMAND_NAME not in already_registered:
+                optional_limit = max(0, command_limit - 1)
+            skipped_auto = 0
 
             for cmd_def in COMMAND_REGISTRY:
                 if not _is_gateway_available(cmd_def, config_overrides):
@@ -3110,6 +3175,9 @@ class DiscordAdapter(BasePlatformAdapter):
                 # Discord command names: lowercase, hyphens OK, max 32 chars.
                 discord_name = cmd_def.name.lower()[:32]
                 if discord_name in already_registered:
+                    continue
+                if len(already_registered) >= optional_limit:
+                    skipped_auto += 1
                     continue
                 auto_cmd = _build_auto_slash_command(
                     cmd_def.name,
@@ -3128,6 +3196,15 @@ class DiscordAdapter(BasePlatformAdapter):
                 "Discord auto-registered %d commands from COMMAND_REGISTRY",
                 len(already_registered),
             )
+            if skipped_auto:
+                logger.warning(
+                    "[Discord] Skipped %d optional COMMAND_REGISTRY slash "
+                    "command(s) to stay within Discord's %d-command global "
+                    "limit and reserve /%s",
+                    skipped_auto,
+                    command_limit,
+                    _DISCORD_SKILL_COMMAND_NAME,
+                )
         except Exception as e:
             logger.warning("Discord auto-register from COMMAND_REGISTRY failed: %s", e)
 
@@ -3139,9 +3216,17 @@ class DiscordAdapter(BasePlatformAdapter):
         try:
             from hermes_cli.commands import _iter_plugin_command_entries
 
+            command_limit = self._discord_global_command_limit()
+            optional_limit = command_limit
+            if _DISCORD_SKILL_COMMAND_NAME not in already_registered:
+                optional_limit = max(0, command_limit - 1)
+            skipped_plugins = 0
             for plugin_name, plugin_desc, plugin_args_hint in _iter_plugin_command_entries():
                 discord_name = plugin_name.lower()[:32]
                 if discord_name in already_registered:
+                    continue
+                if len(already_registered) >= optional_limit:
+                    skipped_plugins += 1
                     continue
                 auto_cmd = _build_auto_slash_command(
                     plugin_name,
@@ -3155,6 +3240,15 @@ class DiscordAdapter(BasePlatformAdapter):
                     # Silently skip commands that fail registration (e.g.
                     # name conflict with a subcommand group).
                     pass
+            if skipped_plugins:
+                logger.warning(
+                    "[Discord] Skipped %d optional plugin slash command(s) "
+                    "to stay within Discord's %d-command global limit and "
+                    "reserve /%s",
+                    skipped_plugins,
+                    command_limit,
+                    _DISCORD_SKILL_COMMAND_NAME,
+                )
         except Exception as e:
             logger.warning(
                 "Discord auto-register from plugin commands failed: %s", e
@@ -3163,7 +3257,22 @@ class DiscordAdapter(BasePlatformAdapter):
         # Register skills under a single /skill command group with category
         # subcommand groups.  This uses 1 top-level slot instead of N,
         # supporting up to 25 categories × 25 skills = 625 skills.
-        self._register_skill_group(tree)
+        try:
+            already_registered = {cmd.name for cmd in tree.get_commands()}
+        except Exception:
+            already_registered = set(already_registered)
+        if (
+            _DISCORD_SKILL_COMMAND_NAME not in already_registered
+            and len(already_registered) >= self._discord_global_command_limit()
+        ):
+            logger.warning(
+                "[Discord] Skipping /%s registration because the command tree "
+                "already has %d command(s), Discord's global command limit",
+                _DISCORD_SKILL_COMMAND_NAME,
+                len(already_registered),
+            )
+        else:
+            self._register_skill_group(tree)
 
         # Optional defense-in-depth: hide every slash command from non-admin
         # guild members in Discord's slash picker. Server-side authorization

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -458,6 +458,91 @@ async def test_safe_sync_slash_commands_only_mutates_diffs():
 
 
 @pytest.mark.asyncio
+async def test_safe_sync_slash_commands_deletes_stale_before_create(monkeypatch):
+    """Delete obsolete commands first so apps already at Discord's cap can
+    make room before creating replacement commands.
+    """
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+    monkeypatch.setattr(
+        DiscordAdapter,
+        "_command_sync_mutation_interval_seconds",
+        lambda self: 0,
+    )
+
+    class _DesiredCommand:
+        def __init__(self, payload):
+            self._payload = payload
+
+        def to_dict(self, tree):
+            assert tree is not None
+            return dict(self._payload)
+
+    class _ExistingCommand:
+        def __init__(self, command_id, payload):
+            self.id = command_id
+            self.name = payload["name"]
+            self.type = SimpleNamespace(value=payload["type"])
+            self._payload = payload
+
+        def to_dict(self):
+            return {
+                "id": self.id,
+                "application_id": 999,
+                **self._payload,
+                "name_localizations": {},
+                "description_localizations": {},
+            }
+
+    desired_created = {
+        "name": "metricas",
+        "description": "Show Colmeio metrics dashboard",
+        "type": 1,
+        "options": [],
+    }
+    existing_deleted = _ExistingCommand(
+        13,
+        {
+            "name": "old-command",
+            "description": "To be deleted",
+            "type": 1,
+            "options": [],
+        },
+    )
+    events = []
+
+    async def delete_global_command(app_id, command_id):
+        events.append(("delete", app_id, command_id))
+
+    async def upsert_global_command(app_id, payload):
+        events.append(("upsert", app_id, payload["name"]))
+
+    fake_tree = SimpleNamespace(
+        get_commands=lambda: [_DesiredCommand(desired_created)],
+        fetch_commands=AsyncMock(return_value=[existing_deleted]),
+    )
+    fake_http = SimpleNamespace(
+        upsert_global_command=upsert_global_command,
+        edit_global_command=AsyncMock(),
+        delete_global_command=delete_global_command,
+    )
+    adapter._client = SimpleNamespace(
+        tree=fake_tree,
+        http=fake_http,
+        application_id=999,
+        user=SimpleNamespace(id=999),
+    )
+
+    summary = await adapter._safe_sync_slash_commands()
+
+    assert summary["created"] == 1
+    assert summary["deleted"] == 1
+    assert events == [
+        ("delete", 999, 13),
+        ("upsert", 999, "metricas"),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_safe_sync_slash_commands_recreates_metadata_only_diffs():
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
 

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -180,6 +180,23 @@ async def test_auto_registers_missing_gateway_commands(adapter):
 
 
 @pytest.mark.asyncio
+async def test_register_slash_commands_respects_discord_global_limit(monkeypatch, adapter):
+    """Discord caps global app commands at 100; Hermes should trim optional
+    auto/plugin commands before it builds a command tree that Discord rejects.
+    """
+    monkeypatch.setenv("DISCORD_GLOBAL_COMMAND_LIMIT", "30")
+
+    with patch(
+        "hermes_cli.commands.discord_skill_commands_by_category",
+        return_value=({"general": [("dogfood", "Exploratory QA testing", "/dogfood")]}, [], 0),
+    ):
+        adapter._register_slash_commands()
+
+    assert len(adapter._client.tree.commands) <= 30
+    assert "skill" in adapter._client.tree.commands
+
+
+@pytest.mark.asyncio
 async def test_auto_registered_command_dispatches_correctly(adapter):
     """Auto-registered commands should dispatch via _run_simple_slash."""
     adapter._run_simple_slash = AsyncMock()
@@ -980,4 +997,3 @@ def test_register_skill_command_autocomplete_filters_by_name_and_description(ada
     # (covered in other tests). The autocomplete filter itself is exercised
     # via direct function call in the real-discord integration path.
     assert skill_cmd.callback is not None
-


### PR DESCRIPTION
## Summary

Fixes Hermes Discord gateway startup failures caused by Discord's global application command cap.

Hermes can currently build more top-level slash commands than Discord allows, especially when combining hardcoded commands, `COMMAND_REGISTRY` auto-registration, plugin commands, and the `/skill` command. When the app is already at the command cap, the safe sync path can also fail because it creates or updates desired commands before deleting stale commands.

This can surface as:

- `API call failed after 3 retries: Connection error`
- `API failed after 3 retries — Connection error`
- `Auxiliary title generation failed: Connection error`
- Discord error `30032` during command sync

## What changed

- Added a Discord global command budget helper, defaulting to 100 and clampable by `DISCORD_GLOBAL_COMMAND_LIMIT`.
- Capped optional auto-registered `COMMAND_REGISTRY` slash commands.
- Capped optional plugin slash commands.
- Reserved space for the scalable `/skill` command so the skill catalog does not expand into many top-level commands.
- Added defensive trimming before sync if the desired command payload still exceeds the limit.
- Preserved `/skill` during defensive trimming when possible.
- Changed safe sync ordering to delete obsolete Discord commands before creating new ones, so apps already at the cap can make room before replacement commands are upserted.

## Local mitigation attempted for Zeus

Before this code fix, Zeus was mitigated locally by disabling Discord command sync:

- Added `DISCORD_COMMAND_SYNC_POLICY=off` to `ai.hermes.gateway-zeus` LaunchAgent.
- Tried `launchctl kickstart`; this restarted the service but did not reload the new environment.
- Performed full `launchctl bootout` and `launchctl bootstrap` to reload the plist.
- Verified `launchctl print gui/502/ai.hermes.gateway-zeus` shows `DISCORD_COMMAND_SYNC_POLICY => off`.
- Verified the gateway log reports `Skipping Discord slash command sync (policy=off)`.

This stops Zeus from repeatedly hitting Discord sync failures while the upstream fix is reviewed.

## Tests

```bash
/Users/murai-labs/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_discord_connect.py tests/gateway/test_discord_slash_commands.py -q
```

Result:

```text
51 passed
```

Also ran:

```bash
git diff --check
```

Result: clean.

## Notes

This change does not immediately mutate the live Discord app while sync is disabled. After this lands, Zeus should run one controlled sync with the patched code to prune stale commands and bring the live command set back under Discord's limit.
