### PR TITLE
fix(dashboard): suggest correct `[web]` extra in install hint

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10137,10 +10137,10 @@ def cmd_dashboard(args):
     except ImportError as e:
         print("Web UI dependencies not installed (need fastapi + uvicorn).")
         print(
-            f"Re-install the package into this interpreter so metadata updates apply:\n"
+            f"Install the optional `[web]` extra into this interpreter:\n"
             f"  cd {PROJECT_ROOT}\n"
-            f"  {sys.executable} -m pip install -e .\n"
-            "If `pip` is missing in this venv, use:  uv pip install -e ."
+            f"  {sys.executable} -m pip install -e '.[web]'\n"
+            "If `pip` is missing in this venv, use:  uv pip install -e '.[web]'"
         )
         print(f"Import error: {e}")
         sys.exit(1)


### PR DESCRIPTION
## What

When `hermes dashboard` fails to import `fastapi` / `uvicorn`, the printed remediation tells the user to run:

```
<python> -m pip install -e .
```

That command **doesn't actually install the missing deps** — `fastapi` and `uvicorn[standard]` live under the `[web]` optional extra in `pyproject.toml`, so a plain editable install leaves them out and the next `hermes dashboard` run hits the same error.

This PR updates the hint to:

```
<python> -m pip install -e '.[web]'
```

(and the equivalent `uv pip install -e '.[web]'` fallback).

## Why

Hit on a fresh-ish editable install on macOS — `hermes dashboard` printed the old hint, I followed it verbatim, and got the same import error a second time. Realized only after re-reading `pyproject.toml` that `[web]` was where the deps actually live.

The message change is purely a copy fix; no behavior change.

## Relationship to #9569

Issue [#9569](https://github.com/NousResearch/hermes-agent/issues/9569) tracks a deeper problem: `uv.lock` collapses the `[web]` and `[rl]` extras into a single `extra == 'rl'` marker, so `pip install hermes-agent[all]` (which includes `[web]` but not `[rl]`) ends up without `fastapi`. That's a lockfile/uv-resolver issue and needs a separate fix.

This PR doesn't touch that. It only fixes the **user-facing error copy** so people who hit the missing-fastapi error get pointed at a command that actually works in the common editable-install case.

## Diff

```diff
-            f"Re-install the package into this interpreter so metadata updates apply:\n"
+            f"Install the optional `[web]` extra into this interpreter:\n"
             f"  cd {PROJECT_ROOT}\n"
-            f"  {sys.executable} -m pip install -e .\n"
-            "If `pip` is missing in this venv, use:  uv pip install -e ."
+            f"  {sys.executable} -m pip install -e '.[web]'\n"
+            "If `pip` is missing in this venv, use:  uv pip install -e '.[web]'"
```

## Test plan

Manual: triggered the import error on a venv missing `fastapi`, ran the new suggested command, confirmed `hermes dashboard` boots.

```
$ /path/to/venv/bin/python -c "import fastapi"
ModuleNotFoundError: No module named 'fastapi'

$ /path/to/venv/bin/python -m pip install -e '.[web]'
Successfully installed fastapi-0.133.1 uvicorn-0.41.0 ...

$ /path/to/venv/bin/python -c "import fastapi, uvicorn; print(fastapi.__version__, uvicorn.__version__)"
0.133.1 0.41.0
```

No code paths changed, no new tests warranted — pure error-message copy.
