### PR TITLE
Add Fireworks AI as an inference provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,6 +83,14 @@
 # MINIMAX_CN_BASE_URL=https://api.minimaxi.com/v1  # Override default base URL
 
 # =============================================================================
+# LLM PROVIDER (Fireworks AI)
+# =============================================================================
+# Fireworks AI — fast inference for open and proprietary models
+# Get your key at: https://app.fireworks.ai/settings/users/api-keys
+# FIREWORKS_API_KEY=
+# FIREWORKS_BASE_URL=https://api.fireworks.ai/inference/v1  # Override default base URL
+
+# =============================================================================
 # LLM PROVIDER (OpenCode Zen)
 # =============================================================================
 # OpenCode Zen provides curated, tested models (GPT, Claude, Gemini, MiniMax, GLM, Kimi)

--- a/plugins/model-providers/fireworks/__init__.py
+++ b/plugins/model-providers/fireworks/__init__.py
@@ -1,0 +1,28 @@
+"""Fireworks AI provider profile.
+
+Fireworks AI provides fast, efficient inference for open and proprietary
+models through an OpenAI-compatible chat completions endpoint.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+fireworks = ProviderProfile(
+    name="fireworks",
+    aliases=("fireworks-ai", "fw"),
+    display_name="Fireworks AI",
+    description="Fireworks AI — fast inference for open and proprietary models",
+    signup_url="https://app.fireworks.ai/settings/users/api-keys",
+    env_vars=("FIREWORKS_API_KEY", "FIREWORKS_BASE_URL"),
+    base_url="https://api.fireworks.ai/inference/v1",
+    auth_type="api_key",
+    default_aux_model="accounts/fireworks/models/minimax-m2p5",
+    fallback_models=(
+        "accounts/fireworks/routers/kimi-k2p6-turbo",
+        "accounts/fireworks/models/glm-5p1",
+        "accounts/fireworks/models/minimax-m2p5",
+    ),
+)
+
+register_provider(fireworks)

--- a/plugins/model-providers/fireworks/plugin.yaml
+++ b/plugins/model-providers/fireworks/plugin.yaml
@@ -1,0 +1,5 @@
+name: fireworks-provider
+kind: model-provider
+version: 1.0.0
+description: Fireworks AI — fast inference for open and proprietary models
+author: Nous Research

--- a/tests/plugins/model_providers/test_fireworks_profile.py
+++ b/tests/plugins/model_providers/test_fireworks_profile.py
@@ -1,0 +1,137 @@
+"""Unit tests for the Fireworks provider profile.
+
+Validates registration, discovery, and wire-shape contracts so Fireworks
+requests are correctly shaped without going live.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def fireworks_profile():
+    """Resolve the registered Fireworks profile."""
+    import model_tools  # noqa: F401 — triggers plugin discovery
+    import providers
+
+    profile = providers.get_provider_profile("fireworks")
+    assert profile is not None, "fireworks provider profile must be registered"
+    return profile
+
+
+class TestFireworksProfileBasics:
+    """Core profile metadata."""
+
+    def test_name_and_aliases(self, fireworks_profile):
+        assert fireworks_profile.name == "fireworks"
+        assert "fireworks-ai" in fireworks_profile.aliases
+        assert "fw" in fireworks_profile.aliases
+
+    def test_display_name(self, fireworks_profile):
+        assert fireworks_profile.display_name == "Fireworks AI"
+
+    def test_base_url(self, fireworks_profile):
+        assert fireworks_profile.base_url == "https://api.fireworks.ai/inference/v1"
+
+    def test_env_vars(self, fireworks_profile):
+        assert "FIREWORKS_API_KEY" in fireworks_profile.env_vars
+        assert "FIREWORKS_BASE_URL" in fireworks_profile.env_vars
+
+    def test_auth_type(self, fireworks_profile):
+        assert fireworks_profile.auth_type == "api_key"
+
+    def test_default_aux_model(self, fireworks_profile):
+        assert fireworks_profile.default_aux_model == "accounts/fireworks/models/minimax-m2p5"
+
+    def test_fallback_models(self, fireworks_profile):
+        expected = (
+            "accounts/fireworks/routers/kimi-k2p6-turbo",
+            "accounts/fireworks/models/glm-5p1",
+            "accounts/fireworks/models/minimax-m2p5",
+        )
+        assert fireworks_profile.fallback_models == expected
+
+    def test_get_hostname(self, fireworks_profile):
+        assert fireworks_profile.get_hostname() == "api.fireworks.ai"
+
+
+class TestFireworksWireShape:
+    """Fireworks uses plain OpenAI chat-completions — no extra_body quirks needed."""
+
+    def test_prepare_messages_is_identity(self, fireworks_profile):
+        msgs = [{"role": "user", "content": "hello"}]
+        assert fireworks_profile.prepare_messages(msgs) == msgs
+
+    def test_build_extra_body_empty(self, fireworks_profile):
+        assert fireworks_profile.build_extra_body() == {}
+
+    def test_build_api_kwargs_extras_empty(self, fireworks_profile):
+        extra_body, top_level = fireworks_profile.build_api_kwargs_extras()
+        assert extra_body == {}
+        assert top_level == {}
+
+
+class TestFireworksTransportKwargs:
+    """End-to-end: the transport produces standard OpenAI kwargs."""
+
+    def test_basic_kwargs(self, fireworks_profile):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="accounts/fireworks/routers/kimi-k2p6-turbo",
+            messages=[{"role": "user", "content": "ping"}],
+            tools=None,
+            provider_profile=fireworks_profile,
+            base_url="https://api.fireworks.ai/inference/v1",
+            provider_name="fireworks",
+        )
+        assert kwargs["model"] == "accounts/fireworks/routers/kimi-k2p6-turbo"
+        assert kwargs["messages"] == [{"role": "user", "content": "ping"}]
+        assert "extra_body" not in kwargs
+
+    def test_tools_pass_through(self, fireworks_profile):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "test_tool",
+                    "description": "A test tool",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="accounts/fireworks/models/glm-5p1",
+            messages=[{"role": "user", "content": "call test_tool"}],
+            tools=tools,
+            provider_profile=fireworks_profile,
+            base_url="https://api.fireworks.ai/inference/v1",
+            provider_name="fireworks",
+        )
+        assert kwargs["tools"] == tools
+
+    def test_temperature_passes_through(self, fireworks_profile):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="accounts/fireworks/models/minimax-m2p5",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=None,
+            provider_profile=fireworks_profile,
+            temperature=0.5,
+            base_url="https://api.fireworks.ai/inference/v1",
+            provider_name="fireworks",
+        )
+        assert kwargs["temperature"] == 0.5
+
+
+class TestFireworksConsumerAPI:
+    """Profile is readable from downstream consumers."""
+
+    def test_aux_model_consumer(self, fireworks_profile):
+        from agent.auxiliary_client import _get_aux_model_for_provider
+
+        assert _get_aux_model_for_provider("fireworks") == "accounts/fireworks/models/minimax-m2p5"

--- a/tests/providers/test_plugin_discovery.py
+++ b/tests/providers/test_plugin_discovery.py
@@ -53,12 +53,13 @@ def test_all_34_profiles_register():
 
     profiles = list_providers()
     names = sorted(p.name for p in profiles)
-    assert len(names) == 34, f"Expected 34 profiles, got {len(names)}: {names}"
+    assert len(names) == 35, f"Expected 35 profiles, got {len(names)}: {names}"
 
     # Spot-check representative providers from different categories
     for required in (
         "openrouter", "anthropic", "custom", "bedrock", "openai-codex",
         "minimax-oauth", "gmi", "xiaomi", "alibaba-coding-plan",
+        "fireworks",
     ):
         assert required in names, f"Missing profile: {required}"
 

--- a/tests/run_agent/test_fireworks_live.py
+++ b/tests/run_agent/test_fireworks_live.py
@@ -1,0 +1,80 @@
+"""Live Fireworks smoke test.
+
+Opt-in only:
+    HERMES_LIVE_TESTS=1 pytest tests/run_agent/test_fireworks_live.py -q
+
+Requires FIREWORKS_API_KEY in the process environment.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+LIVE = os.environ.get("HERMES_LIVE_TESTS") == "1"
+FIREWORKS_KEY = os.environ.get("FIREWORKS_API_KEY", "")
+LIVE_BASE_URL = "https://api.fireworks.ai/inference/v1"
+
+pytestmark = [
+    pytest.mark.skipif(not LIVE, reason="live-only: set HERMES_LIVE_TESTS=1"),
+    pytest.mark.skipif(not FIREWORKS_KEY, reason="FIREWORKS_API_KEY not configured"),
+    pytest.mark.integration,
+]
+
+
+def _make_live_client():
+    from openai import OpenAI
+
+    return OpenAI(api_key=FIREWORKS_KEY, base_url=LIVE_BASE_URL)
+
+
+def test_fireworks_basic_chat():
+    """A single-turn chat completion returns non-empty content."""
+    client = _make_live_client()
+
+    response = client.chat.completions.create(
+        model="accounts/fireworks/routers/kimi-k2p6-turbo",
+        messages=[{"role": "user", "content": "Say exactly the word 'pong' and nothing else."}],
+        max_tokens=32,
+        temperature=0.0,
+        timeout=60,
+    )
+
+    content = response.choices[0].message.content
+    assert content and "pong" in content.lower()
+
+
+def test_fireworks_tool_call():
+    """Fireworks model can emit a tool call."""
+    client = _make_live_client()
+
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get weather for a city",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "city": {"type": "string"},
+                    },
+                    "required": ["city"],
+                },
+            },
+        }
+    ]
+
+    response = client.chat.completions.create(
+        model="accounts/fireworks/routers/kimi-k2p6-turbo",
+        messages=[{"role": "user", "content": "What's the weather in San Francisco?"}],
+        tools=tools,
+        max_tokens=256,
+        temperature=0.0,
+        timeout=60,
+    )
+
+    tool_calls = response.choices[0].message.tool_calls
+    assert tool_calls is not None and len(tool_calls) > 0
+    assert tool_calls[0].function.name == "get_weather"


### PR DESCRIPTION
## Summary
- Adds Fireworks AI as a bundled model provider via the standard `ProviderProfile` plugin system
- Auto-wires into auth, config, models, doctor, and transport layers — no manual edits needed
- Supports `accounts/fireworks/routers/kimi-k2p6-turbo`, `accounts/fireworks/models/glm-5p1`, and `accounts/fireworks/models/minimax-m2p5`

## Files added
- `plugins/model-providers/fireworks/__init__.py`
- `plugins/model-providers/fireworks/plugin.yaml`
- `tests/plugins/model_providers/test_fireworks_profile.py`
- `tests/run_agent/test_fireworks_live.py`

## Files modified
- `.env.example` — documents `FIREWORKS_API_KEY` and `FIREWORKS_BASE_URL`
- `tests/providers/test_plugin_discovery.py` — bumps provider count 34→35

## Test plan
- [x] Unit tests pass (`pytest tests/plugins/model_providers/test_fireworks_profile.py`)
- [x] Discovery test passes (`pytest tests/providers/test_plugin_discovery.py`)
- [ ] Live smoke test with `FIREWORKS_API_KEY` set (`pytest tests/run_agent/test_fireworks_live.py`)
- [ ] Verified provider appears in model picker after API key is configured