### PR TITLE
fix(cli): termux-gate composer rendering and skill compat notes

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -257,6 +257,11 @@ def _build_skill_message(
         parts.append("")
         parts.append(f"[Runtime note: {runtime_note}]")
 
+    termux_warning = str(loaded_skill.get("termux_compat_warning") or "").strip()
+    if termux_warning:
+        parts.append("")
+        parts.append(f"[Termux compatibility note: {termux_warning}]")
+
     return "\n".join(parts)
 
 

--- a/cli.py
+++ b/cli.py
@@ -3249,6 +3249,58 @@ class HermesCLI:
         except Exception:
             return shutil.get_terminal_size(default).columns
 
+    @staticmethod
+    def _get_tui_terminal_rows(default: tuple[int, int] = (80, 24)) -> int:
+        """Return the live prompt_toolkit row count, falling back to ``shutil``."""
+        try:
+            from prompt_toolkit.application import get_app
+            return get_app().output.get_size().rows
+        except Exception:
+            return shutil.get_terminal_size(default).lines
+
+    def _tui_input_max_rows(self, rows: Optional[int] = None) -> int:
+        """Return the maximum multiline composer height.
+
+        Desktop terminals keep the long-standing 8-row cap. On Termux/mobile we
+        allow a taller composer so long prompts remain visible while typing.
+        """
+        if not _is_termux_environment():
+            return 8
+        if rows is None:
+            rows = self._get_tui_terminal_rows()
+        try:
+            rows = int(rows or 0)
+        except Exception:
+            rows = 0
+        if rows <= 0:
+            rows = 24
+        # Reserve rows for status/chrome + transcript while still giving enough
+        # room for long prompts on smaller mobile viewports.
+        return max(8, min(16, rows - 8))
+
+    def _resolve_input_available_width(self, prompt_width: int) -> int:
+        """Return safe wrap width for composer line-height calculation.
+
+        Avoid hardcoded fallbacks that can exceed the real mobile viewport and
+        cause wrap/clip artifacts on Termux when reported width briefly glitches.
+        """
+        fallback_cols = max(20, shutil.get_terminal_size((80, 24)).columns)
+        live_cols = 0
+        try:
+            from prompt_toolkit.application import get_app
+            live_cols = int(get_app().output.get_size().columns or 0)
+        except Exception:
+            live_cols = 0
+
+        cols = live_cols if live_cols > 0 else fallback_cols
+        if _is_termux_environment() and live_cols and live_cols < 20 and fallback_cols > live_cols:
+            cols = fallback_cols
+
+        available = int(cols) - max(1, int(prompt_width or 0))
+        if available < 4:
+            available = max(4, fallback_cols - max(1, int(prompt_width or 0)))
+        return max(4, available)
+
     def _use_minimal_tui_chrome(self, width: Optional[int] = None) -> bool:
         """Hide low-value chrome on narrow/mobile terminals to preserve rows."""
         if width is None:
@@ -11617,10 +11669,62 @@ class HermesCLI:
         level = min(rms, 8000) * 7 // 8000
         return _LEVEL_BARS[level]
 
+    def _termux_prompt_fragment(self, style: str, text: str):
+        """Return a Termux-safe prompt fragment with stable width.
+
+        On some mobile/Termux terminals, when prompt states shrink (e.g.
+        busy -> idle) stale trailing glyphs can remain visible, which appears as
+        accumulating arrows in the input area. We keep a small width floor and
+        right-pad shorter states to overwrite leftovers.
+        """
+        text = (text or "").rstrip() + " "
+        try:
+            from prompt_toolkit.utils import get_cwidth
+
+            width = max(1, int(get_cwidth(text)))
+        except Exception:
+            width = max(1, len(text))
+
+        prev = int(getattr(self, "_termux_prompt_clear_width", 0) or 0)
+        target = max(5, prev, width)
+        target = min(target, 12)
+        setattr(self, "_termux_prompt_clear_width", target)
+
+        if width < target:
+            text += " " * (target - width)
+        return [(style, text)]
+
     def _get_tui_prompt_fragments(self):
         """Return the prompt_toolkit fragments for the current interactive state."""
         symbol, state_suffix = self._get_tui_prompt_symbols()
         compact = self._use_minimal_tui_chrome(width=self._get_tui_terminal_width())
+
+        if _is_termux_environment():
+            # Termux/mobile: prefer fixed-width ASCII state labels to avoid
+            # ambiguous-width emoji/icon drift in prompt_toolkit cursor math.
+            if self._voice_recording:
+                return self._termux_prompt_fragment("class:voice-recording", "REC>")
+            if self._voice_processing:
+                return self._termux_prompt_fragment("class:voice-processing", "STT>")
+            if self._sudo_state:
+                return self._termux_prompt_fragment("class:sudo-prompt", "PWD>")
+            if self._secret_state:
+                return self._termux_prompt_fragment("class:sudo-prompt", "KEY>")
+            if self._approval_state:
+                return self._termux_prompt_fragment("class:prompt-working", "ASK>")
+            if getattr(self, "_slash_confirm_state", None):
+                return self._termux_prompt_fragment("class:prompt-working", "ASK>")
+            if self._clarify_freetext:
+                return self._termux_prompt_fragment("class:clarify-selected", "TXT>")
+            if self._clarify_state:
+                return self._termux_prompt_fragment("class:prompt-working", "QRY>")
+            if self._command_running:
+                return self._termux_prompt_fragment("class:prompt-working", "CMD>")
+            if self._agent_running:
+                return self._termux_prompt_fragment("class:prompt-working", "AI>")
+            if self._voice_mode:
+                return self._termux_prompt_fragment("class:voice-prompt", "MIC>")
+            return self._termux_prompt_fragment("class:prompt", symbol)
 
         def _state_fragment(style: str, icon: str, extra: str = ""):
             if compact:
@@ -12865,7 +12969,7 @@ class HermesCLI:
             skill_bundles_provider=lambda: get_skill_bundles(),
         )
         input_area = TextArea(
-            height=Dimension(min=1, max=8, preferred=1),
+            height=Dimension(min=1, max=self._tui_input_max_rows(), preferred=1),
             prompt=get_prompt,
             style='class:input-area',
             multiline=True,
@@ -12889,17 +12993,11 @@ class HermesCLI:
         # wrapping of long lines so the input area always fits its content.
         def _input_height():
             try:
-                from prompt_toolkit.application import get_app
                 from prompt_toolkit.utils import get_cwidth
 
                 doc = input_area.buffer.document
                 prompt_width = max(2, get_cwidth(self._get_tui_prompt_text()))
-                try:
-                    available_width = get_app().output.get_size().columns - prompt_width
-                except Exception:
-                    available_width = shutil.get_terminal_size((80, 24)).columns - prompt_width
-                if available_width < 10:
-                    available_width = 40
+                available_width = self._resolve_input_available_width(prompt_width)
                 visual_lines = 0
                 for line in doc.lines:
                     # Each logical line takes at least 1 visual row; long lines wrap.
@@ -12909,7 +13007,7 @@ class HermesCLI:
                         visual_lines += 1
                     else:
                         visual_lines += max(1, -(-line_width // available_width))  # ceil division
-                return min(max(visual_lines, 1), 8)
+                return min(max(visual_lines, 1), self._tui_input_max_rows())
             except Exception:
                 return 1
 

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -486,6 +486,29 @@ Generate some audio.
         assert "test-skill" in msg
         assert "do stuff" in msg
 
+    def test_includes_termux_compatibility_note_when_present(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "test-skill")
+            scan_skill_commands()
+            with patch(
+                "agent.skill_commands._load_skill_payload",
+                return_value=(
+                    {
+                        "success": True,
+                        "name": "test-skill",
+                        "content": "# Test Skill\n\nUse it.",
+                        "termux_compat_warning": "Linux-targeted commands may differ on Termux.",
+                    },
+                    tmp_path / "test-skill",
+                    "test-skill",
+                ),
+            ):
+                msg = build_skill_invocation_message("/test-skill", "do stuff")
+
+        assert msg is not None
+        assert "Termux compatibility note" in msg
+        assert "Linux-targeted commands may differ on Termux." in msg
+
     def test_returns_none_for_unknown(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
             scan_skill_commands()

--- a/tests/cli/test_cli_skin_integration.py
+++ b/tests/cli/test_cli_skin_integration.py
@@ -1,8 +1,16 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from cli import HermesCLI, _rich_text_from_ansi
 from hermes_cli.skin_engine import get_active_skin, set_active_skin
+
+
+@pytest.fixture(autouse=True)
+def _force_non_termux(monkeypatch):
+    """Keep baseline skin tests deterministic across host platforms."""
+    monkeypatch.setattr("cli._is_termux_environment", lambda: False)
 
 
 def _make_cli_stub():
@@ -55,6 +63,26 @@ class TestCliSkinPromptIntegration:
 
         with patch.object(HermesCLI, "_get_tui_terminal_width", return_value=50):
             assert cli._get_tui_prompt_fragments() == [("class:voice-prompt", "🎤 ")]
+
+    def test_termux_prompt_uses_ascii_state_labels(self):
+        cli = _make_cli_stub()
+        cli._agent_running = True
+
+        with patch("cli._is_termux_environment", return_value=True):
+            frags = cli._get_tui_prompt_fragments()
+
+        assert frags == [("class:prompt-working", "AI>  ")]
+
+    def test_termux_prompt_keeps_width_when_state_shrinks(self):
+        cli = _make_cli_stub()
+
+        with patch("cli._is_termux_environment", return_value=True):
+            cli._agent_running = True
+            busy = cli._get_tui_prompt_fragments()[0][1]
+            cli._agent_running = False
+            idle = cli._get_tui_prompt_fragments()[0][1]
+
+        assert len(idle) >= len(busy)
 
     def test_narrow_terminals_compact_voice_recording_prompt_fragments(self):
         cli = _make_cli_stub()

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -167,6 +167,26 @@ class TestCLIStatusBar:
             assert _input_height() == 2
         mock_shutil.assert_not_called()
 
+    def test_tui_input_max_rows_termux_grows_with_terminal_height(self):
+        cli_obj = _make_cli()
+        with patch("cli._is_termux_environment", return_value=True):
+            assert cli_obj._tui_input_max_rows(rows=18) == 10
+            assert cli_obj._tui_input_max_rows(rows=30) == 16
+
+    def test_tui_input_max_rows_non_termux_stays_legacy_default(self):
+        cli_obj = _make_cli()
+        with patch("cli._is_termux_environment", return_value=False):
+            assert cli_obj._tui_input_max_rows(rows=40) == 8
+
+    def test_resolve_input_available_width_termux_avoids_hardcoded_40(self):
+        cli_obj = _make_cli()
+        mock_app = MagicMock()
+        mock_app.output.get_size.return_value = MagicMock(columns=8)
+        with patch("cli._is_termux_environment", return_value=True), \
+             patch("prompt_toolkit.application.get_app", return_value=mock_app), \
+             patch("shutil.get_terminal_size", return_value=SimpleNamespace(columns=28, lines=24)):
+            assert cli_obj._resolve_input_available_width(prompt_width=4) == 24
+
     def test_build_status_bar_text_no_cost_in_status_bar(self):
         cli_obj = _attach_agent(
             _make_cli(),

--- a/tests/test_cli_skin_integration.py
+++ b/tests/test_cli_skin_integration.py
@@ -1,8 +1,16 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from cli import HermesCLI, _build_compact_banner, _rich_text_from_ansi
 from hermes_cli.skin_engine import get_active_skin, set_active_skin
+
+
+@pytest.fixture(autouse=True)
+def _force_non_termux(monkeypatch):
+    """Keep baseline skin tests deterministic across host platforms."""
+    monkeypatch.setattr("cli._is_termux_environment", lambda: False)
 
 
 def _make_cli_stub():
@@ -48,6 +56,26 @@ class TestCliSkinPromptIntegration:
 
         set_active_skin("ares")
         assert cli._get_tui_prompt_fragments() == [("class:sudo-prompt", "🔑 ⚔ ")]
+
+    def test_termux_prompt_uses_ascii_state_labels(self):
+        cli = _make_cli_stub()
+        cli._agent_running = True
+
+        with patch("cli._is_termux_environment", return_value=True):
+            frags = cli._get_tui_prompt_fragments()
+
+        assert frags == [("class:prompt-working", "AI>  ")]
+
+    def test_termux_prompt_keeps_width_when_state_shrinks(self):
+        cli = _make_cli_stub()
+
+        with patch("cli._is_termux_environment", return_value=True):
+            cli._agent_running = True
+            busy = cli._get_tui_prompt_fragments()[0][1]
+            cli._agent_running = False
+            idle = cli._get_tui_prompt_fragments()[0][1]
+
+        assert len(idle) >= len(busy)
 
     def test_icon_only_skin_symbol_still_visible_in_special_states(self):
         cli = _make_cli_stub()

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -347,6 +347,25 @@ class TestSkillView:
         assert result["name"] == "my-skill"
         assert "Step 1" in result["content"]
 
+    def test_termux_linux_skill_includes_compat_warning(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("PREFIX", "/data/data/com.termux/files/usr")
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "linux-skill", frontmatter_extra="platforms: [linux]\n")
+            raw = skill_view("linux-skill")
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert "termux_compat_warning" in result
+        assert "Termux is Linux-based" in result["termux_compat_warning"]
+
+    def test_termux_unscoped_skill_has_no_compat_warning(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("PREFIX", "/data/data/com.termux/files/usr")
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "generic-skill")
+            raw = skill_view("generic-skill")
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert "termux_compat_warning" not in result
+
     def test_skill_view_applies_template_vars(self, tmp_path):
         with (
             patch("tools.skills_tool.SKILLS_DIR", tmp_path),

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -69,7 +69,11 @@ Usage:
 import json
 import logging
 
-from hermes_constants import get_hermes_home, display_hermes_home
+from hermes_constants import (
+    get_hermes_home,
+    display_hermes_home,
+    is_termux as _is_termux_environment,
+)
 import os
 import re
 from enum import Enum
@@ -157,6 +161,40 @@ def skill_matches_platform(frontmatter: Dict[str, Any]) -> bool:
     """
     from agent.skill_utils import skill_matches_platform as _impl
     return _impl(frontmatter)
+
+
+def _normalized_frontmatter_platforms(frontmatter: Dict[str, Any]) -> Set[str]:
+    """Return normalized platform labels declared in skill frontmatter."""
+    raw_platforms = frontmatter.get("platforms")
+    if not raw_platforms:
+        return set()
+    if not isinstance(raw_platforms, list):
+        raw_platforms = [raw_platforms]
+    normalized: Set[str] = set()
+    for entry in raw_platforms:
+        label = str(entry or "").strip().lower()
+        if not label:
+            continue
+        normalized.add(_PLATFORM_MAP.get(label, label))
+    return normalized
+
+
+def _termux_linux_skill_warning(frontmatter: Dict[str, Any]) -> Optional[str]:
+    """Return a non-blocking warning for Linux-targeted skills on Termux."""
+    if not _is_termux_environment():
+        return None
+    platforms = _normalized_frontmatter_platforms(frontmatter)
+    if not platforms:
+        return None
+    if "linux" not in platforms:
+        return None
+    if "termux" in platforms or "android" in platforms:
+        return None
+    return (
+        "This skill declares Linux compatibility. Termux is Linux-based, but "
+        "Linux-targeted commands/tools may be unavailable or behave differently "
+        "on Android/Termux."
+    )
 
 
 def _normalize_prerequisite_values(value: Any) -> List[str]:
@@ -790,6 +828,8 @@ def _serve_plugin_skill(
             ensure_ascii=False,
         )
 
+    termux_warning = _termux_linux_skill_warning(parsed_frontmatter)
+
     # Injection scan — log but still serve (matches local-skill behaviour)
     if any(p in content.lower() for p in _INJECTION_PATTERNS):
         logger.warning(
@@ -834,17 +874,17 @@ def _serve_plugin_skill(
                 "Could not preprocess plugin skill %s:%s", namespace, bare, exc_info=True
             )
 
-    return json.dumps(
-        {
-            "success": True,
-            "name": f"{namespace}:{bare}",
-            "content": f"{banner}{rendered_content}" if banner else rendered_content,
-            "description": description,
-            "linked_files": None,
-            "readiness_status": SkillReadinessStatus.AVAILABLE.value,
-        },
-        ensure_ascii=False,
-    )
+    result = {
+        "success": True,
+        "name": f"{namespace}:{bare}",
+        "content": f"{banner}{rendered_content}" if banner else rendered_content,
+        "description": description,
+        "linked_files": None,
+        "readiness_status": SkillReadinessStatus.AVAILABLE.value,
+    }
+    if termux_warning:
+        result["termux_compat_warning"] = termux_warning
+    return json.dumps(result, ensure_ascii=False)
 
 
 def skill_view(
@@ -1103,6 +1143,8 @@ def skill_view(
                 },
                 ensure_ascii=False,
             )
+
+        termux_warning = _termux_linux_skill_warning(parsed_frontmatter)
 
         # Check if the skill is disabled by the user
         resolved_name = parsed_frontmatter.get("name", skill_md.parent.name)
@@ -1403,6 +1445,8 @@ def skill_view(
             if setup_needed
             else SkillReadinessStatus.AVAILABLE.value,
         }
+        if termux_warning:
+            result["termux_compat_warning"] = termux_warning
 
         setup_help = next((e["help"] for e in required_env_vars if e.get("help")), None)
         if setup_help:


### PR DESCRIPTION
## What does this PR do?

This PR fixes Termux composer/input rendering issues in Hermes CLI and adds Termux compatibility signaling for Linux-targeted skills.

Specifically, it addresses:
- Prompt/input area accumulating extra arrow glyphs while typing.
- Long prompt typing visibility on mobile (composer too short).
- Word clipping/wrap instability on narrow or odd Termux resolutions.
- Missing runtime context when Linux-declared skills are used on Termux.

All behavioral UI changes are gated to Termux detection, so non-Termux platforms keep existing behavior.

## Related Issue

N/A (user-reported Termux UX regressions from screenshots; no upstream issue number attached yet)

## Type of Change

- [x] ðŸ› Bug fix (non-breaking change that fixes an issue)
- [ ] âœ¨ New feature (non-breaking change that adds functionality)
- [ ] ðŸ”’ Security fix
- [ ] ðŸ“ Documentation update
- [x] âœ… Tests (adding or improving test coverage)
- [ ] â™»ï¸ Refactor (no behavior change)
- [ ] ðŸŽ¯ New skill (bundled or hub)

## Changes Made

### 1) Termux-gated prompt/input rendering hardening (`cli.py`)

- Added `HermesCLI._termux_prompt_fragment(...)`:
  - Maintains stable prompt width with right-padding to clear stale trailing glyphs when prompt states shrink.
  - Prevents repeated arrow accumulation in the typing area on Termux/mobile terminals.

- Updated `HermesCLI._get_tui_prompt_fragments(...)`:
  - Added Termux-only ASCII state labels (`AI>`, `CMD>`, `ASK>`, `MIC>`, etc.) to avoid ambiguous-width emoji/icon drift in prompt width math.
  - Keeps desktop behavior unchanged.

- Added `HermesCLI._get_tui_terminal_rows(...)`.

- Added `HermesCLI._tui_input_max_rows(...)`:
  - Keeps legacy cap (`8`) on non-Termux.
  - Allows taller composer on Termux (`max(8, min(16, rows-8))`) so long prompts remain visible while typing.

- Added `HermesCLI._resolve_input_available_width(...)`:
  - Replaces the brittle hardcoded fallback width behavior for tiny/unstable reported widths.
  - Uses safer live/fallback width resolution tuned for Termux glitches.

- Wired new sizing logic into input area:
  - `TextArea(height=Dimension(min=1, max=self._tui_input_max_rows(), preferred=1))`
  - Dynamic `_input_height()` now uses `_resolve_input_available_width(...)` and the Termux-aware max rows cap.

### 2) Linux skill usage on Termux: explicit compatibility warning (`tools/skills_tool.py`, `agent/skill_commands.py`)

- Added frontmatter helpers:
  - `_normalized_frontmatter_platforms(...)`
  - `_termux_linux_skill_warning(...)`

- For `skill_view(...)` (local and plugin skills):
  - Linux-declared skills remain loadable on Termux.
  - Adds non-blocking `termux_compat_warning` field when a skill declares Linux support but not explicit Termux/Android support.

- Updated skill activation message builder (`agent/skill_commands.py`):
  - If present, injects `[Termux compatibility note: ...]` into the loaded skill message so the agent is explicitly aware Linux-intended commands may behave differently on Termux.

## How to Test

1. Run targeted regression tests:

```bash
scripts/run_tests.sh tests/cli/test_cli_skin_integration.py tests/test_cli_skin_integration.py tests/cli/test_cli_status_bar.py tests/tools/test_skills_tool.py tests/agent/test_skill_commands.py
```

2. Manual Termux checks:

```bash
hermes
```

- Type multiple prompts across several turns and confirm no accumulating arrow glyphs in the input area.
- Paste/type a long multi-line prompt and confirm the composer grows enough to keep more text visible.
- On narrow/odd terminal widths, confirm wrapping remains stable and words are no longer clipped/jittered.
- Load a Linux-declared skill on Termux and confirm a Termux compatibility note is surfaced.

3. Non-Termux sanity:
- Confirm existing prompt symbols/states remain unchanged on desktop Linux/macOS/WSL environments.

## Validation Notes

Executed:

- `scripts/run_tests.sh tests/cli/test_cli_skin_integration.py tests/test_cli_skin_integration.py tests/cli/test_cli_status_bar.py tests/tools/test_skills_tool.py tests/agent/test_skill_commands.py`
- Result: `197 passed`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `scripts/run_tests.sh` full suite and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Termux (Android)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) â€” or N/A (N/A)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys â€” or N/A (N/A)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows â€” or N/A (N/A)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) â€” or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior â€” or N/A (N/A)

## Changed Files

- `cli.py`
- `tools/skills_tool.py`
- `agent/skill_commands.py`
- `tests/cli/test_cli_skin_integration.py`
- `tests/test_cli_skin_integration.py`
- `tests/cli/test_cli_status_bar.py`
- `tests/tools/test_skills_tool.py`
- `tests/agent/test_skill_commands.py`