### PR TITLE
fix(tools): reap orphaned hermes-* sandboxes on first sandbox use (#28807)

### DIFF
--- a/tests/tools/test_terminal_orphan_reconciliation.py
+++ b/tests/tools/test_terminal_orphan_reconciliation.py
@@ -1,0 +1,339 @@
+"""Tests for startup orphan-sandbox reconciliation in ``tools.terminal_tool``.
+
+Covers the helpers added for issue #28807:
+- ``_reconcile_orphaned_docker_sandboxes``
+- ``_reconcile_orphaned_daytona_sandboxes``
+- ``_reconcile_orphaned_sandboxes`` (dispatch by ``env_type``)
+- The one-shot wiring inside ``_start_cleanup_thread``
+"""
+
+import importlib
+import subprocess
+import sys
+import types
+
+import pytest
+
+
+terminal_tool = importlib.import_module("tools.terminal_tool")
+
+
+# ---------- helpers ----------
+
+
+def _stub_get_env_config(monkeypatch, env_type: str) -> None:
+    monkeypatch.setattr(
+        terminal_tool, "_get_env_config", lambda: {"env_type": env_type}
+    )
+
+
+def _record_subprocess(monkeypatch, run_returns):
+    """Patch ``terminal_tool.subprocess.run`` to record calls.
+
+    ``run_returns`` is a list of ``CompletedProcess`` (or exceptions to raise)
+    consumed in order. Returns the call-recording list.
+    """
+    calls = []
+    iterator = iter(run_returns)
+
+    def fake_run(*args, **kwargs):
+        calls.append((args, kwargs))
+        try:
+            nxt = next(iterator)
+        except StopIteration:
+            raise AssertionError(
+                f"subprocess.run called more times than fixture provided. "
+                f"Extra call args={args!r} kwargs={kwargs!r}"
+            )
+        if isinstance(nxt, BaseException):
+            raise nxt
+        return nxt
+
+    monkeypatch.setattr(terminal_tool.subprocess, "run", fake_run)
+    return calls
+
+
+def _completed(stdout: str = "", returncode: int = 0, stderr: str = ""):
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+# ---------- Docker reconciliation ----------
+
+
+class TestDockerReconciliation:
+    def test_reaps_listed_containers(self, monkeypatch, caplog):
+        monkeypatch.setattr(
+            "tools.environments.docker.find_docker", lambda: "/usr/bin/docker"
+        )
+        calls = _record_subprocess(
+            monkeypatch,
+            [
+                _completed(stdout="hermes-aaaaaaaa\nhermes-bbbbbbbb\n"),
+                _completed(),
+                _completed(),
+            ],
+        )
+        with caplog.at_level("INFO", logger=terminal_tool.logger.name):
+            terminal_tool._reconcile_orphaned_docker_sandboxes()
+
+        # First call: docker ps with name filter
+        ps_cmd = calls[0][0][0]
+        assert ps_cmd[:3] == ["/usr/bin/docker", "ps", "-a"]
+        assert "name=^hermes-" in ps_cmd
+        assert "{{.Names}}" in ps_cmd
+
+        # Two rm -f calls, one per container
+        rm_cmds = [c[0][0] for c in calls[1:]]
+        assert rm_cmds[0] == ["/usr/bin/docker", "rm", "-f", "hermes-aaaaaaaa"]
+        assert rm_cmds[1] == ["/usr/bin/docker", "rm", "-f", "hermes-bbbbbbbb"]
+        assert any("reaping 2 Docker" in r.message for r in caplog.records)
+
+    def test_no_docker_binary_noops(self, monkeypatch):
+        monkeypatch.setattr("tools.environments.docker.find_docker", lambda: None)
+        calls = _record_subprocess(monkeypatch, [])  # any call → AssertionError
+        terminal_tool._reconcile_orphaned_docker_sandboxes()
+        assert calls == []
+
+    def test_empty_listing_noops(self, monkeypatch):
+        monkeypatch.setattr(
+            "tools.environments.docker.find_docker", lambda: "/usr/bin/docker"
+        )
+        calls = _record_subprocess(monkeypatch, [_completed(stdout="\n  \n")])
+        terminal_tool._reconcile_orphaned_docker_sandboxes()
+        # Only the ps call was made — no rm.
+        assert len(calls) == 1
+
+    def test_ps_subprocess_error_swallowed(self, monkeypatch, caplog):
+        monkeypatch.setattr(
+            "tools.environments.docker.find_docker", lambda: "/usr/bin/docker"
+        )
+        _record_subprocess(monkeypatch, [OSError("docker daemon down")])
+        with caplog.at_level("WARNING", logger=terminal_tool.logger.name):
+            terminal_tool._reconcile_orphaned_docker_sandboxes()
+        assert any("docker ps failed" in r.message for r in caplog.records)
+
+    def test_ps_nonzero_exit_swallowed(self, monkeypatch, caplog):
+        monkeypatch.setattr(
+            "tools.environments.docker.find_docker", lambda: "/usr/bin/docker"
+        )
+        _record_subprocess(
+            monkeypatch,
+            [_completed(returncode=1, stderr="Cannot connect to daemon")],
+        )
+        with caplog.at_level("WARNING", logger=terminal_tool.logger.name):
+            terminal_tool._reconcile_orphaned_docker_sandboxes()
+        assert any("exited 1" in r.message for r in caplog.records)
+
+    def test_rm_failure_does_not_abort_others(self, monkeypatch, caplog):
+        monkeypatch.setattr(
+            "tools.environments.docker.find_docker", lambda: "/usr/bin/docker"
+        )
+        calls = _record_subprocess(
+            monkeypatch,
+            [
+                _completed(stdout="hermes-aaa\nhermes-bbb\n"),
+                OSError("rm aaa exploded"),  # first rm fails
+                _completed(),  # second rm should still run
+            ],
+        )
+        with caplog.at_level("WARNING", logger=terminal_tool.logger.name):
+            terminal_tool._reconcile_orphaned_docker_sandboxes()
+        # 1 ps + 2 rm attempts
+        assert len(calls) == 3
+        assert any("failed to remove container hermes-aaa" in r.message for r in caplog.records)
+
+
+# ---------- Daytona reconciliation ----------
+
+
+class _FakeSandbox:
+    def __init__(self, name: str, sid: str = "sb-id"):
+        self.name = name
+        self.id = sid
+
+
+class _FakeDaytonaClient:
+    def __init__(self, sandboxes=None, list_raises=None, delete_raises=None):
+        self._sandboxes = sandboxes or []
+        self._list_raises = list_raises
+        self._delete_raises = delete_raises
+        self.deleted = []
+
+    def list(self):
+        if self._list_raises:
+            raise self._list_raises
+        return iter(self._sandboxes)
+
+    def delete(self, sandbox):
+        self.deleted.append(sandbox)
+        if self._delete_raises:
+            raise self._delete_raises
+
+
+def _install_fake_daytona_module(monkeypatch, client_factory):
+    """Install a fake ``daytona`` module so ``from daytona import Daytona`` works."""
+    fake_mod = types.ModuleType("daytona")
+    fake_mod.Daytona = client_factory  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "daytona", fake_mod)
+
+
+class TestDaytonaReconciliation:
+    def test_reaps_hermes_sandboxes(self, monkeypatch, caplog):
+        sandboxes = [
+            _FakeSandbox("hermes-task1"),
+            _FakeSandbox("hermes-task2"),
+            _FakeSandbox("other-project-sb"),
+        ]
+        client = _FakeDaytonaClient(sandboxes=sandboxes)
+        _install_fake_daytona_module(monkeypatch, lambda: client)
+
+        with caplog.at_level("INFO", logger=terminal_tool.logger.name):
+            terminal_tool._reconcile_orphaned_daytona_sandboxes()
+
+        assert [s.name for s in client.deleted] == ["hermes-task1", "hermes-task2"]
+        assert any("reaping 2 Daytona" in r.message for r in caplog.records)
+
+    def test_no_daytona_sdk_noops(self, monkeypatch):
+        # Force ImportError by absent daytona module.
+        monkeypatch.setitem(sys.modules, "daytona", None)
+        # Should not raise.
+        terminal_tool._reconcile_orphaned_daytona_sandboxes()
+
+    def test_client_init_failure_swallowed(self, monkeypatch, caplog):
+        def boom():
+            raise RuntimeError("DAYTONA_API_KEY missing")
+
+        _install_fake_daytona_module(monkeypatch, boom)
+        with caplog.at_level("WARNING", logger=terminal_tool.logger.name):
+            terminal_tool._reconcile_orphaned_daytona_sandboxes()
+        assert any("client init failed" in r.message for r in caplog.records)
+
+    def test_list_failure_swallowed(self, monkeypatch, caplog):
+        client = _FakeDaytonaClient(list_raises=RuntimeError("network unreachable"))
+        _install_fake_daytona_module(monkeypatch, lambda: client)
+        with caplog.at_level("WARNING", logger=terminal_tool.logger.name):
+            terminal_tool._reconcile_orphaned_daytona_sandboxes()
+        assert any("Daytona list failed" in r.message for r in caplog.records)
+        assert client.deleted == []
+
+    def test_delete_failure_does_not_abort_others(self, monkeypatch, caplog):
+        sandboxes = [_FakeSandbox("hermes-a"), _FakeSandbox("hermes-b")]
+        client = _FakeDaytonaClient(
+            sandboxes=sandboxes, delete_raises=RuntimeError("forbidden")
+        )
+        _install_fake_daytona_module(monkeypatch, lambda: client)
+        with caplog.at_level("WARNING", logger=terminal_tool.logger.name):
+            terminal_tool._reconcile_orphaned_daytona_sandboxes()
+        # Both attempted even though both raised.
+        assert [s.name for s in client.deleted] == ["hermes-a", "hermes-b"]
+        assert (
+            sum("failed to delete Daytona" in r.message for r in caplog.records) == 2
+        )
+
+    def test_no_hermes_sandboxes_noops(self, monkeypatch):
+        client = _FakeDaytonaClient(sandboxes=[_FakeSandbox("other-sb")])
+        _install_fake_daytona_module(monkeypatch, lambda: client)
+        terminal_tool._reconcile_orphaned_daytona_sandboxes()
+        assert client.deleted == []
+
+
+# ---------- Dispatch ----------
+
+
+class TestDispatch:
+    def test_docker_env_dispatches_to_docker(self, monkeypatch):
+        _stub_get_env_config(monkeypatch, "docker")
+        called = []
+        monkeypatch.setattr(
+            terminal_tool, "_reconcile_orphaned_docker_sandboxes",
+            lambda: called.append("docker"),
+        )
+        monkeypatch.setattr(
+            terminal_tool, "_reconcile_orphaned_daytona_sandboxes",
+            lambda: called.append("daytona"),
+        )
+        terminal_tool._reconcile_orphaned_sandboxes()
+        assert called == ["docker"]
+
+    def test_daytona_env_dispatches_to_daytona(self, monkeypatch):
+        _stub_get_env_config(monkeypatch, "daytona")
+        called = []
+        monkeypatch.setattr(
+            terminal_tool, "_reconcile_orphaned_docker_sandboxes",
+            lambda: called.append("docker"),
+        )
+        monkeypatch.setattr(
+            terminal_tool, "_reconcile_orphaned_daytona_sandboxes",
+            lambda: called.append("daytona"),
+        )
+        terminal_tool._reconcile_orphaned_sandboxes()
+        assert called == ["daytona"]
+
+    @pytest.mark.parametrize("env_type", ["local", "modal", "ssh", "vercel_sandbox"])
+    def test_other_envs_skip_reconciliation(self, monkeypatch, env_type):
+        _stub_get_env_config(monkeypatch, env_type)
+        called = []
+        monkeypatch.setattr(
+            terminal_tool, "_reconcile_orphaned_docker_sandboxes",
+            lambda: called.append("docker"),
+        )
+        monkeypatch.setattr(
+            terminal_tool, "_reconcile_orphaned_daytona_sandboxes",
+            lambda: called.append("daytona"),
+        )
+        terminal_tool._reconcile_orphaned_sandboxes()
+        assert called == []
+
+
+# ---------- One-shot wiring inside _start_cleanup_thread ----------
+
+
+class TestStartCleanupThreadWiring:
+    @pytest.fixture(autouse=True)
+    def _reset_module_state(self, monkeypatch):
+        """Reset the one-shot flag + cleanup thread globals around each test."""
+        monkeypatch.setattr(terminal_tool, "_orphan_reconciliation_done", False)
+        monkeypatch.setattr(terminal_tool, "_cleanup_thread", None)
+        monkeypatch.setattr(terminal_tool, "_cleanup_running", False)
+        # Prevent real thread creation
+        monkeypatch.setattr(
+            terminal_tool.threading, "Thread",
+            lambda *a, **kw: types.SimpleNamespace(start=lambda: None, is_alive=lambda: False),
+        )
+        yield
+
+    def test_runs_reconciliation_on_first_call(self, monkeypatch):
+        called = []
+        monkeypatch.setattr(
+            terminal_tool, "_reconcile_orphaned_sandboxes",
+            lambda: called.append(True),
+        )
+        terminal_tool._start_cleanup_thread()
+        assert called == [True]
+        assert terminal_tool._orphan_reconciliation_done is True
+
+    def test_skips_reconciliation_on_subsequent_calls(self, monkeypatch):
+        called = []
+        monkeypatch.setattr(
+            terminal_tool, "_reconcile_orphaned_sandboxes",
+            lambda: called.append(True),
+        )
+        terminal_tool._start_cleanup_thread()
+        terminal_tool._start_cleanup_thread()
+        terminal_tool._start_cleanup_thread()
+        assert called == [True]
+
+    def test_reconciliation_exception_does_not_block_cleanup_thread(self, monkeypatch, caplog):
+        def boom():
+            raise RuntimeError("backend exploded")
+
+        monkeypatch.setattr(terminal_tool, "_reconcile_orphaned_sandboxes", boom)
+        with caplog.at_level("WARNING", logger=terminal_tool.logger.name):
+            terminal_tool._start_cleanup_thread()
+        # Flag still marked done so we don't keep retrying.
+        assert terminal_tool._orphan_reconciliation_done is True
+        # Cleanup thread still started (running flag set).
+        assert terminal_tool._cleanup_running is True
+        assert any("unexpected error" in r.message for r in caplog.records)

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1331,11 +1331,133 @@ def _cleanup_thread_worker():
             time.sleep(1)
 
 
+_HERMES_SANDBOX_PREFIX = "hermes-"
+
+
+def _reconcile_orphaned_docker_sandboxes() -> None:
+    """Reap `hermes-*` Docker containers left by previous processes.
+
+    Lists every container (running or stopped) whose name starts with
+    ``hermes-`` and force-removes it. Called once per process under
+    ``_env_lock`` before any sandbox can be created in this process, so the
+    filter inherently cannot hit any container we own.
+    """
+    from tools.environments.docker import find_docker
+    docker_exe = find_docker()
+    if not docker_exe:
+        return
+    try:
+        result = subprocess.run(
+            [docker_exe, "ps", "-a",
+             "--filter", f"name=^{_HERMES_SANDBOX_PREFIX}",
+             "--format", "{{.Names}}"],
+            capture_output=True, text=True, timeout=10,
+        )
+    except (subprocess.SubprocessError, OSError) as e:
+        logger.warning("Orphan reconciliation: docker ps failed: %s", e)
+        return
+    if result.returncode != 0:
+        logger.warning(
+            "Orphan reconciliation: docker ps exited %d: %s",
+            result.returncode, (result.stderr or "").strip(),
+        )
+        return
+    names = [n.strip() for n in result.stdout.splitlines() if n.strip()]
+    if not names:
+        return
+    logger.info(
+        "Orphan reconciliation: reaping %d Docker container(s): %s",
+        len(names), names,
+    )
+    for name in names:
+        try:
+            subprocess.run(
+                [docker_exe, "rm", "-f", name],
+                capture_output=True, text=True, timeout=30,
+            )
+        except (subprocess.SubprocessError, OSError) as e:
+            logger.warning(
+                "Orphan reconciliation: failed to remove container %s: %s",
+                name, e,
+            )
+
+
+def _reconcile_orphaned_daytona_sandboxes() -> None:
+    """Reap `hermes-*` Daytona sandboxes left by previous processes.
+
+    No-ops when the Daytona SDK isn't installed or the client can't
+    initialize (e.g., missing ``DAYTONA_API_KEY``). Called once per process
+    under ``_env_lock`` before any sandbox can be created.
+    """
+    try:
+        from daytona import Daytona  # type: ignore
+    except ImportError:
+        return
+    try:
+        client = Daytona()
+    except Exception as e:
+        logger.warning("Orphan reconciliation: Daytona client init failed: %s", e)
+        return
+    try:
+        sandboxes = list(client.list())
+    except Exception as e:
+        logger.warning("Orphan reconciliation: Daytona list failed: %s", e)
+        return
+    orphans = [
+        s for s in sandboxes
+        if (getattr(s, "name", "") or "").startswith(_HERMES_SANDBOX_PREFIX)
+    ]
+    if not orphans:
+        return
+    logger.info(
+        "Orphan reconciliation: reaping %d Daytona sandbox(es)",
+        len(orphans),
+    )
+    for sandbox in orphans:
+        ref = getattr(sandbox, "name", None) or getattr(sandbox, "id", "?")
+        try:
+            client.delete(sandbox)
+        except Exception as e:
+            logger.warning(
+                "Orphan reconciliation: failed to delete Daytona sandbox %s: %s",
+                ref, e,
+            )
+
+
+def _reconcile_orphaned_sandboxes() -> None:
+    """Dispatch orphan-sandbox reconciliation by configured backend.
+
+    Best-effort and never raises: any backend-specific failure is logged and
+    swallowed so an unhealthy Docker daemon or unreachable Daytona API can't
+    block tool initialization. Called exactly once per process from
+    ``_start_cleanup_thread`` while holding ``_env_lock``.
+    """
+    env_type = _get_env_config().get("env_type", "local")
+    if env_type == "docker":
+        _reconcile_orphaned_docker_sandboxes()
+    elif env_type == "daytona":
+        _reconcile_orphaned_daytona_sandboxes()
+
+
+_orphan_reconciliation_done = False
+
+
 def _start_cleanup_thread():
     """Start the background cleanup thread if not already running."""
-    global _cleanup_thread, _cleanup_running
+    global _cleanup_thread, _cleanup_running, _orphan_reconciliation_done
 
     with _env_lock:
+        if not _orphan_reconciliation_done:
+            # Reap sandboxes left running by a previous gateway process.
+            # Runs once per process under _env_lock, before any sandbox in
+            # this process is created — so the reaper cannot race with
+            # in-flight creation. Failures are logged inside the helpers.
+            _orphan_reconciliation_done = True
+            try:
+                _reconcile_orphaned_sandboxes()
+            except Exception as e:
+                logger.warning("Orphan reconciliation: unexpected error: %s", e)
+
         if _cleanup_thread is None or not _cleanup_thread.is_alive():
             _cleanup_running = True
             _cleanup_thread = threading.Thread(target=_cleanup_thread_worker, daemon=True)


### PR DESCRIPTION
## What does this PR do?

Closes #28807. The idle reaper `_cleanup_inactive_envs()` in `tools/terminal_tool.py` only iterates the in-process `_active_environments` dict. Containers (Docker) and sandboxes (Daytona) left running by a previous gateway process — after a restart or crash — are not tracked and never reaped. Every gateway restart can permanently orphan running sandboxes, leaking host disk (Docker) or Daytona credits/quota.

This PR adds a **one-shot reconciliation pass** that runs the first time `_start_cleanup_thread` is invoked (which happens before any sandbox is created in the new process). The pass dispatches by `_get_env_config()["env_type"]`:

- **`docker`**: lists `hermes-*` containers via `docker ps -a --filter name=^hermes- --format {{.Names}}` and `docker rm -f` each. Uses the existing `find_docker()` resolver so binary discovery (Docker Desktop on macOS, podman fallback, `HERMES_DOCKER_BINARY` override) stays consistent.
- **`daytona`**: lazy-imports the Daytona SDK; if absent, no-op. Otherwise lists workspace sandboxes and `client.delete()` any whose `name` starts with `hermes-`.
- **Other backends** (`local`, `modal`, `ssh`, `vercel_sandbox`, …): no-op.

Reconciliation runs **under the existing `_env_lock`** and is gated by a `_orphan_reconciliation_done` flag so it executes exactly once per process, synchronously, before the cleanup worker thread starts and before any parallel `terminal()` caller can create a new sandbox. This eliminates the race where a freshly-created sandbox could be reaped.

Failures at every layer (binary missing, ImportError, subprocess error, non-zero exit, individual `rm`/`delete` failures) are logged with `logger.warning` and swallowed — an unhealthy Docker daemon or unreachable Daytona API must never block tool initialization.

## Related Issue

Fixes #28807

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/terminal_tool.py`:
  - New `_reconcile_orphaned_docker_sandboxes()` — Docker reaper, uses `find_docker()` + `subprocess.run`.
  - New `_reconcile_orphaned_daytona_sandboxes()` — Daytona reaper, lazy-imports the SDK.
  - New `_reconcile_orphaned_sandboxes()` — dispatches by `env_type`.
  - Module-level `_orphan_reconciliation_done` flag + wiring inside `_start_cleanup_thread()` under `_env_lock`.
- `tests/tools/test_terminal_orphan_reconciliation.py` — new, 21 tests, stdlib + pytest + `monkeypatch` only (no Docker / Daytona dependency in CI).

## How to Test

```bash
# New tests:
pytest tests/tools/test_terminal_orphan_reconciliation.py -v -o addopts=""
# → 21 passed

# Regression on existing terminal tests:
pytest tests/tools/test_terminal_tool_requirements.py \
       tests/tools/test_terminal_compound_background.py \
       tests/tools/test_terminal_task_cwd.py -v -o addopts=""
# → 42 passed

# Lint + Windows safety:
ruff check tools/terminal_tool.py tests/tools/test_terminal_orphan_reconciliation.py
# → All checks passed!
python3 scripts/check-windows-footguns.py tools/terminal_tool.py tests/tools/test_terminal_orphan_reconciliation.py
# → ✓ No Windows footguns found
```

**Manual repro / verification on macOS with Docker Desktop**:

```bash
# 1. Reproduce the orphan-leak:
TERMINAL_ENV=docker hermes -p 'use terminal to echo hi'   # starts hermes-<hex>
docker ps                                                 # confirm hermes-* container running
kill -9 $(pgrep -f "hermes")                              # simulate gateway crash
docker ps                                                 # container still running — orphan

# 2. With this PR, next invocation reaps it before creating a new sandbox:
TERMINAL_ENV=docker hermes -p 'use terminal to echo hi'
# → log line: "Orphan reconciliation: reaping 1 Docker container(s): ['hermes-xxxxxxxx']"
docker ps                                                 # old orphan gone, only the new sandbox remains
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — no PR addresses #28807 (keyword-searched closed PRs for "sandbox reconciliation", "orphan sandbox", "reap orphan" — only adjacent-domain reapers found, none for terminal sandboxes)
- [x] My PR contains **only** changes related to this fix
- [x] I've added 21 tests covering Docker reaping, Daytona reaping, dispatch by `env_type`, one-shot wiring, and every failure path
- [x] Tested on my platform: **macOS 15 (Darwin 25.3.0)**

### Documentation & Housekeeping

- [x] Documentation updates — N/A (internal helper, no public API surface)
- [x] `cli-config.yaml.example` — N/A (no new config keys; reuses `TERMINAL_ENV`)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture change)
- [x] Cross-platform impact: the Docker path runs `subprocess.run([docker, "ps", …])` and `docker rm -f` — same call shape `tools/environments/docker.py` already uses on every platform. Daytona path is a Python SDK call. `scripts/check-windows-footguns.py` clean.