### PR TITLE
Fix browser sandbox detection in containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/opt/hermes/.playwright
 # that would otherwise accumulate when hermes runs as PID 1. See #15012.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    build-essential curl nodejs npm python3 ripgrep ffmpeg gcc python3-dev libffi-dev procps git openssh-client docker-cli tini && \
+    build-essential curl nodejs npm python3 ripgrep ffmpeg gcc python3-dev libffi-dev procps git openssh-client docker-cli tini libnspr4 libnss3 && \
     rm -rf /var/lib/apt/lists/*
 
 # Non-root user for runtime; UID can be overridden via HERMES_UID at runtime

--- a/tests/tools/test_browser_chromium_check.py
+++ b/tests/tools/test_browser_chromium_check.py
@@ -7,6 +7,7 @@ for the full command timeout before surfacing a useless error.
 """
 
 import os
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -17,8 +18,14 @@ from tools import browser_tool as bt
 @pytest.fixture(autouse=True)
 def _reset_chromium_cache():
     bt._cached_chromium_installed = None
+    cache_clear = getattr(bt._browser_sandbox_bypass_reason, "cache_clear", None)
+    if cache_clear:
+        cache_clear()
     yield
     bt._cached_chromium_installed = None
+    cache_clear = getattr(bt._browser_sandbox_bypass_reason, "cache_clear", None)
+    if cache_clear:
+        cache_clear()
 
 
 class TestChromiumSearchRoots:
@@ -50,6 +57,87 @@ class TestChromiumInstalled:
         )
 
         assert bt._chromium_installed() is True
+
+
+class TestBrowserSandboxBypass:
+    def test_root_requires_sandbox_bypass(self, monkeypatch):
+        monkeypatch.setattr(bt.os, "name", "posix")
+        monkeypatch.setattr(bt.sys, "platform", "linux")
+        monkeypatch.setattr(bt.os, "geteuid", lambda: 0, raising=False)
+
+        assert bt._browser_sandbox_bypass_reason() == "running as root"
+
+    def test_apparmor_userns_restriction_requires_sandbox_bypass(self, monkeypatch):
+        monkeypatch.setattr(bt.os, "name", "posix")
+        monkeypatch.setattr(bt.sys, "platform", "linux")
+        monkeypatch.setattr(bt.os, "geteuid", lambda: 1000, raising=False)
+        monkeypatch.setattr(bt, "_apparmor_restricts_unprivileged_userns", lambda: True)
+        monkeypatch.setattr(bt, "_unprivileged_userns_probe_fails", lambda: False)
+
+        assert (
+            bt._browser_sandbox_bypass_reason()
+            == "AppArmor user namespace restrictions detected"
+        )
+
+    def test_failed_unshare_probe_requires_sandbox_bypass(self, monkeypatch):
+        monkeypatch.setattr(bt.os, "name", "posix")
+        monkeypatch.setattr(bt.sys, "platform", "linux")
+        monkeypatch.setattr(bt.os, "geteuid", lambda: 1000, raising=False)
+        monkeypatch.setattr(bt, "_apparmor_restricts_unprivileged_userns", lambda: False)
+        monkeypatch.setattr(bt, "_unprivileged_userns_probe_fails", lambda: True)
+
+        assert (
+            bt._browser_sandbox_bypass_reason()
+            == "unprivileged user namespace probe failed"
+        )
+
+    def test_unshare_probe_failure_detects_blocked_userns(self, monkeypatch):
+        monkeypatch.setattr(bt.os, "name", "posix")
+        monkeypatch.setattr(bt.sys, "platform", "linux")
+        monkeypatch.setattr(bt.shutil, "which", lambda name: "/usr/bin/unshare")
+
+        def fake_run(*args, **kwargs):
+            return subprocess.CompletedProcess(args[0], 1)
+
+        monkeypatch.setattr(bt.subprocess, "run", fake_run)
+
+        assert bt._unprivileged_userns_probe_fails() is True
+
+    def test_unshare_probe_skips_non_linux(self, monkeypatch):
+        monkeypatch.setattr(bt.os, "name", "nt")
+        monkeypatch.setattr(bt.sys, "platform", "win32")
+        monkeypatch.setattr(bt.shutil, "which", lambda name: "/usr/bin/unshare")
+
+        assert bt._unprivileged_userns_probe_fails() is False
+
+    def test_injects_browser_args_when_sandbox_bypass_needed(self, monkeypatch):
+        browser_env = {}
+        monkeypatch.setattr(
+            bt,
+            "_browser_sandbox_bypass_reason",
+            lambda: "unprivileged user namespace probe failed",
+        )
+
+        reason = bt._inject_browser_sandbox_args_if_needed(browser_env)
+
+        assert reason == "unprivileged user namespace probe failed"
+        assert browser_env["AGENT_BROWSER_ARGS"] == "--no-sandbox,--disable-dev-shm-usage"
+
+    @pytest.mark.parametrize(
+        "browser_env",
+        [
+            {"AGENT_BROWSER_ARGS": "--custom-flag"},
+            {"AGENT_BROWSER_CHROME_FLAGS": "--custom-legacy-flag"},
+        ],
+    )
+    def test_preserves_user_browser_args(self, monkeypatch, browser_env):
+        monkeypatch.setattr(bt, "_browser_sandbox_bypass_reason", lambda: "running as root")
+        original = dict(browser_env)
+
+        reason = bt._inject_browser_sandbox_args_if_needed(browser_env)
+
+        assert reason is None
+        assert browser_env == original
 
     def test_true_when_chromium_dir_present(self, monkeypatch, tmp_path):
         monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", str(tmp_path))

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1181,6 +1181,8 @@ _cleanup_done = False
 # Default: 5 minutes. Needs headroom for LLM reasoning between browser commands,
 # especially when subagents are doing multi-step browser tasks.
 BROWSER_SESSION_INACTIVITY_TIMEOUT = int(os.environ.get("BROWSER_INACTIVITY_TIMEOUT", "300"))
+_BROWSER_SANDBOX_BYPASS_ARGS = "--no-sandbox,--disable-dev-shm-usage"
+_APPARMOR_USERNS_RESTRICT_PATH = "/proc/sys/kernel/apparmor_restrict_unprivileged_userns"
 
 # Track last activity time per session
 _session_last_activity: Dict[str, float] = {}
@@ -1191,6 +1193,76 @@ _cleanup_running = False
 # Protects _session_last_activity AND _active_sessions for thread safety
 # (subagents run concurrently via ThreadPoolExecutor)
 _cleanup_lock = threading.Lock()
+
+
+def _apparmor_restricts_unprivileged_userns(
+    restrict_path: str = _APPARMOR_USERNS_RESTRICT_PATH,
+) -> bool:
+    try:
+        with open(restrict_path, encoding="utf-8") as f:
+            return f.read().strip() == "1"
+    except OSError:
+        return False
+
+
+def _unprivileged_userns_probe_fails() -> bool:
+    if os.name != "posix" or not sys.platform.startswith("linux"):
+        return False
+
+    unshare = shutil.which("unshare")
+    if not unshare:
+        return False
+
+    try:
+        proc = subprocess.run(
+            [unshare, "-U", "/bin/true"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=2,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+
+    return proc.returncode != 0
+
+
+@functools.lru_cache(maxsize=1)
+def _browser_sandbox_bypass_reason() -> Optional[str]:
+    if os.name != "posix":
+        return None
+
+    if hasattr(os, "geteuid") and os.geteuid() == 0:
+        return "running as root"
+
+    if _apparmor_restricts_unprivileged_userns():
+        return "AppArmor user namespace restrictions detected"
+
+    if _unprivileged_userns_probe_fails():
+        return "unprivileged user namespace probe failed"
+
+    return None
+
+
+def _inject_browser_sandbox_args_if_needed(browser_env: Dict[str, str]) -> Optional[str]:
+    # Honour either the legacy AGENT_BROWSER_CHROME_FLAGS (never consumed by
+    # agent-browser itself, but documented in older notes) or the real
+    # AGENT_BROWSER_ARGS — if the user pre-sets either, don't overwrite it.
+    if (
+        "AGENT_BROWSER_ARGS" in browser_env
+        or "AGENT_BROWSER_CHROME_FLAGS" in browser_env
+    ):
+        return None
+
+    sandbox_bypass_reason = _browser_sandbox_bypass_reason()
+    if sandbox_bypass_reason:
+        logger.debug(
+            "browser: %s — injecting --no-sandbox",
+            sandbox_bypass_reason,
+        )
+        browser_env["AGENT_BROWSER_ARGS"] = _BROWSER_SANDBOX_BYPASS_ARGS
+
+    return sandbox_bypass_reason
 
 
 def _emergency_cleanup_all_sessions():
@@ -2011,34 +2083,7 @@ def _run_browser_command(
         # - Ubuntu 23.10+ / AppArmor systems: unprivileged user namespaces
         #   are restricted, causing Chromium to exit with "No usable sandbox"
         #   even for non-root users running under systemd or containers.
-        # Honour either the legacy AGENT_BROWSER_CHROME_FLAGS (never consumed by
-        # agent-browser itself, but documented in older notes) or the real
-        # AGENT_BROWSER_ARGS — if the user pre-sets either, don't overwrite it.
-        if (
-            "AGENT_BROWSER_ARGS" not in browser_env
-            and "AGENT_BROWSER_CHROME_FLAGS" not in browser_env
-        ):
-            _needs_sandbox_bypass = False
-            if hasattr(os, "geteuid") and os.geteuid() == 0:
-                _needs_sandbox_bypass = True
-                logger.debug("browser: running as root — injecting --no-sandbox")
-            else:
-                # Detect AppArmor user namespace restrictions (Ubuntu 23.10+)
-                _userns_restrict = "/proc/sys/kernel/apparmor_restrict_unprivileged_userns"
-                try:
-                    with open(_userns_restrict, encoding="utf-8") as _f:
-                        if _f.read().strip() == "1":
-                            _needs_sandbox_bypass = True
-                            logger.debug(
-                                "browser: AppArmor userns restrictions detected — "
-                                "injecting --no-sandbox"
-                            )
-                except OSError:
-                    pass
-            if _needs_sandbox_bypass:
-                browser_env["AGENT_BROWSER_ARGS"] = (
-                    "--no-sandbox,--disable-dev-shm-usage"
-                )
+        _inject_browser_sandbox_args_if_needed(browser_env)
 
         # Use temp files for stdout/stderr instead of pipes.
         # agent-browser starts a background daemon that inherits file


### PR DESCRIPTION
## Summary
- detect non-root containers where unprivileged user namespaces are blocked by probing \unshare -U /bin/true\
- preserve user-provided \AGENT_BROWSER_ARGS\ and legacy \AGENT_BROWSER_CHROME_FLAGS\
- add \libnspr4\ and \libnss3\ to the Debian image dependencies for Chromium/NSS

Fixes #28960.

## Testing
- \.venv\\Scripts\\ruff.exe check tools\\browser_tool.py tests\\tools\\test_browser_chromium_check.py\
- \PYTHONDONTWRITEBYTECODE=1 .venv\\Scripts\\python.exe -m pytest -o addopts= -q -p no:timeout tests\\tools\\test_browser_chromium_check.py\ (18 passed)
- Docker non-root probe on \
ode:22.22.3-bookworm\: \unshare -U /bin/true\ fails with \Operation not permitted\, and the new logic injects \--no-sandbox,--disable-dev-shm-usage\
- Docker \debian:13.4\: \pt-get install -y --no-install-recommends libnspr4 libnss3\ succeeds

Note: I did not run a full Docker image build locally to avoid unnecessary disk usage; the package install and container userns behavior were validated directly.