### PR TITLE
fix(auxiliary): honor vision fallback chain

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4006,7 +4006,7 @@ def _resolve_fallback_entry(entry: Dict[str, Any]) -> Tuple[Optional[Any], Optio
     """Resolve one fallback entry through the central provider router."""
     provider = str(entry.get("provider") or "").strip()
     model = str(entry.get("model") or "").strip() or None
-    if not provider or not model:
+    if not provider:
         return None, None
     base_url = str(entry.get("base_url") or "").strip() or None
     api_key = _fallback_entry_api_key(entry)
@@ -6456,15 +6456,25 @@ def call_llm(
             async_mode=False,
         )
         if client is None and resolved_provider != "auto" and not resolved_base_url:
-            logger.warning(
-                "Vision provider %s unavailable, falling back to auto vision backends",
-                resolved_provider,
-            )
-            effective_provider, client, final_model = resolve_vision_provider_client(
-                provider="auto",
-                model=resolved_model,
-                async_mode=False,
-            )
+            fb_client, fb_model, fb_label = _try_configured_fallback_for_unavailable_client(
+                "vision", resolved_provider)
+            if fb_client is not None:
+                logger.warning(
+                    "Vision provider %s unavailable, using configured fallback %s",
+                    resolved_provider, fb_label,
+                )
+                effective_provider = fb_label
+                client, final_model = fb_client, fb_model
+            else:
+                logger.warning(
+                    "Vision provider %s unavailable, falling back to auto vision backends",
+                    resolved_provider,
+                )
+                effective_provider, client, final_model = resolve_vision_provider_client(
+                    provider="auto",
+                    model=resolved_model,
+                    async_mode=False,
+                )
         if client is None:
             raise RuntimeError(
                 f"No LLM provider configured for task={task} provider={resolved_provider}. "
@@ -7073,15 +7083,26 @@ async def async_call_llm(
             async_mode=True,
         )
         if client is None and resolved_provider != "auto" and not resolved_base_url:
-            logger.warning(
-                "Vision provider %s unavailable, falling back to auto vision backends",
-                resolved_provider,
-            )
-            effective_provider, client, final_model = resolve_vision_provider_client(
-                provider="auto",
-                model=resolved_model,
-                async_mode=True,
-            )
+            fb_client, fb_model, fb_label = _try_configured_fallback_for_unavailable_client(
+                "vision", resolved_provider)
+            if fb_client is not None:
+                logger.warning(
+                    "Vision provider %s unavailable, using configured fallback %s",
+                    resolved_provider, fb_label,
+                )
+                effective_provider = fb_label
+                client, final_model = _to_async_client(
+                    fb_client, fb_model, is_vision=True)
+            else:
+                logger.warning(
+                    "Vision provider %s unavailable, falling back to auto vision backends",
+                    resolved_provider,
+                )
+                effective_provider, client, final_model = resolve_vision_provider_client(
+                    provider="auto",
+                    model=resolved_model,
+                    async_mode=True,
+                )
         if client is None:
             raise RuntimeError(
                 f"No LLM provider configured for task={task} provider={resolved_provider}. "

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6338,7 +6338,7 @@ def _resolve_fallback_entry(entry: Dict[str, Any]) -> Tuple[Optional[Any], Optio
     """Resolve one fallback entry through the central provider router."""
     provider = str(entry.get("provider") or "").strip()
     model = str(entry.get("model") or "").strip() or None
-    if not provider or not model:
+    if not provider:
         return None, None
     base_url = str(entry.get("base_url") or "").strip() or None
     api_key = _fallback_entry_api_key(entry)
@@ -10480,16 +10480,26 @@ def _call_llm_impl(
             main_runtime=main_runtime,
         )
         if client is None and resolved_provider != "auto" and not resolved_base_url:
-            logger.warning(
-                "Vision provider %s unavailable, falling back to auto vision backends",
-                resolved_provider,
-            )
-            effective_provider, client, final_model = resolve_vision_provider_client(
-                provider="auto",
-                model=resolved_model,
-                async_mode=False,
-                main_runtime=main_runtime,
-            )
+            fb_client, fb_model, fb_label = _try_configured_fallback_for_unavailable_client(
+                "vision", resolved_provider)
+            if fb_client is not None:
+                logger.warning(
+                    "Vision provider %s unavailable, using configured fallback %s",
+                    resolved_provider, fb_label,
+                )
+                effective_provider = fb_label
+                client, final_model = fb_client, fb_model
+            else:
+                logger.warning(
+                    "Vision provider %s unavailable, falling back to auto vision backends",
+                    resolved_provider,
+                )
+                effective_provider, client, final_model = resolve_vision_provider_client(
+                    provider="auto",
+                    model=resolved_model,
+                    async_mode=False,
+                    main_runtime=main_runtime,
+                )
         if client is None:
             raise RuntimeError(
                 f"No LLM provider configured for task={task} provider={resolved_provider}. "
@@ -11376,16 +11386,27 @@ async def _async_call_llm_impl(
             main_runtime=main_runtime,
         )
         if client is None and resolved_provider != "auto" and not resolved_base_url:
-            logger.warning(
-                "Vision provider %s unavailable, falling back to auto vision backends",
-                resolved_provider,
-            )
-            effective_provider, client, final_model = resolve_vision_provider_client(
-                provider="auto",
-                model=resolved_model,
-                async_mode=True,
-                main_runtime=main_runtime,
-            )
+            fb_client, fb_model, fb_label = _try_configured_fallback_for_unavailable_client(
+                "vision", resolved_provider)
+            if fb_client is not None:
+                logger.warning(
+                    "Vision provider %s unavailable, using configured fallback %s",
+                    resolved_provider, fb_label,
+                )
+                effective_provider = fb_label
+                client, final_model = _to_async_client(
+                    fb_client, fb_model, is_vision=True)
+            else:
+                logger.warning(
+                    "Vision provider %s unavailable, falling back to auto vision backends",
+                    resolved_provider,
+                )
+                effective_provider, client, final_model = resolve_vision_provider_client(
+                    provider="auto",
+                    model=resolved_model,
+                    async_mode=True,
+                    main_runtime=main_runtime,
+                )
         if client is None:
             raise RuntimeError(
                 f"No LLM provider configured for task={task} provider={resolved_provider}. "

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -4244,6 +4244,202 @@ class TestVisionAutoSkipsKimiCoding:
         })
 
 
+class TestVisionFallbackChain:
+    def test_configured_fallback_chain_passes_explicit_endpoint_fields(
+        self, monkeypatch
+    ):
+        import agent.auxiliary_client as aux
+
+        fake_client = MagicMock(name="fallback_client")
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            lambda task: {
+                "fallback_chain": [
+                    {
+                        "provider": "custom",
+                        "model": "vision-model",
+                        "base_url": "http://127.0.0.1:8090/v1",
+                        "api_key": "no-key-required",
+                    }
+                ]
+            },
+        )
+
+        def fake_resolve_provider_client(
+            provider,
+            model=None,
+            *,
+            explicit_base_url=None,
+            explicit_api_key=None,
+            api_mode=None,
+        ):
+            assert provider == "custom"
+            assert model == "vision-model"
+            assert explicit_base_url == "http://127.0.0.1:8090/v1"
+            assert explicit_api_key == "no-key-required"
+            return fake_client, model
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client.resolve_provider_client",
+            fake_resolve_provider_client,
+        )
+
+        client, model, label = aux._try_configured_fallback_chain(
+            "vision", "ollama-cloud", "unavailable")
+
+        assert client is fake_client
+        assert model == "vision-model"
+        assert label == "fallback_chain[0](custom)"
+
+    def test_fallback_entry_without_explicit_model_resolves_provider_default(
+        self, monkeypatch
+    ):
+        """A fallback_chain entry with only ``provider`` (no ``model``) should
+        still resolve through ``resolve_provider_client``, which returns the
+        provider's default auxiliary model as ``resolved_model``.
+        """
+        import agent.auxiliary_client as aux
+
+        fake_client = MagicMock(name="default_model_client")
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            lambda task: {
+                "fallback_chain": [
+                    {"provider": "openrouter"},
+                ]
+            },
+        )
+
+        def fake_resolve_provider_client(
+            provider,
+            model=None,
+            *,
+            explicit_base_url=None,
+            explicit_api_key=None,
+            api_mode=None,
+        ):
+            assert provider == "openrouter"
+            assert model is None
+            # resolve_provider_client resolves a default model from the
+            # provider profile when model is None.
+            return fake_client, "openrouter/auto/vision"
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client.resolve_provider_client",
+            fake_resolve_provider_client,
+        )
+
+        client, model, label = aux._try_configured_fallback_chain(
+            "vision", "ollama-cloud", "unavailable")
+
+        assert client is fake_client
+        assert model == "openrouter/auto/vision"
+        assert label == "fallback_chain[0](openrouter)"
+
+    def test_unavailable_explicit_vision_provider_uses_configured_fallback_chain(
+        self, monkeypatch
+    ):
+        """A missing explicit vision provider credential should use the
+        configured vision fallback_chain before the generic auto route.
+        """
+        fake_response = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content="fallback vision response")
+                )
+            ]
+        )
+        fake_client = MagicMock(name="fallback_client")
+        fake_client.chat.completions.create.return_value = fake_response
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            lambda task, provider=None, model=None, base_url=None, api_key=None:
+                ("ollama-cloud", "kimi-k2.6:cloud", None, None, None),
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client.resolve_vision_provider_client",
+            MagicMock(return_value=("ollama-cloud", None, None)),
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._try_configured_fallback_for_unavailable_client",
+            MagicMock(return_value=(
+                fake_client,
+                "nvidia/nemotron-nano-12b-v2-vl",
+                "fallback_chain[0](nvidia)",
+            )),
+        )
+
+        response = call_llm(
+            task="vision",
+            messages=[{"role": "user", "content": "describe image"}],
+            max_tokens=20,
+        )
+
+        assert response.choices[0].message.content == "fallback vision response"
+        fake_client.chat.completions.create.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_unavailable_explicit_vision_provider_uses_configured_fallback_chain_async(
+        self, monkeypatch
+    ):
+        """Async path: a missing explicit vision provider credential should use
+        the configured vision fallback_chain before the generic auto route.
+        """
+        fake_response = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content="async fallback vision response")
+                )
+            ]
+        )
+        fake_sync_client = MagicMock(name="fallback_sync_client")
+        fake_async_client = MagicMock(name="fallback_async_client")
+        fake_async_client.chat.completions.create = AsyncMock(
+            return_value=fake_response
+        )
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            lambda task, provider=None, model=None, base_url=None, api_key=None: (
+                "ollama-cloud",
+                "kimi-k2.6:cloud",
+                None,
+                None,
+                None,
+            ),
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client.resolve_vision_provider_client",
+            MagicMock(return_value=("ollama-cloud", None, None)),
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._try_configured_fallback_for_unavailable_client",
+            MagicMock(
+                return_value=(
+                    fake_sync_client,
+                    "nvidia/nemotron-nano-12b-v2-vl",
+                    "fallback_chain[0](nvidia)",
+                )
+            ),
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._to_async_client",
+            MagicMock(
+                return_value=(fake_async_client, "nvidia/nemotron-nano-12b-v2-vl")
+            ),
+        )
+
+        response = await async_call_llm(
+            task="vision",
+            messages=[{"role": "user", "content": "describe image"}],
+            max_tokens=20,
+        )
+
+        assert response.choices[0].message.content == "async fallback vision response"
+        fake_async_client.chat.completions.create.assert_awaited_once()
+
+
 class TestCodexAuxiliaryAdapterTimeout:
     def test_forwards_timeout_to_responses_create(self):
         message_item = SimpleNamespace(

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3374,6 +3374,202 @@ class TestVisionAutoSkipsKimiCoding:
         })
 
 
+class TestVisionFallbackChain:
+    def test_configured_fallback_chain_passes_explicit_endpoint_fields(
+        self, monkeypatch
+    ):
+        import agent.auxiliary_client as aux
+
+        fake_client = MagicMock(name="fallback_client")
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            lambda task: {
+                "fallback_chain": [
+                    {
+                        "provider": "custom",
+                        "model": "vision-model",
+                        "base_url": "http://127.0.0.1:8090/v1",
+                        "api_key": "no-key-required",
+                    }
+                ]
+            },
+        )
+
+        def fake_resolve_provider_client(
+            provider,
+            model=None,
+            *,
+            explicit_base_url=None,
+            explicit_api_key=None,
+            api_mode=None,
+        ):
+            assert provider == "custom"
+            assert model == "vision-model"
+            assert explicit_base_url == "http://127.0.0.1:8090/v1"
+            assert explicit_api_key == "no-key-required"
+            return fake_client, model
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client.resolve_provider_client",
+            fake_resolve_provider_client,
+        )
+
+        client, model, label = aux._try_configured_fallback_chain(
+            "vision", "ollama-cloud", "unavailable")
+
+        assert client is fake_client
+        assert model == "vision-model"
+        assert label == "fallback_chain[0](custom)"
+
+    def test_fallback_entry_without_explicit_model_resolves_provider_default(
+        self, monkeypatch
+    ):
+        """A fallback_chain entry with only ``provider`` (no ``model``) should
+        still resolve through ``resolve_provider_client``, which returns the
+        provider's default auxiliary model as ``resolved_model``.
+        """
+        import agent.auxiliary_client as aux
+
+        fake_client = MagicMock(name="default_model_client")
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            lambda task: {
+                "fallback_chain": [
+                    {"provider": "openrouter"},
+                ]
+            },
+        )
+
+        def fake_resolve_provider_client(
+            provider,
+            model=None,
+            *,
+            explicit_base_url=None,
+            explicit_api_key=None,
+            api_mode=None,
+        ):
+            assert provider == "openrouter"
+            assert model is None
+            # resolve_provider_client resolves a default model from the
+            # provider profile when model is None.
+            return fake_client, "openrouter/auto/vision"
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client.resolve_provider_client",
+            fake_resolve_provider_client,
+        )
+
+        client, model, label = aux._try_configured_fallback_chain(
+            "vision", "ollama-cloud", "unavailable")
+
+        assert client is fake_client
+        assert model == "openrouter/auto/vision"
+        assert label == "fallback_chain[0](openrouter)"
+
+    def test_unavailable_explicit_vision_provider_uses_configured_fallback_chain(
+        self, monkeypatch
+    ):
+        """A missing explicit vision provider credential should use the
+        configured vision fallback_chain before the generic auto route.
+        """
+        fake_response = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content="fallback vision response")
+                )
+            ]
+        )
+        fake_client = MagicMock(name="fallback_client")
+        fake_client.chat.completions.create.return_value = fake_response
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            lambda task, provider=None, model=None, base_url=None, api_key=None:
+                ("ollama-cloud", "kimi-k2.6:cloud", None, None, None),
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client.resolve_vision_provider_client",
+            MagicMock(return_value=("ollama-cloud", None, None)),
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._try_configured_fallback_for_unavailable_client",
+            MagicMock(return_value=(
+                fake_client,
+                "nvidia/nemotron-nano-12b-v2-vl",
+                "fallback_chain[0](nvidia)",
+            )),
+        )
+
+        response = call_llm(
+            task="vision",
+            messages=[{"role": "user", "content": "describe image"}],
+            max_tokens=20,
+        )
+
+        assert response.choices[0].message.content == "fallback vision response"
+        fake_client.chat.completions.create.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_unavailable_explicit_vision_provider_uses_configured_fallback_chain_async(
+        self, monkeypatch
+    ):
+        """Async path: a missing explicit vision provider credential should use
+        the configured vision fallback_chain before the generic auto route.
+        """
+        fake_response = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content="async fallback vision response")
+                )
+            ]
+        )
+        fake_sync_client = MagicMock(name="fallback_sync_client")
+        fake_async_client = MagicMock(name="fallback_async_client")
+        fake_async_client.chat.completions.create = AsyncMock(
+            return_value=fake_response
+        )
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            lambda task, provider=None, model=None, base_url=None, api_key=None: (
+                "ollama-cloud",
+                "kimi-k2.6:cloud",
+                None,
+                None,
+                None,
+            ),
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client.resolve_vision_provider_client",
+            MagicMock(return_value=("ollama-cloud", None, None)),
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._try_configured_fallback_for_unavailable_client",
+            MagicMock(
+                return_value=(
+                    fake_sync_client,
+                    "nvidia/nemotron-nano-12b-v2-vl",
+                    "fallback_chain[0](nvidia)",
+                )
+            ),
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._to_async_client",
+            MagicMock(
+                return_value=(fake_async_client, "nvidia/nemotron-nano-12b-v2-vl")
+            ),
+        )
+
+        response = await async_call_llm(
+            task="vision",
+            messages=[{"role": "user", "content": "describe image"}],
+            max_tokens=20,
+        )
+
+        assert response.choices[0].message.content == "async fallback vision response"
+        fake_async_client.chat.completions.create.assert_awaited_once()
+
+
 class TestCodexAuxiliaryAdapterTimeout:
     def test_forwards_timeout_to_responses_create(self):
         message_item = SimpleNamespace(


### PR DESCRIPTION
## Summary
- pass fallback_chain endpoint overrides through resolve_provider_client using explicit_base_url / explicit_api_key
- make explicit vision-provider initialization failures try auxiliary.vision.fallback_chain before generic auto vision routing
- add regression coverage for custom endpoint fallback entries and unavailable explicit vision providers

## Tests
- /home/edu/workspace/hermes-agent/.venv/bin/python -m pytest -o addopts='' tests/agent/test_auxiliary_client.py::TestAuxiliaryFallbackLayering tests/agent/test_auxiliary_client.py::TestVisionFallbackChain -q
- /home/edu/workspace/hermes-agent/.venv/bin/python -m pytest -o addopts='' tests/agent/test_auxiliary_client.py -q

Note: addopts was disabled locally because this checkout's existing venv does not have the newly-added pytest-timeout plugin installed.