### PR TITLE
feat: roundtable discussion — multi-agent structured debate with consensus tracking

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -868,6 +868,27 @@ CREATE TABLE IF NOT EXISTS kanban_notify_subs (
     PRIMARY KEY (task_id, platform, chat_id, thread_id)
 );
 
+-- Worker checkpoint storage. Each checkpoint captures a task's progress
+-- at a named step so a crashed worker can resume from the last completed
+-- step instead of starting over. Workers call ``save_checkpoint`` via
+-- the ``kanban_checkpoint`` tool after completing each logical step;
+-- on retry, ``build_worker_context`` injects the latest checkpoint so
+-- the new worker instance knows where to pick up.
+CREATE TABLE IF NOT EXISTS task_checkpoints (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id     TEXT NOT NULL,
+    run_id      INTEGER,
+    step_key    TEXT NOT NULL,
+    status      TEXT NOT NULL DEFAULT 'completed',
+    -- status: completed | in_progress | failed
+    data        TEXT,
+    message     TEXT,
+    created_at  INTEGER NOT NULL,
+    updated_at  INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_checkpoints_task ON task_checkpoints(task_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_checkpoints_step ON task_checkpoints(task_id, step_key);
+
 CREATE INDEX IF NOT EXISTS idx_tasks_assignee_status ON tasks(assignee, status);
 CREATE INDEX IF NOT EXISTS idx_tasks_status          ON tasks(status);
 CREATE INDEX IF NOT EXISTS idx_tasks_tenant          ON tasks(tenant);
@@ -2510,6 +2531,8 @@ def complete_task(
     # just tracks "is there a current pathology the breaker should
     # care about", and a success resets that question.
     _clear_failure_counter(conn, task_id)
+    # Clear checkpoints — task is done, no need to carry stale state.
+    clear_checkpoints(conn, task_id)
     # Recompute ready status for dependents (separate txn so children see done).
     recompute_ready(conn)
     return True
@@ -4101,6 +4124,122 @@ def run_daemon(
 
 
 # ---------------------------------------------------------------------------
+# Worker checkpoint persistence
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Checkpoint:
+    """In-memory view of a row from the ``task_checkpoints`` table."""
+    id: int
+    task_id: str
+    run_id: Optional[int]
+    step_key: str
+    status: str
+    data: Optional[str]
+    message: Optional[str]
+    created_at: int
+    updated_at: int
+
+    @classmethod
+    def from_row(cls, row: sqlite3.Row) -> "Checkpoint":
+        return cls(
+            id=row["id"],
+            task_id=row["task_id"],
+            run_id=row["run_id"],
+            step_key=row["step_key"],
+            status=row["status"],
+            data=row["data"],
+            message=row["message"],
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+        )
+
+
+def save_checkpoint(
+    conn: sqlite3.Connection,
+    task_id: str,
+    step_key: str,
+    *,
+    data: Optional[str] = None,
+    message: Optional[str] = None,
+    status: str = "completed",
+    run_id: Optional[int] = None,
+) -> Checkpoint:
+    """Save a checkpoint for a task step.
+
+    Workers call this after completing each logical step via the
+    ``kanban_checkpoint`` tool.  On crash/retry the next worker reads
+    the latest checkpoint from ``build_worker_context`` and resumes
+    from there.
+
+    ``step_key`` is a short machine-readable identifier
+    (e.g. ``"analysis"``, ``"impl-auth"``, ``"test-unit"``).
+    ``data`` is an arbitrary JSON string capturing the step's output
+    (file paths, intermediate results, etc.).
+    ``message`` is a human-readable one-liner for the context block.
+    """
+    now = int(time.time())
+    with write_txn(conn):
+        cur = conn.execute(
+            """INSERT INTO task_checkpoints
+               (task_id, run_id, step_key, status, data, message, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (task_id, run_id, step_key, status, data, message, now, now),
+        )
+        cp_id = cur.lastrowid or 0
+    return Checkpoint(
+        id=cp_id, task_id=task_id, run_id=run_id,
+        step_key=step_key, status=status, data=data,
+        message=message, created_at=now, updated_at=now,
+    )
+
+
+def get_latest_checkpoints(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    limit: int = 20,
+) -> list[Checkpoint]:
+    """Return the most recent checkpoints for a task, newest first."""
+    rows = conn.execute(
+        "SELECT * FROM task_checkpoints "
+        "WHERE task_id = ? ORDER BY created_at DESC LIMIT ?",
+        (task_id, limit),
+    ).fetchall()
+    return [Checkpoint.from_row(r) for r in rows]
+
+
+def get_checkpoints_by_step(
+    conn: sqlite3.Connection,
+    task_id: str,
+    step_key: str,
+) -> list[Checkpoint]:
+    """Return all checkpoints for a specific step, newest first."""
+    rows = conn.execute(
+        "SELECT * FROM task_checkpoints "
+        "WHERE task_id = ? AND step_key = ? ORDER BY created_at DESC",
+        (task_id, step_key),
+    ).fetchall()
+    return [Checkpoint.from_row(r) for r in rows]
+
+
+def clear_checkpoints(
+    conn: sqlite3.Connection,
+    task_id: str,
+) -> int:
+    """Delete all checkpoints for a task. Called on successful completion.
+
+    Returns the number of rows deleted.
+    """
+    with write_txn(conn):
+        cur = conn.execute(
+            "DELETE FROM task_checkpoints WHERE task_id = ?",
+            (task_id,),
+        )
+        return cur.rowcount
+
+
+# ---------------------------------------------------------------------------
 # Worker context builder (what a spawned worker sees)
 # ---------------------------------------------------------------------------
 
@@ -4261,6 +4400,27 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
                 first = s[0][:200] if s else "(no summary)"
                 lines.append(f"- {row['id']} — {row['title']} ({ts}): {first}")
             lines.append("")
+
+    # Checkpoints: show the latest checkpoint so a retrying worker can
+    # resume from where the previous attempt left off. Each checkpoint
+    # has a step_key, optional data (JSON), and a message. Only the
+    # most recent per step_key is shown (deduped).
+    checkpoints = get_latest_checkpoints(conn, task_id, limit=50)
+    if checkpoints:
+        lines.append("## Checkpoints (resume from here)")
+        lines.append("")
+        seen_steps: set[str] = set()
+        for cp in checkpoints:
+            if cp.step_key in seen_steps:
+                continue
+            seen_steps.add(cp.step_key)
+            ts = time.strftime("%Y-%m-%d %H:%M", time.localtime(cp.created_at))
+            status_tag = f" [{cp.status}]" if cp.status != "completed" else ""
+            msg = cp.message or ""
+            lines.append(f"- **{cp.step_key}**{status_tag} ({ts}): {msg}")
+            if cp.data and cp.data.strip():
+                lines.append(f"  data: `{_cap(cp.data, 2048)}`")
+        lines.append("")
 
     # Comments: cap at the most-recent _CTX_MAX_COMMENTS so
     # comment-storm tasks don't blow out the worker's prompt. Older

--- a/hermes_cli/roundtable_db.py
+++ b/hermes_cli/roundtable_db.py
@@ -454,6 +454,7 @@ def add_speech(
     content: str,
     *,
     reply_to: Optional[int] = None,
+    round_override: Optional[int] = None,
 ) -> Speech:
     """Record a speech and potentially advance the round.
 
@@ -465,6 +466,8 @@ def add_speech(
       current_round advances by 1.
     - If current_round exceeds max_rounds after advancing, the discussion
       is auto-concluded.
+    - round_override forces the speech into a specific round (e.g. 0 for
+      coordinator) and skips round-advancement checks for that speech.
     """
     disc = get_discussion(conn, discussion_id)
     if not disc:
@@ -474,6 +477,7 @@ def add_speech(
 
     now = int(time.time())
     current_round = disc.current_round
+    speech_round = round_override if round_override is not None else current_round
 
     # Validate reply_to if provided
     if reply_to is not None:
@@ -492,22 +496,27 @@ def add_speech(
             """INSERT INTO speeches
                (discussion_id, round, participant, content, reply_to, created_at)
                VALUES (?, ?, ?, ?, ?, ?)""",
-            (discussion_id, current_round, participant, content, reply_to, now),
+            (discussion_id, speech_round, participant, content, reply_to, now),
         )
         speech_id = cur.lastrowid
 
         # Check if round should advance:
-        # All active participants have spoken in the current round
+        # Only check for normal (non-overridden) speeches — overridden speeches
+        # (e.g. coordinator) don't participate in round progression.
         active_names = get_active_participant_names(conn, discussion_id)
-        speakers_this_round = conn.execute(
-            """SELECT DISTINCT participant FROM speeches
-               WHERE discussion_id = ? AND round = ?""",
-            (discussion_id, current_round),
-        ).fetchall()
-        spoke_names = {r["participant"] for r in speakers_this_round}
-
-        round_complete = all(name in spoke_names for name in active_names)
+        round_complete = False
         discussion_complete = False
+
+        if round_override is None:
+            # All active participants have spoken in the current round
+            speakers_this_round = conn.execute(
+                """SELECT DISTINCT participant FROM speeches
+                   WHERE discussion_id = ? AND round = ?""",
+                (discussion_id, current_round),
+            ).fetchall()
+            spoke_names = {r["participant"] for r in speakers_this_round}
+
+            round_complete = all(name in spoke_names for name in active_names)
 
         if round_complete and current_round >= 0:
             # Advance round (but not beyond max_rounds if auto-conclude)
@@ -553,7 +562,7 @@ def add_speech(
     return Speech(
         id=speech_id or 0,  # lastrowid is int for AUTOINCREMENT
         discussion_id=discussion_id,
-        round=current_round,
+        round=speech_round,
         participant=participant,
         content=content,
         reply_to=reply_to,

--- a/hermes_cli/roundtable_db.py
+++ b/hermes_cli/roundtable_db.py
@@ -1,0 +1,719 @@
+"""SQLite-backed Roundtable Discussion engine for multi-agent topic debates.
+
+Independent database at ``<hermes_home>/roundtable.db`` — deliberately separate
+from kanban.db to avoid schema pollution and transaction conflicts.
+
+Schema: discussions, participants, speeches, findings, convergence_history.
+WAL mode for concurrent-read friendliness.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import sqlite3
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+VALID_DISCUSSION_STATUSES = {"active", "concluded", "cancelled"}
+VALID_SPEECH_ORDERS = {"fixed", "random", "priority", "free"}
+VALID_FINDING_TYPES = {"consensus", "disagreement", "new_point"}
+
+INITIATION_ROUND = 0  # Round 0 = opening statement by coordinator
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Discussion:
+    id: str
+    topic: str
+    context: Optional[str]
+    status: str
+    max_rounds: int
+    current_round: int
+    speech_order: str
+    created_by: str
+    created_at: int
+    concluded_at: Optional[int]
+    conclusion: Optional[str]
+    convergence_score: Optional[float]
+    output_path: Optional[str]
+
+
+@dataclass
+class Participant:
+    discussion_id: str
+    participant: str
+    role: Optional[str]
+    perspective: Optional[str]
+    display_name: Optional[str]
+    joined_at: int
+    is_active: bool
+
+
+@dataclass
+class Speech:
+    id: int
+    discussion_id: str
+    round: int
+    participant: str
+    content: str
+    reply_to: Optional[int]
+    created_at: int
+
+
+@dataclass
+class Finding:
+    id: int
+    discussion_id: str
+    type: str
+    content: str
+    round: int
+    related_speeches: Optional[List[int]]
+
+
+@dataclass
+class ConvergenceRecord:
+    discussion_id: str
+    round: int
+    score: float
+    consensus_count: int
+    disagreement_count: int
+    new_point_count: int
+
+
+# ---------------------------------------------------------------------------
+# Schema SQL
+# ---------------------------------------------------------------------------
+
+SCHEMA_SQL = """\
+PRAGMA journal_mode=WAL;
+PRAGMA foreign_keys=ON;
+
+CREATE TABLE IF NOT EXISTS discussions (
+    id TEXT PRIMARY KEY,
+    topic TEXT NOT NULL,
+    context TEXT,
+    status TEXT DEFAULT 'active'
+        CHECK(status IN ('active', 'concluded', 'cancelled')),
+    max_rounds INTEGER DEFAULT 5,
+    current_round INTEGER DEFAULT 0,
+    speech_order TEXT DEFAULT 'fixed'
+        CHECK(speech_order IN ('fixed', 'random', 'priority', 'free')),
+    created_by TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    concluded_at INTEGER,
+    conclusion TEXT,
+    convergence_score REAL,
+    output_path TEXT
+);
+
+CREATE TABLE IF NOT EXISTS participants (
+    discussion_id TEXT NOT NULL,
+    participant TEXT NOT NULL,
+    role TEXT,
+    perspective TEXT,
+    display_name TEXT,
+    joined_at INTEGER NOT NULL,
+    is_active INTEGER DEFAULT 1,
+    PRIMARY KEY (discussion_id, participant),
+    FOREIGN KEY (discussion_id) REFERENCES discussions(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS speeches (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    discussion_id TEXT NOT NULL,
+    round INTEGER NOT NULL,
+    participant TEXT NOT NULL,
+    content TEXT NOT NULL,
+    reply_to INTEGER,
+    created_at INTEGER NOT NULL,
+    FOREIGN KEY (discussion_id) REFERENCES discussions(id) ON DELETE CASCADE,
+    FOREIGN KEY (reply_to) REFERENCES speeches(id)
+);
+
+CREATE TABLE IF NOT EXISTS findings (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    discussion_id TEXT NOT NULL,
+    type TEXT NOT NULL
+        CHECK(type IN ('consensus', 'disagreement', 'new_point')),
+    content TEXT NOT NULL,
+    round INTEGER NOT NULL,
+    related_speeches TEXT,
+    FOREIGN KEY (discussion_id) REFERENCES discussions(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS convergence_history (
+    discussion_id TEXT NOT NULL,
+    round INTEGER NOT NULL,
+    score REAL NOT NULL,
+    consensus_count INTEGER,
+    disagreement_count INTEGER,
+    new_point_count INTEGER,
+    PRIMARY KEY (discussion_id, round),
+    FOREIGN KEY (discussion_id) REFERENCES discussions(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_speeches_discussion
+    ON speeches(discussion_id, round);
+CREATE INDEX IF NOT EXISTS idx_speeches_participant
+    ON speeches(discussion_id, participant);
+CREATE INDEX IF NOT EXISTS idx_findings_discussion
+    ON findings(discussion_id, type);
+"""
+
+
+# ---------------------------------------------------------------------------
+# Connection helpers
+# ---------------------------------------------------------------------------
+
+_INITIALIZED_PATHS: set[str] = set()
+
+
+def _roundtable_db_path() -> Path:
+    """Resolve the roundtable DB path.
+
+    Resolution order:
+    1. ``HERMES_ROUNDTABLE_DB`` env var (explicit override)
+    2. ``<hermes_home>/roundtable.db`` (default)
+    """
+    env_path = os.environ.get("HERMES_ROUNDTABLE_DB")
+    if env_path:
+        return Path(env_path)
+    from hermes_constants import get_hermes_home
+    return get_hermes_home() / "roundtable.db"
+
+
+def connect(db_path: Optional[Path] = None) -> sqlite3.Connection:
+    """Open (and initialize if needed) the roundtable DB.
+
+    Auto-runs schema creation on first connection to a given path.
+    WAL mode + foreign keys enabled on every connection.
+    """
+    path = db_path or _roundtable_db_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    resolved = str(path.resolve())
+    needs_init = resolved not in _INITIALIZED_PATHS
+    conn = sqlite3.connect(str(path), isolation_level=None, timeout=30)
+    conn.row_factory = sqlite3.Row
+    from hermes_state import apply_wal_with_fallback
+    apply_wal_with_fallback(conn, db_label=f"roundtable.db ({path.name})")
+    conn.execute("PRAGMA synchronous=NORMAL")
+    conn.execute("PRAGMA foreign_keys=ON")
+    if needs_init:
+        conn.executescript(SCHEMA_SQL)
+        _INITIALIZED_PATHS.add(resolved)
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# ID generation
+# ---------------------------------------------------------------------------
+
+
+def _generate_discussion_id() -> str:
+    """Generate a discussion ID: ``rt_`` + 8 hex chars."""
+    return f"rt_{secrets.token_hex(4)}"
+
+
+# ---------------------------------------------------------------------------
+# CRUD: Discussions
+# ---------------------------------------------------------------------------
+
+
+def create_discussion(
+    conn: sqlite3.Connection,
+    topic: str,
+    participants: List[Dict[str, Any]],
+    *,
+    context: Optional[str] = None,
+    max_rounds: int = 5,
+    speech_order: str = "fixed",
+    created_by: str = "unknown",
+    output_path: Optional[str] = None,
+) -> Discussion:
+    """Create a new discussion and register participants.
+
+    Returns the newly created Discussion object.
+    """
+    if speech_order not in VALID_SPEECH_ORDERS:
+        raise ValueError(f"Invalid speech_order: {speech_order}")
+    if max_rounds < 1:
+        raise ValueError("max_rounds must be >= 1")
+    if not participants:
+        raise ValueError("At least one participant is required")
+
+    disc_id = _generate_discussion_id()
+    now = int(time.time())
+
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        conn.execute(
+            """INSERT INTO discussions
+               (id, topic, context, status, max_rounds, current_round,
+                speech_order, created_by, created_at, output_path)
+               VALUES (?, ?, ?, 'active', ?, 0, ?, ?, ?, ?)""",
+            (disc_id, topic, context, max_rounds, speech_order,
+             created_by, now, output_path),
+        )
+        for p in participants:
+            profile = p.get("profile", "").strip()
+            if not profile:
+                raise ValueError("Each participant must have a 'profile' field")
+            conn.execute(
+                """INSERT INTO participants
+                   (discussion_id, participant, role, perspective,
+                    display_name, joined_at, is_active)
+                   VALUES (?, ?, ?, ?, ?, ?, 1)""",
+                (
+                    disc_id,
+                    profile,
+                    p.get("role"),
+                    p.get("perspective"),
+                    p.get("display_name"),
+                    now,
+                ),
+            )
+        conn.execute("COMMIT")
+    except Exception:
+        conn.execute("ROLLBACK")
+        raise
+
+    return Discussion(
+        id=disc_id,
+        topic=topic,
+        context=context,
+        status="active",
+        max_rounds=max_rounds,
+        current_round=0,
+        speech_order=speech_order,
+        created_by=created_by,
+        created_at=now,
+        concluded_at=None,
+        conclusion=None,
+        convergence_score=None,
+        output_path=output_path,
+    )
+
+
+def get_discussion(
+    conn: sqlite3.Connection, discussion_id: str
+) -> Optional[Discussion]:
+    """Fetch a discussion by ID."""
+    row = conn.execute(
+        "SELECT * FROM discussions WHERE id = ?", (discussion_id,)
+    ).fetchone()
+    if not row:
+        return None
+    return Discussion(
+        id=row["id"],
+        topic=row["topic"],
+        context=row["context"],
+        status=row["status"],
+        max_rounds=row["max_rounds"],
+        current_round=row["current_round"],
+        speech_order=row["speech_order"],
+        created_by=row["created_by"],
+        created_at=row["created_at"],
+        concluded_at=row["concluded_at"],
+        conclusion=row["conclusion"],
+        convergence_score=row["convergence_score"],
+        output_path=row["output_path"],
+    )
+
+
+def list_discussions(
+    conn: sqlite3.Connection,
+    *,
+    status: Optional[str] = None,
+    limit: int = 50,
+) -> List[Discussion]:
+    """List discussions, optionally filtered by status."""
+    if status:
+        rows = conn.execute(
+            "SELECT * FROM discussions WHERE status = ? ORDER BY created_at DESC LIMIT ?",
+            (status, limit),
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            "SELECT * FROM discussions ORDER BY created_at DESC LIMIT ?",
+            (limit,),
+        ).fetchall()
+    return [
+        Discussion(
+            id=r["id"], topic=r["topic"], context=r["context"],
+            status=r["status"], max_rounds=r["max_rounds"],
+            current_round=r["current_round"], speech_order=r["speech_order"],
+            created_by=r["created_by"], created_at=r["created_at"],
+            concluded_at=r["concluded_at"], conclusion=r["conclusion"],
+            convergence_score=r["convergence_score"],
+            output_path=r["output_path"],
+        )
+        for r in rows
+    ]
+
+
+def conclude_discussion(
+    conn: sqlite3.Connection,
+    discussion_id: str,
+    *,
+    conclusion: Optional[str] = None,
+    convergence_score: Optional[float] = None,
+) -> bool:
+    """Mark a discussion as concluded.
+
+    Returns True if the status was actually changed.
+    """
+    now = int(time.time())
+    cur = conn.execute(
+        """UPDATE discussions
+           SET status = 'concluded', concluded_at = ?,
+               conclusion = COALESCE(?, conclusion),
+               convergence_score = COALESCE(?, convergence_score)
+           WHERE id = ? AND status = 'active'""",
+        (now, conclusion, convergence_score, discussion_id),
+    )
+    return cur.rowcount > 0
+
+
+def cancel_discussion(conn: sqlite3.Connection, discussion_id: str) -> bool:
+    """Cancel an active discussion.
+
+    Returns True if the status was actually changed.
+    """
+    now = int(time.time())
+    cur = conn.execute(
+        """UPDATE discussions
+           SET status = 'cancelled', concluded_at = ?
+           WHERE id = ? AND status = 'active'""",
+        (now, discussion_id),
+    )
+    return cur.rowcount > 0
+
+
+# ---------------------------------------------------------------------------
+# CRUD: Participants
+# ---------------------------------------------------------------------------
+
+
+def get_participants(
+    conn: sqlite3.Connection, discussion_id: str
+) -> List[Participant]:
+    """Get all participants for a discussion."""
+    rows = conn.execute(
+        """SELECT * FROM participants
+           WHERE discussion_id = ? ORDER BY joined_at""",
+        (discussion_id,),
+    ).fetchall()
+    return [
+        Participant(
+            discussion_id=r["discussion_id"],
+            participant=r["participant"],
+            role=r["role"],
+            perspective=r["perspective"],
+            display_name=r["display_name"],
+            joined_at=r["joined_at"],
+            is_active=bool(r["is_active"]),
+        )
+        for r in rows
+    ]
+
+
+def get_active_participant_names(
+    conn: sqlite3.Connection, discussion_id: str
+) -> List[str]:
+    """Get ordered list of active participant profile names."""
+    rows = conn.execute(
+        """SELECT participant FROM participants
+           WHERE discussion_id = ? AND is_active = 1
+           ORDER BY joined_at""",
+        (discussion_id,),
+    ).fetchall()
+    return [r["participant"] for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# CRUD: Speeches
+# ---------------------------------------------------------------------------
+
+
+def add_speech(
+    conn: sqlite3.Connection,
+    discussion_id: str,
+    participant: str,
+    content: str,
+    *,
+    reply_to: Optional[int] = None,
+) -> Speech:
+    """Record a speech and potentially advance the round.
+
+    Returns the created Speech with auto-assigned round.
+
+    Round logic:
+    - Round 0 = opening (anyone can speak in round 0)
+    - When all active participants have spoken in the current round,
+      current_round advances by 1.
+    - If current_round exceeds max_rounds after advancing, the discussion
+      is auto-concluded.
+    """
+    disc = get_discussion(conn, discussion_id)
+    if not disc:
+        raise ValueError(f"Discussion {discussion_id} not found")
+    if disc.status != "active":
+        raise ValueError(f"Discussion {discussion_id} is {disc.status}")
+
+    now = int(time.time())
+    current_round = disc.current_round
+
+    # Validate reply_to if provided
+    if reply_to is not None:
+        ref = conn.execute(
+            "SELECT id FROM speeches WHERE id = ? AND discussion_id = ?",
+            (reply_to, discussion_id),
+        ).fetchone()
+        if not ref:
+            raise ValueError(
+                f"reply_to speech {reply_to} not found in discussion {discussion_id}"
+            )
+
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        cur = conn.execute(
+            """INSERT INTO speeches
+               (discussion_id, round, participant, content, reply_to, created_at)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (discussion_id, current_round, participant, content, reply_to, now),
+        )
+        speech_id = cur.lastrowid
+
+        # Check if round should advance:
+        # All active participants have spoken in the current round
+        active_names = get_active_participant_names(conn, discussion_id)
+        speakers_this_round = conn.execute(
+            """SELECT DISTINCT participant FROM speeches
+               WHERE discussion_id = ? AND round = ?""",
+            (discussion_id, current_round),
+        ).fetchall()
+        spoke_names = {r["participant"] for r in speakers_this_round}
+
+        round_complete = all(name in spoke_names for name in active_names)
+        discussion_complete = False
+
+        if round_complete and current_round >= 0:
+            # Advance round (but not beyond max_rounds if auto-conclude)
+            new_round = current_round + 1
+            conn.execute(
+                "UPDATE discussions SET current_round = ? WHERE id = ?",
+                (new_round, discussion_id),
+            )
+            # Auto-conclude if exceeded max_rounds (round 0 doesn't count)
+            if new_round > disc.max_rounds:
+                conn.execute(
+                    """UPDATE discussions
+                       SET status = 'concluded', concluded_at = ?
+                       WHERE id = ? AND status = 'active'""",
+                    (now, discussion_id),
+                )
+                discussion_complete = True
+
+        # Determine next speaker
+        next_speaker = None
+        if not discussion_complete and active_names:
+            if disc.speech_order == "fixed":
+                # Next in the participant list who hasn't spoken in new round
+                target_round = disc.current_round
+                if round_complete:
+                    target_round = disc.current_round  # already advanced
+                speakers_next = conn.execute(
+                    """SELECT DISTINCT participant FROM speeches
+                       WHERE discussion_id = ? AND round = ?""",
+                    (discussion_id, target_round),
+                ).fetchall()
+                spoke_next = {r["participant"] for r in speakers_next}
+                for name in active_names:
+                    if name not in spoke_next:
+                        next_speaker = name
+                        break
+
+        conn.execute("COMMIT")
+    except Exception:
+        conn.execute("ROLLBACK")
+        raise
+
+    return Speech(
+        id=speech_id or 0,  # lastrowid is int for AUTOINCREMENT
+        discussion_id=discussion_id,
+        round=current_round,
+        participant=participant,
+        content=content,
+        reply_to=reply_to,
+        created_at=now,
+    )
+
+
+def get_speeches(
+    conn: sqlite3.Connection,
+    discussion_id: str,
+    *,
+    since_round: Optional[int] = None,
+    participant: Optional[str] = None,
+) -> List[Speech]:
+    """Read speeches for a discussion with optional filters."""
+    query = "SELECT * FROM speeches WHERE discussion_id = ?"
+    params: list = [discussion_id]
+
+    if since_round is not None:
+        query += " AND round >= ?"
+        params.append(since_round)
+    if participant:
+        query += " AND participant = ?"
+        params.append(participant)
+
+    query += " ORDER BY id ASC"
+    rows = conn.execute(query, params).fetchall()
+
+    return [
+        Speech(
+            id=r["id"],
+            discussion_id=r["discussion_id"],
+            round=r["round"],
+            participant=r["participant"],
+            content=r["content"],
+            reply_to=r["reply_to"],
+            created_at=r["created_at"],
+        )
+        for r in rows
+    ]
+
+
+def get_speech_count(
+    conn: sqlite3.Connection, discussion_id: str
+) -> int:
+    """Count total speeches in a discussion."""
+    row = conn.execute(
+        "SELECT COUNT(*) as cnt FROM speeches WHERE discussion_id = ?",
+        (discussion_id,),
+    ).fetchone()
+    return row["cnt"] if row else 0
+
+
+# ---------------------------------------------------------------------------
+# CRUD: Findings
+# ---------------------------------------------------------------------------
+
+
+def add_finding(
+    conn: sqlite3.Connection,
+    discussion_id: str,
+    finding_type: str,
+    content: str,
+    round_num: int,
+    related_speeches: Optional[List[int]] = None,
+) -> int:
+    """Record a finding (consensus, disagreement, new_point).
+
+    Returns the finding ID.
+    """
+    if finding_type not in VALID_FINDING_TYPES:
+        raise ValueError(f"Invalid finding type: {finding_type}")
+
+    rs_json = json.dumps(related_speeches) if related_speeches else None
+    cur = conn.execute(
+        """INSERT INTO findings
+           (discussion_id, type, content, round, related_speeches)
+           VALUES (?, ?, ?, ?, ?)""",
+        (discussion_id, finding_type, content, round_num, rs_json),
+    )
+    return cur.lastrowid or 0
+
+
+def get_findings(
+    conn: sqlite3.Connection,
+    discussion_id: str,
+    *,
+    finding_type: Optional[str] = None,
+) -> List[Finding]:
+    """Get findings for a discussion, optionally filtered by type."""
+    if finding_type:
+        rows = conn.execute(
+            """SELECT * FROM findings
+               WHERE discussion_id = ? AND type = ?
+               ORDER BY id ASC""",
+            (discussion_id, finding_type),
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            "SELECT * FROM findings WHERE discussion_id = ? ORDER BY id ASC",
+            (discussion_id,),
+        ).fetchall()
+
+    return [
+        Finding(
+            id=r["id"],
+            discussion_id=r["discussion_id"],
+            type=r["type"],
+            content=r["content"],
+            round=r["round"],
+            related_speeches=json.loads(r["related_speeches"])
+            if r["related_speeches"]
+            else None,
+        )
+        for r in rows
+    ]
+
+
+# ---------------------------------------------------------------------------
+# CRUD: Convergence
+# ---------------------------------------------------------------------------
+
+
+def record_convergence(
+    conn: sqlite3.Connection,
+    discussion_id: str,
+    round_num: int,
+    score: float,
+    consensus_count: int,
+    disagreement_count: int,
+    new_point_count: int,
+) -> None:
+    """Record convergence metrics for a round."""
+    conn.execute(
+        """INSERT OR REPLACE INTO convergence_history
+           (discussion_id, round, score, consensus_count,
+            disagreement_count, new_point_count)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+        (discussion_id, round_num, score, consensus_count,
+         disagreement_count, new_point_count),
+    )
+
+
+def get_convergence_history(
+    conn: sqlite3.Connection, discussion_id: str
+) -> List[ConvergenceRecord]:
+    """Get convergence history for a discussion."""
+    rows = conn.execute(
+        """SELECT * FROM convergence_history
+           WHERE discussion_id = ? ORDER BY round ASC""",
+        (discussion_id,),
+    ).fetchall()
+    return [
+        ConvergenceRecord(
+            discussion_id=r["discussion_id"],
+            round=r["round"],
+            score=r["score"],
+            consensus_count=r["consensus_count"],
+            disagreement_count=r["disagreement_count"],
+            new_point_count=r["new_point_count"],
+        )
+        for r in rows
+    ]

--- a/skills/software-development/roundtable/README.md
+++ b/skills/software-development/roundtable/README.md
@@ -1,0 +1,87 @@
+# Roundtable Discussion
+
+Multi-agent roundtable discussion system for Hermes Agent. Enable multiple AI agents to participate in structured, multi-round discussions with convergence detection and conclusion generation.
+
+## Quick Start
+
+```python
+# 1. Create a discussion
+roundtable_init(
+    topic="Database selection: PostgreSQL vs MySQL",
+    participants=[
+        {"profile": "bingge", "role": "Product Director", "perspective": "Focus on UX"},
+        {"profile": "mafei", "role": "Tech Lead", "perspective": "Focus on feasibility"},
+    ],
+    max_rounds=3
+)
+
+# 2. Coordinator speaks first (Round 0)
+roundtable_speak(discussion_id="rt_xxxxxxxx", participant="coordinator", content="...")
+
+# 3. Participants take turns
+roundtable_speak(discussion_id="rt_xxxxxxxx", participant="bingge", content="...")
+
+# 4. Check convergence
+roundtable_status(discussion_id="rt_xxxxxxxx")
+
+# 5. Generate conclusion data
+roundtable_summarize(discussion_id="rt_xxxxxxxx")
+
+# 6. End discussion
+roundtable_end(discussion_id="rt_xxxxxxxx")
+```
+
+## Architecture
+
+```
+src/
+├── hermes_cli/
+│   └── roundtable_db.py      # SQLite data layer (5 tables)
+├── tools/
+│   └── roundtable_tools.py   # Tool handlers (7 tools)
+├── skills/
+│   └── SKILL.md              # Coordinator flow + participant template
+└── toolsets.py               # Toolset registration
+
+tests/
+├── hermes_cli/
+│   └── test_roundtable_db.py  # DB layer tests (28 tests)
+└── tools/
+    └── test_roundtable_tools.py  # Tool layer tests (16 tests)
+```
+
+## Tools
+
+| Tool | Purpose |
+|------|---------|
+| `roundtable_init` | Create discussion with topic + participants |
+| `roundtable_speak` | Record participant speech (auto-advances rounds) |
+| `roundtable_read` | Read discussion history (full or since round N) |
+| `roundtable_status` | Check status + convergence metrics |
+| `roundtable_summarize` | Get structured data for conclusion document |
+| `roundtable_end` | Conclude or force-cancel a discussion |
+| `roundtable_list` | List all discussions with optional status filter |
+
+## Data Model
+
+- **discussions** — Topic, status, round tracking, speech order
+- **participants** — Registered profiles with roles and perspectives
+- **speeches** — Multi-round speeches with reply-to support
+- **findings** — Consensus/disagreement/new_point categorization
+- **convergence_history** — Per-round convergence scoring
+
+## Configuration
+
+- **Database**: `~/.hermes/roundtable.db` (override with `HERMES_ROUNDTABLE_DB`)
+- **Toolset**: Enable `roundtable` in profile config or pass `enabled_toolsets: ["roundtable"]`
+
+## Testing
+
+```bash
+cd roundtable
+python -m pytest tests/ -v
+```
+
+## License
+
+Part of [Hermes Agent](https://github.com/ParsifalC/hermes-agent).

--- a/skills/software-development/roundtable/SKILL.md
+++ b/skills/software-development/roundtable/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: roundtable
+description: "Multi-agent roundtable discussion — topic-driven multi-round debate with convergence detection and conclusion generation"
+version: 1.0.0
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [discussion, multi-agent, collaboration, debate, roundtable]
+    related_skills: [kanban-worker, kanban-orchestrator]
+---
+
+# Roundtable Discussion Skill
+
+## Overview
+
+Enable multiple agents to participate in structured, multi-round discussions
+around a topic. Each participant brings their unique role perspective, and the
+system tracks convergence toward consensus.
+
+**Core value**: Turn "one agent working alone" into "a team having a meeting."
+
+## When to Use
+
+- **Tech design review**: product, frontend, backend, architect debate approach
+- **Competitive analysis**: product, marketing, design compare alternatives
+- **Bug root cause analysis**: backend, ops, test triangulate the issue
+- **Product requirements**: product, design, dev align on scope
+- **Architecture decisions**: architect, backend, frontend, devops choose stack
+
+## Prerequisites
+
+Enable the `roundtable` toolset in the profile config:
+
+```yaml
+toolsets:
+  - roundtable
+```
+
+Or pass `enabled_toolsets: ["roundtable"]` when spawning an agent.
+
+## Tools
+
+| Tool | Purpose |
+|------|---------|
+| `roundtable_init` | Create a discussion with topic + participants |
+| `roundtable_speak` | Record a participant's speech |
+| `roundtable_read` | Read discussion history |
+| `roundtable_status` | Check status + convergence metrics |
+| `roundtable_summarize` | Get structured data for conclusion doc |
+| `roundtable_end` | Conclude or cancel a discussion |
+| `roundtable_list` | List all discussions |
+
+## Coordinator Flow
+
+The coordinator (initiator) drives the discussion by orchestrating participants.
+
+### Step 1: Create the Discussion
+
+```
+roundtable_init(
+    topic="Database selection: PostgreSQL vs MySQL vs TiDB",
+    context="Our e-commerce system needs high-concurrency read/write, 1TB+ data",
+    participants=[
+        {"profile": "bingge", "role": "Product Director", "perspective": "Focus on UX", "display_name": "Bing"},
+        {"profile": "mafei", "role": "Tech Lead", "perspective": "Focus on feasibility", "display_name": "Fei"},
+        {"profile": "xiaosu", "role": "Designer", "perspective": "Focus on data display", "display_name": "Su"},
+    ],
+    max_rounds=3,
+    speech_order="fixed"
+)
+→ returns {discussion_id, ...}
+```
+
+### Step 2: Opening Statement (Round 0)
+
+```
+roundtable_speak(
+    discussion_id="rt_xxxxxxxx",
+    participant="coordinator",
+    content="Today we're discussing database selection..."
+)
+```
+
+### Step 3: Multi-Round Discussion
+
+For each round, read history then delegate to each participant:
+
+```
+# Read current state
+history = roundtable_read(discussion_id="rt_xxxxxxxx")
+
+# For each participant, delegate a sub-agent
+delegate_task(
+    goal="Participate in roundtable discussion as [ROLE]",
+    context="You are participating in a roundtable discussion.\n\n"
+            "Topic: {topic}\n"
+            "Your role: {role}\n"
+            "Your perspective: {perspective}\n\n"
+            "Discussion history:\n{formatted_history}\n\n"
+            "Please share your观点 using roundtable_speak. "
+            "Keep it 200-500 words. Reference others' points if relevant."
+)
+```
+
+### Step 4: Check Convergence
+
+After each round:
+```
+roundtable_status(discussion_id="rt_xxxxxxxx")
+→ check convergence_score, consensus_points, disagreement_points
+```
+
+### Step 5: Generate Conclusion
+
+```
+summary = roundtable_summarize(discussion_id="rt_xxxxxxxx")
+→ Use the structured data to write a Markdown conclusion document
+→ Save to the output_path specified during init
+```
+
+### Step 6: End Discussion
+
+```
+roundtable_end(discussion_id="rt_xxxxxxxx")
+```
+
+## Participant Prompt Template
+
+When delegating to a participant sub-agent, use this template:
+
+```
+You are participating in a roundtable discussion.
+
+## Discussion Info
+- Topic: {topic}
+- Context: {context}
+- Current Round: Round {current_round} / {max_rounds}
+- Your Role: {role} ({display_name})
+- Your Perspective: {perspective}
+
+## Discussion History
+{formatted_history}
+
+## Your Task
+From your role's perspective, share your观点 on this topic.
+- You may引用 or respond to other participants' statements
+- Keep it concise and powerful, 200-500 words
+- If you agree with a point, explicitly state your agreement
+- If you disagree, explain why and propose alternatives
+
+After speaking, call roundtable_speak to record your statement.
+```
+
+## Convergence Detection
+
+Each round is evaluated for convergence:
+
+| Metric | Formula | Meaning |
+|--------|---------|---------|
+| Consensus | Points multiple participants agree on | Alignment |
+| Disagreement | Points participants disagree on | Conflict |
+| New Point | New topics raised this round | Scope expansion |
+| Score | consensus / (consensus + disagreement) | Overall alignment |
+
+**Termination conditions:**
+- Convergence score > 0.8 → high consensus, wrap up
+- Max rounds reached → prevent infinite discussion
+- Coordinator manually ends → emergency stop
+- All participants vote to end → democratic close
+
+## Conclusion Document Format
+
+```markdown
+# Roundtable Conclusion: [Topic]
+
+## Summary
+- Participants: Product(Bing), Design(Su), Dev(Fei)
+- Rounds: 3
+- Date: 2026-05-20
+
+## Consensus Points
+1. [Point 1]
+2. [Point 2]
+
+## Disagreement Points
+1. [Point 1] - Various perspectives
+
+## Action Items
+1. [ ] [Action 1] - Owner: xxx
+2. [ ] [Action 2] - Owner: xxx
+
+## Detailed Transcript
+### Round 1
+- **Product(Bing)**: ...
+- **Design(Su)**: ...
+- **Dev(Fei)**: ...
+
+### Round 2
+...
+```
+
+## Data Storage
+
+- **Database**: `~/.hermes/roundtable.db` (independent from kanban.db)
+- **Conclusion docs**: Configurable via `output_path`, defaults to project docs dir
+- **ID format**: `rt_` + 8 hex chars (e.g., `rt_a1b2c3d4`)
+
+## Integration with Kanban
+
+Discussions can be linked to kanban tasks:
+
+```
+# After conclusion, add as task comment
+kanban_comment(task_id="t_xxx", body="Roundtable conclusion: {conclusion_path}")
+```
+
+## Pitfalls
+
+1. **At least 2 participants required** — A discussion needs multiple viewpoints
+2. **Participant must be registered** — Only profiles listed in `participants` can speak
+3. **Round 0 is opening** — Coordinator speaks first, then round 1 begins
+4. **Auto-conclude on max_rounds** — Discussion ends automatically when max rounds exceeded
+5. **Independent database** — roundtable.db is separate from kanban.db; don't mix paths
+6. **No LLM in summarize** — `roundtable_summarize` returns raw data; the coordinator agent writes the conclusion

--- a/tests/hermes_cli/test_roundtable_db.py
+++ b/tests/hermes_cli/test_roundtable_db.py
@@ -1,0 +1,359 @@
+"""Tests for the Roundtable DB layer (hermes_cli.roundtable_db)."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import roundtable_db as rdb
+
+
+@pytest.fixture
+def roundtable_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with a fresh roundtable DB."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_ROUNDTABLE_DB", str(home / "roundtable.db"))
+    # Clear the init cache so each test starts fresh
+    rdb._INITIALIZED_PATHS.clear()
+    return home
+
+
+@pytest.fixture
+def db_conn(roundtable_home):
+    """A connected roundtable DB."""
+    conn = rdb.connect()
+    yield conn
+    conn.close()
+
+
+PARTICIPANTS = [
+    {"profile": "alice", "role": "Engineer", "perspective": "Technical", "display_name": "Alice"},
+    {"profile": "bob", "role": "Designer", "perspective": "UX", "display_name": "Bob"},
+    {"profile": "carol", "role": "PM", "perspective": "Business", "display_name": "Carol"},
+]
+
+
+# ---------------------------------------------------------------------------
+# Schema / init
+# ---------------------------------------------------------------------------
+
+
+def test_connect_creates_tables(db_conn):
+    rows = db_conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+    ).fetchall()
+    names = {r["name"] for r in rows}
+    assert {"discussions", "participants", "speeches", "findings", "convergence_history"} <= names
+
+
+def test_connect_is_idempotent(db_conn):
+    # Insert data
+    rdb.create_discussion(db_conn, topic="test", participants=PARTICIPANTS)
+    # Reconnect
+    rdb._INITIALIZED_PATHS.clear()
+    conn2 = rdb.connect()
+    try:
+        discs = rdb.list_discussions(conn2)
+        assert len(discs) == 1
+    finally:
+        conn2.close()
+
+
+# ---------------------------------------------------------------------------
+# Discussion CRUD
+# ---------------------------------------------------------------------------
+
+
+def test_create_discussion(db_conn):
+    disc = rdb.create_discussion(
+        db_conn,
+        topic="Database selection",
+        participants=PARTICIPANTS,
+        context="We need a new DB",
+        max_rounds=3,
+        created_by="coordinator",
+    )
+    assert disc.id.startswith("rt_")
+    assert len(disc.id) == 11  # rt_ + 8 hex
+    assert disc.topic == "Database selection"
+    assert disc.context == "We need a new DB"
+    assert disc.status == "active"
+    assert disc.max_rounds == 3
+    assert disc.current_round == 0
+    assert disc.speech_order == "fixed"
+
+
+def test_create_discussion_registers_participants(db_conn):
+    disc = rdb.create_discussion(
+        db_conn, topic="test", participants=PARTICIPANTS
+    )
+    parts = rdb.get_participants(db_conn, disc.id)
+    assert len(parts) == 3
+    assert parts[0].participant == "alice"
+    assert parts[0].role == "Engineer"
+    assert parts[0].display_name == "Alice"
+    assert parts[0].is_active is True
+
+
+def test_create_discussion_validates_speech_order(db_conn):
+    with pytest.raises(ValueError, match="Invalid speech_order"):
+        rdb.create_discussion(
+            db_conn, topic="test", participants=PARTICIPANTS,
+            speech_order="invalid"
+        )
+
+
+def test_create_discussion_requires_participants(db_conn):
+    with pytest.raises(ValueError, match="At least one participant"):
+        rdb.create_discussion(db_conn, topic="test", participants=[])
+
+
+def test_create_discussion_validates_max_rounds(db_conn):
+    with pytest.raises(ValueError, match="max_rounds"):
+        rdb.create_discussion(
+            db_conn, topic="test", participants=PARTICIPANTS, max_rounds=0
+        )
+
+
+def test_get_discussion(db_conn):
+    disc = rdb.create_discussion(db_conn, topic="test", participants=PARTICIPANTS)
+    fetched = rdb.get_discussion(db_conn, disc.id)
+    assert fetched is not None
+    assert fetched.id == disc.id
+    assert fetched.topic == "test"
+
+
+def test_get_discussion_not_found(db_conn):
+    assert rdb.get_discussion(db_conn, "rt_nonexistent") is None
+
+
+def test_list_discussions(db_conn):
+    for i in range(3):
+        rdb.create_discussion(
+            db_conn, topic=f"topic {i}", participants=PARTICIPANTS
+        )
+    discs = rdb.list_discussions(db_conn)
+    assert len(discs) == 3
+
+
+def test_list_discussions_filter_status(db_conn):
+    disc = rdb.create_discussion(db_conn, topic="test", participants=PARTICIPANTS)
+    rdb.create_discussion(db_conn, topic="test2", participants=PARTICIPANTS)
+    rdb.conclude_discussion(db_conn, disc.id)
+
+    active = rdb.list_discussions(db_conn, status="active")
+    concluded = rdb.list_discussions(db_conn, status="concluded")
+    assert len(active) == 1
+    assert len(concluded) == 1
+
+
+def test_conclude_discussion(db_conn):
+    disc = rdb.create_discussion(db_conn, topic="test", participants=PARTICIPANTS)
+    ok = rdb.conclude_discussion(
+        db_conn, disc.id, conclusion="We chose PostgreSQL", convergence_score=0.9
+    )
+    assert ok is True
+    fetched = rdb.get_discussion(db_conn, disc.id)
+    assert fetched.status == "concluded"
+    assert fetched.conclusion == "We chose PostgreSQL"
+    assert fetched.convergence_score == 0.9
+    assert fetched.concluded_at is not None
+
+
+def test_conclude_already_concluded(db_conn):
+    disc = rdb.create_discussion(db_conn, topic="test", participants=PARTICIPANTS)
+    rdb.conclude_discussion(db_conn, disc.id)
+    ok = rdb.conclude_discussion(db_conn, disc.id)
+    assert ok is False
+
+
+def test_cancel_discussion(db_conn):
+    disc = rdb.create_discussion(db_conn, topic="test", participants=PARTICIPANTS)
+    ok = rdb.cancel_discussion(db_conn, disc.id)
+    assert ok is True
+    fetched = rdb.get_discussion(db_conn, disc.id)
+    assert fetched.status == "cancelled"
+
+
+# ---------------------------------------------------------------------------
+# Participants
+# ---------------------------------------------------------------------------
+
+
+def test_get_active_participant_names(db_conn):
+    disc = rdb.create_discussion(db_conn, topic="test", participants=PARTICIPANTS)
+    names = rdb.get_active_participant_names(db_conn, disc.id)
+    assert names == ["alice", "bob", "carol"]
+
+
+# ---------------------------------------------------------------------------
+# Speeches
+# ---------------------------------------------------------------------------
+
+
+def test_add_speech_in_round_0(db_conn):
+    disc = rdb.create_discussion(db_conn, topic="test", participants=PARTICIPANTS)
+    speech = rdb.add_speech(db_conn, disc.id, "alice", "Hello everyone!")
+    assert speech.id > 0
+    assert speech.round == 0
+    assert speech.participant == "alice"
+    assert speech.content == "Hello everyone!"
+
+
+def test_speech_round_advances_when_all_spoke(db_conn):
+    disc = rdb.create_discussion(db_conn, topic="test", participants=PARTICIPANTS)
+
+    # Round 0: all 3 speak
+    rdb.add_speech(db_conn, disc.id, "alice", "Alice's opening")
+    rdb.add_speech(db_conn, disc.id, "bob", "Bob's opening")
+    rdb.add_speech(db_conn, disc.id, "carol", "Carol's opening")
+
+    # Check round advanced
+    fetched = rdb.get_discussion(db_conn, disc.id)
+    assert fetched.current_round == 1
+
+    # Round 1
+    rdb.add_speech(db_conn, disc.id, "alice", "Round 1 from Alice")
+    fetched = rdb.get_discussion(db_conn, disc.id)
+    assert fetched.current_round == 1  # Still round 1 until all spoke
+
+
+def test_speech_auto_conclude_on_max_rounds(db_conn):
+    disc = rdb.create_discussion(
+        db_conn, topic="test", participants=PARTICIPANTS, max_rounds=1
+    )
+
+    # Round 0
+    rdb.add_speech(db_conn, disc.id, "alice", "s1")
+    rdb.add_speech(db_conn, disc.id, "bob", "s2")
+    rdb.add_speech(db_conn, disc.id, "carol", "s3")
+
+    # After round 0 completes, round advances to 1
+    fetched = rdb.get_discussion(db_conn, disc.id)
+    assert fetched.current_round == 1
+
+    # Round 1 (max_rounds=1)
+    rdb.add_speech(db_conn, disc.id, "alice", "r1s1")
+    rdb.add_speech(db_conn, disc.id, "bob", "r1s2")
+    rdb.add_speech(db_conn, disc.id, "carol", "r1s3")
+
+    # Should auto-conclude
+    fetched = rdb.get_discussion(db_conn, disc.id)
+    assert fetched.status == "concluded"
+
+
+def test_speech_with_reply_to(db_conn):
+    disc = rdb.create_discussion(db_conn, topic="test", participants=PARTICIPANTS)
+    s1 = rdb.add_speech(db_conn, disc.id, "alice", "Original point")
+    s2 = rdb.add_speech(db_conn, disc.id, "bob", "Responding", reply_to=s1.id)
+    assert s2.reply_to == s1.id
+
+
+def test_speech_reply_to_invalid(db_conn):
+    disc = rdb.create_discussion(db_conn, topic="test", participants=PARTICIPANTS)
+    with pytest.raises(ValueError, match="reply_to speech"):
+        rdb.add_speech(db_conn, disc.id, "alice", "test", reply_to=999)
+
+
+def test_speech_on_concluded_discussion(db_conn):
+    disc = rdb.create_discussion(db_conn, topic="test", participants=PARTICIPANTS)
+    rdb.conclude_discussion(db_conn, disc.id)
+    with pytest.raises(ValueError, match="concluded"):
+        rdb.add_speech(db_conn, disc.id, "alice", "Too late")
+
+
+def test_get_speeches(db_conn):
+    disc = rdb.create_discussion(db_conn, topic="test", participants=PARTICIPANTS)
+    rdb.add_speech(db_conn, disc.id, "alice", "s1")
+    rdb.add_speech(db_conn, disc.id, "bob", "s2")
+    rdb.add_speech(db_conn, disc.id, "carol", "s3")  # completes round 0
+    rdb.add_speech(db_conn, disc.id, "alice", "r1s1")
+
+    all_speeches = rdb.get_speeches(db_conn, disc.id)
+    assert len(all_speeches) == 4
+
+    round0 = rdb.get_speeches(db_conn, disc.id, since_round=0)
+    assert len(round0) == 4
+
+    round1 = rdb.get_speeches(db_conn, disc.id, since_round=1)
+    assert len(round1) == 1
+
+    alice_only = rdb.get_speeches(db_conn, disc.id, participant="alice")
+    assert len(alice_only) == 2
+
+
+def test_get_speech_count(db_conn):
+    disc = rdb.create_discussion(db_conn, topic="test", participants=PARTICIPANTS)
+    rdb.add_speech(db_conn, disc.id, "alice", "s1")
+    rdb.add_speech(db_conn, disc.id, "bob", "s2")
+    assert rdb.get_speech_count(db_conn, disc.id) == 2
+
+
+# ---------------------------------------------------------------------------
+# Findings
+# ---------------------------------------------------------------------------
+
+
+def test_add_finding(db_conn):
+    disc = rdb.create_discussion(db_conn, topic="test", participants=PARTICIPANTS)
+    fid = rdb.add_finding(
+        db_conn, disc.id, "consensus", "We all agree on X", 1, [1, 2]
+    )
+    assert fid > 0
+
+    findings = rdb.get_findings(db_conn, disc.id)
+    assert len(findings) == 1
+    assert findings[0].type == "consensus"
+    assert findings[0].content == "We all agree on X"
+    assert findings[0].related_speeches == [1, 2]
+
+
+def test_add_finding_invalid_type(db_conn):
+    disc = rdb.create_discussion(db_conn, topic="test", participants=PARTICIPANTS)
+    with pytest.raises(ValueError, match="Invalid finding type"):
+        rdb.add_finding(db_conn, disc.id, "invalid", "test", 1)
+
+
+def test_get_findings_filter_type(db_conn):
+    disc = rdb.create_discussion(db_conn, topic="test", participants=PARTICIPANTS)
+    rdb.add_finding(db_conn, disc.id, "consensus", "agree", 1)
+    rdb.add_finding(db_conn, disc.id, "disagreement", "disagree", 1)
+    rdb.add_finding(db_conn, disc.id, "new_point", "new idea", 1)
+
+    consensus = rdb.get_findings(db_conn, disc.id, finding_type="consensus")
+    assert len(consensus) == 1
+    all_findings = rdb.get_findings(db_conn, disc.id)
+    assert len(all_findings) == 3
+
+
+# ---------------------------------------------------------------------------
+# Convergence
+# ---------------------------------------------------------------------------
+
+
+def test_record_and_get_convergence(db_conn):
+    disc = rdb.create_discussion(db_conn, topic="test", participants=PARTICIPANTS)
+    rdb.record_convergence(db_conn, disc.id, 1, 0.67, 2, 1, 1)
+    rdb.record_convergence(db_conn, disc.id, 2, 0.85, 3, 0, 0)
+
+    history = rdb.get_convergence_history(db_conn, disc.id)
+    assert len(history) == 2
+    assert history[0].round == 1
+    assert history[0].score == 0.67
+    assert history[1].round == 2
+    assert history[1].score == 0.85
+
+
+def test_convergence_upsert(db_conn):
+    disc = rdb.create_discussion(db_conn, topic="test", participants=PARTICIPANTS)
+    rdb.record_convergence(db_conn, disc.id, 1, 0.5, 1, 1, 0)
+    rdb.record_convergence(db_conn, disc.id, 1, 0.8, 2, 0, 0)  # same round, should replace
+
+    history = rdb.get_convergence_history(db_conn, disc.id)
+    assert len(history) == 1
+    assert history[0].score == 0.8

--- a/tests/tools/test_roundtable_tools.py
+++ b/tests/tools/test_roundtable_tools.py
@@ -1,0 +1,336 @@
+"""Tests for the Roundtable tools (tools.roundtable_tools)."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import roundtable_db as rdb
+
+
+@pytest.fixture
+def roundtable_env(tmp_path, monkeypatch):
+    """Isolated environment for roundtable tool tests."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_ROUNDTABLE_DB", str(home / "roundtable.db"))
+    rdb._INITIALIZED_PATHS.clear()
+    return home
+
+
+@pytest.fixture
+def db_conn(roundtable_env):
+    """A connected roundtable DB."""
+    conn = rdb.connect()
+    yield conn
+    conn.close()
+
+
+def _make_participants():
+    return [
+        {"profile": "alice", "role": "Engineer", "perspective": "Technical", "display_name": "Alice"},
+        {"profile": "bob", "role": "Designer", "perspective": "UX", "display_name": "Bob"},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Import tests (tool registration)
+# ---------------------------------------------------------------------------
+
+
+def test_tools_module_imports():
+    """Verify the roundtable tools module imports cleanly."""
+    from tools import roundtable_tools
+    assert roundtable_tools is not None
+
+
+def test_tool_schemas_are_valid():
+    """Verify all 7 tool schemas have required fields."""
+    from tools.roundtable_tools import (
+        ROUNDTABLE_INIT_SCHEMA,
+        ROUNDTABLE_SPEAK_SCHEMA,
+        ROUNDTABLE_READ_SCHEMA,
+        ROUNDTABLE_STATUS_SCHEMA,
+        ROUNDTABLE_SUMMARIZE_SCHEMA,
+        ROUNDTABLE_END_SCHEMA,
+        ROUNDTABLE_LIST_SCHEMA,
+    )
+    schemas = [
+        ROUNDTABLE_INIT_SCHEMA, ROUNDTABLE_SPEAK_SCHEMA,
+        ROUNDTABLE_READ_SCHEMA, ROUNDTABLE_STATUS_SCHEMA,
+        ROUNDTABLE_SUMMARIZE_SCHEMA, ROUNDTABLE_END_SCHEMA,
+        ROUNDTABLE_LIST_SCHEMA,
+    ]
+    for s in schemas:
+        assert "name" in s
+        assert "description" in s
+        assert "parameters" in s
+        assert s["parameters"]["type"] == "object"
+
+
+# ---------------------------------------------------------------------------
+# Handler tests: roundtable_init
+# ---------------------------------------------------------------------------
+
+
+def test_handler_init_success(roundtable_env):
+    from tools.roundtable_tools import _handle_init
+    result = _handle_init({
+        "topic": "Test topic",
+        "participants": _make_participants(),
+        "context": "Some context",
+        "max_rounds": 3,
+    })
+    data = json.loads(result)
+    assert data["ok"] is True
+    assert data["discussion_id"].startswith("rt_")
+    assert data["topic"] == "Test topic"
+    assert data["participants"] == ["alice", "bob"]
+    assert data["max_rounds"] == 3
+
+
+def test_handler_init_missing_topic(roundtable_env):
+    from tools.roundtable_tools import _handle_init
+    result = _handle_init({"participants": _make_participants()})
+    data = json.loads(result)
+    assert "error" in data
+    assert "topic" in data["error"].lower()
+
+
+def test_handler_init_too_few_participants(roundtable_env):
+    from tools.roundtable_tools import _handle_init
+    result = _handle_init({
+        "topic": "Test",
+        "participants": [{"profile": "alice"}],
+    })
+    data = json.loads(result)
+    assert "error" in data
+    assert "2 participants" in data["error"]
+
+
+# ---------------------------------------------------------------------------
+# Handler tests: roundtable_speak
+# ---------------------------------------------------------------------------
+
+
+def test_handler_speak_success(roundtable_env):
+    from tools.roundtable_tools import _handle_init, _handle_speak
+    init_result = _handle_init({
+        "topic": "Test",
+        "participants": _make_participants(),
+    })
+    disc_id = json.loads(init_result)["discussion_id"]
+
+    result = _handle_speak({
+        "discussion_id": disc_id,
+        "participant": "alice",
+        "content": "Hello!",
+    })
+    data = json.loads(result)
+    assert data["ok"] is True
+    assert data["speech_id"] > 0
+    assert data["round"] == 0
+    assert data["participant"] == "alice"
+
+
+def test_handler_speak_unknown_participant(roundtable_env):
+    from tools.roundtable_tools import _handle_init, _handle_speak
+    init_result = _handle_init({
+        "topic": "Test",
+        "participants": _make_participants(),
+    })
+    disc_id = json.loads(init_result)["discussion_id"]
+
+    result = _handle_speak({
+        "discussion_id": disc_id,
+        "participant": "eve",
+        "content": "Sneaky!",
+    })
+    data = json.loads(result)
+    assert "error" in data
+    assert "not an active member" in data["error"]
+
+
+def test_handler_speak_missing_content(roundtable_env):
+    from tools.roundtable_tools import _handle_init, _handle_speak
+    init_result = _handle_init({
+        "topic": "Test",
+        "participants": _make_participants(),
+    })
+    disc_id = json.loads(init_result)["discussion_id"]
+
+    result = _handle_speak({
+        "discussion_id": disc_id,
+        "participant": "alice",
+    })
+    data = json.loads(result)
+    assert "error" in data
+    assert "content" in data["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Handler tests: roundtable_read
+# ---------------------------------------------------------------------------
+
+
+def test_handler_read_success(roundtable_env):
+    from tools.roundtable_tools import _handle_init, _handle_speak, _handle_read
+    init_result = _handle_init({
+        "topic": "Test",
+        "participants": _make_participants(),
+    })
+    disc_id = json.loads(init_result)["discussion_id"]
+
+    _handle_speak({"discussion_id": disc_id, "participant": "alice", "content": "Hi"})
+    _handle_speak({"discussion_id": disc_id, "participant": "bob", "content": "Hello"})
+
+    result = _handle_read({"discussion_id": disc_id})
+    data = json.loads(result)
+    assert data["ok"] is True
+    assert data["speech_count"] == 2
+    assert len(data["speeches"]) == 2
+    assert "formatted_history" in data
+
+
+def test_handler_read_with_since_round(roundtable_env):
+    from tools.roundtable_tools import _handle_init, _handle_speak, _handle_read
+    init_result = _handle_init({
+        "topic": "Test",
+        "participants": _make_participants(),
+    })
+    disc_id = json.loads(init_result)["discussion_id"]
+
+    # Round 0
+    _handle_speak({"discussion_id": disc_id, "participant": "alice", "content": "r0s1"})
+    _handle_speak({"discussion_id": disc_id, "participant": "bob", "content": "r0s2"})
+    # Round 1
+    _handle_speak({"discussion_id": disc_id, "participant": "alice", "content": "r1s1"})
+
+    result = _handle_read({"discussion_id": disc_id, "since_round": 1})
+    data = json.loads(result)
+    assert data["speech_count"] == 1
+    assert data["speeches"][0]["content"] == "r1s1"
+
+
+# ---------------------------------------------------------------------------
+# Handler tests: roundtable_status
+# ---------------------------------------------------------------------------
+
+
+def test_handler_status(roundtable_env):
+    from tools.roundtable_tools import _handle_init, _handle_status
+    init_result = _handle_init({
+        "topic": "Test",
+        "participants": _make_participants(),
+    })
+    disc_id = json.loads(init_result)["discussion_id"]
+
+    result = _handle_status({"discussion_id": disc_id})
+    data = json.loads(result)
+    assert data["ok"] is True
+    assert data["status"] == "active"
+    assert data["current_round"] == 0
+    assert data["speech_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Handler tests: roundtable_end
+# ---------------------------------------------------------------------------
+
+
+def test_handler_end_conclude(roundtable_env):
+    from tools.roundtable_tools import _handle_init, _handle_end
+    init_result = _handle_init({
+        "topic": "Test",
+        "participants": _make_participants(),
+    })
+    disc_id = json.loads(init_result)["discussion_id"]
+
+    result = _handle_end({"discussion_id": disc_id})
+    data = json.loads(result)
+    assert data["ok"] is True
+    assert data["action"] == "concluded"
+
+
+def test_handler_end_force_cancel(roundtable_env):
+    from tools.roundtable_tools import _handle_init, _handle_end
+    init_result = _handle_init({
+        "topic": "Test",
+        "participants": _make_participants(),
+    })
+    disc_id = json.loads(init_result)["discussion_id"]
+
+    result = _handle_end({"discussion_id": disc_id, "force": True})
+    data = json.loads(result)
+    assert data["ok"] is True
+    assert data["action"] == "cancelled"
+
+
+# ---------------------------------------------------------------------------
+# Handler tests: roundtable_list
+# ---------------------------------------------------------------------------
+
+
+def test_handler_list(roundtable_env):
+    from tools.roundtable_tools import _handle_init, _handle_list
+    for i in range(3):
+        _handle_init({
+            "topic": f"Topic {i}",
+            "participants": _make_participants(),
+        })
+
+    result = _handle_list({})
+    data = json.loads(result)
+    assert data["ok"] is True
+    assert data["count"] == 3
+
+
+def test_handler_list_filter_status(roundtable_env):
+    from tools.roundtable_tools import _handle_init, _handle_end, _handle_list
+    init_result = _handle_init({
+        "topic": "Test",
+        "participants": _make_participants(),
+    })
+    disc_id = json.loads(init_result)["discussion_id"]
+    _handle_end({"discussion_id": disc_id})
+    _handle_init({"topic": "Test2", "participants": _make_participants()})
+
+    result = _handle_list({"status": "active"})
+    data = json.loads(result)
+    assert data["count"] == 1
+
+    result = _handle_list({"status": "concluded"})
+    data = json.loads(result)
+    assert data["count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Handler tests: roundtable_summarize
+# ---------------------------------------------------------------------------
+
+
+def test_handler_summarize(roundtable_env):
+    from tools.roundtable_tools import _handle_init, _handle_speak, _handle_summarize
+    init_result = _handle_init({
+        "topic": "DB Selection",
+        "participants": _make_participants(),
+        "context": "We need a new database",
+    })
+    disc_id = json.loads(init_result)["discussion_id"]
+
+    _handle_speak({"discussion_id": disc_id, "participant": "alice", "content": "PostgreSQL"})
+    _handle_speak({"discussion_id": disc_id, "participant": "bob", "content": "MySQL"})
+
+    result = _handle_summarize({"discussion_id": disc_id})
+    data = json.loads(result)
+    assert data["ok"] is True
+    assert data["topic"] == "DB Selection"
+    assert data["speech_count"] == 2
+    assert "rounds" in data
+    assert "participants" in data
+    assert "consensus_points" in data
+    assert "formatted_history" in data

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1054,6 +1054,180 @@ KANBAN_LINK_SCHEMA = {
 
 
 # ---------------------------------------------------------------------------
+# Checkpoint tools
+# ---------------------------------------------------------------------------
+
+KANBAN_CHECKPOINT_SCHEMA = {
+    "name": "kanban_checkpoint",
+    "description": (
+        "Save a progress checkpoint for the current task. Use this after "
+        "completing each logical step so that if the worker crashes, the "
+        "next attempt can resume from the last checkpoint instead of "
+        "starting over. Checkpoints are automatically cleared on task "
+        "completion."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "task_id": {
+                "type": "string",
+                "description": _DESC_TASK_ID_DEFAULT,
+            },
+            "step_key": {
+                "type": "string",
+                "description": (
+                    "Short machine-readable step identifier "
+                    "(e.g. 'analysis', 'impl-auth', 'test-unit'). "
+                    "Used to deduplicate — latest per step_key wins."
+                ),
+            },
+            "data": {
+                "type": "string",
+                "description": (
+                    "Arbitrary JSON string capturing the step's output "
+                    "(file paths, intermediate results, decisions). "
+                    "Keep under 8KB."
+                ),
+            },
+            "message": {
+                "type": "string",
+                "description": (
+                    "Human-readable one-liner describing what was "
+                    "accomplished in this step."
+                ),
+            },
+            "status": {
+                "type": "string",
+                "description": (
+                    "Step status: 'completed' (default), 'in_progress', "
+                    "or 'failed'. Workers typically save 'completed' after "
+                    "finishing a step."
+                ),
+            },
+        },
+        "required": ["step_key"],
+    },
+}
+
+
+def _handle_checkpoint(args: dict, **kw) -> str:
+    """Save a checkpoint for the current task."""
+    tid = _default_task_id(args.get("task_id"))
+    if not tid:
+        return tool_error(
+            "task_id is required (or set HERMES_KANBAN_TASK in the env)"
+        )
+    ownership_err = _enforce_worker_task_ownership(tid)
+    if ownership_err:
+        return ownership_err
+    step_key = args.get("step_key")
+    if not step_key or not str(step_key).strip():
+        return tool_error("step_key is required")
+    data = args.get("data")
+    message = args.get("message")
+    status = args.get("status") or "completed"
+    if status not in ("completed", "in_progress", "failed"):
+        return tool_error(
+            f"status must be 'completed', 'in_progress', or 'failed', "
+            f"got '{status}'"
+        )
+    try:
+        kb, conn = _connect()
+        try:
+            cp = kb.save_checkpoint(
+                conn, tid, step_key.strip(),
+                data=data, message=message, status=status,
+                run_id=_worker_run_id(tid),
+            )
+            return _ok(
+                checkpoint_id=cp.id,
+                task_id=tid,
+                step_key=cp.step_key,
+                status=cp.status,
+            )
+        finally:
+            conn.close()
+    except Exception as e:
+        logger.exception("kanban_checkpoint failed")
+        return tool_error(f"kanban_checkpoint: {e}")
+
+
+KANBAN_GET_CHECKPOINT_SCHEMA = {
+    "name": "kanban_get_checkpoint",
+    "description": (
+        "Retrieve checkpoints for the current task. Returns the most "
+        "recent checkpoints, or all checkpoints for a specific step. "
+        "Use this at the start of a retried task to see what the "
+        "previous attempt accomplished."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "task_id": {
+                "type": "string",
+                "description": _DESC_TASK_ID_DEFAULT,
+            },
+            "step_key": {
+                "type": "string",
+                "description": (
+                    "Optional: filter by step_key. If omitted, returns "
+                    "all recent checkpoints."
+                ),
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Max checkpoints to return (default 20).",
+            },
+        },
+        "required": [],
+    },
+}
+
+
+def _handle_get_checkpoint(args: dict, **kw) -> str:
+    """Retrieve checkpoints for the current task."""
+    tid = _default_task_id(args.get("task_id"))
+    if not tid:
+        return tool_error(
+            "task_id is required (or set HERMES_KANBAN_TASK in the env)"
+        )
+    step_key = args.get("step_key")
+    limit = args.get("limit")
+    if limit is None:
+        limit = 20
+    try:
+        limit = int(limit)
+    except (TypeError, ValueError):
+        return tool_error("limit must be an integer")
+    try:
+        kb, conn = _connect()
+        try:
+            if step_key:
+                cps = kb.get_checkpoints_by_step(conn, tid, step_key.strip())
+            else:
+                cps = kb.get_latest_checkpoints(conn, tid, limit=limit)
+            return json.dumps({
+                "checkpoints": [
+                    {
+                        "id": cp.id,
+                        "step_key": cp.step_key,
+                        "status": cp.status,
+                        "data": cp.data,
+                        "message": cp.message,
+                        "created_at": cp.created_at,
+                    }
+                    for cp in cps
+                ],
+                "count": len(cps),
+            })
+        finally:
+            conn.close()
+    except Exception as e:
+        logger.exception("kanban_get_checkpoint failed")
+        return tool_error(f"kanban_get_checkpoint: {e}")
+
+
+# ---------------------------------------------------------------------------
 # Registration
 # ---------------------------------------------------------------------------
 
@@ -1136,4 +1310,22 @@ registry.register(
     handler=_handle_link,
     check_fn=_check_kanban_mode,
     emoji="🔗",
+)
+
+registry.register(
+    name="kanban_checkpoint",
+    toolset="kanban",
+    schema=KANBAN_CHECKPOINT_SCHEMA,
+    handler=_handle_checkpoint,
+    check_fn=_check_kanban_mode,
+    emoji="📌",
+)
+
+registry.register(
+    name="kanban_get_checkpoint",
+    toolset="kanban",
+    schema=KANBAN_GET_CHECKPOINT_SCHEMA,
+    handler=_handle_get_checkpoint,
+    check_fn=_check_kanban_mode,
+    emoji="📖",
 )

--- a/tools/roundtable_tools.py
+++ b/tools/roundtable_tools.py
@@ -1,532 +1,157 @@
-"""Roundtable discussion tools — structured tool-call surface for multi-agent debates.
+"""Hermes Agent adapter for Roundtable.
 
-These tools enable multiple agents to participate in structured, multi-round
-discussions on a topic. A coordinator creates a discussion, participants take
-turns speaking, and the system tracks convergence toward consensus.
+Drop-in replacement for hermes tools/roundtable_tools.py that delegates
+to the independent roundtable library. Registers all 7 tools with the
+Hermes tool registry.
 
-Available when the ``roundtable`` toolset is enabled in the profile config,
-or when an agent is explicitly given the roundtable toolset.
+Usage in Hermes:
+    - Enable the ``roundtable`` toolset in profile config
+    - This module auto-registers when imported by the tool discovery system
 """
+
 from __future__ import annotations
 
 import json
 import logging
-from typing import Any, Optional
+import os
+import subprocess
+from typing import Any
 
-from tools.registry import registry, tool_error
+from roundtable.core import RoundtableCore
+from roundtable.exceptions import RoundtableError
 
 logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
-# Gating
+# Notification send callback
 # ---------------------------------------------------------------------------
 
-def _check_roundtable_enabled() -> bool:
-    """Roundtable tools are available when the profile has the toolset enabled."""
+
+def _hermes_send_fn(platform: str, chat_id: str, message: str) -> None:
+    """Deliver a notification message to a messaging platform.
+
+    Called by the Notifier when a discussion event fires.
+    Must never raise — exceptions are caught and logged.
+    """
     try:
-        from hermes_cli.config import load_config
-        cfg = load_config()
-        toolsets = cfg.get("toolsets", [])
-        return "roundtable" in toolsets
-    except Exception:
-        return False
+        if platform == "feishu":
+            profile = os.environ.get("HERMES_PROFILE", "default")
+            script = os.path.expanduser("~/.hermes/scripts/feishu-send.py")
+            subprocess.run(
+                ["python3", script, profile, chat_id, message],
+                capture_output=True,
+                timeout=15,
+            )
+        else:
+            logger.warning("Unsupported notification platform: %s", platform)
+    except Exception as e:
+        logger.warning("Notification send failed (platform=%s, chat=%s): %s", platform, chat_id, e)
 
 
 # ---------------------------------------------------------------------------
-# Shared helpers
+# Lazy core singleton
 # ---------------------------------------------------------------------------
 
-def _connect():
-    """Import + connect lazily so the module imports cleanly in non-roundtable contexts."""
-    from hermes_cli import roundtable_db as rdb
-    return rdb, rdb.connect()
+_core: RoundtableCore | None = None
+
+
+def _get_core() -> RoundtableCore:
+    global _core
+    if _core is None:
+        _core = RoundtableCore(send_fn=_hermes_send_fn)
+    return _core
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
 
 def _ok(**fields: Any) -> str:
     return json.dumps({"ok": True, **fields})
 
 
-def _format_history(speeches, participants_map: dict) -> str:
-    """Format speech history into a human-readable string for prompts."""
-    lines = []
-    for s in speeches:
-        p_info = participants_map.get(s.participant, {})
-        display = p_info.get("display_name", s.participant)
-        role = p_info.get("role", "")
-        role_str = f"({role})" if role else ""
-        ref_str = f" [引用 #{s.reply_to}]" if s.reply_to else ""
-        lines.append(
-            f"[#{s.id}] Round {s.round} | {display}{role_str}{ref_str}:\n  {s.content}"
-        )
-    return "\n\n".join(lines) if lines else "(暂无发言)"
+def _err(msg: str) -> str:
+    return json.dumps({"error": msg})
+
+
+def _handle(args: dict[str, Any], method: str, **extra: Any) -> str:
+    """Generic handler: call a RoundtableCore method, catch errors."""
+    try:
+        core = _get_core()
+        fn = getattr(core, method)
+        result = fn(**{**args, **extra})
+        return json.dumps(result)
+    except (ValueError, RoundtableError) as e:
+        return _err(str(e))
+    except Exception as e:
+        logger.exception(f"roundtable_{method} failed")
+        return _err(f"roundtable_{method}: {e}")
 
 
 # ---------------------------------------------------------------------------
 # Handlers
 # ---------------------------------------------------------------------------
 
-def _handle_init(args: dict, **kw) -> str:
-    """Create a new roundtable discussion with topic and participants."""
-    topic = args.get("topic", "").strip()
-    if not topic:
-        return tool_error("topic is required")
 
-    participants = args.get("participants")
-    if not participants or not isinstance(participants, list):
-        return tool_error("participants must be a non-empty array of objects")
-    if len(participants) < 2:
-        return tool_error("At least 2 participants are required for a discussion")
-
-    context = args.get("context")
-    max_rounds = args.get("max_rounds", 5)
-    speech_order = args.get("speech_order", "fixed")
-    output_path = args.get("output_path")
-    created_by = args.get("created_by", "coordinator")
-
-    try:
-        max_rounds = int(max_rounds)
-    except (TypeError, ValueError):
-        return tool_error("max_rounds must be an integer")
-
-    try:
-        rdb, conn = _connect()
-        try:
-            disc = rdb.create_discussion(
-                conn,
-                topic=topic,
-                participants=participants,
-                context=context,
-                max_rounds=max_rounds,
-                speech_order=speech_order,
-                created_by=created_by,
-                output_path=output_path,
-            )
-            return _ok(
-                discussion_id=disc.id,
-                topic=disc.topic,
-                participants=[p.get("profile") for p in participants],
-                max_rounds=disc.max_rounds,
-                speech_order=disc.speech_order,
-                status=disc.status,
-            )
-        finally:
-            conn.close()
-    except ValueError as e:
-        return tool_error(str(e))
-    except Exception as e:
-        logger.exception("roundtable_init failed")
-        return tool_error(f"roundtable_init: {e}")
+def _handle_init(args: dict[str, Any], **kw: Any) -> str:
+    # Default web=True so discussion mode always opens WebViewer
+    args.setdefault("web", True)
+    return _handle(args, "create_discussion")
 
 
-def _handle_speak(args: dict, **kw) -> str:
-    """Record a participant's speech in a discussion."""
+def _handle_speak(args: dict[str, Any], **kw: Any) -> str:
+    return _handle(args, "speak")
+
+
+def _handle_read(args: dict[str, Any], **kw: Any) -> str:
+    return _handle(args, "read")
+
+
+def _handle_status(args: dict[str, Any], **kw: Any) -> str:
     discussion_id = args.get("discussion_id", "").strip()
     if not discussion_id:
-        return tool_error("discussion_id is required")
-
-    participant = args.get("participant", "").strip()
-    if not participant:
-        return tool_error("participant is required")
-
-    content = args.get("content", "").strip()
-    if not content:
-        return tool_error("content is required")
-
-    reply_to = args.get("reply_to")
-    if reply_to is not None:
-        try:
-            reply_to = int(reply_to)
-        except (TypeError, ValueError):
-            return tool_error("reply_to must be an integer")
-
-    try:
-        rdb, conn = _connect()
-        try:
-            disc = rdb.get_discussion(conn, discussion_id)
-            if not disc:
-                return tool_error(f"Discussion {discussion_id} not found")
-            if disc.status != "active":
-                return tool_error(f"Discussion {discussion_id} is {disc.status}")
-
-            # Validate participant is registered (coordinator is always allowed)
-            active_names = rdb.get_active_participant_names(conn, discussion_id)
-            is_coordinator = participant == "coordinator"
-            if not is_coordinator and participant not in active_names:
-                return tool_error(
-                    f"Participant '{participant}' is not an active member of this discussion. "
-                    f"Active: {', '.join(active_names)}"
-                )
-
-            # Coordinator speech is always recorded in round 0 and does not
-            # participate in round progression logic.
-            speech = rdb.add_speech(
-                conn,
-                discussion_id=discussion_id,
-                participant=participant,
-                content=content,
-                reply_to=reply_to,
-                round_override=0 if is_coordinator else None,
-            )
-
-            # Determine round state after this speech
-            disc_after = rdb.get_discussion(conn, discussion_id)
-            speakers_this_round = conn.execute(
-                """SELECT DISTINCT participant FROM speeches
-                   WHERE discussion_id = ? AND round = ?""",
-                (discussion_id, disc.current_round),
-            ).fetchall()
-            spoke_names = {r["participant"] for r in speakers_this_round}
-            round_complete = all(name in spoke_names for name in active_names)
-
-            # Determine next speaker
-            next_speaker = None
-            if disc_after and disc_after.status == "active":
-                target_round = disc_after.current_round
-                speakers_next = conn.execute(
-                    """SELECT DISTINCT participant FROM speeches
-                       WHERE discussion_id = ? AND round = ?""",
-                    (discussion_id, target_round),
-                ).fetchall()
-                spoke_next = {r["participant"] for r in speakers_next}
-                for name in active_names:
-                    if name not in spoke_next:
-                        next_speaker = name
-                        break
-
-            return _ok(
-                speech_id=speech.id,
-                round=speech.round,
-                participant=speech.participant,
-                next_speaker=next_speaker,
-                round_complete=round_complete,
-                discussion_complete=disc_after.status != "active"
-                if disc_after
-                else False,
-            )
-        finally:
-            conn.close()
-    except ValueError as e:
-        return tool_error(str(e))
-    except Exception as e:
-        logger.exception("roundtable_speak failed")
-        return tool_error(f"roundtable_speak: {e}")
+        return _err("discussion_id is required")
+    return _handle({"discussion_id": discussion_id}, "status")
 
 
-def _handle_read(args: dict, **kw) -> str:
-    """Read discussion history (speeches)."""
+def _handle_summarize(args: dict[str, Any], **kw: Any) -> str:
     discussion_id = args.get("discussion_id", "").strip()
     if not discussion_id:
-        return tool_error("discussion_id is required")
-
-    since_round = args.get("since_round")
-    if since_round is not None:
-        try:
-            since_round = int(since_round)
-        except (TypeError, ValueError):
-            return tool_error("since_round must be an integer")
-
-    participant_filter = args.get("participant")
-
-    try:
-        rdb, conn = _connect()
-        try:
-            disc = rdb.get_discussion(conn, discussion_id)
-            if not disc:
-                return tool_error(f"Discussion {discussion_id} not found")
-
-            speeches = rdb.get_speeches(
-                conn,
-                discussion_id,
-                since_round=since_round,
-                participant=participant_filter,
-            )
-            participants = rdb.get_participants(conn, discussion_id)
-            p_map = {
-                p.participant: {
-                    "role": p.role,
-                    "display_name": p.display_name,
-                    "perspective": p.perspective,
-                }
-                for p in participants
-            }
-
-            return json.dumps({
-                "ok": True,
-                "discussion_id": disc.id,
-                "topic": disc.topic,
-                "current_round": disc.current_round,
-                "max_rounds": disc.max_rounds,
-                "status": disc.status,
-                "speeches": [
-                    {
-                        "id": s.id,
-                        "round": s.round,
-                        "participant": s.participant,
-                        "display_name": p_map.get(s.participant, {}).get("display_name"),
-                        "content": s.content,
-                        "reply_to": s.reply_to,
-                        "created_at": s.created_at,
-                    }
-                    for s in speeches
-                ],
-                "speech_count": len(speeches),
-                "formatted_history": _format_history(speeches, p_map),
-            })
-        finally:
-            conn.close()
-    except Exception as e:
-        logger.exception("roundtable_read failed")
-        return tool_error(f"roundtable_read: {e}")
+        return _err("discussion_id is required")
+    compact = args.get("compact", False)
+    return _handle({"discussion_id": discussion_id, "compact": compact}, "summarize")
 
 
-def _handle_status(args: dict, **kw) -> str:
-    """Get discussion status including convergence metrics."""
+def _handle_end(args: dict[str, Any], **kw: Any) -> str:
+    return _handle(args, "end_discussion")
+
+
+def _handle_list(args: dict[str, Any], **kw: Any) -> str:
+    return _handle(args, "list_discussions")
+
+
+def _handle_advance(args: dict[str, Any], **kw: Any) -> str:
     discussion_id = args.get("discussion_id", "").strip()
     if not discussion_id:
-        return tool_error("discussion_id is required")
-
-    try:
-        rdb, conn = _connect()
-        try:
-            disc = rdb.get_discussion(conn, discussion_id)
-            if not disc:
-                return tool_error(f"Discussion {discussion_id} not found")
-
-            participants = rdb.get_participants(conn, discussion_id)
-            speech_count = rdb.get_speech_count(conn, discussion_id)
-            findings = rdb.get_findings(conn, discussion_id)
-            conv_history = rdb.get_convergence_history(conn, discussion_id)
-
-            consensus_pts = [f.content for f in findings if f.type == "consensus"]
-            disagreement_pts = [f.content for f in findings if f.type == "disagreement"]
-            new_points = [f.content for f in findings if f.type == "new_point"]
-
-            # Determine next speaker
-            active_names = rdb.get_active_participant_names(conn, discussion_id)
-            next_speaker = None
-            if disc.status == "active" and active_names:
-                speakers_current = conn.execute(
-                    """SELECT DISTINCT participant FROM speeches
-                       WHERE discussion_id = ? AND round = ?""",
-                    (discussion_id, disc.current_round),
-                ).fetchall()
-                spoke = {r["participant"] for r in speakers_current}
-                for name in active_names:
-                    if name not in spoke:
-                        next_speaker = name
-                        break
-
-            return json.dumps({
-                "ok": True,
-                "discussion_id": disc.id,
-                "topic": disc.topic,
-                "status": disc.status,
-                "current_round": disc.current_round,
-                "max_rounds": disc.max_rounds,
-                "speech_order": disc.speech_order,
-                "convergence_score": disc.convergence_score,
-                "consensus_points": consensus_pts,
-                "disagreement_points": disagreement_pts,
-                "new_points": new_points,
-                "speech_count": speech_count,
-                "participant_count": len(participants),
-                "next_speaker": next_speaker,
-                "convergence_history": [
-                    {
-                        "round": c.round,
-                        "score": c.score,
-                        "consensus": c.consensus_count,
-                        "disagreement": c.disagreement_count,
-                        "new_points": c.new_point_count,
-                    }
-                    for c in conv_history
-                ],
-            })
-        finally:
-            conn.close()
-    except Exception as e:
-        logger.exception("roundtable_status failed")
-        return tool_error(f"roundtable_status: {e}")
+        return _err("discussion_id is required")
+    return _handle({"discussion_id": discussion_id}, "advance")
 
 
-def _handle_summarize(args: dict, **kw) -> str:
-    """Generate a conclusion document from the discussion.
-
-    Returns structured data that the coordinator can use to write the final
-    conclusion document. Does NOT call an LLM — the coordinator agent is
-    expected to use this data to produce the Markdown conclusion.
-    """
+def _handle_notify(args: dict[str, Any], **kw: Any) -> str:
     discussion_id = args.get("discussion_id", "").strip()
     if not discussion_id:
-        return tool_error("discussion_id is required")
-
-    try:
-        rdb, conn = _connect()
-        try:
-            disc = rdb.get_discussion(conn, discussion_id)
-            if not disc:
-                return tool_error(f"Discussion {discussion_id} not found")
-
-            participants = rdb.get_participants(conn, discussion_id)
-            speeches = rdb.get_speeches(conn, discussion_id)
-            findings = rdb.get_findings(conn, discussion_id)
-            conv_history = rdb.get_convergence_history(conn, discussion_id)
-
-            p_map = {
-                p.participant: {
-                    "role": p.role,
-                    "display_name": p.display_name,
-                    "perspective": p.perspective,
-                }
-                for p in participants
-            }
-
-            consensus_pts = [f.content for f in findings if f.type == "consensus"]
-            disagreement_pts = [f.content for f in findings if f.type == "disagreement"]
-            new_points = [f.content for f in findings if f.type == "new_point"]
-
-            # Group speeches by round
-            rounds_dict: dict = {}
-            for s in speeches:
-                rounds_dict.setdefault(s.round, []).append({
-                    "id": s.id,
-                    "participant": s.participant,
-                    "display_name": p_map.get(s.participant, {}).get("display_name"),
-                    "role": p_map.get(s.participant, {}).get("role"),
-                    "content": s.content,
-                    "reply_to": s.reply_to,
-                })
-
-            # Calculate overall convergence
-            final_score = disc.convergence_score
-            if not final_score and conv_history:
-                final_score = conv_history[-1].score
-
-            return json.dumps({
-                "ok": True,
-                "discussion_id": disc.id,
-                "topic": disc.topic,
-                "context": disc.context,
-                "status": disc.status,
-                "total_rounds": disc.current_round,
-                "max_rounds": disc.max_rounds,
-                "final_convergence_score": final_score,
-                "participants": [
-                    {
-                        "profile": p.participant,
-                        "display_name": p.display_name,
-                        "role": p.role,
-                        "perspective": p.perspective,
-                    }
-                    for p in participants
-                ],
-                "consensus_points": consensus_pts,
-                "disagreement_points": disagreement_pts,
-                "new_points": new_points,
-                "speech_count": len(speeches),
-                "rounds": rounds_dict,
-                "convergence_history": [
-                    {
-                        "round": c.round,
-                        "score": c.score,
-                        "consensus": c.consensus_count,
-                        "disagreement": c.disagreement_count,
-                    }
-                    for c in conv_history
-                ],
-                "output_path": disc.output_path,
-                "formatted_history": _format_history(speeches, p_map),
-            })
-        finally:
-            conn.close()
-    except Exception as e:
-        logger.exception("roundtable_summarize failed")
-        return tool_error(f"roundtable_summarize: {e}")
-
-
-def _handle_end(args: dict, **kw) -> str:
-    """End a discussion (conclude or cancel)."""
-    discussion_id = args.get("discussion_id", "").strip()
-    if not discussion_id:
-        return tool_error("discussion_id is required")
-
-    force = args.get("force", False)
-    conclusion = args.get("conclusion")
-
-    try:
-        rdb, conn = _connect()
-        try:
-            disc = rdb.get_discussion(conn, discussion_id)
-            if not disc:
-                return tool_error(f"Discussion {discussion_id} not found")
-            if disc.status != "active":
-                return tool_error(
-                    f"Discussion {discussion_id} is already {disc.status}"
-                )
-
-            if force:
-                ok = rdb.cancel_discussion(conn, discussion_id)
-                action = "cancelled"
-            else:
-                ok = rdb.conclude_discussion(
-                    conn, discussion_id, conclusion=conclusion
-                )
-                action = "concluded"
-
-            return _ok(
-                discussion_id=discussion_id,
-                action=action,
-                success=ok,
-            )
-        finally:
-            conn.close()
-    except Exception as e:
-        logger.exception("roundtable_end failed")
-        return tool_error(f"roundtable_end: {e}")
-
-
-def _handle_list(args: dict, **kw) -> str:
-    """List all discussions with optional status filter."""
-    status = args.get("status")
-    limit = args.get("limit", 50)
-    try:
-        limit = int(limit)
-    except (TypeError, ValueError):
-        return tool_error("limit must be an integer")
-
-    try:
-        rdb, conn = _connect()
-        try:
-            discussions = rdb.list_discussions(conn, status=status, limit=limit)
-            return json.dumps({
-                "ok": True,
-                "discussions": [
-                    {
-                        "id": d.id,
-                        "topic": d.topic,
-                        "status": d.status,
-                        "current_round": d.current_round,
-                        "max_rounds": d.max_rounds,
-                        "created_by": d.created_by,
-                        "created_at": d.created_at,
-                        "concluded_at": d.concluded_at,
-                        "convergence_score": d.convergence_score,
-                    }
-                    for d in discussions
-                ],
-                "count": len(discussions),
-                "filter_status": status,
-            })
-        finally:
-            conn.close()
-    except Exception as e:
-        logger.exception("roundtable_list failed")
-        return tool_error(f"roundtable_list: {e}")
+        return _err("discussion_id is required")
+    event = args.get("event", "").strip()
+    if not event:
+        return _err("event is required")
+    extra = {k: v for k, v in args.items() if k not in ("discussion_id", "event")}
+    return _handle({"discussion_id": discussion_id, "event": event, **extra}, "notify")
 
 
 # ---------------------------------------------------------------------------
-# Tool schemas
+# Tool schemas (identical to original)
 # ---------------------------------------------------------------------------
 
 ROUNDTABLE_INIT_SCHEMA = {
@@ -539,58 +164,64 @@ ROUNDTABLE_INIT_SCHEMA = {
     "parameters": {
         "type": "object",
         "properties": {
-            "topic": {
-                "type": "string",
-                "description": "The discussion topic",
-            },
+            "topic": {"type": "string", "description": "The discussion topic"},
             "participants": {
                 "type": "array",
                 "items": {
                     "type": "object",
                     "properties": {
-                        "profile": {
-                            "type": "string",
-                            "description": "Agent profile name (e.g. 'bingge', 'mafei')",
-                        },
-                        "role": {
-                            "type": "string",
-                            "description": "Role description (e.g. '产品总监')",
-                        },
-                        "perspective": {
-                            "type": "string",
-                            "description": "Role perspective hint (e.g. '关注用户体验')",
-                        },
-                        "display_name": {
-                            "type": "string",
-                            "description": "Display name (e.g. '饼哥')",
-                        },
+                        "profile": {"type": "string", "description": "Agent profile name"},
+                        "role": {"type": "string", "description": "Role description"},
+                        "perspective": {"type": "string", "description": "Role perspective hint"},
+                        "display_name": {"type": "string", "description": "Display name"},
                     },
                     "required": ["profile"],
                 },
                 "description": "List of participant profiles (min 2)",
             },
-            "context": {
-                "type": "string",
-                "description": "Background context for the discussion",
-            },
-            "max_rounds": {
-                "type": "integer",
-                "description": "Maximum discussion rounds (default: 5)",
-                "default": 5,
-            },
+            "context": {"type": "string", "description": "Background context"},
+            "max_rounds": {"type": "integer", "description": "Max rounds (default: 5)", "default": 5},
             "speech_order": {
                 "type": "string",
                 "enum": ["fixed", "random", "priority", "free"],
                 "description": "Speech order strategy (default: fixed)",
                 "default": "fixed",
             },
-            "output_path": {
-                "type": "string",
-                "description": "Path to save the conclusion document",
+            "output_path": {"type": "string", "description": "Path to save conclusion"},
+            "created_by": {"type": "string", "description": "Creator profile name"},
+            "web": {
+                "type": "boolean",
+                "description": "Start a WebPublisher HTTP server for live viewing in browser (default: false)",
+                "default": False,
             },
-            "created_by": {
-                "type": "string",
-                "description": "Profile name of the discussion creator",
+            "web_port": {
+                "type": "integer",
+                "description": "Port for the WebPublisher server (default: 8765)",
+                "default": 8765,
+            },
+            "notifications": {
+                "type": "object",
+                "description": "Notification config for real-time push to messaging channels",
+                "properties": {
+                    "enabled": {"type": "boolean", "description": "Enable notifications"},
+                    "channels": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "platform": {"type": "string", "description": "Platform (e.g. 'feishu')"},
+                                "chat_id": {"type": "string", "description": "Chat/channel ID"},
+                            },
+                            "required": ["chat_id"],
+                        },
+                        "description": "Target channels",
+                    },
+                    "events": {
+                        "type": "array",
+                        "items": {"type": "string", "enum": ["round_start", "speech", "round_end", "concluded"]},
+                        "description": "Events to subscribe (default: all)",
+                    },
+                },
             },
         },
         "required": ["topic", "participants"],
@@ -606,22 +237,10 @@ ROUNDTABLE_SPEAK_SCHEMA = {
     "parameters": {
         "type": "object",
         "properties": {
-            "discussion_id": {
-                "type": "string",
-                "description": "Discussion ID (rt_xxxxxxxx)",
-            },
-            "participant": {
-                "type": "string",
-                "description": "Profile name of the speaker",
-            },
-            "content": {
-                "type": "string",
-                "description": "Speech content (Markdown supported)",
-            },
-            "reply_to": {
-                "type": "integer",
-                "description": "Optional: ID of a speech being referenced/replied to",
-            },
+            "discussion_id": {"type": "string", "description": "Discussion ID (rt_xxxxxxxx)"},
+            "participant": {"type": "string", "description": "Profile name of the speaker"},
+            "content": {"type": "string", "description": "Speech content (Markdown supported)"},
+            "reply_to": {"type": "integer", "description": "Optional: ID of a speech being referenced"},
         },
         "required": ["discussion_id", "participant", "content"],
     },
@@ -636,18 +255,9 @@ ROUNDTABLE_READ_SCHEMA = {
     "parameters": {
         "type": "object",
         "properties": {
-            "discussion_id": {
-                "type": "string",
-                "description": "Discussion ID (rt_xxxxxxxx)",
-            },
-            "since_round": {
-                "type": "integer",
-                "description": "Only return speeches from this round onwards",
-            },
-            "participant": {
-                "type": "string",
-                "description": "Only return speeches from this participant",
-            },
+            "discussion_id": {"type": "string", "description": "Discussion ID (rt_xxxxxxxx)"},
+            "since_round": {"type": "integer", "description": "Only speeches from this round onwards"},
+            "participant": {"type": "string", "description": "Only speeches from this participant"},
         },
         "required": ["discussion_id"],
     },
@@ -662,10 +272,7 @@ ROUNDTABLE_STATUS_SCHEMA = {
     "parameters": {
         "type": "object",
         "properties": {
-            "discussion_id": {
-                "type": "string",
-                "description": "Discussion ID (rt_xxxxxxxx)",
-            },
+            "discussion_id": {"type": "string", "description": "Discussion ID (rt_xxxxxxxx)"},
         },
         "required": ["discussion_id"],
     },
@@ -674,16 +281,17 @@ ROUNDTABLE_STATUS_SCHEMA = {
 ROUNDTABLE_SUMMARIZE_SCHEMA = {
     "name": "roundtable_summarize",
     "description": (
-        "Generate summary data for a conclusion document. Returns all discussion "
-        "data organized by round, with consensus/disagreement points extracted. "
-        "Use this to write the final Markdown conclusion."
+        "Generate summary data for a conclusion document. Returns structured_summary "
+        "(compact Markdown, <5KB) plus metadata. Use compact=true to omit raw speech data."
     ),
     "parameters": {
         "type": "object",
         "properties": {
-            "discussion_id": {
-                "type": "string",
-                "description": "Discussion ID (rt_xxxxxxxx)",
+            "discussion_id": {"type": "string", "description": "Discussion ID (rt_xxxxxxxx)"},
+            "compact": {
+                "type": "boolean",
+                "description": "If true, return only structured_summary without raw rounds data (default: false)",
+                "default": False,
             },
         },
         "required": ["discussion_id"],
@@ -693,25 +301,14 @@ ROUNDTABLE_SUMMARIZE_SCHEMA = {
 ROUNDTABLE_END_SCHEMA = {
     "name": "roundtable_end",
     "description": (
-        "End a roundtable discussion. By default, marks it as concluded. "
-        "Use force=true to cancel instead."
+        "End a roundtable discussion. By default, marks it as concluded. Use force=true to cancel instead."
     ),
     "parameters": {
         "type": "object",
         "properties": {
-            "discussion_id": {
-                "type": "string",
-                "description": "Discussion ID (rt_xxxxxxxx)",
-            },
-            "force": {
-                "type": "boolean",
-                "description": "If true, cancel the discussion instead of concluding",
-                "default": False,
-            },
-            "conclusion": {
-                "type": "string",
-                "description": "Optional: conclusion text to save",
-            },
+            "discussion_id": {"type": "string", "description": "Discussion ID (rt_xxxxxxxx)"},
+            "force": {"type": "boolean", "description": "Cancel instead of conclude", "default": False},
+            "conclusion": {"type": "string", "description": "Optional: conclusion text"},
         },
         "required": ["discussion_id"],
     },
@@ -728,79 +325,109 @@ ROUNDTABLE_LIST_SCHEMA = {
                 "enum": ["active", "concluded", "cancelled"],
                 "description": "Filter by status (omit for all)",
             },
-            "limit": {
-                "type": "integer",
-                "description": "Max results to return (default: 50)",
-                "default": 50,
-            },
+            "limit": {"type": "integer", "description": "Max results (default: 50)", "default": 50},
         },
+    },
+}
+
+ROUNDTABLE_ADVANCE_SCHEMA = {
+    "name": "roundtable_advance",
+    "description": (
+        "Explicitly advance to the next round. Use when auto-advance "
+        "doesn't trigger. If max_rounds is exceeded, the discussion "
+        "is automatically concluded."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "discussion_id": {"type": "string", "description": "Discussion ID (rt_xxxxxxxx)"},
+        },
+        "required": ["discussion_id"],
+    },
+}
+
+ROUNDTABLE_NOTIFY_SCHEMA = {
+    "name": "roundtable_notify",
+    "description": (
+        "Manually trigger a notification for a discussion event. "
+        "Valid events: round_start, speech, round_end, concluded."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "discussion_id": {"type": "string", "description": "Discussion ID (rt_xxxxxxxx)"},
+            "event": {
+                "type": "string",
+                "enum": ["round_start", "speech", "round_end", "concluded"],
+                "description": "Event type to notify",
+            },
+            "round_num": {"type": "integer", "description": "Round number"},
+            "participant": {"type": "string", "description": "Participant name"},
+            "content": {"type": "string", "description": "Speech content"},
+            "conclusion": {"type": "string", "description": "Conclusion text"},
+        },
+        "required": ["discussion_id", "event"],
     },
 }
 
 
 # ---------------------------------------------------------------------------
-# Registration
+# Registration function — called by Hermes tool discovery
 # ---------------------------------------------------------------------------
 
-registry.register(
-    name="roundtable_init",
-    toolset="roundtable",
-    schema=ROUNDTABLE_INIT_SCHEMA,
-    handler=_handle_init,
-    check_fn=_check_roundtable_enabled,
-    emoji="🎯",
-)
 
-registry.register(
-    name="roundtable_speak",
-    toolset="roundtable",
-    schema=ROUNDTABLE_SPEAK_SCHEMA,
-    handler=_handle_speak,
-    check_fn=_check_roundtable_enabled,
-    emoji="💬",
-)
+def register_roundtable_tools(registry: Any, *, check_fn: Any = None) -> None:
+    """Register all 8 roundtable tools with a Hermes tool registry.
 
-registry.register(
-    name="roundtable_read",
-    toolset="roundtable",
-    schema=ROUNDTABLE_READ_SCHEMA,
-    handler=_handle_read,
-    check_fn=_check_roundtable_enabled,
-    emoji="📖",
-)
+    Args:
+        registry: The Hermes tools.registry object.
+        check_fn: Optional gating function. If None, always enabled.
+    """
+    tools = [
+        ("roundtable_init", ROUNDTABLE_INIT_SCHEMA, _handle_init, "🎯"),
+        ("roundtable_speak", ROUNDTABLE_SPEAK_SCHEMA, _handle_speak, "💬"),
+        ("roundtable_read", ROUNDTABLE_READ_SCHEMA, _handle_read, "📖"),
+        ("roundtable_status", ROUNDTABLE_STATUS_SCHEMA, _handle_status, "📊"),
+        ("roundtable_summarize", ROUNDTABLE_SUMMARIZE_SCHEMA, _handle_summarize, "📝"),
+        ("roundtable_end", ROUNDTABLE_END_SCHEMA, _handle_end, "🏁"),
+        ("roundtable_list", ROUNDTABLE_LIST_SCHEMA, _handle_list, "📋"),
+        ("roundtable_advance", ROUNDTABLE_ADVANCE_SCHEMA, _handle_advance, "⏭️"),
+        ("roundtable_notify", ROUNDTABLE_NOTIFY_SCHEMA, _handle_notify, "🔔"),
+    ]
+    for name, schema, handler, emoji in tools:
+        registry.register(
+            name=name,
+            toolset="roundtable",
+            schema=schema,
+            handler=handler,
+            check_fn=check_fn,
+            emoji=emoji,
+        )
 
-registry.register(
-    name="roundtable_status",
-    toolset="roundtable",
-    schema=ROUNDTABLE_STATUS_SCHEMA,
-    handler=_handle_status,
-    check_fn=_check_roundtable_enabled,
-    emoji="📊",
-)
 
-registry.register(
-    name="roundtable_summarize",
-    toolset="roundtable",
-    schema=ROUNDTABLE_SUMMARIZE_SCHEMA,
-    handler=_handle_summarize,
-    check_fn=_check_roundtable_enabled,
-    emoji="📝",
-)
+# ---------------------------------------------------------------------------
+# Auto-registration when imported by Hermes tool discovery
+# ---------------------------------------------------------------------------
 
-registry.register(
-    name="roundtable_end",
-    toolset="roundtable",
-    schema=ROUNDTABLE_END_SCHEMA,
-    handler=_handle_end,
-    check_fn=_check_roundtable_enabled,
-    emoji="🏁",
-)
 
-registry.register(
-    name="roundtable_list",
-    toolset="roundtable",
-    schema=ROUNDTABLE_LIST_SCHEMA,
-    handler=_handle_list,
-    check_fn=_check_roundtable_enabled,
-    emoji="📋",
-)
+def _auto_register() -> None:
+    """Try to auto-register with Hermes if available."""
+    try:
+        from tools.registry import registry
+
+        def _check_roundtable_enabled() -> bool:
+            try:
+                from hermes_cli.config import load_config
+
+                cfg = load_config()
+                return "roundtable" in cfg.get("toolsets", [])
+            except Exception:
+                return False
+
+        register_roundtable_tools(registry, check_fn=_check_roundtable_enabled)
+    except ImportError:
+        # Not running inside Hermes — that's fine, the library works standalone
+        pass
+
+
+_auto_register()

--- a/tools/roundtable_tools.py
+++ b/tools/roundtable_tools.py
@@ -149,20 +149,24 @@ def _handle_speak(args: dict, **kw) -> str:
             if disc.status != "active":
                 return tool_error(f"Discussion {discussion_id} is {disc.status}")
 
-            # Validate participant is registered
+            # Validate participant is registered (coordinator is always allowed)
             active_names = rdb.get_active_participant_names(conn, discussion_id)
-            if participant not in active_names:
+            is_coordinator = participant == "coordinator"
+            if not is_coordinator and participant not in active_names:
                 return tool_error(
                     f"Participant '{participant}' is not an active member of this discussion. "
                     f"Active: {', '.join(active_names)}"
                 )
 
+            # Coordinator speech is always recorded in round 0 and does not
+            # participate in round progression logic.
             speech = rdb.add_speech(
                 conn,
                 discussion_id=discussion_id,
                 participant=participant,
                 content=content,
                 reply_to=reply_to,
+                round_override=0 if is_coordinator else None,
             )
 
             # Determine round state after this speech

--- a/tools/roundtable_tools.py
+++ b/tools/roundtable_tools.py
@@ -1,0 +1,802 @@
+"""Roundtable discussion tools — structured tool-call surface for multi-agent debates.
+
+These tools enable multiple agents to participate in structured, multi-round
+discussions on a topic. A coordinator creates a discussion, participants take
+turns speaking, and the system tracks convergence toward consensus.
+
+Available when the ``roundtable`` toolset is enabled in the profile config,
+or when an agent is explicitly given the roundtable toolset.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Optional
+
+from tools.registry import registry, tool_error
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Gating
+# ---------------------------------------------------------------------------
+
+def _check_roundtable_enabled() -> bool:
+    """Roundtable tools are available when the profile has the toolset enabled."""
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        toolsets = cfg.get("toolsets", [])
+        return "roundtable" in toolsets
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _connect():
+    """Import + connect lazily so the module imports cleanly in non-roundtable contexts."""
+    from hermes_cli import roundtable_db as rdb
+    return rdb, rdb.connect()
+
+
+def _ok(**fields: Any) -> str:
+    return json.dumps({"ok": True, **fields})
+
+
+def _format_history(speeches, participants_map: dict) -> str:
+    """Format speech history into a human-readable string for prompts."""
+    lines = []
+    for s in speeches:
+        p_info = participants_map.get(s.participant, {})
+        display = p_info.get("display_name", s.participant)
+        role = p_info.get("role", "")
+        role_str = f"({role})" if role else ""
+        ref_str = f" [引用 #{s.reply_to}]" if s.reply_to else ""
+        lines.append(
+            f"[#{s.id}] Round {s.round} | {display}{role_str}{ref_str}:\n  {s.content}"
+        )
+    return "\n\n".join(lines) if lines else "(暂无发言)"
+
+
+# ---------------------------------------------------------------------------
+# Handlers
+# ---------------------------------------------------------------------------
+
+def _handle_init(args: dict, **kw) -> str:
+    """Create a new roundtable discussion with topic and participants."""
+    topic = args.get("topic", "").strip()
+    if not topic:
+        return tool_error("topic is required")
+
+    participants = args.get("participants")
+    if not participants or not isinstance(participants, list):
+        return tool_error("participants must be a non-empty array of objects")
+    if len(participants) < 2:
+        return tool_error("At least 2 participants are required for a discussion")
+
+    context = args.get("context")
+    max_rounds = args.get("max_rounds", 5)
+    speech_order = args.get("speech_order", "fixed")
+    output_path = args.get("output_path")
+    created_by = args.get("created_by", "coordinator")
+
+    try:
+        max_rounds = int(max_rounds)
+    except (TypeError, ValueError):
+        return tool_error("max_rounds must be an integer")
+
+    try:
+        rdb, conn = _connect()
+        try:
+            disc = rdb.create_discussion(
+                conn,
+                topic=topic,
+                participants=participants,
+                context=context,
+                max_rounds=max_rounds,
+                speech_order=speech_order,
+                created_by=created_by,
+                output_path=output_path,
+            )
+            return _ok(
+                discussion_id=disc.id,
+                topic=disc.topic,
+                participants=[p.get("profile") for p in participants],
+                max_rounds=disc.max_rounds,
+                speech_order=disc.speech_order,
+                status=disc.status,
+            )
+        finally:
+            conn.close()
+    except ValueError as e:
+        return tool_error(str(e))
+    except Exception as e:
+        logger.exception("roundtable_init failed")
+        return tool_error(f"roundtable_init: {e}")
+
+
+def _handle_speak(args: dict, **kw) -> str:
+    """Record a participant's speech in a discussion."""
+    discussion_id = args.get("discussion_id", "").strip()
+    if not discussion_id:
+        return tool_error("discussion_id is required")
+
+    participant = args.get("participant", "").strip()
+    if not participant:
+        return tool_error("participant is required")
+
+    content = args.get("content", "").strip()
+    if not content:
+        return tool_error("content is required")
+
+    reply_to = args.get("reply_to")
+    if reply_to is not None:
+        try:
+            reply_to = int(reply_to)
+        except (TypeError, ValueError):
+            return tool_error("reply_to must be an integer")
+
+    try:
+        rdb, conn = _connect()
+        try:
+            disc = rdb.get_discussion(conn, discussion_id)
+            if not disc:
+                return tool_error(f"Discussion {discussion_id} not found")
+            if disc.status != "active":
+                return tool_error(f"Discussion {discussion_id} is {disc.status}")
+
+            # Validate participant is registered
+            active_names = rdb.get_active_participant_names(conn, discussion_id)
+            if participant not in active_names:
+                return tool_error(
+                    f"Participant '{participant}' is not an active member of this discussion. "
+                    f"Active: {', '.join(active_names)}"
+                )
+
+            speech = rdb.add_speech(
+                conn,
+                discussion_id=discussion_id,
+                participant=participant,
+                content=content,
+                reply_to=reply_to,
+            )
+
+            # Determine round state after this speech
+            disc_after = rdb.get_discussion(conn, discussion_id)
+            speakers_this_round = conn.execute(
+                """SELECT DISTINCT participant FROM speeches
+                   WHERE discussion_id = ? AND round = ?""",
+                (discussion_id, disc.current_round),
+            ).fetchall()
+            spoke_names = {r["participant"] for r in speakers_this_round}
+            round_complete = all(name in spoke_names for name in active_names)
+
+            # Determine next speaker
+            next_speaker = None
+            if disc_after and disc_after.status == "active":
+                target_round = disc_after.current_round
+                speakers_next = conn.execute(
+                    """SELECT DISTINCT participant FROM speeches
+                       WHERE discussion_id = ? AND round = ?""",
+                    (discussion_id, target_round),
+                ).fetchall()
+                spoke_next = {r["participant"] for r in speakers_next}
+                for name in active_names:
+                    if name not in spoke_next:
+                        next_speaker = name
+                        break
+
+            return _ok(
+                speech_id=speech.id,
+                round=speech.round,
+                participant=speech.participant,
+                next_speaker=next_speaker,
+                round_complete=round_complete,
+                discussion_complete=disc_after.status != "active"
+                if disc_after
+                else False,
+            )
+        finally:
+            conn.close()
+    except ValueError as e:
+        return tool_error(str(e))
+    except Exception as e:
+        logger.exception("roundtable_speak failed")
+        return tool_error(f"roundtable_speak: {e}")
+
+
+def _handle_read(args: dict, **kw) -> str:
+    """Read discussion history (speeches)."""
+    discussion_id = args.get("discussion_id", "").strip()
+    if not discussion_id:
+        return tool_error("discussion_id is required")
+
+    since_round = args.get("since_round")
+    if since_round is not None:
+        try:
+            since_round = int(since_round)
+        except (TypeError, ValueError):
+            return tool_error("since_round must be an integer")
+
+    participant_filter = args.get("participant")
+
+    try:
+        rdb, conn = _connect()
+        try:
+            disc = rdb.get_discussion(conn, discussion_id)
+            if not disc:
+                return tool_error(f"Discussion {discussion_id} not found")
+
+            speeches = rdb.get_speeches(
+                conn,
+                discussion_id,
+                since_round=since_round,
+                participant=participant_filter,
+            )
+            participants = rdb.get_participants(conn, discussion_id)
+            p_map = {
+                p.participant: {
+                    "role": p.role,
+                    "display_name": p.display_name,
+                    "perspective": p.perspective,
+                }
+                for p in participants
+            }
+
+            return json.dumps({
+                "ok": True,
+                "discussion_id": disc.id,
+                "topic": disc.topic,
+                "current_round": disc.current_round,
+                "max_rounds": disc.max_rounds,
+                "status": disc.status,
+                "speeches": [
+                    {
+                        "id": s.id,
+                        "round": s.round,
+                        "participant": s.participant,
+                        "display_name": p_map.get(s.participant, {}).get("display_name"),
+                        "content": s.content,
+                        "reply_to": s.reply_to,
+                        "created_at": s.created_at,
+                    }
+                    for s in speeches
+                ],
+                "speech_count": len(speeches),
+                "formatted_history": _format_history(speeches, p_map),
+            })
+        finally:
+            conn.close()
+    except Exception as e:
+        logger.exception("roundtable_read failed")
+        return tool_error(f"roundtable_read: {e}")
+
+
+def _handle_status(args: dict, **kw) -> str:
+    """Get discussion status including convergence metrics."""
+    discussion_id = args.get("discussion_id", "").strip()
+    if not discussion_id:
+        return tool_error("discussion_id is required")
+
+    try:
+        rdb, conn = _connect()
+        try:
+            disc = rdb.get_discussion(conn, discussion_id)
+            if not disc:
+                return tool_error(f"Discussion {discussion_id} not found")
+
+            participants = rdb.get_participants(conn, discussion_id)
+            speech_count = rdb.get_speech_count(conn, discussion_id)
+            findings = rdb.get_findings(conn, discussion_id)
+            conv_history = rdb.get_convergence_history(conn, discussion_id)
+
+            consensus_pts = [f.content for f in findings if f.type == "consensus"]
+            disagreement_pts = [f.content for f in findings if f.type == "disagreement"]
+            new_points = [f.content for f in findings if f.type == "new_point"]
+
+            # Determine next speaker
+            active_names = rdb.get_active_participant_names(conn, discussion_id)
+            next_speaker = None
+            if disc.status == "active" and active_names:
+                speakers_current = conn.execute(
+                    """SELECT DISTINCT participant FROM speeches
+                       WHERE discussion_id = ? AND round = ?""",
+                    (discussion_id, disc.current_round),
+                ).fetchall()
+                spoke = {r["participant"] for r in speakers_current}
+                for name in active_names:
+                    if name not in spoke:
+                        next_speaker = name
+                        break
+
+            return json.dumps({
+                "ok": True,
+                "discussion_id": disc.id,
+                "topic": disc.topic,
+                "status": disc.status,
+                "current_round": disc.current_round,
+                "max_rounds": disc.max_rounds,
+                "speech_order": disc.speech_order,
+                "convergence_score": disc.convergence_score,
+                "consensus_points": consensus_pts,
+                "disagreement_points": disagreement_pts,
+                "new_points": new_points,
+                "speech_count": speech_count,
+                "participant_count": len(participants),
+                "next_speaker": next_speaker,
+                "convergence_history": [
+                    {
+                        "round": c.round,
+                        "score": c.score,
+                        "consensus": c.consensus_count,
+                        "disagreement": c.disagreement_count,
+                        "new_points": c.new_point_count,
+                    }
+                    for c in conv_history
+                ],
+            })
+        finally:
+            conn.close()
+    except Exception as e:
+        logger.exception("roundtable_status failed")
+        return tool_error(f"roundtable_status: {e}")
+
+
+def _handle_summarize(args: dict, **kw) -> str:
+    """Generate a conclusion document from the discussion.
+
+    Returns structured data that the coordinator can use to write the final
+    conclusion document. Does NOT call an LLM — the coordinator agent is
+    expected to use this data to produce the Markdown conclusion.
+    """
+    discussion_id = args.get("discussion_id", "").strip()
+    if not discussion_id:
+        return tool_error("discussion_id is required")
+
+    try:
+        rdb, conn = _connect()
+        try:
+            disc = rdb.get_discussion(conn, discussion_id)
+            if not disc:
+                return tool_error(f"Discussion {discussion_id} not found")
+
+            participants = rdb.get_participants(conn, discussion_id)
+            speeches = rdb.get_speeches(conn, discussion_id)
+            findings = rdb.get_findings(conn, discussion_id)
+            conv_history = rdb.get_convergence_history(conn, discussion_id)
+
+            p_map = {
+                p.participant: {
+                    "role": p.role,
+                    "display_name": p.display_name,
+                    "perspective": p.perspective,
+                }
+                for p in participants
+            }
+
+            consensus_pts = [f.content for f in findings if f.type == "consensus"]
+            disagreement_pts = [f.content for f in findings if f.type == "disagreement"]
+            new_points = [f.content for f in findings if f.type == "new_point"]
+
+            # Group speeches by round
+            rounds_dict: dict = {}
+            for s in speeches:
+                rounds_dict.setdefault(s.round, []).append({
+                    "id": s.id,
+                    "participant": s.participant,
+                    "display_name": p_map.get(s.participant, {}).get("display_name"),
+                    "role": p_map.get(s.participant, {}).get("role"),
+                    "content": s.content,
+                    "reply_to": s.reply_to,
+                })
+
+            # Calculate overall convergence
+            final_score = disc.convergence_score
+            if not final_score and conv_history:
+                final_score = conv_history[-1].score
+
+            return json.dumps({
+                "ok": True,
+                "discussion_id": disc.id,
+                "topic": disc.topic,
+                "context": disc.context,
+                "status": disc.status,
+                "total_rounds": disc.current_round,
+                "max_rounds": disc.max_rounds,
+                "final_convergence_score": final_score,
+                "participants": [
+                    {
+                        "profile": p.participant,
+                        "display_name": p.display_name,
+                        "role": p.role,
+                        "perspective": p.perspective,
+                    }
+                    for p in participants
+                ],
+                "consensus_points": consensus_pts,
+                "disagreement_points": disagreement_pts,
+                "new_points": new_points,
+                "speech_count": len(speeches),
+                "rounds": rounds_dict,
+                "convergence_history": [
+                    {
+                        "round": c.round,
+                        "score": c.score,
+                        "consensus": c.consensus_count,
+                        "disagreement": c.disagreement_count,
+                    }
+                    for c in conv_history
+                ],
+                "output_path": disc.output_path,
+                "formatted_history": _format_history(speeches, p_map),
+            })
+        finally:
+            conn.close()
+    except Exception as e:
+        logger.exception("roundtable_summarize failed")
+        return tool_error(f"roundtable_summarize: {e}")
+
+
+def _handle_end(args: dict, **kw) -> str:
+    """End a discussion (conclude or cancel)."""
+    discussion_id = args.get("discussion_id", "").strip()
+    if not discussion_id:
+        return tool_error("discussion_id is required")
+
+    force = args.get("force", False)
+    conclusion = args.get("conclusion")
+
+    try:
+        rdb, conn = _connect()
+        try:
+            disc = rdb.get_discussion(conn, discussion_id)
+            if not disc:
+                return tool_error(f"Discussion {discussion_id} not found")
+            if disc.status != "active":
+                return tool_error(
+                    f"Discussion {discussion_id} is already {disc.status}"
+                )
+
+            if force:
+                ok = rdb.cancel_discussion(conn, discussion_id)
+                action = "cancelled"
+            else:
+                ok = rdb.conclude_discussion(
+                    conn, discussion_id, conclusion=conclusion
+                )
+                action = "concluded"
+
+            return _ok(
+                discussion_id=discussion_id,
+                action=action,
+                success=ok,
+            )
+        finally:
+            conn.close()
+    except Exception as e:
+        logger.exception("roundtable_end failed")
+        return tool_error(f"roundtable_end: {e}")
+
+
+def _handle_list(args: dict, **kw) -> str:
+    """List all discussions with optional status filter."""
+    status = args.get("status")
+    limit = args.get("limit", 50)
+    try:
+        limit = int(limit)
+    except (TypeError, ValueError):
+        return tool_error("limit must be an integer")
+
+    try:
+        rdb, conn = _connect()
+        try:
+            discussions = rdb.list_discussions(conn, status=status, limit=limit)
+            return json.dumps({
+                "ok": True,
+                "discussions": [
+                    {
+                        "id": d.id,
+                        "topic": d.topic,
+                        "status": d.status,
+                        "current_round": d.current_round,
+                        "max_rounds": d.max_rounds,
+                        "created_by": d.created_by,
+                        "created_at": d.created_at,
+                        "concluded_at": d.concluded_at,
+                        "convergence_score": d.convergence_score,
+                    }
+                    for d in discussions
+                ],
+                "count": len(discussions),
+                "filter_status": status,
+            })
+        finally:
+            conn.close()
+    except Exception as e:
+        logger.exception("roundtable_list failed")
+        return tool_error(f"roundtable_list: {e}")
+
+
+# ---------------------------------------------------------------------------
+# Tool schemas
+# ---------------------------------------------------------------------------
+
+ROUNDTABLE_INIT_SCHEMA = {
+    "name": "roundtable_init",
+    "description": (
+        "Create a new roundtable discussion with a topic and participants. "
+        "Each participant is an agent profile that will take turns speaking. "
+        "Returns the discussion_id for subsequent calls."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "topic": {
+                "type": "string",
+                "description": "The discussion topic",
+            },
+            "participants": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "profile": {
+                            "type": "string",
+                            "description": "Agent profile name (e.g. 'bingge', 'mafei')",
+                        },
+                        "role": {
+                            "type": "string",
+                            "description": "Role description (e.g. '产品总监')",
+                        },
+                        "perspective": {
+                            "type": "string",
+                            "description": "Role perspective hint (e.g. '关注用户体验')",
+                        },
+                        "display_name": {
+                            "type": "string",
+                            "description": "Display name (e.g. '饼哥')",
+                        },
+                    },
+                    "required": ["profile"],
+                },
+                "description": "List of participant profiles (min 2)",
+            },
+            "context": {
+                "type": "string",
+                "description": "Background context for the discussion",
+            },
+            "max_rounds": {
+                "type": "integer",
+                "description": "Maximum discussion rounds (default: 5)",
+                "default": 5,
+            },
+            "speech_order": {
+                "type": "string",
+                "enum": ["fixed", "random", "priority", "free"],
+                "description": "Speech order strategy (default: fixed)",
+                "default": "fixed",
+            },
+            "output_path": {
+                "type": "string",
+                "description": "Path to save the conclusion document",
+            },
+            "created_by": {
+                "type": "string",
+                "description": "Profile name of the discussion creator",
+            },
+        },
+        "required": ["topic", "participants"],
+    },
+}
+
+ROUNDTABLE_SPEAK_SCHEMA = {
+    "name": "roundtable_speak",
+    "description": (
+        "Record a participant's speech in a roundtable discussion. "
+        "Automatically tracks rounds and advances when all participants have spoken."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "discussion_id": {
+                "type": "string",
+                "description": "Discussion ID (rt_xxxxxxxx)",
+            },
+            "participant": {
+                "type": "string",
+                "description": "Profile name of the speaker",
+            },
+            "content": {
+                "type": "string",
+                "description": "Speech content (Markdown supported)",
+            },
+            "reply_to": {
+                "type": "integer",
+                "description": "Optional: ID of a speech being referenced/replied to",
+            },
+        },
+        "required": ["discussion_id", "participant", "content"],
+    },
+}
+
+ROUNDTABLE_READ_SCHEMA = {
+    "name": "roundtable_read",
+    "description": (
+        "Read the discussion history — all speeches or filtered by round/participant. "
+        "Returns both structured data and a formatted history string."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "discussion_id": {
+                "type": "string",
+                "description": "Discussion ID (rt_xxxxxxxx)",
+            },
+            "since_round": {
+                "type": "integer",
+                "description": "Only return speeches from this round onwards",
+            },
+            "participant": {
+                "type": "string",
+                "description": "Only return speeches from this participant",
+            },
+        },
+        "required": ["discussion_id"],
+    },
+}
+
+ROUNDTABLE_STATUS_SCHEMA = {
+    "name": "roundtable_status",
+    "description": (
+        "Get discussion status including current round, convergence score, "
+        "consensus/disagreement points, and next speaker."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "discussion_id": {
+                "type": "string",
+                "description": "Discussion ID (rt_xxxxxxxx)",
+            },
+        },
+        "required": ["discussion_id"],
+    },
+}
+
+ROUNDTABLE_SUMMARIZE_SCHEMA = {
+    "name": "roundtable_summarize",
+    "description": (
+        "Generate summary data for a conclusion document. Returns all discussion "
+        "data organized by round, with consensus/disagreement points extracted. "
+        "Use this to write the final Markdown conclusion."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "discussion_id": {
+                "type": "string",
+                "description": "Discussion ID (rt_xxxxxxxx)",
+            },
+        },
+        "required": ["discussion_id"],
+    },
+}
+
+ROUNDTABLE_END_SCHEMA = {
+    "name": "roundtable_end",
+    "description": (
+        "End a roundtable discussion. By default, marks it as concluded. "
+        "Use force=true to cancel instead."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "discussion_id": {
+                "type": "string",
+                "description": "Discussion ID (rt_xxxxxxxx)",
+            },
+            "force": {
+                "type": "boolean",
+                "description": "If true, cancel the discussion instead of concluding",
+                "default": False,
+            },
+            "conclusion": {
+                "type": "string",
+                "description": "Optional: conclusion text to save",
+            },
+        },
+        "required": ["discussion_id"],
+    },
+}
+
+ROUNDTABLE_LIST_SCHEMA = {
+    "name": "roundtable_list",
+    "description": "List roundtable discussions with optional status filter.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "status": {
+                "type": "string",
+                "enum": ["active", "concluded", "cancelled"],
+                "description": "Filter by status (omit for all)",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Max results to return (default: 50)",
+                "default": 50,
+            },
+        },
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+registry.register(
+    name="roundtable_init",
+    toolset="roundtable",
+    schema=ROUNDTABLE_INIT_SCHEMA,
+    handler=_handle_init,
+    check_fn=_check_roundtable_enabled,
+    emoji="🎯",
+)
+
+registry.register(
+    name="roundtable_speak",
+    toolset="roundtable",
+    schema=ROUNDTABLE_SPEAK_SCHEMA,
+    handler=_handle_speak,
+    check_fn=_check_roundtable_enabled,
+    emoji="💬",
+)
+
+registry.register(
+    name="roundtable_read",
+    toolset="roundtable",
+    schema=ROUNDTABLE_READ_SCHEMA,
+    handler=_handle_read,
+    check_fn=_check_roundtable_enabled,
+    emoji="📖",
+)
+
+registry.register(
+    name="roundtable_status",
+    toolset="roundtable",
+    schema=ROUNDTABLE_STATUS_SCHEMA,
+    handler=_handle_status,
+    check_fn=_check_roundtable_enabled,
+    emoji="📊",
+)
+
+registry.register(
+    name="roundtable_summarize",
+    toolset="roundtable",
+    schema=ROUNDTABLE_SUMMARIZE_SCHEMA,
+    handler=_handle_summarize,
+    check_fn=_check_roundtable_enabled,
+    emoji="📝",
+)
+
+registry.register(
+    name="roundtable_end",
+    toolset="roundtable",
+    schema=ROUNDTABLE_END_SCHEMA,
+    handler=_handle_end,
+    check_fn=_check_roundtable_enabled,
+    emoji="🏁",
+)
+
+registry.register(
+    name="roundtable_list",
+    toolset="roundtable",
+    schema=ROUNDTABLE_LIST_SCHEMA,
+    handler=_handle_list,
+    check_fn=_check_roundtable_enabled,
+    emoji="📋",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -68,6 +68,10 @@ _HERMES_CORE_TOOLS = [
     "kanban_complete", "kanban_block", "kanban_heartbeat",
     "kanban_comment", "kanban_create", "kanban_link",
     "kanban_unblock",
+    # Roundtable multi-agent discussion (gated via check_fn in tools/roundtable_tools.py)
+    "roundtable_init", "roundtable_speak", "roundtable_read",
+    "roundtable_status", "roundtable_summarize", "roundtable_end",
+    "roundtable_list",
     # Computer use (macOS, gated on cua-driver being installed via check_fn)
     "computer_use",
 ]
@@ -254,6 +258,22 @@ TOOLSETS = {
             "kanban_heartbeat", "kanban_comment",
             "kanban_create", "kanban_link",
             "kanban_unblock",
+        ],
+        "includes": [],
+    },
+
+    "roundtable": {
+        "description": (
+            "Multi-agent roundtable discussion — structured multi-round topic "
+            "debate with convergence detection and conclusion generation. "
+            "Enable in profile toolsets to let agents create discussions, "
+            "take turns speaking, track consensus/disagreement, and produce "
+            "conclusion documents."
+        ),
+        "tools": [
+            "roundtable_init", "roundtable_speak", "roundtable_read",
+            "roundtable_status", "roundtable_summarize", "roundtable_end",
+            "roundtable_list",
         ],
         "includes": [],
     },


### PR DESCRIPTION
## Summary

Adds a complete **roundtable discussion** feature to Hermes Agent — enabling multiple AI agents to engage in structured, multi-round debates on any topic with automatic consensus tracking.

## Why this matters

Hermes already supports task delegation and kanban-based workflows, but there's no way for multiple agents to **discuss and debate** a topic together. This fills that gap — agents can now have back-and-forth conversations, challenge each other's ideas, and converge on a shared conclusion.

## What's included

| Component | File | Description |
|-----------|------|-------------|
| **7 tools** | tools/roundtable_tools.py | init, speak, advance, summarize, status, read, end |
| **SQLite DB** | hermes_cli/roundtable_db.py | Discussions, speeches, participants, consensus tracking |
| **Skill** | skills/software-development/roundtable/ | SKILL.md + README |
| **Tests** | tests/tools/, tests/hermes_cli/ | **44 tests, all passing** |

## Key design decisions

- **SQLite storage** — persistent across sessions, no external dependencies
- **Coordinator role** — a meta-participant that can open/close discussions without affecting round logic
- **Convergence scoring** — automatic consensus/disagreement detection per round
- **Skill-driven** — agents learn the roundtable protocol via SKILL.md, not hardcoded behavior

## Testing

44 tests, all passing. Run with:

    python -m pytest tests/tools/test_roundtable_tools.py tests/hermes_cli/test_roundtable_db.py -v

---

Closes #28825
