### PR TITLE
fix: harden Telegram topic routing across session splits

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -605,7 +605,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         "message_thread_id": None,
                         "direct_messages_topic_id": int(direct_topic_id),
                     }
-                return {}
+                return {"message_thread_id": cls._message_thread_id_for_send(thread_id)}
             return {"message_thread_id": cls._message_thread_id_for_send(thread_id)}
         direct_topic_id = cls._metadata_direct_messages_topic_id(metadata)
         if direct_topic_id is not None:
@@ -702,7 +702,7 @@ class TelegramAdapter(BasePlatformAdapter):
         media_label: str,
         reset_media: Optional[Any] = None,
     ) -> Any:
-        """Retry stale private-topic media replies once without the topic anchor."""
+        """Retry stale private-topic media replies once without only the reply anchor."""
         try:
             return await send_fn(**send_kwargs)
         except Exception as send_err:
@@ -714,7 +714,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 raise
             logger.warning(
                 "[%s] Reply target deleted for Telegram %s, "
-                "retrying without reply/topic anchor: %s",
+                "retrying without reply anchor while preserving topic routing: %s",
                 self.name,
                 media_label,
                 send_err,
@@ -723,8 +723,6 @@ class TelegramAdapter(BasePlatformAdapter):
                 reset_media()
             retry_kwargs = dict(send_kwargs)
             retry_kwargs["reply_to_message_id"] = None
-            retry_kwargs.pop("message_thread_id", None)
-            retry_kwargs.pop("direct_messages_topic_id", None)
             return await send_fn(**retry_kwargs)
 
     def _fallback_ips(self) -> list[str]:
@@ -1808,27 +1806,24 @@ class TelegramAdapter(BasePlatformAdapter):
                                 continue
                             err_lower = str(send_err).lower()
                             if "message to be replied not found" in err_lower and reply_to_id is not None:
-                                # Original message was deleted before we
-                                # could reply. For private-topic fallback
-                                # sends, message_thread_id is only valid with
-                                # the reply anchor, so drop both together.
+                                # Original message was deleted before we could
+                                # reply. Preserve private-topic routing and
+                                # retry without only the stale reply anchor; if
+                                # Telegram rejects the topic itself later, the
+                                # thread-not-found/topic fallback path handles it.
                                 logger.warning(
-                                    "[%s] Reply target deleted, retrying without reply_to: %s",
+                                    "[%s] Reply target deleted, retrying without reply_to while preserving topic routing: %s",
                                     self.name, send_err,
                                 )
                                 reply_to_id = None
-                                if metadata and metadata.get("telegram_dm_topic_reply_fallback"):
-                                    thread_kwargs = {}
-                                    effective_thread_id = None
-                                else:
-                                    thread_kwargs = self._thread_kwargs_for_send(
-                                        chat_id,
-                                        thread_id,
-                                        metadata,
-                                        reply_to_message_id=reply_to_id,
-                                        reply_to_mode=self._reply_to_mode,
-                                    )
-                                    effective_thread_id = thread_kwargs.get("message_thread_id")
+                                thread_kwargs = self._thread_kwargs_for_send(
+                                    chat_id,
+                                    thread_id,
+                                    metadata,
+                                    reply_to_message_id=reply_to_id,
+                                    reply_to_mode=self._reply_to_mode,
+                                )
+                                effective_thread_id = thread_kwargs.get("message_thread_id")
                                 continue
                             # Other BadRequest errors are permanent — don't retry
                             raise
@@ -2145,15 +2140,14 @@ class TelegramAdapter(BasePlatformAdapter):
                     break
                 except Exception as send_err:
                     if "reply message not found" in str(send_err).lower():
-                        # Drop the reply anchor and try again.  Private DM
-                        # topic fallback needs the anchor and topic id together;
-                        # forum topics can still safely keep message_thread_id.
-                        retry_thread_kwargs = (
-                            {}
-                            if metadata and metadata.get("telegram_dm_topic_reply_fallback")
-                            else self._thread_kwargs_for_send(
-                                chat_id, thread_id, metadata, reply_to_message_id=None
-                            )
+                        # Drop only the stale reply anchor and try again while
+                        # preserving topic routing when possible.
+                        retry_thread_kwargs = self._thread_kwargs_for_send(
+                            chat_id,
+                            thread_id,
+                            metadata,
+                            reply_to_message_id=None,
+                            reply_to_mode=self._reply_to_mode,
                         )
                         try:
                             sent_msg = await self._bot.send_message(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2038,6 +2038,77 @@ class GatewayRunner:
             session_id=session_entry.session_id,
         )
 
+    def _compression_tip_for_session(self, session_id: str) -> str:
+        """Return the latest compression continuation for ``session_id``."""
+        if not session_id or self._session_db is None:
+            return session_id
+        try:
+            tip = self._session_db.get_compression_tip(str(session_id))
+        except Exception:
+            logger.debug("Failed to resolve compression tip for %s", session_id, exc_info=True)
+            return session_id
+        return str(tip or session_id)
+
+    def _refresh_telegram_topic_binding_after_session_switch(
+        self,
+        source: SessionSource,
+        session_entry,
+        *,
+        old_session_id: Optional[str] = None,
+        reason: str,
+    ) -> None:
+        """Keep Telegram DM-topic bindings aligned after a session_id rollover."""
+        if not self._is_telegram_topic_lane(source) or self._session_db is None:
+            return
+        try:
+            if not getattr(source, "thread_id", None) and old_session_id:
+                old_binding = self._session_db.get_telegram_topic_binding_by_session(
+                    session_id=str(old_session_id),
+                )
+                if old_binding and old_binding.get("thread_id"):
+                    source.thread_id = str(old_binding["thread_id"])
+                    logger.debug(
+                        "Restored Telegram source.thread_id=%s from old binding after %s",
+                        source.thread_id,
+                        reason,
+                    )
+            self._record_telegram_topic_binding(source, session_entry)
+        except Exception:
+            logger.debug(
+                "Failed to refresh Telegram DM topic binding after %s",
+                reason,
+                exc_info=True,
+            )
+
+    def _evict_cached_agent_on_session_mismatch(
+        self,
+        session_key: str,
+        canonical_session_id: str,
+    ) -> None:
+        """Evict a cached agent whose loaded session disagrees with the route."""
+        if not session_key or not canonical_session_id:
+            return
+        cache = getattr(self, "_agent_cache", None)
+        lock = getattr(self, "_agent_cache_lock", None)
+        if cache is None or lock is None:
+            return
+        with lock:
+            cached = cache.get(session_key)
+            agent = cached[0] if isinstance(cached, tuple) and cached else cached
+            cached_session_id = getattr(agent, "session_id", None) if agent is not None else None
+            if (
+                isinstance(cached_session_id, str)
+                and cached_session_id
+                and cached_session_id != canonical_session_id
+            ):
+                logger.warning(
+                    "Evicting cached agent for %s after session mismatch: agent=%s canonical=%s",
+                    session_key,
+                    cached_session_id,
+                    canonical_session_id,
+                )
+                cache.pop(session_key, None)
+
     def _recover_telegram_topic_thread_id(
         self,
         source: SessionSource,
@@ -7862,7 +7933,40 @@ class GatewayRunner:
                 binding = None
             if binding:
                 bound_session_id = str(binding.get("session_id") or "")
-                if bound_session_id and bound_session_id != session_entry.session_id:
+                compression_tip = self._compression_tip_for_session(bound_session_id)
+                followed_compression_tip = False
+                if compression_tip and compression_tip != bound_session_id:
+                    followed_compression_tip = True
+                    source.thread_id = str(binding.get("thread_id") or source.thread_id or "")
+                    if compression_tip != session_entry.session_id:
+                        advanced = self.session_store.advance_session_after_compression(
+                            session_key,
+                            session_entry.session_id,
+                            compression_tip,
+                        )
+                        if advanced is not None:
+                            session_entry = advanced
+                    self._refresh_telegram_topic_binding_after_session_switch(
+                        source,
+                        session_entry,
+                        old_session_id=bound_session_id,
+                        reason="compression tip resolution",
+                    )
+                    self._evict_cached_agent_on_session_mismatch(
+                        session_key,
+                        session_entry.session_id,
+                    )
+                    bound_session_id = compression_tip
+                    logger.info(
+                        "Telegram topic binding followed compression tip: %s → %s",
+                        binding.get("session_id"),
+                        compression_tip,
+                    )
+                if (
+                    bound_session_id
+                    and bound_session_id != session_entry.session_id
+                    and not followed_compression_tip
+                ):
                     # Route the override through SessionStore so the session_key
                     # → session_id mapping is persisted to disk and the previous
                     # lane session is ended cleanly. Mutating session_entry in
@@ -7871,6 +7975,10 @@ class GatewayRunner:
                     switched = self.session_store.switch_session(session_key, bound_session_id)
                     if switched is not None:
                         session_entry = switched
+                        self._evict_cached_agent_on_session_mismatch(
+                            session_key,
+                            session_entry.session_id,
+                        )
             else:
                 try:
                     self._record_telegram_topic_binding(source, session_entry)
@@ -8243,10 +8351,36 @@ class GatewayRunner:
                                     # a new session_id.  Write compressed messages into
                                     # the NEW session so the old transcript stays intact
                                     # and searchable via session_search.
+                                    _hyg_old_sid = session_entry.session_id
                                     _hyg_new_sid = _hyg_agent.session_id
-                                    if _hyg_new_sid != session_entry.session_id:
-                                        session_entry.session_id = _hyg_new_sid
-                                        self.session_store._save()
+                                    if _hyg_new_sid != _hyg_old_sid:
+                                        advanced_entry = self.session_store.advance_session_after_compression(
+                                            session_key,
+                                            _hyg_old_sid,
+                                            _hyg_new_sid,
+                                        )
+                                        if advanced_entry is not None:
+                                            session_entry = advanced_entry
+
+                                        # Carry Telegram DM-topic bindings across
+                                        # hygiene compression splits too. This
+                                        # pre-agent compressor rotates the
+                                        # session_id before the normal
+                                        # _run_agent() split handler can run, so
+                                        # without rebinding here the topic binding
+                                        # table keeps pointing at the old session
+                                        # and the next inbound message can switch
+                                        # the lane back to stale history.
+                                        self._refresh_telegram_topic_binding_after_session_switch(
+                                            source,
+                                            session_entry,
+                                            old_session_id=_hyg_old_sid,
+                                            reason="hygiene compression",
+                                        )
+                                        self._evict_cached_agent_on_session_mismatch(
+                                            session_key,
+                                            session_entry.session_id,
+                                        )
 
                                     self.session_store.rewrite_transcript(
                                         session_entry.session_id, _compressed
@@ -16267,16 +16401,31 @@ class GatewayRunner:
                 with _cache_lock:
                     cached = _cache.get(session_key)
                     if cached and cached[1] == _sig:
-                        agent = cached[0]
-                        # Refresh LRU order so the cap enforcement evicts
-                        # truly-oldest entries, not the one we just used.
-                        if hasattr(_cache, "move_to_end"):
-                            try:
-                                _cache.move_to_end(session_key)
-                            except KeyError:
-                                pass
-                        self._init_cached_agent_for_turn(agent, _interrupt_depth)
-                        logger.debug("Reusing cached agent for session %s", session_key)
+                        cached_agent = cached[0]
+                        cached_session_id = getattr(cached_agent, "session_id", None)
+                        if (
+                            isinstance(cached_session_id, str)
+                            and cached_session_id
+                            and cached_session_id != session_id
+                        ):
+                            logger.warning(
+                                "Evicting cached agent for %s before turn: agent=%s canonical=%s",
+                                session_key,
+                                cached_session_id,
+                                session_id,
+                            )
+                            _cache.pop(session_key, None)
+                        else:
+                            agent = cached_agent
+                            # Refresh LRU order so the cap enforcement evicts
+                            # truly-oldest entries, not the one we just used.
+                            if hasattr(_cache, "move_to_end"):
+                                try:
+                                    _cache.move_to_end(session_key)
+                                except KeyError:
+                                    pass
+                            self._init_cached_agent_for_turn(agent, _interrupt_depth)
+                            logger.debug("Reusing cached agent for session %s", session_key)
 
             if agent is None:
                 # Config changed or first message — create fresh agent
@@ -16845,45 +16994,33 @@ class GatewayRunner:
             _session_was_split = False
             if agent and session_key and hasattr(agent, 'session_id') and agent.session_id != session_id:
                 _session_was_split = True
+                new_agent_session_id = str(getattr(agent, 'session_id'))
                 logger.info(
                     "Session split detected: %s → %s (compression)",
-                    session_id, agent.session_id,
+                    session_id, new_agent_session_id,
                 )
-                entry = self.session_store._entries.get(session_key)
-                if entry:
-                    entry.session_id = agent.session_id
-                    self.session_store._save()
+                entry = self.session_store.advance_session_after_compression(
+                    session_key,
+                    session_id,
+                    new_agent_session_id,
+                )
+                if entry is None:
+                    entry = self.session_store._entries.get(session_key)
+                    if entry:
+                        entry.session_id = new_agent_session_id
+                        self.session_store._save()
 
-                # If this is a Telegram DM and source.thread_id was lost during
-                # the session split (synthetic / recovered event), restore it
-                # from the binding so _thread_metadata_for_source produces the
-                # correct message_thread_id instead of routing to the General
-                # thread.  Failure here is non-fatal — we log and continue;
-                # worst case the message lands in General, which is the
-                # pre-fix behaviour.
-                if (
-                    getattr(source, "platform", None) == Platform.TELEGRAM
-                    and getattr(source, "chat_type", None) == "dm"
-                    and getattr(source, "thread_id", None) is None
-                    and self._session_db is not None
-                ):
-                    try:
-                        _binding = self._session_db.get_telegram_topic_binding_by_session(
-                            session_id=agent.session_id,
-                        )
-                        if _binding and _binding.get("thread_id"):
-                            source.thread_id = str(_binding["thread_id"])
-                            logger.debug(
-                                "Restored source.thread_id=%s from binding after session split %s → %s",
-                                source.thread_id,
-                                session_id,
-                                agent.session_id,
-                            )
-                    except Exception:
-                        logger.debug(
-                            "Failed to restore thread_id from binding after session split",
-                            exc_info=True,
-                        )
+                if entry:
+                    self._refresh_telegram_topic_binding_after_session_switch(
+                        source,
+                        entry,
+                        old_session_id=session_id,
+                        reason="run-time compression split",
+                    )
+                    self._evict_cached_agent_on_session_mismatch(
+                        session_key,
+                        entry.session_id,
+                    )
 
             effective_session_id = getattr(agent, 'session_id', session_id) if agent else session_id
 

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1234,6 +1234,60 @@ class SessionStore:
 
         return new_entry
 
+    def advance_session_after_compression(
+        self,
+        session_key: str,
+        old_session_id: str,
+        new_session_id: str,
+    ) -> Optional[SessionEntry]:
+        """Advance a route to a compression continuation session.
+
+        This is intentionally narrower than ``switch_session()``. Compression
+        has already ended ``old_session_id`` with ``end_reason='compression'``
+        and created ``new_session_id`` as its child continuation. Publishing
+        that continuation through the gateway route must not re-end the parent
+        as a user-visible ``session_switch`` or reopen the compressed child.
+        """
+        if not session_key or not new_session_id:
+            return None
+
+        with self._lock:
+            self._ensure_loaded_locked()
+
+            entry = self._entries.get(session_key)
+            if entry is None:
+                return None
+            if old_session_id and entry.session_id != old_session_id:
+                logger.debug(
+                    "Compression route advance for %s expected %s but found %s; advancing to %s anyway",
+                    session_key,
+                    old_session_id,
+                    entry.session_id,
+                    new_session_id,
+                )
+            if entry.session_id == new_session_id:
+                return entry
+
+            now = _now()
+            advanced = SessionEntry(
+                session_key=session_key,
+                session_id=new_session_id,
+                created_at=entry.created_at,
+                updated_at=now,
+                origin=entry.origin,
+                display_name=entry.display_name,
+                platform=entry.platform,
+                chat_type=entry.chat_type,
+                last_prompt_tokens=0,
+                suspended=entry.suspended,
+                resume_pending=entry.resume_pending,
+                resume_reason=entry.resume_reason,
+                last_resume_marked_at=entry.last_resume_marked_at,
+            )
+            self._entries[session_key] = advanced
+            self._save()
+            return advanced
+
     def list_sessions(self, active_minutes: Optional[int] = None) -> List[SessionEntry]:
         """List all sessions, optionally filtered by activity."""
         with self._lock:

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -715,8 +715,8 @@ async def test_send_dm_topic_fallback_without_anchor_does_not_crash():
 
 
 @pytest.mark.asyncio
-async def test_send_dm_topic_reply_not_found_retry_drops_thread_id():
-    """If Telegram deletes the reply anchor, private-topic retry must drop thread id too."""
+async def test_send_dm_topic_reply_not_found_retry_preserves_thread_id():
+    """If Telegram deletes the reply anchor, private-topic retry must preserve thread routing."""
     adapter = _make_adapter()
     call_log = []
 
@@ -742,7 +742,7 @@ async def test_send_dm_topic_reply_not_found_retry_drops_thread_id():
     assert call_log[0]["reply_to_message_id"] == 462
     assert call_log[0]["message_thread_id"] == 20197
     assert call_log[1]["reply_to_message_id"] is None
-    assert "message_thread_id" not in call_log[1]
+    assert call_log[1]["message_thread_id"] == 20197
     assert "direct_messages_topic_id" not in call_log[1]
 
 
@@ -757,7 +757,7 @@ async def test_send_dm_topic_reply_not_found_retry_drops_thread_id():
         ("send_voice", "send_audio", "audio_path", "clip.mp3", b"mp3-data"),
     ],
 )
-async def test_native_media_dm_topic_reply_not_found_retry_drops_thread_id(
+async def test_native_media_dm_topic_reply_not_found_retry_preserves_thread_id(
     tmp_path,
     method_name,
     bot_method_name,
@@ -792,12 +792,12 @@ async def test_native_media_dm_topic_reply_not_found_retry_drops_thread_id(
     assert call_log[0]["reply_to_message_id"] == 462
     assert call_log[0]["message_thread_id"] == 20197
     assert call_log[1]["reply_to_message_id"] is None
-    assert "message_thread_id" not in call_log[1]
+    assert call_log[1]["message_thread_id"] == 20197
     assert "direct_messages_topic_id" not in call_log[1]
 
 
 @pytest.mark.asyncio
-async def test_animation_dm_topic_reply_not_found_retry_drops_thread_id():
+async def test_animation_dm_topic_reply_not_found_retry_preserves_thread_id():
     adapter = _make_adapter()
     call_log = []
 
@@ -823,12 +823,12 @@ async def test_animation_dm_topic_reply_not_found_retry_drops_thread_id():
     assert call_log[0]["reply_to_message_id"] == 462
     assert call_log[0]["message_thread_id"] == 20197
     assert call_log[1]["reply_to_message_id"] is None
-    assert "message_thread_id" not in call_log[1]
+    assert call_log[1]["message_thread_id"] == 20197
     assert "direct_messages_topic_id" not in call_log[1]
 
 
 @pytest.mark.asyncio
-async def test_media_group_dm_topic_reply_not_found_retry_drops_thread_id(tmp_path):
+async def test_media_group_dm_topic_reply_not_found_retry_preserves_thread_id(tmp_path):
     adapter = _make_adapter()
     image_path = tmp_path / "photo.png"
     image_path.write_bytes(b"png-data")
@@ -855,12 +855,12 @@ async def test_media_group_dm_topic_reply_not_found_retry_drops_thread_id(tmp_pa
     assert call_log[0]["reply_to_message_id"] == 462
     assert call_log[0]["message_thread_id"] == 20197
     assert call_log[1]["reply_to_message_id"] is None
-    assert "message_thread_id" not in call_log[1]
+    assert call_log[1]["message_thread_id"] == 20197
     assert "direct_messages_topic_id" not in call_log[1]
 
 
 @pytest.mark.asyncio
-async def test_send_image_url_dm_topic_reply_not_found_retry_drops_thread_id(monkeypatch):
+async def test_send_image_url_dm_topic_reply_not_found_retry_preserves_thread_id(monkeypatch):
     adapter = _make_adapter()
     call_log = []
 
@@ -889,12 +889,12 @@ async def test_send_image_url_dm_topic_reply_not_found_retry_drops_thread_id(mon
     assert call_log[0]["reply_to_message_id"] == 462
     assert call_log[0]["message_thread_id"] == 20197
     assert call_log[1]["reply_to_message_id"] is None
-    assert "message_thread_id" not in call_log[1]
+    assert call_log[1]["message_thread_id"] == 20197
     assert "direct_messages_topic_id" not in call_log[1]
 
 
 @pytest.mark.asyncio
-async def test_send_image_upload_dm_topic_reply_not_found_retry_drops_thread_id(monkeypatch):
+async def test_send_image_upload_dm_topic_reply_not_found_retry_preserves_thread_id(monkeypatch):
     adapter = _make_adapter()
     call_log = []
 
@@ -951,7 +951,7 @@ async def test_send_image_upload_dm_topic_reply_not_found_retry_drops_thread_id(
     assert call_log[1]["reply_to_message_id"] == 462
     assert call_log[1]["message_thread_id"] == 20197
     assert call_log[2]["reply_to_message_id"] is None
-    assert "message_thread_id" not in call_log[2]
+    assert call_log[2]["message_thread_id"] == 20197
     assert "direct_messages_topic_id" not in call_log[2]
 
 

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -1326,3 +1326,177 @@ def test_session_split_restores_source_thread_id_from_binding(tmp_path):
     meta = GatewayRunner._thread_metadata_for_source(runner, source)
     assert meta is not None
     assert meta["thread_id"] == "17585"
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for compression split topic-binding carry-forward
+# ---------------------------------------------------------------------------
+
+def test_compression_split_rebinds_topic_binding_from_old_to_new_session(tmp_path):
+    """A compression-created session split must move the topic binding forward.
+
+    Regression for the Telegram topic split-brain bug: the JSON session index can
+    point a topic lane at the new compressed session while
+    telegram_dm_topic_bindings still points at the old session. The next inbound
+    message then switches the topic back to stale history.
+    """
+    db = SessionDB(db_path=tmp_path / "state.db")
+    old_sid = "sess-before-compression"
+    new_sid = "sess-after-compression"
+    thread_id = "17585"
+    session_key = "agent:main:telegram:dm:208214988:17585"
+    db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
+    db.create_session(session_id=old_sid, source="telegram", user_id="208214988")
+    db.create_session(
+        session_id=new_sid,
+        source="telegram",
+        user_id="208214988",
+        parent_session_id=old_sid,
+    )
+    db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id=thread_id,
+        user_id="208214988",
+        session_key=session_key,
+        session_id=old_sid,
+    )
+
+    # This mirrors the gateway compression split carry-forward logic: when the
+    # source still has its thread_id, rebind the same Telegram topic to the new
+    # compressed session id.
+    source = _make_source(thread_id=thread_id)
+    db.bind_telegram_topic(
+        chat_id=source.chat_id,
+        thread_id=source.thread_id,
+        user_id=source.user_id,
+        session_key=session_key,
+        session_id=new_sid,
+    )
+
+    binding = db.get_telegram_topic_binding(chat_id="208214988", thread_id=thread_id)
+    assert binding is not None
+    assert binding["session_id"] == new_sid
+    assert db.get_telegram_topic_binding_by_session(session_id=old_sid) is None
+    assert db.get_telegram_topic_binding_by_session(session_id=new_sid)["thread_id"] == thread_id
+
+
+def test_compression_split_recovers_thread_from_old_binding_before_rebind(tmp_path):
+    """If source.thread_id was stripped/lost, recover it from the old binding first."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    old_sid = "sess-before-compression"
+    new_sid = "sess-after-compression"
+    thread_id = "17585"
+    session_key = "agent:main:telegram:dm:208214988:17585"
+    db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
+    db.create_session(session_id=old_sid, source="telegram", user_id="208214988")
+    db.create_session(
+        session_id=new_sid,
+        source="telegram",
+        user_id="208214988",
+        parent_session_id=old_sid,
+    )
+    db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id=thread_id,
+        user_id="208214988",
+        session_key=session_key,
+        session_id=old_sid,
+    )
+
+    source = _make_source(thread_id=None)
+    old_binding = db.get_telegram_topic_binding_by_session(session_id=old_sid)
+    recovered_thread_id = str(old_binding["thread_id"])
+    source.thread_id = recovered_thread_id
+    db.bind_telegram_topic(
+        chat_id=source.chat_id,
+        thread_id=recovered_thread_id,
+        user_id=source.user_id,
+        session_key=session_key,
+        session_id=new_sid,
+    )
+
+    assert source.thread_id == thread_id
+    binding = db.get_telegram_topic_binding(chat_id="208214988", thread_id=thread_id)
+    assert binding is not None
+    assert binding["session_id"] == new_sid
+    assert db.get_telegram_topic_binding_by_session(session_id=old_sid) is None
+    assert db.get_telegram_topic_binding_by_session(session_id=new_sid)["thread_id"] == thread_id
+
+def test_session_store_advance_after_compression_does_not_mark_session_switch(tmp_path):
+    """Publishing a compression child must not rewrite DB end_reason as session_switch."""
+    from gateway.session import SessionStore
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    store = SessionStore(tmp_path / "sessions", GatewayConfig(),)
+    store._db = db
+    source = _make_source(thread_id="17585")
+    entry = store.get_or_create_session(source)
+    old_sid = entry.session_id
+    new_sid = "sess-after-compression"
+    db.end_session(old_sid, "compression")
+    db.create_session(
+        session_id=new_sid,
+        source="telegram",
+        user_id=source.user_id,
+        parent_session_id=old_sid,
+    )
+
+    advanced = store.advance_session_after_compression(entry.session_key, old_sid, new_sid)
+
+    assert advanced is not None
+    assert advanced.session_id == new_sid
+    assert store.get_or_create_session(source).session_id == new_sid
+    old_row = db.get_session(old_sid)
+    assert old_row is not None
+    assert old_row["end_reason"] == "compression"
+
+
+def test_telegram_binding_resolution_follows_compression_tip_without_session_switch(tmp_path):
+    """Stale bindings should be advanced to compression tips before history loads."""
+    from gateway.session import SessionStore
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    store = SessionStore(tmp_path / "sessions", GatewayConfig(),)
+    store._db = db
+    source = _make_source(thread_id="17585")
+    entry = store.get_or_create_session(source)
+    old_sid = entry.session_id
+    new_sid = "sess-after-compression"
+    db.enable_telegram_topic_mode(chat_id=source.chat_id, user_id=source.user_id)
+    db.bind_telegram_topic(
+        chat_id=source.chat_id,
+        thread_id=source.thread_id,
+        user_id=source.user_id,
+        session_key=entry.session_key,
+        session_id=old_sid,
+    )
+    db.end_session(old_sid, "compression")
+    db.create_session(
+        session_id=new_sid,
+        source="telegram",
+        user_id=source.user_id,
+        parent_session_id=old_sid,
+    )
+
+    runner = _make_runner(session_db=db)
+    runner.session_store = store
+    session_entry = store.get_or_create_session(source)
+    binding = db.get_telegram_topic_binding(chat_id=source.chat_id, thread_id=source.thread_id)
+    tip = runner._compression_tip_for_session(binding["session_id"])
+    advanced = store.advance_session_after_compression(
+        entry.session_key,
+        session_entry.session_id,
+        tip,
+    )
+    runner._refresh_telegram_topic_binding_after_session_switch(
+        source,
+        advanced,
+        old_session_id=binding["session_id"],
+        reason="test",
+    )
+
+    assert tip == new_sid
+    assert store.get_or_create_session(source).session_id == new_sid
+    rebound = db.get_telegram_topic_binding(chat_id=source.chat_id, thread_id=source.thread_id)
+    assert rebound["session_id"] == new_sid
+    assert db.get_session(old_sid)["end_reason"] == "compression"


### PR DESCRIPTION
## Summary
- advance gateway routes to compression-created child sessions without rewriting compression lineage as ordinary session switches
- keep Telegram DM-topic bindings aligned across both runtime and pre-agent hygiene compression splits
- resolve stale Telegram topic bindings to the latest compression tip before transcript/history load
- evict cached agents when their loaded session id disagrees with the canonical route session
- preserve Telegram topic routing when retrying sends after a stale/deleted reply anchor

## Why
Long Telegram DM-topic conversations can cross compression/hygiene thresholds and create child sessions. If the JSON route/session index advances but `telegram_dm_topic_bindings` still points at the pre-compression/root session, the next Telegram message reloads the old large transcript. That can cause repeated compression, stale cached-agent promotion, and visible topic/session chaos.

This patch is intentionally broader than a single rebind call. It treats compression as route publication, protects compression lineage, self-heals stale bindings, prevents cached-agent/session mismatches, and avoids falling back to the wrong Telegram topic when only the reply anchor is stale.

## Related issues and PRs consulted
- Related issue: #20470 — Telegram DM topic binding not refreshed after compression-induced session split, causing preflight compression loops.
- Related issue: #27166 — Telegram DM topic response routed to All Messages after a session split.
- Consulted PR: #20485 — refresh Telegram DM topic binding after session split. This covered the direct rebind shape but did not fully cover compression route publication / lineage preservation.
- Consulted PR: #23195 — sync Telegram topic binding after session split. This overlapped with binding carry-forward, but this PR folds that behavior into the broader compression-route path.
- Consulted PR: #26204 — publish compression route advances. This informed the distinction between route advancement and ordinary session switching.
- Consulted PR: #28524 — restore Telegram DM topic thread_id after session split. This addressed part of the thread recovery failure and is complemented here by stale-binding tip resolution and cached-agent eviction.

## Main changes
- Add `SessionStore.advance_session_after_compression()` as a narrow alternative to `switch_session()` for compression continuations.
- Add gateway helpers to:
  - follow `SessionDB.get_compression_tip()` for stale Telegram bindings
  - refresh Telegram topic bindings after session id rollover
  - recover a lost `source.thread_id` from the old binding before rebinding
  - evict cached agents with mismatched session ids
- Apply the route-publication path in:
  - inbound Telegram topic binding resolution before history load
  - pre-agent hygiene compression
  - runtime compression split handling after an agent turn
- Preserve `message_thread_id`/topic routing when Telegram rejects only a stale `reply_to_message_id`.

## Test plan
- `python -m pytest tests/gateway/test_telegram_topic_mode.py tests/gateway/test_telegram_thread_fallback.py -o 'addopts=' -q`

Result: `87 passed in 12.98s`

Additional local verification from the development session:
- dependency-focused subsets covering ACP/FastAPI/WebSocket collection passed: `434 passed`
- full suite was attempted but exceeded the local 600s timeout before completion
