### PR TITLE
fix: exclude .stash directory from skill scanning

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -283,7 +283,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
 
         for scan_dir in dirs_to_scan:
             for skill_md in iter_skill_index_files(scan_dir, "SKILL.md"):
-                if any(part in {'.git', '.github', '.hub', '.archive'} for part in skill_md.parts):
+                if any(part in {'.git', '.github', '.hub', '.archive', '.stash'} for part in skill_md.parts):
                     continue
                 try:
                     content = skill_md.read_text(encoding='utf-8')

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -30,6 +30,7 @@ EXCLUDED_SKILL_DIRS = frozenset(
         ".github",
         ".hub",
         ".archive",
+        ".stash",
         ".venv",
         "venv",
         "node_modules",


### PR DESCRIPTION
## What does this PR do?

Add '.stash' to the exclusion sets in both:
- EXCLUDED_SKILL_DIRS (skill_utils.py) — used by iter_skill_index_files
- The inline path-part check in scan_skill_commands (skill_commands.py)

Fixes #

The Stash skill-sync tool stores its working data (including a full snapshot copy of all skills) in a .stash/ subdirectory inside the skills tree.  When Hermes walks the skills directory it recursively enters .stash/snapshot/ and indexes every SKILL.md twice — once from the canonical location and again from the stash snapshot.  On an installation with ~110 skills this doubles the skill index to ~220 entries, wasting context tokens in every turn.

## Type of Change

- [X ] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

The fix covers all three scan paths: slash command registration, system prompt skill index, and manifest/snapshot building.

## How to Test

Context size is smaller if using .stash


