### PR TITLE
fix(moonshot): flatten union types before set check to avoid TypeError (#28787, #28291)

### DIFF
--- a/agent/moonshot_schema.py
+++ b/agent/moonshot_schema.py
@@ -166,6 +166,14 @@ def _repair_schema(node: Any, is_schema: bool = True) -> Any:
 
 def _fill_missing_type(node: Dict[str, Any]) -> Dict[str, Any]:
     """Infer a reasonable ``type`` if this schema node has none."""
+    # JSON Schema allows ``type`` to be a list (union type, e.g.
+    # ["number", "string"]).  Moonshot only accepts scalar types, so
+    # flatten the union by taking the first entry.  This must happen
+    # *before* the set-membership check below, because lists are
+    # unhashable and would crash with TypeError.  See #28787, #28291.
+    if "type" in node and isinstance(node["type"], list):
+        node["type"] = node["type"][0] if node["type"] else "string"
+
     if "type" in node and node["type"] not in {None, ""}:
         return node
 

--- a/tests/agent/test_moonshot_schema.py
+++ b/tests/agent/test_moonshot_schema.py
@@ -118,6 +118,30 @@ class TestMissingTypeFilled:
         assert "type" not in out["properties"]["payload"]
         assert out["properties"]["payload"]["$ref"] == "#/$defs/Payload"
 
+    def test_union_type_list_flattened_to_first(self):
+        """JSON Schema union types (``type: ["number", "string"]``) must
+        be flattened to a scalar before the set-membership guard, because
+        lists are unhashable.  See #28787, #28291."""
+        params = {
+            "type": "object",
+            "properties": {
+                "value": {"type": ["number", "string"]},
+            },
+        }
+        out = sanitize_moonshot_tool_parameters(params)
+        assert out["properties"]["value"]["type"] == "number"
+
+    def test_empty_union_type_defaults_to_string(self):
+        """An empty union type list should fall back to ``string``."""
+        params = {
+            "type": "object",
+            "properties": {
+                "empty": {"type": []},
+            },
+        }
+        out = sanitize_moonshot_tool_parameters(params)
+        assert out["properties"]["empty"]["type"] == "string"
+
 
 class TestAnyOfParentType:
     """Rule 2: type must not appear at the anyOf parent level.


### PR DESCRIPTION
## Summary

Fix `TypeError: unhashable type: 'list'` in Moonshot schema sanitizer when tool parameters use JSON Schema union types (`"type": ["number", "string"]`).

Fixes #28787. Fixes #28291.

## Problem

When a tool parameter schema contains a union type (e.g., `"type": ["number", "string"]`), the `_fill_missing_type()` function in `moonshot_schema.py` crashes at the set-membership check:

```python
if "type" in node and node["type"] not in {None, ""}:  # TypeError!
```

Python cannot hash a list, so checking list membership in a set raises `TypeError: unhashable type: 'list'`.

This makes kimi-k2.6 completely unusable through Ollama providers, as every API call triggers this crash and falls back to the configured fallback model.

## Root Cause

`_fill_missing_type()` assumes `node["type"]` is always a scalar (string or None). JSON Schema allows `type` to be an array of types (union type), but Moonshot only accepts scalar types.

## Fix

Added an `isinstance(node["type"], list)` guard before the set check. If `type` is a list:
- Non-empty list: take the first element as the scalar type
- Empty list: fall back to `"string"`

## Testing

- **2 new tests** in `tests/agent/test_moonshot_schema.py`:
  - `test_union_type_list_flattened_to_first`: `["number", "string"]` → `"number"`
  - `test_empty_union_type_defaults_to_string`: `[]` → `"string"`
- **44 total tests passed** (2 new + 42 existing moonshot schema tests)
