### PR TITLE
fix(gateway): prevent 100% CPU spin when QQBot WebSocket is closed

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -655,6 +655,8 @@ class QQAdapter(BasePlatformAdapter):
         """Read WebSocket frames until connection closes."""
         if not self._ws:
             raise RuntimeError("WebSocket not connected")
+        if self._ws.closed:
+            raise RuntimeError("WebSocket closed")
 
         while self._running and self._ws and not self._ws.closed:
             msg = await self._ws.receive()

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1255,6 +1255,7 @@ AUTHOR_MAP = {
     "120500656+oooindefatigable@users.noreply.github.com": "ooovenenoso",
     "vanthinh6886@gmail.com": "vanthinh6886",  # PR #28018 salvage (yaml/flock/atomic write guards)
     "erik.engervall@gmail.com": "erikengervall",  # PR #28774 (firecrawl integration tag)
+    "win847@users.noreply.github.com": "win847",
 }
 
 

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -410,6 +410,33 @@ class TestQQCloseError:
 
 
 # ---------------------------------------------------------------------------
+# _read_events
+# ---------------------------------------------------------------------------
+
+class TestQQReadEvents:
+    """Tests for QQAdapter._read_events()."""
+
+    @pytest.mark.asyncio
+    async def test_raises_on_closed_ws(self):
+        """When self._ws.closed is True, _read_events should raise RuntimeError,
+        preventing the caller from silently resetting backoff_idx."""
+        from gateway.platforms.qqbot import QQAdapter
+        adapter = QQAdapter(_make_config(app_id="a", client_secret="b"))
+        adapter._ws = SimpleNamespace(closed=True)
+        with pytest.raises(RuntimeError, match="WebSocket closed"):
+            await adapter._read_events()
+
+    @pytest.mark.asyncio
+    async def test_raises_on_missing_ws(self):
+        """When self._ws is None, _read_events should raise RuntimeError."""
+        from gateway.platforms.qqbot import QQAdapter
+        adapter = QQAdapter(_make_config(app_id="a", client_secret="b"))
+        adapter._ws = None
+        with pytest.raises(RuntimeError, match="WebSocket not connected"):
+            await adapter._read_events()
+
+
+# ---------------------------------------------------------------------------
 # _dispatch_payload
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
When the QQ Bot WebSocket transitions to a closed state (msg.type == WSMsgType.CLOSED), _read_events() raises RuntimeError once, which is caught by the except Exception block. However, _reconnect() only sets self._ws.closed = True but does not set self._ws = None. On the next loop iteration, _read_events() checks 'if not self._ws' (False, since it is still set) and enters the inner while loop, whose condition 'not self._ws.closed' is immediately False. The function returns normally without raising, causing the outer loop to reset backoff_idx to 0 - resulting in a tight 100% CPU spin loop that never reconnects until the process is killed.

Fix: add a 'self._ws.closed' guard at the top of _read_events() so it raises RuntimeError consistently whenever the transport is unusable, forcing the caller's except Exception block to drive proper reconnection with backoff.