### PR TITLE
fix(credential_pool): cap retry delay at 3600s to prevent indefinite freeze

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -239,26 +239,33 @@ def _parse_absolute_timestamp(value: Any) -> Optional[float]:
     return None
 
 
+# Hard ceiling on how long a credential can be frozen due to a provider-
+# reported retry delay, regardless of which code path derives reset_at.
+# Shared by _extract_retry_delay_seconds() and _normalize_error_context().
+_MAX_DELAY = 3600.0
+
+
 def _extract_retry_delay_seconds(message: str) -> Optional[float]:
     if not message:
         return None
     delay_match = re.search(r"quotaResetDelay[:\s\"]+(\d+(?:\.\d+)?)(ms|s)", message, re.IGNORECASE)
     if delay_match:
         value = float(delay_match.group(1))
-        return value / 1000.0 if delay_match.group(2).lower() == "ms" else value
+        raw = value / 1000.0 if delay_match.group(2).lower() == "ms" else value
+        return min(raw, _MAX_DELAY)
     sec_match = re.search(r"retry\s+(?:after\s+)?(\d+(?:\.\d+)?)\s*(?:sec|secs|seconds|s\b)", message, re.IGNORECASE)
     if sec_match:
-        return float(sec_match.group(1))
+        return min(float(sec_match.group(1)), _MAX_DELAY)
     # "Resets in 4hr 5min" format used by OpenCode Go weekly usage limits
     hr_min_match = re.search(r"resets?\s+in\s+(\d+)\s*hr\s+(\d+)\s*min", message, re.IGNORECASE)
     if hr_min_match:
-        return int(hr_min_match.group(1)) * 3600 + int(hr_min_match.group(2)) * 60
+        return min(int(hr_min_match.group(1)) * 3600 + int(hr_min_match.group(2)) * 60, _MAX_DELAY)
     hr_only_match = re.search(r"resets?\s+in\s+(\d+)\s*hr\b", message, re.IGNORECASE)
     if hr_only_match:
-        return int(hr_only_match.group(1)) * 3600
+        return min(int(hr_only_match.group(1)) * 3600, _MAX_DELAY)
     min_only_match = re.search(r"resets?\s+in\s+(\d+)\s*min\b", message, re.IGNORECASE)
     if min_only_match:
-        return int(min_only_match.group(1)) * 60
+        return min(int(min_only_match.group(1)) * 60, _MAX_DELAY)
     return None
 
 
@@ -283,7 +290,13 @@ def _normalize_error_context(error_context: Optional[Dict[str, Any]]) -> Dict[st
         if retry_delay_seconds is not None:
             parsed_reset_at = time.time() + retry_delay_seconds
     if parsed_reset_at is not None:
-        normalized["reset_at"] = parsed_reset_at
+        # Cap regardless of source: a provider-supplied reset_at/resets_at/
+        # retry_until (e.g. from agent_runtime_helpers.extract_api_error_context,
+        # which parses retry_after/Retry-After/quotaResetDelay/"resets in"
+        # without any bound) can be arbitrarily far in the future. This is
+        # the single chokepoint that becomes last_error_reset_at, so capping
+        # here covers every upstream source uniformly.
+        normalized["reset_at"] = min(parsed_reset_at, time.time() + _MAX_DELAY)
     return normalized
 
 

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -24,6 +24,66 @@ def _jwt_with_claims(claims: dict) -> str:
     return f"{_part({'alg': 'none', 'typ': 'JWT'})}.{_part(claims)}.sig"
 
 
+def test_extract_retry_delay_seconds_caps_huge_retry_after():
+    from agent.credential_pool import _extract_retry_delay_seconds, _MAX_DELAY
+
+    assert _extract_retry_delay_seconds("retry after 999999999 seconds") == _MAX_DELAY
+
+
+def test_extract_retry_delay_seconds_caps_huge_quota_reset_delay():
+    from agent.credential_pool import _extract_retry_delay_seconds, _MAX_DELAY
+
+    assert _extract_retry_delay_seconds("quotaResetDelay: 99999999s") == _MAX_DELAY
+
+
+def test_extract_retry_delay_seconds_passes_through_small_values():
+    from agent.credential_pool import _extract_retry_delay_seconds
+
+    assert _extract_retry_delay_seconds("retry after 30 seconds") == 30.0
+
+
+def test_normalize_error_context_caps_huge_provider_reset_at(monkeypatch):
+    """A provider-supplied absolute reset_at (as agent_runtime_helpers.extract_api_error_context
+    would set from an uncapped retry_after/Retry-After/quotaResetDelay/"resets in" value) must
+    still be capped at _MAX_DELAY -- this is the bypass path flagged in review: reset_at is
+    already present so _extract_retry_delay_seconds() is never called."""
+    from agent.credential_pool import _normalize_error_context, _MAX_DELAY
+
+    monkeypatch.setattr("agent.credential_pool.time.time", lambda: 1_000.0)
+    huge_reset_at = 1_000.0 + 999_999_999  # e.g. from extract_api_error_context's retry_after path
+    normalized = _normalize_error_context({"reset_at": huge_reset_at, "message": "rate limited"})
+    assert normalized["reset_at"] == 1_000.0 + _MAX_DELAY
+
+
+def test_normalize_error_context_caps_huge_resets_in_message(monkeypatch):
+    """A message-derived reset_at (e.g. "Resets in 6hr 29min" -> 23340s) is capped here too."""
+    from agent.credential_pool import _normalize_error_context, _MAX_DELAY
+
+    monkeypatch.setattr("agent.credential_pool.time.time", lambda: 1_000.0)
+    normalized = _normalize_error_context(
+        {"message": "Weekly usage limit reached. Resets in 6hr 29min."}
+    )
+    assert normalized["reset_at"] == 1_000.0 + _MAX_DELAY
+
+
+def test_normalize_error_context_preserves_reset_at_within_cap(monkeypatch):
+    from agent.credential_pool import _normalize_error_context, _MAX_DELAY
+
+    monkeypatch.setattr("agent.credential_pool.time.time", lambda: 1_000.0)
+    normalized = _normalize_error_context({"reset_at": 1_000.0 + 1_800})
+    assert normalized["reset_at"] == 1_000.0 + 1_800
+
+
+def test_normalize_error_context_caps_huge_epoch_ms_reset_at(monkeypatch):
+    """x-ratelimit-reset style header value: huge epoch-milliseconds string far in the future."""
+    from agent.credential_pool import _normalize_error_context, _MAX_DELAY
+
+    monkeypatch.setattr("agent.credential_pool.time.time", lambda: 1_000.0)
+    huge_epoch_ms = str(int((1_000.0 + 999_999_999) * 1000))
+    normalized = _normalize_error_context({"reset_at": huge_epoch_ms})
+    assert normalized["reset_at"] == 1_000.0 + _MAX_DELAY
+
+
 def test_fill_first_selection_skips_recently_exhausted_entry(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     _write_auth_store(


### PR DESCRIPTION
## What does this PR do?
`_extract_retry_delay_seconds` returned an unbounded float parsed from a provider error message. A malformed or adversarial response containing 'retry after 999999999 seconds' would set `last_error_reset_at` to `time.time() + 999999999`, freezing the credential for 31+ years with no visible signal.

## Type of Change
- [x] Bug fix

## Changes Made
- Added `_MAX_DELAY = 3600.0` constant inside `_extract_retry_delay_seconds`
- Capped both return paths (`quotaResetDelay` and `retry after`) with `min(raw, _MAX_DELAY)`
- Maximum freeze is now 1 hour regardless of provider response content

## How to Test
- Call `_extract_retry_delay_seconds('retry after 999999999 seconds')` — should return `3600.0`
- Call `_extract_retry_delay_seconds('quotaResetDelay: 99999999s')` — should return `3600.0`
- Normal values under 3600s pass through unchanged

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] No sensitive data (keys, tokens, secrets) included