### PR TITLE
fix: keep terminal stderr out of file tool output

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -594,3 +594,42 @@ class _DeletedTestGitBaselineCheck:
     helper is restored or replaced.
     """
     pass
+
+
+class TestSeparatedStdoutStderr:
+    def test_local_environment_keeps_stderr_out_of_stdout(self, tmp_path):
+        """Backend stderr must not contaminate stdout consumed by file tools."""
+        from tools.environments.local import LocalEnvironment
+
+        env = LocalEnvironment(cwd=str(tmp_path), timeout=5)
+        try:
+            env._snapshot_ready = False
+            result = env.execute("printf 'payload'; printf 'ssh warning\\n' >&2")
+        finally:
+            env.cleanup()
+
+        assert result["output"] == "payload"
+        assert result["stderr"] == "ssh warning\n"
+
+    def test_terminal_tool_still_surfaces_stderr_to_users(self, tmp_path, monkeypatch):
+        """Separating streams internally must not hide stderr from terminal_tool."""
+        from tools import terminal_tool as terminal_module
+        from tools.environments.local import LocalEnvironment
+
+        env = LocalEnvironment(cwd=str(tmp_path), timeout=5)
+        monkeypatch.setitem(terminal_module._active_environments, "default", env)
+        monkeypatch.setitem(terminal_module._last_activity, "default", 0)
+        try:
+            payload = terminal_module.terminal_tool(
+                "printf 'payload'; printf 'ssh warning\\n' >&2",
+                timeout=5,
+            )
+        finally:
+            env.cleanup()
+            terminal_module._active_environments.pop("default", None)
+            terminal_module._last_activity.pop("default", None)
+
+        import json
+        result = json.loads(payload)
+        assert result["output"] == "payload\nssh warning"
+        assert result["exit_code"] == 0

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -144,7 +144,7 @@ def _popen_bash(
     proc = subprocess.Popen(
         cmd,
         stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
+        stderr=subprocess.PIPE,
         stdin=subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
         text=True,
         **kwargs,
@@ -197,6 +197,9 @@ class ProcessHandle(Protocol):
 
     @property
     def stdout(self) -> IO[str] | None: ...
+
+    @property
+    def stderr(self) -> IO[str] | None: ...
 
     @property
     def returncode(self) -> int | None: ...
@@ -481,51 +484,28 @@ class BaseEnvironment(ABC):
     # ------------------------------------------------------------------
 
     def _wait_for_process(self, proc: ProcessHandle, timeout: int = 120) -> dict:
-        """Poll-based wait with interrupt checking and stdout draining.
+        """Poll-based wait with interrupt checking and stdout/stderr draining.
 
         Shared across all backends — not overridden.
 
-        Fires the ``activity_callback`` (if set on this instance) every 10s
-        while the process is running so the gateway's inactivity timeout
-        doesn't kill long-running commands.
-
-        Also wraps the poll loop in a ``try/finally`` that guarantees we
-        call ``self._kill_process(proc)`` if we exit via ``KeyboardInterrupt``
-        or ``SystemExit``.  Without this, the local backend (which spawns
-        subprocesses with ``os.setsid`` into their own process group) leaves
-        an orphan with ``PPID=1`` when python is shut down mid-tool — the
-        ``sleep 300``-survives-30-min bug Physikal and I both hit.
+        ``output`` intentionally contains stdout only.  Stderr is returned in a
+        separate ``stderr`` field so file tools can consume command stdout as
+        bytes from the target file without SSH/client warnings being prepended.
+        The terminal tool recombines both streams for user-visible shell output.
         """
         output_chunks: list[str] = []
+        stderr_chunks: list[str] = []
 
-        # Non-blocking drain via select().
-        #
-        # The old pattern — ``for line in proc.stdout`` — blocks on
-        # ``readline()`` until the pipe reaches EOF.  When the user's command
-        # backgrounds a process (``cmd &``, ``setsid cmd & disown``, etc.),
-        # that backgrounded grandchild inherits the write-end of our stdout
-        # pipe via ``fork()``.  Even after ``bash`` itself exits, the pipe
-        # stays open because the grandchild still holds it — so the drain
-        # thread never returns and the tool hangs for the full lifetime of
-        # the grandchild (issue #8340: users reported indefinite hangs when
-        # restarting uvicorn with ``setsid ... & disown``).
-        #
-        # The fix: select() with a short poll interval, and stop draining
-        # shortly after ``bash`` exits even if the pipe hasn't EOF'd yet.
-        # Any output the grandchild writes after that point goes to an
-        # orphaned pipe (harmless — the kernel reaps it when our end closes).
-        #
-        # Decoding: we ``os.read()`` raw bytes in fixed-size chunks (4096)
-        # so a single multibyte UTF-8 character can split across reads.  An
-        # incremental decoder buffers partial sequences across chunks, and
-        # ``errors="replace"`` mirrors the baseline ``TextIOWrapper`` (which
-        # was constructed with ``encoding="utf-8", errors="replace"`` on
-        # ``Popen``) so binary or mis-encoded output is preserved with
-        # U+FFFD substitution rather than clobbering the whole buffer.
-        decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
-
-        def _drain():
-            fd = proc.stdout.fileno()
+        def _drain_stream(stream, chunks: list[str]) -> None:
+            if stream is None:
+                return
+            decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
+            try:
+                fd = stream.fileno()
+                if not isinstance(fd, int):
+                    return
+            except (AttributeError, ValueError, OSError):
+                return
             # select.select does NOT work on pipe fds on Windows (only sockets).
             # Use blocking os.read in a daemon thread instead — safe because
             # EOF arrives promptly when bash exits.
@@ -535,17 +515,18 @@ class BaseEnvironment(ABC):
                         chunk = os.read(fd, 4096)
                         if not chunk:
                             break
-                        output_chunks.append(decoder.decode(chunk))
+                        chunks.append(decoder.decode(chunk))
                 except (ValueError, OSError):
                     pass
                 finally:
                     try:
                         tail = decoder.decode(b"", final=True)
                         if tail:
-                            output_chunks.append(tail)
+                            chunks.append(tail)
                     except Exception:
                         pass
                 return
+
             idle_after_exit = 0
             try:
                 while True:
@@ -560,7 +541,7 @@ class BaseEnvironment(ABC):
                             break
                         if not chunk:
                             break  # true EOF — all writers closed
-                        output_chunks.append(decoder.decode(chunk))
+                        chunks.append(decoder.decode(chunk))
                         idle_after_exit = 0
                     elif proc.poll() is not None:
                         # bash is gone and the pipe was idle for ~100ms.  Give
@@ -570,18 +551,24 @@ class BaseEnvironment(ABC):
                         if idle_after_exit >= 3:
                             break
             finally:
-                # Flush any bytes buffered mid-sequence.  With ``errors="replace"``
-                # this emits U+FFFD for any final incomplete sequence rather than
-                # raising.
                 try:
                     tail = decoder.decode(b"", final=True)
                     if tail:
-                        output_chunks.append(tail)
+                        chunks.append(tail)
                 except Exception:
                     pass
 
-        drain_thread = threading.Thread(target=_drain, daemon=True)
-        drain_thread.start()
+        drain_threads = [
+            threading.Thread(target=_drain_stream, args=(proc.stdout, output_chunks), daemon=True)
+        ]
+        stderr_stream = getattr(proc, "stderr", None)
+        if stderr_stream is not None:
+            drain_threads.append(
+                threading.Thread(target=_drain_stream, args=(stderr_stream, stderr_chunks), daemon=True)
+            )
+        for drain_thread in drain_threads:
+            drain_thread.start()
+
         deadline = time.monotonic() + timeout
         _now = time.monotonic()
         _activity_state = {
@@ -589,15 +576,10 @@ class BaseEnvironment(ABC):
             "start": _now,
         }
 
-        # --- Debug tracing (opt-in via HERMES_DEBUG_INTERRUPT=1) -------------
-        # Captures loop entry/exit, interrupt state changes, and periodic
-        # heartbeats so we can diagnose "agent never sees the interrupt"
-        # reports without reproducing locally.
         _tid = threading.current_thread().ident
         _pid = getattr(proc, "pid", None)
         _iter_count = 0
         _last_heartbeat = _now
-        _last_interrupt_state = False
         _cb_was_none = _get_activity_callback() is None
         if _DEBUG_INTERRUPT:
             logger.info(
@@ -619,9 +601,11 @@ class BaseEnvironment(ABC):
                             _tid, _pid, _iter_count, time.monotonic() - _activity_state["start"],
                         )
                     self._kill_process(proc)
-                    drain_thread.join(timeout=2)
+                    for drain_thread in drain_threads:
+                        drain_thread.join(timeout=2)
                     return {
                         "output": "".join(output_chunks) + "\n[Command interrupted]",
+                        "stderr": "".join(stderr_chunks),
                         "returncode": 130,
                     }
                 if time.monotonic() > deadline:
@@ -632,21 +616,19 @@ class BaseEnvironment(ABC):
                             _tid, _pid, _iter_count, timeout,
                         )
                     self._kill_process(proc)
-                    drain_thread.join(timeout=2)
+                    for drain_thread in drain_threads:
+                        drain_thread.join(timeout=2)
                     partial = "".join(output_chunks)
                     timeout_msg = f"\n[Command timed out after {timeout}s]"
                     return {
                         "output": partial + timeout_msg
                         if partial
                         else timeout_msg.lstrip(),
+                        "stderr": "".join(stderr_chunks),
                         "returncode": 124,
                     }
-                # Periodic activity touch so the gateway knows we're alive
                 touch_activity_if_due(_activity_state, "terminal command running")
 
-                # Heartbeat every ~30s: proves the loop is alive and reports
-                # the activity-callback state (thread-local, can get clobbered
-                # by nested tool calls or executor thread reuse).
                 if _DEBUG_INTERRUPT and time.monotonic() - _last_heartbeat >= 30.0:
                     _cb_now_none = _get_activity_callback() is None
                     logger.info(
@@ -664,13 +646,6 @@ class BaseEnvironment(ABC):
 
                 time.sleep(0.2)
         except (KeyboardInterrupt, SystemExit):
-            # Signal arrived (SIGTERM/SIGHUP/SIGINT) or sys.exit() was called
-            # while we were polling.  The local backend spawns subprocesses
-            # with os.setsid, which puts them in their own process group — so
-            # if we let the interrupt propagate without killing the child,
-            # python exits and the child is reparented to init (PPID=1) and
-            # keeps running as an orphan.  Killing the process group here
-            # guarantees the tool's side effects stop when the agent stops.
             if _DEBUG_INTERRUPT:
                 logger.info(
                     "[interrupt-debug] _wait_for_process EXCEPTION_EXIT "
@@ -680,20 +655,21 @@ class BaseEnvironment(ABC):
                 )
             try:
                 self._kill_process(proc)
-                drain_thread.join(timeout=2)
+                for drain_thread in drain_threads:
+                    drain_thread.join(timeout=2)
             except Exception:
-                pass  # cleanup is best-effort
+                pass
             raise
 
-        # Drain thread now exits promptly after bash does (~300ms idle
-        # check).  A short join is enough; a long one would be a bug since
-        # it means the non-blocking loop itself stopped cooperating.
-        drain_thread.join(timeout=2)
+        for drain_thread in drain_threads:
+            drain_thread.join(timeout=2)
 
-        try:
-            proc.stdout.close()
-        except Exception:
-            pass
+        for stream in (proc.stdout, getattr(proc, "stderr", None)):
+            try:
+                if stream is not None:
+                    stream.close()
+            except Exception:
+                pass
 
         if _DEBUG_INTERRUPT:
             logger.info(
@@ -704,7 +680,11 @@ class BaseEnvironment(ABC):
                 proc.returncode,
             )
 
-        return {"output": "".join(output_chunks), "returncode": proc.returncode}
+        return {
+            "output": "".join(output_chunks),
+            "stderr": "".join(stderr_chunks),
+            "returncode": proc.returncode,
+        }
 
     def _kill_process(self, proc: ProcessHandle):
         """Terminate a process. Subclasses may override for process-group kill."""
@@ -840,4 +820,3 @@ class BaseEnvironment(ABC):
         from tools.terminal_tool import _transform_sudo_command
 
         return _transform_sudo_command(command)
-

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -529,7 +529,7 @@ class LocalEnvironment(BaseEnvironment):
             encoding="utf-8",
             errors="replace",
             stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
+            stderr=subprocess.PIPE,
             stdin=subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
             preexec_fn=None if _IS_WINDOWS else os.setsid,
             creationflags=subprocess.CREATE_NO_WINDOW if _IS_WINDOWS else 0,

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2071,8 +2071,16 @@ def terminal_tool(
                 # Got a result
                 break
             
-            # Extract output
+            # Extract output. Environment backends keep stdout/stderr separate so
+            # file tools can consume stdout without backend diagnostics leaking
+            # into file content. The terminal tool is user-facing, so preserve
+            # the historical behavior of showing both streams.
             output = result.get("output", "")
+            stderr = result.get("stderr", "")
+            if stderr:
+                if output and not output.endswith("\n"):
+                    output += "\n"
+                output += stderr
             returncode = result.get("returncode", 0)
 
             # Add helpful message for sudo failures in messaging context


### PR DESCRIPTION
## Summary
- capture backend stdout and stderr separately in shared environment execution
- return stderr in a separate result field so file tools consume clean stdout only
- preserve terminal UX by recombining stderr into `terminal_tool` output

## Repro
Before this patch, `LocalEnvironment.execute("printf 'payload'; printf 'ssh warning\\n' >&2")` returned `output == "payloadssh warning\n"`, which is the same failure mode as SSH startup warnings being folded into file-tool payloads.

## Test plan
- `scripts/run_tests.sh tests/tools/test_file_operations.py::TestSeparatedStdoutStderr -q`
- `scripts/run_tests.sh tests/tools/test_file_operations.py::TestSeparatedStdoutStderr tests/tools/test_base_environment.py tests/tools/test_ssh_environment.py tests/tools/test_docker_environment.py tests/tools/test_terminal_tool.py tests/tools/test_terminal_timeout_output.py tests/tools/test_terminal_output_transform_hook.py -q`
- `scripts/run_tests.sh --lf -q`

Note: attempted full `scripts/run_tests.sh`; local tool call hit the 600s execution cap at ~88% after showing two failures. Re-running the last-failed set with `--lf` passed (`6 passed`).
