### PR TITLE
fix(gateway): notify on reconnect exhaustion + surface telegram retrying state (#29005)

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -553,7 +553,19 @@ class QQAdapter(BasePlatformAdapter):
                         RATE_LIMIT_DELAY,
                     )
                     if backoff_idx >= MAX_RECONNECT_ATTEMPTS:
-                        self._mark_disconnected()
+                        # Mark retryable so the gateway watcher re-adds us
+                        # to its background reconnect queue (#29005) — a
+                        # bare _mark_disconnected() leaves the listener
+                        # task dead with nothing watching.
+                        self._set_fatal_error(
+                            "qq_reconnect_exhausted",
+                            (
+                                f"Rate-limited reconnect exhausted after "
+                                f"{MAX_RECONNECT_ATTEMPTS} attempts"
+                            ),
+                            retryable=True,
+                        )
+                        await self._notify_fatal_error()
                         return
                     await asyncio.sleep(RATE_LIMIT_DELAY)
                     if await self._reconnect(backoff_idx):
@@ -607,7 +619,17 @@ class QQAdapter(BasePlatformAdapter):
                     backoff_idx += 1
                     if backoff_idx >= MAX_RECONNECT_ATTEMPTS:
                         logger.error("[%s] Max reconnect attempts reached (QQCloseError)", self._log_tag)
-                        self._mark_disconnected()
+                        # Surface as retryable-fatal so the gateway
+                        # reconnect watcher takes over (#29005).
+                        self._set_fatal_error(
+                            "qq_reconnect_exhausted",
+                            (
+                                f"WebSocket reconnect exhausted after "
+                                f"{MAX_RECONNECT_ATTEMPTS} attempts (last close code {code})"
+                            ),
+                            retryable=True,
+                        )
+                        await self._notify_fatal_error()
                         return
 
             except Exception as exc:
@@ -619,7 +641,18 @@ class QQAdapter(BasePlatformAdapter):
 
                 if backoff_idx >= MAX_RECONNECT_ATTEMPTS:
                     logger.error("[%s] Max reconnect attempts reached", self._log_tag)
-                    self._mark_disconnected()
+                    # See sibling QQCloseError branch above — handing this
+                    # off to the gateway watcher is the only thing that
+                    # ever brings the adapter back (#29005).
+                    self._set_fatal_error(
+                        "qq_reconnect_exhausted",
+                        (
+                            f"WebSocket reconnect exhausted after "
+                            f"{MAX_RECONNECT_ATTEMPTS} attempts: {exc}"
+                        ),
+                        retryable=True,
+                    )
+                    await self._notify_fatal_error()
                     return
 
                 if await self._reconnect(backoff_idx):

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -786,6 +786,22 @@ class TelegramAdapter(BasePlatformAdapter):
             "[%s] Telegram network error (attempt %d/%d), reconnecting in %ds. Error: %s",
             self.name, attempt, MAX_NETWORK_RETRIES, delay, error,
         )
+        # Surface the degraded state to external monitors via the runtime
+        # status file BEFORE we sleep — otherwise everything reading
+        # ``platforms.telegram.state`` keeps seeing ``connected`` for up
+        # to ~55 minutes while the reconnect ladder churns (#29005).  The
+        # state flips to ``fatal`` only at attempt 11 today; this fills
+        # the gap.  Reuses the same ``retrying`` value the gateway's
+        # fatal-error handler already writes for retryable failures.
+        self._write_runtime_status_safe(
+            "polling_retrying",
+            platform_state="retrying",
+            error_code="telegram_network_error",
+            error_message=(
+                f"Network error retry {attempt}/{MAX_NETWORK_RETRIES} "
+                f"(next in {delay}s): {error}"
+            ),
+        )
         await asyncio.sleep(delay)
 
         try:
@@ -807,6 +823,17 @@ class TelegramAdapter(BasePlatformAdapter):
                 self.name, attempt,
             )
             self._polling_network_error_count = 0
+            # Clear the ``retrying`` status we wrote before sleeping so
+            # external monitors stop alerting once polling is healthy
+            # again (#29005).  ``_mark_connected`` would also clobber
+            # ``_fatal_error_*`` fields the adapter may have set
+            # elsewhere; this is the surgical equivalent.
+            self._write_runtime_status_safe(
+                "polling_recovered",
+                platform_state="connected",
+                error_code=None,
+                error_message=None,
+            )
             # start_polling() returning is necessary but not sufficient:
             # PTB's Updater can be left in a state where `running` is True
             # but the underlying long-poll task is wedged on a stale httpx

--- a/tests/gateway/test_platform_reconnect_fatal_notify.py
+++ b/tests/gateway/test_platform_reconnect_fatal_notify.py
@@ -1,0 +1,288 @@
+"""Regression coverage for #29005 — platform adapters silently stop
+when their internal reconnect ladder exhausts, leaving the gateway
+process alive but the bot permanently dead.
+
+The fix has two halves:
+
+* **QQBot (P0)** — three ``MAX_RECONNECT_ATTEMPTS`` exit paths in
+  ``QQAdapter._listen_loop`` swapped ``_mark_disconnected()`` for
+  ``_set_fatal_error(..., retryable=True)`` + ``await
+  _notify_fatal_error()``, so the gateway's
+  ``_platform_reconnect_watcher`` actually re-queues the platform
+  for background reconnection.
+
+* **Telegram (P1)** — ``_handle_polling_network_error`` now writes
+  ``platform_state="retrying"`` to the runtime status file before
+  each back-off sleep (was: status stayed ``connected`` for the
+  full ~55-min retry window) and ``"connected"`` again on
+  successful reconnect.
+
+These tests exercise each half at the adapter level — no real
+network, no real WebSocket — so they're hermetic and stay under a
+couple of seconds.
+"""
+from __future__ import annotations
+
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Shared scaffolding
+# ---------------------------------------------------------------------------
+
+
+def _ensure_telegram_mock():
+    """Telegram's PTB dependency is optional; stub the surface we touch
+    so import doesn't pull the real package on minimal test installs."""
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+
+    telegram_mod = MagicMock()
+    telegram_mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    telegram_mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    telegram_mod.constants.ChatType.GROUP = "group"
+    telegram_mod.constants.ChatType.SUPERGROUP = "supergroup"
+    telegram_mod.constants.ChatType.CHANNEL = "channel"
+    telegram_mod.constants.ChatType.PRIVATE = "private"
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, telegram_mod)
+
+
+_ensure_telegram_mock()
+
+
+# ===========================================================================
+# QQBot — reconnect exhaustion must notify the gateway watcher
+# ===========================================================================
+
+
+class TestQQBotReconnectExhaustionNotifies:
+    """All three ``MAX_RECONNECT_ATTEMPTS`` exits in ``_listen_loop``
+    must fire ``_notify_fatal_error`` so ``_platform_reconnect_watcher``
+    can re-queue the platform.  A bare ``_mark_disconnected()`` (the
+    pre-fix behaviour) lets the listener task die in silence.
+
+    Rather than driving the full ``_listen_loop`` (which would need a
+    fake WebSocket + heartbeat plumbing), we set up the same end-state
+    each branch reaches — ``backoff_idx >= MAX_RECONNECT_ATTEMPTS`` —
+    and assert the helper that runs at that point routes through the
+    fatal-error escalation.
+    """
+
+    def _make_adapter(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.qqbot import QQAdapter
+
+        adapter = QQAdapter(PlatformConfig(enabled=True, extra={
+            "app_id": "test-app",
+            "client_secret": "test-secret",
+        }))
+        # Replace status-file write with a no-op recorder so we can
+        # assert without touching the real ~/.hermes status dir.
+        adapter._write_runtime_status_safe = MagicMock()
+        return adapter
+
+    @pytest.mark.asyncio
+    async def test_set_fatal_error_runs_handler_with_retryable(self):
+        """``_set_fatal_error(retryable=True)`` + ``_notify_fatal_error``
+        must invoke the gateway-registered handler with the same
+        ``retryable`` flag the watcher branches on."""
+        adapter = self._make_adapter()
+        handler = AsyncMock()
+        adapter.set_fatal_error_handler(handler)
+
+        adapter._set_fatal_error(
+            "qq_reconnect_exhausted",
+            "WebSocket reconnect exhausted after 100 attempts",
+            retryable=True,
+        )
+        await adapter._notify_fatal_error()
+
+        handler.assert_awaited_once()
+        called_with = handler.await_args.args[0]
+        assert called_with is adapter
+        assert adapter.fatal_error_code == "qq_reconnect_exhausted"
+        assert adapter.fatal_error_retryable is True
+        assert "100 attempts" in (adapter.fatal_error_message or "")
+
+    def test_exhaustion_paths_use_set_fatal_error_not_mark_disconnected(self):
+        """Static guard: the three ``MAX_RECONNECT_ATTEMPTS`` exit
+        sites in ``_listen_loop`` must invoke ``_set_fatal_error`` and
+        ``_notify_fatal_error``.  A future refactor that drops one of
+        the escalations and falls back to ``_mark_disconnected()`` —
+        the pre-#29005 behaviour — would re-open the bug.
+        """
+        import inspect
+
+        from gateway.platforms.qqbot import adapter as qq_adapter_mod
+
+        src = inspect.getsource(qq_adapter_mod.QQAdapter._listen_loop)
+        # Three exhaustion sites → at least three fatal-error
+        # escalations, each paired with a notify.
+        assert src.count("_set_fatal_error(") >= 3, (
+            "Expected at least 3 _set_fatal_error() calls in "
+            "_listen_loop (rate-limit, QQCloseError, generic Exception); "
+            "found only %d.  Reverting any exhaustion site to "
+            "_mark_disconnected() re-opens #29005." % src.count("_set_fatal_error(")
+        )
+        assert src.count("_notify_fatal_error()") >= 3, (
+            "Every fatal-error escalation on the exhaustion path must "
+            "be followed by `await self._notify_fatal_error()` so the "
+            "gateway watcher actually picks the platform up (#29005)."
+        )
+        # The exhaustion error code is shared across the three sites
+        # for easy log greps.
+        assert "qq_reconnect_exhausted" in src
+
+    @pytest.mark.asyncio
+    async def test_notify_fatal_error_noop_without_handler(self):
+        """Adapters started outside a GatewayRunner (CLI smoke tests,
+        local debug) must not crash when no handler is registered."""
+        adapter = self._make_adapter()
+        # No handler set; should silently return.
+        adapter._set_fatal_error("qq_reconnect_exhausted", "x", retryable=True)
+        await adapter._notify_fatal_error()  # must not raise
+
+
+# ===========================================================================
+# Telegram — retry window must surface as platform_state=retrying
+# ===========================================================================
+
+
+class TestTelegramPollingRetryStatus:
+    """``_handle_polling_network_error`` must mark the runtime status
+    ``retrying`` *during* the back-off window (not just at the final
+    fatal-error step) so external monitors can detect degraded
+    connectivity earlier.  On successful reconnect it must flip back
+    to ``connected``.
+    """
+
+    def _make_adapter(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.telegram import TelegramAdapter
+
+        adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+        # Record every status write so we can assert ordering.
+        adapter._write_runtime_status_safe = MagicMock()
+        return adapter
+
+    @pytest.mark.asyncio
+    async def test_retry_window_writes_retrying_state(self):
+        """Any non-final attempt (1..MAX_NETWORK_RETRIES) must emit a
+        ``platform_state=retrying`` write before sleeping — that's the
+        window external monitors were blind to (#29005)."""
+        adapter = self._make_adapter()
+        adapter._polling_network_error_count = 0  # → attempt 1 after increment
+
+        mock_updater = MagicMock()
+        mock_updater.running = True
+        mock_updater.stop = AsyncMock()
+        mock_updater.start_polling = AsyncMock()  # success path
+        mock_app = MagicMock()
+        mock_app.updater = mock_updater
+        mock_app.bot.get_me = AsyncMock()
+        adapter._app = mock_app
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            await adapter._handle_polling_network_error(RuntimeError("connection reset"))
+
+        writes = [call.kwargs for call in adapter._write_runtime_status_safe.call_args_list]
+        states = [w.get("platform_state") for w in writes]
+        assert "retrying" in states, (
+            "Expected platform_state=retrying during the back-off window; "
+            "got writes: %r" % writes
+        )
+
+    @pytest.mark.asyncio
+    async def test_retrying_write_carries_diagnostic_message(self):
+        """The retrying write must include the attempt counter so
+        operators can tell *which* attempt is in flight from the
+        runtime status payload alone."""
+        adapter = self._make_adapter()
+        adapter._polling_network_error_count = 2  # → attempt 3 after increment
+
+        mock_updater = MagicMock()
+        mock_updater.running = True
+        mock_updater.stop = AsyncMock()
+        mock_updater.start_polling = AsyncMock(side_effect=Exception("still bad"))
+        mock_app = MagicMock()
+        mock_app.updater = mock_updater
+        adapter._app = mock_app
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            await adapter._handle_polling_network_error(RuntimeError("dns failed"))
+
+        retrying_writes = [
+            call.kwargs
+            for call in adapter._write_runtime_status_safe.call_args_list
+            if call.kwargs.get("platform_state") == "retrying"
+        ]
+        assert retrying_writes, "expected at least one retrying write"
+        msg = retrying_writes[0].get("error_message", "")
+        assert "3/10" in msg, (
+            f"expected attempt counter '3/10' in error_message; got {msg!r}"
+        )
+        assert retrying_writes[0].get("error_code") == "telegram_network_error"
+
+        # Clean up the self-rescheduled retry task to keep pytest tidy.
+        for t in list(adapter._background_tasks):
+            t.cancel()
+
+    @pytest.mark.asyncio
+    async def test_successful_reconnect_flips_state_back_to_connected(self):
+        """When start_polling succeeds, the next status write must
+        clear the retrying state so external monitors stop alerting."""
+        adapter = self._make_adapter()
+        adapter._polling_network_error_count = 0
+
+        mock_updater = MagicMock()
+        mock_updater.running = True
+        mock_updater.stop = AsyncMock()
+        mock_updater.start_polling = AsyncMock()  # success
+        mock_app = MagicMock()
+        mock_app.updater = mock_updater
+        mock_app.bot.get_me = AsyncMock()
+        adapter._app = mock_app
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            await adapter._handle_polling_network_error(RuntimeError("blip"))
+
+        states = [
+            call.kwargs.get("platform_state")
+            for call in adapter._write_runtime_status_safe.call_args_list
+        ]
+        # Both transitions must be present, retrying BEFORE connected.
+        assert "retrying" in states
+        assert "connected" in states
+        assert states.index("retrying") < states.index("connected"), (
+            "retrying state must be written before the connected state "
+            f"on a successful reconnect; got {states!r}"
+        )
+
+        # Background heartbeat probe gets scheduled — cancel so it
+        # doesn't run after the test.
+        for t in list(adapter._background_tasks):
+            t.cancel()
+
+    @pytest.mark.asyncio
+    async def test_final_attempt_still_escalates_to_fatal(self):
+        """The new retrying-status writes must not change the existing
+        contract that attempt MAX_NETWORK_RETRIES+1 calls
+        ``_set_fatal_error`` + ``_notify_fatal_error`` so the gateway
+        watcher takes over.  No regression for #3173."""
+        adapter = self._make_adapter()
+        # MAX_NETWORK_RETRIES is 10; pushing the counter to 10 makes
+        # the next increment → 11 → escalation branch.
+        adapter._polling_network_error_count = 10
+        handler = AsyncMock()
+        adapter.set_fatal_error_handler(handler)
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            await adapter._handle_polling_network_error(RuntimeError("final"))
+
+        assert adapter.fatal_error_code == "telegram_network_error"
+        assert adapter.fatal_error_retryable is True
+        handler.assert_awaited_once()


### PR DESCRIPTION
## What does this PR do?

Fixes #29005 — both halves of the reported regression:

**P0 — QQBot:** the three `MAX_RECONNECT_ATTEMPTS` exit paths in `QQAdapter._listen_loop` ended with a bare `_mark_disconnected()` and a `return`. That writes `platform_state=disconnected` to the runtime status file and kills the listener task — but does **not** fire the `fatal_error_handler` that `GatewayRunner._platform_reconnect_watcher` is wired through. With no fatal-error event, the watcher never adds the platform to `_failed_platforms` and the adapter stays permanently dead while the gateway process keeps running. Reporter's log shows exactly this: QQBot exhausts its 100-attempt budget at 07:33 and from then on nothing tries to bring it back. Fix replaces each `_mark_disconnected()` with `_set_fatal_error(..., retryable=True)` + `await _notify_fatal_error()`, so the same gateway watcher that already handles Telegram / WhatsApp / Slack picks the platform up with exponential back-off (cap 5 min, circuit-broken after 10 consecutive failures).

**P1 — Telegram:** during the polling reconnect ladder (`_handle_polling_network_error`, default 10 attempts with exponential back-off capped at 60 s ≈ 55 min total), `platform_state` stays at `connected` because `_mark_connected()` was called at startup. Anything reading `platforms.telegram.state` (Prometheus exporter, kanban dashboard, status MCP) has no way to tell the bot has been unreachable for several minutes. The fatal-state flip only happens at attempt 11. Fix writes `platform_state=retrying` before each back-off sleep with the attempt counter + last error in `error_message`, and writes `connected` back on successful reconnect.

Both halves reuse the existing `_set_fatal_error` / `_write_runtime_status_safe` helpers and the existing `retrying` state string the gateway's fatal-error handler already emits — no new schema, no new env vars, no public-API change.

## Related Issue

Fixes #29005.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/qqbot/adapter.py` (+36/-3) — `_listen_loop`:
  - Replace `_mark_disconnected()` with `_set_fatal_error("qq_reconnect_exhausted", ..., retryable=True)` + `await _notify_fatal_error()` at all three `MAX_RECONNECT_ATTEMPTS` exits (rate-limit branch, generic `QQCloseError` branch, generic `Exception` branch).
  - Single shared error code; messages differentiate the root cause so log greps still tell the three sites apart.
- `gateway/platforms/telegram.py` (+27) — `_handle_polling_network_error`:
  - Before sleeping: `_write_runtime_status_safe(platform_state="retrying", error_code="telegram_network_error", error_message="Network error retry N/MAX (next in Xs): <err>")`.
  - After successful `start_polling()`: write `platform_state="connected"` to clear the retrying state.
- `tests/gateway/test_platform_reconnect_fatal_notify.py` (+288, new) — 7 regression tests across 2 classes:
  - `TestQQBotReconnectExhaustionNotifies` (3 cases) — handler awaited with `retryable=True`; static guard over `_listen_loop` source proving at least 3 `_set_fatal_error` + 3 `_notify_fatal_error` escalations and the `qq_reconnect_exhausted` code remain; handler-less adapters don't crash.
  - `TestTelegramPollingRetryStatus` (4 cases) — first-attempt `retrying` write happens; the write carries the `N/MAX` counter + `telegram_network_error` code; successful reconnect emits `retrying` then `connected` in order; final-attempt fatal escalation still fires (no regression for #3173).

No production code outside the two adapter files modified.

## How to Test

1. Check out this branch and ensure `.venv` is set up: `python3 -m venv .venv && source .venv/bin/activate && pip install -e \".[all,dev]\"`
2. Run the new tests on their own:
   ```
   scripts/run_tests.sh tests/gateway/test_platform_reconnect_fatal_notify.py -v
   ```
   Expected: 7 passed.
3. Run the surrounding suite to confirm no cross-file regressions:
   ```
   scripts/run_tests.sh tests/gateway/test_platform_reconnect_fatal_notify.py \
     tests/gateway/test_telegram_network_reconnect.py \
     tests/gateway/test_qqbot.py
   ```
   Expected: 166 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(qqbot): ...`, `fix(telegram): ...`, `test(gateway): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/gateway/test_platform_reconnect_fatal_notify.py` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.2 (Darwin 24.6.0), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (no public-API change; inline comments call out the gateway-watcher contract + #29005)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — both adapters' status-write helpers are platform-agnostic; fix is reachable on every OS that runs the gateway
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/gateway/test_platform_reconnect_fatal_notify.py -v
4 workers [7 items]
============================== 7 passed in 1.17s ===============================

$ scripts/run_tests.sh tests/gateway/test_platform_reconnect_fatal_notify.py \
    tests/gateway/test_telegram_network_reconnect.py \
    tests/gateway/test_qqbot.py
4 workers [166 items]
======================== 166 passed, 1 warning in 2.20s ========================
```

Made with [Cursor](https://cursor.com)