### PR TITLE
fix(qqbot): prevent event-loop busy-spin when WebSocket is half-closed

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -652,8 +652,20 @@ class QQAdapter(BasePlatformAdapter):
             return False
 
     async def _read_events(self) -> None:
-        """Read WebSocket frames until connection closes."""
-        if not self._ws:
+        """Read WebSocket frames until the connection closes.
+
+        This coroutine must terminate by raising (or by ``self._running``
+        flipping to ``False``) whenever the socket is unusable. Returning
+        normally while the underlying transport is closed lets the outer
+        ``_listen_loop`` re-enter ``_read_events`` immediately; because no
+        ``await`` in that path actually suspends, the event loop is starved
+        and the whole gateway hangs at 100% CPU.
+        """
+        if not self._ws or self._ws.closed:
+            # ``self._ws`` can be a stale, already-closed reference when a
+            # previous reconnect attempt failed before ``_open_ws`` had a
+            # chance to replace it. Surface that to ``_listen_loop`` so it
+            # backs off and reconnects instead of spinning on a dead socket.
             raise RuntimeError("WebSocket not connected")
 
         while self._running and self._ws and not self._ws.closed:
@@ -669,6 +681,9 @@ class QQAdapter(BasePlatformAdapter):
                 raise QQCloseError(msg.data, msg.extra)
             elif msg.type in {aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.ERROR}:
                 raise RuntimeError("WebSocket closed")
+            # Any other frame type (BINARY, PONG, CONTINUATION, CLOSING, ...)
+            # is ignored on purpose; the ``await self._ws.receive()`` above
+            # is the suspension point that keeps the event loop alive.
 
     async def _heartbeat_loop(self) -> None:
         """Send periodic heartbeats (QQ Gateway expects op 1 heartbeat with latest seq).

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -1810,3 +1810,62 @@ class TestSendUpdatePrompt:
 
         adapter.send_with_keyboard = fake_swk  # type: ignore[assignment]
         await adapter.send_update_prompt(chat_id="u", prompt="ok?")
+
+
+# ---------------------------------------------------------------------------
+# _read_events guard against busy-spin on a stale/closed WebSocket
+# ---------------------------------------------------------------------------
+
+class TestReadEventsClosedSocket:
+    """Regression tests for the QQ adapter event-read loop.
+
+    A previous version of ``_read_events`` returned normally when
+    ``self._ws.closed`` was already True, which let ``_listen_loop`` re-enter
+    the coroutine without ever suspending. That caused the gateway to spin at
+    100% CPU after a failed reconnect (e.g. an empty response from
+    ``_get_gateway_url``), starving the asyncio event loop for every other
+    platform and even blocking systemd from shutting the process down.
+    """
+
+    def _make_adapter(self):
+        from gateway.platforms.qqbot import QQAdapter
+        return QQAdapter(_make_config(app_id="a", client_secret="b"))
+
+    @pytest.mark.asyncio
+    async def test_raises_when_ws_is_none(self):
+        adapter = self._make_adapter()
+        adapter._ws = None
+        with pytest.raises(RuntimeError, match="WebSocket not connected"):
+            await adapter._read_events()
+
+    @pytest.mark.asyncio
+    async def test_raises_when_ws_is_closed(self):
+        """Stale, already-closed ``_ws`` must raise instead of returning.
+
+        Returning lets the outer ``_listen_loop`` busy-spin because no
+        ``await`` in the path actually yields back to the event loop.
+        """
+        adapter = self._make_adapter()
+        ws = mock.Mock()
+        ws.closed = True
+        # ``receive`` should never be awaited on a closed socket.
+        ws.receive = mock.Mock(side_effect=AssertionError(
+            "_read_events must not call receive() on a closed socket"))
+        adapter._ws = ws
+        with pytest.raises(RuntimeError, match="WebSocket not connected"):
+            await adapter._read_events()
+
+    @pytest.mark.asyncio
+    async def test_does_not_busy_spin_on_closed_socket(self):
+        """End-to-end guard: a regression must manifest as a timeout rather
+        than hanging CI forever."""
+        adapter = self._make_adapter()
+        ws = mock.Mock()
+        ws.closed = True
+        adapter._ws = ws
+
+        async def call():
+            with pytest.raises(RuntimeError):
+                await adapter._read_events()
+
+        await asyncio.wait_for(call(), timeout=1.0)


### PR DESCRIPTION
## Summary

`gateway/platforms/qqbot/adapter.py::QQAdapter._read_events` can return
normally on a stale, already-closed `ClientWebSocketResponse`. When that
happens the outer `_listen_loop` re-enters `_read_events` immediately
without any awaitable actually suspending, the asyncio event loop is
starved, and the whole gateway hangs at 100% CPU. This PR makes
`_read_events` raise in that situation so `_listen_loop` reaches its
reconnect path, and adds regression tests.

## Trigger / observed failure

In production a single failed QQ-Bot reconnect at `06:35:14` (gateway
URL request returned an empty body) froze the gateway for 4h 24m until
operator intervention.

Log evidence right before the hang:

```
06:35:14 WARNING [QQBot] WebSocket error: WebSocket closed
06:35:14 INFO    [QQBot] Reconnecting in 2s (attempt 1)...
06:35:46 WARNING [QQBot] Reconnect failed: Failed to get QQ Bot gateway URL:
# no further log lines for the next 4h+
```

`py-spy dump` against the wedged process (`MainThread` at ~100% CPU, all
other threads idle):

```
Thread <pid> (active+gil): "MainThread"
    _read_events (gateway/platforms/qqbot/adapter.py:656)
    _listen_loop (gateway/platforms/qqbot/adapter.py:492)
    run_gateway (hermes_cli/gateway.py:3255)
    ...
```

Side-effects of the hang:

* Other platforms running on the same event loop (Telegram, cron ticker,
  heartbeats) silently stopped firing.
* `systemctl restart` could not shut the process down — the asyncio
  signal handler never ran because the loop was starved. The process
  had to be `SIGKILL`'d.

## Root cause

When `_reconnect()` fails before `_open_ws()` is entered (e.g.
`_get_gateway_url()` raises or returns empty), `self._ws` is left
pointing at the previous, already-closed `ClientWebSocketResponse`
— it is **not** `None`, and `self._ws.closed` is `True`.

The next `_listen_loop` iteration calls `_read_events`:

```python
async def _read_events(self) -> None:
    if not self._ws:                              # _ws is not None, skipped
        raise RuntimeError("WebSocket not connected")

    while self._running and self._ws and not self._ws.closed:
        ...                                       # condition False, body never runs
```

The function returns. Back in `_listen_loop`:

```python
while self._running:
    try:
        await self._read_events()   # returns immediately, no suspension
        backoff_idx = 0
        ...
```

Because no `await` in this path actually yields (`_read_events` only
suspends inside `self._ws.receive()`, which is unreachable), CPython
holds the GIL and the asyncio loop never runs any other task. From the
outside the process looks alive (PID present, `Active: running`) but is
completely unresponsive.

## Fix

* Treat `self._ws is None or self._ws.closed` as a precondition failure
  in `_read_events` and `raise RuntimeError("WebSocket not connected")`.
  This routes control back to `_listen_loop`, which already handles the
  exception path and goes through `_mark_transport_disconnected()` +
  `_reconnect()`.
* Document the invariant in the docstring (the coroutine must terminate
  via `raise` or via `self._running` being cleared — never return
  normally on a non-functional socket) so future edits don't silently
  reintroduce the regression.

The change is intentionally small. The reconnect machinery itself is
already correct; the bug is specifically that `_read_events` is too
permissive about what counts as a runnable read.

## Tests

Added `tests/gateway/test_qqbot.py::TestReadEventsClosedSocket`:

* `test_raises_when_ws_is_none` — preserves the existing contract.
* `test_raises_when_ws_is_closed` — pins the new behaviour and asserts
  `receive()` is never even called on a closed socket.
* `test_does_not_busy_spin_on_closed_socket` — wraps the call in
  `asyncio.wait_for(..., timeout=1.0)` so a future regression surfaces
  as a CI timeout instead of an indefinite hang.

Full QQ-Bot test module passes locally:

```
$ ./venv/bin/python -m pytest tests/gateway/test_qqbot.py -q
...
147 passed, 1 warning in 15.97s
```

## Risk / compatibility

* No public API or configuration change.
* Behaviour change is limited to the case `_ws is not None and _ws.closed
  is True`, which previously caused a silent infinite loop. In every
  branch where `_listen_loop` already expected an exception (transient
  WS error, server CLOSE, etc.) the new path is equivalent.
* No new dependencies.
