### PR TITLE
feat(memory): add memory.suppress_builtin_when_external opt-in

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -959,6 +959,7 @@ def init_agent(
     agent._memory_enabled = False
     agent._user_profile_enabled = False
     agent._memory_nudge_interval = 10
+    agent._memory_suppress_builtin_when_external = False
     agent._turns_since_memory = 0
     agent._iters_since_skill = 0
     if not skip_memory:
@@ -967,6 +968,9 @@ def init_agent(
             agent._memory_enabled = mem_config.get("memory_enabled", False)
             agent._user_profile_enabled = mem_config.get("user_profile_enabled", False)
             agent._memory_nudge_interval = int(mem_config.get("nudge_interval", 10))
+            agent._memory_suppress_builtin_when_external = bool(
+                mem_config.get("suppress_builtin_when_external", False)
+            )
             if agent._memory_enabled or agent._user_profile_enabled:
                 from tools.memory_tool import MemoryStore
                 agent._memory_store = MemoryStore(

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -240,7 +240,25 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # ── Volatile tier (changes per session/turn — never cached) ───
     volatile_parts: List[str] = []
 
-    if agent._memory_store:
+    # External memory provider system prompt block.
+    # Built ahead of the built-in block so we can suppress built-in injection
+    # when an external provider with content is configured AND the user opted
+    # in via ``memory.suppress_builtin_when_external`` — this avoids
+    # double-injecting the same information into every system prompt
+    # (see #28796). The default keeps the historical additive behavior.
+    _ext_mem_block = ""
+    if agent._memory_manager:
+        try:
+            _ext_mem_block = agent._memory_manager.build_system_prompt() or ""
+        except Exception:
+            _ext_mem_block = ""
+
+    _suppress_builtin = bool(
+        getattr(agent, "_memory_suppress_builtin_when_external", False)
+        and _ext_mem_block
+    )
+
+    if agent._memory_store and not _suppress_builtin:
         if agent._memory_enabled:
             mem_block = agent._memory_store.format_for_system_prompt("memory")
             if mem_block:
@@ -251,14 +269,8 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             if user_block:
                 volatile_parts.append(user_block)
 
-    # External memory provider system prompt block (additive to built-in)
-    if agent._memory_manager:
-        try:
-            _ext_mem_block = agent._memory_manager.build_system_prompt()
-            if _ext_mem_block:
-                volatile_parts.append(_ext_mem_block)
-        except Exception:
-            pass
+    if _ext_mem_block:
+        volatile_parts.append(_ext_mem_block)
 
     from hermes_time import now as _hermes_now
     now = _hermes_now()

--- a/tests/agent/test_system_prompt_memory_suppression.py
+++ b/tests/agent/test_system_prompt_memory_suppression.py
@@ -1,0 +1,124 @@
+"""Tests for ``memory.suppress_builtin_when_external`` in system prompt assembly.
+
+Regression coverage for #28796: when an external memory provider returns a
+non-empty system-prompt block AND the user opted in via
+``memory.suppress_builtin_when_external``, the built-in MEMORY.md / USER.md
+blocks must not be injected — they'd duplicate the same content the external
+provider already covers.
+
+The default (opt-out absent or false) preserves the historical additive
+behavior, so existing deployments keep both blocks.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent import system_prompt as sp
+
+
+def _make_agent(*, builtin: str, external: str, suppress: bool):
+    """Build a stub AIAgent exposing only the fields ``build_system_prompt_parts`` reads."""
+    mem_store = MagicMock()
+    mem_store.format_for_system_prompt.side_effect = lambda kind: {
+        "memory": "MEMORY:" + builtin if builtin else "",
+        "user": "USER:" + builtin if builtin else "",
+    }[kind]
+
+    mem_mgr = MagicMock()
+    mem_mgr.build_system_prompt.return_value = external
+
+    return SimpleNamespace(
+        # Identity / context
+        load_soul_identity=False,
+        skip_context_files=True,
+        valid_tool_names=set(),
+        provider="openrouter",
+        model="test/model",
+        platform="cli",
+        # Tool-use enforcement (the function reads this — set to "false" so we
+        # don't take any extra branches)
+        _tool_use_enforcement="false",
+        # Memory state
+        _memory_store=mem_store,
+        _memory_enabled=True,
+        _user_profile_enabled=True,
+        _memory_manager=mem_mgr,
+        _memory_suppress_builtin_when_external=suppress,
+        # Session/identity (consumed by the timestamp line)
+        pass_session_id=False,
+        session_id="sess-test",
+        # Kanban worker guidance (None → branch skipped)
+        _kanban_worker_guidance=None,
+    )
+
+
+@pytest.fixture
+def stub_ra():
+    """Stub the lazy ``_ra()`` indirection so we don't pull run_agent helpers."""
+    stub = MagicMock()
+    stub.load_soul_md.return_value = ""
+    stub.build_environment_hints.return_value = ""
+    stub.build_context_files_prompt.return_value = ""
+    stub.build_nous_subscription_prompt.return_value = ""
+    stub.build_skills_system_prompt.return_value = ""
+    stub.get_toolset_for_tool.return_value = None
+    with patch.object(sp, "_ra", return_value=stub):
+        yield stub
+
+
+class TestSuppressBuiltinWhenExternal:
+    def test_default_keeps_both_blocks(self, stub_ra):
+        """No flag set → built-in memory + external block both injected (back-compat)."""
+        agent = _make_agent(builtin="abc", external="EXTERNAL_CTX", suppress=False)
+        parts = sp.build_system_prompt_parts(agent)
+        vol = parts["volatile"]
+        assert "MEMORY:abc" in vol
+        assert "USER:abc" in vol
+        assert "EXTERNAL_CTX" in vol
+
+    def test_suppression_drops_builtin_when_external_has_content(self, stub_ra):
+        """Flag on + external provider has content → built-in blocks suppressed."""
+        agent = _make_agent(builtin="abc", external="EXTERNAL_CTX", suppress=True)
+        parts = sp.build_system_prompt_parts(agent)
+        vol = parts["volatile"]
+        assert "MEMORY:abc" not in vol
+        assert "USER:abc" not in vol
+        assert "EXTERNAL_CTX" in vol
+
+    def test_suppression_inactive_when_external_empty(self, stub_ra):
+        """Flag on but external returns empty → built-in still injected.
+
+        Otherwise a misconfigured external provider would silently strip the
+        user's MEMORY.md / USER.md from every system prompt.
+        """
+        agent = _make_agent(builtin="abc", external="", suppress=True)
+        parts = sp.build_system_prompt_parts(agent)
+        vol = parts["volatile"]
+        assert "MEMORY:abc" in vol
+        assert "USER:abc" in vol
+
+    def test_suppression_safe_when_no_external_provider(self, stub_ra):
+        """No external provider at all → flag is harmless."""
+        agent = _make_agent(builtin="abc", external="", suppress=True)
+        agent._memory_manager = None
+        parts = sp.build_system_prompt_parts(agent)
+        vol = parts["volatile"]
+        assert "MEMORY:abc" in vol
+        assert "USER:abc" in vol
+
+    def test_external_provider_exception_does_not_break_builtin(self, stub_ra):
+        """If the external provider's build_system_prompt raises, fall back cleanly.
+
+        The suppression flag must not trigger (because _ext_mem_block ends
+        up empty) and the built-in block must still be injected.
+        """
+        agent = _make_agent(builtin="abc", external="", suppress=True)
+        agent._memory_manager.build_system_prompt.side_effect = RuntimeError("boom")
+        parts = sp.build_system_prompt_parts(agent)
+        vol = parts["volatile"]
+        assert "MEMORY:abc" in vol
+        assert "USER:abc" in vol

--- a/website/docs/user-guide/features/memory.md
+++ b/website/docs/user-guide/features/memory.md
@@ -215,7 +215,17 @@ memory:
 
 For deeper, persistent memory that goes beyond MEMORY.md and USER.md, Hermes ships with 8 external memory provider plugins — including Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, and Supermemory.
 
-External providers run **alongside** built-in memory (never replacing it) and add capabilities like knowledge graphs, semantic search, automatic fact extraction, and cross-session user modeling.
+External providers run **alongside** built-in memory by default (never replacing it) and add capabilities like knowledge graphs, semantic search, automatic fact extraction, and cross-session user modeling.
+
+If you've migrated existing notes into the external provider and don't want the built-in MEMORY.md / USER.md blocks injected into the system prompt on top of the provider's own context, opt in to suppression:
+
+```yaml
+memory:
+  provider: openviking          # or honcho, mem0, hindsight, ...
+  suppress_builtin_when_external: true
+```
+
+When set, the built-in memory and user-profile blocks are skipped whenever the external provider returns a non-empty system-prompt block. If the external provider has no content yet (or temporarily errors out), the built-in blocks are still injected so you don't silently lose your notes.
 
 ```bash
 hermes memory setup      # pick a provider and configure it


### PR DESCRIPTION
## Summary
Opt-in config knob to stop double-injecting MEMORY.md/USER.md into the system prompt when an external memory provider (OpenViking, Honcho, etc.) is configured and already supplies its own context block.

Before this change, `agent/system_prompt.py` unconditionally appended both the built-in memory/user blocks **and** `MemoryManager.build_system_prompt()`. Users who migrated their notes into an external provider saw the same information twice on every turn and the only workaround was manually flipping `memory_enabled: false` (which also disables the `memory` tool).

## Behavior

```yaml
memory:
  provider: openviking
  suppress_builtin_when_external: true   # new, default false
```

- Flag **false / absent** → historical additive behavior, byte-stable for existing deployments.
- Flag **true** + external provider returns non-empty block → built-in memory/user blocks are skipped, external block is injected.
- Flag **true** + external provider returns empty (no content yet, transient error, exception) → built-in blocks are still injected. We never silently strip the user's notes.

External-provider exceptions are caught and treated as "empty block", same as the prior behavior.

## Files
- `agent/system_prompt.py` — build the external block first, gate the built-in injection on `(_suppress && _ext_mem_block)`.
- `agent/agent_init.py` — read `memory.suppress_builtin_when_external` from config, default `False`, expose as `agent._memory_suppress_builtin_when_external`.
- `tests/agent/test_system_prompt_memory_suppression.py` — 5 cases (default keeps both, suppress drops built-in, empty external keeps built-in, no manager configured, external raises).
- `website/docs/user-guide/features/memory.md` — document the new knob and the "we don't silently strip" safety.

## Test Plan
- [x] `python -m pytest tests/agent/test_system_prompt_memory_suppression.py -q -o 'addopts='` → 5 passed
- [x] `python -m pytest tests/agent/test_memory_provider.py tests/run_agent/test_memory_provider_init.py tests/agent/test_system_prompt_restore.py tests/agent/test_system_prompt_memory_suppression.py -q -o 'addopts='` → 78 passed in 98s

Closes #28796