### PR TITLE
fix(delegate): tolerate non-string tool message content (#28639)

### DIFF
--- a/tests/test_delegate_tool_trace.py
+++ b/tests/test_delegate_tool_trace.py
@@ -1,0 +1,132 @@
+"""Regression tests for delegate_tool tool-trace helpers.
+
+Covers _looks_like_error_output and the tool-trace assembly path that
+consumes it, including the fix for #28639 where non-string tool message
+content (list/dict) caused AttributeError.
+"""
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Import the helper under test
+# ---------------------------------------------------------------------------
+from tools.delegate_tool import _looks_like_error_output
+
+
+# ===========================================================================
+# _looks_like_error_output — basic behaviour
+# ===========================================================================
+
+class TestLooksLikeErrorOutput:
+    """Unit tests for _looks_like_error_output."""
+
+    # -- falsy / empty cases --------------------------------------------------
+
+    @pytest.mark.parametrize("value", ["", None, False])
+    def test_falsy_returns_false(self, value):
+        assert _looks_like_error_output(value) is False
+
+    # -- plain string inputs --------------------------------------------------
+
+    def test_normal_text(self):
+        assert _looks_like_error_output("hello world") is False
+
+    def test_error_colon_prefix(self):
+        assert _looks_like_error_output("Error: something went wrong") is True
+
+    def test_failed_colon_prefix(self):
+        assert _looks_like_error_output("Failed: could not connect") is True
+
+    def test_traceback_prefix(self):
+        assert _looks_like_error_output("Traceback (most recent call last):") is True
+
+    def test_exception_prefix(self):
+        assert _looks_like_error_output("Exception: bad value") is True
+
+    # -- JSON payloads --------------------------------------------------------
+
+    def test_json_with_error_key(self):
+        assert _looks_like_error_output('{"error": "timeout"}') is True
+
+    def test_json_with_status_error(self):
+        assert _looks_like_error_output('{"status": "error"}') is True
+
+    def test_json_with_status_failed(self):
+        assert _looks_like_error_output('{"status": "failed"}') is True
+
+    def test_json_normal(self):
+        assert _looks_like_error_output('{"result": "ok"}') is False
+
+    # ===========================================================================
+    # Regression: non-string content (#28639)
+    # ===========================================================================
+
+    def test_list_content_does_not_crash(self):
+        """list content should be coerced to str, not raise AttributeError."""
+        result = _looks_like_error_output([{"type": "text", "text": "hello"}])
+        assert isinstance(result, bool)
+
+    def test_list_content_with_error(self):
+        """str(list-of-dicts) starts with '[' → JSON parse path, but str()
+        repr isn't valid JSON so it falls through to the prefix check.
+        The first line is "[{'type': 'text', ...}]" which doesn't start
+        with an error prefix, so the result is False — but it must not crash."""
+        result = _looks_like_error_output([{"type": "text", "text": "Error: crash"}])
+        assert isinstance(result, bool)
+        # str() of a list-of-dicts produces Python repr, not JSON,
+        # so the error keyword is buried inside brackets and not detected.
+        assert result is False
+
+    def test_dict_content_does_not_crash(self):
+        result = _looks_like_error_output({"key": "value"})
+        assert isinstance(result, bool)
+
+    def test_number_content_does_not_crash(self):
+        result = _looks_like_error_output(42)
+        assert isinstance(result, bool)
+
+    def test_nested_list_content(self):
+        result = _looks_like_error_output([[1, 2], [3, 4]])
+        assert isinstance(result, bool)
+
+
+# ===========================================================================
+# Integration: tool-trace assembly with non-string content
+# ===========================================================================
+
+class TestToolTraceAssembly:
+    """Verify that the _run_single_child tool-trace builder tolerates
+    non-string tool message content (the exact crash path from #28639).
+
+    We simulate the relevant code path by importing the function and
+    feeding it messages with mixed content types.
+    """
+
+    def test_trace_with_list_content_messages(self):
+        """Messages with list content should not crash tool-trace assembly."""
+        # We can't easily call _run_single_child without a full agent mock,
+        # but we can verify the helper path directly.
+        messages = [
+            {"role": "assistant", "tool_calls": [
+                {"id": "tc_1", "function": {"name": "terminal", "arguments": "{}"}},
+            ]},
+            {"role": "tool", "tool_call_id": "tc_1", "content": [
+                {"type": "text", "text": "file not found"},
+            ]},
+        ]
+
+        # Simulate what the trace builder does at line ~1656-1660
+        for msg in messages:
+            if msg.get("role") == "tool":
+                content = msg.get("content", "")
+                # This was the crash line — must not raise
+                if not isinstance(content, str):
+                    content = str(content)
+                is_error = _looks_like_error_output(content)
+                result_meta = {
+                    "result_bytes": len(content),
+                    "status": "error" if is_error else "ok",
+                }
+                assert "status" in result_meta
+                assert isinstance(result_meta["result_bytes"], int)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -274,7 +274,7 @@ def _extract_output_tail(
     return tail
 
 
-def _looks_like_error_output(content: str) -> bool:
+def _looks_like_error_output(content) -> bool:
     """Conservative stderr/error detector for tool-result previews.
 
     The old heuristic flagged any preview containing the substring "error",
@@ -286,6 +286,9 @@ def _looks_like_error_output(content: str) -> bool:
     """
     if not content:
         return False
+
+    if not isinstance(content, str):
+        content = str(content)
 
     head = content.lstrip()
     if head.startswith("{") or head.startswith("["):
@@ -1654,6 +1657,8 @@ def _run_single_child(
                             trace_by_id[tc_id] = entry_t
                 elif msg.get("role") == "tool":
                     content = msg.get("content", "")
+                    if not isinstance(content, str):
+                        content = str(content)
                     is_error = _looks_like_error_output(content)
                     result_meta = {
                         "result_bytes": len(content),


### PR DESCRIPTION
## Summary

Fixes #28639

When tool responses contain list or dict content (e.g. from browser or file tools), `_looks_like_error_output` in `tools/delegate_tool.py` crashed with `AttributeError` because it assumed all content is a string.

## Changes

**`tools/delegate_tool.py`** (+6 -1):
- Remove `str` type annotation from `_looks_like_error_output` parameter to accept any type
- Add `isinstance` guard in `_looks_like_error_output`: coerce non-string content via `str()` before inspecting
- Add `isinstance` guard in `_run_with_thread_capture` tool-trace assembly: coerce non-string tool message content before passing to `_looks_like_error_output`

**`tests/test_delegate_tool_trace.py`** (new, 132 lines):
- Unit tests for `_looks_like_error_output` with string, list, dict, number, and nested content
- Regression tests specifically for the #28639 crash path
- Integration test simulating the tool-trace assembly path with list-content messages

## Testing

- All new tests pass
- Fail-without-fix verified: reverting the production change while keeping the test file causes test failures on the regression tests
- No regressions in existing test suite

## Verification

```
$ python3 -m pytest tests/test_delegate_tool_trace.py -v -o "addopts="
# All 18 tests pass
```
