### PR TITLE
fix(send_message): offload blocking SMTP calls to asyncio.to_thread

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1503,11 +1503,14 @@ async def _send_email(extra, chat_id, message):
         msg["Subject"] = "Hermes Agent"
         msg["Date"] = formatdate(localtime=True)
 
-        server = smtplib.SMTP(smtp_host, smtp_port)
-        server.starttls(context=ssl.create_default_context())
-        server.login(address, password)
-        server.send_message(msg)
-        server.quit()
+        def _smtp_send():
+            server = smtplib.SMTP(smtp_host, smtp_port)
+            server.starttls(context=ssl.create_default_context())
+            server.login(address, password)
+            server.send_message(msg)
+            server.quit()
+
+        await asyncio.to_thread(_smtp_send)
         return {"success": True, "platform": "email", "chat_id": chat_id}
     except Exception as e:
         return _error(f"Email send failed: {e}")


### PR DESCRIPTION
## What does this PR do?
`_send_email` used synchronous `smtplib` calls inside an `async def`. On a slow SMTP server, `SMTP()`, `starttls()`, `login()`, and `send_message()` block the asyncio event loop for the full TCP connect + TLS + auth + send round-trip — stalling all concurrent gateway messages during that window.

## Type of Change
- [x] Bug fix

## Changes Made
- Wrapped the five `smtplib` calls in a local `_smtp_send()` helper
- Offloaded via `await asyncio.to_thread(_smtp_send)` so the event loop is free during the SMTP operation
- No functional change to SMTP behavior

## How to Test
- Send an email via Hermes while another platform message arrives concurrently — no stall
- Existing email send behavior unchanged

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] No sensitive data (keys, tokens, secrets) included