### PR TITLE
fix(tools): include review and scheduled in kanban_list status enum

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -234,6 +234,49 @@ def test_list_rejects_invalid_status(monkeypatch, worker_env):
     assert "status must be one of" in json.loads(out).get("error", "")
 
 
+def test_list_status_enum_matches_valid_statuses():
+    """The kanban_list status enum surfaced to the LLM must cover the full
+    set of statuses the kernel (and the CLI's --status) accepts. A strict
+    function-calling provider can only emit enum values, so any lane
+    missing here (previously 'review' and 'scheduled') is unreachable via
+    the tool even though list_tasks would accept it. This invariant fails
+    CI if a new lane is added to kb.VALID_STATUSES without updating the
+    schema.
+    """
+    from hermes_cli import kanban_db as kb
+    from tools.kanban_tools import KANBAN_LIST_SCHEMA
+
+    enum = KANBAN_LIST_SCHEMA["parameters"]["properties"]["status"]["enum"]
+    assert set(enum) == kb.VALID_STATUSES, (
+        f"status enum {sorted(enum)} drifted from "
+        f"VALID_STATUSES {sorted(kb.VALID_STATUSES)}"
+    )
+    # No duplicates slipped in.
+    assert len(enum) == len(set(enum)), f"duplicate status in enum: {enum}"
+
+
+def test_list_filters_review_status(monkeypatch, worker_env):
+    """A task in the 'review' lane is discoverable via the tool's status
+    filter. Regression: 'review' was missing from the schema enum, so
+    strict providers could never query this lane."""
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    from hermes_cli import kanban_db as kb
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="awaiting review", assignee="factory")
+        conn.execute("UPDATE tasks SET status='review' WHERE id=?", (tid,))
+        conn.commit()
+    finally:
+        conn.close()
+
+    from tools import kanban_tools as kt
+    out = kt._handle_list({"status": "review"})
+    d = json.loads(out)
+    ids = [t["id"] for t in d["tasks"]]
+    assert tid in ids
+    assert all(t["status"] == "review" for t in d["tasks"])
+
+
 def test_list_rejects_bad_limit(monkeypatch, worker_env):
     monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
     from tools import kanban_tools as kt

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -841,9 +841,15 @@ KANBAN_LIST_SCHEMA = {
             },
             "status": {
                 "type": "string",
+                # Must stay in sync with kb.VALID_STATUSES — the CLI's
+                # --status accepts the full set, so a strict
+                # function-calling provider must be able to emit every
+                # lane here too (e.g. 'review', 'scheduled'). The
+                # invariant is pinned by a test in
+                # tests/tools/test_kanban_tools.py.
                 "enum": [
-                    "triage", "todo", "ready", "running",
-                    "blocked", "done", "archived",
+                    "triage", "todo", "scheduled", "ready", "running",
+                    "blocked", "review", "done", "archived",
                 ],
                 "description": "Optional task status filter.",
             },


### PR DESCRIPTION
## What & why
The kanban_list tool schema advertised "the same core filters as the CLI"
but its status enum hardcoded only 7 of the 9 kb.VALID_STATUSES, omitting
"review" and "scheduled". Under strict function-calling providers a model
can only emit enumerated values, so orchestrators could never query those
two lanes via the tool even though list_tasks and the CLI's --status both
accept them.

## How to test
- scripts/run_tests.sh tests/tools/test_kanban_tools.py -q
- New: test_list_status_enum_matches_valid_statuses (invariant guard),
  test_list_filters_review_status (behavior).

