### PR TITLE
fix(gateway): bridge terminal.docker_extra_args and docker_forward_env to env

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -507,6 +507,7 @@ def load_cli_config() -> Dict[str, Any]:
         "lifetime_seconds": "TERMINAL_LIFETIME_SECONDS",
         "docker_image": "TERMINAL_DOCKER_IMAGE",
         "docker_forward_env": "TERMINAL_DOCKER_FORWARD_ENV",
+        "docker_extra_args": "TERMINAL_DOCKER_EXTRA_ARGS",
         "singularity_image": "TERMINAL_SINGULARITY_IMAGE",
         "modal_image": "TERMINAL_MODAL_IMAGE",
         "daytona_image": "TERMINAL_DAYTONA_IMAGE",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -619,6 +619,7 @@ if _config_path.exists():
                 "lifetime_seconds": "TERMINAL_LIFETIME_SECONDS",
                 "docker_image": "TERMINAL_DOCKER_IMAGE",
                 "docker_forward_env": "TERMINAL_DOCKER_FORWARD_ENV",
+                "docker_extra_args": "TERMINAL_DOCKER_EXTRA_ARGS",
                 "singularity_image": "TERMINAL_SINGULARITY_IMAGE",
                 "modal_image": "TERMINAL_MODAL_IMAGE",
                 "daytona_image": "TERMINAL_DAYTONA_IMAGE",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5203,6 +5203,8 @@ def set_config_value(key: str, value: str):
         "terminal.docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
         "terminal.docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
         "terminal.docker_env": "TERMINAL_DOCKER_ENV",
+        "terminal.docker_extra_args": "TERMINAL_DOCKER_EXTRA_ARGS",
+        "terminal.docker_forward_env": "TERMINAL_DOCKER_FORWARD_ENV",
         # terminal.cwd intentionally excluded — CLI resolves at runtime,
         # gateway bridges it in gateway/run.py. Persisting to .env causes
         # stale values to poison child processes.

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -132,6 +132,20 @@ class TestConfigYamlRouting:
         assert "vercel_runtime: python3.13" in config
         assert "TERMINAL_VERCEL_RUNTIME=python3.13" in env_content
 
+    def test_terminal_docker_extra_args_goes_to_config_and_env(self, _isolated_hermes_home):
+        set_config_value("terminal.docker_extra_args", '["--read-only", "--tmpfs", "/root:rw,exec,size=1g,mode=1777"]')
+        config = _read_config(_isolated_hermes_home)
+        env_content = _read_env(_isolated_hermes_home)
+        assert "docker_extra_args:" in config
+        assert 'TERMINAL_DOCKER_EXTRA_ARGS=["--read-only", "--tmpfs", "/root:rw,exec,size=1g,mode=1777"]' in env_content
+
+    def test_terminal_docker_forward_env_goes_to_config_and_env(self, _isolated_hermes_home):
+        set_config_value("terminal.docker_forward_env", '["GITHUB_TOKEN", "NPM_TOKEN"]')
+        config = _read_config(_isolated_hermes_home)
+        env_content = _read_env(_isolated_hermes_home)
+        assert "docker_forward_env:" in config
+        assert 'TERMINAL_DOCKER_FORWARD_ENV=["GITHUB_TOKEN", "NPM_TOKEN"]' in env_content
+
 
 # ---------------------------------------------------------------------------
 # Empty / falsy values — regression tests for #4277

--- a/tests/tools/test_terminal_config_env_sync.py
+++ b/tests/tools/test_terminal_config_env_sync.py
@@ -24,7 +24,13 @@ mirrors the pattern used in tests/hermes_cli/test_config_drift.py.
 """
 
 import ast
+import importlib
 import inspect
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
 
 
 def _extract_dict_values(source: str, dict_name: str) -> set[str]:
@@ -224,3 +230,88 @@ def test_docker_env_is_bridged_everywhere():
     assert "docker_env" in _gateway_env_map_keys()
     assert "docker_env" in _save_config_env_sync_keys()
     assert "TERMINAL_DOCKER_ENV" in _terminal_tool_env_var_names()
+
+
+def test_docker_extra_args_is_bridged_everywhere():
+    """Regression pin for docker_extra_args being silently ignored.
+
+    ``terminal.docker_extra_args`` lets operators pass extra flags (e.g.
+    ``--read-only``, ``--security-opt``) to ``docker run``.  It was present
+    in terminal_tool._get_env_config but missing from all three bridge
+    maps, so config.yaml values were dropped before reaching the tool.
+    """
+    assert "docker_extra_args" in _cli_env_map_keys()
+    assert "docker_extra_args" in _gateway_env_map_keys()
+    assert "docker_extra_args" in _save_config_env_sync_keys()
+    assert "TERMINAL_DOCKER_EXTRA_ARGS" in _terminal_tool_env_var_names()
+
+
+def test_docker_forward_env_is_bridged_everywhere():
+    """Regression pin for docker_forward_env being silently ignored.
+
+    ``terminal.docker_forward_env`` controls which host env vars are
+    forwarded into the Docker container.  Like docker_extra_args, it
+    was read by terminal_tool but missing from the _config_to_env_sync
+    bridge, so ``hermes config set`` could not update it.
+    """
+    assert "docker_forward_env" in _cli_env_map_keys()
+    assert "docker_forward_env" in _gateway_env_map_keys()
+    assert "docker_forward_env" in _save_config_env_sync_keys()
+    assert "TERMINAL_DOCKER_FORWARD_ENV" in _terminal_tool_env_var_names()
+
+
+# ---------------------------------------------------------------------------
+# Gateway bridge behaviour — list-valued keys must be JSON-encoded
+# ---------------------------------------------------------------------------
+
+class TestGatewayBridge:
+    """gateway/run.py bridges config.yaml → env vars at module load time."""
+
+    def test_docker_extra_args_yaml_to_env_bridge(self, tmp_path, monkeypatch):
+        """terminal.docker_extra_args (list) is JSON-encoded into the env."""
+        extra_args = ["--read-only", "--tmpfs", "/root:rw,exec,size=1g,mode=1777"]
+        hermes_home = tmp_path / "hermes_test_bridge"
+        hermes_home.mkdir(exist_ok=True)
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            f"terminal:\n  docker_extra_args: {json.dumps(extra_args)}\n"
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("TERMINAL_DOCKER_EXTRA_ARGS", raising=False)
+        monkeypatch.delenv("TERMINAL_DOCKER_FORWARD_ENV", raising=False)
+
+        # Force re-import so module-level bridge runs against our temp config.
+        for mod_name in list(sys.modules):
+            if mod_name.startswith("gateway.run"):
+                del sys.modules[mod_name]
+
+        import gateway.run as _gr  # noqa: F401
+
+        env_val = os.environ.get("TERMINAL_DOCKER_EXTRA_ARGS")
+        assert env_val is not None
+        assert json.loads(env_val) == extra_args
+
+    def test_docker_forward_env_yaml_to_env_bridge(self, tmp_path, monkeypatch):
+        """terminal.docker_forward_env (list) is JSON-encoded into the env."""
+        forward_env = ["GITHUB_TOKEN", "NPM_TOKEN"]
+        hermes_home = tmp_path / "hermes_test_bridge"
+        hermes_home.mkdir(exist_ok=True)
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            f"terminal:\n  docker_forward_env: {json.dumps(forward_env)}\n"
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("TERMINAL_DOCKER_EXTRA_ARGS", raising=False)
+        monkeypatch.delenv("TERMINAL_DOCKER_FORWARD_ENV", raising=False)
+
+        for mod_name in list(sys.modules):
+            if mod_name.startswith("gateway.run"):
+                del sys.modules[mod_name]
+
+        import gateway.run as _gr  # noqa: F401
+
+        env_val = os.environ.get("TERMINAL_DOCKER_FORWARD_ENV")
+        assert env_val is not None
+        assert json.loads(env_val) == forward_env


### PR DESCRIPTION
gateway/run.py's _terminal_env_map omitted docker_extra_args and docker_forward_env, so values set via hermes config set or written directly to config.yaml were silently dropped before terminal_tool could read the corresponding env vars. The documented Docker hardening path (--read-only, --security-opt, custom --tmpfs) was non-functional on the YAML path; operators had to bypass it by exporting env vars in .env directly.

This adds both keys to the bridge dict and to _config_to_env_sync in hermes_cli/config.py so config set writes them correctly too.

Fixes #28863