### PR TITLE
fix(001): hide api-only dashboard plugin fixture

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4044,6 +4044,16 @@ async def set_dashboard_theme(body: ThemeSetBody):
 # Dashboard plugin system
 # ---------------------------------------------------------------------------
 
+def _dashboard_plugin_has_frontend_asset(plugin: Dict[str, Any]) -> bool:
+    entry = plugin.get("entry")
+    if not isinstance(entry, str) or not entry.strip():
+        return False
+
+    base = Path(plugin["_dir"]).resolve()
+    target = (base / entry).resolve()
+    return target.is_relative_to(base) and target.is_file()
+
+
 def _discover_dashboard_plugins() -> list:
     """Scan plugins/*/dashboard/manifest.json for dashboard extensions.
 
@@ -4136,10 +4146,18 @@ def _get_dashboard_plugins(force_rescan: bool = False) -> list:
     return _dashboard_plugins_cache
 
 
+def _get_frontend_dashboard_plugins(force_rescan: bool = False) -> list:
+    return [
+        plugin
+        for plugin in _get_dashboard_plugins(force_rescan=force_rescan)
+        if _dashboard_plugin_has_frontend_asset(plugin)
+    ]
+
+
 @app.get("/api/dashboard/plugins")
 async def get_dashboard_plugins():
     """Return discovered dashboard plugins (excludes user-hidden ones)."""
-    plugins = _get_dashboard_plugins()
+    plugins = _get_frontend_dashboard_plugins()
     # Read user's hidden plugins list from config.
     config = load_config()
     hidden: list = cfg_get(config, "dashboard", "hidden_plugins", default=[]) or []
@@ -4154,7 +4172,7 @@ async def get_dashboard_plugins():
 @app.get("/api/dashboard/plugins/rescan")
 async def rescan_dashboard_plugins():
     """Force re-scan of dashboard plugins."""
-    plugins = _get_dashboard_plugins(force_rescan=True)
+    plugins = _get_frontend_dashboard_plugins(force_rescan=True)
     return {"ok": True, "count": len(plugins)}
 
 
@@ -4181,7 +4199,7 @@ def _merged_plugins_hub() -> Dict[str, Any]:
         _read_manifest as _read_plugin_manifest_at,
     )
 
-    dashboard_list = _get_dashboard_plugins()
+    dashboard_list = _get_frontend_dashboard_plugins()
     dash_by_name = {str(p["name"]): p for p in dashboard_list}
 
     disabled_set = _get_disabled_set()

--- a/plugins/example-dashboard/dashboard/manifest.json
+++ b/plugins/example-dashboard/dashboard/manifest.json
@@ -1,14 +1,14 @@
 {
   "name": "example",
   "label": "Example",
-  "description": "Example dashboard plugin — used by test suite for auth coverage",
+  "description": "Backend-only test fixture used by the auth coverage suite",
   "icon": "Sparkles",
   "version": "1.0.0",
   "tab": {
     "path": "/example",
-    "position": "after:skills"
+    "hidden": true
   },
   "slots": [],
-  "entry": "dist/index.js",
+  "entry": null,
   "api": "plugin_api.py"
 }

--- a/plugins/example-dashboard/dashboard/plugin_api.py
+++ b/plugins/example-dashboard/dashboard/plugin_api.py
@@ -1,9 +1,10 @@
-"""Example dashboard plugin — backend API routes.
+"""Backend-only example dashboard plugin API routes.
 
 Mounted at /api/plugins/example/ by the dashboard plugin system.
 
 This minimal plugin exists so the test suite has a stable, side-effect-free
-GET endpoint to verify that plugin API routes work with auth.
+GET endpoint to verify that plugin API routes work with auth. It intentionally
+does not ship a frontend bundle or sidebar tab.
 """
 
 from fastapi import APIRouter

--- a/specs/001-example-dashboard-plugin-discovery/audit-trail.md
+++ b/specs/001-example-dashboard-plugin-discovery/audit-trail.md
@@ -1,0 +1,48 @@
+# Audit Trail: 001-example-dashboard-plugin-discovery
+
+## Phase 0: Trigger
+
+- Started: 2026-05-20T04:25:00Z
+- Gate Result: PASS
+- Artifacts: micro-constitution.md
+
+## Phase 1: Spequafy
+
+- Gate Result: PASS
+- Artifacts: problems.md, spec.md, checklists/requirements.md
+
+## Phase 2: Clarify
+
+- Gate Result: PASS
+- Decision: The bundled example plugin is backend-only because its API module
+  describes test-suite auth coverage and no UI bundle exists.
+
+## Phase 3: Research
+
+- Gate Result: PASS
+- Artifacts: research.md
+
+## Phase 4: Plan
+
+- Gate Result: PASS
+- Artifacts: plan.md
+
+## Phase 5: Tasks
+
+- Gate Result: PASS
+- Artifacts: tasks.md
+
+## Phase 6: Implement
+
+- Gate Result: PASS
+- Artifacts: code, docs, tests
+
+## Phase 7: Review
+
+- Gate Result: PASS
+- Local checks:
+  - `git diff --check` PASS
+  - `/Users/shawnowen/.hermes/hermes-agent/venv/bin/python -m ruff check hermes_cli/web_server.py tests/test_project_metadata.py tests/hermes_cli/test_web_server.py` PASS
+  - `scripts/run_tests.sh tests/test_project_metadata.py tests/hermes_cli/test_web_server.py::TestDashboardPluginManifestExtensions tests/hermes_cli/test_web_server.py::TestPluginAPIAuth` PASS, 20 tests
+  - `scripts/run_tests.sh tests/test_project_metadata.py tests/hermes_cli/test_web_server.py` PASS, 153 tests
+- Completed: 2026-05-20T04:42:52Z

--- a/specs/001-example-dashboard-plugin-discovery/checklists/requirements.md
+++ b/specs/001-example-dashboard-plugin-discovery/checklists/requirements.md
@@ -1,0 +1,8 @@
+# Requirements Checklist
+
+- [x] Requirements are testable.
+- [x] Requirements preserve plugin API auth coverage.
+- [x] Requirements distinguish frontend discovery from API mounting.
+- [x] Requirements include documentation and regression coverage.
+- [x] Requirements avoid touching unrelated dirty files from the original
+  checkout.

--- a/specs/001-example-dashboard-plugin-discovery/micro-constitution.md
+++ b/specs/001-example-dashboard-plugin-discovery/micro-constitution.md
@@ -1,0 +1,38 @@
+# Micro-Constitution: 001-example-dashboard-plugin-discovery
+
+- Spec ID: 001
+- Feature Name: example-dashboard-plugin-discovery
+- Target Repository: /Users/shawnowen/dev/sandbox/hermes-codex-example-dashboard-fix
+- Branch: codex/fix-example-dashboard-plugin
+- Autonomy Level: HIGH
+- Deploy Target: none
+- Score Threshold: 10
+
+## Problem Statement
+
+Hermes dashboard Sessions page QA stopped on the first browser issue at
+http://127.0.0.1:5173/sessions. The bundled Example dashboard plugin is
+discovered in the dashboard sidebar/plugin loader and its manifest declares
+entry "dist/index.js", but plugins/example-dashboard/dashboard/dist/index.js is
+missing. The browser console reports "[plugins] Failed to load example from
+/dashboard-plugins/example/dist/index.js?..." and direct requests to both the
+Vite proxy URL and backend URL return HTTP 404 File not found. Determine
+whether the Example dashboard plugin should ship a built dist bundle or be
+excluded/hidden from runtime dashboard discovery because it is test-only.
+Implement the governed fix, add regression coverage, update docs/tests as
+needed, and preserve unrelated dirty files.
+
+Evidence folder:
+/Users/shawnowen/dev/sandbox/hermes/handoffs/sessions-ui-qa-2026-05-20T0425Z
+
+## Success Criteria
+
+- SC-001: `/api/dashboard/plugins` does not return the backend-only `example`
+  fixture unless it has a real frontend entry asset.
+- SC-002: `/api/plugins/example/hello` remains mounted for auth middleware
+  regression coverage.
+- SC-003: Bundled dashboard manifests that declare `entry` or `css` assets are
+  covered by a metadata regression test.
+- SC-004: Dashboard plugin documentation explains backend-only API fixtures and
+  loadable frontend asset requirements.
+- SC-005: Unrelated dirty files in the original checkout remain untouched.

--- a/specs/001-example-dashboard-plugin-discovery/plan.md
+++ b/specs/001-example-dashboard-plugin-discovery/plan.md
@@ -1,0 +1,44 @@
+# Plan: Example Dashboard Plugin Discovery
+
+## Technical Context
+
+- Language: Python backend, TypeScript/React dashboard frontend.
+- Runtime loader: `hermes_cli/web_server.py` exposes dashboard plugin manifests
+  to `web/src/plugins/usePlugins.ts`.
+- Test runner: `scripts/run_tests.sh`.
+
+## Files Modified
+
+- `hermes_cli/web_server.py`
+- `plugins/example-dashboard/dashboard/manifest.json`
+- `plugins/example-dashboard/dashboard/plugin_api.py`
+- `tests/test_project_metadata.py`
+- `tests/hermes_cli/test_web_server.py`
+- `website/docs/user-guide/features/extending-the-dashboard.md`
+- `specs/001-example-dashboard-plugin-discovery/micro-constitution.md`
+- `specs/001-example-dashboard-plugin-discovery/problems.md`
+- `specs/001-example-dashboard-plugin-discovery/spec.md`
+- `specs/001-example-dashboard-plugin-discovery/research.md`
+- `specs/001-example-dashboard-plugin-discovery/plan.md`
+- `specs/001-example-dashboard-plugin-discovery/tasks.md`
+- `specs/001-example-dashboard-plugin-discovery/checklists/requirements.md`
+- `specs/001-example-dashboard-plugin-discovery/audit-trail.md`
+- `specs/001-example-dashboard-plugin-discovery/scorecard.md`
+
+## Implementation
+
+1. Add a backend helper that verifies a dashboard manifest has a loadable
+   frontend `entry` asset inside its dashboard directory.
+2. Use that helper for `/api/dashboard/plugins`, plugin hub dashboard metadata,
+   and rescan counts.
+3. Leave internal manifest discovery unchanged for API route mounting and static
+   asset serving.
+4. Mark the bundled example fixture as API-only with `entry: null`.
+5. Add unit coverage for API-only filtering and declared bundled asset presence.
+6. Update docs to describe backend-only API fixtures.
+
+## Risk
+
+Third-party manifests that relied on missing frontend bundles being returned to
+the loader will no longer appear until the asset exists. That is intentional;
+the old behavior produced broken tabs and script 404s.

--- a/specs/001-example-dashboard-plugin-discovery/problems.md
+++ b/specs/001-example-dashboard-plugin-discovery/problems.md
@@ -1,0 +1,36 @@
+# Problems: Example Dashboard Plugin Discovery
+
+## Facts & Assumptions
+
+- The bundled `plugins/example-dashboard/dashboard/manifest.json` identifies the
+  plugin as a test-suite fixture for auth coverage.
+- The fixture has `plugin_api.py` but no `dashboard/dist/index.js`.
+- `hermes_cli/web_server.py` mounted plugin API routes from manifests and also
+  returned those manifests to the frontend plugin loader.
+- `web/src/plugins/usePlugins.ts` blindly loaded every manifest entry as a
+  script.
+- Assumption: backend-only dashboard plugin fixtures should not create sidebar
+  tabs or frontend loader requests.
+
+## Problem
+
+Backend-only dashboard plugin manifests are treated as frontend plugins even
+when their declared JavaScript bundle is missing. The resulting 404 blocks QA
+on the first visible browser issue and creates a broken Example tab for users.
+
+## Root Cause
+
+Dashboard manifest discovery did not distinguish API-only manifests from
+loadable frontend plugin manifests.
+
+## Affected Surfaces
+
+- Dashboard plugin discovery endpoint: `/api/dashboard/plugins`
+- Dashboard plugin hub metadata
+- Bundled `example-dashboard` fixture
+- Metadata tests for bundled dashboard assets
+- Dashboard plugin authoring docs
+
+## Problem Score
+
+10/10

--- a/specs/001-example-dashboard-plugin-discovery/research.md
+++ b/specs/001-example-dashboard-plugin-discovery/research.md
@@ -1,0 +1,29 @@
+# Research: Example Dashboard Plugin Discovery
+
+## Findings
+
+- `plugins/example-dashboard/dashboard/plugin_api.py` states the fixture exists
+  so the test suite has a stable side-effect-free GET endpoint for auth
+  coverage.
+- `plugins/example-dashboard/dashboard/manifest.json` declared
+  `entry: "dist/index.js"` even though no `dist/` directory exists.
+- `hermes_cli/web_server.py` used one manifest list for frontend discovery,
+  static asset serving, plugin hub metadata, and API route mounting.
+- `web/src/plugins/usePlugins.ts` constructs
+  `/dashboard-plugins/<name>/<entry>` for every returned manifest.
+- Existing docs describe a separate reference Example plugin in
+  `hermes-example-plugins`, so the bundled fixture is not the intended user
+  facing demo.
+
+## Decision
+
+Keep the bundled `example` plugin as a backend-only fixture and exclude it from
+frontend runtime discovery unless it has a real entry asset. This preserves the
+auth regression route and removes the broken sidebar/plugin loader surface.
+
+## Alternatives
+
+- Ship a minimal `dist/index.js`: rejected because it would turn a test fixture
+  into a visible or globally loaded runtime plugin.
+- Remove the manifest: rejected because API route mounting uses the manifest's
+  `api` declaration.

--- a/specs/001-example-dashboard-plugin-discovery/scorecard.md
+++ b/specs/001-example-dashboard-plugin-discovery/scorecard.md
@@ -1,0 +1,16 @@
+# Scorecard: 001-example-dashboard-plugin-discovery
+
+Status: Local implementation complete pending pushed PR and remote CI.
+
+| Requirement | Verdict | Evidence |
+|---|---|---|
+| R1 Autonomous Execution | PASS | Implemented in isolated worktree without approval pauses. |
+| R2 Spec Completeness | PASS | Spec artifacts under this directory. |
+| R3 Clarification Resolution | PASS | Backend-only decision documented in research.md. |
+| R4 Plan-to-Spec Traceability | PASS | tasks.md maps implementation work to success criteria. |
+| R5 Implementation Correctness | PASS | Ruff and focused web-server/metadata tests passed. |
+| R6 CI/CD Pipeline Green | PENDING | Requires pushed PR. |
+| R7 PR Review | PENDING | Requires pushed PR. |
+| R8 Deployment Verification | N/A | deploy_target=none. |
+| R9 Self-Correction Integrity | PASS | Test environment plugin gap handled by installing pytest-timeout. |
+| R10 Audit Trail and Scorecard | PASS | audit-trail.md and scorecard.md present. |

--- a/specs/001-example-dashboard-plugin-discovery/spec.md
+++ b/specs/001-example-dashboard-plugin-discovery/spec.md
@@ -1,0 +1,42 @@
+# Spec 001: Example Dashboard Plugin Discovery
+
+Status: Implemented
+
+## User Story
+
+As a Hermes dashboard user, I need backend-only dashboard plugin fixtures to stay
+out of frontend plugin discovery so the dashboard does not load missing bundles
+or render broken plugin tabs.
+
+## Functional Requirements
+
+- FR-001: Preserve internal discovery of all dashboard manifests so plugin API
+  routes can still mount.
+- FR-002: Return only frontend-loadable dashboard plugins from
+  `/api/dashboard/plugins`.
+- FR-003: Treat a non-string, empty, or missing frontend `entry` as not
+  frontend-loadable.
+- FR-004: Verify the declared `entry` path resolves inside the plugin
+  `dashboard/` directory and points to an existing file before returning it to
+  the frontend loader.
+- FR-005: Keep `/api/plugins/example/hello` available for authenticated route
+  coverage.
+- FR-006: Add regression coverage for missing declared dashboard assets.
+- FR-007: Document backend-only API fixture behavior.
+
+## Acceptance Criteria
+
+- AC-001: The internal discovery list still includes `example` with `has_api`.
+- AC-002: The frontend discovery list excludes `example`.
+- AC-003: The frontend discovery list includes bundled plugins with real
+  `dist/index.js` assets, including `kanban` and `hermes-achievements`.
+- AC-004: The metadata test fails if a bundled manifest declares a missing
+  `entry` or `css` asset.
+- AC-005: Dashboard plugin docs explain `entry: null` for backend-only API
+  fixtures.
+
+## Out of Scope
+
+- Shipping a real Example dashboard UI bundle.
+- Reworking the frontend plugin SDK or registration lifecycle.
+- Changing plugin API auth semantics.

--- a/specs/001-example-dashboard-plugin-discovery/tasks.md
+++ b/specs/001-example-dashboard-plugin-discovery/tasks.md
@@ -1,0 +1,16 @@
+# Tasks: Example Dashboard Plugin Discovery
+
+- [x] T001 [SC-001,SC-002] Add frontend asset gating while preserving internal
+  discovery for API mounting -- `hermes_cli/web_server.py`
+- [x] T002 [SC-001] Mark bundled example dashboard fixture as backend-only --
+  `plugins/example-dashboard/dashboard/manifest.json`
+- [x] T003 [SC-002] Clarify the fixture docstring --
+  `plugins/example-dashboard/dashboard/plugin_api.py`
+- [x] T004 [SC-003] Add metadata regression coverage for declared dashboard
+  assets -- `tests/test_project_metadata.py`
+- [x] T005 [SC-001,SC-002] Add runtime discovery regression coverage --
+  `tests/hermes_cli/test_web_server.py`
+- [x] T006 [SC-004] Document backend-only dashboard API fixtures --
+  `website/docs/user-guide/features/extending-the-dashboard.md`
+- [x] T007 [SC-005] Preserve unrelated dirty files by implementing in a clean
+  sibling worktree -- `/Users/shawnowen/dev/sandbox/hermes-codex-example-dashboard-fix`

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2050,6 +2050,22 @@ class TestDashboardPluginManifestExtensions:
             "chat:top",
         ]
 
+    def test_api_only_plugin_is_not_returned_to_frontend_loader(self):
+        """The bundled example plugin is an API fixture and has no JS bundle."""
+        from hermes_cli import web_server
+
+        web_server._dashboard_plugins_cache = None
+        all_plugins = web_server._get_dashboard_plugins(force_rescan=True)
+        api_fixture = next(p for p in all_plugins if p["name"] == "example")
+        assert api_fixture["has_api"] is True
+
+        frontend_names = {
+            p["name"]
+            for p in web_server._get_frontend_dashboard_plugins(force_rescan=True)
+        }
+        assert "example" not in frontend_names
+        assert {"kanban", "hermes-achievements"}.issubset(frontend_names)
+
 
 # ---------------------------------------------------------------------------
 # /api/pty WebSocket — terminal bridge for the dashboard "Chat" tab.

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -1,5 +1,6 @@
 """Regression tests for packaging metadata in pyproject.toml."""
 
+import json
 from pathlib import Path
 import tomllib
 
@@ -122,3 +123,24 @@ def test_dashboard_plugin_manifests_and_assets_are_packaged():
     assert "*/dashboard/manifest.json" in plugin_data
     assert "*/dashboard/dist/*" in plugin_data
     assert "*/dashboard/dist/**/*" in plugin_data
+
+
+def test_bundled_dashboard_manifest_declared_assets_exist():
+    """A runtime-discovered dashboard manifest must not point at missing files."""
+    repo_root = Path(__file__).resolve().parents[1]
+    missing: list[str] = []
+
+    for manifest_path in sorted((repo_root / "plugins").glob("*/dashboard/manifest.json")):
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        for field in ("entry", "css"):
+            asset = manifest.get(field)
+            if asset is None:
+                continue
+            if not isinstance(asset, str) or not asset:
+                missing.append(f"{manifest_path.relative_to(repo_root)}:{field}=<invalid>")
+                continue
+            if not (manifest_path.parent / asset).is_file():
+                rel_manifest = manifest_path.relative_to(repo_root)
+                missing.append(f"{rel_manifest}:{field}={asset}")
+
+    assert not missing, "Missing bundled dashboard plugin assets: " + ", ".join(missing)

--- a/website/docs/user-guide/features/extending-the-dashboard.md
+++ b/website/docs/user-guide/features/extending-the-dashboard.md
@@ -460,9 +460,11 @@ None of them are required; include only the layers you need.
 | `tab.override` | No | Set to a built-in route path (`"/"`, `"/sessions"`, `"/config"`, ...) to **replace** that page instead of adding a new tab. See [Replacing built-in pages](#replacing-built-in-pages-taboverride). |
 | `tab.hidden` | No | When true, register the component and any slots without adding a tab to the nav. Used by slot-only plugins. See [Slot-only plugins](#slot-only-plugins-tabhidden). |
 | `slots` | No | Named shell slots this plugin populates. **Documentation aid only** — actual registration happens from the JS bundle via `registerSlot()`. Listing slots here makes discovery surfaces more informative. |
-| `entry` | Yes | Path to the JS bundle relative to `dashboard/`. Defaults to `dist/index.js`. |
+| `entry` | Yes for UI plugins | Path to the JS bundle relative to `dashboard/`. Defaults to `dist/index.js` when a UI bundle is expected. Backend-only API fixtures may set `entry` to `null`; they are mounted under `/api/plugins/<name>/` but are not returned by `/api/dashboard/plugins`. |
 | `css` | No | Path to a CSS file to inject as a `<link>` tag. |
 | `api` | No | Path to a Python file with FastAPI routes. Mounted at `/api/plugins/<name>/`. |
+
+Runtime discovery only returns manifests whose declared `entry` file exists under the plugin's `dashboard/` directory. A missing JS bundle is treated as "not a frontend plugin" rather than a broken tab; the backend `api` route still mounts when declared.
 
 #### Available icons
 


### PR DESCRIPTION
## What does this PR do?

Fixes dashboard plugin discovery so backend-only dashboard plugin fixtures stay mounted for API tests but are not returned to the frontend loader unless their declared JS entry asset exists. This removes the broken Example plugin tab/script load at `/dashboard-plugins/example/dist/index.js` while preserving `/api/plugins/example/hello` auth coverage.

## Related Issue

N/A - handoff: `/Users/shawnowen/dev/sandbox/hermes/handoffs/sessions-ui-qa-2026-05-20T0425Z`

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Filter `/api/dashboard/plugins`, plugin hub dashboard metadata, and rescan counts to manifests with real frontend entry assets.
- Mark `plugins/example-dashboard` as a backend-only API fixture with `entry: null`.
- Add regressions for API-only filtering and declared bundled dashboard assets.
- Document backend-only dashboard API fixtures and runtime asset gating.
- Add Spequa Spec 001 artifacts for the governed fix.

## How to Test

1. `git diff --check`
2. `/Users/shawnowen/.hermes/hermes-agent/venv/bin/python -m ruff check hermes_cli/web_server.py tests/test_project_metadata.py tests/hermes_cli/test_web_server.py`
3. `scripts/run_tests.sh tests/test_project_metadata.py tests/hermes_cli/test_web_server.py`

Results:

```text
git diff --check: PASS
ruff check touched Python files: PASS
scripts/run_tests.sh tests/test_project_metadata.py tests/hermes_cli/test_web_server.py: 153 passed in 4.00s
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact - N/A, path checks use existing `Path.is_relative_to` runtime pattern
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## For New Skills

N/A

## Screenshots / Logs

N/A
