### PR TITLE
feat(agent-init): warn on empty fallback_providers with retry-prone primary

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -62,6 +62,14 @@ from utils import base_url_host_matches
 logger = logging.getLogger("run_agent")
 
 
+# Primary providers known to throw prolonged overload / rate-limit storms
+# (Anthropic 529s under Claude Code OAuth, OpenAI Codex CLI burst limits).
+# When configured as primary with NO fallback chain, retries happen
+# in-loop and look like a silent hang — see init_agent() for the
+# session-start warning that surfaces this configuration risk.
+_RETRY_PRONE_PROVIDERS_WITHOUT_FALLBACK = frozenset({"anthropic", "openai-codex"})
+
+
 def _ra():
     """Lazy reference to ``run_agent`` so callers can patch
     ``run_agent.OpenAI`` / ``run_agent.cleanup_vm`` / ... and have those
@@ -813,6 +821,29 @@ def init_agent(
         else:
             print(f"🔄 Fallback chain ({len(agent._fallback_chain)} providers): " +
                   " → ".join(f"{f['model']} ({f['provider']})" for f in agent._fallback_chain))
+    elif not agent._fallback_chain and agent.provider in _RETRY_PRONE_PROVIDERS_WITHOUT_FALLBACK:
+        # Primary providers known for prolonged overload / rate-limit storms
+        # (Anthropic 529s, ChatGPT-OAuth Codex burst limits) silently retry
+        # in-loop when the fallback chain is empty, which has bitten real
+        # sessions (builder/ops 2026-05-18→19).  Surface a one-line WARNING
+        # at session start so operators can `hermes fallback add` before
+        # hitting an outage.  The warning goes through ``logger`` (visible
+        # in ~/.hermes/logs/errors.log) and, in non-quiet interactive runs,
+        # to stdout so it can't be missed.
+        try:
+            from hermes_cli.profiles import get_active_profile_name
+            _profile = get_active_profile_name() or "default"
+        except Exception:
+            _profile = "default"
+        _flag = "" if _profile in (None, "", "default") else f" -p {_profile}"
+        _msg = (
+            f"empty fallback_providers with primary={agent.provider} — "
+            f"overload / rate-limit will cause silent in-loop retries. "
+            f"Add a backup with: hermes{_flag} fallback add"
+        )
+        logger.warning(_msg)
+        if not agent.quiet_mode:
+            print(f"⚠️  {_msg}")
 
     # Get available tools with filtering
     agent.tools = _ra().get_tool_definitions(

--- a/tests/run_agent/test_empty_fallback_warning.py
+++ b/tests/run_agent/test_empty_fallback_warning.py
@@ -1,0 +1,146 @@
+"""Tests for the session-start warning emitted when a retry-prone
+primary provider (Anthropic, OpenAI Codex) boots with an EMPTY
+``fallback_providers`` chain.
+
+This guards against the silent in-loop retry storm pattern seen on
+2026-05-18→19 (builder/ops outage), where an Anthropic primary with no
+fallback configured hit prolonged 529 overload and looked like a hang.
+"""
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from run_agent import AIAgent
+
+
+def _make_agent(*, provider, fallback_model=None, quiet_mode=True, base_url=None):
+    """Construct a minimal AIAgent with a specified primary provider."""
+    # base_url is sniffed by agent_init to derive provider when ``provider``
+    # arg is None; keep them aligned to avoid drift.
+    if base_url is None:
+        base_url = {
+            "anthropic": "https://api.anthropic.com",
+            "openai-codex": "https://chatgpt.com/backend-api/codex",
+            "openrouter": "https://openrouter.ai/api/v1",
+        }.get(provider, "https://openrouter.ai/api/v1")
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            provider=provider,
+            api_key="test-key",
+            base_url=base_url,
+            quiet_mode=quiet_mode,
+            skip_context_files=True,
+            skip_memory=True,
+            fallback_model=fallback_model,
+        )
+        agent.client = MagicMock()
+        return agent
+
+
+class TestEmptyFallbackWarning:
+    """Warn ONLY when primary is retry-prone AND chain is empty."""
+
+    @pytest.mark.parametrize("provider", ["anthropic", "openai-codex"])
+    def test_warns_for_retry_prone_primary_with_empty_chain(self, provider, caplog):
+        with caplog.at_level(logging.WARNING, logger="run_agent"):
+            agent = _make_agent(provider=provider, fallback_model=None)
+        assert agent._fallback_chain == []
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("empty fallback_providers" in r.getMessage() for r in warnings), \
+            f"expected empty-fallback WARNING for primary={provider!r}, " \
+            f"got {[r.getMessage() for r in warnings]!r}"
+        msg = next(r.getMessage() for r in warnings
+                   if "empty fallback_providers" in r.getMessage())
+        assert f"primary={provider}" in msg
+        assert "hermes" in msg and "fallback add" in msg
+
+    @pytest.mark.parametrize("provider", ["anthropic", "openai-codex"])
+    def test_warning_includes_profile_flag_when_non_default(self, provider, caplog):
+        with (
+            patch("hermes_cli.profiles.get_active_profile_name",
+                  return_value="ops"),
+            caplog.at_level(logging.WARNING, logger="run_agent"),
+        ):
+            _make_agent(provider=provider, fallback_model=None)
+        msg = next(r.getMessage() for r in caplog.records
+                   if "empty fallback_providers" in r.getMessage())
+        assert "hermes -p ops fallback add" in msg
+
+    @pytest.mark.parametrize("provider", ["anthropic", "openai-codex"])
+    def test_warning_omits_profile_flag_for_default(self, provider, caplog):
+        with (
+            patch("hermes_cli.profiles.get_active_profile_name",
+                  return_value="default"),
+            caplog.at_level(logging.WARNING, logger="run_agent"),
+        ):
+            _make_agent(provider=provider, fallback_model=None)
+        msg = next(r.getMessage() for r in caplog.records
+                   if "empty fallback_providers" in r.getMessage())
+        # bare ``hermes fallback add`` — no ``-p`` flag for the root profile.
+        assert "hermes fallback add" in msg
+        assert "-p" not in msg
+
+    def test_no_warning_for_openrouter_primary(self, caplog):
+        """Aggregators (OpenRouter, AI Gateway) already do server-side
+        retries / failover; an empty user-side chain is not a hazard."""
+        with caplog.at_level(logging.WARNING, logger="run_agent"):
+            agent = _make_agent(provider="openrouter", fallback_model=None)
+        assert agent._fallback_chain == []
+        assert not any("empty fallback_providers" in r.getMessage()
+                       for r in caplog.records)
+
+    @pytest.mark.parametrize("provider", ["anthropic", "openai-codex"])
+    def test_no_warning_when_chain_configured(self, provider, caplog):
+        with caplog.at_level(logging.WARNING, logger="run_agent"):
+            _make_agent(
+                provider=provider,
+                fallback_model=[{"provider": "openrouter",
+                                  "model": "anthropic/claude-sonnet-4"}],
+            )
+        assert not any("empty fallback_providers" in r.getMessage()
+                       for r in caplog.records)
+
+    @pytest.mark.parametrize("provider", ["anthropic", "openai-codex"])
+    def test_warning_stdout_in_interactive_mode(self, provider, capsys, caplog):
+        """In non-quiet mode the warning must also reach stdout — quiet
+        mode swallows the print but the logger.warning still fires."""
+        with caplog.at_level(logging.WARNING, logger="run_agent"):
+            _make_agent(provider=provider, fallback_model=None, quiet_mode=False)
+        captured = capsys.readouterr().out
+        assert "empty fallback_providers" in captured
+        assert "⚠️" in captured
+        # And the logger emission must have happened too.
+        assert any("empty fallback_providers" in r.getMessage()
+                   for r in caplog.records)
+
+    @pytest.mark.parametrize("provider", ["anthropic", "openai-codex"])
+    def test_warning_logger_fires_in_quiet_mode(self, provider, capsys, caplog):
+        """Quiet mode (gateway / batch_runner) must still emit the
+        WARNING to the logger — only the stdout print is suppressed."""
+        with caplog.at_level(logging.WARNING, logger="run_agent"):
+            _make_agent(provider=provider, fallback_model=None, quiet_mode=True)
+        captured = capsys.readouterr().out
+        assert "empty fallback_providers" not in captured
+        assert any("empty fallback_providers" in r.getMessage()
+                   for r in caplog.records)
+
+    @pytest.mark.parametrize("provider", ["anthropic", "openai-codex"])
+    def test_warning_survives_profile_lookup_failure(self, provider, caplog):
+        """If ``get_active_profile_name`` raises, the warning still
+        fires with the bare-``hermes`` suggestion (no ``-p`` flag)."""
+        with (
+            patch("hermes_cli.profiles.get_active_profile_name",
+                  side_effect=RuntimeError("no profile system")),
+            caplog.at_level(logging.WARNING, logger="run_agent"),
+        ):
+            _make_agent(provider=provider, fallback_model=None)
+        msg = next(r.getMessage() for r in caplog.records
+                   if "empty fallback_providers" in r.getMessage())
+        assert "hermes fallback add" in msg
+        assert "-p" not in msg


### PR DESCRIPTION
## Why

When `AIAgent` boots with an empty `fallback_providers` chain AND the primary provider is one of the known retry-prone backends (Anthropic via OAuth, OpenAI Codex CLI), retry storms during prolonged overload happen *in-loop* and look like a silent hang. We hit this for real on 2026-05-18→19 (builder/ops outage), and it took the operator a while to realize the chain was empty rather than the providers being down.

This adds a one-line WARNING at session start so the misconfiguration surfaces immediately.

## What

- New module-level constant in `agent/agent_init.py`:
  ```python
  _RETRY_PRONE_PROVIDERS_WITHOUT_FALLBACK = frozenset({"anthropic", "openai-codex"})
  ```
- New `elif` branch in `init_agent()` after the existing positive-print path. When `agent._fallback_chain` is empty AND `agent.provider` is in the set, emit:
  ```
  ⚠️  empty fallback_providers with primary=anthropic — overload / rate-limit will cause silent in-loop retries.
      Add a backup with: hermes [-p <profile>] fallback add
  ```
- Profile suffix is omitted for the `default` profile and on lookup failure.
- WARNING goes through the existing `run_agent` logger (so it lands in `~/.hermes/logs/errors.log` even in quiet mode) AND `print()`s to stdout in non-quiet interactive runs.
- Aggregators (`openrouter`, `ai-gateway`) are deliberately excluded — they do server-side failover.

## Tests

`tests/run_agent/test_empty_fallback_warning.py` — 15 new tests covering:
- Warning fires for each retry-prone primary
- Profile flag inclusion/omission (default profile gets no `-p`)
- Negative cases (openrouter primary; chain configured) → no warning
- Quiet-mode logger emission, non-quiet stdout emission
- Resilience to profile-lookup exceptions

Full local test runs:
- New tests: **15/15 pass**
- Existing related suites: `test_fallback_cmd.py` + `test_fallback_eviction.py` → **49/49 pass**

## Risk

- Additive only — no behavior change when chain is non-empty or primary is anything other than `anthropic`/`openai-codex`.
- Print line is gated by `not agent.quiet_mode` so batch_runner / gateway don't get stdout noise.
- The frozenset is conservative; aggregators excluded by design.

## Origin

Kanban task t_7b4e65cd. Reviewed locally before opening this PR; diff is 31 LoC + 146 LoC of tests.
