### PR TITLE
feat: support delegation temperature override

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1227,6 +1227,7 @@ DEFAULT_CONFIG = {
                                        # raise if children time out before producing output.
         "reasoning_effort": "",  # reasoning effort for subagents: "xhigh", "high", "medium",
                                  # "low", "minimal", "none" (empty = inherit parent's level)
+        "temperature": "",  # optional subagent temperature override (0-2; empty = inherit request defaults)
         "max_concurrent_children": 3,  # max parallel children per batch; floor of 1 enforced, no ceiling
         # Orchestrator role controls (see tools/delegate_tool.py:_get_max_spawn_depth
         # and _get_orchestrator_enabled).  Values are clamped to [1, 3] with a

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -414,6 +414,32 @@ class TestDelegateTask(unittest.TestCase):
         mock_child.thinking_callback("deliberating...")
         parent.tool_progress_callback.assert_not_called()
 
+    def test_child_applies_delegation_temperature_override(self):
+        parent = _make_mock_parent(depth=0)
+        parent.request_overrides = {"parallel_tool_calls": False}
+
+        with patch("tools.delegate_tool._load_config", return_value={"temperature": 0.7}), \
+             patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            MockAgent.return_value = mock_child
+
+            _build_child_agent(
+                task_index=0,
+                goal="Use creative temperature",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        _, kwargs = MockAgent.call_args
+        self.assertEqual(kwargs["request_overrides"], {
+            "parallel_tool_calls": False,
+            "temperature": 0.7,
+        })
+
 
 class TestToolNamePreservation(unittest.TestCase):
     """Verify _last_resolved_tool_names is restored after subagent runs."""

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1076,6 +1076,28 @@ def _build_child_agent(
     except Exception as exc:
         logger.debug("Could not load delegation reasoning_effort: %s", exc)
 
+    # Resolve request overrides: inherit parent overrides, then let
+    # delegation.temperature tune the child without affecting the parent.
+    child_request_overrides = dict(getattr(parent_agent, "request_overrides", None) or {})
+    try:
+        if "temperature" in delegation_cfg:
+            delegation_temperature = delegation_cfg.get("temperature")
+            if delegation_temperature is not None and str(delegation_temperature).strip() != "":
+                parsed_temperature = float(delegation_temperature)
+                if 0 <= parsed_temperature <= 2:
+                    child_request_overrides["temperature"] = parsed_temperature
+                else:
+                    logger.warning(
+                        "Invalid delegation.temperature %r; expected a number between 0 and 2",
+                        delegation_temperature,
+                    )
+    except (TypeError, ValueError) as exc:
+        logger.warning(
+            "Invalid delegation.temperature %r; expected a number between 0 and 2: %s",
+            delegation_cfg.get("temperature"),
+            exc,
+        )
+
     # Inherit the parent's fallback provider chain so subagents can recover
     # from rate-limits and credential exhaustion exactly like the top-level
     # agent does.  _fallback_chain is a list accepted by AIAgent's
@@ -1116,6 +1138,7 @@ def _build_child_agent(
         reasoning_config=child_reasoning,
         prefill_messages=getattr(parent_agent, "prefill_messages", None),
         fallback_model=parent_fallback,
+        request_overrides=child_request_overrides,
         enabled_toolsets=child_toolsets,
         quiet_mode=True,
         ephemeral_system_prompt=child_prompt,

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -266,6 +266,7 @@ delegation:
   # max_concurrent_children: 3              # Parallel children per batch (default: 3)
   # max_spawn_depth: 1                      # Tree depth (1-3, default 1 = flat). Raise to 2 to allow orchestrator children to spawn leaves; 3 for three levels.
   # orchestrator_enabled: true              # Disable to force all children to leaf role.
+  # temperature: 0.7                        # Optional child request temperature (0-2; omitted = inherit defaults)
   model: "google/gemini-3-flash-preview"             # Optional provider/model override
   provider: "openrouter"                             # Optional built-in provider
   api_mode: anthropic_messages                       # optional; auto-detected from base_url for anthropic_messages endpoints


### PR DESCRIPTION
## Summary
- Add `delegation.temperature` as an optional subagent request override.
- Preserve parent `request_overrides` while letting the delegation config tune child temperature.
- Document the new config key and cover it with a focused delegation unit test.

Closes #29109

## Validation
- `/Users/cosmopolitan/.hermes/hermes-agent/venv/bin/python -m pytest -o 'addopts=' tests/tools/test_delegate.py::TestDelegateTask::test_child_applies_delegation_temperature_override -q`
- `/Users/cosmopolitan/.hermes/hermes-agent/venv/bin/python -m pytest -o 'addopts=' tests/tools/test_delegate.py -q`
- `/Users/cosmopolitan/.hermes/hermes-agent/venv/bin/python -m pytest -o 'addopts=' tests/tools/test_delegate_toolset_scope.py tests/tools/test_delegate_composite_toolsets.py tests/tools/test_delegate_subagent_timeout_diagnostic.py -q`
- `git diff --check`
- `npm run build` in `website/` (succeeds; existing unrelated Docusaurus broken-link/anchor warnings remain)
