### PR TITLE
feat(web): improve models fallback management

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -51,6 +51,19 @@ from agent.model_metadata import (
     parse_available_output_tokens_from_error,
     save_context_length,
 )
+from agent.nous_rate_guard import (
+    clear_nous_rate_limit,
+    format_remaining,
+    is_genuine_nous_rate_limit,
+    nous_rate_limit_remaining,
+    record_nous_rate_limit,
+)
+from agent.provider_rate_guard import (
+    clear_provider_cooldown,
+    is_usage_limit_context,
+    provider_cooldown_remaining,
+    record_provider_cooldown,
+)
 from agent.process_bootstrap import _install_safe_stdio
 from agent.prompt_caching import apply_anthropic_cache_control
 from agent.retry_utils import jittered_backoff
@@ -1155,6 +1168,47 @@ def run_conversation(
         api_kwargs = None  # Guard against UnboundLocalError in except handler
 
         while retry_count < max_retries:
+            # ── Generic provider usage-cap guard ──────────────────
+            # Subscription-backed providers such as openai-codex can return
+            # account-level usage caps with a reset window. Once one session
+            # observes that, skip direct calls until reset and fail over
+            # immediately. This avoids retry amplification across gateway,
+            # CLI, cron, and auxiliary sessions.
+            if agent.provider == "openai-codex":
+                try:
+                    _provider_remaining = provider_cooldown_remaining(agent.provider)
+                    if _provider_remaining is not None and _provider_remaining > 0:
+                        _provider_msg = (
+                            f"{agent.provider} usage limit active — "
+                            f"resets in {format_remaining(_provider_remaining)}."
+                        )
+                        agent._vprint(
+                            f"{agent.log_prefix}⏳ {_provider_msg} Trying fallback...",
+                            force=True,
+                        )
+                        agent._emit_status(f"⏳ {_provider_msg}")
+                        if agent._try_activate_fallback():
+                            retry_count = 0
+                            compression_attempts = 0
+                            primary_recovery_attempted = False
+                            continue
+                        agent._persist_session(messages, conversation_history)
+                        return {
+                            "final_response": (
+                                f"⏳ {_provider_msg}\n\n"
+                                "No fallback provider available. "
+                                "Try again after the reset, or add a "
+                                "fallback provider in config.yaml."
+                            ),
+                            "messages": messages,
+                            "api_calls": api_call_count,
+                            "completed": False,
+                            "failed": True,
+                            "error": _provider_msg,
+                        }
+                except Exception:
+                    pass
+
             # ── Nous Portal rate limit guard ──────────────────────
             # If another session already recorded that Nous is rate-
             # limited, skip the API call entirely.  Each attempt
@@ -1934,6 +1988,8 @@ def run_conversation(
                         )
                 
                 has_retried_429 = False  # Reset on success
+                if agent.provider == "openai-codex":
+                    clear_provider_cooldown(agent.provider)
                 # Note: don't clear the retry buffer here — an "API call
                 # success" only means we got bytes back, not that we got
                 # usable content. Empty responses still loop through the
@@ -2258,6 +2314,16 @@ def run_conversation(
                             force=True,
                         )
                         continue
+
+                if (
+                    agent.provider == "openai-codex"
+                    and classified.reason == FailoverReason.rate_limit
+                    and is_usage_limit_context(error_context)
+                ):
+                    record_provider_cooldown(
+                        agent.provider,
+                        error_context=error_context,
+                    )
 
                 recovered_with_pool, has_retried_429 = agent._recover_with_credential_pool(
                     status_code=status_code,

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -228,6 +228,27 @@ def _try_refresh_nous_paid_entitlement_credentials(agent) -> bool:
         return False
 
 
+def _pool_may_recover_from_rate_limit_local(
+    pool, *, provider: str | None = None, base_url: str | None = None
+) -> bool:
+    """Decide whether credential-pool rotation can recover a provider limit.
+
+    run_agent exports the same helper in the monolithic runtime, but some
+    packaged/extracted conversation-loop paths can reach this module without
+    that symbol available on run_agent. Keep the fallback decision local so
+    provider failures classify cleanly instead of cascading into an internal
+    NameError/AttributeError.
+    """
+    if pool is None:
+        return False
+    if not pool.has_available():
+        return False
+    if provider == "google-gemini-cli" or str(base_url or "").startswith("cloudcode-pa://"):
+        return False
+    return len(pool.entries()) > 1
+
+
+
 def _restore_or_build_system_prompt(agent, system_message, conversation_history):
     """Restore the cached system prompt from the session DB or build it fresh.
 
@@ -2760,7 +2781,12 @@ def run_conversation(
                     # still recover.  See _pool_may_recover_from_rate_limit
                     # for the single-credential-pool and CloudCode-quota
                     # exceptions.  Fixes #11314 and #13636.
-                    pool_may_recover = _ra()._pool_may_recover_from_rate_limit(
+                    _pool_recovery_check = getattr(
+                        _ra(),
+                        "_pool_may_recover_from_rate_limit",
+                        _pool_may_recover_from_rate_limit_local,
+                    )
+                    pool_may_recover = _pool_recovery_check(
                         agent._credential_pool,
                         provider=agent.provider,
                         base_url=getattr(agent, "base_url", None),

--- a/agent/provider_rate_guard.py
+++ b/agent/provider_rate_guard.py
@@ -1,0 +1,190 @@
+"""Cross-session provider cooldown guard.
+
+Records provider usage-cap/reset windows in a small shared state file so
+gateway, CLI, cron, and auxiliary sessions can fail over without hammering a
+known-capped primary provider.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import tempfile
+import time
+from typing import Any, Optional
+
+from utils import atomic_replace
+
+logger = logging.getLogger(__name__)
+
+_STATE_SUBDIR = "rate_limits"
+
+
+def _hermes_home() -> str:
+    try:
+        from hermes_constants import get_hermes_home
+
+        return get_hermes_home()
+    except Exception:
+        return os.path.join(os.path.expanduser("~"), ".hermes")
+
+
+def _safe_provider_name(provider: str) -> str:
+    safe = re.sub(r"[^A-Za-z0-9_.-]+", "-", (provider or "").strip().lower())
+    return safe.strip("-") or "unknown"
+
+
+def _state_path(provider: str) -> str:
+    return os.path.join(_hermes_home(), _STATE_SUBDIR, f"{_safe_provider_name(provider)}.json")
+
+
+def _parse_reset_at(raw: Any) -> Optional[float]:
+    if raw in {None, ""}:
+        return None
+    now = time.time()
+    if isinstance(raw, (int, float)):
+        value = float(raw)
+        if value > now:
+            return value
+        if value > 0:
+            return now + value
+        return None
+    if isinstance(raw, str):
+        value = raw.strip()
+        if not value:
+            return None
+        try:
+            numeric = float(value)
+            if numeric > now:
+                return numeric
+            if numeric > 0:
+                return now + numeric
+        except ValueError:
+            pass
+        try:
+            from datetime import datetime, timezone
+
+            normalized = value.replace("Z", "+00:00")
+            parsed = datetime.fromisoformat(normalized)
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            timestamp = parsed.timestamp()
+            if timestamp > now:
+                return timestamp
+        except Exception:
+            return None
+    return None
+
+
+def _reset_from_context(error_context: Optional[dict[str, Any]]) -> Optional[float]:
+    if not isinstance(error_context, dict):
+        return None
+    for key in ("reset_at", "resets_at", "retry_after"):
+        parsed = _parse_reset_at(error_context.get(key))
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def record_provider_cooldown(
+    provider: str,
+    *,
+    error_context: Optional[dict[str, Any]] = None,
+    default_cooldown: float = 300.0,
+) -> None:
+    """Record a provider cooldown window.
+
+    ``error_context`` may carry an absolute reset timestamp, ISO timestamp, or
+    retry-after seconds. If none is present, a short default cooldown prevents
+    immediate retry storms while avoiding a long false-positive outage.
+    """
+
+    provider = _safe_provider_name(provider)
+    now = time.time()
+    reset_at = _reset_from_context(error_context)
+    if reset_at is None:
+        reset_at = now + default_cooldown
+
+    path = _state_path(provider)
+    state_dir = os.path.dirname(path)
+    try:
+        os.makedirs(state_dir, exist_ok=True)
+        state = {
+            "provider": provider,
+            "reset_at": reset_at,
+            "recorded_at": now,
+            "reset_seconds": reset_at - now,
+            "reason": (error_context or {}).get("reason"),
+            "message": (error_context or {}).get("message"),
+        }
+        fd, tmp_path = tempfile.mkstemp(dir=state_dir, suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(state, f)
+            atomic_replace(tmp_path, path)
+        except Exception:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+        logger.info(
+            "Provider cooldown recorded: provider=%s resets_in=%.0fs",
+            provider,
+            reset_at - now,
+        )
+    except Exception as exc:
+        logger.debug("Failed to write provider cooldown state for %s: %s", provider, exc)
+
+
+def provider_cooldown_remaining(provider: str) -> Optional[float]:
+    """Return remaining cooldown seconds, or None if provider is available."""
+
+    path = _state_path(provider)
+    try:
+        with open(path, encoding="utf-8") as f:
+            state = json.load(f)
+        remaining = float(state.get("reset_at", 0)) - time.time()
+        if remaining > 0:
+            return remaining
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+        return None
+    except (FileNotFoundError, json.JSONDecodeError, KeyError, TypeError, ValueError):
+        return None
+
+
+def clear_provider_cooldown(provider: str) -> None:
+    """Clear a provider cooldown after a successful primary-provider request."""
+
+    try:
+        os.unlink(_state_path(provider))
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        logger.debug("Failed to clear provider cooldown state for %s: %s", provider, exc)
+
+
+def is_usage_limit_context(error_context: Optional[dict[str, Any]]) -> bool:
+    if not isinstance(error_context, dict):
+        return False
+    reason = str(error_context.get("reason") or "").lower()
+    message = str(error_context.get("message") or "").lower()
+    return (
+        "usage_limit" in reason
+        or "usage limit has been reached" in message
+        or "plan_type=plus" in message
+    )
+
+
+__all__ = [
+    "clear_provider_cooldown",
+    "is_usage_limit_context",
+    "provider_cooldown_remaining",
+    "record_provider_cooldown",
+]
+

--- a/agent/provider_rate_guard.py
+++ b/agent/provider_rate_guard.py
@@ -187,4 +187,3 @@ __all__ = [
     "provider_cooldown_remaining",
     "record_provider_cooldown",
 ]
-

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -169,9 +169,12 @@ class ChatCompletionsTransport(ProviderTransport):
         for msg in sanitized:
             if not isinstance(msg, dict):
                 continue
+            # Internal DB/search metadata. OpenAI-compatible wire payloads
+            # use ``name`` / ``tool_call_id`` for tool messages; providers
+            # such as Groq reject the extra ``tool_name`` field.
+            msg.pop("tool_name", None)
             msg.pop("codex_reasoning_items", None)
             msg.pop("codex_message_items", None)
-            msg.pop("tool_name", None)
             # Drop all Hermes-internal scaffolding markers (``_``-prefixed).
             # OpenAI's message schema has no ``_``-prefixed fields, so this
             # is safe and future-proofs against new markers being added.

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -507,6 +507,12 @@ class ModelAssignment(BaseModel):
     task: str = ""
 
 
+class FallbackProvidersUpdate(BaseModel):
+    """Payload for PUT /api/model/fallbacks."""
+
+    fallbacks: List[Dict[str, Any]]
+
+
 _GATEWAY_HEALTH_URL = os.getenv("GATEWAY_HEALTH_URL")
 try:
     _GATEWAY_HEALTH_TIMEOUT = float(os.getenv("GATEWAY_HEALTH_TIMEOUT", "3"))
@@ -1181,6 +1187,50 @@ async def set_model_assignment(body: ModelAssignment):
         _log.exception("POST /api/model/set failed")
         raise HTTPException(status_code=500, detail="Failed to save model assignment")
 
+
+@app.get("/api/model/fallbacks")
+def get_model_fallbacks():
+    """Return the configured fallback provider chain."""
+    try:
+        from hermes_cli.fallback_cmd import _read_chain
+
+        cfg = load_config()
+        return {"fallbacks": _read_chain(cfg)}
+    except Exception:
+        _log.exception("GET /api/model/fallbacks failed")
+        raise HTTPException(status_code=500, detail="Failed to read fallback providers")
+
+
+@app.put("/api/model/fallbacks")
+def set_model_fallbacks(body: FallbackProvidersUpdate):
+    """Persist fallback providers in config.yaml order."""
+    cleaned: List[Dict[str, Any]] = []
+    for entry in body.fallbacks:
+        if not isinstance(entry, dict):
+            continue
+        provider = str(entry.get("provider") or "").strip()
+        model = str(entry.get("model") or "").strip()
+        if not provider or not model:
+            raise HTTPException(status_code=400, detail="fallback provider and model are required")
+        item: Dict[str, Any] = {"provider": provider, "model": model}
+        for key in ("base_url", "api_mode"):
+            value = str(entry.get(key) or "").strip()
+            if value:
+                item[key] = value
+        cleaned.append(item)
+
+    try:
+        from hermes_cli.fallback_cmd import _write_chain
+
+        cfg = load_config()
+        _write_chain(cfg, cleaned)
+        save_config(cfg)
+        return {"ok": True, "fallbacks": cleaned}
+    except HTTPException:
+        raise
+    except Exception:
+        _log.exception("PUT /api/model/fallbacks failed")
+        raise HTTPException(status_code=500, detail="Failed to save fallback providers")
 
 
 

--- a/tests/agent/test_provider_rate_guard.py
+++ b/tests/agent/test_provider_rate_guard.py
@@ -1,0 +1,30 @@
+import time
+
+from agent import provider_rate_guard as guard
+
+
+def test_provider_cooldown_records_and_expires(tmp_path, monkeypatch):
+    monkeypatch.setattr(guard, "_hermes_home", lambda: str(tmp_path))
+
+    guard.record_provider_cooldown(
+        "openai-codex",
+        error_context={"reason": "usage_limit_reached", "reset_at": time.time() + 60},
+    )
+
+    remaining = guard.provider_cooldown_remaining("openai-codex")
+    assert remaining is not None
+    assert 0 < remaining <= 60
+
+    guard.clear_provider_cooldown("openai-codex")
+    assert guard.provider_cooldown_remaining("openai-codex") is None
+
+
+def test_usage_limit_context_matches_codex_plus_message():
+    assert guard.is_usage_limit_context(
+        {"message": "HTTP 429: The usage limit has been reached, plan_type=plus"}
+    )
+
+
+def test_usage_limit_context_rejects_generic_rate_limit():
+    assert not guard.is_usage_limit_context({"message": "Too many requests"})
+

--- a/tests/agent/test_provider_rate_guard.py
+++ b/tests/agent/test_provider_rate_guard.py
@@ -27,4 +27,3 @@ def test_usage_limit_context_matches_codex_plus_message():
 
 def test_usage_limit_context_rejects_generic_rate_limit():
     assert not guard.is_usage_limit_context({"message": "Too many requests"})
-

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -207,6 +207,32 @@ class TestWebServerEndpoints:
         defaults = resp.json()
         assert "model" in defaults
 
+    def test_model_fallbacks_round_trip(self):
+        from hermes_cli.config import load_config
+
+        payload = {
+            "fallbacks": [
+                {"provider": "openrouter", "model": "anthropic/claude-sonnet-4.6"},
+                {"provider": "nous", "model": "hermes-4"},
+            ]
+        }
+
+        put_resp = self.client.put("/api/model/fallbacks", json=payload)
+        assert put_resp.status_code == 200
+        assert put_resp.json()["fallbacks"] == payload["fallbacks"]
+
+        get_resp = self.client.get("/api/model/fallbacks")
+        assert get_resp.status_code == 200
+        assert get_resp.json()["fallbacks"] == payload["fallbacks"]
+        assert load_config()["fallback_providers"] == payload["fallbacks"]
+
+    def test_model_fallbacks_reject_missing_model(self):
+        resp = self.client.put(
+            "/api/model/fallbacks",
+            json={"fallbacks": [{"provider": "openrouter", "model": ""}]},
+        )
+        assert resp.status_code == 400
+
     def test_get_env_vars(self):
         resp = self.client.get("/api/env")
         assert resp.status_code == 200

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -7,6 +7,7 @@ advancement through multiple providers.
 
 from unittest.mock import MagicMock, patch
 
+from agent.conversation_loop import _pool_may_recover_from_rate_limit_local
 from run_agent import AIAgent, _pool_may_recover_from_rate_limit
 
 
@@ -220,6 +221,22 @@ class TestPoolRotationRoom:
 
     def test_many_credentials_available_returns_true(self):
         assert _pool_may_recover_from_rate_limit(_pool(10)) is True
+
+
+class TestConversationLoopPoolRecoveryLocal:
+    def test_local_helper_matches_pool_rotation_room_rules(self):
+        """conversation_loop keeps a local fallback when run_agent lacks the helper."""
+        assert _pool_may_recover_from_rate_limit_local(None) is False
+        assert _pool_may_recover_from_rate_limit_local(_pool(1)) is False
+        assert _pool_may_recover_from_rate_limit_local(_pool(2)) is True
+        assert _pool_may_recover_from_rate_limit_local(_pool(2), provider="google-gemini-cli") is False
+        assert (
+            _pool_may_recover_from_rate_limit_local(
+                _pool(2),
+                base_url="cloudcode-pa://project",
+            )
+            is False
+        )
 
 
 # ── Skip-self dedup (#22548) ───────────────────────────────────────────────

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -256,6 +256,13 @@ export const api = {
   getModelInfo: () => fetchJSON<ModelInfoResponse>("/api/model/info"),
   getModelOptions: () => fetchJSON<ModelOptionsResponse>("/api/model/options"),
   getAuxiliaryModels: () => fetchJSON<AuxiliaryModelsResponse>("/api/model/auxiliary"),
+  getFallbackProviders: () => fetchJSON<FallbackProvidersResponse>("/api/model/fallbacks"),
+  saveFallbackProviders: (fallbacks: FallbackProviderEntry[]) =>
+    fetchJSON<FallbackProvidersSaveResponse>("/api/model/fallbacks", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ fallbacks }),
+    }),
   setModelAssignment: (body: ModelAssignmentRequest) =>
     fetchJSON<ModelAssignmentResponse>("/api/model/set", {
       method: "POST",
@@ -844,6 +851,22 @@ export interface AuxiliaryTaskAssignment {
 export interface AuxiliaryModelsResponse {
   tasks: AuxiliaryTaskAssignment[];
   main: { provider: string; model: string };
+}
+
+export interface FallbackProviderEntry {
+  provider: string;
+  model: string;
+  base_url?: string;
+  api_mode?: string;
+}
+
+export interface FallbackProvidersResponse {
+  fallbacks: FallbackProviderEntry[];
+}
+
+export interface FallbackProvidersSaveResponse {
+  ok: boolean;
+  fallbacks: FallbackProviderEntry[];
 }
 
 export interface ModelAssignmentRequest {

--- a/web/src/pages/ModelsPage.tsx
+++ b/web/src/pages/ModelsPage.tsx
@@ -653,7 +653,10 @@ function FallbackProvidersPanel({ refreshKey }: { refreshKey: number }) {
   }, []);
 
   useEffect(() => {
-    loadFallbacks();
+    const timer = window.setTimeout(() => {
+      loadFallbacks();
+    }, 0);
+    return () => window.clearTimeout(timer);
   }, [loadFallbacks, refreshKey]);
 
   const persist = async (next: FallbackProviderEntry[]) => {
@@ -993,7 +996,10 @@ export default function ModelsPage() {
   }, [days, loading, load, setAfterTitle, setEnd, t.common.refresh]);
 
   useEffect(() => {
-    load();
+    const timer = window.setTimeout(() => {
+      load();
+    }, 0);
+    return () => window.clearTimeout(timer);
   }, [load]);
 
   return (

--- a/web/src/pages/ModelsPage.tsx
+++ b/web/src/pages/ModelsPage.tsx
@@ -16,6 +16,7 @@ import { api } from "@/lib/api";
 import type {
   AuxiliaryModelsResponse,
   AuxiliaryTaskAssignment,
+  FallbackProviderEntry,
   ModelsAnalyticsModelEntry,
   ModelsAnalyticsResponse,
 } from "@/lib/api";
@@ -634,6 +635,133 @@ function AuxiliaryTasksModal({
   );
 }
 
+function FallbackProvidersPanel({ refreshKey }: { refreshKey: number }) {
+  const [fallbacks, setFallbacks] = useState<FallbackProviderEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  const loadFallbacks = useCallback(() => {
+    setLoading(true);
+    setError(null);
+    api
+      .getFallbackProviders()
+      .then((res) => setFallbacks(res.fallbacks ?? []))
+      .catch((e) => setError(e instanceof Error ? e.message : String(e)))
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    loadFallbacks();
+  }, [loadFallbacks, refreshKey]);
+
+  const persist = async (next: FallbackProviderEntry[]) => {
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await api.saveFallbackProviders(next);
+      setFallbacks(res.fallbacks ?? next);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const move = (index: number, direction: -1 | 1) => {
+    const target = index + direction;
+    if (target < 0 || target >= fallbacks.length) return;
+    const next = [...fallbacks];
+    [next[index], next[target]] = [next[target], next[index]];
+    void persist(next);
+  };
+
+  return (
+    <div className="space-y-2" data-testid="fallback-providers-panel">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <div className="text-xs font-medium uppercase tracking-wider">Fallback providers</div>
+          <div className="text-[10px] text-muted-foreground">
+            Tried in order when the primary model fails.
+          </div>
+        </div>
+        <Button
+          size="sm"
+          outlined
+          onClick={() => setPickerOpen(true)}
+          disabled={saving}
+          className="text-xs"
+          data-testid="add-fallback-provider"
+        >
+          Add fallback
+        </Button>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <Spinner /> Loading fallback providers…
+        </div>
+      ) : fallbacks.length === 0 ? (
+        <div className="border border-dashed border-border/70 px-3 py-3 text-xs text-muted-foreground">
+          No fallback providers configured.
+        </div>
+      ) : (
+        <div className="space-y-1">
+          {fallbacks.map((fb, index) => (
+            <div
+              key={`${fb.provider}:${fb.model}:${index}`}
+              className="flex items-center justify-between gap-3 bg-muted/20 border border-border/50 px-3 py-2"
+              data-testid="fallback-provider-row"
+            >
+              <div className="min-w-0 flex-1">
+                <div className="text-xs font-mono truncate" data-testid="fallback-provider-model">
+                  {fb.provider} · {fb.model}
+                </div>
+                <div className="text-[10px] text-muted-foreground">
+                  #{index + 1} fallback{fb.base_url ? ` · ${fb.base_url}` : ""}
+                </div>
+              </div>
+              <div className="flex shrink-0 items-center gap-1">
+                <Button size="sm" outlined disabled={saving || index === 0} onClick={() => move(index, -1)}>
+                  Up
+                </Button>
+                <Button size="sm" outlined disabled={saving || index === fallbacks.length - 1} onClick={() => move(index, 1)}>
+                  Down
+                </Button>
+                <Button
+                  size="sm"
+                  outlined
+                  disabled={saving}
+                  onClick={() => void persist(fallbacks.filter((_, i) => i !== index))}
+                >
+                  Remove
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {saving && <div className="text-[10px] text-muted-foreground">Saving…</div>}
+      {error && <div className="text-[10px] text-destructive">{error}</div>}
+
+      {pickerOpen && (
+        <ModelPickerDialog
+          key={`fallback-picker-${refreshKey}-${fallbacks.length}`}
+          loader={api.getModelOptions}
+          alwaysGlobal
+          title="Add Fallback Provider"
+          onApply={async ({ provider, model }) => {
+            await persist([...fallbacks, { provider, model }]);
+          }}
+          onClose={() => setPickerOpen(false)}
+        />
+      )}
+    </div>
+  );
+}
+
 function ModelSettingsPanel({
   aux,
   refreshKey,
@@ -730,6 +858,8 @@ function ModelSettingsPanel({
             Configure
           </Button>
         </div>
+
+        <FallbackProvidersPanel refreshKey={refreshKey} />
 
         {picker && (
           <ModelPickerDialog


### PR DESCRIPTION
## Summary
- Add model fallback management endpoints for the web UI.
- Add fallback provider controls to the Models page.
- Defer Models page effect loads so fallback data loading does not race/error during render.

## Context
Clean replacement for the blocked draft PR #27648. This branch is rebased onto current upstream main and keeps the scope to the web/model fallback changes only.

## Verification
- uv run --extra dev pytest tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_model_fallbacks_round_trip tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_model_fallbacks_reject_missing_model -q -> 2 passed
- npm run build in web/ -> passed

## Notes
Full tests/hermes_cli/test_web_server.py currently has unrelated PTY websocket failures on macOS. Full web lint currently reports pre-existing unrelated errors outside this patch.
