### PR TITLE
fix(cli): only add kanban audit comments after successful block/schedule

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1902,8 +1902,6 @@ def _cmd_block(args: argparse.Namespace) -> int:
     failed: list[str] = []
     with kb.connect() as conn:
         for tid in ids:
-            if reason:
-                kb.add_comment(conn, tid, author, f"BLOCKED: {reason}")
             if not kb.block_task(
                 conn,
                 tid,
@@ -1913,6 +1911,8 @@ def _cmd_block(args: argparse.Namespace) -> int:
                 failed.append(tid)
                 print(f"cannot block {tid}", file=sys.stderr)
             else:
+                if reason:
+                    kb.add_comment(conn, tid, author, f"BLOCKED: {reason}")
                 print(f"Blocked {tid}" + (f": {reason}" if reason else ""))
     return 0 if not failed else 1
 
@@ -1924,8 +1924,6 @@ def _cmd_schedule(args: argparse.Namespace) -> int:
     failed: list[str] = []
     with kb.connect() as conn:
         for tid in ids:
-            if reason:
-                kb.add_comment(conn, tid, author, f"SCHEDULED: {reason}")
             if not kb.schedule_task(
                 conn,
                 tid,
@@ -1935,6 +1933,8 @@ def _cmd_schedule(args: argparse.Namespace) -> int:
                 failed.append(tid)
                 print(f"cannot schedule {tid}", file=sys.stderr)
             else:
+                if reason:
+                    kb.add_comment(conn, tid, author, f"SCHEDULED: {reason}")
                 print(f"Scheduled {tid}" + (f": {reason}" if reason else ""))
     return 0 if not failed else 1
 

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -158,6 +158,34 @@ def test_run_slash_block_unblock_cycle(kanban_home):
     assert "Unblocked" in kc.run_slash(f"unblock {tid}")
 
 
+@pytest.mark.parametrize(
+    ("command", "reason", "expected_error"),
+    [
+        ("block", "need-human", "cannot block"),
+        ("schedule", "later", "cannot schedule"),
+    ],
+)
+def test_run_slash_does_not_add_audit_comment_when_transition_fails(
+    kanban_home,
+    command,
+    reason,
+    expected_error,
+):
+    payload = json.loads(kc.run_slash("create 'x' --assignee alice --json"))
+    tid = payload["id"]
+    assert "Completed" in kc.run_slash(f"complete {tid}")
+
+    out = kc.run_slash(f"{command} {tid} {reason}")
+    assert expected_error in out
+
+    with kb.connect() as conn:
+        task = kb.get_task(conn, tid)
+        comments = kb.list_comments(conn, tid)
+    assert task is not None
+    assert task.status == "done"
+    assert comments == []
+
+
 def test_run_slash_json_output(kanban_home):
     out = kc.run_slash("create 'jsontask' --assignee alice --json")
     payload = json.loads(out)


### PR DESCRIPTION
## Summary

Fix `/kanban block` and `/kanban schedule` so they only append `BLOCKED:` / `SCHEDULED:` audit comments after the state transition succeeds.

Before this change, the CLI wrote the comment first and then attempted the transition. If the transition failed, the task kept its original status but still showed a misleading audit comment in the timeline.

## Why

This made kanban history unreliable: operators and later workers could see a `BLOCKED:` or `SCHEDULED:` comment on a task that was never actually blocked or scheduled.

## Changes

- Move audit comment creation behind successful `kb.block_task(...)`
- Move audit comment creation behind successful `kb.schedule_task(...)`
- Add a regression test covering both failed `block` and failed `schedule` transitions on a terminal task

## Testing

Passed locally on Windows:

```bash
pytest tests/hermes_cli/test_kanban_cli.py -k "block_unblock_cycle or audit_comment" -q

3 passed, 45 deselected in 3.55s