### PR TITLE
feat(cli/gateway): /dashboard slash command lists agent dashboard URLs

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7690,14 +7690,14 @@ class HermesCLI:
         handle_skills_slash(cmd, ChatConsole())
 
     def _handle_dashboard_command(self):
-        """List configured agent dashboard URLs (RFD-0002 §11)."""
+        """List configured agent dashboard URLs."""
         dash_cfg = (self.config.get("dashboard") or {}) if isinstance(self.config, dict) else {}
         hosts = dash_cfg.get("agent_hosts") or []
         if not hosts:
             print("  No agent hosts configured. Add to ~/.hermes/config.yaml under dashboard.agent_hosts.")
             return
         print()
-        print("  Agents Dashboards:")
+        print("  Agents Dashboard:")
         for host in hosts:
             name = host.get("name", "?") if isinstance(host, dict) else "?"
             url = host.get("url", "") if isinstance(host, dict) else ""

--- a/cli.py
+++ b/cli.py
@@ -7690,14 +7690,14 @@ class HermesCLI:
         handle_skills_slash(cmd, ChatConsole())
 
     def _handle_dashboard_command(self):
-        """List configured fleet dashboard URLs (RFD-0002 §11)."""
+        """List configured agent dashboard URLs (RFD-0002 §11)."""
         dash_cfg = (self.config.get("dashboard") or {}) if isinstance(self.config, dict) else {}
-        hosts = dash_cfg.get("fleet_hosts") or []
+        hosts = dash_cfg.get("agent_hosts") or []
         if not hosts:
-            print("  No fleet hosts configured. Add to ~/.hermes/config.yaml under dashboard.fleet_hosts.")
+            print("  No agent hosts configured. Add to ~/.hermes/config.yaml under dashboard.agent_hosts.")
             return
         print()
-        print("  Fleet Dashboards:")
+        print("  Agents Dashboards:")
         for host in hosts:
             name = host.get("name", "?") if isinstance(host, dict) else "?"
             url = host.get("url", "") if isinstance(host, dict) else ""

--- a/cli.py
+++ b/cli.py
@@ -7689,6 +7689,21 @@ class HermesCLI:
         from hermes_cli.skills_hub import handle_skills_slash
         handle_skills_slash(cmd, ChatConsole())
 
+    def _handle_dashboard_command(self):
+        """List configured fleet dashboard URLs (RFD-0002 §11)."""
+        dash_cfg = (self.config.get("dashboard") or {}) if isinstance(self.config, dict) else {}
+        hosts = dash_cfg.get("fleet_hosts") or []
+        if not hosts:
+            print("  No fleet hosts configured. Add to ~/.hermes/config.yaml under dashboard.fleet_hosts.")
+            return
+        print()
+        print("  Fleet Dashboards:")
+        for host in hosts:
+            name = host.get("name", "?") if isinstance(host, dict) else "?"
+            url = host.get("url", "") if isinstance(host, dict) else ""
+            print(f"    {name}: {url}")
+        print()
+
     def _show_gateway_status(self):
         """Show status of the gateway and connected messaging platforms."""
         from gateway.config import load_gateway_config, Platform
@@ -7974,6 +7989,8 @@ class HermesCLI:
                 self._handle_skills_command(cmd_original)
         elif canonical == "platforms":
             self._show_gateway_status()
+        elif canonical == "dashboard":
+            self._handle_dashboard_command()
         elif canonical == "status":
             self._show_session_status()
         elif canonical == "statusbar":

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9243,7 +9243,7 @@ class GatewayRunner:
         On Telegram (DM or group), emits an InlineKeyboardMarkup with one
         button per host (url buttons). On other platforms, falls back to a
         plain text list of URLs. Hosts read from CLI config key
-        ``dashboard.agent_hosts`` (RFD-0002 §11).
+        ``dashboard.agent_hosts``.
         """
         from hermes_cli.config import load_config as _load_cli_config
         try:
@@ -9273,7 +9273,7 @@ class GatewayRunner:
                     try:
                         await bot.send_message(
                             chat_id=int(source.chat_id),
-                            text="🚀 Agents Dashboards",
+                            text="🚀 Agents Dashboard",
                             reply_markup=keyboard,
                         )
                         return None  # already sent
@@ -9284,7 +9284,7 @@ class GatewayRunner:
                 pass
 
         # Text fallback (non-Telegram, or Telegram send failed)
-        lines = ["**Agents Dashboards:**"]
+        lines = ["**Agents Dashboard:**"]
         for h in hosts:
             name = h.get("name") or h.get("url")
             lines.append(f"• {name}: {h.get('url')}")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9238,12 +9238,12 @@ class GatewayRunner:
 
 
     async def _handle_dashboard_command(self, event: MessageEvent) -> Optional[str]:
-        """Handle /dashboard — list fleet dashboard URLs.
+        """Handle /dashboard — list agent dashboard URLs.
 
         On Telegram (DM or group), emits an InlineKeyboardMarkup with one
         button per host (url buttons). On other platforms, falls back to a
         plain text list of URLs. Hosts read from CLI config key
-        ``dashboard.fleet_hosts`` (RFD-0002 §11).
+        ``dashboard.agent_hosts`` (RFD-0002 §11).
         """
         from hermes_cli.config import load_config as _load_cli_config
         try:
@@ -9251,13 +9251,13 @@ class GatewayRunner:
         except Exception:
             _cfg = {}
         dash_cfg = (_cfg.get("dashboard") or {}) if isinstance(_cfg, dict) else {}
-        hosts_raw = dash_cfg.get("fleet_hosts") or []
+        hosts_raw = dash_cfg.get("agent_hosts") or []
         hosts: list[dict] = [h for h in hosts_raw if isinstance(h, dict) and h.get("url")]
 
         if not hosts:
             return (
-                "No fleet hosts configured. Add to ~/.hermes/config.yaml under "
-                "`dashboard.fleet_hosts` as a list of {name, url} entries."
+                "No agent hosts configured. Add to ~/.hermes/config.yaml under "
+                "`dashboard.agent_hosts` as a list of {name, url} entries."
             )
 
         source = event.source
@@ -9273,7 +9273,7 @@ class GatewayRunner:
                     try:
                         await bot.send_message(
                             chat_id=int(source.chat_id),
-                            text="🚀 Fleet Dashboards",
+                            text="🚀 Agents Dashboards",
                             reply_markup=keyboard,
                         )
                         return None  # already sent
@@ -9284,7 +9284,7 @@ class GatewayRunner:
                 pass
 
         # Text fallback (non-Telegram, or Telegram send failed)
-        lines = ["**Fleet Dashboards:**"]
+        lines = ["**Agents Dashboards:**"]
         for h in hosts:
             name = h.get("name") or h.get("url")
             lines.append(f"• {name}: {h.get('url')}")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1364,6 +1364,29 @@ def _preserve_queued_followup_history_offset(
     return merged
 
 
+def _build_dashboard_keyboard(hosts):
+    """Build an InlineKeyboardMarkup for /dashboard.
+
+    Returns None when ``hosts`` is empty, so callers can fall back to plain
+    text. Each host dict must have ``url``; ``name`` falls back to the url.
+    Imports ``telegram`` lazily so the gateway can run without it installed.
+    """
+    if not hosts:
+        return None
+    from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+    rows = [
+        [InlineKeyboardButton(
+            text=str(h.get("name") or h.get("url")),
+            url=str(h.get("url")),
+        )]
+        for h in hosts
+        if isinstance(h, dict) and h.get("url")
+    ]
+    if not rows:
+        return None
+    return InlineKeyboardMarkup(rows)
+
+
 class GatewayRunner:
     """
     Main gateway controller.
@@ -7160,6 +7183,9 @@ class GatewayRunner:
         if canonical == "platform":
             return await self._handle_platform_command(event)
 
+        if canonical == "dashboard":
+            return await self._handle_dashboard_command(event)
+
         if canonical == "restart":
             return await self._handle_restart_command(event)
         
@@ -9210,6 +9236,59 @@ class GatewayRunner:
             f"Slash commands you can run: {runnable_str}"
         )
 
+
+    async def _handle_dashboard_command(self, event: MessageEvent) -> Optional[str]:
+        """Handle /dashboard — list fleet dashboard URLs.
+
+        On Telegram (DM or group), emits an InlineKeyboardMarkup with one
+        button per host (url buttons). On other platforms, falls back to a
+        plain text list of URLs. Hosts read from CLI config key
+        ``dashboard.fleet_hosts`` (RFD-0002 §11).
+        """
+        from hermes_cli.config import load_config as _load_cli_config
+        try:
+            _cfg = _load_cli_config() or {}
+        except Exception:
+            _cfg = {}
+        dash_cfg = (_cfg.get("dashboard") or {}) if isinstance(_cfg, dict) else {}
+        hosts_raw = dash_cfg.get("fleet_hosts") or []
+        hosts: list[dict] = [h for h in hosts_raw if isinstance(h, dict) and h.get("url")]
+
+        if not hosts:
+            return (
+                "No fleet hosts configured. Add to ~/.hermes/config.yaml under "
+                "`dashboard.fleet_hosts` as a list of {name, url} entries."
+            )
+
+        source = event.source
+        is_telegram = source and source.platform == Platform.TELEGRAM
+        adapter = self.adapters.get(source.platform) if source else None
+
+        if is_telegram and adapter is not None:
+            try:
+                keyboard = _build_dashboard_keyboard(hosts)
+                # Use the underlying bot send_message to attach reply_markup.
+                bot = getattr(adapter, "_bot", None) if keyboard is not None else None
+                if bot is not None:
+                    try:
+                        await bot.send_message(
+                            chat_id=int(source.chat_id),
+                            text="🚀 Fleet Dashboards",
+                            reply_markup=keyboard,
+                        )
+                        return None  # already sent
+                    except Exception as _e:
+                        logger.warning("dashboard: telegram inline send failed: %s", _e)
+                        # Fall through to text reply.
+            except ImportError:
+                pass
+
+        # Text fallback (non-Telegram, or Telegram send failed)
+        lines = ["**Fleet Dashboards:**"]
+        for h in hosts:
+            name = h.get("name") or h.get("url")
+            lines.append(f"• {name}: {h.get('url')}")
+        return "\n".join(lines)
 
     async def _handle_kanban_command(self, event: MessageEvent) -> str:
         """Handle /kanban — delegate to the shared kanban CLI.

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -204,7 +204,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
                args_hint="[days]"),
     CommandDef("platforms", "Show gateway/messaging platform status", "Info",
                cli_only=True, aliases=("gateway",)),
-    CommandDef("dashboard", "List fleet dashboard URLs (Telegram: inline buttons)", "Info"),
+    CommandDef("dashboard", "List agent dashboard URLs (Telegram: inline buttons)", "Info"),
     CommandDef("platform", "Pause, resume, or list a failing gateway platform", "Info",
                gateway_only=True, args_hint="<pause|resume|list> [name]"),
     CommandDef("copy", "Copy the last assistant response to clipboard", "Info",

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -204,6 +204,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
                args_hint="[days]"),
     CommandDef("platforms", "Show gateway/messaging platform status", "Info",
                cli_only=True, aliases=("gateway",)),
+    CommandDef("dashboard", "List fleet dashboard URLs (Telegram: inline buttons)", "Info"),
     CommandDef("platform", "Pause, resume, or list a failing gateway platform", "Info",
                gateway_only=True, args_hint="<pause|resume|list> [name]"),
     CommandDef("copy", "Copy the last assistant response to clipboard", "Info",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1089,7 +1089,7 @@ DEFAULT_CONFIG = {
         # Set this to True to re-enable the surfaces with the understanding
         # that the numbers are a local lower-bound estimate, not billing.
         "show_token_analytics": False,
-        # List of {name, url} dicts surfaced by /dashboard slash command (RFD-0002 §11)
+        # List of {name, url} dicts surfaced by /dashboard slash command.
         "agent_hosts": [],
     },
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1090,7 +1090,7 @@ DEFAULT_CONFIG = {
         # that the numbers are a local lower-bound estimate, not billing.
         "show_token_analytics": False,
         # List of {name, url} dicts surfaced by /dashboard slash command (RFD-0002 §11)
-        "fleet_hosts": [],
+        "agent_hosts": [],
     },
 
     # Privacy settings

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1089,6 +1089,8 @@ DEFAULT_CONFIG = {
         # Set this to True to re-enable the surfaces with the understanding
         # that the numbers are a local lower-bound estimate, not billing.
         "show_token_analytics": False,
+        # List of {name, url} dicts surfaced by /dashboard slash command (RFD-0002 §11)
+        "fleet_hosts": [],
     },
 
     # Privacy settings

--- a/tests/gateway/test_dashboard_command.py
+++ b/tests/gateway/test_dashboard_command.py
@@ -1,0 +1,82 @@
+"""Unit tests for the /dashboard slash command helper.
+
+Exercises ``gateway.run._build_dashboard_keyboard`` — the pure helper that
+constructs the Telegram InlineKeyboardMarkup. Avoids spinning up a real
+Telegram client.
+
+Works against both the real python-telegram-bot package and the
+MagicMock stand-in installed by tests/gateway/conftest.py: we inject
+lightweight local fakes for ``InlineKeyboardButton`` /
+``InlineKeyboardMarkup`` into ``sys.modules['telegram']`` for the
+duration of each test so attribute round-tripping is observable.
+"""
+import sys
+import types
+
+import pytest
+
+pytest.importorskip("telegram")
+
+from gateway.run import _build_dashboard_keyboard  # noqa: E402
+
+
+class _FakeButton:
+    def __init__(self, *, text=None, url=None, **_):
+        self.text = text
+        self.url = url
+
+
+class _FakeMarkup:
+    def __init__(self, rows):
+        self.inline_keyboard = tuple(tuple(r) for r in rows)
+
+
+@pytest.fixture
+def fake_telegram(monkeypatch):
+    """Swap telegram.InlineKeyboardButton/Markup for local fakes.
+
+    Restored automatically via monkeypatch teardown — no cross-test
+    pollution of ``sys.modules``.
+    """
+    tg = sys.modules["telegram"]
+    monkeypatch.setattr(tg, "InlineKeyboardButton", _FakeButton, raising=False)
+    monkeypatch.setattr(tg, "InlineKeyboardMarkup", _FakeMarkup, raising=False)
+    yield
+
+
+def _flatten(kb):
+    rows = getattr(kb, "inline_keyboard", None)
+    assert rows is not None, "keyboard missing inline_keyboard attribute"
+    return [btn for row in rows for btn in row]
+
+
+def test_build_dashboard_keyboard_empty_returns_none():
+    # No telegram import needed — empty short-circuits.
+    assert _build_dashboard_keyboard([]) is None
+    assert _build_dashboard_keyboard(None) is None
+
+
+def test_build_dashboard_keyboard_with_hosts(fake_telegram):
+    hosts = [
+        {"name": "emma", "url": "https://x"},
+        {"name": "i7", "url": "https://y"},
+    ]
+    kb = _build_dashboard_keyboard(hosts)
+    assert isinstance(kb, _FakeMarkup)
+    buttons = _flatten(kb)
+    assert [b.text for b in buttons] == ["emma", "i7"]
+    assert [b.url for b in buttons] == ["https://x", "https://y"]
+
+
+def test_build_dashboard_keyboard_skips_invalid_entries(fake_telegram):
+    hosts = [
+        {"name": "ok", "url": "https://ok"},
+        {"name": "no-url"},  # missing url -> skipped
+        "not-a-dict",         # wrong type -> skipped
+    ]
+    kb = _build_dashboard_keyboard(hosts)
+    assert isinstance(kb, _FakeMarkup)
+    buttons = _flatten(kb)
+    assert len(buttons) == 1
+    assert buttons[0].text == "ok"
+    assert buttons[0].url == "https://ok"

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -87,6 +87,13 @@ class TestCommandRegistry:
             assert not (cmd.cli_only and cmd.gateway_only), \
                 f"{cmd.name} cannot be both cli_only and gateway_only"
 
+    def test_dashboard_command_registered(self):
+        names = [c.name for c in COMMAND_REGISTRY]
+        assert "dashboard" in names, "dashboard command missing from registry"
+        cmd = next(c for c in COMMAND_REGISTRY if c.name == "dashboard")
+        assert cmd.category == "Info"
+        assert resolve_command("dashboard").name == "dashboard"
+
 
 # ---------------------------------------------------------------------------
 # resolve_command tests


### PR DESCRIPTION
## Summary
Adds a `/dashboard` slash command driven by `dashboard.agent_hosts` in `~/.hermes/config.yaml`.

- CLI (`cli.py::_handle_dashboard_command`): prints `name: url` lines, friendly empty-state.
- Gateway (`gateway/run.py::_handle_dashboard_command` + `_build_dashboard_keyboard`): on Telegram emits `InlineKeyboardMarkup` (one URL button per host); Markdown list fallback for other platforms.
- Config default: `dashboard.agent_hosts: []` (`hermes_cli/config.py`).
- Registered in `COMMAND_REGISTRY` (`hermes_cli/commands.py`).

Terminology is **agents dashboard** (not fleet dashboard) — the thing aggregated is each per-agent UI, not host metrics.

Design context: <https://github.com/qike-ms/hive/blob/main/docs/fleet-orchestration/hermes-hub-spoke-design.md> (Agents Dashboard, Stage 2).

## Test Plan
- `tests/gateway/test_dashboard_command.py` covers the keyboard helper (empty → None, valid entries → buttons with text+url, invalid entries skipped).
- `tests/hermes_cli/test_commands.py` asserts registry membership + category + alias resolution.
- Full file suites: `147 passed in 3.11s` on m5.

Trio-reviewed by codex / claude / opencode against the diff; terminology consolidated to `agent_hosts` / "Agents Dashboard" before push.

Closes #29095
