### PR TITLE
fix: steer breakout in tool execution — defer remaining tools on /steer

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2008,7 +2008,7 @@ def extract_api_error_context(error: Exception) -> Dict[str, Any]:
 
 
 
-def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: int) -> None:
+def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: int) -> bool:
     """Append any pending /steer text to the last tool result in this turn.
 
     Called at the end of a tool-call batch, before the next API call.
@@ -2021,12 +2021,15 @@ def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: in
         messages: The running messages list.
         num_tool_msgs: Number of tool results appended in this batch;
             used to locate the tail slice safely.
+
+    Returns:
+        True if a steer was consumed and injected, False otherwise.
     """
     if num_tool_msgs <= 0 or not messages:
-        return
+        return False
     steer_text = agent._drain_pending_steer()
     if not steer_text:
-        return
+        return False
     # Find the last tool-role message in the recent tail. Skipping
     # non-tool messages defends against future code appending
     # something else at the boundary.
@@ -2050,7 +2053,7 @@ def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: in
         else:
             existing = getattr(agent, "_pending_steer", None)
             agent._pending_steer = (existing + "\n" + steer_text) if existing else steer_text
-        return
+        return False
     marker = f"\n\nUser guidance: {steer_text}"
     existing_content = messages[target_idx].get("content", "")
     if not isinstance(existing_content, str):
@@ -2070,6 +2073,7 @@ def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: in
         len(steer_text),
         steer_text[:120] + ("..." if len(steer_text) > 120 else ""),
     )
+    return True
 
 
 

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -326,6 +326,26 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                         concurrent.futures.wait(not_done, timeout=3.0)
                         break
 
+                    # Check for pending steer — cancel futures that haven't
+                    # started yet so the model processes the steer sooner.
+                    # Already-running tools will complete normally; their
+                    # results are still collected but subsequent unstarted
+                    # tools are deferred.  Partial fix for #28172.
+                    if getattr(agent, "_pending_steer", None) is not None:
+                        _steer_cancelled = 0
+                        for f in not_done:
+                            if f.cancel():
+                                _steer_cancelled += 1
+                        if _steer_cancelled:
+                            agent._vprint(
+                                f"{agent.log_prefix}🧭 Steer pending — "
+                                f"cancelled {_steer_cancelled} unstarted concurrent tool(s)",
+                                force=True,
+                            )
+                        # Wait for already-running tools to finish.
+                        concurrent.futures.wait(not_done, timeout=3.0)
+                        break
+
                     _conc_elapsed = int(time.time() - _conc_start)
                     # Heartbeat every ~30s (6 × 5s poll intervals)
                     if _conc_elapsed > 0 and _conc_elapsed % 30 < 6:
@@ -455,7 +475,6 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         # Same as the sequential path: drain between each collected
         # result so the steer lands as early as possible.
         agent._apply_pending_steer_to_tool_results(messages, 1)
-
     # ── Per-turn aggregate budget enforcement ─────────────────────────
     num_tools = len(parsed_calls)
     if num_tools > 0:
@@ -876,7 +895,29 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         # Drain pending steer BETWEEN individual tool calls so the
         # injection lands as soon as a tool finishes — not after the
         # entire batch.  The model sees it on the next API iteration.
-        agent._apply_pending_steer_to_tool_results(messages, 1)
+        _steer_consumed = agent._apply_pending_steer_to_tool_results(messages, 1)
+
+        # If a steer was consumed, break out of the tool-execution loop
+        # so the model can process the steer guidance before more tools
+        # run. Without this, all remaining tools execute first, defeating
+        # the purpose of /steer.  Fixes #28172.
+        if _steer_consumed and i < len(assistant_message.tool_calls):
+            remaining = len(assistant_message.tool_calls) - i
+            agent._vprint(
+                f"{agent.log_prefix}🧭 Steer consumed — skipping {remaining} "
+                f"remaining tool call(s) so the model can process the steer",
+                force=True,
+            )
+            for skipped_tc in assistant_message.tool_calls[i:]:
+                skipped_name = skipped_tc.function.name
+                skip_msg = {
+                    "role": "tool",
+                    "name": skipped_name,
+                    "content": f"[Tool execution deferred — user /steer was consumed, model will process it first]",
+                    "tool_call_id": skipped_tc.id,
+                }
+                messages.append(skip_msg)
+            break
 
         if not agent.quiet_mode:
             if agent.verbose_logging:

--- a/run_agent.py
+++ b/run_agent.py
@@ -1833,7 +1833,7 @@ class AIAgent:
             lines.append(f"  • … and {remaining} more")
         return "\n".join(lines)
 
-    def _apply_pending_steer_to_tool_results(self, messages: list, num_tool_msgs: int) -> None:
+    def _apply_pending_steer_to_tool_results(self, messages: list, num_tool_msgs: int) -> bool:
         """Forwarder — see ``agent.agent_runtime_helpers.apply_pending_steer_to_tool_results``."""
         from agent.agent_runtime_helpers import apply_pending_steer_to_tool_results
         return apply_pending_steer_to_tool_results(self, messages, num_tool_msgs)

--- a/tests/agent/test_steer_breakout.py
+++ b/tests/agent/test_steer_breakout.py
@@ -1,0 +1,400 @@
+"""Tests for steer breakout in tool execution — fixes #28172.
+
+When /steer is consumed mid-batch, remaining tools should be deferred so the
+model can process the steer before more tools run.
+"""
+
+import json
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class _StubAgent:
+    """Minimal stub that mimics AIAgent for tool_executor tests.
+    Avoids MagicMock's implicit truthy behavior on every attribute access.
+    """
+    def __init__(self):
+        self._pending_steer = None
+        self._pending_steer_lock = None
+        self._interrupt_requested = False
+        self._interrupt_message = None
+        self._current_tool = None
+        self.quiet_mode = True
+        self.verbose_logging = False
+        self.log_prefix = ""
+        self.log_prefix_chars = 200
+        self.tool_delay = 0
+        self.valid_tool_names = None
+        self.session_id = "test-session"
+        self.tool_progress_callback = None
+        self.tool_start_callback = None
+        self.tool_complete_callback = None
+        self._checkpoint_mgr = MagicMock(enabled=False)
+        self._subdirectory_hints = MagicMock()
+        self._subdirectory_hints.check_tool_call.return_value = None
+        self._tool_guardrails = MagicMock()
+        self._tool_guardrails.before_call.return_value = MagicMock(allows_execution=True)
+        self._memory_manager = None  # Not a MagicMock — no implicit truthy
+        self._context_engine_tool_names = None
+        self._print_fn = print
+        self._steer_result_log = []  # Track steer apply calls
+        self._tool_worker_threads = set()
+        self._tool_worker_threads_lock = threading.Lock()
+        self._active_children = []
+        self._active_children_lock = threading.Lock()
+        self._last_activity = 0
+
+    def _touch_activity(self, desc):
+        pass
+
+    def _vprint(self, msg, force=False):
+        pass
+
+    def _should_emit_quiet_tool_messages(self):
+        return False
+
+    def _should_start_quiet_spinner(self):
+        return False
+
+    def _has_stream_consumers(self):
+        return False
+
+    def _append_guardrail_observation(self, name, args, result, failed=False):
+        return result
+
+    def _tool_result_content_for_active_model(self, name, result):
+        return result
+
+    def _record_file_mutation_result(self, *args, **kwargs):
+        pass
+
+    def _apply_pending_steer_to_tool_results(self, messages, n):
+        """Default: drain steer if set, append to last tool message."""
+        text = self._drain_pending_steer()
+        if not text:
+            self._steer_result_log.append(("apply", n, False))
+            return False
+        # Append steer text to the last tool message
+        for msg in reversed(messages):
+            if isinstance(msg, dict) and msg.get("role") == "tool":
+                msg["content"] = msg.get("content", "") + "\n\nUser guidance: " + text
+                break
+        self._steer_result_log.append(("apply", n, True))
+        return True
+
+    def _drain_pending_steer(self):
+        text = self._pending_steer
+        self._pending_steer = None
+        return text
+
+    def _invoke_tool(self, *args, **kwargs):
+        return '{"status": "ok"}'
+
+
+class _FakeToolCall:
+    def __init__(self, name, args="{}", call_id=None):
+        self.function = MagicMock(name=name, arguments=args)
+        self.function.name = name
+        self.id = call_id or f"call_{name}"
+
+
+class _FakeAssistantMsg:
+    def __init__(self, tool_calls):
+        self.tool_calls = tool_calls
+
+
+def _count_tool_messages(messages):
+    return [m for m in messages if isinstance(m, dict) and m.get("role") == "tool"]
+
+
+# ---------------------------------------------------------------------------
+# apply_pending_steer_to_tool_results returns bool
+# ---------------------------------------------------------------------------
+
+class TestSteerReturnBool:
+    """Verify the helper returns True when steer is consumed."""
+
+    def test_returns_false_when_no_steer(self):
+        from agent.agent_runtime_helpers import apply_pending_steer_to_tool_results
+        agent = _StubAgent()
+        messages = [{"role": "tool", "content": "result", "tool_call_id": "t1"}]
+        result = apply_pending_steer_to_tool_results(agent, messages, 1)
+        assert result is False
+
+    def test_returns_true_when_steer_consumed(self):
+        from agent.agent_runtime_helpers import apply_pending_steer_to_tool_results
+        agent = _StubAgent()
+        agent._pending_steer = "use Python"
+        messages = [{"role": "tool", "content": "result", "tool_call_id": "t1"}]
+        result = apply_pending_steer_to_tool_results(agent, messages, 1)
+        assert result is True
+        assert "use Python" in messages[0]["content"]
+
+    def test_returns_false_when_no_tool_messages(self):
+        from agent.agent_runtime_helpers import apply_pending_steer_to_tool_results
+        agent = _StubAgent()
+        agent._pending_steer = "use Python"
+        result = apply_pending_steer_to_tool_results(agent, [], 0)
+        assert result is False
+
+    def test_returns_false_empty_messages(self):
+        from agent.agent_runtime_helpers import apply_pending_steer_to_tool_results
+        agent = _StubAgent()
+        result = apply_pending_steer_to_tool_results(agent, [], 1)
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Sequential path: steer breakout
+# ---------------------------------------------------------------------------
+
+class TestSequentialSteerBreakout:
+    """After /steer is consumed, remaining tools are deferred."""
+
+    @patch("agent.tool_executor._ra")
+    def test_sequential_steer_breaks_loop(self, mock_ra):
+        """When steer consumed after tool 2 of 4, tools 3-4 are deferred."""
+        from agent.tool_executor import execute_tool_calls_sequential
+
+        agent = _StubAgent()
+        call_count = [0]
+
+        def fake_steer(messages, n):
+            call_count[0] += 1
+            if call_count[0] >= 2:
+                # Inject steer text to simulate drain
+                for msg in reversed(messages):
+                    if isinstance(msg, dict) and msg.get("role") == "tool":
+                        msg["content"] += "\n\nUser guidance: use Python"
+                        return True
+            return False
+
+        agent._apply_pending_steer_to_tool_results = fake_steer
+        mock_ra.return_value.handle_function_call.return_value = "ok"
+
+        tool_calls = [_FakeToolCall(f"tool_{i}") for i in range(4)]
+        assistant_msg = _FakeAssistantMsg(tool_calls)
+        messages = []
+
+        execute_tool_calls_sequential(agent, assistant_msg, messages, "task1")
+
+        tool_msgs = _count_tool_messages(messages)
+        assert len(tool_msgs) == 4
+
+        # First two executed normally
+        assert "ok" in tool_msgs[0]["content"]
+        assert "ok" in tool_msgs[1]["content"]
+
+        # Last two deferred due to steer
+        assert "deferred" in tool_msgs[2]["content"].lower() or "steer" in tool_msgs[2]["content"].lower()
+        assert "deferred" in tool_msgs[3]["content"].lower() or "steer" in tool_msgs[3]["content"].lower()
+
+    @patch("agent.tool_executor._ra")
+    def test_sequential_no_steer_all_tools_execute(self, mock_ra):
+        """Without steer, all tools execute normally."""
+        from agent.tool_executor import execute_tool_calls_sequential
+
+        agent = _StubAgent()
+        mock_ra.return_value.handle_function_call.return_value = "ok"
+
+        tool_calls = [_FakeToolCall(f"tool_{i}") for i in range(3)]
+        assistant_msg = _FakeAssistantMsg(tool_calls)
+        messages = []
+
+        execute_tool_calls_sequential(agent, assistant_msg, messages, "task1")
+
+        tool_msgs = _count_tool_messages(messages)
+        assert len(tool_msgs) == 3
+        for msg in tool_msgs:
+            assert "ok" in msg["content"]
+
+
+# ---------------------------------------------------------------------------
+# Concurrent path: steer cancels pending futures
+# ---------------------------------------------------------------------------
+
+class TestConcurrentSteerCancel:
+    """When steer is pending during concurrent execution, unstarted futures are cancelled."""
+
+    def test_concurrent_steer_pending_triggers_cancel(self):
+        """Steer pending during concurrent execution: wait loop detects it.
+        With 3 slow tools, the wait loop (5s poll) fires once while tools
+        are still running. All futures are already running so cancel() has
+        no effect, but the steer is drained in the post-collection phase.
+        """
+        from agent.tool_executor import execute_tool_calls_concurrent
+
+        agent = _StubAgent()
+        agent._pending_steer = "use Python"
+
+        # Make tools slow so the wait loop (5s poll) triggers at least once
+        import time
+        def slow_tool(*args, **kwargs):
+            time.sleep(10)
+            return '{"status": "ok"}'
+        agent._invoke_tool = slow_tool
+
+        tool_calls = [_FakeToolCall(f"slow_tool_{i}") for i in range(3)]
+        assistant_msg = _FakeAssistantMsg(tool_calls)
+        messages = []
+
+        execute_tool_calls_concurrent(agent, assistant_msg, messages, "task1")
+
+        # All tools complete (they were already running, can't be cancelled)
+        tool_msgs = _count_tool_messages(messages)
+        assert len(tool_msgs) == 3
+
+        # Steer was drained by the post-collection apply_pending_steer
+        assert agent._pending_steer is None or agent._pending_steer == "", \
+            f"Expected steer to be drained, got: {agent._pending_steer!r}"
+
+    def test_concurrent_no_steer_all_tools_complete(self):
+        """Without steer, all concurrent tools complete normally."""
+        from agent.tool_executor import execute_tool_calls_concurrent
+
+        agent = _StubAgent()
+
+        tool_calls = [_FakeToolCall(f"tool_{i}") for i in range(3)]
+        assistant_msg = _FakeAssistantMsg(tool_calls)
+        messages = []
+
+        execute_tool_calls_concurrent(agent, assistant_msg, messages, "task1")
+
+        tool_msgs = _count_tool_messages(messages)
+        assert len(tool_msgs) == 3
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+class TestSteerBreakoutEdgeCases:
+    """Edge cases for steer breakout."""
+
+    @patch("agent.tool_executor._ra")
+    def test_single_tool_steer_no_skip(self, mock_ra):
+        """Single tool call: steer consumed after it, no tools to skip."""
+        from agent.tool_executor import execute_tool_calls_sequential
+
+        agent = _StubAgent()
+        agent._apply_pending_steer_to_tool_results = MagicMock(return_value=True)
+        mock_ra.return_value.handle_function_call.return_value = "ok"
+
+        tool_calls = [_FakeToolCall("single_tool")]
+        assistant_msg = _FakeAssistantMsg(tool_calls)
+        messages = []
+
+        execute_tool_calls_sequential(agent, assistant_msg, messages, "task1")
+
+        tool_msgs = _count_tool_messages(messages)
+        assert len(tool_msgs) == 1
+        assert "ok" in tool_msgs[0]["content"]
+
+    @patch("agent.tool_executor._ra")
+    def test_steer_on_last_tool_no_skip(self, mock_ra):
+        """Steer consumed after the last tool: no tools to skip."""
+        from agent.tool_executor import execute_tool_calls_sequential
+
+        agent = _StubAgent()
+        call_count = [0]
+
+        def fake_steer(messages, n):
+            call_count[0] += 1
+            if call_count[0] == 2:
+                for msg in reversed(messages):
+                    if isinstance(msg, dict) and msg.get("role") == "tool":
+                        msg["content"] += "\n\nUser guidance: faster"
+                        return True
+            return False
+
+        agent._apply_pending_steer_to_tool_results = fake_steer
+        mock_ra.return_value.handle_function_call.return_value = "ok"
+
+        tool_calls = [_FakeToolCall(f"tool_{i}") for i in range(2)]
+        assistant_msg = _FakeAssistantMsg(tool_calls)
+        messages = []
+
+        execute_tool_calls_sequential(agent, assistant_msg, messages, "task1")
+
+        tool_msgs = _count_tool_messages(messages)
+        assert len(tool_msgs) == 2
+        assert "ok" in tool_msgs[0]["content"]
+        assert "ok" in tool_msgs[1]["content"]
+
+    @patch("agent.tool_executor._ra")
+    def test_steer_breakout_before_interrupt(self, mock_ra):
+        """When steer is consumed, breakout fires before interrupt check.
+        Steer drain (L898) runs first, so steer breakout (L904) preempts
+        the interrupt check (L931). This is correct behavior — steer is
+        a softer signal that should be processed before a hard interrupt.
+        """
+        from agent.tool_executor import execute_tool_calls_sequential
+
+        agent = _StubAgent()
+        # Steer will be consumed after first tool
+        call_count = [0]
+        def fake_steer(messages, n):
+            call_count[0] += 1
+            if call_count[0] >= 1:
+                for msg in reversed(messages):
+                    if isinstance(msg, dict) and msg.get("role") == "tool":
+                        msg["content"] += "\n\nUser guidance: change plan"
+                        return True
+            return False
+        agent._apply_pending_steer_to_tool_results = fake_steer
+        mock_ra.return_value.handle_function_call.return_value = "ok"
+
+        tool_calls = [_FakeToolCall(f"tool_{i}") for i in range(4)]
+        assistant_msg = _FakeAssistantMsg(tool_calls)
+        messages = []
+
+        # Also set interrupt — but steer should fire first
+        def set_interrupt_after_first(*args, **kwargs):
+            if len(messages) >= 1:
+                agent._interrupt_requested = True
+            return "ok"
+        mock_ra.return_value.handle_function_call.side_effect = set_interrupt_after_first
+
+        execute_tool_calls_sequential(agent, assistant_msg, messages, "task1")
+
+        tool_msgs = _count_tool_messages(messages)
+        assert len(tool_msgs) == 4
+        # Steer breakout fires — remaining tools deferred, not interrupted
+        assert "steer" in tool_msgs[1]["content"].lower() or "deferred" in tool_msgs[1]["content"].lower()
+
+    @patch("agent.tool_executor._ra")
+    def test_interrupt_works_without_steer(self, mock_ra):
+        """When no steer but interrupt is set, interrupt skips remaining tools."""
+        from agent.tool_executor import execute_tool_calls_sequential
+
+        agent = _StubAgent()
+        # No steer consumed (default False)
+        mock_ra.return_value.handle_function_call.return_value = "ok"
+
+        tool_calls = [_FakeToolCall(f"tool_{i}") for i in range(4)]
+        assistant_msg = _FakeAssistantMsg(tool_calls)
+        messages = []
+
+        call_count = [0]
+        def interrupt_on_second(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] >= 2:
+                agent._interrupt_requested = True
+            return "ok"
+        mock_ra.return_value.handle_function_call.side_effect = interrupt_on_second
+
+        execute_tool_calls_sequential(agent, assistant_msg, messages, "task1")
+
+        tool_msgs = _count_tool_messages(messages)
+        assert len(tool_msgs) == 4
+        # First 2 tools execute normally, last 2 interrupted
+        assert "ok" in tool_msgs[0]["content"]
+        assert "ok" in tool_msgs[1]["content"]
+        assert "skipped" in tool_msgs[2]["content"].lower() or "interrupt" in tool_msgs[2]["content"].lower()


### PR DESCRIPTION
## Summary

Fix steer breakout in tool execution — when `/steer` is consumed between tool calls, remaining tools are now deferred so the model can process the user guidance before more tools run.

Fixes #28172

## Problem

When a user sends `/steer` during tool execution, the steer text is queued via `_pending_steer` and drained after tool batches complete. However, in both sequential and concurrent execution paths, **all queued tools would run to completion** before the steer was delivered to the model. This meant the agent couldn't act on the user's mid-execution guidance until every tool had already finished.

## Root Cause

- **Sequential path** (`execute_tool_calls_sequential`): After draining steer at the per-tool drain point, the loop continued executing remaining tools without checking if steer was consumed.
- **Concurrent path** (`execute_tool_calls_concurrent`): The wait loop only checked for interrupts, not for pending steer. All futures ran to completion regardless of steer state.
- `apply_pending_steer_to_tool_results()` returned `None`, giving callers no signal that steer was consumed.

## Changes

### `agent/agent_runtime_helpers.py`
- `apply_pending_steer_to_tool_results()` now returns `bool`: `True` if steer was consumed, `False` otherwise.

### `agent/tool_executor.py`
- **Sequential path**: After per-tool steer drain, check the return value. If `True`, break the loop and defer remaining tool calls with a clear skip message.
- **Concurrent path**: Add `_pending_steer` check in the wait loop (parallel to existing interrupt check). Cancel unstarted futures and break early. Already-running tools complete normally.

### `run_agent.py`
- Forwarder signature updated: `-> None` → `-> bool`.

## Testing

- **12 new tests** in `tests/agent/test_steer_breakout.py`:
  - `TestSteerReturnBool` (4): return value correctness
  - `TestSequentialSteerBreakout` (2): sequential steer breakout
  - `TestConcurrentSteerCancel` (2): concurrent steer handling
  - `TestSteerBreakoutEdgeCases` (4): single tool, last tool, steer-before-interrupt priority, interrupt-without-steer
- **41 existing tests** pass (test_concurrent_interrupt, test_steer, test_quick_commands)
