### PR TITLE
fix(computer-use): target app windows across Spaces

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -289,6 +289,84 @@ class TestCaptureResponse:
 
 
 # ---------------------------------------------------------------------------
+# cua-driver backend window selection
+# ---------------------------------------------------------------------------
+
+class TestCuaDriverBackendWindowSelection:
+    def test_capture_lists_all_windows_and_prefers_large_titled_app_window(self):
+        from tools.computer_use.cua_backend import CuaDriverBackend
+
+        class FakeSession:
+            def __init__(self):
+                self.calls = []
+
+            def call_tool(self, name, args):
+                self.calls.append((name, args))
+                if name == "list_windows":
+                    return {
+                        "data": None,
+                        "images": [],
+                        "structuredContent": {
+                            "windows": [
+                                {
+                                    "app_name": "Google Chrome",
+                                    "pid": 100,
+                                    "window_id": 1,
+                                    "is_on_screen": True,
+                                    "title": "",
+                                    "z_index": 0,
+                                    "bounds": {"width": 1, "height": 1},
+                                },
+                                {
+                                    "app_name": "Google Chrome",
+                                    "pid": 100,
+                                    "window_id": 2,
+                                    "is_on_screen": False,
+                                    "title": "JDI Reports - Google Chrome",
+                                    "z_index": 10,
+                                    "bounds": {"width": 1440, "height": 900},
+                                },
+                                {
+                                    "app_name": "Safari",
+                                    "pid": 200,
+                                    "window_id": 3,
+                                    "is_on_screen": True,
+                                    "title": "Frontmost unrelated app",
+                                    "z_index": -1,
+                                    "bounds": {"width": 1200, "height": 800},
+                                },
+                            ]
+                        },
+                    }
+                if name == "get_window_state":
+                    return {
+                        "data": "✅ Google Chrome — 0 elements\nAXWindow \"JDI Reports - Google Chrome\"",
+                        "images": [],
+                        "structuredContent": {},
+                    }
+                raise AssertionError(f"unexpected tool: {name}")
+
+        backend = object.__new__(CuaDriverBackend)
+        session = FakeSession()
+        backend_any: Any = backend
+        backend_any._session = session
+        backend_any._active_pid = None
+        backend_any._active_window_id = None
+
+        result = backend.capture(mode="ax", app="Chrome")
+
+        assert session.calls[0] == ("list_windows", {"on_screen_only": False})
+        assert backend._active_pid == 100
+        assert backend._active_window_id == 2
+        assert session.calls[1] == (
+            "get_window_state",
+            {"pid": 100, "window_id": 2},
+        )
+        assert result.app == "Google Chrome"
+        assert result.window_title == "JDI Reports - Google Chrome"
+
+
+# ---------------------------------------------------------------------------
 # Anthropic adapter: multimodal tool-result conversion
 # ---------------------------------------------------------------------------
 

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -348,8 +348,12 @@ class CuaDriverBackend(ComputerUseBackend):
         Maps hermes `capture(mode, app)` → cua-driver `list_windows` +
         `get_window_state` (ax/som) or `screenshot` (vision).
         """
-        # Step 1: enumerate on-screen windows to find target pid/window_id.
-        lw_out = self._session.call_tool("list_windows", {"on_screen_only": True})
+        # Step 1: enumerate windows to find target pid/window_id.
+        # Use all windows, not only the current Space. cua-driver can target
+        # background windows on other Spaces; restricting to on-screen/current
+        # Space silently falls back to the frontmost unrelated app when the
+        # requested `app` is open elsewhere (e.g. Chrome in another Space).
+        lw_out = self._session.call_tool("list_windows", {"on_screen_only": False})
 
         # Prefer structuredContent.windows (MCP 2024-11-05+); fall back to
         # text-line parsing for older cua-driver builds.
@@ -364,6 +368,7 @@ class CuaDriverBackend(ComputerUseBackend):
                     "off_screen": not w.get("is_on_screen", True),
                     "title": w.get("title", ""),
                     "z_index": w.get("z_index", 0),
+                    "bounds": w.get("bounds") or {},
                 }
                 for w in raw_windows
             ]
@@ -378,14 +383,32 @@ class CuaDriverBackend(ComputerUseBackend):
                                  elements=[], app="", window_title="", png_bytes_len=0)
 
         # Filter by app name (case-insensitive substring) if requested.
+        app_filtered = False
         if app:
             app_lower = app.lower()
             filtered = [w for w in windows if app_lower in w["app_name"].lower()]
             if filtered:
                 windows = filtered
+                app_filtered = True
 
-        # Pick first on-screen window (sorted by z_index / z-order above).
-        target = next((w for w in windows if not w["off_screen"]), windows[0])
+        # Pick the target window. For an explicit app on another Space,
+        # cua-driver reports many untitled Chrome/Safari helper windows as
+        # off-screen; prefer titled, large content windows over menu bars and
+        # 1x1/helper windows. Without an app filter, keep the z-order/frontmost
+        # behavior.
+        if app_filtered:
+            def _target_score(w: Dict[str, Any]) -> Tuple[int, int, int, int]:
+                b = w.get("bounds") or {}
+                area = int(b.get("width", 0) or 0) * int(b.get("height", 0) or 0)
+                return (
+                    1 if w.get("title") else 0,
+                    1 if not w.get("off_screen") else 0,
+                    area,
+                    -int(w.get("z_index", 0) or 0),
+                )
+            target = max(windows, key=_target_score)
+        else:
+            target = next((w for w in windows if not w["off_screen"]), windows[0])
         self._active_pid = target["pid"]
         self._active_window_id = target["window_id"]
         app_name = target["app_name"]


### PR DESCRIPTION
## Summary
- List all cua-driver windows instead of only on-screen/current-Space windows so explicit app captures can target apps on other Spaces
- Prefer titled, large content windows for explicit app captures to avoid helper/menu/1x1 windows
- Add regression coverage for cross-Space app window selection

## Test Plan
- python -m py_compile tools/computer_use/cua_backend.py tests/tools/test_computer_use.py
- python -m pytest tests/tools/test_computer_use.py -q -o 'addopts='