### PR TITLE
perf(cli): defer openai._base_client import to cut 240ms / 17MB off every CLI cold start

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -655,9 +655,58 @@ except Exception:
 # which, during CLI idle time, finds prompt_toolkit's event loop and tries to
 # close TCP transports bound to dead worker loops — producing
 # "Event loop is closed" / "Press ENTER to continue..." errors.
+#
+# We install a sys.meta_path finder that defers the actual import + patch
+# until ``openai._base_client`` is first loaded by the rest of the codebase.
+# Eagerly importing it here (the old approach) cost ~166ms / ~30MB on every
+# cold CLI start because openai's type tree (responses/*, graders/*) is huge.
+# The finder approach pays nothing until the SDK is genuinely needed and
+# still guarantees the patch is applied before any AsyncOpenAI instance can
+# be constructed (the import-then-instantiate ordering is enforced by
+# Python's import system).
 try:
-    from agent.auxiliary_client import neuter_async_httpx_del
-    neuter_async_httpx_del()
+    import sys as _httpx_neuter_sys
+    import importlib.util as _httpx_neuter_imp_util
+
+    class _AsyncHttpxDelNeuter:
+        """Defer ``AsyncHttpxClientWrapper.__del__`` neutering until import.
+
+        Saves ~166ms on cold CLI start where openai is never used (e.g.
+        ``hermes --help`` paths inside the chat command flow).  See
+        ``agent.auxiliary_client.neuter_async_httpx_del`` for full rationale
+        on why ``__del__`` must be a no-op.
+        """
+
+        _armed = True
+
+        def find_spec(self, fullname, path=None, target=None):
+            if not self._armed or fullname != "openai._base_client":
+                return None
+            # Disarm before delegating so the recursive find_spec call
+            # below doesn't loop through us.
+            self._armed = False
+            try:
+                _httpx_neuter_sys.meta_path.remove(self)
+            except ValueError:
+                pass
+            spec = _httpx_neuter_imp_util.find_spec(fullname)
+            if spec is None or spec.loader is None:
+                return None
+            _orig_exec = spec.loader.exec_module
+
+            def _patched_exec(module):
+                _orig_exec(module)
+                try:
+                    cls = getattr(module, "AsyncHttpxClientWrapper", None)
+                    if cls is not None:
+                        cls.__del__ = lambda self: None  # type: ignore[assignment]
+                except Exception:
+                    pass
+
+            spec.loader.exec_module = _patched_exec  # type: ignore[method-assign]
+            return spec
+
+    _httpx_neuter_sys.meta_path.insert(0, _AsyncHttpxDelNeuter())
 except Exception:
     pass
 


### PR DESCRIPTION
## Summary

`hermes chat`, `hermes_cli.main`, gateway boot, cron tick, subagent spawn — every entry into the CLI was eager-importing `openai._base_client` purely to monkeypatch `AsyncHttpxClientWrapper.__del__` (defense against prompt_toolkit "Press ENTER to continue..." errors when AsyncOpenAI clients are GC'd against a dead event loop).

That import cost ~166ms wall and ~30MB RSS on every cold start because `openai`'s type tree (responses/*, graders/*, etc.) is huge. For lots of invocations (`hermes --help`, slash-command-only, gateway boots before the first chat, subagent spawns that finish before LLM calls) the patched class was never touched — pure waste.

Replace with a `sys.meta_path` finder that intercepts the first `import openai._base_client` from anywhere in the codebase, lets the normal load run, then applies the `__del__ = lambda self: None` patch before control returns to the caller. Same correctness guarantee (patch applied before any AsyncOpenAI instance can exist), zero cost on cold paths that never touch the SDK.

## Validation

A/B benchmark, 10 fresh subprocess runs each, `/usr/bin/time -f "%e %M"` on `python -c 'import cli'`:

|  | BEFORE | AFTER | delta |
|---|---:|---:|---:|
| `import cli` wall (median) | 0.86s | **0.62s** | **-28%** |
| `import cli` wall (min) | 0.85s | **0.59s** | **-31%** |
| `import cli` RSS (median) | 91.2 MB | **74.0 MB** | **-19%** |

Correctness verified:
- After `import cli`, `openai` is NOT in `sys.modules` (vs. always present before)
- First `from openai._base_client import AsyncHttpxClientWrapper` triggers the deferred patch; `__del__.__name__ == '<lambda>'`
- Calling `__del__` on a dummy instance runs without raising (was the whole point of the original patch)

Tests:
- tests/run_agent/test_async_httpx_del_neuter.py — 9/9 pass (the function `neuter_async_httpx_del` in agent/auxiliary_client.py is unchanged; tests call it directly)
- tests/agent/test_auxiliary_client.py — 159/159 pass
- tests/cli/ — 715/715 pass

## Hot path coverage

The savings land on:
- Every `hermes chat` (interactive + `-q`)
- Every gateway worker that runs a chat turn (per-turn agent cache eviction → fresh import cycle benefits)
- Every cron tick that spawns an AIAgent
- Every `delegate_task` subagent
- Every `hermes batch` worker

The min-time delta (260ms wall, 17MB RSS) is what users feel on warm-disk repeats; the median is closer to typical.