### PR TITLE
fix(whatsapp): forward quotedMessageId/context to agent prompt

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -1268,6 +1268,16 @@ class WhatsAppAdapter(BasePlatformAdapter):
                         except Exception as e:
                             print(f"[{self.name}] Failed to read document text: {e}", flush=True)
 
+            # Forward quoted-message context so reply-based corrections keep
+            # their reference. The bridge (PR #25489) already extracts
+            # quotedMessageId / hasQuotedMessage from Baileys' contextInfo;
+            # we just need to map it to the structured field the agent prompt
+            # builder consumes.  No local text cache for the quoted body yet,
+            # so reply_to_text stays None — matching the Matrix adapter.
+            reply_to_message_id = None
+            if data.get("hasQuotedMessage"):
+                reply_to_message_id = data.get("quotedMessageId") or None
+
             return MessageEvent(
                 text=body,
                 message_type=msg_type,
@@ -1276,6 +1286,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
                 message_id=data.get("messageId"),
                 media_urls=cached_urls,
                 media_types=media_types,
+                reply_to_message_id=reply_to_message_id,
             )
         except Exception as e:
             print(f"[{self.name}] Error building event: {e}")

--- a/tests/gateway/test_whatsapp_formatting.py
+++ b/tests/gateway/test_whatsapp_formatting.py
@@ -325,6 +325,78 @@ class TestBridgeEventMetadata:
         assert event.raw_message["quotedRemoteJid"] == "15551234567@s.whatsapp.net"
         assert event.raw_message["hasQuotedMessage"] is True
 
+    @pytest.mark.asyncio
+    async def test_quoted_message_id_forwarded_to_agent_context(self):
+        """Reply context reaches the agent via reply_to_message_id."""
+        adapter = _make_adapter()
+        data = {
+            "messageId": "incoming-msg",
+            "chatId": "15551234567@s.whatsapp.net",
+            "senderId": "15551234567@s.whatsapp.net",
+            "senderName": "Tester",
+            "chatName": "Tester",
+            "isGroup": False,
+            "body": "Actually, change it to BL-99",
+            "hasMedia": False,
+            "mediaUrls": [],
+            "quotedMessageId": "ABC123",
+            "quotedParticipant": "99999999999@s.whatsapp.net",
+            "hasQuotedMessage": True,
+        }
+
+        event = await adapter._build_message_event(data)
+
+        assert event is not None
+        assert event.reply_to_message_id == "ABC123"
+        assert event.reply_to_text is None  # bridge doesn't emit quoted text yet
+
+    @pytest.mark.asyncio
+    async def test_non_reply_message_unchanged(self):
+        """Normal messages leave reply_to_message_id unset."""
+        adapter = _make_adapter()
+        data = {
+            "messageId": "plain-msg",
+            "chatId": "15551234567@s.whatsapp.net",
+            "senderId": "15551234567@s.whatsapp.net",
+            "senderName": "Tester",
+            "chatName": "Tester",
+            "isGroup": False,
+            "body": "Please prioritize KL-42",
+            "hasMedia": False,
+            "mediaUrls": [],
+        }
+
+        event = await adapter._build_message_event(data)
+
+        assert event is not None
+        assert event.reply_to_message_id is None
+        assert event.text == "Please prioritize KL-42"
+
+    def test_reply_to_bot_admission_control_still_works(self):
+        """_message_is_reply_to_bot continues to function after adapter change."""
+        adapter = _make_adapter()
+        # bot IDs are normalised inside the adapter; set via the bridge data field
+        data_reply_to_bot = {
+            "body": "approved",
+            "botIds": ["99999999999@s.whatsapp.net"],
+            "quotedParticipant": "99999999999@s.whatsapp.net",
+            "hasQuotedMessage": True,
+        }
+        data_reply_to_other = {
+            "body": "approved",
+            "botIds": ["99999999999@s.whatsapp.net"],
+            "quotedParticipant": "11111111111@s.whatsapp.net",
+            "hasQuotedMessage": True,
+        }
+        data_no_quote = {
+            "body": "hello",
+            "botIds": ["99999999999@s.whatsapp.net"],
+        }
+
+        assert adapter._message_is_reply_to_bot(data_reply_to_bot) is True
+        assert adapter._message_is_reply_to_bot(data_reply_to_other) is False
+        assert adapter._message_is_reply_to_bot(data_no_quote) is False
+
 
 # ---------------------------------------------------------------------------
 # display_config tier classification


### PR DESCRIPTION
The WhatsApp bridge (PR #25489) already extracts quotedMessageId, quotedParticipant, quotedRemoteJid, and hasQuotedMessage from Baileys' contextInfo, but the adapter in gateway/platforms/whatsapp.py only used quotedParticipant for admission control. The remaining fields were dropped, so reply-based corrections in WhatsApp lost all context — the agent only saw the new reply text with no reference to the quoted message.

This forwards the quoted-message context to the agent using the same shape as the Matrix adapter (see #27946 fix), keeping cross-platform behavior consistent. Non-reply messages are unchanged.

Fixes #28823