### PR TITLE
feat(slack): render clarify prompts as Block Kit buttons

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -452,6 +452,9 @@ class SlackAdapter(BasePlatformAdapter):
         # Track pending approval message_ts → resolved flag to prevent
         # double-clicks on approval buttons.
         self._approval_resolved: Dict[str, bool] = {}
+        # Track pending clarify message_ts → resolved flag (same double-click
+        # guard pattern as approvals).
+        self._clarify_resolved: Dict[str, bool] = {}
         # Track timestamps of messages sent by the bot so we can respond
         # to thread replies even without an explicit @mention.
         self._bot_message_ts: set = set()
@@ -1184,6 +1187,17 @@ class SlackAdapter(BasePlatformAdapter):
                 "hermes_confirm_cancel",
             ):
                 self._app.action(_action_id)(self._handle_slash_confirm_action)
+
+            # Register Block Kit action handlers for clarify buttons
+            # (multiple-choice prompts; see tools/clarify_gateway.py).
+            # One per choice slot (Slack requires unique action_id per
+            # button within a message) plus the Other / free-text button.
+            from tools.clarify_tool import MAX_CHOICES as _MAX_CLARIFY_CHOICES
+            _clarify_action_ids = tuple(
+                f"hermes_clarify_choice_{i}" for i in range(_MAX_CLARIFY_CHOICES)
+            ) + ("hermes_clarify_other",)
+            for _action_id in _clarify_action_ids:
+                self._app.action(_action_id)(self._handle_clarify_action)
 
             # Register plugin-provided Block Kit action handlers.
             #
@@ -3684,6 +3698,226 @@ class SlackAdapter(BasePlatformAdapter):
             )
 
         # (approval state already consumed by atomic pop above)
+
+    # ----- Clarify button support (Block Kit) -----
+
+    async def send_clarify(
+        self,
+        chat_id: str,
+        question: str,
+        choices: Optional[List[str]],
+        clarify_id: str,
+        session_key: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Render a clarify prompt as Block Kit buttons.
+
+        Multi-choice mode (``choices`` non-empty): one button per option +
+        a final ✏️ Other (type answer) button. Clicking a choice button
+        resolves the clarify via ``resolve_gateway_clarify``; clicking
+        Other flips the entry into text-capture mode via
+        ``mark_awaiting_text`` so the next message becomes the response.
+
+        Open-ended mode (``choices`` empty/None): falls back to the base
+        adapter's plain-text render — the gateway's text-intercept then
+        captures the next message in the session.
+        """
+        if not self._app:
+            return SendResult(success=False, error="Not connected")
+
+        if not choices:
+            return await super().send_clarify(
+                chat_id=chat_id,
+                question=question,
+                choices=choices,
+                clarify_id=clarify_id,
+                session_key=session_key,
+                metadata=metadata,
+            )
+
+        try:
+            thread_ts = self._resolve_thread_ts(None, metadata)
+
+            # Slack section blocks cap mrkdwn text at 3000 characters.
+            question_text = f"❓ {question}"
+            if len(question_text) > 3000:
+                question_text = question_text[:2997] + "..."
+
+            # Slack plain_text button labels cap at 75 chars — truncate
+            # defensively. The full choice text still drives the
+            # resolver via clarify_gateway's stored entry, so truncation
+            # only affects the visible button label.
+            button_elements: List[Dict[str, Any]] = []
+            for idx, choice in enumerate(choices):
+                label = str(choice)
+                if len(label) > 72:
+                    label = label[:69] + "..."
+                button_elements.append({
+                    "type": "button",
+                    "text": {"type": "plain_text", "text": f"{idx + 1}. {label}"},
+                    # Each button needs a unique action_id within a single
+                    # message — Slack rejects duplicates with invalid_blocks.
+                    # Mirrors send_exec_approval's per-button labels.
+                    "action_id": f"hermes_clarify_choice_{idx}",
+                    "value": f"{clarify_id}|{idx}",
+                })
+            button_elements.append({
+                "type": "button",
+                "text": {"type": "plain_text", "text": "✏️ Other (type answer)"},
+                "action_id": "hermes_clarify_other",
+                "value": clarify_id,
+            })
+
+            blocks = [
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": question_text,
+                    },
+                },
+                {
+                    "type": "actions",
+                    "elements": button_elements,
+                },
+            ]
+
+            kwargs: Dict[str, Any] = {
+                "channel": chat_id,
+                "text": question_text,
+                "blocks": blocks,
+            }
+            if thread_ts:
+                kwargs["thread_ts"] = thread_ts
+
+            result = await self._get_client(chat_id).chat_postMessage(**kwargs)
+            msg_ts = result.get("ts", "")
+            if msg_ts:
+                self._clarify_resolved[msg_ts] = False
+
+            return SendResult(success=True, message_id=msg_ts, raw_response=result)
+        except Exception as e:
+            logger.error("[Slack] send_clarify failed: %s", e, exc_info=True)
+            return SendResult(success=False, error=str(e))
+
+    async def _handle_clarify_action(self, ack, body, action) -> None:
+        """Handle a clarify button click from Block Kit.
+
+        ``hermes_clarify_choice`` (value=``clarify_id|idx``): resolve the
+        clarify with the choice text.
+        ``hermes_clarify_other`` (value=``clarify_id``): flip the entry
+        into text-capture mode; the gateway's text-intercept will resolve
+        once the user types their answer.
+        """
+        await ack()
+
+        action_id = action.get("action_id", "")
+        value = action.get("value", "")
+        message = body.get("message", {})
+        msg_ts = message.get("ts", "")
+        channel_id = body.get("channel", {}).get("id", "")
+        user_name = body.get("user", {}).get("name", "unknown")
+        user_id = body.get("user", {}).get("id", "")
+
+        # Same interactive-auth gate as exec-approval and slash-confirm.
+        if not self._is_interactive_user_authorized(
+            user_id,
+            channel_id=channel_id,
+            user_name=user_name,
+        ):
+            logger.warning(
+                "[Slack] Unauthorized clarify click by %s (%s) — ignoring",
+                user_name, user_id,
+            )
+            return
+
+        # Prevent double-clicks — atomic pop; first caller gets False, others get True (default)
+        if self._clarify_resolved.pop(msg_ts, True):
+            return
+
+        from tools import clarify_gateway as cm
+
+        if action_id == "hermes_clarify_other":
+            clarify_id = value
+            if not cm.mark_awaiting_text(clarify_id):
+                logger.warning(
+                    "[Slack] clarify Other click for unknown clarify_id %s",
+                    clarify_id,
+                )
+                return
+            decision_text = f"✏️ {user_name} chose Other — type your answer"
+            choice_text: Optional[str] = None
+        elif action_id.startswith("hermes_clarify_choice_"):
+            # value carries clarify_id|idx; idx is also encoded in the
+            # action_id suffix (Slack requires unique action_ids).
+            if "|" not in value:
+                logger.warning("[Slack] Malformed clarify-choice value: %s", value)
+                return
+            clarify_id, _, idx_str = value.partition("|")
+            try:
+                idx = int(idx_str)
+            except ValueError:
+                logger.warning("[Slack] Malformed clarify-choice idx: %s", idx_str)
+                return
+
+            with cm._lock:
+                entry = cm._entries.get(clarify_id)
+            if entry is None or not entry.choices or idx < 0 or idx >= len(entry.choices):
+                logger.warning(
+                    "[Slack] clarify-choice click for unknown clarify_id %s idx %s",
+                    clarify_id, idx,
+                )
+                return
+            choice_text = entry.choices[idx]
+            decision_text = f"✅ {user_name} chose: {choice_text}"
+        else:
+            logger.warning("[Slack] clarify action with unexpected action_id: %s", action_id)
+            return
+
+        # Update the message to show the resolution and remove buttons.
+        original_text = ""
+        for block in message.get("blocks", []):
+            if block.get("type") == "section":
+                original_text = block.get("text", {}).get("text", "")
+                break
+
+        updated_blocks = [
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": original_text or "Clarify prompt",
+                },
+            },
+            {
+                "type": "context",
+                "elements": [
+                    {"type": "mrkdwn", "text": decision_text},
+                ],
+            },
+        ]
+
+        try:
+            await self._get_client(channel_id).chat_update(
+                channel=channel_id,
+                ts=msg_ts,
+                text=decision_text,
+                blocks=updated_blocks,
+            )
+        except Exception as e:
+            logger.warning("[Slack] Failed to update clarify message: %s", e)
+
+        if choice_text is not None:
+            try:
+                cm.resolve_gateway_clarify(clarify_id, choice_text)
+                logger.info(
+                    "Slack button resolved clarify for clarify_id %s (choice=%s, user=%s)",
+                    clarify_id, choice_text, user_name,
+                )
+            except Exception as exc:
+                logger.error("Failed to resolve clarify from Slack button: %s", exc, exc_info=True)
+        # On Other, the entry stays pending until the next text reply
+        # is captured by the gateway intercept.
 
     # ----- Thread context fetching -----
 

--- a/tests/gateway/test_slack_clarify_buttons.py
+++ b/tests/gateway/test_slack_clarify_buttons.py
@@ -1,0 +1,470 @@
+"""Tests for Slack Block Kit clarify buttons.
+
+Mirrors test_slack_approval_buttons.py for the new ``send_clarify`` and
+``hermes_clarify_*`` action dispatch.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure the repo root is importable
+# ---------------------------------------------------------------------------
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+# ---------------------------------------------------------------------------
+# Minimal Slack SDK mock so SlackAdapter can be imported
+# ---------------------------------------------------------------------------
+def _ensure_slack_mock():
+    if "slack_bolt" in sys.modules:
+        return
+    slack_bolt = MagicMock()
+    slack_bolt.async_app.AsyncApp = MagicMock
+    sys.modules["slack_bolt"] = slack_bolt
+    sys.modules["slack_bolt.async_app"] = slack_bolt.async_app
+    handler_mod = MagicMock()
+    handler_mod.AsyncSocketModeHandler = MagicMock
+    sys.modules["slack_bolt.adapter"] = MagicMock()
+    sys.modules["slack_bolt.adapter.socket_mode"] = MagicMock()
+    sys.modules["slack_bolt.adapter.socket_mode.async_handler"] = handler_mod
+    sdk_mod = MagicMock()
+    sdk_mod.web = MagicMock()
+    sdk_mod.web.async_client = MagicMock()
+    sdk_mod.web.async_client.AsyncWebClient = MagicMock
+    sys.modules["slack_sdk"] = sdk_mod
+    sys.modules["slack_sdk.web"] = sdk_mod.web
+    sys.modules["slack_sdk.web.async_client"] = sdk_mod.web.async_client
+
+
+_ensure_slack_mock()
+
+from plugins.platforms.slack.adapter import SlackAdapter
+from gateway.config import PlatformConfig
+
+
+def _make_adapter():
+    config = PlatformConfig(enabled=True, token="xoxb-test-token")
+    adapter = SlackAdapter(config)
+    adapter._app = MagicMock()
+    adapter._bot_user_id = "U_BOT"
+    adapter._team_clients = {"T1": AsyncMock()}
+    adapter._team_bot_user_ids = {"T1": "U_BOT"}
+    adapter._channel_team = {"C1": "T1"}
+    return adapter
+
+
+class _AuthRunner:
+    def __init__(self, auth_fn=None):
+        self._auth_fn = auth_fn or (lambda _source: True)
+        self.seen_sources = []
+
+    async def handle(self, event):
+        return None
+
+    def _is_user_authorized(self, source):
+        self.seen_sources.append(source)
+        return self._auth_fn(source)
+
+
+def _attach_auth_runner(adapter, auth_fn=None):
+    runner = _AuthRunner(auth_fn=auth_fn)
+    adapter.set_message_handler(runner.handle)
+    return runner
+
+
+def _clear_clarify_state():
+    from tools import clarify_gateway as cm
+    with cm._lock:
+        cm._entries.clear()
+        cm._session_index.clear()
+        cm._notify_cbs.clear()
+
+
+# ===========================================================================
+# send_clarify — Block Kit render
+# ===========================================================================
+
+class TestSlackSendClarify:
+    """Verify the rendered prompt has buttons or none, and registers state."""
+
+    def setup_method(self):
+        _clear_clarify_state()
+
+    @pytest.mark.asyncio
+    async def test_multi_choice_renders_buttons_and_other(self):
+        adapter = _make_adapter()
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_postMessage = AsyncMock(return_value={"ts": "100.1"})
+
+        result = await adapter.send_clarify(
+            chat_id="C1",
+            question="Which preset?",
+            choices=["Classic", "Golden Hour", "Vibrant", "Blue Tint"],
+            clarify_id="cid1",
+            session_key="sk1",
+        )
+
+        assert result.success is True
+        assert result.message_id == "100.1"
+
+        kwargs = mock_client.chat_postMessage.call_args[1]
+        assert kwargs["text"] == "❓ Which preset?"
+        blocks = kwargs["blocks"]
+        assert len(blocks) == 2
+        assert blocks[0]["type"] == "section"
+        assert "Which preset?" in blocks[0]["text"]["text"]
+        assert blocks[1]["type"] == "actions"
+        elements = blocks[1]["elements"]
+        # 4 choices + 1 Other
+        assert len(elements) == 5
+        # First four are choice buttons. Each needs a unique action_id
+        # (Slack rejects duplicates within a message); idx is encoded in
+        # the action_id suffix AND in the value field.
+        seen_action_ids = set()
+        for idx, choice in enumerate(["Classic", "Golden Hour", "Vibrant", "Blue Tint"]):
+            el = elements[idx]
+            assert el["action_id"] == f"hermes_clarify_choice_{idx}"
+            assert el["action_id"] not in seen_action_ids
+            seen_action_ids.add(el["action_id"])
+            assert el["value"] == f"cid1|{idx}"
+            assert choice in el["text"]["text"]
+        # Last is the Other button
+        other = elements[-1]
+        assert other["action_id"] == "hermes_clarify_other"
+        assert other["value"] == "cid1"
+        # Double-click guard registered
+        assert adapter._clarify_resolved.get("100.1") is False
+
+    @pytest.mark.asyncio
+    async def test_open_ended_falls_through_to_base(self):
+        """No choices → no Block Kit buttons; the base adapter renders the
+        question as plain text and the gateway text-intercept catches the
+        reply."""
+        adapter = _make_adapter()
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_postMessage = AsyncMock(return_value={"ts": "100.2"})
+
+        result = await adapter.send_clarify(
+            chat_id="C1",
+            question="What is your name?",
+            choices=None,
+            clarify_id="cid2",
+            session_key="sk2",
+        )
+
+        assert result.success is True
+        # Base path goes through send() → chat_postMessage with text only,
+        # no blocks key.
+        kwargs = mock_client.chat_postMessage.call_args[1]
+        assert "blocks" not in kwargs
+        assert "What is your name?" in kwargs["text"]
+
+    @pytest.mark.asyncio
+    async def test_not_connected(self):
+        adapter = _make_adapter()
+        adapter._app = None
+        result = await adapter.send_clarify(
+            chat_id="C1",
+            question="?",
+            choices=["a"],
+            clarify_id="cid3",
+            session_key="sk3",
+        )
+        assert result.success is False
+
+    @pytest.mark.asyncio
+    async def test_long_choice_label_truncated(self):
+        adapter = _make_adapter()
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_postMessage = AsyncMock(return_value={"ts": "100.3"})
+
+        long_choice = "x" * 200
+        await adapter.send_clarify(
+            chat_id="C1",
+            question="?",
+            choices=[long_choice],
+            clarify_id="cid4",
+            session_key="sk4",
+        )
+        kwargs = mock_client.chat_postMessage.call_args[1]
+        label = kwargs["blocks"][1]["elements"][0]["text"]["text"]
+        # Numeric prefix + truncated body + ellipsis, well under Slack's 75-char
+        # plain_text cap.
+        assert len(label) < 80
+        assert label.endswith("...")
+
+    @pytest.mark.asyncio
+    async def test_long_question_is_budgeted_under_section_cap(self):
+        adapter = _make_adapter()
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_postMessage = AsyncMock(return_value={"ts": "100.5"})
+
+        await adapter.send_clarify(
+            chat_id="C1",
+            question="x" * 4000,
+            choices=["a", "b"],
+            clarify_id="cid-long",
+            session_key="sk-long",
+        )
+
+        kwargs = mock_client.chat_postMessage.call_args[1]
+        section_text = kwargs["blocks"][0]["text"]["text"]
+        assert len(section_text) <= 3000
+        assert section_text.endswith("...")
+        assert kwargs["text"] == section_text
+
+    @pytest.mark.asyncio
+    async def test_inherits_thread_ts_from_metadata(self):
+        adapter = _make_adapter()
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_postMessage = AsyncMock(return_value={"ts": "100.4"})
+
+        await adapter.send_clarify(
+            chat_id="C1",
+            question="?",
+            choices=["a", "b"],
+            clarify_id="cid5",
+            session_key="sk5",
+            metadata={"thread_id": "9000.0"},
+        )
+        kwargs = mock_client.chat_postMessage.call_args[1]
+        assert kwargs.get("thread_ts") == "9000.0"
+
+
+# ===========================================================================
+# _handle_clarify_action — button click handler
+# ===========================================================================
+
+class TestSlackClarifyAction:
+    """Verify clicking a button resolves the clarify primitive."""
+
+    def setup_method(self):
+        _clear_clarify_state()
+
+    @pytest.mark.asyncio
+    async def test_choice_click_resolves_with_choice_text(self):
+        from tools import clarify_gateway as cm
+
+        adapter = _make_adapter()
+        runner = _attach_auth_runner(adapter)
+        cm.register("cidA", "sk-cb", "Which preset?", ["Classic", "Golden Hour"])
+        adapter._clarify_resolved["1.2"] = False
+
+        ack = AsyncMock()
+        body = {
+            "message": {
+                "ts": "1.2",
+                "blocks": [
+                    {"type": "section", "text": {"type": "mrkdwn", "text": "❓ Which preset?"}},
+                    {"type": "actions", "elements": []},
+                ],
+            },
+            "channel": {"id": "C1"},
+            "user": {"name": "norbert", "id": "U_NORB"},
+        }
+        action = {
+            "action_id": "hermes_clarify_choice_0",
+            "value": "cidA|1",  # Golden Hour
+        }
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+
+        await adapter._handle_clarify_action(ack, body, action)
+
+        ack.assert_called_once()
+        assert runner.seen_sources
+        assert runner.seen_sources[0].user_id == "U_NORB"
+        # The entry should have been resolved with the choice text.
+        with cm._lock:
+            entry = cm._entries.get("cidA")
+        assert entry is not None
+        assert entry.response == "Golden Hour"
+        assert entry.event.is_set()
+        # Chat message updated to show the decision.
+        update_kwargs = mock_client.chat_update.call_args[1]
+        assert "Golden Hour" in update_kwargs["text"]
+        assert "norbert" in update_kwargs["text"]
+
+    @pytest.mark.asyncio
+    async def test_other_click_flips_to_text_mode(self):
+        from tools import clarify_gateway as cm
+
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter)
+        cm.register("cidB", "sk-other", "Pick", ["x", "y"])
+        adapter._clarify_resolved["1.3"] = False
+
+        ack = AsyncMock()
+        body = {
+            "message": {
+                "ts": "1.3",
+                "blocks": [
+                    {"type": "section", "text": {"type": "mrkdwn", "text": "❓ Pick"}},
+                ],
+            },
+            "channel": {"id": "C1"},
+            "user": {"name": "alice", "id": "U_ALICE"},
+        }
+        action = {"action_id": "hermes_clarify_other", "value": "cidB"}
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+
+        await adapter._handle_clarify_action(ack, body, action)
+
+        # Entry now awaiting text — NOT yet resolved.
+        with cm._lock:
+            entry = cm._entries.get("cidB")
+        assert entry is not None
+        assert entry.awaiting_text is True
+        assert not entry.event.is_set()
+        # User sees the "type your answer" decision text.
+        update_kwargs = mock_client.chat_update.call_args[1]
+        assert "Other" in update_kwargs["text"]
+
+    @pytest.mark.asyncio
+    async def test_double_click_guarded(self):
+        from tools import clarify_gateway as cm
+
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter)
+        cm.register("cidC", "sk-dbl", "Pick", ["x", "y"])
+        adapter._clarify_resolved["1.4"] = True  # Already resolved
+
+        ack = AsyncMock()
+        body = {
+            "message": {"ts": "1.4", "blocks": []},
+            "channel": {"id": "C1"},
+            "user": {"name": "alice", "id": "U_ALICE"},
+        }
+        action = {"action_id": "hermes_clarify_choice_0", "value": "cidC|0"}
+
+        with patch("tools.clarify_gateway.resolve_gateway_clarify") as mock_resolve:
+            await adapter._handle_clarify_action(ack, body, action)
+
+        ack.assert_called_once()
+        mock_resolve.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_gateway_runner_unauthorized_user_rejected(self):
+        from tools import clarify_gateway as cm
+
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter, auth_fn=lambda _source: False)
+        cm.register("cidD", "sk-auth", "Pick", ["a"])
+        adapter._clarify_resolved["1.5"] = False
+
+        ack = AsyncMock()
+        body = {
+            "message": {"ts": "1.5", "blocks": []},
+            "channel": {"id": "C1"},
+            "user": {"name": "mallory", "id": "U_MAL"},
+        }
+        action = {"action_id": "hermes_clarify_choice_0", "value": "cidD|0"}
+
+        await adapter._handle_clarify_action(ack, body, action)
+
+        # Entry must remain unresolved.
+        with cm._lock:
+            entry = cm._entries.get("cidD")
+        assert entry is not None
+        assert not entry.event.is_set()
+        # And the double-click guard must NOT have been consumed —
+        # an authorized user re-trying still gets a chance.
+        assert adapter._clarify_resolved.get("1.5") is False
+
+    @pytest.mark.asyncio
+    async def test_global_gateway_allowlist_authorizes_click(self, monkeypatch):
+        from tools import clarify_gateway as cm
+
+        adapter = _make_adapter()
+        monkeypatch.delenv("SLACK_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.delenv("SLACK_ALLOWED_USERS", raising=False)
+        monkeypatch.setenv("GATEWAY_ALLOWED_USERS", "U_GOOD")
+        cm.register("cid-global", "sk-global", "Pick", ["a"])
+        adapter._clarify_resolved["1.9"] = False
+
+        ack = AsyncMock()
+        body = {
+            "message": {"ts": "1.9", "blocks": []},
+            "channel": {"id": "C1"},
+            "user": {"name": "gail", "id": "U_GOOD"},
+        }
+        action = {"action_id": "hermes_clarify_choice_0", "value": "cid-global|0"}
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+
+        await adapter._handle_clarify_action(ack, body, action)
+
+        with cm._lock:
+            entry = cm._entries.get("cid-global")
+        assert entry is not None
+        assert entry.response == "a"
+        assert entry.event.is_set()
+
+    @pytest.mark.asyncio
+    async def test_unknown_clarify_id_does_not_crash(self):
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter)
+        adapter._clarify_resolved["1.6"] = False
+
+        ack = AsyncMock()
+        body = {
+            "message": {"ts": "1.6", "blocks": []},
+            "channel": {"id": "C1"},
+            "user": {"name": "alice", "id": "U_ALICE"},
+        }
+        action = {"action_id": "hermes_clarify_choice_0", "value": "missing|0"}
+
+        # No registered entry for clarify_id "missing" — must just warn,
+        # not raise.
+        await adapter._handle_clarify_action(ack, body, action)
+        ack.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_malformed_value_does_not_crash(self):
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter)
+        adapter._clarify_resolved["1.7"] = False
+
+        ack = AsyncMock()
+        body = {
+            "message": {"ts": "1.7", "blocks": []},
+            "channel": {"id": "C1"},
+            "user": {"name": "alice", "id": "U_ALICE"},
+        }
+        # No pipe separator at all.
+        action = {"action_id": "hermes_clarify_choice_0", "value": "no-pipe-here"}
+
+        await adapter._handle_clarify_action(ack, body, action)
+        ack.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_idx_out_of_range_does_not_crash(self):
+        from tools import clarify_gateway as cm
+
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter)
+        cm.register("cidE", "sk-oob", "Pick", ["only-one"])
+        adapter._clarify_resolved["1.8"] = False
+
+        ack = AsyncMock()
+        body = {
+            "message": {"ts": "1.8", "blocks": []},
+            "channel": {"id": "C1"},
+            "user": {"name": "alice", "id": "U_ALICE"},
+        }
+        # idx=5 is out of range for a single-choice entry.
+        action = {"action_id": "hermes_clarify_choice_0", "value": "cidE|5"}
+
+        await adapter._handle_clarify_action(ack, body, action)
+        with cm._lock:
+            entry = cm._entries.get("cidE")
+        assert entry is not None
+        assert not entry.event.is_set()


### PR DESCRIPTION
## What does this PR do?

Adds native Slack Block Kit buttons for multi-choice `clarify` prompts, bringing Slack to parity with Telegram and Discord. A choice click resolves the waiting clarify request; `Other` switches the existing gateway flow into free-text capture. Open-ended clarifies continue to use the base adapter's text behavior.

The refreshed implementation incorporates both issues from the automated maintainer sweep: clarify actions reuse Slack's shared interactive-user authorization policy, and long questions are budgeted under Slack's 3000-character section-text limit.

## Related Issue

N/A — platform parity feature; no separate upstream issue is open.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/slack/adapter.py`
  - Adds `send_clarify()` Block Kit rendering with unique per-choice action IDs and an `Other` action.
  - Adds atomic action-resolution guarding and message updates after a decision.
  - Routes clarify clicks through `_is_interactive_user_authorized`, preserving GatewayRunner auth and global gateway allowlist policy.
  - Budgets/truncates long question text under Slack's 3000-character section-block cap.
- `tests/gateway/test_slack_clarify_buttons.py`
  - Covers rendering, open-ended fallback, thread inheritance, choice/Other resolution, double-clicks, malformed and missing entries, unique action IDs, shared auth policy, and long-question truncation.

## How to Test

1. Run `HOME=/tmp/hermes-ci-home scripts/run_tests.sh -j 1 tests/gateway/test_slack_clarify_buttons.py tests/gateway/test_slack_approval_buttons.py`.
2. Confirm all 41 tests pass.
3. In Slack, trigger a multi-choice clarify, click a choice, and confirm the message records the decision and the agent continues; verify `Other` accepts the next free-text reply.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, Python 3.11

The canonical full suite was run on the same current upstream base via the #30592 control branch. Its failures/timeouts were outside this two-file diff and matched current-main macOS/environment-sensitive areas. The Slack clarify and existing approval-button files pass 41/41.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
Slack clarify + approval buttons: 41 passed, 0 failed
ruff check .: passed
git diff --check upstream/main...HEAD: passed
check-windows-footguns.py --diff upstream/main: passed (2 files scanned)
```
