### PR TITLE
fix(send_message): log and surface channel resolution errors

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -230,6 +230,48 @@ class TestSendMessageTool:
             force_document=False,
         )
 
+    def test_channel_resolution_not_found_message_unchanged(self):
+        """resolve_channel_name returning None (channel simply not found) is
+        untouched by this fix -- still the generic 'use action=list' hint."""
+        with patch("gateway.channel_directory.resolve_channel_name", return_value=None):
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "telegram:Nonexistent Channel",
+                        "message": "hello",
+                    }
+                )
+            )
+
+        assert "error" in result
+        assert "Could not resolve 'Nonexistent Channel' on telegram." in result["error"]
+        assert "send_message(action='list')" in result["error"]
+
+    def test_channel_resolution_exception_is_logged_and_sanitized(self):
+        """resolve_channel_name raising is logged and the surfaced error is
+        sanitized -- exception text must not leak tokens/URLs/credentials."""
+        with patch(
+            "gateway.channel_directory.resolve_channel_name",
+            side_effect=Exception("lookup failed: https://api.example.com/?api_key=SUPERSECRET123"),
+        ), patch("tools.send_message_tool.logger") as logger_mock:
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "telegram:Coaching Chat / topic 17585",
+                        "message": "hello",
+                    }
+                )
+            )
+
+        assert "error" in result
+        assert "SUPERSECRET123" not in result["error"]
+        assert "api_key=***" in result["error"]
+        assert "Coaching Chat / topic 17585" in result["error"]
+        assert "Try using a numeric channel ID instead." in result["error"]
+        logger_mock.warning.assert_called_once()
+
     def test_display_label_target_resolves_via_channel_directory(self, tmp_path):
         config, telegram_cfg = _make_config()
         cache_file = tmp_path / "channel_directory.json"

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -196,11 +196,15 @@ def _handle_send(args):
                     "error": f"Could not resolve '{target_ref}' on {platform_name}. "
                     f"Use send_message(action='list') to see available targets."
                 })
-        except Exception:
-            return json.dumps({
-                "error": f"Could not resolve '{target_ref}' on {platform_name}. "
+        except Exception as e:
+            logger.warning(
+                "Channel name resolution failed for '%s' on %s: %s",
+                target_ref, platform_name, e, exc_info=True,
+            )
+            return json.dumps(_error(
+                f"Could not resolve '{target_ref}' on {platform_name}: {e}. "
                 f"Try using a numeric channel ID instead."
-            })
+            ))
 
     from tools.interrupt import is_interrupted
     if is_interrupted():


### PR DESCRIPTION
## What does this PR do?
The channel-name resolution block in `send_message_tool.py` used a bare `except Exception:` that silently discarded the real error. Import failures, DB errors, and permission issues all returned the same generic 'Could not resolve' message — indistinguishable from a simple channel-not-found.

## Type of Change
- [x] Bug fix

## Changes Made
- Bound the exception to `e`
- Added `logger.warning(..., exc_info=True)` so the full traceback appears in logs
- Included `str(e)` in the returned error JSON so callers also see the actual failure reason

## How to Test
- Trigger a DB error or import failure in channel resolution — error message now includes the actual exception
- Normal channel-not-found behavior unchanged

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] No sensitive data (keys, tokens, secrets) included