### PR TITLE
fix(kanban-dashboard): avoid partial PATCH commits on rejected status moves

### DIFF
--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -628,6 +628,89 @@ class UpdateTaskBody(BaseModel):
     metadata: Optional[dict] = None
 
 
+def _raise_ready_blockers(conn: sqlite3.Connection, task_id: str) -> None:
+    blockers = _parents_blocking_ready(conn, task_id)
+    if not blockers:
+        return
+    names = ", ".join(
+        f"{p['title']!r} ({p['id']}, status={p['status']})"
+        for p in blockers
+    )
+    raise HTTPException(
+        status_code=409,
+        detail=(
+            f"Cannot move to 'ready': blocked by parent(s) "
+            f"not done — {names}"
+        ),
+    )
+
+
+def _preflight_update_task_patch(
+    conn: sqlite3.Connection,
+    task: kanban_db.Task,
+    payload: UpdateTaskBody,
+) -> None:
+    """Reject invalid PATCH combinations before mutating any task fields.
+
+    The dashboard lets one PATCH update several fields at once. Validate the
+    request up front so a later 4xx (for example an invalid status move) does
+    not leave earlier field writes committed.
+    """
+    if payload.title is not None and not payload.title.strip():
+        raise HTTPException(status_code=400, detail="title cannot be empty")
+
+    if (
+        payload.assignee is not None
+        and task.claim_lock is not None
+        and task.status == "running"
+    ):
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"cannot reassign {task.id}: currently running (claimed). "
+                "Wait for completion or reclaim the stale lock first."
+            ),
+        )
+
+    s = payload.status
+    if s is None:
+        return
+    if s == "done":
+        if task.status not in {"running", "ready", "blocked"}:
+            raise HTTPException(
+                status_code=409,
+                detail=f"status transition to {s!r} not valid from current state",
+            )
+    elif s == "blocked":
+        if task.status not in {"running", "ready"}:
+            raise HTTPException(
+                status_code=409,
+                detail=f"status transition to {s!r} not valid from current state",
+            )
+    elif s == "scheduled":
+        if task.status not in {"todo", "ready", "running", "blocked"}:
+            raise HTTPException(
+                status_code=409,
+                detail=f"status transition to {s!r} not valid from current state",
+            )
+    elif s == "ready":
+        if task.status not in {"blocked", "scheduled"}:
+            _raise_ready_blockers(conn, task.id)
+    elif s == "archived":
+        if task.status == "archived":
+            raise HTTPException(
+                status_code=409,
+                detail=f"status transition to {s!r} not valid from current state",
+            )
+    elif s == "running":
+        raise HTTPException(
+            status_code=400,
+            detail="Cannot set status to 'running' directly; use the dispatcher/claim path",
+        )
+    elif s not in {"todo", "triage"}:
+        raise HTTPException(status_code=400, detail=f"unknown status: {s}")
+
+
 @router.patch("/tasks/{task_id}")
 def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Query(None)):
     board = _resolve_board(board)
@@ -636,6 +719,7 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
         task = kanban_db.get_task(conn, task_id)
         if task is None:
             raise HTTPException(status_code=404, detail=f"task {task_id} not found")
+        _preflight_update_task_patch(conn, task, payload)
 
         # --- assignee ----------------------------------------------------
         if payload.assignee is not None:
@@ -687,19 +771,7 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                 # can render an actionable toast instead of a silent no-op.
                 # See #26744.
                 if s == "ready":
-                    blockers = _parents_blocking_ready(conn, task_id)
-                    if blockers:
-                        names = ", ".join(
-                            f"{p['title']!r} ({p['id']}, status={p['status']})"
-                            for p in blockers
-                        )
-                        raise HTTPException(
-                            status_code=409,
-                            detail=(
-                                f"Cannot move to 'ready': blocked by parent(s) "
-                                f"not done — {names}"
-                            ),
-                        )
+                    _raise_ready_blockers(conn, task_id)
                 raise HTTPException(
                     status_code=409,
                     detail=f"status transition to {s!r} not valid from current state",
@@ -724,8 +796,6 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
             with kanban_db.write_txn(conn):
                 sets, vals = [], []
                 if payload.title is not None:
-                    if not payload.title.strip():
-                        raise HTTPException(status_code=400, detail="title cannot be empty")
                     sets.append("title = ?")
                     vals.append(payload.title.strip())
                 if payload.body is not None:

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -437,6 +437,27 @@ def test_patch_reassign(client):
     assert r.json()["task"]["assignee"] == "b"
 
 
+def test_patch_failed_status_move_does_not_commit_assignee(client):
+    parent = client.post("/api/plugins/kanban/tasks", json={"title": "p"}).json()["task"]
+    child = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "c", "parents": [parent["id"]], "assignee": "a"},
+    ).json()["task"]
+    assert child["status"] == "todo"
+    assert child["assignee"] == "a"
+
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{child['id']}",
+        json={"assignee": "b", "status": "ready"},
+    )
+    assert r.status_code == 409
+    assert "Cannot move to 'ready'" in r.json()["detail"]
+
+    child_after = client.get(f"/api/plugins/kanban/tasks/{child['id']}").json()["task"]
+    assert child_after["status"] == "todo"
+    assert child_after["assignee"] == "a"
+
+
 def test_patch_priority_and_edit(client):
     t = client.post("/api/plugins/kanban/tasks", json={"title": "x"}).json()["task"]
     r = client.patch(


### PR DESCRIPTION
## Summary
Fix the Kanban dashboard task PATCH endpoint so invalid multi-field updates do not partially commit earlier mutations.

Previously, a request like:
- `PATCH /api/plugins/kanban/tasks/{id}`
- body: `{"assignee":"bob","status":"ready"}`

could return `409` for the rejected `ready` transition while still persisting the assignee change. This left the dashboard in a misleading half-applied state.

## What changed
- Add a preflight validation step before mutating any task fields in `update_task()`
- Reuse the existing parent-blocker error message for rejected `ready` promotions
- Keep title validation in the same preflight path so invalid PATCHes fail before any writes happen

## Test coverage
Added a regression test covering the failing case:
- rejected `status=ready` move with an assignee change leaves both `status` and `assignee` unchanged

## Validation
- Passed:
  - `uv run pytest tests/plugins/test_kanban_dashboard_plugin.py -k "failed_status_move_does_not_commit_assignee" --timeout-method=thread`
