### PR TITLE
fix(terminal): add docker_extra_args to all three config-to-env bridge maps (#28863)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -525,6 +525,7 @@ def load_cli_config() -> Dict[str, Any]:
         "docker_env": "TERMINAL_DOCKER_ENV",
         "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
         "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
+        "docker_extra_args": "TERMINAL_DOCKER_EXTRA_ARGS",
         "sandbox_dir": "TERMINAL_SANDBOX_DIR",
         # Persistent shell (non-local backends)
         "persistent_shell": "TERMINAL_PERSISTENT_SHELL",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -635,6 +635,7 @@ if _config_path.exists():
                 "docker_env": "TERMINAL_DOCKER_ENV",
                 "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
                 "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
+                "docker_extra_args": "TERMINAL_DOCKER_EXTRA_ARGS",
                 "sandbox_dir": "TERMINAL_SANDBOX_DIR",
                 "persistent_shell": "TERMINAL_PERSISTENT_SHELL",
             }

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5202,6 +5202,7 @@ def set_config_value(key: str, value: str):
         "terminal.vercel_runtime": "TERMINAL_VERCEL_RUNTIME",
         "terminal.docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
         "terminal.docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
+        "terminal.docker_extra_args": "TERMINAL_DOCKER_EXTRA_ARGS",
         "terminal.docker_env": "TERMINAL_DOCKER_ENV",
         # terminal.cwd intentionally excluded — CLI resolves at runtime,
         # gateway bridges it in gateway/run.py. Persisting to .env causes


### PR DESCRIPTION
## Summary

Add `docker_extra_args` to all three config→env bridge maps so `terminal.docker_extra_args` from config.yaml actually reaches the terminal tool.

Fixes #28863

## Problem

`terminal.docker_extra_args` in config.yaml is silently dropped. The terminal tool reads `TERMINAL_DOCKER_EXTRA_ARGS` (terminal_tool.py L1093), but none of the three bridge paths populated it:

1. **gateway/run.py** `_terminal_env_map` — gateway/messaging platform startup
2. **cli.py** `env_mappings` — CLI/TUI startup  
3. **hermes_cli/config.py** `_config_to_env_sync` — `hermes config set` one-shot

This is the same class of bug as `docker_run_as_host_user` and `docker_mount_cwd_to_workspace` before it — a new config key added to the terminal defaults (config.py L654) without updating all bridge maps.

## Fix

Add `"docker_extra_args": "TERMINAL_DOCKER_EXTRA_ARGS"` to all three dicts. Three files, one line each.

## Testing

- **Existing sync test** (`test_terminal_config_env_sync.py::test_cli_and_gateway_env_maps_agree`) now passes (was failing before this fix)
- **29 terminal config tests** all pass, 0 failures
