### PR TITLE
fix(gemini): parse and apply retry_after backoff from body on 429 errors

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2852,6 +2852,16 @@ def run_conversation(
                                 _retry_after = min(float(_ra_raw), 120)  # Cap at 2 minutes
                             except (TypeError, ValueError):
                                 pass
+                    # Also check the exception's own retry_after attribute
+                    # (e.g. GeminiAPIError parses "Please retry in Xs" from
+                    # the response body when no Retry-After header is present).
+                    if _retry_after is None:
+                        _exc_retry_after = getattr(api_error, "retry_after", None)
+                        if _exc_retry_after is not None:
+                            try:
+                                _retry_after = min(float(_exc_retry_after), 120)  # Cap at 2 minutes
+                            except (TypeError, ValueError):
+                                pass
                 wait_time = _retry_after if _retry_after else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
                 if is_rate_limited:
                     agent._emit_status(f"⏱️ Rate limited. Waiting {wait_time:.1f}s (attempt {retry_count + 1}/{max_retries})...")

--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -742,6 +742,18 @@ def gemini_http_error(response: httpx.Response) -> GeminiAPIError:
         except (TypeError, ValueError):
             retry_after = None
 
+    # Gemini 429 responses often embed the retry delay in the error message
+    # body (e.g. "Please retry in 28.135353458s") instead of the Retry-After
+    # header.  Parse it as a fallback when the header is missing/unparseable.
+    if retry_after is None and err_message:
+        import re
+        _retry_match = re.search(r"[Rr]etry\s+(?:after|in)\s+([\d.]+)\s*s", err_message)
+        if _retry_match:
+            try:
+                retry_after = float(_retry_match.group(1))
+            except (TypeError, ValueError):
+                pass
+
     code = f"gemini_http_{status}"
     if status == 401:
         code = "gemini_unauthorized"

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,8 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "james@nousresearch.com": "jdelmerico",
+    "jdelmerico@gmail.com": "jdelmerico",
     # teknium (multiple emails)
     "teknium1@gmail.com": "teknium1",
     "30366221+WorldWriter@users.noreply.github.com": "WorldWriter",


### PR DESCRIPTION
This PR adds support for parsing the `retry_after` interval directly from the Gemini HTTP 429 response body when the standard `Retry-After` header is missing or unparseable.

### Changes
1. **`agent/gemini_native_adapter.py`**:
   - Parses `Please retry in Xs` using a regular expression fallback if the `Retry-After` header is absent or unparseable.
2. **`agent/conversation_loop.py`**:
   - Respects the parsed `retry_after` attribute of `GeminiAPIError` (and any exception with that attribute) directly inside `run_conversation` rather than relying solely on the headers of the raw response.

This elegantly prevents the client from falling back to hardcoded/jittered defaults when the server explicitly specifies a required backoff.