### PR TITLE
fix(oneshot): don't swallow stderr on failure; enable faulthandler

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -22,9 +22,11 @@ Env var fallbacks (used when the corresponding arg is not passed):
 
 from __future__ import annotations
 
+import faulthandler
 import logging
 import os
 import sys
+import tempfile
 from contextlib import redirect_stderr, redirect_stdout
 from typing import Optional
 
@@ -171,20 +173,47 @@ def run_oneshot(
     os.environ["HERMES_YOLO_MODE"] = "1"
     os.environ["HERMES_ACCEPT_HOOKS"] = "1"
 
-    # Redirect stderr AND stdout to devnull for the entire call tree.
-    # We'll print the final response to the real stdout at the end.
+    # Wire faulthandler to the real stderr fd before any redirect so that a
+    # C-level crash (SIGSEGV/SIGABRT inside a native extension) gets a stack
+    # trace to the operator's terminal. `contextlib.redirect_stderr` only
+    # swaps `sys.stderr`; faulthandler holds the underlying fd, so it
+    # survives the redirect block below.
+    if not faulthandler.is_enabled():
+        try:
+            faulthandler.enable(file=sys.stderr, all_threads=True)
+        except (RuntimeError, OSError):
+            # Some embedded contexts don't expose a real stderr fd; the
+            # fallback is silently dropping the trace — same as today.
+            pass
+
+    # Redirect stderr to a temp buffer (not /dev/null) so that, on a
+    # silent failure, we can surface what the agent actually printed
+    # instead of leaving the operator with zero signal. stdout still
+    # goes to devnull — the only stdout we want is the final response,
+    # which we write to the real stdout below.
+    real_stderr = sys.stderr
     real_stdout = sys.stdout
     devnull = open(os.devnull, "w", encoding="utf-8")
+    stderr_buf = tempfile.SpooledTemporaryFile(
+        max_size=64 * 1024, mode="w+", encoding="utf-8", errors="replace"
+    )
 
+    response = ""
     try:
-        with redirect_stdout(devnull), redirect_stderr(devnull):
-            response = _run_agent(
-                prompt,
-                model=model,
-                provider=provider,
-                toolsets=explicit_toolsets,
-                use_config_toolsets=use_config_toolsets,
-            )
+        try:
+            with redirect_stdout(devnull), redirect_stderr(stderr_buf):
+                response = _run_agent(
+                    prompt,
+                    model=model,
+                    provider=provider,
+                    toolsets=explicit_toolsets,
+                    use_config_toolsets=use_config_toolsets,
+                )
+        except BaseException:
+            # Surface the captured stderr (which would otherwise be silently
+            # discarded) before letting the exception propagate.
+            _dump_stderr_buf(stderr_buf, real_stderr)
+            raise
     finally:
         try:
             devnull.close()
@@ -196,7 +225,45 @@ def run_oneshot(
         if not response.endswith("\n"):
             real_stdout.write("\n")
         real_stdout.flush()
+        try:
+            stderr_buf.close()
+        except Exception:
+            pass
+        return 0
+
+    # Empty response — the agent ran to completion but produced nothing.
+    # Without the captured stderr the operator has zero signal; surface
+    # the tail so they can diagnose (rate limits, auth failures, model
+    # returned empty, etc.) instead of seeing a silent exit 0.
+    _dump_stderr_buf(stderr_buf, real_stderr, header="hermes -z: empty response; stderr tail follows:\n")
     return 0
+
+
+def _dump_stderr_buf(buf, sink, *, header: str = "", tail_bytes: int = 8 * 1024) -> None:
+    """Write the tail of `buf` to `sink`. No-op on empty buffer."""
+    try:
+        buf.seek(0, 2)  # to end
+        size = buf.tell()
+        if size <= 0:
+            return
+        buf.seek(max(0, size - tail_bytes))
+        data = buf.read()
+    except Exception:
+        return
+    if not data:
+        return
+    if header:
+        try:
+            sink.write(header)
+        except Exception:
+            pass
+    try:
+        sink.write(data)
+        if not data.endswith("\n"):
+            sink.write("\n")
+        sink.flush()
+    except Exception:
+        pass
 
 
 def _create_session_db_for_oneshot():


### PR DESCRIPTION
## Summary

`hermes_cli/oneshot.py:run_oneshot` redirects **both** stdout and stderr to `/dev/null` for the entire `_run_agent` call tree. This keeps the success path quiet (the original goal) but discards *every* diagnostic when something goes wrong:

- C-level crash inside a native extension → process dies with SIGSEGV, exit 139, **zero output** (no Python traceback, no faulthandler trace, no last-log-line).
- Unhandled Python exception inside the agent → traceback printed to the redirected `sys.stderr`, never reaches the operator (the exception object propagates, but anything the agent wrote to `stderr` along the way is gone).
- Empty-response return (provider returned empty content, retries exhausted with no usable text, etc.) → exit 0 with empty stdout, no clue what happened.

This was concretely felt while debugging #29021 — the only symptom of a `pydantic-core` thread segfault was `hermes -z "ping"` returning empty stdout. Adding a single `print` was the only way to learn the process had been SIGSEGV'd at all.

## What this PR changes

`run_oneshot` keeps the silent-on-success behavior but stops discarding diagnostics on failure:

1. **`faulthandler.enable(file=sys.stderr, all_threads=True)`** is wired before the redirect block. `contextlib.redirect_stderr` only swaps `sys.stderr` (Python-level); faulthandler holds the underlying fd, so a C-level SIGSEGV/SIGABRT stack still reaches the operator's terminal.

   *Caveat:* Rust PyO3 panics that call libc `abort()` cannot be caught by faulthandler — those still die mute. This catches everything else: numpy aborts, ctypes mis-calls, double-frees, openssl issues, etc.

2. **Redirected stderr → `SpooledTemporaryFile`** instead of `/dev/null`. On any exception escaping `_run_agent`, the tail of that buffer is written to the real stderr **before** the exception propagates. On an empty-response return, the tail is also surfaced with an explicit `hermes -z: empty response; stderr tail follows:` header.

The happy path is unchanged: stdout = final response, stderr = empty.

## Test plan

Validated end-to-end in the Hermes venv (Linux x86_64 musl, Python 3.11.15):

- [x] **Happy path:** `hermes -z "responda apenas 'pong'" --model openrouter/owl-alpha --provider openrouter` → stdout=`pong`, stderr=0 bytes, exit 0. Identical to current behavior.
- [x] **Python exception path:** monkey-patched `_run_agent` to write to `sys.stderr` and then raise. With this PR, the stderr write reaches the operator (instead of being swallowed) and the exception propagates as before.
- [x] **SIGSEGV path (pydantic-core 2.41.5 + Responses API + thread):** still dies hard with no output — Rust `abort()` is uncatchable by faulthandler. Acknowledged in commit message; the dep bump in #29021 is what fixes that particular crash, not this PR.

## Platforms tested

- Linux 6.8.0 x86_64, musllinux (Alpine container), Python 3.11.15

## Related

Companion to #29021 (pydantic bump). #29021 fixes the specific crash; this PR fixes the *diagnosability gap* that hid the crash and turned a 30-second triage into a multi-hour investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)