### PR TITLE
fix: stabilize tool schema ordering

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -52,7 +52,11 @@ from agent.tool_guardrails import (
 from hermes_cli.config import cfg_get
 from hermes_cli.timeouts import get_provider_request_timeout
 from hermes_constants import get_hermes_home
-from model_tools import check_toolset_requirements, get_tool_definitions
+from model_tools import (
+    check_toolset_requirements,
+    get_tool_definitions,
+    sort_openai_tool_schemas,
+)
 from utils import base_url_host_matches
 
 # Use the same logger name as run_agent so tests patching ``run_agent.logger``
@@ -1063,6 +1067,7 @@ def init_agent(
             if _tname:
                 agent.valid_tool_names.add(_tname)
                 _existing_tool_names.add(_tname)
+        agent.tools = sort_openai_tool_schemas(agent.tools)
 
     # Skills config: nudge interval for skill creation reminders
     agent._skill_nudge_interval = 10
@@ -1374,6 +1379,7 @@ def init_agent(
                 agent.valid_tool_names.add(_tname)
                 agent._context_engine_tool_names.add(_tname)
                 _existing_tool_names.add(_tname)
+        agent.tools = sort_openai_tool_schemas(agent.tools)
 
     # Notify context engine of session start
     if hasattr(agent, "context_compressor") and agent.context_compressor:

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -233,6 +233,9 @@ def interruptible_api_call(agent, api_kwargs: dict):
 def build_api_kwargs(agent, api_messages: list) -> dict:
     """Build the keyword arguments dict for the active API mode."""
     tools_for_api = agent.tools
+    if tools_for_api:
+        from model_tools import sort_openai_tool_schemas
+        tools_for_api = sort_openai_tool_schemas(tools_for_api)
 
     if agent.api_mode == "anthropic_messages":
         _transport = agent._get_transport()

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -23,6 +23,11 @@ from agent.prompt_builder import DEFAULT_AGENT_IDENTITY
 logger = logging.getLogger(__name__)
 
 
+def _sort_responses_tools(tools: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Return Responses-format function tools in stable name order."""
+    return sorted(tools, key=lambda tool: str(tool.get("name", "")))
+
+
 # Matches Codex/Harmony tool-call serialization that occasionally leaks into
 # assistant-message content when the model fails to emit a structured
 # ``function_call`` item.  Accepts the common forms:
@@ -738,6 +743,7 @@ def _preflight_codex_api_kwargs(
                     "parameters": parameters,
                 }
             )
+        normalized_tools = _sort_responses_tools(normalized_tools)
 
     store = api_kwargs.get("store", False)
     if store is not False:

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -40,6 +40,7 @@ from agent.prompt_builder import (
     TOOL_USE_ENFORCEMENT_GUIDANCE,
     TOOL_USE_ENFORCEMENT_MODELS,
 )
+from model_tools import sort_openai_tool_schemas
 
 
 def _ra():
@@ -325,7 +326,7 @@ def format_tools_for_system_message(agent: Any) -> str:
 
     # Convert tool definitions to the format expected in trajectories
     formatted_tools = []
-    for tool in agent.tools:
+    for tool in sort_openai_tool_schemas(agent.tools):
         func = tool["function"]
         formatted_tool = {
             "name": func["name"],

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -17,6 +17,7 @@ from agent.moonshot_schema import is_moonshot_model, sanitize_moonshot_tools
 from agent.prompt_builder import DEVELOPER_ROLE_MODELS
 from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse, ToolCall, Usage
+from model_tools import sort_openai_tool_schemas
 
 
 def _build_gemini_thinking_config(model: str, reasoning_config: dict | None) -> dict | None:
@@ -249,7 +250,7 @@ class ChatCompletionsTransport(ProviderTransport):
             # etc.) compatible, in addition to direct moonshot.ai endpoints.
             if is_moonshot_model(model):
                 tools = sanitize_moonshot_tools(tools)
-            api_kwargs["tools"] = tools
+            api_kwargs["tools"] = sort_openai_tool_schemas(tools)
 
         # max_tokens resolution — priority: ephemeral > user > provider default
         max_tokens_fn = params.get("max_tokens_param_fn")
@@ -437,7 +438,7 @@ class ChatCompletionsTransport(ProviderTransport):
         if tools:
             if is_moonshot_model(model):
                 tools = sanitize_moonshot_tools(tools)
-            api_kwargs["tools"] = tools
+            api_kwargs["tools"] = sort_openai_tool_schemas(tools)
 
         # max_tokens resolution — priority: ephemeral > user > profile default
         max_tokens_fn = params.get("max_tokens_param_fn")

--- a/cli.py
+++ b/cli.py
@@ -9790,6 +9790,8 @@ class HermesCLI:
                 self.agent.tools = get_tool_definitions(
                     enabled_toolsets=self.agent.enabled_toolsets
                     if hasattr(self.agent, "enabled_toolsets") else None,
+                    disabled_toolsets=self.agent.disabled_toolsets
+                    if hasattr(self.agent, "disabled_toolsets") else None,
                     quiet_mode=True,
                 )
                 self.agent.valid_tool_names = {

--- a/model_tools.py
+++ b/model_tools.py
@@ -254,6 +254,14 @@ _LEGACY_TOOLSET_MAP = {
 _tool_defs_cache: Dict[tuple, List[Dict[str, Any]]] = {}
 
 
+def sort_openai_tool_schemas(tools: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Return OpenAI tool schemas in stable function-name order."""
+    return sorted(
+        tools,
+        key=lambda t: str(t.get("function", {}).get("name", "")),
+    )
+
+
 def _clear_tool_defs_cache() -> None:
     """Drop memoized get_tool_definitions() results. Called when dynamic
     schema dependencies change (e.g. discord capability cache reset,
@@ -466,9 +474,6 @@ def _compute_tool_definitions(
         else:
             print("🛠️  No tools selected (all filtered out or unavailable)")
 
-    global _last_resolved_tool_names
-    _last_resolved_tool_names = [t["function"]["name"] for t in filtered_tools]
-
     # Sanitize schemas for broad backend compatibility. llama.cpp's
     # json-schema-to-grammar converter (used by its OAI server to build
     # GBNF tool-call parsers) rejects some shapes that cloud providers
@@ -480,6 +485,11 @@ def _compute_tool_definitions(
         filtered_tools = sanitize_tool_schemas(filtered_tools)
     except Exception as e:  # pragma: no cover — defensive
         logger.warning("Schema sanitization skipped: %s", e)
+
+    filtered_tools = sort_openai_tool_schemas(filtered_tools)
+
+    global _last_resolved_tool_names
+    _last_resolved_tool_names = [t["function"]["name"] for t in filtered_tools]
 
     return filtered_tools
 

--- a/tests/cli/test_cli_mcp_reload_toolsets.py
+++ b/tests/cli/test_cli_mcp_reload_toolsets.py
@@ -1,0 +1,41 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from cli import HermesCLI
+
+
+def test_reload_mcp_preserves_disabled_toolsets():
+    cli_obj = HermesCLI.__new__(HermesCLI)
+    cli_obj._command_running = True
+    cli_obj.conversation_history = []
+    cli_obj.agent = SimpleNamespace(
+        enabled_toolsets=["browser", "mcp-lean_ctx"],
+        disabled_toolsets=["messaging"],
+        tools=[],
+        valid_tool_names=set(),
+        _persist_session=lambda *args, **kwargs: None,
+    )
+
+    fake_tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "mcp_lean_ctx_ctx_call",
+                "description": "Invoke lean-ctx.",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+
+    with patch("tools.mcp_tool.shutdown_mcp_servers"), \
+         patch("tools.mcp_tool.discover_mcp_tools", return_value=fake_tools), \
+         patch("cli.get_tool_definitions", return_value=fake_tools) as mock_defs:
+        cli_obj._reload_mcp()
+
+    mock_defs.assert_called_once_with(
+        enabled_toolsets=["browser", "mcp-lean_ctx"],
+        disabled_toolsets=["messaging"],
+        quiet_mode=True,
+    )
+    assert cli_obj.agent.tools == fake_tools
+    assert cli_obj.agent.valid_tool_names == {"mcp_lean_ctx_ctx_call"}

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -71,6 +71,18 @@ def _make_agent(monkeypatch, provider, api_mode="chat_completions", base_url="ht
 
 # ── _build_api_kwargs tests ─────────────────────────────────────────────────
 
+def test_chat_completions_sorts_tools_at_transport_boundary(monkeypatch):
+    agent = _make_agent(monkeypatch, "custom", base_url="http://localhost:8080/v1", model="local-model")
+    agent.tools = _tool_defs("mcp_lean_ctx_ctx_call", "feishu_doc_read")
+
+    kwargs = agent._build_api_kwargs([{"role": "user", "content": "Ping"}])
+
+    assert [tool["function"]["name"] for tool in kwargs["tools"]] == [
+        "feishu_doc_read",
+        "mcp_lean_ctx_ctx_call",
+    ]
+
+
 class TestBuildApiKwargsOpenRouter:
     def test_uses_chat_completions_format(self, monkeypatch):
         agent = _make_agent(monkeypatch, "openrouter")

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -313,6 +313,35 @@ def test_build_api_kwargs_codex(monkeypatch):
     assert "extra_body" not in kwargs
 
 
+def test_build_api_kwargs_codex_sorts_responses_tools(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    agent.tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "mcp_lean_ctx_ctx_call",
+                "description": "Invoke any lean-ctx tool by name.",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "feishu_doc_read",
+                "description": "Read the full content of a Feishu/Lark document as plain text.",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        },
+    ]
+
+    kwargs = agent._build_api_kwargs([{"role": "user", "content": "Ping"}])
+
+    assert [tool["name"] for tool in kwargs["tools"]] == [
+        "feishu_doc_read",
+        "mcp_lean_ctx_ctx_call",
+    ]
+
+
 def test_build_api_kwargs_codex_clamps_minimal_effort(monkeypatch):
     """'minimal' reasoning effort is clamped to 'low' on the Responses API.
 

--- a/tests/test_get_tool_definitions_cache_isolation.py
+++ b/tests/test_get_tool_definitions_cache_isolation.py
@@ -52,6 +52,17 @@ class TestQuietModeCacheIsolation:
         cached = next(iter(model_tools._tool_defs_cache.values()))
         assert second is not cached
 
+    def test_tool_names_sorted_on_cache_miss_and_hit(self):
+        """Tool order is part of the OpenAI-compatible payload cache key."""
+        first = model_tools.get_tool_definitions(quiet_mode=True)
+        second = model_tools.get_tool_definitions(quiet_mode=True)
+
+        first_names = [t["function"]["name"] for t in first]
+        second_names = [t["function"]["name"] for t in second]
+
+        assert first_names == sorted(first_names)
+        assert second_names == sorted(second_names)
+
     def test_caller_mutation_does_not_poison_cache(self):
         """Simulate run_agent appending LCM tool schemas to the returned
         list. A second call must NOT see those appended entries."""

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -9,10 +9,32 @@ from model_tools import (
     handle_function_call,
     get_all_tool_names,
     get_toolset_for_tool,
+    sort_openai_tool_schemas,
     _AGENT_LOOP_TOOLS,
     _LEGACY_TOOLSET_MAP,
     TOOL_TO_TOOLSET_MAP,
 )
+
+
+# =========================================================================
+# Tool schema ordering
+# =========================================================================
+
+def test_sort_openai_tool_schemas_preserves_set_and_sorts_by_function_name():
+    tools = [
+        {"type": "function", "function": {"name": "memory_search"}},
+        {"type": "function", "function": {"name": "context_expand"}},
+        {"type": "function", "function": {"name": "browser_navigate"}},
+    ]
+
+    sorted_tools = sort_openai_tool_schemas(tools)
+
+    assert [t["function"]["name"] for t in sorted_tools] == [
+        "browser_navigate",
+        "context_expand",
+        "memory_search",
+    ]
+    assert {id(t) for t in sorted_tools} == {id(t) for t in tools}
 
 
 # =========================================================================


### PR DESCRIPTION
## Summary
- sort OpenAI tool schemas by function name after schema sanitization
- keep runtime-injected memory/context-engine tools in the same stable order
- sort the tool list before API kwargs and system prompt tool rendering
- re-sort at the final Chat Completions and Codex Responses request boundaries so provider-specific schema rewrites cannot reintroduce order drift
- preserve `disabled_toolsets` when `/reload-mcp` refreshes the active agent tool surface, so MCP reloads do not accidentally change the prompt tool inventory mid-session

## Evidence
Local llama.cpp/ik_llama.cpp prompt-cache replay showed equivalent tool sets being presented in different orders across requests, invalidating the common prefix:

```text
======== Cache: cache_size = 122274, n_past0 =  7001, n_past1 =  7001, n_past_prompt1 = 7001,  n_past2 =  7001, n_past_prompt2 =  7001
Common part does not match fully
cache :  {"name": "feishu_doc_read", "description": "Read the full content of a Feishu/Lark document as plain text.
prompt:  {"name": "mcp_lean_ctx_ctx_call", "description": "Invoke any lean-ctx tool by name.", "parameters": {"properties
slot apply_checkp: id  0 | task 2640 | n_past = 7001, slot.prompt.tokens.size() = 122274, seq_id = 0, pos_min = 122273
slot apply_checkp: id  0 | task 2640 | forcing full prompt re-processing due to lack of cache data (likely due to SWA, see https://github.com/ggml-org/llama.cpp/pull/13194#issuecomment-2868343055)
slot apply_checkp: id  0 | task 2640 | erased invalidated context checkpoint (pos_min = 120492, pos_max = 120492, size = 150.547 MiB)
slot apply_checkp: id  0 | task 2640 | erased invalidated context checkpoint (pos_min = 122273, pos_max = 122273, size = 150.560 MiB)
INFO [   launch_slot_with_task] slot is processing task | tid="136530539577344" timestamp=1779205209 id_slot=0 id_task=2563
======== Cache: cache_size = 116815, n_past0 =  7001, n_past1 =  7001, n_past_prompt1 = 7001,  n_past2 =  7001, n_past_prompt2 =  7001
Common part does not match fully
cache :  {"name": "mcp_lean_ctx_ctx_call", "description": "Invoke any lean-ctx tool by name.", "parameters": {"properties
prompt:  {"name": "feishu_doc_read", "description": "Read the full content of a Feishu/Lark document as plain text.
slot apply_checkp: id  0 | task 2563 | n_past = 7001, slot.prompt.tokens.size() = 116815, seq_id = 0, pos_min = 116814
slot apply_checkp: id  0 | task 2563 | forcing full prompt re-processing due to lack of cache data (likely due to SWA, see https://github.com/ggml-org/llama.cpp/pull/13194#issuecomment-2868343055)
slot apply_checkp: id  0 | task 2563 | erased invalidated context checkpoint (pos_min = 116632, pos_max = 116632, size = 150.517 MiB)
slot apply_checkp: id  0 | task 2563 | erased invalidated context checkpoint (pos_min = 116814, pos_max = 116814, size = 150.519 MiB)
```

A later replay still showed the same failure class after the first fix, this time with the final request payload ordering `mcp_lean_ctx_ctx_call` before `feishu_doc_read`:

```text
INFO [   launch_slot_with_task] slot is processing task | tid="136007071322112" timestamp=1779224415 id_slot=0 id_task=9299
======== Cache: cache_size = 105293, n_past0 =  7001, n_past1 =  7001, n_past_prompt1 = 7001,  n_past2 =  7001, n_past_prompt2 =  7001
Common part does not match fully
cache :  {"name": "mcp_lean_ctx_ctx_call", "description": "Invoke any lean-ctx tool by name.", "parameters": {"properties
prompt:  {"name": "feishu_doc_read", "description": "Read the full content of a Feishu/Lark document as plain text.
slot apply_checkp: id  0 | task 9299 | n_past = 7001, slot.prompt.tokens.size() = 105293, seq_id = 0, pos_min = 105292
slot apply_checkp: id  0 | task 9299 | forcing full prompt re-processing due to lack of cache data (likely due to SWA, see https://github.com/ggml-org/llama.cpp/pull/13194#issuecomment-2868343055)
```

This update adds defensive ordering at the final transport/preflight boundary so the wire payload remains stable even if a provider-specific sanitizer rewrites schemas after the central `agent.tools` sort.

A follow-up local trace showed another cache-break class where the active tool inventory changed mid-session rather than only reordering. The `/reload-mcp` refresh path rebuilt `agent.tools` with `enabled_toolsets` but omitted `disabled_toolsets`, so disabled platform/toolset filters could be lost after an MCP reload. This PR now preserves both filters during reload to avoid accidental prompt tool-surface changes.

## Tests
- `/home/zeljko/.hermes/hermes-agent/venv/bin/python -m pytest /home/zeljko/.hermes/hermes-agent/tests/run_agent/test_run_agent_codex_responses.py::test_build_api_kwargs_codex_sorts_responses_tools /home/zeljko/.hermes/hermes-agent/tests/run_agent/test_provider_parity.py::test_chat_completions_sorts_tools_at_transport_boundary /home/zeljko/.hermes/hermes-agent/tests/test_model_tools.py`
- `27 passed`
- `venv/bin/python -m pytest tests/cli/test_cli_mcp_reload_toolsets.py`
- `1 passed`
- `venv/bin/python -m pytest tests/run_agent/test_provider_parity.py::test_chat_completions_sorts_tools_at_transport_boundary tests/run_agent/test_run_agent_codex_responses.py -q`
- `65 passed`
