### PR TITLE
feat(goal): support GCW supervision resume contracts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,4 @@ models-dev-upstream/
 hermes_cli/tui_dist/*
 hermes_cli/scripts/
 docs/superpowers/*
+.gitnexus

--- a/cli.py
+++ b/cli.py
@@ -8777,12 +8777,30 @@ class HermesCLI:
                 _cprint(f"  ⏸ Goal paused: {state.goal}")
             return
 
-        if lower == "resume":
-            state = mgr.resume()
+        if lower == "resume" or lower.startswith("resume "):
+            epic_contract = None
+            if lower.startswith("resume "):
+                contract_path = arg.split(None, 1)[1].strip()
+                try:
+                    from hermes_cli.goals import read_epic_goal_supervision_contract_json
+
+                    epic_contract = read_epic_goal_supervision_contract_json(contract_path)
+                except Exception as exc:
+                    _cprint(f"  /goal resume: invalid Epic supervision contract: {exc}")
+                    return
+            try:
+                state = mgr.resume(epic_goal_supervision=epic_contract)
+            except Exception as exc:
+                _cprint(f"  /goal resume: invalid Epic supervision contract: {exc}")
+                return
             if state is None:
                 _cprint(f"  {_DIM}No goal to resume.{_RST}")
             else:
                 _cprint(f"  ▶ Goal resumed: {state.goal}")
+                readback = mgr.formatted_epic_goal_resume_readback()
+                if readback:
+                    for line in readback.splitlines():
+                        _cprint(f"  {line}")
                 _cprint(
                     f"  {_DIM}Send any message (or press Enter on an empty prompt "
                     f"is a no-op; type 'continue' to kick it off).{_RST}"

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -57,7 +57,7 @@ class CronPromptInjectionBlocked(Exception):
     """
 
 
-def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str] | None:
+def _resolve_cron_enabled_toolsets(job: dict, cfg: object) -> list[str] | None:
     """Resolve the toolset list for a cron job.
 
     Precedence:
@@ -79,13 +79,52 @@ def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str] | None:
         return per_job
     try:
         from hermes_cli.tools_config import _get_platform_tools  # lazy: avoid heavy import at cron module load
-        return sorted(_get_platform_tools(cfg or {}, "cron"))
+        cfg_dict = cfg if isinstance(cfg, dict) else {}
+        return sorted(_get_platform_tools(cfg_dict, "cron"))
     except Exception as exc:
         logger.warning(
             "Cron toolset resolution failed, falling back to full default toolset: %s",
             exc,
         )
         return None
+
+
+def _cron_needs_memory_tool_store(enabled_toolsets: list[str] | None) -> bool:
+    """Return true when a cron job explicitly enables the built-in memory tool.
+
+    Cron agents intentionally run with ``skip_memory=True`` so MEMORY.md and
+    USER.md are not injected into non-interactive scheduled prompts.  That also
+    leaves ``AIAgent._memory_store`` unset, which makes explicit ``memory`` tool
+    calls fail with "Memory is not available."  Jobs that deliberately include
+    the ``memory`` toolset still need a live store for read/write operations;
+    attach it after construction without enabling prompt injection.
+    """
+    return bool(enabled_toolsets and "memory" in enabled_toolsets)
+
+
+def _attach_cron_memory_tool_store(agent, cfg: object) -> bool:
+    """Attach a MemoryStore for cron memory-tool jobs, without prompt injection."""
+    try:
+        cfg_dict = cfg if isinstance(cfg, dict) else {}
+        mem_config = (cfg_dict.get("memory", {}) or {}) if isinstance(cfg_dict, dict) else {}
+        from tools.memory_tool import MemoryStore
+
+        store = MemoryStore(
+            memory_char_limit=mem_config.get("memory_char_limit", 2200),
+            user_char_limit=mem_config.get("user_char_limit", 1375),
+        )
+        store.load_from_disk()
+        agent._memory_store = store
+        # Keep cron prompt/user-profile injection and nudges disabled. The
+        # store exists only so explicit memory tool calls can mutate/read disk.
+        agent._memory_enabled = False
+        agent._user_profile_enabled = False
+        agent._memory_nudge_interval = 0
+        return True
+    except Exception as exc:
+        logger.warning("Cron memory tool store initialization failed: %s", exc)
+        return False
+
 
 # Valid delivery platforms — used to validate user-supplied platform names
 # in cron delivery targets, preventing env var enumeration via crafted names.
@@ -1552,6 +1591,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 job_id, _mcp_exc,
             )
 
+        _enabled_toolsets = _resolve_cron_enabled_toolsets(job, _cfg)
         agent = AIAgent(
             model=model,
             api_key=runtime.get("api_key"),
@@ -1570,7 +1610,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             providers_order=pr.get("order"),
             provider_sort=pr.get("sort"),
             openrouter_min_coding_score=(_cfg.get("openrouter") or {}).get("min_coding_score"),
-            enabled_toolsets=_resolve_cron_enabled_toolsets(job, _cfg),
+            enabled_toolsets=_enabled_toolsets,
             disabled_toolsets=["cronjob", "messaging", "clarify"],
             quiet_mode=True,
             # Cron jobs should always inherit the user's SOUL.md identity from
@@ -1584,6 +1624,9 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             session_id=_cron_session_id,
             session_db=_session_db,
         )
+
+        if _cron_needs_memory_tool_store(_enabled_toolsets):
+            _attach_cron_memory_tool_store(agent, _cfg)
         
         # Run the agent with an *inactivity*-based timeout: the job can run
         # for hours if it's actively calling tools / receiving stream tokens,

--- a/docs/brainstorms/2026-05-17-gcw-goal-supervisor-requirements.md
+++ b/docs/brainstorms/2026-05-17-gcw-goal-supervisor-requirements.md
@@ -1,0 +1,157 @@
+---
+date: 2026-05-17
+topic: gcw-goal-supervisor
+category: brainstorm
+---
+
+# GCW Goal Supervisor Requirements
+
+## Summary
+
+本方案定义一个 Evidence-Aware GCW Goal Supervisor：用 Hermes `/goal` 负责 GCW 长任务的跨 turn 持续推进和恢复，但只允许 GCW ledger/status/close-run 证据决定完成状态。`/subgoal` 第一版用于承接中途补充的验收标准、审批提醒和证据要求，但不直接改写 GCW workflow、AC queue 或 validator gates。
+
+---
+
+## Problem Frame
+
+GCW 已经有正式 PMO 契约：issue URL 是入口，ledger/status 是 truth source，PMO 只调度 bounded child executors，最终 closeout 必须经过 validator、completion guard、final evidence 和明确 terminal state。这个体系解决了“做完了吗”的可信度问题，但在长任务上仍有执行摩擦：跨 turn、跨天、等待 worker、等待审批或恢复会话时，用户往往需要反复说“继续”“查一下状态”“别忘了某个验收条件”。
+
+Hermes `/goal` 刚好补上持续推进能力：它能让一个目标跨 turn 存活，自动判断是否继续，并支持 pause/resume/status。Hermes `/subgoal` 则补上中途补充标准的轻量入口。但 `/goal` 的 judge 默认只看最近 assistant response，这与 GCW 的机器证据原则存在错层风险：如果不约束，Hermes 可能把“看起来完成”误当作 GCW done。
+
+---
+
+## Actors
+
+- A1. 用户 / Owner：发起 `/gcw <issue-url>` 或要求继续某个 GCW 任务，补充中途标准或审批决策。
+- A2. Hermes Goal Supervisor：负责持续 readback、推进、状态汇报和 continuation 控制。
+- A3. GCW PMO：dispatcher-only 状态机，读取 ledger/status，调度 child executors，执行 validator/approval/closeout gates。
+- A4. Child Executors：Codex / Hermes SubAgent / 其他 bounded executor，产出 phase report、handoff、测试、PR、部署或其他 evidence。
+- A5. Goal Judge：Hermes auxiliary judge，只基于 supervisor 的证据摘要判断 goal 是否继续或停止。
+
+---
+
+## Key Flows
+
+- F1. GCW goal 启动
+  - **Trigger:** 用户发起或继续一个明确的 `/gcw <issue-url>` 工作。
+  - **Actors:** A1, A2, A3
+  - **Steps:** Supervisor 验证这是 GCW 类目标；确认有 canonical issue URL；读取或初始化 GCW run 状态；设置 `/goal` 的持续目标；首轮输出 ledger-backed status。
+  - **Outcome:** 有一个 active supervisor goal，且它绑定到一个 GCW issue/run，而不是 free-form 聊天目标。
+  - **Covered by:** R1, R2, R3
+
+- F2. 每轮 evidence-aware continuation
+  - **Trigger:** `/goal` continuation 触发，或用户要求“继续/状态”。
+  - **Actors:** A2, A3, A4, A5
+  - **Steps:** Supervisor 先 readback GCW status/ledger/worker evidence；判断当前是否可推进；必要时触发 PMO 下一步；输出固定证据摘要；Goal Judge 只基于这份摘要决定 continue 或 stop。
+  - **Outcome:** 长任务能自动持续推进，但不会绕过 GCW truth source。
+  - **Covered by:** R4, R5, R6, R7, R8
+
+- F3. 补充标准与审批提醒
+  - **Trigger:** 用户在 active GCW goal 中添加 `/subgoal`，例如补充 smoke、截图、审批、证据格式或边界约束。
+  - **Actors:** A1, A2, A5
+  - **Steps:** Supervisor 将该 subgoal 纳入下一轮 continuation 和 judge 可见标准；在状态摘要中标记其是否只是提醒，还是需要后续规划升级为正式 GCW gate。
+  - **Outcome:** 中途补充不会丢在聊天里，但第一版不自动修改 GCW validator/AC 体系。
+  - **Covered by:** R9, R10, R11
+
+- F4. Terminal-state stop
+  - **Trigger:** GCW closeout、completion guard、worker readback 或 PMO 状态进入 `done`、`blocked`、`needs_user`、`approval_required`；`partial` 仅在被明确标记为 owner-facing final handoff 时停止，否则继续。
+  - **Actors:** A2, A3, A5, A1
+  - **Steps:** Supervisor 显示 terminal-state evidence；Goal Judge 停止 auto-continuation；只有 `done` 被表达为成功，其余状态必须表达为停止并报告原因/下一步输入。
+  - **Outcome:** `/goal` 停止不等于 GCW 成功，terminal state 语义被完整保留。
+  - **Covered by:** R12, R13, R14
+
+---
+
+## Requirements
+
+**Goal supervisor boundary**
+- R1. GCW supervisor goal 必须绑定 canonical issue URL；没有 issue URL 的正式 GCW 工作不得进入 supervisor auto-continuation。
+- R2. Supervisor 不得替代 `/gcw`、GCW PMO、validator、completion guard 或 close-run；它只负责持续推进、readback、状态汇报和 continuation 控制。
+- R3. 普通 Hermes `/goal` 仍可用于非 GCW 轻任务；GCW 类 goal 必须明确标识为 GCW supervisor，而不是 free-form goal。
+
+**Evidence-aware continuation**
+- R4. 每个 GCW supervisor turn 必须先读取 GCW truth source，再输出状态；不得仅依据聊天记忆、child executor 自述或上一轮 assistant response 继续推进或判定完成。
+- R5. 每轮状态摘要必须覆盖：issue URL、当前 GCW phase/run 状态、ledger/status readback、worker 状态、validator/closeout 结果、missing gates、terminal-state candidate、关键 evidence 链接或路径。
+- R6. Goal Judge 只能基于 supervisor 的 evidence summary 判断是否继续或停止；不能直接把实现描述、PR 存在、issue 关闭、worker 自称 done 等单一信号当作 GCW 成功。
+- R7. 如果 GCW 状态显示 workflow 只初始化但没有真实 phase_started / worker evidence，Supervisor 必须报告 initialization-only 风险并继续 readback/恢复，而不是声称工作已经启动。
+- R8. 当 worker 仍 pending/running，或 artifact/manifest/status 缺失时，Supervisor 必须继续或报告 blocked/partial；不得进入成功完成。
+
+**Subgoal handling**
+- R9. `/subgoal` 第一版用于追加 judge-visible 补充标准、审批提醒、证据要求或边界约束。
+- R10. `/subgoal` 第一版不得自动改写 GCW workflow template、AC queue、validator gates 或 approval gates。
+- R11. 当 subgoal 看起来应成为正式 GCW gate 时，Supervisor 必须在状态中显式标记“需要后续升级为 GCW gate/AC”的决策点，而不是静默当作已生效的机器门。
+
+**Terminal-state semantics**
+- R12. 只有 GCW `done` 且 closeout/evidence 满足要求时，Supervisor goal 才能表达为成功完成。
+- R13. GCW `blocked`、`needs_user`、`approval_required` 必须停止 auto-continuation 并报告原因、证据和下一步需要的输入；这些状态不得被表达为成功。`partial`、stale worker、missing artifact、PR-only/local-only evidence、缺 validator/closeout gate 默认继续，除非 GCW artifact 明确将其定义为 owner-facing final handoff。
+- R14. 如果 Goal Judge 因模型错误、解析失败或证据不足无法可靠判断，系统应保守继续或暂停，并要求 readback/人工确认，而不是直接成功。
+
+**Resume and status behavior**
+- R15. `/goal resume` 或用户说“继续这个 GCW”时，Supervisor 的第一步必须是 GCW readback，而不是直接继续执行。
+- R16. `/goal status` 对 GCW supervisor 应返回 PMO 可读的短状态：issue、phase/run、terminal candidate、missing gates、worker/evidence 状态和下一步。
+- R17. 当真实用户消息进入 active GCW goal 时，该消息应优先于 queued continuation；如果消息补充约束，应引导或转化为 subgoal，而不是丢失。
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R1, R2, R3.** Given 用户要求“用 GCW 继续这个需求”但没有 issue URL，when Supervisor 尝试启动 GCW goal，then 它拒绝进入 GCW auto-continuation，并要求提供 canonical issue URL。
+- AE2. **Covers R4, R5, R6.** Given child executor 回复“done”，但 status/ledger 没有 completion guard 或 close-run evidence，when `/goal` judge 评估本轮，then Supervisor 摘要必须显示 missing gates，judge 不得把目标判为成功。
+- AE3. **Covers R7.** Given `/gcw` run 只有 workflow initialized 和 `next_action=continue PMO dispatch`，when Supervisor readback，then 它报告 initialization-only 风险并继续恢复/调度，而不是说工作已开始。
+- AE4. **Covers R9, R10, R11.** Given 用户中途 `/subgoal 必须带 active smoke 证据`，when 下一轮 continuation 运行，then smoke 要求出现在 judge-visible criteria 和状态摘要中，但不得声称 GCW validator 已经新增 smoke gate；若需要正式 gate，必须显式标为后续升级点。
+- AE5. **Covers R12, R13.** Given GCW closeout 返回 `needs_user`，when Supervisor 汇报，then `/goal` 停止并说明需要什么用户输入，不能显示“Goal achieved”。
+- AE6. **Covers R15, R16.** Given 用户隔天说“继续昨天那个 GCW”，when Supervisor 恢复，then 首轮输出 readback 状态和下一步，而不是直接启动新的 executor 或复述旧聊天结论。
+
+---
+
+## Success Criteria
+
+- 长 GCW 任务不再需要用户反复输入“继续”，Supervisor 能在安全边界内持续推进或停止汇报。
+- PMO 状态汇报从聊天记忆转为 ledger/status/evidence-backed，能清楚说明当前 phase、worker、missing gates、terminal candidate 和下一步。
+- `/goal` 的成功判定不污染 GCW done：没有 closeout/evidence 的任务不会被误报成功。
+- `/subgoal` 能承接中途补充标准，并明确区分“judge-visible 标准”和“正式 GCW gate”。
+- 下游 `gh:plan` 不需要重新发明 terminal-state mapping、evidence summary、subgoal v1 边界或 resume/readback 行为。
+
+---
+
+## Scope Boundaries
+
+- 不在第一版自动改 GCW workflow templates、routing rules、validator gates、AC queue 或 approval gate 体系。
+- 不用 `/goal` 替代 `/gcw`；GCW 仍是正式 PMO entrypoint。
+- 不允许无 issue URL 的正式 GCW supervisor goal。
+- 不做 UI 看板、移动端状态页或完整 PMO dashboard。
+- 不让 Goal Judge 单独决定 GCW `done`；它只判断 supervisor evidence summary 是否达到停止条件。
+- 不把 child executor 自报 done、PR 存在、issue closed、local Kanban done 等单一信号作为 Story/GCW 成功依据。
+
+---
+
+## Key Decisions
+
+- 选择方案 B：Evidence-Aware Supervisor，而不是轻包装或完整 subgoal-to-gate sync。理由是它能挡住最大错层风险，同时避免第一版过度改造 GCW。
+- `/goal` 的角色是持续推进和恢复，不是验收权威。完成权威仍是 GCW ledger/status/close-run/final evidence。
+- `/subgoal` v1 是 judge-visible criteria 和 PMO 提醒，不是正式机器 gate。正式 gate sync 留给后续阶段。
+- Terminal-state mapping 必须保留 GCW 语义：`done` 是成功；`blocked|needs_user|approval_required` 是非成功停止并报告；`partial` 默认继续，只有被 GCW artifact 明确标为 owner-facing final handoff 时才停止。
+
+---
+
+## Dependencies / Assumptions
+
+- GCW run 必须能提供可读的 status/ledger/worker/evidence readback；如果 active deployment schema 不稳定，planning 需先定义兼容读取策略。
+- Hermes `/goal` judge 当前主要看最近 response，因此 supervisor response 的 evidence summary 格式会直接影响判定质量。
+- 用户确认第一版按方案 B 推进，暂不做 subgoal 到正式 AC/validator gate 的自动同步。
+- 当前需求文档聚焦产品/行为契约；具体命令、文件、schema、prompt 细节由 `gh:plan` 决定。
+
+---
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+- 无。当前 scope 已足够进入 planning。
+
+### Deferred to Planning
+
+- [Affects R4-R6][Technical] Supervisor evidence summary 采用现有 `/goal` continuation prompt、GCW PMO status line，还是新增专门的 GCW supervisor status contract？
+- [Affects R7-R8][Technical] 如何检测 initialization-only、stale worker、missing artifact 等 readback 风险，并映射到 continue/partial/blocked？
+- [Affects R9-R11][Technical] `/subgoal` 文本如何在状态摘要中标识为 soft criterion、approval reminder 或 candidate formal gate？
+- [Affects R12-R14][Technical] Goal Judge 的 prompt 是否需要 GCW-specific override，以避免把 blocked/needs_user 当成 achieved？

--- a/docs/ideation/2026-05-17-hermes-goal-subgoal-gcw-ideation.md
+++ b/docs/ideation/2026-05-17-hermes-goal-subgoal-gcw-ideation.md
@@ -1,0 +1,103 @@
+---
+date: 2026-05-17
+topic: hermes-goal-subgoal-gcw
+focus: Hermes /goal 与 /subgoal 对 GCW 的参考价值和结合建议
+---
+
+# Ideation: Hermes Goal/Subgoal × GCW 结合建议
+
+## Codebase Context
+
+- Hermes v0.13 引入 `/goal`：跨 turn 持久目标，after-turn auxiliary judge 判断 done/continue，自动注入 continuation prompt，默认 20 turn budget，支持 `/goal status|pause|resume|clear`，状态可随 `/resume` 恢复。
+- Hermes v0.14 引入 `/subgoal`：给 active `/goal` 追加用户补充标准，judge prompt 和 continuation prompt 都能看到；在 Gateway 中作为 control-plane mutation，可 mid-run 安全添加/删除/清空。
+- GCW 是更正式的 PMO 状态机：issue URL mandatory，PMO dispatcher-only，ledger/status 是 truth source，child executors 有界，validator/approval/final evidence 是硬门，terminal success 只有 `done`；`blocked|needs_user|approval_required` 是非成功停止；`partial` 默认继续，除非 artifact 明确说明它是 owner-facing final handoff。
+- 关键错层风险：`/goal` 的 judge 主要看最近 assistant response；GCW 的完成必须看 `status.json`、`ledger-updates.jsonl`、validator/close-run、PR/deploy/smoke/issue comment 等机器证据。因此 `/goal` 可做外层持续推进器，不能替代 GCW validator/closeout。
+- HKTMemory 召回未发现同主题历史 ideation；近 30 天本 repo ideation 仅有 BOSS 招聘浏览器 profile 相关，主题不重合。
+
+## Ranked Ideas
+
+### 1. GCW Goal Supervisor：用 `/goal` 做长程 GCW 外层监督循环
+**Description:** 为每个 `/gcw <issue-url>` 自动建立一个 supervisor goal：目标不是“做完需求”，而是“持续推进 GCW，直到 close-run 给出 `done`，或给出 `blocked|needs_user|approval_required`/owner-facing final `partial` 非成功停止，并每轮报告 ledger-backed status”。
+**Warrant:** `direct:` Hermes `/goal` 已支持跨 turn 持续推进、judge、pause/resume/status；GCW contract 要求 PMO dispatcher-only、ledger/status truth、terminal states。
+**Rationale:** 解决 GCW 长任务跨 turn/跨天时需要人反复说“继续”的问题，但不破坏 GCW 作为事实源和验收源的地位。
+**Downsides:** 需要让 goal judge 明确只判断 GCW terminal-state 报告是否达到，而不是判断实现本身是否“看起来完成”。
+**Confidence:** 92%
+**Complexity:** Medium
+**Status:** Unexplored
+
+### 2. Evidence-Aware Goal Judge：让 `/goal` 只基于 GCW 证据摘要判 done
+**Description:** GCW supervisor 每轮必须输出固定证据摘要：issue URL、current phase、status.json path、ledger tail、validator/close-run verdict、missing gates、final evidence links。`/goal` judge 只对这个摘要判定是否继续。
+**Warrant:** `direct:` `/goal` judge 只天然看到最近 response；GCW truth 在 ledger/status/artifacts，不在聊天记忆。
+**Rationale:** 这是防止“agent 自称完成”污染 GCW done 的关键护栏，也是 `/goal` 和 GCW 结合的最低可用条件。
+**Downsides:** 需要标准化 supervisor turn 的输出格式；否则 judge 仍可能依据自然语言误判。
+**Confidence:** 95%
+**Complexity:** Low-Medium
+**Status:** Unexplored
+
+### 3. `/subgoal` → Acceptance Criteria Queue：把 mid-run 用户补充变成可验证门槛
+**Description:** 用户在 GCW 执行中补充“必须带截图”“不要改 public API”“需要 active smoke”等要求时，先落为 `/subgoal`，再同步到 GCW workflow/AC/validator gate 队列；未同步前只能作为提醒，不能算正式 done gate。
+**Warrant:** `direct:` `/subgoal` 可 mid-run 安全加入 judge 可见标准；GCW 的正式完成依赖 validator gates 和 final evidence。
+**Rationale:** 解决 PMO/老板临时补充要求容易留在聊天里、没进入执行系统的问题，同时避免 `/subgoal` 文本标准被误当成 GCW 机器门。
+**Downsides:** 需要定义 subgoal 到 AC/validator 的映射规则，以及哪些 subgoal 只作软约束。
+**Confidence:** 90%
+**Complexity:** Medium
+**Status:** Unexplored
+
+### 4. Approval-as-Subgoal：把审批门显式放入 active goal
+**Description:** 当 GCW 进入 `workflow_pending_user_confirmation`、`approval_required`、生产变更、关闭 issue、发布等节点时，自动添加 approval subgoal，并让 supervisor goal 暂停/报告 `needs_user`，直到审批证据写入 ledger。
+**Warrant:** `direct:` GCW 有 approval gates 和 `needs_user`；`/subgoal` 是 mid-run control-plane criteria，judge 可见。
+**Rationale:** 让长程自动推进具备“刹车”，防止 `/goal` 的持续性越过 GCW 的人工授权边界。
+**Downsides:** 若 approval subgoal 未与 ledger evidence 绑定，可能变成聊天提示而非真实审批门。
+**Confidence:** 88%
+**Complexity:** Low-Medium
+**Status:** Unexplored
+
+### 5. Goal/GCW Terminal-State Mapping：保留 `blocked|needs_user|partial` 语义，不要折叠成 goal success
+**Description:** 建立明确映射：GCW `done` 才对应 goal achieved；GCW `blocked|needs_user|approval_required` 对应非成功 stop-with-report；GCW `partial` 默认继续，只有 artifact 明确把它定义为 owner-facing final handoff 时才 stop-with-report；`continue` 对应继续 PMO dispatch/readback。
+**Warrant:** `direct:` `/goal` 内部是 done/continue；GCW final states 更丰富，并且 human override 不能把缺失机器门转为 done。
+**Rationale:** 避免最危险的错层：Hermes 认为“任务已结束”就把 GCW 的 blocker/partial 当成功汇报。
+**Downsides:** 需要改造文案和 judge prompt，让“停止自动继续”与“成功完成”分离。
+**Confidence:** 94%
+**Complexity:** Low
+**Status:** Unexplored
+
+### 6. GCW Resume Readback：`/goal resume` 先读 ledger/status，再恢复下一步
+**Description:** 恢复一个 GCW goal 时，第一步不是继续执行，而是读取 `status.json`、`ledger-updates.jsonl`、worker manifests、issue comments，重建 current phase、pending gates 和 terminal risk，再决定是否继续。
+**Warrant:** `direct:` `/goal` state survives resume；GCW 已知存在 initialization-only/no-op、worker stale、artifact missing 等恢复风险，必须 readback。
+**Rationale:** 让“继续昨天那个 issue”真正可用，减少跨天长任务的上下文漂移和误报进度。
+**Downsides:** readback 规则需要维护；如果 artifact schema 漂移，需要兼容层。
+**Confidence:** 89%
+**Complexity:** Medium
+**Status:** Unexplored
+
+### 7. Issue-URL-Bound Goal：GCW 类 goal 必须绑定 canonical issue
+**Description:** 对所有 GCW supervisor goal 强制 issue URL：没有 URL 不启动 dispatcher、不建 ledger、不进入 auto-continuation；只允许普通 `/goal` 做非 GCW 的轻任务。
+**Warrant:** `direct:` GCW canonical entrypoint 是 `/gcw <issue-url>` 且 issue URL mandatory；Hermes `/goal` 是 free-form text。
+**Rationale:** 把 Hermes 长程执行纳入 demand-pool / GitHub Issue 事实源，避免 PMO 追踪黑洞。
+**Downsides:** 对临时探索任务略重；需要保留“普通 goal”和“GCW goal”的分层。
+**Confidence:** 91%
+**Complexity:** Low
+**Status:** Unexplored
+
+## Rejection Summary
+
+| # | Idea | Reason Rejected |
+|---|------|-----------------|
+| 1 | 自动 Issue Intake 到完整 GCW 任务包 | 和 Issue-URL-Bound Goal + subgoal/AC mapping 重叠，范围更大，容易滑向 planner。 |
+| 2 | 自动拆分 Bounded Child Executors | GCW 已有 workflow/routing/phase contract，作为独立新想法重复现有机制。 |
+| 3 | Goal-as-Compound-Interest Ledger | 表达有启发，但不够具体；已吸收到 Evidence-Aware Judge 和 Resume Readback。 |
+| 4 | Final Evidence Compounding | 价值成立，但更像 `gh:compound` / knowledge-distiller 主题，不是 goal/subgoal 与 GCW 的核心结合点。 |
+| 5 | PMO 状态面板 | 与 `/goal status` 汇总 ledger truth 相关，但作为产品面板需要更多 UI/PMO 设计，当前阶段并入 supervisor status 输出。 |
+| 6 | Subgoal-Based Assumption Refactoring | 偏 brainstorm 变体；核心已由 `/subgoal` → AC Queue 覆盖。 |
+| 7 | Approval Gate 变成 Subgoal | 保留为 Approval-as-Subgoal，但必须强调 ledger approval evidence。 |
+| 8 | Pause/Resume as Option Value | 概念表达好，但功能落点由 GCW Resume Readback 覆盖。 |
+| 9 | Bounded Child Executors as Goal Leverage Multipliers | 太接近 GCW 现有 dispatcher/child executor contract，缺少新机制。 |
+| 10 | 自动维护 GCW Ledger / Status Truth | 过大且可能违反 PMO dispatcher-only；保留较窄的 evidence summary/readback。 |
+
+## Recommended Next Step
+
+建议先进入 `gh:brainstorm` 的种子不是“全量集成”，而是：
+
+> GCW Goal Supervisor：用 Hermes `/goal` 做外层持续推进器，但以 GCW ledger/status/close-run 作为唯一完成依据，并用 `/subgoal` 接收 mid-run AC/approval 补充。
+
+这条能直接回答“参考价值”和“结合建议”，且风险边界最清楚：`/goal` 负责持续性，GCW 负责事实源、执行契约和验收。

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10447,11 +10447,27 @@ class GatewayRunner:
                 logger.debug("goal pause: pending continuation cleanup failed: %s", exc)
             return t("gateway.goal.paused", goal=state.goal)
 
-        if lower == "resume":
-            state = mgr.resume()
+        if lower == "resume" or lower.startswith("resume "):
+            epic_contract = None
+            if lower.startswith("resume "):
+                contract_path = args.split(None, 1)[1].strip()
+                try:
+                    from hermes_cli.goals import read_epic_goal_supervision_contract_json
+
+                    epic_contract = read_epic_goal_supervision_contract_json(contract_path)
+                except Exception as exc:
+                    return f"/goal resume: invalid Epic supervision contract: {exc}"
+            try:
+                state = mgr.resume(epic_goal_supervision=epic_contract)
+            except Exception as exc:
+                return f"/goal resume: invalid Epic supervision contract: {exc}"
             if state is None:
                 return t("gateway.goal.no_resume")
-            return t("gateway.goal.resumed", goal=state.goal)
+            message = t("gateway.goal.resumed", goal=state.goal)
+            readback = mgr.formatted_epic_goal_resume_readback()
+            if readback:
+                message = f"{message}\n{readback}"
+            return message
 
         if lower in {"clear", "stop", "done"}:
             had = mgr.has_goal()

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -31,11 +31,15 @@ from __future__ import annotations
 
 import json
 import logging
+import posixpath
 import re
 import time
+from datetime import datetime, timezone
+from pathlib import PurePosixPath
 from dataclasses import dataclass, field, asdict
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import quote, unquote, urlparse
 
 logger = logging.getLogger(__name__)
 
@@ -197,6 +201,11 @@ class GoalState:
     # them into the verdict. Backwards-compatible: defaults to empty so
     # old state_meta rows load unchanged.
     subgoals: List[str] = field(default_factory=list)
+    # Optional GCW Epic supervision contract persisted with the goal. When set,
+    # /goal resume can emit deterministic readback before the normal goal loop
+    # continues. This is candidate/readback state only; GCW validator and
+    # completion guard artifacts remain the closeout authorities.
+    epic_goal_supervision: Optional[Dict[str, Any]] = None
 
     def to_json(self) -> str:
         return json.dumps(asdict(self), ensure_ascii=False)
@@ -208,6 +217,13 @@ class GoalState:
         subgoals: List[str] = []
         if isinstance(raw_subgoals, list):
             subgoals = [str(s).strip() for s in raw_subgoals if str(s).strip()]
+        raw_epic_goal_supervision = data.get("epic_goal_supervision")
+        epic_goal_supervision = None
+        if isinstance(raw_epic_goal_supervision, dict):
+            try:
+                epic_goal_supervision = normalize_epic_goal_supervision(raw_epic_goal_supervision)
+            except Exception as exc:
+                logger.warning("GoalState: ignoring invalid epic_goal_supervision: %s", exc)
         return cls(
             goal=data.get("goal", ""),
             status=data.get("status", "active"),
@@ -220,6 +236,7 @@ class GoalState:
             paused_reason=data.get("paused_reason"),
             consecutive_parse_failures=int(data.get("consecutive_parse_failures", 0) or 0),
             subgoals=subgoals,
+            epic_goal_supervision=epic_goal_supervision,
         )
 
     # --- subgoals helpers -------------------------------------------------
@@ -315,6 +332,449 @@ def clear_goal(session_id: str) -> None:
         return
     state.status = "cleared"
     save_goal(session_id, state)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Epic GCW goal supervision contract
+# ──────────────────────────────────────────────────────────────────────
+
+EPIC_GOAL_SUPERVISION_SCHEMA_VERSION = "epic_goal_supervision.v1"
+GCW_FORMAL_GATES_SCHEMA_VERSION = "gcw-formal-gates.v1"
+
+ALLOWED_GITHUB_EVIDENCE_REPOS = {
+    "wangrenzhu-ola/ai-infra-demand-pool",
+    "wangrenzhu-ola/hermes-agent",
+    "wangrenzhu-ola/infra-hermes-core-skills",
+}
+
+EPIC_SUPERVISOR_DECISIONS = {
+    "continue_current_story",
+    "stop_with_report",
+    "dispatch_next_story",
+    "blocked",
+    "needs_user",
+    "approval_required",
+    "partial",
+    "parent_closeout_candidate",
+}
+
+EPIC_STORY_STATES = {
+    "running",
+    "blocked",
+    "needs_user",
+    "approval_required",
+    "partial",
+    "completed_candidate",
+    "completed",
+}
+
+EVIDENCE_REF_TYPES = {
+    "status_json",
+    "workflow_json",
+    "ledger",
+    "phase_report",
+    "phase_handoff",
+    "worker",
+    "validator",
+    "completion_guard",
+    "pr",
+    "ci",
+    "issue_comment",
+    "active_readback",
+    "formal_gate_export",
+    "hierarchy_readback",
+    "dogfood",
+}
+
+EVIDENCE_REF_STATUSES = {"present", "missing", "stale", "pass", "fail", "unknown"}
+_REQUIRED_STORY_CLOSEOUT_EVIDENCE = {"validator", "completion_guard"}
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+_CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+_HEADER_BOUNDARY = r"(?=(?:\s+[\"']?\b(?:authorization|cookie|set-cookie)\b[\"']?\s*[:=])|[\r\n,\]\}]|$)"
+_AUTH_HEADER_RE = re.compile(
+    r"(?i)\b(authorization)\b[\"']?\s*[:=]\s*(?:\"[^\"\r\n]*\"|'[^'\r\n]*'|.*?)" + _HEADER_BOUNDARY
+)
+_COOKIE_HEADER_RE = re.compile(
+    r"(?i)\b(cookie|set-cookie)\b[\"']?\s*[:=]\s*(?:\"[^\"\r\n]*\"|'[^'\r\n]*'|.*?)" + _HEADER_BOUNDARY
+)
+_SECRET_VALUE_RE = re.compile(
+    r"(?i)\b(api[_-]?key|access[_-]?token|refresh[_-]?token|token|session[_-]?id|password|secret)\b[\"']?"
+    r"\s*[:=]\s*(\"[^\"]*\"|'[^']*'|[^\s,;&\]}]+)"
+)
+_ENV_SECRET_VALUE_RE = re.compile(
+    r"(?i)\b([A-Z0-9_]*(?:API[_-]?KEY|ACCESS[_-]?TOKEN|REFRESH[_-]?TOKEN|TOKEN|SESSION[_-]?ID|PASSWORD|SECRET))\b[\"']?"
+    r"\s*[:=]\s*(\"[^\"]*\"|'[^']*'|[^\s,;&\]}]+)"
+)
+_BARE_AUTH_TOKEN_RE = re.compile(r"(?i)\b(bearer|basic)\s+[A-Za-z0-9._~+/=-]{8,}")
+_URL_SECRET_QUERY_RE = re.compile(
+    r"(?i)([?&](?:api[_-]?key|access[_-]?token|refresh[_-]?token|token|session[_-]?id|password|secret)=)[^&\s]+"
+)
+
+
+class EpicGoalContractError(ValueError):
+    """Raised when an Epic goal supervision contract is invalid."""
+
+
+def sanitize_evidence_text(value: Any, *, limit: int = 1000) -> str:
+    """Return publication-safe bounded text for evidence refs and reports."""
+    text = "" if value is None else str(value)
+    text = _ANSI_ESCAPE_RE.sub("", text)
+    text = _CONTROL_CHARS_RE.sub("", text)
+    text = _AUTH_HEADER_RE.sub(lambda m: f"{m.group(1)}=<redacted>", text)
+    text = _COOKIE_HEADER_RE.sub(lambda m: f"{m.group(1)}=<redacted>", text)
+    text = _ENV_SECRET_VALUE_RE.sub(lambda m: f"{m.group(1)}=<redacted>", text)
+    text = _SECRET_VALUE_RE.sub(lambda m: f"{m.group(1)}=<redacted>", text)
+    text = _BARE_AUTH_TOKEN_RE.sub(lambda m: f"{m.group(1)} <redacted>", text)
+    text = _URL_SECRET_QUERY_RE.sub(lambda m: f"{m.group(1)}<redacted>", text)
+    text = text.replace("```", "`\u200b``")
+    if len(text) > limit:
+        text = text[:limit] + "… [truncated]"
+    return text
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _canonical_repo_from_github_url(url: str) -> Optional[str]:
+    parsed = urlparse(url)
+    if (
+        parsed.scheme != "https"
+        or parsed.netloc.lower() != "github.com"
+        or parsed.params
+        or parsed.query
+        or parsed.fragment
+    ):
+        return None
+    decoded_parts = [unquote(p) for p in parsed.path.split("/") if p]
+    if any(part in {".", ".."} or part.startswith("/") for part in decoded_parts):
+        return None
+    parts = decoded_parts
+    if len(parts) < 2:
+        return None
+    return f"{parts[0]}/{parts[1]}"
+
+
+def _validate_issue_url(value: Any, *, field_name: str, repo: Optional[str] = None) -> str:
+    url = sanitize_evidence_text(value, limit=500).strip()
+    parsed = urlparse(url)
+    parts = [p for p in parsed.path.split("/") if p]
+    if (
+        parsed.scheme != "https"
+        or parsed.netloc.lower() != "github.com"
+        or parsed.params
+        or parsed.query
+        or parsed.fragment
+        or len(parts) != 4
+        or parts[2] != "issues"
+        or not parts[3].isdigit()
+        or any(unquote(p) in {".", ".."} or unquote(p).startswith("/") for p in parts)
+    ):
+        raise EpicGoalContractError(f"{field_name} must be a canonical GitHub issue URL")
+    actual_repo = f"{parts[0]}/{parts[1]}"
+    if repo and actual_repo != repo:
+        raise EpicGoalContractError(f"{field_name} repo {actual_repo!r} does not match {repo!r}")
+    if actual_repo not in ALLOWED_GITHUB_EVIDENCE_REPOS:
+        raise EpicGoalContractError(f"{field_name} repo {actual_repo!r} is not allowlisted")
+    return url
+
+
+def _normalize_metadata(raw: Any, *, limit: int = 20) -> Dict[str, Any]:
+    if not isinstance(raw, dict):
+        return {}
+    out: Dict[str, Any] = {}
+    for key, value in list(raw.items())[:limit]:
+        clean_key = sanitize_evidence_text(key, limit=80)
+        if isinstance(value, (str, int, float, bool)) or value is None:
+            out[clean_key] = sanitize_evidence_text(value, limit=500) if isinstance(value, str) else value
+        elif isinstance(value, list):
+            out[clean_key] = [sanitize_evidence_text(v, limit=200) for v in value[:10]]
+        elif isinstance(value, dict):
+            out[clean_key] = _normalize_metadata(value, limit=10)
+        else:
+            out[clean_key] = sanitize_evidence_text(value, limit=200)
+    return out
+
+
+def _normalize_file_evidence_uri(parsed: Any) -> str:
+    """Return a canonical local file:// evidence URI or raise."""
+    decoded_path = unquote(parsed.path or "")
+    if (
+        parsed.netloc
+        or parsed.params
+        or parsed.query
+        or parsed.fragment
+        or not decoded_path.startswith("/")
+        or decoded_path.startswith("//")
+    ):
+        raise EpicGoalContractError("file evidence refs must use a normalized absolute local file:// path")
+    if ".." in PurePosixPath(decoded_path).parts:
+        raise EpicGoalContractError("file evidence refs must use a normalized absolute local file:// path")
+    normalized_path = posixpath.normpath(decoded_path)
+    if normalized_path != decoded_path:
+        raise EpicGoalContractError("file evidence refs must use a normalized absolute local file:// path")
+    return "file://" + quote(normalized_path, safe="/")
+
+
+def _normalize_parent_terminal_candidate(value: Any) -> Optional[bool]:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    raise EpicGoalContractError("parent_terminal_candidate must be a boolean or null")
+
+
+def normalize_evidence_ref(raw: Any, *, required: bool = False) -> Dict[str, Any]:
+    """Normalize and validate a machine-readable, publication-safe evidence ref."""
+    if not isinstance(raw, dict):
+        raise EpicGoalContractError("evidence ref must be an object")
+    ref_type = sanitize_evidence_text(raw.get("type"), limit=80).strip()
+    if ref_type not in EVIDENCE_REF_TYPES:
+        raise EpicGoalContractError(f"unsupported evidence ref type: {ref_type!r}")
+    uri = sanitize_evidence_text(raw.get("uri"), limit=1000).strip()
+    parsed = urlparse(uri)
+    if parsed.scheme == "https":
+        repo = _canonical_repo_from_github_url(uri)
+        if repo not in ALLOWED_GITHUB_EVIDENCE_REPOS:
+            raise EpicGoalContractError(f"evidence ref GitHub repo {repo!r} is not allowlisted")
+    elif parsed.scheme == "file":
+        uri = _normalize_file_evidence_uri(parsed)
+    else:
+        raise EpicGoalContractError("evidence ref uri must be file:// or allowlisted https://github.com")
+    status = sanitize_evidence_text(raw.get("status") or "unknown", limit=40).strip()
+    if status not in EVIDENCE_REF_STATUSES:
+        raise EpicGoalContractError(f"unsupported evidence ref status: {status!r}")
+    return {
+        "type": ref_type,
+        "uri": uri,
+        "status": status,
+        "required": bool(raw.get("required", required)),
+        "observed_at": sanitize_evidence_text(raw.get("observed_at") or _now_iso(), limit=80),
+        "metadata": _normalize_metadata(raw.get("metadata")),
+    }
+
+
+def normalize_epic_goal_supervision(raw: Any) -> Dict[str, Any]:
+    """Validate and normalize an ``epic_goal_supervision.v1`` contract.
+
+    The returned dict is safe to persist in Goal state, phase handoffs, and
+    human-facing reports. It intentionally emits candidate/decision state only;
+    GCW validator and completion guard remain the closeout authorities.
+    """
+    if not isinstance(raw, dict):
+        raise EpicGoalContractError("Epic goal supervision contract must be an object")
+    if raw.get("schema_version") != EPIC_GOAL_SUPERVISION_SCHEMA_VERSION:
+        raise EpicGoalContractError("unsupported epic goal supervision schema_version")
+    source_repo = sanitize_evidence_text(raw.get("source_repo"), limit=200).strip()
+    if source_repo not in ALLOWED_GITHUB_EVIDENCE_REPOS:
+        raise EpicGoalContractError(f"source_repo {source_repo!r} is not allowlisted")
+
+    parent_epic_issue = _validate_issue_url(raw.get("parent_epic_issue"), field_name="parent_epic_issue", repo=source_repo)
+    goal_issue = _validate_issue_url(raw.get("goal_issue"), field_name="goal_issue", repo=source_repo)
+    feature_issue = _validate_issue_url(raw.get("feature_issue"), field_name="feature_issue", repo=source_repo)
+    ordered_story_issues = [
+        _validate_issue_url(v, field_name="ordered_story_issues[]", repo=source_repo)
+        for v in (raw.get("ordered_story_issues") or [])
+    ]
+    if not ordered_story_issues:
+        raise EpicGoalContractError("ordered_story_issues must be non-empty")
+    active_story_issue = _validate_issue_url(raw.get("active_story_issue"), field_name="active_story_issue", repo=source_repo)
+    if active_story_issue not in ordered_story_issues:
+        raise EpicGoalContractError("active_story_issue must appear in ordered_story_issues")
+    blocked_story_issues = [
+        _validate_issue_url(v, field_name="blocked_story_issues[]", repo=source_repo)
+        for v in (raw.get("blocked_story_issues") or [])
+    ]
+
+    story_statuses: Dict[str, Dict[str, Any]] = {}
+    for key, value in (raw.get("story_statuses") or {}).items():
+        if not isinstance(value, dict):
+            raise EpicGoalContractError("story_statuses values must be objects")
+        story_key = sanitize_evidence_text(key, limit=40).strip()
+        state = sanitize_evidence_text(value.get("state") or "running", limit=40).strip()
+        if state not in EPIC_STORY_STATES:
+            raise EpicGoalContractError(f"unsupported story state: {state!r}")
+        refs = [normalize_evidence_ref(ref) for ref in (value.get("last_evidence_refs") or [])]
+        story_statuses[story_key] = {
+            "state": state,
+            "run_id": sanitize_evidence_text(value.get("run_id"), limit=200),
+            "run_dir": sanitize_evidence_text(value.get("run_dir"), limit=1000),
+            "artifact_base": sanitize_evidence_text(value.get("artifact_base"), limit=1000),
+            "last_evidence_refs": refs,
+            "missing_gates": [sanitize_evidence_text(g, limit=200) for g in (value.get("missing_gates") or [])],
+            "metadata": _normalize_metadata(value.get("metadata")),
+        }
+
+    out = {
+        "schema_version": EPIC_GOAL_SUPERVISION_SCHEMA_VERSION,
+        "parent_epic_issue": parent_epic_issue,
+        "goal_issue": goal_issue,
+        "feature_issue": feature_issue,
+        "source_repo": source_repo,
+        "ordered_story_issues": ordered_story_issues,
+        "active_story_issue": active_story_issue,
+        "blocked_story_issues": blocked_story_issues,
+        "story_statuses": story_statuses,
+        "hierarchy_evidence_refs": [normalize_evidence_ref(ref) for ref in (raw.get("hierarchy_evidence_refs") or [])],
+        "formal_gate_exports": [normalize_evidence_ref(ref) for ref in (raw.get("formal_gate_exports") or [])],
+        "missing_gates": [sanitize_evidence_text(g, limit=200) for g in (raw.get("missing_gates") or [])],
+        "next_allowed_action": sanitize_evidence_text(raw.get("next_allowed_action") or "continue_current_story", limit=80),
+        "parent_terminal_candidate": _normalize_parent_terminal_candidate(raw.get("parent_terminal_candidate")),
+        "resume_readback_required": bool(raw.get("resume_readback_required", True)),
+        "updated_at": sanitize_evidence_text(raw.get("updated_at") or _now_iso(), limit=80),
+        "metadata": _normalize_metadata(raw.get("metadata")),
+    }
+    if out["next_allowed_action"] not in EPIC_SUPERVISOR_DECISIONS:
+        raise EpicGoalContractError("next_allowed_action is not a supported Epic supervisor decision")
+    return out
+
+
+def evaluate_epic_goal_resume_readback(contract: Dict[str, Any]) -> Dict[str, Any]:
+    """Compute the next Epic supervisor action from normalized evidence.
+
+    This is a readback/candidate decision helper. It never marks the parent Epic
+    closed and never treats self-report, PR-only, or local-artifact-only refs as
+    sufficient Story closeout evidence.
+    """
+    c = normalize_epic_goal_supervision(contract)
+    active_url = c["active_story_issue"]
+    active_number = active_url.rstrip("/").split("/")[-1]
+    story = c["story_statuses"].get(active_number) or {}
+    state = story.get("state") or "running"
+    parent_missing_gates = list(c.get("missing_gates") or [])
+    story_missing_gates = list(story.get("missing_gates") or [])
+    refs = story.get("last_evidence_refs") or []
+    passed_required_types = {
+        ref["type"]
+        for ref in refs
+        if ref.get("type") in _REQUIRED_STORY_CLOSEOUT_EVIDENCE and _is_trusted_closeout_ref(ref)
+    }
+    missing_required_evidence = sorted(_REQUIRED_STORY_CLOSEOUT_EVIDENCE - passed_required_types)
+
+    if state in {"blocked", "needs_user", "approval_required", "partial"}:
+        decision = state
+    elif story_missing_gates or missing_required_evidence or state not in {"completed", "completed_candidate"}:
+        decision = "continue_current_story"
+    else:
+        idx = c["ordered_story_issues"].index(active_url)
+        if idx < len(c["ordered_story_issues"]) - 1:
+            decision = "dispatch_next_story"
+        else:
+            decision = "stop_with_report" if parent_missing_gates else "parent_closeout_candidate"
+
+    return {
+        "schema_version": "epic_goal_resume_readback.v1",
+        "decision": decision,
+        "active_story_issue": active_url,
+        "active_story_state": state,
+        "missing_gates": parent_missing_gates + story_missing_gates,
+        "missing_required_evidence": missing_required_evidence,
+        "evidence_refs": refs,
+        "parent_terminal_candidate": decision == "parent_closeout_candidate",
+        "observed_at": _now_iso(),
+    }
+
+
+def _is_trusted_closeout_ref(ref: Dict[str, Any]) -> bool:
+    """Return True only for validator/completion refs backed by closeout authority."""
+    if ref.get("status") != "pass":
+        return False
+    uri = ref.get("uri") or ""
+    parsed = urlparse(uri)
+    if parsed.scheme != "https" or _canonical_repo_from_github_url(uri) not in ALLOWED_GITHUB_EVIDENCE_REPOS:
+        return False
+    parts = [unquote(p) for p in parsed.path.split("/") if p]
+    if len(parts) >= 5 and parts[2:4] == ["actions", "runs"] and parts[4].isdigit():
+        return True
+    if len(parts) >= 4 and parts[2] in {"check-runs", "checks"} and parts[3].isdigit():
+        return True
+    # Trust comes from constrained allowlisted HTTPS closeout-authority
+    # provenance; local files, issue/PR/comment URLs, and arbitrary repo paths
+    # cannot self-assert closeout authority through contract metadata.
+    return False
+
+
+def read_epic_goal_resume_readback_json(path: str) -> Dict[str, Any]:
+    """Load an epic_goal_supervision.v1 JSON file and return readback JSON."""
+    with open(path, "r", encoding="utf-8") as f:
+        return evaluate_epic_goal_resume_readback(json.load(f))
+
+
+def read_epic_goal_supervision_contract_json(path: str) -> Dict[str, Any]:
+    """Load and normalize an epic_goal_supervision.v1 contract for persistence."""
+    with open(path, "r", encoding="utf-8") as f:
+        return normalize_epic_goal_supervision(json.load(f))
+
+
+def format_epic_goal_resume_readback(readback: Dict[str, Any]) -> str:
+    """Render deterministic, sanitized one-screen readback for /goal resume."""
+    decision = sanitize_evidence_text(readback.get("decision"), limit=80)
+    active = sanitize_evidence_text(readback.get("active_story_issue"), limit=300)
+    state = sanitize_evidence_text(readback.get("active_story_state"), limit=80)
+    missing_gates = [sanitize_evidence_text(g, limit=120) for g in (readback.get("missing_gates") or [])]
+    missing_evidence = [
+        sanitize_evidence_text(g, limit=120) for g in (readback.get("missing_required_evidence") or [])
+    ]
+    lines = [
+        "Epic goal resume readback:",
+        f"- decision: {decision}",
+        f"- active_story_issue: {active}",
+        f"- active_story_state: {state}",
+        f"- parent_terminal_candidate: {bool(readback.get('parent_terminal_candidate'))}",
+    ]
+    if missing_gates:
+        lines.append(f"- missing_gates: {', '.join(missing_gates)}")
+    if missing_evidence:
+        lines.append(f"- missing_required_evidence: {', '.join(missing_evidence)}")
+    refs = readback.get("evidence_refs") or []
+    if refs:
+        lines.append("- evidence_refs:")
+        for ref in refs[:8]:
+            if not isinstance(ref, dict):
+                continue
+            ref_type = sanitize_evidence_text(ref.get("type"), limit=80)
+            status = sanitize_evidence_text(ref.get("status"), limit=40)
+            uri = sanitize_evidence_text(ref.get("uri"), limit=300)
+            lines.append(f"  - {ref_type} [{status}] {uri}")
+        if len(refs) > 8:
+            lines.append(f"  - … {len(refs) - 8} more refs")
+    lines.append("Authority boundary: this is readback/candidate state only; GCW validator and completion guard remain closeout authorities.")
+    return "\n".join(lines)
+
+
+def _main(argv: Optional[List[str]] = None) -> int:
+    """Small agent-native CLI for GCW readback probes.
+
+    Usage: python -m hermes_cli.goals epic-readback /path/to/contract.json
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser(prog="python -m hermes_cli.goals")
+    sub = parser.add_subparsers(dest="command", required=True)
+    epic = sub.add_parser("epic-readback", help="emit epic_goal_resume_readback.v1 JSON")
+    epic.add_argument("contract_json", help="path to an epic_goal_supervision.v1 JSON contract")
+    args = parser.parse_args(argv)
+    if args.command == "epic-readback":
+        try:
+            payload = read_epic_goal_resume_readback_json(args.contract_json)
+        except (EpicGoalContractError, OSError, json.JSONDecodeError) as exc:
+            import sys
+
+            error_payload = {
+                "schema_version": "epic_goal_resume_readback_error.v1",
+                "error": exc.__class__.__name__,
+                "message": sanitize_evidence_text(str(exc), limit=1000),
+            }
+            print(json.dumps(error_payload, ensure_ascii=False, sort_keys=True), file=sys.stderr)
+            return 1
+        print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+        return 0
+    parser.error(f"unsupported command: {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -596,15 +1056,42 @@ class GoalManager:
         save_goal(self.session_id, self._state)
         return self._state
 
-    def resume(self, *, reset_budget: bool = True) -> Optional[GoalState]:
+    def resume(
+        self,
+        *,
+        reset_budget: bool = True,
+        epic_goal_supervision: Optional[Dict[str, Any]] = None,
+    ) -> Optional[GoalState]:
         if not self._state:
             return None
+        if epic_goal_supervision is not None:
+            self._state.epic_goal_supervision = normalize_epic_goal_supervision(epic_goal_supervision)
         self._state.status = "active"
         self._state.paused_reason = None
         if reset_budget:
             self._state.turns_used = 0
         save_goal(self.session_id, self._state)
         return self._state
+
+    def attach_epic_goal_supervision(self, contract: Dict[str, Any]) -> Dict[str, Any]:
+        """Persist a normalized Epic supervision contract on the current goal."""
+        if self._state is None or not self.has_goal():
+            raise RuntimeError("no active goal")
+        self._state.epic_goal_supervision = normalize_epic_goal_supervision(contract)
+        save_goal(self.session_id, self._state)
+        return self._state.epic_goal_supervision
+
+    def epic_goal_resume_readback(self) -> Optional[Dict[str, Any]]:
+        """Return deterministic Epic readback for the persisted contract, if any."""
+        if not self._state or not self._state.epic_goal_supervision:
+            return None
+        return evaluate_epic_goal_resume_readback(self._state.epic_goal_supervision)
+
+    def formatted_epic_goal_resume_readback(self) -> Optional[str]:
+        readback = self.epic_goal_resume_readback()
+        if readback is None:
+            return None
+        return format_epic_goal_resume_readback(readback)
 
     def clear(self) -> None:
         if self._state is None:
@@ -818,4 +1305,12 @@ __all__ = [
     "save_goal",
     "clear_goal",
     "judge_goal",
+    "EpicGoalContractError",
+    "normalize_evidence_ref",
+    "normalize_epic_goal_supervision",
+    "evaluate_epic_goal_resume_readback",
+    "read_epic_goal_resume_readback_json",
+    "read_epic_goal_supervision_contract_json",
+    "format_epic_goal_resume_readback",
+    "sanitize_evidence_text",
 ]

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -91,6 +91,24 @@ CONTINUATION_PROMPT_WITH_SUBGOALS_TEMPLATE = (
     "and stop."
 )
 
+# GCW-bound goals need stricter continuation than a normal free-form goal:
+# the next turn must re-read GCW's machine state before doing more work, and
+# must not let the /goal loop invent completion from chat-only progress.
+GCW_CONTINUATION_EVIDENCE_BLOCK = (
+    "\n\nGCW evidence-aware supervisor requirements:\n"
+    "- Treat GCW status/ledger/phase artifacts as the source of truth.\n"
+    "- Before continuing or declaring progress, read back the canonical issue "
+    "URL, status.json, ledger-updates.jsonl, phase report/handoff paths, "
+    "worker/process state, validator/closeout evidence, and missing gates.\n"
+    "- Only GCW terminal state `done` plus required evidence can satisfy the "
+    "goal successfully. `blocked`, `needs_user`, or `approval_required` may "
+    "stop only as a truthful non-success handoff with owner input/risk "
+    "acceptance named. `partial`, stale workers, missing artifacts, PR-only "
+    "evidence, or missing validator/closeout gates must continue.\n"
+    "- /subgoal criteria are judge-visible reminders/candidate gates unless a "
+    "later GCW artifact explicitly promotes them into validator/AC gates."
+)
+
 
 JUDGE_SYSTEM_PROMPT = (
     "You are a strict judge evaluating whether an autonomous agent has "
@@ -131,6 +149,26 @@ JUDGE_USER_PROMPT_WITH_SUBGOALS_TEMPLATE = (
     "ANY criterion lacks specific evidence in the response, the goal "
     "is NOT done — return CONTINUE.\n\n"
     "Is the goal AND every additional criterion satisfied?"
+)
+
+GCW_JUDGE_EVIDENCE_BLOCK = (
+    "\n\nGCW-bound goal rule: If this goal involves GCW, /gcw, GaleHarness, "
+    "status.json, ledger-updates.jsonl, phase reports/handoffs, or GitHub "
+    "Issue closeout, require a concrete evidence summary in the agent's "
+    "response. The summary must identify the issue/run, GCW status/phase, "
+    "ledger/status readback, worker/process or terminal artifact evidence, "
+    "validator/closeout state, missing gates, terminal candidate, and evidence "
+    "links/paths. Mark DONE as successful only when the response shows GCW "
+    "terminal state `done` and required evidence. Also mark DONE for a "
+    "truthful terminal non-success handoff when the response explicitly reports "
+    "`blocked`, `needs_user`, or `approval_required` and identifies the owner "
+    "input/risk acceptance required. A `partial` state may stop only when the "
+    "response cites GCW artifact evidence that defines it as an owner-facing "
+    "final handoff; otherwise partial must continue. The reason for any "
+    "non-success stop must say it is blocked/needs user/partial handoff, not "
+    "completed. If it reports ordinary `partial`, stale worker, missing "
+    "report/handoff, PR-only, issue-only, local-only evidence, or any missing "
+    "validator/closeout gate, return CONTINUE."
 )
 
 
@@ -292,6 +330,19 @@ def _truncate(text: str, limit: int) -> str:
     return text[:limit] + "… [truncated]"
 
 
+_GCW_GOAL_RE = re.compile(
+    r"(\bgcw\b|/gcw|galeharness|status\.json|ledger-updates\.jsonl|"
+    r"phase report|handoff|completion guard|github\.com/.+/issues/\d+)",
+    re.IGNORECASE,
+)
+
+
+def _is_gcw_bound_goal(goal: str, subgoals: Optional[List[str]] = None) -> bool:
+    """Heuristic: should /goal apply the GCW evidence-aware contract?"""
+    text = "\n".join([goal or "", *[s or "" for s in (subgoals or [])]])
+    return bool(_GCW_GOAL_RE.search(text))
+
+
 _JSON_OBJECT_RE = re.compile(r"\{.*?\}", re.DOTALL)
 
 
@@ -435,6 +486,8 @@ def judge_goal(
             response=_truncate(last_response, _JUDGE_RESPONSE_SNIPPET_CHARS),
             current_time=current_time,
         )
+    if _is_gcw_bound_goal(goal, clean_subgoals):
+        prompt += GCW_JUDGE_EVIDENCE_BLOCK
 
     try:
         resp = client.chat.completions.create(
@@ -740,11 +793,15 @@ class GoalManager:
         if not self._state or self._state.status != "active":
             return None
         if self._state.subgoals:
-            return CONTINUATION_PROMPT_WITH_SUBGOALS_TEMPLATE.format(
+            prompt = CONTINUATION_PROMPT_WITH_SUBGOALS_TEMPLATE.format(
                 goal=self._state.goal,
                 subgoals_block=self._state.render_subgoals_block(),
             )
-        return CONTINUATION_PROMPT_TEMPLATE.format(goal=self._state.goal)
+        else:
+            prompt = CONTINUATION_PROMPT_TEMPLATE.format(goal=self._state.goal)
+        if _is_gcw_bound_goal(self._state.goal, self._state.subgoals):
+            prompt += GCW_CONTINUATION_EVIDENCE_BLOCK
+        return prompt
 
 
 __all__ = [
@@ -754,6 +811,8 @@ __all__ = [
     "CONTINUATION_PROMPT_WITH_SUBGOALS_TEMPLATE",
     "JUDGE_USER_PROMPT_TEMPLATE",
     "JUDGE_USER_PROMPT_WITH_SUBGOALS_TEMPLATE",
+    "GCW_CONTINUATION_EVIDENCE_BLOCK",
+    "GCW_JUDGE_EVIDENCE_BLOCK",
     "DEFAULT_MAX_TURNS",
     "load_goal",
     "save_goal",

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -12,6 +12,31 @@ from tools.env_passthrough import clear_env_passthrough
 from tools.credential_files import clear_credential_files
 
 
+HOME_CHANNEL_ENV_VARS = (
+    "MATRIX_HOME_ROOM",
+    "MATRIX_HOME_CHANNEL",
+    "TELEGRAM_HOME_CHANNEL",
+    "DISCORD_HOME_CHANNEL",
+    "SLACK_HOME_CHANNEL",
+    "SIGNAL_HOME_CHANNEL",
+    "MATTERMOST_HOME_CHANNEL",
+    "SMS_HOME_CHANNEL",
+    "EMAIL_HOME_ADDRESS",
+    "DINGTALK_HOME_CHANNEL",
+    "BLUEBUBBLES_HOME_CHANNEL",
+    "FEISHU_HOME_CHANNEL",
+    "WECOM_HOME_CHANNEL",
+    "WEIXIN_HOME_CHANNEL",
+    "QQBOT_HOME_CHANNEL",
+    "QQ_HOME_CHANNEL",
+)
+
+
+def clear_home_channel_env(monkeypatch):
+    for env_var in HOME_CHANNEL_ENV_VARS:
+        monkeypatch.delenv(env_var, raising=False)
+
+
 class TestResolveOrigin:
     def test_full_origin(self):
         job = {
@@ -105,24 +130,7 @@ class TestResolveDeliveryTarget:
     def test_origin_delivery_without_origin_falls_back_to_supported_home_channels(
         self, monkeypatch, platform, env_var, chat_id
     ):
-        for fallback_env in (
-            "MATRIX_HOME_ROOM",
-            "MATRIX_HOME_CHANNEL",
-            "TELEGRAM_HOME_CHANNEL",
-            "DISCORD_HOME_CHANNEL",
-            "SLACK_HOME_CHANNEL",
-            "SIGNAL_HOME_CHANNEL",
-            "MATTERMOST_HOME_CHANNEL",
-            "SMS_HOME_CHANNEL",
-            "EMAIL_HOME_ADDRESS",
-            "DINGTALK_HOME_CHANNEL",
-            "BLUEBUBBLES_HOME_CHANNEL",
-            "FEISHU_HOME_CHANNEL",
-            "WECOM_HOME_CHANNEL",
-            "WEIXIN_HOME_CHANNEL",
-            "QQ_HOME_CHANNEL",
-        ):
-            monkeypatch.delenv(fallback_env, raising=False)
+        clear_home_channel_env(monkeypatch)
         monkeypatch.setenv(env_var, chat_id)
 
         assert _resolve_delivery_target({"deliver": "origin"}) == {
@@ -405,12 +413,10 @@ class TestRoutingIntents:
         """deliver='all' fans out to every platform with a configured home channel."""
         from cron.scheduler import _resolve_delivery_targets
 
+        clear_home_channel_env(monkeypatch)
         monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "-111")
         monkeypatch.setenv("DISCORD_HOME_CHANNEL", "-222")
         monkeypatch.setenv("SLACK_HOME_CHANNEL", "C333")
-        # Sanity: platforms without the env var must NOT appear in the expansion.
-        monkeypatch.delenv("SIGNAL_HOME_CHANNEL", raising=False)
-        monkeypatch.delenv("MATRIX_HOME_ROOM", raising=False)
 
         targets = _resolve_delivery_targets({"deliver": "all", "origin": None})
         platforms = sorted(t["platform"] for t in targets)
@@ -425,6 +431,7 @@ class TestRoutingIntents:
         """'telegram:-999,all' yields every home channel + the explicit target without dupes."""
         from cron.scheduler import _resolve_delivery_targets
 
+        clear_home_channel_env(monkeypatch)
         monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "-111")
         monkeypatch.setenv("DISCORD_HOME_CHANNEL", "-222")
 
@@ -444,12 +451,7 @@ class TestRoutingIntents:
         """deliver='all' with nothing connected returns [] — delivery is recorded as failed upstream."""
         from cron.scheduler import _resolve_delivery_targets
 
-        for var in ("TELEGRAM_HOME_CHANNEL", "DISCORD_HOME_CHANNEL", "SLACK_HOME_CHANNEL",
-                    "SIGNAL_HOME_CHANNEL", "MATRIX_HOME_ROOM", "MATTERMOST_HOME_CHANNEL",
-                    "SMS_HOME_CHANNEL", "EMAIL_HOME_ADDRESS", "DINGTALK_HOME_CHANNEL",
-                    "FEISHU_HOME_CHANNEL", "WECOM_HOME_CHANNEL", "WEIXIN_HOME_CHANNEL",
-                    "BLUEBUBBLES_HOME_CHANNEL", "QQBOT_HOME_CHANNEL", "QQ_HOME_CHANNEL"):
-            monkeypatch.delenv(var, raising=False)
+        clear_home_channel_env(monkeypatch)
 
         assert _resolve_delivery_targets({"deliver": "all", "origin": None}) == []
 
@@ -457,6 +459,7 @@ class TestRoutingIntents:
         """'origin,all' delivers to the origin platform plus every other home channel."""
         from cron.scheduler import _resolve_delivery_targets
 
+        clear_home_channel_env(monkeypatch)
         monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "-111")
         monkeypatch.setenv("DISCORD_HOME_CHANNEL", "-222")
 
@@ -478,6 +481,7 @@ class TestRoutingIntents:
         """'ALL' / 'All' / 'all' are all recognized."""
         from cron.scheduler import _resolve_delivery_targets
 
+        clear_home_channel_env(monkeypatch)
         monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "-111")
         monkeypatch.setenv("DISCORD_HOME_CHANNEL", "-222")
 
@@ -1005,6 +1009,49 @@ class TestRunJobSessionPersistence:
 
         kwargs = mock_agent_cls.call_args.kwargs
         assert kwargs["enabled_toolsets"] == ["web", "terminal", "file"]
+
+    def test_run_job_memory_toolset_attaches_store_without_prompt_injection(self, tmp_path):
+        """Cron keeps memory out of the prompt but memory-tool jobs need a store."""
+        (tmp_path / "config.yaml").write_text(
+            "memory:\n  memory_char_limit: 123\n  user_char_limit: 45\n",
+            encoding="utf-8",
+        )
+        job = {
+            "id": "memory-tool-job",
+            "name": "memory tool",
+            "prompt": "compress memory",
+            "enabled_toolsets": ["file", "memory", "terminal"],
+        }
+        fake_db, patches = self._make_run_job_patches(tmp_path)
+        created = []
+
+        class FakeMemoryStore:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+                self.loaded = False
+                created.append(self)
+
+            def load_from_disk(self):
+                self.loaded = True
+
+        with patches[0], patches[1], patches[2], patches[3], patches[4], \
+             patch("run_agent.AIAgent") as mock_agent_cls, \
+             patch("tools.memory_tool.MemoryStore", FakeMemoryStore):
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            run_job(job)
+
+        kwargs = mock_agent_cls.call_args.kwargs
+        assert kwargs["skip_memory"] is True
+        assert kwargs["enabled_toolsets"] == ["file", "memory", "terminal"]
+        assert len(created) == 1
+        assert created[0].kwargs == {"memory_char_limit": 123, "user_char_limit": 45}
+        assert created[0].loaded is True
+        assert mock_agent._memory_store is created[0]
+        assert mock_agent._memory_enabled is False
+        assert mock_agent._user_profile_enabled is False
+        assert mock_agent._memory_nudge_interval == 0
 
     def test_run_job_enabled_toolsets_resolves_from_platform_config_when_not_set(self, tmp_path):
         """When a job has no explicit enabled_toolsets, the scheduler now

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -639,6 +639,19 @@ class TestContinuationPromptWithSubgoals:
         assert "1. write tests" in prompt
         assert "2. update docs" in prompt
 
+    def test_gcw_goal_continuation_requires_evidence_readback(self, hermes_home):
+        from hermes_cli.goals import GoalManager
+        mgr = GoalManager(session_id="cp-gcw")
+        mgr.set("Continue GCW https://github.com/acme/repo/issues/123 until done")
+        prompt = mgr.next_continuation_prompt()
+        assert prompt is not None
+        assert "GCW evidence-aware supervisor requirements" in prompt
+        assert "status.json" in prompt
+        assert "ledger-updates.jsonl" in prompt
+        assert "partial" in prompt
+        assert "must continue" in prompt
+        assert "needs_user" in prompt
+
 
 class TestJudgeGoalWithSubgoals:
     def test_judge_uses_subgoals_template_when_provided(self, hermes_home):
@@ -694,7 +707,6 @@ class TestJudgeGoalWithSubgoals:
         from hermes_cli import goals
 
         captured = {}
-
         class _FakeMsg:
             content = '{"done": true, "reason": "ok"}'
         class _FakeChoice:
@@ -719,6 +731,46 @@ class TestJudgeGoalWithSubgoals:
         user_msg = next((m["content"] for m in sent_messages if m["role"] == "user"), "")
         assert "Additional criteria" not in user_msg
         assert "ship it" in user_msg
+
+    def test_gcw_bound_judge_prompt_requires_terminal_evidence(self, hermes_home):
+        from unittest.mock import patch
+        from hermes_cli import goals
+
+        captured = {}
+        class _FakeMsg:
+            content = '{"done": false, "reason": "missing GCW terminal evidence"}'
+        class _FakeChoice:
+            message = _FakeMsg()
+        class _FakeResp:
+            choices = [_FakeChoice()]
+        class _FakeClient:
+            class chat:
+                class completions:
+                    @staticmethod
+                    def create(**kwargs):
+                        captured.update(kwargs)
+                        return _FakeResp()
+
+        with patch("agent.auxiliary_client.get_text_auxiliary_client",
+                   return_value=(_FakeClient, "fake-model")), \
+             patch("agent.auxiliary_client.get_auxiliary_extra_body",
+                   return_value=None):
+            verdict, reason, _ = goals.judge_goal(
+                "Finish /gcw https://github.com/acme/repo/issues/123",
+                "status=partial; PR opened",
+                subgoals=["do not bypass validator gates"],
+            )
+
+        sent_messages = captured.get("messages") or []
+        user_msg = next((m["content"] for m in sent_messages if m["role"] == "user"), "")
+        assert "GCW-bound goal rule" in user_msg
+        assert "terminal state `done`" in user_msg
+        assert "missing report/handoff" in user_msg
+        assert "owner-facing final handoff" in user_msg
+        assert "ordinary `partial`" in user_msg
+        assert "validator/closeout" in user_msg
+        assert verdict == "continue"
+        assert "missing GCW" in reason
 
 
 class TestStatusLineSubgoalCount:

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import subprocess
+import sys
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -790,3 +792,398 @@ class TestStatusLineSubgoalCount:
         mgr.add_subgoal("b")
         line = mgr.status_line()
         assert "2 subgoals" in line
+
+# ──────────────────────────────────────────────────────────────────────
+# Epic GCW goal supervision contract
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _valid_epic_contract(**overrides):
+    base = {
+        "schema_version": "epic_goal_supervision.v1",
+        "parent_epic_issue": "https://github.com/wangrenzhu-ola/ai-infra-demand-pool/issues/259",
+        "goal_issue": "https://github.com/wangrenzhu-ola/ai-infra-demand-pool/issues/243",
+        "feature_issue": "https://github.com/wangrenzhu-ola/ai-infra-demand-pool/issues/235",
+        "source_repo": "wangrenzhu-ola/ai-infra-demand-pool",
+        "ordered_story_issues": [
+            "https://github.com/wangrenzhu-ola/ai-infra-demand-pool/issues/260",
+            "https://github.com/wangrenzhu-ola/ai-infra-demand-pool/issues/273",
+            "https://github.com/wangrenzhu-ola/ai-infra-demand-pool/issues/274",
+        ],
+        "active_story_issue": "https://github.com/wangrenzhu-ola/ai-infra-demand-pool/issues/274",
+        "blocked_story_issues": [],
+        "story_statuses": {
+            "274": {
+                "state": "running",
+                "run_id": "gcw-ai-infra-demand-pool-issue-274",
+                "run_dir": "/Users/wangrenzhu/.hermes/runs/gcw/gcw-ai-infra-demand-pool-issue-274",
+                "artifact_base": "/Users/wangrenzhu/.hermes/runs/gcw",
+                "last_evidence_refs": [
+                    {
+                        "type": "status_json",
+                        "uri": "file:///Users/wangrenzhu/.hermes/runs/gcw/gcw-ai-infra-demand-pool-issue-274/status.json",
+                        "status": "present",
+                    }
+                ],
+                "missing_gates": ["validator"],
+            }
+        },
+        "hierarchy_evidence_refs": [
+            {
+                "type": "hierarchy_readback",
+                "uri": "https://github.com/wangrenzhu-ola/ai-infra-demand-pool/issues/259",
+                "status": "present",
+            }
+        ],
+        "formal_gate_exports": [],
+        "missing_gates": [],
+        "next_allowed_action": "continue_current_story",
+        "resume_readback_required": True,
+    }
+    base.update(overrides)
+    return base
+
+
+class TestEpicGoalSupervisionContract:
+    def test_valid_contract_normalizes_and_preserves_run_dir(self):
+        from hermes_cli.goals import normalize_epic_goal_supervision
+
+        out = normalize_epic_goal_supervision(_valid_epic_contract())
+        assert out["schema_version"] == "epic_goal_supervision.v1"
+        assert out["active_story_issue"].endswith("/274")
+        assert out["story_statuses"]["274"]["run_dir"].endswith("issue-274")
+        assert out["hierarchy_evidence_refs"][0]["type"] == "hierarchy_readback"
+
+    def test_rejects_wrong_schema_and_noncanonical_issue_url(self):
+        from hermes_cli.goals import EpicGoalContractError, normalize_epic_goal_supervision
+
+        with pytest.raises(EpicGoalContractError):
+            normalize_epic_goal_supervision(_valid_epic_contract(schema_version="v0"))
+        with pytest.raises(EpicGoalContractError):
+            normalize_epic_goal_supervision(_valid_epic_contract(active_story_issue="https://example.com/x"))
+        with pytest.raises(EpicGoalContractError):
+            normalize_epic_goal_supervision(
+                _valid_epic_contract(
+                    active_story_issue="https://github.com/wangrenzhu-ola/ai-infra-demand-pool/issues/274?token=secret"
+                )
+            )
+
+    def test_rejects_cross_repo_story_and_disallowed_evidence_scheme(self):
+        from hermes_cli.goals import EpicGoalContractError, normalize_epic_goal_supervision
+
+        with pytest.raises(EpicGoalContractError):
+            normalize_epic_goal_supervision(
+                _valid_epic_contract(
+                    ordered_story_issues=["https://github.com/other/repo/issues/1"],
+                    active_story_issue="https://github.com/other/repo/issues/1",
+                )
+            )
+        contract = _valid_epic_contract()
+        contract["story_statuses"]["274"]["last_evidence_refs"] = [
+            {"type": "status_json", "uri": "ssh://host/tmp/status.json", "status": "present"}
+        ]
+        with pytest.raises(EpicGoalContractError):
+            normalize_epic_goal_supervision(contract)
+
+    def test_sanitizes_evidence_text(self):
+        from hermes_cli.goals import sanitize_evidence_text
+
+        clean = sanitize_evidence_text("token=abc123\x1b[31m bad\x00 ``` fence", limit=200)
+        assert "abc123" not in clean
+        assert "\x1b" not in clean
+        assert "\x00" not in clean
+        assert "`\u200b``" in clean
+
+        auth_clean = sanitize_evidence_text("Authorization: Bearer auth-prefix auth-suffix Cookie: sid=secret")
+        assert "auth-prefix" not in auth_clean
+        assert "auth-suffix" not in auth_clean
+        assert "sid=secret" not in auth_clean
+        assert "Authorization=<redacted>" in auth_clean
+
+        json_header_clean = sanitize_evidence_text(
+            '{"Authorization": "Bearer json-auth-token", "Cookie": "sid=json-cookie"}'
+        )
+        assert "json-auth-token" not in json_header_clean
+        assert "json-cookie" not in json_header_clean
+
+        url_clean = sanitize_evidence_text("https://example.test/cb?token=url-token&ok=1")
+        assert "token=url-token" not in url_clean
+        assert "token=<redacted>" in url_clean
+
+        env_clean = sanitize_evidence_text("GITHUB_TOKEN=ghs-secret OPENAI_API_KEY=sk-secret Bearer bare-secret-token")
+        assert "ghs-secret" not in env_clean
+        assert "sk-secret" not in env_clean
+        assert "bare-secret-token" not in env_clean
+
+    def test_file_evidence_refs_must_be_canonical_local_absolute_paths(self):
+        from hermes_cli.goals import EpicGoalContractError, normalize_evidence_ref
+
+        for uri in [
+            "file:relative/status.json",
+            "file://host/tmp/status.json",
+            "file:///tmp/../secret/status.json",
+            "file:///%2Ftmp/status.json",
+            "file:////tmp/status.json",
+            "file:///tmp/status.json?token=abc",
+        ]:
+            with pytest.raises(EpicGoalContractError):
+                normalize_evidence_ref({"type": "status_json", "uri": uri, "status": "present"})
+
+        for uri in [
+            "https://github.com/wangrenzhu-ola/ai-infra-demand-pool/../../evil/repo/issues/1",
+            "https://github.com/wangrenzhu-ola/ai-infra-demand-pool/%2e%2e/%2e%2e/evil/repo/issues/1",
+        ]:
+            with pytest.raises(EpicGoalContractError):
+                normalize_evidence_ref({"type": "status_json", "uri": uri, "status": "present"})
+
+        ref = normalize_evidence_ref({"type": "status_json", "uri": "file:///tmp/status.json", "status": "present"})
+        assert ref["uri"] == "file:///tmp/status.json"
+
+    def test_parent_terminal_candidate_is_strict_bool_or_null(self):
+        from hermes_cli.goals import EpicGoalContractError, normalize_epic_goal_supervision
+
+        assert normalize_epic_goal_supervision(_valid_epic_contract(parent_terminal_candidate=True))[
+            "parent_terminal_candidate"
+        ] is True
+        assert normalize_epic_goal_supervision(_valid_epic_contract(parent_terminal_candidate=None))[
+            "parent_terminal_candidate"
+        ] is None
+        with pytest.raises(EpicGoalContractError):
+            normalize_epic_goal_supervision(_valid_epic_contract(parent_terminal_candidate="yes"))
+
+
+class TestEpicGoalResumeReadback:
+    def test_missing_validator_or_completion_guard_blocks_next_story(self):
+        from hermes_cli.goals import evaluate_epic_goal_resume_readback
+
+        decision = evaluate_epic_goal_resume_readback(_valid_epic_contract())
+        assert decision["decision"] == "continue_current_story"
+        assert "completion_guard" in decision["missing_required_evidence"]
+        assert "validator" in decision["missing_required_evidence"]
+        assert decision["parent_terminal_candidate"] is False
+
+    def test_blocked_partial_needs_user_are_preserved(self):
+        from hermes_cli.goals import evaluate_epic_goal_resume_readback
+
+        for state in ["blocked", "partial", "needs_user", "approval_required"]:
+            contract = _valid_epic_contract()
+            contract["story_statuses"]["274"]["state"] = state
+            contract["story_statuses"]["274"]["missing_gates"] = []
+            assert evaluate_epic_goal_resume_readback(contract)["decision"] == state
+
+    def test_local_file_only_story_evidence_does_not_emit_parent_closeout_candidate(self):
+        from hermes_cli.goals import evaluate_epic_goal_resume_readback
+
+        contract = _valid_epic_contract()
+        contract["story_statuses"]["274"].update(
+            {
+                "state": "completed",
+                "missing_gates": [],
+                "last_evidence_refs": [
+                    {
+                        "type": "validator",
+                        "uri": "file:///Users/wangrenzhu/.hermes/runs/gcw/gcw-ai-infra-demand-pool-issue-274/validator.json",
+                        "status": "pass",
+                        "metadata": {"trusted_closeout_evidence": True},
+                    },
+                    {
+                        "type": "completion_guard",
+                        "uri": "file:///Users/wangrenzhu/.hermes/runs/gcw/gcw-ai-infra-demand-pool-issue-274/completion_guard.json",
+                        "status": "pass",
+                        "metadata": {"authority": "ci"},
+                    },
+                ],
+            }
+        )
+        decision = evaluate_epic_goal_resume_readback(contract)
+        assert decision["decision"] == "continue_current_story"
+        assert decision["parent_terminal_candidate"] is False
+        assert decision["missing_required_evidence"] == ["completion_guard", "validator"]
+
+    def test_issue_or_pr_urls_cannot_self_assert_trusted_closeout_evidence(self):
+        from hermes_cli.goals import EpicGoalContractError, evaluate_epic_goal_resume_readback
+
+        contract = _valid_epic_contract()
+        contract["story_statuses"]["274"].update(
+            {
+                "state": "completed",
+                "missing_gates": [],
+                "last_evidence_refs": [
+                    {
+                        "type": "validator",
+                        "uri": "https://github.com/wangrenzhu-ola/ai-infra-demand-pool/issues/274",
+                        "status": "pass",
+                        "metadata": {"trusted_closeout_evidence": True},
+                    },
+                    {
+                        "type": "completion_guard",
+                        "uri": "https://github.com/wangrenzhu-ola/ai-infra-demand-pool/pull/274",
+                        "status": "pass",
+                        "metadata": {"authority": "ci"},
+                    },
+                ],
+            }
+        )
+        decision = evaluate_epic_goal_resume_readback(contract)
+        assert decision["decision"] == "continue_current_story"
+        assert decision["parent_terminal_candidate"] is False
+
+        for uri in [
+            "https://github.com/wangrenzhu-ola/ai-infra-demand-pool/../../evil/repo/issues/1",
+            "https://github.com/wangrenzhu-ola/ai-infra-demand-pool/%2e%2e/%2e%2e/evil/repo/issues/1",
+        ]:
+            contract = _valid_epic_contract()
+            contract["story_statuses"]["274"]["last_evidence_refs"] = [
+                {"type": "validator", "uri": uri, "status": "pass"}
+            ]
+            with pytest.raises(EpicGoalContractError):
+                evaluate_epic_goal_resume_readback(contract)
+
+    def test_trusted_story_evidence_passes_emits_parent_closeout_candidate_only(self):
+        from hermes_cli.goals import evaluate_epic_goal_resume_readback
+
+        contract = _valid_epic_contract()
+        contract["story_statuses"]["274"].update(
+            {
+                "state": "completed",
+                "missing_gates": [],
+                "last_evidence_refs": [
+                    {
+                        "type": "validator",
+                        "uri": "https://github.com/wangrenzhu-ola/ai-infra-demand-pool/actions/runs/274",
+                        "status": "pass",
+                    },
+                    {
+                        "type": "completion_guard",
+                        "uri": "https://github.com/wangrenzhu-ola/ai-infra-demand-pool/actions/runs/274",
+                        "status": "pass",
+                        "metadata": {"trusted_closeout_evidence": True},
+                    },
+                ],
+            }
+        )
+        decision = evaluate_epic_goal_resume_readback(contract)
+        assert decision["decision"] == "parent_closeout_candidate"
+        assert decision["parent_terminal_candidate"] is True
+
+    def test_parent_missing_gate_blocks_parent_closeout_candidate(self):
+        from hermes_cli.goals import evaluate_epic_goal_resume_readback
+
+        contract = _valid_epic_contract(missing_gates=["active_smoke"])
+        contract["story_statuses"]["274"].update(
+            {
+                "state": "completed",
+                "missing_gates": [],
+                "last_evidence_refs": [
+                    {
+                        "type": "validator",
+                        "uri": "https://github.com/wangrenzhu-ola/ai-infra-demand-pool/actions/runs/274",
+                        "status": "pass",
+                    },
+                    {
+                        "type": "completion_guard",
+                        "uri": "https://github.com/wangrenzhu-ola/ai-infra-demand-pool/actions/runs/274",
+                        "status": "pass",
+                        "metadata": {"trusted_closeout_evidence": True},
+                    },
+                ],
+            }
+        )
+        decision = evaluate_epic_goal_resume_readback(contract)
+        assert decision["decision"] == "stop_with_report"
+        assert decision["parent_terminal_candidate"] is False
+        assert "active_smoke" in decision["missing_gates"]
+
+    def test_goal_manager_resume_persists_and_renders_epic_readback(self, hermes_home):
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="epic-resume-sid")
+        mgr.set("finish GCW https://github.com/wangrenzhu-ola/ai-infra-demand-pool/issues/274")
+        mgr.pause()
+        state = mgr.resume(epic_goal_supervision=_valid_epic_contract())
+        assert state is not None
+        assert state.epic_goal_supervision is not None
+
+        reloaded = GoalManager(session_id="epic-resume-sid")
+        readback = reloaded.epic_goal_resume_readback()
+        assert readback is not None
+        assert readback["schema_version"] == "epic_goal_resume_readback.v1"
+        assert readback["decision"] == "continue_current_story"
+
+        rendered = reloaded.formatted_epic_goal_resume_readback()
+        assert rendered is not None
+        assert "Epic goal resume readback" in rendered
+        assert "decision: continue_current_story" in rendered
+        assert "completion_guard" in rendered
+        assert "validator" in rendered
+        assert "Authority boundary" in rendered
+
+    def test_goal_manager_resume_rejects_invalid_epic_contract(self, hermes_home):
+        from hermes_cli.goals import EpicGoalContractError, GoalManager
+
+        mgr = GoalManager(session_id="epic-resume-invalid")
+        mgr.set("finish GCW https://github.com/wangrenzhu-ola/ai-infra-demand-pool/issues/274")
+        invalid = _valid_epic_contract(
+            active_story_issue="https://github.com/wangrenzhu-ola/ai-infra-demand-pool/issues/274?token=secret"
+        )
+        with pytest.raises(EpicGoalContractError):
+            mgr.resume(epic_goal_supervision=invalid)
+
+
+
+def test_epic_goal_readback_cli_emits_json(tmp_path):
+    contract = _valid_epic_contract()
+    contract["story_statuses"]["274"].update(
+        {
+            "state": "completed",
+            "missing_gates": [],
+            "last_evidence_refs": [
+                {
+                    "type": "validator",
+                    "uri": "https://github.com/wangrenzhu-ola/ai-infra-demand-pool/actions/runs/274",
+                    "status": "pass",
+                },
+                {
+                    "type": "completion_guard",
+                    "uri": "https://github.com/wangrenzhu-ola/ai-infra-demand-pool/actions/runs/274",
+                    "status": "pass",
+                },
+            ],
+        }
+    )
+    contract_path = tmp_path / "contract.json"
+    contract_path.write_text(json.dumps(contract), encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, "-m", "hermes_cli.goals", "epic-readback", str(contract_path)],
+        cwd=str(__import__("pathlib").Path(__file__).resolve().parents[2]),
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    payload = json.loads(result.stdout)
+    assert payload["schema_version"] == "epic_goal_resume_readback.v1"
+    assert payload["decision"] == "parent_closeout_candidate"
+
+
+def test_epic_goal_readback_cli_emits_json_error_without_traceback(tmp_path):
+    contract = _valid_epic_contract(
+        active_story_issue="https://github.com/wangrenzhu-ola/ai-infra-demand-pool/issues/274?token=SECRET123"
+    )
+    contract_path = tmp_path / "invalid-contract.json"
+    contract_path.write_text(json.dumps(contract), encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, "-m", "hermes_cli.goals", "epic-readback", str(contract_path)],
+        cwd=str(__import__("pathlib").Path(__file__).resolve().parents[2]),
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 1
+    assert result.stdout == ""
+    assert "Traceback" not in result.stderr
+    assert "SECRET123" not in result.stderr
+    payload = json.loads(result.stderr)
+    assert payload["schema_version"] == "epic_goal_resume_readback_error.v1"
+    assert payload["error"] == "EpicGoalContractError"

--- a/tests/tui_gateway/test_goal_command.py
+++ b/tests/tui_gateway/test_goal_command.py
@@ -11,6 +11,7 @@ uses to render a system line and fire the kickoff prompt.
 from __future__ import annotations
 
 import importlib
+import json
 import threading
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -139,6 +140,36 @@ def test_goal_resume_reactivates(server, session):
     from hermes_cli.goals import GoalManager
 
     assert GoalManager(session_key).state.status == "active"
+
+
+def test_goal_resume_with_epic_contract_emits_readback(server, session, tmp_path):
+    from tests.hermes_cli.test_goals import _valid_epic_contract
+
+    sid, session_key, _ = session
+    _call(server, "command.dispatch", name="goal", arg="finish GCW issue 274", session_id=sid)
+    _call(server, "command.dispatch", name="goal", arg="pause", session_id=sid)
+    contract_path = tmp_path / "epic-contract.json"
+    contract_path.write_text(json.dumps(_valid_epic_contract()), encoding="utf-8")
+
+    r = _call(
+        server,
+        "command.dispatch",
+        name="goal",
+        arg=f"resume {contract_path}",
+        session_id=sid,
+    )
+    assert r["result"]["type"] == "exec"
+    output = r["result"]["output"]
+    assert "Epic goal resume readback" in output
+    assert "decision: continue_current_story" in output
+    assert "missing_required_evidence: completion_guard, validator" in output
+
+    from hermes_cli.goals import GoalManager
+
+    mgr = GoalManager(session_key)
+    readback = mgr.epic_goal_resume_readback()
+    assert readback is not None
+    assert readback["decision"] == "continue_current_story"
 
 
 def test_goal_clear_removes_active_goal(server, session):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4756,20 +4756,30 @@ def _(rid, params: dict) -> dict:
             state = mgr.pause(reason="user-paused")
             out = "No goal set." if state is None else f"⏸ Goal paused: {state.goal}"
             return _ok(rid, {"type": "exec", "output": out})
-        if lower == "resume":
-            state = mgr.resume()
+        if lower == "resume" or lower.startswith("resume "):
+            epic_contract = None
+            if lower.startswith("resume "):
+                contract_path = arg.split(None, 1)[1].strip()
+                try:
+                    from hermes_cli.goals import read_epic_goal_supervision_contract_json
+
+                    epic_contract = read_epic_goal_supervision_contract_json(contract_path)
+                except Exception as exc:
+                    return _err(rid, 4004, f"invalid Epic supervision contract: {exc}")
+            try:
+                state = mgr.resume(epic_goal_supervision=epic_contract)
+            except Exception as exc:
+                return _err(rid, 4004, f"invalid Epic supervision contract: {exc}")
             if state is None:
                 return _ok(rid, {"type": "exec", "output": "No goal to resume."})
-            return _ok(
-                rid,
-                {
-                    "type": "exec",
-                    "output": (
-                        f"▶ Goal resumed: {state.goal}\n"
-                        "Send any message to continue, or wait — I'll take the next step on the next turn."
-                    ),
-                },
+            readback = mgr.formatted_epic_goal_resume_readback()
+            output = (
+                f"▶ Goal resumed: {state.goal}\n"
+                "Send any message to continue, or wait — I'll take the next step on the next turn."
             )
+            if readback:
+                output = f"▶ Goal resumed: {state.goal}\n{readback}\nSend any message to continue, or wait — I'll take the next step on the next turn."
+            return _ok(rid, {"type": "exec", "output": output})
         if lower in {"clear", "stop", "done"}:
             had = mgr.has_goal()
             mgr.clear()


### PR DESCRIPTION
## Summary
- add an Epic/GCW goal supervision contract persisted on `/goal resume <contract.json>`
- emit deterministic evidence readback across CLI, gateway, and TUI before the normal goal loop continues
- add allowlisted evidence URI validation/sanitization plus closeout gate semantics
- fix cron memory-tool jobs by attaching a memory store without prompt memory injection

## Validation
- `PYTHONPATH=. /Users/wangrenzhu/work/hermes-agent/.venv/bin/python -m pytest -q tests/hermes_cli/test_goals.py tests/tui_gateway/test_goal_command.py tests/cron/test_scheduler.py` (208 passed)
- same targeted suite passed earlier on the operator checkout via `./scripts/run_tests.sh` (202 passed before upstream rebase)
- added-line secret scan: 0 matches

## Notes
This is the clean branch rebased onto current upstream `main`; supersedes PR #28998, whose head included fork-local commits and was conflicting.
