### PR TITLE
fix(gateway): transcribe native voice notes (Discord + DingTalk)

### DIFF
--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -774,7 +774,14 @@ class DingTalkAdapter(BasePlatformAdapter):
                             elif mapped == "audio":
                                 media_types.append("audio")
                                 if msg_type == MessageType.TEXT:
-                                    msg_type = MessageType.AUDIO
+                                    # DingTalk's "voice" rich-text item is a
+                                    # native voice note — route through STT.
+                                    # "audio" comes from file uploads only;
+                                    # keep those as AUDIO (no auto-STT).
+                                    if item_type == "voice":
+                                        msg_type = MessageType.VOICE
+                                    else:
+                                        msg_type = MessageType.AUDIO
                             elif mapped == "video":
                                 media_types.append("video")
                                 if msg_type == MessageType.TEXT:

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -3602,6 +3602,24 @@ class DiscordAdapter(BasePlatformAdapter):
             return 32 * 1024 * 1024
         return max(0, value)
 
+    @staticmethod
+    def _is_discord_voice_message_attachment(att: Any) -> bool:
+        """Return True when a Discord audio attachment is a native voice note."""
+        marker = getattr(att, "is_voice_message", None)
+        if marker is not None:
+            if callable(marker):
+                try:
+                    return bool(marker())
+                except Exception as exc:
+                    logger.debug("[Discord] is_voice_message() failed for attachment: %s", exc)
+                    return False
+            return bool(marker)
+
+        return (
+            getattr(att, "duration", None) is not None
+            and getattr(att, "waveform", None) is not None
+        )
+
     def _discord_free_response_channels(self) -> set:
         """Return Discord channel IDs where no bot mention is required.
 
@@ -4542,7 +4560,10 @@ class DiscordAdapter(BasePlatformAdapter):
                     elif att.content_type.startswith("video/"):
                         msg_type = MessageType.VIDEO
                     elif att.content_type.startswith("audio/"):
-                        msg_type = MessageType.AUDIO
+                        if self._is_discord_voice_message_attachment(att):
+                            msg_type = MessageType.VOICE
+                        else:
+                            msg_type = MessageType.AUDIO
                     else:
                         doc_ext = ""
                         if att.filename:

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -542,6 +542,58 @@ class TestExtractText:
         assert DingTalkAdapter._extract_text(msg) == ""
 
 
+class TestExtractMedia:
+    """_extract_media must split native voice rich-text items (auto-STT)
+    from generic audio file uploads (kept as attachments, no STT)."""
+
+    def _msg_with_rich_text(self, items):
+        msg = MagicMock()
+        msg.text = None
+        msg.image_content = None
+        msg.rich_text_content = None
+        msg.rich_text = items
+        return msg
+
+    def test_voice_rich_text_item_classified_as_voice(self):
+        """Native DingTalk voice notes (type=voice) must enter the auto-STT
+        path via MessageType.VOICE — the gateway skips STT for AUDIO."""
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        from gateway.platforms.base import MessageType
+
+        msg = self._msg_with_rich_text(
+            [{"type": "voice", "downloadCode": "dl_voice_abc"}]
+        )
+        msg_type, urls, mtypes = DingTalkAdapter._extract_media(
+            DingTalkAdapter, msg
+        )
+        assert msg_type == MessageType.VOICE
+        assert urls == ["dl_voice_abc"]
+        assert mtypes == ["audio"]
+
+    def test_audio_rich_text_item_stays_audio(self):
+        """Generic audio uploads (e.g. an mp3 the user attached) must NOT
+        be auto-transcribed — they stay MessageType.AUDIO."""
+        from gateway.platforms.dingtalk import DingTalkAdapter, DINGTALK_TYPE_MAPPING
+        from gateway.platforms.base import MessageType
+
+        # Simulate a future/non-voice audio rich-text item by extending the
+        # mapping so item_type != "voice" but still routes through the
+        # ``mapped == "audio"`` branch.
+        DINGTALK_TYPE_MAPPING["audio"] = "audio"
+        try:
+            msg = self._msg_with_rich_text(
+                [{"type": "audio", "downloadCode": "dl_audio_xyz"}]
+            )
+            msg_type, urls, mtypes = DingTalkAdapter._extract_media(
+                DingTalkAdapter, msg
+            )
+            assert msg_type == MessageType.AUDIO
+            assert urls == ["dl_audio_xyz"]
+            assert mtypes == ["audio"]
+        finally:
+            del DINGTALK_TYPE_MAPPING["audio"]
+
+
 # ---------------------------------------------------------------------------
 # Group gating — require_mention + allowed_users (parity with other platforms)
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_discord_attachment_download.py
+++ b/tests/gateway/test_discord_attachment_download.py
@@ -59,6 +59,7 @@ def _ensure_discord_mock():
 _ensure_discord_mock()
 
 from gateway.platforms.discord import DiscordAdapter  # noqa: E402
+from gateway.platforms.base import MessageType  # noqa: E402
 
 
 # Minimal valid image / audio / PDF bytes so the cache_*_from_bytes
@@ -358,3 +359,91 @@ class TestHandleMessageUsesAuthenticatedRead:
         event = adapter.handle_message.call_args[0][0]
         assert event.media_urls == ["/tmp/img_from_read.png"]
         assert event.media_types == ["image/png"]
+
+    @pytest.mark.asyncio
+    async def test_native_voice_note_is_classified_as_voice(self, monkeypatch):
+        """Discord native voice notes must enter the auto-STT voice path."""
+        adapter = _make_adapter()
+        adapter._client = SimpleNamespace(user=SimpleNamespace(id=999))
+        adapter.handle_message = AsyncMock()
+
+        with patch(
+            "gateway.platforms.discord.cache_audio_from_bytes",
+            return_value="/tmp/voice_from_read.ogg",
+        ):
+            att = SimpleNamespace(
+                url="https://cdn.discordapp.com/attachments/fake/voice.ogg",
+                filename="voice.ogg",
+                content_type="audio/ogg",
+                size=len(_OGG_BYTES),
+                read=AsyncMock(return_value=_OGG_BYTES),
+                is_voice_message=lambda: True,
+            )
+            from datetime import datetime, timezone
+
+            class _FakeDMChannel:
+                id = 100
+                name = "dm"
+
+            monkeypatch.setattr(
+                "gateway.platforms.discord.discord.DMChannel",
+                _FakeDMChannel,
+            )
+            chan = _FakeDMChannel()
+            msg = SimpleNamespace(
+                id=1, content="", attachments=[att], mentions=[],
+                reference=None,
+                created_at=datetime.now(timezone.utc),
+                channel=chan,
+                author=SimpleNamespace(id=42, display_name="U", name="U"),
+            )
+            await adapter._handle_message(msg)
+
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.VOICE
+        assert event.media_urls == ["/tmp/voice_from_read.ogg"]
+        assert event.media_types == ["audio/ogg"]
+
+    @pytest.mark.asyncio
+    async def test_plain_audio_attachment_stays_audio(self, monkeypatch):
+        """Plain audio uploads should stay out of automatic voice-note STT."""
+        adapter = _make_adapter()
+        adapter._client = SimpleNamespace(user=SimpleNamespace(id=999))
+        adapter.handle_message = AsyncMock()
+
+        with patch(
+            "gateway.platforms.discord.cache_audio_from_bytes",
+            return_value="/tmp/audio_from_read.ogg",
+        ):
+            att = SimpleNamespace(
+                url="https://cdn.discordapp.com/attachments/fake/audio.ogg",
+                filename="audio.ogg",
+                content_type="audio/ogg",
+                size=len(_OGG_BYTES),
+                read=AsyncMock(return_value=_OGG_BYTES),
+                is_voice_message=lambda: False,
+            )
+            from datetime import datetime, timezone
+
+            class _FakeDMChannel:
+                id = 100
+                name = "dm"
+
+            monkeypatch.setattr(
+                "gateway.platforms.discord.discord.DMChannel",
+                _FakeDMChannel,
+            )
+            chan = _FakeDMChannel()
+            msg = SimpleNamespace(
+                id=1, content="", attachments=[att], mentions=[],
+                reference=None,
+                created_at=datetime.now(timezone.utc),
+                channel=chan,
+                author=SimpleNamespace(id=42, display_name="U", name="U"),
+            )
+            await adapter._handle_message(msg)
+
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.AUDIO
+        assert event.media_urls == ["/tmp/audio_from_read.ogg"]
+        assert event.media_types == ["audio/ogg"]


### PR DESCRIPTION
Salvages #28918 (helix4u/Gille) onto current main + extends the same fix to DingTalk after a parity audit.

## Summary

Discord and DingTalk native voice notes were being classified as `MessageType.AUDIO` instead of `MessageType.VOICE`. Gateway STT routing at `gateway/run.py:7605` intentionally skips `AUDIO` (file uploads — never auto-transcribe an mp3) and always STTs `VOICE` (voice bubbles — always transcribe). Discord and DingTalk are the only two voice-capable platforms that never emitted `VOICE`, contradicting the docs at `website/docs/user-guide/features/tts.md:302`.

This wasn't a recent regression — `git log -S 'MessageType.VOICE' -- gateway/platforms/discord.py` returns zero results. Discord auto-STT never worked. DingTalk had a `'voice' -> 'audio'` mapping in `DINGTALK_TYPE_MAPPING` that hinted at the intent but never reached `VOICE`.

## Changes

- `gateway/platforms/discord.py` — cherry-picked from #28918. Use `Attachment.is_voice_message()` (with duration+waveform fallback for older discord.py) to split native voice notes from generic audio uploads. **Authored by @helix4u.**
- `gateway/platforms/dingtalk.py` — when a rich-text item has `type: voice`, route to `MessageType.VOICE` instead of `MessageType.AUDIO`. Generic audio uploads (mapped to `file` by `DINGTALK_TYPE_MAPPING`) remain `DOCUMENT` as before.
- `tests/gateway/test_discord_attachment_download.py` — regression tests from #28918 covering both voice-note and plain-audio paths.
- `tests/gateway/test_dingtalk.py` — new `TestExtractMedia` covering the same split.

Other platforms audited (telegram, whatsapp, signal, slack, matrix, mattermost, bluebubbles, wecom, weixin, yuanbao, qqbot) all already emit `MessageType.VOICE` correctly. Feishu has no separate voice-note semantic in its API — every audio comes in as type `audio` (file upload), so leaving it as `AUDIO` is policy-correct.

## Validation

| | Targeted suite | Result |
|---|---|---|
| `test_discord_attachment_download.py` | 14 tests (incl. 2 new) | pass |
| `test_dingtalk.py` | 67 tests (incl. 2 new) | pass |
| `test_telegram_audio_vs_voice.py` | parity check | pass |
| `test_stt_config.py` | STT routing | pass |

`scripts/run_tests.sh tests/gateway/test_dingtalk.py tests/gateway/test_discord_attachment_download.py tests/gateway/test_telegram_audio_vs_voice.py tests/gateway/test_stt_config.py` — 92 passed.

Closes #28918.