### PR TITLE
feat(clarify): raise MAX_CHOICES from 4 to 10

### DIFF
--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -758,9 +758,12 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
         # Mirror Telegram: render full choice text in body so long
         # options aren't truncated to the 20-char button label cap.
-        # Truncate choices to MAX_CHOICES (4) — the tool layer enforces
-        # this already, but be defensive.
-        choices_list = [str(c).strip() for c in choices[:10] if str(c).strip()]
+        # WhatsApp list messages allow 10 rows total. Reserve one row for
+        # the "Other" escape hatch so max-size clarify prompts still fit.
+        choices_limit = 10 if len(choices) <= 3 else 9
+        choices_list = [
+            str(c).strip() for c in choices[:choices_limit] if str(c).strip()
+        ]
         option_lines = "\n".join(
             f"{i + 1}. {c}" for i, c in enumerate(choices_list)
         )

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -1665,6 +1665,33 @@ class TestSendClarifyButtons:
         assert "Other" in rows[4]["title"]
 
     @pytest.mark.asyncio
+    async def test_ten_choices_list_mode_reserves_row_for_other(self):
+        """WhatsApp list messages cap at 10 rows including Other."""
+        adapter = _make_adapter()
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(200, {"messages": [{"id": "wamid.q10"}]})
+        )
+
+        result = await adapter.send_clarify(
+            chat_id="15551234567",
+            question="Pick one",
+            choices=[f"Choice {i}" for i in range(1, 11)],
+            clarify_id="q10",
+            session_key="sess-10",
+        )
+
+        assert result.success
+        payload = adapter._http_client.post.call_args.kwargs["json"]
+        assert payload["interactive"]["type"] == "list"
+        rows = payload["interactive"]["action"]["sections"][0]["rows"]
+        assert len(rows) == 10
+        assert rows[0]["id"] == "cl:q10:0"
+        assert rows[8]["id"] == "cl:q10:8"
+        assert rows[9]["id"] == "cl:q10:other"
+        assert "Other" in rows[9]["title"]
+
+    @pytest.mark.asyncio
     async def test_open_ended_falls_back_to_plain_text(self):
         """No choices → plain text send, no interactive payload."""
         adapter = _make_adapter()

--- a/tests/tools/test_clarify_tool.py
+++ b/tests/tools/test_clarify_tool.py
@@ -73,7 +73,7 @@ class TestClarifyToolChoicesValidation:
             choices_passed.extend(choices or [])
             return "picked"
 
-        many_choices = ["a", "b", "c", "d", "e", "f", "g"]
+        many_choices = [f"opt{i}" for i in range(MAX_CHOICES + 3)]
         clarify_tool("Pick one", choices=many_choices, callback=mock_callback)
 
         assert len(choices_passed) == MAX_CHOICES
@@ -254,6 +254,6 @@ class TestClarifySchema:
         choices_spec = CLARIFY_SCHEMA["parameters"]["properties"]["choices"]
         assert choices_spec.get("maxItems") == MAX_CHOICES
 
-    def test_max_choices_is_four(self):
-        """MAX_CHOICES constant should be 4."""
-        assert MAX_CHOICES == 4
+    def test_supports_ten_predefined_choices(self):
+        """Real-world choice sets can expose at least ten options."""
+        assert MAX_CHOICES >= 10

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -16,8 +16,9 @@ from typing import List, Optional, Callable
 
 
 # Maximum number of predefined choices the agent can offer.
-# A 5th "Other (type your answer)" option is always appended by the UI.
-MAX_CHOICES = 4
+# An "Other (type your answer)" option is always appended by the UI, so
+# the user sees at most MAX_CHOICES + 1 actionable buttons.
+MAX_CHOICES = 10
 
 
 def _flatten_choice(c) -> str:
@@ -127,8 +128,8 @@ CLARIFY_SCHEMA = {
     "description": (
         "Ask the user a question when you need clarification, feedback, or a "
         "decision before proceeding. Supports two modes:\n\n"
-        "1. **Multiple choice** — provide up to 4 choices. The user picks one "
-        "or types their own answer via a 5th 'Other' option.\n"
+        "1. **Multiple choice** — provide up to 10 choices. The user picks one "
+        "or types their own answer via the appended 'Other' option.\n"
         "2. **Open-ended** — omit choices entirely. The user types a free-form "
         "response.\n\n"
         "CRITICAL: when you are offering options, put each option ONLY in the "
@@ -163,7 +164,7 @@ CLARIFY_SCHEMA = {
                 "maxItems": MAX_CHOICES,
                 "description": (
                     "REQUIRED whenever you are presenting selectable options: "
-                    "each distinct option is its own array element (up to 4). "
+                    "each distinct option is its own array element (up to 10). "
                     "The UI renders these as pickable rows and auto-appends an "
                     "'Other (type your answer)' option. Omit this parameter "
                     "entirely ONLY for a genuinely open-ended free-text question."


### PR DESCRIPTION
## What does this PR do?

Raises the `clarify` tool's global predefined-choice limit from 4 to 10 while keeping platform payloads valid. This supports realistic framework, store, preset, and configuration pickers without forcing valid options into free-text entry.

The automated maintainer sweep identified WhatsApp Cloud's native 10-row list limit: ten predefined choices plus `Other` would produce eleven rows. This PR now reserves one row for the required free-text path, rendering nine predefined rows plus `Other` on WhatsApp while other adapters can use all ten choices.

## Related Issue

N/A — this limit was found through skill-authoring use; no separate upstream issue is open.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/clarify_tool.py`
  - Raises `MAX_CHOICES` from 4 to 10.
  - Updates the tool and parameter descriptions to match the new limit.
- `gateway/platforms/whatsapp_cloud.py`
  - Caps native clarify list rows at nine predefined choices plus `Other`.
- `tests/tools/test_clarify_tool.py`
  - Updates the constant and trimming regressions for the new limit.
- `tests/gateway/test_whatsapp_cloud.py`
  - Adds the requested 10-choice payload regression asserting nine predefined rows plus `Other`.

## How to Test

1. Run `HOME=/tmp/hermes-ci-home scripts/run_tests.sh -j 1 tests/gateway/test_whatsapp_cloud.py tests/tools/test_clarify_tool.py`.
2. Confirm all 141 tests pass.
3. Send a 10-choice clarify through WhatsApp Cloud and verify the native list contains nine predefined rows plus `Other`, without exceeding ten rows.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, Python 3.11

The canonical full suite was run on the same current upstream base via the #30592 control branch. Its failures/timeouts were outside these four changed files and matched current-main macOS/environment-sensitive areas. The complete affected test files pass 141/141.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
WhatsApp Cloud + clarify tool: 141 passed, 0 failed
ruff check .: passed
git diff --check upstream/main...HEAD: passed
check-windows-footguns.py --diff upstream/main: passed (4 files scanned)
```
