### PR TITLE
fix(gateway): keep launchd gateways alive after clean exits

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18154,11 +18154,9 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         return False  # → sys.exit(1) in the caller
 
     # When the gateway is restarting via the service manager (SIGUSR1 →
-    # launchd_restart or /restart / /update commands), exit with code 75 so
-    # that launchd's ``KeepAlive → SuccessfulExit → false`` policy treats
-    # the exit as *unsuccessful* and relaunches the service.  This mirrors
-    # the systemd ``RestartForceExitStatus=75`` convention already used by
-    # the systemd unit template.
+    # launchd_restart or /restart / /update commands), exit with code 75.
+    # systemd uses ``RestartForceExitStatus=75`` and launchd uses
+    # ``KeepAlive=true`` to relaunch the service after the drain completes.
     if runner._restart_via_service:
         logger.info(
             "Exiting with code 75 (service-restart requested) so "

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -208,8 +208,8 @@ def _graceful_restart_via_sigusr1(pid: int, drain_timeout: float) -> bool:
     SIGUSR1 is wired in gateway/run.py to ``request_restart(via_service=True)``
     which drains in-flight agent runs (up to ``agent.restart_drain_timeout``
     seconds), then exits with code 75.  Both systemd (``Restart=always``
-    + ``RestartForceExitStatus=75``) and launchd (``KeepAlive.SuccessfulExit
-    = false``) relaunch the process after the graceful exit.
+    + ``RestartForceExitStatus=75``) and launchd (``KeepAlive=true``)
+    relaunch the process after the graceful exit.
 
     This is the drain-aware alternative to ``systemctl restart`` / ``SIGTERM``,
     which SIGKILL in-flight agents after a short timeout.
@@ -2852,10 +2852,7 @@ def generate_launchd_plist() -> str:
     <true/>
     
     <key>KeepAlive</key>
-    <dict>
-        <key>SuccessfulExit</key>
-        <false/>
-    </dict>
+    <true/>
     
     <key>StandardOutPath</key>
     <string>{log_dir}/gateway.log</string>
@@ -2972,7 +2969,7 @@ def launchd_stop():
         pass
     # bootout unloads the service definition so KeepAlive doesn't respawn
     # the process.  A plain `kill SIGTERM` only signals the process — launchd
-    # immediately restarts it because KeepAlive.SuccessfulExit = false.
+    # immediately restarts it because KeepAlive=true keeps the job resident.
     # `hermes gateway start` re-bootstraps when it detects the job is unloaded.
     try:
         subprocess.run(["launchctl", "bootout", target], check=True, timeout=90)

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1,6 +1,7 @@
 """Tests for gateway service management helpers."""
 
 import os
+import plistlib
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
@@ -474,6 +475,12 @@ class TestLaunchdServiceRecovery:
             gateway_cli._get_restart_drain_timeout()
             == DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
         )
+
+    def test_launchd_plist_keeps_gateway_alive_after_clean_exit(self):
+        """launchd should respawn the daemon even after a clean SIGTERM/exit(0)."""
+        plist = plistlib.loads(gateway_cli.generate_launchd_plist().encode("utf-8"))
+
+        assert plist["KeepAlive"] is True
 
     def test_launchd_install_repairs_outdated_plist_without_force(self, tmp_path, monkeypatch):
         plist_path = tmp_path / "ai.hermes.gateway.plist"


### PR DESCRIPTION
## Summary
- switch generated launchd gateway plist from `KeepAlive.SuccessfulExit=false` to `KeepAlive=true`
- keep explicit `launchctl bootout` stop behavior so intentional stops stay stopped
- update restart comments to match the new launchd policy

## Why
Issue #4587 called out a latent macOS multi-profile failure mode: an unexpected clean gateway exit can leave a launchd-managed profile permanently down until manual `kickstart`. Bug 1/2 have since been fixed, and this completes the remaining launchd resilience gap.

Closes #4587

## Test plan
- `HERMES_TEST_WORKERS=1 scripts/run_tests.sh tests/hermes_cli/test_gateway_service.py::TestLaunchdServiceRecovery::test_launchd_plist_keeps_gateway_alive_after_clean_exit`
- `HERMES_TEST_WORKERS=1 scripts/run_tests.sh tests/hermes_cli/test_gateway_service.py::TestLaunchdServiceRecovery`
- `HERMES_TEST_WORKERS=1 scripts/run_tests.sh tests/hermes_cli/test_gateway.py tests/gateway/test_status.py`

## Notes
- A broader local run of `tests/hermes_cli/test_gateway_service.py tests/hermes_cli/test_gateway.py tests/gateway/test_status.py` still has 6 pre-existing macOS/user-systemd preflight failures unrelated to this launchd change.