### PR TITLE
feat: add skin-configurable status_prefix for status bar model label

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -12996,7 +12996,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         if self._command_running:
             return _state_fragment("class:prompt-working", self._command_spinner_frame())
         if self._agent_running:
-            return _state_fragment("class:prompt-working", "⚕")
+            _working_icon = "⚕"
+            try:
+                from hermes_cli.skin_engine import get_active_skin
+                _working_icon = get_active_skin().get_branding("status_prefix", "⚕").rstrip()
+            except Exception:
+                pass
+            return _state_fragment("class:prompt-working", _working_icon)
         if self._voice_mode:
             return _state_fragment("class:voice-prompt", "🎤")
         return [("class:prompt", symbol)]

--- a/cli.py
+++ b/cli.py
@@ -5062,8 +5062,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
     def _build_status_bar_text(self, width: Optional[int] = None) -> str:
         """Return a compact one-line session status string for the TUI footer."""
-        from hermes_cli.skin_engine import get_active_skin
-        _prefix = get_active_skin().get_branding("status_prefix", "⚕ ")
+        from hermes_cli.skin_engine import get_active_status_prefix
+        _prefix = get_active_status_prefix()
         try:
             snapshot = self._get_status_bar_snapshot()
             if width is None:
@@ -5134,8 +5134,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         if not self._status_bar_visible or getattr(self, '_model_picker_state', None):
             return []
         try:
-            from hermes_cli.skin_engine import get_active_skin
-            _prefix = get_active_skin().get_branding("status_prefix", "⚕ ")
+            from hermes_cli.skin_engine import get_active_status_prefix
+            _prefix = get_active_status_prefix()
             snapshot = self._get_status_bar_snapshot()
             # Use prompt_toolkit's own terminal width when running inside the
             # TUI — shutil.get_terminal_size() can return stale or fallback
@@ -12998,8 +12998,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         if self._agent_running:
             _working_icon = "⚕"
             try:
-                from hermes_cli.skin_engine import get_active_skin
-                _working_icon = get_active_skin().get_branding("status_prefix", "⚕").rstrip()
+                from hermes_cli.skin_engine import get_active_status_prefix
+                _working_icon = get_active_status_prefix().rstrip()
             except Exception:
                 pass
             return _state_fragment("class:prompt-working", _working_icon)

--- a/cli.py
+++ b/cli.py
@@ -5062,6 +5062,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
     def _build_status_bar_text(self, width: Optional[int] = None) -> str:
         """Return a compact one-line session status string for the TUI footer."""
+        from hermes_cli.skin_engine import get_active_skin
+        _prefix = get_active_skin().get_branding("status_prefix", "⚕ ")
         try:
             snapshot = self._get_status_bar_snapshot()
             if width is None:
@@ -5072,12 +5074,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
             yolo_active = self._is_session_yolo_active()
             if width < 52:
-                text = f"⚕ {snapshot['model_short']} · {duration_label}"
+                text = f"{_prefix}{snapshot['model_short']} · {duration_label}"
                 if yolo_active:
                     text += " · ⚠ YOLO"
                 return self._trim_status_bar_text(text, width)
             if width < 76:
-                parts = [f"⚕ {snapshot['model_short']}", percent_label]
+                parts = [f"{_prefix}{snapshot['model_short']}", percent_label]
                 compressions = snapshot.get("compressions", 0)
                 if compressions:
                     parts.append(f"🗜️ {compressions}")
@@ -5103,7 +5105,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 context_label = "ctx --"
 
             compressions = snapshot.get("compressions", 0)
-            parts = [f"⚕ {snapshot['model_short']}", context_label, percent_label]
+            parts = [f"{_prefix}{snapshot['model_short']}", context_label, percent_label]
             if compressions:
                 parts.append(f"🗜️ {compressions}")
             bg_count = snapshot.get("active_background_tasks", 0)
@@ -5126,12 +5128,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 parts.append("⚠ YOLO")
             return self._trim_status_bar_text(" │ ".join(parts), width)
         except Exception:
-            return f"⚕ {self.model if getattr(self, 'model', None) else 'Hermes'}"
+            return f"{_prefix}{self.model if getattr(self, 'model', None) else 'Hermes'}"
 
     def _get_status_bar_fragments(self):
         if not self._status_bar_visible or getattr(self, '_model_picker_state', None):
             return []
         try:
+            from hermes_cli.skin_engine import get_active_skin
+            _prefix = get_active_skin().get_branding("status_prefix", "⚕ ")
             snapshot = self._get_status_bar_snapshot()
             # Use prompt_toolkit's own terminal width when running inside the
             # TUI — shutil.get_terminal_size() can return stale or fallback
@@ -5144,7 +5148,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
             if width < 52:
                 frags = [
-                    ("class:status-bar", " ⚕ "),
+                    ("class:status-bar", f" {_prefix}"),
                     ("class:status-bar-strong", snapshot["model_short"]),
                     ("class:status-bar-dim", " · "),
                     ("class:status-bar-dim", duration_label),
@@ -5162,7 +5166,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     bg_proc_count = snapshot.get("active_background_processes", 0)
                     bg_subagent_count = snapshot.get("active_background_subagents", 0)
                     frags = [
-                        ("class:status-bar", " ⚕ "),
+                        ("class:status-bar", f" {_prefix}"),
                         ("class:status-bar-strong", snapshot["model_short"]),
                         ("class:status-bar-dim", " · "),
                         (self._status_bar_context_style(percent), percent_label),
@@ -5201,7 +5205,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     bg_proc_count = snapshot.get("active_background_processes", 0)
                     bg_subagent_count = snapshot.get("active_background_subagents", 0)
                     frags = [
-                        ("class:status-bar", " ⚕ "),
+                        ("class:status-bar", f" {_prefix}"),
                         ("class:status-bar-strong", snapshot["model_short"]),
                         ("class:status-bar-dim", " │ "),
                         ("class:status-bar-dim", context_label),

--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -835,6 +835,28 @@ def get_active_prompt_symbol(fallback: str = "❯") -> str:
 
 
 
+def get_active_status_prefix(fallback: str = "⚕ ") -> str:
+    """Return the status bar prefix with a guaranteed trailing space.
+
+    Skins store ``status_prefix`` with a trailing space by convention
+    (e.g. ``⚕ ``, ``✦ ``, ``⚔ ``).  This helper guarantees the trailing
+    space is always present so callers—such as
+    :meth:`_build_status_bar_text`, :meth:`_get_status_bar_fragments`,
+    and :meth:`_get_tui_prompt_fragments`—can compose the prefix into
+    rendered text or fragments without hand-rolling whitespace.
+
+    For the agent-running prompt icon (which already adds its own
+    spacing), strip the result: ``get_active_status_prefix().rstrip()``.
+    """
+    try:
+        raw = get_active_skin().get_branding("status_prefix", fallback)
+    except Exception:
+        raw = fallback
+    if not raw or not raw.strip():
+        return fallback
+    return f"{raw.rstrip()} "
+
+
 def get_active_help_header(fallback: str = "(^_^)? Available Commands") -> str:
     """Get the /help header from the active skin."""
     try:

--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -69,6 +69,7 @@ All fields are optional. Missing values inherit from the ``default`` skin.
       welcome: "Welcome message"          # Shown at CLI startup
       goodbye: "Goodbye! ⚕"              # Shown on exit
       response_label: " ⚕ Hermes "       # Response box header label
+      status_prefix: "⚕ "                # Status bar prefix before model name
       prompt_symbol: "❯"                 # Input prompt symbol (bare token; renderers add trailing space)
       help_header: "(^_^)? Commands"      # /help header text
 
@@ -191,6 +192,7 @@ _BUILTIN_SKINS: Dict[str, Dict[str, Any]] = {
             "welcome": "Welcome to Hermes Agent! Type your message or /help for commands.",
             "goodbye": "Goodbye! ⚕",
             "response_label": " ⚕ Hermes ",
+            "status_prefix": "⚕ ",
             "prompt_symbol": "❯",
             "help_header": "(^_^)? Available Commands",
         },
@@ -243,6 +245,7 @@ _BUILTIN_SKINS: Dict[str, Dict[str, Any]] = {
             "welcome": "Welcome to Ares Agent! Type your message or /help for commands.",
             "goodbye": "Farewell, warrior! ⚔",
             "response_label": " ⚔ Ares ",
+            "status_prefix": "⚔ ",
             "prompt_symbol": "⚔",
             "help_header": "(⚔) Available Commands",
         },
@@ -302,6 +305,7 @@ _BUILTIN_SKINS: Dict[str, Dict[str, Any]] = {
             "welcome": "Welcome to Hermes Agent! Type your message or /help for commands.",
             "goodbye": "Goodbye! ⚕",
             "response_label": " ⚕ Hermes ",
+            "status_prefix": "⚕ ",
             "prompt_symbol": "❯",
             "help_header": "[?] Available Commands",
         },
@@ -341,6 +345,7 @@ _BUILTIN_SKINS: Dict[str, Dict[str, Any]] = {
             "welcome": "Welcome to Hermes Agent! Type your message or /help for commands.",
             "goodbye": "Goodbye! ⚕",
             "response_label": " ⚕ Hermes ",
+            "status_prefix": "⚕ ",
             "prompt_symbol": "❯",
             "help_header": "(^_^)? Available Commands",
         },
@@ -378,6 +383,7 @@ _BUILTIN_SKINS: Dict[str, Dict[str, Any]] = {
             "welcome": "Welcome to Hermes Agent! Type your message or /help for commands.",
             "goodbye": "Goodbye! ⚕",
             "response_label": " ⚕ Hermes ",
+            "status_prefix": "⚕ ",
             "prompt_symbol": "❯",
             "help_header": "[?] Available Commands",
         },
@@ -415,6 +421,7 @@ _BUILTIN_SKINS: Dict[str, Dict[str, Any]] = {
             "welcome": "Welcome to Hermes Agent! Type your message or /help for commands.",
             "goodbye": "Goodbye! \u2695",
             "response_label": " \u2695 Hermes ",
+            "status_prefix": "\u2695 ",
             "prompt_symbol": "\u276f",
             "help_header": "(^_^)? Available Commands",
         },
@@ -468,6 +475,7 @@ _BUILTIN_SKINS: Dict[str, Dict[str, Any]] = {
             "welcome": "Welcome to Poseidon Agent! Type your message or /help for commands.",
             "goodbye": "Fair winds! Ψ",
             "response_label": " Ψ Poseidon ",
+            "status_prefix": "Ψ ",
             "prompt_symbol": "Ψ",
             "help_header": "(Ψ) Available Commands",
         },
@@ -540,6 +548,7 @@ _BUILTIN_SKINS: Dict[str, Dict[str, Any]] = {
             "welcome": "Welcome to Sisyphus Agent! Type your message or /help for commands.",
             "goodbye": "The boulder waits. ◉",
             "response_label": " ◉ Sisyphus ",
+            "status_prefix": "◉ ",
             "prompt_symbol": "◉",
             "help_header": "(◉) Available Commands",
         },
@@ -618,6 +627,7 @@ _BUILTIN_SKINS: Dict[str, Dict[str, Any]] = {
             "welcome": "Welcome to Charizard Agent! Type your message or /help for commands.",
             "goodbye": "Flame out! ✦",
             "response_label": " ✦ Charizard ",
+            "status_prefix": "✦ ",
             "prompt_symbol": "✦",
             "help_header": "(✦) Available Commands",
         },

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import cli as cli_mod
 from cli import HermesCLI
+from hermes_cli.skin_engine import set_active_skin
 
 
 def _make_cli(model: str = "anthropic/claude-sonnet-4-20250514"):
@@ -149,6 +150,7 @@ class TestCLIStatusBar:
             context_length=200_000,
         )
 
+        set_active_skin("default")
         text = cli_obj._build_status_bar_text(width=60)
 
         assert "⚕" in text
@@ -159,6 +161,7 @@ class TestCLIStatusBar:
     def test_build_status_bar_text_handles_missing_agent(self):
         cli_obj = _make_cli()
 
+        set_active_skin("default")
         text = cli_obj._build_status_bar_text(width=100)
 
         assert "⚕" in text

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -681,3 +681,110 @@ class TestIdleSinceLastTurn:
         cli_obj._prompt_duration = 7.0
         text = cli_obj._build_status_bar_text(width=160)
         assert "✓ 42s" in text
+class TestStatusPrefixSkinConfigurable:
+    """Tests for skin-configurable status_prefix."""
+
+    def test_get_active_status_prefix_default(self):
+        """Default skin returns ⚕ with trailing space."""
+        from hermes_cli.skin_engine import get_active_status_prefix, set_active_skin
+        set_active_skin("default")
+        prefix = get_active_status_prefix()
+        assert prefix == "⚕ "
+        assert prefix.endswith(" ")
+
+    def test_get_active_status_prefix_non_default_skin(self):
+        """Non-default skin (ares) returns ⚔ with trailing space."""
+        from hermes_cli.skin_engine import get_active_status_prefix, set_active_skin
+        set_active_skin("ares")
+        prefix = get_active_status_prefix()
+        assert prefix == "⚔ "
+        assert prefix.endswith(" ")
+
+    def test_get_active_status_prefix_fallback_on_import_error(self):
+        """Returns fallback when skin engine import fails."""
+        from unittest.mock import patch
+        from hermes_cli.skin_engine import get_active_status_prefix
+        with patch(
+            "hermes_cli.skin_engine.get_active_skin",
+            side_effect=ImportError("no skin engine"),
+        ):
+            prefix = get_active_status_prefix()
+        assert prefix == "⚕ "
+
+    def test_get_active_status_prefix_empty_skin_value(self):
+        """Returns fallback when skin stores empty status_prefix."""
+        from unittest.mock import patch
+        from hermes_cli.skin_engine import get_active_status_prefix
+        fake_skin = MagicMock()
+        fake_skin.get_branding.return_value = ""
+        with patch(
+            "hermes_cli.skin_engine.get_active_skin", return_value=fake_skin
+        ):
+            prefix = get_active_status_prefix()
+        assert prefix == "⚕ "
+
+    def test_build_status_bar_text_uses_skin_prefix(self):
+        """_build_status_bar_text includes non-default prefix."""
+        from hermes_cli.skin_engine import set_active_skin
+        set_active_skin("ares")
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=1_000,
+            completion_tokens=500,
+            total_tokens=1_500,
+            api_calls=1,
+            context_tokens=1_000,
+            context_length=32_000,
+        )
+        text = cli_obj._build_status_bar_text()
+        assert text.startswith("⚔ ")
+
+    def test_status_bar_fragments_use_skin_prefix(self):
+        """_get_status_bar_fragments includes non-default prefix."""
+        from unittest.mock import MagicMock, patch
+        from hermes_cli.skin_engine import set_active_skin
+        set_active_skin("ares")
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=1_000,
+            completion_tokens=500,
+            total_tokens=1_500,
+            api_calls=1,
+            context_tokens=1_000,
+            context_length=32_000,
+        )
+        cli_obj._status_bar_visible = True
+        mock_app = MagicMock()
+        mock_app.output.get_size.return_value = MagicMock(columns=80)
+        with patch("prompt_toolkit.application.get_app", return_value=mock_app):
+            frags = cli_obj._get_status_bar_fragments()
+        combined = "".join(text for _, text in frags)
+        assert "⚔ " in combined
+
+    def test_agent_running_prompt_icon_uses_skin_prefix(self):
+        """Agent-running state shows skin prefix (rstripped) instead of ⚕."""
+        from hermes_cli.skin_engine import set_active_skin
+        set_active_skin("charizard")
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=1_000,
+            completion_tokens=500,
+            total_tokens=1_500,
+            api_calls=1,
+            context_tokens=1_000,
+            context_length=32_000,
+        )
+        cli_obj._agent_running = True
+        cli_obj._voice_recording = False
+        cli_obj._voice_processing = False
+        cli_obj._sudo_state = False
+        cli_obj._secret_state = False
+        cli_obj._approval_state = False
+        cli_obj._clarify_state = False
+        cli_obj._clarify_freetext = False
+        cli_obj._command_running = False
+        cli_obj._voice_mode = False
+        frags = cli_obj._get_tui_prompt_fragments()
+        combined = "".join(text for _, text in frags)
+        assert "✦" in combined
+        assert "⚕" not in combined

--- a/website/docs/user-guide/features/skins.md
+++ b/website/docs/user-guide/features/skins.md
@@ -96,6 +96,7 @@ Text strings used throughout the CLI interface.
 | `welcome` | Welcome message shown at CLI startup | `Welcome to Hermes Agent! Type your message or /help for commands.` |
 | `goodbye` | Message shown on exit | `Goodbye! ⚕` |
 | `response_label` | Label on the response box header | ` ⚕ Hermes ` |
+| `status_prefix` | Prefix before the model name in the status bar (normalized to exactly one trailing space) | `⚕ ` |
 | `prompt_symbol` | Symbol before the user input prompt (bare token, renderers add a trailing space) | `❯` |
 | `help_header` | Header text for the `/help` command output | `(^_^)? Available Commands` |
 
@@ -169,6 +170,7 @@ branding:
   welcome: "Welcome to My Agent! Type your message or /help for commands."
   goodbye: "See you later! ⚡"
   response_label: " ⚡ My Agent "
+  status_prefix: "⚡ "
   prompt_symbol: "⚡"
   help_header: "(⚡) Available Commands"
 


### PR DESCRIPTION
Previously the status bar always showed "⚕" before the model name, hardcoded in `_build_status_bar_text` and `_get_status_bar_fragments`. Other branding elements (`response_label`, `goodbye`, `prompt_symbol`) were already skin-configurable, but the status bar prefix was missed.

Also fixes `_get_tui_prompt_fragments()` which hardcoded "⚕" for the agent-running state (visible in the prompt area during response generation), bypassing the skin's `status_prefix` — causing the input prompt to show ⚕ instead of the skin-configured icon (e.g. ✦) while the agent was thinking.

This PR:
- Adds `status_prefix` to the skin branding schema (default: `"⚕ "`)
- Adds `status_prefix` to all 9 built-in skins branding dicts (ares: `"⚔ "`, poseidon: `"Ψ "`, sisyphus: `"◉ "`, charizard: `"✦ "`, others: `"⚕ "`)
- Replaces hardcoded `"⚕ "` in CLI status bar rendering with `get_branding("status_prefix")` lookups
- Replaces hardcoded `"⚕"` in agent-running prompt icon with skin `status_prefix` (rstripped)
- Updates skin-customization reference docs

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)

## How to Test

1. `/skin jingguang` → status bar shows model name with ✦ prefix; prompt area during agent generation shows ✦ instead of ⚕
2. `/skin ares` → status bar shows ⚔ before model name
3. `/skin default` → status bar restores ⚕ prefix (unchanged)
4. `pytest tests/hermes_cli/test_skin_engine.py -v` → 33 passed

## Checklist

### Code
- [x] I have read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs
- [x] My PR contains only changes related to this fix/feature
- [x] I have run tests and all pass
- [x] I have added tests for my changes (existing skin tests cover the new branding key)
- [x] I have tested on: macOS 26.5