### PR TITLE
fix: deliver plugin-transformed final_response through streaming gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ models-dev-upstream/
 hermes_cli/tui_dist/*
 hermes_cli/scripts/
 docs/superpowers/*
+graphify-out/

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1534,7 +1534,9 @@ class HermesACPAgent(acp.Agent):
                 )
             except Exception:
                 logger.debug("Failed to auto-title ACP session %s", session_id, exc_info=True)
-        if final_response and conn and not streamed_message:
+        if final_response and conn:
+            # Always deliver the final response — plugins may have transformed
+            # it after streaming finished (e.g. transform_llm_output hook).
             update = acp.update_agent_message_text(final_response)
             await conn.session_update(session_id, update)
 

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1537,6 +1537,11 @@ class HermesACPAgent(acp.Agent):
         if final_response and conn:
             # Always deliver the final response — plugins may have transformed
             # it after streaming finished (e.g. transform_llm_output hook).
+            logger.warning(
+                "TRACE: delivering final_response to ACP, streamed=%s len=%d has_debug=%s",
+                streamed_message, len(final_response),
+                "🔧 [Debug]" in final_response,
+            )
             update = acp.update_agent_message_text(final_response)
             await conn.session_update(session_id, update)
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4031,6 +4031,8 @@ def run_conversation(
         except Exception as _ver_err:
             logger.debug("file-mutation verifier footer failed: %s", _ver_err)
 
+    _response_transformed = False
+
     # Plugin hook: transform_llm_output
     # Fired once per turn after the tool-calling loop completes.
     # Plugins can transform the LLM's output text before it's returned.
@@ -4045,9 +4047,11 @@ def run_conversation(
                 model=agent.model,
                 platform=getattr(agent, "platform", None) or "",
             )
+            _response_transformed = False
             for _hook_result in _transform_results:
                 if isinstance(_hook_result, str) and _hook_result:
                     final_response = _hook_result
+                    _response_transformed = True
                     break  # First non-empty string wins
         except Exception as exc:
             logger.warning("transform_llm_output hook failed: %s", exc)
@@ -4099,6 +4103,7 @@ def run_conversation(
         "failed": failed,
         "partial": False,  # True only when stopped due to invalid tool calls
         "interrupted": interrupted,
+        "response_transformed": _response_transformed,
         "response_previewed": getattr(agent, "_response_was_previewed", False),
         "model": agent.model,
         "provider": agent.provider,

--- a/docs/dev/FIX-plugin-transform-llm-output-streaming.md
+++ b/docs/dev/FIX-plugin-transform-llm-output-streaming.md
@@ -1,0 +1,100 @@
+# FIX: plugin transform_llm_output content suppressed on streaming platforms
+
+**Date**: 2026-05-20  
+**Author**: Kai.Xu  
+**Upstream PR**: [#29119](https://github.com/NousResearch/hermes-agent/pull/29119)
+
+---
+
+## 1. Problem
+
+Plugin hooks registered on `transform_llm_output` modify the final response AFTER streaming completes. However, three separate suppression points in the codebase silently discard the transformed content, making the hook effectively invisible on all streaming platforms (Discord, Telegram, ACP, etc.).
+
+## 2. Root Cause
+
+### Suppression Point 1: ACP Adapter
+
+`acp_adapter/server.py:1537` — the `not streamed_message` guard skips `final_response` delivery when streaming was used:
+
+```python
+if final_response and conn and not streamed_message:  # ← blocks transformed content
+    update = acp.update_agent_message_text(final_response)
+```
+
+### Suppression Point 2: Gateway Final-Send Gate
+
+`gateway/run.py:17578` — the normal final send is suppressed when content was already streamed:
+
+```python
+if not _is_empty_sentinel and (_streamed or _previewed or _content_delivered):
+    response["already_sent"] = True  # ← transformed content never sent
+```
+
+### Suppression Point 3: Field Stripping in run_sync()
+
+`gateway/run.py:16939-16958` — `run_sync()` cherry-picks fields from the `run_conversation()` result dict into a new response dict. The `response_transformed` flag (set by the conversation loop when a hook modifies the response) was not included in the cherry-pick list:
+
+```python
+return {
+    "final_response": final_response,
+    "response_previewed": result.get("response_previewed", False),
+    # response_transformed was MISSING here
+}
+```
+
+This broke the data flow: conversation_loop → result dict → gateway response → suppression check.
+
+## 3. Fix (5 coordinated changes)
+
+### 3.1 `agent/conversation_loop.py`
+- Initialize `_response_transformed = False` before the hook section
+- Set `_response_transformed = True` when a `transform_llm_output` hook returns a non-empty string
+- Include `"response_transformed": _response_transformed` in the result dict
+
+### 3.2 `gateway/run.py` — `run_sync()` return dict
+- Add `"response_transformed": result.get("response_transformed", False)` to the cherry-picked fields (both normal and error return paths)
+
+### 3.3 `gateway/run.py` — suppression check
+- When `response_transformed=True`, edit the existing streamed message in-place via the adapter's `edit_message()` with the full transformed content
+- Set `already_sent=True` to prevent the normal send from creating a duplicate message
+
+### 3.4 `gateway/stream_consumer.py`
+- Expose `message_id` and `accumulated_text` as public read-only `@property` attributes so the gateway can access the streamed message identifier for editing
+
+### 3.5 `acp_adapter/server.py`
+- Remove the `not streamed_message` guard — the final response (possibly transformed by plugins) should always be delivered to the ACP client
+
+## 4. Data Flow After Fix
+
+```
+LLM generates response → streamed to client (message_id=X)
+transform_llm_output hook appends content → response_transformed=True
+     ↓
+conversation_loop: result["response_transformed"] = True
+     ↓
+gateway run_sync(): propagates response_transformed
+     ↓
+gateway suppression check: transformed=True, has message_id
+     ↓
+adapter.edit_message(chat_id, message_id, content=final_response_with_transform)
+     ↓
+already_sent=True → normal send suppressed (no duplicate)
+```
+
+## 5. Behavior
+
+| Scenario | Before | After |
+|----------|--------|-------|
+| Plugin active, streaming | Transformed content silently dropped | Content appended via message edit |
+| Plugin active, non-streaming | Works | Works (unchanged) |
+| Plugin inactive | Normal delivery | Normal delivery (unchanged) |
+| No plugin installed | Normal delivery | Normal delivery (unchanged) |
+
+## 6. Verification
+
+```bash
+# Gateway trace log
+grep "TRACE: final-send check" agent.log
+# transformed=True  → message edited in-place, no duplicate
+# transformed=False → original suppression path, no duplicate
+```

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17694,6 +17694,11 @@ class GatewayRunner:
             # after streaming finished — when the response was transformed, always
             # send the final version so the appended content reaches the client.
             _transformed = bool(response.get("response_transformed"))
+            logger.warning(
+                "TRACE: final-send check transformed=%s streamed=%s previewed=%s content_delivered=%s final_len=%s",
+                _transformed, _streamed, _previewed, _content_delivered,
+                len(response.get("final_response") or ""),
+            )
             if not _is_empty_sentinel and not _transformed and (_streamed or _previewed or _content_delivered):
                 logger.info(
                     "Suppressing normal final send for session %s: final delivery already confirmed (streamed=%s previewed=%s content_delivered=%s).",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17053,6 +17053,7 @@ class GatewayRunner:
                 "context_length": _context_length,
                 "session_id": effective_session_id,
                 "response_previewed": result.get("response_previewed", False),
+                "response_transformed": result.get("response_transformed", False),
             }
         
         # Start progress message sender if enabled

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17690,7 +17690,11 @@ class GatewayRunner:
             _content_delivered = bool(
                 _sc and getattr(_sc, "final_content_delivered", False)
             )
-            if not _is_empty_sentinel and (_streamed or _previewed or _content_delivered):
+            # Plugin hooks (e.g. transform_llm_output) may have appended content
+            # after streaming finished — when the response was transformed, always
+            # send the final version so the appended content reaches the client.
+            _transformed = bool(response.get("response_transformed"))
+            if not _is_empty_sentinel and not _transformed and (_streamed or _previewed or _content_delivered):
                 logger.info(
                     "Suppressing normal final send for session %s: final delivery already confirmed (streamed=%s previewed=%s content_delivered=%s).",
                     session_key or "?",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17709,6 +17709,28 @@ class GatewayRunner:
                     _content_delivered,
                 )
                 response["already_sent"] = True
+            elif not _is_empty_sentinel and _transformed and _sc is not None:
+                # Plugin hooks transformed the response after streaming — edit the
+                # existing streamed message instead of sending a duplicate.
+                _sc_msg_id = _sc.message_id
+                if _sc_msg_id:
+                    try:
+                        await _sc.adapter.edit_message(
+                            chat_id=source.chat_id,
+                            message_id=_sc_msg_id,
+                            content=response["final_response"],
+                            finalize=True,
+                        )
+                        response["already_sent"] = True
+                        logger.info(
+                            "Edited streamed message %s for session %s to include plugin-transformed content.",
+                            _sc_msg_id, session_key or "?",
+                        )
+                    except Exception as _edit_err:
+                        logger.warning(
+                            "Failed to edit streamed message for session %s: %s",
+                            session_key or "?", _edit_err,
+                        )
 
         # Schedule deletion of tracked temporary progress bubbles after the
         # final response lands. Failed runs skip this so bubbles remain as

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -193,6 +193,16 @@ class GatewayStreamConsumer:
         return self._final_response_sent
 
     @property
+    def message_id(self) -> str | None:
+        """The Discord/chat message ID of the last-sent or edited message."""
+        return self._message_id
+
+    @property
+    def accumulated_text(self) -> str:
+        """The accumulated streamed text (without think-block content)."""
+        return self._accumulated
+
+    @property
     def final_content_delivered(self) -> bool:
         """True when the final response content reached the user, even if
         the subsequent cosmetic edit (cursor removal) failed."""


### PR DESCRIPTION
## Problem

Plugin hooks registered on `transform_llm_output` modify the final response AFTER streaming completes. However, three separate suppression points silently discard the transformed content:

1. **ACP adapter** (`acp_adapter/server.py`): `not streamed_message` guard skips `final_response` delivery when streaming was used
2. **Gateway suppression** (`gateway/run.py`): `_streamed or _content_delivered` check suppresses the normal final send entirely
3. **Gateway `run_sync()`** (`gateway/run.py`): cherry-picks fields from the `run_conversation` result dict into a new response dict, but omits critical fields

The net effect is that any content appended by a `transform_llm_output` hook never reaches end users on streaming platforms (Discord, Telegram, ACP, etc.).

## Fix (4 coordinated changes)

### 1. `agent/conversation_loop.py`
Set `response_transformed=True` when a `transform_llm_output` hook returns a non-empty string. Expose this as `response_transformed` in the result dict.

### 2. `gateway/run.py` — `run_sync()` return dict
Add `response_transformed` to the cherry-picked fields so the flag survives the gateway's response construction.

### 3. `gateway/run.py` — suppression check
When `response_transformed=True`, edit the existing streamed message in-place (via the adapter's `edit_message`) with the full transformed content, then set `already_sent=True`. This avoids creating a duplicate message while ensuring the transformed content reaches the client.

### 4. `gateway/stream_consumer.py`
Expose `message_id` and `accumulated_text` as public read-only properties so the gateway can perform the in-place edit.

### 5. `acp_adapter/server.py`
Remove the `not streamed_message` guard — the final response (possibly transformed by plugins) should always be delivered to the ACP client.

## Test plan

1. Enable a `transform_llm_output` plugin that appends text
2. Send a message via Discord or any streaming platform
3. Verify the appended text appears in the SAME message (not a duplicate)
4. Disable the plugin — verify no duplicate messages or extra text