### PR TITLE
fix(kanban): pass skills from decomposer to child tasks

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3146,6 +3146,7 @@ def decompose_triage_task(
             "body": "...",                     # optional
             "assignee": "profile-name",        # optional, None -> default fallback
             "parents": [0, 2],                 # indices into this same children list
+            "skills": ["skill-name"],          # optional list of skill names
         }
 
     Returns the list of created child task ids (in input order) on
@@ -3233,11 +3234,18 @@ def decompose_triage_task(
             title = child["title"].strip()
             body = child.get("body")
             assignee = _canonical_assignee(child.get("assignee"))
+            # Extract optional skills from the child dict.
+            raw_skills = child.get("skills")
+            skills_val = None
+            if isinstance(raw_skills, list) and raw_skills:
+                cleaned = [s for s in raw_skills if isinstance(s, str) and s.strip()]
+                if cleaned:
+                    skills_val = json.dumps(cleaned)
             conn.execute(
                 "INSERT INTO tasks "
                 "(id, title, body, assignee, status, workspace_kind, "
-                " tenant, created_at, created_by) "
-                "VALUES (?, ?, ?, ?, 'todo', 'scratch', ?, ?, ?)",
+                " tenant, created_at, created_by, skills) "
+                "VALUES (?, ?, ?, ?, 'todo', 'scratch', ?, ?, ?, ?)",
                 (
                     new_id,
                     title,
@@ -3246,6 +3254,7 @@ def decompose_triage_task(
                     tenant,
                     now,
                     (author or "decomposer"),
+                    skills_val,
                 ),
             )
             _append_event(

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -70,7 +70,8 @@ Output a single JSON object with this exact shape:
         "title": "<concrete task title, imperative voice, <= 80 chars>",
         "body":  "<detailed spec for the worker on this child task>",
         "assignee": "<profile name from the roster, or null for default>",
-        "parents": [<int>, ...]
+        "parents": [<int>, ...],
+        "skills": ["<skill-name>", ...]  # optional — skill bundles to force-load
       },
       ...
     ]
@@ -89,6 +90,9 @@ Rules:
     and the system will route to the default_assignee.
   - Each child task body is what a fresh worker will read with no other
     context — be specific about goal, approach, and acceptance criteria.
+  - Use "skills" to specify skill bundles the worker should force-load
+    (e.g. ["github-workflow", "test-driven-development"]). Omit if no
+    special skills are needed.
 
 When the task is genuinely a single unit of work (no useful decomposition),
 return:
@@ -431,11 +435,18 @@ def decompose_task(
             parents = []
         # Clean parent indices: drop non-int and out-of-range.
         clean_parents = [p for p in parents if isinstance(p, int) and 0 <= p < len(raw_tasks) and p != idx]
+        # Extract optional skills list from the decomposer response.
+        raw_skills = entry.get("skills")
+        if isinstance(raw_skills, list):
+            skills_list = [s for s in raw_skills if isinstance(s, str) and s.strip()]
+        else:
+            skills_list = []
         children.append({
             "title": title.strip()[:200],
             "body": body.strip(),
             "assignee": chosen,
             "parents": clean_parents,
+            "skills": skills_list,
         })
 
     try:


### PR DESCRIPTION
## What

The Kanban decomposer LLM was never able to pass skill bundles (`skills`) to child tasks during decomposition. This was because:

1. **`kanban_decompose.py`** did not extract `skills` from the decomposer's JSON response and did not include it in the `children` dict passed to the DB
2. **`kanban_db.py`** `decompose_triage_task()` INSERT omitted the `skills` column entirely

## This PR fixes both:

- **`kanban_decompose.py`**: Adds `skills` to the decomposer system prompt schema so the LLM knows it can include skill bundles. Extracts and validates `skills` from the LLM response and includes it in the `children` dict.
- **`kanban_db.py`**: Adds the `skills` column to the INSERT statement in `decompose_triage_task()`, JSON-serializes the skills list, and updates the docstring to document the new field.

## Testing

All 167 kanban tests pass (9 decompose + 158 DB).

## Impact

This is a **bug fix** — the `skills` field was always supported by `create_task()` but the decomposer path was bypassing it entirely. Existing tasks are unaffected; only new decompositions will now correctly propagate skill bundles to child tasks.
