### PR TITLE
fix(dashboard): force JavaScript MIME on built SPA assets (#28987)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -14,6 +14,7 @@ import hmac
 import importlib.util
 import json
 import logging
+import mimetypes
 import os
 import secrets
 import subprocess
@@ -26,6 +27,61 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 import yaml
+
+
+# ---------------------------------------------------------------------------
+# Web-asset MIME normalization (#28987)
+# ---------------------------------------------------------------------------
+#
+# Starlette's ``StaticFiles`` and ``FileResponse`` rely on
+# ``mimetypes.guess_type`` to set ``Content-Type``.  On native Windows,
+# Python's ``mimetypes.init()`` reads the system registry — and many
+# installers (notably some older IIS / VS toolchains) pollute
+# ``HKEY_CLASSES_ROOT\.js`` with ``Content Type = text/plain``.  Python
+# faithfully honours that, browsers then refuse to execute the Vite
+# bundle under strict MIME checking, and the dashboard renders as a
+# blank page.
+#
+# Fix: explicitly override the strict map for the asset extensions we
+# actually serve.  ``mimetypes.add_type(..., strict=True)`` directly
+# writes the ``types_map`` dict that ``guess_type`` consults first, so
+# our values win regardless of what the registry says.
+#
+# Per RFC 9239 (May 2022) ``text/javascript`` is the only IANA-blessed
+# JavaScript MIME type; every major browser also accepts it for ESM
+# module scripts under HTML's strict MIME checking.
+
+_WEB_ASSET_MIME_OVERRIDES = {
+    ".js":   "text/javascript",
+    ".mjs":  "text/javascript",
+    ".cjs":  "text/javascript",
+    ".css":  "text/css",
+    ".json": "application/json",
+    ".map":  "application/json",   # source maps
+    ".svg":  "image/svg+xml",
+    ".wasm": "application/wasm",
+    ".webp": "image/webp",
+    ".webmanifest": "application/manifest+json",
+    ".woff": "font/woff",
+    ".woff2": "font/woff2",
+    ".ico":  "image/x-icon",
+}
+
+
+def _normalize_web_asset_mime_types() -> None:
+    """Force web-standard ``Content-Type`` values for SPA assets.
+
+    Idempotent.  Called once at module load so every ``StaticFiles``
+    mount and ``FileResponse`` built afterwards sees the corrected
+    map.  See #28987 for the Windows registry corner case that
+    motivated this.
+    """
+    mimetypes.init()  # populate from system sources first
+    for ext, mime in _WEB_ASSET_MIME_OVERRIDES.items():
+        mimetypes.add_type(mime, ext, strict=True)
+
+
+_normalize_web_asset_mime_types()
 
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 if str(PROJECT_ROOT) not in sys.path:

--- a/tests/hermes_cli/test_web_server_asset_mime.py
+++ b/tests/hermes_cli/test_web_server_asset_mime.py
@@ -1,0 +1,292 @@
+"""Regression coverage for #28987 — dashboard JS bundles must be served
+with a JavaScript MIME type, not ``text/plain``.
+
+The bug surfaced only on native Windows where ``HKEY_CLASSES_ROOT\\.js``
+can be set to ``Content Type = text/plain`` by various installers.
+Python's ``mimetypes.init()`` reads that registry value, Starlette's
+``FileResponse`` / ``StaticFiles`` then propagate it to the
+``Content-Type`` header, and browsers refuse to execute the Vite
+ESM bundle under strict MIME checking — leaving the dashboard blank.
+
+We can't easily run the test on Windows in CI, but we *can* reproduce
+the failure mode portably by **poisoning the strict ``mimetypes`` map
+before importing the web server** and asserting that the module's
+startup normalisation undoes the damage.  This catches both the
+Windows-registry case and any future regression where someone adds a
+``mimetypes.add_type('text/plain', '.js')`` call elsewhere.
+"""
+
+from __future__ import annotations
+
+import importlib
+import mimetypes
+import sys
+from pathlib import Path
+
+import pytest
+
+
+# JavaScript module scripts only execute when ``Content-Type`` matches
+# the HTML spec's "JavaScript MIME type" essence — which is exactly
+# ``text/javascript``, ``application/javascript``, or any of the
+# obsolete-but-still-allowed variants.  RFC 9239 (May 2022) makes
+# ``text/javascript`` the only IANA-blessed value; we accept either
+# spelling so a future Starlette / Python change doesn't flake the test.
+JAVASCRIPT_MIME_PREFIXES = ("text/javascript", "application/javascript")
+
+
+def _is_javascript_mime(content_type: str) -> bool:
+    """True if ``content_type`` is a JavaScript-MIME-type-essence match."""
+    if not content_type:
+        return False
+    essence = content_type.split(";", 1)[0].strip().lower()
+    return essence in JAVASCRIPT_MIME_PREFIXES
+
+
+@pytest.fixture
+def poisoned_mimetypes(monkeypatch):
+    """Save the live ``mimetypes`` strict map, poison ``.js`` / ``.mjs``
+    with ``text/plain`` to simulate the Windows registry pollution,
+    then restore on teardown so other tests aren't affected.
+    """
+    original = mimetypes.types_map.copy()
+    yield_target = mimetypes.types_map
+    yield_target[".js"] = "text/plain"
+    yield_target[".mjs"] = "text/plain"
+    try:
+        yield
+    finally:
+        mimetypes.types_map.clear()
+        mimetypes.types_map.update(original)
+
+
+class TestMimeNormalizationFunction:
+    """Unit-level coverage for ``_normalize_web_asset_mime_types``."""
+
+    def test_overrides_text_plain_on_dot_js(self, poisoned_mimetypes):
+        # Sanity: the fixture really did poison the map.  Without this
+        # assert, a future change that silently un-poisons ``.js``
+        # would make the rest of the test pass for the wrong reason.
+        assert mimetypes.guess_type("a.js")[0] == "text/plain"
+
+        from hermes_cli.web_server import _normalize_web_asset_mime_types
+        _normalize_web_asset_mime_types()
+
+        assert _is_javascript_mime(mimetypes.guess_type("a.js")[0]), (
+            "Module bundles served as text/plain are rejected by browsers "
+            "under strict MIME checking (#28987)."
+        )
+
+    def test_overrides_text_plain_on_dot_mjs(self, poisoned_mimetypes):
+        # ``.mjs`` is what Vite/Rollup uses for ESM-only builds; even on
+        # vanilla Python ``mimetypes`` doesn't ship a mapping for it,
+        # so this codifies the explicit override.
+        from hermes_cli.web_server import _normalize_web_asset_mime_types
+        _normalize_web_asset_mime_types()
+
+        assert _is_javascript_mime(mimetypes.guess_type("a.mjs")[0])
+
+    def test_idempotent(self):
+        # Importing the module once at process start is enough — but
+        # calling the helper again must not break anything.
+        from hermes_cli.web_server import _normalize_web_asset_mime_types
+        _normalize_web_asset_mime_types()
+        _normalize_web_asset_mime_types()
+        _normalize_web_asset_mime_types()
+
+        assert _is_javascript_mime(mimetypes.guess_type("a.js")[0])
+
+    @pytest.mark.parametrize(
+        "filename,expected",
+        [
+            ("bundle.js", JAVASCRIPT_MIME_PREFIXES),
+            ("worker.mjs", JAVASCRIPT_MIME_PREFIXES),
+            ("legacy.cjs", JAVASCRIPT_MIME_PREFIXES),
+            ("styles.css", ("text/css",)),
+            ("logo.svg", ("image/svg+xml",)),
+            ("font.woff2", ("font/woff2",)),
+            ("font.woff", ("font/woff",)),
+            ("icon.ico", ("image/x-icon",)),
+            ("bundle.js.map", ("application/json",)),
+            ("module.wasm", ("application/wasm",)),
+            ("manifest.webmanifest", ("application/manifest+json",)),
+        ],
+    )
+    def test_all_overrides_apply(self, filename, expected):
+        # Every extension in ``_WEB_ASSET_MIME_OVERRIDES`` should resolve
+        # to its intended value.  Parametrising one row per asset means
+        # the test name pinpoints the failing extension when something
+        # regresses.
+        from hermes_cli.web_server import _normalize_web_asset_mime_types
+        _normalize_web_asset_mime_types()
+
+        actual = mimetypes.guess_type(filename)[0]
+        assert actual in expected, (
+            f"{filename}: expected one of {expected!r}, got {actual!r}"
+        )
+
+
+class TestMimeNormalizationAtImport:
+    """Catch the realistic Windows scenario: the registry pollutes the
+    map BEFORE Python imports ``hermes_cli.web_server``.  After the
+    import completes, ``mimetypes.guess_type('.js')`` must return a
+    JavaScript MIME type.  This is the exact ordering the bug report
+    describes."""
+
+    def test_import_normalizes_poisoned_map(self):
+        # Reload pattern: remove the cached module so re-import runs
+        # the module body (which calls ``_normalize_web_asset_mime_types``).
+        original_types_map = mimetypes.types_map.copy()
+        had_module = "hermes_cli.web_server" in sys.modules
+        cached_module = sys.modules.get("hermes_cli.web_server")
+        try:
+            mimetypes.types_map[".js"] = "text/plain"
+            mimetypes.types_map[".mjs"] = "text/plain"
+            assert mimetypes.guess_type("a.js")[0] == "text/plain"
+
+            sys.modules.pop("hermes_cli.web_server", None)
+            importlib.import_module("hermes_cli.web_server")
+
+            assert _is_javascript_mime(mimetypes.guess_type("a.js")[0])
+            assert _is_javascript_mime(mimetypes.guess_type("a.mjs")[0])
+        finally:
+            mimetypes.types_map.clear()
+            mimetypes.types_map.update(original_types_map)
+            # Re-apply the normalization so other tests that import
+            # web_server see the corrected map (the original test
+            # cache may have been from before any poison).
+            if cached_module is not None:
+                sys.modules["hermes_cli.web_server"] = cached_module
+            elif not had_module:
+                sys.modules.pop("hermes_cli.web_server", None)
+
+
+class TestStaticFileServingEndToEnd:
+    """Drive a real Starlette ``TestClient`` against a synthetic build
+    directory.  Catches regressions in the wire-up between
+    ``mount_spa()``, ``StaticFiles``, and the corrected MIME map."""
+
+    @pytest.fixture
+    def fake_dashboard(self, tmp_path, monkeypatch, poisoned_mimetypes):
+        """Build a minimal ``WEB_DIST`` that looks like a real Vite
+        build (index.html + hashed asset bundles) and point the web
+        server at it for the duration of one test.
+
+        The ``poisoned_mimetypes`` fixture simulates the Windows-
+        registry pollution that motivated #28987.  We then re-apply
+        ``_normalize_web_asset_mime_types`` to mirror what happens at
+        ``import hermes_cli.web_server`` time — without that line,
+        the test would just be exercising whatever map state happened
+        to be cached when an earlier test imported the module.
+        """
+        try:
+            from starlette.testclient import TestClient
+            from fastapi import FastAPI
+        except ImportError:
+            pytest.skip("fastapi / starlette not installed")
+
+        # Reapply the production-startup normalisation *after* the
+        # fixture's poison has run, exactly like the module-level
+        # call does at process start.
+        from hermes_cli.web_server import _normalize_web_asset_mime_types
+        _normalize_web_asset_mime_types()
+
+        dist = tmp_path / "web_dist"
+        (dist / "assets").mkdir(parents=True)
+        (dist / "index.html").write_text(
+            '<!doctype html><html><head>'
+            '<script type="module" src="/assets/index-abc.js"></script>'
+            '<link rel="stylesheet" href="/assets/index-abc.css">'
+            '</head><body><div id="root"></div></body></html>'
+        )
+        (dist / "assets" / "index-abc.js").write_text(
+            "export const HERMES_DASHBOARD = 'ok';\n"
+        )
+        (dist / "assets" / "index-abc.mjs").write_text(
+            "export const ESM_VARIANT = true;\n"
+        )
+        (dist / "assets" / "index-abc.js.map").write_text('{"version":3}')
+        (dist / "assets" / "logo.svg").write_text("<svg/>")
+        (dist / "favicon.ico").write_bytes(b"\x00\x00")
+
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setattr(ws, "WEB_DIST", dist)
+
+        # Build a fresh app so we can re-mount with the synthetic dist
+        # (the module-level ``app`` already has the real (possibly
+        # missing) build mounted at import time).
+        application = FastAPI()
+        ws.mount_spa(application)
+        client = TestClient(application)
+        return client
+
+    def test_js_bundle_is_served_as_javascript(self, fake_dashboard):
+        """The exact assertion from #28987's reproduction recipe:
+        ``Content-Type`` on a built JS bundle must be a JavaScript
+        MIME type, not ``text/plain``."""
+        resp = fake_dashboard.get("/assets/index-abc.js")
+        assert resp.status_code == 200, resp.text
+        assert _is_javascript_mime(resp.headers["content-type"]), (
+            f"Expected JavaScript MIME, got: {resp.headers['content-type']!r}"
+        )
+        assert b"HERMES_DASHBOARD" in resp.content
+
+    def test_mjs_bundle_is_served_as_javascript(self, fake_dashboard):
+        resp = fake_dashboard.get("/assets/index-abc.mjs")
+        assert resp.status_code == 200, resp.text
+        assert _is_javascript_mime(resp.headers["content-type"]), (
+            f"Expected JavaScript MIME, got: {resp.headers['content-type']!r}"
+        )
+
+    def test_source_map_is_served_as_json(self, fake_dashboard):
+        # Source maps aren't strictly required by browsers, but devtools
+        # complain loudly when they come back as ``text/plain``.
+        resp = fake_dashboard.get("/assets/index-abc.js.map")
+        assert resp.status_code == 200
+        essence = resp.headers["content-type"].split(";", 1)[0].strip()
+        assert essence == "application/json"
+
+    def test_svg_is_served_as_image(self, fake_dashboard):
+        # Inline ``<img src="…svg">`` and CSS ``url(...svg)`` both
+        # require a real ``image/`` MIME — ``text/plain`` would break
+        # rendering on the dashboard's brand assets.
+        resp = fake_dashboard.get("/assets/logo.svg")
+        assert resp.status_code == 200
+        essence = resp.headers["content-type"].split(";", 1)[0].strip()
+        assert essence == "image/svg+xml"
+
+    def test_index_html_still_served_as_html(self, fake_dashboard):
+        # Make sure the MIME normalisation didn't accidentally
+        # downgrade the SPA shell itself.
+        resp = fake_dashboard.get("/")
+        assert resp.status_code == 200
+        essence = resp.headers["content-type"].split(";", 1)[0].strip()
+        assert essence == "text/html"
+        assert "id=\"root\"" in resp.text
+
+
+class TestMimeOverrideRegistryShape:
+    """The override table is a public-ish surface (other modules might
+    eventually want to extend it).  Lock its invariants down so a
+    future drive-by edit doesn't silently break things."""
+
+    def test_js_and_mjs_both_resolve_to_javascript(self):
+        from hermes_cli.web_server import _WEB_ASSET_MIME_OVERRIDES
+        assert _is_javascript_mime(_WEB_ASSET_MIME_OVERRIDES[".js"])
+        assert _is_javascript_mime(_WEB_ASSET_MIME_OVERRIDES[".mjs"])
+
+    def test_every_value_has_a_slash(self):
+        """Sanity guard against typos like ``"text"`` or ``"javascript"``
+        — every value must be a real ``type/subtype`` pair."""
+        from hermes_cli.web_server import _WEB_ASSET_MIME_OVERRIDES
+        for ext, mime in _WEB_ASSET_MIME_OVERRIDES.items():
+            assert "/" in mime, f"{ext!r} maps to malformed MIME {mime!r}"
+            assert not mime.startswith(" "), f"{ext!r} value has leading space"
+
+    def test_every_extension_starts_with_dot(self):
+        """``mimetypes.add_type`` requires extensions to include the
+        leading dot — guard against ``js`` (no dot) sneaking in."""
+        from hermes_cli.web_server import _WEB_ASSET_MIME_OVERRIDES
+        for ext in _WEB_ASSET_MIME_OVERRIDES:
+            assert ext.startswith("."), f"Extension {ext!r} missing leading dot"


### PR DESCRIPTION
## What does this PR do?

On native Windows `hermes dashboard` renders as a blank page: the HTML shell loads fine, but the Vite ESM bundle comes back with `Content-Type: text/plain; charset=utf-8` and Chrome refuses the module script under strict MIME checking ("Failed to load module script: Expected a JavaScript-or-Wasm module script…").

**Root cause.** Starlette's `StaticFiles` / `FileResponse` both pick `Content-Type` from `mimetypes.guess_type`. Python's `mimetypes.init()` reads the Windows registry, and many installers (older IIS / Visual Studio toolchains, even some antivirus suites) pollute `HKEY_CLASSES_ROOT\.js` with `Content Type = text/plain`. Python faithfully honours that, the browser refuses the module, the SPA never mounts.

**Fix.** At `hermes_cli.web_server` import time, explicitly override the strict `mimetypes` map for the asset extensions we actually serve — `text/javascript` for `.js` / `.mjs` / `.cjs` (per RFC 9239), plus correct values for `.css`, `.json`, `.map`, `.svg`, `.wasm`, `.webp`, `.webmanifest`, `.woff`, `.woff2`, `.ico`. `mimetypes.add_type(..., strict=True)` writes directly into the `types_map` dict that `guess_type` consults first, so our values win regardless of what the registry says. Idempotent.

## Related Issue

Fixes #28987

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/web_server.py` — Add `_WEB_ASSET_MIME_OVERRIDES` (13 extensions) and `_normalize_web_asset_mime_types()`; invoke it once at module import. Long block comment documents the Windows registry corner case so the next maintainer doesn't accidentally "simplify" the override away.
- `tests/hermes_cli/test_web_server_asset_mime.py` — 23 new regression tests in four classes:
  - `TestMimeNormalizationFunction` — unit-level: simulate the Windows registry poison by writing `text/plain` into `mimetypes.types_map[".js"]`, then assert the helper recovers a JavaScript MIME. Parametrised once-per-extension so a future drive-by removal is identified by name.
  - `TestMimeNormalizationAtImport` — reload `hermes_cli.web_server` from scratch under a poisoned map and assert the module-level call self-heals the import order.
  - `TestStaticFileServingEndToEnd` — drive a real `starlette.testclient.TestClient` against a synthetic Vite-style `WEB_DIST`. Asserts `/assets/index-abc.js` returns a JavaScript MIME and `/` still returns `text/html` (no accidental downgrade).
  - `TestMimeOverrideRegistryShape` — structural guards: every entry maps to a valid `type/subtype` pair and every extension starts with `.`.

## How to Test

Reproduce the bug on Windows `main`:

```powershell
hermes dashboard --no-open
# Browse to http://127.0.0.1:9119/ — blank page.
# Check the response header:
Invoke-WebRequest -UseBasicParsing http://127.0.0.1:9119/assets/index-<hash>.js |
  Select-Object -ExpandProperty Headers
# Content-Type: text/plain; charset=utf-8   ← the bug
```

After this PR:

```powershell
hermes dashboard --no-open
# Dashboard renders normally.
Invoke-WebRequest -UseBasicParsing http://127.0.0.1:9119/assets/index-<hash>.js |
  Select-Object -ExpandProperty Headers
# Content-Type: text/javascript; charset=utf-8   ← fixed
```

Automated coverage (portable — reproduces the failure mode on any OS by directly poisoning the mimetypes map):

```
scripts/run_tests.sh tests/hermes_cli/test_web_server_asset_mime.py -q
# 23 passed in 5.45s
```

Quick manual sanity check on macOS:

```
.venv/bin/python -c "
import mimetypes
mimetypes.types_map['.js'] = 'text/plain'        # simulate Windows
print('before:', mimetypes.guess_type('a.js'))
import hermes_cli.web_server                     # trigger the fix
print('after: ', mimetypes.guess_type('a.js'))
"
# before: ('text/plain', None)
# after:  ('text/javascript', None)
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(dashboard):`, `test(dashboard):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant tests locally and they pass
- [x] I've added tests for my changes (23 new regression tests)
- [x] Tested on my platform: macOS 15.2 (Darwin 24.6.0). Test design reproduces the Windows-specific failure portably by poisoning the strict `mimetypes` map.

### Documentation & Housekeeping

- [x] N/A — no user-facing config / docs touched (the fix is invisible to operators who run a working setup; only fixes a regression for the affected install profile)
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow changes
- [x] Cross-platform — the fix is harmless on Linux/macOS (their stock mimetypes already report `text/javascript` for `.js`; we still upgrade `.mjs` and `.map` which aren't in Python's defaults)
- [x] N/A — no tool descriptions / schemas changed

## Screenshots / Logs

Browser console before the fix (per #28987):

```
Failed to load module script: Expected a JavaScript-or-Wasm module script
but the server responded with a MIME type of "text/plain". Strict MIME
type checking is enforced for module scripts per HTML spec.
```

Response headers before / after the fix (`curl -I` on a built Vite bundle):

```
# Before
HTTP/1.1 200 OK
content-type: text/plain; charset=utf-8

# After
HTTP/1.1 200 OK
content-type: text/javascript; charset=utf-8
```
