### PR TITLE
fix(matrix): preserve Element reply quote context

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -583,6 +583,25 @@ def _extract_matrix_reply_context(
     return stripped_body, _extract_html_matrix_reply_fallback(formatted_body)
 
 
+def _extract_matrix_event_text(event: Any) -> Optional[str]:
+    """Extract the visible body text from a Matrix event fetched by event ID."""
+    content = getattr(event, "content", None)
+    if hasattr(content, "serialize"):
+        try:
+            content = content.serialize()
+        except Exception:
+            return None
+    if not isinstance(content, dict):
+        return None
+
+    body = content.get("body")
+    if not isinstance(body, str):
+        return None
+    stripped_body, _ = _extract_matrix_reply_context(body, content.get("formatted_body"))
+    text = stripped_body.strip()
+    return text or None
+
+
 def _create_matrix_session(proxy_url: str | None):
     """Create an ``aiohttp.ClientSession`` whose proxy applies to *all* requests.
 
@@ -2726,6 +2745,37 @@ class MatrixAdapter(BasePlatformAdapter):
 
         return body, is_dm, chat_type, thread_id, display_name, source
 
+    async def _resolve_reply_context(
+        self,
+        room_id: str,
+        reply_to_event_id: str,
+        body: str,
+        raw_body: str,
+        formatted_body: Any = None,
+    ) -> tuple[str, Optional[str]]:
+        """Strip local reply fallback and best-effort resolve replied-to text."""
+        _, reply_to_text = _extract_matrix_reply_context(raw_body, formatted_body)
+        stripped_body, _ = _extract_matrix_reply_context(body, formatted_body)
+        if reply_to_text:
+            return stripped_body, reply_to_text
+
+        client = self._client
+        if not client or not hasattr(client, "get_event"):
+            return stripped_body, None
+
+        try:
+            parent_event = await client.get_event(room_id, reply_to_event_id)
+        except Exception as exc:
+            logger.debug(
+                "Matrix: could not fetch replied-to event %s in %s: %s",
+                reply_to_event_id,
+                room_id,
+                exc,
+            )
+            return stripped_body, None
+
+        return stripped_body, _extract_matrix_event_text(parent_event)
+
     async def _handle_text_message(
         self,
         room_id: str,
@@ -2763,8 +2813,13 @@ class MatrixAdapter(BasePlatformAdapter):
         if reply_to:
             formatted_body = source_content.get("formatted_body")
             raw_body = source_content.get("body", "") or ""
-            _, reply_to_text = _extract_matrix_reply_context(raw_body, formatted_body)
-            body, _ = _extract_matrix_reply_context(body, formatted_body)
+            body, reply_to_text = await self._resolve_reply_context(
+                room_id,
+                reply_to,
+                body,
+                raw_body,
+                formatted_body,
+            )
 
         # Re-run bang normalization after reply-fallback stripping so a quoted
         # reply whose actual content is a bang command (e.g. ``> quoted\n\n!model``)
@@ -2979,8 +3034,13 @@ class MatrixAdapter(BasePlatformAdapter):
         if reply_to:
             formatted_body = source_content.get("formatted_body")
             raw_body = source_content.get("body", "") or ""
-            _, reply_to_text = _extract_matrix_reply_context(raw_body, formatted_body)
-            body, _ = _extract_matrix_reply_context(body, formatted_body)
+            body, reply_to_text = await self._resolve_reply_context(
+                room_id,
+                reply_to,
+                body,
+                raw_body,
+                formatted_body,
+            )
 
         if msgtype == "m.image" and _looks_like_matrix_image_filename(body):
             body = ""

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -452,6 +452,137 @@ def _matrix_event_timestamp_seconds(event: Any) -> float:
     return ts
 
 
+_MATRIX_REPLY_SENDER_PREFIX_RE = re.compile(r"^<@[^>]+>\s*")
+
+
+class _MatrixReplyHTMLParser(HTMLParser):
+    """Extract text from Element's ``<mx-reply>`` HTML fallback block."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self._depth = 0
+        self._parts: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        tag = tag.lower()
+        if tag == "mx-reply":
+            self._depth += 1
+            return
+        if self._depth and tag in {"br", "div", "p"}:
+            self._parts.append("\n")
+
+    def handle_endtag(self, tag: str) -> None:
+        tag = tag.lower()
+        if self._depth and tag in {"blockquote", "div", "p"}:
+            self._parts.append("\n")
+        if tag == "mx-reply" and self._depth:
+            self._depth -= 1
+
+    def handle_data(self, data: str) -> None:
+        if self._depth and data:
+            self._parts.append(data)
+
+    def text(self) -> str:
+        return "".join(self._parts)
+
+
+def _clean_matrix_reply_quote_text(text: str) -> Optional[str]:
+    """Normalize Matrix reply fallback text to just the quoted message."""
+    lines = str(text or "").replace("\r\n", "\n").replace("\r", "\n").split("\n")
+    lines = [line.strip() for line in lines]
+    while lines and not lines[0]:
+        lines.pop(0)
+    while lines and not lines[-1]:
+        lines.pop()
+    if not lines:
+        return None
+
+    # Formatted Element replies render the metadata as the first line:
+    # "In reply to Alice".  The quoted body starts after the following <br>.
+    if lines and lines[0].lower().startswith("in reply to"):
+        lines = lines[1:]
+        while lines and not lines[0]:
+            lines.pop(0)
+        if not lines:
+            return None
+
+    # Plain Matrix fallbacks start with "> <@sender:server> quoted text".
+    lines[0] = _MATRIX_REPLY_SENDER_PREFIX_RE.sub("", lines[0]).strip()
+    while lines and not lines[0]:
+        lines.pop(0)
+    quote = "\n".join(lines).strip()
+    return quote or None
+
+
+def _extract_plain_matrix_reply_fallback(body: str) -> tuple[str, Optional[str]]:
+    """Return ``(body_without_reply_fallback, quoted_text)`` for Matrix replies.
+
+    Matrix reply events include a plain-text fallback that starts with quoted
+    ``>`` lines, followed by a blank separator and then the user's real message.
+    The adapter must strip the fallback from the trigger text while preserving
+    the quoted text as ``MessageEvent.reply_to_text`` for gateway context
+    injection.
+    """
+    body = str(body or "")
+    if not body.startswith(">"):
+        return body, None
+
+    lines = body.split("\n")
+    quote_lines: list[str] = []
+    body_start_index: Optional[int] = None
+    for idx, line in enumerate(lines):
+        if line.startswith("> "):
+            quote_lines.append(line[2:])
+            continue
+        if line == ">":
+            quote_lines.append("")
+            continue
+        if line == "":
+            body_start_index = idx + 1
+            break
+        # A user can legitimately start a Matrix reply with a Markdown
+        # blockquote.  Only strip when the standard blank separator exists.
+        return body, None
+
+    if body_start_index is None:
+        return body, None
+
+    stripped_body = "\n".join(lines[body_start_index:])
+    if not stripped_body:
+        return body, None
+    quote_text = _clean_matrix_reply_quote_text("\n".join(quote_lines))
+    return stripped_body, quote_text
+
+
+def _extract_html_matrix_reply_fallback(formatted_body: Any) -> Optional[str]:
+    """Extract quote text from Element's rich ``<mx-reply>`` fallback."""
+    if not isinstance(formatted_body, str) or "<mx-reply" not in formatted_body.lower():
+        return None
+    parser = _MatrixReplyHTMLParser()
+    try:
+        parser.feed(formatted_body)
+        parser.close()
+    except Exception:
+        return None
+    return _clean_matrix_reply_quote_text(parser.text())
+
+
+def _extract_matrix_reply_context(
+    body: str,
+    formatted_body: Any = None,
+) -> tuple[str, Optional[str]]:
+    """Strip Matrix reply fallback from ``body`` and return quoted text.
+
+    Prefer the plain fallback because it is what Element shows as text and it
+    preserves line breaks exactly.  Fall back to the rich ``<mx-reply>`` block
+    when a client sends only the HTML fallback.
+    """
+    stripped_body, quote_text = _extract_plain_matrix_reply_fallback(body)
+    if quote_text:
+        return stripped_body, quote_text
+    return stripped_body, _extract_html_matrix_reply_fallback(formatted_body)
+
+
 def _create_matrix_session(proxy_url: str | None):
     """Create an ``aiohttp.ClientSession`` whose proxy applies to *all* requests.
 
@@ -2624,25 +2755,16 @@ class MatrixAdapter(BasePlatformAdapter):
 
         # Reply-to detection.
         reply_to = None
+        reply_to_text = None
         in_reply_to = relates_to.get("m.in_reply_to", {})
         if in_reply_to:
             reply_to = in_reply_to.get("event_id")
 
-        # Strip reply fallback from body.
-        if reply_to and body.startswith("> "):
-            lines = body.split("\n")
-            stripped = []
-            past_fallback = False
-            for line in lines:
-                if not past_fallback:
-                    if line.startswith("> ") or line == ">":
-                        continue
-                    if line == "":
-                        past_fallback = True
-                        continue
-                    past_fallback = True
-                stripped.append(line)
-            body = "\n".join(stripped) if stripped else body
+        if reply_to:
+            formatted_body = source_content.get("formatted_body")
+            raw_body = source_content.get("body", "") or ""
+            _, reply_to_text = _extract_matrix_reply_context(raw_body, formatted_body)
+            body, _ = _extract_matrix_reply_context(body, formatted_body)
 
         # Re-run bang normalization after reply-fallback stripping so a quoted
         # reply whose actual content is a bang command (e.g. ``> quoted\n\n!model``)
@@ -2660,6 +2782,7 @@ class MatrixAdapter(BasePlatformAdapter):
             raw_message=source_content,
             message_id=event_id,
             reply_to_message_id=reply_to,
+            reply_to_text=reply_to_text,
         )
 
         if msg_type == MessageType.TEXT and self._text_batch_delay_seconds > 0:
@@ -2848,6 +2971,17 @@ class MatrixAdapter(BasePlatformAdapter):
             return
         body, is_dm, chat_type, thread_id, display_name, source = ctx
 
+        reply_to = None
+        reply_to_text = None
+        in_reply_to = relates_to.get("m.in_reply_to", {})
+        if in_reply_to:
+            reply_to = in_reply_to.get("event_id")
+        if reply_to:
+            formatted_body = source_content.get("formatted_body")
+            raw_body = source_content.get("body", "") or ""
+            _, reply_to_text = _extract_matrix_reply_context(raw_body, formatted_body)
+            body, _ = _extract_matrix_reply_context(body, formatted_body)
+
         if msgtype == "m.image" and _looks_like_matrix_image_filename(body):
             body = ""
 
@@ -2867,6 +3001,8 @@ class MatrixAdapter(BasePlatformAdapter):
             message_id=event_id,
             media_urls=media_urls,
             media_types=media_types,
+            reply_to_message_id=reply_to,
+            reply_to_text=reply_to_text,
         )
 
         await self.handle_message(msg_event)
@@ -3277,6 +3413,14 @@ class MatrixAdapter(BasePlatformAdapter):
                     f"{existing.text}\n{event.text}" if existing.text else event.text
                 )
             existing._last_chunk_len = chunk_len  # type: ignore[attr-defined]
+            if event.reply_to_message_id:
+                # Preserve quote context from a later message in the batch.
+                # Matrix reply fallbacks have already been stripped from
+                # event.text, so dropping these fields would make the
+                # gateway's generic reply-to injection impossible.
+                existing.reply_to_message_id = event.reply_to_message_id
+            if event.reply_to_text:
+                existing.reply_to_text = event.reply_to_text
             if event.media_urls:
                 existing.media_urls.extend(event.media_urls)
                 existing.media_types.extend(event.media_types)

--- a/tests/gateway/test_matrix_mention.py
+++ b/tests/gateway/test_matrix_mention.py
@@ -303,6 +303,7 @@ async def test_html_mx_reply_sets_reply_to_text_when_plain_body_has_no_fallback(
     monkeypatch.setenv("MATRIX_AUTO_THREAD", "false")
 
     adapter = _make_adapter()
+    adapter._client = SimpleNamespace(get_event=AsyncMock())
     _set_dm(adapter)
     formatted = (
         '<mx-reply><blockquote>'
@@ -325,6 +326,95 @@ async def test_html_mx_reply_sets_reply_to_text_when_plain_body_has_no_fallback(
     assert msg.text == "follow up"
     assert msg.reply_to_message_id == "$quoted2"
     assert msg.reply_to_text == "quoted HTML text"
+    adapter._client.get_event.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reply_without_fallback_fetches_parent_event_text(monkeypatch):
+    """Clients that only send m.in_reply_to should still get reply context."""
+    monkeypatch.delenv("MATRIX_REQUIRE_MENTION", raising=False)
+    monkeypatch.delenv("MATRIX_FREE_RESPONSE_ROOMS", raising=False)
+    monkeypatch.setenv("MATRIX_AUTO_THREAD", "false")
+
+    adapter = _make_adapter()
+    adapter._client = SimpleNamespace(
+        get_event=AsyncMock(
+            return_value=SimpleNamespace(
+                content={"body": "parent message from Cinny", "msgtype": "m.text"}
+            )
+        )
+    )
+    _set_dm(adapter)
+    event = _make_event("follow up", reply_to_event_id="$cinny-parent")
+
+    await adapter._on_room_message(event)
+
+    adapter._client.get_event.assert_awaited_once_with(
+        "!room1:example.org", "$cinny-parent"
+    )
+    adapter.handle_message.assert_awaited_once()
+    msg = adapter.handle_message.await_args.args[0]
+    assert msg.text == "follow up"
+    assert msg.reply_to_message_id == "$cinny-parent"
+    assert msg.reply_to_text == "parent message from Cinny"
+
+
+@pytest.mark.asyncio
+async def test_reply_parent_fetch_failure_keeps_message_without_reply_text(monkeypatch):
+    """Parent fetch is best effort; failures must not drop the current reply."""
+    monkeypatch.delenv("MATRIX_REQUIRE_MENTION", raising=False)
+    monkeypatch.delenv("MATRIX_FREE_RESPONSE_ROOMS", raising=False)
+    monkeypatch.setenv("MATRIX_AUTO_THREAD", "false")
+
+    adapter = _make_adapter()
+    adapter._client = SimpleNamespace(get_event=AsyncMock(side_effect=RuntimeError("boom")))
+    _set_dm(adapter)
+    event = _make_event("follow up", reply_to_event_id="$missing-parent")
+
+    await adapter._on_room_message(event)
+
+    adapter._client.get_event.assert_awaited_once_with(
+        "!room1:example.org", "$missing-parent"
+    )
+    adapter.handle_message.assert_awaited_once()
+    msg = adapter.handle_message.await_args.args[0]
+    assert msg.text == "follow up"
+    assert msg.reply_to_message_id == "$missing-parent"
+    assert msg.reply_to_text is None
+
+
+@pytest.mark.asyncio
+async def test_media_reply_without_fallback_fetches_parent_event_text(monkeypatch):
+    """Media replies from clients without fallback should still carry context."""
+    monkeypatch.delenv("MATRIX_REQUIRE_MENTION", raising=False)
+    monkeypatch.delenv("MATRIX_FREE_RESPONSE_ROOMS", raising=False)
+    monkeypatch.setenv("MATRIX_AUTO_THREAD", "false")
+
+    adapter = _make_adapter()
+    adapter._client = SimpleNamespace(
+        get_event=AsyncMock(
+            return_value=SimpleNamespace(
+                content={"body": "please inspect this image", "msgtype": "m.text"}
+            )
+        )
+    )
+    _set_dm(adapter)
+    event = _make_event(
+        "screenshot.png",
+        reply_to_event_id="$cinny-media-parent",
+        msgtype="m.image",
+    )
+
+    await adapter._on_room_message(event)
+
+    adapter._client.get_event.assert_awaited_once_with(
+        "!room1:example.org", "$cinny-media-parent"
+    )
+    adapter.handle_message.assert_awaited_once()
+    msg = adapter.handle_message.await_args.args[0]
+    assert msg.text == ""
+    assert msg.reply_to_message_id == "$cinny-media-parent"
+    assert msg.reply_to_text == "please inspect this image"
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_matrix_mention.py
+++ b/tests/gateway/test_matrix_mention.py
@@ -1,5 +1,6 @@
 """Tests for Matrix require-mention gating and auto-thread features."""
 
+import asyncio
 import json
 import time
 from types import SimpleNamespace
@@ -47,6 +48,8 @@ def _make_event(
     formatted_body=None,
     thread_id=None,
     mention_user_ids=None,
+    reply_to_event_id=None,
+    msgtype="m.text",
 ):
     """Create a fake room message event.
 
@@ -54,7 +57,7 @@ def _make_event(
     ``event.event_id``, ``event.timestamp``, and ``event.content``
     (a dict with ``msgtype``, ``body``, etc.).
     """
-    content = {"body": body, "msgtype": "m.text"}
+    content = {"body": body, "msgtype": msgtype}
     if formatted_body:
         content["formatted_body"] = formatted_body
         content["format"] = "org.matrix.custom.html"
@@ -66,6 +69,8 @@ def _make_event(
     if thread_id:
         relates_to["rel_type"] = "m.thread"
         relates_to["event_id"] = thread_id
+    if reply_to_event_id:
+        relates_to["m.in_reply_to"] = {"event_id": reply_to_event_id}
     if relates_to:
         content["m.relates_to"] = relates_to
 
@@ -257,6 +262,151 @@ class TestOutboundMentions:
         content = self._sent_content(self.mock_client)
         assert content["msgtype"] == "m.notice"
         assert content["m.mentions"] == {"user_ids": ["@alice:example.org"]}
+
+
+# ---------------------------------------------------------------------------
+# Matrix reply quote context
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reply_fallback_sets_reply_to_text_and_strips_trigger_body(monkeypatch):
+    """Element reply fallbacks must populate reply_to_text for context injection."""
+    monkeypatch.delenv("MATRIX_REQUIRE_MENTION", raising=False)
+    monkeypatch.delenv("MATRIX_FREE_RESPONSE_ROOMS", raising=False)
+    monkeypatch.setenv("MATRIX_AUTO_THREAD", "false")
+
+    adapter = _make_adapter()
+    _set_dm(adapter)
+    event = _make_event(
+        "> <@alice:example.org> first quoted line\n"
+        "> second quoted line\n"
+        "\n"
+        "what should I do with this?",
+        reply_to_event_id="$quoted1",
+    )
+
+    await adapter._on_room_message(event)
+
+    adapter.handle_message.assert_awaited_once()
+    msg = adapter.handle_message.await_args.args[0]
+    assert msg.text == "what should I do with this?"
+    assert msg.reply_to_message_id == "$quoted1"
+    assert msg.reply_to_text == "first quoted line\nsecond quoted line"
+
+
+@pytest.mark.asyncio
+async def test_html_mx_reply_sets_reply_to_text_when_plain_body_has_no_fallback(monkeypatch):
+    """Formatted Element mx-reply blocks are a fallback source for quote text."""
+    monkeypatch.delenv("MATRIX_REQUIRE_MENTION", raising=False)
+    monkeypatch.delenv("MATRIX_FREE_RESPONSE_ROOMS", raising=False)
+    monkeypatch.setenv("MATRIX_AUTO_THREAD", "false")
+
+    adapter = _make_adapter()
+    _set_dm(adapter)
+    formatted = (
+        '<mx-reply><blockquote>'
+        '<a href="https://matrix.to/#/!room:example.org/$quoted2">In reply to</a> '
+        '<a href="https://matrix.to/#/@alice:example.org">Alice</a><br>'
+        'quoted <b>HTML</b> text'
+        '</blockquote></mx-reply>'
+        'follow up'
+    )
+    event = _make_event(
+        "follow up",
+        formatted_body=formatted,
+        reply_to_event_id="$quoted2",
+    )
+
+    await adapter._on_room_message(event)
+
+    adapter.handle_message.assert_awaited_once()
+    msg = adapter.handle_message.await_args.args[0]
+    assert msg.text == "follow up"
+    assert msg.reply_to_message_id == "$quoted2"
+    assert msg.reply_to_text == "quoted HTML text"
+
+
+@pytest.mark.asyncio
+async def test_reply_fallback_without_new_body_keeps_raw_body(monkeypatch):
+    """Fallback-only bodies have no user reply text, so do not inject quote context."""
+    monkeypatch.delenv("MATRIX_REQUIRE_MENTION", raising=False)
+    monkeypatch.delenv("MATRIX_FREE_RESPONSE_ROOMS", raising=False)
+    monkeypatch.setenv("MATRIX_AUTO_THREAD", "false")
+
+    adapter = _make_adapter()
+    _set_dm(adapter)
+    body = "> <@alice:example.org> quoted only\n\n"
+    event = _make_event(body, reply_to_event_id="$quoted-empty")
+
+    await adapter._on_room_message(event)
+
+    adapter.handle_message.assert_awaited_once()
+    msg = adapter.handle_message.await_args.args[0]
+    assert msg.text == body
+    assert msg.reply_to_message_id == "$quoted-empty"
+    assert msg.reply_to_text is None
+
+
+@pytest.mark.asyncio
+async def test_media_reply_fallback_sets_reply_to_text(monkeypatch):
+    """Media replies should also carry quoted Matrix text into reply_to_text."""
+    monkeypatch.delenv("MATRIX_REQUIRE_MENTION", raising=False)
+    monkeypatch.delenv("MATRIX_FREE_RESPONSE_ROOMS", raising=False)
+    monkeypatch.setenv("MATRIX_AUTO_THREAD", "false")
+
+    adapter = _make_adapter()
+    _set_dm(adapter)
+    event = _make_event(
+        "> <@alice:example.org> inspect this screenshot\n"
+        "\n"
+        "screenshot.png",
+        reply_to_event_id="$quoted-media",
+        msgtype="m.image",
+    )
+
+    await adapter._on_room_message(event)
+
+    adapter.handle_message.assert_awaited_once()
+    msg = adapter.handle_message.await_args.args[0]
+    assert msg.text == ""
+    assert msg.reply_to_message_id == "$quoted-media"
+    assert msg.reply_to_text == "inspect this screenshot"
+
+
+@pytest.mark.asyncio
+async def test_batched_text_reply_preserves_reply_to_text(monkeypatch):
+    """Matrix text batching must not drop reply_to_text from a later reply."""
+    monkeypatch.delenv("MATRIX_REQUIRE_MENTION", raising=False)
+    monkeypatch.delenv("MATRIX_FREE_RESPONSE_ROOMS", raising=False)
+    monkeypatch.setenv("MATRIX_AUTO_THREAD", "false")
+
+    adapter = _make_adapter()
+    _set_dm(adapter)
+    adapter._text_batch_delay_seconds = 60.0
+
+    first = _make_event("first message", event_id="$first")
+    reply = _make_event(
+        "> <@alice:example.org> quoted message\n\nsecond message",
+        event_id="$second",
+        reply_to_event_id="$quoted-batch",
+    )
+
+    try:
+        await adapter._on_room_message(first)
+        await adapter._on_room_message(reply)
+
+        assert len(adapter._pending_text_batches) == 1
+        pending = next(iter(adapter._pending_text_batches.values()))
+        assert pending.text == "first message\nsecond message"
+        assert pending.reply_to_message_id == "$quoted-batch"
+        assert pending.reply_to_text == "quoted message"
+    finally:
+        tasks = list(adapter._pending_text_batch_tasks.values())
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Matrix / Element reply events already expose the replied-to event ID via `m.relates_to.m.in_reply_to`, but Hermes was discarding the quoted message text. `_handle_text_message()` stripped the Element plain-text `> ...` fallback and then built a `MessageEvent` with only `reply_to_message_id`; because `reply_to_text` stayed empty, the gateway's existing `[Replying to: "..."]` prompt injection never ran.

This PR preserves that quoted context by parsing Matrix reply fallbacks into `MessageEvent.reply_to_text` while keeping the user's actual trigger text clean.

Key design choice: this uses the platform-neutral `reply_to_text` field and the existing `GatewayRunner._prepare_inbound_message_text()` injection path instead of putting a Matrix-specific `[Replying to: ...]` prefix directly into the adapter's message body. That keeps Matrix aligned with Telegram, Signal, Slack, WeCom, and the generic reply-context tests.

## Related Issue

Fixes #27946.

Related: #27983. This is an alternate/superset approach that keeps the quote in `reply_to_text`, adds Element `<mx-reply>` fallback support, preserves media reply context, and covers Matrix text batching.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/matrix.py`
  - Extracts Matrix reply fallback parsing helpers.
  - Strips Element plain-text reply fallback blocks from the trigger body while preserving quoted text in `reply_to_text`.
  - Falls back to parsing Element rich `<mx-reply>` HTML when the plain body has no fallback.
  - Carries `reply_to_message_id` / `reply_to_text` for media events as well as text events.
  - Preserves reply context when a reply arrives inside Matrix's text-batching window.
  - Leaves normal Markdown blockquotes untouched unless the event has an actual Matrix reply relation.

- `tests/gateway/test_matrix_mention.py`
  - Adds regression coverage for plain Element reply fallback extraction.
  - Adds coverage for rich `<mx-reply>` HTML fallback extraction.
  - Adds fallback-only body coverage to avoid injecting quote context when no new reply text exists.
  - Adds media reply quote-context coverage.
  - Adds batching coverage so a later reply in a text batch does not lose `reply_to_text`.

## How to Test

Focused tests and checks run locally:

```bash
scripts/run_tests.sh tests/gateway/test_matrix_mention.py tests/gateway/test_reply_to_injection.py -q -o 'addopts='
# 62 passed

/home/adityargadgil/.hermes/hermes-agent/venv/bin/python -m ruff check gateway/platforms/matrix.py tests/gateway/test_matrix_mention.py
# All checks passed!

git diff --check
# no output

python3 -m py_compile gateway/platforms/matrix.py tests/gateway/test_matrix_mention.py
# no output
```

Regression proof:

- The new plain fallback tests failed before the production change because `reply_to_text` was `None`.
- The batching test failed before the batching preservation fix because a later quoted reply was merged into the pending batch with `reply_to_message_id == None` and `reply_to_text == None`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit message follows [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs and found related #27983; the difference is documented above
- [x] My PR contains only changes related to this fix
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] Documentation update is N/A — this fixes inbound platform behavior without changing user-facing configuration
- [x] `cli-config.yaml.example` update is N/A — no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update is N/A — no architecture/workflow changes
- [x] Cross-platform impact considered — uses Python stdlib only and touches Matrix adapter behavior
- [x] Tool descriptions/schemas update is N/A — no tool schema changed
