### PR TITLE
test(plugins): cover xAI web search plugin in bundled-plugin contract

### DIFF
--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -70,9 +70,9 @@ def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 class TestBundledPluginsRegister:
-    """All seven bundled web plugins discover and register correctly."""
+    """All bundled web plugins discover and register correctly."""
 
-    def test_all_seven_plugins_present_in_registry(self) -> None:
+    def test_all_bundled_plugins_present_in_registry(self) -> None:
         _ensure_plugins_loaded()
         from agent.web_search_registry import list_providers
 
@@ -85,6 +85,7 @@ class TestBundledPluginsRegister:
             "parallel",
             "searxng",
             "tavily",
+            "xai",
         ]
 
     @pytest.mark.parametrize(
@@ -100,6 +101,9 @@ class TestBundledPluginsRegister:
             # disabled in the migration (fell through to a legacy inline
             # path); the follow-up commit enabled it natively.
             ("firecrawl", True, True, True),
+            # xai: search-only (Grok's agentic web_search tool). No extract
+            # or crawl — pair with Firecrawl / Tavily / Exa for those.
+            ("xai", True, False, False),
         ],
     )
     def test_capability_flags_match_spec(
@@ -120,7 +124,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl"],
+        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
     )
     def test_each_plugin_has_name_and_display_name(self, plugin_name: str) -> None:
         _ensure_plugins_loaded()
@@ -133,7 +137,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl"],
+        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
     )
     def test_each_plugin_has_setup_schema(self, plugin_name: str) -> None:
         """``get_setup_schema()`` returns a dict the picker can consume."""


### PR DESCRIPTION
## What does this PR do?

The xAI web search plugin landed in commit a0c031299 ("feat(web): add xAI Web Search provider plugin") as the 8th bundled web provider, but `tests/plugins/web/test_web_search_provider_plugins.py` still expected exactly the original seven (brave-free, ddgs, exa, firecrawl, parallel, searxng, tavily). The `test_all_seven_plugins_present_in_registry` assertion fails on every post-merge run of `main`, e.g. https://github.com/NousResearch/hermes-agent/actions/runs/26138063691/job/76877433972 and https://github.com/NousResearch/hermes-agent/actions/runs/26138014706/job/76877288367.

This PR extends the bundled-plugin contract to cover xai:

- Rename `test_all_seven_plugins_present_in_registry` → `test_all_bundled_plugins_present_in_registry` (number-neutral so the next plugin addition doesn't bit-rot the name) and add `"xai"` to the expected sorted list.
- Add `("xai", True, False, False)` to the capability-flags parametrize (search-only — no extract or crawl, matching `plugins/web/xai/provider.py`'s `supports_*` impl).
- Add `"xai"` to the name / display-name and setup-schema parametrize lists so every bundled plugin has the same contract coverage.

## Related Issue

_None — this aligns the test contract to the same-day landing of `a0c031299`._

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tests/plugins/web/test_web_search_provider_plugins.py` — extend the four `TestBundledPluginsRegister` tests (presence, capability flags, name/display, setup schema) to cover the xAI plugin.

## How to Test

1. Reproduce on `main`:
   ```
   uv run --with pytest --with pytest-xdist --with pytest-asyncio --with pytest-timeout python3 -m pytest tests/plugins/web/test_web_search_provider_plugins.py::TestBundledPluginsRegister::test_all_seven_plugins_present_in_registry -v
   ```
   → fails with `assert ['brave-free', ..., 'xai'] == ['brave-free', ..., 'tavily']`.
2. With this PR applied:
   ```
   uv run --with pytest --with pytest-xdist --with pytest-asyncio --with pytest-timeout python3 -m pytest tests/plugins/web/test_web_search_provider_plugins.py -v
   ```
   → all 48 tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`test(plugins):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass (48/48)
- [x] I've added tests for my changes (the change *is* the test alignment)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (pure-Python test parametrize change)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

- Open PR #26021 (`feat(web): add Gemini Google Search Grounding provider`) also touches this file to add a 9th provider (gemini). Cleanly stackable: if #26021 lands first, the rebase here just adds `"xai"` next to `"gemini"` in the same lists; if this PR lands first, #26021 adds `"gemini"` next to the now-present `"xai"`. Either order produces the same final state.

> Audited siblings: the only related entry-point for "bundled web plugin contract" is this one file. `tools/web_tools.py` already references `"xai"` in `_is_backend_available()` (added in a0c031299); `agent/web_search_registry.py` discovers plugins dynamically. No widening needed beyond this test file.