### PR TITLE
feat: load Jira issues for ticket-driven work

### DIFF
--- a/tests/tools/test_jira_tool.py
+++ b/tests/tools/test_jira_tool.py
@@ -1,0 +1,135 @@
+import json
+from unittest.mock import patch
+
+import pytest
+
+from tools.jira_tool import extract_issue_key, jira_get_issue, normalize_issue
+
+
+@pytest.mark.parametrize(
+    ("reference", "expected"),
+    [
+        ("CPG-1489", "CPG-1489"),
+        ("Please do https://flash-ai.atlassian.net/browse/CPG-1489", "CPG-1489"),
+        ("https://flash-ai.atlassian.net/jira/software/c/projects/CPG/issues/CPG-1489", "CPG-1489"),
+    ],
+)
+def test_extract_issue_key_accepts_key_and_urls(reference, expected):
+    assert extract_issue_key(reference) == expected
+
+
+def test_jira_get_issue_fetches_by_url_with_basic_auth(monkeypatch):
+    monkeypatch.setenv("JIRA_EMAIL", "dev@example.com")
+    monkeypatch.setenv("JIRA_API_TOKEN", "secret-token")
+    monkeypatch.delenv("JIRA_SITE_URL", raising=False)
+    monkeypatch.delenv("ATLASSIAN_SITE_URL", raising=False)
+    monkeypatch.delenv("JIRA_BEARER_TOKEN", raising=False)
+
+    jira_payload = {
+        "key": "CPG-1489",
+        "names": {"customfield_10010": "Acceptance Criteria"},
+        "fields": {
+            "summary": "Hermes agent: complete Jira tickets from URL/key",
+            "description": {
+                "type": "doc",
+                "content": [
+                    {
+                        "type": "paragraph",
+                        "content": [{"type": "text", "text": "Implement ticket-driven orchestration."}],
+                    }
+                ],
+            },
+            "labels": ["automation"],
+            "components": [{"name": "agent"}],
+            "status": {"name": "To Do"},
+            "issuetype": {"name": "Story"},
+            "priority": {"name": "High"},
+            "assignee": {"displayName": "Devin"},
+            "customfield_10010": {
+                "type": "doc",
+                "content": [
+                    {
+                        "type": "bulletList",
+                        "content": [
+                            {"type": "listItem", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "Accept URL"}]}]},
+                            {"type": "listItem", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "Accept key"}]}]},
+                        ],
+                    }
+                ],
+            },
+        },
+    }
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return json.dumps(jira_payload).encode("utf-8")
+
+    captured = {}
+
+    def fake_urlopen(request, timeout):
+        captured["url"] = request.full_url
+        captured["auth"] = request.headers["Authorization"]
+        captured["timeout"] = timeout
+        return FakeResponse()
+
+    with patch("tools.jira_tool.urllib.request.urlopen", side_effect=fake_urlopen):
+        result = json.loads(jira_get_issue("https://flash-ai.atlassian.net/browse/CPG-1489"))
+
+    assert result["success"] is True
+    assert result["key"] == "CPG-1489"
+    assert result["url"] == "https://flash-ai.atlassian.net/browse/CPG-1489"
+    assert result["summary"] == "Hermes agent: complete Jira tickets from URL/key"
+    assert result["description"] == "Implement ticket-driven orchestration."
+    assert result["labels"] == ["automation"]
+    assert result["components"] == ["agent"]
+    assert result["custom_fields"] == {"Acceptance Criteria": "- Accept URL\n- Accept key"}
+    assert captured["url"].startswith("https://flash-ai.atlassian.net/rest/api/3/issue/CPG-1489?")
+    assert captured["auth"].startswith("Basic ")
+    assert captured["timeout"] == 30
+
+
+def test_jira_get_issue_requires_site_for_bare_key(monkeypatch):
+    monkeypatch.setenv("JIRA_EMAIL", "dev@example.com")
+    monkeypatch.setenv("JIRA_API_TOKEN", "secret-token")
+    monkeypatch.delenv("JIRA_SITE_URL", raising=False)
+    monkeypatch.delenv("ATLASSIAN_SITE_URL", raising=False)
+    monkeypatch.delenv("JIRA_BEARER_TOKEN", raising=False)
+
+    result = json.loads(jira_get_issue("CPG-1489"))
+
+    assert result["success"] is False
+    assert "JIRA_SITE_URL" in result["error"]
+
+
+def test_normalize_issue_includes_links_and_subtasks():
+    issue = {
+        "key": "CPG-1489",
+        "fields": {
+            "summary": "Parent work",
+            "issuelinks": [
+                {
+                    "type": {"name": "Blocks"},
+                    "outwardIssue": {
+                        "key": "CPG-1490",
+                        "fields": {"summary": "Child work", "status": {"name": "Open"}},
+                    },
+                }
+            ],
+            "subtasks": [
+                {"key": "CPG-1491", "fields": {"summary": "Subtask", "status": {"name": "Done"}}}
+            ],
+        },
+    }
+
+    normalized = normalize_issue(issue, site_url="https://example.atlassian.net")
+
+    assert normalized["issue_links"] == [
+        {"type": "Blocks", "direction": "outward", "key": "CPG-1490", "summary": "Child work", "status": "Open"}
+    ]
+    assert normalized["subtasks"] == [{"key": "CPG-1491", "summary": "Subtask", "status": "Done"}]

--- a/tools/jira_tool.py
+++ b/tools/jira_tool.py
@@ -1,0 +1,318 @@
+"""Jira issue loading tools.
+
+The tool intentionally keeps scope read-only. It accepts either a Jira issue key
+(e.g. CPG-123) or a full issue URL and returns normalized ticket content for the
+agent to use when implementing work.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import re
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+from tools.registry import registry, tool_error, tool_result
+
+ISSUE_KEY_RE = re.compile(r"\b[A-Z][A-Z0-9]+-\d+\b")
+JIRA_URL_RE = re.compile(r"^https?://[^\s/]+/(?:browse|jira/(?:software|core)/c/projects/[^/]+/issues)/([A-Z][A-Z0-9]+-\d+)", re.I)
+
+FIELD_ALLOWLIST = {
+    "summary",
+    "description",
+    "issuetype",
+    "status",
+    "priority",
+    "assignee",
+    "reporter",
+    "labels",
+    "components",
+    "fixVersions",
+    "versions",
+    "parent",
+    "issuelinks",
+    "subtasks",
+    "attachment",
+    "project",
+}
+
+CUSTOM_FIELD_NAME_HINTS = (
+    "acceptance",
+    "criteria",
+    "component",
+    "repository",
+    "repo",
+    "team",
+    "epic",
+    "story points",
+    "environment",
+    "labels",
+)
+
+
+class JiraConfigurationError(RuntimeError):
+    pass
+
+
+class JiraRequestError(RuntimeError):
+    pass
+
+
+def _has_env(name: str) -> bool:
+    return bool((os.getenv(name) or "").strip())
+
+
+def _jira_requirements_met() -> bool:
+    return bool((_has_env("JIRA_API_TOKEN") and _has_env("JIRA_EMAIL")) or _has_env("JIRA_BEARER_TOKEN"))
+
+
+def _normalize_site(site: str | None) -> str | None:
+    if not site:
+        return None
+    site = site.strip().rstrip("/")
+    if not site:
+        return None
+    if not site.startswith(("http://", "https://")):
+        site = "https://" + site
+    return site
+
+
+def _site_from_reference(reference: str) -> str | None:
+    parsed = urllib.parse.urlparse(reference)
+    if parsed.scheme in {"http", "https"} and parsed.netloc:
+        return f"{parsed.scheme}://{parsed.netloc}"
+    return None
+
+
+def extract_issue_key(reference: str) -> str:
+    """Extract a Jira issue key from a URL or key-like reference."""
+    reference = (reference or "").strip()
+    if not reference:
+        raise ValueError("Provide a Jira issue key or URL.")
+    match = JIRA_URL_RE.search(reference)
+    if match:
+        return match.group(1).upper()
+    match = ISSUE_KEY_RE.search(reference)
+    if match:
+        return match.group(0).upper()
+    raise ValueError(f"Could not find a Jira issue key in {reference!r}.")
+
+
+def _resolve_site(reference: str, site_url: str | None = None) -> str:
+    site = _normalize_site(site_url) or _site_from_reference(reference) or _normalize_site(os.getenv("JIRA_SITE_URL")) or _normalize_site(os.getenv("ATLASSIAN_SITE_URL"))
+    if not site:
+        raise JiraConfigurationError("Set JIRA_SITE_URL (or ATLASSIAN_SITE_URL), or pass a full Jira issue URL.")
+    return site
+
+
+def _auth_header() -> str:
+    bearer = (os.getenv("JIRA_BEARER_TOKEN") or "").strip()
+    if bearer:
+        return f"Bearer {bearer}"
+    email = (os.getenv("JIRA_EMAIL") or "").strip()
+    token = (os.getenv("JIRA_API_TOKEN") or "").strip()
+    if not email or not token:
+        raise JiraConfigurationError("Set JIRA_EMAIL + JIRA_API_TOKEN, or JIRA_BEARER_TOKEN.")
+    encoded = base64.b64encode(f"{email}:{token}".encode("utf-8")).decode("ascii")
+    return f"Basic {encoded}"
+
+
+def _request_json(url: str, *, timeout: int = 30) -> dict[str, Any]:
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": _auth_header(),
+            "Accept": "application/json",
+            "User-Agent": "hermes-agent-jira-tool/1.0",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")[:1000]
+        raise JiraRequestError(f"Jira returned HTTP {exc.code}: {body}") from exc
+    except urllib.error.URLError as exc:
+        raise JiraRequestError(f"Could not reach Jira: {exc.reason}") from exc
+    except json.JSONDecodeError as exc:
+        raise JiraRequestError("Jira returned invalid JSON.") from exc
+
+
+def _adf_to_text(node: Any) -> str:
+    """Convert Atlassian Document Format fragments to readable plain text."""
+    if node is None:
+        return ""
+    if isinstance(node, str):
+        return node
+    if isinstance(node, list):
+        return "\n".join(part for part in (_adf_to_text(item).strip() for item in node) if part)
+    if not isinstance(node, dict):
+        return str(node)
+
+    node_type = node.get("type")
+    if node_type == "text":
+        return str(node.get("text") or "")
+    if node_type == "hardBreak":
+        return "\n"
+    if node_type in {"mention", "emoji", "inlineCard"}:
+        attrs = node.get("attrs") or {}
+        return str(attrs.get("text") or attrs.get("url") or attrs.get("shortName") or "")
+
+    children = [_adf_to_text(child) for child in node.get("content") or []]
+    text = "".join(children) if node_type in {"paragraph", "heading", "listItem"} else "\n".join(part.strip() for part in children if part.strip())
+
+    if node_type == "bulletList":
+        lines = [line.strip() for line in text.splitlines() if line.strip()]
+        return "\n".join(f"- {line}" for line in lines)
+    if node_type == "orderedList":
+        lines = [line.strip() for line in text.splitlines() if line.strip()]
+        return "\n".join(f"{idx}. {line}" for idx, line in enumerate(lines, 1))
+    return text.strip()
+
+
+def _name(value: Any) -> Any:
+    if isinstance(value, dict):
+        return value.get("displayName") or value.get("name") or value.get("value") or value.get("key") or value.get("id")
+    return value
+
+
+def _names(values: Any) -> list[Any]:
+    if not isinstance(values, list):
+        return []
+    return [item for item in (_name(value) for value in values) if item not in (None, "")]
+
+
+def _simplify_link(link: dict[str, Any]) -> dict[str, Any]:
+    link_type = (link.get("type") or {}).get("name")
+    outward = link.get("outwardIssue") or {}
+    inward = link.get("inwardIssue") or {}
+    other = outward or inward
+    direction = "outward" if outward else "inward" if inward else None
+    fields = other.get("fields") or {}
+    return {
+        "type": link_type,
+        "direction": direction,
+        "key": other.get("key"),
+        "summary": fields.get("summary"),
+        "status": _name(fields.get("status")),
+    }
+
+
+def _compact_field(value: Any) -> Any:
+    if value in (None, "", [], {}):
+        return None
+    if isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, list):
+        compacted = [_compact_field(item) for item in value]
+        return [item for item in compacted if item not in (None, "", [], {})] or None
+    if isinstance(value, dict):
+        if value.get("type") == "doc" or "content" in value:
+            text = _adf_to_text(value)
+            return text or None
+        named = _name(value)
+        if named and named != value:
+            return named
+        compacted = {k: _compact_field(v) for k, v in value.items() if k not in {"avatarUrls", "self", "iconUrl"}}
+        return {k: v for k, v in compacted.items() if v not in (None, "", [], {})} or None
+    return str(value)
+
+
+def normalize_issue(issue: dict[str, Any], *, site_url: str) -> dict[str, Any]:
+    fields = issue.get("fields") or {}
+    names = issue.get("names") or {}
+    custom_fields: dict[str, Any] = {}
+
+    for field_id, value in fields.items():
+        if field_id in FIELD_ALLOWLIST or not field_id.startswith("customfield_"):
+            continue
+        display_name = str(names.get(field_id) or field_id)
+        lowered = display_name.lower()
+        if any(hint in lowered for hint in CUSTOM_FIELD_NAME_HINTS):
+            compact = _compact_field(value)
+            if compact not in (None, "", [], {}):
+                custom_fields[display_name] = compact
+
+    key = issue.get("key")
+    normalized = {
+        "success": True,
+        "key": key,
+        "url": f"{site_url}/browse/{key}" if key else issue.get("self"),
+        "summary": fields.get("summary"),
+        "description": _adf_to_text(fields.get("description")),
+        "issue_type": _name(fields.get("issuetype")),
+        "status": _name(fields.get("status")),
+        "priority": _name(fields.get("priority")),
+        "assignee": _name(fields.get("assignee")),
+        "reporter": _name(fields.get("reporter")),
+        "labels": fields.get("labels") or [],
+        "components": _names(fields.get("components")),
+        "fix_versions": _names(fields.get("fixVersions")),
+        "affected_versions": _names(fields.get("versions")),
+        "project": _name(fields.get("project")),
+        "parent": _compact_field(fields.get("parent")),
+        "subtasks": [
+            {"key": item.get("key"), "summary": (item.get("fields") or {}).get("summary"), "status": _name((item.get("fields") or {}).get("status"))}
+            for item in fields.get("subtasks") or []
+        ],
+        "issue_links": [_simplify_link(link) for link in fields.get("issuelinks") or []],
+        "attachments": [
+            {"filename": item.get("filename"), "mimeType": item.get("mimeType"), "size": item.get("size"), "content": item.get("content")}
+            for item in fields.get("attachment") or []
+        ],
+        "custom_fields": custom_fields,
+    }
+    return {k: v for k, v in normalized.items() if v not in (None, "", [], {})}
+
+
+def jira_get_issue(reference: str, site_url: str | None = None) -> str:
+    """Load and normalize a Jira issue by URL or issue key."""
+    try:
+        issue_key = extract_issue_key(reference)
+        site = _resolve_site(reference, site_url)
+        query = urllib.parse.urlencode({"fields": "*all", "expand": "names"})
+        issue = _request_json(f"{site}/rest/api/3/issue/{urllib.parse.quote(issue_key)}?{query}")
+        return tool_result(normalize_issue(issue, site_url=site))
+    except (ValueError, JiraConfigurationError, JiraRequestError) as exc:
+        return tool_error(str(exc), success=False)
+
+
+JIRA_GET_ISSUE_SCHEMA = {
+    "name": "jira_get_issue",
+    "description": (
+        "Read a Jira issue by full issue URL or issue key (for example CPG-123). "
+        "Use this before implementing work requested from a Jira ticket. Returns summary, "
+        "description, acceptance-criteria-like custom fields, labels, components, links, subtasks, and attachments. "
+        "Read-only; does not transition or comment on issues."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "reference": {
+                "type": "string",
+                "description": "Jira issue key or full Jira issue URL, e.g. CPG-123 or https://example.atlassian.net/browse/CPG-123.",
+            },
+            "site_url": {
+                "type": "string",
+                "description": "Optional Jira site base URL. Required for bare issue keys unless JIRA_SITE_URL or ATLASSIAN_SITE_URL is configured.",
+            },
+        },
+        "required": ["reference"],
+    },
+}
+
+
+registry.register(
+    name="jira_get_issue",
+    toolset="jira",
+    schema=JIRA_GET_ISSUE_SCHEMA,
+    handler=lambda args, **kw: jira_get_issue(args.get("reference", ""), site_url=args.get("site_url")),
+    check_fn=_jira_requirements_met,
+    requires_env=["JIRA_EMAIL", "JIRA_API_TOKEN"],
+    emoji="🎫",
+    max_result_size_chars=100_000,
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -31,6 +31,8 @@ from typing import List, Dict, Any, Set, Optional
 _HERMES_CORE_TOOLS = [
     # Web
     "web_search", "web_extract",
+    # Jira issue loading
+    "jira_get_issue",
     # Terminal + process management
     "terminal", "process",
     # File manipulation
@@ -81,6 +83,12 @@ TOOLSETS = {
     "search": {
         "description": "Web search only (no content extraction/scraping)",
         "tools": ["web_search"],
+        "includes": []
+    },
+
+    "jira": {
+        "description": "Read Jira issue content by URL or issue key for ticket-driven implementation work",
+        "tools": ["jira_get_issue"],
         "includes": []
     },
     

--- a/website/docs/guides/jira-ticket-driven-development.md
+++ b/website/docs/guides/jira-ticket-driven-development.md
@@ -1,0 +1,48 @@
+---
+title: "Jira ticket-driven development"
+description: "Use Jira issue URLs or keys as the source of truth for Hermes implementation work."
+---
+
+# Jira ticket-driven development
+
+Hermes can load Jira issue content when you give it a full issue URL or an issue key such as `CPG-1489`. When the `jira_get_issue` tool is available, ask Hermes to complete the ticket and include the Jira reference:
+
+```text
+Complete https://example.atlassian.net/browse/CPG-1489 and open PRs in the affected repos.
+```
+
+```text
+Complete CPG-1489. Read the Jira ticket first, then implement the acceptance criteria.
+```
+
+The tool returns normalized issue content: summary, description, labels, components, status, priority, issue links, subtasks, attachments, and custom fields whose names look like acceptance criteria, repository, team, component, epic, or environment metadata.
+
+## Setup
+
+Add Jira credentials to `~/.hermes/.env` or your deployment secret manager:
+
+```bash
+JIRA_SITE_URL=https://example.atlassian.net
+JIRA_EMAIL=dev@example.com
+JIRA_API_TOKEN=atlassian-api-token
+```
+
+For deployments that use bearer auth, set `JIRA_BEARER_TOKEN` instead of `JIRA_EMAIL` and `JIRA_API_TOKEN`.
+
+Use least-privilege Jira credentials. The built-in Jira tool is read-only and only calls Jira's issue read endpoint; it does not transition, comment on, or edit issues.
+
+## Operational limits and conventions
+
+- Full Jira URLs include the site, so `JIRA_SITE_URL` is optional for those. Bare issue keys require `JIRA_SITE_URL` or `ATLASSIAN_SITE_URL`.
+- Hermes relies on the ticket fields, linked issues, labels, and components to infer the relevant repository or repositories. If multiple repos are involved, mention them in the ticket description, labels, components, or a repository-related custom field.
+- Branch names should include the ticket key when practical, for example `feat/cpg-1489-jira-ticket-tool`.
+- Keep one PR per affected repository unless the team explicitly asks for a different shape.
+- Very large attachments are not downloaded automatically; the tool exposes attachment metadata and URLs so the agent can decide whether to fetch a specific file with an appropriate tool.
+- Jira write-back is intentionally out of scope for the first integration. If your team wants a Jira comment, remote link, or transition, ask explicitly and provide/write-enable a separate integration.
+- Repository access, maximum concurrent repos, and CI requirements are governed by the normal terminal/GitHub credentials available to the Hermes runtime. If a ticket spans more repos than the runtime can access, Hermes should open PRs for accessible repos and report the blocked repos clearly.
+
+## Security notes
+
+- Store Jira tokens only in `~/.hermes/.env`, the gateway's secret store, or your orchestrator's secret manager. Do not put them in prompts, tickets, or repo files.
+- Prefer project-scoped or read-only Jira tokens where Atlassian permissions allow it.
+- The tool never prints the token and returns only normalized issue data.

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -96,6 +96,11 @@ All variables go in `~/.hermes/.env`. You can also set them with `hermes config 
 | `HERMES_KANBAN_BOARD` | Pin the active kanban board for this process. Takes precedence over `~/.hermes/kanban/current`; the dispatcher injects this into worker subprocess env so workers physically cannot see tasks on other boards. Defaults to `default`. Slug validation: lowercase alphanumerics + hyphens + underscores, 1-64 chars |
 | `HERMES_KANBAN_DB` | Pin the kanban database file path directly (highest precedence; beats `HERMES_KANBAN_BOARD` and `HERMES_KANBAN_HOME`). The dispatcher injects this into worker subprocess env so profile workers converge on the dispatcher's board |
 | `HERMES_KANBAN_WORKSPACES_ROOT` | Pin the kanban workspaces root directly (highest precedence for workspaces; beats `HERMES_KANBAN_HOME`). The dispatcher injects this into worker subprocess env |
+| `JIRA_SITE_URL` | Default Jira site base URL for bare issue keys passed to `jira_get_issue` (for example `https://example.atlassian.net`). Full issue URLs can provide the site without this variable. |
+| `ATLASSIAN_SITE_URL` | Alias for `JIRA_SITE_URL`. |
+| `JIRA_EMAIL` | Jira/Atlassian account email for API-token Basic auth. Store only in `~/.hermes/.env` or a secret manager. |
+| `JIRA_API_TOKEN` | Jira/Atlassian API token for read-only issue loading. Prefer least-privilege project scopes where available. |
+| `JIRA_BEARER_TOKEN` | Alternative Jira bearer token. When set, Hermes uses it instead of `JIRA_EMAIL` + `JIRA_API_TOKEN`. |
 
 ## Provider Auth (OAuth)
 

--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -109,6 +109,12 @@ Scoped to the Feishu document-comment handler. Drives comment read/write operati
 |------|-------------|----------------------|
 | `image_generate` | Generate high-quality images from text prompts using FAL.ai. The underlying model is user-configured (default: FLUX 2 Klein 9B, sub-1s generation) and is not selectable by the agent. Returns a single image URL. Display it using… | FAL_KEY |
 
+## `jira` toolset
+
+| Tool | Description | Requires environment |
+|------|-------------|----------------------|
+| `jira_get_issue` | Read a Jira issue by URL or key before implementing ticket-driven work. Returns normalized summary, description, labels, components, links, subtasks, attachments, and acceptance-criteria-like custom fields. | `JIRA_EMAIL` + `JIRA_API_TOKEN`, or `JIRA_BEARER_TOKEN` |
+
 ## `memory` toolset
 
 | Tool | Description | Requires environment |


### PR DESCRIPTION
## Summary
- add a read-only `jira_get_issue` tool that accepts Jira URLs or issue keys and normalizes ticket content for implementation work
- include Jira in the core/default tool surface and add a dedicated `jira` toolset
- document Jira credentials, security expectations, branching/PR conventions, and operational limits

## Test Plan
- `python3 -m pytest tests/tools/test_jira_tool.py tests/test_toolsets.py -q`
- `python3 -m pytest tests/test_model_tools.py tests/tools/test_jira_tool.py -q`
- `.venv/bin/ruff check tools/jira_tool.py tests/tools/test_jira_tool.py toolsets.py` (or py_compile fallback if ruff is unavailable)

Jira: CPG-1489
