### PR TITLE
fix: wrap Kanban lanes at narrow widths

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -1942,23 +1942,23 @@
     const { t } = useI18n();
     const tenants = (props.board && props.board.tenants) || [];
     const assignees = (props.board && props.board.assignees) || [];
-    return h("div", { className: "flex flex-wrap items-end gap-3" },
-      h("div", { className: "flex flex-col gap-1",
+    return h("div", { className: "hermes-kanban-toolbar flex flex-wrap items-end gap-3" },
+      h("div", { className: "hermes-kanban-toolbar-field flex flex-col gap-1",
                  title: "Fuzzy-match tasks by id, title, or description. Matches across all columns." },
         h(Label, { className: "text-xs text-muted-foreground" }, tx(t, "search", "Search")),
         h(Input, {
           placeholder: tx(t, "filterCards", "Filter cards…"),
           value: props.search,
           onChange: function (e) { props.setSearch(e.target.value); },
-          className: "w-56 h-8",
+          className: "hermes-kanban-toolbar-input w-56 h-8",
         }),
       ),
-      h("div", { className: "flex flex-col gap-1",
+      h("div", { className: "hermes-kanban-toolbar-field flex flex-col gap-1",
                  title: "Tenants are free-form tags on a task (e.g. customer, project, team). Set them via the task drawer or kanban_create." },
         h(Label, { className: "text-xs text-muted-foreground" }, tx(t, "tenant", "Tenant")),
         h(Select, Object.assign({
           value: props.tenantFilter,
-          className: "h-8",
+          className: "hermes-kanban-toolbar-input h-8",
         }, selectChangeHandler(props.setTenantFilter)),
           h(SelectOption, { value: "" }, tx(t, "allTenants", "All tenants")),
           tenants.map(function (tn) {
@@ -1966,12 +1966,12 @@
           }),
         ),
       ),
-      h("div", { className: "flex flex-col gap-1",
+      h("div", { className: "hermes-kanban-toolbar-field flex flex-col gap-1",
                  title: "Filter by assigned Hermes profile. Profiles are the named agent identities that claim and work on tasks." },
         h(Label, { className: "text-xs text-muted-foreground" }, tx(t, "assignee", "Assignee")),
         h(Select, Object.assign({
           value: props.assigneeFilter,
-          className: "h-8",
+          className: "hermes-kanban-toolbar-input h-8",
         }, selectChangeHandler(props.setAssigneeFilter)),
           h(SelectOption, { value: "" }, tx(t, "allProfiles", "All profiles")),
           assignees.map(function (a) {
@@ -1997,7 +1997,7 @@
         }),
         tx(t, "lanesByProfile", "Lanes by profile"),
       ),
-      h("div", { className: "flex-1" }),
+      h("div", { className: "hermes-kanban-toolbar-spacer flex-1" }),
       h(Button, {
         onClick: props.onNudgeDispatch,
         size: "sm",

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -7,6 +7,15 @@
 
 .hermes-kanban {
   width: 100%;
+  max-width: 100%;
+  min-width: 0;
+}
+
+.hermes-kanban-toolbar,
+.hermes-kanban-columns,
+.hermes-kanban-bulk {
+  min-width: 0;
+  max-width: 100%;
 }
 
 /* ---- Code/pre reset (theme-immune default) --------------------------- *
@@ -63,18 +72,17 @@
 /* ---- Columns layout -------------------------------------------------- */
 
 .hermes-kanban-columns {
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 280px), 1fr));
   gap: 0.75rem;
   align-items: start;
-  overflow-x: auto;
-  scrollbar-width: none;
-}
-.hermes-kanban-columns::-webkit-scrollbar {
-  display: none;
+  overflow-x: visible;
 }
 
 .hermes-kanban-column {
-  flex: 0 0 280px;
+  box-sizing: border-box;
+  min-width: 0;
+  width: 100%;
   display: flex;
   flex-direction: column;
   background: color-mix(in srgb, var(--color-card) 85%, transparent);
@@ -84,6 +92,49 @@
   min-height: 200px;
   max-height: calc(100vh - 220px);
   transition: border-color 120ms ease, background-color 120ms ease;
+}
+
+@media (max-width: 900px) {
+  .hermes-kanban-toolbar {
+    align-items: stretch;
+  }
+
+  .hermes-kanban-toolbar-field {
+    flex: 1 1 12rem;
+    min-width: min(100%, 12rem);
+  }
+
+  .hermes-kanban-toolbar-input {
+    width: 100% !important;
+  }
+
+  .hermes-kanban-toolbar-spacer {
+    display: none;
+  }
+
+  .hermes-kanban-toolbar > button {
+    flex: 1 1 9rem;
+    min-width: min(100%, 9rem);
+  }
+
+  .hermes-kanban-column {
+    width: 100%;
+    max-height: none;
+  }
+}
+
+@media (max-width: 640px) {
+  .hermes-kanban-toolbar-field,
+  .hermes-kanban-toolbar > label,
+  .hermes-kanban-toolbar > button {
+    flex-basis: 100%;
+  }
+
+  .hermes-kanban-bulk > button,
+  .hermes-kanban-bulk-reassign,
+  .hermes-kanban-bulk-priority {
+    flex: 1 1 100%;
+  }
 }
 
 .hermes-kanban-column--drop {


### PR DESCRIPTION
## Summary
- Change Kanban dashboard lane layout from a non-wrapping horizontal strip to an auto-fitting CSS grid.
- Allow lanes such as IN PROGRESS, BLOCKED, REVIEW, and DONE to wrap underneath earlier lanes when the available width shrinks.
- Keep toolbar controls responsive at narrower widths.

## Validation
- Cato review accepted the corrected behavior in Kanban task t_e6390158.
- Narrow fixture check at 1030px: 8 lanes rendered as 3 rows, no page or lane-container horizontal overflow.
- Wide fixture check at 2630px: 8 lanes rendered as 1 row, no horizontal overflow.
- Ran: git diff --check -- plugins/kanban/dashboard/dist/index.js plugins/kanban/dashboard/dist/style.css

## Notes
- This updates checked-in plugin dashboard dist assets only; no separate source bundle exists under plugins/kanban/dashboard in this checkout.