### PR TITLE
fix: prevent kanban auto-unblocking retry loops

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -85,7 +85,7 @@ _TELEGRAM_NOISY_STATUS_RE = re.compile(
 )
 
 _GATEWAY_PROVIDER_ERROR_RE = re.compile(
-    r"("  # infrastructure/provider error preambles, not ordinary assistant prose
+    r"^\s*(?:[⚠❌]\ufe0f?\s*)?(?:"  # infrastructure/provider error preambles only
     r"api\s+(?:call\s+)?failed"
     r"|provider\s+authentication\s+failed"
     r"|non-retryable\s+error"

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2041,19 +2041,17 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
 
 
 def recompute_ready(conn: sqlite3.Connection) -> int:
-    """Promote ``todo`` tasks to ``ready`` when all parents are ``done`` or ``archived``.
+    """Promote dependency-satisfied tasks to ``ready``.
+
+    ``todo`` tasks are promoted when all parents are ``done`` or ``archived``.
+    ``blocked`` tasks are also considered for promotion so circuit-breaker or
+    direct-DB blocks can recover when dependencies are satisfied, *except* when
+    the latest block/unblock event is a worker/operator ``blocked`` event. Those
+    sticky blocks represent explicit review/input stops and require
+    :func:`unblock_task` to avoid dispatcher retry loops.
 
     Returns the number of tasks promoted.  Safe to call inside or outside
     an existing transaction; it opens its own IMMEDIATE txn.
-
-    ``blocked`` tasks are also considered for promotion (so a task
-    blocked purely by a parent dependency unblocks itself when the
-    parent completes), *except* when the most recent block event was a
-    worker-initiated ``kanban_block`` — those stay blocked until an
-    explicit ``kanban_unblock`` (#28712).  Without that guard, a
-    ``review-required`` handoff would auto-respawn, the fresh worker
-    would find nothing to do, exit cleanly, get recorded as a protocol
-    violation, and the cycle would repeat indefinitely.
     """
     promoted = 0
     with write_txn(conn):
@@ -2064,10 +2062,9 @@ def recompute_ready(conn: sqlite3.Connection) -> int:
             task_id = row["id"]
             cur_status = row["status"]
             if cur_status == "blocked" and _has_sticky_block(conn, task_id):
-                # Worker / operator asked for human review — do not
-                # silently auto-recover.  ``unblock_task`` is the only
-                # legitimate exit (it emits ``"unblocked"`` which flips
-                # this predicate back).
+                # Worker / operator asked for human review — do not silently
+                # auto-recover. ``unblock_task`` emits "unblocked" and is the
+                # only legitimate transition back to runnable work.
                 continue
             parents = conn.execute(
                 "SELECT t.status FROM tasks t "
@@ -2076,9 +2073,6 @@ def recompute_ready(conn: sqlite3.Connection) -> int:
                 (task_id,),
             ).fetchall()
             if all(p["status"] in ("done", "archived") for p in parents):
-                # Blocked tasks also get their failure counters reset —
-                # this is effectively an auto-unblock (circuit-breaker
-                # recovery; worker-initiated blocks are skipped above).
                 if cur_status == "blocked":
                     conn.execute(
                         "UPDATE tasks SET status = 'ready', "
@@ -2094,7 +2088,6 @@ def recompute_ready(conn: sqlite3.Connection) -> int:
                 _append_event(conn, task_id, "promoted", None)
                 promoted += 1
     return promoted
-
 
 # ---------------------------------------------------------------------------
 # Claim / complete / block

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -80,3 +80,15 @@ def test_telegram_final_response_keeps_normal_answers():
     answer = "Here is the clean summary you asked for."
 
     assert _sanitize_gateway_final_response(Platform.TELEGRAM, answer) == answer
+
+
+def test_telegram_final_response_keeps_answers_that_mention_old_provider_errors():
+    """Quoting a previous provider error in a normal answer must not trigger replacement."""
+    answer = (
+        "네, 이제 됩니다.\n\n"
+        "정리하면:\n"
+        "- 이전 오류: `Provider authentication failed`\n"
+        "- 현재 상태: 정상"
+    )
+
+    assert _sanitize_gateway_final_response(Platform.TELEGRAM, answer) == answer

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -245,32 +245,34 @@ def test_recompute_ready_cascades_through_chain(kanban_home):
         assert kb.get_task(conn, c).status == "ready"
 
 
-def test_recompute_ready_promotes_blocked_with_done_parents(kanban_home):
-    """blocked tasks with all parents done should be promoted to ready."""
+def test_recompute_ready_does_not_auto_unblock_worker_blocked_with_done_parents(kanban_home):
+    """worker/operator blocked tasks require explicit unblock even when dependencies are done."""
     with kb.connect() as conn:
         parent = kb.create_task(conn, title="parent", assignee="a")
         child = kb.create_task(
             conn, title="child", assignee="a", parents=[parent],
         )
-        # Complete the parent
         kb.claim_task(conn, parent)
         kb.complete_task(conn, parent, result="ok")
-        # Manually block the child (simulates a worker that failed
-        # after the parent finished)
-        conn.execute(
-            "UPDATE tasks SET status='blocked', consecutive_failures=5, "
-            "last_failure_error='persistent error' WHERE id=?",
-            (child,),
-        )
-        conn.commit()
-        assert kb.get_task(conn, child).status == "blocked"
-        # recompute_ready should promote blocked → ready and reset failures
-        promoted = kb.recompute_ready(conn)
-        assert promoted == 1
+        assert kb.get_task(conn, child).status == "ready"
+
+        assert kb.block_task(conn, child, reason="review required") is True
         task = kb.get_task(conn, child)
+        assert task is not None
+        assert task.status == "blocked"
+
+        # recompute_ready must not promote worker/operator blocked → ready;
+        # otherwise the gateway dispatcher can retry review-required tasks forever.
+        promoted = kb.recompute_ready(conn)
+        assert promoted == 0
+        task = kb.get_task(conn, child)
+        assert task is not None
+        assert task.status == "blocked"
+
+        assert kb.unblock_task(conn, child) is True
+        task = kb.get_task(conn, child)
+        assert task is not None
         assert task.status == "ready"
-        assert task.consecutive_failures == 0
-        assert task.last_failure_error is None
 
 
 def test_recompute_ready_fan_in_waits_for_all_parents(kanban_home):


### PR DESCRIPTION
## Summary
- Prevent worker/operator blocked Kanban tasks from being auto-promoted back to ready by recompute_ready.
- Keep circuit-breaker/direct DB blocked recovery behavior from latest main.
- Tighten Telegram gateway provider-error filtering so quoted historical errors are not replaced.

## Test plan
- `python -m pytest -o addopts="" tests/gateway/test_telegram_noise_filter.py tests/hermes_cli/test_kanban_db.py -q`
- Result: 165 passed

Note: local environment lacks pytest-timeout, so addopts was disabled for this targeted run.