### PR TITLE
fix(chat_completions): strip internal tool_name from messages for strict providers

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -112,11 +112,21 @@ class ChatCompletionsTransport(ProviderTransport):
     def convert_messages(
         self, messages: list[dict[str, Any]], **kwargs
     ) -> list[dict[str, Any]]:
-        """Messages are already in OpenAI format — sanitize Codex leaks only.
+        """Messages are already in OpenAI format — strip internal fields
+        that strict chat-completions providers reject with HTTP 400/422.
 
-        Strips Codex Responses API fields (``codex_reasoning_items`` /
-        ``codex_message_items`` on the message, ``call_id``/``response_item_id``
-        on tool_calls) that strict chat-completions providers reject with 400/422.
+        Strips:
+
+        - Codex Responses API fields: ``codex_reasoning_items`` /
+          ``codex_message_items`` on the message, ``call_id`` /
+          ``response_item_id`` on ``tool_calls`` entries.
+        - ``tool_name`` on tool-result messages — written by
+          ``make_tool_result_message()`` for the SQLite FTS index, but not
+          part of the Chat Completions schema. Strict providers (Fireworks,
+          Moonshot/Kimi) reject any payload containing it with
+          ``Extra inputs are not permitted, field: 'messages[N].tool_name'``.
+          Permissive providers (OpenRouter, MiniMax) silently ignore the
+          field, which masked the bug for months.
         """
         needs_sanitize = False
         for msg in messages:

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -122,7 +122,11 @@ class ChatCompletionsTransport(ProviderTransport):
         for msg in messages:
             if not isinstance(msg, dict):
                 continue
-            if "codex_reasoning_items" in msg or "codex_message_items" in msg:
+            if (
+                "codex_reasoning_items" in msg
+                or "codex_message_items" in msg
+                or "tool_name" in msg
+            ):
                 needs_sanitize = True
                 break
             tool_calls = msg.get("tool_calls")
@@ -145,6 +149,7 @@ class ChatCompletionsTransport(ProviderTransport):
                 continue
             msg.pop("codex_reasoning_items", None)
             msg.pop("codex_message_items", None)
+            msg.pop("tool_name", None)
             tool_calls = msg.get("tool_calls")
             if isinstance(tool_calls, list):
                 for tc in tool_calls:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -372,6 +372,7 @@ AUTHOR_MAP = {
     "bloodcarter@gmail.com": "bloodcarter",
     "scott@scotttrinh.com": "scotttrinh",
     "quocanh261997@gmail.com": "quocanh261997",
+    "savanne.kham@protonmail.com": "savanne-kham",  # PR #28958 salvage (strip tool_name for strict providers)
     # contributors (from noreply pattern)
     "david.vv@icloud.com": "davidvv",
     "wangqiang@wangqiangdeMac-mini.local": "xiaoqiang243",

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -46,6 +46,26 @@ class TestChatCompletionsBasic:
         assert "codex_reasoning_items" in msgs[0]
         assert "codex_message_items" in msgs[0]
 
+    def test_convert_messages_strips_tool_name(self, transport):
+        """Internal `tool_name` (used for FTS indexing in the SQLite store) is
+        not part of the OpenAI Chat Completions schema. Strict providers like
+        Moonshot/Kimi reject it with HTTP 400 'Extra inputs are not permitted'.
+        """
+        msgs = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": None,
+             "tool_calls": [{"id": "call_1", "type": "function",
+                             "function": {"name": "execute_code", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "call_1", "tool_name": "execute_code",
+             "content": "result"},
+        ]
+        result = transport.convert_messages(msgs)
+        assert "tool_name" not in result[2]
+        assert result[2]["content"] == "result"
+        assert result[2]["tool_call_id"] == "call_1"
+        # Original list untouched (deepcopy-on-demand)
+        assert msgs[2]["tool_name"] == "execute_code"
+
 
 class TestChatCompletionsBuildKwargs:
 


### PR DESCRIPTION
Salvages #28958 by @savanne-kham onto current main, with a broader docstring describing the bigger user impact than the original PR captured.

## What this fixes

Community report (porkmagus, May 19): every API call after the first tool-call dies with HTTP 400 on Fireworks/Firepass, Moonshot/Kimi, and other strict OpenAI-compatible providers:

```
Extra inputs are not permitted, field: 'messages[N].tool_name', value: 'skill_view'
```

Repros from a fresh session — the first turn that triggers any tool kills the conversation; user has to restart hermes.

## Root cause

`agent/tool_dispatch_helpers.py` `make_tool_result_message()` deliberately attaches `tool_name` to every tool-result dict so `run_agent._flush_messages_to_session_db()` can persist it for SQLite FTS indexing. That field is **not** part of the OpenAI Chat Completions schema and rides into the next-turn wire payload.

Permissive providers (OpenRouter, MiniMax) silently dropped the extra field, masking the bug. Strict providers (Fireworks, Moonshot/Kimi) reject the entire request.

## Changes

- `agent/transports/chat_completions.py` — extend the existing `needs_sanitize` detection and per-message `pop` step to cover `tool_name`, same pattern already used for `codex_reasoning_items` / `codex_message_items`. Broadened the docstring to explicitly name which providers reject it and why permissive providers masked the bug.
- `tests/agent/transports/test_chat_completions.py` — new `test_convert_messages_strips_tool_name` covers strip + deepcopy-on-demand contract (FTS-side `tool_name` must survive on the original message).
- `scripts/release.py` — AUTHOR_MAP entry for savanne.kham@protonmail.com.

## Validation

| | Before | After |
|---|---|---|
| Fireworks/Moonshot tool turn | HTTP 400 `tool_name not permitted` | succeeds |
| In-memory message `tool_name` | preserved | preserved (deepcopy-on-demand) |
| Session DB FTS index | populated | populated |
| transport tests | 66/66 | 67/67 |

E2E verified via direct `convert_messages()` call on a realistic tool-result message: `tool_name` is absent from the serialized payload, but the original message dict retains it.

Closes #28958.

Co-authored-by: Savanne Kham <savanne.kham@protonmail.com>