### PR TITLE
fix(config): preserve request_timeout_seconds and stale_timeout_seconds in custom_providers normalization

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3099,6 +3099,14 @@ def _normalize_custom_provider_entry(
     if isinstance(rate_limit_delay, (int, float)) and rate_limit_delay >= 0:
         normalized["rate_limit_delay"] = rate_limit_delay
 
+    request_timeout_seconds = entry.get("request_timeout_seconds")
+    if isinstance(request_timeout_seconds, (int, float)) and request_timeout_seconds > 0:
+        normalized["request_timeout_seconds"] = request_timeout_seconds
+
+    stale_timeout_seconds = entry.get("stale_timeout_seconds")
+    if isinstance(stale_timeout_seconds, (int, float)) and stale_timeout_seconds > 0:
+        normalized["stale_timeout_seconds"] = stale_timeout_seconds
+
     discover_models = entry.get("discover_models")
     if isinstance(discover_models, bool):
         normalized["discover_models"] = discover_models

--- a/tests/hermes_cli/test_custom_provider_context_length.py
+++ b/tests/hermes_cli/test_custom_provider_context_length.py
@@ -238,3 +238,117 @@ class TestContextProbeTiers:
             assert a > b, f"tiers must strictly descend, got {a} then {b}"
         # 128K is still a tier (users relying on it probe-down get there)
         assert 128_000 in CONTEXT_PROBE_TIERS
+
+
+class TestNormalizeCustomProviderTimeouts:
+    """_normalize_custom_provider_entry must preserve timeout fields.
+
+    Regression guard: request_timeout_seconds and stale_timeout_seconds were
+    listed in _KNOWN_KEYS (so no unknown-key warning fired) but were never
+    extracted into the normalized dict — silently dropped for any
+    custom_providers list entry. rate_limit_delay and context_length are
+    extracted correctly; timeouts must follow the same pattern.
+    """
+
+    def test_request_timeout_seconds_survives_normalization(self):
+        from hermes_cli.config import _normalize_custom_provider_entry
+        entry = {
+            "name": "slow-llm",
+            "base_url": "http://localhost:11434/v1",
+            "api_key": "k",
+            "request_timeout_seconds": 300,
+        }
+        result = _normalize_custom_provider_entry(entry)
+        assert result is not None
+        assert result.get("request_timeout_seconds") == 300
+
+    def test_stale_timeout_seconds_survives_normalization(self):
+        from hermes_cli.config import _normalize_custom_provider_entry
+        entry = {
+            "name": "slow-llm",
+            "base_url": "http://localhost:11434/v1",
+            "api_key": "k",
+            "stale_timeout_seconds": 60,
+        }
+        result = _normalize_custom_provider_entry(entry)
+        assert result is not None
+        assert result.get("stale_timeout_seconds") == 60
+
+    def test_both_timeout_fields_survive_together(self):
+        from hermes_cli.config import _normalize_custom_provider_entry
+        entry = {
+            "name": "slow-llm",
+            "base_url": "http://localhost:11434/v1",
+            "api_key": "k",
+            "request_timeout_seconds": 300,
+            "stale_timeout_seconds": 60,
+        }
+        result = _normalize_custom_provider_entry(entry)
+        assert result is not None
+        assert result.get("request_timeout_seconds") == 300
+        assert result.get("stale_timeout_seconds") == 60
+
+    def test_timeout_consistent_with_rate_limit_delay(self):
+        """All three per-provider throttle fields must survive normalization together."""
+        from hermes_cli.config import _normalize_custom_provider_entry
+        entry = {
+            "name": "slow-llm",
+            "base_url": "http://localhost:11434/v1",
+            "api_key": "k",
+            "rate_limit_delay": 1.5,
+            "request_timeout_seconds": 300,
+            "stale_timeout_seconds": 60,
+        }
+        result = _normalize_custom_provider_entry(entry)
+        assert result is not None
+        assert result.get("rate_limit_delay") == 1.5
+        assert result.get("request_timeout_seconds") == 300
+        assert result.get("stale_timeout_seconds") == 60
+
+    def test_zero_timeout_is_rejected(self):
+        from hermes_cli.config import _normalize_custom_provider_entry
+        entry = {
+            "name": "llm",
+            "base_url": "http://localhost:11434/v1",
+            "api_key": "k",
+            "request_timeout_seconds": 0,
+        }
+        result = _normalize_custom_provider_entry(entry)
+        assert result is not None
+        assert "request_timeout_seconds" not in result
+
+    def test_negative_timeout_is_rejected(self):
+        from hermes_cli.config import _normalize_custom_provider_entry
+        entry = {
+            "name": "llm",
+            "base_url": "http://localhost:11434/v1",
+            "api_key": "k",
+            "request_timeout_seconds": -10,
+        }
+        result = _normalize_custom_provider_entry(entry)
+        assert result is not None
+        assert "request_timeout_seconds" not in result
+
+    def test_absent_timeout_not_in_result(self):
+        from hermes_cli.config import _normalize_custom_provider_entry
+        entry = {
+            "name": "llm",
+            "base_url": "http://localhost:11434/v1",
+            "api_key": "k",
+        }
+        result = _normalize_custom_provider_entry(entry)
+        assert result is not None
+        assert "request_timeout_seconds" not in result
+        assert "stale_timeout_seconds" not in result
+
+    def test_float_timeout_accepted(self):
+        from hermes_cli.config import _normalize_custom_provider_entry
+        entry = {
+            "name": "llm",
+            "base_url": "http://localhost:11434/v1",
+            "api_key": "k",
+            "request_timeout_seconds": 30.5,
+        }
+        result = _normalize_custom_provider_entry(entry)
+        assert result is not None
+        assert result.get("request_timeout_seconds") == 30.5


### PR DESCRIPTION
## Bug

  `request_timeout_seconds` and `stale_timeout_seconds` are listed in
  `_KNOWN_KEYS` inside `_normalize_custom_provider_entry()` — so no
  "unknown config keys ignored" warning fires — but neither field is
  ever extracted into the normalized dict.

  A user who writes:

  ```yaml
  custom_providers:
    - name: "slow-local-llm"
      base_url: "http://localhost:11434/v1"
      request_timeout_seconds: 300

  gets a silent no-op. The value is accepted without warning, then
  discarded during normalization, so the timeout never takes effect.

  rate_limit_delay and context_length are extracted correctly by
  the same function. request_timeout_seconds and stale_timeout_seconds
  must follow the identical pattern.

  Fix

  Extract both timeout fields in _normalize_custom_provider_entry()
  using the same guard as rate_limit_delay (positive int/float only).

  Tests

  8 new tests covering: positive values, float values, zero/negative
  rejection, absent fields, and consistency with rate_limit_delay.
  ```