### PR TITLE
feat(firecrawl): add integration tag for Hermes usage (pending telemetry opt-in)

### DIFF
--- a/plugins/browser/firecrawl/provider.py
+++ b/plugins/browser/firecrawl/provider.py
@@ -39,6 +39,12 @@ logger = logging.getLogger(__name__)
 
 _BASE_URL = "https://api.firecrawl.dev"
 
+# Integration tag sent on every browser-session create so Firecrawl can
+# attribute Hermes usage. Mirrors FIRECRAWL_INTEGRATION_TAG in the web
+# plugin; kept here rather than imported to keep the two firecrawl
+# plugins import-independent.
+FIRECRAWL_INTEGRATION_TAG = "hermes"
+
 
 class FirecrawlBrowserProvider(BrowserProvider):
     """Firecrawl (https://firecrawl.dev) cloud browser backend.
@@ -80,7 +86,10 @@ class FirecrawlBrowserProvider(BrowserProvider):
     def create_session(self, task_id: str) -> Dict[str, object]:
         ttl = int(os.environ.get("FIRECRAWL_BROWSER_TTL", "300"))
 
-        body: Dict[str, object] = {"ttl": ttl}
+        body: Dict[str, object] = {
+            "ttl": ttl,
+            "integration": FIRECRAWL_INTEGRATION_TAG,
+        }
 
         try:
             response = requests.post(

--- a/plugins/web/firecrawl/provider.py
+++ b/plugins/web/firecrawl/provider.py
@@ -56,6 +56,11 @@ from tools.website_policy import check_website_access
 logger = logging.getLogger(__name__)
 
 
+# Integration tag passed to Firecrawl on every call so they can attribute
+# usage back to Hermes.
+FIRECRAWL_INTEGRATION_TAG = "hermes"
+
+
 # ---------------------------------------------------------------------------
 # Lazy Firecrawl SDK proxy
 # ---------------------------------------------------------------------------
@@ -408,7 +413,11 @@ class FirecrawlWebSearchProvider(WebSearchProvider):
         # let it propagate so the dispatcher emits the legacy envelope shape.
         client = _get_firecrawl_client()
         try:
-            response = client.search(query=query, limit=limit)
+            response = client.search(
+                query=query,
+                limit=limit,
+                integration=FIRECRAWL_INTEGRATION_TAG,
+            )
             web_results = _extract_web_search_results(response)
             logger.info("Firecrawl: found %d search results", len(web_results))
             return {"success": True, "data": {"web": web_results}}
@@ -487,6 +496,7 @@ class FirecrawlWebSearchProvider(WebSearchProvider):
                             _get_firecrawl_client().scrape,
                             url=url,
                             formats=formats,
+                            integration=FIRECRAWL_INTEGRATION_TAG,
                         ),
                         timeout=60,
                     )
@@ -623,6 +633,7 @@ class FirecrawlWebSearchProvider(WebSearchProvider):
             crawl_params = {
                 "limit": limit,
                 "scrape_options": {"formats": ["markdown"]},
+                "integration": FIRECRAWL_INTEGRATION_TAG,
             }
 
             # The SDK call is sync; run in a thread so we don't block the


### PR DESCRIPTION
Re-opens the change from #28774 (originally by @erikengervall, merged then reverted in #28862) as a tracking PR.

Original commit cherry-picked with authorship preserved.

## Why this is parked, not merged

The change tags every Firecrawl API call with `integration: "hermes"` so Firecrawl can attribute usage back to us. It is well-intentioned and harmless on its own, but it is **outbound third-party usage attribution** — a form of telemetry — and Hermes does not currently have a user-facing opt-in mechanism for any outbound telemetry / attribution / analytics.

Our standing policy: we are not adding any more outbound telemetry than what is strictly required for a feature to function, until we land a generic opt-in gating mechanism (config gate + setup wizard prompt + clear user-facing toggle).

## What needs to happen before merge

1. A general opt-in telemetry gate (e.g. `telemetry.attribution: false` default, prompted during `hermes setup`, exposed in `hermes tools`).
2. This PR updated so both Firecrawl call sites read that gate and only send the `integration` field when the user has opted in.
3. Docs updated to disclose what is sent, to whom, and how to disable.

Tracking under the `telemetry` label so we can find this when the gating infra lands.

## Validation
Same change as #28774; no new code paths beyond the cherry-pick. Will need to be rebased + gated before it can ship.
