### PR TITLE
fix(status): show profile project dir in CLI/TUI /status

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5564,14 +5564,13 @@ class HermesCLI:
         model = getattr(self, "model", None) or "(unknown)"
         is_running = bool(getattr(self, "_agent_running", False))
 
-        lines = [
-            "Hermes CLI Status",
-            "",
-            f"Session ID: {self.session_id}",
-            f"Path: {display_hermes_home()}",
-        ]
+        from hermes_constants import format_status_location_lines
+
+        lines: list[str] = []
         if title:
             lines.append(f"Title: {title}")
+        lines.append(f"Session ID: {self.session_id}")
+        lines.extend(format_status_location_lines())
         lines.extend([
             f"Model: {model} ({provider})",
             f"Created: {created_at.strftime('%Y-%m-%d %H:%M')}",

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -228,11 +228,77 @@ def display_hermes_home() -> str:
     ``~/.hermes``.  For code that needs a real ``Path``, use
     :func:`get_hermes_home` instead.
     """
-    home = get_hermes_home()
+    return display_path(get_hermes_home())
+
+
+def display_path(path: str | Path) -> str:
+    """Return a user-friendly ``~/…`` path when under the user home directory."""
     try:
-        return "~/" + str(home.relative_to(Path.home()))
+        resolved = Path(path).expanduser().resolve()
+    except (OSError, RuntimeError):
+        return str(path)
+    try:
+        return "~/" + str(resolved.relative_to(Path.home()))
     except ValueError:
-        return str(home)
+        return str(resolved)
+
+
+def format_status_location_lines() -> list[str]:
+    """Lines for CLI/TUI /status: profile, config home, and terminal working dir.
+
+    ``HERMES_HOME`` (shown as HERMES_HOME) is the profile data directory — not the
+    same as the project folder where ``bin/`` and terminal commands run.
+    """
+    lines: list[str] = []
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+
+        lines.append(f"Profile: {get_active_profile_name()}")
+    except Exception:
+        pass
+
+    cwd = os.environ.get("TERMINAL_CWD", "").strip()
+    if not cwd or cwd in {".", "auto", "cwd"}:
+        try:
+            from hermes_cli.config import load_config
+
+            terminal = load_config().get("terminal") or {}
+            if isinstance(terminal, dict):
+                cwd = str(terminal.get("cwd", "") or "").strip()
+        except Exception:
+            pass
+    if not cwd or cwd in {".", "auto", "cwd"}:
+        try:
+            cwd = os.getcwd()
+        except OSError:
+            cwd = ""
+
+    # Dashboard/TUI processes often inherit hermes-agent/ as cwd; prefer the
+    # profile's project folder when it exists (e.g. ~/.hermes/projects/<profile>).
+    def _cwd_looks_like_hermes_agent(path: str) -> bool:
+        if not path:
+            return True
+        try:
+            return Path(path).expanduser().resolve().name == "hermes-agent"
+        except (OSError, RuntimeError):
+            return path.rstrip("/").endswith("hermes-agent")
+
+    if not cwd or _cwd_looks_like_hermes_agent(cwd):
+        try:
+            from hermes_cli.profiles import get_active_profile_name
+
+            profile = get_active_profile_name()
+            if profile not in ("default", "custom"):
+                project = get_default_hermes_root() / "projects" / profile
+                if project.is_dir():
+                    cwd = str(project)
+        except Exception:
+            pass
+
+    lines.append(f"Home Path: {display_hermes_home()}")
+    if cwd:
+        lines.append(f"Working Dir: {display_path(cwd)}")
+    return lines
 
 
 def get_subprocess_home() -> str | None:

--- a/tests/cli/test_cli_status_command.py
+++ b/tests/cli/test_cli_status_command.py
@@ -59,6 +59,21 @@ def test_status_prefix_prefers_status_command_over_statusbar_toggle():
     assert cli_obj._status_bar_visible is True
 
 
+def test_show_session_status_omits_title_line_when_empty():
+    cli_obj = _make_cli()
+    cli_obj._session_db.get_session.return_value = {"title": "", "started_at": 1775791440}
+
+    with patch(
+        "hermes_constants.format_status_location_lines",
+        return_value=["Profile: scraping-prompts", "Home Path: ~/.hermes", "Working Dir: ~/p"],
+    ):
+        cli_obj._show_session_status()
+
+    printed = "\n".join(str(call.args[0]) for call in cli_obj.console.print.call_args_list)
+    assert "Title:" not in printed
+    assert "Session ID: session-123" in printed
+
+
 def test_show_session_status_prints_gateway_style_summary():
     cli_obj = _make_cli()
     cli_obj.agent = SimpleNamespace(
@@ -70,13 +85,22 @@ def test_show_session_status_prints_gateway_style_summary():
         "started_at": 1775791440,
     }
 
-    with patch("cli.display_hermes_home", return_value="~/.hermes"):
+    with patch(
+        "hermes_constants.format_status_location_lines",
+        return_value=[
+            "Profile: default",
+            "Home Path: ~/.hermes",
+            "Working Dir: ~/projects/demo",
+        ],
+    ):
         cli_obj._show_session_status()
 
     printed = "\n".join(str(call.args[0]) for call in cli_obj.console.print.call_args_list)
-    assert "Hermes CLI Status" in printed
+    assert "Hermes CLI Status" not in printed
     assert "Session ID: session-123" in printed
-    assert "Path: ~/.hermes" in printed
+    assert printed.index("Title: My titled session") < printed.index("Session ID:")
+    assert "Profile: default" in printed
+    assert "Working Dir: ~/projects/demo" in printed
     assert "Title: My titled session" in printed
     assert "Model: openai/gpt-5.4 (openai)" in printed
     assert "Tokens: 321" in printed

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -171,3 +171,44 @@ class TestParseReasoningEffort:
         """
         documented = {"minimal", "low", "medium", "high", "xhigh"}
         assert documented.issubset(set(VALID_REASONING_EFFORTS))
+
+
+class TestFormatStatusLocationLines:
+    def test_profile_home_and_working_dir(self, tmp_path, monkeypatch):
+        native = tmp_path / ".hermes"
+        profile = native / "profiles" / "scraping-prompts"
+        project = native / "projects" / "scraping-prompts"
+        profile.mkdir(parents=True)
+        project.mkdir(parents=True)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile))
+        monkeypatch.setenv("TERMINAL_CWD", str(project))
+
+        from hermes_constants import format_status_location_lines
+
+        lines = format_status_location_lines()
+        assert lines == [
+            "Profile: scraping-prompts",
+            "Home Path: ~/.hermes/profiles/scraping-prompts",
+            "Working Dir: ~/.hermes/projects/scraping-prompts",
+        ]
+
+    def test_working_dir_prefers_project_over_hermes_agent_cwd(
+        self, tmp_path, monkeypatch
+    ):
+        native = tmp_path / ".hermes"
+        profile = native / "profiles" / "scraping-prompts"
+        project = native / "projects" / "scraping-prompts"
+        agent_dir = native / "hermes-agent"
+        profile.mkdir(parents=True)
+        project.mkdir(parents=True)
+        agent_dir.mkdir(parents=True)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile))
+        monkeypatch.setenv("TERMINAL_CWD", str(agent_dir))
+
+        from hermes_constants import format_status_location_lines
+
+        lines = format_status_location_lines()
+        assert "Profile: scraping-prompts" in lines
+        assert "Working Dir: ~/.hermes/projects/scraping-prompts" in lines

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2202,6 +2202,27 @@ def test_commands_catalog_filters_gateway_only_commands_and_keeps_status_visible
     assert "/set-home" not in canon
 
 
+def test_session_status_omits_title_line_when_empty(monkeypatch):
+    server._sessions["sid"] = _session(agent=None, running=False)
+
+    class _DB:
+        def get_session(self, key):
+            return {"title": "", "started_at": 1_700_000_000}
+
+    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+    try:
+        resp = server.handle_request(
+            {"id": "1", "method": "session.status", "params": {"session_id": "sid"}}
+        )
+    finally:
+        server._sessions.pop("sid", None)
+
+    out = resp["result"]["output"]
+    assert "Title:" not in out
+    assert "Session ID:" in out
+    assert "Hermes TUI Status" not in out
+
+
 def test_session_status_reads_live_gateway_agent(monkeypatch):
     agent = types.SimpleNamespace(
         model="live-model",
@@ -2228,9 +2249,9 @@ def test_session_status_reads_live_gateway_agent(monkeypatch):
         server._sessions.pop("sid", None)
 
     out = resp["result"]["output"]
-    assert "Hermes TUI Status" in out
+    assert "Hermes TUI Status" not in out
+    assert out.index("Title: Live TUI") < out.index("Session ID: session-key")
     assert "Session ID: session-key" in out
-    assert "Title: Live TUI" in out
     assert "Model: live-model (live-provider)" in out
     assert "Tokens: 1,234" in out
     assert "Agent Running: Yes" in out

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2430,7 +2430,7 @@ def _(rid, params: dict) -> dict:
     if err:
         return err
 
-    from hermes_constants import display_hermes_home
+    from hermes_constants import format_status_location_lines
 
     key = session.get("session_key") or params.get("session_id") or ""
     agent = session.get("agent")
@@ -2460,15 +2460,12 @@ def _(rid, params: dict) -> dict:
     usage = _get_usage(agent) if agent is not None else {}
     provider = getattr(agent, "provider", None) or "unknown"
     model = getattr(agent, "model", None) or "(unknown)"
-    lines = [
-        "Hermes TUI Status",
-        "",
-        f"Session ID: {key}",
-        f"Path: {display_hermes_home()}",
-    ]
     title = (meta.get("title") or "").strip()
+    lines: list[str] = []
     if title:
         lines.append(f"Title: {title}")
+    lines.append(f"Session ID: {key}")
+    lines.extend(format_status_location_lines())
     lines.extend(
         [
             f"Model: {model} ({provider})",


### PR DESCRIPTION
## Summary

- Add `format_status_location_lines()` so `/status` shows Profile, Home Path, and Working Dir consistently in CLI and TUI.
- When cwd is missing or points at the `hermes-agent` checkout, resolve Working Dir to `~/.hermes/projects/<profile>` for non-default profiles.
- Drop redundant status banners; show optional Title, then Session ID, then location lines.

## Test plan

- [ ] `pytest tests/test_hermes_constants.py tests/cli/test_cli_status_command.py tests/test_tui_gateway_server.py`
- [ ] Run `/status` from dashboard TUI and CLI with a custom profile; Working Dir should show the profile project path, not the agent checkout.