### PR TITLE
fix(kanban): make swarm graph idempotent on retry after partial failure

### DIFF
--- a/hermes_cli/kanban_swarm.py
+++ b/hermes_cli/kanban_swarm.py
@@ -74,6 +74,21 @@ def _swarm_context(root_id: str, goal: str) -> str:
     )
 
 
+def _child_idempotency_key(root_key: Optional[str], role: str) -> Optional[str]:
+    """Derive a stable idempotency key for a swarm child card.
+
+    Returns ``None`` when the swarm was created without an ``idempotency_key``
+    so non-idempotent callers keep getting a fresh graph on every call. When a
+    key is present, every child card gets a deterministic key derived from it,
+    so a retry after a partial failure re-attaches to the already-created cards
+    instead of building a second parallel graph under the same root. See
+    :func:`create_swarm`.
+    """
+    if not root_key:
+        return None
+    return f"{root_key}::swarm::{role}"
+
+
 def create_swarm(
     conn: sqlite3.Connection,
     *,
@@ -96,6 +111,11 @@ def create_swarm(
     The returned graph is immediately dispatchable: the planning root is marked
     ``done`` with topology metadata, parallel workers are ``ready``, the verifier
     waits for every worker, and the synthesizer waits for the verifier.
+
+    When ``idempotency_key`` is provided the whole graph is idempotent: a retry
+    after a partial failure (e.g. the process dies before the topology comment
+    is written) recovers the same cards instead of creating a second parallel
+    graph under the root.
     """
 
     goal = _require_text(goal, "goal")
@@ -127,9 +147,13 @@ def create_swarm(
         skills=["kanban-orchestrator"],
     )
 
-    # If idempotency returned an existing non-archived root, do not duplicate the
-    # swarm graph. Recover the topology from the root's latest blackboard, if it
-    # was created by this helper previously.
+    # Fast path: if idempotency returned an existing non-archived root that a
+    # previous call already built in full, recover the topology from its latest
+    # blackboard and return without touching the graph. If that previous call
+    # died before writing the topology comment (see end of this function), the
+    # topology is missing here and we fall through -- the derived child
+    # idempotency keys below then re-attach to the existing cards instead of
+    # duplicating the whole graph.
     existing = latest_blackboard(conn, root).get("topology")
     if isinstance(existing, dict):
         worker_ids = [str(x) for x in existing.get("worker_ids", []) if x]
@@ -156,7 +180,7 @@ def create_swarm(
 
     context_suffix = _swarm_context(root, goal)
     worker_ids: list[str] = []
-    for spec in worker_specs:
+    for index, spec in enumerate(worker_specs):
         worker_id = kb.create_task(
             conn,
             title=spec.title,
@@ -170,6 +194,7 @@ def create_swarm(
             workspace_path=workspace_path,
             skills=spec.skills or None,
             max_runtime_seconds=spec.max_runtime_seconds,
+            idempotency_key=_child_idempotency_key(idempotency_key, f"worker:{index}"),
         )
         worker_ids.append(worker_id)
 
@@ -191,6 +216,7 @@ def create_swarm(
         workspace_kind=workspace_kind,
         workspace_path=workspace_path,
         skills=["requesting-code-review"],
+        idempotency_key=_child_idempotency_key(idempotency_key, "verifier"),
     )
 
     synthesizer_body = (
@@ -210,6 +236,7 @@ def create_swarm(
         workspace_kind=workspace_kind,
         workspace_path=workspace_path,
         skills=["avoid-ai-writing"],
+        idempotency_key=_child_idempotency_key(idempotency_key, "synthesizer"),
     )
 
     created = SwarmCreated(root, worker_ids, verifier, synthesizer)

--- a/tests/hermes_cli/test_kanban_swarm.py
+++ b/tests/hermes_cli/test_kanban_swarm.py
@@ -1,6 +1,9 @@
 import json
 
+import pytest
+
 from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_swarm as ks
 from hermes_cli.kanban_swarm import (
     SwarmWorkerSpec,
     create_swarm,
@@ -73,6 +76,65 @@ def test_swarm_blackboard_merges_structured_updates(tmp_path):
         assert board["sources"] == ["https://example.com/a"]
         assert board["risks"] == {"missing_primary_source": True}
         assert board["_authors"]["sources"] == "researcher"
+    finally:
+        conn.close()
+
+
+def test_create_swarm_is_idempotent_after_partial_failure(tmp_path, monkeypatch):
+    """A retry with the same idempotency_key after a crash between graph build
+    and the topology write must recover the existing cards, not build a second
+    parallel graph under the root."""
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        swarm_kwargs = dict(
+            goal="Research two branches then verify and synthesize.",
+            workers=[
+                SwarmWorkerSpec(profile="a", title="Branch A", body="A"),
+                SwarmWorkerSpec(profile="b", title="Branch B", body="B"),
+            ],
+            verifier_assignee="reviewer",
+            synthesizer_assignee="writer",
+            idempotency_key="swarm-key-1",
+        )
+
+        # Simulate a partial failure: the whole graph is written, but the
+        # process dies before the topology blackboard comment is posted. The
+        # already-committed task rows survive (autocommit + per-call write_txn).
+        def _boom(*args, **kwargs):
+            raise RuntimeError("simulated crash before topology write")
+
+        monkeypatch.setattr(ks, "post_blackboard_update", _boom)
+        with pytest.raises(RuntimeError):
+            create_swarm(conn, **swarm_kwargs)
+        monkeypatch.undo()
+
+        root_id = conn.execute(
+            "SELECT id FROM tasks WHERE idempotency_key = ? "
+            "ORDER BY created_at DESC LIMIT 1",
+            ("swarm-key-1",),
+        ).fetchone()["id"]
+
+        # The crash left a complete graph but no topology recovery marker.
+        first_workers = sorted(kb.child_ids(conn, root_id))
+        assert len(first_workers) == 2
+        assert "topology" not in latest_blackboard(conn, root_id)
+        task_count = conn.execute("SELECT COUNT(*) AS n FROM tasks").fetchone()["n"]
+        assert task_count == 5  # root + 2 workers + verifier + synthesizer
+
+        # Retry with the same key: must re-attach, not duplicate.
+        created = create_swarm(conn, **swarm_kwargs)
+
+        assert created.root_id == root_id
+        assert sorted(created.worker_ids) == first_workers
+        assert sorted(kb.child_ids(conn, root_id)) == first_workers
+        # No second worker/verifier/synthesizer set was created.
+        retry_count = conn.execute("SELECT COUNT(*) AS n FROM tasks").fetchone()["n"]
+        assert retry_count == 5
+        # The verifier still gates on exactly the original two workers.
+        assert set(kb.parent_ids(conn, created.verifier_id)) == set(first_workers)
+        assert kb.parent_ids(conn, created.synthesizer_id) == [created.verifier_id]
+        # Topology marker is now durably written.
+        assert latest_blackboard(conn, root_id).get("topology")
     finally:
         conn.close()
 


### PR DESCRIPTION
## Summary

`create_swarm` writes its task graph as several independently-committed
statements — the kanban DB connection is autocommit (`isolation_level=None`)
and each `create_task`/`complete_task`/`add_comment` runs in its own
`BEGIN IMMEDIATE` transaction, so nothing wraps the whole swarm build. The
`topology` blackboard comment used to dedup a repeated call is written **last**,
and the worker/verifier/synthesizer cards were created **without** an
`idempotency_key`.

So if a call dies after creating (some of) the graph but before the topology
comment lands, a retry with the same `idempotency_key` finds the root via
idempotency, misses the topology dedup short-circuit, and builds a **second**
full worker/verifier/synthesizer graph under the same root — doubling workers
and compute and leaving orphan cards. Idempotency breaks in exactly the
retry-after-failure case it exists to protect.

**Fix:** derive a stable per-child `idempotency_key` from the root's key
(`<key>::swarm::worker:<i>`, `::verifier`, `::synthesizer`) and pass it to each
child `create_task`. This reuses the existing, tested idempotency path, so a
retry re-attaches to the already-created cards (or completes the missing tail)
instead of duplicating. When no `idempotency_key` is supplied, behavior is
unchanged (a fresh graph per call). No DB-layer or transaction-model changes.

## Test plan

- [x] Added `test_create_swarm_is_idempotent_after_partial_failure`: simulates a
  crash between graph build and the topology write, retries with the same key,
  and asserts the root keeps exactly 2 workers, total card count stays 5 (not 9),
  the same worker/verifier/synthesizer ids come back, and topology is now written.
- [x] Confirmed the new test **fails** on the pre-fix code (retry produced a
  different worker set).
