### PR TITLE
feat(line): inline-button approval prompts (Allow Once / Session / Always / Deny)

### DIFF
--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -65,6 +65,7 @@ import base64
 import enum
 import hashlib
 import hmac
+import itertools
 import json
 import logging
 import mimetypes
@@ -582,6 +583,58 @@ def build_postback_button_message(
     }
 
 
+# Approval button labels — LINE caps action.label at 20 chars.
+_APPROVAL_BUTTON_LABELS: Tuple[Tuple[str, str], ...] = (
+    ("once", "✅ Allow Once"),
+    ("session", "✅ Session"),
+    ("always", "✅ Always"),
+    ("deny", "❌ Deny"),
+)
+_APPROVAL_PROMPT_TEXT = "⚠️ Approve dangerous command?"
+
+
+def build_exec_approval_button_message(
+    command: str, description: str, approval_id: int
+) -> Dict[str, Any]:
+    """Template Buttons message with 4 actions for dangerous-command approval.
+
+    The command itself rides in a separate text bubble preceding this one —
+    LINE caps the Buttons template ``text`` field at 160 chars, which is
+    too tight for arbitrary shell commands.  Here we render just the
+    prompt + button row; the command preview is sent as a normal bubble.
+
+    Each button carries postback data the adapter parses on tap:
+
+        ``{"action": "approve", "choice": "once|session|always|deny",
+           "approval_id": <int>}``
+
+    The choice is then routed to ``tools.approval.resolve_gateway_approval``
+    via ``_handle_postback_event`` — same unblock primitive every other
+    platform's button flow uses.
+    """
+    alt = f"Approval required: {description}"
+    actions = [
+        {
+            "type": "postback",
+            "label": label,
+            "data": json.dumps(
+                {"action": "approve", "choice": choice, "approval_id": approval_id}
+            ),
+            "displayText": label,
+        }
+        for choice, label in _APPROVAL_BUTTON_LABELS
+    ]
+    return {
+        "type": "template",
+        "altText": alt if len(alt) <= 400 else alt[:397] + "...",
+        "template": {
+            "type": "buttons",
+            "text": _APPROVAL_PROMPT_TEXT,
+            "actions": actions,
+        },
+    }
+
+
 # Prefixes the gateway uses for system busy-acks (interrupting / queued /
 # steered). When the postback cache has a PENDING entry we *bypass* the
 # cache for these so they reach the user as visible bubbles instead of
@@ -721,6 +774,13 @@ class LineAdapter(BasePlatformAdapter):
         # Pending-button slot per chat — ensures one outstanding postback
         # button per chat at a time. Postback cache request_id keyed by chat_id.
         self._pending_buttons: Dict[str, str] = {}
+
+        # Exec-approval button state — approval_id -> session_key.
+        # Populated by send_exec_approval, drained by _handle_postback_event
+        # when the user taps Allow Once / Session / Always / Deny.  Mirrors
+        # the Telegram adapter's ``_approval_state`` exactly.
+        self._approval_state: Dict[int, str] = {}
+        self._approval_counter = itertools.count(1)
 
     # ------------------------------------------------------------------
     # Connection lifecycle
@@ -980,7 +1040,13 @@ class LineAdapter(BasePlatformAdapter):
         await self.handle_message(event_obj)
 
     async def _handle_postback_event(self, event: Dict[str, Any]) -> None:
-        """User tapped the slow-LLM postback button — deliver cached payload."""
+        """Route postback taps by action.
+
+        Two actions are currently understood:
+
+        * ``show_response`` — slow-LLM postback delivering cached payload.
+        * ``approve`` — dangerous-command approval (once/session/always/deny).
+        """
         postback = event.get("postback") or {}
         data = postback.get("data", "") or ""
         reply_token = event.get("replyToken", "")
@@ -992,7 +1058,13 @@ class LineAdapter(BasePlatformAdapter):
         except (TypeError, json.JSONDecodeError):
             return
 
-        if parsed.get("action") != "show_response":
+        action = parsed.get("action")
+
+        if action == "approve":
+            await self._handle_approval_postback(parsed, reply_token)
+            return
+
+        if action != "show_response":
             return
         request_id = parsed.get("request_id", "")
         if not request_id:
@@ -1037,6 +1109,67 @@ class LineAdapter(BasePlatformAdapter):
                 await self._client.reply(reply_token, [_text_message(self.pending_text)])
             except Exception:
                 pass
+
+    async def _handle_approval_postback(
+        self, parsed: Dict[str, Any], reply_token: str
+    ) -> None:
+        """Resolve a dangerous-command approval from a button tap.
+
+        Drains the ``approval_id`` → ``session_key`` map (pop, so a
+        second tap on the same prompt is a no-op), echoes a confirmation
+        bubble back via the *postback* reply token (always fresh, always
+        free — taps generate a new token even after the original message's
+        token has expired), then calls
+        ``tools.approval.resolve_gateway_approval`` to unblock the waiting
+        agent thread.  Same primitive Telegram, Slack, Discord, Feishu use.
+        """
+        choice = parsed.get("choice")
+        approval_id = parsed.get("approval_id")
+        if choice not in ("once", "session", "always", "deny"):
+            return
+        if not isinstance(approval_id, int):
+            return
+
+        session_key = self._approval_state.pop(approval_id, None)
+        if not session_key:
+            # Double-tap or stale button after gateway restart — let the
+            # user know without raising.
+            if self._client and reply_token:
+                try:
+                    await self._client.reply(
+                        reply_token,
+                        [_text_message("This approval has already been resolved.")],
+                    )
+                except Exception as exc:
+                    logger.debug("LINE: stale-approval ack reply failed: %s", exc)
+            return
+
+        label_map = {
+            "once": "✅ Approved once",
+            "session": "✅ Approved for session",
+            "always": "✅ Approved permanently",
+            "deny": "❌ Denied",
+        }
+        label = label_map.get(choice, "Resolved")
+
+        if self._client and reply_token:
+            try:
+                await self._client.reply(reply_token, [_text_message(label)])
+            except Exception as exc:
+                logger.warning("LINE: approval confirmation reply failed: %s", exc)
+
+        try:
+            from tools.approval import resolve_gateway_approval
+
+            count = resolve_gateway_approval(session_key, choice)
+            logger.info(
+                "LINE button resolved %d approval(s) for session %s (choice=%s)",
+                count,
+                session_key,
+                choice,
+            )
+        except Exception as exc:
+            logger.error("LINE: failed to resolve gateway approval: %s", exc)
 
     async def _download_media(self, message_id: str, msg_type: str) -> Optional[str]:
         if not self._client or not message_id:
@@ -1135,6 +1268,73 @@ class LineAdapter(BasePlatformAdapter):
         """Trigger LINE's loading-animation indicator (DM only)."""
         if self._client and chat_id:
             await self._client.loading(chat_id)
+
+    async def send_exec_approval(
+        self,
+        chat_id: str,
+        command: str,
+        session_key: str,
+        description: str = "dangerous command",
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a 4-button Template Buttons approval prompt.
+
+        Two LINE messages in one Push call:
+
+        1.  A plain text bubble with the command preview + reason (because
+            the Buttons template's ``text`` field maxes at 160 chars, far
+            short of arbitrary shell commands).
+        2.  A Buttons template carrying four postback actions
+            (once / session / always / deny).
+
+        Each tap fires a postback the adapter routes via
+        ``_handle_postback_event`` → ``tools.approval.resolve_gateway_approval``,
+        the same unblock primitive every other platform's button flow uses.
+
+        Approval prompts fire mid-agent-turn, long after the inbound
+        message's reply token has expired, so we always Push (metered).
+        On free-tier this is a couple hundred messages a month, which is
+        adequate for hobby use; production deployments should budget for
+        Push volume proportional to the dangerous-command rate.
+        """
+        if not self._client:
+            return SendResult(success=False, error="LINE adapter not connected")
+
+        try:
+            approval_id = next(self._approval_counter)
+
+            # Build preview bubble — LINE caps a single text bubble at 5000
+            # chars; we chunk via the same splitter normal sends use, then
+            # reserve the final slot for the Buttons template.
+            cmd_preview = command if len(command) <= 3800 else command[:3797] + "..."
+            preview_text = (
+                f"⚠️ Dangerous command requires approval:\n"
+                f"{cmd_preview}\n\n"
+                f"Reason: {description}"
+            )
+            preview_chunks = split_for_line(preview_text)
+            text_slots_available = LINE_MAX_MESSAGES_PER_CALL - 1  # leave room for buttons
+            messages: List[Dict[str, Any]] = [
+                _text_message(c) for c in preview_chunks[:text_slots_available]
+            ]
+            messages.append(
+                build_exec_approval_button_message(command, description, approval_id)
+            )
+
+            # Approval prompts always Push — reply tokens are tied to the
+            # inbound user message and have long expired by the time the
+            # agent reaches the gate.
+            await self._client.push(chat_id, messages)
+
+            # Record the session_key only after the send actually lands —
+            # otherwise a failed send leaves a dangling map entry the
+            # postback handler can never consume.
+            self._approval_state[approval_id] = session_key
+
+            return SendResult(success=True, message_id=str(approval_id))
+        except Exception as exc:
+            logger.warning("LINE: send_exec_approval failed: %s", exc)
+            return SendResult(success=False, error=str(exc))
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         """Best-effort chat info derived from the chat_id prefix.

--- a/tests/gateway/test_line_approval_buttons.py
+++ b/tests/gateway/test_line_approval_buttons.py
@@ -1,0 +1,273 @@
+"""Tests for the LINE adapter's dangerous-command approval buttons.
+
+Mirrors ``test_telegram_approval_buttons.py`` /
+``test_feishu_approval_buttons.py`` — verifies that LineAdapter
+implements the cross-adapter ``send_exec_approval`` contract and routes
+button postbacks back through ``tools.approval.resolve_gateway_approval``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tests.gateway._plugin_adapter_loader import load_plugin_adapter
+
+_line = load_plugin_adapter("line")
+
+LineAdapter = _line.LineAdapter
+build_exec_approval_button_message = _line.build_exec_approval_button_message
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def adapter(monkeypatch):
+    """LineAdapter with mocked HTTP client."""
+    monkeypatch.delenv("LINE_CHANNEL_ACCESS_TOKEN", raising=False)
+    monkeypatch.delenv("LINE_CHANNEL_SECRET", raising=False)
+    from gateway.config import PlatformConfig
+    cfg = PlatformConfig(enabled=True, extra={
+        "channel_access_token": "tok",
+        "channel_secret": "sec",
+    })
+    ad = LineAdapter(cfg)
+    ad._client = MagicMock()
+    ad._client.reply = AsyncMock()
+    ad._client.push = AsyncMock()
+    return ad
+
+
+# ---------------------------------------------------------------------------
+# build_exec_approval_button_message — pure builder, no I/O
+# ---------------------------------------------------------------------------
+
+class TestBuilder:
+
+    def test_returns_buttons_template_with_four_actions(self):
+        msg = build_exec_approval_button_message(
+            command="rm -rf /", description="MEDIUM gate", approval_id=42
+        )
+        assert msg["type"] == "template"
+        assert msg["template"]["type"] == "buttons"
+        actions = msg["template"]["actions"]
+        assert len(actions) == 4
+
+    def test_action_data_carries_choice_and_approval_id(self):
+        msg = build_exec_approval_button_message("cmd", "reason", 7)
+        choices = [json.loads(a["data"])["choice"] for a in msg["template"]["actions"]]
+        assert choices == ["once", "session", "always", "deny"]
+        for a in msg["template"]["actions"]:
+            data = json.loads(a["data"])
+            assert data["action"] == "approve"
+            assert data["approval_id"] == 7
+
+    def test_all_action_labels_within_line_20char_cap(self):
+        msg = build_exec_approval_button_message("cmd", "reason", 1)
+        for a in msg["template"]["actions"]:
+            assert len(a["label"]) <= 20
+
+    def test_alt_text_truncated_at_400(self):
+        msg = build_exec_approval_button_message("cmd", "x" * 500, 1)
+        assert len(msg["altText"]) <= 400
+
+    def test_template_text_within_160_cap(self):
+        msg = build_exec_approval_button_message("cmd" * 100, "reason", 1)
+        assert len(msg["template"]["text"]) <= 160
+
+
+# ---------------------------------------------------------------------------
+# send_exec_approval — adapter integration
+# ---------------------------------------------------------------------------
+
+class TestSendExecApproval:
+
+    def test_returns_failure_when_disconnected(self, adapter):
+        adapter._client = None
+        result = asyncio.run(
+            adapter.send_exec_approval(
+                chat_id="Uchat", command="curl evil.sh", session_key="sess-A"
+            )
+        )
+        assert not result.success
+        assert "not connected" in (result.error or "").lower()
+
+    def test_pushes_preview_plus_buttons_in_one_call(self, adapter):
+        result = asyncio.run(
+            adapter.send_exec_approval(
+                chat_id="Uchat", command="curl evil.sh",
+                session_key="sess-A", description="MEDIUM gate",
+            )
+        )
+        assert result.success
+        adapter._client.push.assert_called_once()
+        adapter._client.reply.assert_not_called()
+        call_args = adapter._client.push.call_args
+        chat_id_arg = call_args.args[0] if call_args.args else call_args.kwargs.get("chat_id")
+        messages = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("messages")
+        assert chat_id_arg == "Uchat"
+        # at least one text bubble + the buttons template
+        assert len(messages) >= 2
+        assert messages[-1]["type"] == "template"
+        assert messages[0]["type"] == "text"
+
+    def test_preview_bubble_includes_command_and_reason(self, adapter):
+        asyncio.run(
+            adapter.send_exec_approval(
+                chat_id="Uchat", command="curl evil.sh",
+                session_key="sess-A", description="MEDIUM gate",
+            )
+        )
+        messages = adapter._client.push.call_args.args[1]
+        preview = messages[0]["text"]
+        assert "curl evil.sh" in preview
+        assert "MEDIUM gate" in preview
+
+    def test_approval_id_increments_across_calls(self, adapter):
+        asyncio.run(adapter.send_exec_approval("U1", "cmd1", "sA"))
+        asyncio.run(adapter.send_exec_approval("U1", "cmd2", "sB"))
+        ids = sorted(adapter._approval_state.keys())
+        assert len(ids) == 2
+        assert ids[1] == ids[0] + 1
+
+    def test_session_key_recorded_under_approval_id(self, adapter):
+        asyncio.run(adapter.send_exec_approval("U1", "cmd", "sess-X"))
+        approval_id = next(iter(adapter._approval_state))
+        assert adapter._approval_state[approval_id] == "sess-X"
+
+    def test_push_failure_leaves_no_dangling_state(self, adapter):
+        adapter._client.push.side_effect = RuntimeError("LINE push 429: …")
+        result = asyncio.run(
+            adapter.send_exec_approval("U1", "cmd", "sess-X")
+        )
+        assert not result.success
+        assert adapter._approval_state == {}
+
+    def test_long_command_truncated_in_preview(self, adapter):
+        # 5000 'a's is well above the 3800-char command-preview cap.
+        long_cmd = "a" * 5000
+        asyncio.run(
+            adapter.send_exec_approval("U1", long_cmd, "sess-X")
+        )
+        messages = adapter._client.push.call_args.args[1]
+        preview = messages[0]["text"]
+        # The preview must truncate the command (ellipsis marker present)
+        # and must not contain anywhere close to the full 5000 chars worth
+        # of command body — comfortably under the cap leaves headroom for
+        # the surrounding prompt/reason text.
+        assert "..." in preview
+        command_a_count = sum(1 for c in preview if c == "a")
+        assert command_a_count < 4000
+
+
+# ---------------------------------------------------------------------------
+# Postback routing — button taps call resolve_gateway_approval
+# ---------------------------------------------------------------------------
+
+class TestApprovalPostback:
+
+    def _postback_event(self, approval_id: int, choice: str) -> dict:
+        return {
+            "type": "postback",
+            "replyToken": "tok-postback",
+            "source": {"type": "user", "userId": "Uchat"},
+            "postback": {
+                "data": json.dumps({
+                    "action": "approve",
+                    "choice": choice,
+                    "approval_id": approval_id,
+                }),
+            },
+        }
+
+    @pytest.mark.parametrize("choice", ["once", "session", "always", "deny"])
+    def test_each_choice_resolves_session(self, adapter, choice):
+        # Pre-seed the approval map as send_exec_approval would have.
+        adapter._approval_state[99] = "sess-A"
+        with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
+            asyncio.run(adapter._handle_postback_event(self._postback_event(99, choice)))
+        mock_resolve.assert_called_once_with("sess-A", choice)
+        assert 99 not in adapter._approval_state
+
+    def test_double_tap_does_not_call_resolve(self, adapter):
+        adapter._approval_state[5] = "sess-Z"
+        with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
+            asyncio.run(adapter._handle_postback_event(self._postback_event(5, "once")))
+            asyncio.run(adapter._handle_postback_event(self._postback_event(5, "always")))
+        assert mock_resolve.call_count == 1
+
+    def test_double_tap_sends_already_resolved_message(self, adapter):
+        adapter._approval_state[5] = "sess-Z"
+        with patch("tools.approval.resolve_gateway_approval", return_value=1):
+            asyncio.run(adapter._handle_postback_event(self._postback_event(5, "once")))
+            adapter._client.reply.reset_mock()
+            asyncio.run(adapter._handle_postback_event(self._postback_event(5, "once")))
+        # Second tap still issues a reply (the "already resolved" notice).
+        adapter._client.reply.assert_called_once()
+        sent_text = adapter._client.reply.call_args.args[1][0]["text"]
+        assert "already" in sent_text.lower()
+
+    def test_unknown_choice_is_ignored(self, adapter):
+        adapter._approval_state[3] = "sess-bad"
+        with patch("tools.approval.resolve_gateway_approval") as mock_resolve:
+            asyncio.run(adapter._handle_postback_event(self._postback_event(3, "obliterate")))
+        mock_resolve.assert_not_called()
+        # State remains so a real choice can still be acted on.
+        assert adapter._approval_state[3] == "sess-bad"
+
+    def test_non_int_approval_id_is_ignored(self, adapter):
+        event = self._postback_event(0, "once")
+        event["postback"]["data"] = json.dumps({
+            "action": "approve", "choice": "once", "approval_id": "not-an-int",
+        })
+        with patch("tools.approval.resolve_gateway_approval") as mock_resolve:
+            asyncio.run(adapter._handle_postback_event(event))
+        mock_resolve.assert_not_called()
+
+    def test_confirmation_reply_uses_postback_token(self, adapter):
+        adapter._approval_state[11] = "sess-K"
+        with patch("tools.approval.resolve_gateway_approval", return_value=1):
+            asyncio.run(adapter._handle_postback_event(self._postback_event(11, "session")))
+        # Postback always uses reply (free), never push.
+        adapter._client.reply.assert_called_once()
+        args = adapter._client.reply.call_args.args
+        assert args[0] == "tok-postback"
+        assert "session" in args[1][0]["text"].lower()
+
+    def test_show_response_action_still_routes_to_slow_llm_handler(self, adapter):
+        """Sanity-check that adding the approve branch didn't break the
+        existing show_response postback path."""
+        # Stub the slow-LLM cache lookup so we don't have to fully wire it.
+        event = {
+            "type": "postback",
+            "replyToken": "tok-x",
+            "source": {"type": "user", "userId": "Uchat"},
+            "postback": {
+                "data": json.dumps({
+                    "action": "show_response", "request_id": "nope-not-here",
+                }),
+            },
+        }
+        # Should not raise even when request_id is unknown.
+        asyncio.run(adapter._handle_postback_event(event))
+        # And it must not have called resolve_gateway_approval.
+        # (Implicit: no patch needed — the import inside the approve branch
+        # is what would fail if the dispatch leaked into the wrong path.)
+
+
+# ---------------------------------------------------------------------------
+# Class-method visibility — the gateway uses `getattr(type(...), name)`
+# ---------------------------------------------------------------------------
+
+def test_send_exec_approval_visible_on_class():
+    """``gateway/run.py:_approval_notify_sync`` does
+    ``getattr(type(_status_adapter), "send_exec_approval", None)`` to detect
+    button support — verify the method really exists on the class so the
+    duck-type check fires.
+    """
+    assert getattr(LineAdapter, "send_exec_approval", None) is not None


### PR DESCRIPTION
## Summary

LINE's dangerous-command approval today is text-only — the user has to type ``/approve``, ``/approve session``, ``/approve always``, or ``/deny`` into the chat.  Every other platform with a button UI (Telegram, Slack, Discord, Feishu, QQBot) renders four tappable buttons instead.  This PR brings LINE up to parity using **Template Buttons** + postback dispatch.

Surfaced by a user in Taiwan running a private LINE OA who pointed out the friction: ~~"在 LINE 上面如果遇到需要使用者允許的指令的話，會有點麻煩 … 之前 Telegram 聊天室窗中這會變成一個可以點按的按鈕，方便許多"~~ (rough English: "approval prompts in LINE are clunky — Telegram makes them tappable buttons, much easier").

## How it works

`LineAdapter.send_exec_approval` sends two LINE messages in one Push call:

1. **Command preview** — a plain text bubble carrying the command + reason.  Separated because the Buttons template's `text` field caps at 160 chars, which is too tight for arbitrary shell commands.
2. **Buttons template** — four postback actions: ``✅ Allow Once`` / ``✅ Session`` / ``✅ Always`` / ``❌ Deny``.  Each carries postback data ``{\"action\": \"approve\", \"choice\": <...>, \"approval_id\": <int>}``.

`_handle_postback_event` is refactored to dispatch on the `action` field — the existing slow-LLM `show_response` path is untouched (regression test included); a new `approve` branch routes the choice into ``tools.approval.resolve_gateway_approval(session_key, choice)`` — the same unblock primitive every other platform's button flow uses.

The ``_approval_state`` map (``approval_id → session_key``) mirrors Telegram's exactly, with ``pop``-based discipline: a second tap on the same prompt is a safe no-op and gets an \"already resolved\" reply via the fresh postback reply token.

## Trade-offs documented in the docstring

* **Push, not Reply.** Approval prompts fire mid-agent-turn, well after the inbound message's reply token has expired (~60s window).  Each prompt costs one Push call against the LINE quota (200 free/month on the developer tier).  In exchange the user gets a tappable UX, and the per-tap *acknowledgement* messages reuse the fresh postback reply token, so confirmations stay free.
* **No message edit.** LINE has no edit-message API, so we can't strike out the prompt and replace it with \"✅ Approved by …\" the way Telegram does.  Instead we send a follow-up text bubble with the chosen label (``✅ Approved once``, ``✅ Approved permanently``, ``❌ Denied``, etc.).

## Duck-typing contract

``gateway/run.py:_approval_notify_sync`` does:

```python
if getattr(type(_status_adapter), \"send_exec_approval\", None) is not None:
    # ... call it; on SendResult(success=False), log warning and fall through to text
```

So adding the method on the class is enough — no base-class change, no platform-registry change, no env or config knob.  Adapters that fail to push will still degrade cleanly to the existing text path.

## Tests

`tests/gateway/test_line_approval_buttons.py` — 23 tests, all passing.

* **Builder**: four actions, correct choice ordering (`once → session → always → deny`), action-label / altText / template-text caps respected, postback data well-formed JSON.
* **`send_exec_approval`**: pushes preview + buttons in one call, command and reason show in preview bubble, approval_id increments, session is recorded *only after* a successful send (failed Push leaves no dangling state), long commands are truncated, returns ``SendResult(success=False)`` when disconnected so the gateway can fall back to text.
* **`_handle_approval_postback`**: each of the four choices routes to `resolve_gateway_approval` with the right kwargs; double-tap is idempotent and surfaces a user-visible \"already resolved\" notice; unknown choice or non-int approval_id are silently ignored; confirmation reply uses the postback reply token; existing `show_response` postback path still works after the dispatch-on-action refactor.
* **Class-level visibility**: `getattr(type(adapter), \"send_exec_approval\", None)` is not None — guards the duck-typing probe in `gateway/run.py`.

The existing ``tests/gateway/test_line_plugin.py`` (73 tests) still passes unchanged.

## Test plan
- [x] Unit suite (23 new + 73 existing LINE tests pass)
- [x] **Live verified** on a real LINE Official Account: prompt appeared, tapping ``Always`` produced ``LINE button resolved 1 approval(s) for session agent:main:line:dm:Uxxxx (choice=always)`` and the agent then ran the gated command end-to-end.
- [ ] Live verified in group / room (untested — same code path, same fix applies)

## Note on overlap with #23569

This branch is based on a clean ``origin/main`` and does **not** include the ``create_source`` → ``build_source`` typo fix from #23569.  Without that fix, inbound LINE messages don't dispatch at all, so this feature can't be triggered end-to-end on plain ``main``.  Suggested merge order: land #23569 first (1-line fix), then this PR rebases cleanly on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
