### PR TITLE
fix(run_agent): unfreeze first tool call after idle on macOS (#28834)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6754,8 +6754,19 @@ class AIAgent:
             # Explicitly read proxy settings while still honoring NO_PROXY for
             # loopback / local endpoints such as a locally hosted sub2api.
             _proxy = _get_proxy_for_base_url(base_url)
+            # ``retries=1`` covers the narrow window where a request
+            # checks out a connection from httpx's keepalive pool that
+            # the peer has already closed but TCP keepalive hasn't yet
+            # noticed.  Without it, the first post-idle tool call after
+            # a 2-3 minute pause hangs / errors out with no recovery
+            # path until the user kicks the loop (#28834).  httpx only
+            # retries connection-establishment failures, so this can't
+            # double-submit a half-sent request.
             return _httpx.Client(
-                transport=_httpx.HTTPTransport(socket_options=_sock_opts),
+                transport=_httpx.HTTPTransport(
+                    socket_options=_sock_opts,
+                    retries=1,
+                ),
                 proxy=_proxy,
             )
         except Exception:

--- a/run_agent.py
+++ b/run_agent.py
@@ -6730,12 +6730,25 @@ class AIAgent:
             import socket as _socket
 
             _sock_opts = [(_socket.SOL_SOCKET, _socket.SO_KEEPALIVE, 1)]
+            # "Idle before first probe" — Linux exposes this as TCP_KEEPIDLE,
+            # macOS uses TCP_KEEPALIVE for the same knob.  Pick whichever is
+            # available so both platforms land on the same 30 s warm-up.
             if hasattr(_socket, "TCP_KEEPIDLE"):
                 _sock_opts.append((_socket.IPPROTO_TCP, _socket.TCP_KEEPIDLE, 30))
-                _sock_opts.append((_socket.IPPROTO_TCP, _socket.TCP_KEEPINTVL, 10))
-                _sock_opts.append((_socket.IPPROTO_TCP, _socket.TCP_KEEPCNT, 3))
             elif hasattr(_socket, "TCP_KEEPALIVE"):
                 _sock_opts.append((_socket.IPPROTO_TCP, _socket.TCP_KEEPALIVE, 30))
+            # Probe interval + retry count are independent of the idle
+            # constant's name; macOS exposes them under the same TCP_*
+            # symbols as Linux on Python ≥3.10.  Setting them on the macOS
+            # branch too keeps dead-peer detection bounded at ~60 s on both
+            # platforms — without it, macOS falls back to the kernel default
+            # of 75 s × 8 ≈ 10 min and idle provider sockets silently
+            # zombify between requests, freezing the next tool call after a
+            # 2-3 minute pause (#28834).
+            if hasattr(_socket, "TCP_KEEPINTVL"):
+                _sock_opts.append((_socket.IPPROTO_TCP, _socket.TCP_KEEPINTVL, 10))
+            if hasattr(_socket, "TCP_KEEPCNT"):
+                _sock_opts.append((_socket.IPPROTO_TCP, _socket.TCP_KEEPCNT, 3))
             # When a custom transport is provided, httpx won't auto-read proxy
             # from env vars (allow_env_proxies = trust_env and transport is None).
             # Explicitly read proxy settings while still honoring NO_PROXY for

--- a/tests/run_agent/test_keepalive_socket_options.py
+++ b/tests/run_agent/test_keepalive_socket_options.py
@@ -22,6 +22,7 @@ import socket
 from unittest.mock import patch
 
 import httpx
+import pytest
 
 from run_agent import AIAgent
 
@@ -75,11 +76,21 @@ class TestKeepaliveSharedKnobs:
     def test_keepintvl_set_to_10s(self):
         # Without this, macOS inherits KEEPINTVL=75 s and the dead-peer
         # detection window blows past the issue's "2-3 minute pause".
+        # The production helper sets this knob best-effort behind a
+        # ``hasattr`` gate, so skip on hosts that don't expose the
+        # constant — the exact value contract is pinned in the macOS
+        # facade test where the constant is deliberately present.
+        if not hasattr(socket, "TCP_KEEPINTVL"):
+            pytest.skip("host socket module lacks TCP_KEEPINTVL")
         opts = _socket_options()
         assert _opt_value(opts, socket.IPPROTO_TCP, "TCP_KEEPINTVL") == 10
 
     def test_keepcnt_set_to_3(self):
-        # Same story for KEEPCNT — kernel default is 8 on macOS.
+        # Same story for KEEPCNT — kernel default is 8 on macOS. Best-effort
+        # behind ``hasattr`` in the helper, so skip when the host lacks the
+        # constant; the value is pinned in the macOS facade test.
+        if not hasattr(socket, "TCP_KEEPCNT"):
+            pytest.skip("host socket module lacks TCP_KEEPCNT")
         opts = _socket_options()
         assert _opt_value(opts, socket.IPPROTO_TCP, "TCP_KEEPCNT") == 3
 

--- a/tests/run_agent/test_keepalive_socket_options.py
+++ b/tests/run_agent/test_keepalive_socket_options.py
@@ -1,0 +1,179 @@
+"""Regression coverage for #28834 — first tool call after a 2-3 minute
+idle pause freezes at "[Calling tool: ...]" because the provider
+socket has silently zombified and neither the macOS TCP keepalive
+budget nor the httpx pool retried fast enough to recover.
+
+The fix has two halves, both inside
+``AIAgent._build_keepalive_http_client``:
+
+* set ``TCP_KEEPINTVL`` / ``TCP_KEEPCNT`` on **both** the Linux and
+  macOS branches so the dead-peer detection budget is bounded at
+  ~60 s on both platforms (was ~10 min on macOS)
+* pass ``retries=1`` to ``httpx.HTTPTransport`` so a stale-pool
+  connection that beats the keepalive timer triggers a single
+  transparent re-dial instead of bubbling up as a freeze
+
+These tests pin both halves at the socket-option / transport level
+so neither half can silently regress.
+"""
+from __future__ import annotations
+
+import socket
+from unittest.mock import patch
+
+import httpx
+
+from run_agent import AIAgent
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _socket_options() -> list:
+    """Return the list of ``(level, opt, value)`` socket options that the
+    keepalive client would apply on the current host."""
+    client = AIAgent._build_keepalive_http_client("https://api.example.com/v1")
+    assert client is not None, "keepalive client must be built on a supported host"
+    try:
+        transport = client._transport
+        # httpx 0.28 exposes the SOCKET_OPTION iterable on _pool, older
+        # builds stored it on the transport directly.
+        opts = getattr(transport, "_socket_options", None)
+        if opts is None:
+            opts = getattr(getattr(transport, "_pool", None), "_socket_options", None)
+        return list(opts or [])
+    finally:
+        client.close()
+
+
+def _opt_value(opts, level, name) -> int | None:
+    """Return the value set for ``(level, getattr(socket, name))`` or
+    ``None`` when the option is absent.  Resolves the constant by name
+    so missing attributes (e.g. ``TCP_KEEPIDLE`` on macOS) don't
+    AttributeError the helper itself."""
+    opt = getattr(socket, name, None)
+    if opt is None:
+        return None
+    for _l, _o, _v in opts:
+        if _l == level and _o == opt:
+            return _v
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Both platforms share these knobs.
+# ---------------------------------------------------------------------------
+
+
+class TestKeepaliveSharedKnobs:
+    def test_so_keepalive_enabled(self):
+        opts = _socket_options()
+        assert _opt_value(opts, socket.SOL_SOCKET, "SO_KEEPALIVE") == 1
+
+    def test_keepintvl_set_to_10s(self):
+        # Without this, macOS inherits KEEPINTVL=75 s and the dead-peer
+        # detection window blows past the issue's "2-3 minute pause".
+        opts = _socket_options()
+        assert _opt_value(opts, socket.IPPROTO_TCP, "TCP_KEEPINTVL") == 10
+
+    def test_keepcnt_set_to_3(self):
+        # Same story for KEEPCNT — kernel default is 8 on macOS.
+        opts = _socket_options()
+        assert _opt_value(opts, socket.IPPROTO_TCP, "TCP_KEEPCNT") == 3
+
+    def test_idle_warmup_set_to_30s(self):
+        # One of TCP_KEEPIDLE (Linux) or TCP_KEEPALIVE (macOS) must
+        # carry the 30 s warm-up — whichever the host happens to
+        # expose.  Both being unset would mean the agent waits the
+        # full kernel default (2 h on Linux) before probing.
+        opts = _socket_options()
+        idle = _opt_value(opts, socket.IPPROTO_TCP, "TCP_KEEPIDLE")
+        alive = _opt_value(opts, socket.IPPROTO_TCP, "TCP_KEEPALIVE")
+        assert 30 in {idle, alive}
+
+
+# ---------------------------------------------------------------------------
+# macOS-specific branch — emulate the platform's hasattr profile so the
+# test passes on any host (CI runners are Linux).
+# ---------------------------------------------------------------------------
+
+
+class TestMacOSKeepaliveParity:
+    def test_macos_branch_still_sets_intvl_and_cnt(self):
+        """On a host where ``socket.TCP_KEEPIDLE`` is missing (the macOS
+        profile), the helper must still emit the INTVL/CNT options.
+
+        Stubs the module-level attribute lookup so the helper takes the
+        ``elif hasattr(_socket, "TCP_KEEPALIVE")`` branch even on Linux
+        CI runners that natively have ``TCP_KEEPIDLE``.
+        """
+        # Build a socket module facade whose attribute surface mirrors
+        # macOS: TCP_KEEPALIVE + TCP_KEEPINTVL + TCP_KEEPCNT, no
+        # TCP_KEEPIDLE.  ``hasattr`` checks inside the helper resolve
+        # against this facade.
+        class _MacSocket:
+            SOL_SOCKET = socket.SOL_SOCKET
+            SO_KEEPALIVE = socket.SO_KEEPALIVE
+            IPPROTO_TCP = socket.IPPROTO_TCP
+            TCP_KEEPALIVE = 0x10
+            TCP_KEEPINTVL = 0x101
+            TCP_KEEPCNT = 0x102
+            # Intentionally NO TCP_KEEPIDLE — that's the whole point.
+
+        with patch.dict("sys.modules", {"socket": _MacSocket}):
+            client = AIAgent._build_keepalive_http_client("https://api.example.com/v1")
+        assert client is not None
+        try:
+            transport = client._transport
+            opts = list(
+                getattr(transport, "_socket_options", None)
+                or getattr(getattr(transport, "_pool", None), "_socket_options", None)
+                or []
+            )
+        finally:
+            client.close()
+
+        flat = [(level, opt) for (level, opt, _v) in opts]
+        assert (_MacSocket.SOL_SOCKET, _MacSocket.SO_KEEPALIVE) in flat
+        assert (_MacSocket.IPPROTO_TCP, _MacSocket.TCP_KEEPALIVE) in flat
+        assert (_MacSocket.IPPROTO_TCP, _MacSocket.TCP_KEEPINTVL) in flat
+        assert (_MacSocket.IPPROTO_TCP, _MacSocket.TCP_KEEPCNT) in flat
+        # And the values must match the documented 30 s / 10 s / 3
+        # budget — a future tweak that silently relaxes them would
+        # re-open #28834.
+        as_dict = {(level, opt): val for (level, opt, val) in opts}
+        assert as_dict[(_MacSocket.IPPROTO_TCP, _MacSocket.TCP_KEEPALIVE)] == 30
+        assert as_dict[(_MacSocket.IPPROTO_TCP, _MacSocket.TCP_KEEPINTVL)] == 10
+        assert as_dict[(_MacSocket.IPPROTO_TCP, _MacSocket.TCP_KEEPCNT)] == 3
+
+
+# ---------------------------------------------------------------------------
+# Stale-pool retry — the second half of the fix.
+# ---------------------------------------------------------------------------
+
+
+class TestStalePoolRetry:
+    def test_http_transport_retries_once(self):
+        """The transport must be built with ``retries=1`` so a
+        zombie connection from the keepalive pool gets transparently
+        re-dialled instead of hanging the next ``chat.completions``
+        call (#28834).  httpx only retries connection-establishment
+        failures, so this can't double-submit a half-sent request.
+        """
+        client = AIAgent._build_keepalive_http_client("https://api.example.com/v1")
+        assert client is not None
+        try:
+            transport = client._transport
+            assert isinstance(transport, httpx.HTTPTransport)
+            # httpcore's ConnectionPool stores ``_retries`` — both
+            # http1 and http2 pool variants honour the kwarg.
+            pool = getattr(transport, "_pool", None)
+            retries = getattr(pool, "_retries", None)
+            assert retries == 1, (
+                f"expected httpx.HTTPTransport(retries=1) for stale-pool recovery "
+                f"(#28834); pool reports retries={retries!r}"
+            )
+        finally:
+            client.close()


### PR DESCRIPTION
## What does this PR do?

Fixes #28834 — first tool call after a 2-3 minute idle pause freezes at `[Calling tool: ...]` until the user kicks the loop (e.g. with `/goal`).

Root cause is in `AIAgent._build_keepalive_http_client` (`run_agent.py`), which configures the TCP keepalive socket options applied to every provider connection. Two adjacent bugs combine to produce the freeze:

1. The Linux branch sets `TCP_KEEPIDLE` / `TCP_KEEPINTVL` / `TCP_KEEPCNT` together → dead peer detected in ~60 s. The macOS branch only sets `TCP_KEEPALIVE` (the idle knob's macOS name) and falls through, leaving `KEEPINTVL` and `KEEPCNT` at kernel defaults of 75 s × 8 ≈ **10 minutes**. After a 2-3 min idle, the provider socket is silently dropped by intermediate NAT/firewall but macOS doesn't notice for nearly 10 more minutes.
2. Even with the keepalive fix, there's still a narrow window where httpx's keepalive pool hands out a zombie connection to the next request before the keepalive timer has had a chance to mark it dead. Without a connection-level retry, that request hangs / errors with no automatic recovery.

The fix is two small changes inside `_build_keepalive_http_client`, each in its own commit:

- Split `TCP_KEEPINTVL` / `TCP_KEEPCNT` out of the `TCP_KEEPIDLE` branch and gate them on their own `hasattr` checks — both are exposed on macOS in Python ≥ 3.10. macOS now matches Linux's ~60 s detection budget.
- Pass `retries=1` to `httpx.HTTPTransport` so a stale-pool connection that beats the keepalive timer triggers a single transparent re-dial. `httpx` only retries connection-establishment failures, so this can't double-submit a half-sent request.

## Related Issue

Fixes #28834.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `run_agent.py` (+27/-3) — `_build_keepalive_http_client`:
  - Set `TCP_KEEPINTVL=10` and `TCP_KEEPCNT=3` on both the Linux and macOS branches via independent `hasattr` checks (was Linux-only).
  - Pass `retries=1` to `httpx.HTTPTransport` so connection-establishment failures (stale pool connections) re-dial transparently.
- `tests/run_agent/test_keepalive_socket_options.py` (+179, new) — three test classes covering the new contract:
  - `TestKeepaliveSharedKnobs` — 4 cases running against the real host's socket module: `SO_KEEPALIVE` on, `TCP_KEEPINTVL=10`, `TCP_KEEPCNT=3`, and a 30 s idle warm-up under whichever of `TCP_KEEPIDLE` / `TCP_KEEPALIVE` the platform exposes.
  - `TestMacOSKeepaliveParity` — 1 case stubbing `sys.modules['socket']` with a macOS-flavored facade (no `TCP_KEEPIDLE`) so the test exercises the macOS branch even on Linux CI runners. Pins all three values (30 / 10 / 3) to lock the budget.
  - `TestStalePoolRetry` — 1 case asserting the constructed `httpx.HTTPTransport` carries `retries=1` via the underlying `httpcore` pool's `_retries` attribute.

No other production files touched. No config schema changes, no new env vars, no public-API surface change.

## How to Test

1. Check out this branch and ensure `.venv` is set up: `python3 -m venv .venv && source .venv/bin/activate && pip install -e ".[all,dev]"`
2. Run the new tests on their own:
   ```
   scripts/run_tests.sh tests/run_agent/test_keepalive_socket_options.py -v
   ```
   Expected: 6 passed.
3. Run the wider OpenAI-client transport suite to confirm no cross-file regressions:
   ```
   scripts/run_tests.sh tests/run_agent/test_keepalive_socket_options.py \
     tests/run_agent/test_create_openai_client_reuse.py \
     tests/run_agent/test_create_openai_client_proxy_env.py \
     tests/run_agent/test_create_openai_client_kwargs_isolation.py \
     tests/run_agent/test_async_httpx_del_neuter.py \
     tests/run_agent/test_sequential_chats_live.py
   ```
   Expected: 27 passed, 1 skipped.
4. (Optional, on macOS only — reproduces the original issue) Open `hermes` in interactive mode, run any tool call, idle 3 minutes, then send a request that requires another tool call. Before the fix: hangs at `[Calling tool: ...]`. After the fix: completes within the usual latency.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(run_agent): ...` × 2, `test(run_agent): ...` × 1)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/run_agent/test_keepalive_socket_options.py` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.2 (Darwin 24.6.0), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (no public-API change; inline comments updated to call out the macOS gap + #28834)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — macOS branch fixed to match Linux; Windows path is unchanged (the helper short-circuits via `try/except`, and Windows has no `TCP_KEEPINTVL`); fix is the documented behaviour on both supported platforms
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/run_agent/test_keepalive_socket_options.py -v
4 workers [6 items]
============================== 6 passed in 1.59s ===============================

$ scripts/run_tests.sh tests/run_agent/test_keepalive_socket_options.py \
    tests/run_agent/test_create_openai_client_reuse.py \
    tests/run_agent/test_create_openai_client_proxy_env.py \
    tests/run_agent/test_create_openai_client_kwargs_isolation.py \
    tests/run_agent/test_async_httpx_del_neuter.py \
    tests/run_agent/test_sequential_chats_live.py
4 workers [28 items]
======================== 27 passed, 1 skipped in 3.94s =========================
```