### PR TITLE
Ignore local Hermes runtime files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,10 @@ node_modules
 **/node_modules
 .venv
 **/.venv
+.notebooklm-cli-venv/
+.notebooklm-playwright/
+.pip-cache/
+.uv-cache/
 
 # Built artifacts that are regenerated inside the image.  Excluded so local
 # rebuilds on the developer's machine don't invalidate the npm-install layer
@@ -25,6 +29,8 @@ ui-tui/packages/hermes-ink/dist/
 
 # Runtime data (bind-mounted at /opt/data; must not leak into build context)
 data/
+.hermes-docker/
+.notebooklm-home/
 
 # Compose/profile runtime state (bind-mounted; avoid ownership/secret issues)
 hermes-config/

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,13 @@ __pycache__/
 .env.production.local
 .env.development
 .env.test
+.hermes-docker/
+.notebooklm-home/
+.notebooklm-cli-venv/
+.notebooklm-playwright/
+.pip-cache/
+.uv-cache/
+compose.hermes.local.yml
 export*
 __pycache__/model_tools.cpython-310.pyc
 __pycache__/web_tools.cpython-310.pyc


### PR DESCRIPTION
## What changed
- Ignore local Hermes Docker/runtime folders and NotebookLM local state in .gitignore.
- Exclude the same local runtime/cache directories from Docker build context via .dockerignore.

## Why
- Prevent local secrets, runtime state, cache directories, and personal compose files from being committed or sent into Docker builds.

## Verification
- git check-ignore -v .hermes-docker .notebooklm-home .notebooklm-cli-venv .notebooklm-playwright .pip-cache .uv-cache compose.hermes.local.yml
- git diff --check upstream/main..HEAD -- .gitignore .dockerignore

## Risks / rollback
- Low risk: ignore-only change.
- Rollback: revert commit ec641d497 or remove the added ignore entries.