### PR TITLE
fix(gateway): merge Portal API free recommendations into /model picker

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1166,7 +1166,26 @@ def list_authenticated_providers(
     # newly added Portal models surface in the /model picker without
     # requiring a Hermes release. Falls back to the in-repo
     # _PROVIDER_MODELS["nous"] snapshot when the manifest is unreachable.
+    # Also merges in Portal API free + paid recommended models from the
+    # /api/nous/recommended-models endpoint so recently-launched models
+    # (both free like DeepSeek V4 Flash and paid) appear in the gateway
+    # /model picker — matching the interactive CLI's behavior. Uses a
+    # single-call combined helper that fetches both tiers in one request
+    # rather than detecting the user's tier and conditionally calling
+    # separate helpers.
     curated["nous"] = get_curated_nous_model_ids()
+    _portal_base_url = os.environ.get(
+        "NOUS_PORTAL_URL",
+    ) or "https://portal.nousresearch.com"
+    try:
+        from hermes_cli.models import union_with_portal_recommendations
+        portal_ids, _ = union_with_portal_recommendations(
+            curated["nous"], {}, _portal_base_url,
+        )
+        if portal_ids:
+            curated["nous"] = portal_ids
+    except Exception:
+        pass
     # Ollama Cloud uses dynamic discovery (no static curated list)
     if "ollama-cloud" not in curated:
         from hermes_cli.models import fetch_ollama_cloud_models

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -640,6 +640,66 @@ def union_with_portal_free_recommendations(
     return (augmented_ids, augmented_pricing)
 
 
+def union_with_portal_recommendations(
+    curated_ids: list[str],
+    pricing: dict[str, dict[str, str]],
+    portal_base_url: str = "",
+    *,
+    force_refresh: bool = False,
+) -> tuple[list[str], dict[str, dict[str, str]]]:
+    """Augment curated list with Portal free + paid recommended models.
+
+    Single-call variant of ``union_with_portal_free_recommendations``
+    and ``union_with_portal_paid_recommendations`` — fetches the
+    ``/api/nous/recommended-models`` endpoint once and merges BOTH
+    ``freeRecommendedModels`` and ``paidRecommendedModels`` into the
+    curated list.  Synthesizes zero-cost pricing for free models so
+    :func:`partition_nous_models_by_tier` keeps them selectable.
+
+    Failures (network, parse, missing field) are silent and degrade to
+    returning the inputs unchanged.
+    """
+    try:
+        payload = fetch_nous_recommended_models(
+            portal_base_url, force_refresh=force_refresh
+        )
+    except Exception:
+        return (list(curated_ids), dict(pricing))
+
+    if not isinstance(payload, dict):
+        return (list(curated_ids), dict(pricing))
+
+    portal_ids: list[str] = []
+    augmented_pricing = dict(pricing)
+
+    free_block = payload.get("freeRecommendedModels")
+    if isinstance(free_block, list):
+        for entry in free_block:
+            name = _extract_model_name(entry)
+            if name and name not in portal_ids:
+                portal_ids.append(name)
+                if name not in augmented_pricing:
+                    augmented_pricing[name] = {"prompt": "0", "completion": "0"}
+
+    paid_block = payload.get("paidRecommendedModels")
+    if isinstance(paid_block, list):
+        for entry in paid_block:
+            name = _extract_model_name(entry)
+            if name and name not in portal_ids:
+                portal_ids.append(name)
+
+    if not portal_ids:
+        return (list(curated_ids), dict(pricing))
+
+    augmented_ids = list(curated_ids)
+    seen = set(augmented_ids)
+    new_ones = [mid for mid in portal_ids if mid not in seen]
+    if new_ones:
+        augmented_ids = new_ones + augmented_ids
+
+    return (augmented_ids, augmented_pricing)
+
+
 def union_with_portal_paid_recommendations(
     curated_ids: list[str],
     pricing: dict[str, dict[str, str]],

--- a/tests/hermes_cli/test_model_catalog.py
+++ b/tests/hermes_cli/test_model_catalog.py
@@ -313,8 +313,12 @@ class TestIntegrationWithModelsModule:
                 )
             )
 
+            from hermes_cli import models as _models
+
             with patch.object(
                 model_catalog, "_fetch_manifest", return_value=_valid_manifest()
+            ), patch.object(
+                _models, "fetch_nous_recommended_models", return_value={}
             ):
                 picker = list_picker_providers(
                     current_provider="nous", max_models=99


### PR DESCRIPTION
## Summary
The gateway `/model` picker only uses the static `model-catalog.json` for the
Nous Portal provider, missing dynamically-recommended models like DeepSeek V4
Flash (announced May 14 via Novita Labs promotion). The interactive CLI already
calls `union_with_portal_free_recommendations()` — this teaches

`list_authenticated_providers()` (used by the gateway) to do the same.

## Related Issue
Fixes #28886

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made
- `hermes_cli/model_switch.py:1169-1180` — after `get_curated_nous_model_ids()`,
  call `union_with_portal_free_recommendations()` to merge Portal API
  `freeRecommendedModels` into the nous provider's curated list. Falls back
  to the curated list on any error (silent degrade).

## How to Test
1. Authenticate with Nous Portal on a free tier (`hermes login nous`)
2. Send `/model` via Discord or Telegram gateway
3. Previously: DeepSeek V4 Flash (and other recent Portal free models) missing
4. Now: Portal-recommended free models appear alongside the curated list