### PR TITLE
fix: add html to extract_media extension list for native file delivery

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2159,7 +2159,7 @@ class BasePlatformAdapter(ABC):
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:html|png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()


### PR DESCRIPTION
## Summary

One-line fix to add `html` to the extension list in `BasePlatformAdapter.extract_media()` regex.

## Problem

The `extract_media` static method detects `MEDIA:<path>` tags in agent responses and extracts file paths for native platform delivery. The bare-path alternative in the regex matches files by extension, but `html` was missing from the alternation list.

This meant that when an agent generated artifacts like `MEDIA:/path/to/dashboard.html`, the file was never detected for native delivery.

## Fix

Add `html|` at the start of the extension alternation in `gateway/platforms/base.py:2162`:

```diff
- \.(?:png|jpe?g|gif|webp|...
+ \.(?:html|png|jpe?g|gif|webp|...
```

## Verification

Tested with the Python `re` module — the fixed regex now correctly matches paths like `MEDIA:/path/to/file.html` at end-of-string.