### PR TITLE
fix(discord): transcribe native voice notes

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -3602,6 +3602,24 @@ class DiscordAdapter(BasePlatformAdapter):
             return 32 * 1024 * 1024
         return max(0, value)
 
+    @staticmethod
+    def _is_discord_voice_message_attachment(att: Any) -> bool:
+        """Return True when a Discord audio attachment is a native voice note."""
+        marker = getattr(att, "is_voice_message", None)
+        if marker is not None:
+            if callable(marker):
+                try:
+                    return bool(marker())
+                except Exception as exc:
+                    logger.debug("[Discord] is_voice_message() failed for attachment: %s", exc)
+                    return False
+            return bool(marker)
+
+        return (
+            getattr(att, "duration", None) is not None
+            and getattr(att, "waveform", None) is not None
+        )
+
     def _discord_free_response_channels(self) -> set:
         """Return Discord channel IDs where no bot mention is required.
 
@@ -4542,7 +4560,10 @@ class DiscordAdapter(BasePlatformAdapter):
                     elif att.content_type.startswith("video/"):
                         msg_type = MessageType.VIDEO
                     elif att.content_type.startswith("audio/"):
-                        msg_type = MessageType.AUDIO
+                        if self._is_discord_voice_message_attachment(att):
+                            msg_type = MessageType.VOICE
+                        else:
+                            msg_type = MessageType.AUDIO
                     else:
                         doc_ext = ""
                         if att.filename:

--- a/tests/gateway/test_discord_attachment_download.py
+++ b/tests/gateway/test_discord_attachment_download.py
@@ -59,6 +59,7 @@ def _ensure_discord_mock():
 _ensure_discord_mock()
 
 from gateway.platforms.discord import DiscordAdapter  # noqa: E402
+from gateway.platforms.base import MessageType  # noqa: E402
 
 
 # Minimal valid image / audio / PDF bytes so the cache_*_from_bytes
@@ -358,3 +359,91 @@ class TestHandleMessageUsesAuthenticatedRead:
         event = adapter.handle_message.call_args[0][0]
         assert event.media_urls == ["/tmp/img_from_read.png"]
         assert event.media_types == ["image/png"]
+
+    @pytest.mark.asyncio
+    async def test_native_voice_note_is_classified_as_voice(self, monkeypatch):
+        """Discord native voice notes must enter the auto-STT voice path."""
+        adapter = _make_adapter()
+        adapter._client = SimpleNamespace(user=SimpleNamespace(id=999))
+        adapter.handle_message = AsyncMock()
+
+        with patch(
+            "gateway.platforms.discord.cache_audio_from_bytes",
+            return_value="/tmp/voice_from_read.ogg",
+        ):
+            att = SimpleNamespace(
+                url="https://cdn.discordapp.com/attachments/fake/voice.ogg",
+                filename="voice.ogg",
+                content_type="audio/ogg",
+                size=len(_OGG_BYTES),
+                read=AsyncMock(return_value=_OGG_BYTES),
+                is_voice_message=lambda: True,
+            )
+            from datetime import datetime, timezone
+
+            class _FakeDMChannel:
+                id = 100
+                name = "dm"
+
+            monkeypatch.setattr(
+                "gateway.platforms.discord.discord.DMChannel",
+                _FakeDMChannel,
+            )
+            chan = _FakeDMChannel()
+            msg = SimpleNamespace(
+                id=1, content="", attachments=[att], mentions=[],
+                reference=None,
+                created_at=datetime.now(timezone.utc),
+                channel=chan,
+                author=SimpleNamespace(id=42, display_name="U", name="U"),
+            )
+            await adapter._handle_message(msg)
+
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.VOICE
+        assert event.media_urls == ["/tmp/voice_from_read.ogg"]
+        assert event.media_types == ["audio/ogg"]
+
+    @pytest.mark.asyncio
+    async def test_plain_audio_attachment_stays_audio(self, monkeypatch):
+        """Plain audio uploads should stay out of automatic voice-note STT."""
+        adapter = _make_adapter()
+        adapter._client = SimpleNamespace(user=SimpleNamespace(id=999))
+        adapter.handle_message = AsyncMock()
+
+        with patch(
+            "gateway.platforms.discord.cache_audio_from_bytes",
+            return_value="/tmp/audio_from_read.ogg",
+        ):
+            att = SimpleNamespace(
+                url="https://cdn.discordapp.com/attachments/fake/audio.ogg",
+                filename="audio.ogg",
+                content_type="audio/ogg",
+                size=len(_OGG_BYTES),
+                read=AsyncMock(return_value=_OGG_BYTES),
+                is_voice_message=lambda: False,
+            )
+            from datetime import datetime, timezone
+
+            class _FakeDMChannel:
+                id = 100
+                name = "dm"
+
+            monkeypatch.setattr(
+                "gateway.platforms.discord.discord.DMChannel",
+                _FakeDMChannel,
+            )
+            chan = _FakeDMChannel()
+            msg = SimpleNamespace(
+                id=1, content="", attachments=[att], mentions=[],
+                reference=None,
+                created_at=datetime.now(timezone.utc),
+                channel=chan,
+                author=SimpleNamespace(id=42, display_name="U", name="U"),
+            )
+            await adapter._handle_message(msg)
+
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.AUDIO
+        assert event.media_urls == ["/tmp/audio_from_read.ogg"]
+        assert event.media_types == ["audio/ogg"]


### PR DESCRIPTION
## What does this PR do?

Fixes Discord native voice-note handling so inbound voice notes are classified as `MessageType.VOICE` instead of generic `MessageType.AUDIO`.

Discord.py exposes native voice-note metadata through `Attachment.is_voice_message()`. Hermes was only checking `content_type.startswith("audio/")`, which routed Discord voice notes into the plain audio attachment path. The gateway intentionally skips automatic STT for `MessageType.AUDIO`, so native Discord voice notes were cached as files instead of being automatically transcribed.

This keeps ordinary audio uploads as `MessageType.AUDIO` and only marks native Discord voice-message attachments as `MessageType.VOICE`.

## Related Issue

Support report: Discord voice notes stopped auto-transcribing after update.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/discord.py`: detect native Discord voice-note attachments with `attachment.is_voice_message()` before the generic `audio/*` branch.
- `tests/gateway/test_discord_attachment_download.py`: add regression coverage proving native voice notes become `MessageType.VOICE` while ordinary audio uploads remain `MessageType.AUDIO`.

## How to Test

1. Send a native Discord voice note to the Hermes Discord bot.
2. Confirm the Discord adapter emits a `MessageType.VOICE` event for the attachment.
3. Confirm the gateway auto-STT path handles the voice note instead of surfacing it only as a generic audio file attachment.

Targeted tests run locally:

- `python -m pytest tests/gateway/test_discord_attachment_download.py tests/gateway/test_telegram_audio_vs_voice.py -q` — 19 passed
- `python -m pytest tests/gateway/test_stt_config.py -q` — 6 passed

Full suite run locally:

- `scripts/run_tests.sh` — 17 failed, 24561 passed, 54 skipped, 250 warnings in 646.20s

Full-suite failures observed:

- `tests/gateway/test_api_server.py::TestAdapterInit::test_default_config`
- `tests/gateway/test_approve_deny_commands.py::TestBlockingApprovalE2E::test_blocking_approval_approve_once`
- `tests/gateway/test_approve_deny_commands.py::TestBlockingApprovalE2E::test_blocking_approval_deny`
- `tests/gateway/test_config.py::TestLoadGatewayConfig::test_bridges_quoted_false_platform_enabled_from_config_yaml`
- `tests/gateway/test_discord_bot_filter.py::TestDiscordBotFilter::test_default_is_none`
- `tests/gateway/test_restart_resume_pending.py::test_clean_drain_does_not_mark_resume_pending`
- `tests/gateway/test_restart_resume_pending.py::test_drain_timeout_only_marks_still_running_sessions`
- `tests/gateway/test_runner_startup_failures.py::test_start_gateway_replace_force_uses_terminate_pid`
- `tests/hermes_cli/test_gateway_service.py::TestGatewaySystemServiceRouting::test_gateway_install_passes_system_flags`
- `tests/hermes_cli/test_gateway_wsl.py::TestGatewayCommandWSLMessages::test_install_wsl_with_systemd_warns`
- `tests/hermes_cli/test_update_gateway_restart.py::TestLaunchdPlistPath::test_plist_path_starts_with_venv_bin`
- `tests/tools/test_file_operations.py::TestGitBaselineCheck::test_git_not_available_returns_none`
- `tests/tools/test_file_operations.py::TestGitBaselineCheck::test_not_in_git_repo_returns_none`
- `tests/tools/test_file_operations.py::TestGitBaselineCheck::test_clean_repo_returns_none`
- `tests/tools/test_file_operations.py::TestGitBaselineCheck::test_dirty_repo_returns_warning`
- `tests/tools/test_file_operations.py::TestGitBaselineCheck::test_write_file_includes_git_warning_when_dirty`
- `tests/tools/test_tirith_security.py::TestDiskFailureMarker::test_cosign_missing_marker_clears_when_cosign_appears`

The Discord voice-note regression tests added by this PR pass in the targeted run.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2 / Linux local test environment

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Targeted test output:

- `tests/gateway/test_discord_attachment_download.py tests/gateway/test_telegram_audio_vs_voice.py`: 19 passed
- `tests/gateway/test_stt_config.py`: 6 passed

Full suite output summary:

- `scripts/run_tests.sh`: 17 failed, 24561 passed, 54 skipped, 250 warnings in 646.20s
