### PR TITLE
fix(kanban): stop bulk dashboard update from mutating fields after a refused op

### DIFF
--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -974,6 +974,13 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
 
     This is an *independent* iteration — per-task failures don't abort
     siblings. Returns per-id outcome so the UI can surface partials.
+
+    Within a single id, the first failed operation (refused archive,
+    refused status transition, or refused assignment) records the error
+    and skips the remaining field mutations for that row — mirroring the
+    single-task PATCH, which raises and commits nothing further. Without
+    this, a row whose status change was refused would still be silently
+    reprioritized or reassigned by the same request.
     """
     ids = [i for i in (payload.ids or []) if i]
     if not ids:
@@ -993,6 +1000,8 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                 if payload.archive:
                     if not kanban_db.archive_task(conn, tid):
                         entry.update(ok=False, error="archive refused")
+                        results.append(entry)
+                        continue
                 if payload.status is not None and not payload.archive:
                     s = payload.status
                     if s == "done":
@@ -1030,6 +1039,8 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                         continue
                     if not ok:
                         entry.update(ok=False, error=f"transition to {s!r} refused")
+                        results.append(entry)
+                        continue
                 if payload.assignee is not None:
                     try:
                         if payload.reclaim_first:
@@ -1043,8 +1054,12 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                             )
                         if not ok:
                             entry.update(ok=False, error="assign refused")
+                            results.append(entry)
+                            continue
                     except RuntimeError as e:
                         entry.update(ok=False, error=str(e))
+                        results.append(entry)
+                        continue
                 if payload.priority is not None:
                     with kanban_db.write_txn(conn):
                         conn.execute(

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -1090,6 +1090,60 @@ def test_bulk_partial_failure_doesnt_abort_siblings(client):
         assert t["priority"] == 7
 
 
+def test_bulk_refused_status_does_not_apply_other_fields(client):
+    """A refused status transition in a bulk patch must not silently apply
+    the same request's priority/assignee mutations.
+
+    Parity with the single-task PATCH, which raises 409 on a refused
+    transition and commits nothing further. Regression guard: previously
+    the bulk loop recorded ``ok=False`` for the refused status but fell
+    through and still wrote priority/assignee onto the same row.
+    """
+    # Parent stays un-done, so the child sits in 'todo' and cannot be
+    # blocked (block_task only transitions from running/ready).
+    parent = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "parent"}
+    ).json()["task"]
+    child = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "child", "assignee": "orig", "parents": [parent["id"]]},
+    ).json()["task"]
+    assert child["status"] == "todo"
+    assert child["priority"] == 0
+
+    r = client.post(
+        "/api/plugins/kanban/tasks/bulk",
+        json={
+            "ids": [child["id"]],
+            "status": "blocked",     # refused: child is in 'todo'
+            "assignee": "hijacked",  # must NOT be applied
+            "priority": 9,           # must NOT be applied
+        },
+    )
+    assert r.status_code == 200
+    results = r.json()["results"]
+    assert len(results) == 1
+    assert results[0]["id"] == child["id"]
+    assert results[0]["ok"] is False
+    assert "blocked" in results[0]["error"]
+
+    # The refused row must be untouched.
+    after = client.get(
+        f"/api/plugins/kanban/tasks/{child['id']}"
+    ).json()["task"]
+    assert after["status"] == "todo"
+    assert after["priority"] == 0
+    assert after["assignee"] == "orig"
+
+    # No phantom reprioritized event leaked into the timeline.
+    conn = kb.connect()
+    try:
+        kinds = [e.kind for e in kb.list_events(conn, child["id"])]
+    finally:
+        conn.close()
+    assert "reprioritized" not in kinds
+
+
 def test_bulk_empty_ids_400(client):
     r = client.post("/api/plugins/kanban/tasks/bulk", json={"ids": []})
     assert r.status_code == 400


### PR DESCRIPTION
## Summary
`POST /api/plugins/kanban/tasks/bulk` applied `priority`/`assignee` to a task even when that task's status transition (or archive) in the **same** request was refused. The single-task `PATCH /tasks/{id}` raises `409` on a refused transition and commits nothing further — the bulk path silently diverged, reporting `ok: false` for the row while still mutating it.

## What changed
`bulk_update` now short-circuits a row on its **first** failed operation — refused archive, refused status transition, or refused assignment. It records the error and skips the remaining field writes for that id, matching single-PATCH atomicity. Other ids in the batch are still processed independently, and the all-success path is unchanged.

## Why it matters
A multi-select action that combines a status change with a priority/assignee change would silently reprioritize/reassign exactly the cards whose status change was rejected — and write a phantom `reprioritized` event into their timeline — while the UI reported the operation as failed.

## Reproduction (before)
```
# child sits in 'todo' (parent not done); block_task only transitions from running/ready
POST /api/plugins/kanban/tasks/bulk
{ "ids": ["<child>"], "status": "blocked", "priority": 9 }

→ results[0] = { "ok": false, "error": "transition to 'blocked' refused" }
  but GET task shows priority == 9 and a 'reprioritized' event was written
```
After the fix, the refused row keeps its original status/priority/assignee and emits no `reprioritized` event.

## Test plan
- Added `test_bulk_refused_status_does_not_apply_other_fields`: a refused status combined with `priority` + `assignee` returns `ok: false`, leaves the row untouched, and writes no phantom `reprioritized` event.
- Existing bulk-endpoint tests in `tests/plugins/test_kanban_dashboard_plugin.py` still pass.
