### PR TITLE
fix(xai-proxy): handle 429 rate-limit responses in proxy retry path

### DIFF
--- a/hermes_cli/proxy/adapters/xai.py
+++ b/hermes_cli/proxy/adapters/xai.py
@@ -79,7 +79,7 @@ class XAIGrokAdapter(UpstreamAdapter):
         failed_credential: UpstreamCredential,
         status_code: int,
     ) -> Optional[UpstreamCredential]:
-        if status_code != 401:
+        if status_code not in {401, 429}:
             return None
 
         with self._lock:
@@ -87,16 +87,25 @@ class XAIGrokAdapter(UpstreamAdapter):
             if pool is None:
                 return None
 
-            refreshed = pool.try_refresh_current()
-            if refreshed is None:
+            if status_code == 429:
+                # Mark the rate-limited key with its 1-hour cooldown and rotate
+                # to the next available credential. Returns None when the pool
+                # has no other key to offer — the 429 will flow back to the client.
                 refreshed = pool.mark_exhausted_and_rotate(status_code=status_code)
+            else:
+                refreshed = pool.try_refresh_current()
+                if refreshed is None:
+                    refreshed = pool.mark_exhausted_and_rotate(status_code=status_code)
             if refreshed is None:
                 return None
 
             retry_cred = self._credential_from_entry(refreshed)
             if retry_cred.bearer == failed_credential.bearer:
                 return None
-            logger.info("proxy: xAI upstream rejected bearer; retrying with refreshed pool credential")
+            logger.info(
+                "proxy: xAI upstream returned %s; retrying with rotated pool credential",
+                status_code,
+            )
             return retry_cred
 
     def _load_pool(self) -> Optional[CredentialPool]:

--- a/hermes_cli/proxy/server.py
+++ b/hermes_cli/proxy/server.py
@@ -206,7 +206,7 @@ def create_app(adapter: UpstreamAdapter) -> "web.Application":
             return session_or_response
         session = session_or_response
 
-        if upstream_resp.status == 401:
+        if upstream_resp.status in {401, 429}:
             try:
                 retry_cred = adapter.get_retry_credential(
                     failed_credential=cred,


### PR DESCRIPTION
## What does this PR do?
`get_retry_credential` was only invoked on HTTP 401. A 429 Too Many Requests from xAI was silently streamed back to the client with no key rotation or back-off signal — the rate-limited key stayed active and would be reused on the next request.

## Type of Change
- [x] Bug fix

## Changes Made
- `server.py`: widen retry gate from `== 401` to `in {401, 429}` so the adapter is consulted on rate-limit responses
- `xai.py`: on 429, skip token refresh (irrelevant for rate limits) and call `mark_exhausted_and_rotate(status_code=429)` to stamp the 1-hour cooldown on the offending key and return the next available credential. Returns `None` if pool is exhausted — 429 flows back to client unchanged

## How to Test
- Trigger a 429 from xAI proxy — rate-limited key should be rotated out, next key used for retry
- Single-key pool: 429 still flows back to client correctly

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] No sensitive data (keys, tokens, secrets) included