### PR TITLE
fix(gateway): refresh cached aiohttp SSL contexts after CA setup

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -513,6 +513,31 @@ def _ensure_ssl_certs() -> None:
             os.environ["SSL_CERT_FILE"] = candidate
             return
 
+
+def _refresh_aiohttp_ssl_contexts_if_loaded() -> None:
+    """Rebuild aiohttp's cached SSL contexts after CA env setup.
+
+    aiohttp.connector creates module-level default SSLContext objects at import
+    time. On uv Python builds whose compiled-in default trust store is empty on
+    this host, importing aiohttp before we set SSL_CERT_FILE leaves
+    ``_SSL_CONTEXT_VERIFIED`` with zero trusted CAs for the rest of the
+    process. Refresh it here so later ws_connect()/request() calls pick up the
+    configured CA bundle regardless of import order.
+    """
+    aiohttp_connector = sys.modules.get("aiohttp.connector")
+    if aiohttp_connector is None:
+        return
+
+    make_ssl_context = getattr(aiohttp_connector, "_make_ssl_context", None)
+    if not callable(make_ssl_context):
+        return
+
+    try:
+        aiohttp_connector._SSL_CONTEXT_VERIFIED = make_ssl_context(True)
+        aiohttp_connector._SSL_CONTEXT_UNVERIFIED = make_ssl_context(False)
+    except Exception:
+        pass
+
 def _home_target_env_var(platform_name: str) -> str:
     """Return the configured home-target env var for a platform.
 
@@ -543,6 +568,7 @@ def _restart_notification_pending() -> bool:
 os.environ["_HERMES_GATEWAY"] = "1"
 
 _ensure_ssl_certs()
+_refresh_aiohttp_ssl_contexts_if_loaded()
 
 # Add parent directory to path
 sys.path.insert(0, str(Path(__file__).parent.parent))

--- a/tests/gateway/test_ssl_certs.py
+++ b/tests/gateway/test_ssl_certs.py
@@ -1,13 +1,13 @@
-"""Tests for SSL certificate auto-detection in gateway/run.py."""
+"""Tests for SSL certificate handling helpers in gateway/run.py."""
 
 import importlib
 import os
+import sys
 from unittest.mock import patch, MagicMock
 
 
-def _load_ensure_ssl():
-    """Import _ensure_ssl_certs fresh (gateway/run.py has heavy deps, so we
-    extract just the function source to avoid importing the whole gateway)."""
+def _load_ssl_helpers():
+    """Load the SSL helper functions without importing the whole gateway."""
     # We can test via the actual module since conftest isolates HERMES_HOME,
     # but we need to be careful about side effects.  Instead, replicate the
     # logic in a controlled way.
@@ -15,7 +15,7 @@ def _load_ensure_ssl():
     import textwrap, ssl as _ssl  # noqa: F401
 
     code = textwrap.dedent("""\
-    import os, ssl
+    import os, ssl, sys
 
     def _ensure_ssl_certs():
         if "SSL_CERT_FILE" in os.environ:
@@ -38,21 +38,36 @@ def _load_ensure_ssl():
             if os.path.exists(candidate):
                 os.environ["SSL_CERT_FILE"] = candidate
                 return
+
+    def _refresh_aiohttp_ssl_contexts_if_loaded():
+        aiohttp_connector = sys.modules.get("aiohttp.connector")
+        if aiohttp_connector is None:
+            return
+
+        make_ssl_context = getattr(aiohttp_connector, "_make_ssl_context", None)
+        if not callable(make_ssl_context):
+            return
+
+        try:
+            aiohttp_connector._SSL_CONTEXT_VERIFIED = make_ssl_context(True)
+            aiohttp_connector._SSL_CONTEXT_UNVERIFIED = make_ssl_context(False)
+        except Exception:
+            pass
     """)
     mod = ModuleType("_ssl_helper")
     exec(code, mod.__dict__)
-    return mod._ensure_ssl_certs
+    return mod._ensure_ssl_certs, mod._refresh_aiohttp_ssl_contexts_if_loaded
 
 
 class TestEnsureSslCerts:
     def test_respects_existing_env_var(self):
-        fn = _load_ensure_ssl()
+        fn, _ = _load_ssl_helpers()
         with patch.dict(os.environ, {"SSL_CERT_FILE": "/custom/ca.pem"}):
             fn()
             assert os.environ["SSL_CERT_FILE"] == "/custom/ca.pem"
 
     def test_sets_from_ssl_default_paths(self, tmp_path):
-        fn = _load_ensure_ssl()
+        fn, _ = _load_ssl_helpers()
         cert = tmp_path / "ca.crt"
         cert.write_text("FAKE CERT")
 
@@ -67,7 +82,7 @@ class TestEnsureSslCerts:
             assert os.environ.get("SSL_CERT_FILE") == str(cert)
 
     def test_no_op_when_nothing_found(self):
-        fn = _load_ensure_ssl()
+        fn, _ = _load_ssl_helpers()
         mock_paths = MagicMock()
         mock_paths.cafile = None
         mock_paths.openssl_cafile = None
@@ -79,3 +94,37 @@ class TestEnsureSslCerts:
              patch.dict("sys.modules", {"certifi": None}):
             fn()
             assert "SSL_CERT_FILE" not in os.environ
+
+
+class TestRefreshAiohttpSslContexts:
+    def test_refreshes_cached_verified_and_unverified_contexts(self):
+        _, refresh = _load_ssl_helpers()
+
+        class FakeConnectorModule:
+            _SSL_CONTEXT_VERIFIED = "stale-verified"
+            _SSL_CONTEXT_UNVERIFIED = "stale-unverified"
+
+            @staticmethod
+            def _make_ssl_context(verified):
+                return f"fresh-{verified}"
+
+        original = sys.modules.get("aiohttp.connector")
+        try:
+            sys.modules["aiohttp.connector"] = FakeConnectorModule
+            refresh()
+            assert FakeConnectorModule._SSL_CONTEXT_VERIFIED == "fresh-True"
+            assert FakeConnectorModule._SSL_CONTEXT_UNVERIFIED == "fresh-False"
+        finally:
+            if original is None:
+                sys.modules.pop("aiohttp.connector", None)
+            else:
+                sys.modules["aiohttp.connector"] = original
+
+    def test_no_op_when_aiohttp_connector_not_loaded(self):
+        _, refresh = _load_ssl_helpers()
+        original = sys.modules.pop("aiohttp.connector", None)
+        try:
+            refresh()
+        finally:
+            if original is not None:
+                sys.modules["aiohttp.connector"] = original


### PR DESCRIPTION
## What does this PR do?

Fixes a gateway startup regression where `aiohttp` can cache an empty default
SSL trust store before `gateway.run` finishes CA bundle setup.

On some uv Python builds, `aiohttp.connector` creates its module-level default
SSL contexts at import time. If `aiohttp` is imported before `gateway.run`
sets `SSL_CERT_FILE`, later WebSocket/HTTP calls can keep using the stale cached
context and fail with:

`SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED]`

This change keeps the existing `_ensure_ssl_certs()` behavior, then refreshes
`aiohttp`'s cached verified/unverified SSL contexts if `aiohttp.connector` was
already imported. That makes the fix independent of import order and avoids
QQBot/gateway TLS failures without changing adapter behavior.

## Related Issue

No dedicated issue yet.

This is a follow-up to the gateway CA auto-detection work added in #1494.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `_refresh_aiohttp_ssl_contexts_if_loaded()` to [`gateway/run.py`](gateway/run.py)
- Call the refresh helper immediately after `_ensure_ssl_certs()` in [`gateway/run.py`](gateway/run.py)
- Extended [`tests/gateway/test_ssl_certs.py`](tests/gateway/test_ssl_certs.py) with coverage for the `aiohttp.connector` import-order case
- Kept the change scoped to gateway SSL bootstrap only; no config/schema/user-facing command changes

## How to Test

1. Run the targeted regression test:
   ```bash
   pytest -q -o addopts='' tests/gateway/test_ssl_certs.py