### PR TITLE
Per-model token tracking for mid-session model switches

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1376,7 +1376,8 @@ def init_agent(
     agent.session_estimated_cost_usd = 0.0
     agent.session_cost_status = "unknown"
     agent.session_cost_source = "none"
-    
+    agent.session_usage_by_model: dict[str, dict] = {}
+
     # ── Ollama num_ctx injection ──
     # Ollama defaults to 2048 context regardless of the model's capabilities.
     # When running against an Ollama server, detect the model's max context

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1565,6 +1565,24 @@ def run_conversation(
                     agent.session_cache_write_tokens += canonical_usage.cache_write_tokens
                     agent.session_reasoning_tokens += canonical_usage.reasoning_tokens
 
+                    # ── Per-model breakdown ──
+                    m = agent.session_usage_by_model.setdefault(agent.model, {
+                        "input_tokens": 0,
+                        "output_tokens": 0,
+                        "cache_read_tokens": 0,
+                        "cache_write_tokens": 0,
+                        "reasoning_tokens": 0,
+                        "api_calls": 0,
+                        "cost": 0.0,
+                    })
+                    m["input_tokens"] += canonical_usage.input_tokens
+                    m["output_tokens"] += canonical_usage.output_tokens
+                    m["cache_read_tokens"] += canonical_usage.cache_read_tokens
+                    m["cache_write_tokens"] += canonical_usage.cache_write_tokens
+                    m["reasoning_tokens"] += canonical_usage.reasoning_tokens
+                    m["api_calls"] += 1
+                    m["cost"] += float(cost_result.amount_usd or 0)
+
                     # Log API call details for debugging/observability
                     _cache_pct = ""
                     if canonical_usage.cache_read_tokens and prompt_tokens:
@@ -1605,6 +1623,7 @@ def run_conversation(
                             # affects 0 rows without error).
                             if not agent._session_db_created:
                                 agent._ensure_db_session()
+                            usage_by_model_json = json.dumps(agent.session_usage_by_model)
                             agent._session_db.update_token_counts(
                                 agent.session_id,
                                 input_tokens=canonical_usage.input_tokens,
@@ -1622,6 +1641,7 @@ def run_conversation(
                                 if cost_result.status == "included" else None,
                                 model=agent.model,
                                 api_call_count=1,
+                                usage_by_model=usage_by_model_json,
                             )
                         except Exception as e:
                             # Log token persistence failures so they're

--- a/agent/insights.py
+++ b/agent/insights.py
@@ -181,7 +181,8 @@ class InsightsEngine:
                      "message_count, tool_call_count, input_tokens, output_tokens, "
                      "cache_read_tokens, cache_write_tokens, billing_provider, "
                      "billing_base_url, billing_mode, estimated_cost_usd, "
-                     "actual_cost_usd, cost_status, cost_source")
+                     "actual_cost_usd, cost_status, cost_source, "
+                     "usage_by_model")
 
     # Pre-computed query strings — f-string evaluated once at class definition,
     # not at runtime, so no user-controlled value can alter the query structure.
@@ -491,25 +492,52 @@ class InsightsEngine:
         })
 
         for s in sessions:
-            model = s.get("model") or "unknown"
-            # Normalize: strip provider prefix for display
-            display_model = model.split("/")[-1] if "/" in model else model
-            d = model_data[display_model]
-            d["sessions"] += 1
-            inp = s.get("input_tokens") or 0
-            out = s.get("output_tokens") or 0
-            cache_read = s.get("cache_read_tokens") or 0
-            cache_write = s.get("cache_write_tokens") or 0
-            d["input_tokens"] += inp
-            d["output_tokens"] += out
-            d["cache_read_tokens"] += cache_read
-            d["cache_write_tokens"] += cache_write
-            d["total_tokens"] += inp + out + cache_read + cache_write
-            d["tool_calls"] += s.get("tool_call_count") or 0
-            estimate, status = _estimate_cost(s)
-            d["cost"] += estimate
-            d["has_pricing"] = _has_known_pricing(model, s.get("billing_provider"), s.get("billing_base_url"))
-            d["cost_status"] = status
+            usage_by_model_raw = s.get("usage_by_model")
+            if usage_by_model_raw and isinstance(usage_by_model_raw, str):
+                try:
+                    usage_by_model = json.loads(usage_by_model_raw)
+                except (json.JSONDecodeError, TypeError):
+                    usage_by_model = None
+            else:
+                usage_by_model = None
+
+            if usage_by_model:
+                for model_key, mdata in usage_by_model.items():
+                    display_model = model_key.split("/")[-1] if "/" in model_key else model_key
+                    d = model_data[display_model]
+                    d["sessions"] += 1
+                    inp = mdata.get("input_tokens", 0)
+                    out = mdata.get("output_tokens", 0)
+                    cache_read = mdata.get("cache_read_tokens", 0)
+                    cache_write = mdata.get("cache_write_tokens", 0)
+                    d["input_tokens"] += inp
+                    d["output_tokens"] += out
+                    d["cache_read_tokens"] += cache_read
+                    d["cache_write_tokens"] += cache_write
+                    d["total_tokens"] += inp + out + cache_read + cache_write
+                    d["tool_calls"] += mdata.get("api_calls", 0)
+                    d["cost"] += mdata.get("cost", 0.0)
+                    d["has_pricing"] = _has_known_pricing(model_key, s.get("billing_provider"), s.get("billing_base_url"))
+            else:
+                model = s.get("model") or "unknown"
+                # Normalize: strip provider prefix for display
+                display_model = model.split("/")[-1] if "/" in model else model
+                d = model_data[display_model]
+                d["sessions"] += 1
+                inp = s.get("input_tokens") or 0
+                out = s.get("output_tokens") or 0
+                cache_read = s.get("cache_read_tokens") or 0
+                cache_write = s.get("cache_write_tokens") or 0
+                d["input_tokens"] += inp
+                d["output_tokens"] += out
+                d["cache_read_tokens"] += cache_read
+                d["cache_write_tokens"] += cache_write
+                d["total_tokens"] += inp + out + cache_read + cache_write
+                d["tool_calls"] += s.get("tool_call_count") or 0
+                estimate, status = _estimate_cost(s)
+                d["cost"] += estimate
+                d["has_pricing"] = _has_known_pricing(model, s.get("billing_provider"), s.get("billing_base_url"))
+                d["cost_status"] = status
 
         result = [
             {"model": model, **data}

--- a/cli.py
+++ b/cli.py
@@ -9253,48 +9253,93 @@ class HermesCLI:
         compressions = compressor.compression_count
 
         msg_count = len(self.conversation_history)
-        cost_result = estimate_usage_cost(
-            agent.model,
-            CanonicalUsage(
-                input_tokens=input_tokens,
-                output_tokens=output_tokens,
-                cache_read_tokens=cache_read_tokens,
-                cache_write_tokens=cache_write_tokens,
-            ),
-            provider=getattr(agent, "provider", None),
-            base_url=getattr(agent, "base_url", None),
-        )
         elapsed = format_duration_compact((datetime.now() - self.session_start).total_seconds())
 
         print("  📊 Session Token Usage")
         print(f"  {'─' * 40}")
-        print(f"  Model:                     {agent.model}")
-        print(f"  Input tokens:              {input_tokens:>10,}")
-        print(f"  Cache read tokens:         {cache_read_tokens:>10,}")
-        print(f"  Cache write tokens:        {cache_write_tokens:>10,}")
-        print(f"  Output tokens:             {output_tokens:>10,}")
-        if reasoning_tokens:
-            print(f"  ↳ Reasoning (subset):      {reasoning_tokens:>10,}")
-        print(f"  Prompt tokens (total):     {prompt:>10,}")
-        print(f"  Completion tokens:         {completion:>10,}")
-        print(f"  Total tokens:              {total:>10,}")
-        print(f"  API calls:                 {calls:>10,}")
-        print(f"  Session duration:          {elapsed:>10}")
-        print(f"  Cost status:              {cost_result.status:>10}")
-        print(f"  Cost source:              {cost_result.source:>10}")
-        if cost_result.amount_usd is not None:
-            prefix = "~" if cost_result.status == "estimated" else ""
-            print(f"  Total cost:              {prefix}${float(cost_result.amount_usd):>10.4f}")
-        elif cost_result.status == "included":
-            print(f"  Total cost:              {'included':>10}")
+
+        usage_by_model = getattr(agent, "session_usage_by_model", {}) or {}
+        if usage_by_model and len(usage_by_model) > 1:
+            total_cost = 0.0
+            overall_status = "unknown"
+            overall_source = "none"
+            for model_key, mdata in usage_by_model.items():
+                cost_r = estimate_usage_cost(
+                    model_key,
+                    CanonicalUsage(
+                        input_tokens=mdata["input_tokens"],
+                        output_tokens=mdata["output_tokens"],
+                        cache_read_tokens=mdata["cache_read_tokens"],
+                        cache_write_tokens=mdata["cache_write_tokens"],
+                    ),
+                    provider=getattr(agent, "provider", None),
+                    base_url=getattr(agent, "base_url", None),
+                )
+                cost_amt = float(cost_r.amount_usd or 0)
+                total_cost += cost_amt
+                if cost_r.status != "unknown":
+                    overall_status = cost_r.status
+                    overall_source = cost_r.source
+                print(f"  Model:  {model_key}")
+                print(f"    Input:           {mdata['input_tokens']:>10,}")
+                print(f"    Output:          {mdata['output_tokens']:>10,}")
+                if mdata.get("cache_read_tokens"):
+                    print(f"    Cache read:      {mdata['cache_read_tokens']:>10,}")
+                if mdata.get("cache_write_tokens"):
+                    print(f"    Cache write:     {mdata['cache_write_tokens']:>10,}")
+                if mdata.get("reasoning_tokens"):
+                    print(f"    Reasoning:       {mdata['reasoning_tokens']:>10,}")
+                print(f"    API calls:       {mdata.get('api_calls', 0):>10,}")
+                print(f"    Cost:            ${cost_amt:.4f}")
+            print(f"  {'─' * 40}")
+            print(f"  Input tokens (total):      {input_tokens:>10,}")
+            print(f"  Output tokens (total):     {output_tokens:>10,}")
+            print(f"  Total tokens:              {total:>10,}")
+            print(f"  API calls (total):         {calls:>10,}")
+            print(f"  Session duration:          {elapsed:>10}")
+            print(f"  Cost status:              {overall_status:>10}")
+            print(f"  Total cost:              ${total_cost:>10.4f}")
+            print(f"  {'─' * 40}")
         else:
-            print(f"  Total cost:              {'n/a':>10}")
-        print(f"  {'─' * 40}")
+            cost_result = estimate_usage_cost(
+                agent.model,
+                CanonicalUsage(
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    cache_read_tokens=cache_read_tokens,
+                    cache_write_tokens=cache_write_tokens,
+                ),
+                provider=getattr(agent, "provider", None),
+                base_url=getattr(agent, "base_url", None),
+            )
+            print(f"  Model:                     {agent.model}")
+            print(f"  Input tokens:              {input_tokens:>10,}")
+            print(f"  Cache read tokens:         {cache_read_tokens:>10,}")
+            print(f"  Cache write tokens:        {cache_write_tokens:>10,}")
+            print(f"  Output tokens:             {output_tokens:>10,}")
+            if reasoning_tokens:
+                print(f"  ↳ Reasoning (subset):      {reasoning_tokens:>10,}")
+            print(f"  Prompt tokens (total):     {prompt:>10,}")
+            print(f"  Completion tokens:         {completion:>10,}")
+            print(f"  Total tokens:              {total:>10,}")
+            print(f"  API calls:                 {calls:>10,}")
+            print(f"  Session duration:          {elapsed:>10}")
+            print(f"  Cost status:              {cost_result.status:>10}")
+            print(f"  Cost source:              {cost_result.source:>10}")
+            if cost_result.amount_usd is not None:
+                prefix = "~" if cost_result.status == "estimated" else ""
+                print(f"  Total cost:              {prefix}${float(cost_result.amount_usd):>10.4f}")
+            elif cost_result.status == "included":
+                print(f"  Total cost:              {'included':>10}")
+            else:
+                print(f"  Total cost:              {'n/a':>10}")
+            print(f"  {'─' * 40}")
+            if cost_result.status == "unknown":
+                print(f"  Note:             Pricing unknown for {agent.model}")
+
         print(f"  Current context:  {last_prompt:,} / {ctx_len:,} ({pct:.0f}%)")
         print(f"  Messages:         {msg_count}")
         print(f"  Compressions:     {compressions}")
-        if cost_result.status == "unknown":
-            print(f"  Note:             Pricing unknown for {agent.model}")
 
         # Account limits -- fetched off-thread with a hard timeout so slow
         # provider APIs don't hang the prompt.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12249,25 +12249,50 @@ class GatewayRunner:
             lines.append(t("gateway.usage.label_total", count=f"{agent.session_total_tokens:,}"))
             lines.append(t("gateway.usage.label_api_calls", count=agent.session_api_calls))
 
-            # Cost estimation
+            # Cost estimation — per-model breakdown when multiple models used
             try:
                 from agent.usage_pricing import CanonicalUsage, estimate_usage_cost
-                cost_result = estimate_usage_cost(
-                    agent.model,
-                    CanonicalUsage(
-                        input_tokens=input_tokens,
-                        output_tokens=output_tokens,
-                        cache_read_tokens=cache_read,
-                        cache_write_tokens=cache_write,
-                    ),
-                    provider=getattr(agent, "provider", None),
-                    base_url=getattr(agent, "base_url", None),
-                )
-                if cost_result.amount_usd is not None:
-                    prefix = "~" if cost_result.status == "estimated" else ""
-                    lines.append(t("gateway.usage.label_cost", prefix=prefix, amount=f"{float(cost_result.amount_usd):.4f}"))
-                elif cost_result.status == "included":
-                    lines.append(t("gateway.usage.label_cost_included"))
+                usage_by_model = getattr(agent, "session_usage_by_model", {}) or {}
+                if usage_by_model and len(usage_by_model) > 1:
+                    total_cost = 0.0
+                    any_estimated = False
+                    for model_key, mdata in usage_by_model.items():
+                        cost_r = estimate_usage_cost(
+                            model_key,
+                            CanonicalUsage(
+                                input_tokens=mdata["input_tokens"],
+                                output_tokens=mdata["output_tokens"],
+                                cache_read_tokens=mdata["cache_read_tokens"],
+                                cache_write_tokens=mdata["cache_write_tokens"],
+                            ),
+                            provider=getattr(agent, "provider", None),
+                            base_url=getattr(agent, "base_url", None),
+                        )
+                        cost_amt = float(cost_r.amount_usd or 0)
+                        total_cost += cost_amt
+                        if cost_r.status == "estimated":
+                            any_estimated = True
+                        lines.append(f"`{model_key}` — In: {mdata['input_tokens']:,}  Out: {mdata['output_tokens']:,}  "
+                                     f"Cost: ${cost_amt:.4f}  Calls: {mdata.get('api_calls', 0)}")
+                    cost_prefix = "~" if any_estimated else ""
+                    lines.append(t("gateway.usage.label_cost", prefix=cost_prefix, amount=f"{total_cost:.4f}"))
+                else:
+                    cost_result = estimate_usage_cost(
+                        agent.model,
+                        CanonicalUsage(
+                            input_tokens=input_tokens,
+                            output_tokens=output_tokens,
+                            cache_read_tokens=cache_read,
+                            cache_write_tokens=cache_write,
+                        ),
+                        provider=getattr(agent, "provider", None),
+                        base_url=getattr(agent, "base_url", None),
+                    )
+                    if cost_result.amount_usd is not None:
+                        prefix = "~" if cost_result.status == "estimated" else ""
+                        lines.append(t("gateway.usage.label_cost", prefix=prefix, amount=f"{float(cost_result.amount_usd):.4f}"))
+                    elif cost_result.status == "included":
+                        lines.append(t("gateway.usage.label_cost_included"))
             except Exception:
                 pass
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -33,7 +33,7 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 11
+SCHEMA_VERSION = 12
 
 # ---------------------------------------------------------------------------
 # WAL-compatibility fallback
@@ -218,6 +218,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     handoff_state TEXT,
     handoff_platform TEXT,
     handoff_error TEXT,
+    usage_by_model TEXT,
     FOREIGN KEY (parent_session_id) REFERENCES sessions(id)
 );
 
@@ -768,6 +769,7 @@ class SessionDB:
         billing_base_url: Optional[str] = None,
         billing_mode: Optional[str] = None,
         api_call_count: int = 0,
+        usage_by_model: Optional[str] = None,
         absolute: bool = False,
     ) -> None:
         """Update token counters and backfill model if not already set.
@@ -791,20 +793,21 @@ class SessionDB:
                    cache_read_tokens = ?,
                    cache_write_tokens = ?,
                    reasoning_tokens = ?,
-                   estimated_cost_usd = COALESCE(?, 0),
-                   actual_cost_usd = CASE
-                       WHEN ? IS NULL THEN actual_cost_usd
-                       ELSE ?
-                   END,
-                   cost_status = COALESCE(?, cost_status),
-                   cost_source = COALESCE(?, cost_source),
-                   pricing_version = COALESCE(?, pricing_version),
-                   billing_provider = COALESCE(billing_provider, ?),
-                   billing_base_url = COALESCE(billing_base_url, ?),
-                   billing_mode = COALESCE(billing_mode, ?),
-                   model = COALESCE(model, ?),
-                   api_call_count = ?
-                   WHERE id = ?"""
+                estimated_cost_usd = COALESCE(?, 0),
+                actual_cost_usd = CASE
+                    WHEN ? IS NULL THEN actual_cost_usd
+                    ELSE ?
+                END,
+                cost_status = COALESCE(?, cost_status),
+                cost_source = COALESCE(?, cost_source),
+                pricing_version = COALESCE(?, pricing_version),
+                billing_provider = COALESCE(billing_provider, ?),
+                billing_base_url = COALESCE(billing_base_url, ?),
+                billing_mode = COALESCE(billing_mode, ?),
+                model = COALESCE(model, ?),
+                usage_by_model = COALESCE(?, usage_by_model),
+                api_call_count = ?
+                WHERE id = ?"""
         else:
             sql = """UPDATE sessions SET
                    input_tokens = input_tokens + ?,
@@ -824,6 +827,7 @@ class SessionDB:
                    billing_base_url = COALESCE(billing_base_url, ?),
                    billing_mode = COALESCE(billing_mode, ?),
                    model = COALESCE(model, ?),
+                   usage_by_model = COALESCE(?, usage_by_model),
                    api_call_count = COALESCE(api_call_count, 0) + ?
                    WHERE id = ?"""
         params = (
@@ -842,6 +846,7 @@ class SessionDB:
             billing_base_url,
             billing_mode,
             model,
+            usage_by_model,
             api_call_count,
             session_id,
         )

--- a/run_agent.py
+++ b/run_agent.py
@@ -555,7 +555,8 @@ class AIAgent:
         self.session_estimated_cost_usd = 0.0
         self.session_cost_status = "unknown"
         self.session_cost_source = "none"
-        
+        self.session_usage_by_model: dict[str, dict] = {}
+
         # Turn counter (added after reset_session_state was first written — #2635)
         self._user_turn_count = 0
 

--- a/tests/agent/test_insights.py
+++ b/tests/agent/test_insights.py
@@ -1,5 +1,6 @@
 """Tests for agent/insights.py — InsightsEngine analytics and reporting."""
 
+import json
 import time
 import pytest
 from pathlib import Path
@@ -319,6 +320,65 @@ class TestInsightsPopulated:
         # Claude-sonnet has 2 sessions (s1 + s4)
         claude = next(m for m in models if "claude-sonnet" in m["model"])
         assert claude["sessions"] == 2
+
+    def test_model_breakdown_with_usage_by_model_json(self, db):
+        """_compute_model_breakdown uses usage_by_model JSON when present."""
+        now = time.time()
+        # Create a session with usage_by_model JSON set directly
+        db.create_session(session_id="s_multi", source="cli", model="gpt-4o")
+        db._conn.execute(
+            "UPDATE sessions SET usage_by_model = ? WHERE id = 's_multi'",
+            (json.dumps({
+                "gpt-4o": {"input_tokens": 300, "output_tokens": 150, "cache_read_tokens": 10,
+                           "cache_write_tokens": 5, "reasoning_tokens": 0, "api_calls": 3, "cost": 0.03},
+                "claude-sonnet": {"input_tokens": 500, "output_tokens": 200, "cache_read_tokens": 20,
+                                  "cache_write_tokens": 10, "reasoning_tokens": 50, "api_calls": 2, "cost": 0.05},
+            }),),
+        )
+        db.update_token_counts("s_multi", input_tokens=800, output_tokens=350,
+                               api_call_count=5)
+        db._conn.commit()
+
+        engine = InsightsEngine(db)
+        report = engine.generate(days=30)
+        models = report["models"]
+
+        model_names = [m["model"] for m in models]
+        assert "gpt-4o" in model_names
+        assert "claude-sonnet" in model_names
+
+        gpt4o = next(m for m in models if m["model"] == "gpt-4o")
+        assert gpt4o["input_tokens"] == 300
+        assert gpt4o["output_tokens"] == 150
+        assert gpt4o["cache_read_tokens"] == 10
+        assert gpt4o["cache_write_tokens"] == 5
+        assert gpt4o["tool_calls"] == 3
+        assert gpt4o["cost"] == 0.03
+
+        claude = next(m for m in models if m["model"] == "claude-sonnet")
+        assert claude["input_tokens"] == 500
+        assert claude["output_tokens"] == 200
+        assert claude["cache_read_tokens"] == 20
+        assert claude["cache_write_tokens"] == 10
+        assert claude["tool_calls"] == 2
+        assert claude["cost"] == 0.05
+
+    def test_model_breakdown_falls_back_to_single_model_without_usage_by_model(self, db):
+        """When usage_by_model is not set, breakdown uses the model column."""
+        db.create_session(session_id="s_single", source="cli", model="deepseek-chat")
+        db.update_token_counts("s_single", input_tokens=1000, output_tokens=500,
+                               api_call_count=5)
+        db._conn.commit()
+
+        engine = InsightsEngine(db)
+        report = engine.generate(days=30)
+        models = report["models"]
+
+        model_names = [m["model"] for m in models]
+        assert "deepseek-chat" in model_names
+        ds = next(m for m in models if m["model"] == "deepseek-chat")
+        assert ds["input_tokens"] == 1000
+        assert ds["output_tokens"] == 500
 
     def test_platform_breakdown(self, populated_db):
         engine = InsightsEngine(populated_db)

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1,5 +1,6 @@
 """Tests for hermes_state.py — SessionDB SQLite CRUD, FTS5 search, export."""
 
+import json
 import time
 import pytest
 from pathlib import Path
@@ -129,12 +130,225 @@ class TestSessionLifecycle:
         session = db.get_session("s1")
         assert session["model"] == "anthropic/claude-opus-4.6"
 
+    def test_update_token_counts_usage_by_model_incremental(self, db):
+        """usage_by_model is set on first call and overwritten on subsequent calls."""
+        db.create_session(session_id="s1", source="cli")
+        db.update_token_counts("s1", input_tokens=100, output_tokens=50,
+                               usage_by_model='{"model-a": {"input_tokens": 100, "output_tokens": 50, "cache_read_tokens": 0, "cache_write_tokens": 0, "reasoning_tokens": 0, "api_calls": 1, "cost": 0.01}}')
+        db.update_token_counts("s1", input_tokens=100, output_tokens=50,
+                               usage_by_model='{"model-a": {"input_tokens": 100, "output_tokens": 50, "cache_read_tokens": 0, "cache_write_tokens": 0, "reasoning_tokens": 0, "api_calls": 1, "cost": 0.01}, "model-b": {"input_tokens": 200, "output_tokens": 100, "cache_read_tokens": 0, "cache_write_tokens": 0, "reasoning_tokens": 0, "api_calls": 1, "cost": 0.02}}')
+
+        session = db.get_session("s1")
+        assert session["usage_by_model"] is not None
+        ubm = json.loads(session["usage_by_model"])
+        assert "model-a" in ubm
+        assert "model-b" in ubm
+        assert ubm["model-b"]["input_tokens"] == 200
+
+    def test_update_token_counts_usage_by_model_absolute(self, db):
+        """absolute mode sets usage_by_model directly."""
+        db.create_session(session_id="s1", source="cli")
+        db.update_token_counts("s1", input_tokens=100, output_tokens=50, absolute=True,
+                               usage_by_model='{"model-x": {"input_tokens": 100, "output_tokens": 50, "cache_read_tokens": 0, "cache_write_tokens": 0, "reasoning_tokens": 0, "api_calls": 1, "cost": 0.03}}')
+
+        session = db.get_session("s1")
+        assert session["usage_by_model"] is not None
+        ubm = json.loads(session["usage_by_model"])
+        assert "model-x" in ubm
+        assert ubm["model-x"]["api_calls"] == 1
+
+    def test_update_token_counts_usage_by_model_defaults_to_none(self, db):
+        """When usage_by_model is not passed, existing value is preserved."""
+        db.create_session(session_id="s1", source="cli")
+        db.update_token_counts("s1", input_tokens=100, output_tokens=50,
+                               usage_by_model='{"m1": {"input_tokens": 100, "output_tokens": 50, "cache_read_tokens": 0, "cache_write_tokens": 0, "reasoning_tokens": 0, "api_calls": 1, "cost": 0.01}}')
+        db.update_token_counts("s1", input_tokens=100, output_tokens=50)
+
+        session = db.get_session("s1")
+        # Value preserved from first call
+        ubm = json.loads(session["usage_by_model"])
+        assert "m1" in ubm
+
     def test_parent_session(self, db):
         db.create_session(session_id="parent", source="cli")
         db.create_session(session_id="child", source="cli", parent_session_id="parent")
 
         child = db.get_session("child")
         assert child["parent_session_id"] == "parent"
+
+
+# =========================================================================
+# Per-model token tracking (mid-session switch)
+# =========================================================================
+
+class TestPerModelTrackingMidSession:
+    """Simulate what conversation_loop does when the user switches models mid-session.
+
+    This tests the core aggregation logic: cumulative counters match the sum
+    of per-model counters, and serialization round-trips correctly.
+    """
+
+    @staticmethod
+    def _simulate_call(usage_by_model, model, inp, out, cache_read=0, cache_write=0,
+                       reasoning=0, cost=0.0):
+        """Simulate one 'API call' — exactly what conversation_loop does."""
+        m = usage_by_model.setdefault(model, {
+            "input_tokens": 0, "output_tokens": 0,
+            "cache_read_tokens": 0, "cache_write_tokens": 0,
+            "reasoning_tokens": 0, "api_calls": 0, "cost": 0.0,
+        })
+        m["input_tokens"] += inp
+        m["output_tokens"] += out
+        m["cache_read_tokens"] += cache_read
+        m["cache_write_tokens"] += cache_write
+        m["reasoning_tokens"] += reasoning
+        m["api_calls"] += 1
+        m["cost"] += cost
+
+    def test_per_model_counts_after_mid_session_switch(self):
+        """Two models used in one session — each model's tokens tracked separately."""
+        usage_by_model = {}
+        cumulative = {"input": 0, "output": 0, "cache_read": 0,
+                      "cache_write": 0, "reasoning": 0, "calls": 0}
+
+        # Model A — 2 calls
+        self._simulate_call(usage_by_model, "gpt-4o", inp=500, out=200, cost=0.025)
+        cumulative["input"] += 500
+        cumulative["output"] += 200
+        cumulative["calls"] += 1
+
+        self._simulate_call(usage_by_model, "gpt-4o", inp=300, out=100,
+                            cache_read=50, cost=0.015)
+        cumulative["input"] += 300
+        cumulative["output"] += 100
+        cumulative["cache_read"] += 50
+        cumulative["calls"] += 1
+
+        # ── Switch model mid-session ──
+
+        # Model B — 1 call
+        self._simulate_call(usage_by_model, "claude-sonnet", inp=1000, out=500,
+                            cache_write=200, reasoning=100, cost=0.075)
+        cumulative["input"] += 1000
+        cumulative["output"] += 500
+        cumulative["cache_write"] += 200
+        cumulative["reasoning"] += 100
+        cumulative["calls"] += 1
+
+        # ── Assert per-model correctness ──
+        assert len(usage_by_model) == 2, "should have exactly 2 model entries"
+
+        gpt4o = usage_by_model["gpt-4o"]
+        assert gpt4o["input_tokens"] == 800       # 500 + 300
+        assert gpt4o["output_tokens"] == 300       # 200 + 100
+        assert gpt4o["cache_read_tokens"] == 50
+        assert gpt4o["cache_write_tokens"] == 0
+        assert gpt4o["reasoning_tokens"] == 0
+        assert gpt4o["api_calls"] == 2
+        assert gpt4o["cost"] == pytest.approx(0.04)  # 0.025 + 0.015
+
+        claude = usage_by_model["claude-sonnet"]
+        assert claude["input_tokens"] == 1000
+        assert claude["output_tokens"] == 500
+        assert claude["cache_read_tokens"] == 0
+        assert claude["cache_write_tokens"] == 200
+        assert claude["reasoning_tokens"] == 100
+        assert claude["api_calls"] == 1
+        assert claude["cost"] == pytest.approx(0.075)
+
+        # ── Cumulative totals = sum of per-model ──
+        total_input = sum(m["input_tokens"] for m in usage_by_model.values())
+        total_output = sum(m["output_tokens"] for m in usage_by_model.values())
+        assert total_input == cumulative["input"]   # 800 + 1000 = 1800
+        assert total_output == cumulative["output"]  # 300 + 500 = 800
+        assert total_input == 1800
+        assert total_output == 800
+
+    def test_serialization_round_trip(self, db):
+        """usage_by_model survives JSON serialize → DB write → read → parse."""
+        usage_by_model = {}
+
+        # Two models, two calls each (simulating conversation_loop logic)
+        self._simulate_call(usage_by_model, "gpt-4o", inp=500, out=200, cost=0.025)
+        self._simulate_call(usage_by_model, "gpt-4o", inp=300, out=100, cost=0.015)
+        self._simulate_call(usage_by_model, "claude-sonnet", inp=1000, out=500, cost=0.075)
+        self._simulate_call(usage_by_model, "claude-sonnet", inp=200, out=50, cost=0.01)
+
+        # Serialize (as conversation_loop does)
+        usage_by_model_json = json.dumps(usage_by_model)
+
+        # Write to DB (as conversation_loop does)
+        db.create_session(session_id="s_mid", source="cli", model="claude-sonnet")
+        db.update_token_counts(
+            "s_mid", input_tokens=2000, output_tokens=850,
+            api_call_count=4, usage_by_model=usage_by_model_json,
+        )
+
+        # Read back
+        session = db.get_session("s_mid")
+        assert session["usage_by_model"] is not None
+        restored = json.loads(session["usage_by_model"])
+
+        assert len(restored) == 2
+        assert restored["gpt-4o"]["input_tokens"] == 800
+        assert restored["gpt-4o"]["api_calls"] == 2
+        assert restored["gpt-4o"]["cost"] == pytest.approx(0.04)
+        assert restored["claude-sonnet"]["input_tokens"] == 1200  # 1000 + 200
+        assert restored["claude-sonnet"]["api_calls"] == 2
+        assert restored["claude-sonnet"]["cost"] == pytest.approx(0.085)
+
+    def test_cumulative_counters_equal_sum_of_per_model(self, db):
+        """Cumulative session counters should match the aggregation of per-model data."""
+        usage_by_model = {}
+
+        # Simulate a session with 3 model switches
+        self._simulate_call(usage_by_model, "model-a", inp=100, out=50)
+        self._simulate_call(usage_by_model, "model-a", inp=200, out=100)
+        self._simulate_call(usage_by_model, "model-b", inp=400, out=200,
+                            cache_read=30, cache_write=10, reasoning=50)
+        self._simulate_call(usage_by_model, "model-c", inp=800, out=400,
+                            cache_read=60)
+
+        total_inp = sum(m["input_tokens"] for m in usage_by_model.values())
+        total_out = sum(m["output_tokens"] for m in usage_by_model.values())
+        total_cache_r = sum(m["cache_read_tokens"] for m in usage_by_model.values())
+        total_cache_w = sum(m["cache_write_tokens"] for m in usage_by_model.values())
+        total_reas = sum(m["reasoning_tokens"] for m in usage_by_model.values())
+        total_calls = sum(m["api_calls"] for m in usage_by_model.values())
+
+        assert total_inp == 100 + 200 + 400 + 800  # = 1500
+        assert total_out == 50 + 100 + 200 + 400     # = 750
+        assert total_cache_r == 30 + 60               # = 90
+        assert total_cache_w == 10
+        assert total_reas == 50
+        assert total_calls == 4
+
+        # Serialize and store to DB
+        usage_by_model_json = json.dumps(usage_by_model)
+        db.create_session(session_id="s_multi_model", source="cli", model="model-c")
+        db.update_token_counts(
+            "s_multi_model",
+            input_tokens=total_inp, output_tokens=total_out,
+            cache_read_tokens=total_cache_r, cache_write_tokens=total_cache_w,
+            reasoning_tokens=total_reas,
+            api_call_count=total_calls, usage_by_model=usage_by_model_json,
+        )
+
+        # Read back and verify DB round-trip preserves totals
+        session = db.get_session("s_multi_model")
+        assert session["input_tokens"] == 1500
+        assert session["output_tokens"] == 750
+        assert session["cache_read_tokens"] == 90
+        assert session["cache_write_tokens"] == 10
+        assert session["reasoning_tokens"] == 50
+        assert session["api_call_count"] == 4
+        assert session["model"] == "model-c"  # last-writer-wins as before
+
+        restored = json.loads(session["usage_by_model"])
+        assert len(restored) == 3
+        assert restored["model-a"]["api_calls"] == 2
+        assert restored["model-b"]["api_calls"] == 1
+        assert restored["model-c"]["api_calls"] == 1
 
 
 # =========================================================================
@@ -1447,13 +1661,19 @@ class TestSchemaInit:
     def test_schema_version(self, db):
         cursor = db._conn.execute("SELECT version FROM schema_version")
         version = cursor.fetchone()[0]
-        assert version == 11
+        assert version == 12
 
     def test_title_column_exists(self, db):
         """Verify the title column was created in the sessions table."""
         cursor = db._conn.execute("PRAGMA table_info(sessions)")
         columns = {row[1] for row in cursor.fetchall()}
         assert "title" in columns
+
+    def test_usage_by_model_column_exists(self, db):
+        """Verify the usage_by_model column was created in the sessions table."""
+        cursor = db._conn.execute("PRAGMA table_info(sessions)")
+        columns = {row[1] for row in cursor.fetchall()}
+        assert "usage_by_model" in columns
 
     def test_topic_mode_schema_is_not_auto_migrated_on_open(self, tmp_path):
         """Opening an old DB should not add topic-mode columns until /topic opts in.
@@ -1744,7 +1964,7 @@ class TestSchemaInit:
 
         # Verify migration
         cursor = migrated_db._conn.execute("SELECT version FROM schema_version")
-        assert cursor.fetchone()[0] == 11
+        assert cursor.fetchone()[0] == 12
 
         # Verify title column exists and is NULL for existing sessions
         session = migrated_db.get_session("existing")
@@ -2939,7 +3159,7 @@ class TestFTS5ToolCallMigration:
                 "SELECT version FROM schema_version LIMIT 1"
             ).fetchone()
             version = row["version"] if hasattr(row, "keys") else row[0]
-            assert version == 11
+            assert version == 12
         finally:
             session_db.close()
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1289,6 +1289,7 @@ def _get_usage(agent) -> dict:
         "completion": g("session_completion_tokens"),
         "total": g("session_total_tokens"),
         "calls": g("session_api_calls"),
+        "usage_by_model": getattr(agent, "session_usage_by_model", None) or None,
     }
     comp = getattr(agent, "context_compressor", None)
     if comp:


### PR DESCRIPTION
Closes #28637

Adds a `usage_by_model TEXT` JSON column to the `sessions` table that
records per-model token/cost breakdown on every API call, enabling
accurate cost attribution and display after mid-session `/model`
switches.

### Changes

- **Schema**: `usage_by_model TEXT` column on `sessions`, auto-added to
  existing DBs via `_reconcile_columns()`, bump SCHEMA_VERSION to 12
- **In-memory**: `agent.session_usage_by_model` dict on `AIAgent`
- **Per-call tracking**: populates per-model counters in
  `conversation_loop.py` — tokens, cache, reasoning, API calls, and
  cost — then serializes to JSON and persists on every turn
- **CLI `/usage`**: per-model breakdown when multiple models detected;
  single-model fallback for legacy sessions
- **Gateway `/usage`**: same breakdown in messaging platforms
- **`/insights`**: model breakdown uses `usage_by_model` when present,
  falls back to `model` column for backward compat
- **TUI**: `usage_by_model` included in Python → TypeScript payload
  (display rendering not yet implemented — separate follow-up)
- **Tests**: round-trip serialization, cumulative sum invariant, backward
  compat fallback, schema version bump

### Backward compatibility

- Old sessions without the column render single-model as before
- `_reconcile_columns()` adds the column on next startup — zero-downtime
- Cumulative counters (`input_tokens`, `output_tokens`, etc.) are
  unchanged