### PR TITLE
fix(local): expose macOS keychains in profile home

### DIFF
--- a/tests/test_subprocess_home_isolation.py
+++ b/tests/test_subprocess_home_isolation.py
@@ -179,6 +179,48 @@ class TestMakeRunEnvHomeInjection:
         assert result["HERMES_HOME"] == str(profile)
         assert result["HOME"] == str(profile / "home")
 
+    def test_macos_keychains_symlink_created_for_profile_home(self, tmp_path, monkeypatch):
+        real_home = tmp_path / "real-home"
+        real_keychains = real_home / "Library" / "Keychains"
+        real_keychains.mkdir(parents=True)
+        hermes_home = tmp_path / "hermes"
+        profile_home = hermes_home / "home"
+        profile_home.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("HOME", str(real_home))
+        monkeypatch.setenv("PATH", "/usr/bin:/bin")
+
+        import tools.environments.local as local_env
+        monkeypatch.setattr(local_env, "_IS_MACOS", True)
+
+        result = local_env._make_run_env({})
+
+        linked_keychains = profile_home / "Library" / "Keychains"
+        assert result["HOME"] == str(profile_home)
+        assert linked_keychains.is_symlink()
+        assert linked_keychains.resolve() == real_keychains
+
+    def test_macos_keychains_symlink_preserves_existing_profile_path(self, tmp_path, monkeypatch):
+        real_home = tmp_path / "real-home"
+        (real_home / "Library" / "Keychains").mkdir(parents=True)
+        hermes_home = tmp_path / "hermes"
+        profile_home = hermes_home / "home"
+        existing_keychains = profile_home / "Library" / "Keychains"
+        existing_keychains.mkdir(parents=True)
+        sentinel = existing_keychains / "profile-only.keychain-db"
+        sentinel.write_text("keep me")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("HOME", str(real_home))
+        monkeypatch.setenv("PATH", "/usr/bin:/bin")
+
+        import tools.environments.local as local_env
+        monkeypatch.setattr(local_env, "_IS_MACOS", True)
+
+        local_env._make_run_env({})
+
+        assert not existing_keychains.is_symlink()
+        assert sentinel.read_text() == "keep me"
+
 
 # ---------------------------------------------------------------------------
 # _sanitize_subprocess_env() injection
@@ -230,6 +272,26 @@ class TestSanitizeSubprocessEnvHomeInjection:
 
         assert result["HERMES_HOME"] == str(profile)
         assert result["HOME"] == str(profile / "home")
+
+    def test_macos_keychains_symlink_created_for_background_env(self, tmp_path, monkeypatch):
+        real_home = tmp_path / "real-home"
+        real_keychains = real_home / "Library" / "Keychains"
+        real_keychains.mkdir(parents=True)
+        hermes_home = tmp_path / "hermes"
+        profile_home = hermes_home / "home"
+        profile_home.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        import tools.environments.local as local_env
+        monkeypatch.setattr(local_env, "_IS_MACOS", True)
+
+        base_env = {"HOME": str(real_home), "PATH": "/usr/bin"}
+        result = local_env._sanitize_subprocess_env(base_env)
+
+        linked_keychains = profile_home / "Library" / "Keychains"
+        assert result["HOME"] == str(profile_home)
+        assert linked_keychains.is_symlink()
+        assert linked_keychains.resolve() == real_keychains
 
 
 # ---------------------------------------------------------------------------

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -15,6 +15,7 @@ from tools.environments.base import BaseEnvironment, _pipe_stdin
 from hermes_cli._subprocess_compat import windows_hide_flags
 
 _IS_WINDOWS = platform.system() == "Windows"
+_IS_MACOS = platform.system() == "Darwin"
 
 logger = logging.getLogger(__name__)
 
@@ -183,6 +184,48 @@ def _inject_context_hermes_home(env: dict) -> None:
         pass
 
 
+def _link_macos_keychains_into_profile_home(
+    profile_home: str | None,
+    real_home: str | None,
+) -> None:
+    """Expose the user's macOS login keychains inside an isolated profile HOME.
+
+    Hermes profile HOME isolation keeps git/ssh/npm/gh state scoped to the
+    active profile by pointing subprocess ``HOME`` at ``$HERMES_HOME/home``.
+    On macOS, however, many CLIs ask the system keychain APIs to load the
+    default login keychain from ``$HOME/Library/Keychains``. If we rewrite
+    ``HOME`` without making that path visible, tools such as Claude Code report
+    "not logged in" despite the user being authenticated in their real shell.
+
+    We intentionally link only ``Library/Keychains`` rather than the whole
+    ``Library`` tree, preserving profile isolation for ordinary config files
+    while keeping OS-managed credentials reachable. Existing profile paths are
+    never replaced: users may deliberately maintain a profile-specific keychain
+    directory or symlink.
+    """
+    if not _IS_MACOS or not profile_home or not real_home:
+        return
+
+    try:
+        profile_home_path = Path(profile_home).expanduser()
+        real_keychains = Path(real_home).expanduser() / "Library" / "Keychains"
+        if not real_keychains.exists():
+            return
+
+        profile_library = profile_home_path / "Library"
+        profile_keychains = profile_library / "Keychains"
+        if profile_keychains.exists() or profile_keychains.is_symlink():
+            return
+
+        profile_library.mkdir(parents=True, exist_ok=True)
+        profile_keychains.symlink_to(real_keychains, target_is_directory=True)
+    except OSError:
+        logger.debug(
+            "Failed to link macOS Keychains into isolated profile HOME",
+            exc_info=True,
+        )
+
+
 def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = None) -> dict:
     """Filter Hermes-managed secrets from a subprocess environment."""
     try:
@@ -211,6 +254,7 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
     from hermes_constants import get_subprocess_home
     _profile_home = get_subprocess_home()
     if _profile_home:
+        _link_macos_keychains_into_profile_home(_profile_home, sanitized.get("HOME"))
         sanitized["HOME"] = _profile_home
 
     return sanitized
@@ -315,6 +359,7 @@ def _make_run_env(env: dict) -> dict:
     from hermes_constants import get_subprocess_home
     _profile_home = get_subprocess_home()
     if _profile_home:
+        _link_macos_keychains_into_profile_home(_profile_home, run_env.get("HOME"))
         run_env["HOME"] = _profile_home
 
     # Inject ContextVar-based session vars into subprocess env.


### PR DESCRIPTION
## Summary
- Preserve access to the user's macOS login keychains when subprocess HOME is redirected to an isolated Hermes profile home.
- Symlink only `Library/Keychains` into `$HERMES_HOME/home`, leaving the rest of the profile home isolated.
- Do not overwrite an existing profile `Library/Keychains` directory or symlink.

Fixes #29015.

## Why
`_make_run_env()` and `_sanitize_subprocess_env()` intentionally rewrite `HOME` to `$HERMES_HOME/home` for profile isolation. On macOS, CLIs such as Claude Code resolve login credentials through `$HOME/Library/Keychains`; once HOME points at the isolated profile home, those tools report unauthenticated even though the user is logged in from their normal shell.

## Validation
- `python3 -m pytest -o addopts='' tests/test_subprocess_home_isolation.py -q` → 19 passed
- `python3 -m pytest -o addopts='' tests/tools/test_env_passthrough.py -q` → 17 passed
- `python3 -m py_compile tools/environments/local.py tests/test_subprocess_home_isolation.py`
- `git diff --check`

## Notes
I used `-o addopts=''` for the focused pytest runs because this local checkout does not have the `pytest-timeout` plugin installed, while the repository config includes timeout addopts.
