### PR TITLE
feat(email): support Gmail OAuth auth

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1476,9 +1476,12 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     # Email
     email_addr = os.getenv("EMAIL_ADDRESS")
     email_pwd = os.getenv("EMAIL_PASSWORD")
+    email_auth_mode = os.getenv("EMAIL_AUTH_MODE", "password").strip().lower()
     email_imap = os.getenv("EMAIL_IMAP_HOST")
     email_smtp = os.getenv("EMAIL_SMTP_HOST")
-    if all([email_addr, email_pwd, email_imap, email_smtp]):
+    email_token = os.getenv("GOOGLE_TOKEN_FILE") or str(get_hermes_home() / "google_token.json")
+    email_has_auth = bool(email_pwd) or (email_auth_mode == "google_oauth" and Path(email_token).expanduser().exists())
+    if all([email_addr, email_has_auth, email_imap, email_smtp]):
         if Platform.EMAIL not in config.platforms:
             config.platforms[Platform.EMAIL] = PlatformConfig()
         config.platforms[Platform.EMAIL].enabled = True
@@ -1486,6 +1489,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             "address": email_addr,
             "imap_host": email_imap,
             "smtp_host": email_smtp,
+            "auth_mode": email_auth_mode,
         })
     email_home = os.getenv("EMAIL_HOME_ADDRESS")
     if email_home and Platform.EMAIL in config.platforms:

--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -16,6 +16,7 @@ Environment variables:
 """
 
 import asyncio
+import base64
 import email as email_lib
 import imaplib
 import logging
@@ -42,6 +43,7 @@ from gateway.platforms.base import (
     cache_image_from_bytes,
 )
 from gateway.config import Platform, PlatformConfig
+from hermes_cli.config import get_hermes_home
 
 logger = logging.getLogger(__name__)
 # Automated sender patterns — emails from these are silently ignored
@@ -64,6 +66,67 @@ MAX_MESSAGE_LENGTH = 50_000
 
 # Supported image extensions for inline detection
 _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".gif", ".webp"}
+
+
+def _google_token_path() -> Path:
+    """Return the Hermes Google OAuth token path used by Workspace setup."""
+    configured = os.getenv("GOOGLE_TOKEN_FILE")
+    if configured:
+        return Path(configured).expanduser()
+    return get_hermes_home() / "google_token.json"
+
+
+def _email_auth_mode() -> str:
+    return os.getenv("EMAIL_AUTH_MODE", "password").strip().lower()
+
+
+def _load_google_access_token() -> str:
+    """Load and refresh the Google OAuth access token for Gmail IMAP/SMTP."""
+    token_path = _google_token_path()
+    if not token_path.exists():
+        raise FileNotFoundError(f"Google OAuth token not found: {token_path}")
+
+    try:
+        from google.auth.transport.requests import Request
+        from google.oauth2.credentials import Credentials
+    except ImportError as exc:  # pragma: no cover - environment-specific dependency error
+        raise RuntimeError("Google OAuth dependencies are not installed") from exc
+
+    creds = Credentials.from_authorized_user_file(str(token_path))
+    if not creds.valid:
+        if not creds.refresh_token:
+            raise RuntimeError("Google OAuth token is invalid and has no refresh token")
+        creds.refresh(Request())
+        token_path.write_text(creds.to_json())
+    if not creds.token:
+        raise RuntimeError("Google OAuth token has no access token")
+    return creds.token
+
+
+def _xoauth2_string(address: str, access_token: str) -> bytes:
+    return f"user={address}\x01auth=Bearer {access_token}\x01\x01".encode()
+
+
+def _imap_login(imap: "imaplib.IMAP4", address: str, password: str, auth_mode: str) -> None:
+    """Authenticate to IMAP with password or Gmail OAuth XOAUTH2."""
+    if auth_mode == "google_oauth":
+        token = _load_google_access_token()
+        imap.authenticate("XOAUTH2", lambda _challenge: _xoauth2_string(address, token))
+        return
+    imap.login(address, password)
+
+
+def _smtp_login(smtp: smtplib.SMTP, address: str, password: str, auth_mode: str) -> None:
+    """Authenticate to SMTP with password or Gmail OAuth XOAUTH2."""
+    if auth_mode == "google_oauth":
+        token = _load_google_access_token()
+        encoded = base64.b64encode(_xoauth2_string(address, token)).decode()
+        code, response = smtp.docmd("AUTH", "XOAUTH2 " + encoded)
+        if code != 235:
+            raise smtplib.SMTPAuthenticationError(code, response)
+        return
+    smtp.login(address, password)
+
 
 def _send_imap_id(imap: "imaplib.IMAP4") -> None:
     """Send RFC 2971 IMAP ID command identifying this client.
@@ -105,9 +168,12 @@ def check_email_requirements() -> bool:
     pwd = os.getenv("EMAIL_PASSWORD")
     imap = os.getenv("EMAIL_IMAP_HOST")
     smtp = os.getenv("EMAIL_SMTP_HOST")
-    if not all([addr, pwd, imap, smtp]):
-        return False
-    return True
+    if all([addr, pwd, imap, smtp]):
+        return True
+    auth_mode = _email_auth_mode()
+    if auth_mode == "google_oauth":
+        return bool(addr and imap and smtp and _google_token_path().exists())
+    return False
 
 
 def _decode_header_value(raw: str) -> str:
@@ -250,6 +316,7 @@ class EmailAdapter(BasePlatformAdapter):
 
         self._address = os.getenv("EMAIL_ADDRESS", "")
         self._password = os.getenv("EMAIL_PASSWORD", "")
+        self._auth_mode = "password" if self._password else _email_auth_mode()
         self._imap_host = os.getenv("EMAIL_IMAP_HOST", "")
         self._imap_port = int(os.getenv("EMAIL_IMAP_PORT", "993"))
         self._smtp_host = os.getenv("EMAIL_SMTP_HOST", "")
@@ -298,7 +365,7 @@ class EmailAdapter(BasePlatformAdapter):
         try:
             # Test IMAP connection
             imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
-            imap.login(self._address, self._password)
+            _imap_login(imap, self._address, self._password, self._auth_mode)
             _send_imap_id(imap)
             # Mark all existing messages as seen so we only process new ones
             imap.select("INBOX")
@@ -318,7 +385,7 @@ class EmailAdapter(BasePlatformAdapter):
             # Test SMTP connection
             smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
             smtp.starttls(context=ssl.create_default_context())
-            smtp.login(self._address, self._password)
+            _smtp_login(smtp, self._address, self._password, self._auth_mode)
             smtp.quit()
             logger.info("[Email] SMTP connection test passed.")
         except Exception as e:
@@ -367,7 +434,7 @@ class EmailAdapter(BasePlatformAdapter):
         try:
             imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
             try:
-                imap.login(self._address, self._password)
+                _imap_login(imap, self._address, self._password, self._auth_mode)
                 _send_imap_id(imap)
                 imap.select("INBOX")
 
@@ -551,7 +618,7 @@ class EmailAdapter(BasePlatformAdapter):
         smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
         try:
             smtp.starttls(context=ssl.create_default_context())
-            smtp.login(self._address, self._password)
+            _smtp_login(smtp, self._address, self._password, self._auth_mode)
             smtp.send_message(msg)
         finally:
             try:
@@ -673,7 +740,7 @@ class EmailAdapter(BasePlatformAdapter):
         smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
         try:
             smtp.starttls(context=ssl.create_default_context())
-            smtp.login(self._address, self._password)
+            _smtp_login(smtp, self._address, self._password, self._auth_mode)
             smtp.send_message(msg)
         finally:
             try:
@@ -752,7 +819,7 @@ class EmailAdapter(BasePlatformAdapter):
         smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
         try:
             smtp.starttls(context=ssl.create_default_context())
-            smtp.login(self._address, self._password)
+            _smtp_login(smtp, self._address, self._password, self._auth_mode)
             smtp.send_message(msg)
         finally:
             try:

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -57,6 +57,22 @@ class TestConfigEnvOverrides(unittest.TestCase):
         self.assertIsNotNone(home)
         self.assertEqual(home.chat_id, "user@test.com")
 
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "hermes@test.com",
+        "EMAIL_AUTH_MODE": "google_oauth",
+        "EMAIL_IMAP_HOST": "imap.gmail.com",
+        "EMAIL_SMTP_HOST": "smtp.gmail.com",
+        "GOOGLE_TOKEN_FILE": "/tmp/google_token.json",
+    }, clear=True)
+    @patch("gateway.config.Path.exists", return_value=True)
+    def test_email_config_loaded_with_google_oauth_without_password(self, _mock_exists):
+        from gateway.config import GatewayConfig, Platform, _apply_env_overrides
+        config = GatewayConfig()
+        _apply_env_overrides(config)
+        self.assertIn(Platform.EMAIL, config.platforms)
+        self.assertTrue(config.platforms[Platform.EMAIL].enabled)
+        self.assertEqual(config.platforms[Platform.EMAIL].extra["auth_mode"], "google_oauth")
+
     @patch.dict(os.environ, {}, clear=True)
     def test_email_not_loaded_without_env(self):
         from gateway.config import GatewayConfig, Platform, _apply_env_overrides
@@ -79,6 +95,30 @@ class TestCheckRequirements(unittest.TestCase):
 
     @patch.dict(os.environ, {
         "EMAIL_ADDRESS": "a@b.com",
+        "EMAIL_AUTH_MODE": "google_oauth",
+        "EMAIL_IMAP_HOST": "imap.gmail.com",
+        "EMAIL_SMTP_HOST": "smtp.gmail.com",
+        "GOOGLE_TOKEN_FILE": "/tmp/google_token.json",
+    }, clear=True)
+    @patch("gateway.platforms.email.Path.exists", return_value=True)
+    def test_requirements_met_with_google_oauth_token(self, _mock_exists):
+        from gateway.platforms.email import check_email_requirements
+        self.assertTrue(check_email_requirements())
+
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "a@b.com",
+        "EMAIL_AUTH_MODE": "google_oauth",
+        "EMAIL_IMAP_HOST": "imap.gmail.com",
+        "EMAIL_SMTP_HOST": "smtp.gmail.com",
+        "GOOGLE_TOKEN_FILE": "/tmp/missing_google_token.json",
+    }, clear=True)
+    @patch("gateway.platforms.email.Path.exists", return_value=False)
+    def test_requirements_not_met_with_google_oauth_missing_token(self, _mock_exists):
+        from gateway.platforms.email import check_email_requirements
+        self.assertFalse(check_email_requirements())
+
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "a@b.com",
     }, clear=True)
     def test_requirements_not_met(self):
         from gateway.platforms.email import check_email_requirements
@@ -92,6 +132,33 @@ class TestCheckRequirements(unittest.TestCase):
 
 class TestHelperFunctions(unittest.TestCase):
     """Test email parsing helper functions."""
+
+    def test_imap_login_uses_xoauth2_for_google_oauth(self):
+        from gateway.platforms.email import _imap_login
+
+        imap = MagicMock()
+        with patch("gateway.platforms.email._load_google_access_token", return_value="access-token"):
+            _imap_login(imap, "hermes@gmail.com", "", "google_oauth")
+
+        imap.authenticate.assert_called_once()
+        mechanism, callback = imap.authenticate.call_args.args
+        self.assertEqual(mechanism, "XOAUTH2")
+        self.assertEqual(callback(None), b"user=hermes@gmail.com\x01auth=Bearer access-token\x01\x01")
+        imap.login.assert_not_called()
+
+    def test_smtp_login_uses_xoauth2_for_google_oauth(self):
+        from gateway.platforms.email import _smtp_login
+
+        smtp = MagicMock()
+        smtp.docmd.return_value = (235, b"2.7.0 Accepted")
+        with patch("gateway.platforms.email._load_google_access_token", return_value="access-token"):
+            _smtp_login(smtp, "hermes@gmail.com", "", "google_oauth")
+
+        smtp.docmd.assert_called_once()
+        command, payload = smtp.docmd.call_args.args
+        self.assertEqual(command, "AUTH")
+        self.assertTrue(payload.startswith("XOAUTH2 "))
+        smtp.login.assert_not_called()
 
     def test_decode_header_plain(self):
         from gateway.platforms.email import _decode_header_value

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -320,7 +320,8 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `SMS_HOME_CHANNEL` | Phone number for cron job / notification delivery |
 | `SMS_HOME_CHANNEL_NAME` | Display name for the SMS home channel |
 | `EMAIL_ADDRESS` | Email address for the Email gateway adapter |
-| `EMAIL_PASSWORD` | Password or app password for the email account |
+| `EMAIL_PASSWORD` | Password or app password for the email account (required unless `EMAIL_AUTH_MODE=google_oauth`) |
+| `EMAIL_AUTH_MODE` | Email authentication mode: `password` (default) or `google_oauth` for Gmail XOAUTH2 via `GOOGLE_TOKEN_FILE` |
 | `EMAIL_IMAP_HOST` | IMAP hostname for the email adapter |
 | `EMAIL_IMAP_PORT` | IMAP port |
 | `EMAIL_SMTP_HOST` | SMTP hostname for the email adapter |
@@ -330,6 +331,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `EMAIL_HOME_ADDRESS_NAME` | Display name for the email home target |
 | `EMAIL_POLL_INTERVAL` | Email polling interval in seconds |
 | `EMAIL_ALLOW_ALL_USERS` | Allow all inbound email senders |
+| `GOOGLE_TOKEN_FILE` | Optional Google OAuth token path used by `EMAIL_AUTH_MODE=google_oauth` (defaults to `$HERMES_HOME/google_token.json`) |
 | `DINGTALK_CLIENT_ID` | DingTalk bot AppKey from developer portal ([open.dingtalk.com](https://open.dingtalk.com)) |
 | `DINGTALK_CLIENT_SECRET` | DingTalk bot AppSecret from developer portal |
 | `DINGTALK_ALLOWED_USERS` | Comma-separated DingTalk user IDs allowed to message the bot |

--- a/website/docs/user-guide/messaging/email.md
+++ b/website/docs/user-guide/messaging/email.md
@@ -74,6 +74,20 @@ EMAIL_POLL_INTERVAL=15                 # Seconds between inbox checks (default: 
 EMAIL_HOME_ADDRESS=your@email.com      # Default delivery target for cron jobs
 ```
 
+### Gmail OAuth / XOAUTH2
+
+For Gmail accounts that already have a Hermes Google Workspace OAuth token, you can use OAuth instead of storing an email password:
+
+```bash
+EMAIL_ADDRESS=hermes@gmail.com
+EMAIL_AUTH_MODE=google_oauth
+EMAIL_IMAP_HOST=imap.gmail.com
+EMAIL_SMTP_HOST=smtp.gmail.com
+GOOGLE_TOKEN_FILE=/Users/you/.hermes/google_token.json  # Optional; defaults to $HERMES_HOME/google_token.json
+```
+
+The token must include a refresh token and Gmail IMAP/SMTP-compatible scopes. Hermes refreshes the access token before authenticating to IMAP and SMTP with XOAUTH2. If `EMAIL_PASSWORD` is set, password auth is still used for backwards compatibility.
+
 ---
 
 ## Step 2: Start the Gateway
@@ -152,9 +166,9 @@ Email access follows the same pattern as all other Hermes platforms:
 | Problem | Solution |
 |---------|----------|
 | **"IMAP connection failed"** at startup | Verify `EMAIL_IMAP_HOST` and `EMAIL_IMAP_PORT`. Ensure IMAP is enabled on the account. For Gmail, enable it in Settings → Forwarding and POP/IMAP. |
-| **"SMTP connection failed"** at startup | Verify `EMAIL_SMTP_HOST` and `EMAIL_SMTP_PORT`. Check that your password is correct (use App Password for Gmail). |
+| **"SMTP connection failed"** at startup | Verify `EMAIL_SMTP_HOST` and `EMAIL_SMTP_PORT`. Check that your password is correct (use App Password for Gmail), or that `EMAIL_AUTH_MODE=google_oauth` points at a valid Google token. |
 | **Messages not received** | Check `EMAIL_ALLOWED_USERS` includes the sender's email. Check spam folder — some providers flag automated replies. |
-| **"Authentication failed"** | For Gmail, you must use an App Password, not your regular password. Ensure 2FA is enabled first. |
+| **"Authentication failed"** | For password auth on Gmail, use an App Password, not your regular password. For `google_oauth`, verify `GOOGLE_TOKEN_FILE` exists, has a refresh token, and was granted Gmail IMAP/SMTP-compatible scopes. |
 | **Duplicate replies** | Ensure only one gateway instance is running. Check `hermes gateway status`. |
 | **Slow response** | The default poll interval is 15 seconds. Reduce with `EMAIL_POLL_INTERVAL=5` for faster response (but more IMAP connections). |
 | **Replies not threading** | The adapter uses In-Reply-To headers. Some email clients (especially web-based) may not thread correctly with automated messages. |
@@ -179,7 +193,8 @@ Email access follows the same pattern as all other Hermes platforms:
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `EMAIL_ADDRESS` | Yes | — | Agent's email address |
-| `EMAIL_PASSWORD` | Yes | — | Email password or app password |
+| `EMAIL_PASSWORD` | Yes unless using Google OAuth | — | Email password or app password |
+| `EMAIL_AUTH_MODE` | No | `password` | Set to `google_oauth` to authenticate Gmail IMAP/SMTP with XOAUTH2 and `GOOGLE_TOKEN_FILE` |
 | `EMAIL_IMAP_HOST` | Yes | — | IMAP server host (e.g., `imap.gmail.com`) |
 | `EMAIL_SMTP_HOST` | Yes | — | SMTP server host (e.g., `smtp.gmail.com`) |
 | `EMAIL_IMAP_PORT` | No | `993` | IMAP server port |
@@ -188,3 +203,4 @@ Email access follows the same pattern as all other Hermes platforms:
 | `EMAIL_ALLOWED_USERS` | No | — | Comma-separated allowed sender addresses |
 | `EMAIL_HOME_ADDRESS` | No | — | Default delivery target for cron jobs |
 | `EMAIL_ALLOW_ALL_USERS` | No | `false` | Allow all senders (not recommended) |
+| `GOOGLE_TOKEN_FILE` | No | `$HERMES_HOME/google_token.json` | Google OAuth token path for `EMAIL_AUTH_MODE=google_oauth` |


### PR DESCRIPTION
## Linear
- Closes VIS-171

## Summary
- Adds `EMAIL_AUTH_MODE=google_oauth` for the email gateway so Gmail IMAP and SMTP can authenticate with XOAUTH2 from the Hermes Google token file.
- Keeps password/app-password auth as the default and preserves password precedence when `EMAIL_PASSWORD` is set.
- Updates env override gating, requirement checks, tests, and email docs for the OAuth mode.

## Test plan
- [x] `.venv/bin/python -m pytest tests/gateway/test_email.py -q` — 65 passed
- [x] `.venv/bin/python -m py_compile gateway/config.py gateway/platforms/email.py`
- [x] `git diff --check`

## Review notes
- Live Gmail smoke was not run because this unattended job should not use mailbox credentials or send email.
- OAuth token loading reuses the existing Google token file path (`GOOGLE_TOKEN_FILE` or `$HERMES_HOME/google_token.json`) and refreshes before XOAUTH2 auth.

## Scope control
In scope:
- Gateway Email IMAP/SMTP OAuth authentication support.
- Docs and targeted unit tests.

Out of scope / follow-up Linear issues:
- OAuth setup wizard changes for generating Gmail scopes.
- Live mailbox verification and credential setup.
