### PR TITLE
fix(i18n): make columnLabels.scheduled + columnHelp.scheduled optional

### DIFF
--- a/web/src/i18n/types.ts
+++ b/web/src/i18n/types.ts
@@ -666,6 +666,7 @@ export interface Translations {
     columnLabels: {
       triage: string;
       todo: string;
+      scheduled?: string;
       ready: string;
       running: string;
       blocked: string;
@@ -675,6 +676,7 @@ export interface Translations {
     columnHelp: {
       triage: string;
       todo: string;
+      scheduled?: string;
       ready: string;
       running: string;
       blocked: string;


### PR DESCRIPTION
### Summary
`web/src/i18n/en.ts` declares `scheduled` keys under `columnLabels` and
`columnHelp` (lines 661 and 671), but the `Translations` interface in
`web/src/i18n/types.ts` doesn't include them. `tsc -b && vite build`
(which `hermes dashboard` invokes on launch) fails with TS2353:

```
src/i18n/en.ts(661,7): error TS2353: Object literal may only specify known
  properties, and 'scheduled' does not exist in type '{ triage: string; …
src/i18n/en.ts(671,7): error TS2353: …
```

`hermes dashboard` then exits before binding a port.

### Fix
Mark the property optional (`scheduled?: string`) in both `columnLabels`
and `columnHelp`. This satisfies `en.ts` without forcing the 15 other
untranslated locale files to add it. Once translations land in the other
locale files, the `?` can be removed at the maintainer's discretion.

### Reproduce before
```
cd web && npm run build
# tsc emits TS2353 at en.ts:661 and en.ts:671 → build aborts
```

### Verify after
```
cd web && npm run build       # ✓ built in ~5s (vite emits ../hermes_cli/web_dist/...)
hermes dashboard --port 8090  # binds → HTTP 200 at http://127.0.0.1:8090
```

### Scope
- 2 lines added, 1 file (`web/src/i18n/types.ts`).
- No runtime behavior change for already-translated locales.
- Untranslated locales now render `undefined` for the `scheduled` column
  label/help (graceful — same as any unset i18n key) instead of failing
  the entire build.
