### PR TITLE
Redesign web dashboard with clean Apple-inspired UI

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -52,71 +52,61 @@ export default function App() {
 
   return (
     <div className="flex min-h-screen flex-col bg-background text-foreground overflow-x-hidden">
-      {/* Global grain + warm glow (matches landing page) */}
       <div className="noise-overlay" />
       <div className="warm-glow" />
 
-      {/* ---- Header with grid-border nav ---- */}
-      <header className="sticky top-0 z-40 border-b border-border bg-background/90 backdrop-blur-sm">
-        <div className="mx-auto flex h-12 max-w-[1400px] items-stretch">
-          {/* Brand — abbreviated on mobile */}
-          <div className="flex items-center border-r border-border px-3 sm:px-5 shrink-0">
-            <span className="font-collapse text-lg sm:text-xl font-bold tracking-wider uppercase blend-lighter">
-              H<span className="hidden sm:inline">ermes </span>A<span className="hidden sm:inline">gent</span>
+      <header className="sticky top-0 z-40 border-b border-black/[0.06] bg-white/72 backdrop-blur-2xl supports-[backdrop-filter]:bg-white/62">
+        <div className="mx-auto flex min-h-14 max-w-[1180px] flex-col gap-2 px-4 py-2 sm:min-h-[64px] sm:flex-row sm:items-center sm:gap-5 sm:px-6">
+          <button
+            type="button"
+            onClick={() => setPage("status")}
+            className="flex shrink-0 items-center gap-2 rounded-full px-1 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30"
+          >
+            <span className="flex h-7 w-7 items-center justify-center rounded-full bg-foreground text-[0.72rem] font-semibold text-background shadow-sm">
+              H
             </span>
-          </div>
+            <span className="text-sm font-semibold tracking-[-0.02em] sm:text-base">
+              Hermes Agent
+            </span>
+          </button>
 
-          {/* Nav — icons only on mobile, icon+label on sm+ */}
-          <nav className="flex items-stretch overflow-x-auto scrollbar-none">
+          <nav className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto rounded-full bg-black/[0.035] p-1 scrollbar-none">
             {NAV_ITEMS.map(({ id, label, icon: Icon }) => (
               <button
                 key={id}
                 type="button"
                 onClick={() => setPage(id)}
-                className={`group relative inline-flex items-center gap-1 sm:gap-1.5 border-r border-border px-2.5 sm:px-4 py-2 font-display text-[0.65rem] sm:text-[0.8rem] tracking-[0.12em] uppercase whitespace-nowrap transition-colors cursor-pointer shrink-0 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring ${
+                className={`inline-flex shrink-0 items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium tracking-[-0.01em] transition-all cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30 sm:text-sm ${
                   page === id
-                    ? "text-foreground"
-                    : "text-muted-foreground hover:text-foreground"
+                    ? "bg-white text-foreground shadow-[0_1px_8px_rgba(0,0,0,0.08)]"
+                    : "text-muted-foreground hover:bg-white/60 hover:text-foreground"
                 }`}
               >
-                <Icon className="h-4 w-4 sm:h-3.5 sm:w-3.5 shrink-0" />
-                <span className="hidden sm:inline">{label}</span>
-                {/* Hover highlight */}
-                <span className="absolute inset-0 bg-foreground pointer-events-none transition-opacity duration-150 group-hover:opacity-5 opacity-0" />
-                {/* Active indicator */}
-                {page === id && (
-                  <span className="absolute bottom-0 left-0 right-0 h-px bg-foreground" />
-                )}
+                <Icon className="h-3.5 w-3.5 shrink-0" />
+                <span>{label}</span>
               </button>
             ))}
           </nav>
 
-          {/* Version badge — hidden on mobile */}
-          <div className="ml-auto hidden sm:flex items-center px-4 text-muted-foreground">
-            <span className="font-display text-[0.7rem] tracking-[0.15em] uppercase opacity-50">
-              Web UI
-            </span>
+          <div className="hidden shrink-0 items-center gap-2 rounded-full bg-white px-3 py-1.5 text-xs font-medium text-muted-foreground shadow-sm ring-1 ring-black/[0.04] lg:flex">
+            <span className="h-1.5 w-1.5 rounded-full bg-success" />
+            Web UI
           </div>
         </div>
       </header>
 
       <main
         key={animKey}
-        className="relative z-2 mx-auto w-full max-w-[1400px] flex-1 px-3 sm:px-6 py-4 sm:py-8"
+        className="relative z-10 mx-auto w-full max-w-[1180px] flex-1 px-4 py-6 sm:px-6 sm:py-10"
         style={{ animation: "fade-in 150ms ease-out" }}
       >
         <PageComponent />
       </main>
 
-      {/* ---- Footer ---- */}
-      <footer className="relative z-2 border-t border-border">
-        <div className="mx-auto flex max-w-[1400px] items-center justify-between px-3 sm:px-6 py-3">
-          <span className="font-display text-[0.7rem] sm:text-[0.8rem] tracking-[0.12em] uppercase opacity-50">
-            Hermes Agent
-          </span>
-          <span className="font-display text-[0.6rem] sm:text-[0.7rem] tracking-[0.15em] uppercase text-foreground/40">
-            Nous Research
-          </span>
+      <footer className="relative z-10 border-t border-black/[0.06] bg-white/50">
+        <div className="mx-auto flex max-w-[1180px] items-center justify-between px-4 py-5 text-xs text-muted-foreground sm:px-6">
+          <span>Hermes Agent</span>
+          <span>Nous Research</span>
         </div>
       </footer>
     </div>

--- a/web/src/components/ui/badge.tsx
+++ b/web/src/components/ui/badge.tsx
@@ -2,16 +2,16 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
-  "inline-flex items-center border px-2 py-0.5 font-compressed text-[0.65rem] tracking-[0.15em] uppercase transition-colors",
+  "inline-flex items-center rounded-full px-2.5 py-1 text-[0.72rem] font-medium tracking-[-0.01em] transition-colors",
   {
     variants: {
       variant: {
-        default: "border-foreground/20 bg-foreground/10 text-foreground",
-        secondary: "border-border bg-secondary text-secondary-foreground",
-        destructive: "border-destructive/30 bg-destructive/15 text-destructive",
-        outline: "border-border text-muted-foreground",
-        success: "grain border-emerald-600/30 bg-emerald-950/70 text-emerald-400",
-        warning: "border-warning/30 bg-warning/15 text-warning",
+        default: "bg-foreground text-background",
+        secondary: "bg-secondary text-secondary-foreground",
+        destructive: "bg-red-50 text-destructive ring-1 ring-red-100",
+        outline: "bg-muted text-muted-foreground ring-1 ring-border",
+        success: "bg-green-50 text-success ring-1 ring-green-100",
+        warning: "bg-amber-50 text-warning ring-1 ring-amber-100",
       },
     },
     defaultVariants: {

--- a/web/src/components/ui/button.tsx
+++ b/web/src/components/ui/button.tsx
@@ -2,23 +2,23 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap font-display text-xs tracking-[0.1em] uppercase transition-colors cursor-pointer"
-  + " disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-full text-sm font-medium tracking-[-0.01em] transition-all cursor-pointer"
+  + " focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30 disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {
-        default: "bg-foreground/90 text-background hover:bg-foreground",
+        default: "bg-primary text-primary-foreground shadow-sm hover:bg-[#0077ed]",
         destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
-        outline: "border border-border bg-transparent hover:bg-foreground/10 hover:text-foreground",
+        outline: "border border-border bg-card/70 hover:bg-white hover:shadow-sm",
         secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost: "hover:bg-foreground/10 hover:text-foreground",
-        link: "text-foreground underline-offset-4 hover:underline",
+        ghost: "hover:bg-foreground/5 hover:text-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-9 px-4 py-2",
-        sm: "h-8 px-3 text-[0.65rem]",
-        lg: "h-10 px-8",
-        icon: "h-9 w-9",
+        default: "h-10 px-4 py-2",
+        sm: "h-8 px-3 text-xs",
+        lg: "h-11 px-7",
+        icon: "h-10 w-10",
       },
     },
     defaultVariants: {

--- a/web/src/components/ui/card.tsx
+++ b/web/src/components/ui/card.tsx
@@ -4,7 +4,7 @@ export function Card({ className, ...props }: React.HTMLAttributes<HTMLDivElemen
   return (
     <div
       className={cn(
-        "border border-border bg-card/80 text-card-foreground overflow-hidden w-full",
+        "w-full overflow-hidden rounded-[24px] border border-border/70 bg-card/90 text-card-foreground shadow-[0_20px_60px_rgba(0,0,0,0.06)] backdrop-blur-xl",
         className,
       )}
       {...props}
@@ -13,17 +13,17 @@ export function Card({ className, ...props }: React.HTMLAttributes<HTMLDivElemen
 }
 
 export function CardHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn("flex flex-col gap-1.5 p-4 border-b border-border", className)} {...props} />;
+  return <div className={cn("flex flex-col gap-2 px-5 pt-5 pb-3", className)} {...props} />;
 }
 
 export function CardTitle({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
-  return <h3 className={cn("font-expanded text-sm font-bold tracking-[0.08em] uppercase blend-lighter", className)} {...props} />;
+  return <h3 className={cn("text-[0.95rem] font-semibold tracking-[-0.01em] text-foreground", className)} {...props} />;
 }
 
 export function CardDescription({ className, ...props }: React.HTMLAttributes<HTMLParagraphElement>) {
-  return <p className={cn("font-display text-xs text-muted-foreground", className)} {...props} />;
+  return <p className={cn("text-sm leading-5 text-muted-foreground", className)} {...props} />;
 }
 
 export function CardContent({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn("p-4", className)} {...props} />;
+  return <div className={cn("px-5 pb-5", className)} {...props} />;
 }

--- a/web/src/components/ui/input.tsx
+++ b/web/src/components/ui/input.tsx
@@ -4,9 +4,9 @@ export function Input({ className, ...props }: React.InputHTMLAttributes<HTMLInp
   return (
     <input
       className={cn(
-        "flex h-9 w-full border border-border bg-background/40 px-3 py-1 font-courier text-sm transition-colors",
+        "flex h-10 w-full rounded-full border border-border bg-white/80 px-4 py-2 text-sm transition-all shadow-sm",
         "placeholder:text-muted-foreground",
-        "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-foreground/30 focus-visible:border-foreground/25",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/25 focus-visible:border-primary/30 focus-visible:bg-white",
         "disabled:cursor-not-allowed disabled:opacity-50",
         className,
       )}

--- a/web/src/components/ui/select.tsx
+++ b/web/src/components/ui/select.tsx
@@ -4,8 +4,8 @@ export function Select({ className, ...props }: React.SelectHTMLAttributes<HTMLS
   return (
     <select
       className={cn(
-        "flex h-9 w-full border border-border bg-background/40 px-3 py-1 font-courier text-sm",
-        "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-foreground/30 focus-visible:border-foreground/25",
+        "flex h-10 w-full rounded-full border border-border bg-white/80 px-4 py-2 text-sm transition-all shadow-sm",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/25 focus-visible:border-primary/30 focus-visible:bg-white",
         "disabled:cursor-not-allowed disabled:opacity-50",
         className,
       )}

--- a/web/src/components/ui/tabs.tsx
+++ b/web/src/components/ui/tabs.tsx
@@ -18,7 +18,7 @@ export function TabsList({ className, ...props }: React.HTMLAttributes<HTMLDivEl
   return (
     <div
       className={cn(
-        "inline-flex h-9 items-center justify-start border-b border-border text-muted-foreground",
+        "inline-flex items-center justify-start gap-1 rounded-full bg-black/[0.035] p-1 text-muted-foreground",
         className,
       )}
       {...props}
@@ -37,11 +37,11 @@ export function TabsTrigger({
     <button
       type="button"
       className={cn(
-        "relative inline-flex items-center justify-center whitespace-nowrap px-3 py-1.5 font-display text-xs tracking-[0.1em] uppercase transition-all cursor-pointer",
-        "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+        "relative inline-flex items-center justify-center whitespace-nowrap rounded-full px-3 py-1.5 text-sm font-medium tracking-[-0.01em] transition-all cursor-pointer",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/25",
         active
-          ? "text-foreground after:absolute after:bottom-0 after:left-0 after:right-0 after:h-px after:bg-foreground"
-          : "hover:text-foreground",
+          ? "bg-white text-foreground shadow-[0_1px_8px_rgba(0,0,0,0.08)]"
+          : "hover:bg-white/60 hover:text-foreground",
         className,
       )}
       onClick={onClick}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,8 +1,8 @@
 @import "tailwindcss";
 
 /* ------------------------------------------------------------------ */
-/* Hermes Agent — Design tokens                                        */
-/* Matched to hermes-agent.nousresearch.com (dark teal theme)          */
+/* Hermes Agent — Web UI design tokens                                 */
+/* Clean Apple-like dashboard rhythm: readable, quiet, spacious.        */
 /* ------------------------------------------------------------------ */
 
 /* --- Font faces --- */
@@ -17,42 +17,44 @@
 @font-face { font-family: "Mondwest"; src: url("/fonts/Mondwest-Regular.woff2") format("woff2"); font-weight: 400; font-display: swap; }
 
 @theme {
-  /* ---- Hermes palette (dark teal, from live site) ---- */
-  --color-background: #041C1C;
-  --color-foreground: #ffe6cb;
-  --color-card: #062424;
-  --color-card-foreground: #ffe6cb;
-  --color-primary: #ffe6cb;
-  --color-primary-foreground: #041C1C;
-  --color-secondary: #0a2e2e;
-  --color-secondary-foreground: #ffe6cb;
-  --color-muted: #083030;
-  --color-muted-foreground: #8aaa9a;
-  --color-accent: #0c3838;
-  --color-accent-foreground: #ffe6cb;
-  --color-destructive: #fb2c36;
-  --color-destructive-foreground: #fff;
-  --color-success: #4ade80;
-  --color-warning: #ffbd38;
-  --color-border: color-mix(in srgb, #ffe6cb 15%, transparent);
-  --color-input: color-mix(in srgb, #ffe6cb 15%, transparent);
-  --color-ring: #ffe6cb;
-  --color-popover: #062424;
-  --color-popover-foreground: #ffe6cb;
+  /* ---- Apple-inspired neutral palette ---- */
+  --color-background: #f5f5f7;
+  --color-foreground: #1d1d1f;
+  --color-card: #ffffff;
+  --color-card-foreground: #1d1d1f;
+  --color-primary: #0071e3;
+  --color-primary-foreground: #ffffff;
+  --color-secondary: #e8e8ed;
+  --color-secondary-foreground: #1d1d1f;
+  --color-muted: #f2f2f5;
+  --color-muted-foreground: #6e6e73;
+  --color-accent: #eaf3ff;
+  --color-accent-foreground: #0066cc;
+  --color-destructive: #d70015;
+  --color-destructive-foreground: #ffffff;
+  --color-success: #248a3d;
+  --color-warning: #b26a00;
+  --color-border: rgba(0, 0, 0, 0.08);
+  --color-input: rgba(0, 0, 0, 0.12);
+  --color-ring: #0071e3;
+  --color-popover: #ffffff;
+  --color-popover-foreground: #1d1d1f;
 
   /* ---- Font stacks ---- */
-  --font-sans: "Mondwest", Arial, sans-serif;
-  --font-mono: "Courier Prime", "Courier New", monospace;
-  --font-display: "Mondwest", Arial, sans-serif;
-  --font-expanded: "RulesExpanded", Arial, sans-serif;
-  --font-compressed: "RulesCompressed", Arial, sans-serif;
+  --font-sans: system-ui, -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --font-mono: ui-monospace, "SF Mono", SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  --font-display: system-ui, -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --font-expanded: system-ui, -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --font-compressed: system-ui, -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
 }
 
 /* ---- Global body ---- */
 body {
   margin: 0;
-  font-family: "Mondwest", Arial, sans-serif;
-  background: var(--color-background);
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  background:
+    radial-gradient(circle at 50% -20%, rgba(255, 255, 255, 0.85), transparent 32rem),
+    linear-gradient(180deg, #ffffff 0%, #f5f5f7 34%, #f2f2f5 100%);
   color: var(--color-foreground);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -143,11 +145,13 @@ code {
 }
 
 /* ---- Font utilities ---- */
-.font-display { font-family: "Mondwest", Arial, sans-serif; }
-.font-expanded { font-family: "RulesExpanded", Arial, sans-serif; }
-.font-compressed { font-family: "RulesCompressed", Arial, sans-serif; }
+.font-display,
+.font-expanded,
+.font-compressed {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+}
 .font-courier { font-family: "Courier Prime", "Courier New", monospace; }
-.font-collapse { font-family: "Collapse", Arial, sans-serif; }
+.font-collapse { font-family: system-ui, -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif; }
 .font-mono-ui { font-family: ui-monospace, "SF Mono", "Cascadia Mono", Menlo, monospace; }
 
 /* ---- Subtle grain overlay for badges ---- */
@@ -163,27 +167,21 @@ code {
   background: repeating-conic-gradient(currentColor 0% 25%, #0000 0% 50%) 0 0 / 2px 2px;
 }
 
-/* ---- Global noise grain (canonical: color-dodge, #eaeaea, high density) ---- */
+/* ---- Global noise grain disabled for readability ---- */
 .noise-overlay {
-  pointer-events: none;
-  position: fixed;
-  inset: 0;
-  z-index: 101;
-  mix-blend-mode: color-dodge;
-  opacity: 0.10;
-  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 512 512' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' fill='%23eaeaea' filter='url(%23n)' opacity='0.6'/%3E%3C/svg%3E");
-  background-size: 512px 512px;
+  display: none;
 }
 
-/* ---- Vignette (canonical: top-left amber radial, lighten blend) ---- */
+/* ---- Soft top light, not texture ---- */
 .warm-glow {
   pointer-events: none;
   position: fixed;
   inset: 0;
-  z-index: 99;
-  mix-blend-mode: lighten;
-  opacity: 0.22;
-  background: radial-gradient(ellipse at 0% 0%, rgba(255,189,56,0.35) 0%, rgba(255,189,56,0) 60%);
+  z-index: 0;
+  opacity: 0.65;
+  background:
+    radial-gradient(circle at 50% 0%, rgba(255, 255, 255, 0.95) 0%, rgba(255, 255, 255, 0) 34rem),
+    radial-gradient(circle at 82% 12%, rgba(0, 113, 227, 0.08) 0%, rgba(0, 113, 227, 0) 22rem);
 }
 
 /* ---- Reduced motion ---- */

--- a/web/src/pages/StatusPage.tsx
+++ b/web/src/pages/StatusPage.tsx
@@ -58,8 +58,37 @@ export default function StatusPage() {
 
   if (!status) {
     return (
-      <div className="flex items-center justify-center py-24">
-        <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+      <div className="flex flex-col gap-7" aria-busy="true">
+        <section className="overflow-hidden rounded-[32px] bg-[#1d1d1f] px-6 py-8 text-white shadow-[0_30px_80px_rgba(0,0,0,0.16)] sm:px-10 sm:py-12">
+          <div className="grid gap-8 lg:grid-cols-[1.15fr_0.85fr] lg:items-end">
+            <div className="max-w-2xl">
+              <div className="mb-5 h-4 w-36 animate-pulse rounded-full bg-white/14" />
+              <div className="h-12 w-full max-w-xl animate-pulse rounded-2xl bg-white/12 sm:h-16" />
+              <div className="mt-4 h-5 w-full max-w-lg animate-pulse rounded-full bg-white/10" />
+            </div>
+            <div className="grid gap-3 rounded-[24px] bg-white/[0.08] p-4 ring-1 ring-white/10">
+              {[0, 1, 2].map((item) => (
+                <div key={item} className="flex items-center justify-between border-b border-white/10 pb-3 last:border-0 last:pb-0">
+                  <div className="h-4 w-24 animate-pulse rounded-full bg-white/12" />
+                  <div className="h-6 w-20 animate-pulse rounded-full bg-white/16" />
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+        <div className="grid gap-4 sm:grid-cols-3">
+          {["Agent", "Gateway", "Sessions"].map((label) => (
+            <Card key={label}>
+              <CardHeader>
+                <CardTitle>{label}</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="h-8 w-32 animate-pulse rounded-full bg-muted" />
+                <div className="mt-3 h-6 w-20 animate-pulse rounded-full bg-muted" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
       </div>
     );
   }
@@ -112,10 +141,37 @@ export default function StatusPage() {
 
 
   return (
-    <div className="flex flex-col gap-6">
-      {/* Alert banner — breaks grid monotony for critical states */}
+    <div className="flex flex-col gap-7">
+      <section className="overflow-hidden rounded-[32px] bg-[#1d1d1f] px-6 py-8 text-white shadow-[0_30px_80px_rgba(0,0,0,0.16)] sm:px-10 sm:py-12">
+        <div className="grid gap-8 lg:grid-cols-[1.15fr_0.85fr] lg:items-end">
+          <div className="max-w-2xl">
+            <p className="mb-3 text-sm font-medium text-white/56">Hermes Control Center</p>
+            <h1 className="text-4xl font-semibold tracking-[-0.045em] sm:text-6xl">
+              Everything important, in one calm view.
+            </h1>
+            <p className="mt-4 max-w-xl text-base leading-7 text-white/68 sm:text-lg">
+              Monitor the agent, gateway, platforms, and recent work without the noisy generic AI-dashboard chrome.
+            </p>
+          </div>
+          <div className="grid gap-3 rounded-[24px] bg-white/[0.08] p-4 ring-1 ring-white/10 backdrop-blur-xl">
+            <div className="flex items-center justify-between border-b border-white/10 pb-3">
+              <span className="text-sm text-white/56">Gateway</span>
+              <Badge variant={gwBadge.badge}>{gwBadge.label}</Badge>
+            </div>
+            <div className="flex items-center justify-between border-b border-white/10 pb-3">
+              <span className="text-sm text-white/56">Version</span>
+              <span className="font-mono-ui text-sm">v{status.version}</span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-white/56">Active sessions</span>
+              <span className="font-semibold">{status.active_sessions}</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
       {alerts.length > 0 && (
-        <div className="border border-destructive/30 bg-destructive/[0.06] p-4">
+        <div className="rounded-[24px] border border-red-100 bg-red-50 p-5 shadow-sm">
           <div className="flex items-start gap-3">
             <AlertTriangle className="h-5 w-5 text-destructive shrink-0 mt-0.5" />
             <div className="flex flex-col gap-2 min-w-0">
@@ -173,7 +229,7 @@ export default function StatusPage() {
             {activeSessions.map((s) => (
               <div
                 key={s.id}
-                className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 border border-border p-3 w-full"
+                className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 rounded-2xl bg-muted/70 p-4 w-full"
               >
                 <div className="flex flex-col gap-1 min-w-0 w-full">
                   <div className="flex items-center gap-2">
@@ -208,7 +264,7 @@ export default function StatusPage() {
             {recentSessions.map((s) => (
               <div
                 key={s.id}
-                className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 border border-border p-3 w-full"
+                className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 rounded-2xl bg-muted/70 p-4 w-full"
               >
                 <div className="flex flex-col gap-1 min-w-0 w-full">
                   <span className="font-medium text-sm truncate">{s.title ?? "Untitled"}</span>
@@ -258,7 +314,7 @@ function PlatformsCard({ platforms }: PlatformsCardProps) {
           return (
             <div
               key={name}
-              className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 border border-border p-3 w-full"
+              className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 rounded-2xl bg-muted/70 p-4 w-full"
             >
               <div className="flex items-center gap-3 min-w-0 w-full">
                 <IconComponent className={`h-4 w-4 shrink-0 ${


### PR DESCRIPTION
## Summary
- Restyle the web dashboard shell toward a clean, Apple-like UI with a light neutral palette, pill navigation, softer cards, and system typography
- Refresh shared UI primitives: cards, badges, buttons, inputs, selects, and tabs
- Add a calmer Status page overview and skeleton loading state so data flows as sections instead of generic dashboard widgets

## Verification
- cd web && npm run build
- Browser visual QA at http://127.0.0.1:5173 for the dashboard shell and Sessions page
- Confirmed no browser console errors in Vite dev shell