### PR TITLE
Add input/output token counts to gateway runtime footer

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7642,6 +7642,8 @@ class GatewayRunner:
                     model=agent_result.get("model"),
                     context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                     context_length=agent_result.get("context_length") or None,
+                    input_tokens=agent_result.get("turn_input_tokens"),
+                    output_tokens=agent_result.get("turn_output_tokens"),
                     cwd=os.environ.get("TERMINAL_CWD", ""),
                 )
             except Exception as _footer_err:
@@ -15225,6 +15227,8 @@ class GatewayRunner:
                 else:
                     _run_message = message
 
+                _start_input_toks = getattr(agent, "session_input_tokens", 0) or 0
+                _start_output_toks = getattr(agent, "session_output_tokens", 0) or 0
                 result = agent.run_conversation(_run_message, conversation_history=agent_history, task_id=session_id)
             finally:
                 unregister_gateway_notify(_approval_session_key)
@@ -15249,6 +15253,14 @@ class GatewayRunner:
                 _input_toks = getattr(_agent, "session_prompt_tokens", 0)
                 _output_toks = getattr(_agent, "session_completion_tokens", 0)
                 _context_length = getattr(_agent.context_compressor, "context_length", 0) or 0
+            _turn_input_toks = max(
+                0,
+                (getattr(_agent, "session_input_tokens", 0) or 0) - (_start_input_toks or 0),
+            ) if _agent else 0
+            _turn_output_toks = max(
+                0,
+                (getattr(_agent, "session_output_tokens", 0) or 0) - (_start_output_toks or 0),
+            ) if _agent else 0
             _resolved_model = getattr(_agent, "model", None) if _agent else None
 
             if not final_response:
@@ -15269,6 +15281,8 @@ class GatewayRunner:
                     "last_prompt_tokens": _last_prompt_toks,
                     "input_tokens": _input_toks,
                     "output_tokens": _output_toks,
+                    "turn_input_tokens": _turn_input_toks,
+                    "turn_output_tokens": _turn_output_toks,
                     "model": _resolved_model,
                     "context_length": _context_length,
                 }
@@ -15388,6 +15402,8 @@ class GatewayRunner:
                 "last_prompt_tokens": _last_prompt_toks,
                 "input_tokens": _input_toks,
                 "output_tokens": _output_toks,
+                "turn_input_tokens": _turn_input_toks,
+                "turn_output_tokens": _turn_output_toks,
                 "model": _resolved_model,
                 "context_length": _context_length,
                 "session_id": effective_session_id,

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -1,6 +1,6 @@
 """Gateway runtime-metadata footer.
 
-Renders a compact footer showing runtime state (model, context %, cwd) and
+Renders a compact footer showing runtime state (model, token in/out, context %, cwd) and
 appends it to the FINAL message of an agent turn when enabled.  Off by default
 to keep replies minimal.
 
@@ -9,7 +9,7 @@ Config (``~/.hermes/config.yaml``)::
     display:
       runtime_footer:
         enabled: true                       # off by default
-        fields: [model, context_pct, cwd]   # order shown; drop any to hide
+        fields: [model, input_tokens, output_tokens, context_pct, cwd]   # order shown; drop any to hide
 
 Per-platform overrides live under ``display.platforms.<platform>.runtime_footer``.
 Users can toggle the global setting with ``/footer on|off`` from both the CLI
@@ -31,6 +31,13 @@ from typing import Any, Iterable, Optional
 
 _DEFAULT_FIELDS: tuple[str, ...] = ("model", "context_pct", "cwd")
 _SEP = " · "
+
+
+def _token_count_label(prefix: str, count: Optional[int]) -> str:
+    """Return a compact token label like ``in 12,345`` or ``""`` when empty."""
+    if count is None or count < 0:
+        return ""
+    return f"{prefix} {count:,}"
 
 
 def _home_relative_cwd(cwd: str) -> str:
@@ -94,6 +101,8 @@ def format_runtime_footer(
     model: Optional[str],
     context_tokens: int,
     context_length: Optional[int],
+    input_tokens: Optional[int] = None,
+    output_tokens: Optional[int] = None,
     cwd: Optional[str] = None,
     fields: Iterable[str] = _DEFAULT_FIELDS,
 ) -> str:
@@ -108,6 +117,14 @@ def format_runtime_footer(
             m = _model_short(model)
             if m:
                 parts.append(m)
+        elif field == "input_tokens":
+            label = _token_count_label("in", input_tokens)
+            if label:
+                parts.append(label)
+        elif field == "output_tokens":
+            label = _token_count_label("out", output_tokens)
+            if label:
+                parts.append(label)
         elif field == "context_pct":
             if context_length and context_length > 0 and context_tokens >= 0:
                 pct = max(0, min(100, round((context_tokens / context_length) * 100)))
@@ -130,6 +147,8 @@ def build_footer_line(
     model: Optional[str],
     context_tokens: int,
     context_length: Optional[int],
+    input_tokens: Optional[int] = None,
+    output_tokens: Optional[int] = None,
     cwd: Optional[str] = None,
 ) -> str:
     """Top-level entry point used by gateway/run.py.
@@ -145,6 +164,8 @@ def build_footer_line(
         model=model,
         context_tokens=context_tokens,
         context_length=context_length,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
         cwd=cwd,
         fields=cfg.get("fields") or _DEFAULT_FIELDS,
     )

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -137,6 +137,19 @@ def test_format_footer_custom_field_order():
     assert out == "50% · gpt-5.4"
 
 
+def test_format_footer_renders_token_fields_when_requested():
+    out = format_runtime_footer(
+        model="openai/gpt-5.4",
+        context_tokens=0,
+        context_length=None,
+        input_tokens=12345,
+        output_tokens=678,
+        cwd="",
+        fields=("model", "input_tokens", "output_tokens"),
+    )
+    assert out == "gpt-5.4 · in 12,345 · out 678"
+
+
 def test_format_footer_unknown_field_silently_ignored():
     out = format_runtime_footer(
         model="openai/gpt-5.4",
@@ -229,6 +242,27 @@ def test_build_footer_returns_rendered_when_enabled(monkeypatch, tmp_path):
     (tmp_path / "proj").mkdir(exist_ok=True)
     assert "gpt-5.4" in out
     assert "25%" in out
+
+
+def test_build_footer_can_render_tokens_only():
+    out = build_footer_line(
+        user_config={
+            "display": {
+                "runtime_footer": {
+                    "enabled": True,
+                    "fields": ["model", "input_tokens", "output_tokens"],
+                }
+            }
+        },
+        platform_key="discord",
+        model="openai/gpt-5.4",
+        context_tokens=0,
+        context_length=None,
+        input_tokens=4321,
+        output_tokens=210,
+        cwd="",
+    )
+    assert out == "gpt-5.4 · in 4,321 · out 210"
 
 
 def test_build_footer_per_platform_off_suppresses():


### PR DESCRIPTION
## Summary
- Capture per-turn input/output token deltas for gateway-dispatched agent replies
- Add runtime footer fields for input_tokens and output_tokens
- Add footer formatting tests for token fields

## Test Plan
- Not run in this session; change is covered by added unit tests.