### PR TITLE
fix(cli): keep threaded completions responsive without breaking ghost text

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -12671,12 +12671,15 @@ class HermesCLI:
 
         # Create the input area with multiline (Alt+Enter), autocomplete, and paste handling
         from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
+        from prompt_toolkit.completion import ThreadedCompleter
 
 
-        _completer = SlashCommandCompleter(
+        _base_completer = SlashCommandCompleter(
             skill_commands_provider=lambda: get_skill_commands(),
             command_filter=cli_ref._command_available,
         )
+        _completer = ThreadedCompleter(_base_completer)
+        _base_completer.refresh_project_files_async()
         input_area = TextArea(
             height=Dimension(min=1, max=8, preferred=1),
             prompt=get_prompt,
@@ -12689,7 +12692,7 @@ class HermesCLI:
             complete_while_typing=True,
             auto_suggest=SlashCommandAutoSuggest(
                 history_suggest=AutoSuggestFromHistory(),
-                completer=_completer,
+                completer=_base_completer,
             ),
         )
         # Keep prompt_toolkit on its simple tempfile path. Setting

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -15,6 +15,7 @@ import os
 import re
 import shutil
 import subprocess
+import threading
 import time
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
@@ -1127,6 +1128,9 @@ class SlashCommandCompleter(Completer):
         self._file_cache: list[str] = []
         self._file_cache_time: float = 0.0
         self._file_cache_cwd: str = ""
+        self._file_cache_lock = threading.Lock()
+        self._file_cache_refreshing = False
+        self._file_cache_refresh_cwd = ""
 
     def _command_allowed(self, slash_command: str) -> bool:
         if self._command_filter is None:
@@ -1345,17 +1349,8 @@ class SlashCommandCompleter(Completer):
         query = word[1:]  # strip the @
         yield from self._fuzzy_file_completions(word, query, limit)
 
-    def _get_project_files(self) -> list[str]:
-        """Return cached list of project files (refreshed every 5s)."""
-        cwd = os.getcwd()
-        now = time.monotonic()
-        if (
-            self._file_cache
-            and self._file_cache_cwd == cwd
-            and now - self._file_cache_time < 5.0
-        ):
-            return self._file_cache
-
+    def _scan_project_files(self, cwd: str) -> list[str]:
+        """Scan project files for fuzzy @ completions."""
         files: list[str] = []
         # Try rg first (fast, respects .gitignore), then fd, then find.
         for cmd in [
@@ -1380,10 +1375,60 @@ class SlashCommandCompleter(Completer):
                     break
             except (subprocess.TimeoutExpired, OSError):
                 continue
+        return files
 
-        self._file_cache = files
-        self._file_cache_time = now
-        self._file_cache_cwd = cwd
+    def _refresh_project_files(self, cwd: str) -> None:
+        """Refresh the project file cache for a given cwd."""
+        try:
+            files = self._scan_project_files(cwd)
+            now = time.monotonic()
+            with self._file_cache_lock:
+                self._file_cache = files
+                self._file_cache_time = now
+                self._file_cache_cwd = cwd
+        finally:
+            with self._file_cache_lock:
+                if self._file_cache_refresh_cwd == cwd:
+                    self._file_cache_refreshing = False
+                    self._file_cache_refresh_cwd = ""
+
+    def refresh_project_files_async(self, cwd: str | None = None) -> bool:
+        """Kick off a background refresh if one is not already in flight."""
+        target_cwd = cwd or os.getcwd()
+        with self._file_cache_lock:
+            if self._file_cache_refreshing and self._file_cache_refresh_cwd == target_cwd:
+                return False
+            self._file_cache_refreshing = True
+            self._file_cache_refresh_cwd = target_cwd
+        thread = threading.Thread(
+            target=self._refresh_project_files,
+            args=(target_cwd,),
+            name="hermes-cli-file-cache-refresh",
+            daemon=True,
+        )
+        thread.start()
+        return True
+
+    def _get_project_files(self) -> list[str]:
+        """Return cached list of project files, refreshing stale entries asynchronously."""
+        cwd = os.getcwd()
+        now = time.monotonic()
+        with self._file_cache_lock:
+            cached_files = list(self._file_cache)
+            cache_cwd = self._file_cache_cwd
+            cache_time = self._file_cache_time
+
+        if cached_files and cache_cwd == cwd:
+            if now - cache_time < 5.0:
+                return cached_files
+            self.refresh_project_files_async(cwd)
+            return cached_files
+
+        files = self._scan_project_files(cwd)
+        with self._file_cache_lock:
+            self._file_cache = files
+            self._file_cache_time = time.monotonic()
+            self._file_cache_cwd = cwd
         return files
 
     @staticmethod

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -1,5 +1,8 @@
 """Tests for the central command registry and autocomplete."""
 
+import time
+
+from prompt_toolkit.completion import ThreadedCompleter
 from prompt_toolkit.completion import CompleteEvent
 from prompt_toolkit.document import Document
 
@@ -724,8 +727,34 @@ class TestGhostText:
         completer = SlashCommandCompleter(command_filter=lambda cmd: cmd != "/fast")
         assert _suggestion("/fa", completer=completer) is None
 
+    def test_threaded_completer_uses_base_completer_for_ghost_text(self):
+        base_completer = SlashCommandCompleter(command_filter=lambda cmd: cmd != "/fast")
+        threaded = ThreadedCompleter(base_completer)
+        assert list(threaded.get_completions(Document("/he"), CompleteEvent(completion_requested=True)))
+        assert _suggestion("/fa", completer=base_completer) is None
+
     def test_no_suggestion_for_non_slash(self):
         assert _suggestion("hello") is None
+
+
+class TestProjectFileCache:
+    def test_returns_stale_cache_while_refreshing_in_background(self, monkeypatch):
+        completer = SlashCommandCompleter()
+        completer._file_cache = ["cached.py"]
+        completer._file_cache_cwd = "/tmp/project"
+        completer._file_cache_time = time.monotonic() - 10.0
+
+        refresh_calls: list[str] = []
+        monkeypatch.setattr("hermes_cli.commands.os.getcwd", lambda: "/tmp/project")
+
+        def fake_refresh(cwd: str | None = None) -> bool:
+            refresh_calls.append(cwd or "")
+            return True
+
+        monkeypatch.setattr(completer, "refresh_project_files_async", fake_refresh)
+
+        assert completer._get_project_files() == ["cached.py"]
+        assert refresh_calls == ["/tmp/project"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes a CLI autocomplete regression introduced while making file completion more responsive.

The original change wrapped `SlashCommandCompleter` in `ThreadedCompleter` to avoid blocking the TUI when project file completion had to scan the repo. That direction was good, but it also passed the wrapped completer into `SlashCommandAutoSuggest`, which expects `SlashCommandCompleter` internals like `_command_allowed()`. As a result, slash-command ghost text could break at runtime.

This PR keeps the threaded UI completer for responsiveness, while preserving the base completer for ghost-text behavior.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- In `cli.py`, keep a separate base `SlashCommandCompleter` and wrap only the UI-facing completer in `ThreadedCompleter`
- Pass the base completer to `SlashCommandAutoSuggest` so slash ghost text continues to work
- Prewarm the project file cache at CLI startup
- In `hermes_cli/commands.py`, split file discovery into scan/refresh helpers and refresh stale project file caches asynchronously
- Return stale cached file results immediately while a background refresh runs
- Add regression coverage for threaded-completer ghost-text compatibility
- Add tests for stale-cache background refresh behavior

## How to Test

1. Start Hermes:
   ```bash
   source .venv/bin/activate
   ./hermes
   ```
2. In the CLI, type `/he` and confirm slash ghost text and `/help` completion still work
3. In the CLI, type `@cl` or another bare `@...` file query and confirm file completions appear without freezing the UI
4. Optionally accept a suggested file completion and verify the CLI stays responsive

## Verification

Ran:

```bash
scripts/run_tests.sh tests/hermes_cli/test_commands.py tests/hermes_cli/test_path_completion.py
ruff check .
python scripts/check-windows-footguns.py --all
```

Also manually smoke-tested the real `hermes` TUI:
- CLI startup
- slash-command completion (`/he`)
- bare `@...` file discovery (`@cl`)

## Platform Tested

- Ubuntu/Linux

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu/Linux

### Documentation & Housekeeping

- [x] I've considered cross-platform impact (Windows, macOS) — or N/A
- [x] I've updated relevant documentation if needed — N/A
- [x] I've updated `cli-config.yaml.example` if needed — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if needed — N/A
- [x] I've updated tool descriptions/schemas if needed — N/A

## Screenshots / Logs

- Targeted tests passed: `171 passed`
- Live CLI smoke test completed successfully
