### PR TITLE
docs: clarify xurl auth path in Docker

### DIFF
--- a/skills/social-media/xurl/SKILL.md
+++ b/skills/social-media/xurl/SKILL.md
@@ -48,6 +48,8 @@ Forbidden flags in agent commands (they accept inline secrets):
 
 App credential registration and credential rotation must be done by the user manually, outside the agent session. After credentials are registered, the user authenticates with `xurl auth oauth2` — also outside the agent session. Tokens persist to `~/.xurl` in YAML. Each app has isolated tokens. OAuth 2.0 tokens auto-refresh.
 
+When Hermes runs in the official Docker image, tool subprocesses use the isolated home directory at `$HERMES_HOME/home` (usually `/opt/data/home`). In that environment, complete xurl setup from the same home that Hermes tools will use, for example with `HOME=/opt/data/home`, so the resulting `.xurl` directory is visible to agent-run `xurl` commands.
+
 ---
 
 ## Installation

--- a/website/docs/user-guide/docker.md
+++ b/website/docs/user-guide/docker.md
@@ -121,6 +121,8 @@ The `/opt/data` volume is the single source of truth for all Hermes state. It ma
 | `logs/` | Runtime logs |
 | `skins/` | Custom CLI skins |
 
+Tool subprocesses may use an isolated home under this volume, typically `/opt/data/home`. When a third-party CLI stores its own state under `~` (for example `xurl` writing OAuth state to `~/.xurl`), run its one-time setup with the same home that Hermes tools will see, such as `HOME=/opt/data/home`, rather than `HOME=/opt/data`.
+
 :::warning
 Never run two Hermes **gateway** containers against the same data directory simultaneously — session files and memory stores are not designed for concurrent write access.
 :::

--- a/website/docs/user-guide/skills/bundled/social-media/social-media-xurl.md
+++ b/website/docs/user-guide/skills/bundled/social-media/social-media-xurl.md
@@ -62,6 +62,8 @@ Forbidden flags in agent commands (they accept inline secrets):
 
 App credential registration and credential rotation must be done by the user manually, outside the agent session. After credentials are registered, the user authenticates with `xurl auth oauth2` — also outside the agent session. Tokens persist to `~/.xurl` in YAML. Each app has isolated tokens. OAuth 2.0 tokens auto-refresh.
 
+When Hermes runs in the official Docker image, tool subprocesses use the isolated home directory at `$HERMES_HOME/home` (usually `/opt/data/home`). In that environment, complete xurl setup from the same home that Hermes tools will use, for example with `HOME=/opt/data/home`, so the resulting `.xurl` directory is visible to agent-run `xurl` commands.
+
 ---
 
 ## Installation


### PR DESCRIPTION
## Summary
- Document that Docker tool subprocesses use the isolated `$HERMES_HOME/home` path for home-directory CLI state.
- Add the xurl-specific Docker pitfall to both the bundled skill source and generated skill docs.
- Point users at `HOME=/opt/data/home` so `.xurl` is visible to Hermes-run xurl commands.

Fixes #29108

## Validation
- `git diff --check`
- `npm run build` from `website/` succeeded; Docusaurus emitted pre-existing broken-link/broken-anchor warnings unrelated to the edited xurl/Docker docs.
