### PR TITLE
docs(web): document dashboard RTL chat limits

### DIFF
--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -79,6 +79,16 @@ The **Chat** tab embeds the full Hermes TUI (the same interface you get from `he
 - xterm.js's WebGL renderer paints each cell to an integer-pixel grid; mouse tracking (SGR 1006), wide characters (Unicode 11), and box-drawing glyphs all render natively
 - Resizing the browser window resizes the TUI via the `@xterm/addon-fit` addon
 
+**RTL and complex-script text:** the Chat tab is a browser-rendered terminal,
+not a normal DOM text control. xterm.js preserves terminal cell layout, but it
+does not apply full browser paragraph direction or glyph shaping for
+right-to-left and complex scripts such as Arabic, Persian, Urdu, and Hebrew.
+Use the Chat tab for terminal commands, logs, Latin text, box drawing, and
+wide-character layouts; for RTL-heavy chat, use the
+[API server](./api-server.md) from a native client or web frontend that renders
+messages in regular DOM controls such as a `textarea dir="auto"` with
+`unicode-bidi: plaintext`.
+
 **Resume an existing session:** from the **Sessions** tab, click the play icon (▶) next to any session. That jumps to `/chat?resume=<id>` and launches the TUI with `--resume`, loading the full history.
 
 **Prerequisites:**


### PR DESCRIPTION
## What does this PR do?

Addresses #29047.

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- Standardizes the PR description to the same review format used in #29640.
- Preserves the original detailed description below so no context is lost.

## Why this shape

Issue #29047 reports that Arabic text in the dashboard chat pane appears left-to-right with disconnected letters. Replacing the chat surface is a larger product/design change, and the dashboard currently embeds the real TUI rather than a separate DOM chat implementation. This PR makes the limitation explicit and gives affected users a supported workaround through the documented HTTP API path.

## Tests

The original PR body below contains the previous validation notes, commands, or test plan.
No code changes are introduced by this formatting update itself.

## Related PRs / issues

- Related to #29047. - Related to #15238. - Related to #18788. - Related to #21955.

<details>
<summary>Original body</summary>

﻿## Related Issue

Addresses #29047.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactor
- [ ] Test update

## What changed

The Web Dashboard guide now documents the current RTL and complex-script limitation of the `/chat` tab. The note explains that the tab renders the real Hermes TUI through xterm.js, which preserves terminal cell layout but does not provide normal browser paragraph direction or glyph shaping for Arabic, Persian, Urdu, Hebrew, and similar scripts.

It also points RTL-heavy workflows to the existing OpenAI-compatible API server path, where downstream clients can render messages in normal DOM controls such as `textarea dir="auto"` with `unicode-bidi: plaintext`.

## Why

Issue #29047 reports that Arabic text in the dashboard chat pane appears left-to-right with disconnected letters. Replacing the chat surface is a larger product/design change, and the dashboard currently embeds the real TUI rather than a separate DOM chat implementation. This PR makes the limitation explicit and gives affected users a supported workaround through the documented HTTP API path.

## Duplicate/overlap check

I searched the current open PR queue for direct overlap with `Arabic`, `RTL`, `xterm`, `web dashboard`, and `#29047` before opening this.

Related but not duplicate:

- #15238 adds TUI bidi regression coverage, not web dashboard documentation.
- #18788 focuses on Safari WebGL box-drawing glyph rendering.
- #21955 focuses on native dashboard chat text selection.
- Other active dashboard PRs in the queue touch navigation, host allowlists, themes, PWA metadata, and terminal hardening, but do not document the RTL/complex-script limitation from #29047.

## How to Test

- `git diff --check -- website/docs/user-guide/features/web-dashboard.md`
- `npm --prefix website ci`
- `npm --prefix website run build`

Build completed successfully. Docusaurus still reports pre-existing broken link/anchor warnings elsewhere in the docs site; this change does not introduce a new broken link.

## Risk

Low. This is a docs-only clarification for an existing limitation and links to an already documented API-server workaround path.

## Checklist

- [x] I have read the contributing guidelines
- [x] I searched existing issues and PRs for duplicates
- [x] The change is focused and minimal
- [x] I ran focused validation for the touched area
- [x] I documented pre-existing validation warnings separately from this change

</details>

---

_Generated by Hermes Turbo_