### PR TITLE
Fix: long cron messages silently lost when split across multiple Discord sends

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -585,12 +585,14 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         # rooms (e.g. Matrix) where the standalone HTTP path cannot encrypt.
         runtime_adapter = (adapters or {}).get(platform)
         delivered = False
+        adapter_partial_failure = False
         if runtime_adapter is not None and loop is not None and getattr(loop, "is_running", lambda: False)():
             send_metadata = {"thread_id": thread_id} if thread_id else None
             try:
                 # Send cleaned text (MEDIA tags stripped) — not the raw content
                 text_to_send = cleaned_delivery_content.strip()
                 adapter_ok = True
+                total_parts = 1
                 if text_to_send:
                     from agent.async_utils import safe_schedule_threadsafe
                     future = safe_schedule_threadsafe(
@@ -605,13 +607,39 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                         except TimeoutError:
                             future.cancel()
                             raise
-                        if send_result and not getattr(send_result, "success", True):
-                            err = getattr(send_result, "error", "unknown")
-                            logger.warning(
-                                "Job '%s': live adapter send to %s:%s failed (%s), falling back to standalone",
-                                job["id"], platform_name, chat_id, err,
-                            )
-                            adapter_ok = False  # fall through to standalone path
+
+                        raw_response = getattr(send_result, "raw_response", None) if send_result else None
+                        if not isinstance(raw_response, dict):
+                            raw_response = {}
+                        message_ids = raw_response.get("message_ids") or []
+                        total_parts = raw_response.get("total_parts")
+                        if total_parts is None:
+                            total_parts = len(message_ids) if message_ids else 1
+                        succeeded_parts = raw_response.get("succeeded_parts")
+                        if succeeded_parts is None:
+                            succeeded_parts = len(message_ids) if message_ids else (1 if getattr(send_result, "success", True) else 0)
+                        warnings = raw_response.get("warnings") or []
+
+                        send_success = bool(getattr(send_result, "success", True)) if send_result else True
+                        if send_result and (not send_success or warnings):
+                            err = getattr(send_result, "error", None) or "; ".join(str(w) for w in warnings) or "unknown"
+                            if total_parts > 1 and 0 < succeeded_parts < total_parts:
+                                msg = (
+                                    f"PARTIAL delivery to {platform_name}:{chat_id} "
+                                    f"({succeeded_parts}/{total_parts} parts succeeded): {err}"
+                                )
+                                logger.warning(
+                                    "Job '%s': %s; not retrying standalone to avoid duplicate parts",
+                                    job["id"], msg,
+                                )
+                                delivery_errors.append(msg)
+                                adapter_partial_failure = True
+                            else:
+                                logger.warning(
+                                    "Job '%s': live adapter send to %s:%s failed (%s), falling back to standalone",
+                                    job["id"], platform_name, chat_id, err,
+                                )
+                            adapter_ok = False  # fall through to standalone path unless partial
 
                 # Send extracted media files as native attachments via the live adapter
                 if adapter_ok and media_files:
@@ -626,13 +654,22 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     )
 
                 if adapter_ok:
-                    logger.info("Job '%s': delivered to %s:%s via live adapter", job["id"], platform_name, chat_id)
+                    if text_to_send and total_parts > 1:
+                        logger.info(
+                            "Job '%s': delivered all %s parts to %s:%s via live adapter",
+                            job["id"], total_parts, platform_name, chat_id,
+                        )
+                    else:
+                        logger.info("Job '%s': delivered to %s:%s via live adapter", job["id"], platform_name, chat_id)
                     delivered = True
             except Exception as e:
                 logger.warning(
                     "Job '%s': live adapter delivery to %s:%s failed (%s), falling back to standalone",
                     job["id"], platform_name, chat_id, e,
                 )
+
+        if adapter_partial_failure:
+            continue
 
         if not delivered:
             # Standalone path: run the async send in a fresh event loop (safe from any thread)

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1415,6 +1415,7 @@ class DiscordAdapter(BasePlatformAdapter):
             chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
 
             message_ids = []
+            warnings: list[str] = []
             reference = None
 
             if reply_to and self._reply_to_mode != "off":
@@ -1455,12 +1456,21 @@ class DiscordAdapter(BasePlatformAdapter):
                             reply_to,
                         )
                         reference = None
-                        msg = await channel.send(
-                            content=chunk,
-                            reference=None,
-                        )
+                        try:
+                            msg = await channel.send(
+                                content=chunk,
+                                reference=None,
+                            )
+                        except Exception as retry_exc:
+                            warning = f"Failed to send Discord chunk {i + 1}/{len(chunks)} after retry without reply reference: {retry_exc}"
+                            logger.warning("[%s] %s", self.name, warning)
+                            warnings.append(warning)
+                            continue
                     else:
-                        raise
+                        warning = f"Failed to send Discord chunk {i + 1}/{len(chunks)}: {e}"
+                        logger.warning("[%s] %s", self.name, warning)
+                        warnings.append(warning)
+                        continue
                 message_ids.append(str(msg.id))
 
             # Track the last message we sent in this channel for history
@@ -1469,10 +1479,26 @@ class DiscordAdapter(BasePlatformAdapter):
                 _target_id = thread_id or chat_id
                 self._last_self_message_id[_target_id] = message_ids[-1]
 
+            total_parts = len(chunks)
+            succeeded_parts = len(message_ids)
+            failed_parts = max(0, total_parts - succeeded_parts)
+            raw_response: Dict[str, Any] = {
+                "message_ids": message_ids,
+                "total_parts": total_parts,
+                "succeeded_parts": succeeded_parts,
+                "failed_parts": failed_parts,
+            }
+            if warnings:
+                raw_response["warnings"] = warnings
+            error = None
+            if failed_parts:
+                error = f"PARTIAL delivery ({succeeded_parts}/{total_parts} parts succeeded): {'; '.join(warnings) or 'unknown error'}"
+
             return SendResult(
-                success=True,
+                success=failed_parts == 0,
                 message_id=message_ids[0] if message_ids else None,
-                raw_response={"message_ids": message_ids}
+                error=error,
+                raw_response=raw_response,
             )
 
         except Exception as e:  # pragma: no cover - defensive logging
@@ -1524,13 +1550,26 @@ class DiscordAdapter(BasePlatformAdapter):
                 logger.warning("[%s] %s", self.name, warning)
                 warnings.append(warning)
 
-        raw_response: Dict[str, Any] = {"message_ids": message_ids, "thread_id": thread_id}
+        total_parts = len(chunks)
+        succeeded_parts = len(message_ids)
+        failed_parts = max(0, total_parts - succeeded_parts)
+        raw_response: Dict[str, Any] = {
+            "message_ids": message_ids,
+            "thread_id": thread_id,
+            "total_parts": total_parts,
+            "succeeded_parts": succeeded_parts,
+            "failed_parts": failed_parts,
+        }
         if warnings:
             raw_response["warnings"] = warnings
+        error = None
+        if failed_parts:
+            error = f"PARTIAL forum delivery ({succeeded_parts}/{total_parts} parts succeeded): {'; '.join(warnings)}"
 
         return SendResult(
-            success=True,
+            success=failed_parts == 0,
             message_id=message_ids[0],
+            error=error,
             raw_response=raw_response,
         )
 

--- a/tests/cron/test_discord_multipart_delivery.py
+++ b/tests/cron/test_discord_multipart_delivery.py
@@ -1,0 +1,107 @@
+"""Proposed pytest coverage for Discord multipart cron delivery.
+
+These tests target the API-compatible behavior proposed in
+/tmp/cron-multipart-bug-fix.patch. They intentionally use small fakes instead
+of a live Discord connection.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+HERMES_ROOT = Path("/usr/local/lib/hermes-agent")
+if str(HERMES_ROOT) not in sys.path:
+    sys.path.insert(0, str(HERMES_ROOT))
+
+from gateway.config import PlatformConfig  # noqa: E402
+from gateway.platforms.discord import DiscordAdapter  # noqa: E402
+
+
+class FakeMessage:
+    def __init__(self, message_id: int):
+        self.id = message_id
+
+
+class FakeChannel:
+    def __init__(self, *, fail_on_call: int | None = None):
+        self.fail_on_call = fail_on_call
+        self.sent: list[dict] = []
+        self.type = 0  # not a forum channel
+
+    async def send(self, **kwargs):
+        call_number = len(self.sent) + 1
+        if self.fail_on_call == call_number:
+            raise RuntimeError(f"simulated Discord send failure on call {call_number}")
+        self.sent.append(kwargs)
+        return FakeMessage(10_000 + call_number)
+
+
+class FakeClient:
+    def __init__(self, channel: FakeChannel):
+        self.channel = channel
+
+    def get_channel(self, channel_id: int):
+        return self.channel
+
+    async def fetch_channel(self, channel_id: int):  # pragma: no cover - fallback only
+        return self.channel
+
+
+def make_adapter(channel: FakeChannel) -> DiscordAdapter:
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="fake-token"))
+    adapter._client = FakeClient(channel)
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_short_message_sends_once_and_succeeds():
+    channel = FakeChannel()
+    adapter = make_adapter(channel)
+
+    result = await adapter.send("123", "short cron response")
+
+    assert result.success is True
+    assert len(channel.sent) == 1
+    assert result.error is None
+    assert result.raw_response["message_ids"] == ["10001"]
+    assert result.raw_response["total_parts"] == 1
+    assert result.raw_response["succeeded_parts"] == 1
+    assert result.raw_response["failed_parts"] == 0
+
+
+@pytest.mark.asyncio
+async def test_long_message_sends_multiple_parts_and_reports_all_success():
+    channel = FakeChannel()
+    adapter = make_adapter(channel)
+    long_message = "A" * 4300
+
+    result = await adapter.send("123", long_message)
+
+    assert result.success is True
+    assert len(channel.sent) > 1
+    assert result.error is None
+    assert result.raw_response["total_parts"] == len(channel.sent)
+    assert result.raw_response["succeeded_parts"] == len(channel.sent)
+    assert result.raw_response["failed_parts"] == 0
+    assert len(result.raw_response["message_ids"]) == len(channel.sent)
+
+
+@pytest.mark.asyncio
+async def test_long_message_partial_failure_is_reported_as_failed():
+    channel = FakeChannel(fail_on_call=2)
+    adapter = make_adapter(channel)
+    long_message = "B" * 4300
+
+    result = await adapter.send("123", long_message)
+
+    assert result.success is False
+    assert result.raw_response["total_parts"] > 1
+    assert result.raw_response["succeeded_parts"] < result.raw_response["total_parts"]
+    assert result.raw_response["failed_parts"] >= 1
+    assert "PARTIAL delivery" in result.error
+    assert "2/" in result.raw_response["warnings"][0]
+    assert "simulated Discord send failure" in result.raw_response["warnings"][0]


### PR DESCRIPTION
# Fix: long cron messages silently lost when split across multiple Discord sends

## Summary

Fixes a cron delivery bug where long Discord messages could be split into multiple sends, lose one or more later parts, and still be logged as delivered by the cron scheduler.

## Reproduction steps

1. Configure Hermes Agent with Discord gateway delivery enabled.
2. Create/run a cron job that returns a short response, e.g. ~80 characters.
   - Expected/current: the response arrives in Discord.
3. Create/run a cron job that returns a long response over Discord's 2000-character message limit, e.g. a multi-section report around 2900+ characters.
   - Current: Discord receives only the first part or an incomplete set of parts in failure scenarios.
   - Current logs can still show a successful delivery message such as:
     `delivered to discord:<channel_id> via live adapter`.

## Root cause

Discord delivery is multipart for long responses:

- `DiscordAdapter.send()` formats the content and calls `truncate_message(..., MAX_MESSAGE_LENGTH)`.
- It then sends each chunk with separate `channel.send(...)` calls.

The cron scheduler live-adapter path schedules only one `runtime_adapter.send(...)` coroutine and checks only the top-level `SendResult.success`. It does not inspect multipart metadata or warnings.

Additionally, the Discord forum-channel path already records follow-up chunk failures in `raw_response['warnings']`, but still returns `SendResult(success=True)`, which makes partial delivery indistinguishable from complete delivery to the scheduler.

## Fix summary

- Aggregate Discord multipart send outcomes into the existing `SendResult` object without changing the public `send()` or `metadata` interfaces.
- Add part counts to `raw_response`:
  - `message_ids`
  - `total_parts`
  - `succeeded_parts`
  - `failed_parts`
  - optional `warnings`
- Return `success=False` and a clear error for partial Discord delivery.
- Update cron scheduler live-adapter handling to:
  - log `delivered all N parts` for complete multipart success;
  - log `PARTIAL delivery (X/Y parts succeeded)` for partial failures;
  - return a delivery error so cron job state exposes `last_delivery_error`;
  - avoid standalone retry after partial live delivery to prevent duplicate first parts.

## Test coverage

Proposed pytest coverage is included for:

1. Short Discord message under 2000 characters:
   - one send call;
   - `success=True`;
   - part counts report `1/1`.
2. Long Discord message over 2000 characters with all sends succeeding:
   - multiple send calls;
   - `success=True`;
   - `succeeded_parts == total_parts`.
3. Long Discord message where send call 2 fails:
   - aggregate `success=False`;
   - partial-delivery error is present;
   - `failed_parts >= 1` and warnings identify the failed chunk.

## Compatibility

This change keeps the adapter API backward-compatible. Callers still receive a single `SendResult`; the fix only improves the correctness of `success`, `error`, and optional `raw_response` metadata.
