### PR TITLE
fix(gateway): recognize Windows drive-letter paths in extract_local_files() bare-path uploads

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2543,8 +2543,9 @@ class BasePlatformAdapter(ABC):
         
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
+        # Path anchor matches Unix (~/, /...) and Windows (C:/..., C:\...) absolute paths.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/|[A-Za-z]:[/\\])\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()
@@ -2613,9 +2614,10 @@ class BasePlatformAdapter(ABC):
 
         # (?<![/:\w.]) prevents matching inside URLs (e.g. https://…/img.png)
         #             and relative paths (./foo.png)
-        # (?:~/|/)    anchors to absolute or home-relative paths
+        # (?:~/|/|<drive>:[/\\]) anchors to absolute or home-relative paths,
+        #             including Windows drive-letter paths (C:/..., C:\...).
         path_re = re.compile(
-            r'(?<![/:\w.])(?:~/|/)(?:[\w.\-]+/)*[\w.\-]+\.(?:' + ext_part + r')\b',
+            r'(?<![/:\w.])(?:~/|/|[A-Za-z]:[/\\])(?:[\w.\-]+[/\\])*[\w.\-]+\.(?:' + ext_part + r')\b',
             re.IGNORECASE,
         )
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2543,9 +2543,8 @@ class BasePlatformAdapter(ABC):
         
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
-        # Path anchor matches Unix (~/, /...) and Windows (C:/..., C:\...) absolute paths.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/|[A-Za-z]:[/\\])\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()

--- a/tests/gateway/test_extract_local_files.py
+++ b/tests/gateway/test_extract_local_files.py
@@ -336,9 +336,35 @@ class TestEdgeCases:
         paths, _ = _extract("File at /tmp/my file.png here")
         assert paths == []
 
-    def test_windows_path_not_matched(self):
-        """Windows-style paths should not match."""
-        paths, _ = _extract("See C:\\Users\\test\\image.png")
+    @pytest.mark.parametrize(
+        "content,expected",
+        [
+            # Backslash separators (native Windows style)
+            ("See C:\\Users\\test\\image.png here", "C:\\Users\\test\\image.png"),
+            # Forward slashes with drive letter (common in cross-platform code)
+            ("See C:/Users/test/image.png here", "C:/Users/test/image.png"),
+            # Non-C: drive
+            ("Video at D:/data/clip.mp4 ready", "D:/data/clip.mp4"),
+            # Lowercase drive letter
+            ("Path e:/audio/track.mp3 done", "e:/audio/track.mp3"),
+        ],
+    )
+    def test_windows_drive_letter_paths_matched(self, content, expected):
+        """Windows drive-letter paths (C:/..., C:\\...) must be detected (issue #28989).
+
+        Prior behavior anchored on (?:~/|/) only, which silently dropped
+        Windows absolute paths so the agent's bare-path references were
+        sent as text instead of native uploads.
+        """
+        paths, cleaned = _extract(content)
+        assert paths == [expected]
+        assert expected not in cleaned
+
+    def test_relative_windows_path_not_matched(self):
+        """Regression guard: a bare Windows-style filename without a drive
+        letter must still not match (e.g. ``foo\\bar.png`` is treated as
+        relative, like its Unix sibling ``foo/bar.png``)."""
+        paths, _ = _extract("File at foo\\bar.png here")
         assert paths == []
 
     def test_relative_path_not_matched(self):

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -757,6 +757,47 @@ class TestSignalMediaExtraction:
         assert media[0][0] == "/tmp/reply.ogg"
         assert media[0][1] is True  # is_voice flag
 
+    @pytest.mark.parametrize(
+        "content,expected_path",
+        [
+            # Windows drive letter with forward slashes (common in cross-platform code)
+            ("Here is the chart.\nMEDIA:C:/Users/gizmo/image.jpg", "C:/Users/gizmo/image.jpg"),
+            # Windows drive letter with backslashes (native Windows path style)
+            ("Here is the chart.\nMEDIA:C:\\Users\\gizmo\\image.jpg", "C:\\Users\\gizmo\\image.jpg"),
+            # Non-C: drive letter
+            ("MEDIA:D:/data/clip.mp4", "D:/data/clip.mp4"),
+            # Lowercase drive letter
+            ("MEDIA:e:/audio/track.mp3", "e:/audio/track.mp3"),
+        ],
+    )
+    def test_extract_media_recognizes_windows_paths(self, content, expected_path):
+        """extract_media() must recognize Windows drive-letter paths (issue #28989).
+
+        Prior to the fix, the regex anchor was (?:~/|/) which only matched Unix
+        absolute/home paths. On Windows, MEDIA:C:/... tags were not extracted and
+        the raw text was sent to messaging platforms instead of the actual file.
+        """
+        from gateway.platforms.base import BasePlatformAdapter
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert len(media) == 1, f"Windows path not extracted from {content!r}"
+        # extract_media runs os.path.expanduser; for a Windows-style absolute
+        # path there is no leading ~ to expand, so the path is unchanged.
+        assert media[0][0] == expected_path
+        assert "MEDIA:" not in cleaned
+
+    def test_extract_media_still_rejects_relative_paths(self):
+        """Regression guard: relative tokens after MEDIA: must not be captured.
+
+        The earlier \\S+ fallback that captured plain words was removed in
+        ea49b3862; this verifies the Windows-path widening did not re-introduce
+        the same false positive.
+        """
+        from gateway.platforms.base import BasePlatformAdapter
+        media, _ = BasePlatformAdapter.extract_media("MEDIA:description")
+        assert media == []
+        media2, _ = BasePlatformAdapter.extract_media("MEDIA:relative/path.png")
+        assert media2 == []
+
     def test_signal_has_all_media_methods(self, monkeypatch):
         """SignalAdapter must override all media send methods used by gateway."""
         adapter = _make_signal_adapter(monkeypatch)

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -757,47 +757,6 @@ class TestSignalMediaExtraction:
         assert media[0][0] == "/tmp/reply.ogg"
         assert media[0][1] is True  # is_voice flag
 
-    @pytest.mark.parametrize(
-        "content,expected_path",
-        [
-            # Windows drive letter with forward slashes (common in cross-platform code)
-            ("Here is the chart.\nMEDIA:C:/Users/gizmo/image.jpg", "C:/Users/gizmo/image.jpg"),
-            # Windows drive letter with backslashes (native Windows path style)
-            ("Here is the chart.\nMEDIA:C:\\Users\\gizmo\\image.jpg", "C:\\Users\\gizmo\\image.jpg"),
-            # Non-C: drive letter
-            ("MEDIA:D:/data/clip.mp4", "D:/data/clip.mp4"),
-            # Lowercase drive letter
-            ("MEDIA:e:/audio/track.mp3", "e:/audio/track.mp3"),
-        ],
-    )
-    def test_extract_media_recognizes_windows_paths(self, content, expected_path):
-        """extract_media() must recognize Windows drive-letter paths (issue #28989).
-
-        Prior to the fix, the regex anchor was (?:~/|/) which only matched Unix
-        absolute/home paths. On Windows, MEDIA:C:/... tags were not extracted and
-        the raw text was sent to messaging platforms instead of the actual file.
-        """
-        from gateway.platforms.base import BasePlatformAdapter
-        media, cleaned = BasePlatformAdapter.extract_media(content)
-        assert len(media) == 1, f"Windows path not extracted from {content!r}"
-        # extract_media runs os.path.expanduser; for a Windows-style absolute
-        # path there is no leading ~ to expand, so the path is unchanged.
-        assert media[0][0] == expected_path
-        assert "MEDIA:" not in cleaned
-
-    def test_extract_media_still_rejects_relative_paths(self):
-        """Regression guard: relative tokens after MEDIA: must not be captured.
-
-        The earlier \\S+ fallback that captured plain words was removed in
-        ea49b3862; this verifies the Windows-path widening did not re-introduce
-        the same false positive.
-        """
-        from gateway.platforms.base import BasePlatformAdapter
-        media, _ = BasePlatformAdapter.extract_media("MEDIA:description")
-        assert media == []
-        media2, _ = BasePlatformAdapter.extract_media("MEDIA:relative/path.png")
-        assert media2 == []
-
     def test_signal_has_all_media_methods(self, monkeypatch):
         """SignalAdapter must override all media send methods used by gateway."""
         adapter = _make_signal_adapter(monkeypatch)


### PR DESCRIPTION
## What does this PR do?

`gateway.platforms.base.BasePlatformAdapter.extract_local_files()` anchors its bare-path regex on `(?:~/|/)`, which only matches Unix absolute/home paths. Windows drive-letter paths (`C:/Users/...`, `C:\\Users\\...`, `D:/...`, etc.) silently fail to match, so the gateway never recognizes them as native uploads and the raw text is sent through to the messaging platform instead.

The fix widens the path anchor to `(?:~/|/|[A-Za-z]:[/\\])` and allows `\\` as an in-path separator. A `(?<![/:\w.])` negative lookbehind is already present so URLs and relative paths (`./foo.png`) continue to be rejected.

> Audited siblings: `extract_media()` in the same file has the same Unix-only anchor, but @liuhao1024 already covered it in #24049 (plus GIS extension additions). After @alt-glitch's partial-overlap flag I reverted the `extract_media()` half of this PR so the two PRs no longer compete on the same surface — this PR is now scoped to the parallel `extract_local_files()` bug only.

## Related Issue

Discovered while reviewing #28989 (which reports the `extract_media()` half). This PR does not close #28989 — #24049 is the canonical fix there.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/base.py` — widen the `extract_local_files()` path anchor to accept `[A-Za-z]:[/\\]` drive-letter prefixes and `\\` as an in-path separator.
- `tests/gateway/test_extract_local_files.py` — replace the now-obsolete `test_windows_path_not_matched` assertion with a parametrized positive test across four drive-letter shapes (uppercase `C:`, lowercase `e:`, forward and back slashes, non-`C:` drive) plus a regression guard confirming a bare relative `foo\\bar.png` still does NOT match.

## How to Test

1. Reproduce the bug on `origin/main`:
   ```
   uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/gateway/test_extract_local_files.py::TestEdgeCases::test_windows_drive_letter_paths_matched -v
   ```
   → fails (anchor doesn't match Windows paths).
2. Apply this PR and rerun the same command → 4/4 pass.
3. Full file regression: `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/gateway/test_extract_local_files.py -v` → 48 passed locally.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (the function-level comment above the regex is updated to describe the new anchor)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — this IS the cross-platform fix; the new regex is OS-neutral
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

- #24049 (@liuhao1024) — covers `extract_media()` Windows-path anchor + GIS extensions. Canonical fix for #28989. **No overlap with this PR after the narrowing in $SHA.**
- #24384 (@Kyzcreig) — `extract_media()` prefix-glue, space-truncation, and allowlist narrowing. Orthogonal to this PR.
- #20843 (@liuhao1024) — removes the `extract_local_files()` CALL from `_deliver_media_from_response()`. If that PR lands first, this PR becomes a defense-in-depth improvement to the function for callers that still invoke it directly.

CI failures on this PR are pre-existing baselines on `origin/main` (test_restart_resume_pending, test_anthropic_error_handling 429/500 timeouts, test_file_operations missing `_check_git_baseline`, etc.) — none touch `gateway/platforms/base.py` or the `extract_local_files` test file.