### PR TITLE
fix blank tool_name entries in state.db and JSON session logs

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -39,7 +39,7 @@ from agent.message_sanitization import (
     _repair_tool_call_arguments,
     _sanitize_surrogates,
 )
-from agent.tool_dispatch_helpers import _trajectory_normalize_msg
+from agent.tool_dispatch_helpers import _trajectory_normalize_msg, make_tool_result_message
 from agent.trajectory import convert_scratchpad_to_think
 from agent.error_classifier import classify_api_error, FailoverReason
 from utils import base_url_host_matches, base_url_hostname, env_var_enabled, atomic_json_write
@@ -317,12 +317,11 @@ def sanitize_tool_call_arguments(
                 if existing_tool_msg is None:
                     messages.insert(
                         insert_at,
-                        {
-                            "role": "tool",
-                            "name": function_name if function_name != "?" else "",
-                            "tool_call_id": tool_call_id,
-                            "content": marker,
-                        },
+                        make_tool_result_message(
+                            function_name if function_name != "?" else "",
+                            marker,
+                            tool_call_id,
+                        ),
                     )
                     insert_at += 1
                 else:

--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -317,6 +317,19 @@ def _trajectory_normalize_msg(msg: Dict[str, Any]) -> Dict[str, Any]:
     return msg
 
 
+def make_tool_result_message(name: str, content: Any, tool_call_id: str) -> dict:
+    """Build a tool-result message dict with both the OpenAI-format ``name``
+    field (required by the wire format and provider adapters) and the internal
+    ``tool_name`` field (written to the session DB messages table)."""
+    return {
+        "role": "tool",
+        "name": name,
+        "tool_name": name,
+        "content": content,
+        "tool_call_id": tool_call_id,
+    }
+
+
 __all__ = [
     "_NEVER_PARALLEL_TOOLS",
     "_PARALLEL_SAFE_TOOLS",
@@ -333,4 +346,5 @@ __all__ = [
     "_extract_file_mutation_targets",
     "_extract_error_preview",
     "_trajectory_normalize_msg",
+    "make_tool_result_message",
 ]

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -35,6 +35,7 @@ from agent.tool_dispatch_helpers import (
     _is_multimodal_tool_result,
     _multimodal_text_summary,
     _append_subdir_hint_to_multimodal,
+    make_tool_result_message,
 )
 from tools.terminal_tool import (
     _get_approval_callback,
@@ -74,12 +75,11 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     if agent._interrupt_requested:
         print(f"{agent.log_prefix}⚡ Interrupt: skipping {num_tools} tool call(s)")
         for tc in tool_calls:
-            messages.append({
-                "role": "tool",
-                "name": tc.function.name,
-                "content": f"[Tool execution cancelled — {tc.function.name} was skipped due to user interrupt]",
-                "tool_call_id": tc.id,
-            })
+            messages.append(make_tool_result_message(
+                tc.function.name,
+                f"[Tool execution cancelled — {tc.function.name} was skipped due to user interrupt]",
+                tc.id,
+            ))
         return
 
     # ── Parse args + pre-execution bookkeeping ───────────────────────
@@ -443,13 +443,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         # image tool result never poisons canonical session history.
         # String results pass through unchanged.
         _tool_content = agent._tool_result_content_for_active_model(name, function_result)
-        tool_msg = {
-            "role": "tool",
-            "name": name,
-            "content": _tool_content,
-            "tool_call_id": tc.id,
-        }
-        messages.append(tool_msg)
+        messages.append(make_tool_result_message(name, _tool_content, tc.id))
 
         # ── Per-tool /steer drain ───────────────────────────────────
         # Same as the sequential path: drain between each collected
@@ -864,13 +858,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         # Unwrap _multimodal dicts to an OpenAI-style content list
         # (see parallel path for rationale). String results pass through.
         _tool_content = agent._tool_result_content_for_active_model(function_name, function_result)
-        tool_msg = {
-            "role": "tool",
-            "name": function_name,
-            "content": _tool_content,
-            "tool_call_id": tool_call.id
-        }
-        messages.append(tool_msg)
+        messages.append(make_tool_result_message(function_name, _tool_content, tool_call.id))
 
         # ── Per-tool /steer drain ───────────────────────────────────
         # Drain pending steer BETWEEN individual tool calls so the
@@ -892,13 +880,11 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             agent._vprint(f"{agent.log_prefix}⚡ Interrupt: skipping {remaining} remaining tool call(s)", force=True)
             for skipped_tc in assistant_message.tool_calls[i:]:
                 skipped_name = skipped_tc.function.name
-                skip_msg = {
-                    "role": "tool",
-                    "name": skipped_name,
-                    "content": f"[Tool execution skipped — {skipped_name} was not started. User sent a new message]",
-                    "tool_call_id": skipped_tc.id
-                }
-                messages.append(skip_msg)
+                messages.append(make_tool_result_message(
+                    skipped_name,
+                    f"[Tool execution skipped — {skipped_name} was not started. User sent a new message]",
+                    skipped_tc.id,
+                ))
             break
 
         if agent.tool_delay > 0 and i < len(assistant_message.tool_calls):

--- a/mini_swe_runner.py
+++ b/mini_swe_runner.py
@@ -38,6 +38,7 @@ from typing import List, Dict, Any, Optional, Literal
 
 import fire
 from dotenv import load_dotenv
+from agent.tool_dispatch_helpers import make_tool_result_message
 
 # Load environment variables
 load_dotenv()
@@ -536,11 +537,9 @@ Complete the user's task step by step."""
                             completed = True
                         
                         # Add tool response
-                        messages.append({
-                            "role": "tool",
-                            "content": result_json,
-                            "tool_call_id": tc.id
-                        })
+                        messages.append(make_tool_result_message(
+                            tc.function.name, result_json, tc.id,
+                        ))
                         
                         print(f"   ✅ exit_code={result['exit_code']}, output={len(result['output'])} chars")
                     

--- a/tests/run_agent/test_tool_name_db_persistence.py
+++ b/tests/run_agent/test_tool_name_db_persistence.py
@@ -1,0 +1,45 @@
+"""Test that tool_name is correctly persisted to the session DB for tool-result messages.
+
+make_tool_result_message() sets tool_name on every tool-result dict at construction
+time. This test verifies that the value survives the flush path into the session DB.
+"""
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+from agent.tool_dispatch_helpers import make_tool_result_message
+
+
+def _make_agent(session_db):
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        return AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            session_db=session_db,
+        )
+
+
+def test_tool_name_persisted_to_session_db():
+    """tool_name set by make_tool_result_message must be passed through to
+    append_message so the column is populated on first flush to the session DB."""
+    session_db = MagicMock()
+    agent = _make_agent(session_db)
+
+    messages = [
+        {"role": "user", "content": "run a command"},
+        make_tool_result_message("terminal", "$ ls\nfile.txt", "c1"),
+    ]
+    agent._flush_messages_to_session_db(messages)
+
+    tool_appends = [
+        c for c in session_db.append_message.call_args_list
+        if c.kwargs.get("role") == "tool"
+    ]
+    assert len(tool_appends) == 1
+    assert tool_appends[0].kwargs["tool_name"] == "terminal"

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -267,6 +267,23 @@ class TestMessageStorage:
             ).fetchone()
         assert row["content"] == "plain text"
 
+    def test_replace_messages_persists_tool_name(self, db):
+        """`replace_messages` (used by /retry, /undo, /compress) must write
+        tool_name to the DB for messages built by make_tool_result_message."""
+        from agent.tool_dispatch_helpers import make_tool_result_message
+        db.create_session(session_id="s1", source="cli")
+        db.replace_messages(
+            "s1",
+            [
+                {"role": "user", "content": "do something"},
+                make_tool_result_message("web_search", "some results", "c1"),
+            ],
+        )
+
+        msgs = db.get_messages("s1")
+        tool_msg = next(m for m in msgs if m["role"] == "tool")
+        assert tool_msg["tool_name"] == "web_search"
+
     def test_replace_messages_handles_multimodal_content(self, db):
         """`replace_messages` (used by /retry, /undo, /compress) must also
         handle list content without crashing."""


### PR DESCRIPTION
## What does this PR do?

This PR fixes blank tool_name entries in state.db and JSON session logs. It refactors the tool message construction for the OpenAI format at 6 sites and adds "tool_name" to the message. This doesn't cause any problems for the existing code but means that session persistence can pick it up.

The alternative would have been to check for both "name" and "tool_name" at various persistence points - some existing code already does this. But that seems a fragile solution if downstream code is changed or new peristence paths added - that kind of thing might have caused this very bug!

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #28915 

## Type of Change

<!-- Check the one that applies. -->

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [X] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

  - `agent/tool_dispatch_helpers.py` — adds make_tool_result_message(name, content, tool_call_id) factory and exports it via `__all__`
  - `agent/tool_executor.py` — all four tool-result construction sites (sequential normal, sequential interrupt skip, concurrent normal, concurrent interrupt skip) replaced with make_tool_result_message
  - `agent/agent_runtime_helpers.py` — repair/rewrite path updated to use make_tool_result_message
  - `mini_swe_runner.py` — tool response construction updated; also adds the missing "name" field which was previously absent entirely
  - `tests/run_agent/test_tool_name_db_persistence.py` — new test verifying tool_name survives the flush path into the session DB
  - `tests/test_hermes_state.py` — new test verifying tool_name is correctly written by replace_messages (used by /retry, /undo, /compress)


## How to Test

  1. Run hermes and send a prompt that triggers a tool call (e.g. ask it to run a terminal command or search the web)
  2. After the response completes, query the session DB:
  ```
sqlite3 ~/.hermes/state.db
SELECT role, tool_name, substr(content,1,80) FROM messages ORDER BY timestamp DESC LIMIT 5;
```
  3. The role = 'tool' row should have tool_name populated with the function name rather than NULL

Also added tests:

  - `tests/run_agent/test_tool_name_db_persistence.py` — new file; tests that tool_name set by make_tool_result_message survives the flush path into the session DB (_flush_messages_to_session_db)
  - `tests/test_hermes_state.py` — existing file; one new test added (test_replace_messages_persists_tool_name) to the TestMessageStorage class, covering the replace_messages path used by /retry, /undo, and /compress

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [X] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [X] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [X] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [X] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [X] I've run `pytest tests/ -q` and all tests pass
- [X] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [X] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

