### PR TITLE
fix(codex): gate unsupported reasoning fields

### DIFF
--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -137,8 +137,26 @@ class ResponsesApiTransport(ProviderTransport):
                 if github_reasoning is not None:
                     kwargs["reasoning"] = github_reasoning
             else:
-                kwargs["reasoning"] = {"effort": reasoning_effort, "summary": "auto"}
-                kwargs["include"] = ["reasoning.encrypted_content"]
+                model_name = str(model or "").lower().rsplit("/", 1)[-1]
+                supports_encrypted_reasoning = (
+                    "codex" in model_name
+                    or model_name.startswith("o3")
+                    or model_name.startswith("o4")
+                )
+                supports_reasoning_effort = (
+                    supports_encrypted_reasoning
+                    or model_name.startswith("gpt-5.2")
+                    or model_name.startswith("gpt-5.3")
+                    or model_name.startswith("gpt-5.4")
+                    or model_name.startswith("gpt-5.5")
+                )
+                if supports_reasoning_effort:
+                    kwargs["reasoning"] = {"effort": reasoning_effort, "summary": "auto"}
+                kwargs["include"] = (
+                    ["reasoning.encrypted_content"]
+                    if supports_encrypted_reasoning
+                    else []
+                )
         elif not is_github_responses and not is_xai_responses:
             kwargs["include"] = []
 

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -376,6 +376,40 @@ def test_build_api_kwargs_codex_preserves_supported_efforts(monkeypatch):
         assert kwargs["reasoning"]["effort"] == effort, f"{effort} should pass through unchanged"
 
 
+def test_codex_transport_omits_reasoning_for_unsupported_gpt5_mini():
+    from agent.transports.codex import ResponsesApiTransport
+
+    kwargs = ResponsesApiTransport().build_kwargs(
+        model="gpt-5-mini",
+        messages=[
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hi"},
+        ],
+        tools=None,
+        reasoning_config={"enabled": True, "effort": "medium"},
+    )
+
+    assert "reasoning" not in kwargs
+    assert kwargs["include"] == []
+
+
+def test_codex_transport_keeps_reasoning_effort_without_encrypted_include_for_gpt54():
+    from agent.transports.codex import ResponsesApiTransport
+
+    kwargs = ResponsesApiTransport().build_kwargs(
+        model="gpt-5.4",
+        messages=[
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hi"},
+        ],
+        tools=None,
+        reasoning_config={"enabled": True, "effort": "high"},
+    )
+
+    assert kwargs["reasoning"] == {"effort": "high", "summary": "auto"}
+    assert kwargs["include"] == []
+
+
 def test_build_api_kwargs_copilot_responses_omits_openai_only_fields(monkeypatch):
     agent = _build_copilot_agent(monkeypatch)
     kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])


### PR DESCRIPTION
## Summary
- avoid sending Responses reasoning fields to unsupported plain GPT-5 mini models
- keep reasoning effort for newer GPT-5.2+ Responses models
- preserve encrypted reasoning include for native Codex/o-series models

## Tests
- python -m pytest -o addopts= tests\\run_agent\\test_run_agent_codex_responses.py::test_codex_transport_omits_reasoning_for_unsupported_gpt5_mini tests\\run_agent\\test_run_agent_codex_responses.py::test_codex_transport_keeps_reasoning_effort_without_encrypted_include_for_gpt54 tests\\run_agent\\test_codex_xai_oauth_recovery.py::test_codex_transport_native_codex_still_replays_reasoning_in_input tests\\run_agent\\test_run_agent_codex_responses.py::test_build_api_kwargs_codex -q

## Notes
This is the narrow upstreamable slice from a production Garagebox runtime patch. Diagnostic sentinel and terminal-helper timeout changes were intentionally not included because they need separate design/review.