### PR TITLE
fix(kanban): refuse to rmtree workspace_path outside managed scratch root (#28818)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3038,15 +3038,24 @@ def complete_task(
 # ---------------------------------------------------------------------------
 
 def _is_managed_scratch_path(p: Path) -> bool:
-    """Return True iff *p* lives inside a kanban-managed scratch root.
+    """Return True iff *p* is a strict descendant of a kanban-managed scratch root.
 
-    A managed root is one of:
+    A managed root is exclusively a ``workspaces/`` directory — never the
+    broader kanban home, a board root, or sibling subtrees like ``logs/`` or
+    ``boards/<slug>/`` itself. Allowed roots:
 
     * ``HERMES_KANBAN_WORKSPACES_ROOT`` when set (worker-side override
       injected by the dispatcher).
-    * The current kanban home's ``kanban/`` subtree, which covers both the
-      legacy default-board scratch root (``<kanban_home>/kanban/workspaces``)
-      and per-board roots (``<kanban_home>/kanban/boards/<slug>/workspaces``).
+    * ``<kanban_home>/kanban/workspaces`` — legacy default-board scratch root.
+    * ``<kanban_home>/kanban/boards/<slug>/workspaces`` for each board slug
+      that currently exists on disk.
+
+    The check requires strict descendancy: a path equal to one of these
+    roots is NOT managed (deleting the workspaces root would wipe every
+    task's scratch dir at once), and a path that resolves to ``<kanban_home>
+    /kanban`` itself, ``<kanban_home>/kanban/logs``, or
+    ``<kanban_home>/kanban/boards/<slug>`` is rejected because those
+    subtrees hold Hermes' own DB, metadata, and logs, not task workspaces.
 
     Used by :func:`_cleanup_workspace` to refuse to ``shutil.rmtree`` paths
     outside Hermes-managed storage. A board ``default_workdir`` pointing at a
@@ -3065,10 +3074,36 @@ def _is_managed_scratch_path(p: Path) -> bool:
         except OSError:
             pass
     try:
-        roots.append((kanban_home() / "kanban").resolve(strict=False))
+        home = kanban_home()
     except OSError:
-        pass
+        home = None
+    if home is not None:
+        try:
+            roots.append((home / "kanban" / "workspaces").resolve(strict=False))
+        except OSError:
+            pass
+        try:
+            boards_parent = (home / "kanban" / "boards").resolve(strict=False)
+        except OSError:
+            boards_parent = None
+        if boards_parent is not None:
+            try:
+                entries = list(boards_parent.iterdir())
+            except OSError:
+                entries = []
+            for entry in entries:
+                try:
+                    if not entry.is_dir():
+                        continue
+                except OSError:
+                    continue
+                try:
+                    roots.append((entry / "workspaces").resolve(strict=False))
+                except OSError:
+                    continue
     for root in roots:
+        if p_abs == root:
+            continue
         try:
             if p_abs.is_relative_to(root):
                 return True

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3037,6 +3037,46 @@ def complete_task(
 # Workspace / tmux cleanup
 # ---------------------------------------------------------------------------
 
+def _is_managed_scratch_path(p: Path) -> bool:
+    """Return True iff *p* lives inside a kanban-managed scratch root.
+
+    A managed root is one of:
+
+    * ``HERMES_KANBAN_WORKSPACES_ROOT`` when set (worker-side override
+      injected by the dispatcher).
+    * The current kanban home's ``kanban/`` subtree, which covers both the
+      legacy default-board scratch root (``<kanban_home>/kanban/workspaces``)
+      and per-board roots (``<kanban_home>/kanban/boards/<slug>/workspaces``).
+
+    Used by :func:`_cleanup_workspace` to refuse to ``shutil.rmtree`` paths
+    outside Hermes-managed storage. A board ``default_workdir`` pointing at a
+    real source tree can otherwise pair with ``workspace_kind='scratch'`` and
+    cause task completion to delete user data (#28818).
+    """
+    try:
+        p_abs = p.resolve(strict=False)
+    except OSError:
+        return False
+    roots: list[Path] = []
+    override = os.environ.get("HERMES_KANBAN_WORKSPACES_ROOT", "").strip()
+    if override:
+        try:
+            roots.append(Path(override).expanduser().resolve(strict=False))
+        except OSError:
+            pass
+    try:
+        roots.append((kanban_home() / "kanban").resolve(strict=False))
+    except OSError:
+        pass
+    for root in roots:
+        try:
+            if p_abs.is_relative_to(root):
+                return True
+        except ValueError:
+            continue
+    return False
+
+
 def _cleanup_workspace(conn: sqlite3.Connection, task_id: str) -> None:
     """Remove a task's scratch workspace dir and kill its stale tmux session.
 
@@ -3059,8 +3099,21 @@ def _cleanup_workspace(conn: sqlite3.Connection, task_id: str) -> None:
         import shutil
         wp = Path(path)
         if wp.is_dir():
-            shutil.rmtree(wp, ignore_errors=True)
-            _log.debug("Removed scratch workspace: %s", wp)
+            # Containment guard (#28818): a board's ``default_workdir`` can
+            # pair ``workspace_kind='scratch'`` with a user-supplied path
+            # pointing at a real source tree. Without this check, task
+            # completion would unconditionally ``shutil.rmtree`` that path
+            # and silently delete the user's source data.
+            if _is_managed_scratch_path(wp):
+                shutil.rmtree(wp, ignore_errors=True)
+                _log.debug("Removed scratch workspace: %s", wp)
+            else:
+                _log.warning(
+                    "Refusing to remove out-of-scratch workspace for task %s: %s "
+                    "(workspace_kind='scratch' but path is outside any "
+                    "kanban-managed workspaces root)",
+                    task_id, wp,
+                )
         # Also kill the tmux session for the worker that owned this task,
         # if the tmux session is now dead (worker process exited).
         _cleanup_worker_tmux(conn, task_id)

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1561,6 +1561,47 @@ def test_is_managed_scratch_path_rejects_real_source_tree(kanban_home, tmp_path)
     assert not kb._is_managed_scratch_path(real)
 
 
+def test_is_managed_scratch_path_rejects_kanban_metadata_subtrees(kanban_home):
+    """Hermes' own DB/metadata/log subtrees under ``<kanban_home>/kanban`` are NOT managed.
+
+    Regression guard for the Copilot finding on #28819: a scratch task whose
+    ``workspace_path`` was mis-set to the kanban home, the logs dir, or a
+    board's metadata dir (i.e. the board root itself, not its ``workspaces/``
+    child) must be refused. Without this, the containment check would happily
+    ``shutil.rmtree`` Hermes' DB/metadata/logs on task completion.
+    """
+    kanban_root = kanban_home / "kanban"
+    kanban_root.mkdir(parents=True, exist_ok=True)
+    assert not kb._is_managed_scratch_path(kanban_root)
+
+    logs_dir = kanban_root / "logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    assert not kb._is_managed_scratch_path(logs_dir)
+
+    board_root = kanban_root / "boards" / "my-board"
+    board_root.mkdir(parents=True, exist_ok=True)
+    # The board root itself is NOT a managed scratch dir — only the
+    # ``workspaces/`` child (and its descendants) are.
+    assert not kb._is_managed_scratch_path(board_root)
+
+    # Sibling subtrees of ``workspaces/`` under a board (e.g. its kanban.db
+    # or board.json living next to ``workspaces/``) are also not managed.
+    board_logs = board_root / "logs"
+    board_logs.mkdir(parents=True, exist_ok=True)
+    assert not kb._is_managed_scratch_path(board_logs)
+
+    # Now create the board's workspaces dir and a task scratch dir under it —
+    # the latter is the only thing the guard should allow.
+    board_workspaces = board_root / "workspaces"
+    board_workspaces.mkdir(parents=True, exist_ok=True)
+    # The workspaces root itself is also NOT managed — deleting it would
+    # wipe every task's scratch dir at once.
+    assert not kb._is_managed_scratch_path(board_workspaces)
+    task_dir = board_workspaces / "task-42"
+    task_dir.mkdir(parents=True, exist_ok=True)
+    assert kb._is_managed_scratch_path(task_dir)
+
+
 # ---------------------------------------------------------------------------
 # Tenancy
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1471,6 +1471,97 @@ def test_worktree_workspace_returns_intended_path(kanban_home, tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# Scratch cleanup containment (#28818)
+# ---------------------------------------------------------------------------
+
+def test_cleanup_workspace_removes_managed_scratch_dir(kanban_home):
+    """A scratch workspace under the kanban workspaces root is removed."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="scratchy")
+        task = kb.get_task(conn, t)
+        ws = kb.resolve_workspace(task)
+        kb.set_workspace_path(conn, t, ws)
+        assert ws.is_dir()
+        kb.complete_task(conn, t, result="ok")
+    assert not ws.exists(), "Hermes-managed scratch dir should be cleaned up"
+
+
+def test_cleanup_workspace_refuses_path_outside_scratch_root(kanban_home, tmp_path):
+    """A scratch task with a user path outside the workspaces root must NOT be deleted (#28818).
+
+    Reproduces the data-loss vector where a board's ``default_workdir`` is set
+    to a real source directory; tasks created without an explicit
+    ``workspace_kind`` inherit ``scratch`` semantics, and the old cleanup path
+    would ``shutil.rmtree`` the user's source tree on task completion.
+    """
+    real_source = tmp_path / "real-source"
+    real_source.mkdir()
+    (real_source / ".git").mkdir()
+    (real_source / "README.md").write_text("important", encoding="utf-8")
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="ship")
+        # Simulate the bad state directly: workspace_kind='scratch' (default)
+        # but workspace_path pointing at the user's real source tree, which is
+        # exactly what board.default_workdir produces when the task is created
+        # without an explicit workspace_kind.
+        conn.execute(
+            "UPDATE tasks SET workspace_kind=?, workspace_path=? WHERE id=?",
+            ("scratch", str(real_source), t),
+        )
+        conn.commit()
+        kb.complete_task(conn, t, result="ok")
+
+    assert real_source.exists(), "User source tree must not be deleted by scratch cleanup"
+    assert (real_source / ".git").exists()
+    assert (real_source / "README.md").read_text(encoding="utf-8") == "important"
+
+
+def test_cleanup_workspace_honors_workspaces_root_env_override(tmp_path, monkeypatch):
+    """``HERMES_KANBAN_WORKSPACES_ROOT`` extends the managed-scratch set.
+
+    Worker subprocesses run with this env var injected by the dispatcher. The
+    cleanup containment check must treat paths under it as managed even when
+    they sit outside the active kanban home.
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    workspaces_override = tmp_path / "ext-workspaces"
+    workspaces_override.mkdir()
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACES_ROOT", str(workspaces_override))
+    kb.init_db()
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="ext")
+        scratch_dir = workspaces_override / t
+        scratch_dir.mkdir()
+        conn.execute(
+            "UPDATE tasks SET workspace_kind=?, workspace_path=? WHERE id=?",
+            ("scratch", str(scratch_dir), t),
+        )
+        conn.commit()
+        kb.complete_task(conn, t, result="ok")
+
+    assert not scratch_dir.exists(), "Override-root scratch dir should be cleaned up"
+
+
+def test_is_managed_scratch_path_accepts_per_board_workspaces(kanban_home, tmp_path):
+    """Per-board scratch dirs under ``<kanban_home>/kanban/boards/<slug>/workspaces`` are managed."""
+    board_scratch = kanban_home / "kanban" / "boards" / "my-board" / "workspaces" / "task-1"
+    board_scratch.mkdir(parents=True)
+    assert kb._is_managed_scratch_path(board_scratch)
+
+
+def test_is_managed_scratch_path_rejects_real_source_tree(kanban_home, tmp_path):
+    """A path outside any managed root (e.g. a user's repo) is NOT managed."""
+    real = tmp_path / "code" / "my-project"
+    real.mkdir(parents=True)
+    assert not kb._is_managed_scratch_path(real)
+
+
+# ---------------------------------------------------------------------------
 # Tenancy
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What does this PR do?

Fixes a data-loss vector in kanban scratch cleanup (#28818, marked P0 in the issue body). A board's `default_workdir` (set via `hermes kanban boards set-default-workdir <board> <path>`) is copied into `tasks.workspace_path` for tasks created without an explicit `workspace_kind`. Those tasks default to `workspace_kind='scratch'`, so when the task completes, `_cleanup_workspace` runs `shutil.rmtree(wp, ignore_errors=True)` — unconditionally deleting the user's real source tree as if it were disposable scratch storage.

The fix adds a containment guard: `_cleanup_workspace` now only deletes paths under a kanban-managed scratch root. A managed root is either `HERMES_KANBAN_WORKSPACES_ROOT` (the worker-side override the dispatcher injects into worker env at `kanban_db.py:5236`) or anywhere under `<kanban_home>/kanban/`, which covers both the legacy default-board root (`<kanban_home>/kanban/workspaces`) and per-board roots (`<kanban_home>/kanban/boards/<slug>/workspaces`) returned by `workspaces_root()`. Anything else gets a warning log and is left alone, so a misconfigured `default_workdir` can no longer destroy user data.

Mirrors `workspaces_root()`'s full input precedence (`HERMES_KANBAN_WORKSPACES_ROOT` > computed-from-board) so cleanup containment lines up exactly with the dispatcher's worker-env injection.

## Related Issue

Fixes #28818

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/kanban_db.py` — add `_is_managed_scratch_path(p)` helper that checks `p` against `HERMES_KANBAN_WORKSPACES_ROOT` and `<kanban_home>/kanban/`. `_cleanup_workspace` now gates the existing `shutil.rmtree` call on that check and emits a `_log.warning` instead of deleting when the path is out of scope.
- `tests/hermes_cli/test_kanban_db.py` — 5 new tests covering the regression and the supporting helper: managed scratch dirs still get cleaned up; user source trees outside the managed roots survive task completion (with `.git` and a sentinel file preserved); `HERMES_KANBAN_WORKSPACES_ROOT` override paths are still eligible for cleanup; per-board scratch dirs under `<kanban_home>/kanban/boards/<slug>/workspaces` are recognised as managed; arbitrary user paths are rejected.

## How to Test

1. Repro the original bug (without the fix):
   ```
   hermes kanban boards set-default-workdir my-board /path/to/real/source
   hermes kanban add "do something" --board my-board   # no --workspace-kind
   hermes kanban complete <task_id>                    # /path/to/real/source is rmtree'd
   ```
2. With the fix applied, the same sequence leaves `/path/to/real/source` intact and emits a warning: `Refusing to remove out-of-scratch workspace for task <id>: /path/to/real/source (workspace_kind='scratch' but path is outside any kanban-managed workspaces root)`.
3. Focused tests:
   ```
   uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/hermes_cli/test_kanban_db.py -v
   ```
   163 tests pass locally, including the 5 new ones. Regression-guard: temporarily bypassing the new `_is_managed_scratch_path(wp)` check makes `test_cleanup_workspace_refuses_path_outside_scratch_root` fail with `User source tree must not be deleted by scratch cleanup`, confirming the test catches the data-loss bug.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings on `_is_managed_scratch_path` and `_cleanup_workspace` explain the containment rule and reference #28818
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `Path.is_relative_to` + `Path.resolve(strict=False)` are portable; no platform-specific code paths
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Sibling code paths that may need the same fix

> Sibling code paths that may need the same fix:
>
> - `create_task` (`hermes_cli/kanban_db.py:1469-1474`) — inherits `board.default_workdir` into `workspace_path` while leaving `workspace_kind` at its default `'scratch'`. Defaulting `workspace_kind='dir'` when a `default_workdir` is inherited would also prevent the bad state at the source. Intentionally left out of this PR's scope to keep the diff small and the behavior change conservative — happy to widen.
> - `hermes kanban boards set-default-workdir` (CLI handler in `hermes_cli/kanban.py`) — could emit a warning when the target exists and is outside `<kanban_home>/kanban/`, surfacing the misconfiguration before any task runs. Also a candidate for widening.

The current containment guard is sufficient on its own to close the data-loss vector — the two siblings would harden the same surface but are not required for the fix to be safe.