### PR TITLE
fix: preserve unicode in YAML writes

### DIFF
--- a/tests/hermes_cli/test_atomic_yaml_write.py
+++ b/tests/hermes_cli/test_atomic_yaml_write.py
@@ -42,3 +42,14 @@ class TestAtomicYamlWrite:
         text = target.read_text(encoding="utf-8")
         assert "key: value" in text
         assert "# comment" in text
+
+    def test_preserves_readable_unicode(self, tmp_path):
+        target = tmp_path / "data.yaml"
+        data = {"telegram": {"channel_prompts": {"6842": "Ты — тёплая помощница. Пиши по-русски."}}}
+
+        atomic_yaml_write(target, data)
+
+        text = target.read_text(encoding="utf-8")
+        assert yaml.safe_load(text) == data
+        assert "Ты — тёплая помощница. Пиши по-русски." in text
+        assert "\\u0422" not in text

--- a/utils.py
+++ b/utils.py
@@ -170,7 +170,13 @@ def atomic_yaml_write(
     )
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
-            yaml.dump(data, f, default_flow_style=default_flow_style, sort_keys=sort_keys)
+            yaml.dump(
+                data,
+                f,
+                default_flow_style=default_flow_style,
+                sort_keys=sort_keys,
+                allow_unicode=True,
+            )
             if extra_content:
                 f.write(extra_content)
             f.flush()


### PR DESCRIPTION
## Summary
- Pass `allow_unicode=True` when writing YAML via `atomic_yaml_write`
- Add a regression test covering Cyrillic Telegram channel prompts

## Problem
Config values containing non-ASCII text could be serialized as Unicode escape sequences like `\u0422`, making `config.yaml` hard to read after Hermes rewrites it.

## Test Plan
- `python -m pytest tests/hermes_cli/test_atomic_yaml_write.py tests/cli/test_cli_save_config_value.py -q -o 'addopts='`