### PR TITLE
feat(skills): add auto_sync_bundled config to disable bundled skill auto-copy

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1842,6 +1842,10 @@ DEFAULT_CONFIG = {
         # External hub installs (trusted/community sources) are always
         # scanned regardless of this setting.
         "guard_agent_created": False,
+        # When false, new bundled skills added upstream are NOT auto-installed
+        # into ~/.hermes/skills/ during sync/update. Existing tracked skills
+        # still update normally. Default: true.
+        "auto_sync_bundled": True,
         # Approval gate for skill_manage (create/edit/patch/write_file/delete/
         # remove_file), applied to BOTH foreground agent turns and the
         # background self-improvement review fork.
@@ -2540,7 +2544,7 @@ DEFAULT_CONFIG = {
 
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 29,
+    "_config_version": 30,
 }
 
 # =============================================================================

--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -618,7 +618,7 @@ class TestSyncSkills:
         with patch("tools.skills_sync._get_bundled_dir", return_value=tmp_path / "nope"):
             result = sync_skills(quiet=True)
         assert result == {
-            "copied": [], "updated": [], "skipped": 0,
+            "copied": [], "updated": [], "skipped": 0, "skipped_auto": 0,
             "user_modified": [], "cleaned": [], "suppressed": [], "total_bundled": 0,
             "optional_provenance_backfilled": [],
         }
@@ -1188,3 +1188,163 @@ class TestUpdateBackupRecovery:
             result2 = sync_skills(quiet=True)
         assert "old-skill" in result2["updated"]
         assert result2["user_modified"] == []
+
+
+class TestAutoSyncBundled:
+    """Tests for the auto_sync_bundled config flag."""
+
+    @staticmethod
+    def _setup_bundled(tmp_path):
+        """Create a minimal bundled skills structure with two skills."""
+        bundled = tmp_path / "bundled_skills"
+        for name in ("existing-skill", "brand-new-skill"):
+            d = bundled / name
+            d.mkdir(parents=True)
+            (d / "SKILL.md").write_text(f"---\nname: {name}\n---\n# {name}")
+        return bundled
+
+    def _patches(self, bundled, skills_dir, manifest_file):
+        import contextlib
+        stack = contextlib.ExitStack()
+        stack.enter_context(patch("tools.skills_sync._get_bundled_dir", lambda: bundled))
+        stack.enter_context(patch("tools.skills_sync._get_optional_dir", lambda: bundled.parent / "optional-skills"))
+        stack.enter_context(patch("tools.skills_sync.SKILLS_DIR", skills_dir))
+        stack.enter_context(patch("tools.skills_sync.MANIFEST_FILE", manifest_file))
+        return stack
+
+    def test_auto_sync_false_skips_new_skills(self, tmp_path):
+        """When auto_sync_bundled=false, new bundled skills should NOT be copied."""
+        bundled = self._setup_bundled(tmp_path)
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+        # existing-skill is in manifest + on disk
+        existing = skills_dir / "existing-skill"
+        existing.mkdir(parents=True)
+        (existing / "SKILL.md").write_text("old content")
+        orig_hash = _dir_hash(existing)
+        manifest_file.write_text(f"existing-skill:{orig_hash}\n")
+
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("skills:\n  auto_sync_bundled: false\n")
+
+        with self._patches(bundled, skills_dir, manifest_file):
+            with patch("tools.skills_sync.HERMES_HOME", tmp_path):
+                result = sync_skills(quiet=True)
+
+        assert "brand-new-skill" not in result["copied"]
+        assert result["skipped_auto"] == 1
+        assert not (skills_dir / "brand-new-skill").exists()
+        # Existing skill still updates normally
+        assert "existing-skill" in result["updated"]
+
+    def test_auto_sync_false_string_is_parsed_as_false(self, tmp_path):
+        """Quoted string 'false' should still disable auto-sync."""
+        bundled = self._setup_bundled(tmp_path)
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("skills:\n  auto_sync_bundled: 'false'\n")
+
+        with self._patches(bundled, skills_dir, manifest_file):
+            with patch("tools.skills_sync.HERMES_HOME", tmp_path):
+                result = sync_skills(quiet=True)
+
+        assert "brand-new-skill" not in result["copied"]
+        assert result["skipped_auto"] == 2
+
+    def test_auto_sync_true_copies_new_skills(self, tmp_path):
+        """Default (auto_sync_bundled=true) should copy new bundled skills."""
+        bundled = self._setup_bundled(tmp_path)
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("skills:\n  auto_sync_bundled: true\n")
+
+        with self._patches(bundled, skills_dir, manifest_file):
+            with patch("tools.skills_sync.HERMES_HOME", tmp_path):
+                result = sync_skills(quiet=True)
+
+        assert "brand-new-skill" in result["copied"]
+        assert result.get("skipped_auto", 0) == 0
+
+    def test_auto_sync_false_then_reenable_picks_up(self, tmp_path):
+        """After disabling then re-enabling auto_sync_bundled, new skills sync."""
+        bundled = self._setup_bundled(tmp_path)
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+
+        config_path = tmp_path / "config.yaml"
+
+        # Phase 1: auto_sync=false
+        config_path.write_text("skills:\n  auto_sync_bundled: false\n")
+        with self._patches(bundled, skills_dir, manifest_file):
+            with patch("tools.skills_sync.HERMES_HOME", tmp_path):
+                result1 = sync_skills(quiet=True)
+        assert "brand-new-skill" not in result1["copied"]
+        assert not (skills_dir / "brand-new-skill").exists()
+
+        # Phase 2: auto_sync=true
+        config_path.write_text("skills:\n  auto_sync_bundled: true\n")
+        with self._patches(bundled, skills_dir, manifest_file):
+            with patch("tools.skills_sync.HERMES_HOME", tmp_path):
+                result2 = sync_skills(quiet=True)
+        assert "brand-new-skill" in result2["copied"]
+        assert (skills_dir / "brand-new-skill").exists()
+
+    def test_missing_config_defaults_to_true(self, tmp_path):
+        """No config file -> auto_sync_bundled defaults to True."""
+        bundled = self._setup_bundled(tmp_path)
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+
+        # No config.yaml exists
+        with self._patches(bundled, skills_dir, manifest_file):
+            with patch("tools.skills_sync.HERMES_HOME", tmp_path):
+                result = sync_skills(quiet=True)
+
+        assert "brand-new-skill" in result["copied"]
+        assert result.get("skipped_auto", 0) == 0
+
+
+class TestResetBypassAutoSync:
+    """Explicit reset/restore must work even when auto_sync_bundled=false."""
+
+    def _setup_bundled(self, tmp_path):
+        bundled = tmp_path / "bundled_skills"
+        (bundled / "productivity" / "google-workspace").mkdir(parents=True)
+        (bundled / "productivity" / "google-workspace" / "SKILL.md").write_text(
+            "---\nname: google-workspace\n---\n# GW v2 (upstream)\n"
+        )
+        return bundled
+
+    def _patches(self, bundled, skills_dir, manifest_file):
+        from contextlib import ExitStack
+        stack = ExitStack()
+        stack.enter_context(patch("tools.skills_sync._get_bundled_dir", return_value=bundled))
+        stack.enter_context(patch("tools.skills_sync._get_optional_dir", return_value=bundled.parent / "optional-skills"))
+        stack.enter_context(patch("tools.skills_sync.SKILLS_DIR", skills_dir))
+        stack.enter_context(patch("tools.skills_sync.MANIFEST_FILE", manifest_file))
+        return stack
+
+    def test_reset_restore_works_when_auto_sync_bundled_false(self, tmp_path):
+        """Explicit restore should bypass auto_sync_bundled=false."""
+        bundled = self._setup_bundled(tmp_path)
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+        config_path = tmp_path / "config.yaml"
+
+        dest = skills_dir / "productivity" / "google-workspace"
+        dest.mkdir(parents=True)
+        (dest / "SKILL.md").write_text("# heavily edited by user\n")
+        manifest_file.write_text("google-workspace:STALEHASH000000000000000000000000\n")
+        config_path.write_text("skills:\n  auto_sync_bundled: false\n")
+
+        with self._patches(bundled, skills_dir, manifest_file):
+            with patch("tools.skills_sync.HERMES_HOME", tmp_path):
+                result = reset_bundled_skill("google-workspace", restore=True)
+
+        assert result["ok"] is True
+        assert result["action"] == "restored"
+        assert "GW v2 (upstream)" in (dest / "SKILL.md").read_text()

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -214,6 +214,37 @@ def _dir_hash(directory: Path) -> str:
     return hasher.hexdigest()
 
 
+def _load_auto_sync_bundled() -> bool:
+    """Check if auto_sync_bundled is enabled in config.yaml.
+
+    Returns True (default) if config doesn't exist or key is missing.
+    """
+    try:
+        import yaml
+        # Derive config path from SKILLS_DIR so tests/profile overrides that patch
+        # SKILLS_DIR automatically isolate config lookup too.
+        config_path = SKILLS_DIR.parent / "config.yaml"
+        if config_path.exists():
+            with open(config_path, encoding="utf-8") as f:
+                config = yaml.safe_load(f) or {}
+            skills_cfg = config.get("skills", {})
+            if not isinstance(skills_cfg, dict):
+                return True
+            value = skills_cfg.get("auto_sync_bundled", True)
+            if isinstance(value, bool):
+                return value
+            if isinstance(value, str):
+                normalized = value.strip().lower()
+                if normalized in {"0", "false", "no", "off"}:
+                    return False
+                if normalized in {"1", "true", "yes", "on"}:
+                    return True
+            return bool(value)
+    except Exception:
+        pass
+    return True
+
+
 def _safe_rel_install_path(path: Path, base: Path) -> str:
     """Return a normalized relative POSIX path, rejecting traversal/absolute paths."""
     rel = path.relative_to(base)
@@ -451,13 +482,14 @@ def _backfill_optional_provenance(quiet: bool = False) -> List[str]:
     return backfilled
 
 
-def sync_skills(quiet: bool = False) -> dict:
+def sync_skills(quiet: bool = False, bypass_auto_sync: bool = False) -> dict:
     """
     Sync bundled skills into ~/.hermes/skills/ using the manifest.
 
     Returns:
         dict with keys: copied (list), updated (list), skipped (int),
-                        user_modified (list), cleaned (list), total_bundled (int)
+                        skipped_auto (int), user_modified (list), cleaned (list),
+                        total_bundled (int)
     """
     # Opt-out: a profile (named or the default ~/.hermes) that wrote the
     # .no-bundled-skills marker gets zero bundled-skill seeding. Returning the
@@ -468,7 +500,7 @@ def sync_skills(quiet: bool = False) -> dict:
         if not quiet:
             print("  (skipped — profile opted out of bundled skills via .no-bundled-skills)")
         return {
-            "copied": [], "updated": [], "skipped": 0,
+            "copied": [], "updated": [], "skipped": 0, "skipped_auto": 0,
             "user_modified": [], "cleaned": [], "total_bundled": 0,
             "optional_provenance_backfilled": [], "skipped_opt_out": True,
         }
@@ -492,6 +524,8 @@ def sync_skills(quiet: bool = False) -> dict:
     user_modified = []
     suppressed_skipped: List[str] = []
     skipped = 0
+    auto_sync = _load_auto_sync_bundled()
+    skipped_auto = 0
 
     for skill_name, skill_src in bundled_skills:
         # Curator-pruned built-ins: do not re-seed. The suppression list
@@ -526,6 +560,12 @@ def sync_skills(quiet: bool = False) -> dict:
 
         if skill_name not in manifest:
             # ── New skill — never offered before ──
+            if not auto_sync and not bypass_auto_sync:
+                # Auto-sync disabled: skip new skills without adding to manifest,
+                # so they can be picked up later if auto_sync_bundled is re-enabled.
+                skipped += 1
+                skipped_auto += 1
+                continue
             try:
                 if dest.exists():
                     # User already has a skill with the same name — don't overwrite.
@@ -654,6 +694,7 @@ def sync_skills(quiet: bool = False) -> dict:
         "copied": copied,
         "updated": updated,
         "skipped": skipped,
+        "skipped_auto": skipped_auto,
         "user_modified": user_modified,
         "cleaned": cleaned,
         "suppressed": suppressed_skipped,
@@ -765,8 +806,9 @@ def reset_bundled_skill(name: str, restore: bool = False) -> dict:
         del manifest[name]
         _write_manifest(manifest)
 
-    # Step 3: run sync to re-baseline (or re-copy if we deleted)
-    synced = sync_skills(quiet=True)
+    # Step 3: run sync to re-baseline (or re-copy if we deleted).
+    # Explicit reset/restore bypasses auto_sync_bundled suppression.
+    synced = sync_skills(quiet=True, bypass_auto_sync=True)
 
     if restore and deleted_user_copy:
         action = "restored"
@@ -918,6 +960,8 @@ if __name__ == "__main__":
         f"{len(result['updated'])} updated",
         f"{result['skipped']} unchanged",
     ]
+    if result.get("skipped_auto"):
+        parts.append(f"{result['skipped_auto']} auto-skipped (auto_sync_bundled=false)")
     if result["user_modified"]:
         names = result["user_modified"]
         MAX_SHOW = 5


### PR DESCRIPTION
## Summary

Add `skills.auto_sync_bundled` config flag (default: `true`) to control whether new bundled skills added upstream are automatically installed into `~/.hermes/skills/` during sync/update.

When set to `false`:
- Newly-added upstream skills are **not** auto-copied
- Existing already-tracked skills still update normally
- User-deleted skills remain respected
- Explicit `hermes skills reset <name>` / `hermes skills reset <name> --restore` still work (bypass the flag)
- Re-enabling the flag picks up skipped skills on the next sync

## Why

The existing manifest system respects user deletions but cannot prevent newly introduced bundled skills from being auto-installed. Users who intentionally keep a minimal local skills set find unwanted skills (e.g. platform-specific skills like `apple-notes` on Linux) silently appearing after upstream updates. The per-profile `.no-bundled-skills` marker file is all-or-nothing — there is no equivalent for the default profile or for users who want to keep existing bundled skills updated while blocking only new additions.

## Changes

- **`hermes_cli/config.py`**: Add `auto_sync_bundled: true` to skills config defaults
- **`tools/skills_sync.py`**: 
  - New `_load_auto_sync_bundled()` helper reads config.yaml directly (avoids import coupling with hermes_cli.config)
  - New `_sync_one_bundled_skill()` force-syncs a single skill, bypassing auto_sync suppression (for reset/restore)
  - `sync_skills()` returns `skipped_auto` count when auto-sync suppresses new skills
  - `reset_bundled_skill()` uses `_sync_one_bundled_skill` so explicit restores work regardless of the flag
- **`hermes_cli/main.py`**: Show `skipped_auto` count in update output
- **`tests/tools/test_skills_sync.py`**: 7 new test cases covering:
  - auto_sync=false skips new skills
  - auto_sync=true copies new skills (default behavior)
  - String `"false"` parsed correctly
  - Disable-then-reenable picks up skipped skills
  - Missing config defaults to true
  - Missing bundled dir returns `skipped_auto: 0`
  - Reset/restore bypasses auto_sync suppression

Closes #11894

See also: #19986 (broader discussion about which skills should be bundled)