### PR TITLE
feat(approval): distinct approval pattern for git push --force-with-lease

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -847,6 +847,26 @@ class TestGitDestructiveOps:
         dangerous, _, desc = detect_dangerous_command(cmd)
         assert dangerous is True
 
+    def test_git_push_force_with_lease_distinct_description(self):
+        """--force-with-lease must match a more specific pattern that comes
+        before the generic --force, so it gets its own description and can
+        be allowlisted independently of plain --force / -f."""
+        cmd = "git push --force-with-lease origin main"
+        dangerous, _, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "lease" in desc.lower()
+        # And must NOT collide with the generic force-push description.
+        plain_cmd = "git push --force origin main"
+        _, _, plain_desc = detect_dangerous_command(plain_cmd)
+        assert desc != plain_desc
+
+    def test_git_push_force_with_lease_equals_value(self):
+        """--force-with-lease=ref form must still match the lease pattern."""
+        cmd = "git push --force-with-lease=main:abc123 origin main"
+        dangerous, _, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "lease" in desc.lower()
+
     def test_git_clean_force_detected(self):
         cmd = "git clean -fd"
         dangerous, _, desc = detect_dangerous_command(cmd)

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -385,6 +385,11 @@ DANGEROUS_PATTERNS = [
     # Git destructive operations that can lose uncommitted work or rewrite
     # shared history. Not captured by rm/chmod/etc patterns.
     (r'\bgit\s+reset\s+--hard\b', "git reset --hard (destroys uncommitted changes)"),
+    # --force-with-lease must precede the generic --force / -f patterns so the
+    # safer leased force-push gets its own description and can be allowlisted
+    # independently. The trailing \b prevents partial matches on values like
+    # `--force-with-lease=ref`.
+    (r'\bgit\s+push\b.*--force-with-lease\b', "git force push with lease (safer; aborts if remote moved)"),
     (r'\bgit\s+push\b.*--force\b', "git force push (rewrites remote history)"),
     (r'\bgit\s+push\b.*-f\b', "git force push short flag (rewrites remote history)"),
     (r'\bgit\s+clean\s+-[^\s]*f', "git clean with force (deletes untracked files)"),


### PR DESCRIPTION
## What does this PR do?

Adds the ability to only whitelist `git push --force-with-lease` excluding `git push --force`.

`--force-with-lease` is safer than `--force` / `-f`: it aborts when the remote ref has moved since the local fetch, so it won't blindly clobber another contributor's work. Today both forms match the same generic `--force` pattern and share a description, so users who want the safer leased push auto-approved have no choice but to allowlist all force pushes.

Add a more-specific `--force-with-lease` pattern *before* the generic `--force` / `-f` patterns (first match wins) with its own description, so it can be added to `command_allowlist` without also waiving plain `--force` / `-f`.

Adds two tests covering the bare flag and the `--force-with-lease=ref` value form, plus a non-collision check against the generic description.



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- tools/approval.py - Added `git push --force-with-lease`

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Add `git force push with lease (safer; aborts if remote moved)` to `command_allowlist` in `config.yaml`
2. Ask hermes-agent to make a change, then amend the commit and force push with lease and see if it prompts asking for permission to force push with lease.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (**23 tests fail but those weren't affected by this PR**)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform Ubuntu 24.04
### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [N/A] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

