### PR TITLE
feat: add Hermes self-knowledge

### DIFF
--- a/.github/workflows/self-knowledge.yml
+++ b/.github/workflows/self-knowledge.yml
@@ -1,0 +1,15 @@
+name: Self Knowledge
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv sync --all-extras --dev
+      - run: uv run hermes self-knowledge --check || true

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -100,6 +100,16 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # Pointer to the hermes-agent skill + docs for user questions about Hermes itself.
     stable_parts.append(HERMES_AGENT_HELP_GUIDANCE)
 
+    # Repo-grounded self-knowledge. Slim by default so it improves self-description
+    # without bloating the stable prompt; HERMES_SELF_KNOWLEDGE_PROMPT=off disables it.
+    try:
+        from hermes_cli.self_knowledge.summary import build_slim_summary
+        _self_knowledge = build_slim_summary()
+        if _self_knowledge:
+            stable_parts.append(_self_knowledge)
+    except Exception:
+        pass
+
     # Tool-aware behavioral guidance: only inject when the tools are loaded
     tool_guidance = []
     if "memory" in agent.valid_tool_names:

--- a/context/self/.hermes-agent-allowlist.txt
+++ b/context/self/.hermes-agent-allowlist.txt
@@ -1,0 +1,2 @@
+# References in hand-written self-knowledge sections that should be ignored by drift checks.
+# One exact reference per line.

--- a/context/self/hermes-agent.md
+++ b/context/self/hermes-agent.md
@@ -1,0 +1,396 @@
+# Hermes Agent Self-Knowledge
+
+## Identity
+
+Hermes Agent is a tool-using AI assistant and automation runtime created by Nous Research. It operates through CLI, TUI, API, scheduler, gateway platforms, skills, tools, and plugins.
+
+This document is the repo-grounded self-inventory for Hermes. Hand-written sections explain identity and operating principles; AUTO sections are regenerated from code so Hermes does not rely on stale prose when describing its own capabilities.
+
+## Operating Principles
+
+- Treat code and configured registries as the source of truth.
+- Keep generated inventory local, deterministic, and free of network calls.
+- Never include secret values, tokens, API keys, or private user data in this document.
+- Prefer compact summaries over exhaustive dumps.
+- Preserve hand-written context when refreshing generated sections.
+
+## Capabilities at a Glance
+
+<!-- AUTO-START: capabilities -->
+| Tool | Toolset | Description |
+|---|---|---|
+| browser_back | browser | Navigate back to the previous page in browser history. Requires browser_navigate to be called first. |
+| browser_click | browser | Click on an element identified by its ref ID from the snapshot (e.g., '@e5'). The ref IDs are shown in square brackets in the snapshot output. Requires browser_navigate and browser_snapshot to be called first. |
+| browser_console | browser | Get browser console output and JavaScript errors from the current page. Returns console.log/warn/error/info messages and uncaught JS exceptions. Use this to detect silent JavaScript errors, failed API calls, and application warnings. Requires browser_navigate to be called first. When 'expression' is provided, evaluates JavaScript in the page context and returns the result — use this for DOM inspection, reading page state, or extracting data programmatically. |
+| browser_get_images | browser | Get a list of all images on the current page with their URLs and alt text. Useful for finding images to analyze with the vision tool. Requires browser_navigate to be called first. |
+| browser_navigate | browser | Navigate to a URL in the browser. Initializes the session and loads the page. Must be called before other browser tools. For simple information retrieval, prefer web_search or web_extract (faster, cheaper). For plain-text endpoints — URLs ending in .md, .txt, .json, .yaml, .yml, .csv, .xml, raw.githubusercontent.com, or any documented API endpoint — prefer curl via the terminal tool or web_extract; the browser stack is overkill and much slower for these. Use browser tools when you need to interact with a page (click, fill forms, dynamic content). Returns a compact page snapshot with interactive elements and ref IDs — no need to call browser_snapshot separately after navigating. |
+| browser_press | browser | Press a keyboard key. Useful for submitting forms (Enter), navigating (Tab), or keyboard shortcuts. Requires browser_navigate to be called first. |
+| browser_scroll | browser | Scroll the page in a direction. Use this to reveal more content that may be below or above the current viewport. Requires browser_navigate to be called first. |
+| browser_snapshot | browser | Get a text-based snapshot of the current page's accessibility tree. Returns interactive elements with ref IDs (like @e1, @e2) for browser_click and browser_type. full=false (default): compact view with interactive elements. full=true: complete page content. Snapshots over 8000 chars are truncated or LLM-summarized. Requires browser_navigate first. Note: browser_navigate already returns a compact snapshot — use this to refresh after interactions that change the page, or with full=true for complete content. |
+| browser_type | browser | Type text into an input field identified by its ref ID. Clears the field first, then types the new text. Requires browser_navigate and browser_snapshot to be called first. |
+| browser_vision | browser | Take a screenshot of the current page and analyze it with vision AI. Use this when you need to visually understand what's on the page - especially useful for CAPTCHAs, visual verification challenges, complex layouts, or when the text snapshot doesn't capture important visual information. Returns both the AI analysis and a screenshot_path that you can share with the user by including MEDIA:<screenshot_path> in your response. Requires browser_navigate to be called first. |
+| browser_cdp | browser-cdp | Send a raw Chrome DevTools Protocol (CDP) command. Escape hatch for browser operations not covered by browser_navigate, browser_click, browser_console, etc. **Requires a reachable CDP endpoint.** Available when the user has run '/browser connect' to attach to a running Chrome, or when 'browser.cdp_url' is set in config.yaml. Not currently wired up for cloud backends (Browserbase, Browser Use, Firecrawl) — those expose CDP per session but live-session routing is a follow-up. Camofox is REST-only and will never support CDP. If the tool is in your toolset at all, a CDP endpoint is already reachable. **CDP method reference:** https://chromedevtools.github.io/devtools-protocol/ — use web_extract on a method's URL (e.g. '/tot/Page/#method-handleJavaScriptDialog') to look up parameters and return shape. **Common patterns:** - List tabs: method='Target.getTargets', params={} - Handle a native JS dialog: method='Page.handleJavaScriptDialog', params={'accept': true, 'promptText': ''}, target_id=<tabId> - Get all cookies: method='Network.getAllCookies', params={} - Eval in a specific tab: method='Runtime.evaluate', params={'expression': '...', 'returnByValue': true}, target_id=<tabId> - Set viewport for a tab: method='Emulation.setDeviceMetricsOverride', params={'width': 1280, 'height': 720, 'deviceScaleFactor': 1, 'mobile': false}, target_id=<tabId> **Usage rules:** - Browser-level methods (Target.*, Browser.*, Storage.*): omit target_id and frame_id. - Page-level methods (Page.*, Runtime.*, DOM.*, Emulation.*, Network.* scoped to a tab): pass target_id from Target.getTargets. - **Cross-origin iframe scope** (Runtime.evaluate inside an OOPIF, Page.* targeting a frame target, etc.): pass frame_id from the browser_snapshot frame_tree output. This routes through the CDP supervisor's live connection — the only reliable way on Browserbase where stateless CDP calls hit signed-URL expiry. - Each stateless call (without frame_id) is independent — sessions and event subscriptions do not persist between calls. For stateful workflows, prefer the dedicated browser tools or use frame_id routing. |
+| browser_dialog | browser-cdp | Respond to a native JavaScript dialog (alert / confirm / prompt / beforeunload) that is currently blocking the page. **Workflow:** call ``browser_snapshot`` first — if a dialog is open, it appears in the ``pending_dialogs`` field with ``id``, ``type``, and ``message``. Then call this tool with ``action='accept'`` or ``action='dismiss'``. **Prompt dialogs:** pass ``prompt_text`` to supply the response string. Ignored for alert/confirm/beforeunload. **Multiple dialogs:** if more than one dialog is queued (rare — happens when a second dialog fires while the first is still open), pass ``dialog_id`` from the snapshot to disambiguate. **Availability:** only present when a CDP-capable backend is attached — Browserbase sessions, local Chrome via ``/browser connect``, or ``browser.cdp_url`` in config.yaml. Not available on Camofox (REST-only) or the default Playwright local browser (CDP port is hidden). |
+| clarify | clarify | Ask the user a question when you need clarification, feedback, or a decision before proceeding. Supports two modes: 1. **Multiple choice** — provide up to 4 choices. The user picks one or types their own answer via a 5th 'Other' option. 2. **Open-ended** — omit choices entirely. The user types a free-form response. Use this tool when: - The task is ambiguous and you need the user to choose an approach - You want post-task feedback ('How did that work out?') - You want to offer to save a skill or update memory - A decision has meaningful trade-offs the user should weigh in on Do NOT use this tool for simple yes/no confirmation of dangerous commands (the terminal tool handles that). Prefer making a reasonable default choice yourself when the decision is low-stakes. |
+| execute_code | code_execution | Run a Python script that can call Hermes tools programmatically. Use this when you need 3+ tool calls with processing logic between them, need to filter/reduce large tool outputs before they enter your context, need conditional branching (if X then Y else Z), or need to loop (fetch N pages, process N files, retry on failure). Use normal tool calls instead when: single tool call with no processing, you need to see the full result and apply complex reasoning, or the task requires interactive user input. Available via `from hermes_tools import ...`: web_search(query: str, limit: int = 5) -> dict Returns {"data": {"web": [{"url", "title", "description"}, ...]}} web_extract(urls: list[str]) -> dict Returns {"results": [{"url", "title", "content", "error"}, ...]} where content is markdown read_file(path: str, offset: int = 1, limit: int = 500) -> dict Lines are 1-indexed. Returns {"content": "...", "total_lines": N} write_file(path: str, content: str) -> dict Always overwrites the entire file. search_files(pattern: str, target="content", path=".", file_glob=None, limit=50) -> dict target: "content" (search inside files) or "files" (find files by name). Returns {"matches": [...]} patch(path: str, old_string: str, new_string: str, replace_all: bool = False) -> dict Replaces old_string with new_string in the file. terminal(command: str, timeout=None, workdir=None) -> dict Foreground only (no background/pty). Returns {"output": "...", "exit_code": N} Limits: 5-minute timeout, 50KB stdout cap, max 50 tool calls per script. terminal() is foreground-only (no background or pty). Scripts run in the session's working directory with the active venv's python, so project deps (pandas, etc.) and relative paths work like in terminal(). Print your final result to stdout. Use Python stdlib (json, re, math, csv, datetime, collections, etc.) for processing between tool calls. Also available (no import needed — built into hermes_tools): json_parse(text: str) — json.loads with strict=False; use for terminal() output with control chars shell_quote(s: str) — shlex.quote(); use when interpolating dynamic strings into shell commands retry(fn, max_attempts=3, delay=2) — retry with exponential backoff for transient failures |
+| computer_use | computer_use | Universal macOS desktop control via cua-driver. Works with any tool-capable model (Anthropic, OpenAI, OpenRouter, local vLLM, etc.). Background computer-use: does NOT steal the user's cursor or keyboard focus. |
+| cronjob | cronjob | Manage scheduled cron jobs with a single compressed tool. Use action='create' to schedule a new job from a prompt or one or more skills. Use action='list' to inspect jobs. Use action='update', 'pause', 'resume', 'remove', or 'run' to manage an existing job. To stop a job the user no longer wants: first action='list' to find the job_id, then action='remove' with that job_id. Never guess job IDs — always list first. Jobs run in a fresh session with no current-chat context, so prompts must be self-contained. If skills are provided on create, the future cron run loads those skills in order, then follows the prompt as the task instruction. On update, passing skills=[] clears attached skills. NOTE: The agent's final response is auto-delivered to the target. Put the primary user-facing content in the final response. Cron jobs run autonomously with no user present — they cannot ask questions or request clarification. Important safety rule: cron-run sessions should not recursively schedule more cron jobs. |
+| delegate_task | delegation | Spawn one or more subagents in isolated contexts. Description is rebuilt at every get_definitions() call to reflect the user's current delegation limits. |
+| discord | discord | Read and participate in a Discord server. Available actions: search_members(guild_id, query) — find members by name prefix fetch_messages(channel_id) — recent messages; optional before/after snowflakes create_thread(channel_id, name) — create a public thread; optional message_id anchor Use the channel_id from the current conversation context. Use search_members to look up user IDs by name prefix. |
+| discord_admin | discord_admin | Manage a Discord server via the REST API. Available actions: list_guilds() — list servers the bot is in server_info(guild_id) — server details + member counts list_channels(guild_id) — all channels grouped by category channel_info(channel_id) — single channel details list_roles(guild_id) — roles sorted by position member_info(guild_id, user_id) — lookup a specific member list_pins(channel_id) — pinned messages in a channel pin_message(channel_id, message_id) — pin a message unpin_message(channel_id, message_id) — unpin a message delete_message(channel_id, message_id) — delete a message rename_thread(channel_id, name) — rename an existing thread by thread channel ID add_role(guild_id, user_id, role_id) — assign a role remove_role(guild_id, user_id, role_id) — remove a role Call list_guilds first to discover guild_ids, then list_channels for channel_ids. Runtime errors will tell you if the bot lacks a specific per-guild permission (e.g. MANAGE_ROLES for add_role). |
+| feishu_doc_read | feishu_doc | Read Feishu document content |
+| feishu_drive_add_comment | feishu_drive | Add a whole-document comment |
+| feishu_drive_list_comment_replies | feishu_drive | List comment replies |
+| feishu_drive_list_comments | feishu_drive | List document comments |
+| feishu_drive_reply_comment | feishu_drive | Reply to a document comment |
+| patch | file | Targeted find-and-replace edits in files. Use this instead of sed/awk in terminal. Uses fuzzy matching (9 strategies) so minor whitespace/indentation differences won't break it. Returns a unified diff. Auto-runs syntax checks after editing. REPLACE MODE (mode='replace', default): find a unique string and replace it. REQUIRED PARAMETERS: mode, path, old_string, new_string. PATCH MODE (mode='patch'): apply V4A multi-file patches for bulk changes. REQUIRED PARAMETERS: mode, patch. |
+| read_file | file | Read a text file with line numbers and pagination. Use this instead of cat/head/tail in terminal. Output format: 'LINE_NUM\|CONTENT'. Suggests similar filenames if not found. Use offset and limit for large files. Reads exceeding ~100K characters are rejected; use offset and limit to read specific sections of large files. NOTE: Cannot read images or binary files — use vision_analyze for images. |
+| search_files | file | Search file contents or find files by name. Use this instead of grep/rg/find/ls in terminal. Ripgrep-backed, faster than shell equivalents. Content search (target='content'): Regex search inside files. Output modes: full matches with line numbers, file paths only, or match counts. File search (target='files'): Find files by glob pattern (e.g., '*.py', '*config*'). Also use this instead of ls — results sorted by modification time. |
+| write_file | file | Write content to a file, completely replacing existing content. Use this instead of echo/cat heredoc in terminal. Creates parent directories automatically. OVERWRITES the entire file — use 'patch' for targeted edits. Auto-runs syntax checks on .py/.json/.yaml/.toml and other linted languages; only NEW errors introduced by this write are surfaced (pre-existing errors are filtered out). |
+| yb_query_group_info | hermes-yuanbao | Query basic info about a group (called '派/Pai' in the app), including group name, owner, and member count. |
+| yb_query_group_members | hermes-yuanbao | Query members of a group (called '派/Pai' in the app). Use this tool when you need to @mention someone, find a user by name, list bots (including Yuanbao AI), or list all members. IMPORTANT: You MUST call this tool before @mentioning any user, because you need the exact nickname to construct the @mention format. |
+| yb_search_sticker | hermes-yuanbao | Search the built-in Yuanbao sticker (TIM face / 表情包) catalogue by keyword. Returns the top matching candidates with sticker_id, name, and description. Use this BEFORE yb_send_sticker to discover the right sticker_id. Sticker = 贴纸 = TIM face — NOT a message reaction. Prefer sending a sticker over bare Unicode emoji when reacting/expressing emotion. |
+| yb_send_dm | hermes-yuanbao | Send a private/direct message (DM) to a user in a group, with optional media files. This tool automatically looks up the user by name in the group member list and sends the message. Use this when someone asks to privately message / 私信 / DM a user. Supports text, images, and file attachments. You can also provide user_id directly if already known. |
+| yb_send_sticker | hermes-yuanbao | Send a built-in sticker (TIMFaceElem / 贴纸表情) to the current Yuanbao chat. Call yb_search_sticker first if you don't know the sticker_id/name. Sticker = 贴纸 = TIM face — NOT a message reaction. CRITICAL: Whenever the user asks you to send a sticker / 贴纸 / 表情包, you MUST use this tool. DO NOT draw a PNG via execute_code / Pillow / matplotlib and then call send_image_file — that produces a fake 'sticker' image instead of a real TIM face and is the WRONG path. If no suitable sticker_id is known, call yb_search_sticker first. When the recent thread shows users sending stickers, prefer matching that tone by replying with a sticker instead of (or in addition to) text. |
+| ha_call_service | homeassistant | Call a Home Assistant service to control a device. Use ha_list_services to discover available services and their parameters for each domain. |
+| ha_get_state | homeassistant | Get the detailed state of a single Home Assistant entity, including all attributes (brightness, color, temperature setpoint, sensor readings, etc.). |
+| ha_list_entities | homeassistant | List Home Assistant entities. Optionally filter by domain (light, switch, climate, sensor, binary_sensor, cover, fan, etc.) or by area name (living room, kitchen, bedroom, etc.). |
+| ha_list_services | homeassistant | List available Home Assistant services (actions) for device control. Shows what actions can be performed on each device type and what parameters they accept. Use this to discover how to control devices found via ha_list_entities. |
+| image_generate | image_gen | Generate high-quality images from text prompts. The underlying backend (FAL, OpenAI, etc.) and model are user-configured and not selectable by the agent. Returns either a URL or an absolute file path in the `image` field; display it with markdown ![description](url-or-path) and the gateway will deliver it. |
+| kanban_block | kanban | Transition the task to blocked because you need human input to proceed. ``reason`` will be shown to the human on the board and included in context when someone unblocks you. Use for genuine blockers only — don't block on things you can resolve yourself. |
+| kanban_comment | kanban | Append a comment to a task's thread. Use for durable notes that should outlive this run (questions for the next worker, partial findings, rationale). Ephemeral reasoning doesn't belong here — use your normal response instead. |
+| kanban_complete | kanban | Mark your current task done with a structured handoff for downstream workers and humans. Prefer ``summary`` for a human-readable 1-3 sentence description of what you did; put machine-readable facts in ``metadata`` (changed_files, tests_run, decisions, findings, etc). At least one of ``summary`` or ``result`` is required. If you created new tasks via ``kanban_create`` during this run, list their ids in ``created_cards`` — the kernel verifies them so phantom references are caught before they leak into downstream automation. |
+| kanban_create | kanban | Create a new kanban task, optionally as a child of the current one (pass the current task id in ``parents``). Used by orchestrator workers to fan out — decompose work into child tasks with specific assignees, link them into a pipeline, then complete your own task. The dispatcher picks up the new tasks on its next tick and spawns the assigned profiles. |
+| kanban_heartbeat | kanban | Signal that you're still alive during a long operation (training, encoding, large crawls). Call every few minutes so humans see liveness separately from PID checks. Pure side effect — no work changes. |
+| kanban_link | kanban | Add a parent→child dependency edge after both tasks already exist. The child won't promote to 'ready' until all parents are 'done'. Cycles and self-links are rejected. |
+| kanban_list | kanban | List Kanban task summaries so an orchestrator profile can discover work to route. Supports the same core filters as the CLI: assignee, status, tenant, include_archived, and limit. Returns compact rows with ids, title, status, assignee, priority, parent/child ids, and counts. Bounded to 50 rows by default, 200 max, with truncation metadata. Also recomputes ready tasks before listing, matching the CLI. Orchestrator-only — dispatcher-spawned task workers never see this tool. |
+| kanban_show | kanban | Read a task's full state — title, body, assignee, parent task handoffs, your prior attempts on this task if any, comments, and recent events. Use this to (re)orient yourself before starting work, especially on retries. The response includes a pre-formatted ``worker_context`` string suitable for inclusion verbatim in your reasoning. |
+| kanban_unblock | kanban | Move a blocked Kanban task back to ready. Orchestrator-only — only profiles with the kanban toolset can unblock routed work; dispatcher-spawned task workers never see this tool. |
+| memory | memory | Save durable information to persistent memory that survives across sessions. Memory is injected into future turns, so keep it compact and focused on facts that will still matter later. WHEN TO SAVE (do this proactively, don't wait to be asked): - User corrects you or says 'remember this' / 'don't do that again' - User shares a preference, habit, or personal detail (name, role, timezone, coding style) - You discover something about the environment (OS, installed tools, project structure) - You learn a convention, API quirk, or workflow specific to this user's setup - You identify a stable fact that will be useful again in future sessions PRIORITY: User preferences and corrections > environment facts > procedural knowledge. The most valuable memory prevents the user from having to repeat themselves. Do NOT save task progress, session outcomes, completed-work logs, or temporary TODO state to memory; use session_search to recall those from past transcripts. If you've discovered a new way to do something, solved a problem that could be necessary later, save it as a skill with the skill tool. TWO TARGETS: - 'user': who the user is -- name, role, preferences, communication style, pet peeves - 'memory': your notes -- environment facts, project conventions, tool quirks, lessons learned ACTIONS: add (new entry), replace (update existing -- old_text identifies it), remove (delete -- old_text identifies it). SKIP: trivial/obvious info, things easily re-discovered, raw data dumps, and temporary task state. |
+| send_message | messaging | Send a message to a connected messaging platform, or list available targets. IMPORTANT: When the user asks to send to a specific channel or person (not just a bare platform name), call send_message(action='list') FIRST to see available targets, then send to the correct one. If the user just says a platform name like 'send to telegram', send directly to the home channel without listing first. |
+| mixture_of_agents | moa | Route a hard problem through multiple frontier LLMs collaboratively. Makes 5 API calls (4 reference models + 1 aggregator) with maximum reasoning effort — use sparingly for genuinely difficult problems. Best for: complex math, advanced algorithms, multi-step analytical reasoning, problems benefiting from diverse perspectives. |
+| session_search | session_search | Search your long-term memory of past conversations, or browse recent sessions. This is your recall -- every past session is searchable, and this tool summarizes what happened. TWO MODES: 1. Recent sessions (no query): Call with no arguments to see what was worked on recently. Returns titles, previews, and timestamps. Zero LLM cost, instant. Start here when the user asks what were we working on or what did we do recently. 2. Keyword search (with query): Search for specific topics across all past sessions. Returns LLM-generated summaries of matching sessions. USE THIS PROACTIVELY when: - The user says 'we did this before', 'remember when', 'last time', 'as I mentioned' - The user asks about a topic you worked on before but don't have in current context - The user references a project, person, or concept that seems familiar but isn't in memory - You want to check if you've solved a similar problem before - The user asks 'what did we do about X?' or 'how did we fix Y?' Don't hesitate to search when it is actually cross-session -- it's fast and cheap. Better to search and confirm than to guess or ask the user to repeat themselves. Search syntax: keywords joined with OR for broad recall (elevenlabs OR baseten OR funding), phrases for exact match ("docker networking"), boolean (python NOT java), prefix (deploy*). IMPORTANT: Use OR between keywords for best results — FTS5 defaults to AND which misses sessions that only mention some terms. If a broad OR query returns nothing, try individual keyword searches in parallel. Returns summaries of the top matching sessions. |
+| skill_manage | skills | Manage skills (create, update, delete). Skills are your procedural memory — reusable approaches for recurring task types. New skills go to ~/.hermes/skills/; existing skills can be modified wherever they live. Actions: create (full SKILL.md + optional category), patch (old_string/new_string — preferred for fixes), edit (full SKILL.md rewrite — major overhauls only), delete, write_file, remove_file. On delete, pass `absorbed_into=<umbrella>` when you're merging this skill's content into another one, or `absorbed_into=""` when you're pruning it with no forwarding target. This lets the curator tell consolidation from pruning without guessing, so downstream consumers (cron jobs that reference the old skill name, etc.) get updated correctly. The target you name in `absorbed_into` must already exist — create/patch the umbrella first, then delete. Create when: complex task succeeded (5+ calls), errors overcome, user-corrected approach worked, non-trivial workflow discovered, or user asks you to remember a procedure. Update when: instructions stale/wrong, OS-specific failures, missing steps or pitfalls found during use. If you used a skill and hit issues not covered by it, patch it immediately. After difficult/iterative tasks, offer to save as a skill. Skip for simple one-offs. Confirm with user before creating/deleting. Good skills: trigger conditions, numbered steps with exact commands, pitfalls section, verification steps. Use skill_view() to see format examples. Pinned skills are protected from deletion only — skill_manage(action='delete') will refuse with a message pointing the user to `hermes curator unpin <name>`. Patches and edits go through on pinned skills so you can still improve them as pitfalls come up; pin only guards against irrecoverable loss. |
+| skill_view | skills | Skills allow for loading information about specific tasks and workflows, as well as scripts and templates. Load a skill's full content or access its linked files (references, templates, scripts). First call returns SKILL.md content plus a 'linked_files' dict showing available references/templates/scripts. To access those, call again with file_path parameter. |
+| skills_list | skills | List available skills (name + description). Use skill_view(name) to load full content. |
+| process | terminal | Manage background processes started with terminal(background=true). Actions: 'list' (show all), 'poll' (check status + new output), 'log' (full output with pagination), 'wait' (block until done or timeout), 'kill' (terminate), 'write' (send raw stdin data without newline), 'submit' (send data + Enter, for answering prompts), 'close' (close stdin/send EOF). |
+| terminal | terminal | Execute shell commands on a Linux environment. Filesystem usually persists between calls. Do NOT use cat/head/tail to read files — use read_file instead. Do NOT use grep/rg/find to search — use search_files instead. Do NOT use ls to list directories — use search_files(target='files') instead. Do NOT use sed/awk to edit files — use patch instead. Do NOT use echo/cat heredoc to create files — use write_file instead. Reserve terminal for: builds, installs, git, processes, scripts, network, package managers, and anything that needs a shell. Foreground (default): Commands return INSTANTLY when done, even if the timeout is high. Set timeout=300 for long builds/scripts — you'll still get the result in seconds if it's fast. Prefer foreground for short commands. Background: Set background=true to get a session_id. Two patterns: (1) Long-lived processes that never exit (servers, watchers). (2) Long-running tasks with notify_on_complete=true — you can keep working on other things and the system auto-notifies you when the task finishes. Great for test suites, builds, deployments, or anything that takes more than a minute. For servers/watchers, do NOT use shell-level background wrappers (nohup/disown/setsid/trailing '&') in foreground mode. Use background=true so Hermes can track lifecycle and output. After starting a server, verify readiness with a health check or log signal, then run tests in a separate terminal() call. Avoid blind sleep loops. Use process(action="poll") for progress checks, process(action="wait") to block until done. Working directory: Use 'workdir' for per-command cwd. PTY mode: Set pty=true for interactive CLI tools (Codex, Claude Code, Python REPL). Do NOT use vim/nano/interactive tools without pty=true — they hang without a pseudo-terminal. Pipe git output to cat if it might page. |
+| todo | todo | Manage your task list for the current session. Use for complex tasks with 3+ steps or when the user provides multiple tasks. Call with no parameters to read the current list. Writing: - Provide 'todos' array to create/update items - merge=false (default): replace the entire list with a fresh plan - merge=true: update existing items by id, add any new ones Each item: {id: string, content: string, status: pending\|in_progress\|completed\|cancelled} List order is priority. Only ONE item in_progress at a time. Mark items completed immediately when done. If something fails, cancel it and add a revised item. Always returns the full current list. |
+| text_to_speech | tts | Convert text to speech audio. Returns a MEDIA: path that the platform delivers as native audio. Compatible providers render as a voice bubble on Telegram; otherwise audio is sent as a regular attachment. In CLI mode, saves to ~/voice-memos/. Voice and provider are user-configured (built-in providers like edge/openai or custom command providers under tts.providers.<name>), not model-selected. |
+| video_analyze | video | Analyze a video from a URL or local file path using a multimodal AI model. Sends the video to a video-capable model (e.g. Gemini) for understanding. Use this for video files — for images, use vision_analyze instead. Supports mp4, webm, mov, avi, mkv, mpeg formats. Note: large videos (>20 MB) may be slow; max ~50 MB. |
+| video_generate | video_gen | (rebuilt at get_definitions() time — see _build_dynamic_video_schema) |
+| vision_analyze | vision | Load an image into the conversation so you can see it. Accepts a URL, local file path, or data URL. When your active model has native vision, the image is attached to your context directly and you read the pixels yourself on the next turn — call this any time the user references an image (filepath in their message, URL in tool output, screenshot from the browser, etc.). For non-vision models, falls back to an auxiliary vision model that returns a text description. |
+| web_extract | web | Extract content from web page URLs. Returns page content in markdown format. Also works with PDF URLs (arxiv papers, documents, etc.) — pass the PDF link directly and it converts to markdown text. Pages under 5000 chars return full markdown; larger pages are LLM-summarized and capped at ~5000 chars per page. Pages over 2M chars are refused. If a URL fails or times out, use the browser tool to access it instead. |
+| web_search | web | Search the web for information. Returns up to 5 results by default with titles, URLs, and descriptions. The query is passed through to the configured backend, so operators such as site:domain, filetype:pdf, intitle:word, -term, and "exact phrase" may work when the backend supports them. |
+| x_search | x_search | Search X (Twitter) posts, profiles, and threads using xAI's built-in X Search tool. Use this for current discussion, reactions, or claims on X rather than general web pages. Available when xAI credentials are configured (SuperGrok OAuth or XAI_API_KEY). |
+<!-- AUTO-END: capabilities -->
+
+## Toolsets
+
+<!-- AUTO-START: toolsets -->
+Core default tools: 48
+
+| Toolset | Description | Tools | Includes |
+|---|---|---|---|
+| browser | Browser automation for web interaction (navigate, click, type, scroll, iframes, hold-click) with web search for finding URLs | 13 | - |
+| clarify | Ask the user clarifying questions (multiple-choice or open-ended) | 1 | - |
+| code_execution | Run Python scripts that call tools programmatically (reduces LLM round trips) | 1 | - |
+| computer_use | Background macOS desktop control via cua-driver — screenshots, mouse, keyboard, scroll, drag. Does NOT steal the user's cursor or keyboard focus. Works with any tool-capable model. | 1 | - |
+| cronjob | Cronjob management tool - create, list, update, pause, resume, remove, and trigger scheduled tasks | 1 | - |
+| debugging | Debugging and troubleshooting toolkit | 2 | web, file |
+| delegation | Spawn subagents with isolated context for complex subtasks | 1 | - |
+| discord | Discord read and participate tools (fetch messages, search members, create threads) | 1 | - |
+| discord_admin | Discord server management (list channels/roles, pin messages, assign roles) | 1 | - |
+| feishu_doc | Read Feishu/Lark document content | 1 | - |
+| feishu_drive | Feishu/Lark document comment operations (list, reply, add) | 4 | - |
+| file | File manipulation tools: read, write, patch (with fuzzy matching), and search (content + files) | 4 | - |
+| hermes-acp | Editor integration (VS Code, Zed, JetBrains) — coding-focused tools without messaging, audio, or clarify UI | 29 | - |
+| hermes-api-server | OpenAI-compatible API server — full agent tools accessible via HTTP (no interactive UI tools like clarify or send_message) | 35 | - |
+| hermes-bluebubbles | BlueBubbles iMessage bot toolset - Apple iMessage via local BlueBubbles server | 48 | - |
+| hermes-cli | Full interactive CLI toolset - all default tools plus cronjob management | 48 | - |
+| hermes-cron | Default cron toolset - same core tools as hermes-cli; gated by `hermes tools` | 48 | - |
+| hermes-dingtalk | DingTalk bot toolset - enterprise messaging platform (full access) | 48 | - |
+| hermes-discord | Discord bot toolset - full access (terminal has safety checks via dangerous command approval) | 50 | - |
+| hermes-email | Email bot toolset - interact with Hermes via email (IMAP/SMTP) | 48 | - |
+| hermes-feishu | Feishu/Lark bot toolset - enterprise messaging via Feishu/Lark (full access) | 53 | - |
+| hermes-gateway | Gateway toolset - union of all messaging platform tools | 0 | hermes-telegram, hermes-discord, hermes-whatsapp, hermes-slack, hermes-signal, hermes-bluebubbles, hermes-homeassistant, hermes-email, hermes-sms, hermes-mattermost, hermes-matrix, hermes-dingtalk, hermes-feishu, hermes-wecom, hermes-wecom-callback, hermes-weixin, hermes-qqbot, hermes-webhook, hermes-yuanbao |
+| hermes-homeassistant | Home Assistant bot toolset - smart home event monitoring and control | 48 | - |
+| hermes-matrix | Matrix bot toolset - decentralized encrypted messaging (full access) | 48 | - |
+| hermes-mattermost | Mattermost bot toolset - self-hosted team messaging (full access) | 48 | - |
+| hermes-qqbot | QQBot toolset - QQ messaging via Official Bot API v2 (full access) | 48 | - |
+| hermes-signal | Signal bot toolset - encrypted messaging platform (full access) | 48 | - |
+| hermes-slack | Slack bot toolset - full access for workspace use (terminal has safety checks) | 48 | - |
+| hermes-sms | SMS bot toolset - interact with Hermes via SMS (Twilio) | 48 | - |
+| hermes-telegram | Telegram bot toolset - full access for personal use (terminal has safety checks) | 48 | - |
+| hermes-webhook | Webhook toolset - receive and process external webhook events | 48 | - |
+| hermes-wecom | WeCom bot toolset - enterprise WeChat messaging (full access) | 48 | - |
+| hermes-wecom-callback | WeCom callback toolset - enterprise self-built app messaging (full access) | 48 | - |
+| hermes-weixin | Weixin bot toolset - personal WeChat messaging via iLink (full access) | 48 | - |
+| hermes-whatsapp | WhatsApp bot toolset - similar to Telegram (personal messaging, more trusted) | 48 | - |
+| hermes-yuanbao | Yuanbao Bot 元宝消息平台工具集 - 群信息、成员查询、私聊、贴纸表情 | 53 | - |
+| homeassistant | Home Assistant smart home control and monitoring | 4 | - |
+| image_gen | Creative generation tools (images) | 1 | - |
+| kanban | Kanban multi-agent coordination — only active when the agent is spawned by the kanban dispatcher (HERMES_KANBAN_TASK env set). The dispatcher runs inside the gateway by default; see `kanban.dispatch_in_gateway` in config.yaml. Lets workers mark tasks done with structured handoffs, block for human input, heartbeat during long ops, comment on threads, and (for orchestrators) list, unblock, and fan out tasks. | 9 | - |
+| memory | Persistent memory across sessions (personal notes + user profile) | 1 | - |
+| messaging | Cross-platform messaging: send messages to Telegram, Discord, Slack, SMS, etc. | 1 | - |
+| moa | Advanced reasoning and problem-solving tools | 1 | - |
+| safe | Safe toolkit without terminal access | 0 | web, vision, image_gen |
+| search | Web search only (no content extraction/scraping) | 1 | - |
+| session_search | Search and recall past conversations with summarization | 1 | - |
+| skills | Access, create, edit, and manage skill documents with specialized instructions and knowledge | 3 | - |
+| spotify | Native Spotify playback, search, playlist, album, and library tools | 7 | - |
+| terminal | Terminal/command execution and process management tools | 2 | - |
+| todo | Task planning and tracking for multi-step work | 1 | - |
+| tts | Text-to-speech: convert text to audio with Edge TTS (free), ElevenLabs, OpenAI, or xAI | 1 | - |
+| video | Video analysis and understanding tools (opt-in, not in default toolset) | 1 | - |
+| video_gen | Video generation tools. Single ``video_generate`` tool covers text-to-video (prompt only) and image-to-video (prompt + image_url) — the active backend auto-routes. Configure via ``hermes tools`` → Video Generation. | 1 | - |
+| vision | Image analysis and vision tools | 1 | - |
+| web | Web research and content extraction tools | 2 | - |
+| x_search | Search X (Twitter) posts and threads via xAI's built-in x_search Responses tool. Available when xAI credentials are configured (SuperGrok OAuth or XAI_API_KEY). Off by default; enable in `hermes tools` → X (Twitter) Search. | 1 | - |
+| yuanbao | Yuanbao platform tools - group info, member queries, DM, stickers | 5 | - |
+<!-- AUTO-END: toolsets -->
+
+## Slash Commands
+
+<!-- AUTO-START: slash_commands -->
+| Command | Category | Scope | Description |
+|---|---|---|---|
+| /busy | Configuration | cli | Control what Enter does while Hermes is working |
+| /codex-runtime | Configuration | cli+gateway | Toggle codex app-server runtime for OpenAI/Codex models |
+| /config | Configuration | cli | Show current configuration |
+| /fast | Configuration | cli+gateway | Toggle fast mode — OpenAI Priority Processing / Anthropic Fast Mode (Normal/Fast) |
+| /footer | Configuration | cli+gateway | Toggle gateway runtime-metadata footer on final replies |
+| /indicator | Configuration | cli | Pick the TUI busy-indicator style |
+| /model | Configuration | cli+gateway | Switch model for this session |
+| /personality | Configuration | cli+gateway | Set a predefined personality |
+| /reasoning | Configuration | cli+gateway | Manage reasoning effort and display |
+| /skin | Configuration | cli | Show or change the display skin/theme |
+| /statusbar | Configuration | cli | Toggle the context/model status bar |
+| /verbose | Configuration | cli | Cycle tool progress display: off -> new -> all -> verbose |
+| /voice | Configuration | cli+gateway | Toggle voice mode |
+| /yolo | Configuration | cli+gateway | Toggle YOLO mode (skip all dangerous command approvals) |
+| /quit | Exit | cli | Exit the CLI (use --delete to also remove session history) |
+| /commands | Info | gateway | Browse all commands and skills (paginated) |
+| /copy | Info | cli | Copy the last assistant response to clipboard |
+| /debug | Info | cli+gateway | Upload debug report (system info + logs) and get shareable links |
+| /gquota | Info | cli | Show Google Gemini Code Assist quota usage |
+| /help | Info | cli+gateway | Show available commands |
+| /image | Info | cli | Attach a local image file for your next prompt |
+| /insights | Info | cli+gateway | Show usage insights and analytics |
+| /paste | Info | cli | Attach clipboard image from your clipboard |
+| /platform | Info | gateway | Pause, resume, or list a failing gateway platform |
+| /platforms | Info | cli | Show gateway/messaging platform status |
+| /profile | Info | cli+gateway | Show active profile name and home directory |
+| /update | Info | gateway | Update Hermes Agent to the latest version |
+| /usage | Info | cli+gateway | Show token usage and rate limits for the current session |
+| /whoami | Info | cli+gateway | Show your slash command access (admin / user) |
+| /agents | Session | cli+gateway | Show active agents and running tasks |
+| /approve | Session | gateway | Approve a pending dangerous command |
+| /background | Session | cli+gateway | Run a prompt in the background |
+| /branch | Session | cli+gateway | Branch the current session (explore a different path) |
+| /clear | Session | cli | Clear screen and start a new session |
+| /compress | Session | cli+gateway | Manually compress conversation context |
+| /deny | Session | gateway | Deny a pending dangerous command |
+| /goal | Session | cli+gateway | Set a standing goal Hermes works on across turns until achieved |
+| /handoff | Session | cli | Hand off this session to a messaging platform (Telegram, Discord, etc.) |
+| /history | Session | cli | Show conversation history |
+| /new | Session | cli+gateway | Start a new session (fresh session ID + history) |
+| /queue | Session | cli+gateway | Queue a prompt for the next turn (doesn't interrupt) |
+| /redraw | Session | cli | Force a full UI repaint (recovers from terminal drift) |
+| /restart | Session | gateway | Gracefully restart the gateway after draining active runs |
+| /resume | Session | cli+gateway | Resume a previously-named session |
+| /retry | Session | cli+gateway | Retry the last message (resend to agent) |
+| /rollback | Session | cli+gateway | List or restore filesystem checkpoints |
+| /save | Session | cli | Save the current conversation |
+| /sessions | Session | cli+gateway | Browse and resume previous sessions |
+| /sethome | Session | gateway | Set this chat as the home channel |
+| /snapshot | Session | cli | Create or restore state snapshots of Hermes config/state |
+| /status | Session | cli+gateway | Show session info |
+| /steer | Session | cli+gateway | Inject a message after the next tool call without interrupting |
+| /stop | Session | cli+gateway | Kill all running background processes |
+| /subgoal | Session | cli+gateway | Add or manage extra criteria on the active goal |
+| /title | Session | cli+gateway | Set a title for the current session |
+| /topic | Session | gateway | Enable or inspect Telegram DM topic sessions |
+| /undo | Session | cli+gateway | Remove the last user/assistant exchange |
+| /browser | Tools & Skills | cli | Connect browser tools to your live Chrome via CDP |
+| /cron | Tools & Skills | cli | Manage scheduled tasks |
+| /curator | Tools & Skills | cli+gateway | Background skill maintenance (status, run, pin, archive, list-archived) |
+| /kanban | Tools & Skills | cli+gateway | Multi-profile collaboration board (tasks, links, comments) |
+| /plugins | Tools & Skills | cli | List installed plugins and their status |
+| /reload | Tools & Skills | cli | Reload .env variables into the running session |
+| /reload-mcp | Tools & Skills | cli+gateway | Reload MCP servers from config |
+| /reload-skills | Tools & Skills | cli+gateway | Re-scan ~/.hermes/skills/ for newly installed or removed skills |
+| /skills | Tools & Skills | cli | Search, install, inspect, or manage skills |
+| /tools | Tools & Skills | cli | Manage tools: /tools [list\|disable\|enable] [name...] |
+| /toolsets | Tools & Skills | cli | List available toolsets |
+<!-- AUTO-END: slash_commands -->
+
+## Gateway Platforms
+
+<!-- AUTO-START: gateway_platforms -->
+| Platform | Adapter |
+|---|---|
+| api_server | gateway/platforms/api_server.py |
+| base | gateway/platforms/base.py |
+| bluebubbles | gateway/platforms/bluebubbles.py |
+| dingtalk | gateway/platforms/dingtalk.py |
+| discord | gateway/platforms/discord.py |
+| email | gateway/platforms/email.py |
+| feishu | gateway/platforms/feishu.py |
+| feishu_comment | gateway/platforms/feishu_comment.py |
+| feishu_comment_rules | gateway/platforms/feishu_comment_rules.py |
+| helpers | gateway/platforms/helpers.py |
+| homeassistant | gateway/platforms/homeassistant.py |
+| matrix | gateway/platforms/matrix.py |
+| mattermost | gateway/platforms/mattermost.py |
+| msgraph_webhook | gateway/platforms/msgraph_webhook.py |
+| signal | gateway/platforms/signal.py |
+| signal_rate_limit | gateway/platforms/signal_rate_limit.py |
+| slack | gateway/platforms/slack.py |
+| sms | gateway/platforms/sms.py |
+| telegram | gateway/platforms/telegram.py |
+| telegram_network | gateway/platforms/telegram_network.py |
+| webhook | gateway/platforms/webhook.py |
+| wecom | gateway/platforms/wecom.py |
+| wecom_callback | gateway/platforms/wecom_callback.py |
+| wecom_crypto | gateway/platforms/wecom_crypto.py |
+| weixin | gateway/platforms/weixin.py |
+| whatsapp | gateway/platforms/whatsapp.py |
+| yuanbao | gateway/platforms/yuanbao.py |
+| yuanbao_media | gateway/platforms/yuanbao_media.py |
+| yuanbao_proto | gateway/platforms/yuanbao_proto.py |
+| yuanbao_sticker | gateway/platforms/yuanbao_sticker.py |
+<!-- AUTO-END: gateway_platforms -->
+
+## Voice / STT / TTS Loop
+
+<!-- AUTO-START: voice_loop -->
+Voice input routes platform audio through gateway callbacks, STT, agent response generation, optional TTS, and voice playback.
+
+| Surface | Status |
+|---|---|
+| tools/transcription_tools.py | present |
+| tools/tts_tool.py | present |
+| tools/voice_mode.py | present |
+| gateway/platforms/discord.py | present |
+| gateway/run.py | present |
+<!-- AUTO-END: voice_loop -->
+
+## Skills and Agent Profiles
+
+<!-- AUTO-START: skills_profiles -->
+Total skills discovered: 267
+
+Profiles: profile-chad, profile-ffm-ceo, profile-heidi, profile-hmg-ceo, profile-main, profile-ohp-ceo, profile-scout, profile-scribe, profile-virtuity-ceo, profile-zentry-architecture, profile-zentry-build, profile-zentry-pm, profile-zentry-qa, profile-zentry-ux
+
+| Category | Skills |
+|---|---|
+| apple | 10 |
+| autonomous-ai-agents | 8 |
+| creative | 38 |
+| data-science | 2 |
+| devops | 6 |
+| dogfood | 2 |
+| email | 2 |
+| gaming | 4 |
+| github | 12 |
+| hermes-agents | 14 |
+| mcp | 2 |
+| media | 10 |
+| mlops | 18 |
+| note-taking | 2 |
+| openclaw-imports | 78 |
+| productivity | 19 |
+| red-teaming | 2 |
+| research | 10 |
+| smart-home | 2 |
+| social-media | 2 |
+| software-development | 22 |
+| yuanbao | 2 |
+<!-- AUTO-END: skills_profiles -->
+
+## Plugins and Integrations
+
+<!-- AUTO-START: plugins_integrations -->
+Credential-like environment keys present: 5 names redacted by design.
+
+| Plugin | Path |
+|---|---|
+| __pycache__ | plugins/__pycache__ |
+| browser | plugins/browser |
+| context_engine | plugins/context_engine |
+| disk-cleanup | plugins/disk-cleanup |
+| example-dashboard | plugins/example-dashboard |
+| google_meet | plugins/google_meet |
+| hermes-achievements | plugins/hermes-achievements |
+| image_gen | plugins/image_gen |
+| kanban | plugins/kanban |
+| memory | plugins/memory |
+| model-providers | plugins/model-providers |
+| observability | plugins/observability |
+| platforms | plugins/platforms |
+| spotify | plugins/spotify |
+| teams_pipeline | plugins/teams_pipeline |
+| video_gen | plugins/video_gen |
+| web | plugins/web |
+<!-- AUTO-END: plugins_integrations -->
+
+## Recent Activity
+
+<!-- AUTO-START: recent_activity -->
+- bdc2113b5 2026-05-17 fix(xai): wire schema sanitizer into post-refactor build_api_kwargs
+- 2551f0813 2026-05-17 fix(schema_sanitizer): strip pattern/format from Responses-format tools for xAI compatibility
+- 532b209f0 2026-05-17 fix(run_agent): scope kimi tool-reasoning trigger to host, not model name substring
+- af7b38d78 2026-05-17 test(voice_cli): drop stale ≥1 requirement for force=True error _vprint calls
+- 0b491c466 2026-05-17 fix(model_switch): preserve explicit custom-provider model list when no api_key
+- bfcab25dc 2026-05-17 test(tools_config): align post_setup parametrize with current browser provider catalog
+- f27416dc8 2026-05-17 fix(cli): include send in _BUILTIN_SUBCOMMANDS for plugin discovery gating
+- dfc6ea72c 2026-05-17 test(gateway): include direct_messages_topic_id in telegram DM metadata assertions
+- 06924e827 2026-05-17 test(gateway): accept trust_env in fake aiohttp ClientSession lambdas
+- e66a3e86e 2026-05-17 chore(acp): bump registry manifest to 0.14.0 matching pyproject
+- 822e92edb 2026-05-17 fix(aux): default OpenRouter auxiliary to gemini-3-flash-preview
+- e3f7ff112 2026-05-16 test(xai-oauth): pin PKCE token-exchange wire format
+- cb53c40e4 2026-05-16 fix(xai-oauth): echo code_challenge in token POST so PKCE exchange succeeds
+- bc7c608d5 2026-05-16 fix(gateway): ignore inaccessible service path dirs
+- 1a82b7a1f 2026-05-16 fix(tests): stabilize xai env and provider parity
+- 73df32921 2026-05-15 fix(doctor): flag missing credentials for active openrouter provider
+- a2cc30544 2026-05-17 chore(release): map vaddisrinivas for #26394 salvage
+- 7847a58b3 2026-05-15 fix(docker): preload messaging gateway deps
+- 4a7cd2e16 2026-05-15 fix(codex): allow kanban worker board writes
+- ee7cd1028 2026-05-17 chore(release): map hehehe0803 email for #26212 salvage
+- 280c63ce9 2026-05-16 fix(mcp): prevent parallel-safe prefix collisions
+- 874dad5cc 2026-05-16 test(delegation): add regression test for runtime missing 'provider' key
+- 84667cbc2 2026-05-16 fix(delegation): preserve configured_provider name when runtime returns 'custom'
+- 08a66b2ae 2026-05-17 Merge pull request #27489 from NousResearch/bb/tui-composer-cursor-drift-v2
+- 3f01e9493 2026-05-17 chore(release): AUTHOR_MAP entries for batch salvage group 6 contributors
+- 74031e1e2 2026-05-17 fix(dashboard): respect HERMES_BASE_PATH in WebSocket URLs (#25547)
+- 714b3b2bd 2026-05-17 fix(web_server): pass proxy_headers=False to uvicorn.run so the dashboard's loopback gate sees the real connection peer
+- 4afd479f5 2026-05-13 fix(gateway): use service restart path in Docker/Podman containers
+- 55d6a1636 2026-05-17 fix(agent): honor provider timeout config in streaming API calls
+- 2f28b60a4 2026-05-16 fix(send_message): preserve Slack and Matrix thread targets resolved from channel directory
+- d5a0815c3 2026-05-16 fix(transports): use monotonic deadlines in codex app-server turn loop
+- 37286a5bc 2026-05-17 chore(release): map QuenVix, Mind-Dragon, soynchux emails for Tier 4 salvage
+- d0f551b44 2026-05-17 fix(doctor): show xAI OAuth login state in hermes doctor Auth Providers section
+- 016893f5e 2026-05-17 feat(status): show xAI OAuth login state in hermes status
+- e10bb9dff 2026-05-17 fix(doctor): isolate per-provider OAuth imports to prevent fallback regression
+- e89d78ff0 2026-05-17 fix(doctor): suppress stale XAI_API_KEY issue when xAI OAuth is healthy
+- caac54796 2026-05-17 chore: revert unrelated package-lock + nix hash churn to keep PR diff minimal
+- 711f46e4b 2026-05-17 review(tui): update stale comment refs to renamed visualLines helper
+- 220736f41 2026-05-17 chore(nix): refresh ui-tui npmDeps hash after wrap-ansi direct-dep drop
+- 8c78f533d 2026-05-17 review(tui): route cursorLayout through @hermes/ink wrapAnsi shim (Bun runtime parity)
+<!-- AUTO-END: recent_activity -->
+
+## Open Questions / Unknowns
+
+- Which generated sections should be included in the always-on slim prompt summary versus available only on demand?
+- Which plugin integrations should be summarized as first-class capabilities versus implementation details?
+- When stable, should CI drift checks become strict or remain advisory?
+
+## Pointers
+
+- `AGENTS.md` — development guide and source map for Hermes internals.
+- `tools/registry.py` — runtime tool registry and discovery path.
+- `toolsets.py` — named toolset definitions and default core tools.
+- `hermes_cli/commands.py` — slash command registry shared by CLI and gateway surfaces.
+- `agent/prompt_builder.py` — system prompt assembly.
+- `gateway/` — messaging gateway, platform adapters, and voice routing.

--- a/docs/plans/2026-05-19-hermes-self-knowledge.md
+++ b/docs/plans/2026-05-19-hermes-self-knowledge.md
@@ -1,0 +1,701 @@
+# Hermes Self-Knowledge Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Build a living, repo-grounded Hermes self-knowledge document that refreshes from code, can be drift-checked, and can feed a slim summary into the system prompt without manual upkeep.
+
+**Architecture:** Add a small `hermes_cli.self_knowledge` package that owns markdown AUTO-block parsing, generators, rendering, drift checks, and CLI handlers. The repo self-knowledge doc lives at `context/self/hermes-agent.md`; generated sections read from Hermes’ existing runtime sources of truth: `tools/registry.py`, `toolsets.py`, `hermes_cli/commands.py`, `gateway/platforms/`, skills directories, plugins, and voice/STT/TTS config surfaces. Prompt injection uses a slim cached summary from `agent/prompt_builder.py` so prompt cache churn stays controlled.
+
+**Tech Stack:** Python, argparse, pytest, markdown files, GitHub Actions. No network calls in rendering, hooks, or checks.
+
+---
+
+## Ground Truth Discovered
+
+- Tool registry: `tools/registry.py`, especially `discover_builtin_tools()`, `registry`, `ToolEntry`, and snapshot helpers.
+- Toolsets: `toolsets.py`, especially `_HERMES_CORE_TOOLS` and `TOOLSETS`.
+- Slash commands: `hermes_cli/commands.py`, especially `COMMAND_REGISTRY`.
+- CLI entry: `hermes_cli/main.py`; add a top-level `self-knowledge` subcommand alongside existing subcommands.
+- Prompt assembly: `agent/prompt_builder.py`; `AIAgent._build_system_prompt()` calls this module.
+- Gateway/voice surface: `gateway/platforms/`, `gateway/run.py`, `tools/transcription_tools.py`, `tools/tts_tool.py`, `tools/voice_mode.py`.
+- CI exists under `.github/workflows/`; use a soft check at first.
+- Current working tree already has unrelated local modifications in `gateway/platforms/discord.py`, `tests/tools/test_discord_tool.py`, and `tools/discord_tool.py`. Do not overwrite them.
+
+---
+
+## Proposed Self-Knowledge Document Layout
+
+Create `context/self/hermes-agent.md`:
+
+1. Identity — hand-written
+2. Operating principles — hand-written
+3. Capabilities at a glance — AUTO from `tools/registry.py`
+4. Toolsets — AUTO from `toolsets.py`
+5. Slash commands — AUTO from `hermes_cli/commands.py`
+6. Gateway platforms — AUTO from `gateway/platforms/`
+7. Voice / STT / TTS loop — AUTO from voice modules and config schema, not secrets
+8. Skills and agent profiles — AUTO from repo skills plus profile skill metadata
+9. Plugins and integrations — AUTO from `plugins/`, config schema, and env var names only, never values
+10. Recent activity — AUTO from local `git log --since=14.days`
+11. Open questions / unknowns — hand-written
+12. Pointers — hand-written links to `AGENTS.md`, website developer docs, and relevant runbooks
+
+All AUTO blocks use:
+
+```markdown
+<!-- AUTO-START: capabilities -->
+_this section is generated; do not edit by hand_
+<!-- AUTO-END: capabilities -->
+```
+
+---
+
+## Phase 1 — Doc Scaffold + AUTO Block Parser
+
+### Task 1: Add the initial self-knowledge markdown scaffold
+
+**Objective:** Create the doc with stable hand-written sections and placeholder AUTO blocks.
+
+**Files:**
+- Create: `context/self/hermes-agent.md`
+
+**Step 1: Write the scaffold**
+
+Include the layout above. Keep hand-written sections short. Each generated section must have a unique AUTO block name.
+
+**Step 2: Verify markers are paired**
+
+Run:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+p = Path('context/self/hermes-agent.md')
+text = p.read_text()
+starts = text.count('<!-- AUTO-START:')
+ends = text.count('<!-- AUTO-END:')
+print(starts, ends)
+assert starts == ends and starts >= 8
+PY
+```
+
+Expected: prints matching counts and exits 0.
+
+**Step 3: Commit**
+
+```bash
+git add context/self/hermes-agent.md
+git commit -m "docs: add Hermes self-knowledge scaffold"
+```
+
+### Task 2: Add parser module and fixtures
+
+**Objective:** Parse and replace AUTO blocks without touching hand-written content.
+
+**Files:**
+- Create: `hermes_cli/self_knowledge/__init__.py`
+- Create: `hermes_cli/self_knowledge/parser.py`
+- Create: `tests/self_knowledge/test_parser.py`
+
+**Step 1: Write failing parser tests**
+
+Test cases:
+- Parse block names and bodies.
+- Round-trip serialization is exact for LF files.
+- Round-trip serialization is exact for CRLF files.
+- Replacing one block leaves surrounding handwritten text byte-for-byte unchanged.
+- Duplicate block names raise `ValueError`.
+- Missing end marker raises `ValueError`.
+
+**Step 2: Implement parser**
+
+Recommended API:
+
+```python
+@dataclass(frozen=True)
+class AutoBlock:
+    name: str
+    start: int
+    end: int
+    body_start: int
+    body_end: int
+    body: str
+
+AUTO_START_RE = re.compile(r"<!--\s*AUTO-START:\s*([a-z0-9_-]+)\s*-->")
+AUTO_END_RE = re.compile(r"<!--\s*AUTO-END:\s*([a-z0-9_-]+)\s*-->")
+
+def parse_auto_blocks(text: str) -> dict[str, AutoBlock]: ...
+def replace_auto_blocks(text: str, replacements: Mapping[str, str]) -> str: ...
+```
+
+Implementation detail: preserve the file's existing newline convention by replacing only the body span between markers.
+
+**Step 3: Run tests**
+
+```bash
+pytest tests/self_knowledge/test_parser.py -q
+```
+
+Expected: all parser tests pass.
+
+**Step 4: Commit**
+
+```bash
+git add hermes_cli/self_knowledge tests/self_knowledge/test_parser.py
+git commit -m "feat: add self-knowledge auto-block parser"
+```
+
+---
+
+## Phase 2 — Introspecting Generators + Renderer
+
+### Task 3: Add renderer orchestration
+
+**Objective:** Wire block names to generator functions and support dry-run vs write.
+
+**Files:**
+- Create: `hermes_cli/self_knowledge/renderer.py`
+- Create: `tests/self_knowledge/test_renderer.py`
+
+**Step 1: Write tests**
+
+Test that:
+- Unknown AUTO block names render a clear unavailable placeholder, not a crash.
+- Known block replacements preserve hand-written sections.
+- Renderer returns the rendered markdown string and can optionally write to disk.
+
+**Step 2: Implement renderer**
+
+Recommended API:
+
+```python
+DOC_PATH = Path('context/self/hermes-agent.md')
+
+Generator = Callable[[], str]
+GENERATORS: dict[str, Generator] = {}
+
+def render_self_knowledge(doc_path: Path = DOC_PATH) -> str: ...
+def refresh_self_knowledge(doc_path: Path = DOC_PATH) -> bool: ...  # True if changed
+```
+
+Use a placeholder like:
+
+```markdown
+_unavailable: no generator registered for this AUTO block_
+```
+
+**Step 3: Run tests**
+
+```bash
+pytest tests/self_knowledge/test_renderer.py -q
+```
+
+Expected: pass.
+
+**Step 4: Commit**
+
+```bash
+git add hermes_cli/self_knowledge/renderer.py tests/self_knowledge/test_renderer.py
+git commit -m "feat: add self-knowledge renderer"
+```
+
+### Task 4: Add capabilities generator from live registry
+
+**Objective:** Generate tool capability rows from the same registry runtime uses.
+
+**Files:**
+- Create: `hermes_cli/self_knowledge/generators.py`
+- Modify: `hermes_cli/self_knowledge/renderer.py`
+- Create/Modify: `tests/self_knowledge/test_generators.py`
+
+**Step 1: Write fixture test**
+
+Use lightweight fake `ToolEntry`-like objects or monkeypatch `tools.registry.registry._snapshot_entries()`.
+
+Expected markdown columns:
+
+```markdown
+| Tool | Toolset | Description |
+|---|---|---|
+| web_search | web | Search the web... |
+```
+
+**Step 2: Implement generator**
+
+Import discovery safely:
+
+```python
+def generate_capabilities() -> str:
+    try:
+        from tools.registry import discover_builtin_tools, registry
+        discover_builtin_tools()
+        entries = sorted(registry._snapshot_entries(), key=lambda e: (e.toolset, e.name))
+    except Exception as exc:
+        return f"_unavailable: could not load tool registry ({type(exc).__name__})_"
+    ...
+```
+
+Do not call each tool's external check function here; this is inventory, not availability probing.
+
+**Step 3: Register generator for `capabilities`**
+
+Update `GENERATORS` in `renderer.py`.
+
+**Step 4: Verify**
+
+```bash
+pytest tests/self_knowledge/test_generators.py::test_generate_capabilities -q
+python -m hermes_cli.self_knowledge.dev_render_preview
+```
+
+If no dev preview module exists yet, use a small inline Python import for now.
+
+**Step 5: Commit**
+
+```bash
+git add hermes_cli/self_knowledge tests/self_knowledge/test_generators.py
+git commit -m "feat: generate self-knowledge capabilities"
+```
+
+### Task 5: Add toolsets and slash-command generators
+
+**Objective:** Summarize named toolsets and commands from existing single sources of truth.
+
+**Files:**
+- Modify: `hermes_cli/self_knowledge/generators.py`
+- Modify: `hermes_cli/self_knowledge/renderer.py`
+- Modify: `tests/self_knowledge/test_generators.py`
+
+**Step 1: Add tests**
+
+- `generate_toolsets()` imports `TOOLSETS` and `_HERMES_CORE_TOOLS` from `toolsets.py`.
+- `generate_slash_commands()` imports `COMMAND_REGISTRY` from `hermes_cli.commands`.
+- Assert markdown includes name, description/category, and count/availability scope.
+
+**Step 2: Implement generators**
+
+Keep output compact:
+
+```markdown
+| Toolset | Description | Tools | Includes |
+|---|---|---:|---|
+```
+
+```markdown
+| Command | Category | Scope | Description |
+|---|---|---|---|
+```
+
+Scope logic: `cli_only`, `gateway_only`, otherwise `cli+gateway`.
+
+**Step 3: Register blocks**
+
+Block names: `toolsets`, `slash_commands`.
+
+**Step 4: Run tests and commit**
+
+```bash
+pytest tests/self_knowledge/test_generators.py -q
+git add hermes_cli/self_knowledge tests/self_knowledge/test_generators.py
+git commit -m "feat: generate toolset and command self-knowledge"
+```
+
+### Task 6: Add gateway, voice, skills, plugins, and recent activity generators
+
+**Objective:** Cover the Hermes-specific surfaces not in the generic prompt.
+
+**Files:**
+- Modify: `hermes_cli/self_knowledge/generators.py`
+- Modify: `hermes_cli/self_knowledge/renderer.py`
+- Modify: `tests/self_knowledge/test_generators.py`
+
+**Step 1: Gateway platforms**
+
+Read `gateway/platforms/*.py`; list platform module names. Prefer static file scan over importing adapters to avoid optional dependency side effects.
+
+**Step 2: Voice loop**
+
+Static summary from known files:
+- `tools/transcription_tools.py`
+- `tools/tts_tool.py`
+- `tools/voice_mode.py`
+- `gateway/platforms/discord.py`
+
+Do not read or print secret values. If reading config for provider names, use keys only and redact values by design.
+
+**Step 3: Skills and profiles**
+
+Use `agent.skill_utils` helpers where safe; otherwise scan `skills/**/SKILL.md` and `~/.hermes/skills/**/SKILL.md` frontmatter using existing parsing helpers. Summarize counts by category and list profile skills separately.
+
+**Step 4: Plugins and integrations**
+
+Scan `plugins/*` directory names and config/env key names only. Never include API key values.
+
+**Step 5: Recent activity**
+
+Use local git only:
+
+```python
+subprocess.run(['git', 'log', '--since=14 days ago', '--pretty=format:%h %ad %s', '--date=short'], ...)
+```
+
+If git is unavailable, return `_unavailable: git log failed_`.
+
+**Step 6: Run and commit**
+
+```bash
+pytest tests/self_knowledge/test_generators.py -q
+git add hermes_cli/self_knowledge tests/self_knowledge/test_generators.py
+git commit -m "feat: generate Hermes platform self-knowledge"
+```
+
+### Task 7: Refresh the doc end-to-end
+
+**Objective:** Render all AUTO blocks into `context/self/hermes-agent.md`.
+
+**Files:**
+- Modify: `context/self/hermes-agent.md`
+
+**Step 1: Run renderer**
+
+Use the renderer import until CLI lands:
+
+```bash
+python - <<'PY'
+from hermes_cli.self_knowledge.renderer import refresh_self_knowledge
+changed = refresh_self_knowledge()
+print('changed=', changed)
+PY
+```
+
+**Step 2: Verify no stale diff after second render**
+
+```bash
+python - <<'PY'
+from hermes_cli.self_knowledge.renderer import refresh_self_knowledge
+assert refresh_self_knowledge() is False
+PY
+```
+
+**Step 3: Commit**
+
+```bash
+git add context/self/hermes-agent.md
+git commit -m "docs: refresh Hermes self-knowledge inventory"
+```
+
+---
+
+## Phase 3 — Drift Checker + CLI
+
+### Task 8: Add drift checker core
+
+**Objective:** Check hand-written sections for stale file/path/name references.
+
+**Files:**
+- Create: `hermes_cli/self_knowledge/drift.py`
+- Create: `context/self/.hermes-agent-allowlist.txt`
+- Create: `tests/self_knowledge/test_drift.py`
+
+**Step 1: Write tests**
+
+Test `DriftFinding` output for:
+- Missing file path reference in hand-written text.
+- Existing file path passes.
+- References inside AUTO blocks are ignored.
+- Allowlisted reference is ignored.
+
+**Step 2: Implement dataclass**
+
+```python
+@dataclass(frozen=True)
+class DriftFinding:
+    kind: str
+    reference: str
+    location_in_doc: str
+    reason: str
+```
+
+**Step 3: Implement extraction**
+
+Start conservative:
+- File paths matching `(?:[\w.-]+/)+[\w.-]+`.
+- Backticked qualified symbols like `ToolRegistry.get_entry`.
+- Backticked tool/subagent/integration names only if present in generated inventory.
+
+Avoid `grep`; use Python `Path.exists()` and AST for symbols.
+
+**Step 4: Run tests and commit**
+
+```bash
+pytest tests/self_knowledge/test_drift.py -q
+git add hermes_cli/self_knowledge/drift.py context/self/.hermes-agent-allowlist.txt tests/self_knowledge/test_drift.py
+git commit -m "feat: add self-knowledge drift checker"
+```
+
+### Task 9: Add `hermes self-knowledge` CLI
+
+**Objective:** Expose render, refresh, and drift checks as official CLI commands.
+
+**Files:**
+- Create: `hermes_cli/self_knowledge/cli.py`
+- Modify: `hermes_cli/main.py`
+- Create: `tests/self_knowledge/test_cli.py`
+
+**Step 1: Add CLI module**
+
+Support:
+
+```bash
+hermes self-knowledge --render
+hermes self-knowledge --refresh
+hermes self-knowledge --check
+hermes self-knowledge --check --strict
+```
+
+Return codes:
+- render: `0`
+- refresh: `0`
+- check soft: `0`, prints warnings
+- check strict: `1` if any finding
+
+**Step 2: Wire into `hermes_cli/main.py`**
+
+Add a top-level parser near other maintenance subcommands. Keep import lazy:
+
+```python
+self_knowledge_parser = subparsers.add_parser('self-knowledge', help='Render/check Hermes self-knowledge')
+from hermes_cli.self_knowledge.cli import configure_parser as configure_self_knowledge_parser
+configure_self_knowledge_parser(self_knowledge_parser)
+```
+
+**Step 3: Run tests and smoke commands**
+
+```bash
+pytest tests/self_knowledge/test_cli.py -q
+hermes self-knowledge --render >/tmp/hermes-self-knowledge.md
+hermes self-knowledge --check
+```
+
+Expected: no crash; soft warnings acceptable if narrative is not final.
+
+**Step 4: Commit**
+
+```bash
+git add hermes_cli/main.py hermes_cli/self_knowledge/cli.py tests/self_knowledge/test_cli.py
+git commit -m "feat: add self-knowledge CLI"
+```
+
+---
+
+## Phase 4 — Pre-Commit Hook + CI Soft Check
+
+### Task 10: Add idempotent hook installer
+
+**Objective:** Install a local hook that refreshes and stages the self-knowledge doc without clobbering existing hooks.
+
+**Files:**
+- Create: `scripts/install-self-knowledge-hook.sh`
+- Create: `tests/self_knowledge/test_hook_installer.py` or shell test if existing convention prefers it
+
+**Step 1: Implement installer behavior**
+
+Requirements:
+- Idempotent; running twice does not duplicate the block.
+- Refuses to overwrite a foreign hook unless `--force` is passed.
+- Hook body runs:
+
+```bash
+hermes self-knowledge --refresh
+if ! git diff --quiet -- context/self/hermes-agent.md; then
+  git add context/self/hermes-agent.md
+fi
+```
+
+**Step 2: Verify manually in a temp repo**
+
+Use a temp directory in tests, not the real `.git/hooks`.
+
+**Step 3: Commit**
+
+```bash
+git add scripts/install-self-knowledge-hook.sh tests/self_knowledge/test_hook_installer.py
+git commit -m "feat: add self-knowledge pre-commit hook installer"
+```
+
+### Task 11: Add GitHub Actions soft check
+
+**Objective:** Warn on drift in PRs without blocking initially.
+
+**Files:**
+- Modify: `.github/workflows/tests.yml` or create `.github/workflows/self-knowledge.yml`
+
+**Step 1: Prefer a separate workflow**
+
+Create `.github/workflows/self-knowledge.yml`:
+
+```yaml
+name: Self Knowledge
+on:
+  pull_request:
+  push:
+    branches: [main]
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv sync --all-extras --dev
+      - run: uv run hermes self-knowledge --check || true
+```
+
+Soft by design. Once stable, remove `|| true` and use `--strict`.
+
+**Step 2: Commit**
+
+```bash
+git add .github/workflows/self-knowledge.yml
+git commit -m "ci: add soft self-knowledge drift check"
+```
+
+---
+
+## Phase 5 — Prompt Injection
+
+### Task 12: Add slim-summary builder
+
+**Objective:** Build a small prompt-safe summary from the rendered doc.
+
+**Files:**
+- Create: `hermes_cli/self_knowledge/summary.py`
+- Create: `tests/self_knowledge/test_summary.py`
+
+**Step 1: Write tests**
+
+Assert summary includes:
+- Identity heading/body excerpt
+- Operating principles excerpt
+- Capability names only, not full descriptions
+- Maximum approximate character budget, e.g. `<= 2500` chars
+
+**Step 2: Implement summary**
+
+Recommended API:
+
+```python
+def build_slim_summary(doc_text: str, max_chars: int = 2500) -> str: ...
+def load_slim_summary(path: Path = DOC_PATH) -> str: ...
+```
+
+If doc is missing, return empty string. No crashes in prompt assembly.
+
+**Step 3: Commit**
+
+```bash
+pytest tests/self_knowledge/test_summary.py -q
+git add hermes_cli/self_knowledge/summary.py tests/self_knowledge/test_summary.py
+git commit -m "feat: add self-knowledge slim summary"
+```
+
+### Task 13: Inject summary into prompt behind config flag
+
+**Objective:** Make Hermes aware of its current capabilities without blowing up prompt size or cache stability.
+
+**Files:**
+- Modify: `agent/prompt_builder.py`
+- Modify: `tests/run_agent/test_run_agent.py` or add `tests/self_knowledge/test_prompt_injection.py`
+- Optionally document config in website docs later
+
+**Step 1: Add config gate**
+
+Use config shape:
+
+```yaml
+self_knowledge:
+  enabled: true
+  prompt_mode: slim   # off|slim|full later; default slim
+```
+
+Do not require users to configure this manually. Default should be safe and small.
+
+**Step 2: Add prompt block function**
+
+In `agent/prompt_builder.py`, add a small helper near other prompt section renderers:
+
+```python
+def render_self_knowledge_prompt_block(config: dict | None = None) -> str:
+    mode = ((config or {}).get('self_knowledge') or {}).get('prompt_mode', 'slim')
+    enabled = ((config or {}).get('self_knowledge') or {}).get('enabled', True)
+    if not enabled or mode == 'off':
+        return ''
+    try:
+        from hermes_cli.self_knowledge.summary import load_slim_summary
+        summary = load_slim_summary()
+    except Exception:
+        return ''
+    if not summary.strip():
+        return ''
+    return '## Hermes self-knowledge\n' + summary.strip()
+```
+
+Then integrate in the existing prompt assembly path with minimal movement. Preserve existing ordering and prompt caching as much as possible.
+
+**Step 3: Add tests**
+
+Tests should verify:
+- Disabled config omits block.
+- Missing doc omits block cleanly.
+- Enabled config includes a known capability name from fixture doc.
+
+**Step 4: Commit**
+
+```bash
+pytest tests/self_knowledge/test_prompt_injection.py tests/run_agent/test_run_agent.py -q
+git add agent/prompt_builder.py tests/self_knowledge/test_prompt_injection.py
+git commit -m "feat: inject slim self-knowledge into system prompt"
+```
+
+---
+
+## Final Verification
+
+Run:
+
+```bash
+pytest tests/self_knowledge -q
+hermes self-knowledge --refresh
+hermes self-knowledge --check
+python - <<'PY'
+from pathlib import Path
+text = Path('context/self/hermes-agent.md').read_text()
+assert '<!-- AUTO-START: capabilities -->' in text
+assert 'web_search' in text or 'terminal' in text
+print('self-knowledge doc looks populated')
+PY
+git diff --check
+```
+
+Optional broader test if time allows:
+
+```bash
+scripts/run_tests.sh tests/self_knowledge tests/run_agent/test_run_agent.py
+```
+
+---
+
+## Risks / Guardrails
+
+- **Prompt cache churn:** inject only slim summary by default. Full doc should remain optional and off.
+- **Import side effects:** use static scans for plugins/platforms where imports may require optional dependencies.
+- **Secrets:** never print env/config values. Print provider names and key names only.
+- **Hook annoyance:** hook refreshes and stages; CI soft-checks first. Do not strict-gate until the doc has survived real commits.
+- **Current dirty tree:** do not touch unrelated modified files from voice work unless this plan is being implemented in a fresh branch/worktree.
+
+---
+
+## Follow-Ups After Initial Ship
+
+1. Promote CI from soft check to `--check --strict` after a week of clean runs.
+2. Add profile/persona-specific summaries for Hermes agents like `profile-main`, `profile-heidi`, and `profile-chad`.
+3. Add a voice-mode self-test command that confirms Discord voice, STT, TTS, and latency surfaces are configured.

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10243,7 +10243,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
         "dump", "fallback", "gateway", "hooks", "import", "insights",
         "kanban", "login", "logout", "logs", "lsp", "mcp", "memory",
         "model", "pairing", "plugins", "postinstall", "profile", "proxy",
-        "send", "sessions", "setup",
+        "send", "self-knowledge", "sessions", "setup",
         "skills", "slack", "status", "tools", "uninstall", "update",
         "version", "webhook", "whatsapp", "chat",
         # Help-ish invocations — plugin commands not being listed in
@@ -10356,6 +10356,18 @@ def main():
 
     parser, subparsers, chat_parser = build_top_level_parser()
     chat_parser.set_defaults(func=cmd_chat)
+
+    # =========================================================================
+    # self-knowledge command
+    # =========================================================================
+    self_knowledge_parser = subparsers.add_parser(
+        "self-knowledge",
+        help="Render or check Hermes self-knowledge",
+        description="Render, refresh, or drift-check the repo-grounded Hermes self-knowledge document.",
+    )
+    from hermes_cli.self_knowledge.cli import configure_parser as configure_self_knowledge_parser
+
+    configure_self_knowledge_parser(self_knowledge_parser)
 
     # =========================================================================
     # model command

--- a/hermes_cli/self_knowledge/__init__.py
+++ b/hermes_cli/self_knowledge/__init__.py
@@ -1,0 +1,1 @@
+"""Living self-knowledge rendering and drift-checking for Hermes Agent."""

--- a/hermes_cli/self_knowledge/cli.py
+++ b/hermes_cli/self_knowledge/cli.py
@@ -1,0 +1,67 @@
+"""CLI plumbing for `hermes self-knowledge`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hermes_cli.self_knowledge.drift import ALLOWLIST_PATH, DOC_PATH, PROJECT_ROOT, check_drift
+from hermes_cli.self_knowledge.renderer import refresh_self_knowledge, render_self_knowledge
+
+
+def run_self_knowledge_command(
+    *,
+    render: bool,
+    refresh: bool,
+    check: bool,
+    strict: bool,
+    doc_path: Path = DOC_PATH,
+    project_root: Path = PROJECT_ROOT,
+    allowlist_path: Path = ALLOWLIST_PATH,
+) -> int:
+    """Run the requested self-knowledge operation and return a process code."""
+    if render:
+        print(render_self_knowledge(doc_path))
+    if refresh:
+        changed = refresh_self_knowledge(doc_path)
+        print("self-knowledge refreshed" if changed else "self-knowledge already current")
+    if check:
+        findings = check_drift(
+            doc_path,
+            project_root=project_root,
+            allowlist_path=allowlist_path,
+        )
+        if not findings:
+            print("self-knowledge drift check passed")
+        else:
+            print(f"self-knowledge drift findings: {len(findings)}")
+            for finding in findings:
+                print(
+                    f"- {finding.kind}: {finding.reference} at "
+                    f"{finding.location_in_doc} — {finding.reason}"
+                )
+            if strict:
+                return 1
+    if not any((render, refresh, check)):
+        print(render_self_knowledge(doc_path))
+    return 0
+
+
+def _cmd_self_knowledge(args) -> None:
+    code = run_self_knowledge_command(
+        render=bool(args.render),
+        refresh=bool(args.refresh),
+        check=bool(args.check),
+        strict=bool(args.strict),
+    )
+    if code:
+        raise SystemExit(code)
+
+
+def configure_parser(parser) -> None:
+    """Configure an argparse parser for the self-knowledge command."""
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--render", action="store_true", help="Render the self-knowledge doc to stdout")
+    group.add_argument("--refresh", action="store_true", help="Refresh the self-knowledge doc on disk")
+    group.add_argument("--check", action="store_true", help="Check hand-written sections for drift")
+    parser.add_argument("--strict", action="store_true", help="Exit non-zero when --check finds drift")
+    parser.set_defaults(func=_cmd_self_knowledge)

--- a/hermes_cli/self_knowledge/drift.py
+++ b/hermes_cli/self_knowledge/drift.py
@@ -1,0 +1,118 @@
+"""Conservative drift checks for hand-written self-knowledge sections."""
+
+from __future__ import annotations
+
+import ast
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from hermes_cli.self_knowledge.parser import parse_auto_blocks
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DOC_PATH = PROJECT_ROOT / "context" / "self" / "hermes-agent.md"
+ALLOWLIST_PATH = PROJECT_ROOT / "context" / "self" / ".hermes-agent-allowlist.txt"
+
+BACKTICK_RE = re.compile(r"`([^`]+)`")
+FILE_PATH_RE = re.compile(r"(?:[\w.-]+/)+[\w.-]+")
+SYMBOL_RE = re.compile(r"^[A-Za-z_]\w*(?:\.[A-Za-z_]\w*){2,}$")
+
+
+@dataclass(frozen=True)
+class DriftFinding:
+    kind: str
+    reference: str
+    location_in_doc: str
+    reason: str
+
+
+def _strip_auto_blocks(text: str) -> str:
+    blocks = parse_auto_blocks(text)
+    stripped = text
+    for block in sorted(blocks.values(), key=lambda b: b.start, reverse=True):
+        stripped = stripped[: block.start] + "\n" * stripped[block.start : block.end].count("\n") + stripped[block.end :]
+    return stripped
+
+
+def _load_allowlist(path: Path | None) -> set[str]:
+    if path is None or not path.exists():
+        return set()
+    return {
+        line.strip()
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    }
+
+
+def _line_for_offset(text: str, offset: int) -> int:
+    return text.count("\n", 0, offset) + 1
+
+
+def _symbol_exists(reference: str, project_root: Path) -> bool:
+    parts = reference.split(".")
+    for split_at in range(len(parts) - 1, 0, -1):
+        module_parts = parts[:split_at]
+        attrs = parts[split_at:]
+        module_path = project_root.joinpath(*module_parts).with_suffix(".py")
+        if not module_path.exists():
+            init_path = project_root.joinpath(*module_parts, "__init__.py")
+            module_path = init_path if init_path.exists() else module_path
+        if not module_path.exists():
+            continue
+        try:
+            tree = ast.parse(module_path.read_text(encoding="utf-8"), filename=str(module_path))
+        except (OSError, SyntaxError, UnicodeDecodeError):
+            return False
+        names = {
+            node.name
+            for node in tree.body
+            if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef))
+        }
+        names.update(
+            target.id
+            for node in tree.body
+            if isinstance(node, ast.Assign)
+            for target in node.targets
+            if isinstance(target, ast.Name)
+        )
+        return bool(attrs and attrs[0] in names)
+    return False
+
+
+def check_drift(
+    doc_path: Path = DOC_PATH,
+    *,
+    project_root: Path = PROJECT_ROOT,
+    allowlist_path: Path | None = ALLOWLIST_PATH,
+) -> list[DriftFinding]:
+    """Return drift findings for hand-written self-knowledge references."""
+    path = Path(doc_path)
+    text = path.read_text(encoding="utf-8")
+    hand_text = _strip_auto_blocks(text)
+    allowlist = _load_allowlist(allowlist_path)
+    findings: list[DriftFinding] = []
+
+    references: list[tuple[str, int]] = []
+    for match in BACKTICK_RE.finditer(hand_text):
+        references.append((match.group(1).strip(), match.start(1)))
+    for match in FILE_PATH_RE.finditer(hand_text):
+        references.append((match.group(0).strip(), match.start(0)))
+
+    seen: set[tuple[str, int]] = set()
+    for reference, offset in references:
+        if (reference, offset) in seen or reference in allowlist:
+            continue
+        seen.add((reference, offset))
+        location = f"{path}:{_line_for_offset(hand_text, offset)}"
+        if "/" in reference and not reference.startswith(("http://", "https://")):
+            if not (Path(project_root) / reference).exists():
+                findings.append(
+                    DriftFinding("file_path", reference, location, "referenced path does not exist")
+                )
+        elif SYMBOL_RE.match(reference):
+            if not _symbol_exists(reference, Path(project_root)):
+                findings.append(
+                    DriftFinding("symbol", reference, location, "referenced symbol was not found")
+                )
+    return findings

--- a/hermes_cli/self_knowledge/generators.py
+++ b/hermes_cli/self_knowledge/generators.py
@@ -1,0 +1,200 @@
+"""AUTO-block generators for the Hermes self-knowledge document."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _md(value: Any) -> str:
+    text = "" if value is None else str(value)
+    text = " ".join(text.split())
+    return text.replace("|", "\\|") or "-"
+
+
+def _table(headers: list[str], rows: list[list[Any]]) -> str:
+    if not rows:
+        return "_none discovered_"
+    lines = [
+        "| " + " | ".join(headers) + " |",
+        "|" + "|".join("---" for _ in headers) + "|",
+    ]
+    for row in rows:
+        lines.append("| " + " | ".join(_md(cell) for cell in row) + " |")
+    return "\n".join(lines)
+
+
+def _load_tool_entries():
+    from tools.registry import discover_builtin_tools, registry
+
+    discover_builtin_tools()
+    return registry._snapshot_entries()
+
+
+def generate_capabilities() -> str:
+    """Generate a compact inventory from the runtime tool registry."""
+    try:
+        entries = sorted(_load_tool_entries(), key=lambda e: (e.toolset, e.name))
+    except Exception as exc:
+        return f"_unavailable: could not load tool registry ({type(exc).__name__})_"
+
+    rows = [[entry.name, entry.toolset, entry.description] for entry in entries]
+    return _table(["Tool", "Toolset", "Description"], rows)
+
+
+def _load_toolsets():
+    from toolsets import TOOLSETS, _HERMES_CORE_TOOLS
+
+    return TOOLSETS, _HERMES_CORE_TOOLS
+
+
+def generate_toolsets() -> str:
+    """Generate toolset inventory from `toolsets.py`."""
+    try:
+        toolsets, core_tools = _load_toolsets()
+    except Exception as exc:
+        return f"_unavailable: could not load toolsets ({type(exc).__name__})_"
+
+    rows = []
+    for name, data in sorted(toolsets.items()):
+        tools = data.get("tools", []) or []
+        includes = data.get("includes", []) or []
+        rows.append([name, data.get("description", ""), len(tools), ", ".join(includes) or "-"])
+    rendered = _table(["Toolset", "Description", "Tools", "Includes"], rows)
+    return f"Core default tools: {len(core_tools)}\n\n{rendered}"
+
+
+def _load_commands():
+    from hermes_cli.commands import COMMAND_REGISTRY
+
+    return COMMAND_REGISTRY
+
+
+def _command_scope(command: Any) -> str:
+    if getattr(command, "cli_only", False):
+        return "cli"
+    if getattr(command, "gateway_only", False):
+        return "gateway"
+    return "cli+gateway"
+
+
+def generate_slash_commands() -> str:
+    """Generate slash command inventory from the shared command registry."""
+    try:
+        commands = sorted(_load_commands(), key=lambda c: (c.category, c.name))
+    except Exception as exc:
+        return f"_unavailable: could not load slash commands ({type(exc).__name__})_"
+
+    rows = [[f"/{cmd.name}", cmd.category, _command_scope(cmd), cmd.description] for cmd in commands]
+    return _table(["Command", "Category", "Scope", "Description"], rows)
+
+
+def generate_gateway_platforms() -> str:
+    """Generate platform adapter inventory by static file scan."""
+    platforms_dir = PROJECT_ROOT / "gateway" / "platforms"
+    if not platforms_dir.exists():
+        return "_unavailable: gateway/platforms directory not found_"
+    rows = []
+    for path in sorted(platforms_dir.glob("*.py")):
+        if path.name == "__init__.py" or path.stem.startswith("_"):
+            continue
+        rows.append([path.stem, str(path.relative_to(PROJECT_ROOT))])
+    return _table(["Platform", "Adapter"], rows)
+
+
+def generate_voice_loop() -> str:
+    """Generate a compact voice/STT/TTS surface summary without secrets."""
+    known_files = [
+        "tools/transcription_tools.py",
+        "tools/tts_tool.py",
+        "tools/voice_mode.py",
+        "gateway/platforms/discord.py",
+        "gateway/run.py",
+    ]
+    rows = []
+    for rel in known_files:
+        path = PROJECT_ROOT / rel
+        rows.append([rel, "present" if path.exists() else "missing"])
+    return "Voice input routes platform audio through gateway callbacks, STT, agent response generation, optional TTS, and voice playback.\n\n" + _table(["Surface", "Status"], rows)
+
+
+def _skill_frontmatter_name(path: Path) -> str:
+    try:
+        text = path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return path.parent.name
+    if not text.startswith("---"):
+        return path.parent.name
+    end = text.find("\n---", 3)
+    if end == -1:
+        return path.parent.name
+    for line in text[3:end].splitlines():
+        if line.startswith("name:"):
+            return line.split(":", 1)[1].strip().strip('"\'') or path.parent.name
+    return path.parent.name
+
+
+def generate_skills_profiles() -> str:
+    """Generate skill counts and profile-skill inventory by static scan."""
+    roots = [PROJECT_ROOT / "skills", Path.home() / ".hermes" / "skills"]
+    skill_paths: list[Path] = []
+    for root in roots:
+        if root.exists():
+            skill_paths.extend(root.glob("**/SKILL.md"))
+
+    categories = Counter()
+    profiles = []
+    for path in skill_paths:
+        name = _skill_frontmatter_name(path)
+        parts = path.parent.parts
+        category = "uncategorized"
+        if "skills" in parts:
+            idx = parts.index("skills")
+            if idx + 1 < len(parts):
+                category = parts[idx + 1]
+        categories[category] += 1
+        if name.startswith("profile-") or category == "hermes-agents":
+            profiles.append(name)
+
+    rows = [[category, count] for category, count in sorted(categories.items())]
+    profile_line = ", ".join(sorted(set(profiles))) or "none discovered"
+    return f"Total skills discovered: {len(skill_paths)}\n\nProfiles: {profile_line}\n\n" + _table(["Category", "Skills"], rows)
+
+
+def generate_plugins_integrations() -> str:
+    """Generate plugin/integration inventory from local plugin directories and env key names."""
+    plugins_dir = PROJECT_ROOT / "plugins"
+    rows = []
+    if plugins_dir.exists():
+        for path in sorted(p for p in plugins_dir.iterdir() if p.is_dir() and not p.name.startswith(".")):
+            rows.append([path.name, str(path.relative_to(PROJECT_ROOT))])
+    env_names = sorted(name for name in os.environ if name.endswith(("API_KEY", "TOKEN", "SECRET")))
+    env_summary = f"Credential-like environment keys present: {len(env_names)} names redacted by design."
+    return env_summary + "\n\n" + _table(["Plugin", "Path"], rows)
+
+
+def generate_recent_activity() -> str:
+    """Generate recent commit activity from local git history."""
+    try:
+        result = subprocess.run(
+            ["git", "log", "--since=14 days ago", "--pretty=format:%h %ad %s", "--date=short"],
+            cwd=PROJECT_ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except Exception as exc:
+        return f"_unavailable: git log failed ({type(exc).__name__})_"
+    if result.returncode != 0:
+        return f"_unavailable: git log failed (exit {result.returncode})_"
+    lines = [line for line in result.stdout.splitlines() if line.strip()]
+    if not lines:
+        return "_no commits in the last 14 days_"
+    return "\n".join(f"- {line}" for line in lines[:40])

--- a/hermes_cli/self_knowledge/parser.py
+++ b/hermes_cli/self_knowledge/parser.py
@@ -1,0 +1,124 @@
+"""Parser for markdown AUTO blocks used by Hermes self-knowledge docs."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Mapping
+
+
+AUTO_START_RE = re.compile(r"<!--\s*AUTO-START:\s*([a-z0-9_-]+)\s*-->")
+AUTO_END_RE = re.compile(r"<!--\s*AUTO-END:\s*([a-z0-9_-]+)\s*-->")
+
+
+@dataclass(frozen=True)
+class AutoBlock:
+    """Location and content for one AUTO block in a markdown document."""
+
+    name: str
+    start: int
+    end: int
+    body_start: int
+    body_end: int
+    body: str
+
+
+def _line_end_after(text: str, index: int) -> int:
+    """Return the position immediately after the line ending at or after *index*."""
+    newline = text.find("\n", index)
+    if newline == -1:
+        return len(text)
+    return newline + 1
+
+
+def _line_start_before(text: str, index: int) -> int:
+    """Return the start position of the line containing *index*."""
+    newline = text.rfind("\n", 0, index)
+    return 0 if newline == -1 else newline + 1
+
+
+def parse_auto_blocks(text: str) -> dict[str, AutoBlock]:
+    """Parse AUTO blocks from *text*.
+
+    Blocks are delimited by matching HTML comments:
+    ``<!-- AUTO-START: name -->`` and ``<!-- AUTO-END: name -->``.
+    Returned blocks preserve byte offsets into the original Python string so
+    callers can replace only generated bodies and leave hand-written prose
+    untouched.
+    """
+    blocks: dict[str, AutoBlock] = {}
+    position = 0
+
+    while True:
+        start_match = AUTO_START_RE.search(text, position)
+        if not start_match:
+            break
+
+        name = start_match.group(1)
+        if name in blocks:
+            raise ValueError(f"Duplicate AUTO block: {name}")
+
+        body_start = _line_end_after(text, start_match.end())
+        end_match = AUTO_END_RE.search(text, body_start)
+        if not end_match:
+            raise ValueError(f"Missing AUTO-END marker for block: {name}")
+
+        end_name = end_match.group(1)
+        if end_name != name:
+            raise ValueError(
+                f"Mismatched AUTO block markers: start {name!r}, end {end_name!r}"
+            )
+
+        body_end = _line_start_before(text, end_match.start())
+        blocks[name] = AutoBlock(
+            name=name,
+            start=start_match.start(),
+            end=end_match.end(),
+            body_start=body_start,
+            body_end=body_end,
+            body=text[body_start:body_end],
+        )
+        position = end_match.end()
+
+    return blocks
+
+
+def _line_ending_near(text: str, index: int) -> str:
+    """Infer the line ending around *index*, defaulting to LF."""
+    previous = text.rfind("\n", 0, index)
+    if previous != -1 and previous > 0 and text[previous - 1] == "\r":
+        return "\r\n"
+    next_newline = text.find("\n", index)
+    if next_newline != -1 and next_newline > 0 and text[next_newline - 1] == "\r":
+        return "\r\n"
+    return "\n"
+
+
+def _format_replacement_body(text: str, block: AutoBlock, replacement: str) -> str:
+    """Normalize a replacement so markers stay on their own lines."""
+    newline = _line_ending_near(text, block.body_start)
+    body = replacement.replace("\r\n", "\n").replace("\r", "\n")
+    if newline != "\n":
+        body = body.replace("\n", newline)
+    if body and not body.endswith(newline):
+        body += newline
+    return body
+
+
+def replace_auto_blocks(text: str, replacements: Mapping[str, str]) -> str:
+    """Replace AUTO block bodies using *replacements*.
+
+    Unknown replacement keys are ignored. Blocks not present in replacements are
+    left untouched, making a no-replacement round trip an exact no-op.
+    """
+    blocks = parse_auto_blocks(text)
+    if not replacements:
+        return text
+
+    rendered = text
+    for block in sorted(blocks.values(), key=lambda b: b.body_start, reverse=True):
+        if block.name not in replacements:
+            continue
+        body = _format_replacement_body(text, block, replacements[block.name])
+        rendered = rendered[: block.body_start] + body + rendered[block.body_end :]
+    return rendered

--- a/hermes_cli/self_knowledge/renderer.py
+++ b/hermes_cli/self_knowledge/renderer.py
@@ -1,0 +1,54 @@
+"""Render Hermes self-knowledge markdown by refreshing AUTO blocks."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+from hermes_cli.self_knowledge import generators
+from hermes_cli.self_knowledge.parser import parse_auto_blocks, replace_auto_blocks
+
+
+DOC_PATH = Path("context/self/hermes-agent.md")
+Generator = Callable[[], str]
+GENERATORS: dict[str, Generator] = {
+    "capabilities": generators.generate_capabilities,
+    "toolsets": generators.generate_toolsets,
+    "slash_commands": generators.generate_slash_commands,
+    "gateway_platforms": generators.generate_gateway_platforms,
+    "voice_loop": generators.generate_voice_loop,
+    "skills_profiles": generators.generate_skills_profiles,
+    "plugins_integrations": generators.generate_plugins_integrations,
+    "recent_activity": generators.generate_recent_activity,
+}
+
+
+def _render_block(name: str) -> str:
+    generator = GENERATORS.get(name)
+    if generator is None:
+        return f"_unavailable: no generator registered for `{name}`_"
+    try:
+        rendered = generator()
+    except Exception as exc:  # pragma: no cover - defensive boundary
+        return f"_unavailable: generator `{name}` failed ({type(exc).__name__})_"
+    rendered = rendered.strip()
+    return rendered or f"_unavailable: generator `{name}` returned no content_"
+
+
+def render_self_knowledge(doc_path: Path = DOC_PATH) -> str:
+    """Return *doc_path* with every AUTO block body freshly rendered."""
+    text = Path(doc_path).read_text(encoding="utf-8")
+    blocks = parse_auto_blocks(text)
+    replacements = {name: _render_block(name) for name in blocks}
+    return replace_auto_blocks(text, replacements)
+
+
+def refresh_self_knowledge(doc_path: Path = DOC_PATH) -> bool:
+    """Write rendered self-knowledge to disk. Return True when the file changed."""
+    path = Path(doc_path)
+    original = path.read_text(encoding="utf-8")
+    rendered = render_self_knowledge(path)
+    if rendered == original:
+        return False
+    path.write_text(rendered, encoding="utf-8")
+    return True

--- a/hermes_cli/self_knowledge/summary.py
+++ b/hermes_cli/self_knowledge/summary.py
@@ -1,0 +1,73 @@
+"""Slim prompt summary for Hermes self-knowledge."""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+from hermes_cli.self_knowledge.drift import DOC_PATH
+from hermes_cli.self_knowledge.parser import parse_auto_blocks
+
+
+SECTION_RE = re.compile(r"^##\s+(.+?)\s*$", re.MULTILINE)
+
+
+def _section(text: str, heading: str) -> str:
+    matches = list(SECTION_RE.finditer(text))
+    for idx, match in enumerate(matches):
+        if match.group(1).strip().lower() == heading.lower():
+            start = match.end()
+            end = matches[idx + 1].start() if idx + 1 < len(matches) else len(text)
+            return text[start:end].strip()
+    return ""
+
+
+def _capability_names(text: str, *, max_capabilities: int) -> list[str]:
+    blocks = parse_auto_blocks(text)
+    block = blocks.get("capabilities")
+    if not block:
+        return []
+    names: list[str] = []
+    for line in block.body.splitlines():
+        line = line.strip()
+        if not line.startswith("|") or "---" in line or "Tool |" in line:
+            continue
+        parts = [part.strip() for part in line.strip("|").split("|")]
+        if parts and parts[0] and parts[0] != "-":
+            names.append(parts[0].replace("\\|", "|"))
+        if len(names) >= max_capabilities:
+            break
+    return names
+
+
+def build_slim_summary(doc_path: Path = DOC_PATH, *, max_capabilities: int = 60) -> str:
+    """Build a compact self-knowledge block for stable prompt injection.
+
+    Controlled by HERMES_SELF_KNOWLEDGE_PROMPT:
+    - off/false/0/no: disabled
+    - slim/true/1/yes or unset: slim summary
+    """
+    mode = os.getenv("HERMES_SELF_KNOWLEDGE_PROMPT", "slim").strip().lower()
+    if mode in {"off", "false", "0", "no", "disabled"}:
+        return ""
+    path = Path(doc_path)
+    if not path.exists():
+        return ""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+    identity = _section(text, "Identity")
+    principles = _section(text, "Core Principles")
+    capability_names = _capability_names(text, max_capabilities=max_capabilities)
+
+    parts = ["Hermes self-knowledge (repo-grounded slim summary):"]
+    if identity:
+        parts.append("Identity:\n" + identity)
+    if principles:
+        parts.append("Core principles:\n" + principles)
+    if capability_names:
+        parts.append("Capabilities: " + ", ".join(capability_names))
+    return "\n\n".join(parts).strip()

--- a/scripts/install-self-knowledge-hook.sh
+++ b/scripts/install-self-knowledge-hook.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+force=0
+if [[ "${1:-}" == "--force" ]]; then
+  force=1
+fi
+
+if ! git_root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+  echo "error: not inside a git repository" >&2
+  exit 1
+fi
+
+hook_dir="$git_root/.git/hooks"
+hook_path="$hook_dir/pre-commit"
+start_marker="# >>> hermes self-knowledge hook >>>"
+end_marker="# <<< hermes self-knowledge hook <<<"
+
+block="${start_marker}
+# Auto-refresh repo-grounded Hermes self-knowledge before commits.
+if command -v hermes >/dev/null 2>&1; then
+  hermes self-knowledge --refresh
+else
+  python -m hermes_cli.main self-knowledge --refresh
+fi
+if ! git diff --quiet -- context/self/hermes-agent.md; then
+  git add context/self/hermes-agent.md
+fi
+${end_marker}"
+
+mkdir -p "$hook_dir"
+
+if [[ -f "$hook_path" ]]; then
+  if grep -Fq "$start_marker" "$hook_path"; then
+    tmp="$(mktemp)"
+    awk -v start="$start_marker" -v end="$end_marker" '
+      $0 == start {skip=1; next}
+      $0 == end {skip=0; next}
+      !skip {print}
+    ' "$hook_path" > "$tmp"
+    {
+      cat "$tmp"
+      printf "\n%s\n" "$block"
+    } > "$hook_path"
+    rm -f "$tmp"
+  elif [[ "$force" -eq 1 ]]; then
+    tmp="$(mktemp)"
+    cat "$hook_path" > "$tmp"
+    {
+      cat "$tmp"
+      printf "\n%s\n" "$block"
+    } > "$hook_path"
+    rm -f "$tmp"
+  else
+    echo "error: foreign pre-commit hook exists; rerun with --force to append Hermes block" >&2
+    exit 2
+  fi
+else
+  {
+    printf '#!/usr/bin/env bash\nset -euo pipefail\n\n'
+    printf "%s\n" "$block"
+  } > "$hook_path"
+fi
+
+chmod +x "$hook_path"
+echo "installed Hermes self-knowledge pre-commit hook: $hook_path"

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1016,6 +1016,22 @@ class TestBuildSystemPrompt:
         prompt = agent._build_system_prompt()
         assert "NOUS SUBSCRIPTION BLOCK" in prompt
 
+    def test_includes_repo_grounded_self_knowledge_summary(self, agent, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.self_knowledge.summary.build_slim_summary",
+            lambda: "SELF KNOWLEDGE SUMMARY",
+        )
+        prompt = agent._build_system_prompt()
+        assert "SELF KNOWLEDGE SUMMARY" in prompt
+
+    def test_self_knowledge_summary_failure_is_nonfatal(self, agent, monkeypatch):
+        def fail():
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr("hermes_cli.self_knowledge.summary.build_slim_summary", fail)
+        prompt = agent._build_system_prompt()
+        assert DEFAULT_AGENT_IDENTITY in prompt
+
     def test_skills_prompt_derives_available_toolsets_from_loaded_tools(self):
         tools = _make_tool_defs("web_search", "skills_list", "skill_view", "skill_manage")
         toolset_map = {

--- a/tests/self_knowledge/test_cli.py
+++ b/tests/self_knowledge/test_cli.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.self_knowledge.cli import run_self_knowledge_command
+
+
+def test_cli_render_prints_rendered_doc(tmp_path, capsys, monkeypatch):
+    doc = tmp_path / "self.md"
+    doc.write_text("<!-- AUTO-START: known -->\nold\n<!-- AUTO-END: known -->\n")
+    monkeypatch.setattr(
+        "hermes_cli.self_knowledge.renderer.GENERATORS",
+        {"known": lambda: "new"},
+    )
+
+    code = run_self_knowledge_command(render=True, refresh=False, check=False, strict=False, doc_path=doc)
+
+    assert code == 0
+    assert "new" in capsys.readouterr().out
+
+
+def test_cli_refresh_writes_doc(tmp_path, monkeypatch):
+    doc = tmp_path / "self.md"
+    doc.write_text("<!-- AUTO-START: known -->\nold\n<!-- AUTO-END: known -->\n")
+    monkeypatch.setattr(
+        "hermes_cli.self_knowledge.renderer.GENERATORS",
+        {"known": lambda: "new"},
+    )
+
+    code = run_self_knowledge_command(render=False, refresh=True, check=False, strict=False, doc_path=doc)
+
+    assert code == 0
+    assert "new" in doc.read_text()
+
+
+def test_cli_check_soft_returns_zero_with_findings(tmp_path, capsys):
+    doc = tmp_path / "self.md"
+    doc.write_text("mentions `missing/file.py`\n")
+
+    code = run_self_knowledge_command(
+        render=False,
+        refresh=False,
+        check=True,
+        strict=False,
+        doc_path=doc,
+        project_root=tmp_path,
+        allowlist_path=tmp_path / "missing-allowlist.txt",
+    )
+
+    assert code == 0
+    assert "referenced path does not exist" in capsys.readouterr().out
+
+
+def test_cli_check_strict_returns_one_with_findings(tmp_path):
+    doc = tmp_path / "self.md"
+    doc.write_text("mentions `missing/file.py`\n")
+
+    code = run_self_knowledge_command(
+        render=False,
+        refresh=False,
+        check=True,
+        strict=True,
+        doc_path=doc,
+        project_root=tmp_path,
+        allowlist_path=tmp_path / "missing-allowlist.txt",
+    )
+
+    assert code == 1

--- a/tests/self_knowledge/test_drift.py
+++ b/tests/self_knowledge/test_drift.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+
+from hermes_cli.self_knowledge.drift import check_drift
+
+
+def test_missing_file_path_reference_reports_finding(tmp_path):
+    doc = tmp_path / "self.md"
+    doc.write_text("Hand text mentions `missing/file.py`.\n")
+
+    findings = check_drift(doc, project_root=tmp_path)
+
+    assert findings
+    assert findings[0].kind == "file_path"
+    assert findings[0].reference == "missing/file.py"
+
+
+def test_existing_file_path_reference_passes(tmp_path):
+    (tmp_path / "existing").mkdir()
+    (tmp_path / "existing" / "file.py").write_text("")
+    doc = tmp_path / "self.md"
+    doc.write_text("Hand text mentions `existing/file.py`.\n")
+
+    assert check_drift(doc, project_root=tmp_path) == []
+
+
+def test_references_inside_auto_blocks_are_ignored(tmp_path):
+    doc = tmp_path / "self.md"
+    doc.write_text(
+        "<!-- AUTO-START: capabilities -->\n`missing/file.py`\n<!-- AUTO-END: capabilities -->\n"
+    )
+
+    assert check_drift(doc, project_root=tmp_path) == []
+
+
+def test_allowlisted_reference_is_ignored(tmp_path):
+    doc = tmp_path / "self.md"
+    doc.write_text("Hand text mentions `missing/file.py`.\n")
+    allowlist = tmp_path / "allow.txt"
+    allowlist.write_text("missing/file.py\n")
+
+    assert check_drift(doc, project_root=tmp_path, allowlist_path=allowlist) == []
+
+
+def test_symbol_reference_reports_missing_symbol(tmp_path):
+    module = tmp_path / "pkg" / "mod.py"
+    module.parent.mkdir()
+    module.write_text("class Thing:\n    pass\n")
+    doc = tmp_path / "self.md"
+    doc.write_text("Hand text mentions `pkg.mod.Missing`.\n")
+
+    findings = check_drift(doc, project_root=tmp_path)
+
+    assert any(f.kind == "symbol" and f.reference == "pkg.mod.Missing" for f in findings)

--- a/tests/self_knowledge/test_generators.py
+++ b/tests/self_knowledge/test_generators.py
@@ -1,0 +1,68 @@
+from types import SimpleNamespace
+
+from hermes_cli.self_knowledge import generators
+
+
+def test_generate_capabilities_from_registry_entries(monkeypatch):
+    entries = [
+        SimpleNamespace(name="web_search", toolset="web", description="Search the web"),
+        SimpleNamespace(name="terminal", toolset="terminal", description="Run commands"),
+    ]
+
+    monkeypatch.setattr(generators, "_load_tool_entries", lambda: entries)
+
+    rendered = generators.generate_capabilities()
+
+    assert "| Tool | Toolset | Description |" in rendered
+    assert "| terminal | terminal | Run commands |" in rendered
+    assert "| web_search | web | Search the web |" in rendered
+
+
+def test_generate_toolsets_from_toolsets_module(monkeypatch):
+    monkeypatch.setattr(
+        generators,
+        "_load_toolsets",
+        lambda: ({"web": {"description": "Web tools", "tools": ["web_search"], "includes": []}}, ["web_search"]),
+    )
+
+    rendered = generators.generate_toolsets()
+
+    assert "| Toolset | Description | Tools | Includes |" in rendered
+    assert "| web | Web tools | 1 | - |" in rendered
+    assert "Core default tools" in rendered
+
+
+def test_generate_slash_commands_from_registry(monkeypatch):
+    commands = [
+        SimpleNamespace(name="voice", category="Configuration", description="Toggle voice mode", cli_only=False, gateway_only=False),
+        SimpleNamespace(name="clear", category="Session", description="Clear screen", cli_only=True, gateway_only=False),
+    ]
+    monkeypatch.setattr(generators, "_load_commands", lambda: commands)
+
+    rendered = generators.generate_slash_commands()
+
+    assert "| Command | Category | Scope | Description |" in rendered
+    assert "| /voice | Configuration | cli+gateway | Toggle voice mode |" in rendered
+    assert "| /clear | Session | cli | Clear screen |" in rendered
+
+
+def test_generate_gateway_platforms_from_files(tmp_path, monkeypatch):
+    platforms = tmp_path / "gateway" / "platforms"
+    platforms.mkdir(parents=True)
+    (platforms / "discord.py").write_text("# adapter")
+    (platforms / "__init__.py").write_text("")
+    monkeypatch.setattr(generators, "PROJECT_ROOT", tmp_path)
+
+    rendered = generators.generate_gateway_platforms()
+
+    assert "discord" in rendered
+    assert "__init__" not in rendered
+
+
+def test_generate_recent_activity_handles_git_failure(monkeypatch):
+    def fail(*args, **kwargs):
+        raise OSError("no git")
+
+    monkeypatch.setattr(generators.subprocess, "run", fail)
+
+    assert "_unavailable: git log failed" in generators.generate_recent_activity()

--- a/tests/self_knowledge/test_hook_installer.py
+++ b/tests/self_knowledge/test_hook_installer.py
@@ -1,0 +1,44 @@
+import subprocess
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "install-self-knowledge-hook.sh"
+
+
+def _git_init(path: Path):
+    subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True, text=True)
+
+
+def test_hook_installer_is_idempotent(tmp_path):
+    _git_init(tmp_path)
+
+    subprocess.run([str(SCRIPT)], cwd=tmp_path, check=True, capture_output=True, text=True)
+    subprocess.run([str(SCRIPT)], cwd=tmp_path, check=True, capture_output=True, text=True)
+
+    hook = tmp_path / ".git" / "hooks" / "pre-commit"
+    text = hook.read_text()
+    assert text.count(">>> hermes self-knowledge hook >>>") == 1
+    assert "hermes self-knowledge --refresh" in text
+
+
+def test_hook_installer_refuses_foreign_hook_without_force(tmp_path):
+    _git_init(tmp_path)
+    hook = tmp_path / ".git" / "hooks" / "pre-commit"
+    hook.write_text("#!/usr/bin/env bash\necho foreign\n")
+
+    result = subprocess.run([str(SCRIPT)], cwd=tmp_path, capture_output=True, text=True)
+
+    assert result.returncode == 2
+    assert "foreign pre-commit hook exists" in result.stderr
+
+
+def test_hook_installer_force_appends_to_foreign_hook(tmp_path):
+    _git_init(tmp_path)
+    hook = tmp_path / ".git" / "hooks" / "pre-commit"
+    hook.write_text("#!/usr/bin/env bash\necho foreign\n")
+
+    subprocess.run([str(SCRIPT), "--force"], cwd=tmp_path, check=True, capture_output=True, text=True)
+
+    text = hook.read_text()
+    assert "echo foreign" in text
+    assert "hermes self-knowledge --refresh" in text

--- a/tests/self_knowledge/test_parser.py
+++ b/tests/self_knowledge/test_parser.py
@@ -1,0 +1,92 @@
+import pytest
+
+from hermes_cli.self_knowledge.parser import parse_auto_blocks, replace_auto_blocks
+
+
+def test_parse_auto_blocks_returns_names_and_bodies():
+    text = """Intro
+<!-- AUTO-START: capabilities -->
+old body
+<!-- AUTO-END: capabilities -->
+Outro
+"""
+
+    blocks = parse_auto_blocks(text)
+
+    assert list(blocks) == ["capabilities"]
+    assert blocks["capabilities"].body == "old body\n"
+
+
+def test_replace_auto_blocks_preserves_handwritten_text():
+    text = """# Title
+
+Hand written before.
+
+<!-- AUTO-START: capabilities -->
+old body
+<!-- AUTO-END: capabilities -->
+
+Hand written after.
+"""
+
+    rendered = replace_auto_blocks(text, {"capabilities": "new body"})
+
+    assert rendered == """# Title
+
+Hand written before.
+
+<!-- AUTO-START: capabilities -->
+new body
+<!-- AUTO-END: capabilities -->
+
+Hand written after.
+"""
+
+
+def test_round_trip_without_replacements_is_noop_lf():
+    text = """A
+<!-- AUTO-START: one -->
+body
+<!-- AUTO-END: one -->
+B
+"""
+
+    assert replace_auto_blocks(text, {}) == text
+
+
+def test_round_trip_without_replacements_is_noop_crlf():
+    text = "A\r\n<!-- AUTO-START: one -->\r\nbody\r\n<!-- AUTO-END: one -->\r\nB\r\n"
+
+    assert replace_auto_blocks(text, {}) == text
+
+
+def test_duplicate_auto_block_names_raise_value_error():
+    text = """<!-- AUTO-START: one -->
+a
+<!-- AUTO-END: one -->
+<!-- AUTO-START: one -->
+b
+<!-- AUTO-END: one -->
+"""
+
+    with pytest.raises(ValueError, match="Duplicate AUTO block"):
+        parse_auto_blocks(text)
+
+
+def test_missing_end_marker_raises_value_error():
+    text = """<!-- AUTO-START: one -->
+body
+"""
+
+    with pytest.raises(ValueError, match="Missing AUTO-END"):
+        parse_auto_blocks(text)
+
+
+def test_mismatched_end_marker_raises_value_error():
+    text = """<!-- AUTO-START: one -->
+body
+<!-- AUTO-END: two -->
+"""
+
+    with pytest.raises(ValueError, match="Mismatched AUTO block"):
+        parse_auto_blocks(text)

--- a/tests/self_knowledge/test_renderer.py
+++ b/tests/self_knowledge/test_renderer.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+from hermes_cli.self_knowledge.renderer import (
+    render_self_knowledge,
+    refresh_self_knowledge,
+)
+
+
+def test_renderer_preserves_handwritten_sections(tmp_path, monkeypatch):
+    doc = tmp_path / "self.md"
+    doc.write_text(
+        "Before\n<!-- AUTO-START: known -->\nold\n<!-- AUTO-END: known -->\nAfter\n"
+    )
+    monkeypatch.setattr(
+        "hermes_cli.self_knowledge.renderer.GENERATORS",
+        {"known": lambda: "new"},
+    )
+
+    rendered = render_self_knowledge(doc)
+
+    assert rendered == "Before\n<!-- AUTO-START: known -->\nnew\n<!-- AUTO-END: known -->\nAfter\n"
+
+
+def test_renderer_unknown_block_gets_unavailable_placeholder(tmp_path, monkeypatch):
+    doc = tmp_path / "self.md"
+    doc.write_text("<!-- AUTO-START: missing -->\nold\n<!-- AUTO-END: missing -->\n")
+    monkeypatch.setattr("hermes_cli.self_knowledge.renderer.GENERATORS", {})
+
+    rendered = render_self_knowledge(doc)
+
+    assert "_unavailable: no generator registered for `missing`_" in rendered
+
+
+def test_refresh_self_knowledge_writes_only_when_changed(tmp_path, monkeypatch):
+    doc = tmp_path / "self.md"
+    doc.write_text("<!-- AUTO-START: known -->\nold\n<!-- AUTO-END: known -->\n")
+    monkeypatch.setattr(
+        "hermes_cli.self_knowledge.renderer.GENERATORS",
+        {"known": lambda: "new"},
+    )
+
+    assert refresh_self_knowledge(doc) is True
+    assert "new" in doc.read_text()
+    assert refresh_self_knowledge(doc) is False
+
+
+def test_render_self_knowledge_accepts_path_objects(tmp_path, monkeypatch):
+    doc = Path(tmp_path / "self.md")
+    doc.write_text("<!-- AUTO-START: known -->\nold\n<!-- AUTO-END: known -->\n")
+    monkeypatch.setattr(
+        "hermes_cli.self_knowledge.renderer.GENERATORS",
+        {"known": lambda: "new"},
+    )
+
+    assert "new" in render_self_knowledge(doc)

--- a/tests/self_knowledge/test_summary.py
+++ b/tests/self_knowledge/test_summary.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+from hermes_cli.self_knowledge.summary import build_slim_summary
+
+
+def test_build_slim_summary_extracts_identity_principles_and_capabilities(tmp_path):
+    doc = tmp_path / "self.md"
+    doc.write_text(
+        "# Hermes Agent Self-Knowledge\n\n"
+        "## Identity\n\nHermes is an agent.\n\n"
+        "## Core Principles\n\n- Be accurate\n- Use tools\n\n"
+        "## Capabilities at a Glance\n\n"
+        "<!-- AUTO-START: capabilities -->\n"
+        "| Tool | Toolset | Description |\n"
+        "|---|---|---|\n"
+        "| web_search | web | Search the web |\n"
+        "| terminal | terminal | Run commands |\n"
+        "<!-- AUTO-END: capabilities -->\n\n"
+        "## Open Questions / Unknowns\n\nNone.\n"
+    )
+
+    summary = build_slim_summary(doc, max_capabilities=1)
+
+    assert "Hermes self-knowledge" in summary
+    assert "Hermes is an agent." in summary
+    assert "- Be accurate" in summary
+    assert "Capabilities: web_search" in summary
+    assert "terminal" not in summary
+
+
+def test_build_slim_summary_missing_doc_returns_empty(tmp_path):
+    assert build_slim_summary(tmp_path / "missing.md") == ""
+
+
+def test_build_slim_summary_can_be_disabled(monkeypatch, tmp_path):
+    doc = tmp_path / "self.md"
+    doc.write_text("## Identity\n\nHello\n")
+    monkeypatch.setenv("HERMES_SELF_KNOWLEDGE_PROMPT", "off")
+
+    assert build_slim_summary(doc) == ""


### PR DESCRIPTION
## Summary
- Add repo-grounded Hermes self-knowledge markdown with AUTO-rendered sections
- Add parser, renderer, generators, drift checker, CLI, and hook installer
- Inject a slim self-knowledge summary into the stable system prompt with an env var off-switch

## Test Plan
- python -m hermes_cli.main self-knowledge --check
- pytest tests/self_knowledge -q
- pytest tests/run_agent/test_run_agent.py::TestBuildSystemPrompt -q
- git diff --check

## Notes
- GitHub Actions self-knowledge check is soft for now to avoid blocking unrelated PRs while this settles.