### PR TITLE
fix(anthropic): remove mcp_ tool prefix on OAuth path that triggers overage gate

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -312,7 +312,10 @@ def _detect_claude_code_version() -> str:
 
 
 _CLAUDE_CODE_SYSTEM_PREFIX = "You are Claude Code, Anthropic's official CLI for Claude."
-_MCP_TOOL_PREFIX = "mcp_"
+
+# _MCP_TOOL_PREFIX removed — was used to prefix all tool names on the OAuth
+# path, which triggered Anthropic's overage gate for Pro/Max subscribers.
+# See issue #28849.
 
 
 def _get_claude_code_version() -> str:
@@ -2097,23 +2100,14 @@ def build_anthropic_kwargs(
                 text = text.replace("Nous Research", "Anthropic")
                 block["text"] = text
 
-        # 3. Prefix tool names with mcp_ (Claude Code convention)
-        if anthropic_tools:
-            for tool in anthropic_tools:
-                if "name" in tool:
-                    tool["name"] = _MCP_TOOL_PREFIX + tool["name"]
-
-        # 4. Prefix tool names in message history (tool_use and tool_result blocks)
-        for msg in anthropic_messages:
-            content = msg.get("content")
-            if isinstance(content, list):
-                for block in content:
-                    if isinstance(block, dict):
-                        if block.get("type") == "tool_use" and "name" in block:
-                            if not block["name"].startswith(_MCP_TOOL_PREFIX):
-                                block["name"] = _MCP_TOOL_PREFIX + block["name"]
-                        elif block.get("type") == "tool_result" and "tool_use_id" in block:
-                            pass  # tool_result uses ID, not name
+        # 3. (removed) Previously prefixed all tool names with mcp_ under the
+        #    assumption that the Anthropic API expected it for OAuth sessions.
+        #    In practice, the mcp_ prefix triggers Anthropic's overage gate
+        #    for Pro/Max subscribers (who have usage-based billing disabled by
+        #    default), causing every tool-bearing request to fail with HTTP 400
+        #    "out of extra usage" — even when 95%+ of the included quota remains.
+        #    The real Claude Code CLI only prefixes tools from user-installed
+        #    MCP servers, not its built-in tools.  See issue #28849.
 
     kwargs: Dict[str, Any] = {
         "model": model,

--- a/tests/agent/test_oauth_mcp_prefix_removed.py
+++ b/tests/agent/test_oauth_mcp_prefix_removed.py
@@ -1,0 +1,103 @@
+"""Test that OAuth Anthropic path does NOT add mcp_ prefix to tool names.
+
+Regression test for issue #28849: the mcp_ prefix on all tools triggered
+Anthropic's overage gate for Pro/Max subscribers, causing HTTP 400 errors
+on every tool-bearing request.
+"""
+import pytest
+
+
+def _make_tools(names):
+    """Create minimal tool schemas in OpenAI format."""
+    return [
+        {"type": "function", "function": {
+            "name": n, "description": f"tool {n}",
+            "parameters": {"type": "object", "properties": {}}
+        }}
+        for n in names
+    ]
+
+
+def _make_tool_use_history(tool_name):
+    """Create a message history with a tool_use block."""
+    return [
+        {"role": "user", "content": "test"},
+        {"role": "assistant", "content": [
+            {"type": "tool_use", "id": "tu_1", "name": tool_name,
+             "input": {}},
+        ]},
+    ]
+
+
+class TestNoMcpPrefixOnOAuth:
+    """The mcp_ prefix must NOT be added to built-in tool names."""
+
+    def test_tool_names_not_prefixed_oauth(self):
+        """On the OAuth path, tool names should keep their original names."""
+        from agent.anthropic_adapter import build_anthropic_kwargs
+
+        tools = _make_tools(["terminal", "read_file", "web_search"])
+        kwargs = build_anthropic_kwargs(
+            model="claude-sonnet-4-5",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=tools,
+            max_tokens=1024,
+            reasoning_config=None,
+            is_oauth=True,
+        )
+        result_names = [t["name"] for t in kwargs["tools"]]
+        assert result_names == ["terminal", "read_file", "web_search"]
+
+    def test_tool_names_not_prefixed_non_oauth(self):
+        """On the non-OAuth path, tool names should also keep original names."""
+        from agent.anthropic_adapter import build_anthropic_kwargs
+
+        tools = _make_tools(["terminal", "execute_code"])
+        kwargs = build_anthropic_kwargs(
+            model="claude-sonnet-4-5",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=tools,
+            max_tokens=1024,
+            reasoning_config=None,
+            is_oauth=False,
+        )
+        result_names = [t["name"] for t in kwargs["tools"]]
+        assert result_names == ["terminal", "execute_code"]
+
+    def test_history_tool_use_names_not_prefixed(self):
+        """Tool names in message history should not be mangled with mcp_."""
+        from agent.anthropic_adapter import build_anthropic_kwargs
+
+        messages = _make_tool_use_history("terminal")
+        kwargs = build_anthropic_kwargs(
+            model="claude-sonnet-4-5",
+            messages=messages,
+            tools=_make_tools(["terminal"]),
+            max_tokens=1024,
+            reasoning_config=None,
+            is_oauth=True,
+        )
+        # The tool_use block in the converted messages should keep "terminal"
+        assistant_blocks = [
+            b for m in kwargs["messages"]
+            if isinstance(m.get("content"), list)
+            for b in m["content"]
+            if isinstance(b, dict) and b.get("type") == "tool_use"
+        ]
+        for block in assistant_blocks:
+            assert not block["name"].startswith("mcp_"), \
+                f"tool_use name '{block['name']}' should not have mcp_ prefix"
+
+    def test_no_tools_no_crash(self):
+        """OAuth path should work fine with no tools at all."""
+        from agent.anthropic_adapter import build_anthropic_kwargs
+
+        kwargs = build_anthropic_kwargs(
+            model="claude-sonnet-4-5",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=None,
+            max_tokens=1024,
+            reasoning_config=None,
+            is_oauth=True,
+        )
+        assert "tools" not in kwargs or kwargs.get("tools") is None


### PR DESCRIPTION
## Summary

Remove the `mcp_` tool name prefix that was applied to **all** tools on the Anthropic OAuth path. This prefix triggered Anthropic's overage gate for Pro/Max subscribers, causing every tool-bearing request to fail with HTTP 400 "out of extra usage".

Fixes #28849

## Problem

`build_anthropic_kwargs()` unconditionally prefixed every tool name with `mcp_` when `is_oauth=True`:

```python
# Before (removed)
if is_oauth:
    for tool in anthropic_tools:
        tool["name"] = "mcp_" + tool["name"]  # e.g. "mcp_terminal"
```

Anthropic treats `mcp_`-prefixed tools as MCP server extensions, billing them against a separate "extra usage" bucket. Pro/Max subscribers who have extra usage disabled get an immediate HTTP 400 rejection — even when 95%+ of their included quota remains unused.

## Root Cause

The prefix was modeled after Claude Code CLI's behavior, but Claude Code only prefixes tools from user-installed MCP servers — **not** its built-in tools like `Read`, `Write`, `Bash`. Hermes was incorrectly prefixing all tools including built-in ones (`terminal`, `read_file`, `web_search`, etc.).

## Fix

Removed the `mcp_` prefix logic entirely (steps 3 and 4 in the OAuth block). Tool names are now passed through unchanged.

## Testing

- **4 new tests** in `tests/agent/test_oauth_mcp_prefix_removed.py`:
  - Tool names not prefixed on OAuth path
  - Tool names not prefixed on non-OAuth path
  - Tool names in message history not prefixed
  - No crash when tools=None
- **163 total tests passed** (4 new + 159 existing anthropic adapter + oauth guard tests)
