### PR TITLE
fix(cron): repair migrated timezone offsets

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -292,6 +292,51 @@ def _ensure_aware(dt: datetime) -> datetime:
     return dt.astimezone(target_tz)
 
 
+def _cron_matches_datetime(schedule: Dict[str, Any], dt: datetime) -> bool:
+    """Return whether ``dt`` is an exact occurrence for a cron schedule."""
+    if schedule.get("kind") != "cron" or not HAS_CRONITER:
+        return False
+
+    expr = schedule.get("expr")
+    if not expr:
+        return False
+
+    try:
+        match = getattr(croniter, "match", None)
+        if match:
+            return bool(match(expr, dt))
+        return croniter(expr, dt - timedelta(seconds=1)).get_next(datetime) == dt
+    except Exception:
+        return False
+
+
+def _repair_cron_next_run_timezone(
+    job: Dict[str, Any],
+    next_run_dt: datetime,
+    now: datetime,
+) -> Optional[str]:
+    """Rebase migrated cron timestamps to Hermes' current wall-clock timezone.
+
+    Cron expressions describe local wall-clock times.  If a recurring cron job
+    persisted ``21:00`` with an old UTC offset, comparing the old instant after
+    Hermes moves timezones can make the job appear due hours early.  Keep the
+    stored wall-clock fields and attach the current Hermes timezone, then let
+    normal due/stale handling decide whether to run or fast-forward.
+    """
+    schedule = job.get("schedule", {})
+    if schedule.get("kind") != "cron":
+        return None
+
+    if next_run_dt.utcoffset() == now.utcoffset():
+        return None
+
+    rebased = next_run_dt.replace(tzinfo=now.tzinfo)
+    if not _cron_matches_datetime(schedule, rebased):
+        return None
+
+    return rebased.isoformat()
+
+
 def _recoverable_oneshot_run_at(
     schedule: Dict[str, Any],
     now: datetime,
@@ -1020,7 +1065,24 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
                     needs_save = True
                     break
 
-        next_run_dt = _ensure_aware(datetime.fromisoformat(next_run))
+        stored_next_run_dt = datetime.fromisoformat(next_run)
+        next_run_dt = _ensure_aware(stored_next_run_dt)
+        repaired_next = _repair_cron_next_run_timezone(job, stored_next_run_dt, now)
+        if repaired_next and repaired_next != next_run:
+            next_run = repaired_next
+            next_run_dt = _ensure_aware(datetime.fromisoformat(repaired_next))
+            logger.info(
+                "Job '%s' had next_run_at in an old timezone offset; "
+                "repairing to current wall-clock run at %s",
+                job.get("name", job["id"]),
+                repaired_next,
+            )
+            for rj in raw_jobs:
+                if rj["id"] == job["id"]:
+                    rj["next_run_at"] = repaired_next
+                    needs_save = True
+                    break
+
         if next_run_dt <= now:
             schedule = job.get("schedule", {})
             kind = schedule.get("kind")

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -684,6 +684,76 @@ class TestGetDueJobs:
         due = get_due_jobs()
         assert len(due) == 0
 
+    def test_cron_next_run_old_timezone_offset_is_repaired_before_due_check(
+        self, tmp_cron_dir, monkeypatch
+    ):
+        pytest.importorskip("croniter")
+        current_tz = timezone(timedelta(hours=2))
+        old_tz = timezone(timedelta(hours=10))
+        now = datetime(2026, 5, 19, 13, 2, 0, tzinfo=current_tz)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        save_jobs(
+            [{
+                "id": "cron-tz-migrate",
+                "name": "Tuesday evening",
+                "prompt": "...",
+                "schedule": {"kind": "cron", "expr": "0 21 * * 2", "display": "0 21 * * 2"},
+                "schedule_display": "0 21 * * 2",
+                "repeat": {"times": None, "completed": 0},
+                "enabled": True,
+                "state": "scheduled",
+                "paused_at": None,
+                "paused_reason": None,
+                "created_at": "2026-05-12T21:00:00+10:00",
+                "next_run_at": datetime(2026, 5, 19, 21, 0, 0, tzinfo=old_tz).isoformat(),
+                "last_run_at": None,
+                "last_status": None,
+                "last_error": None,
+                "deliver": "local",
+                "origin": None,
+            }]
+        )
+
+        assert get_due_jobs() == []
+        repaired = datetime.fromisoformat(get_job("cron-tz-migrate")["next_run_at"])
+        assert repaired == datetime(2026, 5, 19, 21, 0, 0, tzinfo=current_tz)
+
+    def test_cron_next_run_timezone_repair_still_fast_forwards_stale_wall_time(
+        self, tmp_cron_dir, monkeypatch
+    ):
+        pytest.importorskip("croniter")
+        current_tz = timezone(timedelta(hours=2))
+        old_tz = timezone(timedelta(hours=10))
+        now = datetime(2026, 5, 19, 23, 30, 0, tzinfo=current_tz)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        save_jobs(
+            [{
+                "id": "cron-tz-stale",
+                "name": "Tuesday evening stale",
+                "prompt": "...",
+                "schedule": {"kind": "cron", "expr": "0 21 * * 2", "display": "0 21 * * 2"},
+                "schedule_display": "0 21 * * 2",
+                "repeat": {"times": None, "completed": 0},
+                "enabled": True,
+                "state": "scheduled",
+                "paused_at": None,
+                "paused_reason": None,
+                "created_at": "2026-05-12T21:00:00+10:00",
+                "next_run_at": datetime(2026, 5, 19, 21, 0, 0, tzinfo=old_tz).isoformat(),
+                "last_run_at": None,
+                "last_status": None,
+                "last_error": None,
+                "deliver": "local",
+                "origin": None,
+            }]
+        )
+
+        assert get_due_jobs() == []
+        fast_forwarded = datetime.fromisoformat(get_job("cron-tz-stale")["next_run_at"])
+        assert fast_forwarded == datetime(2026, 5, 26, 21, 0, 0, tzinfo=current_tz)
+
     def test_disabled_not_returned(self, tmp_cron_dir):
         job = create_job(prompt="Disabled", schedule="every 1h")
         jobs = load_jobs()


### PR DESCRIPTION
## Summary
- Detect persisted cron `next_run_at` values that still use an old UTC offset after Hermes timezone migration
- Rebase those timestamps to the current Hermes timezone while preserving the intended cron wall-clock time
- Keep stale-run fast-forward behavior intact so missed schedules do not backfill unexpectedly

Fixes #28934

## Test Plan
- [x] `python -m pytest tests/cron/test_jobs.py::TestGetDueJobs -q -o addopts=` — 10 passed
- [x] `python -m pytest tests/cron/test_jobs.py -q -o addopts=` — 81 passed
- [x] `python -m pytest tests/cron -q -o addopts=` — 375 passed
