### PR TITLE
fix(whatsapp): match reply-to-bot when botIds carry device suffix

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -404,8 +404,16 @@ class WhatsAppAdapter(BasePlatformAdapter):
         bot_ids = set()
         for candidate in data.get("botIds") or []:
             normalized = self._normalize_whatsapp_id(candidate)
-            if normalized:
-                bot_ids.add(normalized)
+            if not normalized:
+                continue
+            bot_ids.add(normalized)
+            # Baileys quotedParticipant arrives without the multi-device
+            # suffix (e.g. "123@s.whatsapp.net"), but sock.user.{id,lid}
+            # in botIds carries it (e.g. "123@10@s.whatsapp.net"). Add a
+            # suffix-stripped alias so reply-to-bot detection matches.
+            parts = normalized.split("@")
+            if len(parts) > 2:
+                bot_ids.add(f"{parts[0]}@{parts[-1]}")
         return bot_ids
 
     def _message_is_reply_to_bot(self, data: Dict[str, Any]) -> bool:

--- a/tests/gateway/test_whatsapp_group_gating.py
+++ b/tests/gateway/test_whatsapp_group_gating.py
@@ -371,3 +371,38 @@ def test_is_broadcast_chat_helper_recognizes_common_jids():
     assert WhatsAppAdapter._is_broadcast_chat("120363001234567890@g.us") is False
     assert WhatsAppAdapter._is_broadcast_chat("") is False
     assert WhatsAppAdapter._is_broadcast_chat(None) is False  # type: ignore[arg-type]
+
+
+# --- Regression: device-suffix mismatch in reply-to-bot detection (issue #29023) ---
+
+def test_reply_to_bot_matches_device_suffixed_bot_ids():
+    """quotedParticipant from Baileys arrives without the multi-device suffix,
+    but sock.user.{id,lid} in botIds carries one. _bot_ids_from_message must
+    expose a suffix-stripped alias so the membership check succeeds."""
+    adapter = _make_adapter(require_mention=True)
+
+    # Multi-device botIds (note the `:10` device suffix → normalized to `@10`)
+    data = _group_message(
+        "thanks bot",
+        botIds=[
+            "5511999999999:10@s.whatsapp.net",
+            "99999999999999:10@lid",
+        ],
+        quotedParticipant="5511999999999@s.whatsapp.net",
+    )
+
+    assert adapter._message_is_reply_to_bot(data) is True
+    assert adapter._should_process_message(data) is True
+
+
+def test_reply_to_bot_legacy_non_multidevice_unchanged():
+    """Legacy (no device suffix) botIds should still match without any alias."""
+    adapter = _make_adapter(require_mention=True)
+
+    data = _group_message(
+        "thanks bot",
+        botIds=["15551230000@s.whatsapp.net", "15551230000@lid"],
+        quotedParticipant="15551230000@s.whatsapp.net",
+    )
+
+    assert adapter._message_is_reply_to_bot(data) is True


### PR DESCRIPTION
## Summary

Fixes #29023. WhatsApp reply-to-bot detection (`_message_is_reply_to_bot`) consistently returned `False` on multi-device accounts because of a normalized-ID shape mismatch:

- Baileys delivers `quotedParticipant` **without** the device suffix: `"5511999999999@s.whatsapp.net"`
- `sock.user.{id,lid}` populates `botIds` **with** the device suffix (`:N` → normalized to `@N`): `"5511999999999@10@s.whatsapp.net"`

The set-membership check in `gateway/platforms/whatsapp.py` therefore never matched, breaking the reply-to-bot admission shortcut in groups configured with `require_mention: true`. This is especially painful for voice notes, where WhatsApp doesn't support text @mentions at all — there's literally no other way to wake the bot.

## Fix

In `_bot_ids_from_message`, when a normalized bot id has three `@`-separated parts (i.e. carries a device suffix), add a suffix-stripped alias alongside the original. Legacy two-part ids are unchanged, so single-device accounts keep their existing behavior.

```python
parts = normalized.split("@")
if len(parts) > 2:
    bot_ids.add(f"{parts[0]}@{parts[-1]}")
```

This is exactly the patch the issue author proposed in the Fix section.

## Tests

Added two regression tests in `tests/gateway/test_whatsapp_group_gating.py`:

- `test_reply_to_bot_matches_device_suffixed_bot_ids` — multi-device botIds (`:10` suffix) + non-suffixed `quotedParticipant` must match and admit the message under `require_mention=true`.
- `test_reply_to_bot_legacy_non_multidevice_unchanged` — legacy two-part ids continue to match as before.

```
$ python -m pytest tests/gateway/test_whatsapp_group_gating.py -q
28 passed in 2.52s
```

## Risk

Tiny, surgical, single-function change. The added alias is only emitted when the id has a third `@`-separated component, so it cannot affect legacy callers. No other code paths consume `_bot_ids_from_message` in a way that would break on the extra alias (the other callers use it for `split('@', 1)[0]` bare-id extraction and `in`-checks against `mentionedIds`).