### PR TITLE
fix(chat_completions): strip tool_name from messages for strict providers

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -122,7 +122,11 @@ class ChatCompletionsTransport(ProviderTransport):
         for msg in messages:
             if not isinstance(msg, dict):
                 continue
-            if "codex_reasoning_items" in msg or "codex_message_items" in msg:
+            if (
+                "codex_reasoning_items" in msg
+                or "codex_message_items" in msg
+                or "tool_name" in msg
+            ):
                 needs_sanitize = True
                 break
             tool_calls = msg.get("tool_calls")
@@ -145,6 +149,7 @@ class ChatCompletionsTransport(ProviderTransport):
                 continue
             msg.pop("codex_reasoning_items", None)
             msg.pop("codex_message_items", None)
+            msg.pop("tool_name", None)
             tool_calls = msg.get("tool_calls")
             if isinstance(tool_calls, list):
                 for tc in tool_calls:

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -46,6 +46,26 @@ class TestChatCompletionsBasic:
         assert "codex_reasoning_items" in msgs[0]
         assert "codex_message_items" in msgs[0]
 
+    def test_convert_messages_strips_tool_name(self, transport):
+        """Internal `tool_name` (used for FTS indexing in the SQLite store) is
+        not part of the OpenAI Chat Completions schema. Strict providers like
+        Moonshot/Kimi reject it with HTTP 400 'Extra inputs are not permitted'.
+        """
+        msgs = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": None,
+             "tool_calls": [{"id": "call_1", "type": "function",
+                             "function": {"name": "execute_code", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "call_1", "tool_name": "execute_code",
+             "content": "result"},
+        ]
+        result = transport.convert_messages(msgs)
+        assert "tool_name" not in result[2]
+        assert result[2]["content"] == "result"
+        assert result[2]["tool_call_id"] == "call_1"
+        # Original list untouched (deepcopy-on-demand)
+        assert msgs[2]["tool_name"] == "execute_code"
+
 
 class TestChatCompletionsBuildKwargs:
 


### PR DESCRIPTION
## What does this PR do?

The internal `tool_name` key on `role=tool` messages — stored in the
`messages.tool_name` SQLite column for FTS indexing — is not part of the
OpenAI Chat Completions schema. Strict OpenAI-compatible providers, notably
**Moonshot AI (Kimi)**, reject any request containing it with HTTP 400:

```
Error from provider: Extra inputs are not permitted,
field: 'messages[N].tool_name', value: 'execute_code'
```

This PR adds `tool_name` to the sanitize block in
`ChatCompletionsTransport.convert_messages`, alongside the existing
Codex Responses API fields (`codex_reasoning_items`, `codex_message_items`),
so it is popped before the request is sent.

The strip is unconditional (matches the existing Codex-strip pattern):
`tool_name` is never part of any documented OpenAI Chat Completions payload,
so removing it before send is safe for every provider while fixing the
strict ones. Permissive backends (MiniMax, OpenRouter on most routes) were
ignoring the extra field and masking the bug.

## Related Issue

Fixes #

<!-- No tracking issue opened — full repro and root-cause analysis are
included in this PR. Happy to open one and link if maintainers prefer. -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/transports/chat_completions.py` — extend the `needs_sanitize`
  detection and the per-message `pop` step in `convert_messages` to cover
  the `tool_name` key.
- `tests/agent/transports/test_chat_completions.py` — add
  `test_convert_messages_strips_tool_name` covering both the strip on the
  returned list and the deepcopy-on-demand contract (original input
  untouched).

## How to Test

Reproducer:

```
hermes chat --model kimi-k2.6
> list the top 5 Hacker News stories
```

Before the fix:
1. assistant emits `tool_call(execute_code)`
2. the tool result message is persisted with `tool_name='execute_code'`
3. the next-turn payload includes `messages[N].tool_name`
4. Kimi rejects with HTTP 400 (`Extra inputs are not permitted, field:
   'messages[N].tool_name'`)

After the fix:
1. Same flow, but `convert_messages` strips `tool_name` before send.
2. Request succeeds, multi-turn tool-using conversations complete normally
   on `kimi-k2.6` (verified end-to-end on macOS 15.x, Hermes Agent v0.14.0).

Automated:

```
pytest tests/agent/transports/test_chat_completions.py -q
```

The new test (`test_convert_messages_strips_tool_name`) asserts:
- `tool_name` is removed from the returned message
- `tool_call_id` and `content` are preserved
- the original input list is unmodified (deepcopy-on-demand contract)

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(chat_completions): …`)
- [x] I searched for existing PRs/issues — none target this specific field
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/agent/transports/test_chat_completions.py -q` and all tests pass
- [x] I've added a test for the fix
- [x] I've tested on my platform: macOS 15.x (Apple Silicon)

### Documentation & Housekeeping

- [x] N/A — no public docs reference the internal `tool_name` field
- [x] N/A — no config keys added/changed
- [x] N/A — no architectural or workflow changes
- [x] Cross-platform: the change is a pure dictionary pop, no platform-specific behavior
- [x] N/A — no tool descriptions/schemas changed
