### PR TITLE
fix: pass session_id and tool_call_id in pre_tool_call hook

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -128,6 +128,8 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             from hermes_cli.plugins import get_pre_tool_call_block_message
             block_message = get_pre_tool_call_block_message(
                 function_name, function_args, task_id=effective_task_id or "",
+                session_id=agent.session_id or "",
+                tool_call_id=tool_call.id,
             )
         except Exception:
             block_message = None
@@ -502,6 +504,8 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             from hermes_cli.plugins import get_pre_tool_call_block_message
             _block_msg = get_pre_tool_call_block_message(
                 function_name, function_args, task_id=effective_task_id or "",
+                session_id=agent.session_id or "",
+                tool_call_id=tool_call.id,
             )
         except Exception:
             pass

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2273,6 +2273,60 @@ class TestConcurrentToolExecution:
         assert json.loads(result) == {"error": "Blocked"}
         assert agent._turns_since_memory == 5
 
+    def test_sequential_pre_tool_call_receives_session_id_and_tool_call_id(self, agent, monkeypatch):
+        """Sequential path should forward session_id and tool_call_id to
+        get_pre_tool_call_block_message so plugin hooks can correlate."""
+        tool_call = _mock_tool_call(
+            name="web_search",
+            arguments='{"query":"test"}',
+            call_id="call-abc-123",
+        )
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tool_call])
+        messages = []
+
+        captured_kwargs = {}
+        def _capture_block(*args, **kwargs):
+            captured_kwargs.update(kwargs)
+            return None  # don't block
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins.get_pre_tool_call_block_message",
+            _capture_block,
+        )
+        agent.session_id = "test-session-42"
+        with patch("run_agent.handle_function_call", return_value='{"results":[]}'):
+            agent._execute_tool_calls_sequential(mock_msg, messages, "task-1")
+
+        assert captured_kwargs["session_id"] == "test-session-42"
+        assert captured_kwargs["tool_call_id"] == "call-abc-123"
+
+    def test_concurrent_pre_tool_call_receives_session_id_and_tool_call_id(self, agent, monkeypatch):
+        """Concurrent path should forward session_id and tool_call_id to
+        get_pre_tool_call_block_message so plugin hooks can correlate."""
+        tool_call = _mock_tool_call(
+            name="web_search",
+            arguments='{"query":"test"}',
+            call_id="call-xyz-789",
+        )
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tool_call])
+        messages = []
+
+        captured_kwargs = {}
+        def _capture_block(*args, **kwargs):
+            captured_kwargs.update(kwargs)
+            return None  # don't block
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins.get_pre_tool_call_block_message",
+            _capture_block,
+        )
+        agent.session_id = "test-session-99"
+        with patch("run_agent.handle_function_call", return_value='{"results":[]}'):
+            agent._execute_tool_calls_concurrent(mock_msg, messages, "task-1")
+
+        assert captured_kwargs["session_id"] == "test-session-99"
+        assert captured_kwargs["tool_call_id"] == "call-xyz-789"
+
 
 class TestPathsOverlap:
     """Unit tests for the _paths_overlap helper."""


### PR DESCRIPTION
## Summary

Fixes #28961

The concurrent (`execute_tool_calls_concurrent`) and sequential (`execute_tool_calls_sequential`) paths called `get_pre_tool_call_block_message` **without** `session_id` and `tool_call_id`, unlike the `_invoke_tool` path which already forwarded both parameters.

This meant plugin hooks receiving `pre_tool_call` events could not correlate the call back to a specific session or tool invocation.

## Changes

- **`agent/tool_executor.py`** — Forward `session_id=agent.session_id` and `tool_call_id=tool_call.id` in both the concurrent (L129-131) and sequential (L504-506) execution paths, matching the existing `_invoke_tool` pattern.
- **`tests/run_agent/test_run_agent.py`** — 2 new tests verifying kwargs propagation through both paths.

## Testing

```
340/340 tests passed (0 regression)
```

New tests:
- `test_sequential_pre_tool_call_receives_session_id_and_tool_call_id`
- `test_concurrent_pre_tool_call_receives_session_id_and_tool_call_id`
