### PR TITLE
fix(model-switch): mark bare custom provider as current

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1720,7 +1720,10 @@ def list_authenticated_providers(
             results.append({
                 "slug": slug,
                 "name": grp["name"],
-                "is_current": slug == current_provider,
+                "is_current": slug == current_provider or (
+                    bool(current_base_url)
+                    and _grp_url_norm == current_base_url.strip().rstrip("/").lower()
+                ),
                 "is_user_defined": True,
                 "models": grp["models"],
                 "total_models": len(grp["models"]),

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -343,6 +343,7 @@ def test_list_authenticated_providers_bare_custom_slug_recovers(monkeypatch):
     group = matches[0]
     # Canonical slug, NOT the bare "custom" that caused #17478
     assert group["slug"] == "custom:ollama"
+    assert group["is_current"] is True
 
 
 def test_list_authenticated_providers_distinct_endpoints_stay_separate(monkeypatch):


### PR DESCRIPTION
Salvage of #23559 by @LeonSGP43 onto current main.

## Summary
Fixes `hermes model` picker listing the wrong custom provider as current when the active provider slug is the bare `custom` bucket. The picker now also matches by current base_url, so the correct custom endpoint is marked `is_current`.

Fixes #20811.

## Changes
- `hermes_cli/model_switch.py`: `is_current` falls back to comparing `current_base_url` against the group's normalized URL when the slug match fails (`_grp_url_norm` is already computed in the same function).
- `tests/hermes_cli/test_model_switch_custom_providers.py`: tightened the existing bare-custom regression test to also assert `is_current is True`.

## Validation
`tests/hermes_cli/test_model_switch_custom_providers.py`: 18/18 passing.

Original PR #23559 cherry-picked cleanly (981 commits stale, no conflicts). LeonSGP43's authorship preserved.