### PR TITLE
fix(api_server): soften markdown-blocking prompt to allow user override (#28876)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -579,10 +579,14 @@ PLATFORM_HINTS = {
         "— when a sticker is the right response, use yb_send_sticker."
     ),
     "api_server": (
-        "You're responding through an API server. The rendering layer is unknown — "
-        "assume plain text. No markdown formatting (no asterisks, bullets, headers, "
-        "code fences). Treat this like a conversation, not a document. Keep responses "
-        "brief and natural."
+        "You're responding through an API server. The default rendering "
+        "layer is unknown — assume plain text unless the user's system "
+        "prompt explicitly requests rich formatting (markdown, LaTeX, etc.). "
+        "When plain text is appropriate, avoid markdown formatting (no "
+        "asterisks, bullets, headers, code fences). Treat this like a "
+        "conversation, not a document. Keep responses brief and natural. "
+        "If the user's system prompt specifies a rendering preference "
+        "(e.g. markdown, HTML), follow that preference instead."
     ),
     "webui": (
         "You are in the Hermes WebUI, a browser-based chat interface. "


### PR DESCRIPTION
## Summary

Soften the `api_server` platform hint to allow markdown when the user's system prompt explicitly requests it.

Fixes #28876

## Problem

The `api_server` platform hint in `PLATFORM_HINTS` unconditionally instructs the model to avoid all markdown formatting:

> *"assume plain text. No markdown formatting (no asterisks, bullets, headers, code fences)"*

This cannot be overridden by user system prompts because platform hints are injected as stable parts of the system prompt. Users connecting via API with markdown-capable clients (e.g. third-party web UIs) cannot get formatted responses.

## Fix

Changed the prompt to default to plain text but explicitly allow override:

> *"assume plain text unless the user's system prompt explicitly requests rich formatting (markdown, LaTeX, etc.)"*
>
> *"If the user's system prompt specifies a rendering preference (e.g. markdown, HTML), follow that preference instead."*

This preserves the safe default (plain text for unknown rendering layers) while giving users control.

## Testing

- **124 prompt_builder tests** passed, 0 failures
- Existing `test_platform_hints_known_platforms` verifies `api_server` key presence
