### PR TITLE
feat: add kanban blocked router

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5104,6 +5104,12 @@ class GatewayRunner:
             )
             stale_timeout_seconds = 0
 
+        # Blocked router: disabled by default. When enabled, dispatch_once scans
+        # sticky blocked tasks and creates idempotent PM follow-ups before ready
+        # task spawning.
+        raw_blocked_router = kanban_cfg.get("blocked_router", {})
+        blocked_router_config = raw_blocked_router if isinstance(raw_blocked_router, dict) else {}
+
         # Initial delay so the gateway finishes wiring adapters before the
         # dispatcher spawns workers (those workers may hit gateway notify
         # subscriptions etc.). Matches the notifier watcher's delay.
@@ -5173,6 +5179,7 @@ class GatewayRunner:
                     max_in_progress=max_in_progress,
                     failure_limit=failure_limit,
                     stale_timeout_seconds=stale_timeout_seconds,
+                    blocked_router_config=blocked_router_config,
                 )
             except sqlite3.DatabaseError as exc:
                 if _is_corrupt_board_db_error(exc):
@@ -5354,13 +5361,14 @@ class GatewayRunner:
                 results = await asyncio.to_thread(_tick_once)
                 any_spawned = False
                 for slug, res in (results or []):
-                    if res is not None and getattr(res, "spawned", None):
-                        any_spawned = True
+                    if res is not None and (getattr(res, "spawned", None) or getattr(res, "blocked_routed", None)):
+                        any_spawned = any_spawned or bool(getattr(res, "spawned", None))
                         # Quiet by default — only log when something actually
                         # happened, so an idle gateway stays silent.
                         logger.info(
                             "kanban dispatcher [%s]: spawned=%d reclaimed=%d "
-                            "crashed=%d timed_out=%d promoted=%d auto_blocked=%d",
+                            "crashed=%d timed_out=%d promoted=%d auto_blocked=%d "
+                            "blocked_routed=%d blocked_human_required=%d",
                             slug,
                             len(res.spawned),
                             res.reclaimed,
@@ -5368,6 +5376,8 @@ class GatewayRunner:
                             len(res.timed_out) if hasattr(res.timed_out, "__len__") else 0,
                             res.promoted,
                             len(res.auto_blocked) if hasattr(res.auto_blocked, "__len__") else 0,
+                            len(getattr(res, "blocked_routed", []) or []),
+                            len(getattr(res, "blocked_human_required", []) or []),
                         )
                 # Health telemetry (aggregate across boards)
                 ready_pending = await asyncio.to_thread(_ready_nonempty)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1560,6 +1560,28 @@ DEFAULT_CONFIG = {
         # worker process (if still running host-locally) is terminated
         # before the reclaim.  0 disables stale detection entirely.
         "dispatch_stale_timeout_seconds": 14400,
+        # Disabled-by-default router for machine-actionable blocked handoffs.
+        # It never unblocks the source task; it creates an idempotent PM
+        # follow-up for explicit prefixes such as ``review-required:``.
+        "blocked_router": {
+            "enabled": False,
+            "pm_profile": "",
+            "per_tick": 3,
+            "min_age_seconds": 30,
+            "routed_prefixes": [
+                "review-required:",
+                "pm-actionable:",
+                "recovery-needed:",
+            ],
+            "human_required_prefixes": [
+                "user-decision-required:",
+                "credential-required:",
+                "destructive-action-required:",
+            ],
+            "create_mode": "pm_task",
+            "followup_status": "ready",
+            "pm_instructions": "",
+        },
     },
 
     # execute_code settings — controls the tool used for programmatic tool calls.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -801,6 +801,27 @@ class Event:
     run_id: Optional[int] = None
 
 
+@dataclass
+class BlockedRouteDecision:
+    """Classifier outcome for a sticky blocked task."""
+
+    task_id: str
+    action: str  # "pm_actionable" | "human_required" | "ignored"
+    reason: str
+    matched_prefix: Optional[str] = None
+    block_event_id: Optional[int] = None
+
+
+@dataclass
+class BlockedRouterResult:
+    """Outcome of one blocked-router scan."""
+
+    routed: list[tuple[str, str]] = field(default_factory=list)
+    human_required: list[str] = field(default_factory=list)
+    ignored: list[str] = field(default_factory=list)
+    skipped_existing: list[str] = field(default_factory=list)
+
+
 # ---------------------------------------------------------------------------
 # Schema
 # ---------------------------------------------------------------------------
@@ -1857,6 +1878,290 @@ def list_events(conn: sqlite3.Connection, task_id: str) -> list[Event]:
             )
         )
     return out
+
+
+def latest_block_event(conn: sqlite3.Connection, task_id: str) -> Optional[Event]:
+    """Return the latest sticky blocked event for ``task_id``.
+
+    A blocked event is sticky until a later ``unblocked`` event. This helper
+    intentionally ignores older block events after an unblock so the blocked
+    router does not resurrect stale reasons.
+    """
+    row = conn.execute(
+        "SELECT * FROM task_events "
+        "WHERE task_id = ? AND kind IN ('blocked', 'unblocked') "
+        "ORDER BY created_at DESC, id DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    if not row or row["kind"] != "blocked":
+        return None
+    try:
+        payload = json.loads(row["payload"]) if row["payload"] else None
+    except Exception:
+        payload = None
+    return Event(
+        id=int(row["id"]),
+        task_id=row["task_id"],
+        kind=row["kind"],
+        payload=payload,
+        created_at=int(row["created_at"]),
+        run_id=(int(row["run_id"]) if "run_id" in row.keys() and row["run_id"] is not None else None),
+    )
+
+
+def _normalised_prefixes(prefixes: Iterable[str]) -> list[tuple[str, str]]:
+    out: list[tuple[str, str]] = []
+    for prefix in prefixes or []:
+        text = str(prefix or "").strip()
+        if text:
+            out.append((text, text.casefold()))
+    return out
+
+
+def classify_blocked_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    routed_prefixes: Iterable[str],
+    human_required_prefixes: Iterable[str],
+) -> BlockedRouteDecision:
+    """Classify a blocked task's latest sticky block reason.
+
+    Human-required prefixes win over PM-routable prefixes so a task that
+    mentions credentials or destructive actions is never auto-routed to a PM
+    task by accident.
+    """
+    event = latest_block_event(conn, task_id)
+    payload = event.payload if event and isinstance(event.payload, dict) else {}
+    reason = str((payload or {}).get("reason") or "").strip()
+    folded = reason.casefold()
+    if not reason:
+        return BlockedRouteDecision(task_id, "ignored", "", block_event_id=event.id if event else None)
+
+    for original, prefix in _normalised_prefixes(human_required_prefixes):
+        if prefix and prefix in folded:
+            return BlockedRouteDecision(
+                task_id, "human_required", reason,
+                matched_prefix=original, block_event_id=event.id if event else None,
+            )
+    for original, prefix in _normalised_prefixes(routed_prefixes):
+        if prefix and folded.startswith(prefix):
+            return BlockedRouteDecision(
+                task_id, "pm_actionable", reason,
+                matched_prefix=original, block_event_id=event.id if event else None,
+            )
+    return BlockedRouteDecision(task_id, "ignored", reason, block_event_id=event.id if event else None)
+
+
+def _shorten_text(text: Optional[str], limit: int = 4000) -> str:
+    value = (text or "").strip()
+    if len(value) <= limit:
+        return value
+    return value[: limit - 20].rstrip() + "\n… [truncated]"
+
+
+def _blocked_router_idempotency_key(source_task_id: str, block_event_id: int, pm_profile: str) -> str:
+    return f"blocked-router:{source_task_id}:{block_event_id}:{pm_profile}"
+
+
+def _existing_task_for_idempotency(conn: sqlite3.Connection, key: str) -> Optional[str]:
+    row = conn.execute(
+        "SELECT id FROM tasks WHERE idempotency_key = ? AND status != 'archived' "
+        "ORDER BY created_at DESC LIMIT 1",
+        (key,),
+    ).fetchone()
+    return row["id"] if row else None
+
+
+def _blocked_router_skill_if_available(skill_name: str) -> list[str]:
+    """Return ``[skill_name]`` only when it appears installed.
+
+    Missing optional skills must not make dispatcher-spawned workers fail at
+    startup. This intentionally uses conservative filesystem probing rather
+    than importing the skill loader on the dispatch hot path.
+    """
+    try:
+        root = kanban_home()
+        candidates = [
+            root / "skills",
+            root / "optional-skills",
+        ]
+        for profile_dir in (root / "profiles").glob("*"):
+            candidates.append(profile_dir / "skills")
+        needle = skill_name.casefold()
+        for base in candidates:
+            if not base.exists():
+                continue
+            for skill_md in base.rglob("SKILL.md"):
+                if skill_md.parent.name.casefold() == needle:
+                    return [skill_name]
+                try:
+                    head = skill_md.read_text(encoding="utf-8", errors="ignore")[:500]
+                except OSError:
+                    continue
+                if re.search(r"(?mi)^name:\s*['\"]?" + re.escape(skill_name) + r"['\"]?\s*$", head):
+                    return [skill_name]
+    except Exception:
+        pass
+    return []
+
+
+def route_blocked_task_to_pm(
+    conn: sqlite3.Connection,
+    source_task_id: str,
+    *,
+    pm_profile: str,
+    reason: str,
+    pm_instructions: Optional[str] = None,
+    board: Optional[str] = None,
+) -> Optional[str]:
+    """Create or return an idempotent PM follow-up task for a blocked task."""
+    source = get_task(conn, source_task_id)
+    if source is None:
+        return None
+    event = latest_block_event(conn, source_task_id)
+    if event is None:
+        return None
+    pm = (pm_profile or "default").strip() or "default"
+    key = _blocked_router_idempotency_key(source_task_id, int(event.id), pm)
+    existing = _existing_task_for_idempotency(conn, key)
+    if existing:
+        return existing
+
+    comments = list_comments(conn, source_task_id)[-5:]
+    recent_comments = "\n".join(
+        f"- {c.author or 'unknown'}: {_shorten_text(c.body, 500)}" for c in comments
+    ) or "- (none)"
+    body = (
+        f"Blocked-router PM follow-up for source task `{source_task_id}`.\n\n"
+        f"Source title: {source.title}\n"
+        f"Source assignee: {source.assignee or '(unassigned)'}\n"
+        f"Block reason: {reason}\n"
+        f"Block event id: {event.id}\n\n"
+        "Source body excerpt:\n"
+        f"{_shorten_text(source.body, 4000) or '(empty)'}\n\n"
+        "Recent comments:\n"
+        f"{recent_comments}\n\n"
+        "PM policy / allowed outcomes:\n"
+        "- Inspect linked PRs or external artifacts directly when mentioned.\n"
+        "- Do not implement code directly unless this PM profile is explicitly assigned implementation work.\n"
+        "- If the blocked handoff is approved/resolved, unblock or complete the source task with a clear comment.\n"
+        "- If changes are needed, create a follow-up implementation task assigned to the appropriate developer profile.\n"
+        "- If genuine human input, credentials, or destructive approval is required, escalate with `user-decision-required:`, `credential-required:`, or `destructive-action-required:`.\n"
+    )
+    if pm_instructions and str(pm_instructions).strip():
+        body += "\nConfigured PM instructions:\n" + str(pm_instructions).strip() + "\n"
+
+    return create_task(
+        conn,
+        title=f"PM review/recovery for blocked task {source_task_id}",
+        body=body,
+        assignee=pm,
+        created_by="blocked-router",
+        workspace_kind="scratch",
+        tenant=source.tenant,
+        priority=max(int(source.priority or 0), int(source.priority or 0) + 10),
+        idempotency_key=key,
+        skills=_blocked_router_skill_if_available("kanban-orchestrator") or None,
+        board=board,
+    )
+
+
+def _has_blocked_router_event_since_block(
+    conn: sqlite3.Connection,
+    task_id: str,
+    block_event_id: int,
+    kind: str,
+) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM task_events WHERE task_id = ? AND kind = ? AND id > ? LIMIT 1",
+        (task_id, kind, block_event_id),
+    ).fetchone()
+    return bool(row)
+
+
+def route_blocked_once(
+    conn: sqlite3.Connection,
+    *,
+    enabled: bool,
+    pm_profile: Optional[str],
+    routed_prefixes: Iterable[str],
+    human_required_prefixes: Iterable[str],
+    per_tick: int = 3,
+    min_age_seconds: int = 30,
+    pm_instructions: Optional[str] = None,
+    board: Optional[str] = None,
+) -> BlockedRouterResult:
+    """Scan sticky blocked tasks and create bounded PM follow-ups."""
+    result = BlockedRouterResult()
+    if not enabled:
+        return result
+    pm = (pm_profile or "default").strip() or "default"
+    try:
+        budget = max(1, int(per_tick))
+    except (TypeError, ValueError):
+        budget = 3
+    try:
+        min_age = max(0, int(min_age_seconds))
+    except (TypeError, ValueError):
+        min_age = 30
+    now = int(time.time())
+
+    rows = conn.execute(
+        "SELECT id FROM tasks WHERE status = 'blocked' AND claim_lock IS NULL "
+        "ORDER BY priority DESC, created_at ASC"
+    ).fetchall()
+    routed_count = 0
+    for row in rows:
+        task_id = row["id"]
+        event = latest_block_event(conn, task_id)
+        if event is None:
+            result.ignored.append(task_id)
+            continue
+        if min_age and now - int(event.created_at) < min_age:
+            result.ignored.append(task_id)
+            continue
+        decision = classify_blocked_task(
+            conn, task_id,
+            routed_prefixes=routed_prefixes,
+            human_required_prefixes=human_required_prefixes,
+        )
+        if decision.action == "human_required":
+            result.human_required.append(task_id)
+            if not _has_blocked_router_event_since_block(conn, task_id, event.id, "blocked_route_skipped"):
+                with write_txn(conn):
+                    _append_event(
+                        conn, task_id, "blocked_route_skipped",
+                        {"action": decision.action, "reason": decision.reason, "matched_prefix": decision.matched_prefix},
+                    )
+            continue
+        if decision.action != "pm_actionable":
+            result.ignored.append(task_id)
+            continue
+        key = _blocked_router_idempotency_key(task_id, event.id, pm)
+        existing = _existing_task_for_idempotency(conn, key)
+        if existing:
+            result.skipped_existing.append(task_id)
+            continue
+        if routed_count >= budget:
+            continue
+        pm_task_id = route_blocked_task_to_pm(
+            conn,
+            task_id,
+            pm_profile=pm,
+            reason=decision.reason,
+            pm_instructions=pm_instructions,
+            board=board,
+        )
+        if pm_task_id:
+            routed_count += 1
+            result.routed.append((task_id, pm_task_id))
+            with write_txn(conn):
+                _append_event(
+                    conn, task_id, "blocked_routed",
+                    {"pm_task_id": pm_task_id, "reason": decision.reason, "matched_prefix": decision.matched_prefix},
+                )
+    return result
 
 
 def _append_event(
@@ -3657,6 +3962,14 @@ class DispatchResult:
     Reasons: ``"blocker_auth"`` (quota/auth error — also auto-blocked),
     ``"recent_success"`` (completed run within guard window),
     ``"active_pr"`` (GitHub PR URL in a recent comment)."""
+    blocked_routed: list[tuple[str, str]] = field(default_factory=list)
+    """Blocked-router follow-ups as ``(source_task_id, pm_task_id)`` pairs."""
+    blocked_human_required: list[str] = field(default_factory=list)
+    """Blocked task ids classified as requiring human input/credentials/destructive approval."""
+    blocked_ignored: list[str] = field(default_factory=list)
+    """Blocked task ids ignored by the router (unknown reason, too new, no sticky block)."""
+    blocked_skipped_existing: list[str] = field(default_factory=list)
+    """Blocked task ids that already have a live PM follow-up for the block event."""
 
 
 # Bounded registry of recently-reaped worker child exits, populated by the
@@ -4656,6 +4969,7 @@ def dispatch_once(
     max_in_progress: Optional[int] = None,
     failure_limit: int = DEFAULT_SPAWN_FAILURE_LIMIT,
     stale_timeout_seconds: int = 0,
+    blocked_router_config: Optional[dict] = None,
     board: Optional[str] = None,
 ) -> DispatchResult:
     """Run one dispatcher tick.
@@ -4734,6 +5048,27 @@ def dispatch_once(
     if _crash_auto_blocked:
         result.auto_blocked.extend(_crash_auto_blocked)
     result.timed_out = enforce_max_runtime(conn)
+    if blocked_router_config:
+        br_cfg = blocked_router_config or {}
+        br = route_blocked_once(
+            conn,
+            enabled=bool(br_cfg.get("enabled", False)),
+            pm_profile=br_cfg.get("pm_profile") or None,
+            routed_prefixes=br_cfg.get("routed_prefixes") or [
+                "review-required:", "pm-actionable:", "recovery-needed:",
+            ],
+            human_required_prefixes=br_cfg.get("human_required_prefixes") or [
+                "user-decision-required:", "credential-required:", "destructive-action-required:",
+            ],
+            per_tick=br_cfg.get("per_tick", 3),
+            min_age_seconds=br_cfg.get("min_age_seconds", 30),
+            pm_instructions=br_cfg.get("pm_instructions") or None,
+            board=board,
+        )
+        result.blocked_routed = br.routed
+        result.blocked_human_required = br.human_required
+        result.blocked_ignored = br.ignored
+        result.blocked_skipped_existing = br.skipped_existing
     result.promoted = recompute_ready(conn)
 
     # Count tasks already running so max_spawn enforces concurrency rather
@@ -4917,12 +5252,14 @@ def dispatch_once(
             continue
         # Persist the resolved workspace path so the worker can cd there.
         set_workspace_path(conn, claimed.id, str(workspace))
-        # Force-load sdlc-review skill for review agents.  The
-        # _default_spawn function already auto-loads kanban-worker, and
-        # appends task.skills via --skills.  Setting task.skills here
-        # means the review agent gets both kanban-worker (lifecycle)
-        # and sdlc-review (review logic: AC verification, merge, etc.).
-        claimed.skills = ["sdlc-review"]
+        # Force-load review skill only when it is actually installed. Missing
+        # optional skills must not crash review worker startup; the review
+        # column can still dispatch with the worker's profile defaults.
+        claimed.skills = (
+            _blocked_router_skill_if_available("sdlc-review")
+            or _blocked_router_skill_if_available("requesting-code-review")
+            or None
+        )
         _spawn = spawn_fn if spawn_fn is not None else _default_spawn
         try:
             import inspect

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -71,6 +71,22 @@ class TestLoadConfigDefaults:
             assert config["terminal"]["backend"] == "local"
             assert config["display"]["interim_assistant_messages"] is True
 
+    def test_kanban_blocked_router_defaults_are_conservative(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            config = load_config()
+            router = config["kanban"]["blocked_router"]
+            assert router["enabled"] is False
+            assert router["pm_profile"] == ""
+            assert router["per_tick"] == 3
+            assert router["min_age_seconds"] == 30
+            assert "review-required:" in router["routed_prefixes"]
+            assert "pm-actionable:" in router["routed_prefixes"]
+            assert "recovery-needed:" in router["routed_prefixes"]
+            assert "credential-required:" in router["human_required_prefixes"]
+            assert router["create_mode"] == "pm_task"
+            assert router["followup_status"] == "ready"
+            assert router["pm_instructions"] == ""
+
     def test_legacy_root_level_max_turns_migrates_to_agent_config(self, tmp_path):
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
             config_path = tmp_path / "config.yaml"

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -285,6 +285,230 @@ def test_recompute_ready_fan_in_waits_for_all_parents(kanban_home):
 
 
 # ---------------------------------------------------------------------------
+# Blocked router
+# ---------------------------------------------------------------------------
+
+ROUTED_PREFIXES = ["review-required:", "pm-actionable:", "recovery-needed:"]
+HUMAN_REQUIRED_PREFIXES = [
+    "user-decision-required:",
+    "credential-required:",
+    "destructive-action-required:",
+]
+
+
+def _blocked_task(conn, reason: str, **kwargs) -> str:
+    tid = kb.create_task(
+        conn,
+        title=kwargs.pop("title", "blocked source"),
+        body=kwargs.pop("body", "source body"),
+        assignee=kwargs.pop("assignee", "worker"),
+        priority=kwargs.pop("priority", 5),
+        tenant=kwargs.pop("tenant", None),
+        **kwargs,
+    )
+    assert kb.block_task(conn, tid, reason=reason)
+    return tid
+
+
+def test_latest_block_event_tracks_unblock_boundaries(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="source", assignee="worker")
+        assert kb.latest_block_event(conn, tid) is None
+
+        assert kb.block_task(conn, tid, reason="review-required: check this")
+        first = kb.latest_block_event(conn, tid)
+        assert first is not None
+        assert first.kind == "blocked"
+        assert first.payload["reason"] == "review-required: check this"
+
+        assert kb.unblock_task(conn, tid)
+        assert kb.latest_block_event(conn, tid) is None
+
+        assert kb.block_task(conn, tid, reason="pm-actionable: retry")
+        latest = kb.latest_block_event(conn, tid)
+        assert latest is not None
+        assert latest.id > first.id
+        assert latest.payload["reason"] == "pm-actionable: retry"
+
+
+def test_classify_blocked_task_uses_machine_readable_prefixes(kanban_home):
+    with kb.connect() as conn:
+        review = _blocked_task(conn, "  REVIEW-REQUIRED: PR is ready")
+        pm = _blocked_task(conn, "pm-actionable: split follow-up")
+        credential = _blocked_task(conn, "credential-required: missing token")
+        unknown = _blocked_task(conn, "please look at this")
+
+        assert kb.classify_blocked_task(
+            conn, review,
+            routed_prefixes=ROUTED_PREFIXES,
+            human_required_prefixes=HUMAN_REQUIRED_PREFIXES,
+        ).action == "pm_actionable"
+        assert kb.classify_blocked_task(
+            conn, pm,
+            routed_prefixes=ROUTED_PREFIXES,
+            human_required_prefixes=HUMAN_REQUIRED_PREFIXES,
+        ).action == "pm_actionable"
+        assert kb.classify_blocked_task(
+            conn, credential,
+            routed_prefixes=ROUTED_PREFIXES,
+            human_required_prefixes=HUMAN_REQUIRED_PREFIXES,
+        ).action == "human_required"
+        assert kb.classify_blocked_task(
+            conn, unknown,
+            routed_prefixes=ROUTED_PREFIXES,
+            human_required_prefixes=HUMAN_REQUIRED_PREFIXES,
+        ).action == "ignored"
+
+
+def test_classify_blocked_task_human_required_wins_over_routed_text(kanban_home):
+    with kb.connect() as conn:
+        tid = _blocked_task(
+            conn,
+            "review-required: credential-required: need the user secret",
+        )
+        decision = kb.classify_blocked_task(
+            conn, tid,
+            routed_prefixes=ROUTED_PREFIXES,
+            human_required_prefixes=HUMAN_REQUIRED_PREFIXES,
+        )
+    assert decision.action == "human_required"
+    assert decision.matched_prefix == "credential-required:"
+
+
+def test_route_blocked_task_to_pm_is_idempotent_and_inherits_context(kanban_home):
+    with kb.connect() as conn:
+        source = _blocked_task(
+            conn,
+            "review-required: PR #42 ready",
+            title="Implement thing",
+            body="Full source body",
+            tenant="tenant-a",
+            priority=7,
+        )
+        first = kb.route_blocked_task_to_pm(
+            conn,
+            source,
+            pm_profile="pm-hermes",
+            reason="review-required: PR #42 ready",
+            pm_instructions="Inspect PRs directly.",
+        )
+        second = kb.route_blocked_task_to_pm(
+            conn,
+            source,
+            pm_profile="pm-hermes",
+            reason="review-required: PR #42 ready",
+            pm_instructions="Inspect PRs directly.",
+        )
+        assert first == second
+        pm_task = kb.get_task(conn, first)
+        assert pm_task.assignee == "pm-hermes"
+        assert pm_task.tenant == "tenant-a"
+        assert pm_task.priority >= 7
+        assert pm_task.created_by == "blocked-router"
+        assert pm_task.status == "ready"
+        assert source in (pm_task.body or "")
+        assert "review-required: PR #42 ready" in (pm_task.body or "")
+        assert "Inspect PRs directly." in (pm_task.body or "")
+        assert len([t for t in kb.list_tasks(conn) if t.created_by == "blocked-router"]) == 1
+
+
+def test_route_blocked_once_respects_disabled_min_age_per_tick_and_idempotency(kanban_home):
+    with kb.connect() as conn:
+        old_a = _blocked_task(conn, "review-required: A", priority=10)
+        old_b = _blocked_task(conn, "pm-actionable: B", priority=9)
+        new_c = _blocked_task(conn, "recovery-needed: C", priority=8)
+        # Age only the first two block events.
+        conn.execute(
+            "UPDATE task_events SET created_at = created_at - 60 "
+            "WHERE task_id IN (?, ?) AND kind = 'blocked'",
+            (old_a, old_b),
+        )
+        conn.commit()
+
+        disabled = kb.route_blocked_once(
+            conn,
+            enabled=False,
+            pm_profile="pm-hermes",
+            routed_prefixes=ROUTED_PREFIXES,
+            human_required_prefixes=HUMAN_REQUIRED_PREFIXES,
+        )
+        assert disabled.routed == []
+
+        routed = kb.route_blocked_once(
+            conn,
+            enabled=True,
+            pm_profile="pm-hermes",
+            routed_prefixes=ROUTED_PREFIXES,
+            human_required_prefixes=HUMAN_REQUIRED_PREFIXES,
+            per_tick=1,
+            min_age_seconds=30,
+        )
+        assert len(routed.routed) == 1
+        assert routed.routed[0][0] == old_a
+        assert new_c in routed.ignored
+
+        again = kb.route_blocked_once(
+            conn,
+            enabled=True,
+            pm_profile="pm-hermes",
+            routed_prefixes=ROUTED_PREFIXES,
+            human_required_prefixes=HUMAN_REQUIRED_PREFIXES,
+            per_tick=3,
+            min_age_seconds=30,
+        )
+        assert old_a in again.skipped_existing
+        assert any(source == old_b for source, _pm in again.routed)
+        assert len([t for t in kb.list_tasks(conn) if t.created_by == "blocked-router"]) == 2
+        assert kb.get_task(conn, old_a).status == "blocked"
+
+
+def test_route_blocked_once_skips_human_required_without_pm_task(kanban_home):
+    with kb.connect() as conn:
+        source = _blocked_task(conn, "credential-required: provide API key")
+        result = kb.route_blocked_once(
+            conn,
+            enabled=True,
+            pm_profile="pm-hermes",
+            routed_prefixes=ROUTED_PREFIXES,
+            human_required_prefixes=HUMAN_REQUIRED_PREFIXES,
+            min_age_seconds=0,
+        )
+        assert source in result.human_required
+        assert not [t for t in kb.list_tasks(conn) if t.created_by == "blocked-router"]
+        assert kb.get_task(conn, source).status == "blocked"
+
+
+def test_dispatch_once_runs_blocked_router_before_ready_spawns(
+    kanban_home, all_assignees_spawnable,
+):
+    spawns = []
+
+    def fake_spawn(task, workspace, board=None):
+        spawns.append((task.id, task.assignee, task.body))
+        return 1234
+
+    with kb.connect() as conn:
+        source = _blocked_task(conn, "review-required: PM should review")
+        res = kb.dispatch_once(
+            conn,
+            spawn_fn=fake_spawn,
+            blocked_router_config={
+                "enabled": True,
+                "pm_profile": "pm-hermes",
+                "routed_prefixes": ROUTED_PREFIXES,
+                "human_required_prefixes": HUMAN_REQUIRED_PREFIXES,
+                "min_age_seconds": 0,
+                "per_tick": 3,
+            },
+        )
+        assert res.blocked_routed
+        assert res.blocked_routed[0][0] == source
+        pm_task_id = res.blocked_routed[0][1]
+        assert any(spawn[0] == pm_task_id and spawn[1] == "pm-hermes" for spawn in spawns)
+        assert kb.get_task(conn, source).status == "blocked"
+
+
+# ---------------------------------------------------------------------------
 # Atomic claim (CAS)
 # ---------------------------------------------------------------------------
 
@@ -2593,9 +2817,14 @@ def test_dispatch_review_dry_run(kanban_home, all_assignees_spawnable):
 
 
 def test_dispatch_review_spawns_with_correct_skills(
-    kanban_home, all_assignees_spawnable,
+    kanban_home, all_assignees_spawnable, monkeypatch,
 ):
-    """Review tasks get sdlc-review skill set before spawning."""
+    """Review tasks get an installed review skill set before spawning."""
+    monkeypatch.setattr(
+        kb,
+        "_blocked_router_skill_if_available",
+        lambda name: [name] if name == "sdlc-review" else [],
+    )
     spawned_tasks = []
 
     def capture_spawn(task, workspace, board=None):
@@ -2609,6 +2838,26 @@ def test_dispatch_review_spawns_with_correct_skills(
     assert len(res.spawned) == 1
     assert len(spawned_tasks) == 1
     assert spawned_tasks[0].skills == ["sdlc-review"]
+
+
+def test_dispatch_review_tolerates_missing_review_skills(
+    kanban_home, all_assignees_spawnable, monkeypatch,
+):
+    """Missing optional review skills must not block review dispatch."""
+    monkeypatch.setattr(kb, "_blocked_router_skill_if_available", lambda name: [])
+    spawned_tasks = []
+
+    def capture_spawn(task, workspace, board=None):
+        spawned_tasks.append(task)
+        return 42
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="review me", assignee="alice")
+        _set_task_status(conn, t, "review")
+        res = kb.dispatch_once(conn, spawn_fn=capture_spawn)
+    assert len(res.spawned) == 1
+    assert len(spawned_tasks) == 1
+    assert spawned_tasks[0].skills is None
 
 
 def test_dispatch_review_skips_unassigned(kanban_home):


### PR DESCRIPTION
## Summary
- Add disabled-by-default `kanban.blocked_router` config with PM-routable and human-required prefix policies.
- Add blocked-router helpers for latest block event lookup, deterministic classification, idempotent PM follow-up creation, and bounded router ticks.
- Integrate blocked routing into `dispatch_once()` and gateway dispatcher config/logging.
- Guard review dispatch so missing optional review skills (`sdlc-review` / `requesting-code-review`) do not prevent worker startup.

## Test Plan
- `python -m pytest tests/hermes_cli/test_kanban_db.py -q -o 'addopts='`
- `python -m pytest tests/hermes_cli tests/gateway -k 'kanban or config' -q -o 'addopts='`

## Notes
- Source blocked tasks remain blocked; the router only creates an idempotent PM follow-up task for machine-actionable blockers.
- Human-required blockers such as `credential-required:` are intentionally skipped.