### PR TITLE
fix(windows): remove duplicate creationflags in local subprocess Popen call

### DIFF
--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -532,7 +532,6 @@ class LocalEnvironment(BaseEnvironment):
             stderr=subprocess.STDOUT,
             stdin=subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
             preexec_fn=None if _IS_WINDOWS else os.setsid,
-            creationflags=subprocess.CREATE_NO_WINDOW if _IS_WINDOWS else 0,
             cwd=_popen_cwd,
             **_popen_kwargs,
         )


### PR DESCRIPTION
## Problem

On Windows, every terminal tool call fails with:
```
TypeError: subprocess.Popen() got multiple values for keyword argument 'creationflags'
```

## Root Cause

In `tools/environments/local.py`, the `_run_bash` method passes `creationflags` to `subprocess.Popen()` **twice** on Windows:

1. Via `_popen_kwargs` dict (`windows_hide_flags()` → `CREATE_NO_WINDOW`)
2. Via explicit `creationflags=subprocess.CREATE_NO_WINDOW` parameter

Python raises `TypeError` when the same keyword argument appears twice (once directly, once via `**dict` expansion).

## Fix

Remove the redundant explicit `creationflags` parameter. `_popen_kwargs` already handles it via the established `windows_hide_flags()` compat-layer helper.

## Commit

`2b454a0f1` — single-line deletion, 1 file changed, 1 deletion.