### PR TITLE
feat: add DeepSeek V4 reasoning support

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -339,6 +339,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         or base_url_host_matches(agent.base_url, "moonshot.ai")
         or base_url_host_matches(agent.base_url, "moonshot.cn")
     )
+    _is_deepseek = base_url_host_matches(agent._base_url_lower, "api.deepseek.com")
     _is_tokenhub = base_url_host_matches(agent._base_url_lower, "tokenhub.tencentmaas.com")
     _is_lmstudio = (agent.provider or "").strip().lower() == "lmstudio"
 
@@ -455,6 +456,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         is_github_models=_is_gh,
         is_nvidia_nim=_is_nvidia,
         is_kimi=_is_kimi,
+        is_deepseek=_is_deepseek,
         is_tokenhub=_is_tokenhub,
         is_lmstudio=_is_lmstudio,
         is_custom_provider=agent.provider == "custom",
@@ -975,11 +977,16 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             (agent.provider or "").strip().lower() == "lmstudio"
             and agent._supports_reasoning_extra_body()
         )
+        _is_deepseek_summary = base_url_host_matches(agent._base_url_lower, "api.deepseek.com")
         _lm_reasoning_effort: str | None = (
             agent._resolve_lmstudio_summary_reasoning_effort()
             if _is_lmstudio_summary else None
         )
-        if not _is_lmstudio_summary and agent._supports_reasoning_extra_body():
+        _deepseek_reasoning_effort: str | None = None
+        if _is_deepseek_summary and agent.reasoning_config:
+            _e = str(agent.reasoning_config.get("effort", "high")).strip().lower()
+            _deepseek_reasoning_effort = "max" if _e == "xhigh" else "high"
+        if not _is_lmstudio_summary and not _is_deepseek_summary and agent._supports_reasoning_extra_body():
             if agent.reasoning_config is not None:
                 summary_extra_body["reasoning"] = agent.reasoning_config
             else:
@@ -1009,6 +1016,9 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                 summary_kwargs.update(agent._max_tokens_param(agent.max_tokens))
             if _lm_reasoning_effort is not None:
                 summary_kwargs["reasoning_effort"] = _lm_reasoning_effort
+            if _deepseek_reasoning_effort is not None:
+                summary_kwargs["reasoning_effort"] = _deepseek_reasoning_effort
+                summary_extra_body["thinking"] = {"type": "enabled"}
 
             # Include provider routing preferences
             provider_preferences = {}

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -189,6 +189,7 @@ class ChatCompletionsTransport(ProviderTransport):
             is_kimi: bool
             is_tokenhub: bool
             is_lmstudio: bool
+            is_deepseek: bool
             is_custom_provider: bool
             ollama_num_ctx: int | None
             # Provider routing
@@ -283,6 +284,25 @@ class ChatCompletionsTransport(ProviderTransport):
                         _kimi_effort = _e
                 api_kwargs["reasoning_effort"] = _kimi_effort
 
+        # DeepSeek V4: top-level reasoning_effort + extra_body.thinking
+        # DeepSeek maps low/medium/high → high, xhigh → max
+        is_deepseek = params.get("is_deepseek", False)
+        if is_deepseek:
+            _deepseek_thinking_off = bool(
+                reasoning_config
+                and isinstance(reasoning_config, dict)
+                and reasoning_config.get("enabled") is False
+            )
+            if not _deepseek_thinking_off:
+                _deepseek_effort = "high"
+                if reasoning_config and isinstance(reasoning_config, dict):
+                    _e = (reasoning_config.get("effort") or "").strip().lower()
+                    if _e in {"low", "medium", "high"}:
+                        _deepseek_effort = "high"
+                    elif _e == "xhigh":
+                        _deepseek_effort = "max"
+                api_kwargs["reasoning_effort"] = _deepseek_effort
+
         # Tencent TokenHub: top-level reasoning_effort (unless thinking disabled)
         if is_tokenhub:
             _tokenhub_thinking_off = bool(
@@ -346,6 +366,16 @@ class ChatCompletionsTransport(ProviderTransport):
                     _kimi_thinking_enabled = False
             extra_body["thinking"] = {
                 "type": "enabled" if _kimi_thinking_enabled else "disabled",
+            }
+
+        # DeepSeek extra_body.thinking
+        if is_deepseek:
+            _deepseek_thinking_enabled = True
+            if reasoning_config and isinstance(reasoning_config, dict):
+                if reasoning_config.get("enabled") is False:
+                    _deepseek_thinking_enabled = False
+            extra_body["thinking"] = {
+                "type": "enabled" if _deepseek_thinking_enabled else "disabled",
             }
 
         # Reasoning. LM Studio is handled above via top-level reasoning_effort,


### PR DESCRIPTION
## Summary

DeepSeek V4 (deepseek-v4-flash / deepseek-v4-pro) added thinking mode with client-controllable reasoning effort. Hermes previously had no DeepSeek-specific reasoning handling, so reasoning config was silently dropped when using the direct DeepSeek API.

## What DeepSeek V4 supports

Per [DeepSeek API docs](https://api-docs.deepseek.com/guides/thinking_mode):

- `reasoning_effort` top-level parameter: "high" or "max"
- `extra_body.thinking.type`: "enabled" or "disabled"
- Effort mapping: `low`/`medium` → `high`, `xhigh` → `max`
- Default: thinking enabled at `high` effort

## Changes

### `agent/transports/chat_completions.py`
- Detect DeepSeek via `is_deepseek` flag
- Emit top-level `reasoning_effort` mapped to DeepSeek's levels
- Emit `extra_body.thinking` toggle (enabled/disabled)

### `agent/chat_completion_helpers.py`
- Add `_is_deepseek` detection
- Pass `is_deepseek` through to transport
- Handle DeepSeek reasoning in **summary/compression path** (previously only handled `extra_body.reasoning` for OpenRouter/Anthropic, and `reasoning_effort` for LM Studio)

## Before / After

| Config | Before | After |
|--------|--------|-------|
| `/reasoning high` + DeepSeek direct API | No-op (silently ignored) | `reasoning_effort: high` + `thinking: enabled` |
| `/reasoning xhigh` + DeepSeek direct API | No-op | `reasoning_effort: max` + `thinking: enabled` |
| `/reasoning none` + DeepSeek direct API | No-op | `thinking: disabled` |

## Test plan

1. Set provider to `deepseek` with model `deepseek-v4-pro`
2. Run `/reasoning high` → verify `reasoning_effort: high` sent
3. Run `/reasoning xhigh` → verify `reasoning_effort: max` sent
4. Run `/reasoning none` → verify `thinking: disabled` sent

## Related

- DeepSeek Thinking Mode docs: https://api-docs.deepseek.com/guides/thinking_mode
- Fixes reasoning config being silently ignored for direct DeepSeek API users
