### PR TITLE
[codex] Raise test runner nofile limit

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -4,6 +4,7 @@
 #
 # What this script enforces:
 #   * -n 4 xdist workers (CI has 4 cores; -n auto diverges locally)
+#   * A higher open-file limit before spawning pytest-xdist workers
 #   * TZ=UTC, LANG=C.UTF-8, PYTHONHASHSEED=0 (deterministic)
 #   * Credential env vars blanked (conftest.py also does this, but this
 #     is belt-and-suspenders for anyone running `pytest` outside of
@@ -87,6 +88,64 @@ export LANG=C.UTF-8
 export LC_ALL=C.UTF-8
 export PYTHONHASHSEED=0
 
+# ── File descriptor limit ─────────────────────────────────────────────────
+# macOS interactive shells commonly start with a soft nofile limit of 256.
+# Four xdist workers plus subprocess-heavy tests can exhaust that quickly,
+# after which failures cascade as unrelated imports, sockets, temp files, and
+# pytest pipes all report "Too many open files".
+raise_nofile_limit() {
+  local target="${HERMES_TEST_NOFILE_LIMIT:-4096}"
+  local current hard desired
+
+  case "$target" in
+    ''|*[!0-9]*)
+      echo "warning: invalid HERMES_TEST_NOFILE_LIMIT=$target; leaving open-file limit unchanged" >&2
+      return
+      ;;
+  esac
+
+  current="$(ulimit -n 2>/dev/null || true)"
+  if [ "$current" = "unlimited" ]; then
+    return
+  fi
+  case "$current" in
+    ''|*[!0-9]*)
+      echo "warning: could not read current open-file limit; leaving it unchanged" >&2
+      return
+      ;;
+  esac
+  if [ "$current" -ge "$target" ]; then
+    return
+  fi
+
+  desired="$target"
+  hard="$(ulimit -Hn 2>/dev/null || true)"
+  if [ "$hard" != "unlimited" ]; then
+    case "$hard" in
+      ''|*[!0-9]*)
+        echo "warning: could not read hard open-file limit; leaving it unchanged" >&2
+        return
+        ;;
+    esac
+    if [ "$hard" -lt "$desired" ]; then
+      desired="$hard"
+    fi
+  fi
+
+  if [ "$desired" -le "$current" ]; then
+    echo "warning: open-file limit is $current and cannot be raised toward $target" >&2
+    return
+  fi
+
+  if ulimit -S -n "$desired" 2>/dev/null; then
+    echo "→ raised open-file limit from $current to $(ulimit -n)"
+  else
+    echo "warning: failed to raise open-file limit from $current to $desired" >&2
+  fi
+}
+
+raise_nofile_limit
+
 # ── Live-gateway test guard (developer machines) ────────────────────────────
 # If a system-wide hermes pytest_live_guard plugin is installed at
 # $HOME/.hermes/pytest_live_guard.py, force-load it here so every test run
@@ -112,10 +171,6 @@ WORKERS="${HERMES_TEST_WORKERS:-4}"
 # ── Run pytest ──────────────────────────────────────────────────────────────
 cd "$REPO_ROOT"
 
-# If the first argument starts with `-` treat all args as pytest flags;
-# otherwise treat them as test paths.
-ARGS=("$@")
-
 echo "▶ running pytest with $WORKERS workers, hermetic env, in $REPO_ROOT"
 echo "  (TZ=UTC LANG=C.UTF-8 PYTHONHASHSEED=0; all credential env vars unset)"
 
@@ -131,4 +186,4 @@ exec "$PYTHON" -m pytest \
   --ignore=tests/integration \
   --ignore=tests/e2e \
   -m "not integration" \
-  "${ARGS[@]}"
+  "$@"

--- a/tests/scripts/test_run_tests_script.py
+++ b/tests/scripts/test_run_tests_script.py
@@ -1,0 +1,107 @@
+"""Tests for scripts/run_tests.sh guardrails."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run_with_fake_python(tmp_path: Path, script_args: list[str]):
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.skip("bash is required to exercise scripts/run_tests.sh")
+
+    repo = tmp_path / "repo"
+    scripts_dir = repo / "scripts"
+    venv_bin = repo / ".venv" / "bin"
+    scripts_dir.mkdir(parents=True)
+    venv_bin.mkdir(parents=True)
+
+    script_dst = scripts_dir / "run_tests.sh"
+    shutil.copy2(REPO_ROOT / "scripts" / "run_tests.sh", script_dst)
+
+    (venv_bin / "activate").write_text("", encoding="utf-8")
+    fake_python = venv_bin / "python"
+    fake_python.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            if [ "${1:-}" = "-c" ]; then
+              exit 0
+            fi
+
+            {
+              printf 'nofile=%s\\n' "$(ulimit -n)"
+              printf 'args='
+              printf '[%s]' "$@"
+              printf '\\n'
+            } >> "$FAKE_PYTHON_LOG"
+            exit 0
+            """
+        ),
+        encoding="utf-8",
+    )
+    fake_python.chmod(fake_python.stat().st_mode | stat.S_IXUSR)
+
+    log_path = repo / "fake-python.log"
+    quoted_args = " ".join(script_args)
+    env = {
+        **os.environ,
+        "FAKE_PYTHON_LOG": str(log_path),
+        "HERMES_TEST_NOFILE_LIMIT": "128",
+    }
+    result = subprocess.run(
+        [
+            bash,
+            "-c",
+            f"ulimit -S -n 64 || exit 77; scripts/run_tests.sh {quoted_args}",
+        ],
+        cwd=repo,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode == 77:
+        pytest.skip("shell could not lower the soft open-file limit")
+
+    return result, log_path
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="ulimit is POSIX-only")
+def test_run_tests_raises_soft_nofile_limit_before_pytest(tmp_path):
+    """The canonical runner must raise macOS's low default before xdist starts."""
+    result, log_path = _run_with_fake_python(tmp_path, ["tests/example.py"])
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "raised open-file limit from 64 to 128" in result.stdout
+
+    log_text = log_path.read_text(encoding="utf-8")
+    nofile_line = next(line for line in log_text.splitlines() if line.startswith("nofile="))
+    assert int(nofile_line.removeprefix("nofile=")) >= 128
+    assert "[-m][pytest]" in log_text
+    assert "[-n][4]" in log_text
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="ulimit is POSIX-only")
+def test_run_tests_allows_no_pytest_args(tmp_path):
+    """The full-suite invocation must not trip set -u before pytest starts."""
+    result, log_path = _run_with_fake_python(tmp_path, [])
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    log_text = log_path.read_text(encoding="utf-8")
+    assert "[-m][pytest]" in log_text
+    assert "[tests/example.py]" not in log_text


### PR DESCRIPTION
## Summary

- Raise the soft open-file limit in `scripts/run_tests.sh` before pytest-xdist starts.
- Add focused tests that fake the venv Python to verify the runner raises the limit and accepts empty pytest args.

## Why

macOS shells can start with a low `ulimit -n` value, often 256. Four xdist workers plus subprocess-heavy tests can exhaust that limit and cause noisy, unrelated "Too many open files" failures.

## Impact

Local and CI-like test runs get a higher soft nofile limit when possible, while preserving existing behavior if the limit is already high or cannot be raised.

## Validation

- `bash -n scripts/run_tests.sh`
- `git diff --check`
- `scripts/run_tests.sh tests/scripts/test_run_tests_script.py`
- `scripts/run_tests.sh tests/scripts`
