### PR TITLE
fix: schtasks encoding and zh-CN fallback on Windows gateway install

### DIFF
--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -42,7 +42,7 @@ _SCHTASKS_TIMEOUT_S = 15
 _SCHTASKS_NO_OUTPUT_TIMEOUT_S = 30
 # Patterns in schtasks stderr that mean "fall back to the Startup folder".
 _FALLBACK_PATTERNS = re.compile(
-    r"(access is denied|acceso denegado|přístup byl odepřen|schtasks timed out|schtasks produced no output)",
+    r"(access is denied|acceso denegado|přístup byl odepřen|拒绝访问|schtasks timed out|schtasks produced no output)",
     re.IGNORECASE,
 )
 
@@ -110,6 +110,7 @@ def _exec_schtasks(args: list[str]) -> tuple[int, str, str]:
             [schtasks, *args],
             capture_output=True,
             text=True,
+            encoding="mbcs",  # schtasks outputs in the system ANSI codepage (e.g. GBK on zh-CN)
             timeout=_SCHTASKS_TIMEOUT_S,
             # CREATE_NO_WINDOW avoids a flashing console window when the CLI
             # is itself hosted in a TUI. See tools/browser_tool.py for the


### PR DESCRIPTION
## Summary

Fixes two bugs in gateway_windows.py that prevent the gateway install fallback from working on Chinese (zh-CN) Windows:

### 1. Missing zh-CN error pattern in _FALLBACK_PATTERNS
The fallback regex only matched English/Spanish/Czech "access denied" messages. On zh-CN Windows, schtasks returns "错误: 拒绝访问。" which didn't match, causing a RuntimeError instead of the Startup folder fallback.

Fix: Added "拒绝访问" to the fallback regex.

### 2. UTF-8 decoding failure in _exec_schtasks
subprocess.run(text=True) defaults to UTF-8 decoding, but schtasks.exe outputs in the system ANSI codepage (GBK on zh-CN Windows). This caused UnicodeDecodeError, resulting in empty stderr strings.

Fix: Added encoding="mbcs" to subprocess.run().

## Test Plan
- Tested on zh-CN Windows 10 without admin privileges
- Gateway install now correctly falls back to Startup folder instead of crashing
- Gateway starts successfully via _spawn_detached