### PR TITLE
fix(local): remove duplicate creationflags in _run_bash() on Windows

### DIFF
--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -532,7 +532,6 @@ class LocalEnvironment(BaseEnvironment):
             stderr=subprocess.STDOUT,
             stdin=subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
             preexec_fn=None if _IS_WINDOWS else os.setsid,
-            creationflags=subprocess.CREATE_NO_WINDOW if _IS_WINDOWS else 0,
             cwd=_popen_cwd,
             **_popen_kwargs,
         )


### PR DESCRIPTION
## What does this PR do?

Root cause: `#28874` added `_popen_kwargs = {"creationflags": windows_hide_flags()} if _IS_WINDOWS else {}` and `**_popen_kwargs` to the `subprocess.Popen` call in `LocalEnvironment._run_bash()`, but did not remove the pre-existing explicit argument:

```python
creationflags=subprocess.CREATE_NO_WINDOW if _IS_WINDOWS else 0,
```

On Windows, Python raises `TypeError: Popen.__init__() got multiple values for keyword argument 'creationflags'` on every shell command execution — `_run_bash()` is completely broken.

Fix: remove the stale explicit `creationflags=` argument so `**_popen_kwargs` is the sole source of `creationflags`, matching the pattern already applied correctly in `tools/process_registry.py` (line 566) by the same PR.

## Related Issue

Regression introduced in #28874.

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `tools/environments/local.py`: remove duplicate `creationflags=subprocess.CREATE_NO_WINDOW if _IS_WINDOWS else 0` keyword argument from `subprocess.Popen` call in `_run_bash()` (-1 line)

## How to Test

```
python3.11 -m pytest tests/tools/test_local_env_windows_msys.py tests/tools/test_local_env_blocklist.py -v --override-ini="addopts="
```

## Checklist

- [x] Contributing Guide read | Conventional Commits | No duplicate PR
- [x] Single fix only | Platform: macOS
- [x] Docs — N/A | Cross-platform — Windows crash fix