### PR TITLE
fix(telegram): apply _effective_update_message to _handle_media_message

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -4785,12 +4785,11 @@ class TelegramAdapter(BasePlatformAdapter):
 
     async def _handle_media_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming media messages, downloading images to local cache."""
-        if not update.message:
+        msg = self._effective_update_message(update)
+        if not msg:
             return
-        if not self._should_process_message(update.message):
+        if not self._should_process_message(msg):
             return
-        
-        msg = update.message
         
         # Determine media type
         if msg.sticker:

--- a/tests/gateway/test_telegram_channel_posts.py
+++ b/tests/gateway/test_telegram_channel_posts.py
@@ -98,7 +98,7 @@ def _make_adapter(telegram_adapter_cls):
     return a
 
 
-def _make_channel_message(text="channel id test @hermes_bot"):
+def _make_channel_message(text="channel id test @hermes_bot", sticker=None):
     chat = SimpleNamespace(
         id=-1003950368353,
         type="channel",
@@ -120,6 +120,12 @@ def _make_channel_message(text="channel id test @hermes_bot"):
         quote=None,
         date=None,
         forum_topic_created=None,
+        sticker=sticker,
+        photo=None,
+        video=None,
+        audio=None,
+        voice=None,
+        document=None,
     )
 
 
@@ -177,5 +183,29 @@ async def test_command_handler_uses_effective_message_for_channel_post(telegram_
     event = adapter.handle_message.await_args.args[0]
     assert event.text == "/status"
     assert event.message_type == MessageType.COMMAND
+    assert event.source.chat_type == "channel"
+    assert event.source.chat_id == "-1003950368353"
+
+
+@pytest.mark.asyncio
+async def test_media_handler_uses_effective_message_for_channel_post(telegram_adapter_cls):
+    """_handle_media_message must not drop channel posts.
+
+    PR #28531 fixed text and command handlers to use _effective_update_message
+    but missed _handle_media_message.  A channel_post update carries the media
+    in update.channel_post; update.message is None, so the old early-return
+    guard silently dropped all channel media posts.
+    """
+    adapter = _make_adapter(telegram_adapter_cls)
+    sticker = MagicMock()
+    msg = _make_channel_message(sticker=sticker)
+    update = _make_channel_update(msg)
+    adapter._handle_sticker = AsyncMock()
+    adapter.handle_message = AsyncMock()
+
+    await adapter._handle_media_message(update, MagicMock())
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
     assert event.source.chat_type == "channel"
     assert event.source.chat_id == "-1003950368353"


### PR DESCRIPTION
## Summary

PR #28531 introduced `_effective_update_message` and applied it to
`_handle_text_message`, `_handle_command`, and `_handle_location_message`
so that Telegram channel posts (`update.channel_post`; `update.message == None`)
are routed correctly. `_handle_media_message` was missed.

**Bug**: the `if not update.message: return` guard at the top of
`_handle_media_message` exits immediately for every channel post, silently
dropping all channel media (photos, videos, audio, documents, stickers).

**Fix**: resolve `msg` via `_effective_update_message` at the top of the
handler and remove the now-redundant `msg = update.message` assignment.
Identical to the pattern already applied to the three sibling handlers.

## Changes

- `gateway/platforms/telegram.py`: apply `_effective_update_message` to
  `_handle_media_message` (mirrors `_handle_location_message`)
- `tests/gateway/test_telegram_channel_posts.py`: add
  `test_media_handler_uses_effective_message_for_channel_post`; extend
  `_make_channel_message` with media attribute stubs

## Test plan

- [ ] `scripts/run_tests.sh tests/gateway/test_telegram_channel_posts.py -q` → 4/4
- [ ] `scripts/run_tests.sh tests/gateway/test_telegram_group_gating.py tests/gateway/test_telegram_channel_posts.py -q` → 30/30