### PR TITLE
feat(feishu): add interactive slash confirm cards

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1464,6 +1464,8 @@ class FeishuAdapter(BasePlatformAdapter):
         # Update prompt button state (prompt_id → {session_key, message_id, chat_id})
         self._update_prompt_state: Dict[int, Dict[str, str]] = {}
         self._update_prompt_counter = itertools.count(1)
+        # Slash-confirm button state (confirm_id → {session_key, message_id, chat_id})
+        self._slash_confirm_state: Dict[str, Dict[str, str]] = {}
         # Feishu reaction deletion requires the opaque reaction_id returned
         # by create, so we cache it per message_id.
         self._pending_processing_reactions: "OrderedDict[str, str]" = OrderedDict()
@@ -1985,6 +1987,74 @@ class FeishuAdapter(BasePlatformAdapter):
             return SendResult(success=False, error=str(exc))
 
     @staticmethod
+    def _build_slash_confirm_card(*, title: str, message: str, confirm_id: str) -> Dict[str, Any]:
+        preview = message[:3000] + "..." if len(message) > 3000 else message
+
+        def _btn(label: str, choice: str, btn_type: str = "default") -> dict:
+            return {
+                "tag": "button",
+                "text": {"tag": "plain_text", "content": label},
+                "type": btn_type,
+                "value": {
+                    "hermes_slash_confirm_action": choice,
+                    "confirm_id": confirm_id,
+                },
+            }
+
+        return {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"content": title or "Confirm", "tag": "plain_text"},
+                "template": "orange",
+            },
+            "elements": [
+                {"tag": "markdown", "content": preview},
+                {
+                    "tag": "action",
+                    "actions": [
+                        _btn("Approve Once", "once", "primary"),
+                        _btn("Always Approve", "always"),
+                        _btn("Cancel", "cancel", "danger"),
+                    ],
+                },
+            ],
+        }
+
+    async def send_slash_confirm(
+        self, chat_id: str, title: str, message: str, session_key: str,
+        confirm_id: str, metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a three-button card for generic slash-command confirmation."""
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            payload = json.dumps(
+                self._build_slash_confirm_card(title=title, message=message, confirm_id=confirm_id),
+                ensure_ascii=False,
+            )
+            response = await self._feishu_send_with_retry(
+                chat_id=chat_id,
+                msg_type="interactive",
+                payload=payload,
+                reply_to=None,
+                metadata=metadata,
+            )
+
+            result = self._finalize_send_result(response, "send_slash_confirm failed")
+            if result.success:
+                self._slash_confirm_state[str(confirm_id)] = {
+                    "session_key": session_key,
+                    "message_id": result.message_id or "",
+                    "chat_id": chat_id,
+                    "title": title or "Confirm",
+                }
+            return result
+        except Exception as exc:
+            logger.warning("[Feishu] send_slash_confirm failed: %s", exc)
+            return SendResult(success=False, error=str(exc))
+
+    @staticmethod
     def _build_resolved_approval_card(*, choice: str, user_name: str) -> Dict[str, Any]:
         """Build raw card JSON for a resolved approval action."""
         icon = "❌" if choice == "deny" else "✅"
@@ -2015,6 +2085,26 @@ class FeishuAdapter(BasePlatformAdapter):
             },
             "elements": [
                 {"tag": "markdown", "content": f"Answered by **{user_name}**"},
+            ],
+        }
+
+    @staticmethod
+    def _build_resolved_slash_confirm_card(*, choice: str, user_name: str, title: str = "Confirm") -> Dict[str, Any]:
+        cancelled = choice == "cancel"
+        if choice == "always":
+            label = "Always approved"
+        elif cancelled:
+            label = "Cancelled"
+        else:
+            label = "Approved"
+        return {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"content": f"{'❌' if cancelled else '✅'} {label}", "tag": "plain_text"},
+                "template": "red" if cancelled else "green",
+            },
+            "elements": [
+                {"tag": "markdown", "content": f"**{title or 'Confirm'}**\n\n{label} by {user_name}"},
             ],
         }
 
@@ -2513,11 +2603,21 @@ class FeishuAdapter(BasePlatformAdapter):
             action_value.get("hermes_update_prompt_action")
             if isinstance(action_value, dict) else None
         )
+        slash_confirm_action = (
+            action_value.get("hermes_slash_confirm_action")
+            if isinstance(action_value, dict) else None
+        )
 
         if hermes_action:
             return self._handle_approval_card_action(event=event, action_value=action_value, loop=loop)
         if update_prompt_action:
             return self._handle_update_prompt_card_action(
+                event=event,
+                action_value=action_value,
+                loop=loop,
+            )
+        if slash_confirm_action:
+            return self._handle_slash_confirm_card_action(
                 event=event,
                 action_value=action_value,
                 loop=loop,
@@ -2617,6 +2717,46 @@ class FeishuAdapter(BasePlatformAdapter):
             response.card = card
         return response
 
+    def _handle_slash_confirm_card_action(self, *, event: Any, action_value: Dict[str, Any], loop: Any) -> Any:
+        """Schedule slash-confirm resolution and build the synchronous callback response."""
+        confirm_id = str(action_value.get("confirm_id") or "")
+        if not confirm_id:
+            logger.debug("[Feishu] Card action missing slash confirm_id, ignoring")
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+        state = self._slash_confirm_state.get(confirm_id)
+        if not state:
+            logger.debug("[Feishu] Slash confirm %s already resolved or unknown", confirm_id)
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        choice = str(action_value.get("hermes_slash_confirm_action", "") or "").strip().lower()
+        if choice not in {"once", "always", "cancel"}:
+            logger.debug("[Feishu] Card action has invalid slash-confirm choice=%r", choice)
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        operator = getattr(event, "operator", None)
+        open_id = str(getattr(operator, "open_id", "") or "")
+        if not self._is_interactive_operator_authorized(open_id):
+            logger.warning("[Feishu] Unauthorized slash-confirm click by %s", open_id or "<unknown>")
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        user_name = self._get_cached_sender_name(open_id) or open_id
+        if not self._submit_on_loop(loop, self._resolve_slash_confirm(confirm_id, choice, user_name)):
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        if P2CardActionTriggerResponse is None:
+            return None
+        response = P2CardActionTriggerResponse()
+        if CallBackCard is not None:
+            card = CallBackCard()
+            card.type = "raw"
+            card.data = self._build_resolved_slash_confirm_card(
+                choice=choice,
+                user_name=user_name,
+                title=str(state.get("title") or "Confirm"),
+            )
+            response.card = card
+        return response
+
     async def _resolve_approval(self, approval_id: Any, choice: str, user_name: str) -> None:
         """Pop approval state and unblock the waiting agent thread."""
         state = self._approval_state.pop(approval_id, None)
@@ -2647,6 +2787,27 @@ class FeishuAdapter(BasePlatformAdapter):
             )
         except Exception as exc:
             logger.error("Failed to resolve Feishu update prompt: %s", exc)
+
+    async def _resolve_slash_confirm(self, confirm_id: Any, choice: str, user_name: str) -> None:
+        """Pop slash-confirm state and resolve the generic gateway prompt."""
+        state = self._slash_confirm_state.pop(str(confirm_id), None)
+        if not state:
+            logger.debug("[Feishu] Slash confirm %s already resolved or unknown", confirm_id)
+            return
+        try:
+            from tools import slash_confirm as _slash_confirm_mod
+
+            result_text = await _slash_confirm_mod.resolve(
+                state["session_key"],
+                str(confirm_id),
+                choice,
+            )
+            logger.info(
+                "Feishu slash confirm resolved for session %s (choice=%s, user=%s, result=%s)",
+                state["session_key"], choice, user_name, result_text,
+            )
+        except Exception as exc:
+            logger.error("Failed to resolve Feishu slash confirm: %s", exc)
 
     async def _handle_reaction_event(self, event_type: str, data: Any) -> None:
         """Fetch the reacted-to message; if it was sent by this bot, emit a synthetic text event."""

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -304,6 +304,110 @@ class TestFeishuUpdatePrompt:
 
 
 # ===========================================================================
+# send_slash_confirm — generic slash confirmation card
+# ===========================================================================
+
+class TestFeishuSlashConfirm:
+    """Test send_slash_confirm sends an interactive card."""
+
+    @pytest.mark.asyncio
+    async def test_sends_interactive_card(self):
+        adapter = _make_adapter()
+
+        mock_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="msg_sc_001"),
+        )
+        with patch.object(
+            adapter, "_feishu_send_with_retry", new_callable=AsyncMock,
+            return_value=mock_response,
+        ) as mock_send:
+            result = await adapter.send_slash_confirm(
+                chat_id="oc_12345",
+                title="Reload MCP",
+                message="This will reload MCP tools.",
+                session_key="agent:main:feishu:group:oc_12345",
+                confirm_id="confirm-1",
+                metadata={"thread_id": "th_1"},
+            )
+
+        assert result.success is True
+        assert result.message_id == "msg_sc_001"
+
+        kwargs = mock_send.call_args[1]
+        assert kwargs["chat_id"] == "oc_12345"
+        assert kwargs["msg_type"] == "interactive"
+        assert kwargs["metadata"] == {"thread_id": "th_1"}
+
+        card = json.loads(kwargs["payload"])
+        assert card["header"]["template"] == "orange"
+        assert card["header"]["title"]["content"] == "Reload MCP"
+        assert "This will reload MCP tools." in card["elements"][0]["content"]
+        actions = card["elements"][1]["actions"]
+        assert [a["value"]["hermes_slash_confirm_action"] for a in actions] == [
+            "once",
+            "always",
+            "cancel",
+        ]
+        assert [a["value"]["confirm_id"] for a in actions] == ["confirm-1"] * 3
+
+    @pytest.mark.asyncio
+    async def test_stores_confirm_state(self):
+        adapter = _make_adapter()
+
+        mock_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="msg_sc_002"),
+        )
+        with patch.object(
+            adapter, "_feishu_send_with_retry", new_callable=AsyncMock,
+            return_value=mock_response,
+        ):
+            await adapter.send_slash_confirm(
+                chat_id="oc_12345",
+                title="Confirm",
+                message="Proceed?",
+                session_key="my-session-key",
+                confirm_id="confirm-2",
+            )
+
+        assert adapter._slash_confirm_state["confirm-2"]["session_key"] == "my-session-key"
+        assert adapter._slash_confirm_state["confirm-2"]["message_id"] == "msg_sc_002"
+        assert adapter._slash_confirm_state["confirm-2"]["chat_id"] == "oc_12345"
+
+    @pytest.mark.asyncio
+    async def test_not_connected(self):
+        adapter = _make_adapter()
+        adapter._client = None
+        result = await adapter.send_slash_confirm(
+            chat_id="oc_12345",
+            title="Confirm",
+            message="Proceed?",
+            session_key="s",
+            confirm_id="confirm-3",
+        )
+        assert result.success is False
+
+    @pytest.mark.asyncio
+    async def test_send_failure_returns_error(self):
+        adapter = _make_adapter()
+        with patch.object(
+            adapter, "_feishu_send_with_retry", new_callable=AsyncMock,
+            side_effect=TimeoutError("timed out"),
+        ):
+            result = await adapter.send_slash_confirm(
+                chat_id="oc_12345",
+                title="Confirm",
+                message="Proceed?",
+                session_key="s",
+                confirm_id="confirm-4",
+            )
+
+        assert result.success is False
+        assert "timed out" in (result.error or "")
+
+
+# ===========================================================================
 # _resolve_approval — approval state pop + gateway resolution
 # ===========================================================================
 
@@ -654,6 +758,94 @@ class TestCardActionCallbackResponse:
         assert response.card is None
         mock_submit.assert_not_called()
 
+    def test_returns_card_for_slash_confirm_once(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._slash_confirm_state["confirm-1"] = {
+            "session_key": "sess-sc-1",
+            "message_id": "msg_sc_003",
+            "chat_id": "oc_12345",
+            "title": "Reload MCP",
+        }
+        data = _make_card_action_data(
+            {"hermes_slash_confirm_action": "once", "confirm_id": "confirm-1"},
+            open_id="ou_bob",
+        )
+        adapter._sender_name_cache["ou_bob"] = ("Bob", 9999999999)
+
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is not None
+        card = response.card.data
+        assert card["header"]["template"] == "green"
+        assert "Approved" in card["header"]["title"]["content"]
+        assert "Reload MCP" in card["elements"][0]["content"]
+        assert "Bob" in card["elements"][0]["content"]
+
+    def test_slash_confirm_cancel_uses_red_card(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._slash_confirm_state["confirm-2"] = {
+            "session_key": "sess-sc-2",
+            "message_id": "msg_sc_004",
+            "chat_id": "oc_12345",
+            "title": "Reload MCP",
+        }
+        data = _make_card_action_data(
+            {"hermes_slash_confirm_action": "cancel", "confirm_id": "confirm-2"},
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is not None
+        card = response.card.data
+        assert card["header"]["template"] == "red"
+        assert "Cancelled" in card["header"]["title"]["content"]
+
+    def test_slash_confirm_unknown_id_returns_no_card(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        data = _make_card_action_data(
+            {"hermes_slash_confirm_action": "once", "confirm_id": "missing"},
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe") as mock_submit:
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is None
+        mock_submit.assert_not_called()
+
+    def test_slash_confirm_unauthorized_operator_returns_no_card(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._slash_confirm_state["confirm-3"] = {
+            "session_key": "sess-sc-3",
+            "message_id": "msg_sc_005",
+            "chat_id": "oc_12345",
+            "title": "Reload MCP",
+        }
+        adapter._allowed_group_users = {"ou_allowed"}
+        data = _make_card_action_data(
+            {"hermes_slash_confirm_action": "always", "confirm_id": "confirm-3"},
+            open_id="ou_intruder",
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe") as mock_submit:
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is None
+        mock_submit.assert_not_called()
+
 
 class TestResolveUpdatePrompt:
     """Test update prompt resolution persists the response file."""
@@ -700,3 +892,32 @@ class TestResolveUpdatePrompt:
         await adapter._resolve_update_prompt(99, "n", "Nobody")
 
         assert not (tmp_path / ".hermes" / ".update_response").exists()
+
+
+class TestResolveSlashConfirm:
+    """Test slash-confirm resolution calls the generic primitive."""
+
+    @pytest.mark.asyncio
+    async def test_resolves_once(self):
+        adapter = _make_adapter()
+        adapter._slash_confirm_state["confirm-1"] = {
+            "session_key": "sess-sc-1",
+            "message_id": "msg_sc_003",
+            "chat_id": "oc_12345",
+            "title": "Reload MCP",
+        }
+
+        with patch("tools.slash_confirm.resolve", new_callable=AsyncMock, return_value="done") as mock_resolve:
+            await adapter._resolve_slash_confirm("confirm-1", "once", "Alice")
+
+        mock_resolve.assert_awaited_once_with("sess-sc-1", "confirm-1", "once")
+        assert "confirm-1" not in adapter._slash_confirm_state
+
+    @pytest.mark.asyncio
+    async def test_unknown_confirm_id_drops_silently(self):
+        adapter = _make_adapter()
+
+        with patch("tools.slash_confirm.resolve", new_callable=AsyncMock) as mock_resolve:
+            await adapter._resolve_slash_confirm("missing", "cancel", "Nobody")
+
+        mock_resolve.assert_not_called()


### PR DESCRIPTION
## Summary
- add Feishu interactive cards for the generic gateway slash-confirm flow
- route Feishu card button clicks through `tools.slash_confirm.resolve()` for `once`, `always`, and `cancel` choices
- update the Feishu card in-place after a user responds and cover the new behavior with gateway tests

## Motivation
Feishu already supports interactive cards for command approvals and update prompts, while the generic slash-confirm primitive currently falls back to text replies on Feishu. This brings Feishu in line with the existing button-based confirmation UX available on other gateway platforms without changing the default fallback path.

## Tests
- `/Users/qindongliang/project/pycharm2/hermes-agent/.venv/bin/python -m pytest tests/gateway/test_feishu_approval_buttons.py -q`
- `/Users/qindongliang/project/pycharm2/hermes-agent/.venv/bin/python -m ruff check gateway/platforms/feishu.py tests/gateway/test_feishu_approval_buttons.py`
- `/Users/qindongliang/project/pycharm2/hermes-agent/.venv/bin/python -m py_compile gateway/platforms/feishu.py tests/gateway/test_feishu_approval_buttons.py`