### PR TITLE
fix(kanban): close sqlite connections in specify helpers

### DIFF
--- a/hermes_cli/kanban_specify.py
+++ b/hermes_cli/kanban_specify.py
@@ -31,6 +31,7 @@ Design notes
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os
@@ -150,7 +151,7 @@ def specify_task(
     error, malformed response) — those surface via ``ok=False`` so the
     ``--all`` sweep can continue past individual failures.
     """
-    with kb.connect() as conn:
+    with contextlib.closing(kb.connect()) as conn:
         task = kb.get_task(conn, task_id)
     if task is None:
         return SpecifyOutcome(task_id, False, "unknown task id")
@@ -239,7 +240,7 @@ def specify_task(
                 task_id, False, "LLM response missing title and body"
             )
 
-    with kb.connect() as conn:
+    with contextlib.closing(kb.connect()) as conn:
         ok = kb.specify_triage_task(
             conn,
             task_id,
@@ -261,7 +262,7 @@ def list_triage_ids(*, tenant: Optional[str] = None) -> list[str]:
 
     ``tenant`` narrows the sweep; ``None`` returns every triage task.
     """
-    with kb.connect() as conn:
+    with contextlib.closing(kb.connect()) as conn:
         tasks = kb.list_tasks(
             conn,
             status="triage",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -96,6 +96,7 @@ AUTHOR_MAP = {
     "szymonclawd@mac.home": "szymonclawd",
     "257759490+szymonclawd@users.noreply.github.com": "szymonclawd",
     "101180447+worlldz@users.noreply.github.com": "worlldz",
+    "cryptoworlldz@gmail.com": "worlldz",
     "zhanganzhe@tenclass.com": "luoyuctl",
     "51604064+luoyuctl@users.noreply.github.com": "luoyuctl",
     "127238744+teknium1@users.noreply.github.com": "teknium1",

--- a/tests/hermes_cli/test_kanban_specify.py
+++ b/tests/hermes_cli/test_kanban_specify.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import json as jsonlib
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -212,6 +213,68 @@ def test_list_triage_ids(kanban_home):
     assert set(ids_all) == {a, b}
     ids_tenant = spec.list_triage_ids(tenant="proj-1")
     assert ids_tenant == [b]
+
+
+class _FakeSqliteConn:
+    """Minimal sqlite-like object whose context manager does NOT close().
+
+    Mirrors ``sqlite3.Connection`` behavior closely enough to catch
+    accidental reliance on ``with conn:`` for lifecycle management.
+    """
+
+    def __init__(self):
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_list_triage_ids_closes_connection_even_when_connect_returns_sqlite_like_ctx():
+    fake_conn = _FakeSqliteConn()
+
+    with patch.object(spec.kb, "connect", return_value=fake_conn), patch.object(
+        spec.kb, "list_tasks", return_value=[],
+    ):
+        assert spec.list_triage_ids() == []
+
+    assert fake_conn.closed is True
+
+
+def test_specify_task_unknown_id_closes_connection_even_when_connect_returns_sqlite_like_ctx():
+    fake_conn = _FakeSqliteConn()
+
+    with patch.object(spec.kb, "connect", return_value=fake_conn), patch.object(
+        spec.kb, "get_task", return_value=None,
+    ):
+        outcome = spec.specify_task("t_missing")
+
+    assert outcome.ok is False
+    assert "unknown task" in outcome.reason
+    assert fake_conn.closed is True
+
+
+def test_specify_task_happy_path_closes_write_connection_for_sqlite_like_ctx():
+    read_conn = _FakeSqliteConn()
+    write_conn = _FakeSqliteConn()
+    task = SimpleNamespace(id="t_demo", status="triage", title="rough", body="")
+
+    content = jsonlib.dumps({"title": "clean", "body": "body"})
+    p, _ = _patch_aux_client(content)
+
+    with p, patch.object(spec.kb, "connect", side_effect=[read_conn, write_conn]), patch.object(
+        spec.kb, "get_task", return_value=task,
+    ), patch.object(spec.kb, "specify_triage_task", return_value=True):
+        outcome = spec.specify_task("t_demo", author="ace")
+
+    assert outcome.ok is True
+    assert read_conn.closed is True
+    assert write_conn.closed is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #28802

`hermes_cli.kanban_specify` currently uses `with kb.connect() as conn:` in helper paths like `list_triage_ids()` and `specify_task()`.

For `sqlite3.Connection`, that pattern does not close the connection on exit. It only manages transaction scope, so repeated helper calls leak file descriptors in long-lived processes.

This patch switches those helper paths to explicit closing and adds regression coverage for sqlite-like connections whose context manager does not call `close()`.

Validation:
`uv run --extra dev pytest tests/hermes_cli/test_kanban_specify.py -q -k 'closes_connection or test_list_triage_ids'`

Result:
`3 passed in 8.46s`

Live repro before fix:
`{'base': 5, 'after': 52, 'delta': 47}`

Live repro after fix:
`{'base': 5, 'after': 5, 'delta': 0}`
