### PR TITLE
feat(messaging): add slack_react tool for emoji-only reactions

### DIFF
--- a/tests/tools/test_slack_react_tool.py
+++ b/tests/tools/test_slack_react_tool.py
@@ -1,0 +1,177 @@
+"""Tests for the slack_react tool."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    """Ensure the tool module is imported fresh and registered."""
+    import importlib
+    import tools.slack_react_tool as m  # noqa: F401 — triggers registration
+
+    yield
+
+
+def _call(args, **kw):
+    from tools.slack_react_tool import slack_react_tool
+
+    return json.loads(slack_react_tool(args, **kw))
+
+
+# ---------------------------------------------------------------------------
+# Token resolution
+# ---------------------------------------------------------------------------
+
+class TestTokenResolution:
+    def test_missing_token_returns_error(self):
+        with patch("tools.slack_react_tool._get_slack_token", return_value=None):
+            result = _call({"emoji": "thumbsup", "channel": "C123", "timestamp": "123.456"})
+        assert result["error"].startswith("Slack gateway not configured")
+
+    def test_missing_channel_returns_error(self):
+        with (
+            patch("tools.slack_react_tool._get_slack_token", return_value="xoxb-fake"),
+            patch("tools.slack_react_tool._get_current_context", return_value=(None, None)),
+        ):
+            result = _call({"emoji": "thumbsup", "timestamp": "123.456"})
+        assert "channel" in result["error"]
+
+    def test_missing_timestamp_returns_error(self):
+        with (
+            patch("tools.slack_react_tool._get_slack_token", return_value="xoxb-fake"),
+            patch("tools.slack_react_tool._get_current_context", return_value=("C123", None)),
+        ):
+            result = _call({"emoji": "thumbsup", "channel": "C123"})
+        assert "timestamp" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+class TestHappyPath:
+    def _mock_aiohttp_ok(self):
+        mock_resp = AsyncMock()
+        mock_resp.json = AsyncMock(return_value={"ok": True})
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.post.return_value = mock_resp
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        return mock_session
+
+    def test_successful_reaction(self):
+        mock_session = self._mock_aiohttp_ok()
+        with (
+            patch("tools.slack_react_tool._get_slack_token", return_value="xoxb-fake"),
+            patch("tools.slack_react_tool._get_current_context", return_value=(None, None)),
+            patch("aiohttp.ClientSession", return_value=mock_session),
+        ):
+            result = _call(
+                {"emoji": "white_check_mark", "channel": "C0B3XC4TZ1S", "timestamp": "1716201336.943429"}
+            )
+        assert result["success"] is True
+        assert result["emoji"] == "white_check_mark"
+
+    def test_context_fallback(self):
+        """channel/ts resolved from session context when not passed explicitly."""
+        mock_session = self._mock_aiohttp_ok()
+        with (
+            patch("tools.slack_react_tool._get_slack_token", return_value="xoxb-fake"),
+            patch(
+                "tools.slack_react_tool._get_current_context",
+                return_value=("C_CTX", "111.222"),
+            ),
+            patch("aiohttp.ClientSession", return_value=mock_session),
+        ):
+            result = _call({"emoji": "eyes"})
+        assert result["success"] is True
+        assert result["channel"] == "C_CTX"
+
+    def test_already_reacted_is_success(self):
+        mock_resp = AsyncMock()
+        mock_resp.json = AsyncMock(return_value={"ok": False, "error": "already_reacted"})
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.post.return_value = mock_resp
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch("tools.slack_react_tool._get_slack_token", return_value="xoxb-fake"),
+            patch("tools.slack_react_tool._get_current_context", return_value=(None, None)),
+            patch("aiohttp.ClientSession", return_value=mock_session),
+        ):
+            result = _call({"emoji": "thumbsup", "channel": "C1", "timestamp": "1.2"})
+        assert result["success"] is True
+        assert result.get("note") == "already reacted"
+
+    def test_emoji_colons_stripped(self):
+        mock_session = self._mock_aiohttp_ok()
+        with (
+            patch("tools.slack_react_tool._get_slack_token", return_value="xoxb-fake"),
+            patch("tools.slack_react_tool._get_current_context", return_value=(None, None)),
+            patch("aiohttp.ClientSession", return_value=mock_session),
+        ):
+            result = _call(
+                {"emoji": ":thumbsup:", "channel": "C1", "timestamp": "1.2"}
+            )
+        assert result["success"] is True
+        assert result["emoji"] == "thumbsup"
+
+
+# ---------------------------------------------------------------------------
+# API errors
+# ---------------------------------------------------------------------------
+
+class TestApiErrors:
+    def test_slack_api_error_propagated(self):
+        mock_resp = AsyncMock()
+        mock_resp.json = AsyncMock(return_value={"ok": False, "error": "invalid_name"})
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.post.return_value = mock_resp
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch("tools.slack_react_tool._get_slack_token", return_value="xoxb-fake"),
+            patch("tools.slack_react_tool._get_current_context", return_value=(None, None)),
+            patch("aiohttp.ClientSession", return_value=mock_session),
+        ):
+            result = _call({"emoji": "???", "channel": "C1", "timestamp": "1.2"})
+        assert "error" in result
+        assert "invalid_name" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+class TestRegistration:
+    def test_tool_is_registered(self):
+        from tools.registry import registry
+
+        names = [t["schema"]["name"] for t in registry.get_tools()]
+        assert "slack_react" in names
+
+    def test_toolset_is_messaging(self):
+        from tools.registry import registry
+
+        tool = next(t for t in registry.get_tools() if t["schema"]["name"] == "slack_react")
+        assert tool["toolset"] == "messaging"
+
+    def test_emoji_parameter_required(self):
+        from tools.registry import registry
+
+        tool = next(t for t in registry.get_tools() if t["schema"]["name"] == "slack_react")
+        assert "emoji" in tool["schema"]["parameters"]["required"]

--- a/tools/slack_react_tool.py
+++ b/tools/slack_react_tool.py
@@ -1,0 +1,186 @@
+"""
+slack_react_tool.py — Add an emoji reaction to a Slack message without sending a text reply.
+
+Useful when the agent wants to acknowledge a message (e.g. 👍, 👎, ✅, 🔍) without
+generating any visible response text in the channel.
+"""
+
+import json
+import logging
+from typing import Optional
+
+from tools.registry import registry
+
+logger = logging.getLogger(__name__)
+
+_SCHEMA = {
+    "name": "slack_react",
+    "description": (
+        "Add an emoji reaction to a Slack message without sending any text reply. "
+        "Use this to silently acknowledge messages — e.g. react with 👍 instead of "
+        "typing 'Got it'. Only works when the Slack gateway is configured. "
+        "The target defaults to the current conversation message; supply channel and "
+        "timestamp explicitly to react to a different message.\n\n"
+        "Examples:\n"
+        "  Acknowledge an emoji-only message: slack_react(emoji='thumbsup')\n"
+        "  React to a specific message: slack_react(emoji='white_check_mark', "
+        "channel='C0B3XC4TZ1S', timestamp='1716201336.943429')"
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "emoji": {
+                "type": "string",
+                "description": (
+                    "Slack emoji name without colons, e.g. 'thumbsup', 'eyes', "
+                    "'white_check_mark', 'x', 'wave', 'rocket'. "
+                    "Standard Unicode emoji names work too."
+                ),
+            },
+            "channel": {
+                "type": "string",
+                "description": (
+                    "Slack channel ID (e.g. 'C0B3XC4TZ1S'). "
+                    "Defaults to the current gateway session's channel when omitted."
+                ),
+            },
+            "timestamp": {
+                "type": "string",
+                "description": (
+                    "Message timestamp (ts) to react to, e.g. '1716201336.943429'. "
+                    "Defaults to the triggering message's timestamp when omitted."
+                ),
+            },
+        },
+        "required": ["emoji"],
+    },
+}
+
+
+def _get_slack_token() -> Optional[str]:
+    """Retrieve the Slack bot token from gateway config."""
+    try:
+        from gateway.config import load_gateway_config, Platform
+
+        config = load_gateway_config()
+        for pconfig in config.platforms:
+            if pconfig.platform == Platform.SLACK and pconfig.token:
+                return pconfig.token
+    except Exception:
+        pass
+    return None
+
+
+def _get_current_context() -> tuple[Optional[str], Optional[str]]:
+    """Return (channel_id, message_ts) from the active gateway session context, if available."""
+    try:
+        from gateway.session_context import get_current_session_context
+
+        ctx = get_current_session_context()
+        if ctx:
+            return ctx.get("chat_id"), ctx.get("message_ts")
+    except Exception:
+        pass
+    return None, None
+
+
+def slack_react_tool(args: dict, **kwargs) -> str:
+    emoji: str = args.get("emoji", "").strip().strip(":")
+    if not emoji:
+        return json.dumps({"error": "emoji is required"})
+
+    channel: Optional[str] = args.get("channel") or None
+    timestamp: Optional[str] = args.get("timestamp") or None
+
+    # Fall back to current session context when channel/ts are not provided
+    if not channel or not timestamp:
+        ctx_channel, ctx_ts = _get_current_context()
+        channel = channel or ctx_channel
+        timestamp = timestamp or ctx_ts
+
+    if not channel:
+        return json.dumps({"error": "channel could not be determined — pass channel= explicitly"})
+    if not timestamp:
+        return json.dumps(
+            {"error": "message timestamp could not be determined — pass timestamp= explicitly"}
+        )
+
+    token = _get_slack_token()
+    if not token:
+        return json.dumps({"error": "Slack gateway not configured or no bot token found"})
+
+    import asyncio
+
+    async def _add_reaction() -> dict:
+        try:
+            import aiohttp
+        except ImportError:
+            return {"error": "aiohttp not installed — run: pip install aiohttp"}
+        try:
+            from gateway.platforms.base import resolve_proxy_url, proxy_kwargs_for_aiohttp
+
+            _proxy = resolve_proxy_url()
+            _sess_kw, _req_kw = proxy_kwargs_for_aiohttp(_proxy)
+        except Exception:
+            _sess_kw, _req_kw = {}, {}
+
+        url = "https://slack.com/api/reactions.add"
+        headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+        payload = {"channel": channel, "timestamp": timestamp, "name": emoji}
+
+        try:
+            async with aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=10), **_sess_kw
+            ) as session:
+                async with session.post(
+                    url, headers=headers, json=payload, **_req_kw
+                ) as resp:
+                    data = await resp.json()
+                    if data.get("ok"):
+                        return {
+                            "success": True,
+                            "emoji": emoji,
+                            "channel": channel,
+                            "timestamp": timestamp,
+                        }
+                    err = data.get("error", "unknown")
+                    # "already_reacted" is not a failure — treat as success
+                    if err == "already_reacted":
+                        return {
+                            "success": True,
+                            "emoji": emoji,
+                            "note": "already reacted",
+                        }
+                    return {"error": f"Slack API error: {err}"}
+        except Exception as exc:
+            return {"error": f"Request failed: {exc}"}
+
+    try:
+        loop = asyncio.get_event_loop()
+        if loop.is_running():
+            import concurrent.futures
+
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                future = pool.submit(asyncio.run, _add_reaction())
+                result = future.result(timeout=15)
+        else:
+            result = loop.run_until_complete(_add_reaction())
+    except Exception as exc:
+        result = {"error": f"Async execution failed: {exc}"}
+
+    return json.dumps(result)
+
+
+def _check_slack_react() -> bool:
+    """Tool is available when a Slack gateway config with a token exists."""
+    return _get_slack_token() is not None
+
+
+registry.register(
+    name="slack_react",
+    toolset="messaging",
+    schema=_SCHEMA,
+    handler=lambda args, **kw: slack_react_tool(args, **kw),
+    check_fn=_check_slack_react,
+    emoji="👍",
+)


### PR DESCRIPTION
## Summary

Adds a `slack_react` tool to the `messaging` toolset so the agent can add an emoji reaction to a Slack message without sending any text reply.

This came up in a real SPC deployment where the agent wanted to acknowledge an emoji-only message (e.g. 👍 reaction from a user) without generating a verbose text response — currently the only option is `send_message`, which always produces visible text.

## Behaviour

- Calls `reactions.add` on the Slack Web API.
- `channel` and `timestamp` default to the current gateway session context when omitted, so `slack_react(emoji='thumbsup')` just works during a conversation.
- Strips surrounding colons from emoji names (`:thumbsup:` → `thumbsup`).
- Treats `already_reacted` as a success (idempotent).
- Hidden via `check_fn` when no Slack token is configured.
- Async execution is safe both inside and outside a running event loop.

## Files changed

- `tools/slack_react_tool.py` — new tool, auto-discovered via `registry.register()`
- `tests/tools/test_slack_react_tool.py` — unit tests covering happy path, context fallback, idempotency, error propagation, and registry registration

## Testing

```bash
python -m pytest tests/tools/test_slack_react_tool.py -v
```

Co-authored-by: Sahil Shubham <sahil@southparkcommons.com>
Co-authored-by: Evan Tana <evan@southparkcommons.com>