### PR TITLE
Fix kanban swarm synthesizer spawning with missing skill

### DIFF
--- a/hermes_cli/kanban_swarm.py
+++ b/hermes_cli/kanban_swarm.py
@@ -209,7 +209,6 @@ def create_swarm(
         priority=priority,
         workspace_kind=workspace_kind,
         workspace_path=workspace_path,
-        skills=["avoid-ai-writing"],
     )
 
     created = SwarmCreated(root, worker_ids, verifier, synthesizer)

--- a/tests/hermes_cli/test_kanban_swarm.py
+++ b/tests/hermes_cli/test_kanban_swarm.py
@@ -36,6 +36,8 @@ def test_create_swarm_builds_parallel_workers_verifier_and_synthesizer(tmp_path)
         assert [task.assignee for task in workers] == ["researcher-a", "researcher-b"]
         assert verifier.status == "todo"
         assert synthesizer.status == "todo"
+        assert verifier.skills == ["requesting-code-review"]
+        assert synthesizer.skills is None
         assert set(kb.parent_ids(conn, created.verifier_id)) == set(created.worker_ids)
         assert kb.parent_ids(conn, created.synthesizer_id) == [created.verifier_id]
         assert all(created.root_id in (task.body or "") for task in workers)


### PR DESCRIPTION
## Summary

`create_swarm()` was creating the synthesizer task with a hardcoded
`avoid-ai-writing` skill preload, but that skill is not bundled in this repo.

Kanban dispatch forwards task skills directly to `hermes --skills ...`, and CLI
startup treats unknown preloaded skills as fatal. In practice, this could cause
the final synthesizer worker in a swarm to fail before the agent loop starts.

This change removes the invalid synthesizer skill preload and adds a regression
check to keep the verifier skill intact while ensuring the synthesizer does not
carry a missing forced skill.

## Testing

- `pytest -o addopts="" tests/hermes_cli/test_kanban_swarm.py -q`

Result:
- `3 passed in 2.31s`

