### PR TITLE
feat(plugins): add DaVinci Resolve integration

### DIFF
--- a/plugins/video/davinci_resolve/AGENT_GUIDE.md
+++ b/plugins/video/davinci_resolve/AGENT_GUIDE.md
@@ -1,0 +1,59 @@
+# Agent Guide
+
+You are controlling DaVinci Resolve through either Studio live control or free Resolve interchange files.
+
+Start every unfamiliar session with:
+
+1. `resolve_capabilities`
+2. `resolve_launch`
+3. `resolve_probe`
+4. If `resolve_probe.recommended_mode` is `studio_live_control`, call `resolve_project_summary`.
+5. If `resolve_probe.recommended_mode` is `free_interchange`, do not call live-control tools. Generate import files instead.
+
+For changes, use dry-run first. Only call a mutating tool with `dry_run=false` when the user has approved the plan and you also set `confirm=true`.
+
+Good first real tests:
+
+- Add a marker to the active timeline.
+- Import one known media file into a test bin.
+- Append one known media file to the active timeline.
+- Scan a small media folder, dry-run a scripted timeline, then render only after the user approves.
+
+Do not delete anything unless the user explicitly asks for deletion.
+
+## Studio Scripted Edit Mode
+
+When the user asks for a finished edit from a script and folder of clips:
+
+1. Scan source folders with `resolve_scan_media_folder`.
+2. Interpret the script yourself: identify beats, required visuals, clip order, approximate clip ranges, music mood, and markers.
+3. Build a structured `clips` array for `resolve_create_scripted_timeline`.
+4. Dry-run `resolve_create_scripted_timeline` and explain the edit plan.
+5. Only after approval, call `resolve_create_scripted_timeline` with `dry_run=false` and `confirm=true`.
+6. Dry-run `resolve_render_timeline`, then render with `dry_run=false` and `confirm=true`.
+7. Poll `resolve_render_status` and report the final output location.
+
+Use `start_frame` and `end_frame` for source ranges when the user or your analysis gives ranges. Use `record_frame`, `track_index`, and `media_type` when placing clips on specific tracks. Add markers for script beats, missing-shot notes, or review points.
+
+Do not claim final color, sound mix, effects, or advanced editorial polish unless the plan explicitly encodes those operations or the user asks for a rough cut.
+
+## Free Resolve Mode
+
+Free DaVinci Resolve can import timelines, but it does not reliably expose the external `scriptapp("Resolve")` bridge. When `resolve_probe` reports `free_interchange`, use:
+
+- `resolve_generate_fcpxml_timeline` for timeline assembly from media paths.
+- `resolve_generate_marker_csv` for marker manifests.
+
+Tell the user to import generated FCPXML with **File > Import > Timeline > Import AAF, EDL, XML...**. Do not claim that Hermes can inspect the current free Resolve project live.
+
+## Resolve 20 And Resolve 21 Beta
+
+If the user has both Resolve 20 and Resolve 21 beta installed, ask which version should open before using `resolve_launch`.
+
+Use:
+
+- `variant="resolve20"` or `variant="studio20"` for Resolve 20 installs.
+- `variant="resolve21"`, `variant="studio21"`, or `variant="beta"` for Resolve 21 beta installs.
+- `app_path="/Applications/.../DaVinci Resolve.app"` when the exact side-by-side app bundle path is known.
+
+Do not open production projects in Resolve 21 beta unless the user confirms they have backups. Projects opened in a beta may not be usable again in earlier Resolve versions.

--- a/plugins/video/davinci_resolve/README.md
+++ b/plugins/video/davinci_resolve/README.md
@@ -1,74 +1,300 @@
 # Hermes DaVinci Resolve Plugin
 
-This is a native Hermes Agent plugin adapter for DaVinci Resolve.
+This plugin lets Hermes Agent work with DaVinci Resolve on macOS.
 
-It supports two modes:
+It is intentionally dual-mode:
 
-- **Studio live control**: DaVinci Resolve Studio exposes the local Python scripting API, so Hermes can inspect and modify a running project.
-- **Free Resolve interchange**: free DaVinci Resolve does not expose reliable external live control, so Hermes generates importable files such as FCPXML and marker CSV manifests.
+- **DaVinci Resolve Studio live control**: Hermes can connect to the Resolve Python scripting API, inspect the active project, import media, create timelines, add markers, build scripted rough cuts, and queue renders.
+- **Free DaVinci Resolve interchange**: Hermes cannot reliably control the running free Resolve app through `DaVinciResolveScript.scriptapp("Resolve")`, so the plugin generates importable files such as FCPXML timelines and marker CSV manifests.
 
-## Install Locally
+The design goal is that Hermes can give users a useful editing workflow on the free product while offering direct project control for users who have Studio.
 
-Copy this directory to:
+## What This Plugin Can Do
+
+With DaVinci Resolve Studio, a user can ask Hermes to:
+
+- Open Resolve Studio.
+- Check whether live scripting is reachable.
+- Summarize the active project and current timeline.
+- Scan local folders for footage, music, stills, and other media.
+- Import media into the media pool.
+- Create an empty or media-seeded timeline.
+- Append footage or audio to the active timeline.
+- Add timeline markers.
+- Build a rough cut from a structured script-driven edit plan.
+- Configure and optionally start a render job.
+- Poll render status.
+
+With free DaVinci Resolve, a user can ask Hermes to:
+
+- Scan media folders.
+- Generate an FCPXML timeline that can be imported into Resolve.
+- Generate marker CSV/manifests for review notes or edit beats.
+
+Free Resolve still requires the user to import the generated interchange files through the Resolve UI. The plugin does not claim live project control when the free edition is detected.
+
+## Requirements
+
+- macOS.
+- Hermes Agent with local plugin support.
+- DaVinci Resolve or DaVinci Resolve Studio installed locally.
+- Python environment capable of importing the plugin files.
+- For Studio live control:
+  - DaVinci Resolve Studio must be installed.
+  - Resolve Studio must be open.
+  - A project should be open for project-mutating tools.
+  - Resolve preferences must allow local scripting:
+    - **DaVinci Resolve > Preferences > System > General > External scripting using: Local**
+  - The Resolve scripting module must be available at a standard Blackmagic path or through `RESOLVE_SCRIPT_API`.
+
+The plugin searches common Resolve module locations, including:
+
+```text
+/Library/Application Support/Blackmagic Design/DaVinci Resolve/Developer/Scripting/Modules
+/Applications/DaVinci Resolve/DaVinci Resolve.app/Contents/Libraries/Fusion
+```
+
+## Installation
+
+For a local Hermes install, copy this directory to:
 
 ```bash
 ~/.hermes/plugins/davinci-resolve
 ```
 
-Then restart Hermes. Hermes should discover the plugin and expose the `davinciresolve` toolset.
+Then restart Hermes and confirm that the plugin is discovered.
 
-## Tools
+The plugin metadata lives in `plugin.yaml`. The Python entry point is `__init__.py`, with tool schemas in `schemas.py`, Hermes handlers in `tools.py`, and Resolve-specific behavior in `resolve_bridge/operations.py`.
 
-- `resolve_capabilities`: explain how an LLM agent should use the Resolve tools.
-- `resolve_launch`: open DaVinci Resolve locally and check scripting reachability.
-- `resolve_probe`: read-only scripting diagnostic.
-- `resolve_project_summary`: read-only project/timeline summary.
-- `resolve_import_media`: import files into the media pool.
-- `resolve_create_timeline`: create an empty or media-seeded timeline.
-- `resolve_append_to_current_timeline`: import and append media to the active timeline.
-- `resolve_add_timeline_marker`: add a marker to the active timeline.
-- `resolve_scan_media_folder`: scan a footage/music/stills folder for media Hermes can plan with.
-- `resolve_create_scripted_timeline`: build a Studio timeline from a structured edit plan with source ranges, target tracks, music, and markers.
-- `resolve_render_timeline`: create and optionally start a render job for the current Studio timeline.
-- `resolve_render_status`: check render queue and progress.
-- `resolve_generate_fcpxml_timeline`: generate an FCPXML timeline file for free Resolve.
-- `resolve_generate_marker_csv`: generate a marker CSV/manifest for free Resolve workflows.
+## Tool List
 
-Mutating tools default to `dry_run=true`. To actually modify a Resolve project, call the tool with `dry_run=false` and `confirm=true`.
+Read-only and diagnostic tools:
 
-## Requirements
+- `resolve_capabilities`: returns a compact operating guide for Hermes.
+- `resolve_launch`: opens Resolve or Resolve Studio and reports scripting reachability.
+- `resolve_probe`: imports `DaVinciResolveScript`, checks `scriptapp("Resolve")`, and recommends a mode.
+- `resolve_project_summary`: summarizes the active Studio project and current timeline.
+- `resolve_scan_media_folder`: scans local folders for usable media files.
+- `resolve_render_status`: checks Studio render queue/progress.
 
-- DaVinci Resolve installed locally.
-- Resolve Studio open when using live-control tools.
-- In Studio, **DaVinci Resolve > Preferences > System > General > External scripting using: Local** must be enabled.
-- Resolve scripting module available at a standard path or configured through `RESOLVE_SCRIPT_API` for live-control tools.
-- For free Resolve, use interchange tools and import generated files manually with Resolve's import menus.
+Studio live-control mutating tools:
 
-## Studio Scripted Edit Workflow
+- `resolve_import_media`: imports media into the current project's media pool.
+- `resolve_create_timeline`: creates a timeline, optionally seeded with media.
+- `resolve_append_to_current_timeline`: imports and appends media to the active timeline.
+- `resolve_add_timeline_marker`: adds a marker to the active timeline.
+- `resolve_create_scripted_timeline`: builds a Studio timeline from a structured edit plan.
+- `resolve_render_timeline`: creates and optionally starts a render job.
 
-For a prompt like "take this folder of clips, follow this script, add music like X, and give me a final QuickTime", Hermes should:
+Free Resolve interchange tools:
 
-1. `resolve_launch` with `variant="studio"`.
-2. `resolve_probe` and continue only if `recommended_mode="studio_live_control"`.
-3. `resolve_scan_media_folder` on footage and music folders.
-4. Read the user's script and choose clips/ranges/music as a structured edit plan.
-5. Call `resolve_create_scripted_timeline` with `dry_run=true`.
-6. After approval, call the same tool with `dry_run=false` and `confirm=true`.
-7. Call `resolve_render_timeline` with `dry_run=true`, then with `dry_run=false` and `confirm=true`.
-8. Poll `resolve_render_status` until rendering finishes.
+- `resolve_generate_fcpxml_timeline`: writes an importable `.fcpxml` timeline.
+- `resolve_generate_marker_csv`: writes a marker CSV/manifest.
 
-The plugin does not make creative choices by itself. Hermes makes those choices from the user's script and available media, then passes a structured plan to Resolve.
+## Safety Model
 
-## Free Resolve Workflow
+All mutating Studio tools default to `dry_run=true`.
 
-If `resolve_probe` reports `recommended_mode="free_interchange"`, use:
+To actually change a Resolve Studio project, Hermes must call the tool with:
 
-1. `resolve_generate_fcpxml_timeline` to create a `.fcpxml` file.
-2. In Resolve, choose **File > Import > Timeline > Import AAF, EDL, XML...**.
-3. Select the generated file from `~/Documents/Hermes Resolve Exports` or the requested `output_path`.
+```json
+{
+  "dry_run": false,
+  "confirm": true
+}
+```
 
-Free Resolve workflows cannot read the current project state through Hermes. They are file-based handoffs into Resolve.
+If `dry_run=false` is supplied without `confirm=true`, the plugin rejects the operation. This is deliberate so an agent can show the intended edit plan before touching the user's active project.
 
-## Resolve 20 And Resolve 21 Beta
+Recommended agent behavior:
 
-`resolve_launch` supports `variant` values for `resolve20`, `studio20`, `resolve21`, `studio21`, and `beta`. If multiple Resolve versions are installed with custom app names, pass `app_path` to launch the exact `.app` bundle.
+1. Probe first.
+2. Dry-run every project-changing action.
+3. Explain the planned changes to the user.
+4. Only mutate after explicit user approval.
+5. Never delete media, timelines, bins, or render jobs unless a future tool explicitly implements deletion and the user asks for it.
+
+## Mode Detection
+
+Hermes should start an unfamiliar session with:
+
+1. `resolve_capabilities`
+2. `resolve_launch`
+3. `resolve_probe`
+
+`resolve_probe` returns a `recommended_mode` field:
+
+- `studio_live_control`: the Resolve scripting module imported and `scriptapp("Resolve")` returned a live Resolve object.
+- `free_interchange`: the module imported, free Resolve appears to be installed, but live control is not reachable.
+- `diagnostic`: Resolve scripting is not reachable and the plugin cannot confidently identify the reason.
+
+When `recommended_mode` is `free_interchange`, Hermes should avoid Studio-only live-control tools and use FCPXML/CSV generation instead.
+
+## Studio Workflow: Scripted Rough Cut And Render
+
+For a user request like:
+
+> Take the clips in this folder, edit them together following this script, add music like this reference, and give me a final QuickTime.
+
+Hermes should use this flow for DaVinci Resolve Studio:
+
+1. Call `resolve_launch` with `variant="studio"` or an explicit `app_path`.
+2. Call `resolve_probe`.
+3. Continue only if `recommended_mode` is `studio_live_control`.
+4. Call `resolve_project_summary` to confirm the active project context.
+5. Call `resolve_scan_media_folder` for footage folders and music folders.
+6. Interpret the user's script in the agent layer.
+7. Build a structured `clips` array for `resolve_create_scripted_timeline`.
+8. Include optional `music_paths` and `markers` for review beats, missing-shot notes, or script sections.
+9. Call `resolve_create_scripted_timeline` with `dry_run=true`.
+10. Ask for approval or rely on previously granted approval from the user workflow.
+11. Call `resolve_create_scripted_timeline` with `dry_run=false` and `confirm=true`.
+12. Call `resolve_render_timeline` with `dry_run=true`.
+13. After approval, call `resolve_render_timeline` with `dry_run=false`, `confirm=true`, and `start_render=true`.
+14. Poll `resolve_render_status` until the render completes.
+
+The plugin does not make creative editorial choices by itself. Hermes chooses clips, ranges, order, markers, and music based on the user's instructions and available media, then passes a structured plan to Resolve.
+
+### Example Scripted Timeline Payload
+
+```json
+{
+  "name": "Hermes Rough Cut",
+  "clips": [
+    {
+      "path": "/Users/example/Footage/intro.mov",
+      "name": "Opening shot",
+      "start_frame": 0,
+      "end_frame": 144,
+      "record_frame": 0,
+      "track_index": 1,
+      "note": "Establishes the location from the script opening."
+    },
+    {
+      "path": "/Users/example/Footage/interview_a.mov",
+      "name": "Interview beat 1",
+      "start_frame": 240,
+      "end_frame": 480,
+      "record_frame": 144,
+      "track_index": 1,
+      "note": "Matches the first narration paragraph."
+    }
+  ],
+  "music_paths": [
+    "/Users/example/Music/reference_style_track.wav"
+  ],
+  "markers": [
+    {
+      "frame": 0,
+      "name": "Opening",
+      "color": "Blue",
+      "note": "Start of scripted intro",
+      "duration": 1
+    }
+  ],
+  "bin_name": "Hermes Edit",
+  "dry_run": true
+}
+```
+
+## Free Resolve Workflow: FCPXML Handoff
+
+Free DaVinci Resolve can import timeline interchange files, but it does not reliably expose external live scripting to Hermes. When `resolve_probe` recommends `free_interchange`, Hermes should use this flow:
+
+1. Call `resolve_scan_media_folder` to discover source media.
+2. Interpret the user's script in the agent layer.
+3. Call `resolve_generate_fcpxml_timeline` with a timeline name, media paths, frame rate, dimensions, and optional markers.
+4. Tell the user where the `.fcpxml` file was written.
+5. The user imports it in Resolve:
+   - **File > Import > Timeline > Import AAF, EDL, XML...**
+6. The user relinks media if Resolve asks.
+
+Default interchange output is written under:
+
+```text
+~/Documents/Hermes Resolve Exports
+```
+
+The FCPXML generator is intentionally conservative. It creates a basic timeline assembly suitable for import and further editing. It is not a substitute for Studio's live API and does not inspect the user's open Resolve project.
+
+## Free Resolve Workflow: Marker CSV
+
+For review notes, script beats, or manual edit guidance, Hermes can call:
+
+```text
+resolve_generate_marker_csv
+```
+
+The resulting CSV includes marker frame/time information, names, colors, notes, and durations. This gives a free Resolve user an edit map even when live marker insertion is unavailable.
+
+## Launch Variants
+
+`resolve_launch` supports these `variant` values:
+
+- `auto`
+- `resolve`
+- `studio`
+- `beta`
+- `resolve20`
+- `studio20`
+- `resolve21`
+- `studio21`
+
+If multiple app bundles are installed or renamed, pass `app_path` with the exact `.app` path.
+
+Examples:
+
+```json
+{
+  "variant": "studio21",
+  "wait_seconds": 12
+}
+```
+
+```json
+{
+  "app_path": "/Applications/DaVinci Resolve Studio 21 Beta/DaVinci Resolve Studio.app",
+  "wait_seconds": 12
+}
+```
+
+## Known Limitations
+
+- Live control requires DaVinci Resolve Studio. Free Resolve should use interchange mode.
+- The plugin currently targets macOS paths and app bundles.
+- The scripted edit tool creates practical rough cuts from structured clip plans; it does not perform advanced NLE operations such as transitions, color grading, Fusion effects, detailed audio mixing, transcription, multicam sync, or semantic video analysis by itself.
+- Clip selection and script interpretation happen in Hermes, not inside the plugin.
+- FCPXML interchange is best-effort and intentionally simple so it remains predictable.
+- Render behavior depends on the active Resolve project, installed codecs, Resolve render presets, and Studio scripting availability.
+
+## QA Notes
+
+Local non-Studio QA can cover:
+
+- Plugin import/registration.
+- Schema availability.
+- `resolve_capabilities`.
+- `resolve_probe` diagnostic behavior.
+- `resolve_scan_media_folder`.
+- FCPXML generation.
+- Marker CSV generation.
+- Dry-run behavior for Studio mutating tools.
+
+Studio QA should additionally cover:
+
+- `resolve_launch` with Studio installed.
+- `resolve_probe` returning `recommended_mode="studio_live_control"`.
+- `resolve_project_summary` against an open test project.
+- Importing media into a test bin.
+- Creating a timeline.
+- Appending media to the current timeline.
+- Adding a marker.
+- Creating a scripted timeline from a small clip plan.
+- Creating a render job and polling render status.
+
+Recommended local validation command from the repository root:
+
+```bash
+uv run --with pytest --with pytest-xdist pytest tests/test_davinci_resolve_plugin.py -q
+```
+

--- a/plugins/video/davinci_resolve/README.md
+++ b/plugins/video/davinci_resolve/README.md
@@ -1,0 +1,74 @@
+# Hermes DaVinci Resolve Plugin
+
+This is a native Hermes Agent plugin adapter for DaVinci Resolve.
+
+It supports two modes:
+
+- **Studio live control**: DaVinci Resolve Studio exposes the local Python scripting API, so Hermes can inspect and modify a running project.
+- **Free Resolve interchange**: free DaVinci Resolve does not expose reliable external live control, so Hermes generates importable files such as FCPXML and marker CSV manifests.
+
+## Install Locally
+
+Copy this directory to:
+
+```bash
+~/.hermes/plugins/davinci-resolve
+```
+
+Then restart Hermes. Hermes should discover the plugin and expose the `davinciresolve` toolset.
+
+## Tools
+
+- `resolve_capabilities`: explain how an LLM agent should use the Resolve tools.
+- `resolve_launch`: open DaVinci Resolve locally and check scripting reachability.
+- `resolve_probe`: read-only scripting diagnostic.
+- `resolve_project_summary`: read-only project/timeline summary.
+- `resolve_import_media`: import files into the media pool.
+- `resolve_create_timeline`: create an empty or media-seeded timeline.
+- `resolve_append_to_current_timeline`: import and append media to the active timeline.
+- `resolve_add_timeline_marker`: add a marker to the active timeline.
+- `resolve_scan_media_folder`: scan a footage/music/stills folder for media Hermes can plan with.
+- `resolve_create_scripted_timeline`: build a Studio timeline from a structured edit plan with source ranges, target tracks, music, and markers.
+- `resolve_render_timeline`: create and optionally start a render job for the current Studio timeline.
+- `resolve_render_status`: check render queue and progress.
+- `resolve_generate_fcpxml_timeline`: generate an FCPXML timeline file for free Resolve.
+- `resolve_generate_marker_csv`: generate a marker CSV/manifest for free Resolve workflows.
+
+Mutating tools default to `dry_run=true`. To actually modify a Resolve project, call the tool with `dry_run=false` and `confirm=true`.
+
+## Requirements
+
+- DaVinci Resolve installed locally.
+- Resolve Studio open when using live-control tools.
+- In Studio, **DaVinci Resolve > Preferences > System > General > External scripting using: Local** must be enabled.
+- Resolve scripting module available at a standard path or configured through `RESOLVE_SCRIPT_API` for live-control tools.
+- For free Resolve, use interchange tools and import generated files manually with Resolve's import menus.
+
+## Studio Scripted Edit Workflow
+
+For a prompt like "take this folder of clips, follow this script, add music like X, and give me a final QuickTime", Hermes should:
+
+1. `resolve_launch` with `variant="studio"`.
+2. `resolve_probe` and continue only if `recommended_mode="studio_live_control"`.
+3. `resolve_scan_media_folder` on footage and music folders.
+4. Read the user's script and choose clips/ranges/music as a structured edit plan.
+5. Call `resolve_create_scripted_timeline` with `dry_run=true`.
+6. After approval, call the same tool with `dry_run=false` and `confirm=true`.
+7. Call `resolve_render_timeline` with `dry_run=true`, then with `dry_run=false` and `confirm=true`.
+8. Poll `resolve_render_status` until rendering finishes.
+
+The plugin does not make creative choices by itself. Hermes makes those choices from the user's script and available media, then passes a structured plan to Resolve.
+
+## Free Resolve Workflow
+
+If `resolve_probe` reports `recommended_mode="free_interchange"`, use:
+
+1. `resolve_generate_fcpxml_timeline` to create a `.fcpxml` file.
+2. In Resolve, choose **File > Import > Timeline > Import AAF, EDL, XML...**.
+3. Select the generated file from `~/Documents/Hermes Resolve Exports` or the requested `output_path`.
+
+Free Resolve workflows cannot read the current project state through Hermes. They are file-based handoffs into Resolve.
+
+## Resolve 20 And Resolve 21 Beta
+
+`resolve_launch` supports `variant` values for `resolve20`, `studio20`, `resolve21`, `studio21`, and `beta`. If multiple Resolve versions are installed with custom app names, pass `app_path` to launch the exact `.app` bundle.

--- a/plugins/video/davinci_resolve/__init__.py
+++ b/plugins/video/davinci_resolve/__init__.py
@@ -2,49 +2,25 @@
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
+import platform
 
-PLUGIN_DIR = Path(__file__).resolve().parent
-if str(PLUGIN_DIR) not in sys.path:
-    sys.path.insert(0, str(PLUGIN_DIR))
-
-try:
-    from . import schemas
-    from .tools import (
-        handle_append_to_current_timeline,
-        handle_capabilities,
-        handle_create_scripted_timeline,
-        handle_create_timeline,
-        handle_generate_fcpxml_timeline,
-        handle_generate_marker_csv,
-        handle_import_media,
-        handle_launch,
-        handle_project_summary,
-        handle_probe,
-        handle_render_status,
-        handle_render_timeline,
-        handle_scan_media_folder,
-        handle_timeline_marker,
-    )
-except ImportError:
-    import schemas
-    from tools import (
-        handle_append_to_current_timeline,
-        handle_capabilities,
-        handle_create_scripted_timeline,
-        handle_create_timeline,
-        handle_generate_fcpxml_timeline,
-        handle_generate_marker_csv,
-        handle_import_media,
-        handle_launch,
-        handle_project_summary,
-        handle_probe,
-        handle_render_status,
-        handle_render_timeline,
-        handle_scan_media_folder,
-        handle_timeline_marker,
-    )
+from . import schemas
+from .tools import (
+    handle_append_to_current_timeline,
+    handle_capabilities,
+    handle_create_scripted_timeline,
+    handle_create_timeline,
+    handle_generate_fcpxml_timeline,
+    handle_generate_marker_csv,
+    handle_import_media,
+    handle_launch,
+    handle_project_summary,
+    handle_probe,
+    handle_render_status,
+    handle_render_timeline,
+    handle_scan_media_folder,
+    handle_timeline_marker,
+)
 
 
 TOOLS = [
@@ -135,6 +111,10 @@ TOOLS = [
 ]
 
 
+def _is_macos() -> bool:
+    return platform.system() == "Darwin"
+
+
 def register(ctx):
     for name, schema, handler, description in TOOLS:
         ctx.register_tool(
@@ -142,5 +122,6 @@ def register(ctx):
             toolset="davinciresolve",
             schema=schema,
             handler=handler,
+            check_fn=_is_macos,
             description=description,
         )

--- a/plugins/video/davinci_resolve/__init__.py
+++ b/plugins/video/davinci_resolve/__init__.py
@@ -1,0 +1,146 @@
+"""Hermes plugin registration for DaVinci Resolve tools."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PLUGIN_DIR = Path(__file__).resolve().parent
+if str(PLUGIN_DIR) not in sys.path:
+    sys.path.insert(0, str(PLUGIN_DIR))
+
+try:
+    from . import schemas
+    from .tools import (
+        handle_append_to_current_timeline,
+        handle_capabilities,
+        handle_create_scripted_timeline,
+        handle_create_timeline,
+        handle_generate_fcpxml_timeline,
+        handle_generate_marker_csv,
+        handle_import_media,
+        handle_launch,
+        handle_project_summary,
+        handle_probe,
+        handle_render_status,
+        handle_render_timeline,
+        handle_scan_media_folder,
+        handle_timeline_marker,
+    )
+except ImportError:
+    import schemas
+    from tools import (
+        handle_append_to_current_timeline,
+        handle_capabilities,
+        handle_create_scripted_timeline,
+        handle_create_timeline,
+        handle_generate_fcpxml_timeline,
+        handle_generate_marker_csv,
+        handle_import_media,
+        handle_launch,
+        handle_project_summary,
+        handle_probe,
+        handle_render_status,
+        handle_render_timeline,
+        handle_scan_media_folder,
+        handle_timeline_marker,
+    )
+
+
+TOOLS = [
+    (
+        "resolve_capabilities",
+        schemas.RESOLVE_CAPABILITIES,
+        handle_capabilities,
+        "Explain available DaVinci Resolve tools, workflow order, and safety rules.",
+    ),
+    (
+        "resolve_launch",
+        schemas.RESOLVE_LAUNCH,
+        handle_launch,
+        "Open DaVinci Resolve on this computer and check scripting reachability.",
+    ),
+    (
+        "resolve_probe",
+        schemas.RESOLVE_PROBE,
+        handle_probe,
+        "Check whether DaVinci Resolve scripting is installed and reachable.",
+    ),
+    (
+        "resolve_project_summary",
+        schemas.RESOLVE_PROJECT_SUMMARY,
+        handle_project_summary,
+        "Inspect the current Resolve project and active timeline.",
+    ),
+    (
+        "resolve_import_media",
+        schemas.RESOLVE_IMPORT_MEDIA,
+        handle_import_media,
+        "Import media files into the Resolve media pool.",
+    ),
+    (
+        "resolve_create_timeline",
+        schemas.RESOLVE_CREATE_TIMELINE,
+        handle_create_timeline,
+        "Create a Resolve timeline, optionally seeded with imported media.",
+    ),
+    (
+        "resolve_append_to_current_timeline",
+        schemas.RESOLVE_APPEND_TO_CURRENT_TIMELINE,
+        handle_append_to_current_timeline,
+        "Append media files to the current Resolve timeline.",
+    ),
+    (
+        "resolve_add_timeline_marker",
+        schemas.RESOLVE_ADD_TIMELINE_MARKER,
+        handle_timeline_marker,
+        "Add a marker to the current Resolve timeline.",
+    ),
+    (
+        "resolve_scan_media_folder",
+        schemas.RESOLVE_SCAN_MEDIA_FOLDER,
+        handle_scan_media_folder,
+        "Scan a folder for video, audio, and image media before planning an edit.",
+    ),
+    (
+        "resolve_create_scripted_timeline",
+        schemas.RESOLVE_CREATE_SCRIPTED_TIMELINE,
+        handle_create_scripted_timeline,
+        "Create a Resolve Studio timeline from a structured scripted edit plan.",
+    ),
+    (
+        "resolve_render_timeline",
+        schemas.RESOLVE_RENDER_TIMELINE,
+        handle_render_timeline,
+        "Configure and start rendering the current Resolve Studio timeline.",
+    ),
+    (
+        "resolve_render_status",
+        schemas.RESOLVE_RENDER_STATUS,
+        handle_render_status,
+        "Check Resolve Studio render job progress.",
+    ),
+    (
+        "resolve_generate_fcpxml_timeline",
+        schemas.RESOLVE_GENERATE_FCPXML_TIMELINE,
+        handle_generate_fcpxml_timeline,
+        "Generate an FCPXML timeline that free DaVinci Resolve can import.",
+    ),
+    (
+        "resolve_generate_marker_csv",
+        schemas.RESOLVE_GENERATE_MARKER_CSV,
+        handle_generate_marker_csv,
+        "Generate a marker CSV for free Resolve interchange workflows.",
+    ),
+]
+
+
+def register(ctx):
+    for name, schema, handler, description in TOOLS:
+        ctx.register_tool(
+            name=name,
+            toolset="davinciresolve",
+            schema=schema,
+            handler=handler,
+            description=description,
+        )

--- a/plugins/video/davinci_resolve/plugin.yaml
+++ b/plugins/video/davinci_resolve/plugin.yaml
@@ -1,0 +1,22 @@
+name: davinci-resolve
+version: 0.2.0
+description: Control DaVinci Resolve Studio live, or generate importable interchange files for free DaVinci Resolve.
+author: "Sam Wasserman"
+kind: standalone
+platforms:
+  - macos
+provides_tools:
+  - resolve_capabilities
+  - resolve_launch
+  - resolve_probe
+  - resolve_project_summary
+  - resolve_import_media
+  - resolve_create_timeline
+  - resolve_append_to_current_timeline
+  - resolve_add_timeline_marker
+  - resolve_scan_media_folder
+  - resolve_create_scripted_timeline
+  - resolve_render_timeline
+  - resolve_render_status
+  - resolve_generate_fcpxml_timeline
+  - resolve_generate_marker_csv

--- a/plugins/video/davinci_resolve/resolve_bridge/__init__.py
+++ b/plugins/video/davinci_resolve/resolve_bridge/__init__.py
@@ -1,0 +1,6 @@
+"""Shared DaVinci Resolve scripting bridge used by the Hermes adapter."""
+
+from __future__ import annotations
+
+__all__ = ["operations"]
+

--- a/plugins/video/davinci_resolve/resolve_bridge/operations.py
+++ b/plugins/video/davinci_resolve/resolve_bridge/operations.py
@@ -1,0 +1,1259 @@
+"""Small, defensive wrapper around the DaVinci Resolve scripting API."""
+
+from __future__ import annotations
+
+import importlib
+import csv
+import os
+import platform
+import subprocess
+import sys
+import tempfile
+import time
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Any
+
+
+VIDEO_EXTENSIONS = {
+    ".3g2", ".3gp", ".avi", ".braw", ".cin", ".crm", ".dv", ".flv", ".m2ts",
+    ".m4v", ".mkv", ".mov", ".mp4", ".mpeg", ".mpg", ".mxf", ".r3d", ".ts",
+    ".vob", ".webm",
+}
+
+AUDIO_EXTENSIONS = {
+    ".aac", ".aif", ".aiff", ".bwf", ".flac", ".m4a", ".mp3", ".ogg", ".wav",
+    ".wma",
+}
+
+IMAGE_EXTENSIONS = {
+    ".ari", ".arw", ".bmp", ".cr2", ".cr3", ".dng", ".dpx", ".exr", ".gif",
+    ".heic", ".jpeg", ".jpg", ".nef", ".png", ".psd", ".raf", ".tif", ".tiff",
+}
+
+DEFAULT_MEDIA_EXTENSIONS = VIDEO_EXTENSIONS | AUDIO_EXTENSIONS | IMAGE_EXTENSIONS
+
+COMMON_MODULE_PATHS = [
+    Path("/Library/Application Support/Blackmagic Design/DaVinci Resolve/Developer/Scripting/Modules"),
+    Path("/Applications/DaVinci Resolve/DaVinci Resolve.app/Contents/Libraries/Fusion"),
+]
+
+COMMON_APP_PATHS = [
+    Path("/Applications/DaVinci Resolve/DaVinci Resolve.app"),
+    Path("/Applications/DaVinci Resolve/DaVinci Resolve Studio.app"),
+    Path("/Applications/DaVinci Resolve 20/DaVinci Resolve.app"),
+    Path("/Applications/DaVinci Resolve Studio 20/DaVinci Resolve Studio.app"),
+    Path("/Applications/DaVinci Resolve 21 Beta/DaVinci Resolve.app"),
+    Path("/Applications/DaVinci Resolve Studio 21 Beta/DaVinci Resolve Studio.app"),
+    Path("/Applications/DaVinci Resolve 21 Beta 3/DaVinci Resolve.app"),
+    Path("/Applications/DaVinci Resolve Studio 21 Beta 3/DaVinci Resolve Studio.app"),
+    Path("/Applications/DaVinci Resolve.app"),
+    Path("/Applications/DaVinci Resolve Studio.app"),
+    Path("/Applications/DaVinci Resolve 20.app"),
+    Path("/Applications/DaVinci Resolve Studio 20.app"),
+    Path("/Applications/DaVinci Resolve 21 Beta.app"),
+    Path("/Applications/DaVinci Resolve Studio 21 Beta.app"),
+    Path("/Applications/DaVinci Resolve 21 Beta 3.app"),
+    Path("/Applications/DaVinci Resolve Studio 21 Beta 3.app"),
+]
+
+RESOLVE_APP_PATHS = [
+    Path("/Applications/DaVinci Resolve/DaVinci Resolve.app"),
+    Path("/Applications/DaVinci Resolve.app"),
+]
+
+STUDIO_APP_PATHS = [
+    Path("/Applications/DaVinci Resolve/DaVinci Resolve Studio.app"),
+    Path("/Applications/DaVinci Resolve Studio.app"),
+]
+
+RESOLVE_20_APP_PATHS = [
+    Path("/Applications/DaVinci Resolve 20/DaVinci Resolve.app"),
+    Path("/Applications/DaVinci Resolve 20.app"),
+    Path("/Applications/DaVinci Resolve/DaVinci Resolve.app"),
+    Path("/Applications/DaVinci Resolve.app"),
+]
+
+STUDIO_20_APP_PATHS = [
+    Path("/Applications/DaVinci Resolve Studio 20/DaVinci Resolve Studio.app"),
+    Path("/Applications/DaVinci Resolve Studio 20.app"),
+    Path("/Applications/DaVinci Resolve/DaVinci Resolve Studio.app"),
+    Path("/Applications/DaVinci Resolve Studio.app"),
+]
+
+RESOLVE_21_APP_PATHS = [
+    Path("/Applications/DaVinci Resolve 21 Beta 3/DaVinci Resolve.app"),
+    Path("/Applications/DaVinci Resolve 21 Beta/DaVinci Resolve.app"),
+    Path("/Applications/DaVinci Resolve 21 Beta 3.app"),
+    Path("/Applications/DaVinci Resolve 21 Beta.app"),
+]
+
+STUDIO_21_APP_PATHS = [
+    Path("/Applications/DaVinci Resolve Studio 21 Beta 3/DaVinci Resolve Studio.app"),
+    Path("/Applications/DaVinci Resolve Studio 21 Beta/DaVinci Resolve Studio.app"),
+    Path("/Applications/DaVinci Resolve Studio 21 Beta 3.app"),
+    Path("/Applications/DaVinci Resolve Studio 21 Beta.app"),
+]
+
+
+def _ok(**payload: Any) -> dict[str, Any]:
+    return {"ok": True, **payload}
+
+
+def _error(message: str, **payload: Any) -> dict[str, Any]:
+    return {"ok": False, "error": message, **payload}
+
+
+def _add_existing_module_paths() -> list[str]:
+    added: list[str] = []
+    env_api = os.environ.get("RESOLVE_SCRIPT_API")
+    if env_api:
+        api_modules = Path(env_api).expanduser() / "Modules"
+        if api_modules.exists():
+            sys.path.insert(0, str(api_modules))
+            added.append(str(api_modules))
+
+    for path in COMMON_MODULE_PATHS:
+        if path.exists():
+            sys.path.insert(0, str(path))
+            added.append(str(path))
+
+    return added
+
+
+def _import_resolve_module() -> tuple[Any | None, str | None, list[str]]:
+    added_paths = _add_existing_module_paths()
+    try:
+        return importlib.import_module("DaVinciResolveScript"), None, added_paths
+    except Exception as exc:
+        return None, f"{type(exc).__name__}: {exc}", added_paths
+
+
+def _connect() -> tuple[Any | None, dict[str, Any] | None]:
+    module, import_error, added_paths = _import_resolve_module()
+    if module is None:
+        return None, _error(
+            "DaVinciResolveScript could not be imported.",
+            import_error=import_error,
+            added_sys_paths=added_paths,
+        )
+
+    try:
+        resolve = module.scriptapp("Resolve")
+    except Exception as exc:
+        return None, _error(
+            "DaVinci Resolve scripting module imported, but scriptapp failed.",
+            resolve_error=f"{type(exc).__name__}: {exc}",
+            added_sys_paths=added_paths,
+        )
+
+    if resolve is None:
+        return None, _error(
+            "DaVinci Resolve is not reachable. Open Resolve and enable scripting support.",
+            added_sys_paths=added_paths,
+        )
+
+    return resolve, None
+
+
+def _current_project(resolve: Any) -> tuple[Any | None, dict[str, Any] | None]:
+    project_manager = resolve.GetProjectManager()
+    if not project_manager:
+        return None, _error("Resolve project manager is unavailable.")
+
+    project = project_manager.GetCurrentProject()
+    if not project:
+        return None, _error("No active DaVinci Resolve project is open.")
+
+    return project, None
+
+
+def _media_pool(project: Any) -> tuple[Any | None, dict[str, Any] | None]:
+    media_pool = project.GetMediaPool()
+    if not media_pool:
+        return None, _error("Current Resolve project has no accessible media pool.")
+    return media_pool, None
+
+
+def _guard_mutation(dry_run: bool, confirm: bool, action: str) -> dict[str, Any] | None:
+    if dry_run:
+        return None
+    if not confirm:
+        return _error(
+            f"{action} requires confirm=true when dry_run=false.",
+            dry_run=dry_run,
+            confirm=confirm,
+        )
+    return None
+
+
+def _expand_paths(paths: list[str]) -> list[str]:
+    return [str(Path(path).expanduser().resolve()) for path in paths]
+
+
+def _path_report(paths: list[str]) -> dict[str, list[str]]:
+    existing = [path for path in paths if Path(path).exists()]
+    missing = [path for path in paths if not Path(path).exists()]
+    return {"existing_paths": existing, "missing_paths": missing}
+
+
+def _default_output_dir() -> Path:
+    candidates = [
+        Path.home() / "Documents" / "Hermes Resolve Exports",
+        Path(tempfile.gettempdir()) / "hermes-resolve-exports",
+    ]
+    for path in candidates:
+        try:
+            path.mkdir(parents=True, exist_ok=True)
+            return path
+        except OSError:
+            continue
+    raise OSError("Could not create a writable Resolve interchange output directory.")
+
+
+def _safe_file_stem(value: str) -> str:
+    safe = "".join(ch if ch.isalnum() or ch in {"-", "_"} else "_" for ch in value.strip())
+    return safe.strip("_") or "hermes_resolve"
+
+
+def _output_path(output_path: str | None, name: str, suffix: str) -> Path:
+    if output_path:
+        path = Path(output_path).expanduser().resolve()
+    else:
+        path = _default_output_dir() / f"{_safe_file_stem(name)}{suffix}"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _file_uri(path: str) -> str:
+    resolved = Path(path).expanduser().resolve()
+    return resolved.as_uri()
+
+
+def _seconds_to_frames(seconds: float, frame_rate: int) -> int:
+    return max(1, int(round(seconds * frame_rate)))
+
+
+def _fcpx_time(frames: int, frame_rate: int) -> str:
+    return f"{int(frames)}/{int(frame_rate)}s"
+
+
+def _media_kind(path: str) -> str:
+    suffix = Path(path).suffix.lower()
+    if suffix in VIDEO_EXTENSIONS:
+        return "video"
+    if suffix in AUDIO_EXTENSIONS:
+        return "audio"
+    if suffix in IMAGE_EXTENSIONS:
+        return "image"
+    return "unknown"
+
+
+def _media_type_value(media_type: str | int | None) -> int | None:
+    if media_type is None:
+        return None
+    if isinstance(media_type, int):
+        return media_type
+    normalized = media_type.lower().strip()
+    if normalized == "video":
+        return 1
+    if normalized == "audio":
+        return 2
+    return None
+
+
+def _duration_from_ffprobe(path: str) -> float | None:
+    try:
+        completed = subprocess.run(
+            [
+                "ffprobe",
+                "-v",
+                "error",
+                "-show_entries",
+                "format=duration",
+                "-of",
+                "default=noprint_wrappers=1:nokey=1",
+                path,
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except Exception:
+        return None
+    if completed.returncode != 0:
+        return None
+    try:
+        return float(completed.stdout.strip())
+    except ValueError:
+        return None
+
+
+def _clip_plan_paths(clips: list[dict[str, Any]], music_paths: list[str] | None = None) -> list[str]:
+    paths = [str(clip["path"]) for clip in clips if clip.get("path")]
+    paths.extend(music_paths or [])
+    return paths
+
+
+def _make_path_item_map(imported_items: list[Any], imported_paths: list[str]) -> dict[str, Any]:
+    mapping: dict[str, Any] = {}
+    for path, item in zip(imported_paths, imported_items):
+        if item:
+            mapping[path] = item
+    return mapping
+
+
+def _add_markers_to_timeline(timeline: Any, markers: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
+    added: list[dict[str, Any]] = []
+    for marker in markers or []:
+        frame = int(marker.get("frame", 0))
+        color = str(marker.get("color", "Blue"))
+        name = str(marker.get("name", "Marker"))
+        note = str(marker.get("note", ""))
+        duration = int(marker.get("duration", 1))
+        ok = timeline.AddMarker(frame, color, name, note, duration, str(marker.get("custom_data", "")))
+        added.append({"frame": frame, "name": name, "added": bool(ok)})
+    return added
+
+
+def _probe_recommendation(
+    module_imported: bool,
+    resolve_reachable: bool,
+    existing_app_paths: list[str],
+) -> dict[str, Any]:
+    studio_installed = any("Studio" in path for path in existing_app_paths)
+    resolve_installed = any("DaVinci Resolve.app" in path and "Studio" not in path for path in existing_app_paths)
+    if resolve_reachable:
+        return {
+            "recommended_mode": "studio_live_control",
+            "live_control_available": True,
+            "free_interchange_available": True,
+            "likely_reason": None,
+        }
+    if module_imported and resolve_installed and not studio_installed:
+        return {
+            "recommended_mode": "free_interchange",
+            "live_control_available": False,
+            "free_interchange_available": True,
+            "likely_reason": "free_resolve_external_scripting_unavailable",
+            "next_steps": [
+                "Use resolve_generate_fcpxml_timeline or resolve_generate_marker_csv for free Resolve workflows.",
+                "Install DaVinci Resolve Studio and enable Preferences > System > General > External scripting using: Local for live control.",
+            ],
+        }
+    return {
+        "recommended_mode": "diagnostic",
+        "live_control_available": False,
+        "free_interchange_available": True,
+        "likely_reason": "resolve_scripting_not_reachable",
+        "next_steps": [
+            "Confirm Resolve is fully open.",
+            "If using Studio, enable Preferences > System > General > External scripting using: Local.",
+            "If using free Resolve, use interchange tools instead of live-control tools.",
+        ],
+    }
+
+
+def probe() -> dict[str, Any]:
+    module, import_error, added_paths = _import_resolve_module()
+    resolve_reachable = False
+    resolve_error = None
+    current_project = None
+
+    if module is not None:
+        try:
+            resolve = module.scriptapp("Resolve")
+            resolve_reachable = resolve is not None
+            if resolve_reachable:
+                project_manager = resolve.GetProjectManager()
+                project = project_manager.GetCurrentProject() if project_manager else None
+                current_project = project.GetName() if project else None
+        except Exception as exc:
+            resolve_error = f"{type(exc).__name__}: {exc}"
+
+    existing_app_paths = [str(path) for path in COMMON_APP_PATHS if path.exists()]
+    recommendation = _probe_recommendation(
+        module_imported=module is not None,
+        resolve_reachable=resolve_reachable,
+        existing_app_paths=existing_app_paths,
+    )
+
+    return _ok(
+        platform=platform.platform(),
+        python=sys.version.split()[0],
+        environment={
+            "RESOLVE_SCRIPT_API": os.environ.get("RESOLVE_SCRIPT_API"),
+            "RESOLVE_SCRIPT_LIB": os.environ.get("RESOLVE_SCRIPT_LIB"),
+            "PYTHONPATH": os.environ.get("PYTHONPATH"),
+        },
+        existing_app_paths=existing_app_paths,
+        existing_module_paths=[str(path) for path in COMMON_MODULE_PATHS if path.exists()],
+        added_sys_paths=added_paths,
+        module_imported=module is not None,
+        import_error=import_error,
+        resolve_reachable=resolve_reachable,
+        resolve_error=resolve_error,
+        current_project=current_project,
+        **recommendation,
+    )
+
+
+def capabilities() -> dict[str, Any]:
+    return _ok(
+        purpose=(
+            "Control a local DaVinci Resolve session through Resolve's Python scripting API."
+        ),
+        recommended_workflow=[
+            "Call resolve_capabilities when unsure what this plugin can do.",
+            "Call resolve_launch to open Resolve on the local Mac.",
+            "Call resolve_probe to choose studio_live_control or free_interchange mode.",
+            "In Studio mode, call resolve_project_summary to inspect the current project and timeline.",
+            "For script-driven edits, scan media folders, create a structured edit plan, dry-run resolve_create_scripted_timeline, then render after approval.",
+            "For edits, call the mutating tool with dry_run=true first.",
+            "After user approval, call the same mutating tool with dry_run=false and confirm=true.",
+            "Call resolve_project_summary again to verify the result.",
+            "For free Resolve, generate FCPXML/CSV interchange files and ask the user to import them.",
+        ],
+        tools={
+            "resolve_launch": "Open DaVinci Resolve or Resolve Studio locally.",
+            "resolve_probe": "Check whether Resolve scripting is installed and reachable.",
+            "resolve_project_summary": "Read the active project and timeline state.",
+            "resolve_import_media": "Import footage, audio, stills, or other media into the media pool.",
+            "resolve_create_timeline": "Create an empty timeline or one seeded with media.",
+            "resolve_append_to_current_timeline": "Import media if needed and append it to the active timeline.",
+            "resolve_add_timeline_marker": "Add a marker to the active timeline at a frame.",
+            "resolve_scan_media_folder": "List usable video, audio, and image media in a local folder for edit planning.",
+            "resolve_create_scripted_timeline": "Build a Studio timeline from a structured edit plan with clip ranges, tracks, music, and markers.",
+            "resolve_render_timeline": "Configure and start a Resolve Studio render job for the current timeline.",
+            "resolve_render_status": "Check render progress for a Resolve render job.",
+            "resolve_generate_fcpxml_timeline": "Create an FCPXML timeline file that free Resolve can import manually.",
+            "resolve_generate_marker_csv": "Create a marker CSV/manifest for free Resolve workflows.",
+        },
+        modes={
+            "studio_live_control": [
+                "Requires DaVinci Resolve Studio.",
+                "Requires Preferences > System > General > External scripting using: Local.",
+                "Supports live project inspection and project mutation through Resolve's scripting API.",
+            ],
+            "free_interchange": [
+                "Works with free DaVinci Resolve because it produces importable files instead of using external scripting.",
+                "Requires the user or agent UI automation to import the generated FCPXML/CSV in Resolve.",
+                "Does not provide live project inspection.",
+            ],
+        },
+        current_boundaries=[
+            "The plugin controls Resolve through the scripting API, not by clicking the UI.",
+            "Resolve must be installed locally and usually must finish opening before control tools work.",
+            "Free DaVinci Resolve does not expose reliable external live control; use interchange tools there.",
+            "If Resolve 20 and Resolve 21 beta are installed side by side, use resolve_launch with app_path to pick the exact app bundle.",
+            "Do not open production projects in Resolve 21 beta without a full project library backup and individual project backups.",
+            "Complex color, Fusion, Fairlight, and UI-only operations may need more tool coverage.",
+            "Opening a specific project by database name and finer timeline placement are planned extensions.",
+        ],
+        safety_rules=[
+            "Never delete media, timelines, bins, grades, or render jobs unless the user explicitly asks.",
+            "Use dry_run=true before import, append, timeline creation, or marker changes.",
+            "Use confirm=true only after the user approves the dry-run plan.",
+            "Prefer read-only inspection when project state is unknown.",
+        ],
+        example_prompts=[
+            "Open Resolve, inspect the current project, then tell me what timelines exist.",
+            "Dry-run importing this folder of music into a bin named Score.",
+            "Add a blue timeline marker at frame 0 named Hermes smoke test.",
+            "Create a new timeline from these clips after showing me the dry-run plan.",
+            "Scan this footage folder, build a 60-second cut from my script, add this music, and render a QuickTime.",
+            "Generate an FCPXML timeline I can import into free Resolve from these clips.",
+        ],
+    )
+
+
+def scan_media_folder(
+    folder_path: str,
+    recursive: bool = True,
+    include_extensions: list[str] | None = None,
+    include_durations: bool = False,
+    max_files: int = 500,
+) -> dict[str, Any]:
+    folder = Path(folder_path).expanduser().resolve()
+    if not folder.exists():
+        return _error("Folder does not exist.", folder_path=str(folder))
+    if not folder.is_dir():
+        return _error("folder_path must be a directory.", folder_path=str(folder))
+    if max_files < 1 or max_files > 5000:
+        return _error("max_files must be between 1 and 5000.", max_files=max_files)
+
+    extensions = {
+        ext.lower() if ext.startswith(".") else f".{ext.lower()}"
+        for ext in (include_extensions or sorted(DEFAULT_MEDIA_EXTENSIONS))
+    }
+    iterator = folder.rglob("*") if recursive else folder.iterdir()
+    files: list[dict[str, Any]] = []
+    skipped_count = 0
+    for path in sorted(iterator):
+        if not path.is_file() or path.suffix.lower() not in extensions:
+            continue
+        if len(files) >= max_files:
+            skipped_count += 1
+            continue
+        payload: dict[str, Any] = {
+            "path": str(path),
+            "name": path.name,
+            "stem": path.stem,
+            "extension": path.suffix.lower(),
+            "kind": _media_kind(str(path)),
+            "size_bytes": path.stat().st_size,
+        }
+        if include_durations and payload["kind"] in {"video", "audio"}:
+            payload["duration_seconds"] = _duration_from_ffprobe(str(path))
+        files.append(payload)
+
+    counts = {"video": 0, "audio": 0, "image": 0, "unknown": 0}
+    for item in files:
+        counts[item["kind"]] = counts.get(item["kind"], 0) + 1
+
+    return _ok(
+        folder_path=str(folder),
+        recursive=recursive,
+        include_extensions=sorted(extensions),
+        include_durations=include_durations,
+        max_files=max_files,
+        returned_count=len(files),
+        skipped_count=skipped_count,
+        counts=counts,
+        files=files,
+    )
+
+
+def generate_fcpxml_timeline(
+    name: str,
+    media_paths: list[str],
+    output_path: str | None = None,
+    frame_rate: int = 24,
+    clip_duration_seconds: float = 5.0,
+    width: int = 1920,
+    height: int = 1080,
+    markers: list[dict[str, Any]] | None = None,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    if frame_rate <= 0 or frame_rate > 240:
+        return _error("frame_rate must be between 1 and 240.", frame_rate=frame_rate)
+    if clip_duration_seconds <= 0:
+        return _error("clip_duration_seconds must be greater than 0.", clip_duration_seconds=clip_duration_seconds)
+    if width <= 0 or height <= 0:
+        return _error("width and height must be positive.", width=width, height=height)
+
+    expanded_paths = _expand_paths(media_paths)
+    report = _path_report(expanded_paths)
+    destination = _output_path(output_path, name, ".fcpxml")
+    clip_duration_frames = _seconds_to_frames(clip_duration_seconds, frame_rate)
+    total_duration_frames = clip_duration_frames * len(expanded_paths)
+    plan = {
+        "action": "generate_fcpxml_timeline",
+        "mode": "free_interchange",
+        "timeline_name": name,
+        "output_path": str(destination),
+        "media_paths": expanded_paths,
+        "frame_rate": frame_rate,
+        "clip_duration_seconds": clip_duration_seconds,
+        "width": width,
+        "height": height,
+        "markers": markers or [],
+        **report,
+    }
+    if dry_run:
+        return _ok(dry_run=True, plan=plan)
+    if report["missing_paths"]:
+        return _error("Cannot generate FCPXML with missing media files.", **plan)
+
+    fcpxml = ET.Element("fcpxml", {"version": "1.10"})
+    resources = ET.SubElement(fcpxml, "resources")
+    ET.SubElement(
+        resources,
+        "format",
+        {
+            "id": "r1",
+            "name": f"FFVideoFormat{height}p{frame_rate}",
+            "frameDuration": _fcpx_time(1, frame_rate),
+            "width": str(width),
+            "height": str(height),
+            "colorSpace": "1-1-1 (Rec. 709)",
+        },
+    )
+    for index, media_path in enumerate(expanded_paths, start=2):
+        media_file = Path(media_path)
+        ET.SubElement(
+            resources,
+            "asset",
+            {
+                "id": f"r{index}",
+                "name": media_file.stem,
+                "src": _file_uri(media_path),
+                "start": "0s",
+                "duration": _fcpx_time(clip_duration_frames, frame_rate),
+                "hasVideo": "1",
+                "hasAudio": "1",
+                "audioSources": "1",
+                "audioChannels": "2",
+                "audioRate": "48000",
+            },
+        )
+
+    library = ET.SubElement(fcpxml, "library")
+    event = ET.SubElement(library, "event", {"name": "Hermes Interchange"})
+    project = ET.SubElement(event, "project", {"name": name})
+    sequence = ET.SubElement(
+        project,
+        "sequence",
+        {
+            "format": "r1",
+            "duration": _fcpx_time(total_duration_frames, frame_rate),
+            "tcStart": "0s",
+            "tcFormat": "NDF",
+        },
+    )
+    spine = ET.SubElement(sequence, "spine")
+    normalized_markers = markers or []
+    for index, media_path in enumerate(expanded_paths, start=2):
+        offset_frames = (index - 2) * clip_duration_frames
+        asset_clip = ET.SubElement(
+            spine,
+            "asset-clip",
+            {
+                "name": Path(media_path).stem,
+                "ref": f"r{index}",
+                "offset": _fcpx_time(offset_frames, frame_rate),
+                "start": "0s",
+                "duration": _fcpx_time(clip_duration_frames, frame_rate),
+            },
+        )
+        for marker in normalized_markers:
+            marker_frame = int(marker.get("frame", 0))
+            if offset_frames <= marker_frame < offset_frames + clip_duration_frames:
+                ET.SubElement(
+                    asset_clip,
+                    "marker",
+                    {
+                        "start": _fcpx_time(marker_frame - offset_frames, frame_rate),
+                        "value": str(marker.get("name", "Marker")),
+                        "note": str(marker.get("note", "")),
+                    },
+                )
+
+    tree = ET.ElementTree(fcpxml)
+    ET.indent(tree, space="  ")
+    tree.write(destination, encoding="utf-8", xml_declaration=True)
+    text = destination.read_text(encoding="utf-8")
+    destination.write_text(text.replace("?>\n", "?>\n<!DOCTYPE fcpxml>\n", 1), encoding="utf-8")
+
+    return _ok(
+        dry_run=False,
+        artifact_type="fcpxml",
+        import_instructions=[
+            "Open free DaVinci Resolve.",
+            "Use File > Import > Timeline > Import AAF, EDL, XML...",
+            f"Select {destination}.",
+        ],
+        **plan,
+    )
+
+
+def generate_marker_csv(
+    markers: list[dict[str, Any]],
+    output_path: str | None = None,
+    name: str = "Hermes Markers",
+    frame_rate: int = 24,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    destination = _output_path(output_path, name, ".markers.csv")
+    normalized = []
+    for marker in markers:
+        frame = int(marker.get("frame", 0))
+        normalized.append(
+            {
+                "frame": max(0, frame),
+                "timecode_seconds": f"{max(0, frame) / frame_rate:.3f}",
+                "name": str(marker.get("name", "Marker")),
+                "color": str(marker.get("color", "Blue")),
+                "note": str(marker.get("note", "")),
+                "duration": int(marker.get("duration", 1)),
+            }
+        )
+    plan = {
+        "action": "generate_marker_csv",
+        "mode": "free_interchange",
+        "output_path": str(destination),
+        "name": name,
+        "frame_rate": frame_rate,
+        "markers": normalized,
+    }
+    if dry_run:
+        return _ok(dry_run=True, plan=plan)
+
+    with destination.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=["frame", "timecode_seconds", "name", "color", "note", "duration"],
+        )
+        writer.writeheader()
+        writer.writerows(normalized)
+
+    return _ok(
+        dry_run=False,
+        artifact_type="marker_csv",
+        import_instructions=[
+            "Use this CSV as a marker manifest for free Resolve workflows.",
+            "For live marker insertion, use Resolve Studio or an in-Resolve helper script.",
+        ],
+        **plan,
+    )
+
+
+def _candidate_app_paths(variant: str) -> list[Path]:
+    if variant == "resolve":
+        return RESOLVE_APP_PATHS
+    if variant == "studio":
+        return STUDIO_APP_PATHS
+    if variant == "beta":
+        return [*STUDIO_21_APP_PATHS, *RESOLVE_21_APP_PATHS]
+    if variant == "resolve20":
+        return RESOLVE_20_APP_PATHS
+    if variant == "studio20":
+        return STUDIO_20_APP_PATHS
+    if variant == "resolve21":
+        return RESOLVE_21_APP_PATHS
+    if variant == "studio21":
+        return STUDIO_21_APP_PATHS
+    return [*STUDIO_APP_PATHS, *RESOLVE_APP_PATHS]
+
+
+def launch_resolve(
+    variant: str = "auto",
+    wait_seconds: int = 8,
+    app_path: str | None = None,
+) -> dict[str, Any]:
+    valid_variants = {
+        "auto",
+        "resolve",
+        "studio",
+        "beta",
+        "resolve20",
+        "studio20",
+        "resolve21",
+        "studio21",
+    }
+    if variant not in valid_variants:
+        return _error(
+            "variant must be one of: auto, resolve, studio, beta, resolve20, studio20, resolve21, studio21.",
+            variant=variant,
+        )
+    if wait_seconds < 0 or wait_seconds > 120:
+        return _error("wait_seconds must be between 0 and 120.", wait_seconds=wait_seconds)
+
+    command = None
+    selected_app_path = None
+    if app_path:
+        explicit_path = Path(app_path).expanduser().resolve()
+        if not explicit_path.exists():
+            return _error("Explicit app_path does not exist.", app_path=str(explicit_path))
+        if explicit_path.suffix != ".app":
+            return _error("Explicit app_path must point to a macOS .app bundle.", app_path=str(explicit_path))
+        selected_app_path = str(explicit_path)
+        command = ["open", selected_app_path]
+    else:
+        for candidate in _candidate_app_paths(variant):
+            if candidate.exists():
+                selected_app_path = str(candidate)
+                command = ["open", selected_app_path]
+                break
+
+    if command is None:
+        app_name = "DaVinci Resolve Studio" if variant in {"studio", "studio20", "studio21"} else "DaVinci Resolve"
+        command = ["open", "-a", app_name]
+
+    try:
+        completed = subprocess.run(command, check=False, capture_output=True, text=True)
+    except Exception as exc:
+        return _error(
+            "Failed to start the macOS open command.",
+            launch_error=f"{type(exc).__name__}: {exc}",
+            command=command,
+            app_path=selected_app_path,
+        )
+
+    if completed.returncode != 0:
+        return _error(
+            "macOS open command did not launch Resolve.",
+            command=command,
+            app_path=selected_app_path,
+            returncode=completed.returncode,
+            stderr=completed.stderr.strip(),
+            stdout=completed.stdout.strip(),
+        )
+
+    if wait_seconds:
+        time.sleep(wait_seconds)
+
+    post_launch_probe = probe()
+    return _ok(
+        launched=True,
+        command=command,
+        app_path=selected_app_path,
+        variant=variant,
+        wait_seconds=wait_seconds,
+        post_launch_probe=post_launch_probe,
+    )
+
+
+def project_summary() -> dict[str, Any]:
+    resolve, error = _connect()
+    if error:
+        return error
+
+    project, error = _current_project(resolve)
+    if error:
+        return error
+
+    timeline = project.GetCurrentTimeline()
+    timeline_count = project.GetTimelineCount()
+    timeline_names = []
+    for index in range(1, timeline_count + 1):
+        item = project.GetTimelineByIndex(index)
+        if item:
+            timeline_names.append(item.GetName())
+
+    timeline_payload = None
+    if timeline:
+        markers = timeline.GetMarkers() or {}
+        timeline_payload = {
+            "name": timeline.GetName(),
+            "start_frame": timeline.GetStartFrame(),
+            "end_frame": timeline.GetEndFrame(),
+            "setting_timeline_frame_rate": timeline.GetSetting("timelineFrameRate"),
+            "marker_count": len(markers),
+        }
+
+    return _ok(
+        project_name=project.GetName(),
+        timeline_count=timeline_count,
+        timelines=timeline_names,
+        current_timeline=timeline_payload,
+    )
+
+
+def import_media(
+    paths: list[str],
+    bin_name: str | None = None,
+    dry_run: bool = True,
+    confirm: bool = False,
+) -> dict[str, Any]:
+    guard = _guard_mutation(dry_run, confirm, "Importing media")
+    if guard:
+        return guard
+
+    expanded_paths = _expand_paths(paths)
+    report = _path_report(expanded_paths)
+    plan = {
+        "action": "import_media",
+        "paths": expanded_paths,
+        "bin_name": bin_name,
+        **report,
+    }
+    if dry_run:
+        return _ok(dry_run=True, plan=plan)
+    if report["missing_paths"]:
+        return _error("Cannot import missing media files.", **plan)
+
+    resolve, error = _connect()
+    if error:
+        return error
+
+    project, error = _current_project(resolve)
+    if error:
+        return error
+
+    media_pool, error = _media_pool(project)
+    if error:
+        return error
+
+    if bin_name:
+        root_folder = media_pool.GetRootFolder()
+        target = media_pool.AddSubFolder(root_folder, bin_name)
+        if target:
+            media_pool.SetCurrentFolder(target)
+
+    imported = media_pool.ImportMedia(expanded_paths) or []
+    return _ok(
+        dry_run=False,
+        imported_count=len(imported),
+        imported_names=[item.GetName() for item in imported if item],
+        **plan,
+    )
+
+
+def create_timeline(
+    name: str,
+    media_paths: list[str] | None = None,
+    dry_run: bool = True,
+    confirm: bool = False,
+) -> dict[str, Any]:
+    guard = _guard_mutation(dry_run, confirm, "Creating a timeline")
+    if guard:
+        return guard
+
+    expanded_paths = _expand_paths(media_paths or [])
+    report = _path_report(expanded_paths)
+    plan = {
+        "action": "create_timeline",
+        "name": name,
+        "media_paths": expanded_paths,
+        **report,
+    }
+    if dry_run:
+        return _ok(dry_run=True, plan=plan)
+    if report["missing_paths"]:
+        return _error("Cannot create seeded timeline with missing media files.", **plan)
+
+    resolve, error = _connect()
+    if error:
+        return error
+
+    project, error = _current_project(resolve)
+    if error:
+        return error
+
+    media_pool, error = _media_pool(project)
+    if error:
+        return error
+
+    media_items = media_pool.ImportMedia(expanded_paths) if expanded_paths else []
+    if media_items:
+        timeline = media_pool.CreateTimelineFromClips(name, media_items)
+    else:
+        timeline = media_pool.CreateEmptyTimeline(name)
+
+    if not timeline:
+        return _error("Resolve did not create the timeline.", **plan)
+
+    return _ok(dry_run=False, timeline_name=timeline.GetName(), **plan)
+
+
+def append_to_current_timeline(
+    media_paths: list[str],
+    dry_run: bool = True,
+    confirm: bool = False,
+) -> dict[str, Any]:
+    guard = _guard_mutation(dry_run, confirm, "Appending media to the current timeline")
+    if guard:
+        return guard
+
+    expanded_paths = _expand_paths(media_paths)
+    report = _path_report(expanded_paths)
+    plan = {
+        "action": "append_to_current_timeline",
+        "media_paths": expanded_paths,
+        **report,
+    }
+    if dry_run:
+        return _ok(dry_run=True, plan=plan)
+    if report["missing_paths"]:
+        return _error("Cannot append missing media files.", **plan)
+
+    resolve, error = _connect()
+    if error:
+        return error
+
+    project, error = _current_project(resolve)
+    if error:
+        return error
+
+    if not project.GetCurrentTimeline():
+        return _error("No current timeline is active.", **plan)
+
+    media_pool, error = _media_pool(project)
+    if error:
+        return error
+
+    media_items = media_pool.ImportMedia(expanded_paths) or []
+    appended = media_pool.AppendToTimeline(media_items) or []
+    return _ok(
+        dry_run=False,
+        imported_count=len(media_items),
+        appended_count=len(appended),
+        appended_names=[item.GetName() for item in media_items if item],
+        **plan,
+    )
+
+
+def add_timeline_marker(
+    frame: int,
+    name: str,
+    color: str = "Blue",
+    note: str = "",
+    duration: int = 1,
+    dry_run: bool = True,
+    confirm: bool = False,
+) -> dict[str, Any]:
+    guard = _guard_mutation(dry_run, confirm, "Adding a timeline marker")
+    if guard:
+        return guard
+
+    plan = {
+        "action": "add_timeline_marker",
+        "frame": frame,
+        "color": color,
+        "name": name,
+        "note": note,
+        "duration": duration,
+    }
+    if dry_run:
+        return _ok(dry_run=True, plan=plan)
+
+    resolve, error = _connect()
+    if error:
+        return error
+
+    project, error = _current_project(resolve)
+    if error:
+        return error
+
+    timeline = project.GetCurrentTimeline()
+    if not timeline:
+        return _error("No current timeline is active.", **plan)
+
+    added = timeline.AddMarker(frame, color, name, note, duration, "")
+    if not added:
+        return _error("Resolve did not add the marker.", **plan)
+
+    return _ok(dry_run=False, added=True, **plan)
+
+
+def create_scripted_timeline(
+    name: str,
+    clips: list[dict[str, Any]],
+    music_paths: list[str] | None = None,
+    markers: list[dict[str, Any]] | None = None,
+    bin_name: str | None = "Hermes Edit",
+    dry_run: bool = True,
+    confirm: bool = False,
+) -> dict[str, Any]:
+    guard = _guard_mutation(dry_run, confirm, "Creating a scripted timeline")
+    if guard:
+        return guard
+    if not clips:
+        return _error("clips must contain at least one clip plan item.")
+
+    expanded_clip_paths = _expand_paths([str(clip["path"]) for clip in clips if clip.get("path")])
+    expanded_music_paths = _expand_paths(music_paths or [])
+    all_paths = [*expanded_clip_paths, *expanded_music_paths]
+    report = _path_report(all_paths)
+    normalized_clips: list[dict[str, Any]] = []
+    for index, clip in enumerate(clips):
+        path = str(Path(str(clip.get("path", ""))).expanduser().resolve())
+        clip_plan: dict[str, Any] = {
+            "index": index,
+            "path": path,
+            "name": clip.get("name") or Path(path).stem,
+            "start_frame": int(clip.get("start_frame", 0)),
+            "end_frame": int(clip["end_frame"]) if clip.get("end_frame") is not None else None,
+            "record_frame": int(clip["record_frame"]) if clip.get("record_frame") is not None else None,
+            "media_type": clip.get("media_type"),
+            "track_index": int(clip["track_index"]) if clip.get("track_index") is not None else None,
+            "note": clip.get("note", ""),
+        }
+        if clip_plan["start_frame"] < 0:
+            return _error("clip start_frame cannot be negative.", clip=clip_plan)
+        if clip_plan["end_frame"] is not None and clip_plan["end_frame"] <= clip_plan["start_frame"]:
+            return _error("clip end_frame must be greater than start_frame.", clip=clip_plan)
+        normalized_clips.append(clip_plan)
+
+    normalized_music = [
+        {
+            "path": path,
+            "name": Path(path).stem,
+            "media_type": "audio",
+            "track_index": 1,
+        }
+        for path in expanded_music_paths
+    ]
+    plan = {
+        "action": "create_scripted_timeline",
+        "mode": "studio_live_control",
+        "name": name,
+        "bin_name": bin_name,
+        "clips": normalized_clips,
+        "music": normalized_music,
+        "markers": markers or [],
+        **report,
+    }
+    if dry_run:
+        return _ok(dry_run=True, plan=plan)
+    if report["missing_paths"]:
+        return _error("Cannot create scripted timeline with missing media files.", **plan)
+
+    resolve, error = _connect()
+    if error:
+        return error
+
+    project, error = _current_project(resolve)
+    if error:
+        return error
+
+    media_pool, error = _media_pool(project)
+    if error:
+        return error
+
+    if bin_name:
+        root_folder = media_pool.GetRootFolder()
+        target = media_pool.AddSubFolder(root_folder, bin_name)
+        if target:
+            media_pool.SetCurrentFolder(target)
+
+    imported_items = media_pool.ImportMedia(all_paths) or []
+    item_by_path = _make_path_item_map(imported_items, all_paths)
+    timeline = media_pool.CreateEmptyTimeline(name)
+    if not timeline:
+        return _error("Resolve did not create the scripted timeline.", **plan)
+    project.SetCurrentTimeline(timeline)
+
+    appended_count = 0
+    failed_clips: list[dict[str, Any]] = []
+    append_payloads: list[dict[str, Any]] = []
+    for clip in normalized_clips:
+        item = item_by_path.get(clip["path"])
+        if not item:
+            failed_clips.append({"path": clip["path"], "reason": "media item unavailable after import"})
+            continue
+        payload: dict[str, Any] = {
+            "mediaPoolItem": item,
+            "startFrame": clip["start_frame"],
+        }
+        if clip["end_frame"] is not None:
+            payload["endFrame"] = clip["end_frame"]
+        media_type = _media_type_value(clip.get("media_type"))
+        if media_type is not None:
+            payload["mediaType"] = media_type
+        if clip["track_index"] is not None:
+            payload["trackIndex"] = clip["track_index"]
+        if clip["record_frame"] is not None:
+            payload["recordFrame"] = clip["record_frame"]
+        append_payloads.append(payload)
+
+    if append_payloads:
+        appended = media_pool.AppendToTimeline(append_payloads) or []
+        appended_count += len(appended)
+
+    music_appended_count = 0
+    for music_path in expanded_music_paths:
+        item = item_by_path.get(music_path)
+        if not item:
+            failed_clips.append({"path": music_path, "reason": "music item unavailable after import"})
+            continue
+        payload = {"mediaPoolItem": item, "mediaType": 2, "trackIndex": 1}
+        appended = media_pool.AppendToTimeline([payload]) or []
+        music_appended_count += len(appended)
+
+    added_markers = _add_markers_to_timeline(timeline, markers)
+
+    return _ok(
+        dry_run=False,
+        timeline_name=timeline.GetName(),
+        imported_count=len(imported_items),
+        appended_count=appended_count,
+        music_appended_count=music_appended_count,
+        failed_clips=failed_clips,
+        added_markers=added_markers,
+        **plan,
+    )
+
+
+def render_timeline(
+    target_dir: str,
+    custom_name: str,
+    preset_name: str | None = None,
+    render_format: str | None = "mov",
+    render_codec: str | None = "H264",
+    render_settings: dict[str, Any] | None = None,
+    start_render: bool = True,
+    dry_run: bool = True,
+    confirm: bool = False,
+) -> dict[str, Any]:
+    guard = _guard_mutation(dry_run, confirm, "Rendering the current timeline")
+    if guard:
+        return guard
+
+    target = Path(target_dir).expanduser().resolve()
+    settings = dict(render_settings or {})
+    settings.update({"TargetDir": str(target), "CustomName": custom_name})
+    plan = {
+        "action": "render_timeline",
+        "mode": "studio_live_control",
+        "target_dir": str(target),
+        "custom_name": custom_name,
+        "preset_name": preset_name,
+        "render_format": render_format,
+        "render_codec": render_codec,
+        "render_settings": settings,
+        "start_render": start_render,
+    }
+    if dry_run:
+        return _ok(dry_run=True, plan=plan)
+
+    target.mkdir(parents=True, exist_ok=True)
+    resolve, error = _connect()
+    if error:
+        return error
+    project, error = _current_project(resolve)
+    if error:
+        return error
+    if not project.GetCurrentTimeline():
+        return _error("No current timeline is active.", **plan)
+
+    preset_loaded = None
+    if preset_name:
+        preset_loaded = bool(project.LoadRenderPreset(preset_name))
+    format_codec_set = None
+    if render_format and render_codec:
+        format_codec_set = bool(project.SetCurrentRenderFormatAndCodec(render_format, render_codec))
+    render_settings_set = bool(project.SetRenderSettings(settings))
+    job_id = project.AddRenderJob()
+    if not job_id:
+        return _error(
+            "Resolve did not create a render job.",
+            preset_loaded=preset_loaded,
+            format_codec_set=format_codec_set,
+            render_settings_set=render_settings_set,
+            **plan,
+        )
+
+    started = False
+    if start_render:
+        started = bool(project.StartRendering(job_id))
+
+    return _ok(
+        dry_run=False,
+        job_id=job_id,
+        started=started,
+        preset_loaded=preset_loaded,
+        format_codec_set=format_codec_set,
+        render_settings_set=render_settings_set,
+        **plan,
+    )
+
+
+def render_status(job_id: str | None = None) -> dict[str, Any]:
+    resolve, error = _connect()
+    if error:
+        return error
+    project, error = _current_project(resolve)
+    if error:
+        return error
+
+    status = project.GetRenderJobStatus(job_id) if job_id else None
+    jobs = project.GetRenderJobList() or []
+    return _ok(
+        job_id=job_id,
+        job_status=status,
+        is_rendering=bool(project.IsRenderingInProgress()),
+        render_jobs=jobs,
+    )

--- a/plugins/video/davinci_resolve/resolve_bridge/operations.py
+++ b/plugins/video/davinci_resolve/resolve_bridge/operations.py
@@ -534,7 +534,7 @@ def generate_fcpxml_timeline(
     width: int = 1920,
     height: int = 1080,
     markers: list[dict[str, Any]] | None = None,
-    dry_run: bool = False,
+    dry_run: bool = True,
 ) -> dict[str, Any]:
     if frame_rate <= 0 or frame_rate > 240:
         return _error("frame_rate must be between 1 and 240.", frame_rate=frame_rate)
@@ -663,7 +663,7 @@ def generate_marker_csv(
     output_path: str | None = None,
     name: str = "Hermes Markers",
     frame_rate: int = 24,
-    dry_run: bool = False,
+    dry_run: bool = True,
 ) -> dict[str, Any]:
     destination = _output_path(output_path, name, ".markers.csv")
     normalized = []

--- a/plugins/video/davinci_resolve/resolve_bridge/operations.py
+++ b/plugins/video/davinci_resolve/resolve_bridge/operations.py
@@ -104,38 +104,58 @@ def _error(message: str, **payload: Any) -> dict[str, Any]:
     return {"ok": False, "error": message, **payload}
 
 
-def _add_existing_module_paths() -> list[str]:
-    added: list[str] = []
+def _resolve_module_search_paths() -> list[Path]:
+    paths: list[Path] = []
     env_api = os.environ.get("RESOLVE_SCRIPT_API")
     if env_api:
         api_modules = Path(env_api).expanduser() / "Modules"
         if api_modules.exists():
-            sys.path.insert(0, str(api_modules))
-            added.append(str(api_modules))
+            paths.append(api_modules)
 
     for path in COMMON_MODULE_PATHS:
         if path.exists():
-            sys.path.insert(0, str(path))
-            added.append(str(path))
+            paths.append(path)
 
-    return added
+    return paths
 
 
 def _import_resolve_module() -> tuple[Any | None, str | None, list[str]]:
-    added_paths = _add_existing_module_paths()
     try:
-        return importlib.import_module("DaVinciResolveScript"), None, added_paths
-    except Exception as exc:
-        return None, f"{type(exc).__name__}: {exc}", added_paths
+        return importlib.import_module("DaVinciResolveScript"), None, []
+    except Exception as direct_exc:
+        direct_error = f"{type(direct_exc).__name__}: {direct_exc}"
+
+    searched_paths = _resolve_module_search_paths()
+    errors = [f"default import failed: {direct_error}"]
+    for directory in searched_paths:
+        module_path = directory / "DaVinciResolveScript.py"
+        if not module_path.exists():
+            continue
+        try:
+            spec = importlib.util.spec_from_file_location(
+                "DaVinciResolveScript",
+                module_path,
+            )
+            if spec is None or spec.loader is None:
+                errors.append(f"{module_path}: could not create import spec")
+                continue
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            return module, None, [str(path) for path in searched_paths]
+        except Exception as exc:
+            errors.append(f"{module_path}: {type(exc).__name__}: {exc}")
+
+    return None, "; ".join(errors), [str(path) for path in searched_paths]
 
 
 def _connect() -> tuple[Any | None, dict[str, Any] | None]:
-    module, import_error, added_paths = _import_resolve_module()
+    module, import_error, searched_paths = _import_resolve_module()
     if module is None:
         return None, _error(
             "DaVinciResolveScript could not be imported.",
             import_error=import_error,
-            added_sys_paths=added_paths,
+            added_sys_paths=[],
+            searched_module_paths=searched_paths,
         )
 
     try:
@@ -144,13 +164,15 @@ def _connect() -> tuple[Any | None, dict[str, Any] | None]:
         return None, _error(
             "DaVinci Resolve scripting module imported, but scriptapp failed.",
             resolve_error=f"{type(exc).__name__}: {exc}",
-            added_sys_paths=added_paths,
+            added_sys_paths=[],
+            searched_module_paths=searched_paths,
         )
 
     if resolve is None:
         return None, _error(
             "DaVinci Resolve is not reachable. Open Resolve and enable scripting support.",
-            added_sys_paths=added_paths,
+            added_sys_paths=[],
+            searched_module_paths=searched_paths,
         )
 
     return resolve, None
@@ -356,7 +378,7 @@ def _probe_recommendation(
 
 
 def probe() -> dict[str, Any]:
-    module, import_error, added_paths = _import_resolve_module()
+    module, import_error, searched_paths = _import_resolve_module()
     resolve_reachable = False
     resolve_error = None
     current_project = None
@@ -389,7 +411,8 @@ def probe() -> dict[str, Any]:
         },
         existing_app_paths=existing_app_paths,
         existing_module_paths=[str(path) for path in COMMON_MODULE_PATHS if path.exists()],
-        added_sys_paths=added_paths,
+        added_sys_paths=[],
+        searched_module_paths=searched_paths,
         module_imported=module is not None,
         import_error=import_error,
         resolve_reachable=resolve_reachable,

--- a/plugins/video/davinci_resolve/schemas.py
+++ b/plugins/video/davinci_resolve/schemas.py
@@ -1,0 +1,549 @@
+"""Tool schemas exposed to Hermes."""
+
+from __future__ import annotations
+
+
+DRY_RUN_FIELD = {
+    "type": "boolean",
+    "description": (
+        "When true, report the planned Resolve action without modifying the project. "
+        "Defaults to true for mutating tools."
+    ),
+    "default": True,
+}
+
+CONFIRM_FIELD = {
+    "type": "boolean",
+    "description": (
+        "Must be true when dry_run is false. This prevents accidental project changes."
+    ),
+    "default": False,
+}
+
+MEDIA_PATHS_FIELD = {
+    "type": "array",
+    "items": {"type": "string"},
+    "minItems": 1,
+    "description": "Absolute or user-relative file paths to video, audio, or image media.",
+}
+
+
+RESOLVE_PROBE = {
+    "name": "resolve_probe",
+    "description": (
+        "Read-only diagnostic for DaVinci Resolve scripting. Use before other Resolve "
+        "tools to confirm the module imports and a running Resolve app is reachable."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": False,
+    },
+}
+
+
+RESOLVE_CAPABILITIES = {
+    "name": "resolve_capabilities",
+    "description": (
+        "Return a concise operating guide for how an LLM agent should use this "
+        "DaVinci Resolve plugin, including safe workflow order and available tools."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": False,
+    },
+}
+
+
+RESOLVE_LAUNCH = {
+    "name": "resolve_launch",
+    "description": (
+        "Open DaVinci Resolve or DaVinci Resolve Studio on the local Mac, wait briefly, "
+        "and report whether the Resolve scripting API is reachable."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "variant": {
+                "type": "string",
+                "enum": [
+                    "auto",
+                    "resolve",
+                    "studio",
+                    "beta",
+                    "resolve20",
+                    "studio20",
+                    "resolve21",
+                    "studio21",
+                ],
+                "description": (
+                    "Which Resolve app to launch. Auto tries installed app paths first. "
+                    "Use app_path when multiple versions are installed with custom names."
+                ),
+                "default": "auto",
+            },
+            "app_path": {
+                "type": "string",
+                "description": (
+                    "Optional explicit path to a DaVinci Resolve .app bundle. Use this for "
+                    "side-by-side Resolve 20 and Resolve 21 beta installs."
+                ),
+            },
+            "wait_seconds": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 120,
+                "description": "Seconds to wait before checking scripting reachability.",
+                "default": 8,
+            },
+        },
+        "additionalProperties": False,
+    },
+}
+
+
+RESOLVE_PROJECT_SUMMARY = {
+    "name": "resolve_project_summary",
+    "description": (
+        "Read-only summary of the active DaVinci Resolve project, current timeline, "
+        "timeline count, frame rate, and marker count."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": False,
+    },
+}
+
+
+RESOLVE_IMPORT_MEDIA = {
+    "name": "resolve_import_media",
+    "description": (
+        "Import media files into the current DaVinci Resolve project's media pool. "
+        "Use dry_run first, then call with dry_run=false and confirm=true after the user approves."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "paths": MEDIA_PATHS_FIELD,
+            "bin_name": {
+                "type": "string",
+                "description": "Optional media pool bin name to create/use before importing.",
+            },
+            "dry_run": DRY_RUN_FIELD,
+            "confirm": CONFIRM_FIELD,
+        },
+        "required": ["paths"],
+        "additionalProperties": False,
+    },
+}
+
+
+RESOLVE_CREATE_TIMELINE = {
+    "name": "resolve_create_timeline",
+    "description": (
+        "Create a timeline in the current DaVinci Resolve project. Optionally import "
+        "and seed the timeline with media files. Defaults to dry_run=true."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string",
+                "description": "Name for the new timeline.",
+            },
+            "media_paths": MEDIA_PATHS_FIELD,
+            "dry_run": DRY_RUN_FIELD,
+            "confirm": CONFIRM_FIELD,
+        },
+        "required": ["name"],
+        "additionalProperties": False,
+    },
+}
+
+
+RESOLVE_APPEND_TO_CURRENT_TIMELINE = {
+    "name": "resolve_append_to_current_timeline",
+    "description": (
+        "Import media files if needed and append them to the active DaVinci Resolve timeline. "
+        "Use for adding footage or music to the edit. Defaults to dry_run=true."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "media_paths": MEDIA_PATHS_FIELD,
+            "dry_run": DRY_RUN_FIELD,
+            "confirm": CONFIRM_FIELD,
+        },
+        "required": ["media_paths"],
+        "additionalProperties": False,
+    },
+}
+
+
+RESOLVE_ADD_TIMELINE_MARKER = {
+    "name": "resolve_add_timeline_marker",
+    "description": (
+        "Add a marker to the current Resolve timeline at a frame number. Defaults to dry_run=true."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "frame": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Timeline frame number for the marker.",
+            },
+            "color": {
+                "type": "string",
+                "description": "Resolve marker color, for example Blue, Green, Yellow, Red, or Purple.",
+                "default": "Blue",
+            },
+            "name": {
+                "type": "string",
+                "description": "Marker name.",
+            },
+            "note": {
+                "type": "string",
+                "description": "Optional marker note.",
+                "default": "",
+            },
+            "duration": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Marker duration in frames.",
+                "default": 1,
+            },
+            "dry_run": DRY_RUN_FIELD,
+            "confirm": CONFIRM_FIELD,
+        },
+        "required": ["frame", "name"],
+        "additionalProperties": False,
+    },
+}
+
+
+MARKERS_FIELD = {
+    "type": "array",
+    "description": "Timeline markers to include in generated interchange artifacts.",
+    "items": {
+        "type": "object",
+        "properties": {
+            "frame": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Timeline frame number.",
+            },
+            "name": {
+                "type": "string",
+                "description": "Marker name.",
+            },
+            "color": {
+                "type": "string",
+                "description": "Marker color, for example Blue, Green, Yellow, Red, or Purple.",
+                "default": "Blue",
+            },
+            "note": {
+                "type": "string",
+                "description": "Optional marker note.",
+                "default": "",
+            },
+            "duration": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Duration in frames.",
+                "default": 1,
+            },
+        },
+        "required": ["frame", "name"],
+        "additionalProperties": False,
+    },
+}
+
+
+RESOLVE_GENERATE_FCPXML_TIMELINE = {
+    "name": "resolve_generate_fcpxml_timeline",
+    "description": (
+        "Generate an FCPXML timeline file for free DaVinci Resolve interchange mode. "
+        "Use this when live scripting is unavailable because the user has free Resolve."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string",
+                "description": "Timeline/project name to write into the FCPXML.",
+            },
+            "media_paths": MEDIA_PATHS_FIELD,
+            "output_path": {
+                "type": "string",
+                "description": "Optional destination .fcpxml path. Defaults to ~/Documents/Hermes Resolve Exports.",
+            },
+            "frame_rate": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 240,
+                "description": "Timeline frame rate.",
+                "default": 24,
+            },
+            "clip_duration_seconds": {
+                "type": "number",
+                "exclusiveMinimum": 0,
+                "description": "Assumed duration for each clip when creating the interchange timeline.",
+                "default": 5.0,
+            },
+            "width": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Timeline width.",
+                "default": 1920,
+            },
+            "height": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Timeline height.",
+                "default": 1080,
+            },
+            "markers": MARKERS_FIELD,
+            "dry_run": DRY_RUN_FIELD,
+        },
+        "required": ["name", "media_paths"],
+        "additionalProperties": False,
+    },
+}
+
+
+CLIP_PLAN_FIELD = {
+    "type": "array",
+    "minItems": 1,
+    "description": (
+        "Structured edit decision list generated by Hermes from the user's script. "
+        "Each item points to an imported media file and optional source/record ranges."
+    ),
+    "items": {
+        "type": "object",
+        "properties": {
+            "path": {
+                "type": "string",
+                "description": "Absolute or user-relative media path.",
+            },
+            "name": {
+                "type": "string",
+                "description": "Optional human-readable shot/beat name.",
+            },
+            "start_frame": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Source start frame for this clip. Defaults to 0.",
+                "default": 0,
+            },
+            "end_frame": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Optional source end frame. Omit to append from start_frame onward.",
+            },
+            "record_frame": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Optional timeline frame where this clip should be placed.",
+            },
+            "media_type": {
+                "type": "string",
+                "enum": ["video", "audio"],
+                "description": "Optional AppendToTimeline mediaType: video-only or audio-only.",
+            },
+            "track_index": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Optional target Resolve track index.",
+            },
+            "note": {
+                "type": "string",
+                "description": "Why Hermes selected this clip or which script beat it supports.",
+            },
+        },
+        "required": ["path"],
+        "additionalProperties": False,
+    },
+}
+
+
+RESOLVE_SCAN_MEDIA_FOLDER = {
+    "name": "resolve_scan_media_folder",
+    "description": (
+        "Scan a local folder for video, audio, and still-image media so Hermes can plan "
+        "a scripted edit from available source clips."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "folder_path": {
+                "type": "string",
+                "description": "Folder containing footage, audio, stills, or nested media folders.",
+            },
+            "recursive": {
+                "type": "boolean",
+                "description": "Whether to scan subfolders.",
+                "default": True,
+            },
+            "include_extensions": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional extension allow-list, for example ['.mov', '.mp4', '.wav'].",
+            },
+            "include_durations": {
+                "type": "boolean",
+                "description": "When true, use ffprobe if available to include approximate media durations.",
+                "default": False,
+            },
+            "max_files": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 5000,
+                "description": "Maximum number of media files to return.",
+                "default": 500,
+            },
+        },
+        "required": ["folder_path"],
+        "additionalProperties": False,
+    },
+}
+
+
+RESOLVE_CREATE_SCRIPTED_TIMELINE = {
+    "name": "resolve_create_scripted_timeline",
+    "description": (
+        "Create a DaVinci Resolve Studio timeline from a structured edit plan. Hermes "
+        "should derive the plan from the user's script, then dry-run this tool before "
+        "actual project changes."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string",
+                "description": "Timeline name.",
+            },
+            "clips": CLIP_PLAN_FIELD,
+            "music_paths": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional music/audio files to import and append as audio.",
+            },
+            "markers": MARKERS_FIELD,
+            "bin_name": {
+                "type": "string",
+                "description": "Optional media pool bin for imported edit assets.",
+                "default": "Hermes Edit",
+            },
+            "dry_run": DRY_RUN_FIELD,
+            "confirm": CONFIRM_FIELD,
+        },
+        "required": ["name", "clips"],
+        "additionalProperties": False,
+    },
+}
+
+
+RESOLVE_RENDER_TIMELINE = {
+    "name": "resolve_render_timeline",
+    "description": (
+        "Configure a render job for the current Resolve Studio timeline and optionally "
+        "start rendering a QuickTime/H.264-style output."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "target_dir": {
+                "type": "string",
+                "description": "Output folder for the rendered file.",
+            },
+            "custom_name": {
+                "type": "string",
+                "description": "Render output base filename without extension.",
+            },
+            "preset_name": {
+                "type": "string",
+                "description": "Optional Resolve render preset to load before setting render options.",
+            },
+            "render_format": {
+                "type": "string",
+                "description": "Resolve render format key. Defaults to mov.",
+                "default": "mov",
+            },
+            "render_codec": {
+                "type": "string",
+                "description": "Resolve render codec key. Defaults to H264.",
+                "default": "H264",
+            },
+            "render_settings": {
+                "type": "object",
+                "description": (
+                    "Optional Resolve SetRenderSettings dictionary. TargetDir and CustomName "
+                    "are filled from target_dir and custom_name."
+                ),
+                "additionalProperties": True,
+            },
+            "start_render": {
+                "type": "boolean",
+                "description": "When true, start the render after creating the job.",
+                "default": True,
+            },
+            "dry_run": DRY_RUN_FIELD,
+            "confirm": CONFIRM_FIELD,
+        },
+        "required": ["target_dir", "custom_name"],
+        "additionalProperties": False,
+    },
+}
+
+
+RESOLVE_RENDER_STATUS = {
+    "name": "resolve_render_status",
+    "description": "Check Resolve Studio render progress and render queue state.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "job_id": {
+                "type": "string",
+                "description": "Optional render job id returned by resolve_render_timeline.",
+            },
+        },
+        "additionalProperties": False,
+    },
+}
+
+
+RESOLVE_GENERATE_MARKER_CSV = {
+    "name": "resolve_generate_marker_csv",
+    "description": (
+        "Generate a marker CSV/manifest for free Resolve workflows when live marker "
+        "insertion is unavailable."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "markers": MARKERS_FIELD,
+            "output_path": {
+                "type": "string",
+                "description": "Optional destination CSV path. Defaults to ~/Documents/Hermes Resolve Exports.",
+            },
+            "name": {
+                "type": "string",
+                "description": "Base name for the generated marker file.",
+                "default": "Hermes Markers",
+            },
+            "frame_rate": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 240,
+                "description": "Frame rate used to calculate seconds from frame numbers.",
+                "default": 24,
+            },
+            "dry_run": DRY_RUN_FIELD,
+        },
+        "required": ["markers"],
+        "additionalProperties": False,
+    },
+}

--- a/plugins/video/davinci_resolve/tools.py
+++ b/plugins/video/davinci_resolve/tools.py
@@ -1,0 +1,94 @@
+"""Hermes tool handlers for DaVinci Resolve."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Callable
+
+try:
+    from .resolve_bridge import operations
+except ImportError:
+    from resolve_bridge import operations
+
+
+def _json_call(fn: Callable[..., dict[str, Any]], params: dict[str, Any]) -> str:
+    try:
+        return json.dumps(fn(**params), sort_keys=True)
+    except Exception as exc:
+        return json.dumps(
+            {
+                "ok": False,
+                "error": f"{type(exc).__name__}: {exc}",
+            },
+            sort_keys=True,
+        )
+
+
+def handle_probe(params, **kwargs):
+    del kwargs
+    return _json_call(lambda: operations.probe(), params or {})
+
+
+def handle_capabilities(params, **kwargs):
+    del kwargs
+    return _json_call(lambda: operations.capabilities(), params or {})
+
+
+def handle_launch(params, **kwargs):
+    del kwargs
+    return _json_call(operations.launch_resolve, params or {})
+
+
+def handle_project_summary(params, **kwargs):
+    del kwargs
+    return _json_call(lambda: operations.project_summary(), params or {})
+
+
+def handle_import_media(params, **kwargs):
+    del kwargs
+    return _json_call(operations.import_media, params or {})
+
+
+def handle_create_timeline(params, **kwargs):
+    del kwargs
+    return _json_call(operations.create_timeline, params or {})
+
+
+def handle_append_to_current_timeline(params, **kwargs):
+    del kwargs
+    return _json_call(operations.append_to_current_timeline, params or {})
+
+
+def handle_timeline_marker(params, **kwargs):
+    del kwargs
+    return _json_call(operations.add_timeline_marker, params or {})
+
+
+def handle_generate_fcpxml_timeline(params, **kwargs):
+    del kwargs
+    return _json_call(operations.generate_fcpxml_timeline, params or {})
+
+
+def handle_generate_marker_csv(params, **kwargs):
+    del kwargs
+    return _json_call(operations.generate_marker_csv, params or {})
+
+
+def handle_scan_media_folder(params, **kwargs):
+    del kwargs
+    return _json_call(operations.scan_media_folder, params or {})
+
+
+def handle_create_scripted_timeline(params, **kwargs):
+    del kwargs
+    return _json_call(operations.create_scripted_timeline, params or {})
+
+
+def handle_render_timeline(params, **kwargs):
+    del kwargs
+    return _json_call(operations.render_timeline, params or {})
+
+
+def handle_render_status(params, **kwargs):
+    del kwargs
+    return _json_call(operations.render_status, params or {})

--- a/plugins/video/davinci_resolve/tools.py
+++ b/plugins/video/davinci_resolve/tools.py
@@ -5,10 +5,7 @@ from __future__ import annotations
 import json
 from typing import Any, Callable
 
-try:
-    from .resolve_bridge import operations
-except ImportError:
-    from resolve_bridge import operations
+from .resolve_bridge import operations
 
 
 def _json_call(fn: Callable[..., dict[str, Any]], params: dict[str, Any]) -> str:

--- a/tests/test_davinci_resolve_plugin.py
+++ b/tests/test_davinci_resolve_plugin.py
@@ -176,3 +176,53 @@ def test_davinci_resolve_plugin_manager_loads_with_registry_gating(tmp_path, mon
     assert entry.toolset == "davinciresolve"
     assert entry.check_fn is not None
     assert entry.check_fn() is (platform.system() == "Darwin")
+
+
+def test_davinci_resolve_loads_through_plugin_manager():
+    """Load the plugin through the real PluginManager directory loader.
+
+    Covers the loader-level contract from review: the plugin imports as a
+    package under the ``hermes_plugins`` namespace (package-relative imports
+    resolve without any ``sys.path`` mutation), registration succeeds through
+    the real ``PluginContext``, and the plugin's ``tools.py`` submodule does
+    not shadow Hermes' top-level ``tools`` package.
+    """
+    import tools as hermes_tools
+    from hermes_cli.plugins import PluginManager, PluginManifest
+
+    for name in [
+        m for m in list(sys.modules) if m.startswith("hermes_plugins.video__davinci_resolve")
+    ]:
+        sys.modules.pop(name, None)
+
+    manager = PluginManager()
+    manifest = PluginManifest(
+        name="davinci-resolve",
+        version="1.0.0",
+        description="DaVinci Resolve integration",
+        author="",
+        requires_env=[],
+        provides_tools=[],
+        provides_hooks=[],
+        source="project",
+        path=str(PLUGIN_DIR),
+        kind="standalone",
+        key="video/davinci_resolve",
+    )
+    manager._load_plugin(manifest)
+
+    loaded = manager._plugins["video/davinci_resolve"]
+    assert loaded.error is None, f"plugin failed to load: {loaded.error}"
+    assert loaded.enabled is True
+    assert "resolve_capabilities" in loaded.tools_registered
+    assert "resolve_import_media" in loaded.tools_registered
+
+    # Imported as a namespaced package, not a bare top-level module.
+    assert loaded.module.__name__ == "hermes_plugins.video__davinci_resolve"
+    assert "hermes_plugins.video__davinci_resolve.tools" in sys.modules
+
+    # Hermes' top-level ``tools`` package is untouched by the plugin's tools.py.
+    import tools as tools_after
+
+    assert tools_after is hermes_tools
+    assert Path(tools_after.__file__).resolve() != (PLUGIN_DIR / "tools.py").resolve()

--- a/tests/test_davinci_resolve_plugin.py
+++ b/tests/test_davinci_resolve_plugin.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import platform
 import sys
 from pathlib import Path
+
+import yaml
 
 
 PLUGIN_DIR = Path(__file__).resolve().parents[1] / "plugins" / "video" / "davinci_resolve"
@@ -60,6 +63,7 @@ def test_davinci_resolve_plugin_registers_expected_tools():
         "resolve_generate_marker_csv",
     ]
     assert {tool["toolset"] for tool in ctx.tools} == {"davinciresolve"}
+    assert all(tool["check_fn"]() is (platform.system() == "Darwin") for tool in ctx.tools)
 
 
 def test_davinci_resolve_dry_run_handlers_return_json(tmp_path):
@@ -94,6 +98,39 @@ def test_davinci_resolve_dry_run_handlers_return_json(tmp_path):
     assert render["plan"]["render_codec"] == "H264"
 
 
+def test_davinci_resolve_interchange_generators_default_to_dry_run(tmp_path):
+    tools = _load_tools()
+    media = tmp_path / "clip.mp4"
+    media.write_bytes(b"not real media, but enough for path validation")
+    fcpxml_output = tmp_path / "timeline.fcpxml"
+    marker_output = tmp_path / "markers.csv"
+
+    fcpxml = json.loads(
+        tools.handle_generate_fcpxml_timeline(
+            {
+                "name": "Hermes FCPXML",
+                "media_paths": [str(media)],
+                "output_path": str(fcpxml_output),
+            }
+        )
+    )
+    markers = json.loads(
+        tools.handle_generate_marker_csv(
+            {
+                "markers": [{"frame": 0, "name": "Start"}],
+                "output_path": str(marker_output),
+            }
+        )
+    )
+
+    assert fcpxml["ok"] is True
+    assert fcpxml["dry_run"] is True
+    assert markers["ok"] is True
+    assert markers["dry_run"] is True
+    assert not fcpxml_output.exists()
+    assert not marker_output.exists()
+
+
 def test_davinci_resolve_scan_media_folder(tmp_path):
     tools = _load_tools()
     (tmp_path / "a.mov").write_bytes(b"x")
@@ -112,3 +149,30 @@ def test_davinci_resolve_scan_media_folder(tmp_path):
     assert result["returned_count"] == 1
     assert result["counts"]["video"] == 1
     assert result["files"][0]["name"] == "a.mov"
+
+
+def test_davinci_resolve_plugin_manager_loads_with_registry_gating(tmp_path, monkeypatch):
+    from hermes_cli.plugins import PluginManager
+    from tools.registry import registry
+
+    hermes_home = tmp_path / "hermes_home"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump({"plugins": {"enabled": ["video/davinci_resolve"]}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    manager = PluginManager()
+    manager.discover_and_load()
+
+    loaded = manager._plugins["video/davinci_resolve"]
+    assert loaded.enabled is True
+    assert loaded.error is None
+    assert "resolve_probe" in loaded.tools_registered
+
+    entry = registry.get_entry("resolve_probe")
+    assert entry is not None
+    assert entry.toolset == "davinciresolve"
+    assert entry.check_fn is not None
+    assert entry.check_fn() is (platform.system() == "Darwin")

--- a/tests/test_davinci_resolve_plugin.py
+++ b/tests/test_davinci_resolve_plugin.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+PLUGIN_DIR = Path(__file__).resolve().parents[1] / "plugins" / "video" / "davinci_resolve"
+
+
+def _load_plugin():
+    sys.modules.pop("davinci_resolve_plugin", None)
+    spec = importlib.util.spec_from_file_location(
+        "davinci_resolve_plugin",
+        PLUGIN_DIR / "__init__.py",
+        submodule_search_locations=[str(PLUGIN_DIR)],
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_tools():
+    plugin = _load_plugin()
+    return sys.modules[f"{plugin.__name__}.tools"]
+
+
+class _Ctx:
+    def __init__(self) -> None:
+        self.tools = []
+
+    def register_tool(self, **kwargs):
+        self.tools.append(kwargs)
+
+
+def test_davinci_resolve_plugin_registers_expected_tools():
+    plugin = _load_plugin()
+    ctx = _Ctx()
+
+    plugin.register(ctx)
+
+    names = [tool["name"] for tool in ctx.tools]
+    assert names == [
+        "resolve_capabilities",
+        "resolve_launch",
+        "resolve_probe",
+        "resolve_project_summary",
+        "resolve_import_media",
+        "resolve_create_timeline",
+        "resolve_append_to_current_timeline",
+        "resolve_add_timeline_marker",
+        "resolve_scan_media_folder",
+        "resolve_create_scripted_timeline",
+        "resolve_render_timeline",
+        "resolve_render_status",
+        "resolve_generate_fcpxml_timeline",
+        "resolve_generate_marker_csv",
+    ]
+    assert {tool["toolset"] for tool in ctx.tools} == {"davinciresolve"}
+
+
+def test_davinci_resolve_dry_run_handlers_return_json(tmp_path):
+    tools = _load_tools()
+    media = tmp_path / "clip.mp4"
+    media.write_bytes(b"not real media, but enough for path validation")
+
+    timeline = json.loads(
+        tools.handle_create_scripted_timeline(
+            {
+                "name": "Hermes Dry Run",
+                "clips": [{"path": str(media), "start_frame": 0, "end_frame": 24}],
+                "dry_run": True,
+            }
+        )
+    )
+    assert timeline["ok"] is True
+    assert timeline["dry_run"] is True
+    assert timeline["plan"]["existing_paths"] == [str(media.resolve())]
+
+    render = json.loads(
+        tools.handle_render_timeline(
+            {
+                "target_dir": str(tmp_path),
+                "custom_name": "hermes-render",
+                "dry_run": True,
+            }
+        )
+    )
+    assert render["ok"] is True
+    assert render["plan"]["render_format"] == "mov"
+    assert render["plan"]["render_codec"] == "H264"
+
+
+def test_davinci_resolve_scan_media_folder(tmp_path):
+    tools = _load_tools()
+    (tmp_path / "a.mov").write_bytes(b"x")
+    (tmp_path / "ignore.txt").write_text("ignore", encoding="utf-8")
+
+    result = json.loads(
+        tools.handle_scan_media_folder(
+            {
+                "folder_path": str(tmp_path),
+                "recursive": False,
+            }
+        )
+    )
+
+    assert result["ok"] is True
+    assert result["returned_count"] == 1
+    assert result["counts"]["video"] == 1
+    assert result["files"][0]["name"] == "a.mov"


### PR DESCRIPTION
## Summary

Adds a macOS DaVinci Resolve plugin for Hermes with two operating modes:

- DaVinci Resolve Studio live control through Resolve's Python scripting API
- Free DaVinci Resolve interchange workflows via generated FCPXML and marker CSV files

The plugin registers a `davinciresolve` toolset for probing Resolve availability, importing media, creating timelines, appending clips, adding markers, scanning media folders, building scripted edit timelines, rendering timelines, and checking render status.

## Why

DaVinci Resolve Studio exposes a local scripting API that can let Hermes help users assemble and render edits from natural-language instructions. Free Resolve does not reliably expose external live scripting, so the plugin detects that case and falls back to file-based interchange workflows instead of failing opaquely.

## Tooling added

- `resolve_capabilities`
- `resolve_launch`
- `resolve_probe`
- `resolve_project_summary`
- `resolve_import_media`
- `resolve_create_timeline`
- `resolve_append_to_current_timeline`
- `resolve_add_timeline_marker`
- `resolve_scan_media_folder`
- `resolve_create_scripted_timeline`
- `resolve_render_timeline`
- `resolve_render_status`
- `resolve_generate_fcpxml_timeline`
- `resolve_generate_marker_csv`

Mutating Studio tools default to `dry_run=true` and require `confirm=true` when `dry_run=false`.

## Validation

- `python3 -m compileall plugins/video/davinci_resolve`
- `uv run --with pytest --with pytest-xdist pytest tests/test_davinci_resolve_plugin.py -q`

The focused tests verify plugin registration, JSON handler behavior, dry-run scripted timeline/render planning, and media folder scanning without requiring DaVinci Resolve Studio to be installed.

## Notes

Live control requires DaVinci Resolve Studio on macOS with `Preferences > System > General > External scripting using: Local` enabled. Free Resolve workflows are intentionally limited to generated import artifacts.
