### PR TITLE
fix(tui): termux-gate composer rendering and linux-skill notes

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -257,6 +257,11 @@ def _build_skill_message(
         parts.append("")
         parts.append(f"[Runtime note: {runtime_note}]")
 
+    termux_warning = str(loaded_skill.get("termux_compat_warning") or "").strip()
+    if termux_warning:
+        parts.append("")
+        parts.append(f"[Termux compatibility note: {termux_warning}]")
+
     return "\n".join(parts)
 
 

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -486,6 +486,29 @@ Generate some audio.
         assert "test-skill" in msg
         assert "do stuff" in msg
 
+    def test_includes_termux_compatibility_note_when_present(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "test-skill")
+            scan_skill_commands()
+            with patch(
+                "agent.skill_commands._load_skill_payload",
+                return_value=(
+                    {
+                        "success": True,
+                        "name": "test-skill",
+                        "content": "# Test Skill\n\nUse it.",
+                        "termux_compat_warning": "Linux-targeted commands may differ on Termux.",
+                    },
+                    tmp_path / "test-skill",
+                    "test-skill",
+                ),
+            ):
+                msg = build_skill_invocation_message("/test-skill", "do stuff")
+
+        assert msg is not None
+        assert "Termux compatibility note" in msg
+        assert "Linux-targeted commands may differ on Termux." in msg
+
     def test_returns_none_for_unknown(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
             scan_skill_commands()

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -347,6 +347,25 @@ class TestSkillView:
         assert result["name"] == "my-skill"
         assert "Step 1" in result["content"]
 
+    def test_termux_linux_skill_includes_compat_warning(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("PREFIX", "/data/data/com.termux/files/usr")
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "linux-skill", frontmatter_extra="platforms: [linux]\n")
+            raw = skill_view("linux-skill")
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert "termux_compat_warning" in result
+        assert "Termux is Linux-based" in result["termux_compat_warning"]
+
+    def test_termux_unscoped_skill_has_no_compat_warning(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("PREFIX", "/data/data/com.termux/files/usr")
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "generic-skill")
+            raw = skill_view("generic-skill")
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert "termux_compat_warning" not in result
+
     def test_skill_view_applies_template_vars(self, tmp_path):
         with (
             patch("tools.skills_tool.SKILLS_DIR", tmp_path),

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -69,7 +69,11 @@ Usage:
 import json
 import logging
 
-from hermes_constants import get_hermes_home, display_hermes_home
+from hermes_constants import (
+    get_hermes_home,
+    display_hermes_home,
+    is_termux as _is_termux_environment,
+)
 import os
 import re
 from enum import Enum
@@ -157,6 +161,40 @@ def skill_matches_platform(frontmatter: Dict[str, Any]) -> bool:
     """
     from agent.skill_utils import skill_matches_platform as _impl
     return _impl(frontmatter)
+
+
+def _normalized_frontmatter_platforms(frontmatter: Dict[str, Any]) -> Set[str]:
+    """Return normalized platform labels declared in skill frontmatter."""
+    raw_platforms = frontmatter.get("platforms")
+    if not raw_platforms:
+        return set()
+    if not isinstance(raw_platforms, list):
+        raw_platforms = [raw_platforms]
+    normalized: Set[str] = set()
+    for entry in raw_platforms:
+        label = str(entry or "").strip().lower()
+        if not label:
+            continue
+        normalized.add(_PLATFORM_MAP.get(label, label))
+    return normalized
+
+
+def _termux_linux_skill_warning(frontmatter: Dict[str, Any]) -> Optional[str]:
+    """Return a non-blocking warning for Linux-targeted skills on Termux."""
+    if not _is_termux_environment():
+        return None
+    platforms = _normalized_frontmatter_platforms(frontmatter)
+    if not platforms:
+        return None
+    if "linux" not in platforms:
+        return None
+    if "termux" in platforms or "android" in platforms:
+        return None
+    return (
+        "This skill declares Linux compatibility. Termux is Linux-based, but "
+        "Linux-targeted commands/tools may be unavailable or behave differently "
+        "on Android/Termux."
+    )
 
 
 def _normalize_prerequisite_values(value: Any) -> List[str]:
@@ -790,6 +828,8 @@ def _serve_plugin_skill(
             ensure_ascii=False,
         )
 
+    termux_warning = _termux_linux_skill_warning(parsed_frontmatter)
+
     # Injection scan — log but still serve (matches local-skill behaviour)
     if any(p in content.lower() for p in _INJECTION_PATTERNS):
         logger.warning(
@@ -834,17 +874,17 @@ def _serve_plugin_skill(
                 "Could not preprocess plugin skill %s:%s", namespace, bare, exc_info=True
             )
 
-    return json.dumps(
-        {
-            "success": True,
-            "name": f"{namespace}:{bare}",
-            "content": f"{banner}{rendered_content}" if banner else rendered_content,
-            "description": description,
-            "linked_files": None,
-            "readiness_status": SkillReadinessStatus.AVAILABLE.value,
-        },
-        ensure_ascii=False,
-    )
+    result = {
+        "success": True,
+        "name": f"{namespace}:{bare}",
+        "content": f"{banner}{rendered_content}" if banner else rendered_content,
+        "description": description,
+        "linked_files": None,
+        "readiness_status": SkillReadinessStatus.AVAILABLE.value,
+    }
+    if termux_warning:
+        result["termux_compat_warning"] = termux_warning
+    return json.dumps(result, ensure_ascii=False)
 
 
 def skill_view(
@@ -1103,6 +1143,8 @@ def skill_view(
                 },
                 ensure_ascii=False,
             )
+
+        termux_warning = _termux_linux_skill_warning(parsed_frontmatter)
 
         # Check if the skill is disabled by the user
         resolved_name = parsed_frontmatter.get("name", skill_md.parent.name)
@@ -1403,6 +1445,8 @@ def skill_view(
             if setup_needed
             else SkillReadinessStatus.AVAILABLE.value,
         }
+        if termux_warning:
+            result["termux_compat_warning"] = termux_warning
 
         setup_help = next((e["help"] for e in required_env_vars if e.get("help")), None)
         if setup_help:

--- a/ui-tui/src/__tests__/prompt.test.ts
+++ b/ui-tui/src/__tests__/prompt.test.ts
@@ -16,4 +16,16 @@ describe('composerPromptText', () => {
     expect(composerPromptText('❯', 'custom')).toBe('❯')
     expect(composerPromptText('❯')).toBe('❯')
   })
+
+  it('uses a Termux-safe ASCII prompt marker in normal mode', () => {
+    expect(composerPromptText('❯', 'coder', false, true, 50)).toBe('>')
+  })
+
+  it('keeps profile prefix suppressed on narrow Termux widths', () => {
+    expect(composerPromptText('❯', 'upstr', false, true, 72)).toBe('>')
+  })
+
+  it('allows profile prefix on very wide Termux panes', () => {
+    expect(composerPromptText('❯', 'upstr', false, true, 120)).toBe('upstr >')
+  })
 })

--- a/ui-tui/src/__tests__/termuxComposerLayout.test.ts
+++ b/ui-tui/src/__tests__/termuxComposerLayout.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+
+import { stableComposerColumns, transcriptBodyWidth } from '../lib/inputMetrics.js'
+import { composerPromptText } from '../lib/prompt.js'
+
+describe('Termux composer prompt + width guards', () => {
+  it('uses a single-cell ASCII prompt marker in Termux mode', () => {
+    expect(composerPromptText('❯', 'coder', false, true, 50)).toBe('>')
+  })
+
+  it('suppresses profile prefixes on narrow Termux panes', () => {
+    expect(composerPromptText('❯', 'upstr', false, true, 72)).toBe('>')
+  })
+
+  it('keeps profile context on very wide Termux panes', () => {
+    expect(composerPromptText('❯', 'upstr', false, true, 120)).toBe('upstr >')
+  })
+
+  it('reserves fewer columns for gutter on narrow Termux widths', () => {
+    // 32 columns after prompt: desktop reserves 2 for transcript scrollbar,
+    // Termux keeps those 2 columns for the active composer.
+    expect(stableComposerColumns(40, 8, false)).toBe(28)
+    expect(stableComposerColumns(40, 8, true)).toBe(30)
+
+    // With ample room, Termux still reserves the gutter for alignment.
+    expect(stableComposerColumns(60, 8, true)).toBe(48)
+  })
+
+  it('never over-allocates transcript body width on narrow panes', () => {
+    // Old behavior hard-minned to 20 columns and overflowed narrow layouts.
+    expect(transcriptBodyWidth(24, 'assistant', '>', true)).toBe(19)
+    expect(transcriptBodyWidth(24, 'user', 'upstr >', true)).toBe(14)
+    expect(transcriptBodyWidth(10, 'user', '>', true)).toBeGreaterThanOrEqual(1)
+  })
+
+  it('keeps legacy desktop floor outside Termux mode', () => {
+    expect(transcriptBodyWidth(24, 'assistant', '>')).toBe(20)
+    expect(transcriptBodyWidth(24, 'user', 'upstr >')).toBe(20)
+  })
+})

--- a/ui-tui/src/__tests__/textInputFastEcho.test.ts
+++ b/ui-tui/src/__tests__/textInputFastEcho.test.ts
@@ -178,7 +178,22 @@ describe('supportsFastEchoTerminal', () => {
     expect(supportsFastEchoTerminal({ TERM_PROGRAM: 'Apple_Terminal' } as NodeJS.ProcessEnv)).toBe(false)
   })
 
-  it('keeps fast-echo enabled in VS Code and unknown terminals', () => {
+  it('disables fast-echo by default in Termux mode', () => {
+    expect(
+      supportsFastEchoTerminal({ TERMUX_VERSION: '0.118.0', PREFIX: '/data/data/com.termux/files/usr' } as NodeJS.ProcessEnv)
+    ).toBe(false)
+  })
+
+  it('allows explicit Termux fast-echo opt-in via env override', () => {
+    expect(
+      supportsFastEchoTerminal({
+        HERMES_TUI_TERMUX_FAST_ECHO: '1',
+        TERMUX_VERSION: '0.118.0'
+      } as NodeJS.ProcessEnv)
+    ).toBe(true)
+  })
+
+  it('keeps fast-echo enabled in VS Code and unknown non-Termux terminals', () => {
     expect(supportsFastEchoTerminal({ TERM_PROGRAM: 'vscode' } as NodeJS.ProcessEnv)).toBe(true)
     expect(supportsFastEchoTerminal({ TERM: 'xterm-256color' } as NodeJS.ProcessEnv)).toBe(true)
   })

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -6,7 +6,7 @@ import { useGateway } from '../app/gatewayContext.js'
 import type { AppLayoutProps } from '../app/interfaces.js'
 import { $isBlocked, $overlayState, patchOverlayState } from '../app/overlayStore.js'
 import { $uiState } from '../app/uiStore.js'
-import { INLINE_MODE, SHOW_FPS } from '../config/env.js'
+import { INLINE_MODE, SHOW_FPS, TERMUX_TUI_MODE } from '../config/env.js'
 import { PLACEHOLDER } from '../content/placeholders.js'
 import {
   COMPOSER_PROMPT_GAP_WIDTH,
@@ -169,10 +169,10 @@ const ComposerPane = memo(function ComposerPane({
   const ui = useStore($uiState)
   const isBlocked = useStore($isBlocked)
   const sh = (composer.inputBuf[0] ?? composer.input).startsWith('!')
-  const promptText = composerPromptText(ui.theme.brand.prompt, ui.info?.profile_name, sh)
+  const promptText = composerPromptText(ui.theme.brand.prompt, ui.info?.profile_name, sh, TERMUX_TUI_MODE, composer.cols)
   const promptWidth = composerPromptWidth(promptText)
   const promptBlank = ' '.repeat(promptWidth)
-  const inputColumns = stableComposerColumns(composer.cols, promptWidth)
+  const inputColumns = stableComposerColumns(composer.cols, promptWidth, TERMUX_TUI_MODE)
   const inputHeight = inputVisualHeight(composer.input, inputColumns)
   const inputMouseRef = useRef<null | TextInputMouseApi>(null)
 

--- a/ui-tui/src/components/messageLine.tsx
+++ b/ui-tui/src/components/messageLine.tsx
@@ -1,6 +1,7 @@
 import { Ansi, Box, NoSelect, Text } from '@hermes/ink'
 import { memo, useState } from 'react'
 
+import { TERMUX_TUI_MODE } from '../config/env.js'
 import { LONG_MSG } from '../config/limits.js'
 import { sectionMode } from '../domain/details.js'
 import { userDisplay } from '../domain/messages.js'
@@ -139,7 +140,7 @@ export const MessageLine = memo(function MessageLine({
     }
 
     if (msg.role === 'assistant') {
-      const bodyWidth = transcriptBodyWidth(cols, msg.role, t.brand.prompt)
+      const bodyWidth = transcriptBodyWidth(cols, msg.role, t.brand.prompt, TERMUX_TUI_MODE)
 
       return isStreaming ? (
         // Incremental markdown: split at the last stable block boundary so
@@ -201,7 +202,7 @@ export const MessageLine = memo(function MessageLine({
           </Text>
         </NoSelect>
 
-        <Box width={transcriptBodyWidth(cols, msg.role, t.brand.prompt)}>{content}</Box>
+        <Box width={transcriptBodyWidth(cols, msg.role, t.brand.prompt, TERMUX_TUI_MODE)}>{content}</Box>
       </Box>
     </Box>
   )

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -13,6 +13,7 @@ import {
   isVoiceToggleKey,
   type ParsedVoiceRecordKey
 } from '../lib/platform.js'
+import { isTermuxTuiMode } from '../lib/termux.js'
 
 type InkExt = typeof Ink & {
   stringWidth: (s: string) => number
@@ -298,7 +299,23 @@ export function canFastBackspaceShape(current: string, cursor: number, columns?:
 export function supportsFastEchoTerminal(env: NodeJS.ProcessEnv = process.env): boolean {
   // Terminal.app still shows paint/cursor artifacts under the fast-echo
   // bypass path. Fall back to the normal Ink render path there.
-  return (env.TERM_PROGRAM ?? '').trim() !== 'Apple_Terminal'
+  if ((env.TERM_PROGRAM ?? '').trim() === 'Apple_Terminal') {
+    return false
+  }
+
+  // Termux terminals are especially sensitive to bypass-path cursor drift and
+  // stale paints at soft-wrap boundaries on tall/narrow viewports. Keep this
+  // off by default in Termux mode; allow explicit opt-in for local debugging.
+  if (isTermuxTuiMode(env)) {
+    const override = String(env.HERMES_TUI_TERMUX_FAST_ECHO ?? '').trim().toLowerCase()
+    if (override) {
+      return /^(?:1|true|yes|on)$/i.test(override)
+    }
+
+    return false
+  }
+
+  return true
 }
 
 function renderWithCursor(value: string, cursor: number) {

--- a/ui-tui/src/lib/inputMetrics.ts
+++ b/ui-tui/src/lib/inputMetrics.ts
@@ -177,14 +177,25 @@ export function transcriptGutterWidth(role: Role, userPrompt: string) {
   return role === 'user' ? composerPromptWidth(userPrompt) : 3
 }
 
-export function transcriptBodyWidth(totalCols: number, role: Role, userPrompt: string) {
-  return Math.max(20, totalCols - transcriptGutterWidth(role, userPrompt) - 2)
+export function transcriptBodyWidth(totalCols: number, role: Role, userPrompt: string, termuxMode = false) {
+  const available = Math.max(1, totalCols - transcriptGutterWidth(role, userPrompt) - 2)
+
+  if (termuxMode) {
+    // On narrow / unusual aspect-ratio mobile panes, forcing a wide minimum
+    // width causes right-edge clipping and chopped words.
+    return available
+  }
+
+  return Math.max(20, available)
 }
 
-export function stableComposerColumns(totalCols: number, promptWidth: number) {
+export function stableComposerColumns(totalCols: number, promptWidth: number, termuxMode = false) {
   // Physical render/wrap width. Always reserve outer composer padding and
   // prompt prefix. Only reserve the transcript scrollbar gutter when the
   // terminal is wide enough; on narrow panes, preserving input columns beats
   // keeping gutters visually aligned.
-  return Math.max(1, totalCols - promptWidth - 2 - (totalCols - promptWidth >= 24 ? 2 : 0))
+  const afterPrompt = totalCols - promptWidth
+  const reserveScrollbar = afterPrompt >= (termuxMode ? 36 : 24) ? 2 : 0
+
+  return Math.max(1, totalCols - promptWidth - 2 - reserveScrollbar)
 }

--- a/ui-tui/src/lib/prompt.ts
+++ b/ui-tui/src/lib/prompt.ts
@@ -1,6 +1,30 @@
-export function composerPromptText(prompt: string, profileName?: null | string, shellMode = false): string {
+const TERMUX_SAFE_PROMPT = '>'
+
+export function composerPromptText(
+  prompt: string,
+  profileName?: null | string,
+  shellMode = false,
+  termuxMode = false,
+  totalCols?: number
+): string {
   if (shellMode) {
     return '$'
+  }
+
+  if (termuxMode) {
+    // Termux fonts/terminal backends can render decorative prompt glyphs with
+    // ambiguous width; keep the live composer marker strictly single-cell ASCII
+    // so we never leave stale arrow artifacts while typing.
+    const basePrompt = TERMUX_SAFE_PROMPT
+
+    // On very wide panes we can still include profile context. On narrow/mobile
+    // panes this burns precious columns and increases wrap/clipping risk.
+    const wideEnoughForProfile = typeof totalCols === 'number' ? totalCols >= 90 : false
+    if (wideEnoughForProfile && profileName && !['default', 'custom'].includes(profileName)) {
+      return `${profileName} ${basePrompt}`
+    }
+
+    return basePrompt
   }
 
   if (profileName && !['default', 'custom'].includes(profileName)) {

--- a/ui-tui/src/lib/virtualHeights.ts
+++ b/ui-tui/src/lib/virtualHeights.ts
@@ -1,5 +1,6 @@
 import type { Msg } from '../types.js'
 
+import { TERMUX_TUI_MODE } from '../config/env.js'
 import { transcriptBodyWidth } from './inputMetrics.js'
 
 const hashText = (text: string) => {
@@ -96,7 +97,7 @@ export const estimatedMsgHeight = (
     return Math.max(2, msg.todos.length + 2)
   }
 
-  const bodyWidth = transcriptBodyWidth(cols, msg.role, userPrompt)
+  const bodyWidth = transcriptBodyWidth(cols, msg.role, userPrompt, TERMUX_TUI_MODE)
   const text = msg.text
   let h = wrappedLines(text || ' ', bodyWidth)
 


### PR DESCRIPTION
## What does this PR do?

Fixes several Termux-specific rendering and usability issues in the latest Ink TUI path.

This PR addresses composer prompt artifacts, narrow-pane wrapping/clipping, virtual height mismatches, and fast-echo ghosting on Android/Termux terminals. The fixes are intentionally Termux-gated so existing desktop and non-Termux behavior remains unchanged.

It also improves Linux-targeted bundled skill behavior on Termux by keeping those skills loadable while surfacing a non-blocking compatibility warning that Linux commands/tools may behave differently under Android/Termux.

## Related Issue

Fixes #

## Type of Change

- [x] ðŸ› Bug fix (non-breaking change that fixes an issue)
- [ ] âœ¨ New feature (non-breaking change that adds functionality)
- [ ] ðŸ”’ Security fix
- [ ] ðŸ“ Documentation update
- [x] âœ… Tests (adding or improving test coverage)
- [ ] â™»ï¸ Refactor (no behavior change)
- [ ] ðŸŽ¯ New skill (bundled or hub)

## Changes Made

- `ui-tui/src/lib/prompt.ts`
  - Uses a safe single-cell ASCII prompt marker (`>`) in Termux mode to avoid repeated arrow artifacts caused by ambiguous-width glyph rendering.

- `ui-tui/src/components/appLayout.tsx`
  - Suppresses profile-prefixed prompt text on narrow Termux panes while preserving it on very wide panes, giving typed input more horizontal space.

- `ui-tui/src/lib/inputMetrics.ts`
- `ui-tui/src/components/messageLine.tsx`
- `ui-tui/src/lib/virtualHeights.ts`
  - Makes transcript body width Termux-aware.
  - Removes the desktop-oriented 20-column floor for Termux mode so narrow/tall mobile layouts do not overflow.
  - Prevents right-edge clipping and chopped words on unusual mobile terminal resolutions.
  - Aligns virtual height estimation with the actual rendered Termux width so scrolling/readback stays consistent.

- `ui-tui/src/components/textInput.tsx`
  - Disables fast-echo bypass by default in Termux mode to avoid ghosting/duplication around soft-wrap boundaries.
  - Adds an opt-in debug override:
    - `HERMES_TUI_TERMUX_FAST_ECHO=1`

- `tools/skills_tool.py`
- `agent/skill_commands.py`
- `tests/agent/test_skill_commands.py`
- `tests/tools/test_skills_tool.py`
  - Keeps Linux-targeted bundled skills loadable on Termux.
  - Adds a non-blocking compatibility warning that Linux commands/tools may behave differently on Android/Termux.
  - Surfaces the warning in both `skill_view` payloads and slash skill invocation messages.

## How to Test

1. Run the Python skill-related test suite:

   ```bash
   scripts/run_tests.sh tests/agent/test_skill_commands.py tests/tools/test_skills_tool.py
   ```

   Expected result:

   ```text
   130 passed
   ```

2. Run the TUI type check:

   ```bash
   npm run type-check
   ```

   Expected result: type check passes.

3. Run the targeted TUI tests:

   ```bash
   npm test -- prompt.test.ts
   npm test -- termuxComposerLayout.test.ts
   npm test -- textInputFastEcho
   ```

   Expected result: all targeted tests pass.

4. Manual Termux verification:
   - Launch the Ink TUI in Termux.
   - Confirm the composer prompt renders with a stable `>` marker.
   - Resize to narrow/tall layouts and type long prompts.
   - Confirm long input wraps without right-edge clipping or chopped words.
   - Confirm transcript scrolling/readback remains aligned with rendered content.
   - Confirm fast-echo ghosting/duplication does not occur by default.
   - Optionally set `HERMES_TUI_TERMUX_FAST_ECHO=1` to verify the debug override.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Termux / Android terminal environment

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) â€” or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys â€” or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows â€” or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) â€” or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior â€” or N/A

## For New Skills

N/A â€” this PR does not add a new skill.

## Screenshots / Logs

Python validation:

```text
scripts/run_tests.sh tests/agent/test_skill_commands.py tests/tools/test_skills_tool.py
Result: 130 passed
```

TUI validation:

```text
npm run type-check
Result: pass
```

Targeted TUI tests:

```text
prompt.test.ts
Result: pass

termuxComposerLayout.test.ts
Result: pass

textInputFastEcho supportsFastEchoTerminal subset
Result: pass
```