### PR TITLE
fix(computer-use): stop actions on app target drift

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1415,6 +1415,7 @@ AUTHOR_MAP = {
     "zccyman@163.com": "zccyman",  # PR #25294 (custom provider api_key_env alias)
     # xAI cluster batch salvage (May 2026)
     "lgndscntn@gmail.com": "Fewmanism",  # PR #27420 (threaded xAI OAuth callback)
+    "lgndscntn@googlemail.com": "Fewmanism",  # PR #28830 (computer_use app target drift)
     "slimydog@Faisals-Mac-mini.local": "Slimydog21",  # PR #28021 (strip slash enums xAI Responses)
     "194121339+Slimydog21@users.noreply.github.com": "Slimydog21",  # PR #28021 salvage (noreply form)
     "bitkyc08@gmail.com": "lidge-jun",  # PR #26814 (api server browser security headers)

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -381,6 +381,77 @@ class TestTargetAppDriftGuard:
             ("capture", "som", "Safari"),
         ]
 
+    def test_capture_with_requested_app_preserves_max_elements_cap(self):
+        from tools.computer_use import tool as cu_tool
+        from tools.computer_use.backend import CaptureResult, UIElement
+
+        elements = [
+            UIElement(index=i + 1, role="AXButton", label=f"el-{i}", bounds=(0, 0, 1, 1))
+            for i in range(25)
+        ]
+
+        class SafariBackend:
+            def __init__(self):
+                self.calls = []
+            def capture(self, mode="som", app=None):
+                self.calls.append(("capture", mode, app))
+                return CaptureResult(
+                    mode=mode, width=1, height=1,
+                    elements=list(elements),
+                    app="Safari", window_title="Example",
+                )
+
+        backend = SafariBackend()
+        cu_tool.reset_backend_for_tests()
+        with patch.object(cu_tool, "_get_backend", return_value=backend):
+            out = cu_tool.handle_computer_use({
+                "action": "capture",
+                "mode": "ax",
+                "app": "Safari",
+                "max_elements": 5,
+            })
+
+        parsed = json.loads(out)
+        assert len(parsed["elements"]) == 5
+        assert parsed["total_elements"] == 25
+        assert parsed["truncated_elements"] == 20
+        assert backend.calls == [("capture", "ax", "Safari")]
+
+    def test_failed_action_with_requested_app_skips_capture_after(self):
+        from tools.computer_use import tool as cu_tool
+        from tools.computer_use.backend import ActionResult, CaptureResult
+
+        class FailingSafariBackend:
+            def __init__(self):
+                self.calls = []
+            def capture(self, mode="som", app=None):
+                self.calls.append(("capture", mode, app))
+                return CaptureResult(
+                    mode=mode, width=1, height=1,
+                    app="Safari", window_title="Example",
+                )
+            def scroll(self, **kw):
+                self.calls.append(("scroll", kw))
+                return ActionResult(ok=False, action="scroll", message="element not found")
+
+        backend = FailingSafariBackend()
+        cu_tool.reset_backend_for_tests()
+        with patch.object(cu_tool, "_get_backend", return_value=backend):
+            out = cu_tool.handle_computer_use({
+                "action": "scroll",
+                "app": "Safari",
+                "direction": "down",
+                "capture_after": True,
+            })
+
+        parsed = json.loads(out)
+        assert parsed["ok"] is False
+        assert parsed["action"] == "scroll"
+        assert backend.calls == [
+            ("capture", "ax", "Safari"),
+            ("scroll", {"direction": "down", "amount": 3, "element": None, "x": None, "y": None, "modifiers": None}),
+        ]
+
     def test_app_matcher_accepts_common_localized_macos_names(self):
         from tools.computer_use.tool import _app_matches_requested
 

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -277,6 +277,246 @@ class TestDispatch:
 
 
 # ---------------------------------------------------------------------------
+# Target app drift guard
+# ---------------------------------------------------------------------------
+
+class TestTargetAppDriftGuard:
+    def test_state_changing_action_stops_on_requested_app_mismatch_before_scroll(self):
+        from tools.computer_use import tool as cu_tool
+        from tools.computer_use.backend import ActionResult, CaptureResult
+
+        class DriftBackend:
+            def __init__(self):
+                self.calls = []
+            def capture(self, mode="som", app=None):
+                self.calls.append(("capture", mode, app))
+                return CaptureResult(
+                    mode=mode, width=1, height=1,
+                    app="QuickTime Player", window_title="Movie Recording",
+                )
+            def scroll(self, **kw):
+                self.calls.append(("scroll", kw))
+                return ActionResult(ok=True, action="scroll")
+
+        backend = DriftBackend()
+        cu_tool.reset_backend_for_tests()
+        with patch.object(cu_tool, "_get_backend", return_value=backend):
+            out = cu_tool.handle_computer_use({
+                "action": "scroll",
+                "app": "システム設定",
+                "direction": "down",
+            })
+
+        parsed = json.loads(out)
+        assert parsed["error"] == "target_mismatch"
+        assert parsed["requested_app"] == "システム設定"
+        assert parsed["actual_app"] == "QuickTime Player"
+        assert backend.calls == [("capture", "ax", "システム設定")]
+
+    def test_localized_system_settings_name_matches_english_returned_app(self):
+        from tools.computer_use import tool as cu_tool
+        from tools.computer_use.backend import ActionResult, CaptureResult
+
+        class SystemSettingsBackend:
+            def __init__(self):
+                self.calls = []
+            def capture(self, mode="som", app=None):
+                self.calls.append(("capture", mode, app))
+                return CaptureResult(
+                    mode=mode, width=1, height=1,
+                    app="System Settings", window_title="Sharing",
+                )
+            def scroll(self, **kw):
+                self.calls.append(("scroll", kw))
+                return ActionResult(ok=True, action="scroll")
+
+        backend = SystemSettingsBackend()
+        cu_tool.reset_backend_for_tests()
+        with patch.object(cu_tool, "_get_backend", return_value=backend):
+            out = cu_tool.handle_computer_use({
+                "action": "scroll",
+                "app": "システム設定",
+                "direction": "down",
+            })
+
+        parsed = json.loads(out)
+        assert parsed["ok"] is True
+        assert parsed["action"] == "scroll"
+        assert backend.calls[0] == ("capture", "ax", "システム設定")
+        assert backend.calls[1][0] == "scroll"
+
+    def test_capture_after_reuses_requested_app_for_followup_capture(self):
+        from tools.computer_use import tool as cu_tool
+        from tools.computer_use.backend import ActionResult, CaptureResult
+
+        class SafariBackend:
+            def __init__(self):
+                self.calls = []
+            def capture(self, mode="som", app=None):
+                self.calls.append(("capture", mode, app))
+                return CaptureResult(
+                    mode=mode, width=1, height=1,
+                    app="Safari", window_title="Example",
+                )
+            def scroll(self, **kw):
+                self.calls.append(("scroll", kw))
+                return ActionResult(ok=True, action="scroll")
+
+        backend = SafariBackend()
+        cu_tool.reset_backend_for_tests()
+        with patch.object(cu_tool, "_get_backend", return_value=backend):
+            out = cu_tool.handle_computer_use({
+                "action": "scroll",
+                "app": "Safari",
+                "direction": "down",
+                "capture_after": True,
+            })
+
+        parsed = json.loads(out)
+        assert parsed["ok"] is True
+        assert parsed["app"] == "Safari"
+        assert backend.calls == [
+            ("capture", "ax", "Safari"),
+            ("scroll", {"direction": "down", "amount": 3, "element": None, "x": None, "y": None, "modifiers": None}),
+            ("capture", "som", "Safari"),
+        ]
+
+    def test_app_matcher_accepts_common_localized_macos_names(self):
+        from tools.computer_use.tool import _app_matches_requested
+
+        assert _app_matches_requested("システム設定", "System Settings")
+        assert _app_matches_requested("システム環境設定", "System Preferences")
+        assert not _app_matches_requested("システム設定", "QuickTime Player")
+
+    def test_app_matcher_rejects_short_substring_false_positives(self):
+        from tools.computer_use.tool import _app_matches_requested
+
+        assert not _app_matches_requested("Mail", "Airmail")
+        assert not _app_matches_requested("Settings", "System Settings")
+
+    def test_focus_app_mismatch_includes_available_apps_for_diagnostics(self):
+        from tools.computer_use import tool as cu_tool
+        from tools.computer_use.backend import ActionResult
+
+        class FocusMismatchBackend:
+            def focus_app(self, app, raise_window=False):
+                return ActionResult(
+                    ok=False,
+                    action="focus_app",
+                    message="target_mismatch",
+                    meta={
+                        "error": "target_mismatch",
+                        "actual_app": "QuickTime Player",
+                        "available_apps": ["QuickTime Player", "System Settings"],
+                    },
+                )
+
+        cu_tool.reset_backend_for_tests()
+        with patch.object(cu_tool, "_get_backend", return_value=FocusMismatchBackend()):
+            out = cu_tool.handle_computer_use({
+                "action": "focus_app",
+                "app": "システム設定",
+            })
+
+        parsed = json.loads(out)
+        assert parsed["error"] == "target_mismatch"
+        assert parsed["available_apps"] == ["QuickTime Player", "System Settings"]
+
+    def test_cua_capture_app_filter_uses_localized_alias_without_frontmost_fallback(self):
+        from tools.computer_use.cua_backend import CuaDriverBackend
+
+        class FakeSession:
+            def __init__(self):
+                self.calls = []
+            def call_tool(self, name, args):
+                self.calls.append((name, args))
+                if name == "list_windows":
+                    return {
+                        "data": None,
+                        "images": [],
+                        "structuredContent": {
+                            "windows": [
+                                {
+                                    "app_name": "QuickTime Player",
+                                    "pid": 1076,
+                                    "window_id": 66,
+                                    "is_on_screen": True,
+                                    "title": "Movie Recording",
+                                    "z_index": 0,
+                                },
+                                {
+                                    "app_name": "System Settings",
+                                    "pid": 1043,
+                                    "window_id": 35,
+                                    "is_on_screen": True,
+                                    "title": "Sharing",
+                                    "z_index": 1,
+                                },
+                            ]
+                        },
+                        "isError": False,
+                    }
+                if name == "get_window_state":
+                    return {
+                        "data": '✅ System Settings — 0 elements\nAXWindow "Sharing"',
+                        "images": [],
+                        "structuredContent": None,
+                        "isError": False,
+                    }
+                raise AssertionError(f"unexpected tool call {name}")
+
+        backend = CuaDriverBackend()
+        fake_session = FakeSession()
+        setattr(backend, "_session", fake_session)
+
+        cap = backend.capture(mode="ax", app="システム設定")
+
+        assert cap.app == "System Settings"
+        assert cap.window_title == "Sharing"
+        assert backend._active_pid == 1043
+        assert backend._active_window_id == 35
+        assert fake_session.calls == [
+            ("list_windows", {"on_screen_only": True}),
+            ("get_window_state", {"pid": 1043, "window_id": 35}),
+        ]
+
+    def test_cua_focus_app_mismatch_does_not_target_frontmost_window(self):
+        from tools.computer_use.cua_backend import CuaDriverBackend
+
+        class FakeSession:
+            def call_tool(self, name, args):
+                assert name == "list_windows"
+                return {
+                    "data": None,
+                    "images": [],
+                    "structuredContent": {
+                        "windows": [
+                            {
+                                "app_name": "QuickTime Player",
+                                "pid": 1076,
+                                "window_id": 66,
+                                "is_on_screen": True,
+                                "z_index": 0,
+                            },
+                        ]
+                    },
+                    "isError": False,
+                }
+
+        backend = CuaDriverBackend()
+        setattr(backend, "_session", FakeSession())
+
+        result = backend.focus_app("システム設定")
+
+        assert result.ok is False
+        assert result.meta["error"] == "target_mismatch"
+        assert result.meta["actual_app"] == "QuickTime Player"
+        assert result.meta["available_apps"] == ["QuickTime Player"]
+        assert backend._active_pid is None
+        assert backend._active_window_id is None
+
+
+# ---------------------------------------------------------------------------
 # Safety guards (type / key block lists)
 # ---------------------------------------------------------------------------
 

--- a/tools/computer_use/backend.py
+++ b/tools/computer_use/backend.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Tuple
+import re
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 
 @dataclass
@@ -66,6 +67,93 @@ class ActionResult:
     capture: Optional[CaptureResult] = None
     # Arbitrary extra fields for debugging / telemetry.
     meta: Dict[str, Any] = field(default_factory=dict)
+
+
+# Conservative macOS app-name alias matching shared by the safety wrapper and
+# concrete backends. A false positive could route input to the wrong process;
+# keep aliases explicit rather than broad/fuzzy.
+_APP_ALIASES: Dict[str, Set[str]] = {
+    "システム設定": {
+        "system settings",
+        "system preferences",
+        "システム環境設定",
+        "com.apple.systemsettings",
+        "com.apple.systempreferences",
+    },
+    "システム環境設定": {
+        "system settings",
+        "system preferences",
+        "システム設定",
+        "com.apple.systemsettings",
+        "com.apple.systempreferences",
+    },
+    "system settings": {
+        "システム設定",
+        "システム環境設定",
+        "system preferences",
+        "com.apple.systemsettings",
+        "com.apple.systempreferences",
+    },
+    "system preferences": {
+        "システム設定",
+        "システム環境設定",
+        "system settings",
+        "com.apple.systemsettings",
+        "com.apple.systempreferences",
+    },
+    "com.apple.systemsettings": {
+        "システム設定",
+        "システム環境設定",
+        "system settings",
+        "system preferences",
+        "com.apple.systempreferences",
+    },
+    "com.apple.systempreferences": {
+        "システム設定",
+        "システム環境設定",
+        "system settings",
+        "system preferences",
+        "com.apple.systemsettings",
+    },
+}
+
+
+def _normalize_app_name(value: str) -> str:
+    normalized = (value or "").casefold().strip()
+    if normalized.endswith(".app"):
+        normalized = normalized[:-4]
+    return re.sub(r"[\s_\-.]+", " ", normalized).strip()
+
+
+def _app_name_variants(value: str) -> Set[str]:
+    normalized = _normalize_app_name(value)
+    if not normalized:
+        return set()
+    variants = {normalized}
+    for alias in _APP_ALIASES.get(normalized, set()):
+        variants.add(_normalize_app_name(alias))
+    return variants
+
+
+def app_matches_requested(requested_app: str, actual_app: str) -> bool:
+    """Return True when an actual app/window matches a requested app name.
+
+    Prefer exact names and explicit localized aliases. Allow only conservative
+    one-way containment for multi-word app names so short/generic requests like
+    ``Mail`` or ``Settings`` cannot accidentally match unrelated apps.
+    """
+    requested = _app_name_variants(requested_app)
+    actual = _app_name_variants(actual_app)
+    if not requested or not actual:
+        return False
+    if requested & actual:
+        return True
+    for req in requested:
+        if " " not in req or len(req) < 10:
+            continue
+        if any(req in act for act in actual):
+            return True
+    return False
 
 
 class ComputerUseBackend(ABC):

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -471,7 +471,10 @@ class CuaDriverBackend(ComputerUseBackend):
                     png_b64=None,
                     elements=[],
                     app="",
-                    window_title=f"No on-screen window found for app {app!r}",
+                    window_title=(
+                        f"No on-screen window found for app {app!r}; "
+                        "call list_apps to see available app names"
+                    ),
                     png_bytes_len=0,
                 )
             windows = filtered

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -33,6 +33,7 @@ from tools.computer_use.backend import (
     CaptureResult,
     ComputerUseBackend,
     UIElement,
+    app_matches_requested,
 )
 
 logger = logging.getLogger(__name__)
@@ -457,25 +458,20 @@ class CuaDriverBackend(ComputerUseBackend):
             return CaptureResult(mode=mode, width=0, height=0, png_b64=None,
                                  elements=[], app="", window_title="", png_bytes_len=0)
 
-        # Filter by app name (case-insensitive substring) if requested.
-        # When the filter matches nothing, surface that explicitly instead of
-        # silently capturing the frontmost window — on macOS the `app_name`
-        # returned by list_windows is the localized name (e.g. "計算機"), so
-        # `app="Calculator"` legitimately matches no windows on a non-English
-        # system and the caller needs to retry with the localized name.
+        # Filter by app name (case-insensitive substring plus conservative
+        # localized macOS aliases) if requested. Never fall back to frontmost
+        # when an app was explicitly requested; that is target drift.
         if app:
-            app_lower = app.lower()
-            filtered = [w for w in windows if app_lower in w["app_name"].lower()]
+            filtered = [w for w in windows if app_matches_requested(app, w["app_name"])]
             if not filtered:
                 return CaptureResult(
-                    mode=mode, width=0, height=0, png_b64=None,
-                    elements=[], app="",
-                    window_title=(
-                        f"<no on-screen window matched app={app!r}; "
-                        f"call list_apps to see available app names "
-                        f"(macOS reports localized names, e.g. '計算機' "
-                        f"instead of 'Calculator')>"
-                    ),
+                    mode=mode,
+                    width=0,
+                    height=0,
+                    png_b64=None,
+                    elements=[],
+                    app="",
+                    window_title=f"No on-screen window found for app {app!r}",
                     png_bytes_len=0,
                 )
             windows = filtered
@@ -742,24 +738,32 @@ class CuaDriverBackend(ComputerUseBackend):
             raw_text = lw_out["data"] if isinstance(lw_out["data"], str) else ""
             windows = _parse_windows_from_text(raw_text)
 
-        app_lower = app.lower()
-        matched = [w for w in windows if app_lower in w["app_name"].lower()]
-        # Don't silently fall back to the frontmost window when the filter
-        # matches nothing — that hides the real failure (often a localized
-        # macOS app name mismatch, e.g. caller passed "Calculator" but
-        # list_windows returns "計算機").
-        target = matched[0] if matched else None
-        if target:
-            self._active_pid = target["pid"]
-            self._active_window_id = target["window_id"]
-            self._last_app = target["app_name"]  # preserve for capture_after= follow-ups
+        matched = [w for w in windows if app_matches_requested(app, w["app_name"])]
+        if not matched:
+            actual_app = windows[0]["app_name"] if windows else ""
             return ActionResult(
-                ok=True, action="focus_app",
-                message=f"Targeted {target['app_name']} (pid {self._active_pid}, "
-                        f"window {self._active_window_id}) without raising window.",
+                ok=False,
+                action="focus_app",
+                message=(
+                    f"target_mismatch: requested app {app!r} did not match "
+                    f"any on-screen window; not targeting {actual_app!r}."
+                ),
+                meta={
+                    "error": "target_mismatch",
+                    "requested_app": app,
+                    "actual_app": actual_app,
+                    "available_apps": sorted({w["app_name"] for w in windows if w.get("app_name")}),
+                },
             )
-        return ActionResult(ok=False, action="focus_app",
-                            message=f"No on-screen window found for app '{app}'.")
+        target = matched[0]
+        self._active_pid = target["pid"]
+        self._active_window_id = target["window_id"]
+        self._last_app = target["app_name"]
+        return ActionResult(
+            ok=True, action="focus_app",
+            message=f"Targeted {target['app_name']} (pid {self._active_pid}, "
+                    f"window {self._active_window_id}) without raising window.",
+        )
 
     # ── Internal ───────────────────────────────────────────────────
     def _action(self, name: str, args: Dict[str, Any]) -> ActionResult:

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -47,6 +47,7 @@ from tools.computer_use.backend import (
     CaptureResult,
     ComputerUseBackend,
     UIElement,
+    app_matches_requested,
 )
 
 logger = logging.getLogger(__name__)
@@ -108,12 +109,46 @@ _BLOCKED_TYPE_PATTERNS = [
     re.compile(r":\s*\(\)\s*\{\s*:\|:\s*&\s*\}", re.IGNORECASE),  # fork bomb
 ]
 
-
 def _is_blocked_type(text: str) -> Optional[str]:
     for pat in _BLOCKED_TYPE_PATTERNS:
         if pat.search(text):
             return pat.pattern
     return None
+
+
+def _app_matches_requested(requested_app: str, actual_app: str) -> bool:
+    """Backward-compatible internal wrapper used by tests and callers."""
+    return app_matches_requested(requested_app, actual_app)
+
+
+def _target_mismatch_response(
+    *,
+    requested_app: str,
+    actual_app: str = "",
+    actual_window: str = "",
+    action: str,
+    phase: str,
+    message: str = "",
+    action_ok: Optional[bool] = None,
+    available_apps: Optional[List[str]] = None,
+) -> str:
+    payload: Dict[str, Any] = {
+        "error": "target_mismatch",
+        "action": action,
+        "phase": phase,
+        "requested_app": requested_app,
+        "actual_app": actual_app,
+        "actual_window": actual_window,
+        "message": message or (
+            f"Requested app {requested_app!r} did not match returned app "
+            f"{actual_app!r}. Stopping computer_use automation."
+        ),
+    }
+    if action_ok is not None:
+        payload["action_ok"] = action_ok
+    if available_apps is not None:
+        payload["available_apps"] = available_apps
+    return json.dumps(payload, ensure_ascii=False)
 
 
 # ---------------------------------------------------------------------------
@@ -317,12 +352,32 @@ def _summarize_action(action: str, args: Dict[str, Any]) -> str:
 
 def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) -> Any:
     capture_after = bool(args.get("capture_after"))
+    requested_app = args.get("app")
+
+    if requested_app and action in _DESTRUCTIVE_ACTIONS and action != "focus_app":
+        preflight = backend.capture(mode="ax", app=requested_app)
+        if not _app_matches_requested(requested_app, preflight.app):
+            return _target_mismatch_response(
+                requested_app=requested_app,
+                actual_app=preflight.app,
+                actual_window=preflight.window_title,
+                action=action,
+                phase="before_action",
+            )
 
     if action == "capture":
         mode = str(args.get("mode", "som"))
         if mode not in {"som", "vision", "ax"}:
             return json.dumps({"error": f"bad mode {mode!r}; use som|vision|ax"})
-        cap = backend.capture(mode=mode, app=args.get("app"))
+        cap = backend.capture(mode=mode, app=requested_app)
+        if requested_app and not _app_matches_requested(requested_app, cap.app):
+            return _target_mismatch_response(
+                requested_app=requested_app,
+                actual_app=cap.app,
+                actual_window=cap.window_title,
+                action=action,
+                phase="capture",
+            )
         return _capture_response(cap, max_elements=_coerce_max_elements(args.get("max_elements")))
 
     if action == "wait":
@@ -335,11 +390,22 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
         return json.dumps({"apps": apps, "count": len(apps)})
 
     if action == "focus_app":
-        app = args.get("app")
+        app = requested_app
         if not app:
             return json.dumps({"error": "focus_app requires `app`"})
         res = backend.focus_app(app, raise_window=bool(args.get("raise_window")))
-        return _maybe_follow_capture(backend, res, capture_after)
+        if res.meta.get("error") == "target_mismatch":
+            return _target_mismatch_response(
+                requested_app=app,
+                actual_app=str(res.meta.get("actual_app", "")),
+                actual_window=str(res.meta.get("actual_window", "")),
+                action=action,
+                phase="before_action",
+                message=res.message,
+                action_ok=res.ok,
+                available_apps=res.meta.get("available_apps"),
+            )
+        return _maybe_follow_capture(backend, res, capture_after, requested_app=app)
 
     if action in {"click", "double_click", "right_click", "middle_click"}:
         button = args.get("button")
@@ -360,7 +426,7 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
             x=x, y=y, button=button or "left", click_count=click_count,
             modifiers=args.get("modifiers"),
         )
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(backend, res, capture_after, requested_app=requested_app)
 
     if action == "drag":
         has_elements = args.get("from_element") is not None and args.get("to_element") is not None
@@ -377,7 +443,7 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
             button=args.get("button", "left"),
             modifiers=args.get("modifiers"),
         )
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(backend, res, capture_after, requested_app=requested_app)
 
     if action == "scroll":
         coord = args.get("coordinate") or (None, None)
@@ -389,22 +455,22 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
             y=coord[1] if coord and coord[1] is not None else None,
             modifiers=args.get("modifiers"),
         )
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(backend, res, capture_after, requested_app=requested_app)
 
     if action == "type":
         res = backend.type_text(args.get("text", ""))
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(backend, res, capture_after, requested_app=requested_app)
 
     if action == "key":
         res = backend.key(args.get("keys", ""))
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(backend, res, capture_after, requested_app=requested_app)
 
     if action == "set_value":
         value = args.get("value")
         if value is None:
             return json.dumps({"error": "set_value requires `value`"})
         res = backend.set_value(value=str(value), element=args.get("element"))
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(backend, res, capture_after, requested_app=requested_app)
 
     return json.dumps({"error": f"unknown action {action!r}"})
 
@@ -745,7 +811,10 @@ def _route_capture_through_aux_vision(
 
 
 def _maybe_follow_capture(
-    backend: ComputerUseBackend, res: ActionResult, do_capture: bool,
+    backend: ComputerUseBackend,
+    res: ActionResult,
+    do_capture: bool,
+    requested_app: Optional[str] = None,
 ) -> Any:
     if not do_capture:
         return _text_response(res)
@@ -758,11 +827,20 @@ def _maybe_follow_capture(
         # Preserve the app context established by the preceding capture/focus_app so
         # that capture_after=True re-captures the same app rather than the frontmost
         # window (which may have changed if the action caused a focus shift).
-        last_app = getattr(backend, "_last_app", None)
-        cap = backend.capture(mode="som", app=last_app)
+        follow_app = requested_app or getattr(backend, "_last_app", None)
+        cap = backend.capture(mode="som", app=follow_app)
     except Exception as e:
         logger.warning("follow-up capture failed: %s", e)
         return _text_response(res)
+    if requested_app and not _app_matches_requested(requested_app, cap.app):
+        return _target_mismatch_response(
+            requested_app=requested_app,
+            actual_app=cap.app,
+            actual_window=cap.window_title,
+            action=res.action,
+            phase="after_action",
+            action_ok=res.ok,
+        )
     # Combine action summary with the capture.
     resp = _capture_response(cap)
     if isinstance(resp, dict) and resp.get("_multimodal"):


### PR DESCRIPTION
## What does this PR do?

Stops `computer_use(app=...)` from dispatching state-changing GUI actions when an explicit app target resolves to a different or missing app/window.

The bug was reproduced on macOS with localized System Settings (`システム設定`) and even English app names resolving to a stale/frontmost QuickTime Player window during safe capture-only calls. Since later click/type/scroll actions can target that returned window, the tool now fails closed with a structured `target_mismatch` response instead of continuing automation.

The adjacent terminal escape sequence observed during the incident looked like focus/mouse-reporting bytes, but this PR treats that as a symptom/hypothesis rather than the proven root cause. The proven unsafe behavior is app target drift.

## Related Issue

N/A — reproduced locally during macOS computer-use operation.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/computer_use/backend.py`
  - Add conservative app target matching shared by tool wrapper and concrete backends.
  - Add explicit aliases for localized macOS System Settings/System Preferences names and bundle IDs.
  - Reject short/generic substring false positives such as `Mail` → `Airmail` and `Settings` → `System Settings` unless an explicit alias matches.
- `tools/computer_use/cua_backend.py`
  - Make `capture(app=...)` fail closed when no on-screen window matches instead of silently falling back to the frontmost/stale window.
  - Make `focus_app(app=...)` return `target_mismatch` instead of targeting an unrelated app.
  - Include available app names in mismatch metadata for diagnostics.
- `tools/computer_use/tool.py`
  - Preflight state-changing actions with explicit `app=...` before dispatch.
  - Return structured `target_mismatch` before click/scroll/type/key/set_value/drag when the returned app/window does not match the requested target.
  - Preserve requested app filtering for `capture_after` follow-up captures.
  - Forward `available_apps` in mismatch responses when available.
- `tests/tools/test_computer_use.py`
  - Add wrapper-level regression coverage for target drift before state-changing actions.
  - Add fake-session CUA backend smoke tests that do not touch real user apps or input fields.
  - Add localized app alias and false-positive rejection tests.

The commits are intentionally split so maintainers can cherry-pick the helper, CUA backend hardening, wrapper guard, and tests separately if desired.

## How to Test

Reproduction before fix:

1. Have multiple GUI apps open on macOS, including System Settings and QuickTime Player.
2. Request `computer_use(action="capture", app="システム設定", mode="ax")` or another explicit app.
3. Observe that the returned app/window can be QuickTime/frontmost/stale instead of the requested app.
4. A later state-changing action would then operate on that wrong target.

Verification after fix:

1. `scripts/run_tests.sh tests/tools/test_computer_use.py -q -p no:cacheprovider`
2. `git diff --check origin/main..HEAD`
3. `ruff check tools/computer_use/backend.py tools/computer_use/cua_backend.py tools/computer_use/tool.py tests/tools/test_computer_use.py`
4. `python scripts/check-windows-footguns.py --all`
5. `python -m py_compile tools/computer_use/backend.py tools/computer_use/cua_backend.py tools/computer_use/tool.py tests/tools/test_computer_use.py`

Local results:

```text
scripts/run_tests.sh tests/tools/test_computer_use.py -q -p no:cacheprovider
# 55 passed

git diff --check origin/main..HEAD
# pass

ruff check tools/computer_use/backend.py tools/computer_use/cua_backend.py tools/computer_use/tool.py tests/tools/test_computer_use.py
# pass

python scripts/check-windows-footguns.py --all
# pass

python -m py_compile tools/computer_use/backend.py tools/computer_use/cua_backend.py tools/computer_use/tool.py tests/tools/test_computer_use.py
# pass
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `test(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run targeted pytest for the changed test file and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.5

### Documentation & Housekeeping

- [x] Documentation update N/A — behavior is represented through structured tool errors and regression tests
- [x] `cli-config.yaml.example` update N/A — no config keys added/changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update N/A — no workflow/architecture change
- [x] Cross-platform impact considered — code path is macOS CUA backend + generic wrapper; Windows footgun check passes
- [x] Tool schema update N/A — no schema fields changed

## Screenshots / Logs

No screenshots. Tests use fake/stubbed backends and do not click/type/scroll/focus real user apps.
