### PR TITLE
fix(discord): define UI view classes after lazy install (#26958)

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -111,6 +111,7 @@ def check_discord_requirements() -> bool:
     Intents = _Intents
     commands = _commands
     DISCORD_AVAILABLE = True
+    _define_discord_view_classes()
     return True
 
 
@@ -4949,7 +4950,17 @@ def _component_check_auth(
     return False
 
 
-if DISCORD_AVAILABLE:
+def _define_discord_view_classes() -> None:
+    """Register Discord UI view classes as module globals.
+
+    Called at module load (when discord.py is pre-installed) and also from
+    check_discord_requirements() after a lazy install, so view classes are
+    always defined whenever DISCORD_AVAILABLE is True.  Without this,
+    ExecApprovalView and siblings are only defined at import time; a later
+    lazy install sets DISCORD_AVAILABLE=True but leaves the classes
+    undefined, causing NameError on the first button interaction.
+    """
+    global ExecApprovalView, SlashConfirmView, UpdatePromptView, ModelPickerView, ClarifyChoiceView
 
     class ExecApprovalView(discord.ui.View):
         """
@@ -5649,3 +5660,7 @@ if DISCORD_AVAILABLE:
             self.resolved = True
             for child in self.children:
                 child.disabled = True
+
+
+if DISCORD_AVAILABLE:
+    _define_discord_view_classes()

--- a/tests/gateway/test_discord_lazy_install_views.py
+++ b/tests/gateway/test_discord_lazy_install_views.py
@@ -1,0 +1,81 @@
+"""Regression: Discord UI view classes must be defined after lazy-install.
+
+When discord.py is NOT installed at module load time, the
+``if DISCORD_AVAILABLE:`` guard at the bottom of gateway/platforms/discord.py
+evaluates to False and is skipped — leaving ExecApprovalView and its four
+siblings undefined in the module globals.
+
+check_discord_requirements() must call _define_discord_view_classes() after
+a successful lazy install so that all view classes are available the moment
+DISCORD_AVAILABLE flips to True.  Without this, the first button interaction
+(exec approval, slash confirm, etc.) raises NameError even though
+DISCORD_AVAILABLE=True.
+
+Fixes: lazy-install path NameError for ExecApprovalView, SlashConfirmView,
+UpdatePromptView, ModelPickerView, ClarifyChoiceView.
+"""
+import importlib
+import sys
+from unittest.mock import patch
+
+import pytest
+
+_VIEW_NAMES = [
+    "ExecApprovalView",
+    "SlashConfirmView",
+    "UpdatePromptView",
+    "ModelPickerView",
+    "ClarifyChoiceView",
+]
+
+
+class TestDefineDiscordViewClasses:
+    """_define_discord_view_classes() registers all UI view classes in module globals."""
+
+    def test_registers_all_five_view_classes(self, monkeypatch):
+        """Calling _define_discord_view_classes() must (re)define all 5 view classes."""
+        dp = importlib.import_module("gateway.platforms.discord")
+
+        # Remove the classes to simulate the state where the module was loaded
+        # with DISCORD_AVAILABLE=False (the lazy-install scenario).
+        for name in _VIEW_NAMES:
+            monkeypatch.delattr(dp, name)
+
+        # Pre-condition: classes are gone
+        for name in _VIEW_NAMES:
+            assert not hasattr(dp, name), f"{name} should be absent before the call"
+
+        dp._define_discord_view_classes()
+
+        for name in _VIEW_NAMES:
+            assert hasattr(dp, name), f"{name} must be defined after _define_discord_view_classes()"
+            assert isinstance(getattr(dp, name), type), f"{name} must be a class"
+
+    def test_check_discord_requirements_calls_define_on_lazy_install(self, monkeypatch):
+        """check_discord_requirements() must call _define_discord_view_classes() on
+        a successful lazy install so view classes exist when DISCORD_AVAILABLE=True."""
+        dp = importlib.import_module("gateway.platforms.discord")
+
+        # Simulate discord not yet available at module load.
+        monkeypatch.setattr(dp, "DISCORD_AVAILABLE", False)
+
+        define_called = [False]
+        orig_define = dp._define_discord_view_classes
+
+        def _spy_define():
+            define_called[0] = True
+            orig_define()
+
+        monkeypatch.setattr(dp, "_define_discord_view_classes", _spy_define)
+
+        # Patch lazy_deps.ensure to be a no-op (pretend install succeeds).
+        # The discord imports inside check_discord_requirements() succeed because
+        # _ensure_discord_mock() in conftest.py already registered the mock.
+        with patch("tools.lazy_deps.ensure"):
+            result = dp.check_discord_requirements()
+
+        assert result is True, "check_discord_requirements() should return True after lazy install"
+        assert define_called[0], (
+            "check_discord_requirements() must call _define_discord_view_classes() "
+            "after a successful lazy install so view classes are not undefined"
+        )


### PR DESCRIPTION
## Summary

Salvage of #28261 — fixes the Discord button-based UI lazy-install bug originally reported in #26958 (and again in #28045): all five `discord.ui.View` subclasses (`ExecApprovalView`, `SlashConfirmView`, `UpdatePromptView`, `ModelPickerView`, `ClarifyChoiceView`) are never defined in Docker gateway deployments where `discord.py` is lazy-installed at runtime.

## What was broken

`gateway/platforms/discord.py` lazy-installs `discord.py` via `tools.lazy_deps.ensure("platform.discord")` inside `check_discord_requirements()`. After a successful install it flips `DISCORD_AVAILABLE = True` and re-binds the `discord` module global — but all five `discord.ui.View` subclasses are defined inside a module-level `if DISCORD_AVAILABLE:` block near the bottom of the file. That block ran at import time when `DISCORD_AVAILABLE` was still `False`, so the classes were never defined. When `check_discord_requirements()` later flipped the flag to `True`, the module-level gate had already executed and was never re-evaluated.

Result: any button-based interaction (exec approval, slash confirm, clarify choice, model picker, update prompt) hit `NameError: name 'ExecApprovalView' is not defined`, was silently caught by the gateway's fallback handler, and degraded to the text-based `/approve` flow. Docker users running the messaging gateway without `discord.py` pre-installed saw their interactive UIs simply disappear.

## What changed

Extract the five `View` class definitions into a module-level `_define_discord_view_classes()` helper and call it from both:

1. **`check_discord_requirements()`** — immediately after `DISCORD_AVAILABLE = True` succeeds via lazy install. This is the path Docker images hit.
2. **`if DISCORD_AVAILABLE:` at module bottom** — preserved for normal (non-lazy) installs where `discord.py` is already importable at module load time.

Both call sites use the same helper, so the classes always become defined the moment `DISCORD_AVAILABLE` flips to `True`.

Includes a focused regression test (`tests/gateway/test_discord_lazy_install_views.py`) that:
- Asserts all 5 view classes are registered in module globals after calling the helper.
- Asserts `check_discord_requirements()` invokes the helper after a simulated lazy install.

## Validation

```text
$ bash scripts/run_tests.sh tests/gateway/test_discord_lazy_install_views.py -v
============================== 2 passed in 1.31s ==============================

$ bash scripts/run_tests.sh tests/gateway/ -q -k discord
411 passed, 1 skipped, 10 warnings in 14.92s
```

E2E verified end-to-end against both `origin/main` and this branch with `discord.py` blocked at import time:

```text
origin/main + simulated lazy-install:
  ExecApprovalView: exists=False    ← BUG: classes still missing after DISCORD_AVAILABLE=True
  SlashConfirmView: exists=False
  ...

this branch + simulated lazy-install:
  ExecApprovalView: exists=True is_class=True    ← FIXED
  SlashConfirmView: exists=True is_class=True
  UpdatePromptView: exists=True is_class=True
  ModelPickerView: exists=True is_class=True
  ClarifyChoiceView: exists=True is_class=True
```

Lint:
- `ruff check` — All checks passed!
- `ty` — +10 advisory warnings on `discord.py` (`unresolved-global` × 5, `unresolved-reference` × 5). These are static-analysis artifacts of the `global X` declaration inside a helper function — ty can't model the dynamic-binding pattern statically. Same warning class would appear in PR #27019 and #28729 if they were lint-diffed; it's intrinsic to "define classes inside a callable and expose them as module globals." Not a real defect.

## Credit

- Original bug report by @andrewjmoser in #26958 (excellent diagnosis with the precise module-load-order trace).
- Re-reported by @teslia in #28045 with the user-visible "button fallback to text" symptom.
- Three contributors converged on the same fix shape:
  - **@EloquentBrush0x** (#28261, this salvage) — `_define_discord_view_classes()` with regression tests. Adopted as the base.
  - **@zccyman** (#27019, filed 2026-05-16, earliest) — same helper-function approach with `None` placeholders; but didn't actually wire the helper into `check_discord_requirements()`, so the lazy-install path remained broken.
  - **@LifeJiggy** (#28729) — same shape but unnecessarily deleted unrelated `_component_check_auth` comments and shipped without tests.

Closes #26958.
Closes #28045.
