### PR TITLE
fix(cli): show review lane count in kanban stats output

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2250,7 +2250,7 @@ def _cmd_stats(args: argparse.Namespace) -> int:
         print(json.dumps(stats, indent=2, ensure_ascii=False))
         return 0
     print("By status:")
-    for k in ("triage", "todo", "scheduled", "ready", "running", "blocked", "done"):
+    for k in ("triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done"):
         print(f"  {k:8s}  {stats['by_status'].get(k, 0)}")
     if stats["by_assignee"]:
         print("\nBy assignee:")

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -148,6 +148,30 @@ def test_run_slash_comment_max_len_trims_long_body(kanban_home):
     assert "x" * 30 not in show
 
 
+def test_run_slash_stats_text_includes_review_lane(kanban_home):
+    """``stats`` text output must surface the ``review`` lane.
+
+    board_stats() reports a per-status count for every non-archived
+    status, so the human-readable ``By status:`` block must enumerate
+    ``review`` too — otherwise its count silently disappears while
+    ``--json`` still shows it.
+    """
+    import re
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="needs review", assignee="alice")
+        # Move it into the review lane (autocommit connection persists it).
+        conn.execute("UPDATE tasks SET status = 'review' WHERE id = ?", (tid,))
+
+    out = kc.run_slash("stats")
+    assert "review" in out
+    assert re.search(r"review\s+1", out), out
+
+    # The text path must agree with the JSON path, which already exposed it.
+    out_json = kc.run_slash("stats --json")
+    assert json.loads(out_json)["by_status"].get("review") == 1
+
+
 def test_run_slash_block_unblock_cycle(kanban_home):
     out = kc.run_slash("create 'x' --assignee alice")
     import re


### PR DESCRIPTION

### What & Why
`hermes kanban stats` (text mode) prints a per-status breakdown, but the
hardcoded status list omits `review`:

```python
for k in ("triage", "todo", "scheduled", "ready", "running", "blocked", "done"):
```

`board_stats()` already returns a count for every non-archived status
(`GROUP BY status`), so the data is present — it's just dropped on the way
to the terminal. Result: any task sitting in the `review` lane is invisible
in the human-readable report, the printed totals don't reconcile with
`list --status review`, and the text path silently disagrees with
`stats --json` (which still shows it).

`review` is a first-class, dispatchable lane (workers move tasks into it for
the reviewer agent), so its count belongs in the summary.

### Fix
Add `review` to the display order (between `blocked` and `done`):

```python
for k in ("triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done"):
```

One line, behavior-only, backward compatible.

### How to test
1. Create a task and move it to `review`.
2. `hermes kanban stats` → the `By status:` block now lists `review` with the
   correct count, matching `stats --json`.

Added regression test `test_run_slash_stats_text_includes_review_lane` in
`tests/hermes_cli/test_kanban_cli.py`: it asserts the text output shows
`review 1` and that it agrees with the JSON path. Verified the test **fails
without the fix** and passes with it.

### Platforms
Pure CLI output formatting — platform-independent. `tests/hermes_cli/test_kanban_cli.py`: 47 passed.