### PR TITLE
feat(auth): split Codex and OpenAI OAuth lanes

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -480,6 +480,29 @@ def _codex_cloudflare_headers(access_token: str) -> Dict[str, str]:
     return headers
 
 
+def _openai_oauth_headers(access_token: str, account_id: Optional[str] = None) -> Dict[str, str]:
+    """Headers for Hermes-owned OpenAI OAuth calls to ChatGPT Codex backend."""
+    headers = {
+        "User-Agent": f"HermesAgent/{_HERMES_VERSION}",
+        "originator": "hermes",
+    }
+    acct_id = account_id
+    if (not acct_id) and isinstance(access_token, str) and access_token.strip():
+        try:
+            import base64
+
+            parts = access_token.split(".")
+            if len(parts) >= 2:
+                payload_b64 = parts[1] + "=" * (-len(parts[1]) % 4)
+                claims = json.loads(base64.urlsafe_b64decode(payload_b64))
+                acct_id = claims.get("https://api.openai.com/auth", {}).get("chatgpt_account_id")
+        except Exception:
+            acct_id = None
+    if isinstance(acct_id, str) and acct_id:
+        headers["ChatGPT-Account-Id"] = acct_id
+    return headers
+
+
 def _to_openai_base_url(base_url: str) -> str:
     """Normalize an Anthropic-style base URL to OpenAI-compatible format.
 
@@ -3244,6 +3267,42 @@ def resolve_provider_client(
         return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                 else (client, final_model))
 
+    if provider == "openai-oauth":
+        if not model:
+            logger.warning(
+                "resolve_provider_client: openai-oauth requested without a "
+                "model; pass model explicitly."
+            )
+            return None, None
+        try:
+            from hermes_cli.auth import resolve_openai_oauth_runtime_credentials
+
+            creds = resolve_openai_oauth_runtime_credentials(refresh_if_expiring=False)
+        except Exception as exc:
+            logger.warning(
+                "resolve_provider_client: openai-oauth requested but credentials "
+                "could not be resolved: %s", exc,
+            )
+            return None, None
+        final_model = _normalize_resolved_model(model, provider)
+        base_url = str(creds.get("base_url") or explicit_base_url or _CODEX_AUX_BASE_URL).rstrip("/")
+        api_key = str(creds.get("api_key") or explicit_api_key or "")
+        account_id = str(creds.get("account_id") or "").strip() or None
+        saved_api_mode = api_mode
+        try:
+            if not api_mode:
+                api_mode = "codex_responses"
+            client = OpenAI(
+                api_key=api_key,
+                base_url=base_url,
+                default_headers=_openai_oauth_headers(api_key, account_id),
+            )
+            client = _wrap_if_needed(client, final_model, base_url, api_key)
+        finally:
+            api_mode = saved_api_mode
+        return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+                else (client, final_model))
+
     # ── xAI Grok OAuth (loopback PKCE → Responses API) ───────────────
     # Without this branch, an xai-oauth main provider falls through to the
     # generic ``oauth_external`` arm below and returns ``(None, None)``,
@@ -3663,6 +3722,15 @@ def resolve_provider_client(
             return resolve_provider_client("nous", model, async_mode)
         if provider == "openai-codex":
             return resolve_provider_client("openai-codex", model, async_mode)
+        if provider == "openai-oauth":
+            return resolve_provider_client(
+                "openai-oauth",
+                model,
+                async_mode,
+                explicit_base_url=explicit_base_url,
+                explicit_api_key=explicit_api_key,
+                api_mode=api_mode,
+            )
         if provider == "xai-oauth":
             return resolve_provider_client("xai-oauth", model, async_mode)
         # Other OAuth providers not directly supported

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -831,13 +831,20 @@ def _load_context_cache() -> Dict[str, int]:
         return {}
 
 
-def save_context_length(model: str, base_url: str, length: int) -> None:
+def _context_cache_key(model: str, base_url: str, provider: str | None = None) -> str:
+    key = f"{model}@{base_url}"
+    if provider:
+        return f"{provider}|{key}"
+    return key
+
+
+def save_context_length(model: str, base_url: str, length: int, *, provider: str | None = None) -> None:
     """Persist a discovered context length for a model+provider combo.
 
     Cache key is ``model@base_url`` so the same model name served from
     different providers can have different limits.
     """
-    key = f"{model}@{base_url}"
+    key = _context_cache_key(model, base_url, provider=provider)
     cache = _load_context_cache()
     if cache.get(key) == length:
         return  # already stored
@@ -852,16 +859,16 @@ def save_context_length(model: str, base_url: str, length: int) -> None:
         logger.debug("Failed to save context length cache: %s", e)
 
 
-def get_cached_context_length(model: str, base_url: str) -> Optional[int]:
+def get_cached_context_length(model: str, base_url: str, *, provider: str | None = None) -> Optional[int]:
     """Look up a previously discovered context length for model+provider."""
-    key = f"{model}@{base_url}"
+    key = _context_cache_key(model, base_url, provider=provider)
     cache = _load_context_cache()
     return cache.get(key)
 
 
-def _invalidate_cached_context_length(model: str, base_url: str) -> None:
+def _invalidate_cached_context_length(model: str, base_url: str, *, provider: str | None = None) -> None:
     """Drop a stale cache entry so it gets re-resolved on the next lookup."""
-    key = f"{model}@{base_url}"
+    key = _context_cache_key(model, base_url, provider=provider)
     cache = _load_context_cache()
     if key not in cache:
         return
@@ -1238,14 +1245,9 @@ def _query_anthropic_context_length(model: str, base_url: str, api_key: str) -> 
 
 # Known ChatGPT Codex OAuth context windows (observed via live
 # chatgpt.com/backend-api/codex/models probe, Apr 2026). These are the
-# `context_window` values returned by Codex's /models endpoint.
-#
-# Important exception: gpt-5.4's live /responses path currently accepts far
-# larger prompts (~900k input tokens; empirical ceiling aligns with the public
-# API's ~922k input / 1.05M total budget) even though /models still reports
-# 272k. Hermes treats that route-specific gpt-5.4 behavior as authoritative
-# so long-context ChatGPT OAuth users are not artificially compressed down to
-# the stale /models value.
+# `context_window` values, which are what Codex actually enforces — the
+# direct OpenAI API has larger limits for the same slugs, but Codex OAuth
+# caps lower (e.g. gpt-5.5 is 1.05M on the API, 272K on Codex).
 #
 # Used as a fallback when the live probe fails (no token, network error).
 # Longest keys first so substring match picks the most specific entry.
@@ -1262,17 +1264,19 @@ _CODEX_OAUTH_CONTEXT_FALLBACK: Dict[str, int] = {
     "gpt-5.2-codex": 272_000,
     "gpt-5.4-mini": 272_000,
     "gpt-5.5": 272_000,
-    "gpt-5.4": 1_050_000,
+    "gpt-5.4": 272_000,
     "gpt-5.2": 272_000,
     "gpt-5": 272_000,
 }
 
-# Route-specific empirical overrides for ChatGPT OAuth on the Codex Responses
-# endpoint.  These intentionally override the lower /models-reported
-# `context_window` values when the live inference path proves otherwise.
-_CODEX_RESPONSES_CONTEXT_OVERRIDES: Dict[str, int] = {
+_OPENAI_OAUTH_KNOWN_CONTEXT_LENGTHS: Dict[str, int] = {
     "gpt-5.4": 1_050_000,
+    "gpt-5.5": 272_000,
+    "gpt-5.4-mini": 272_000,
 }
+
+_OPENAI_OAUTH_PROBE_HIGH_INPUT_TOKENS = 900_000
+_OPENAI_OAUTH_PROBE_LOW_INPUT_TOKENS = 300_000
 
 
 _codex_oauth_context_cache: Dict[str, int] = {}
@@ -1343,10 +1347,6 @@ def _resolve_codex_oauth_context_length(
     if not model_bare:
         return None
 
-    override = _CODEX_RESPONSES_CONTEXT_OVERRIDES.get(model_bare.lower())
-    if isinstance(override, int) and override > 0:
-        return override
-
     if access_token:
         live = _fetch_codex_oauth_context_lengths(access_token)
         if model_bare in live:
@@ -1366,6 +1366,111 @@ def _resolve_codex_oauth_context_length(
             return ctx
 
     return None
+
+
+def _openai_oauth_probe_headers(access_token: str, account_id: str | None = None) -> Dict[str, str]:
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "Content-Type": "application/json",
+        "Accept": "text/event-stream",
+        "User-Agent": "HermesAgent/context-probe",
+        "originator": "hermes",
+    }
+    acct_id = account_id
+    if not acct_id:
+        claims = _decode_jwt_claims(access_token)
+        auth_claims = claims.get("https://api.openai.com/auth")
+        if isinstance(auth_claims, dict):
+            acct_id = str(auth_claims.get("chatgpt_account_id") or "").strip() or None
+    if acct_id:
+        headers["ChatGPT-Account-Id"] = acct_id
+    return headers
+
+
+def _openai_oauth_probe_accepts_input_tokens(
+    model: str,
+    access_token: str,
+    input_tokens_target: int,
+) -> bool:
+    if not access_token:
+        return False
+    word_count = max(1, input_tokens_target // 3)
+    prompt = " ".join(f"tok{i:06d}" for i in range(word_count))
+    payload = {
+        "model": _strip_provider_prefix(model).strip(),
+        "instructions": "Reply with exactly one word.",
+        "input": [{
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": prompt}],
+        }],
+        "store": False,
+        "stream": True,
+    }
+    try:
+        resp = requests.post(
+            "https://chatgpt.com/backend-api/codex/responses",
+            headers=_openai_oauth_probe_headers(access_token),
+            json=payload,
+            stream=True,
+            timeout=(10, 120),
+            verify=_resolve_requests_verify(),
+        )
+    except Exception as exc:
+        logger.debug("OpenAI OAuth context probe failed: %s", exc)
+        return False
+
+    if resp.status_code != 200:
+        return False
+
+    try:
+        for raw in resp.iter_lines(decode_unicode=True):
+            if not raw or not raw.startswith("data: "):
+                continue
+            try:
+                obj = json.loads(raw[6:])
+            except Exception:
+                continue
+            event_type = obj.get("type")
+            if event_type == "response.completed":
+                return True
+            if event_type in {"error", "response.failed", "response.incomplete"}:
+                err = obj.get("error") or obj.get("response", {}).get("incomplete_details") or {}
+                if isinstance(err, dict):
+                    code = str(err.get("code") or err.get("reason") or "").strip().lower()
+                    message = str(err.get("message") or "").strip().lower()
+                    if code == "context_length_exceeded" or "context window" in message:
+                        return False
+                return False
+    finally:
+        try:
+            resp.close()
+        except Exception:
+            pass
+    return False
+
+
+def _resolve_openai_oauth_context_length(model: str, access_token: str = "") -> Optional[int]:
+    model_bare = _strip_provider_prefix(model).strip().lower()
+    if not model_bare:
+        return None
+
+    known = _OPENAI_OAUTH_KNOWN_CONTEXT_LENGTHS.get(model_bare)
+    if isinstance(known, int) and known > 0:
+        return known
+
+    from agent.models_dev import lookup_models_dev_context
+
+    metadata_ctx = lookup_models_dev_context("openai", model_bare)
+    if metadata_ctx:
+        high_target = min(_OPENAI_OAUTH_PROBE_HIGH_INPUT_TOKENS, max(_OPENAI_OAUTH_PROBE_LOW_INPUT_TOKENS, metadata_ctx - 150_000))
+        if _openai_oauth_probe_accepts_input_tokens(model_bare, access_token, high_target):
+            return metadata_ctx
+
+    if _openai_oauth_probe_accepts_input_tokens(model_bare, access_token, _OPENAI_OAUTH_PROBE_LOW_INPUT_TOKENS):
+        return metadata_ctx or _OPENAI_OAUTH_PROBE_LOW_INPUT_TOKENS
+
+    return _resolve_codex_oauth_context_length(model_bare, access_token=access_token)
 
 
 def _resolve_nous_context_length(
@@ -1505,7 +1610,8 @@ def get_model_context_length(
     # user can reload the model with a different context_length at any time
     # via /api/v1/models/load), so a stale cached value would mask reloads.
     if base_url and provider != "lmstudio":
-        cached = get_cached_context_length(model, base_url)
+        cached_provider = provider if provider == "openai-oauth" else None
+        cached = get_cached_context_length(model, base_url, provider=cached_provider)
         if cached is not None:
             # Invalidate stale Codex OAuth cache entries: pre-PR #14935 builds
             # resolved gpt-5.x to the direct-API value (e.g. 1.05M) via
@@ -1520,6 +1626,12 @@ def get_model_context_length(
                     model, base_url, f"{cached:,}",
                 )
                 _invalidate_cached_context_length(model, base_url)
+            elif provider == "openai-oauth" and cached <= 272_000 and _strip_provider_prefix(model).strip().lower() == "gpt-5.4":
+                logger.info(
+                    "Dropping stale OpenAI OAuth cache entry %s@%s -> %s; re-resolving effective route context",
+                    model, base_url, f"{cached:,}",
+                )
+                _invalidate_cached_context_length(model, base_url, provider="openai-oauth")
             # Invalidate stale 32k cache entries for Kimi-family models.
             elif cached <= 32768 and _model_name_suggests_kimi(model):
                 logger.info(
@@ -1662,6 +1774,12 @@ def get_model_context_length(
             if base_url:
                 save_context_length(model, base_url, codex_ctx)
             return codex_ctx
+    if effective_provider == "openai-oauth":
+        oauth_ctx = _resolve_openai_oauth_context_length(model, access_token=api_key or "")
+        if oauth_ctx:
+            if base_url:
+                save_context_length(model, base_url, oauth_ctx, provider="openai-oauth")
+            return oauth_ctx
     if effective_provider == "gmi" and base_url:
         # GMI exposes authoritative context_length via /models, but it is not
         # in models.dev yet. Preserve that higher-fidelity endpoint lookup.

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1238,9 +1238,14 @@ def _query_anthropic_context_length(model: str, base_url: str, api_key: str) -> 
 
 # Known ChatGPT Codex OAuth context windows (observed via live
 # chatgpt.com/backend-api/codex/models probe, Apr 2026). These are the
-# `context_window` values, which are what Codex actually enforces — the
-# direct OpenAI API has larger limits for the same slugs, but Codex OAuth
-# caps lower (e.g. gpt-5.5 is 1.05M on the API, 272K on Codex).
+# `context_window` values returned by Codex's /models endpoint.
+#
+# Important exception: gpt-5.4's live /responses path currently accepts far
+# larger prompts (~900k input tokens; empirical ceiling aligns with the public
+# API's ~922k input / 1.05M total budget) even though /models still reports
+# 272k. Hermes treats that route-specific gpt-5.4 behavior as authoritative
+# so long-context ChatGPT OAuth users are not artificially compressed down to
+# the stale /models value.
 #
 # Used as a fallback when the live probe fails (no token, network error).
 # Longest keys first so substring match picks the most specific entry.
@@ -1257,9 +1262,16 @@ _CODEX_OAUTH_CONTEXT_FALLBACK: Dict[str, int] = {
     "gpt-5.2-codex": 272_000,
     "gpt-5.4-mini": 272_000,
     "gpt-5.5": 272_000,
-    "gpt-5.4": 272_000,
+    "gpt-5.4": 1_050_000,
     "gpt-5.2": 272_000,
     "gpt-5": 272_000,
+}
+
+# Route-specific empirical overrides for ChatGPT OAuth on the Codex Responses
+# endpoint.  These intentionally override the lower /models-reported
+# `context_window` values when the live inference path proves otherwise.
+_CODEX_RESPONSES_CONTEXT_OVERRIDES: Dict[str, int] = {
+    "gpt-5.4": 1_050_000,
 }
 
 
@@ -1330,6 +1342,10 @@ def _resolve_codex_oauth_context_length(
     model_bare = _strip_provider_prefix(model).strip()
     if not model_bare:
         return None
+
+    override = _CODEX_RESPONSES_CONTEXT_OVERRIDES.get(model_bare.lower())
+    if isinstance(override, int) and override > 0:
+        return override
 
     if access_token:
         live = _fetch_codex_oauth_context_lengths(access_token)

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -165,7 +165,8 @@ class ResponsesApiTransport(ProviderTransport):
                 kwargs["extra_headers"] = merged_extra_headers
 
         max_tokens = params.get("max_tokens")
-        if max_tokens is not None and not is_codex_backend:
+        provider_name = str(params.get("provider") or "").strip().lower()
+        if max_tokens is not None and not is_codex_backend and provider_name != "openai-oauth":
             kwargs["max_output_tokens"] = max_tokens
 
         if is_xai_responses and session_id:

--- a/cli.py
+++ b/cli.py
@@ -6934,7 +6934,10 @@ class HermesCLI:
         # (e.g. gpt-5.5 is 1.05M on openai but 272K on Codex OAuth).
         mi = result.model_info
         try:
-            from hermes_cli.model_switch import resolve_display_context_length
+            from hermes_cli.model_switch import (
+                format_provider_context_note,
+                resolve_display_context_length,
+            )
             ctx = resolve_display_context_length(
                 result.new_model,
                 result.target_provider,
@@ -6945,6 +6948,13 @@ class HermesCLI:
             )
             if ctx:
                 _cprint(f"    Context: {ctx:,} tokens")
+            provider_context_note = format_provider_context_note(
+                result.new_model,
+                result.target_provider,
+                context_length=ctx,
+            )
+            if provider_context_note:
+                _cprint(f"    Note: {provider_context_note}")
         except Exception:
             pass
         if mi:
@@ -7168,7 +7178,10 @@ class HermesCLI:
         # Copilot, and Nous-enforced caps win over the raw models.dev entry
         # (e.g. gpt-5.5 is 1.05M on openai but 272K on Codex OAuth).
         mi = result.model_info
-        from hermes_cli.model_switch import resolve_display_context_length
+        from hermes_cli.model_switch import (
+            format_provider_context_note,
+            resolve_display_context_length,
+        )
         ctx = resolve_display_context_length(
             result.new_model,
             result.target_provider,
@@ -7179,6 +7192,13 @@ class HermesCLI:
         )
         if ctx:
             _cprint(f"    Context: {ctx:,} tokens")
+        provider_context_note = format_provider_context_note(
+            result.new_model,
+            result.target_provider,
+            context_length=ctx,
+        )
+        if provider_context_note:
+            _cprint(f"    Note: {provider_context_note}")
         if mi:
             if mi.max_output:
                 _cprint(f"    Max output: {mi.max_output:,} tokens")

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -94,6 +94,7 @@ ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120       # refresh 2 min before expiry
 NOUS_INVOKE_JWT_MIN_TTL_SECONDS = ACCESS_TOKEN_REFRESH_SKEW_SECONDS
 DEVICE_AUTH_POLL_INTERVAL_CAP_SECONDS = 1     # poll at most every 1s
 DEFAULT_CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
+DEFAULT_OPENAI_OAUTH_BASE_URL = "https://chatgpt.com/backend-api/codex"
 DEFAULT_XAI_OAUTH_BASE_URL = "https://api.x.ai/v1"
 MINIMAX_OAUTH_CLIENT_ID = "78257093-7e40-4613-99e0-527b14b39113"
 MINIMAX_OAUTH_SCOPE = "group_id profile model.completion"
@@ -112,6 +113,7 @@ STEPFUN_STEP_PLAN_CN_BASE_URL = "https://api.stepfun.com/step_plan/v1"
 CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 CODEX_OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token"
 CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120
+OPENAI_OAUTH_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120
 XAI_OAUTH_ISSUER = "https://auth.x.ai"
 XAI_OAUTH_DISCOVERY_URL = f"{XAI_OAUTH_ISSUER}/.well-known/openid-configuration"
 XAI_OAUTH_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828"
@@ -195,6 +197,12 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         name="OpenAI Codex",
         auth_type="oauth_external",
         inference_base_url=DEFAULT_CODEX_BASE_URL,
+    ),
+    "openai-oauth": ProviderConfig(
+        id="openai-oauth",
+        name="OpenAI (OAuth)",
+        auth_type="oauth_external",
+        inference_base_url=DEFAULT_OPENAI_OAUTH_BASE_URL,
     ),
     "xai-oauth": ProviderConfig(
         id="xai-oauth",
@@ -1406,6 +1414,8 @@ def resolve_provider(
     _PROVIDER_ALIASES = {
         "glm": "zai", "z-ai": "zai", "z.ai": "zai", "zhipu": "zai",
         "google": "gemini", "google-gemini": "gemini", "google-ai-studio": "gemini",
+        "openai-oauth": "openai-oauth", "openai-subscription": "openai-oauth",
+        "chatgpt-oauth": "openai-oauth",
         "x-ai": "xai", "x.ai": "xai", "grok": "xai",
         "xai-oauth": "xai-oauth", "x-ai-oauth": "xai-oauth",
         "grok-oauth": "xai-oauth", "xai-grok-oauth": "xai-oauth",
@@ -1833,6 +1843,119 @@ def _codex_access_token_is_expiring(access_token: Any, skew_seconds: int) -> boo
 
 def _qwen_cli_auth_path() -> Path:
     return Path.home() / ".qwen" / "oauth_creds.json"
+
+
+def _read_openai_oauth_tokens(*, _lock: bool = True) -> Dict[str, Any]:
+    """Read OpenAI OAuth tokens from Hermes auth store (~/.hermes/auth.json)."""
+    if _lock:
+        with _auth_store_lock():
+            auth_store = _load_auth_store()
+    else:
+        auth_store = _load_auth_store()
+    state = _load_provider_state(auth_store, "openai-oauth")
+    if not state:
+        raise AuthError(
+            "No OpenAI OAuth credentials stored. Run `hermes auth add openai-oauth`.",
+            provider="openai-oauth",
+            code="openai_oauth_auth_missing",
+            relogin_required=True,
+        )
+    tokens = state.get("tokens")
+    if not isinstance(tokens, dict):
+        raise AuthError(
+            "OpenAI OAuth state is missing tokens. Re-authenticate with `hermes auth add openai-oauth`.",
+            provider="openai-oauth",
+            code="openai_oauth_auth_invalid_shape",
+            relogin_required=True,
+        )
+    access_token = tokens.get("access_token")
+    refresh_token = tokens.get("refresh_token")
+    if not isinstance(access_token, str) or not access_token.strip():
+        raise AuthError(
+            "OpenAI OAuth state is missing access_token. Re-authenticate with `hermes auth add openai-oauth`.",
+            provider="openai-oauth",
+            code="openai_oauth_access_missing",
+            relogin_required=True,
+        )
+    if not isinstance(refresh_token, str) or not refresh_token.strip():
+        raise AuthError(
+            "OpenAI OAuth state is missing refresh_token. Re-authenticate with `hermes auth add openai-oauth`.",
+            provider="openai-oauth",
+            code="openai_oauth_refresh_missing",
+            relogin_required=True,
+        )
+    return {
+        "tokens": tokens,
+        "last_refresh": state.get("last_refresh"),
+        "account_id": state.get("account_id"),
+    }
+
+
+def _save_openai_oauth_tokens(
+    tokens: Dict[str, str],
+    *,
+    account_id: str = "",
+    last_refresh: str | None = None,
+) -> None:
+    """Save OpenAI OAuth tokens to Hermes auth store (~/.hermes/auth.json)."""
+    if last_refresh is None:
+        last_refresh = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    with _auth_store_lock():
+        auth_store = _load_auth_store()
+        state = _load_provider_state(auth_store, "openai-oauth") or {}
+        state["tokens"] = tokens
+        state["last_refresh"] = last_refresh
+        state["auth_mode"] = "chatgpt"
+        if account_id:
+            state["account_id"] = account_id
+        _save_provider_state(auth_store, "openai-oauth", state)
+        _save_auth_store(auth_store)
+
+
+def _openai_oauth_access_token_is_expiring(access_token: Any, skew_seconds: int) -> bool:
+    claims = _decode_jwt_claims(access_token)
+    exp = claims.get("exp")
+    if not isinstance(exp, (int, float)):
+        return False
+    return float(exp) <= (time.time() + max(0, int(skew_seconds)))
+
+
+def _import_openai_oauth_external_tokens() -> Optional[Dict[str, Any]]:
+    """Best-effort import from a local external OAuth cache.
+
+    This is explicit setup-time convenience only, not a runtime dependency.
+    """
+    override = os.getenv("HERMES_OPENAI_OAUTH_AUTH_PATH", "").strip()
+    auth_path = Path(override).expanduser() if override else (Path.home() / ".local" / "share" / "opencode" / "auth.json")
+    if not auth_path.is_file():
+        return None
+    try:
+        payload = json.loads(auth_path.read_text())
+        state = payload.get("openai") if isinstance(payload, dict) else None
+        if not isinstance(state, dict):
+            return None
+        access_token = str(state.get("access") or "").strip()
+        refresh_token = str(state.get("refresh") or "").strip()
+        if not access_token or not refresh_token:
+            return None
+        if _openai_oauth_access_token_is_expiring(access_token, 0):
+            return None
+        account_id = str(state.get("accountId") or "").strip()
+        if not account_id:
+            claims = _decode_jwt_claims(access_token)
+            auth_claims = claims.get("https://api.openai.com/auth")
+            if isinstance(auth_claims, dict):
+                account_id = str(auth_claims.get("chatgpt_account_id") or "").strip()
+        return {
+            "tokens": {
+                "access_token": access_token,
+                "refresh_token": refresh_token,
+            },
+            "account_id": account_id,
+            "last_refresh": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        }
+    except Exception:
+        return None
 
 
 def _read_qwen_cli_tokens() -> Dict[str, Any]:
@@ -3330,6 +3453,61 @@ def resolve_codex_runtime_credentials(
         "source": "hermes-auth-store",
         "last_refresh": data.get("last_refresh"),
         "auth_mode": "chatgpt",
+    }
+
+
+def resolve_openai_oauth_runtime_credentials(
+    *,
+    force_refresh: bool = False,
+    refresh_if_expiring: bool = True,
+    refresh_skew_seconds: int = OPENAI_OAUTH_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
+) -> Dict[str, Any]:
+    """Resolve runtime credentials for Hermes-owned OpenAI OAuth."""
+    data = _read_openai_oauth_tokens()
+    tokens = dict(data["tokens"])
+    access_token = str(tokens.get("access_token", "") or "").strip()
+    refresh_timeout_seconds = float(os.getenv("HERMES_OPENAI_OAUTH_REFRESH_TIMEOUT_SECONDS", "20"))
+
+    should_refresh = bool(force_refresh)
+    if (not should_refresh) and refresh_if_expiring:
+        should_refresh = _openai_oauth_access_token_is_expiring(access_token, refresh_skew_seconds)
+    if should_refresh:
+        with _auth_store_lock(timeout_seconds=max(float(AUTH_LOCK_TIMEOUT_SECONDS), refresh_timeout_seconds + 5.0)):
+            data = _read_openai_oauth_tokens(_lock=False)
+            tokens = dict(data["tokens"])
+            access_token = str(tokens.get("access_token", "") or "").strip()
+
+            should_refresh = bool(force_refresh)
+            if (not should_refresh) and refresh_if_expiring:
+                should_refresh = _openai_oauth_access_token_is_expiring(access_token, refresh_skew_seconds)
+
+            if should_refresh:
+                refreshed = refresh_codex_oauth_pure(
+                    str(tokens.get("access_token", "") or ""),
+                    str(tokens.get("refresh_token", "") or ""),
+                    timeout_seconds=refresh_timeout_seconds,
+                )
+                tokens["access_token"] = refreshed["access_token"]
+                tokens["refresh_token"] = refreshed["refresh_token"]
+                access_token = str(tokens.get("access_token", "") or "").strip()
+                _save_openai_oauth_tokens(
+                    tokens,
+                    account_id=str(data.get("account_id") or ""),
+                    last_refresh=refreshed.get("last_refresh"),
+                )
+
+    base_url = (
+        os.getenv("HERMES_OPENAI_OAUTH_BASE_URL", "").strip().rstrip("/")
+        or DEFAULT_OPENAI_OAUTH_BASE_URL
+    )
+    return {
+        "provider": "openai-oauth",
+        "base_url": base_url,
+        "api_key": access_token,
+        "source": "hermes-auth-store",
+        "last_refresh": data.get("last_refresh"),
+        "auth_mode": "chatgpt",
+        "account_id": str(data.get("account_id") or "").strip() or None,
     }
 
 
@@ -5469,10 +5647,33 @@ def get_codex_auth_status() -> Dict[str, Any]:
             "auth_mode": creds.get("auth_mode"),
             "source": creds.get("source"),
             "api_key": creds.get("api_key"),
+            "account_id": creds.get("account_id"),
         }
     except AuthError as exc:
         return {
             "logged_in": False,
+            "auth_store": str(_auth_file_path()),
+            "error": str(exc),
+        }
+
+
+def get_openai_oauth_auth_status() -> Dict[str, Any]:
+    try:
+        creds = resolve_openai_oauth_runtime_credentials(refresh_if_expiring=False)
+        return {
+            "logged_in": True,
+            "provider": "openai-oauth",
+            "auth_store": str(_auth_file_path()),
+            "last_refresh": creds.get("last_refresh"),
+            "auth_mode": creds.get("auth_mode"),
+            "source": creds.get("source"),
+            "api_key": creds.get("api_key"),
+            "account_id": creds.get("account_id"),
+        }
+    except AuthError as exc:
+        return {
+            "logged_in": False,
+            "provider": "openai-oauth",
             "auth_store": str(_auth_file_path()),
             "error": str(exc),
         }
@@ -5592,6 +5793,8 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
         return get_nous_auth_status()
     if target == "openai-codex":
         return get_codex_auth_status()
+    if target == "openai-oauth":
+        return get_openai_oauth_auth_status()
     if target == "xai-oauth":
         return get_xai_oauth_auth_status()
     if target == "qwen-oauth":
@@ -6202,6 +6405,96 @@ def _login_openai_codex(
     print(f"  Auth state: {_dhh()}/auth.json")
     print(f"  Config updated: {config_path} (model.provider=openai-codex)")
     _print_openai_codex_context_note()
+
+
+def _login_openai_oauth(
+    args,
+    pconfig: ProviderConfig,
+    *,
+    force_new_login: bool = False,
+) -> None:
+    """OpenAI OAuth login for Hermes-owned auth store.
+
+    Primary path: Hermes runs its own OpenAI device-code flow and stores the
+    resulting tokens under provider ``openai-oauth`` in ~/.hermes/auth.json.
+
+    Optional convenience path: if a local external OAuth cache exists, import
+    it once into Hermes-owned storage so runtime no longer depends on that
+    external file.
+    """
+    del args, pconfig
+
+    if not force_new_login:
+        try:
+            existing = resolve_openai_oauth_runtime_credentials(refresh_if_expiring=False)
+            api_key = existing.get("api_key", "")
+            if isinstance(api_key, str) and api_key and not _openai_oauth_access_token_is_expiring(api_key, 60):
+                print("Existing OpenAI OAuth credentials found in Hermes auth store.")
+                try:
+                    reuse = input("Use existing credentials? [Y/n]: ").strip().lower()
+                except (EOFError, KeyboardInterrupt):
+                    reuse = "y"
+                if reuse in {"", "y", "yes"}:
+                    config_path = _update_config_for_provider(
+                        "openai-oauth",
+                        existing.get("base_url", DEFAULT_OPENAI_OAUTH_BASE_URL),
+                    )
+                    print()
+                    print("Login successful!")
+                    print(f"  Config updated: {config_path} (model.provider=openai-oauth)")
+                    return
+        except AuthError:
+            pass
+
+    if not force_new_login:
+        imported = _import_openai_oauth_external_tokens()
+        if imported:
+            print("Found a local OpenAI OAuth cache on disk.")
+            try:
+                do_import = input("Import these credentials into Hermes? [y/N]: ").strip().lower()
+            except (EOFError, KeyboardInterrupt):
+                do_import = "n"
+            if do_import in {"y", "yes"}:
+                _save_openai_oauth_tokens(
+                    imported["tokens"],
+                    account_id=str(imported.get("account_id") or ""),
+                    last_refresh=imported.get("last_refresh"),
+                )
+                config_path = _update_config_for_provider("openai-oauth", DEFAULT_OPENAI_OAUTH_BASE_URL)
+                print()
+                print("Credentials imported into Hermes auth store.")
+                print(f"  Config updated: {config_path} (model.provider=openai-oauth)")
+                return
+
+    print()
+    print("Signing in to OpenAI OAuth...")
+    print("(Hermes creates its own session and stores it in ~/.hermes/auth.json)")
+    print()
+
+    creds = _codex_device_code_login()
+    account_id = ""
+    try:
+        claims = _decode_jwt_claims(creds["tokens"].get("access_token", ""))
+        auth_claims = claims.get("https://api.openai.com/auth")
+        if isinstance(auth_claims, dict):
+            account_id = str(auth_claims.get("chatgpt_account_id") or "").strip()
+    except Exception:
+        account_id = ""
+
+    _save_openai_oauth_tokens(
+        creds["tokens"],
+        account_id=account_id,
+        last_refresh=creds.get("last_refresh"),
+    )
+    config_path = _update_config_for_provider(
+        "openai-oauth",
+        creds.get("base_url", DEFAULT_OPENAI_OAUTH_BASE_URL),
+    )
+    print()
+    print("Login successful!")
+    from hermes_constants import display_hermes_home as _dhh
+    print(f"  Auth state: {_dhh()}/auth.json")
+    print(f"  Config updated: {config_path} (model.provider=openai-oauth)")
 
 
 def _login_xai_oauth(

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -6126,6 +6126,15 @@ def _login_openai_codex(
 ) -> None:
     """OpenAI Codex login via device code flow. Tokens stored in ~/.hermes/auth.json."""
 
+    _OPENAI_CODEX_CONTEXT_NOTE = (
+        "  Note: ChatGPT OAuth runs through Codex backend limits. For the same GPT-5 "
+        "slug, the direct OpenAI API can expose a larger context window. Use provider "
+        "`openai` with an API key when you need maximum OpenAI context."
+    )
+
+    def _print_openai_codex_context_note() -> None:
+        print(_OPENAI_CODEX_CONTEXT_NOTE)
+
     del args, pconfig  # kept for parity with other provider login helpers
 
     # Check for existing Hermes-owned credentials
@@ -6148,6 +6157,7 @@ def _login_openai_codex(
                     print()
                     print("Login successful!")
                     print(f"  Config updated: {config_path} (model.provider=openai-codex)")
+                    _print_openai_codex_context_note()
                     return
             else:
                 print("Existing Codex credentials are expired. Starting fresh login...")
@@ -6172,6 +6182,7 @@ def _login_openai_codex(
                 print("Credentials imported. Note: if Codex CLI refreshes its token,")
                 print("Hermes will keep working independently with its own session.")
                 print(f"  Config updated: {config_path} (model.provider=openai-codex)")
+                _print_openai_codex_context_note()
                 return
 
     # Run a fresh device code flow — Hermes gets its own OAuth session
@@ -6190,6 +6201,7 @@ def _login_openai_codex(
     from hermes_constants import display_hermes_home as _dhh
     print(f"  Auth state: {_dhh()}/auth.json")
     print(f"  Config updated: {config_path} (model.provider=openai-codex)")
+    _print_openai_codex_context_note()
 
 
 def _login_xai_oauth(

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -33,7 +33,7 @@ from hermes_constants import OPENROUTER_BASE_URL
 
 
 # Providers that support OAuth login in addition to API keys.
-_OAUTH_CAPABLE_PROVIDERS = {"anthropic", "nous", "openai-codex", "xai-oauth", "qwen-oauth", "google-gemini-cli", "minimax-oauth"}
+_OAUTH_CAPABLE_PROVIDERS = {"anthropic", "nous", "openai-codex", "openai-oauth", "xai-oauth", "qwen-oauth", "google-gemini-cli", "minimax-oauth"}
 
 
 def _get_custom_provider_names() -> list:
@@ -330,6 +330,46 @@ def auth_add_command(args) -> None:
             refresh_token=creds["tokens"].get("refresh_token"),
             base_url=creds.get("base_url"),
             last_refresh=creds.get("last_refresh"),
+        )
+        pool.add_entry(entry)
+        print(f'Added {provider} OAuth credential #{len(pool.entries())}: "{entry.label}"')
+        return
+
+    if provider == "openai-oauth":
+        imported = auth_mod._import_openai_oauth_external_tokens()
+        if imported:
+            tokens = imported["tokens"]
+            account_id = str(imported.get("account_id") or "")
+            last_refresh = imported.get("last_refresh")
+        else:
+            creds = auth_mod._codex_device_code_login()
+            tokens = dict(creds["tokens"])
+            last_refresh = creds.get("last_refresh")
+            account_id = ""
+            try:
+                claims = auth_mod._decode_jwt_claims(tokens.get("access_token", ""))
+                auth_claims = claims.get("https://api.openai.com/auth")
+                if isinstance(auth_claims, dict):
+                    account_id = str(auth_claims.get("chatgpt_account_id") or "").strip()
+            except Exception:
+                account_id = ""
+
+        auth_mod._save_openai_oauth_tokens(tokens, account_id=account_id, last_refresh=last_refresh)
+        label = (getattr(args, "label", None) or "").strip() or label_from_token(
+            tokens["access_token"],
+            _oauth_default_label(provider, len(pool.entries()) + 1),
+        )
+        entry = PooledCredential(
+            provider=provider,
+            id=uuid.uuid4().hex[:6],
+            label=label,
+            auth_type=AUTH_TYPE_OAUTH,
+            priority=0,
+            source=f"{SOURCE_MANUAL}:openai_oauth",
+            access_token=tokens["access_token"],
+            refresh_token=tokens.get("refresh_token"),
+            base_url=auth_mod.DEFAULT_OPENAI_OAUTH_BASE_URL,
+            last_refresh=last_refresh,
         )
         pool.add_entry(entry)
         print(f'Added {provider} OAuth credential #{len(pool.entries())}: "{entry.label}"')

--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -12,8 +12,8 @@ import os
 logger = logging.getLogger(__name__)
 
 DEFAULT_CODEX_MODELS: List[str] = [
-    "gpt-5.4",
     "gpt-5.5",
+    "gpt-5.4",
     "gpt-5.4-mini",
     "gpt-5.3-codex",
     # gpt-5.3-codex-spark is in research preview and is exposed *only* via

--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -12,9 +12,9 @@ import os
 logger = logging.getLogger(__name__)
 
 DEFAULT_CODEX_MODELS: List[str] = [
+    "gpt-5.4",
     "gpt-5.5",
     "gpt-5.4-mini",
-    "gpt-5.4",
     "gpt-5.3-codex",
     # gpt-5.3-codex-spark is in research preview and is exposed *only* via
     # the Codex CLI / OAuth backend (chatgpt.com/backend-api/codex/models)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2029,6 +2029,8 @@ def select_provider_and_model(args=None):
         _model_flow_nous(config, current_model, args=args)
     elif selected_provider == "openai-codex":
         _model_flow_openai_codex(config, current_model)
+    elif selected_provider == "openai-oauth":
+        _model_flow_openai_oauth(config, current_model)
     elif selected_provider == "xai-oauth":
         _model_flow_xai_oauth(config, current_model, args=args)
     elif selected_provider == "qwen-oauth":
@@ -2907,6 +2909,95 @@ def _model_flow_openai_codex(config, current_model=""):
         _save_model_choice(selected)
         _update_config_for_provider("openai-codex", DEFAULT_CODEX_BASE_URL)
         print(f"Default model set to: {selected} (via OpenAI Codex)")
+    else:
+        print("No change.")
+
+
+def _model_flow_openai_oauth(config, current_model=""):
+    """OpenAI OAuth provider: ensure logged in, then pick model."""
+    from hermes_cli.auth import (
+        get_openai_oauth_auth_status,
+        _prompt_model_selection,
+        _save_model_choice,
+        _update_config_for_provider,
+        resolve_openai_oauth_runtime_credentials,
+        _login_openai_oauth,
+        DEFAULT_OPENAI_OAUTH_BASE_URL,
+        PROVIDER_REGISTRY,
+    )
+    from hermes_cli.codex_models import get_codex_model_ids
+
+    status = get_openai_oauth_auth_status()
+    if status.get("logged_in"):
+        print("  OpenAI OAuth credentials: ✓")
+        print()
+        print("    1. Use existing credentials")
+        print("    2. Reauthenticate (new OAuth login)")
+        print("    3. Cancel")
+        print()
+        try:
+            choice = input("  Choice [1/2/3]: ").strip()
+        except (KeyboardInterrupt, EOFError):
+            choice = "1"
+
+        if choice == "2":
+            print("Starting a fresh OpenAI OAuth login...")
+            print()
+            try:
+                mock_args = argparse.Namespace()
+                _login_openai_oauth(
+                    mock_args,
+                    PROVIDER_REGISTRY["openai-oauth"],
+                    force_new_login=True,
+                )
+            except SystemExit:
+                print("Login cancelled or failed.")
+                return
+            except Exception as exc:
+                print(f"Login failed: {exc}")
+                return
+            status = get_openai_oauth_auth_status()
+            if not status.get("logged_in"):
+                print("Login failed.")
+                return
+        elif choice == "3":
+            return
+    else:
+        print("Not logged into OpenAI OAuth. Starting login...")
+        print()
+        try:
+            mock_args = argparse.Namespace()
+            _login_openai_oauth(mock_args, PROVIDER_REGISTRY["openai-oauth"])
+        except SystemExit:
+            print("Login cancelled or failed.")
+            return
+        except Exception as exc:
+            print(f"Login failed: {exc}")
+            return
+
+    oauth_token = None
+    try:
+        oauth_status = get_openai_oauth_auth_status()
+        if oauth_status.get("logged_in"):
+            oauth_token = oauth_status.get("api_key")
+    except Exception:
+        pass
+    if not oauth_token:
+        try:
+            oauth_creds = resolve_openai_oauth_runtime_credentials()
+            oauth_token = oauth_creds.get("api_key")
+        except Exception:
+            pass
+
+    oauth_models = get_codex_model_ids(access_token=oauth_token)
+    if "gpt-5.4" in oauth_models:
+        oauth_models = ["gpt-5.4"] + [m for m in oauth_models if m != "gpt-5.4"]
+
+    selected = _prompt_model_selection(oauth_models, current_model=current_model)
+    if selected:
+        _save_model_choice(selected)
+        _update_config_for_provider("openai-oauth", DEFAULT_OPENAI_OAUTH_BASE_URL)
+        print(f"Default model set to: {selected} (via OpenAI OAuth)")
     else:
         print("No change.")
 
@@ -10018,7 +10109,7 @@ def _build_provider_choices() -> list[str]:
     except Exception:
         # Fallback: static list guarantees the CLI always works
         return [
-            "auto", "openrouter", "nous", "openai-codex", "xai-oauth", "copilot-acp", "copilot",
+            "auto", "openrouter", "nous", "openai-codex", "openai-oauth", "xai-oauth", "copilot-acp", "copilot",
             "anthropic", "gemini", "google-gemini-cli", "xai", "bedrock", "azure-foundry",
             "ollama-cloud", "huggingface", "zai", "kimi-coding", "kimi-coding-cn",
             "stepfun", "minimax", "minimax-cn", "kilocode", "novita", "xiaomi", "arcee",

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -608,6 +608,23 @@ def resolve_display_context_length(
     return None
 
 
+def format_provider_context_note(
+    model: str,
+    provider: str,
+    context_length: int | None = None,
+) -> str:
+    """Return user-facing context note for providers with known caps."""
+    normalized = str(provider or "").strip().lower()
+    if normalized != "openai-codex":
+        return ""
+    _ = model, context_length  # reserved for future model-specific wording
+    return (
+        "ChatGPT OAuth uses Codex backend limits; the direct OpenAI API can expose "
+        "larger context windows for the same model. Use provider `openai` with an "
+        "API key when you need the maximum OpenAI context window."
+    )
+
+
 # ---------------------------------------------------------------------------
 # Core model-switching pipeline
 # ---------------------------------------------------------------------------

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1363,7 +1363,7 @@ def list_authenticated_providers(
         if not has_creds:
             continue
 
-        if hermes_slug in {"openai-codex", "copilot", "copilot-acp"}:
+        if hermes_slug in {"openai-codex", "openai-oauth", "copilot", "copilot-acp"}:
             # Use live OAuth-backed discovery so the gateway /model picker
             # matches what the user's authenticated Codex/Copilot backend
             # actually serves — including ChatGPT-Pro-only Codex slugs

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -105,6 +105,13 @@ def _codex_curated_models() -> list[str]:
     return _add_forward_compat_models(list(DEFAULT_CODEX_MODELS))
 
 
+def _openai_oauth_curated_models() -> list[str]:
+    models = _codex_curated_models()
+    if "gpt-5.4" in models:
+        models = ["gpt-5.4"] + [m for m in models if m != "gpt-5.4"]
+    return models
+
+
 # Static fallback for xAI when the models.dev disk cache is empty (fresh
 # install, offline first run, etc.). Mirrors the xAI-direct model IDs from
 # $HERMES_HOME/models_dev_cache.json as of 2026-04-28. Whenever xAI renames
@@ -200,6 +207,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "gpt-4o-mini",
     ],
     "openai-codex": _codex_curated_models(),
+    "openai-oauth": _openai_oauth_curated_models(),
     "xai-oauth": _xai_curated_models(),
     "copilot-acp": [
         "copilot-acp",
@@ -928,6 +936,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("lmstudio",       "LM Studio",                "LM Studio (local desktop app with built-in model server)"),
     ProviderEntry("anthropic",      "Anthropic",                "Anthropic (Claude models — API key or Claude Code)"),
     ProviderEntry("openai-codex",   "OpenAI Codex",             "OpenAI Codex"),
+    ProviderEntry("openai-oauth",   "OpenAI (OAuth)",           "OpenAI via Hermes-owned OAuth session (experimental)"),
     ProviderEntry("alibaba",        "Qwen Cloud",               "Qwen Cloud / DashScope Coding (Qwen + multi-provider)"),
     ProviderEntry("xai-oauth",      "xAI Grok OAuth (SuperGrok Subscription)", "xAI Grok OAuth (SuperGrok Subscription)"),
     ProviderEntry("xiaomi",         "Xiaomi MiMo",              "Xiaomi MiMo (MiMo-V2.5 and V2 models — pro, omni, flash)"),
@@ -2182,6 +2191,21 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
         except Exception:
             access_token = None
         return get_codex_model_ids(access_token=access_token)
+    if normalized == "openai-oauth":
+        from hermes_cli.codex_models import get_codex_model_ids
+
+        access_token = None
+        try:
+            from hermes_cli.auth import resolve_openai_oauth_runtime_credentials
+
+            creds = resolve_openai_oauth_runtime_credentials(refresh_if_expiring=True)
+            access_token = creds.get("api_key")
+        except Exception:
+            access_token = None
+        models = get_codex_model_ids(access_token=access_token)
+        if "gpt-5.4" in models:
+            models = ["gpt-5.4"] + [m for m in models if m != "gpt-5.4"]
+        return models
     if normalized == "xai-oauth":
         return list(_PROVIDER_MODELS.get("xai-oauth", _PROVIDER_MODELS.get("xai", [])))
     if normalized in {"copilot", "copilot-acp"}:

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -60,6 +60,12 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         auth_type="oauth_external",
         base_url_override="https://chatgpt.com/backend-api/codex",
     ),
+    "openai-oauth": HermesOverlay(
+        transport="codex_responses",
+        auth_type="oauth_external",
+        base_url_override="https://chatgpt.com/backend-api/codex",
+        base_url_env_var="HERMES_OPENAI_OAUTH_BASE_URL",
+    ),
     "xai-oauth": HermesOverlay(
         transport="codex_responses",
         auth_type="oauth_external",
@@ -247,6 +253,11 @@ ALIASES: Dict[str, str] = {
     "z.ai": "zai",
     "zhipu": "zai",
 
+    # openai oauth
+    "openai-oauth": "openai-oauth",
+    "openai-subscription": "openai-oauth",
+    "chatgpt-oauth": "openai-oauth",
+
     # xai
     "x-ai": "xai",
     "x.ai": "xai",
@@ -372,6 +383,7 @@ ALIASES: Dict[str, str] = {
 _LABEL_OVERRIDES: Dict[str, str] = {
     "nous": "Nous Portal",
     "openai-codex": "OpenAI Codex",
+    "openai-oauth": "OpenAI (OAuth)",
     "copilot-acp": "GitHub Copilot ACP",
     "stepfun": "StepFun Step Plan",
     "xiaomi": "Xiaomi MiMo",

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -14,11 +14,13 @@ from agent.credential_pool import CredentialPool, PooledCredential, get_custom_p
 from hermes_cli.auth import (
     AuthError,
     DEFAULT_CODEX_BASE_URL,
+    DEFAULT_OPENAI_OAUTH_BASE_URL,
     DEFAULT_QWEN_BASE_URL,
     DEFAULT_XAI_OAUTH_BASE_URL,
     PROVIDER_REGISTRY,
     _agent_key_is_usable,
     format_auth_error,
+    resolve_openai_oauth_runtime_credentials,
     resolve_provider,
     resolve_nous_runtime_credentials,
     resolve_codex_runtime_credentials,
@@ -240,6 +242,10 @@ def _resolve_runtime_from_pool_entry(
     if provider == "openai-codex":
         api_mode = "codex_responses"
         base_url = base_url or DEFAULT_CODEX_BASE_URL
+    elif provider == "openai-oauth":
+        base_url = base_url or DEFAULT_OPENAI_OAUTH_BASE_URL
+        configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
+        api_mode = configured_mode or "codex_responses"
     elif provider == "xai-oauth":
         api_mode = "codex_responses"
         base_url = base_url or DEFAULT_XAI_OAUTH_BASE_URL
@@ -1224,6 +1230,30 @@ def resolve_runtime_provider(
             # fall through to env-var providers (e.g. OpenRouter).
             logger.info("Auto-detected Codex provider but credentials failed; "
                         "falling through to next provider.")
+
+    if provider == "openai-oauth":
+        try:
+            creds = resolve_openai_oauth_runtime_credentials()
+            base_url = (creds.get("base_url") or "").rstrip("/") or DEFAULT_OPENAI_OAUTH_BASE_URL
+            configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
+            api_mode = configured_mode or "codex_responses"
+            return {
+                "provider": "openai-oauth",
+                "api_mode": api_mode,
+                "base_url": base_url,
+                "api_key": creds.get("api_key", ""),
+                "source": creds.get("source", "hermes-auth-store"),
+                "last_refresh": creds.get("last_refresh"),
+                "account_id": creds.get("account_id"),
+                "requested_provider": requested_provider,
+            }
+        except AuthError:
+            if requested_provider != "auto":
+                raise
+            logger.info(
+                "Auto-detected OpenAI OAuth provider but credentials failed; "
+                "falling through to next provider."
+            )
 
     if provider == "xai-oauth":
         try:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1436,6 +1436,14 @@ _OAUTH_PROVIDER_CATALOG: tuple[Dict[str, Any], ...] = (
         "status_fn": None,  # dispatched via auth.get_codex_auth_status
     },
     {
+        "id": "openai-oauth",
+        "name": "OpenAI (OAuth)",
+        "flow": "external",
+        "cli_command": "hermes auth add openai-oauth",
+        "docs_url": "https://platform.openai.com/docs",
+        "status_fn": None,
+    },
+    {
         "id": "qwen-oauth",
         "name": "Qwen (via Qwen CLI)",
         "flow": "external",
@@ -1487,6 +1495,17 @@ def _resolve_provider_status(provider_id: str, status_fn) -> Dict[str, Any]:
                 "token_preview": _truncate_token(raw.get("api_key")),
                 "expires_at": None,
                 "has_refresh_token": False,
+                "last_refresh": raw.get("last_refresh"),
+            }
+        if provider_id == "openai-oauth":
+            raw = hauth.get_openai_oauth_auth_status()
+            return {
+                "logged_in": bool(raw.get("logged_in")),
+                "source": raw.get("source") or "openai_oauth",
+                "source_label": raw.get("auth_mode") or "OpenAI OAuth",
+                "token_preview": _truncate_token(raw.get("api_key")),
+                "expires_at": None,
+                "has_refresh_token": True,
                 "last_refresh": raw.get("last_refresh"),
             }
         if provider_id == "qwen-oauth":

--- a/run_agent.py
+++ b/run_agent.py
@@ -2584,6 +2584,12 @@ class AIAgent:
                 singleton_now = resolve_codex_runtime_credentials(
                     refresh_if_expiring=False,
                 )
+            elif self.provider == "openai-oauth":
+                from hermes_cli.auth import resolve_openai_oauth_runtime_credentials
+
+                singleton_now = resolve_openai_oauth_runtime_credentials(
+                    refresh_if_expiring=False,
+                )
             else:
                 from hermes_cli.auth import resolve_xai_oauth_runtime_credentials
 
@@ -2610,6 +2616,10 @@ class AIAgent:
                 from hermes_cli.auth import resolve_codex_runtime_credentials
 
                 creds = resolve_codex_runtime_credentials(force_refresh=force)
+            elif self.provider == "openai-oauth":
+                from hermes_cli.auth import resolve_openai_oauth_runtime_credentials
+
+                creds = resolve_openai_oauth_runtime_credentials(force_refresh=force)
             else:
                 from hermes_cli.auth import resolve_xai_oauth_runtime_credentials
 
@@ -2788,10 +2798,24 @@ class AIAgent:
         elif base_url_host_matches(base_url, "portal.qwen.ai"):
             self._client_kwargs["default_headers"] = _qwen_portal_headers()
         elif base_url_host_matches(base_url, "chatgpt.com"):
-            from agent.auxiliary_client import _codex_cloudflare_headers
-            self._client_kwargs["default_headers"] = _codex_cloudflare_headers(
-                self._client_kwargs.get("api_key", "")
-            )
+            if self.provider == "openai-oauth":
+                from agent.auxiliary_client import _openai_oauth_headers
+                account_id = None
+                try:
+                    from hermes_cli.auth import resolve_openai_oauth_runtime_credentials
+
+                    _oauth_creds = resolve_openai_oauth_runtime_credentials(refresh_if_expiring=False)
+                    account_id = _oauth_creds.get("account_id")
+                except Exception:
+                    account_id = None
+                self._client_kwargs["default_headers"] = _openai_oauth_headers(
+                    self._client_kwargs.get("api_key", ""), account_id,
+                )
+            else:
+                from agent.auxiliary_client import _codex_cloudflare_headers
+                self._client_kwargs["default_headers"] = _codex_cloudflare_headers(
+                    self._client_kwargs.get("api_key", "")
+                )
         else:
             # No URL-specific headers — check profile.default_headers before clearing.
             _ph_headers = None

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -630,6 +630,33 @@ class TestExplicitProviderRouting:
             for record in caplog.records
         )
 
+    def test_explicit_openai_oauth_uses_direct_client(self, monkeypatch):
+        with patch(
+            "hermes_cli.auth.resolve_openai_oauth_runtime_credentials",
+            return_value={
+                "provider": "openai-oauth",
+                "base_url": "https://chatgpt.com/backend-api/codex",
+                "api_key": "oauth-token",
+                "source": "hermes-auth-store",
+                "account_id": "acct-123",
+            },
+        ), patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            client, model = resolve_provider_client("openai-oauth", "gpt-5.4")
+
+        assert client is not None
+        assert model == "gpt-5.4"
+        assert mock_openai.call_args.kwargs["api_key"] == "oauth-token"
+        assert mock_openai.call_args.kwargs["base_url"] == "https://chatgpt.com/backend-api/codex"
+        assert mock_openai.call_args.kwargs["default_headers"]["originator"] == "hermes"
+        assert mock_openai.call_args.kwargs["default_headers"]["ChatGPT-Account-Id"] == "acct-123"
+
+    def test_explicit_openai_oauth_requires_model(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="agent.auxiliary_client"):
+            client, model = resolve_provider_client("openai-oauth")
+        assert client is None
+        assert model is None
+        assert any("openai-oauth requested without a model" in record.message for record in caplog.records)
+
 class TestGetTextAuxiliaryClient:
     """Test the full resolution chain for get_text_auxiliary_client."""
 

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -265,12 +265,6 @@ class TestCodexOAuthContextLength:
     chatgpt.com/backend-api/codex/models: most models return 272k, while
     models.dev reports 1.05M for gpt-5.5/gpt-5.4 and 400k for the rest.
     (Known exception: gpt-5.3-codex-spark is 128k.)
-
-    Important route-specific exception: live probing of the actual Codex
-    /responses path on May 19, 2026 showed gpt-5.4 accepting ~900k input
-    tokens on ChatGPT OAuth, consistent with the public API's 1.05M total
-    context budget. Hermes therefore overrides the stale /models 272k value
-    for gpt-5.4 only.
     """
 
     def setup_method(self):
@@ -286,7 +280,7 @@ class TestCodexOAuthContextLength:
 
         expected = {
             "gpt-5.5": 272_000,
-            "gpt-5.4": 1_050_000,
+            "gpt-5.4": 272_000,
             "gpt-5.4-mini": 272_000,
             "gpt-5.3-codex": 272_000,
             "gpt-5.3-codex-spark": 128_000,
@@ -309,9 +303,9 @@ class TestCodexOAuthContextLength:
                     "(models.dev leakage?)"
                 )
 
-    def test_live_probe_still_wins_for_non_overridden_models(self):
-        """When a token is provided, the live /models probe still drives
-        non-overridden slugs such as gpt-5.5."""
+    def test_live_probe_overrides_fallback(self):
+        """When a token is provided, the live /models probe is preferred
+        and its context_window drives the result."""
         from agent.model_metadata import get_model_context_length
 
         fake_response = MagicMock()
@@ -319,7 +313,7 @@ class TestCodexOAuthContextLength:
         fake_response.json.return_value = {
             "models": [
                 {"slug": "gpt-5.5", "context_window": 300_000},
-                {"slug": "gpt-5.4", "context_window": 272_000},
+                {"slug": "gpt-5.4", "context_window": 400_000},
             ]
         }
 
@@ -339,32 +333,7 @@ class TestCodexOAuthContextLength:
                 provider="openai-codex",
             )
         assert ctx_55 == 300_000
-        assert ctx_54 == 1_050_000
-
-    def test_gpt_5_4_override_beats_live_models_probe(self):
-        """gpt-5.4's live /responses route accepts ~1.05M total context on
-        ChatGPT OAuth even though /models still reports 272k. The route-
-        specific override must win so Hermes does not compress far too early.
-        """
-        from agent.model_metadata import get_model_context_length
-
-        fake_response = MagicMock()
-        fake_response.status_code = 200
-        fake_response.json.return_value = {
-            "models": [{"slug": "gpt-5.4", "context_window": 272_000}]
-        }
-
-        with patch("agent.model_metadata.requests.get", return_value=fake_response), \
-             patch("agent.model_metadata.get_cached_context_length", return_value=None), \
-             patch("agent.model_metadata.save_context_length"):
-            ctx = get_model_context_length(
-                model="gpt-5.4",
-                base_url="https://chatgpt.com/backend-api/codex",
-                api_key="fake-token",
-                provider="openai-codex",
-            )
-
-        assert ctx == 1_050_000
+        assert ctx_54 == 400_000
 
     def test_probe_failure_falls_back_to_hardcoded(self):
         """If the probe fails (non-200 / network error), we still return
@@ -385,6 +354,58 @@ class TestCodexOAuthContextLength:
                 provider="openai-codex",
             )
         assert ctx == 272_000
+
+
+class TestOpenAIOAuthContextLength:
+    def test_gpt_5_4_uses_known_high_context(self):
+        from agent.model_metadata import get_model_context_length
+
+        with patch("agent.model_metadata.get_cached_context_length", return_value=None), \
+             patch("agent.model_metadata.save_context_length"):
+            ctx = get_model_context_length(
+                model="gpt-5.4",
+                base_url="https://chatgpt.com/backend-api/codex",
+                api_key="fake-token",
+                provider="openai-oauth",
+            )
+        assert ctx == 1_050_000
+
+    def test_gpt_5_5_uses_known_small_context(self):
+        from agent.model_metadata import get_model_context_length
+
+        with patch("agent.model_metadata.get_cached_context_length", return_value=None), \
+             patch("agent.model_metadata.save_context_length"):
+            ctx = get_model_context_length(
+                model="gpt-5.5",
+                base_url="https://chatgpt.com/backend-api/codex",
+                api_key="fake-token",
+                provider="openai-oauth",
+            )
+        assert ctx == 272_000
+
+    def test_provider_scoped_cache_does_not_leak_from_codex(self, tmp_path, monkeypatch):
+        from agent import model_metadata as mm
+
+        cache_file = tmp_path / "context_length_cache.yaml"
+        monkeypatch.setattr(mm, "_get_context_cache_path", lambda: cache_file)
+
+        import yaml as _yaml
+        base_url = "https://chatgpt.com/backend-api/codex"
+        cache_file.write_text(_yaml.dump({"context_lengths": {
+            f"gpt-5.4@{base_url}": 272_000,
+        }}))
+
+        with patch("agent.model_metadata.requests.post") as mock_post, \
+             patch("agent.model_metadata.save_context_length"):
+            ctx = mm.get_model_context_length(
+                model="gpt-5.4",
+                base_url=base_url,
+                api_key="fake-token",
+                provider="openai-oauth",
+            )
+
+        assert ctx == 1_050_000
+        mock_post.assert_not_called()
 
     def test_non_codex_providers_unaffected(self):
         """Resolving gpt-5.5 on non-Codex providers must NOT use the Codex

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -265,6 +265,12 @@ class TestCodexOAuthContextLength:
     chatgpt.com/backend-api/codex/models: most models return 272k, while
     models.dev reports 1.05M for gpt-5.5/gpt-5.4 and 400k for the rest.
     (Known exception: gpt-5.3-codex-spark is 128k.)
+
+    Important route-specific exception: live probing of the actual Codex
+    /responses path on May 19, 2026 showed gpt-5.4 accepting ~900k input
+    tokens on ChatGPT OAuth, consistent with the public API's 1.05M total
+    context budget. Hermes therefore overrides the stale /models 272k value
+    for gpt-5.4 only.
     """
 
     def setup_method(self):
@@ -280,7 +286,7 @@ class TestCodexOAuthContextLength:
 
         expected = {
             "gpt-5.5": 272_000,
-            "gpt-5.4": 272_000,
+            "gpt-5.4": 1_050_000,
             "gpt-5.4-mini": 272_000,
             "gpt-5.3-codex": 272_000,
             "gpt-5.3-codex-spark": 128_000,
@@ -303,9 +309,9 @@ class TestCodexOAuthContextLength:
                     "(models.dev leakage?)"
                 )
 
-    def test_live_probe_overrides_fallback(self):
-        """When a token is provided, the live /models probe is preferred
-        and its context_window drives the result."""
+    def test_live_probe_still_wins_for_non_overridden_models(self):
+        """When a token is provided, the live /models probe still drives
+        non-overridden slugs such as gpt-5.5."""
         from agent.model_metadata import get_model_context_length
 
         fake_response = MagicMock()
@@ -313,7 +319,7 @@ class TestCodexOAuthContextLength:
         fake_response.json.return_value = {
             "models": [
                 {"slug": "gpt-5.5", "context_window": 300_000},
-                {"slug": "gpt-5.4", "context_window": 400_000},
+                {"slug": "gpt-5.4", "context_window": 272_000},
             ]
         }
 
@@ -333,7 +339,32 @@ class TestCodexOAuthContextLength:
                 provider="openai-codex",
             )
         assert ctx_55 == 300_000
-        assert ctx_54 == 400_000
+        assert ctx_54 == 1_050_000
+
+    def test_gpt_5_4_override_beats_live_models_probe(self):
+        """gpt-5.4's live /responses route accepts ~1.05M total context on
+        ChatGPT OAuth even though /models still reports 272k. The route-
+        specific override must win so Hermes does not compress far too early.
+        """
+        from agent.model_metadata import get_model_context_length
+
+        fake_response = MagicMock()
+        fake_response.status_code = 200
+        fake_response.json.return_value = {
+            "models": [{"slug": "gpt-5.4", "context_window": 272_000}]
+        }
+
+        with patch("agent.model_metadata.requests.get", return_value=fake_response), \
+             patch("agent.model_metadata.get_cached_context_length", return_value=None), \
+             patch("agent.model_metadata.save_context_length"):
+            ctx = get_model_context_length(
+                model="gpt-5.4",
+                base_url="https://chatgpt.com/backend-api/codex",
+                api_key="fake-token",
+                provider="openai-codex",
+            )
+
+        assert ctx == 1_050_000
 
     def test_probe_failure_falls_back_to_hardcoded(self):
         """If the probe fails (non-200 / network error), we still return

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -155,6 +155,15 @@ class TestCodexBuildKwargs:
         )
         assert "max_output_tokens" not in kw
 
+    def test_openai_oauth_no_max_output_tokens(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-5.4", messages=messages, tools=[],
+            max_tokens=4096,
+            provider="openai-oauth",
+        )
+        assert "max_output_tokens" not in kw
+
     def test_xai_headers(self, transport):
         messages = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(

--- a/tests/hermes_cli/test_apply_model_switch_result_context.py
+++ b/tests/hermes_cli/test_apply_model_switch_result_context.py
@@ -86,6 +86,8 @@ def test_picker_path_uses_provider_aware_context_on_codex(monkeypatch):
     assert "1,050,000" not in ctx_line, (
         f"picker-path display leaked models.dev's 1.05M for Codex: {ctx_line!r}"
     )
+    note_line = next((l for l in lines if "ChatGPT OAuth uses Codex backend limits" in l), "")
+    assert "direct OpenAI API can expose larger context windows" in note_line
 
 
 def test_picker_path_shows_vendor_value_when_no_provider_cap(monkeypatch):
@@ -150,3 +152,25 @@ def test_picker_path_falls_back_to_model_info_when_resolver_empty(monkeypatch):
     assert "1,050,000" in ctx_line, (
         f"resolver-empty path should fall back to ModelInfo, got: {ctx_line!r}"
     )
+
+
+def test_picker_path_omits_codex_note_on_other_providers(monkeypatch):
+    result = ModelSwitchResult(
+        success=True,
+        new_model="openai/gpt-5.5",
+        target_provider="openrouter",
+        provider_changed=True,
+        api_key="",
+        base_url="https://openrouter.ai/api/v1",
+        api_mode="chat_completions",
+        warning_message="",
+        provider_label="OpenRouter",
+        resolved_via_alias=False,
+        capabilities=None,
+        model_info=_FakeModelInfo(),
+        is_global=False,
+    )
+    with patch("agent.model_metadata.get_model_context_length", return_value=1_050_000):
+        lines = _run_display(monkeypatch, result)
+
+    assert not any("ChatGPT OAuth uses Codex backend limits" in l for l in lines)

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -351,3 +351,27 @@ def test_login_openai_codex_force_new_login_skips_existing_reuse_prompt(monkeypa
 
     assert called["device_login"] == 1
     assert called["tokens"]["access_token"] == "fresh-at"
+
+
+def test_login_prints_codex_context_note(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_codex_runtime_credentials",
+        lambda: (_ for _ in ()).throw(AuthError("missing", provider="openai-codex")),
+    )
+    monkeypatch.setattr("hermes_cli.auth._import_codex_cli_tokens", lambda: None)
+    monkeypatch.setattr(
+        "hermes_cli.auth._codex_device_code_login",
+        lambda: {
+            "tokens": {"access_token": "fresh-at", "refresh_token": "fresh-rt"},
+            "last_refresh": "2026-04-01T00:00:00Z",
+            "base_url": DEFAULT_CODEX_BASE_URL,
+        },
+    )
+    monkeypatch.setattr("hermes_cli.auth._save_codex_tokens", lambda *args, **kwargs: None)
+    monkeypatch.setattr("hermes_cli.auth._update_config_for_provider", lambda *args, **kwargs: "/tmp/config.yaml")
+
+    _login_openai_codex(SimpleNamespace(), PROVIDER_REGISTRY["openai-codex"], force_new_login=True)
+
+    out = capsys.readouterr().out
+    assert "ChatGPT OAuth runs through Codex backend limits" in out
+    assert "provider `openai` with an API key" in out

--- a/tests/hermes_cli/test_model_switch_context_display.py
+++ b/tests/hermes_cli/test_model_switch_context_display.py
@@ -41,6 +41,25 @@ class TestResolveDisplayContextLength:
             "Codex OAuth's 272K cap must win over models.dev's 1.05M for gpt-5.5"
         )
 
+    def test_codex_oauth_gpt_5_4_keeps_high_context(self):
+        """gpt-5.4 on openai-codex is a route-specific exception: the live
+        ChatGPT OAuth /responses path accepts ~1.05M total context even though
+        Codex /models still reports 272k. /model must show the higher value.
+        """
+        fake_mi = _FakeModelInfo(1_050_000)
+        with patch(
+            "agent.model_metadata.get_model_context_length",
+            return_value=1_050_000,
+        ):
+            ctx = resolve_display_context_length(
+                "gpt-5.4",
+                "openai-codex",
+                base_url="https://chatgpt.com/backend-api/codex",
+                api_key="",
+                model_info=fake_mi,
+            )
+        assert ctx == 1_050_000
+
     def test_falls_back_to_model_info_when_resolver_returns_none(self):
         fake_mi = _FakeModelInfo(1_048_576)
         with patch(

--- a/tests/hermes_cli/test_model_switch_context_display.py
+++ b/tests/hermes_cli/test_model_switch_context_display.py
@@ -41,11 +41,9 @@ class TestResolveDisplayContextLength:
             "Codex OAuth's 272K cap must win over models.dev's 1.05M for gpt-5.5"
         )
 
-    def test_codex_oauth_gpt_5_4_keeps_high_context(self):
-        """gpt-5.4 on openai-codex is a route-specific exception: the live
-        ChatGPT OAuth /responses path accepts ~1.05M total context even though
-        Codex /models still reports 272k. /model must show the higher value.
-        """
+    def test_openai_oauth_gpt_5_4_keeps_high_context(self):
+        """gpt-5.4 on openai-oauth should show the high effective context
+        for that experimental provider path."""
         fake_mi = _FakeModelInfo(1_050_000)
         with patch(
             "agent.model_metadata.get_model_context_length",
@@ -53,7 +51,7 @@ class TestResolveDisplayContextLength:
         ):
             ctx = resolve_display_context_length(
                 "gpt-5.4",
-                "openai-codex",
+                "openai-oauth",
                 base_url="https://chatgpt.com/backend-api/codex",
                 api_key="",
                 model_info=fake_mi,

--- a/tests/hermes_cli/test_openai_oauth.py
+++ b/tests/hermes_cli/test_openai_oauth.py
@@ -1,0 +1,157 @@
+import base64
+import json
+import time
+
+import pytest
+
+from hermes_cli.auth import (
+    AuthError,
+    DEFAULT_OPENAI_OAUTH_BASE_URL,
+    PROVIDER_REGISTRY,
+    _import_openai_oauth_external_tokens,
+    get_auth_status,
+    get_openai_oauth_auth_status,
+    resolve_openai_oauth_runtime_credentials,
+)
+
+
+def _jwt_with_exp(exp_epoch: int) -> str:
+    header = base64.urlsafe_b64encode(json.dumps({"alg": "RS256", "typ": "JWT"}).encode()).decode().rstrip("=")
+    payload = base64.urlsafe_b64encode(
+        json.dumps(
+            {
+                "exp": exp_epoch,
+                "https://api.openai.com/auth": {"chatgpt_account_id": "acct-test-123"},
+            }
+        ).encode()
+    ).decode().rstrip("=")
+    return f"{header}.{payload}.sig"
+
+
+def _write_auth_store(tmp_path, payload: dict) -> None:
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "auth.json").write_text(json.dumps(payload, indent=2))
+
+
+def test_provider_registry_contains_openai_oauth():
+    assert "openai-oauth" in PROVIDER_REGISTRY
+    cfg = PROVIDER_REGISTRY["openai-oauth"]
+    assert cfg.auth_type == "oauth_external"
+    assert cfg.inference_base_url == DEFAULT_OPENAI_OAUTH_BASE_URL
+
+
+def test_resolve_openai_oauth_runtime_credentials_reads_auth_store(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "providers": {
+                "openai-oauth": {
+                    "tokens": {
+                        "access_token": _jwt_with_exp(int(time.time()) + 3600),
+                        "refresh_token": "refresh-token",
+                    },
+                    "account_id": "acct-file-456",
+                    "last_refresh": "2026-05-20T00:00:00Z",
+                    "auth_mode": "chatgpt",
+                }
+            },
+        },
+    )
+
+    creds = resolve_openai_oauth_runtime_credentials(refresh_if_expiring=False)
+
+    assert creds["provider"] == "openai-oauth"
+    assert creds["base_url"] == DEFAULT_OPENAI_OAUTH_BASE_URL
+    assert creds["source"] == "hermes-auth-store"
+    assert creds["account_id"] == "acct-file-456"
+
+
+def test_resolve_openai_oauth_runtime_credentials_refreshes_expiring_token(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "providers": {
+                "openai-oauth": {
+                    "tokens": {
+                        "access_token": _jwt_with_exp(int(time.time()) - 10),
+                        "refresh_token": "refresh-token",
+                    },
+                    "account_id": "acct-file-456",
+                }
+            },
+        },
+    )
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.refresh_codex_oauth_pure",
+        lambda *args, **kwargs: {
+            "access_token": _jwt_with_exp(int(time.time()) + 3600),
+            "refresh_token": "refresh-new",
+            "last_refresh": "2026-05-20T00:00:00Z",
+        },
+    )
+
+    creds = resolve_openai_oauth_runtime_credentials()
+    assert creds["api_key"]
+
+
+def test_import_openai_oauth_external_tokens(tmp_path, monkeypatch):
+    auth_path = tmp_path / "external-auth.json"
+    auth_path.write_text(
+        json.dumps(
+            {
+                "openai": {
+                    "type": "oauth",
+                    "access": _jwt_with_exp(int(time.time()) + 3600),
+                    "refresh": "refresh-token",
+                    "accountId": "acct-file-456",
+                }
+            }
+        )
+    )
+    monkeypatch.setenv("HERMES_OPENAI_OAUTH_AUTH_PATH", str(auth_path))
+
+    imported = _import_openai_oauth_external_tokens()
+    assert imported is not None
+    assert imported["tokens"]["refresh_token"] == "refresh-token"
+    assert imported["account_id"] == "acct-file-456"
+
+
+def test_get_openai_oauth_auth_status_dispatches(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "providers": {
+                "openai-oauth": {
+                    "tokens": {
+                        "access_token": _jwt_with_exp(int(time.time()) + 3600),
+                        "refresh_token": "refresh-token",
+                    },
+                    "account_id": "acct-file-456",
+                }
+            },
+        },
+    )
+
+    status = get_openai_oauth_auth_status()
+    dispatched = get_auth_status("openai-oauth")
+
+    assert status["logged_in"] is True
+    assert status["provider"] == "openai-oauth"
+    assert dispatched["logged_in"] is True
+
+
+def test_openai_oauth_missing_store_raises(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+
+    with pytest.raises(AuthError) as exc_info:
+        resolve_openai_oauth_runtime_credentials(refresh_if_expiring=False)
+    assert exc_info.value.code == "openai_oauth_auth_missing"

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -173,6 +173,30 @@ def test_resolve_runtime_provider_qwen_oauth(monkeypatch):
     assert resolved["requested_provider"] == "qwen-oauth"
 
 
+def test_resolve_runtime_provider_openai_oauth(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openai-oauth")
+    monkeypatch.setattr(
+        rp,
+        "resolve_openai_oauth_runtime_credentials",
+        lambda: {
+            "provider": "openai-oauth",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "api_key": "oauth-token",
+            "source": "hermes-auth-store",
+            "account_id": "acct-123",
+        },
+    )
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+
+    resolved = rp.resolve_runtime_provider(requested="openai-oauth")
+
+    assert resolved["provider"] == "openai-oauth"
+    assert resolved["api_mode"] == "codex_responses"
+    assert resolved["base_url"] == "https://chatgpt.com/backend-api/codex"
+    assert resolved["api_key"] == "oauth-token"
+    assert resolved["requested_provider"] == "openai-oauth"
+
+
 def test_resolve_runtime_provider_uses_qwen_pool_entry(monkeypatch):
     class _Entry:
         access_token = "pool-qwen-token"

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -118,7 +118,7 @@ Good defaults:
 | **Custom Endpoint** | VLLM, SGLang, Ollama, or any OpenAI-compatible API | Set base URL + API key |
 
 :::note OpenAI Codex context limits
-`openai-codex` uses ChatGPT OAuth on the Codex backend, and the effective limit is model-specific. Today, `gpt-5.4` is the high-context ChatGPT OAuth choice (~1M total context), while `gpt-5.5` still behaves like a much smaller-window Codex model. If you want the largest ChatGPT-subscription context inside Hermes, pick `gpt-5.4` on `openai-codex`.
+`openai-codex` is Hermes' stable ChatGPT/Codex OAuth lane. `openai-oauth` is a separate experimental OpenAI OAuth lane that can detect a different effective context budget on the same backend. Keep them distinct when comparing context limits or auth behavior.
 :::
 
 For most first-time users: choose a provider, accept the defaults unless you know why you're changing them. The full provider catalog with env vars and setup steps lives on the [Providers](../integrations/providers.md) page.

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -118,7 +118,7 @@ Good defaults:
 | **Custom Endpoint** | VLLM, SGLang, Ollama, or any OpenAI-compatible API | Set base URL + API key |
 
 :::note OpenAI Codex context limits
-`openai-codex` uses ChatGPT OAuth on the Codex backend. Some GPT-5 models have a smaller effective context window there than they do on the direct OpenAI Platform API. If maximum OpenAI context matters more than subscription auth, use provider `openai` with an API key.
+`openai-codex` uses ChatGPT OAuth on the Codex backend, and the effective limit is model-specific. Today, `gpt-5.4` is the high-context ChatGPT OAuth choice (~1M total context), while `gpt-5.5` still behaves like a much smaller-window Codex model. If you want the largest ChatGPT-subscription context inside Hermes, pick `gpt-5.4` on `openai-codex`.
 :::
 
 For most first-time users: choose a provider, accept the defaults unless you know why you're changing them. The full provider catalog with env vars and setup steps lives on the [Providers](../integrations/providers.md) page.

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -117,6 +117,10 @@ Good defaults:
 | **Vercel AI Gateway** | Vercel AI Gateway routing | Set `AI_GATEWAY_API_KEY` |
 | **Custom Endpoint** | VLLM, SGLang, Ollama, or any OpenAI-compatible API | Set base URL + API key |
 
+:::note OpenAI Codex context limits
+`openai-codex` uses ChatGPT OAuth on the Codex backend. Some GPT-5 models have a smaller effective context window there than they do on the direct OpenAI Platform API. If maximum OpenAI context matters more than subscription auth, use provider `openai` with an API key.
+:::
+
 For most first-time users: choose a provider, accept the defaults unless you know why you're changing them. The full provider catalog with env vars and setup steps lives on the [Providers](../integrations/providers.md) page.
 
 :::caution Minimum context: 64K tokens

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -142,7 +142,7 @@ The OpenAI Codex provider authenticates via device code (open a URL, enter a cod
 
 If a token refresh fails with a terminal error (HTTP 4xx, `invalid_grant`, revoked grant, etc.), Hermes marks the refresh token as dead and stops replaying it so you don't see a flood of identical auth failures. The next request surfaces a typed re-auth message instead. Run `hermes auth add codex-oauth` (or `hermes model` → OpenAI Codex) to start a fresh device-code login; the quarantine clears on the next successful exchange.
 
-ChatGPT OAuth on this provider uses the Codex backend, not the direct OpenAI Platform API, and the effective limit is model-specific. In current live testing, `gpt-5.4` is the large-context ChatGPT OAuth option (~1M total context), while `gpt-5.5` still behaves like a smaller-window Codex model. If you want the largest ChatGPT-subscription context inside Hermes, choose `gpt-5.4` on `openai-codex`.
+ChatGPT OAuth on this provider uses the Codex backend, not the direct OpenAI Platform API. Hermes also supports a separate experimental `openai-oauth` lane so Codex behavior and OpenAI OAuth behavior can evolve independently instead of mutating the existing `openai-codex` provider in place.
 :::
 
 :::warning

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -142,7 +142,7 @@ The OpenAI Codex provider authenticates via device code (open a URL, enter a cod
 
 If a token refresh fails with a terminal error (HTTP 4xx, `invalid_grant`, revoked grant, etc.), Hermes marks the refresh token as dead and stops replaying it so you don't see a flood of identical auth failures. The next request surfaces a typed re-auth message instead. Run `hermes auth add codex-oauth` (or `hermes model` → OpenAI Codex) to start a fresh device-code login; the quarantine clears on the next successful exchange.
 
-ChatGPT OAuth on this provider uses the Codex backend, not the direct OpenAI Platform API. That means the same GPT-5 slug can have a smaller effective context window here than it does on `provider: openai`. If you need the maximum OpenAI context window, use the `openai` provider with an API key instead.
+ChatGPT OAuth on this provider uses the Codex backend, not the direct OpenAI Platform API, and the effective limit is model-specific. In current live testing, `gpt-5.4` is the large-context ChatGPT OAuth option (~1M total context), while `gpt-5.5` still behaves like a smaller-window Codex model. If you want the largest ChatGPT-subscription context inside Hermes, choose `gpt-5.4` on `openai-codex`.
 :::
 
 :::warning

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -141,6 +141,8 @@ with the Generative Language API enabled.
 The OpenAI Codex provider authenticates via device code (open a URL, enter a code). Hermes stores the resulting credentials in its own auth store under `~/.hermes/auth.json` and can import existing Codex CLI credentials from `~/.codex/auth.json` when present. No Codex CLI installation is required.
 
 If a token refresh fails with a terminal error (HTTP 4xx, `invalid_grant`, revoked grant, etc.), Hermes marks the refresh token as dead and stops replaying it so you don't see a flood of identical auth failures. The next request surfaces a typed re-auth message instead. Run `hermes auth add codex-oauth` (or `hermes model` → OpenAI Codex) to start a fresh device-code login; the quarantine clears on the next successful exchange.
+
+ChatGPT OAuth on this provider uses the Codex backend, not the direct OpenAI Platform API. That means the same GPT-5 slug can have a smaller effective context window here than it does on `provider: openai`. If you need the maximum OpenAI context window, use the `openai` provider with an API key instead.
 :::
 
 :::warning


### PR DESCRIPTION
## Summary
- preserve the existing `openai-codex` path as the stable ChatGPT/Codex OAuth lane
- add a separate experimental `openai-oauth` provider with its own Hermes-owned auth-store state, Hermes headers, and model picker entry
- add provider-scoped effective context resolution so `openai-oauth` can detect different runtime budgets from `openai-codex` on the same backend

## Why this shape
The prior rejected PR coupled Hermes to OpenCode and impersonated OpenCode on the backend. This draft avoids that split-brain problem in two ways:

- `openai-codex` stays intact instead of being silently mutated
- `openai-oauth` is a distinct experimental lane with its own provider id, runtime resolution, and auth state

This means users can keep the stable Codex flow that already works today, while separately opting into the experimental OpenAI OAuth lane for route/model combinations whose effective context differs.

## Design notes
- `openai-codex`
  - existing Hermes auth flow preserved
  - existing Codex headers preserved
  - existing Codex runtime preserved
- `openai-oauth`
  - Hermes-owned auth store (`~/.hermes/auth.json`)
  - optional one-time external cache import only at setup time
  - Hermes identity headers (`originator: hermes`)
  - same ChatGPT backend route, but context resolved independently

## Effective context detection
`openai-oauth` now resolves context by provider/model/route instead of blindly trusting generic catalog metadata:
1. provider-scoped cached empirical value
2. known per-model override table
3. live route probe (streaming request with distinct-token payload)
4. OpenAI catalog metadata
5. Codex fallback

This keeps `openai-codex` and `openai-oauth` from poisoning each other even when they share the same base URL.

## Testing
- `scripts/run_tests.sh tests/hermes_cli/test_openai_oauth.py tests/hermes_cli/test_runtime_provider_resolution.py::test_resolve_runtime_provider_openai_oauth tests/agent/test_auxiliary_client.py::TestExplicitProviderRouting::test_explicit_openai_oauth_uses_direct_client tests/agent/test_auxiliary_client.py::TestExplicitProviderRouting::test_explicit_openai_oauth_requires_model tests/agent/test_model_metadata.py::TestCodexOAuthContextLength tests/agent/test_model_metadata.py::TestOpenAIOAuthContextLength tests/hermes_cli/test_model_switch_context_display.py tests/agent/transports/test_codex_transport.py::TestCodexBuildKwargs::test_openai_oauth_no_max_output_tokens tests/hermes_cli/test_codex_models.py -q`

## Current behavior captured
- `openai-codex` remains the stable lane
- `openai-oauth` defaults users to `gpt-5.4` for the large-context experimental lane
- context budgets are provider-scoped, not just model-scoped
