### PR TITLE
fix(windows): drop duplicate creationflags kwarg in LocalEnvironment run_bash

### DIFF
--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -532,7 +532,6 @@ class LocalEnvironment(BaseEnvironment):
             stderr=subprocess.STDOUT,
             stdin=subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
             preexec_fn=None if _IS_WINDOWS else os.setsid,
-            creationflags=subprocess.CREATE_NO_WINDOW if _IS_WINDOWS else 0,
             cwd=_popen_cwd,
             **_popen_kwargs,
         )


### PR DESCRIPTION
Commits 8bf09455d (Grogger, explicit creationflags=) and 95683c028 (nekwo, **_popen_kwargs via windows_hide_flags()) landed 77 minutes apart and both injected creationflags into the same subprocess.Popen call. nekwo's commit correctly replaced the explicit line in tools/process_registry.py but only added the kwargs spread in tools/environments/local.py -- leaving creationflags specified twice.

Result on Windows: every LocalEnvironment.init_session() raised "subprocess.Popen() got multiple values for keyword argument 'creationflags'" and fell back to bash -l per command (much slower -- bashrc runs on every shell invocation).

Drop the explicit line so **_popen_kwargs is the single source.