### PR TITLE
fix(gateway): auto-notify fatal errors from _set_fatal_error

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2702,12 +2702,35 @@ class BasePlatformAdapter(ABC):
             return
         self._write_runtime_status_safe("disconnected", platform_state="disconnected", error_code=None, error_message=None)
 
-    def _set_fatal_error(self, code: str, message: str, *, retryable: bool) -> None:
+    def _set_fatal_error(self, code: str, message: str, *, retryable: bool, notify: bool = True) -> None:
         self._running = False
         self._fatal_error_code = code
         self._fatal_error_message = message
         self._fatal_error_retryable = retryable
         self._write_runtime_status_safe("fatal", platform_state="fatal", error_code=code, error_message=message)
+        if notify:
+            self._schedule_fatal_notify()
+
+    def _schedule_fatal_notify(self) -> None:
+        """Schedule ``_notify_fatal_error`` if a handler is registered.
+
+        Adapters call ``_set_fatal_error`` but could forget to notify the
+        gateway.  Auto-notifying here makes the two-step API impossible to
+        misuse.  Adapters that already call ``_notify_fatal_error`` explicitly
+        should pass ``notify=False`` to avoid double-notification.
+        """
+        if self._fatal_error_handler is None:
+            return
+        try:
+            task = asyncio.get_running_loop().create_task(self._notify_fatal_error())
+        except RuntimeError:
+            return
+        try:
+            self._background_tasks.add(task)
+        except TypeError:
+            pass
+        if hasattr(task, "add_done_callback"):
+            task.add_done_callback(self._background_tasks.discard)
 
     def _write_runtime_status_safe(self, context: str, **kwargs) -> None:
         """Write runtime status; log first failure per context at warning, rest at debug.

--- a/gateway/relay/adapter.py
+++ b/gateway/relay/adapter.py
@@ -212,6 +212,7 @@ class RelayAdapter(BasePlatformAdapter):
             "relay_disabled",
             "Relay disabled (opted out — recreate the instance to re-enable)",
             retryable=False,
+            notify=False,
         )
         try:
             await self._notify_fatal_error()

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -946,7 +946,7 @@ class DiscordAdapter(BasePlatformAdapter):
             message = f"Discord gateway task exited: {exc}"
 
         logger.error("[%s] %s", self.name, message, exc_info=exc if exc else False)
-        self._set_fatal_error("discord_gateway_task_exited", message, retryable=True)
+        self._set_fatal_error("discord_gateway_task_exited", message, retryable=True, notify=False)
 
         async def _notify() -> None:
             try:

--- a/plugins/platforms/irc/adapter.py
+++ b/plugins/platforms/irc/adapter.py
@@ -387,7 +387,7 @@ class IRCAdapter(BasePlatformAdapter):
         finally:
             if self.is_connected:
                 logger.warning("IRC: connection lost, marking disconnected")
-                self._set_fatal_error("connection_lost", "IRC connection closed unexpectedly", retryable=True)
+                self._set_fatal_error("connection_lost", "IRC connection closed unexpectedly", retryable=True, notify=False)
                 await self._notify_fatal_error()
 
     async def _handle_line(self, raw: str) -> None:

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -573,6 +573,7 @@ class PhotonAdapter(BasePlatformAdapter):
                 "UPSTREAM_STREAM_DEGRADED",
                 message,
                 retryable=True,
+                notify=False,
             )
             try:
                 await self._notify_fatal_error()
@@ -1029,6 +1030,7 @@ class PhotonAdapter(BasePlatformAdapter):
                 "SIDECAR_CRASHED",
                 f"Photon sidecar exited unexpectedly (code {exit_code})",
                 retryable=True,
+                notify=False,
             )
             try:
                 await self._notify_fatal_error()

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -686,9 +686,9 @@ class TelegramAdapter(BasePlatformAdapter):
         self._drop_delayed_deliveries = True
         super()._mark_disconnected()
 
-    def _set_fatal_error(self, code: str, message: str, *, retryable: bool) -> None:
+    def _set_fatal_error(self, code: str, message: str, *, retryable: bool, notify: bool = True) -> None:
         self._drop_delayed_deliveries = True
-        super()._set_fatal_error(code, message, retryable=retryable)
+        super()._set_fatal_error(code, message, retryable=retryable, notify=notify)
 
     def _should_drop_delayed_delivery(self) -> bool:
         """True once teardown/fatal-error started — delayed flushes must drop.
@@ -2059,7 +2059,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 "Restarting gateway." % MAX_NETWORK_RETRIES
             )
             logger.error("[%s] %s Last error: %s", self.name, message, _redact_telegram_error_text(error))
-            self._set_fatal_error("telegram_network_error", message, retryable=True)
+            self._set_fatal_error("telegram_network_error", message, retryable=True, notify=False)
             await self._notify_fatal_error()
             return
 
@@ -2584,7 +2584,7 @@ class TelegramAdapter(BasePlatformAdapter):
             self.has_fatal_error
             and self.fatal_error_code == "telegram_polling_conflict"
         )
-        self._set_fatal_error("telegram_polling_conflict", message, retryable=False)
+        self._set_fatal_error("telegram_polling_conflict", message, retryable=False, notify=False)
         try:
             if self._app and self._app.updater:
                 await asyncio.wait_for(self._app.updater.stop(), timeout=_UPDATER_STOP_TIMEOUT)

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -774,7 +774,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         message = f"WhatsApp bridge process exited unexpectedly (code {returncode})."
         if not self.has_fatal_error:
             logger.error("[%s] %s", self.name, message)
-            self._set_fatal_error("whatsapp_bridge_exited", message, retryable=True)
+            self._set_fatal_error("whatsapp_bridge_exited", message, retryable=True, notify=False)
             self._close_bridge_log()
             await self._notify_fatal_error()
         return self.fatal_error_message or message

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -1,5 +1,6 @@
 """Tests for gateway/platforms/base.py — MessageEvent, media extraction, message truncation."""
 
+import asyncio
 import os
 import time
 from unittest.mock import patch
@@ -1942,3 +1943,106 @@ class TestMediaFallbackDoesNotLeakHostPath:
         sent_text = adapter.sent[0]["content"]
         assert "Here's the daily summary." in sent_text
         assert self.SENSITIVE_PATH not in sent_text
+
+
+# ---------------------------------------------------------------------------
+# Auto-notify fatal errors (regression)
+# ---------------------------------------------------------------------------
+
+
+class TestSetFatalErrorNotifiesHandler:
+    """When _set_fatal_error() is called with notify=True (the default),
+    the registered handler must be called automatically.  Adapters that
+    already call _notify_fatal_error() explicitly must pass notify=False
+    to avoid double-notification.
+
+    Regression: _set_fatal_error set fatal state without notifying the
+    gateway handler, so adapters that forgot the second step silently
+    dropped the fatal escalation.
+    """
+
+    @pytest.mark.asyncio
+    async def test_auto_notifies_when_handler_registered(self):
+        """notify=True (default) triggers the handler automatically."""
+        adapter = _CapturingAdapter()
+        handler_called = []
+
+        async def handler(a):
+            handler_called.append(a)
+
+        adapter.set_fatal_error_handler(handler)
+        adapter._set_fatal_error("test_err", "msg", retryable=True)
+
+        # Handler runs as a scheduled task — give the event loop a tick.
+        await asyncio.sleep(0)
+        assert len(handler_called) == 1
+        assert handler_called[0] is adapter
+
+    @pytest.mark.asyncio
+    async def test_no_notify_when_notify_false(self):
+        """notify=False suppresses the auto-notify (adapter will call
+        _notify_fatal_error explicitly)."""
+        adapter = _CapturingAdapter()
+        handler_called = []
+
+        async def handler(a):
+            handler_called.append(a)
+
+        adapter.set_fatal_error_handler(handler)
+        adapter._set_fatal_error("test_err", "msg", retryable=True, notify=False)
+
+        await asyncio.sleep(0)
+        assert len(handler_called) == 0
+
+    @pytest.mark.asyncio
+    async def test_no_notify_when_no_handler(self):
+        """No handler registered — _set_fatal_error must not raise."""
+        adapter = _CapturingAdapter()
+        # No handler set — should be a silent no-op.
+        adapter._set_fatal_error("test_err", "msg", retryable=True)
+        await asyncio.sleep(0)  # no crash
+
+    @pytest.mark.asyncio
+    async def test_duplicate_suppression(self):
+        """Calling _set_fatal_error twice with notify=True should not
+        crash even if the handler raises."""
+        adapter = _CapturingAdapter()
+        call_count = 0
+
+        async def handler(a):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise RuntimeError("boom")
+
+        adapter.set_fatal_error_handler(handler)
+        adapter._set_fatal_error("err1", "first", retryable=True)
+        await asyncio.sleep(0)
+        assert call_count == 1
+
+        adapter._set_fatal_error("err2", "second", retryable=True)
+        await asyncio.sleep(0)
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_fatal_error_state_set_before_notify(self):
+        """The fatal error state must be fully written before the handler
+        runs, so the handler can read it."""
+        adapter = _CapturingAdapter()
+        observed_state = []
+
+        async def handler(a):
+            observed_state.append({
+                "code": a._fatal_error_code,
+                "message": a._fatal_error_message,
+                "retryable": a._fatal_error_retryable,
+            })
+
+        adapter.set_fatal_error_handler(handler)
+        adapter._set_fatal_error("auth_fail", "token expired", retryable=False)
+
+        await asyncio.sleep(0)
+        assert len(observed_state) == 1
+        assert observed_state[0]["code"] == "auth_fail"
+        assert observed_state[0]["message"] == "token expired"
+        assert observed_state[0]["retryable"] is False


### PR DESCRIPTION
## Summary
`_set_fatal_error()` flips `_running=False` and writes `gateway_state.json`,
but does not call `_notify_fatal_error()`. If an adapter's disconnect handler
short-circuits on `is_connected` after `_set_fatal_error` already set it to
False, the gateway never learns about the failure — no retry, no log entry,
zombie gateway.

Fix: auto-schedule `_notify_fatal_error()` from inside `_set_fatal_error()`
so the two-step API collapses into a single call. Adapters cannot forget the
second step.

## Related Issue
Fixes #28919

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made
- `gateway/platforms/base.py` — added `_schedule_fatal_notify()` helper called
  at the end of `_set_fatal_error()`. Uses `asyncio.get_running_loop().create_task()`
  wrapped in `try/except RuntimeError` for sync init paths.

## How to Test
1. Unit test: create a mock adapter, call `_set_fatal_error()`, verify
   `_notify_fatal_error()` is invoked (handler called).
2. Integration: simulate a plugin that skips notify — gateway should still
   detect the fatal error and trigger reconnect watcher.