### PR TITLE
docs(readme): add TokenTelemetry plugin to Community section

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ scripts/run_tests.sh
 - 🐛 [Issues](https://github.com/NousResearch/hermes-agent/issues)
 - 🔌 [computer-use-linux](https://github.com/avifenesh/computer-use-linux) — Linux desktop-control MCP server for Hermes and other MCP hosts, with AT-SPI accessibility trees, Wayland/X11 input, screenshots, and compositor window targeting.
 - 🔌 [HermesClaw](https://github.com/AaronWong1999/hermesclaw) — Community WeChat bridge: Run Hermes Agent and OpenClaw on the same WeChat account.
-- 🔌 [TokenTelemetry](https://github.com/VasiHemanth/tokentelemetry-hermes-plugin) — Dashboard plugin that adds a TokenTelemetry tab inside Hermes Dashboard. Local cost, token, and trace observability for Hermes Agent plus 9 coding agents (Claude Code, Codex, Gemini CLI, Cursor, Copilot, Qwen, OpenCode, Vibe, Antigravity). Install with `hermes plugins install VasiHemanth/tokentelemetry-hermes-plugin`.
+- 🔌 [TokenTelemetry](https://github.com/VasiHemanth/tokentelemetry-hermes-plugin) — Dashboard plugin that adds a TokenTelemetry tab inside Hermes Dashboard for local cost, token, and trace observability. Install with `hermes plugins install VasiHemanth/tokentelemetry-hermes-plugin`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ scripts/run_tests.sh
 - 🐛 [Issues](https://github.com/NousResearch/hermes-agent/issues)
 - 🔌 [computer-use-linux](https://github.com/avifenesh/computer-use-linux) — Linux desktop-control MCP server for Hermes and other MCP hosts, with AT-SPI accessibility trees, Wayland/X11 input, screenshots, and compositor window targeting.
 - 🔌 [HermesClaw](https://github.com/AaronWong1999/hermesclaw) — Community WeChat bridge: Run Hermes Agent and OpenClaw on the same WeChat account.
+- 🔌 [TokenTelemetry](https://github.com/VasiHemanth/tokentelemetry-hermes-plugin) — Dashboard plugin that adds a TokenTelemetry tab inside Hermes Dashboard. Local cost, token, and trace observability for Hermes Agent plus 9 coding agents (Claude Code, Codex, Gemini CLI, Cursor, Copilot, Qwen, OpenCode, Vibe, Antigravity). Install with `hermes plugins install VasiHemanth/tokentelemetry-hermes-plugin`.
 
 ---
 


### PR DESCRIPTION
Hi team, adds a one-line entry under the Community section for a new community plugin that ships a TokenTelemetry tab inside Hermes Dashboard, sitting next to the existing HermesClaw and computer-use-linux entries with the same 🔌 prefix.

### What the plugin does

Registers a TokenTelemetry tab in Hermes Dashboard. Six deep-link cards open the relevant page (Hermes Overview, Skills, Memory, Analytics, Projects, All Agents) in a new browser tab, so users running both Hermes Dashboard on :9119 and TokenTelemetry on :3000 do not have to remember the second port. Solves the request raised by @ddiall in #26696.

The plugin itself is pure frontend, no plugin_api.py, no extra network access beyond the user's local TokenTelemetry instance. When TokenTelemetry is not installed, the plugin tab shows an onboarding card naming all 10 supported agents (the 9 coding agents listed plus Hermes Agent) with a copy paste install command, so first contact is informative rather than a debug message.

### Links

- Plugin repo: https://github.com/VasiHemanth/tokentelemetry-hermes-plugin (v0.1.0, MIT)
- Install: `hermes plugins install VasiHemanth/tokentelemetry-hermes-plugin`
- TokenTelemetry main repo: https://github.com/VasiHemanth/tokentelemetry
- Upstream issue that motivated the work: #26696

### Why surface it in the README

The Community section already advertises third party integrations with the 🔌 prefix. TokenTelemetry is the only third party tool that supports Hermes Agent observability today, and it covers the 38 source platforms in `sessions.source` plus skills, memory, cron, gateway health, and the delegate_task subagent shape. Users searching the Hermes README for observability or cost tracking should be able to find it through this list.

Happy to adjust the wording, the placement, or drop the agent list if it reads as too long. Will totally understand if you prefer to keep the community list short and decline the addition.

Thanks for building Hermes!