### PR TITLE
fix(packaging): add hermes_cli.* to setuptools include so proxy subpackage ships in wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,7 +220,7 @@ plugins = [
 ]
 
 [tool.setuptools.packages.find]
-include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*"]
+include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "hermes_cli.*", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary

Add `hermes_cli.*` to setuptools `packages.find` include list so `hermes_cli/proxy/` (and its `adapters/` subpackage) ship in the wheel.

Fixes #27938

## Problem

The v0.14.0 wheel is missing `hermes_cli/proxy/`, so all `hermes proxy` subcommands fail with `ModuleNotFoundError: No module named 'hermes_cli.proxy'` on pip-installed installs.

## Root Cause

`pyproject.toml` configures wheel contents via setuptools `packages.find` include list. The entry `"hermes_cli"` matches only the top-level package — it does **not** recursively discover subpackages like `hermes_cli.proxy` and `hermes_cli.proxy.adapters`.

Every other multi-package entry already has the `.*` glob:
```toml
"agent", "agent.*",
"tools", "tools.*",
"gateway", "gateway.*",
# ...
"hermes_cli",          # ← missing .*
```

## Fix

Add `"hermes_cli.*"` to the include list, matching the pattern used by all other packages:

```diff
-include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "gateway", ...]
+include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "hermes_cli.*", "gateway", ...]
```

## Verification

```python
from setuptools import find_packages

# BEFORE (no .* glob)
find_packages(include=[..., "hermes_cli", ...])
# → ['hermes_cli']  (1 package)

# AFTER (with .* glob)
find_packages(include=[..., "hermes_cli", "hermes_cli.*", ...])
# → ['hermes_cli', 'hermes_cli.proxy', 'hermes_cli.proxy.adapters']  (3 packages)
```

All 88 existing proxy/packaging tests pass. No new tests needed (config-only change).
