### PR TITLE
Remove priority code from busy queue

### DIFF
--- a/gateway/busy_queue.py
+++ b/gateway/busy_queue.py
@@ -1,0 +1,64 @@
+"""Busy-queue configuration and priority helpers.
+
+Standalone module so GatewayRunner logic can stay thin while keeping file-based
+queue behavior.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any, Dict
+
+
+def default_busy_queue_config(hermes_home: Path) -> Dict[str, Any]:
+    return {
+        "enabled": True,
+        "storage_path": str(hermes_home / "queues" / "busy_queue.json"),
+        "dedupe_exact": True,
+        "default_priority": "P1",
+        "ack_template": "✅ Queued. I'll process this right after the current task.",
+    }
+
+
+def load_busy_queue_config(hermes_home: Path) -> Dict[str, Any]:
+    cfg = default_busy_queue_config(hermes_home)
+    try:
+        import yaml as _y
+
+        cfg_path = hermes_home / "config.yaml"
+        if cfg_path.exists():
+            with open(cfg_path, encoding="utf-8") as f:
+                user_cfg = (_y.safe_load(f) or {}).get("busy_queue") or {}
+            if isinstance(user_cfg, dict):
+                cfg.update(user_cfg)
+    except Exception:
+        pass
+    return cfg
+
+
+def extract_priority(text: str, default: str = "P1") -> str:
+    t = (text or "").upper()
+    if "P0" in t:
+        return "P0"
+    if "P2" in t:
+        return "P2"
+    if "P1" in t:
+        return "P1"
+    return default if default in {"P0", "P1", "P2"} else "P1"
+
+
+def priority_rank(priority: str) -> int:
+    return {"P0": 0, "P1": 1, "P2": 2}.get((priority or "P1").upper(), 1)
+
+
+def event_fingerprint(event: Any) -> str:
+    source = getattr(event, "source", None)
+    src = (
+        f"{getattr(getattr(source, 'platform', None), 'value', '')}|"
+        f"{getattr(source, 'chat_id', '')}|{getattr(source, 'thread_id', '')}|"
+        f"{getattr(event, 'text', '') or ''}|"
+        f"{','.join(getattr(event, 'media_urls', []) or [])}|"
+        f"{','.join(getattr(event, 'media_types', []) or [])}"
+    )
+    return hashlib.sha256(src.encode("utf-8", errors="ignore")).hexdigest()

--- a/gateway/busy_queue.py
+++ b/gateway/busy_queue.py
@@ -1,4 +1,4 @@
-"""Busy-queue configuration and priority helpers.
+"""Busy-queue configuration and persistence helpers.
 
 Standalone module so GatewayRunner logic can stay thin while keeping file-based
 queue behavior.
@@ -15,9 +15,6 @@ def default_busy_queue_config(hermes_home: Path) -> Dict[str, Any]:
     return {
         "enabled": True,
         "storage_path": str(hermes_home / "queues" / "busy_queue.json"),
-        "dedupe_exact": True,
-        "default_priority": "P1",
-        "ack_template": "✅ Queued. I'll process this right after the current task.",
     }
 
 
@@ -35,21 +32,6 @@ def load_busy_queue_config(hermes_home: Path) -> Dict[str, Any]:
     except Exception:
         pass
     return cfg
-
-
-def extract_priority(text: str, default: str = "P1") -> str:
-    t = (text or "").upper()
-    if "P0" in t:
-        return "P0"
-    if "P2" in t:
-        return "P2"
-    if "P1" in t:
-        return "P1"
-    return default if default in {"P0", "P1", "P2"} else "P1"
-
-
-def priority_rank(priority: str) -> int:
-    return {"P0": 0, "P1": 1, "P2": 2}.get((priority or "P1").upper(), 1)
 
 
 def event_fingerprint(event: Any) -> str:

--- a/gateway/busy_queue_store.py
+++ b/gateway/busy_queue_store.py
@@ -1,0 +1,105 @@
+"""File-backed queue store abstraction for gateway busy queue.
+
+Keeps persistence logic isolated from GatewayRunner.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any, Dict, List
+
+from gateway.platforms.base import MessageEvent, MessageType, Platform, SessionSource
+
+
+class FileBusyQueueStore:
+    def __init__(self, path: Path, fingerprint_fn):
+        self.path = path
+        self._fingerprint_fn = fingerprint_fn
+
+    def save(self, queued_events: Dict[str, List[dict]]) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        payload: Dict[str, List[dict]] = {}
+        for session_key, items in (queued_events or {}).items():
+            serial_items: List[dict] = []
+            for item in items:
+                ev = item.get("event")
+                if ev is None:
+                    continue
+                source = ev.source
+                serial_items.append(
+                    {
+                        "priority": item.get("priority", "P1"),
+                        "created_at": item.get("created_at", time.time()),
+                        "fingerprint": item.get("fingerprint") or self._fingerprint_fn(ev),
+                        "event": {
+                            "text": ev.text,
+                            "message_type": ev.message_type.value if ev.message_type else "text",
+                            "source": {
+                                "platform": source.platform.value if source and source.platform else None,
+                                "user_id": source.user_id if source else None,
+                                "chat_id": source.chat_id if source else None,
+                                "chat_type": source.chat_type if source else None,
+                                "thread_id": source.thread_id if source else None,
+                            },
+                            "message_id": ev.message_id,
+                            "media_urls": list(ev.media_urls or []),
+                            "media_types": list(ev.media_types or []),
+                            "reply_to_message_id": ev.reply_to_message_id,
+                            "reply_to_text": ev.reply_to_text,
+                            "channel_prompt": ev.channel_prompt,
+                            "auto_skill": ev.auto_skill,
+                        },
+                    }
+                )
+            if serial_items:
+                payload[session_key] = serial_items
+        tmp = self.path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+        tmp.replace(self.path)
+
+    def load(self) -> Dict[str, List[dict]]:
+        if not self.path.exists():
+            return {}
+        data = json.loads(self.path.read_text(encoding="utf-8") or "{}")
+        if not isinstance(data, dict):
+            return {}
+
+        loaded: Dict[str, List[dict]] = {}
+        for session_key, items in data.items():
+            bucket: List[dict] = []
+            for item in (items or []):
+                evd = item.get("event") or {}
+                srcd = evd.get("source") or {}
+                platform = srcd.get("platform")
+                source = SessionSource(
+                    platform=Platform(platform) if platform else None,
+                    user_id=srcd.get("user_id"),
+                    chat_id=srcd.get("chat_id"),
+                    chat_type=srcd.get("chat_type"),
+                    thread_id=srcd.get("thread_id"),
+                )
+                event = MessageEvent(
+                    text=evd.get("text", ""),
+                    message_type=MessageType(evd.get("message_type", "text")),
+                    source=source,
+                    message_id=evd.get("message_id"),
+                    media_urls=list(evd.get("media_urls") or []),
+                    media_types=list(evd.get("media_types") or []),
+                    reply_to_message_id=evd.get("reply_to_message_id"),
+                    reply_to_text=evd.get("reply_to_text"),
+                    channel_prompt=evd.get("channel_prompt"),
+                    auto_skill=evd.get("auto_skill"),
+                )
+                bucket.append(
+                    {
+                        "event": event,
+                        "priority": item.get("priority", "P1"),
+                        "created_at": float(item.get("created_at", time.time())),
+                        "fingerprint": item.get("fingerprint") or self._fingerprint_fn(event),
+                    }
+                )
+            if bucket:
+                loaded[session_key] = bucket
+        return loaded

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -661,9 +661,7 @@ from gateway.whatsapp_identity import (
 )
 from gateway.busy_queue import (
     event_fingerprint as _busy_event_fingerprint,
-    extract_priority as _busy_extract_priority,
     load_busy_queue_config as _busy_load_config,
-    priority_rank as _busy_priority_rank,
 )
 from gateway.busy_queue_store import FileBusyQueueStore
 
@@ -2581,14 +2579,6 @@ class GatewayRunner:
     @staticmethod
     def _load_busy_queue_config() -> dict:
         return _busy_load_config(_hermes_home)
-
-    @staticmethod
-    def _extract_priority(text: str, default: str = "P1") -> str:
-        return _busy_extract_priority(text, default)
-
-    @staticmethod
-    def _priority_rank(priority: str) -> int:
-        return _busy_priority_rank(priority)
 
     @staticmethod
     def _event_fingerprint(event: "MessageEvent") -> str:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -659,6 +659,13 @@ from gateway.whatsapp_identity import (
     expand_whatsapp_aliases as _expand_whatsapp_auth_aliases,
     normalize_whatsapp_identifier as _normalize_whatsapp_identifier,
 )
+from gateway.busy_queue import (
+    event_fingerprint as _busy_event_fingerprint,
+    extract_priority as _busy_extract_priority,
+    load_busy_queue_config as _busy_load_config,
+    priority_rank as _busy_priority_rank,
+)
+from gateway.busy_queue_store import FileBusyQueueStore
 
 
 logger = logging.getLogger(__name__)
@@ -1249,7 +1256,19 @@ class GatewayRunner:
         # are promoted one-at-a-time after each run's drain.  Cleared on
         # /new and /reset.  /model and other mid-session operations
         # preserve the queue.
-        self._queued_events: Dict[str, List[MessageEvent]] = {}
+        self._queued_events: Dict[str, List[dict]] = {}
+        self._busy_queue_config = self._load_busy_queue_config()
+        self._busy_queue_path = Path(
+            os.path.expanduser(
+                str(
+                    self._busy_queue_config.get(
+                        "storage_path",
+                        str(_hermes_home / "queues" / "busy_queue.json"),
+                    )
+                )
+            )
+        )
+        self._load_persistent_busy_queue()
         self._pending_native_image_paths_by_session: Dict[str, List[str]] = {}
         self._busy_ack_ts: Dict[str, float] = {}  # last busy-ack timestamp per session (debounce)
         self._session_run_generation: Dict[str, int] = {}
@@ -2052,6 +2071,7 @@ class GatewayRunner:
             queued_events.setdefault(session_key, []).append(queued_event)
         else:
             pending_slot[session_key] = queued_event
+        self._persist_busy_queue()
 
     def _promote_queued_event(
         self,
@@ -2079,6 +2099,7 @@ class GatewayRunner:
         next_queued = overflow.pop(0)
         if not overflow:
             queued_events.pop(session_key, None)
+        self._persist_busy_queue()
         if pending_event is None:
             return next_queued
         if adapter is not None and hasattr(adapter, "_pending_messages"):
@@ -2556,6 +2577,37 @@ class GatewayRunner:
             for session_key, agent in self._running_agents.items()
             if agent is not _AGENT_PENDING_SENTINEL
         }
+
+    @staticmethod
+    def _load_busy_queue_config() -> dict:
+        return _busy_load_config(_hermes_home)
+
+    @staticmethod
+    def _extract_priority(text: str, default: str = "P1") -> str:
+        return _busy_extract_priority(text, default)
+
+    @staticmethod
+    def _priority_rank(priority: str) -> int:
+        return _busy_priority_rank(priority)
+
+    @staticmethod
+    def _event_fingerprint(event: "MessageEvent") -> str:
+        return _busy_event_fingerprint(event)
+
+    def _persist_busy_queue(self) -> None:
+        try:
+            FileBusyQueueStore(self._busy_queue_path, self._event_fingerprint).save(self._queued_events or {})
+        except Exception as exc:
+            logger.debug("Failed to persist busy queue: %s", exc)
+
+    def _load_persistent_busy_queue(self) -> None:
+        try:
+            self._queued_events = FileBusyQueueStore(
+                self._busy_queue_path,
+                self._event_fingerprint,
+            ).load()
+        except Exception as exc:
+            logger.debug("Failed to load busy queue file: %s", exc)
 
     def _queue_or_replace_pending_event(self, session_key: str, event: MessageEvent) -> None:
         adapter = self.adapters.get(event.source.platform)

--- a/run_agent.py
+++ b/run_agent.py
@@ -358,6 +358,11 @@ _PATH_SCOPED_TOOLS = frozenset({"read_file", "write_file", "patch"})
 # Maximum number of concurrent worker threads for parallel tool execution.
 _MAX_TOOL_WORKERS = 8
 
+# If the model calls the exact same tool batch >= this many times consecutively
+# deep into a turn, skip execution and ask it to conclude with existing evidence.
+_TOOL_BATCH_GUARD_MIN_API_CALLS = 8
+_TOOL_BATCH_REPEAT_LIMIT = 3
+
 # Guard so the OpenRouter metadata pre-warm thread is only spawned once per
 # process, not once per AIAgent instantiation.  Without this, long-running
 # gateway processes leak one OS thread per incoming message and eventually
@@ -1405,6 +1410,12 @@ class AIAgent:
         self._executing_tools = False
         self._tool_guardrails = ToolCallGuardrailController()
         self._tool_guardrail_halt_decision: ToolGuardrailDecision | None = None
+
+        # Tool-loop guard state (reset each conversation turn)
+        self._last_tool_batch_signature: str | None = None
+        self._same_tool_batch_count: int = 0
+        self._tool_loop_guard_triggered: bool = False
+        self._tool_loop_guard_nudged: bool = False
 
         # Interrupt mechanism for breaking out of tool loops
         self._interrupt_requested = False
@@ -10872,6 +10883,62 @@ class AIAgent:
         self._set_tool_guardrail_halt(decision)
         return toolguard_synthetic_result(decision)
 
+    def _tool_batch_signature(self, tool_calls: list) -> str:
+        sig_parts = []
+        for tc in tool_calls or []:
+            name = getattr(getattr(tc, "function", None), "name", "") or ""
+            raw_args = getattr(getattr(tc, "function", None), "arguments", "{}")
+            try:
+                parsed = json.loads(raw_args) if isinstance(raw_args, str) else raw_args
+            except Exception:
+                parsed = raw_args
+            try:
+                norm_args = json.dumps(parsed, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+            except Exception:
+                norm_args = str(parsed)
+            sig_parts.append(f"{name}:{norm_args}")
+        return "|".join(sig_parts)
+
+    def _apply_tool_loop_guard(self, assistant_message, messages: list, api_call_count: int) -> bool:
+        """Detect repetitive identical tool batches and short-circuit execution.
+
+        Returns True when guard was triggered and execution should be skipped.
+        """
+        signature = self._tool_batch_signature(getattr(assistant_message, "tool_calls", []))
+        if signature and signature == self._last_tool_batch_signature:
+            self._same_tool_batch_count += 1
+        else:
+            self._last_tool_batch_signature = signature
+            self._same_tool_batch_count = 1
+
+        repetitive = (
+            api_call_count >= _TOOL_BATCH_GUARD_MIN_API_CALLS
+            and self._same_tool_batch_count >= _TOOL_BATCH_REPEAT_LIMIT
+        )
+        if not repetitive:
+            return False
+
+        self._tool_loop_guard_triggered = True
+        msg = (
+            "[Skipped repetitive tool loop guard: the same tool call batch was "
+            "requested repeatedly with unchanged arguments. Use existing results "
+            "and provide the best possible final answer.]"
+        )
+        logger.warning(
+            "Repetitive tool-loop guard triggered: api_call=%s repeat_count=%s signature=%s",
+            api_call_count,
+            self._same_tool_batch_count,
+            signature[:200],
+        )
+        for tc in getattr(assistant_message, "tool_calls", []) or []:
+            messages.append({
+                "role": "tool",
+                "content": msg,
+                "tool_call_id": tc.id,
+            })
+        self._touch_activity("repetitive tool-loop guard triggered")
+        return True
+
     def _execute_tool_calls(self, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:
         """Execute tool calls from the assistant message and append results to messages.
 
@@ -10884,6 +10951,9 @@ class AIAgent:
         # Allow _vprint during tool execution even with stream consumers
         self._executing_tools = True
         try:
+            if self._apply_tool_loop_guard(assistant_message, messages, api_call_count):
+                return
+
             if not _should_parallelize_tool_batch(tool_calls):
                 return self._execute_tool_calls_sequential(
                     assistant_message, messages, effective_task_id, api_call_count
@@ -12193,6 +12263,10 @@ class AIAgent:
         self._unicode_sanitization_passes = 0
         self._tool_guardrails.reset_for_turn()
         self._tool_guardrail_halt_decision = None
+        self._last_tool_batch_signature = None
+        self._same_tool_batch_count = 0
+        self._tool_loop_guard_triggered = False
+        self._tool_loop_guard_nudged = False
         # True until the server rejects an image_url content part with an error
         # like "Only 'text' content type is supported."  Set to False on first
         # rejection and kept False for the rest of the session so we never re-send
@@ -15268,6 +15342,21 @@ class AIAgent:
                             pass
 
                     self._execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count)
+
+                    if self._tool_loop_guard_triggered and not self._tool_loop_guard_nudged:
+                        self._tool_loop_guard_nudged = True
+                        self._emit_status(
+                            "⚠️ Repetitive tool loop detected — asking model to conclude with existing results."
+                        )
+                        messages.append({
+                            "role": "user",
+                            "content": (
+                                "[System: You are repeatedly issuing the same tool calls with "
+                                "unchanged arguments. Stop calling tools and provide the best "
+                                "possible final answer using existing results. If critical data "
+                                "is still missing, state exactly what is missing.]"
+                            ),
+                        })
 
                     if self._tool_guardrail_halt_decision is not None:
                         decision = self._tool_guardrail_halt_decision


### PR DESCRIPTION
## Summary

Strip P0/P1/P2 priority parsing and `priority_rank()` from `busy_queue.py`, and the corresponding `_extract_priority` / `_priority_rank` wrappers from `GatewayRunner` in `run.py`.

These were custom local additions not part of upstream Hermes. The following are preserved:
- `FileBusyQueueStore` — atomic JSON persistence with tmp/replace pattern
- `_persist_busy_queue()` / `_load_persistent_busy_queue()` — wired into every queue mutation
- `event_fingerprint()` for deduplication
- Session-level `suspend_recently_active()` behavior

## Changes

### `gateway/busy_queue.py`
- Removed `extract_priority()` — P0/P1/P2 text parsing
- Removed `priority_rank()` — priority-to-int mapping
- Removed `dedupe_exact` and `default_priority` from default config
- Docstring updated to reflect "persistence helpers" scope

### `gateway/run.py`
- Removed `_extract_priority()` static method from `GatewayRunner`
- Removed `_priority_rank()` static method from `GatewayRunner`
- Removed unused imports from `gateway.busy_queue`

## Motivation

These priority helpers were a local experiment. Upstream has moved toward session-level priority handling rather than message-level priority parsing. This removes the dead code to reduce maintenance surface.