### PR TITLE
fix(tool-executor): set tool_name on sequential per-iteration interrupt skip messages

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -477,13 +477,11 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 agent._vprint(f"{agent.log_prefix}⚡ Interrupt: skipping {len(remaining_calls)} tool call(s)", force=True)
             for skipped_tc in remaining_calls:
                 skipped_name = skipped_tc.function.name
-                skip_msg = {
-                    "role": "tool",
-                    "name": skipped_name,
-                    "content": f"[Tool execution cancelled — {skipped_name} was skipped due to user interrupt]",
-                    "tool_call_id": skipped_tc.id,
-                }
-                messages.append(skip_msg)
+                messages.append(make_tool_result_message(
+                    skipped_name,
+                    f"[Tool execution cancelled — {skipped_name} was skipped due to user interrupt]",
+                    skipped_tc.id,
+                ))
             break
 
         function_name = tool_call.function.name

--- a/tests/tools/test_interrupt.py
+++ b/tests/tools/test_interrupt.py
@@ -111,6 +111,46 @@ class TestPreToolCheck:
         # No actual tool handlers should have been called
         # (handle_function_call should NOT have been invoked)
 
+    def test_sequential_per_iteration_interrupt_sets_tool_name(self):
+        """execute_tool_calls_sequential per-iteration interrupt must set tool_name.
+
+        Regression: the per-iteration _interrupt_requested check in
+        execute_tool_calls_sequential built skip messages manually without
+        tool_name, while the sibling concurrent path (and the end-of-loop
+        sequential path) were already using make_tool_result_message.
+        """
+        from unittest.mock import MagicMock
+        import types
+        from run_agent import AIAgent
+        from agent.tool_executor import execute_tool_calls_sequential
+
+        tc1 = MagicMock()
+        tc1.id = "tc_1"
+        tc1.function.name = "terminal"
+
+        tc2 = MagicMock()
+        tc2.id = "tc_2"
+        tc2.function.name = "web_search"
+
+        assistant_msg = MagicMock()
+        assistant_msg.tool_calls = [tc1, tc2]
+
+        messages = []
+
+        agent = MagicMock()
+        agent._interrupt_requested = True
+        agent.log_prefix = ""
+
+        execute_tool_calls_sequential(agent, assistant_msg, messages, "task-1")
+
+        assert len(messages) == 2
+        for msg in messages:
+            assert msg.get("tool_name"), (
+                f"tool_name must be set on interrupt skip message, got: {msg}"
+            )
+            assert msg["tool_name"] == msg["name"]
+            assert msg["role"] == "tool"
+
 
 # ---------------------------------------------------------------------------
 # Unit tests: message combining


### PR DESCRIPTION
## Summary

`execute_tool_calls_sequential` checks `_interrupt_requested` at the **top of each loop iteration** before starting the next tool. When triggered, it builds skip messages manually — without `tool_name`. PR #28914 fixed every other interrupt path in the file to use `make_tool_result_message`, but this per-iteration block was missed.

**Before (manual dict, `tool_name` absent):**
```python
skip_msg = {
    "role": "tool",
    "name": skipped_name,
    "content": f"[Tool execution cancelled — {skipped_name} was skipped due to user interrupt]",
    "tool_call_id": skipped_tc.id,
}
messages.append(skip_msg)
```

**After (symmetric with every other interrupt path):**
```python
messages.append(make_tool_result_message(
    skipped_name,
    f"[Tool execution cancelled — {skipped_name} was skipped due to user interrupt]",
    skipped_tc.id,
))
```

Coverage of all interrupt skip paths in `tool_executor.py` after this fix:

| Path | Fixed in |
|---|---|
| `execute_tool_calls_concurrent` pre-flight | #28914 |
| `execute_tool_calls_sequential` end-of-loop | #28914 |
| `execute_tool_calls_sequential` per-iteration ← | **this PR** |

## Test plan

- [x] New regression test `TestPreToolCheck::test_sequential_per_iteration_interrupt_sets_tool_name` asserts `tool_name == name` on all skip messages produced by the per-iteration check
- [x] All existing interrupt tests pass (`tests/tools/test_interrupt.py` — 7 passed)
- [x] Existing `test_tool_name_db_persistence.py` still passes (1 passed)
- [x] `make_tool_result_message` was already imported; no new imports needed
- [x] Zero remaining manual `{"role": "tool", ...}` constructions in `tool_executor.py`