### PR TITLE
docs(google-workspace): fix dead gws CLI link to googleworkspace/cli

### DIFF
--- a/website/docs/user-guide/skills/google-workspace.md
+++ b/website/docs/user-guide/skills/google-workspace.md
@@ -7,7 +7,7 @@ description: "Send email, manage calendar events, search Drive, read/write Sheet
 
 # Google Workspace Skill
 
-Gmail, Calendar, Drive, Contacts, Sheets, and Docs integration for Hermes. Uses OAuth2 with automatic token refresh. Prefers the [Google Workspace CLI (`gws`)](https://github.com/nicholasgasior/gws) when available for broader coverage, and falls back to Google's Python client libraries otherwise.
+Gmail, Calendar, Drive, Contacts, Sheets, and Docs integration for Hermes. Uses OAuth2 with automatic token refresh. Prefers the [Google Workspace CLI (`gws`)](https://github.com/googleworkspace/cli) when available for broader coverage, and falls back to Google's Python client libraries otherwise.
 
 **Skill path:** `skills/productivity/google-workspace/`
 


### PR DESCRIPTION
## Summary
- The Google Workspace skill docs link `gws` to `https://github.com/nicholasgasior/gws`, which returns 404.
- Repointed to `https://github.com/googleworkspace/cli` — the official Google Workspace CLI (Rust, dynamically built from the Google Discovery Service, ~26k stars), which is the `gws` binary the skill actually integrates with.

## Verification
- `curl -I https://github.com/nicholasgasior/gws` → 404
- `curl -I https://github.com/googleworkspace/cli` → 200
- Only one occurrence in the docs tree; the bundled skill's `SKILL.md` and `scripts/gws_bridge.py` use the `gws` binary name and don't link to an upstream URL.

Closes #28922