### PR TITLE
feat(kanban): auto-subscribe on task creation + rerun command + parent workspace

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -341,6 +341,14 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                                "two retries. Omit to use the dispatcher's "
                                "kanban.failure_limit config "
                                f"(default {kb.DEFAULT_FAILURE_LIMIT}).")
+    p_create.add_argument("--subscribe-platform", default=None,
+                          help="Auto-subscribe task notifications for this platform")
+    p_create.add_argument("--subscribe-chat-id", default=None,
+                          help="Chat ID for the notification subscription")
+    p_create.add_argument("--subscribe-thread-id", default=None,
+                          help="Optional thread/topic ID for the notification subscription")
+    p_create.add_argument("--subscribe-user-id", default=None,
+                          help="Optional user ID for the notification subscription")
     p_create.add_argument("--initial-status",
                           choices=sorted(kb.VALID_INITIAL_STATUSES),
                           default="running",
@@ -549,6 +557,13 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
 
     p_unblock = sub.add_parser("unblock", help="Return one or more blocked/scheduled tasks to ready")
     p_unblock.add_argument("task_ids", nargs="+")
+
+    p_rerun = sub.add_parser("rerun", help="Reset a completed/blocked task for another attempt")
+    p_rerun.add_argument("task_id")
+    p_rerun.add_argument("--reason", default=None,
+                         help="Optional reason recorded on the rerun event")
+    p_rerun.add_argument("--reassign-to", dest="new_assignee", default=None,
+                         help="Optional assignee profile to use for the rerun")
 
     p_archive = sub.add_parser("archive", help="Archive one or more tasks")
     p_archive.add_argument("task_ids", nargs="*",
@@ -899,6 +914,7 @@ def kanban_command(args: argparse.Namespace) -> int:
         "block":    _cmd_block,
         "schedule": _cmd_schedule,
         "unblock":  _cmd_unblock,
+        "rerun":    _cmd_rerun,
         "archive":  _cmd_archive,
         "tail":     _cmd_tail,
         "dispatch": _cmd_dispatch,
@@ -1286,6 +1302,26 @@ def _cmd_create(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 2
+    subscribe = None
+    sub_platform = (getattr(args, "subscribe_platform", None) or "").strip()
+    sub_chat_id = (getattr(args, "subscribe_chat_id", None) or "").strip()
+    sub_thread_id = (getattr(args, "subscribe_thread_id", None) or "").strip()
+    sub_user_id = (getattr(args, "subscribe_user_id", None) or "").strip()
+    if any((sub_platform, sub_chat_id, sub_thread_id, sub_user_id)):
+        if not sub_platform or not sub_chat_id:
+            print(
+                "kanban: --subscribe-platform and --subscribe-chat-id must be passed together",
+                file=sys.stderr,
+            )
+            return 2
+        subscribe = {
+            "platform": sub_platform,
+            "chat_id": sub_chat_id,
+        }
+        if sub_thread_id:
+            subscribe["thread_id"] = sub_thread_id
+        if sub_user_id:
+            subscribe["user_id"] = sub_user_id
     with kb.connect() as conn:
         task_id = kb.create_task(
             conn,
@@ -1304,6 +1340,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             max_runtime_seconds=max_runtime,
             skills=getattr(args, "skills", None) or None,
             max_retries=max_retries,
+            subscribe=subscribe,
             initial_status=getattr(args, "initial_status", "running"),
         )
         task = kb.get_task(conn, task_id)
@@ -1953,6 +1990,26 @@ def _cmd_unblock(args: argparse.Namespace) -> int:
             else:
                 print(f"Unblocked {tid}")
     return 0 if not failed else 1
+
+
+def _cmd_rerun(args: argparse.Namespace) -> int:
+    with kb.connect() as conn:
+        ok = kb.rerun_task(
+            conn,
+            args.task_id,
+            reason=getattr(args, "reason", None),
+            new_assignee=getattr(args, "new_assignee", None),
+        )
+        if not ok:
+            print(
+                f"cannot rerun {args.task_id} (not completed/blocked/archived?)",
+                file=sys.stderr,
+            )
+            return 1
+        task = kb.get_task(conn, args.task_id)
+    status = task.status if task else "?"
+    print(f"Rerun {args.task_id} ({status})")
+    return 0
 
 
 def _cmd_archive(args: argparse.Namespace) -> int:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1356,6 +1356,7 @@ def create_task(
     max_runtime_seconds: Optional[int] = None,
     skills: Optional[Iterable[str]] = None,
     max_retries: Optional[int] = None,
+    subscribe: Optional[dict] = None,
     initial_status: str = "running",
     session_id: Optional[str] = None,
     board: Optional[str] = None,
@@ -1383,6 +1384,13 @@ def create_task(
     ``kanban-worker``. Use this to pin a task to a specialist skill
     (e.g. ``skills=["translation"]`` so the worker loads the
     translation skill regardless of the profile's default config).
+
+    ``subscribe`` optionally creates a notification subscription in the
+    same write transaction as the task row. Expected keys: ``platform``
+    and ``chat_id`` (required), plus optional ``thread_id`` and
+    ``user_id``. When ``subscribe`` is omitted, the gateway-provided
+    ``HERMES_NOTIFY_PLATFORM`` / ``HERMES_NOTIFY_CHAT_ID`` env vars are
+    used as a best-effort fallback.
     """
     assignee = _canonical_assignee(assignee)
     if not title or not title.strip():
@@ -1473,6 +1481,33 @@ def create_task(
         if board_default:
             workspace_path = str(board_default)
 
+    resolved_subscribe: Optional[dict[str, str]] = None
+    if not subscribe:
+        sub_platform = os.environ.get("HERMES_NOTIFY_PLATFORM")
+        sub_chat_id = os.environ.get("HERMES_NOTIFY_CHAT_ID")
+        if sub_platform and sub_chat_id:
+            subscribe = {
+                "platform": sub_platform,
+                "chat_id": sub_chat_id,
+            }
+            sub_thread = os.environ.get("HERMES_NOTIFY_THREAD_ID")
+            if sub_thread:
+                subscribe["thread_id"] = sub_thread
+    if isinstance(subscribe, dict):
+        platform = str(subscribe.get("platform") or "").strip()
+        chat_id = str(subscribe.get("chat_id") or "").strip()
+        if platform and chat_id:
+            resolved_subscribe = {
+                "platform": platform,
+                "chat_id": chat_id,
+            }
+            thread_id = str(subscribe.get("thread_id") or "").strip()
+            if thread_id:
+                resolved_subscribe["thread_id"] = thread_id
+            user_id = str(subscribe.get("user_id") or "").strip()
+            if user_id:
+                resolved_subscribe["user_id"] = user_id
+
     # Retry once on the extremely unlikely id collision.
     for attempt in range(2):
         task_id = _new_task_id()
@@ -1557,6 +1592,15 @@ def create_task(
                         "skills": list(skills_list) if skills_list else None,
                     },
                 )
+                if resolved_subscribe:
+                    add_notify_sub(
+                        conn,
+                        task_id=task_id,
+                        platform=resolved_subscribe["platform"],
+                        chat_id=resolved_subscribe["chat_id"],
+                        thread_id=resolved_subscribe.get("thread_id"),
+                        user_id=resolved_subscribe.get("user_id"),
+                    )
             return task_id
         except sqlite3.IntegrityError:
             if attempt == 1:
@@ -3083,6 +3127,119 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
             conn, task_id, "unblocked",
             {"status": new_status} if new_status != "ready" else None,
         )
+        return True
+
+
+def _parent_counts_as_done_for_rerun(
+    conn: sqlite3.Connection,
+    parent_id: str,
+) -> bool:
+    """Return True when ``parent_id`` should satisfy rerun parent gates."""
+    row = conn.execute(
+        "SELECT status FROM tasks WHERE id = ?",
+        (parent_id,),
+    ).fetchone()
+    if row is None:
+        return False
+    status = row["status"]
+    if status in ("done", "archived"):
+        return True
+    if status != "blocked":
+        return False
+    event = conn.execute(
+        "SELECT kind, payload FROM task_events "
+        "WHERE task_id = ? AND kind IN ('blocked', 'unblocked') "
+        "ORDER BY id DESC LIMIT 1",
+        (parent_id,),
+    ).fetchone()
+    if not event or event["kind"] != "blocked" or not event["payload"]:
+        return False
+    try:
+        payload = json.loads(event["payload"])
+    except Exception:
+        payload = None
+    reason = payload.get("reason") if isinstance(payload, dict) else None
+    return isinstance(reason, str) and reason.startswith("review-required")
+
+
+def rerun_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    reason: Optional[str] = None,
+    new_assignee: Optional[str] = None,
+) -> bool:
+    """Reset a completed/blocked task to ready for another attempt.
+
+    Clears claim state, the active run pointer, and the failure counter.
+    Parent gates are re-evaluated: undone parents send the task to
+    ``todo``; ``review-required`` blocked parents count as satisfied for
+    this rerun decision.
+
+    Returns True when the task was reset, False when the task is not in
+    a rerunnable state.
+    """
+    with write_txn(conn):
+        task = get_task(conn, task_id)
+        if not task:
+            return False
+        if task.status not in ("done", "blocked", "archived", "gave_up"):
+            return False
+
+        parent_rows = conn.execute(
+            "SELECT parent_id FROM task_links WHERE child_id = ? ORDER BY parent_id",
+            (task_id,),
+        ).fetchall()
+        new_status = "ready"
+        for row in parent_rows:
+            if not _parent_counts_as_done_for_rerun(conn, row["parent_id"]):
+                new_status = "todo"
+                break
+
+        # Defensive invariant recovery: terminal tasks should not carry
+        # an open run pointer, but clear it safely if some external path
+        # leaked one.
+        if task.current_run_id is not None:
+            _end_run(
+                conn,
+                task_id,
+                outcome="reclaimed",
+                status="reclaimed",
+                summary="invariant recovery on rerun",
+            )
+
+        assignee = _canonical_assignee(new_assignee) if new_assignee is not None else task.assignee
+        cur = conn.execute(
+            """
+            UPDATE tasks
+               SET assignee             = ?,
+                   status               = ?,
+                   started_at           = NULL,
+                   completed_at         = NULL,
+                   claim_lock           = NULL,
+                   claim_expires        = NULL,
+                   worker_pid           = NULL,
+                   last_heartbeat_at    = NULL,
+                   consecutive_failures = 0,
+                   last_failure_error   = NULL,
+                   current_run_id       = NULL
+             WHERE id = ?
+            """,
+            (assignee, new_status, task_id),
+        )
+        if cur.rowcount != 1:
+            return False
+        _append_event(
+            conn,
+            task_id,
+            "rerun",
+            {
+                "reason": reason,
+                "status": new_status,
+                "assignee": assignee,
+            },
+        )
+        conn.execute("DELETE FROM kanban_notify_subs WHERE task_id = ?", (task_id,))
         return True
 
 
@@ -5581,6 +5738,8 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
                     body_lines.append(f"_metadata_: `{_cap(meta_str)}`")
                 except Exception:
                     pass
+            if pt.workspace_path:
+                body_lines.append(f"_Workspace_: `{pt.workspace_path}`")
             lines.extend(body_lines)
             lines.append("")
 
@@ -5745,8 +5904,8 @@ def add_notify_sub(
 ) -> None:
     """Register a gateway source that wants terminal-state notifications
     for ``task_id``. Idempotent on (task, platform, chat, thread)."""
-    now = int(time.time())
-    with write_txn(conn):
+    def _write() -> None:
+        now = int(time.time())
         conn.execute(
             """
             INSERT OR IGNORE INTO kanban_notify_subs
@@ -5767,6 +5926,12 @@ def add_notify_sub(
                 """,
                 (notifier_profile, task_id, platform, chat_id, thread_id or ""),
             )
+
+    if conn.in_transaction:
+        _write()
+        return
+    with write_txn(conn):
+        _write()
 
 
 def list_notify_subs(

--- a/tests/hermes_cli/test_kanban_fixes_p1_p6.py
+++ b/tests/hermes_cli/test_kanban_fixes_p1_p6.py
@@ -1,0 +1,239 @@
+"""Targeted regressions for kanban auto-subscribe and rerun fixes."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_conn(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> sqlite3.Connection:
+    """Fresh in-memory kanban DB with an isolated Hermes home."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    conn = sqlite3.connect(":memory:", isolation_level=None)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys=ON")
+    conn.executescript(kb.SCHEMA_SQL)
+    kb._migrate_add_optional_columns(conn)
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+def test_create_task_with_subscribe_creates_notification_subscription(
+    kanban_conn: sqlite3.Connection,
+) -> None:
+    tid = kb.create_task(
+        kanban_conn,
+        title="subscribed task",
+        assignee="alice",
+        subscribe={
+            "platform": "telegram",
+            "chat_id": "chat-1",
+            "thread_id": "thread-7",
+            "user_id": "user-9",
+        },
+    )
+
+    subs = kb.list_notify_subs(kanban_conn, task_id=tid)
+    assert len(subs) == 1
+    assert subs[0]["platform"] == "telegram"
+    assert subs[0]["chat_id"] == "chat-1"
+    assert subs[0]["thread_id"] == "thread-7"
+    assert subs[0]["user_id"] == "user-9"
+
+
+def test_create_task_without_subscribe_does_not_create_notification_subscription(
+    kanban_conn: sqlite3.Connection,
+) -> None:
+    tid = kb.create_task(kanban_conn, title="plain task", assignee="alice")
+
+    assert kb.list_notify_subs(kanban_conn, task_id=tid) == []
+
+
+def test_create_task_auto_subscribes_from_notification_env(
+    kanban_conn: sqlite3.Connection,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HERMES_NOTIFY_PLATFORM", "discord")
+    monkeypatch.setenv("HERMES_NOTIFY_CHAT_ID", "channel-42")
+    monkeypatch.setenv("HERMES_NOTIFY_THREAD_ID", "topic-11")
+
+    tid = kb.create_task(kanban_conn, title="env-subscribed", assignee="alice")
+
+    subs = kb.list_notify_subs(kanban_conn, task_id=tid)
+    assert len(subs) == 1
+    assert subs[0]["platform"] == "discord"
+    assert subs[0]["chat_id"] == "channel-42"
+    assert subs[0]["thread_id"] == "topic-11"
+
+
+def test_rerun_resets_completed_task_to_ready(kanban_conn: sqlite3.Connection) -> None:
+    tid = kb.create_task(kanban_conn, title="done task", assignee="alice")
+    assert kb.claim_task(kanban_conn, tid) is not None
+    assert kb.complete_task(kanban_conn, tid, result="first pass")
+
+    assert kb.rerun_task(kanban_conn, tid, reason="second pass")
+
+    task = kb.get_task(kanban_conn, tid)
+    assert task is not None
+    assert task.status == "ready"
+    assert task.claim_lock is None
+    assert task.current_run_id is None
+    assert task.completed_at is None
+    assert task.consecutive_failures == 0
+    events = kb.list_events(kanban_conn, tid)
+    assert events[-1].kind == "rerun"
+    assert events[-1].payload["reason"] == "second pass"
+
+
+def test_rerun_resets_blocked_task(kanban_conn: sqlite3.Connection) -> None:
+    tid = kb.create_task(kanban_conn, title="blocked task", assignee="alice")
+    assert kb.claim_task(kanban_conn, tid) is not None
+    assert kb.block_task(kanban_conn, tid, reason="waiting on review")
+    kanban_conn.execute(
+        "UPDATE tasks SET consecutive_failures = 3, last_failure_error = 'boom' WHERE id = ?",
+        (tid,),
+    )
+
+    assert kb.rerun_task(kanban_conn, tid, reason="retry after review")
+
+    task = kb.get_task(kanban_conn, tid)
+    assert task is not None
+    assert task.status == "ready"
+    assert task.consecutive_failures == 0
+    assert task.last_failure_error is None
+
+
+def test_rerun_respects_parent_gates(kanban_conn: sqlite3.Connection) -> None:
+    parent = kb.create_task(kanban_conn, title="parent", assignee="lead")
+    child = kb.create_task(
+        kanban_conn,
+        title="child",
+        assignee="worker",
+        parents=[parent],
+    )
+    assert kb.claim_task(kanban_conn, parent) is not None
+    assert kb.complete_task(kanban_conn, parent, result="ready child")
+    assert kb.claim_task(kanban_conn, child) is not None
+    assert kb.complete_task(kanban_conn, child, result="child complete")
+
+    kanban_conn.execute("UPDATE tasks SET status = 'ready' WHERE id = ?", (parent,))
+
+    assert kb.rerun_task(kanban_conn, child, reason="parent reopened")
+
+    task = kb.get_task(kanban_conn, child)
+    assert task is not None
+    assert task.status == "todo"
+
+
+def test_rerun_can_reassign_task(kanban_conn: sqlite3.Connection) -> None:
+    tid = kb.create_task(kanban_conn, title="reassign me", assignee="alice")
+    assert kb.claim_task(kanban_conn, tid) is not None
+    assert kb.complete_task(kanban_conn, tid, result="done")
+
+    assert kb.rerun_task(kanban_conn, tid, new_assignee="bob")
+
+    task = kb.get_task(kanban_conn, tid)
+    assert task is not None
+    assert task.assignee == "bob"
+    assert task.status == "ready"
+
+
+@pytest.mark.parametrize(
+    ("initial_setup", "expected_status"),
+    [
+        ("ready", "ready"),
+        ("running", "running"),
+        ("todo", "todo"),
+    ],
+)
+def test_rerun_rejects_non_terminal_tasks(
+    kanban_conn: sqlite3.Connection,
+    initial_setup: str,
+    expected_status: str,
+) -> None:
+    if initial_setup == "todo":
+        parent = kb.create_task(kanban_conn, title="parent", assignee="lead")
+        tid = kb.create_task(
+            kanban_conn,
+            title="todo child",
+            assignee="worker",
+            parents=[parent],
+        )
+    else:
+        tid = kb.create_task(kanban_conn, title=f"{initial_setup} task", assignee="alice")
+        if initial_setup == "running":
+            assert kb.claim_task(kanban_conn, tid) is not None
+
+    assert not kb.rerun_task(kanban_conn, tid, reason="should fail")
+    assert kb.get_task(kanban_conn, tid).status == expected_status
+
+
+def test_rerun_clears_notify_subscriptions(kanban_conn: sqlite3.Connection) -> None:
+    tid = kb.create_task(
+        kanban_conn,
+        title="notify me",
+        assignee="alice",
+        subscribe={"platform": "telegram", "chat_id": "chat-9"},
+    )
+    assert kb.claim_task(kanban_conn, tid) is not None
+    assert kb.complete_task(kanban_conn, tid, result="done")
+    assert kb.list_notify_subs(kanban_conn, task_id=tid)
+
+    assert kb.rerun_task(kanban_conn, tid, reason="fresh attempt")
+
+    assert kb.list_notify_subs(kanban_conn, task_id=tid) == []
+
+
+def test_build_worker_context_includes_parent_workspace_path(
+    kanban_conn: sqlite3.Connection,
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "parent-workspace"
+    workspace.mkdir()
+
+    parent = kb.create_task(
+        kanban_conn,
+        title="parent",
+        assignee="researcher",
+        workspace_kind="dir",
+        workspace_path=str(workspace),
+    )
+    assert kb.claim_task(kanban_conn, parent) is not None
+    assert kb.complete_task(kanban_conn, parent, result="parent result")
+    child = kb.create_task(
+        kanban_conn,
+        title="child",
+        assignee="writer",
+        parents=[parent],
+    )
+
+    ctx = kb.build_worker_context(kanban_conn, child)
+    assert f"_Workspace_: `{workspace}`" in ctx
+
+
+def test_build_worker_context_omits_parent_workspace_when_absent(
+    kanban_conn: sqlite3.Connection,
+) -> None:
+    parent = kb.create_task(kanban_conn, title="parent", assignee="researcher")
+    assert kb.claim_task(kanban_conn, parent) is not None
+    assert kb.complete_task(kanban_conn, parent, result="parent result")
+    child = kb.create_task(
+        kanban_conn,
+        title="child",
+        assignee="writer",
+        parents=[parent],
+    )
+
+    ctx = kb.build_worker_context(kanban_conn, child)
+    assert "_Workspace_:" not in ctx

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -668,6 +668,40 @@ def _handle_create(args: dict, **kw) -> str:
     max_runtime_seconds = args.get("max_runtime_seconds")
     initial_status = args.get("initial_status") or "running"
     skills = args.get("skills")
+    subscribe = args.get("subscribe")
+    if subscribe is not None and not isinstance(subscribe, dict):
+        return tool_error(
+            f"subscribe must be an object with platform/chat_id, got {type(subscribe).__name__}"
+        )
+    if isinstance(subscribe, dict):
+        platform = str(subscribe.get("platform") or "").strip()
+        chat_id = str(subscribe.get("chat_id") or "").strip()
+        if not platform or not chat_id:
+            return tool_error(
+                "subscribe.platform and subscribe.chat_id are required when subscribe is provided"
+            )
+        normalized_subscribe: dict[str, str] = {
+            "platform": platform,
+            "chat_id": chat_id,
+        }
+        thread_id = str(subscribe.get("thread_id") or "").strip()
+        if thread_id:
+            normalized_subscribe["thread_id"] = thread_id
+        user_id = str(subscribe.get("user_id") or "").strip()
+        if user_id:
+            normalized_subscribe["user_id"] = user_id
+        subscribe = normalized_subscribe
+    elif not subscribe:
+        sub_platform = os.environ.get("HERMES_NOTIFY_PLATFORM")
+        sub_chat_id = os.environ.get("HERMES_NOTIFY_CHAT_ID")
+        if sub_platform and sub_chat_id:
+            subscribe = {
+                "platform": sub_platform,
+                "chat_id": sub_chat_id,
+            }
+            sub_thread = os.environ.get("HERMES_NOTIFY_THREAD_ID")
+            if sub_thread:
+                subscribe["thread_id"] = sub_thread
     if isinstance(skills, str):
         # Accept a single skill name as a string for convenience.
         skills = [skills]
@@ -702,6 +736,7 @@ def _handle_create(args: dict, **kw) -> str:
                     if max_runtime_seconds is not None else None
                 ),
                 skills=skills,
+                subscribe=subscribe,
                 initial_status=str(initial_status),
                 created_by=os.environ.get("HERMES_PROFILE") or "worker",
                 session_id=session_id,
@@ -1165,6 +1200,36 @@ KANBAN_CREATE_SCHEMA = {
                     "The names must match skills installed on the "
                     "assignee's profile."
                 ),
+            },
+            "subscribe": {
+                "type": "object",
+                "description": (
+                    "Optional notification subscription to create "
+                    "alongside the task. When omitted, the tool falls "
+                    "back to HERMES_NOTIFY_PLATFORM, "
+                    "HERMES_NOTIFY_CHAT_ID, and "
+                    "HERMES_NOTIFY_THREAD_ID when those gateway env "
+                    "vars are present."
+                ),
+                "properties": {
+                    "platform": {
+                        "type": "string",
+                        "description": "Platform name such as telegram, discord, or feishu.",
+                    },
+                    "chat_id": {
+                        "type": "string",
+                        "description": "Chat or channel id for the subscription.",
+                    },
+                    "thread_id": {
+                        "type": "string",
+                        "description": "Optional thread or topic id for threaded platforms.",
+                    },
+                    "user_id": {
+                        "type": "string",
+                        "description": "Optional user id for per-user notification flows.",
+                    },
+                },
+                "required": ["platform", "chat_id"],
             },
             "board": _board_schema_prop(),
         },


### PR DESCRIPTION
## Summary

Implements two kanban features that were previously submitted in PR #28331 (now closed after upstream sync). This PR is a clean re-implementation against the latest upstream/main with updated code.

## Changes

### Feature 1: Auto-subscribe on task creation (P1)
- `create_task()` now accepts an optional `subscribe` dict parameter
- When provided, a `kanban_notify_subs` row is created in the same write transaction
- CLI: `hermes kanban create --subscribe-platform/--chat-id/--thread-id/--user-id`
- Agent tool: `kanban_create` supports a `subscribe` parameter, auto-detects from `HERMES_NOTIFY_PLATFORM/CHAT_ID/THREAD_ID` env vars set by the gateway

### Feature 2: Rerun command + parent workspace (P5, P6)
- `rerun_task()` resets completed/blocked/gave_up tasks to `ready` (or `todo` if parent gates aren't satisfied)
- Clears claim state, failure counter, current run pointer, and notification subscriptions
- CLI: `hermes kanban rerun <task_id> [--reason] [--reassign-to]`
- Parent `workspace_path` is now displayed in `build_worker_context()` parent results section

### Not included
- P2 (review-required promotion): upstream already has a better solution via sticky blocks (#28712)
- P3 (auto-dispatch after unblock): handled by upstream's existing recompute_ready mechanism

## Testing
- 13 new tests covering both features (subscribe create/omit/env, rerun lifecycle/reassign/parent-gate/non-terminal/notify-clear, workspace context)
- 158 existing kanban DB tests all pass (no regressions)
- Tests run via: `pytest tests/hermes_cli/test_kanban_fixes_p1_p6.py` and `pytest tests/hermes_cli/test_kanban_db.py`

## Files changed
- `hermes_cli/kanban_db.py`: +169 lines (subscribe in create_task, rerun_task, parent workspace in build_worker_context, nested-txn-safe add_notify_sub)
- `hermes_cli/kanban.py`: +57 lines (CLI flags for subscribe, rerun subcommand)
- `tools/kanban_tools.py`: +65 lines (subscribe in kanban_create tool schema and handler)
- `tests/hermes_cli/test_kanban_fixes_p1_p6.py`: 239 lines (13 tests)