### PR TITLE
chore: add cypres0099 to AUTHOR_MAP

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -67,6 +67,7 @@ AUTHOR_MAP = {
     "raysun12142006@gmail.com": "yanxue06",
     "alberto.regalado@ymail.com": "ARegalado1",
     "alchemistchaos@protonmail.com": "AlchemistChaos",  # co-author only
+    "cypres0099@users.noreply.github.com": "cypres0099",
     "gilad@smiti.ai": "giladbau",
     "yusufalweshdemir@gmail.com": "Dusk1e",
     "804436395@qq.com": "LaPhilosophie",


### PR DESCRIPTION
## What does this PR do?

Adds `cypres0099@users.noreply.github.com` → `cypres0099` to `scripts/release.py:AUTHOR_MAP`.

Unblocks `check-attribution` for #28885 (slack clarify buttons). Filed as a separate one-line PR per the pattern in `CONTRIBUTING.md`.

## Related Issue

N/A — attribution-only mapping addition.

## Type of Change

- [x] 🛠️ Chore

## Changes Made

- `scripts/release.py`: one entry added to `AUTHOR_MAP`

## How to Test

`check-attribution` CI on the parent feature PR (#28885) should pass once this merges.

## Checklist

- [x] I've read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Searched existing PRs for duplicates (`chore: add … to AUTHOR_MAP` precedent)
- [x] PR contains only this one-line mapping
- [x] No docs/code changes outside `scripts/release.py`