### PR TITLE
fix(cli): add kanban status icons for triage and review

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -32,12 +32,16 @@ from hermes_cli.profiles import get_active_profile_name, get_profile_dir, seed_p
 # Small formatting helpers
 # ---------------------------------------------------------------------------
 
+# One icon per kb.VALID_STATUSES member, so _fmt_task_line never falls back
+# to "?" for a status the board can legitimately surface.
 _STATUS_ICONS = {
+    "triage":   "◇",
     "todo":     "◻",
+    "scheduled":"⏱",
     "ready":    "▶",
     "running":  "●",
-    "scheduled":"⏱",
     "blocked":  "⊘",
+    "review":   "◎",
     "done":     "✓",
     "archived": "—",
 }

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -73,6 +73,31 @@ def test_parse_branch_flag_rejects_empty_and_option_like():
 
 
 # ---------------------------------------------------------------------------
+# Status icon coverage
+# ---------------------------------------------------------------------------
+
+def test_status_icons_cover_all_valid_statuses():
+    # Every status the board can list must have a glyph; otherwise
+    # _fmt_task_line renders "?" for it.
+    missing = kb.VALID_STATUSES - kc._STATUS_ICONS.keys()
+    assert not missing, f"statuses without an icon: {sorted(missing)}"
+
+
+def _make_task(status: str) -> kb.Task:
+    return kb.Task(
+        id="t1", title="x", body=None, assignee=None, status=status,
+        priority=0, created_by=None, created_at=0, started_at=None,
+        completed_at=None, workspace_kind="scratch", workspace_path=None,
+        claim_lock=None, claim_expires=None, tenant=None,
+    )
+
+
+@pytest.mark.parametrize("status", sorted(kb.VALID_STATUSES))
+def test_fmt_task_line_never_falls_back_for_valid_status(status):
+    assert kc._fmt_task_line(_make_task(status)).split(" ", 1)[0] != "?"
+
+
+# ---------------------------------------------------------------------------
 # run_slash smoke tests (end-to-end via the same entry both CLI and gateway use)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

`hermes kanban list` rendered tasks in the `triage` and `review` states with a `?` placeholder instead of a status glyph.

## Why

`_STATUS_ICONS` in `hermes_cli/kanban.py` only mapped 7 of the 9 members of `kb.VALID_STATUSES`. `triage` and `review` are both valid, listable statuses (and `--status review` / `--status triage` are accepted filters), so `_fmt_task_line` fell through to its `"?"` fallback for them. The dashboard's `BOARD_COLUMNS` (`plugins/kanban/dashboard/plugin_api.py`) already covers all of these statuses — only the CLI was out of sync.

## Fix

- Add icons for `triage` (`◇`) and `review` (`◎`) so every valid status has a glyph; reordered the dict to follow the status lifecycle.
- Add tests asserting `_STATUS_ICONS` covers all of `VALID_STATUSES`, plus a parametrized check that `_fmt_task_line` never returns the `?` fallback for any valid status. The invariant test means any future status addition must ship an icon too.

No behavior change beyond the two added glyphs — pure bug fix, no refactor.

## How to test

```bash
hermes kanban create "needs sorting"
hermes kanban move <id> triage   # or: review
hermes kanban list               # row now starts with a glyph, not "?"
```

Automated:

```bash
scripts/run_tests.sh tests/hermes_cli/test_kanban_cli.py -q
```

