### PR TITLE
feat(tts): add Cartesia (Sonic) TTS provider

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1102,7 +1102,7 @@ DEFAULT_CONFIG = {
     # limit (OpenAI 4096, xAI 15000, MiniMax 10000, ElevenLabs 5k-40k model-aware,
     # Gemini 5000, Edge 5000, Mistral 4000, NeuTTS/KittenTTS 2000).
     "tts": {
-        "provider": "edge",  # "edge" (free) | "elevenlabs" (premium) | "openai" | "xai" | "minimax" | "mistral" | "gemini" | "neutts" (local) | "kittentts" (local) | "piper" (local)
+        "provider": "edge",  # "edge" (free) | "elevenlabs" (premium) | "openai" | "cartesia" | "xai" | "minimax" | "mistral" | "gemini" | "neutts" (local) | "kittentts" (local) | "piper" (local)
         "edge": {
             "voice": "en-US-AriaNeural",
             # Popular: AriaNeural, JennyNeural, AndrewNeural, BrianNeural, SoniaNeural
@@ -1115,6 +1115,14 @@ DEFAULT_CONFIG = {
             "model": "gpt-4o-mini-tts",
             "voice": "alloy",
             # Voices: alloy, echo, fable, onyx, nova, shimmer
+        },
+        "cartesia": {
+            "model": "sonic-3.5",  # sonic-3.5 (prod) | sonic-3 | sonic-2 | sonic-turbo
+            "voice_id": "71a7ad14-091c-4e8e-a314-022ece01c121",
+            # "language": "en",   # optional ISO code; omit to let Cartesia auto-detect
+            "sample_rate": 44100,  # 8000|16000|22050|24000|44100|48000
+            "bit_rate": 128000,    # mp3 only: 32000|64000|96000|128000|192000
+            # Requires CARTESIA_API_KEY in ~/.hermes/.env — https://play.cartesia.ai/keys
         },
         "xai": {
             "voice_id": "eve",  # or custom voice ID — see https://docs.x.ai/developers/model-capabilities/audio/custom-voices

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,8 @@ slack = ["slack-bolt==1.27.0", "slack-sdk==3.40.1", "aiohttp==3.13.3"]
 matrix = ["mautrix[encryption]==0.21.0", "Markdown==3.10.2", "aiosqlite==0.22.1", "asyncpg==0.31.0", "aiohttp-socks==0.11.0"]
 cli = ["simple-term-menu==1.6.6"]
 tts-premium = ["elevenlabs==1.59.0"]
+# Cartesia (Sonic) TTS — only loaded when provider=cartesia.
+cartesia = ["cartesia==3.0.2"]
 voice = [
   # Local STT pulls in wheel-only transitive deps (ctranslate2, onnxruntime),
   # so keep it out of the base install for source-build packagers like Homebrew.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1253,6 +1253,7 @@ AUTHOR_MAP = {
     "120500656+oooindefatigable@users.noreply.github.com": "ooovenenoso",
     "vanthinh6886@gmail.com": "vanthinh6886",  # PR #28018 salvage (yaml/flock/atomic write guards)
     "erik.engervall@gmail.com": "erikengervall",  # PR #28774 (firecrawl integration tag)
+    "melubin@pm.me": "marklubin",  # Cartesia (Sonic) TTS provider
 }
 
 

--- a/tests/tools/test_tts_cartesia.py
+++ b/tests/tools/test_tts_cartesia.py
@@ -1,0 +1,285 @@
+"""Tests for the Cartesia (Sonic) TTS provider in tools/tts_tool.py."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    for key in ("CARTESIA_API_KEY", "HERMES_SESSION_PLATFORM"):
+        monkeypatch.delenv(key, raising=False)
+
+
+@pytest.fixture
+def mock_cartesia_module():
+    """Stub the ``cartesia`` SDK so no network call is ever made.
+
+    ``client.tts.generate`` returns a BinaryAPIResponse-like object whose
+    ``write_to_file`` writes deterministic bytes to the requested path.
+    """
+    mock_client = MagicMock()
+
+    def _write_to_file(path):
+        with open(path, "wb") as f:
+            f.write(b"fake-cartesia-audio")
+
+    response = MagicMock()
+    response.write_to_file.side_effect = _write_to_file
+    mock_client.tts.generate.return_value = response
+
+    mock_cartesia_cls = MagicMock(return_value=mock_client)
+    fake_module = MagicMock()
+    fake_module.Cartesia = mock_cartesia_cls
+    # Patch lazy_deps.ensure too so _import_cartesia's lazy-install is a no-op.
+    with patch.dict("sys.modules", {"cartesia": fake_module}), \
+         patch("tools.lazy_deps.ensure", return_value=None):
+        yield mock_client
+
+
+class TestGenerateCartesia:
+    def test_missing_api_key_raises_value_error(self, tmp_path, mock_cartesia_module):
+        from tools.tts_tool import _generate_cartesia
+
+        output_path = str(tmp_path / "test.mp3")
+        with pytest.raises(ValueError, match="CARTESIA_API_KEY"):
+            _generate_cartesia("Hello", output_path, {})
+
+    def test_successful_generation(self, tmp_path, mock_cartesia_module, monkeypatch):
+        from tools.tts_tool import _generate_cartesia
+
+        monkeypatch.setenv("CARTESIA_API_KEY", "test-key")
+        output_path = str(tmp_path / "test.mp3")
+        result = _generate_cartesia("Hello world", output_path, {})
+
+        assert result == output_path
+        assert (tmp_path / "test.mp3").read_bytes() == b"fake-cartesia-audio"
+        mock_cartesia_module.tts.generate.assert_called_once()
+        kwargs = mock_cartesia_module.tts.generate.call_args[1]
+        assert kwargs["transcript"] == "Hello world"
+        assert kwargs["voice"]["mode"] == "id"
+
+    def test_api_key_passed_to_client(self, tmp_path, mock_cartesia_module, monkeypatch):
+        from tools.tts_tool import _generate_cartesia
+
+        monkeypatch.setenv("CARTESIA_API_KEY", "  spaced-key  ")
+        _generate_cartesia("Hi", str(tmp_path / "test.mp3"), {})
+
+        # Key is stripped before being handed to the SDK constructor.
+        import sys
+
+        sys.modules["cartesia"].Cartesia.assert_called_once_with(api_key="spaced-key")
+
+    def test_default_model_and_voice(self, tmp_path, mock_cartesia_module, monkeypatch):
+        from tools.tts_tool import (
+            DEFAULT_CARTESIA_MODEL,
+            DEFAULT_CARTESIA_VOICE_ID,
+            _generate_cartesia,
+        )
+
+        monkeypatch.setenv("CARTESIA_API_KEY", "test-key")
+        _generate_cartesia("Hi", str(tmp_path / "test.mp3"), {})
+
+        kwargs = mock_cartesia_module.tts.generate.call_args[1]
+        assert kwargs["model_id"] == DEFAULT_CARTESIA_MODEL
+        assert kwargs["voice"]["id"] == DEFAULT_CARTESIA_VOICE_ID
+
+    def test_config_overrides_model_and_voice(
+        self, tmp_path, mock_cartesia_module, monkeypatch
+    ):
+        from tools.tts_tool import _generate_cartesia
+
+        monkeypatch.setenv("CARTESIA_API_KEY", "test-key")
+        config = {"cartesia": {"model": "sonic-turbo", "voice_id": "my-voice-uuid"}}
+        _generate_cartesia("Hi", str(tmp_path / "test.mp3"), config)
+
+        kwargs = mock_cartesia_module.tts.generate.call_args[1]
+        assert kwargs["model_id"] == "sonic-turbo"
+        assert kwargs["voice"]["id"] == "my-voice-uuid"
+
+    def test_mp3_output_format(self, tmp_path, mock_cartesia_module, monkeypatch):
+        from tools.tts_tool import (
+            DEFAULT_CARTESIA_BIT_RATE,
+            DEFAULT_CARTESIA_SAMPLE_RATE,
+            _generate_cartesia,
+        )
+
+        monkeypatch.setenv("CARTESIA_API_KEY", "test-key")
+        _generate_cartesia("Hi", str(tmp_path / "test.mp3"), {})
+
+        fmt = mock_cartesia_module.tts.generate.call_args[1]["output_format"]
+        assert fmt["container"] == "mp3"
+        assert fmt["sample_rate"] == DEFAULT_CARTESIA_SAMPLE_RATE
+        assert fmt["bit_rate"] == DEFAULT_CARTESIA_BIT_RATE
+
+    def test_wav_output_format(self, tmp_path, mock_cartesia_module, monkeypatch):
+        from tools.tts_tool import _generate_cartesia
+
+        monkeypatch.setenv("CARTESIA_API_KEY", "test-key")
+        config = {"cartesia": {"sample_rate": 24000}}
+        _generate_cartesia("Hi", str(tmp_path / "test.wav"), config)
+
+        fmt = mock_cartesia_module.tts.generate.call_args[1]["output_format"]
+        assert fmt["container"] == "wav"
+        assert fmt["encoding"] == "pcm_s16le"
+        assert fmt["sample_rate"] == 24000
+        assert "bit_rate" not in fmt
+
+    def test_language_passed_only_when_configured(
+        self, tmp_path, mock_cartesia_module, monkeypatch
+    ):
+        from tools.tts_tool import _generate_cartesia
+
+        monkeypatch.setenv("CARTESIA_API_KEY", "test-key")
+
+        _generate_cartesia("Hi", str(tmp_path / "a.mp3"), {})
+        assert "language" not in mock_cartesia_module.tts.generate.call_args[1]
+
+        _generate_cartesia(
+            "Hi", str(tmp_path / "b.mp3"), {"cartesia": {"language": "fr"}}
+        )
+        assert mock_cartesia_module.tts.generate.call_args[1]["language"] == "fr"
+
+    def test_speed_routed_to_generation_config(
+        self, tmp_path, mock_cartesia_module, monkeypatch
+    ):
+        from tools.tts_tool import _generate_cartesia
+
+        monkeypatch.setenv("CARTESIA_API_KEY", "test-key")
+
+        # Default speed (1.0) must NOT add generation_config.
+        _generate_cartesia("Hi", str(tmp_path / "a.mp3"), {})
+        assert "generation_config" not in mock_cartesia_module.tts.generate.call_args[1]
+
+        # Non-default speed goes through generation_config (v3 SDK norm).
+        _generate_cartesia("Hi", str(tmp_path / "b.mp3"), {"cartesia": {"speed": 1.3}})
+        kwargs = mock_cartesia_module.tts.generate.call_args[1]
+        assert kwargs["generation_config"] == {"speed": 1.3}
+
+    def test_response_read_shape(self, tmp_path, monkeypatch):
+        """SDK variants returning a .read() body are handled."""
+        from tools.tts_tool import _generate_cartesia
+
+        monkeypatch.setenv("CARTESIA_API_KEY", "test-key")
+        mock_client = MagicMock()
+        response = MagicMock(spec=["read"])
+        response.read.return_value = b"read-body-bytes"
+        mock_client.tts.generate.return_value = response
+        fake_module = MagicMock()
+        fake_module.Cartesia = MagicMock(return_value=mock_client)
+
+        out = str(tmp_path / "test.mp3")
+        with patch.dict("sys.modules", {"cartesia": fake_module}), \
+             patch("tools.lazy_deps.ensure", return_value=None):
+            _generate_cartesia("Hi", out, {})
+
+        assert (tmp_path / "test.mp3").read_bytes() == b"read-body-bytes"
+
+    def test_response_bytes_shape(self, tmp_path, monkeypatch):
+        """SDK variants returning raw bytes are handled."""
+        from tools.tts_tool import _generate_cartesia
+
+        monkeypatch.setenv("CARTESIA_API_KEY", "test-key")
+        mock_client = MagicMock()
+        mock_client.tts.generate.return_value = b"raw-bytes-body"
+        fake_module = MagicMock()
+        fake_module.Cartesia = MagicMock(return_value=mock_client)
+
+        out = str(tmp_path / "test.mp3")
+        with patch.dict("sys.modules", {"cartesia": fake_module}), \
+             patch("tools.lazy_deps.ensure", return_value=None):
+            _generate_cartesia("Hi", out, {})
+
+        assert (tmp_path / "test.mp3").read_bytes() == b"raw-bytes-body"
+
+    def test_response_chunk_iterator_shape(self, tmp_path, monkeypatch):
+        """SDK variants yielding a chunk iterator (tts.bytes()) are handled."""
+        from tools.tts_tool import _generate_cartesia
+
+        monkeypatch.setenv("CARTESIA_API_KEY", "test-key")
+        mock_client = MagicMock()
+        mock_client.tts.generate.return_value = iter([b"chunk-1", b"chunk-2"])
+        fake_module = MagicMock()
+        fake_module.Cartesia = MagicMock(return_value=mock_client)
+
+        out = str(tmp_path / "test.mp3")
+        with patch.dict("sys.modules", {"cartesia": fake_module}), \
+             patch("tools.lazy_deps.ensure", return_value=None):
+            _generate_cartesia("Hi", out, {})
+
+        assert (tmp_path / "test.mp3").read_bytes() == b"chunk-1chunk-2"
+
+    def test_client_closed_after_generation(
+        self, tmp_path, mock_cartesia_module, monkeypatch
+    ):
+        from tools.tts_tool import _generate_cartesia
+
+        monkeypatch.setenv("CARTESIA_API_KEY", "test-key")
+        _generate_cartesia("Hi", str(tmp_path / "test.mp3"), {})
+
+        mock_cartesia_module.close.assert_called_once()
+
+
+class TestTtsDispatcherCartesia:
+    def test_dispatcher_success(self, tmp_path, mock_cartesia_module, monkeypatch):
+        from tools.tts_tool import text_to_speech_tool
+
+        monkeypatch.setenv("CARTESIA_API_KEY", "test-key")
+        output_path = str(tmp_path / "out.mp3")
+        with patch(
+            "tools.tts_tool._load_tts_config", return_value={"provider": "cartesia"}
+        ):
+            result = json.loads(
+                text_to_speech_tool("Hello", output_path=output_path)
+            )
+
+        assert result["success"] is True
+        assert result["provider"] == "cartesia"
+        mock_cartesia_module.tts.generate.assert_called_once()
+
+    def test_dispatcher_returns_error_when_sdk_not_installed(
+        self, tmp_path, monkeypatch
+    ):
+        from tools.tts_tool import text_to_speech_tool
+
+        monkeypatch.setenv("CARTESIA_API_KEY", "test-key")
+        with patch(
+            "tools.tts_tool._import_cartesia", side_effect=ImportError("no module")
+        ), patch(
+            "tools.tts_tool._load_tts_config", return_value={"provider": "cartesia"}
+        ):
+            result = json.loads(
+                text_to_speech_tool("Hello", output_path=str(tmp_path / "out.mp3"))
+            )
+
+        assert result["success"] is False
+        assert "cartesia" in result["error"].lower()
+
+    def test_dispatcher_missing_key_returns_error(
+        self, tmp_path, mock_cartesia_module
+    ):
+        from tools.tts_tool import text_to_speech_tool
+
+        with patch(
+            "tools.tts_tool._load_tts_config", return_value={"provider": "cartesia"}
+        ):
+            result = json.loads(
+                text_to_speech_tool("Hello", output_path=str(tmp_path / "out.mp3"))
+            )
+
+        assert result["success"] is False
+        assert "CARTESIA_API_KEY" in result["error"]
+
+
+class TestCartesiaIsBuiltinProvider:
+    def test_cartesia_registered(self):
+        from tools.tts_tool import BUILTIN_TTS_PROVIDERS
+
+        assert "cartesia" in BUILTIN_TTS_PROVIDERS
+
+    def test_cartesia_lazy_dep_registered(self):
+        from tools.lazy_deps import LAZY_DEPS
+
+        assert "tts.cartesia" in LAZY_DEPS
+        assert any("cartesia" in pkg for pkg in LAZY_DEPS["tts.cartesia"])

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -104,6 +104,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     # the full restoration checklist.
     "tts.edge": ("edge-tts==7.2.7",),
     "tts.elevenlabs": ("elevenlabs==1.59.0",),
+    "tts.cartesia": ("cartesia==3.0.2",),
 
     # ─── Speech-to-text providers ──────────────────────────────────────────
     "stt.faster_whisper": (

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -115,6 +115,25 @@ def _import_openai_client():
     from openai import OpenAI as OpenAIClient
     return OpenAIClient
 
+def _import_cartesia():
+    """Lazy import the Cartesia client. Returns the class or raises ImportError.
+
+    Mirrors :func:`_import_elevenlabs`: calls :func:`tools.lazy_deps.ensure`
+    first so the SDK gets installed on demand when the user picks Cartesia by
+    editing config.yaml directly. Raises ``ImportError`` on lazy-install
+    failure so the dispatch's error-handling path keeps working.
+    """
+    try:
+        from tools.lazy_deps import ensure
+        ensure("tts.cartesia", prompt=False)
+    except ImportError:
+        # lazy_deps module itself missing — fall through to the raw import.
+        pass
+    except Exception as e:  # FeatureUnavailable or any unexpected error
+        raise ImportError(str(e))
+    from cartesia import Cartesia
+    return Cartesia
+
 def _import_mistral_client():
     """Lazy import Mistral client. Returns the class or raises ImportError."""
     from mistralai.client import Mistral
@@ -168,6 +187,13 @@ DEFAULT_XAI_LANGUAGE = "en"
 DEFAULT_XAI_SAMPLE_RATE = 24000
 DEFAULT_XAI_BIT_RATE = 128000
 DEFAULT_XAI_BASE_URL = "https://api.x.ai/v1"
+# Cartesia (https://docs.cartesia.ai). sonic-3.5 is the current production
+# default. mp3 @ 44.1kHz/128kbps matches Hermes' default .mp3 output path
+# (Telegram .ogg is produced afterwards via _convert_to_opus).
+DEFAULT_CARTESIA_MODEL = "sonic-3.5"
+DEFAULT_CARTESIA_VOICE_ID = "71a7ad14-091c-4e8e-a314-022ece01c121"
+DEFAULT_CARTESIA_SAMPLE_RATE = 44100
+DEFAULT_CARTESIA_BIT_RATE = 128000
 DEFAULT_GEMINI_TTS_MODEL = "gemini-2.5-flash-preview-tts"
 DEFAULT_GEMINI_TTS_VOICE = "Kore"
 DEFAULT_GEMINI_TTS_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
@@ -339,6 +365,7 @@ BUILTIN_TTS_PROVIDERS = frozenset({
     "edge",
     "elevenlabs",
     "openai",
+    "cartesia",
     "minimax",
     "xai",
     "mistral",
@@ -882,6 +909,94 @@ def _generate_openai_tts(text: str, output_path: str, tts_config: Dict[str, Any]
         response = client.audio.speech.create(**create_kwargs)
 
         response.stream_to_file(output_path)
+        return output_path
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+
+
+# ===========================================================================
+# Provider: Cartesia (Sonic) TTS
+# ===========================================================================
+def _generate_cartesia(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """
+    Generate audio using Cartesia (Sonic) TTS.
+
+    Cartesia's API does not emit Ogg/Opus, so this writes mp3 (or wav when
+    the caller explicitly asked for a ``.wav`` path). The dispatch converts
+    mp3 -> Ogg/Opus via ffmpeg afterwards when a platform such as Telegram
+    needs a native voice bubble (see ``_convert_to_opus``), exactly like the
+    edge/xai/minimax providers.
+
+    Args:
+        text: Text to convert.
+        output_path: Where to save the audio file.
+        tts_config: TTS config dict.
+
+    Returns:
+        Path to the saved audio file.
+    """
+    api_key = (get_env_value("CARTESIA_API_KEY") or "").strip()
+    if not api_key:
+        raise ValueError(
+            "CARTESIA_API_KEY not set. Create a key at https://play.cartesia.ai/keys"
+        )
+
+    car_config = tts_config.get("cartesia", {})
+    model = car_config.get("model", DEFAULT_CARTESIA_MODEL)
+    voice_id = car_config.get("voice_id", DEFAULT_CARTESIA_VOICE_ID)
+    language = car_config.get("language")
+    speed = float(car_config.get("speed", tts_config.get("speed", 1.0)))
+    sample_rate = int(car_config.get("sample_rate", DEFAULT_CARTESIA_SAMPLE_RATE))
+
+    if output_path.endswith(".wav"):
+        output_format = {
+            "container": "wav",
+            "encoding": "pcm_s16le",
+            "sample_rate": sample_rate,
+        }
+    else:
+        output_format = {
+            "container": "mp3",
+            "sample_rate": sample_rate,
+            "bit_rate": int(car_config.get("bit_rate", DEFAULT_CARTESIA_BIT_RATE)),
+        }
+
+    Cartesia = _import_cartesia()
+    client = Cartesia(api_key=api_key)
+
+    generate_kwargs = {
+        "model_id": model,
+        "transcript": text,
+        "voice": {"mode": "id", "id": voice_id},
+        "output_format": output_format,
+    }
+    if language:
+        generate_kwargs["language"] = str(language)
+    if speed != 1.0:
+        # Top-level `speed` is deprecated in the v3 SDK in favour of
+        # generation_config; pass it there to avoid the deprecation path.
+        generate_kwargs["generation_config"] = {"speed": speed}
+
+    try:
+        response = client.tts.generate(**generate_kwargs)
+
+        # tts.generate() returns a BinaryAPIResponse (write_to_file()/read());
+        # the v2-compat tts.bytes() yields raw chunks. Handle every shape so
+        # an SDK minor bump can't silently break audio output.
+        if hasattr(response, "write_to_file"):
+            response.write_to_file(output_path)
+        elif hasattr(response, "read"):
+            with open(output_path, "wb") as f:
+                f.write(response.read())
+        elif isinstance(response, (bytes, bytearray)):
+            with open(output_path, "wb") as f:
+                f.write(response)
+        else:
+            with open(output_path, "wb") as f:
+                for chunk in response:
+                    f.write(chunk if isinstance(chunk, (bytes, bytearray)) else bytes(chunk))
         return output_path
     finally:
         close = getattr(client, "close", None)
@@ -1729,6 +1844,19 @@ def text_to_speech_tool(
             logger.info("Generating speech with OpenAI TTS...")
             _generate_openai_tts(text, file_str, tts_config)
 
+        elif provider == "cartesia":
+            try:
+                _import_cartesia()
+            except ImportError:
+                return json.dumps({
+                    "success": False,
+                    "error": "Cartesia provider selected but the 'cartesia' package is not installed. "
+                             "Run 'hermes tools' and select Cartesia under TTS, or install manually: "
+                             "pip install cartesia"
+                }, ensure_ascii=False)
+            logger.info("Generating speech with Cartesia (Sonic) TTS...")
+            _generate_cartesia(text, file_str, tts_config)
+
         elif provider == "minimax":
             logger.info("Generating speech with MiniMax TTS...")
             _generate_minimax_tts(text, file_str, tts_config)
@@ -1847,7 +1975,7 @@ def text_to_speech_tool(
                 voice_compatible = file_str.endswith(".ogg")
         elif (
             want_opus
-            and provider in {"edge", "neutts", "minimax", "xai", "kittentts", "piper"}
+            and provider in {"edge", "neutts", "minimax", "xai", "kittentts", "piper", "cartesia"}
             and not file_str.endswith(".ogg")
         ):
             opus_path = _convert_to_opus(file_str)


### PR DESCRIPTION
## What does this PR do?

Adds **Cartesia (Sonic)** as a built-in text-to-speech provider, following
the existing `edge` / `elevenlabs` / `openai` / `xai` / `minimax` provider
pattern in `tools/tts_tool.py`.

Cartesia's Sonic models (sonic-3.5 et al.) are a low-latency, high-quality
TTS option that several users have asked for. This wires it in as a
first-class optional provider with the same lazy-install + ffmpeg→Opus
delivery path the other non-Opus providers already use, so it works for
both CLI playback and Telegram/Discord voice bubbles with no extra config.

## Related Issue

Fixes #

<!-- No tracking issue; happy to file one if the maintainers prefer. -->

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `tools/tts_tool.py`
  - `_import_cartesia()` — lazy import mirroring `_import_elevenlabs()`;
    calls `tools.lazy_deps.ensure("tts.cartesia", prompt=False)` so the
    SDK installs on demand when a user selects Cartesia by editing
    `config.yaml` directly, and raises `ImportError` on lazy-install
    failure so the dispatcher's error path keeps working.
  - `_generate_cartesia()` — uses the Cartesia v3 SDK
    (`client.tts.generate`). Writes mp3 by default, or wav (`pcm_s16le`)
    when the caller asked for a `.wav` path. Defensive about the response
    shape: handles `BinaryAPIResponse.write_to_file()`, `.read()`, raw
    `bytes`, and the v2-compat chunk-iterator, so an SDK minor bump can't
    silently break audio output. Always closes the client in a `finally`.
  - Registered `cartesia` in `BUILTIN_TTS_PROVIDERS` and the dispatch
    chain, with an SDK-missing error message consistent with the other
    optional providers.
  - Added `cartesia` to the ffmpeg→Opus set so `.ogg` Telegram voice
    bubbles are produced via `_convert_to_opus` (Cartesia has no native
    Ogg/Opus), exactly like `edge` / `xai` / `minimax`.
  - `DEFAULT_CARTESIA_*` constants (sonic-3.5, mp3 44.1kHz/128kbps).
- `tools/lazy_deps.py` — `tts.cartesia` → `cartesia==3.0.2`.
- `pyproject.toml` — new `cartesia` optional extra, intentionally kept
  out of `[all]` per the existing TTS-provider lazy-install policy
  (same as `tts-premium`).
- `hermes_cli/config.py` — default `tts.cartesia` config block and the
  provider list comment, mirroring the existing `xai`/`minimax` blocks.
- `tests/tools/test_tts_cartesia.py` — 18 unit tests mirroring the
  `test_tts_mistral.py` / `test_tts_gemini.py` style. The `cartesia`
  SDK is mocked via `patch.dict("sys.modules", ...)`; `lazy_deps.ensure`
  is stubbed. **No network calls.**
- `scripts/release.py` — added `melubin@pm.me → marklubin` to
  `AUTHOR_MAP` so the Contributor Attribution Check passes (per the
  instructions emitted by `.github/workflows/contributor-check.yml`).

## How to Test

1. `pip install -e ".[cartesia]"` (or let lazy-install handle it).
2. Add `CARTESIA_API_KEY=...` to `~/.hermes/.env`
   (key from https://play.cartesia.ai/keys).
3. Set `tts.provider: cartesia` in `~/.hermes/config.yaml`.
4. `hermes -q "Say hello and read it back to me with TTS"` — or call the
   `text_to_speech` tool directly — and confirm an mp3 plays back.
5. Unit tests (no network, SDK mocked):
   `pytest tests/tools/test_tts_cartesia.py -q` → 18 passed.
6. Full TTS suite stays green:
   `pytest tests/tools/test_tts_*.py tests/gateway/test_tts_media_routing.py -q`
   → 189 passed.

**Verified end-to-end against a live Cartesia API call** (done manually,
outside the test suite so CI makes no network calls): both the mp3 and
wav output paths produced valid, decodable audio at the requested sample
rate. The mp3 → Ogg/Opus conversion path used for Telegram voice bubbles
is the same shared `_convert_to_opus` helper already covered by
`tests/tools/test_tts_opus_routing.py`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(tts): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [x] I've run the test suite and all tests pass (189 TTS tests; new file 18/18)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.4.0), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — `cli-config.yaml.example`
      is N/A: it has no `tts:` block; per-provider defaults live in
      `DEFAULT_CONFIG` (`hermes_cli/config.py`), consistent with how
      `xai`/`minimax`/`mistral` were added.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (see above)
- [x] I've updated `CONTRIBUTING.md`/`AGENTS.md` if I changed architecture — N/A
- [x] I've considered cross-platform impact — the ffmpeg→Opus path is the
      shared, already-tested one; lazy-install is the standard mechanism;
      `ruff check .` (PLW1514) and the Windows-footgun checker both pass.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
      (additive provider; no schema change to the `text_to_speech` tool)

## Notes for reviewers

- The `cartesia` extra is deliberately **not** in `[all]` — this matches
  the existing TTS lazy-install policy (`tts-premium`/elevenlabs is also
  excluded). The provider lazy-installs on first use.
- `_generate_cartesia` mirrors the edge/xai/minimax "no native Opus,
  convert afterwards" wiring rather than the elevenlabs/openai
  "native-format" path, because Cartesia's API does not emit Ogg/Opus.
- The response-shape handling is intentionally defensive across the
  v2-compat and v3 SDK surfaces; each branch has a dedicated unit test.
