### PR TITLE
fix(cron): require confirmed message_id before counting live-adapter delivery as success

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -684,16 +684,37 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                         except TimeoutError:
                             future.cancel()
                             raise
-                        if send_result and not getattr(send_result, "success", True):
-                            err = getattr(send_result, "error", "unknown")
+                        # Require POSITIVE confirmation that a message was
+                        # actually sent: a SendResult with success True AND a
+                        # real message_id. A None result, success=False, or
+                        # success=True with message_id=None (the adapter's
+                        # "nothing actually sent" skip path — e.g. empty
+                        # content, or a stale adapter after a gateway
+                        # interruption/restart) is NOT a delivery. Without
+                        # this the scheduler logged "delivered via live
+                        # adapter" and set delivered=True while the message
+                        # was silently dropped, never falling back to the
+                        # working standalone HTTP path. Genuine sends always
+                        # carry a real message_id, so confirmed delivery is
+                        # not double-sent.
+                        confirmed = bool(
+                            send_result is not None
+                            and getattr(send_result, "success", False)
+                            and getattr(send_result, "message_id", None) is not None
+                        )
+                        if not confirmed:
+                            err = (
+                                getattr(send_result, "error", None)
+                                or ("sent-but-unconfirmed (no message_id)"
+                                    if send_result is not None else "no result")
+                            )
                             logger.warning(
-                                "Job '%s': live adapter send to %s:%s failed (%s), falling back to standalone",
+                                "Job '%s': live adapter send to %s:%s not confirmed (%s), falling back to standalone",
                                 job["id"], platform_name, chat_id, err,
                             )
                             adapter_ok = False  # fall through to standalone path
                         elif (
-                            send_result
-                            and thread_id
+                            thread_id
                             and getattr(send_result, "raw_response", None)
                             and send_result.raw_response.get("thread_fallback")
                         ):


### PR DESCRIPTION
## Problem

Cron jobs can silently lose their delivered output while the scheduler logs `delivered to <platform>:<chat> via live adapter` and marks the job successful.

Observed in production: a Telegram-delivered cron job ran on schedule, produced output, and the scheduler logged successful live-adapter delivery — but nothing reached the chat. It recurred for every run after a gateway interruption (operator `/stop`, then a backend/config change) until the gateway was restarted.

## Root cause

In `cron/scheduler.py::_deliver_result`, the live-adapter branch initializes `adapter_ok = True` and only flips it to `False` on an *explicit* failure object:

```python
if send_result and not getattr(send_result, "success", True):
    ... adapter_ok = False
```

Adapters have a legitimate "nothing was actually sent" path that still reports success — e.g. `gateway/platforms/telegram.py::send` returns `SendResult(success=True, message_id=None)` for whitespace-only content, and a stale adapter (after a gateway interruption) can hit equivalent no-op paths. With `success=True`, the failure check is skipped, `adapter_ok` stays `True`, the scheduler logs `delivered ... via live adapter`, sets `delivered=True`, and **never falls back to the working standalone HTTP path**. The message is dropped with no error surfaced.

## Fix

Require **positive confirmation** that a message was actually sent: `success is True` **and** `message_id is not None`. Anything else (None result, `success=False`, or `success=True` with `message_id=None`) logs `... not confirmed (...), falling back to standalone` and takes the standalone HTTP path.

Genuine sends always carry a real `message_id` (the only `success=True`/`message_id=None` path is the no-send skip), so confirmed deliveries are never double-sent — no duplicate-message risk. The existing `thread_fallback` branch is preserved and now correctly applies only to a confirmed delivery.

## Testing

- `python -c "import ast; ast.parse(open('cron/scheduler.py').read())"` — syntax clean.
- Verified against the live failure mode: after the fix + a gateway restart, scheduled cron jobs deliver to Telegram again; an unconfirmed live-adapter result now logs the fallback and the standalone path delivers instead of dropping.

Scoped to the live-adapter confirmation logic; no behavior change for the standalone path or for genuinely-confirmed sends.
