### PR TITLE
revert: firecrawl integration attribution tag (#28774)

### DIFF
--- a/plugins/browser/firecrawl/provider.py
+++ b/plugins/browser/firecrawl/provider.py
@@ -39,12 +39,6 @@ logger = logging.getLogger(__name__)
 
 _BASE_URL = "https://api.firecrawl.dev"
 
-# Integration tag sent on every browser-session create so Firecrawl can
-# attribute Hermes usage. Mirrors FIRECRAWL_INTEGRATION_TAG in the web
-# plugin; kept here rather than imported to keep the two firecrawl
-# plugins import-independent.
-FIRECRAWL_INTEGRATION_TAG = "hermes"
-
 
 class FirecrawlBrowserProvider(BrowserProvider):
     """Firecrawl (https://firecrawl.dev) cloud browser backend.
@@ -86,10 +80,7 @@ class FirecrawlBrowserProvider(BrowserProvider):
     def create_session(self, task_id: str) -> Dict[str, object]:
         ttl = int(os.environ.get("FIRECRAWL_BROWSER_TTL", "300"))
 
-        body: Dict[str, object] = {
-            "ttl": ttl,
-            "integration": FIRECRAWL_INTEGRATION_TAG,
-        }
+        body: Dict[str, object] = {"ttl": ttl}
 
         try:
             response = requests.post(

--- a/plugins/web/firecrawl/provider.py
+++ b/plugins/web/firecrawl/provider.py
@@ -56,11 +56,6 @@ from tools.website_policy import check_website_access
 logger = logging.getLogger(__name__)
 
 
-# Integration tag passed to Firecrawl on every call so they can attribute
-# usage back to Hermes.
-FIRECRAWL_INTEGRATION_TAG = "hermes"
-
-
 # ---------------------------------------------------------------------------
 # Lazy Firecrawl SDK proxy
 # ---------------------------------------------------------------------------
@@ -413,11 +408,7 @@ class FirecrawlWebSearchProvider(WebSearchProvider):
         # let it propagate so the dispatcher emits the legacy envelope shape.
         client = _get_firecrawl_client()
         try:
-            response = client.search(
-                query=query,
-                limit=limit,
-                integration=FIRECRAWL_INTEGRATION_TAG,
-            )
+            response = client.search(query=query, limit=limit)
             web_results = _extract_web_search_results(response)
             logger.info("Firecrawl: found %d search results", len(web_results))
             return {"success": True, "data": {"web": web_results}}
@@ -496,7 +487,6 @@ class FirecrawlWebSearchProvider(WebSearchProvider):
                             _get_firecrawl_client().scrape,
                             url=url,
                             formats=formats,
-                            integration=FIRECRAWL_INTEGRATION_TAG,
                         ),
                         timeout=60,
                     )
@@ -633,7 +623,6 @@ class FirecrawlWebSearchProvider(WebSearchProvider):
             crawl_params = {
                 "limit": limit,
                 "scrape_options": {"formats": ["markdown"]},
-                "integration": FIRECRAWL_INTEGRATION_TAG,
             }
 
             # The SDK call is sync; run in a thread so we don't block the


### PR DESCRIPTION
Reverts #28774 (commit 273ff5c4a).

That change tagged every Firecrawl API call (web search, scrape, crawl, browser session) with `integration: "hermes"` so Firecrawl could attribute usage back to the project. It is well-intentioned and harmless on its own, but it is outbound third-party usage attribution — a form of telemetry — and Hermes does not yet have an opt-in gating mechanism for that kind of egress.

Policy: until we land a user-facing opt-in toggle (config gate + setup wizard prompt) for non-essential outbound telemetry/attribution, we are not adding any.

The original PR (#28774) is being reopened and tagged `telemetry` so the contribution can be re-landed cleanly once the gating infrastructure exists.

## Validation
| | Before | After |
|---|---|---|
| `integration` field in Firecrawl web search/scrape/crawl request body | sent every call | not sent |
| `integration` field in Firecrawl browser-session create body | sent every call | not sent |
| `FIRECRAWL_INTEGRATION_TAG` constant | present in both plugins | removed |
