### PR TITLE
fix: restore hindsight local embedded tool availability

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -79,24 +79,99 @@ def _parse_int_setting(value: Any, default: int) -> int:
     try:
         return int(value)
     except (TypeError, ValueError):
-        logger.warning("Invalid integer Hindsight setting %r; using default %s", value, default)
+        logger.warning(
+            "Invalid integer Hindsight setting %r; using default %s", value, default
+        )
         return default
 
 
 def _check_local_runtime() -> tuple[bool, str | None]:
-    """Return whether local embedded Hindsight imports cleanly.
+    """Return whether local embedded Hindsight dependencies import cleanly.
 
-    On older CPUs, importing the local Hindsight stack can raise a runtime
-    error from NumPy before the daemon starts. Treat that as "unavailable"
-    so Hermes can degrade gracefully instead of repeatedly trying to start
-    a broken local memory backend.
+    Older versions of this plugin expected a top-level ``hindsight`` package
+    exposing ``HindsightEmbedded``. Current Hindsight releases split that API
+    across ``hindsight_embed`` (daemon manager) and ``hindsight_client``
+    (HTTP client). Import those concrete dependencies instead.
+
+    On older CPUs, importing the local Hindsight stack can still raise a
+    runtime error from NumPy before the daemon starts. Treat that as
+    "unavailable" so Hermes can degrade gracefully instead of repeatedly
+    trying to start a broken local memory backend.
     """
     try:
-        importlib.import_module("hindsight")
+        importlib.import_module("hindsight_client")
         importlib.import_module("hindsight_embed.daemon_embed_manager")
         return True, None
     except Exception as exc:
         return False, str(exc)
+
+
+class _LocalEmbeddedHindsightClient:
+    """Small adapter for the current daemon-manager + HTTP-client split.
+
+    The plugin historically used ``from hindsight import HindsightEmbedded``.
+    Recent Hindsight packaging no longer exposes that class. Local embedded
+    mode now consists of:
+
+    - ``hindsight_embed.DaemonEmbedManager`` to start/reuse the local daemon
+    - ``hindsight_client.Hindsight`` to speak HTTP to that daemon
+
+    This adapter preserves the bits of the old surface area the plugin relies
+    on: ``_manager``, ``_ensure_started()``, async retain/recall/reflect, and
+    ``close()``/``aclose()`` cleanup.
+    """
+
+    def __init__(self, *, config: dict[str, Any], profile: str, timeout: float):
+        from hindsight_client import Hindsight
+        from hindsight_embed import DaemonEmbedManager
+
+        self._config = config
+        self._profile = profile
+        self._timeout = float(timeout)
+        self._manager = DaemonEmbedManager()
+        self._client_cls = Hindsight
+        self._client = None
+
+    def _ensure_started(self) -> None:
+        env_values = _build_embedded_profile_env(self._config)
+        if not self._manager.ensure_running(env_values, self._profile):
+            raise RuntimeError(
+                f"Failed to start Hindsight daemon for profile '{self._profile}'"
+            )
+
+        base_url = self._manager.get_url(self._profile)
+        current_url = getattr(self._client, "_base_url", None)
+        if self._client is None or current_url != base_url.rstrip("/"):
+            self._client = self._client_cls(base_url=base_url, timeout=self._timeout)
+
+    async def aretain(self, *args, **kwargs):
+        self._ensure_started()
+        return await self._client.aretain(*args, **kwargs)
+
+    async def arecall(self, *args, **kwargs):
+        self._ensure_started()
+        return await self._client.arecall(*args, **kwargs)
+
+    async def areflect(self, *args, **kwargs):
+        self._ensure_started()
+        return await self._client.areflect(*args, **kwargs)
+
+    async def aretain_batch(self, *args, **kwargs):
+        self._ensure_started()
+        return await self._client.aretain_batch(*args, **kwargs)
+
+    async def aclose(self):
+        if self._client is not None:
+            await self._client.aclose()
+
+    def close(self):
+        """Close the underlying HTTP client but leave daemon lifecycle alone."""
+        if self._client is not None:
+            try:
+                _run_sync(self._client.aclose())
+            except Exception:
+                pass
+            self._client = None
 
 
 # ---------------------------------------------------------------------------
@@ -116,13 +191,15 @@ def _meets_minimum_version(actual: str | None, required: str) -> bool:
         return False
     try:
         from packaging.version import Version
+
         return Version(actual) >= Version(required)
     except Exception:
         return False
 
 
-def _fetch_hindsight_api_version(api_url: str, api_key: str | None = None,
-                                 timeout: float = 5.0) -> str | None:
+def _fetch_hindsight_api_version(
+    api_url: str, api_key: str | None = None, timeout: float = 5.0
+) -> str | None:
     """GET ``<api_url>/version`` and return the version string (or None on failure).
 
     Hindsight's `/version` endpoint returns ``{"version": "0.5.6", ...}``.
@@ -131,6 +208,7 @@ def _fetch_hindsight_api_version(api_url: str, api_key: str | None = None,
     """
     import urllib.error
     import urllib.request
+
     if not api_url:
         return None
     url = api_url.rstrip("/") + "/version"
@@ -150,8 +228,9 @@ def _fetch_hindsight_api_version(api_url: str, api_key: str | None = None,
     return str(version) if version else None
 
 
-def _check_api_supports_update_mode_append(api_url: str,
-                                           api_key: str | None = None) -> bool:
+def _check_api_supports_update_mode_append(
+    api_url: str, api_key: str | None = None
+) -> bool:
     """Cached capability check for ``update_mode='append'`` on *api_url*.
 
     Probes once per URL per process. Returns False on any probe failure —
@@ -179,12 +258,17 @@ def _check_api_supports_update_mode_append(api_url: str,
             "processes/sessions create separate documents instead of "
             "appending to a session-scoped one. Upgrade Hindsight to "
             "%s+ to enable update_mode='append' deduplication.",
-            api_url, version, _MIN_VERSION_FOR_UPDATE_MODE_APPEND,
+            api_url,
+            version,
+            _MIN_VERSION_FOR_UPDATE_MODE_APPEND,
             _MIN_VERSION_FOR_UPDATE_MODE_APPEND,
         )
     else:
-        logger.debug("Hindsight API %s version %s supports update_mode='append'",
-                     api_url, version)
+        logger.debug(
+            "Hindsight API %s version %s supports update_mode='append'",
+            api_url,
+            version,
+        )
     return supported
 
 
@@ -222,6 +306,7 @@ def _get_loop() -> asyncio.AbstractEventLoop:
 def _run_sync(coro, timeout: float = _DEFAULT_TIMEOUT):
     """Schedule *coro* on the shared loop and block until done."""
     from agent.async_utils import safe_schedule_threadsafe
+
     loop = _get_loop()
     future = safe_schedule_threadsafe(coro, loop)
     if future is None:
@@ -248,7 +333,10 @@ RETAIN_SCHEMA = {
         "type": "object",
         "properties": {
             "content": {"type": "string", "description": "The information to store."},
-            "context": {"type": "string", "description": "Short label (e.g. 'user preference', 'project decision')."},
+            "context": {
+                "type": "string",
+                "description": "Short label (e.g. 'user preference', 'project decision').",
+            },
             "tags": {
                 "type": "array",
                 "items": {"type": "string"},
@@ -294,6 +382,7 @@ REFLECT_SCHEMA = {
 # Config
 # ---------------------------------------------------------------------------
 
+
 def _load_config() -> dict:
     """Load config from profile-scoped path, legacy path, or env vars.
 
@@ -323,12 +412,18 @@ def _load_config() -> dict:
     return {
         "mode": os.environ.get("HINDSIGHT_MODE", "cloud"),
         "apiKey": os.environ.get("HINDSIGHT_API_KEY", ""),
-        "timeout": _parse_int_setting(os.environ.get("HINDSIGHT_TIMEOUT"), _DEFAULT_TIMEOUT),
-        "idle_timeout": _parse_int_setting(os.environ.get("HINDSIGHT_IDLE_TIMEOUT"), _DEFAULT_IDLE_TIMEOUT),
+        "timeout": _parse_int_setting(
+            os.environ.get("HINDSIGHT_TIMEOUT"), _DEFAULT_TIMEOUT
+        ),
+        "idle_timeout": _parse_int_setting(
+            os.environ.get("HINDSIGHT_IDLE_TIMEOUT"), _DEFAULT_IDLE_TIMEOUT
+        ),
         "retain_tags": os.environ.get("HINDSIGHT_RETAIN_TAGS", ""),
         "retain_source": os.environ.get("HINDSIGHT_RETAIN_SOURCE", ""),
         "retain_user_prefix": os.environ.get("HINDSIGHT_RETAIN_USER_PREFIX", "User"),
-        "retain_assistant_prefix": os.environ.get("HINDSIGHT_RETAIN_ASSISTANT_PREFIX", "Assistant"),
+        "retain_assistant_prefix": os.environ.get(
+            "HINDSIGHT_RETAIN_ASSISTANT_PREFIX", "Assistant"
+        ),
         "banks": {
             "hermes": {
                 "bankId": os.environ.get("HINDSIGHT_BANK_ID", "hermes"),
@@ -378,7 +473,12 @@ def _normalize_retain_tags(value: Any) -> List[str]:
 
 def _utc_timestamp() -> str:
     """Return current UTC timestamp in ISO-8601 with milliseconds and Z suffix."""
-    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+    return (
+        datetime
+        .now(timezone.utc)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z")
+    )
 
 
 def _embedded_profile_name(config: dict[str, Any]) -> str:
@@ -401,7 +501,9 @@ def _load_simple_env(path) -> dict[str, str]:
     return values
 
 
-def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | None = None) -> dict[str, str]:
+def _build_embedded_profile_env(
+    config: dict[str, Any], *, llm_api_key: str | None = None
+) -> dict[str, str]:
     """Build the profile-scoped env file that standalone hindsight-embed consumes."""
     current_key = llm_api_key
     if current_key is None:
@@ -413,10 +515,16 @@ def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | No
 
     current_provider = config.get("llm_provider", "")
     current_model = config.get("llm_model", "")
-    current_base_url = config.get("llm_base_url") or os.environ.get("HINDSIGHT_API_LLM_BASE_URL", "")
+    current_base_url = config.get("llm_base_url") or os.environ.get(
+        "HINDSIGHT_API_LLM_BASE_URL", ""
+    )
 
     # The embedded daemon expects OpenAI wire format for these providers.
-    daemon_provider = "openai" if current_provider in {"openai_compatible", "openrouter"} else current_provider
+    daemon_provider = (
+        "openai"
+        if current_provider in {"openai_compatible", "openrouter"}
+        else current_provider
+    )
 
     env_values = {
         "HINDSIGHT_API_LLM_PROVIDER": str(daemon_provider),
@@ -442,10 +550,17 @@ def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | No
 def _embedded_profile_env_path(config: dict[str, Any]):
     from pathlib import Path
 
-    return Path.home() / ".hindsight" / "profiles" / f"{_embedded_profile_name(config)}.env"
+    return (
+        Path.home()
+        / ".hindsight"
+        / "profiles"
+        / f"{_embedded_profile_name(config)}.env"
+    )
 
 
-def _materialize_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | None = None):
+def _materialize_embedded_profile_env(
+    config: dict[str, Any], *, llm_api_key: str | None = None
+):
     """Write the profile-scoped env file that standalone hindsight-embed uses."""
     profile_env = _embedded_profile_env_path(config)
     profile_env.parent.mkdir(parents=True, exist_ok=True)
@@ -455,6 +570,7 @@ def _materialize_embedded_profile_env(config: dict[str, Any], *, llm_api_key: st
         encoding="utf-8",
     )
     return profile_env
+
 
 def _sanitize_bank_segment(value: str) -> str:
     """Sanitize a bank_id_template placeholder value.
@@ -500,8 +616,12 @@ def _resolve_bank_id_template(template: str, fallback: str, **placeholders: str)
     try:
         rendered = template.format(**sanitized)
     except (KeyError, IndexError) as exc:
-        logger.warning("Invalid bank_id_template %r: %s — using fallback %r",
-                       template, exc, fallback)
+        logger.warning(
+            "Invalid bank_id_template %r: %s — using fallback %r",
+            template,
+            exc,
+            fallback,
+        )
         return fallback
     while "--" in rendered:
         rendered = rendered.replace("--", "-")
@@ -514,6 +634,7 @@ def _resolve_bank_id_template(template: str, fallback: str, **placeholders: str)
 # ---------------------------------------------------------------------------
 # MemoryProvider implementation
 # ---------------------------------------------------------------------------
+
 
 class HindsightMemoryProvider(MemoryProvider):
     """Hindsight long-term memory with knowledge graph and multi-strategy retrieval."""
@@ -606,7 +727,9 @@ class HindsightMemoryProvider(MemoryProvider):
                 or cfg.get("api_key")
                 or os.environ.get("HINDSIGHT_API_KEY", "")
             )
-            has_url = bool(cfg.get("api_url") or os.environ.get("HINDSIGHT_API_URL", ""))
+            has_url = bool(
+                cfg.get("api_url") or os.environ.get("HINDSIGHT_API_URL", "")
+            )
             return has_key or has_url
         except Exception:
             return False
@@ -615,6 +738,7 @@ class HindsightMemoryProvider(MemoryProvider):
         """Write config to $HERMES_HOME/hindsight/config.json."""
         import json
         from pathlib import Path
+
         config_dir = Path(hermes_home) / "hindsight"
         config_dir.mkdir(parents=True, exist_ok=True)
         config_path = config_dir / "config.json"
@@ -641,7 +765,9 @@ class HindsightMemoryProvider(MemoryProvider):
 
         print("\n  Configuring Hindsight memory:\n")
 
-        existing_config = self._config if isinstance(self._config, dict) else _load_config()
+        existing_config = (
+            self._config if isinstance(self._config, dict) else _load_config()
+        )
         if not isinstance(existing_config, dict):
             existing_config = {}
 
@@ -649,11 +775,16 @@ class HindsightMemoryProvider(MemoryProvider):
         mode_values = ["cloud", "local_embedded", "local_external"]
         mode_items = [
             ("Cloud", "Hindsight Cloud API (lightweight, just needs an API key)"),
-            ("Local Embedded", "Run Hindsight locally (downloads ~200MB, needs LLM key)"),
+            (
+                "Local Embedded",
+                "Run Hindsight locally (downloads ~200MB, needs LLM key)",
+            ),
             ("Local External", "Connect to an existing Hindsight instance"),
         ]
         existing_mode = existing_config.get("mode")
-        mode_default_idx = mode_values.index(existing_mode) if existing_mode in mode_values else 0
+        mode_default_idx = (
+            mode_values.index(existing_mode) if existing_mode in mode_values else 0
+        )
         mode_idx = _curses_select("  Select mode", mode_items, default=mode_default_idx)
         mode = mode_values[mode_idx]
 
@@ -675,18 +806,35 @@ class HindsightMemoryProvider(MemoryProvider):
         print("\n  Checking dependencies...")
         uv_path = shutil.which("uv")
         if not uv_path:
-            print("  ⚠ uv not found — install it: curl -LsSf https://astral.sh/uv/install.sh | sh")
-            print(f"  Then run manually: uv pip install --python {sys.executable} {' '.join(deps_to_install)}")
+            print(
+                "  ⚠ uv not found — install it: curl -LsSf https://astral.sh/uv/install.sh | sh"
+            )
+            print(
+                f"  Then run manually: uv pip install --python {sys.executable} {' '.join(deps_to_install)}"
+            )
         else:
             try:
                 subprocess.run(
-                    [uv_path, "pip", "install", "--python", sys.executable, "--quiet", "--upgrade"] + deps_to_install,
-                    check=True, timeout=120, capture_output=True,
+                    [
+                        uv_path,
+                        "pip",
+                        "install",
+                        "--python",
+                        sys.executable,
+                        "--quiet",
+                        "--upgrade",
+                    ]
+                    + deps_to_install,
+                    check=True,
+                    timeout=120,
+                    capture_output=True,
                 )
                 print("  ✓ Dependencies up to date")
             except Exception as e:
                 print(f"  ⚠ Install failed: {e}")
-                print(f"  Run manually: uv pip install --python {sys.executable} {' '.join(deps_to_install)}")
+                print(
+                    f"  Run manually: uv pip install --python {sys.executable} {' '.join(deps_to_install)}"
+                )
 
         # Step 3: Mode-specific config
         if mode == "cloud":
@@ -696,11 +844,19 @@ class HindsightMemoryProvider(MemoryProvider):
                 masked = f"...{existing_key[-4:]}" if len(existing_key) > 4 else "set"
                 sys.stdout.write(f"  API key (current: {masked}, blank to keep): ")
                 sys.stdout.flush()
-                api_key = getpass.getpass(prompt="") if sys.stdin.isatty() else sys.stdin.readline().strip()
+                api_key = (
+                    getpass.getpass(prompt="")
+                    if sys.stdin.isatty()
+                    else sys.stdin.readline().strip()
+                )
             else:
                 sys.stdout.write("  API key: ")
                 sys.stdout.flush()
-                api_key = getpass.getpass(prompt="") if sys.stdin.isatty() else sys.stdin.readline().strip()
+                api_key = (
+                    getpass.getpass(prompt="")
+                    if sys.stdin.isatty()
+                    else sys.stdin.readline().strip()
+                )
             if api_key:
                 env_writes["HINDSIGHT_API_KEY"] = api_key
 
@@ -714,7 +870,11 @@ class HindsightMemoryProvider(MemoryProvider):
 
             sys.stdout.write("  API key (optional, blank to skip): ")
             sys.stdout.flush()
-            api_key = getpass.getpass(prompt="") if sys.stdin.isatty() else sys.stdin.readline().strip()
+            api_key = (
+                getpass.getpass(prompt="")
+                if sys.stdin.isatty()
+                else sys.stdin.readline().strip()
+            )
             if api_key:
                 env_writes["HINDSIGHT_API_KEY"] = api_key
 
@@ -725,8 +885,14 @@ class HindsightMemoryProvider(MemoryProvider):
                 for p in providers_list
             ]
             existing_llm_provider = provider_config.get("llm_provider")
-            llm_default_idx = providers_list.index(existing_llm_provider) if existing_llm_provider in providers_list else 0
-            llm_idx = _curses_select("  Select LLM provider", llm_items, default=llm_default_idx)
+            llm_default_idx = (
+                providers_list.index(existing_llm_provider)
+                if existing_llm_provider in providers_list
+                else 0
+            )
+            llm_idx = _curses_select(
+                "  Select LLM provider", llm_items, default=llm_default_idx
+            )
             llm_provider = providers_list[llm_idx]
 
             provider_config["llm_provider"] = llm_provider
@@ -743,14 +909,20 @@ class HindsightMemoryProvider(MemoryProvider):
             elif llm_provider == "openrouter":
                 provider_config["llm_base_url"] = "https://openrouter.ai/api/v1"
 
-            provider_default_model = _PROVIDER_DEFAULT_MODELS.get(llm_provider, "gpt-4o-mini")
+            provider_default_model = _PROVIDER_DEFAULT_MODELS.get(
+                llm_provider, "gpt-4o-mini"
+            )
             current_model = provider_config.get("llm_model") or provider_default_model
             val = input(f"  LLM model [{current_model}]: ").strip()
             provider_config["llm_model"] = val or current_model
 
             sys.stdout.write("  LLM API key: ")
             sys.stdout.flush()
-            llm_key = getpass.getpass(prompt="") if sys.stdin.isatty() else sys.stdin.readline().strip()
+            llm_key = (
+                getpass.getpass(prompt="")
+                if sys.stdin.isatty()
+                else sys.stdin.readline().strip()
+            )
             if llm_key:
                 env_writes["HINDSIGHT_LLM_API_KEY"] = llm_key
             else:
@@ -769,12 +941,18 @@ class HindsightMemoryProvider(MemoryProvider):
         # Read existing timeout from config if present, otherwise use default.
         # Preserve explicit 0 values instead of treating them as blank.
         existing_timeout = provider_config.get("timeout")
-        timeout_val = existing_timeout if existing_timeout is not None else _DEFAULT_TIMEOUT
+        timeout_val = (
+            existing_timeout if existing_timeout is not None else _DEFAULT_TIMEOUT
+        )
         provider_config["timeout"] = timeout_val
         env_writes["HINDSIGHT_TIMEOUT"] = str(timeout_val)
         if mode == "local_embedded":
             existing_idle_timeout = provider_config.get("idle_timeout")
-            idle_timeout_val = existing_idle_timeout if existing_idle_timeout is not None else _DEFAULT_IDLE_TIMEOUT
+            idle_timeout_val = (
+                existing_idle_timeout
+                if existing_idle_timeout is not None
+                else _DEFAULT_IDLE_TIMEOUT
+            )
             provider_config["idle_timeout"] = idle_timeout_val
             env_writes["HINDSIGHT_IDLE_TIMEOUT"] = str(idle_timeout_val)
         config["memory"]["provider"] = "hindsight"
@@ -791,7 +969,11 @@ class HindsightMemoryProvider(MemoryProvider):
             updated_keys = set()
             new_lines = []
             for line in existing_lines:
-                key_match = line.split("=", 1)[0].strip() if "=" in line and not line.startswith("#") else None
+                key_match = (
+                    line.split("=", 1)[0].strip()
+                    if "=" in line and not line.startswith("#")
+                    else None
+                )
                 if key_match and key_match in env_writes:
                     new_lines.append(f"{key_match}={env_writes[key_match]}")
                     updated_keys.add(key_match)
@@ -806,15 +988,21 @@ class HindsightMemoryProvider(MemoryProvider):
             materialized_config = dict(provider_config)
             config_path = Path(hermes_home) / "hindsight" / "config.json"
             try:
-                materialized_config = json.loads(config_path.read_text(encoding="utf-8"))
+                materialized_config = json.loads(
+                    config_path.read_text(encoding="utf-8")
+                )
             except Exception:
                 pass
 
             llm_api_key = env_writes.get("HINDSIGHT_LLM_API_KEY", "")
             if not llm_api_key:
-                llm_api_key = _load_simple_env(Path(hermes_home) / ".env").get("HINDSIGHT_LLM_API_KEY", "")
+                llm_api_key = _load_simple_env(Path(hermes_home) / ".env").get(
+                    "HINDSIGHT_LLM_API_KEY", ""
+                )
             if not llm_api_key:
-                llm_api_key = _load_simple_env(_embedded_profile_env_path(materialized_config)).get(
+                llm_api_key = _load_simple_env(
+                    _embedded_profile_env_path(materialized_config)
+                ).get(
                     "HINDSIGHT_API_LLM_API_KEY",
                     "",
                 )
@@ -831,41 +1019,199 @@ class HindsightMemoryProvider(MemoryProvider):
 
     def get_config_schema(self):
         return [
-            {"key": "mode", "description": "Connection mode", "default": "cloud", "choices": ["cloud", "local_embedded", "local_external"]},
+            {
+                "key": "mode",
+                "description": "Connection mode",
+                "default": "cloud",
+                "choices": ["cloud", "local_embedded", "local_external"],
+            },
             # Cloud mode
-            {"key": "api_url", "description": "Hindsight Cloud API URL", "default": _DEFAULT_API_URL, "when": {"mode": "cloud"}},
-            {"key": "api_key", "description": "Hindsight Cloud API key", "secret": True, "env_var": "HINDSIGHT_API_KEY", "url": "https://ui.hindsight.vectorize.io", "when": {"mode": "cloud"}},
+            {
+                "key": "api_url",
+                "description": "Hindsight Cloud API URL",
+                "default": _DEFAULT_API_URL,
+                "when": {"mode": "cloud"},
+            },
+            {
+                "key": "api_key",
+                "description": "Hindsight Cloud API key",
+                "secret": True,
+                "env_var": "HINDSIGHT_API_KEY",
+                "url": "https://ui.hindsight.vectorize.io",
+                "when": {"mode": "cloud"},
+            },
             # Local external mode
-            {"key": "api_url", "description": "Hindsight API URL", "default": _DEFAULT_LOCAL_URL, "when": {"mode": "local_external"}},
-            {"key": "api_key", "description": "API key (optional)", "secret": True, "env_var": "HINDSIGHT_API_KEY", "when": {"mode": "local_external"}},
+            {
+                "key": "api_url",
+                "description": "Hindsight API URL",
+                "default": _DEFAULT_LOCAL_URL,
+                "when": {"mode": "local_external"},
+            },
+            {
+                "key": "api_key",
+                "description": "API key (optional)",
+                "secret": True,
+                "env_var": "HINDSIGHT_API_KEY",
+                "when": {"mode": "local_external"},
+            },
             # Local embedded mode
-            {"key": "llm_provider", "description": "LLM provider", "default": "openai", "choices": ["openai", "anthropic", "gemini", "groq", "openrouter", "minimax", "ollama", "lmstudio", "openai_compatible"], "when": {"mode": "local_embedded"}},
-            {"key": "llm_base_url", "description": "Endpoint URL (e.g. http://192.168.1.10:8080/v1)", "default": "", "when": {"mode": "local_embedded", "llm_provider": "openai_compatible"}},
-            {"key": "llm_api_key", "description": "LLM API key (optional for openai_compatible)", "secret": True, "env_var": "HINDSIGHT_LLM_API_KEY", "when": {"mode": "local_embedded"}},
-            {"key": "llm_model", "description": "LLM model", "default": "gpt-4o-mini", "default_from": {"field": "llm_provider", "map": _PROVIDER_DEFAULT_MODELS}, "when": {"mode": "local_embedded"}},
-            {"key": "bank_id", "description": "Memory bank name (static fallback when bank_id_template is unset)", "default": "hermes"},
-            {"key": "bank_id_template", "description": "Optional template to derive bank_id dynamically. Placeholders: {profile}, {workspace}, {platform}, {user}, {session}. Example: hermes-{profile}", "default": ""},
-            {"key": "bank_mission", "description": "Mission/purpose description for the memory bank"},
-            {"key": "bank_retain_mission", "description": "Custom extraction prompt for memory retention"},
-            {"key": "recall_budget", "description": "Recall thoroughness", "default": "mid", "choices": ["low", "mid", "high"]},
-            {"key": "memory_mode", "description": "Memory integration mode", "default": "hybrid", "choices": ["hybrid", "context", "tools"]},
-            {"key": "recall_prefetch_method", "description": "Auto-recall method", "default": "recall", "choices": ["recall", "reflect"]},
-            {"key": "retain_tags", "description": "Default tags applied to retained memories (comma-separated)", "default": ""},
-            {"key": "retain_source", "description": "Metadata source value attached to retained memories", "default": ""},
-            {"key": "retain_user_prefix", "description": "Label used before user turns in retained transcripts", "default": "User"},
-            {"key": "retain_assistant_prefix", "description": "Label used before assistant turns in retained transcripts", "default": "Assistant"},
-            {"key": "recall_tags", "description": "Tags to filter when searching memories (comma-separated)", "default": ""},
-            {"key": "recall_tags_match", "description": "Tag matching mode for recall", "default": "any", "choices": ["any", "all", "any_strict", "all_strict"]},
-            {"key": "auto_recall", "description": "Automatically recall memories before each turn", "default": True},
-            {"key": "auto_retain", "description": "Automatically retain conversation turns", "default": True},
-            {"key": "retain_every_n_turns", "description": "Retain every N turns (1 = every turn)", "default": 1},
-            {"key": "retain_async","description": "Process retain asynchronously on the Hindsight server", "default": True},
-            {"key": "retain_context", "description": "Context label for retained memories", "default": "conversation between Hermes Agent and the User"},
-            {"key": "recall_max_tokens", "description": "Maximum tokens for recall results", "default": 4096},
-            {"key": "recall_max_input_chars", "description": "Maximum input query length for auto-recall", "default": 800},
-            {"key": "recall_prompt_preamble", "description": "Custom preamble for recalled memories in context"},
-            {"key": "timeout", "description": "API request timeout in seconds", "default": _DEFAULT_TIMEOUT},
-            {"key": "idle_timeout", "description": "Embedded daemon idle timeout in seconds (0 disables auto-shutdown)", "default": _DEFAULT_IDLE_TIMEOUT, "when": {"mode": "local_embedded"}},
+            {
+                "key": "llm_provider",
+                "description": "LLM provider",
+                "default": "openai",
+                "choices": [
+                    "openai",
+                    "anthropic",
+                    "gemini",
+                    "groq",
+                    "openrouter",
+                    "minimax",
+                    "ollama",
+                    "lmstudio",
+                    "openai_compatible",
+                ],
+                "when": {"mode": "local_embedded"},
+            },
+            {
+                "key": "llm_base_url",
+                "description": "Endpoint URL (e.g. http://192.168.1.10:8080/v1)",
+                "default": "",
+                "when": {"mode": "local_embedded", "llm_provider": "openai_compatible"},
+            },
+            {
+                "key": "llm_api_key",
+                "description": "LLM API key (optional for openai_compatible)",
+                "secret": True,
+                "env_var": "HINDSIGHT_LLM_API_KEY",
+                "when": {"mode": "local_embedded"},
+            },
+            {
+                "key": "llm_model",
+                "description": "LLM model",
+                "default": "gpt-4o-mini",
+                "default_from": {
+                    "field": "llm_provider",
+                    "map": _PROVIDER_DEFAULT_MODELS,
+                },
+                "when": {"mode": "local_embedded"},
+            },
+            {
+                "key": "bank_id",
+                "description": "Memory bank name (static fallback when bank_id_template is unset)",
+                "default": "hermes",
+            },
+            {
+                "key": "bank_id_template",
+                "description": "Optional template to derive bank_id dynamically. Placeholders: {profile}, {workspace}, {platform}, {user}, {session}. Example: hermes-{profile}",
+                "default": "",
+            },
+            {
+                "key": "bank_mission",
+                "description": "Mission/purpose description for the memory bank",
+            },
+            {
+                "key": "bank_retain_mission",
+                "description": "Custom extraction prompt for memory retention",
+            },
+            {
+                "key": "recall_budget",
+                "description": "Recall thoroughness",
+                "default": "mid",
+                "choices": ["low", "mid", "high"],
+            },
+            {
+                "key": "memory_mode",
+                "description": "Memory integration mode",
+                "default": "hybrid",
+                "choices": ["hybrid", "context", "tools"],
+            },
+            {
+                "key": "recall_prefetch_method",
+                "description": "Auto-recall method",
+                "default": "recall",
+                "choices": ["recall", "reflect"],
+            },
+            {
+                "key": "retain_tags",
+                "description": "Default tags applied to retained memories (comma-separated)",
+                "default": "",
+            },
+            {
+                "key": "retain_source",
+                "description": "Metadata source value attached to retained memories",
+                "default": "",
+            },
+            {
+                "key": "retain_user_prefix",
+                "description": "Label used before user turns in retained transcripts",
+                "default": "User",
+            },
+            {
+                "key": "retain_assistant_prefix",
+                "description": "Label used before assistant turns in retained transcripts",
+                "default": "Assistant",
+            },
+            {
+                "key": "recall_tags",
+                "description": "Tags to filter when searching memories (comma-separated)",
+                "default": "",
+            },
+            {
+                "key": "recall_tags_match",
+                "description": "Tag matching mode for recall",
+                "default": "any",
+                "choices": ["any", "all", "any_strict", "all_strict"],
+            },
+            {
+                "key": "auto_recall",
+                "description": "Automatically recall memories before each turn",
+                "default": True,
+            },
+            {
+                "key": "auto_retain",
+                "description": "Automatically retain conversation turns",
+                "default": True,
+            },
+            {
+                "key": "retain_every_n_turns",
+                "description": "Retain every N turns (1 = every turn)",
+                "default": 1,
+            },
+            {
+                "key": "retain_async",
+                "description": "Process retain asynchronously on the Hindsight server",
+                "default": True,
+            },
+            {
+                "key": "retain_context",
+                "description": "Context label for retained memories",
+                "default": "conversation between Hermes Agent and the User",
+            },
+            {
+                "key": "recall_max_tokens",
+                "description": "Maximum tokens for recall results",
+                "default": 4096,
+            },
+            {
+                "key": "recall_max_input_chars",
+                "description": "Maximum input query length for auto-recall",
+                "default": 800,
+            },
+            {
+                "key": "recall_prompt_preamble",
+                "description": "Custom preamble for recalled memories in context",
+            },
+            {
+                "key": "timeout",
+                "description": "API request timeout in seconds",
+                "default": _DEFAULT_TIMEOUT,
+            },
+            {
+                "key": "idle_timeout",
+                "description": "Embedded daemon idle timeout in seconds (0 disables auto-shutdown)",
+                "default": _DEFAULT_IDLE_TIMEOUT,
+                "when": {"mode": "local_embedded"},
+            },
         ]
 
     def _get_client(self):
@@ -880,43 +1226,42 @@ class HindsightMemoryProvider(MemoryProvider):
                     )
                 try:
                     from tools.lazy_deps import ensure as _lazy_ensure
+
                     _lazy_ensure("memory.hindsight", prompt=False)
                 except ImportError:
                     pass
                 except Exception as _e:
                     raise ImportError(str(_e))
-                from hindsight import HindsightEmbedded
-                HindsightEmbedded.__del__ = lambda self: None
-                llm_provider = self._config.get("llm_provider", "")
-                if llm_provider in {"openai_compatible", "openrouter"}:
-                    llm_provider = "openai"
-                logger.debug("Creating HindsightEmbedded client (profile=%s, provider=%s)",
-                             self._config.get("profile", "hermes"), llm_provider)
-                kwargs = dict(
-                    profile=self._config.get("profile", "hermes"),
-                    llm_provider=llm_provider,
-                    llm_api_key=self._config.get("llmApiKey") or self._config.get("llm_api_key") or os.environ.get("HINDSIGHT_LLM_API_KEY", ""),
-                    llm_model=self._config.get("llm_model", ""),
-                )
-                if self._llm_base_url:
-                    kwargs["llm_base_url"] = self._llm_base_url
+                config = self._config or {}
                 idle_timeout = _parse_int_setting(
-                    self._config.get("idle_timeout")
-                    if self._config.get("idle_timeout") is not None
+                    config.get("idle_timeout")
+                    if config.get("idle_timeout") is not None
                     else os.environ.get("HINDSIGHT_IDLE_TIMEOUT", self._idle_timeout),
                     _DEFAULT_IDLE_TIMEOUT,
                 )
                 self._idle_timeout = idle_timeout
-                kwargs["idle_timeout"] = idle_timeout
-                self._client = HindsightEmbedded(**kwargs)
+                logger.debug(
+                    "Creating local embedded Hindsight client via daemon manager (profile=%s)",
+                    config.get("profile", "hermes"),
+                )
+                self._client = _LocalEmbeddedHindsightClient(
+                    config=config,
+                    profile=config.get("profile", "hermes"),
+                    timeout=self._timeout or _DEFAULT_TIMEOUT,
+                )
             else:
                 from hindsight_client import Hindsight
+
                 timeout = self._timeout or _DEFAULT_TIMEOUT
                 kwargs = {"base_url": self._api_url, "timeout": float(timeout)}
                 if self._api_key:
                     kwargs["api_key"] = self._api_key
-                logger.debug("Creating Hindsight cloud client (url=%s, has_key=%s, timeout=%s)",
-                             self._api_url, bool(self._api_key), kwargs["timeout"])
+                logger.debug(
+                    "Creating Hindsight cloud client (url=%s, has_key=%s, timeout=%s)",
+                    self._api_url,
+                    bool(self._api_key),
+                    kwargs["timeout"],
+                )
                 self._client = Hindsight(**kwargs)
         return self._client
 
@@ -1036,7 +1381,9 @@ class HindsightMemoryProvider(MemoryProvider):
                 return str(url)
         return self._api_url or ""
 
-    def _resolve_retain_target(self, fallback_document_id: str) -> tuple[str, str | None]:
+    def _resolve_retain_target(
+        self, fallback_document_id: str
+    ) -> tuple[str, str | None]:
         """Pick (document_id, update_mode) based on live API capability.
 
         On Hindsight ≥ 0.5.0 the API supports ``update_mode='append'``,
@@ -1073,27 +1420,50 @@ class HindsightMemoryProvider(MemoryProvider):
         try:
             from importlib.metadata import version as pkg_version
             from packaging.version import Version
+
             installed = pkg_version("hindsight-client")
             if Version(installed) < Version(_MIN_CLIENT_VERSION):
-                logger.warning("hindsight-client %s is outdated (need >=%s), attempting upgrade...",
-                               installed, _MIN_CLIENT_VERSION)
+                logger.warning(
+                    "hindsight-client %s is outdated (need >=%s), attempting upgrade...",
+                    installed,
+                    _MIN_CLIENT_VERSION,
+                )
                 import shutil
                 import subprocess
                 import sys
+
                 uv_path = shutil.which("uv")
                 if uv_path:
                     try:
                         subprocess.run(
-                            [uv_path, "pip", "install", "--python", sys.executable,
-                             "--quiet", "--upgrade", f"hindsight-client>={_MIN_CLIENT_VERSION}"],
-                            check=True, timeout=120, capture_output=True,
+                            [
+                                uv_path,
+                                "pip",
+                                "install",
+                                "--python",
+                                sys.executable,
+                                "--quiet",
+                                "--upgrade",
+                                f"hindsight-client>={_MIN_CLIENT_VERSION}",
+                            ],
+                            check=True,
+                            timeout=120,
+                            capture_output=True,
                         )
-                        logger.info("hindsight-client upgraded to >=%s", _MIN_CLIENT_VERSION)
+                        logger.info(
+                            "hindsight-client upgraded to >=%s", _MIN_CLIENT_VERSION
+                        )
                     except Exception as e:
-                        logger.warning("Auto-upgrade failed: %s. Run: uv pip install 'hindsight-client>=%s'",
-                                       e, _MIN_CLIENT_VERSION)
+                        logger.warning(
+                            "Auto-upgrade failed: %s. Run: uv pip install 'hindsight-client>=%s'",
+                            e,
+                            _MIN_CLIENT_VERSION,
+                        )
                 else:
-                    logger.warning("uv not found. Run: pip install 'hindsight-client>=%s'", _MIN_CLIENT_VERSION)
+                    logger.warning(
+                        "uv not found. Run: pip install 'hindsight-client>=%s'",
+                        _MIN_CLIENT_VERSION,
+                    )
         except Exception:
             pass  # packaging not available or other issue — proceed anyway
 
@@ -1112,11 +1482,15 @@ class HindsightMemoryProvider(MemoryProvider):
         self._mode = self._config.get("mode", "cloud")
         # Read timeout from config or env var, fall back to default
         self._timeout = _parse_int_setting(
-            self._config.get("timeout") if self._config.get("timeout") is not None else os.environ.get("HINDSIGHT_TIMEOUT"),
+            self._config.get("timeout")
+            if self._config.get("timeout") is not None
+            else os.environ.get("HINDSIGHT_TIMEOUT"),
             _DEFAULT_TIMEOUT,
         )
         self._idle_timeout = _parse_int_setting(
-            self._config.get("idle_timeout") if self._config.get("idle_timeout") is not None else os.environ.get("HINDSIGHT_IDLE_TIMEOUT"),
+            self._config.get("idle_timeout")
+            if self._config.get("idle_timeout") is not None
+            else os.environ.get("HINDSIGHT_IDLE_TIMEOUT"),
             _DEFAULT_IDLE_TIMEOUT,
         )
         # "local" is a legacy alias for "local_embedded"
@@ -1131,9 +1505,19 @@ class HindsightMemoryProvider(MemoryProvider):
                 )
                 self._mode = "disabled"
                 return
-        self._api_key = self._config.get("apiKey") or self._config.get("api_key") or os.environ.get("HINDSIGHT_API_KEY", "")
-        default_url = _DEFAULT_LOCAL_URL if self._mode in {"local_embedded", "local_external"} else _DEFAULT_API_URL
-        self._api_url = self._config.get("api_url") or os.environ.get("HINDSIGHT_API_URL", default_url)
+        self._api_key = (
+            self._config.get("apiKey")
+            or self._config.get("api_key")
+            or os.environ.get("HINDSIGHT_API_KEY", "")
+        )
+        default_url = (
+            _DEFAULT_LOCAL_URL
+            if self._mode in {"local_embedded", "local_external"}
+            else _DEFAULT_API_URL
+        )
+        self._api_url = self._config.get("api_url") or os.environ.get(
+            "HINDSIGHT_API_URL", default_url
+        )
         self._llm_base_url = self._config.get("llm_base_url", "")
 
         banks = cfg_get(self._config, "banks", "hermes", default={})
@@ -1148,14 +1532,24 @@ class HindsightMemoryProvider(MemoryProvider):
             user=self._user_id,
             session=self._session_id,
         )
-        budget = self._config.get("recall_budget") or self._config.get("budget") or banks.get("budget", "mid")
+        budget = (
+            self._config.get("recall_budget")
+            or self._config.get("budget")
+            or banks.get("budget", "mid")
+        )
         self._budget = budget if budget in _VALID_BUDGETS else "mid"
 
         memory_mode = self._config.get("memory_mode", "hybrid")
-        self._memory_mode = memory_mode if memory_mode in {"context", "tools", "hybrid"} else "hybrid"
+        self._memory_mode = (
+            memory_mode if memory_mode in {"context", "tools", "hybrid"} else "hybrid"
+        )
 
-        prefetch_method = self._config.get("recall_prefetch_method") or self._config.get("prefetch_method", "recall")
-        self._prefetch_method = prefetch_method if prefetch_method in {"recall", "reflect"} else "recall"
+        prefetch_method = self._config.get(
+            "recall_prefetch_method"
+        ) or self._config.get("prefetch_method", "recall")
+        self._prefetch_method = (
+            prefetch_method if prefetch_method in {"recall", "reflect"} else "recall"
+        )
 
         # Bank options
         self._bank_mission = self._config.get("bank_mission", "")
@@ -1170,52 +1564,92 @@ class HindsightMemoryProvider(MemoryProvider):
         self._recall_tags = self._config.get("recall_tags") or None
         self._recall_tags_match = self._config.get("recall_tags_match", "any")
         self._retain_source = str(
-            self._config.get("retain_source") or os.environ.get("HINDSIGHT_RETAIN_SOURCE", "")
+            self._config.get("retain_source")
+            or os.environ.get("HINDSIGHT_RETAIN_SOURCE", "")
         ).strip()
-        self._retain_user_prefix = str(
-            self._config.get("retain_user_prefix") or os.environ.get("HINDSIGHT_RETAIN_USER_PREFIX", "User")
-        ).strip() or "User"
-        self._retain_assistant_prefix = str(
-            self._config.get("retain_assistant_prefix") or os.environ.get("HINDSIGHT_RETAIN_ASSISTANT_PREFIX", "Assistant")
-        ).strip() or "Assistant"
+        self._retain_user_prefix = (
+            str(
+                self._config.get("retain_user_prefix")
+                or os.environ.get("HINDSIGHT_RETAIN_USER_PREFIX", "User")
+            ).strip()
+            or "User"
+        )
+        self._retain_assistant_prefix = (
+            str(
+                self._config.get("retain_assistant_prefix")
+                or os.environ.get("HINDSIGHT_RETAIN_ASSISTANT_PREFIX", "Assistant")
+            ).strip()
+            or "Assistant"
+        )
 
         # Retain controls
         self._auto_retain = self._config.get("auto_retain", True)
-        self._retain_every_n_turns = max(1, int(self._config.get("retain_every_n_turns", 1)))
-        self._retain_context = self._config.get("retain_context", "conversation between Hermes Agent and the User")
+        self._retain_every_n_turns = max(
+            1, int(self._config.get("retain_every_n_turns", 1))
+        )
+        self._retain_context = self._config.get(
+            "retain_context", "conversation between Hermes Agent and the User"
+        )
 
         # Recall controls
         self._auto_recall = self._config.get("auto_recall", True)
         self._recall_max_tokens = int(self._config.get("recall_max_tokens", 4096))
         self._recall_types = self._config.get("recall_types") or None
         self._recall_prompt_preamble = self._config.get("recall_prompt_preamble", "")
-        self._recall_max_input_chars = int(self._config.get("recall_max_input_chars", 800))
+        self._recall_max_input_chars = int(
+            self._config.get("recall_max_input_chars", 800)
+        )
         self._retain_async = self._config.get("retain_async", True)
 
         _client_version = "unknown"
         try:
             from importlib.metadata import version as pkg_version
+
             _client_version = pkg_version("hindsight-client")
         except Exception:
             pass
-        logger.info("Hindsight initialized: mode=%s, api_url=%s, bank=%s, budget=%s, memory_mode=%s, prefetch_method=%s, client=%s",
-                     self._mode, self._api_url, self._bank_id, self._budget, self._memory_mode, self._prefetch_method, _client_version)
+        logger.info(
+            "Hindsight initialized: mode=%s, api_url=%s, bank=%s, budget=%s, memory_mode=%s, prefetch_method=%s, client=%s",
+            self._mode,
+            self._api_url,
+            self._bank_id,
+            self._budget,
+            self._memory_mode,
+            self._prefetch_method,
+            _client_version,
+        )
         if self._bank_id_template:
-            logger.debug("Hindsight bank resolved from template %r: profile=%s workspace=%s platform=%s user=%s -> bank=%s",
-                         self._bank_id_template, self._agent_identity, self._agent_workspace,
-                         self._platform, self._user_id, self._bank_id)
-        logger.debug("Hindsight config: auto_retain=%s, auto_recall=%s, retain_every_n=%d, "
-                     "retain_async=%s, retain_context=%s, recall_max_tokens=%d, recall_max_input_chars=%d, tags=%s, recall_tags=%s",
-                     self._auto_retain, self._auto_recall, self._retain_every_n_turns,
-                     self._retain_async, self._retain_context, self._recall_max_tokens, self._recall_max_input_chars,
-                     self._tags, self._recall_tags)
+            logger.debug(
+                "Hindsight bank resolved from template %r: profile=%s workspace=%s platform=%s user=%s -> bank=%s",
+                self._bank_id_template,
+                self._agent_identity,
+                self._agent_workspace,
+                self._platform,
+                self._user_id,
+                self._bank_id,
+            )
+        logger.debug(
+            "Hindsight config: auto_retain=%s, auto_recall=%s, retain_every_n=%d, "
+            "retain_async=%s, retain_context=%s, recall_max_tokens=%d, recall_max_input_chars=%d, tags=%s, recall_tags=%s",
+            self._auto_retain,
+            self._auto_recall,
+            self._retain_every_n_turns,
+            self._retain_async,
+            self._retain_context,
+            self._recall_max_tokens,
+            self._recall_max_input_chars,
+            self._tags,
+            self._recall_tags,
+        )
 
         # For local mode, start the embedded daemon in the background so it
         # doesn't block the chat. Redirect stdout/stderr to a log file to
         # prevent rich startup output from spamming the terminal.
         if self._mode == "local_embedded":
+
             def _start_daemon():
                 import traceback
+
                 log_dir = get_hermes_home() / "logs"
                 log_dir.mkdir(parents=True, exist_ok=True)
                 log_path = log_dir / "hindsight-embed.log"
@@ -1225,7 +1659,10 @@ class HindsightMemoryProvider(MemoryProvider):
                     # would capture output from other threads.
                     import hindsight_embed.daemon_embed_manager as dem
                     from rich.console import Console
-                    dem.console = Console(file=open(log_path, "a", encoding="utf-8"), force_terminal=False)
+
+                    dem.console = Console(
+                        file=open(log_path, "a", encoding="utf-8"), force_terminal=False
+                    )
 
                     client = self._get_client()
                     profile = self._config.get("profile", "hermes")
@@ -1253,7 +1690,9 @@ class HindsightMemoryProvider(MemoryProvider):
                         f.write(f"\n=== Daemon startup failed: {e} ===\n")
                         traceback.print_exc(file=f)
 
-            t = threading.Thread(target=_start_daemon, daemon=True, name="hindsight-daemon-start")
+            t = threading.Thread(
+                target=_start_daemon, daemon=True, name="hindsight-daemon-start"
+            )
             t.start()
 
     def system_prompt_block(self) -> str:
@@ -1308,40 +1747,64 @@ class HindsightMemoryProvider(MemoryProvider):
             return
         # Truncate query to max chars
         if self._recall_max_input_chars and len(query) > self._recall_max_input_chars:
-            query = query[:self._recall_max_input_chars]
+            query = query[: self._recall_max_input_chars]
 
         def _run():
             try:
                 if self._prefetch_method == "reflect":
-                    logger.debug("Prefetch: calling reflect (bank=%s, query_len=%d)", self._bank_id, len(query))
-                    resp = self._run_hindsight_operation(lambda client: client.areflect(bank_id=self._bank_id, query=query, budget=self._budget))
+                    logger.debug(
+                        "Prefetch: calling reflect (bank=%s, query_len=%d)",
+                        self._bank_id,
+                        len(query),
+                    )
+                    resp = self._run_hindsight_operation(
+                        lambda client: client.areflect(
+                            bank_id=self._bank_id, query=query, budget=self._budget
+                        )
+                    )
                     text = resp.text or ""
                 else:
                     recall_kwargs: dict = {
-                        "bank_id": self._bank_id, "query": query,
-                        "budget": self._budget, "max_tokens": self._recall_max_tokens,
+                        "bank_id": self._bank_id,
+                        "query": query,
+                        "budget": self._budget,
+                        "max_tokens": self._recall_max_tokens,
                     }
                     if self._recall_tags:
                         recall_kwargs["tags"] = self._recall_tags
                         recall_kwargs["tags_match"] = self._recall_tags_match
                     if self._recall_types:
                         recall_kwargs["types"] = self._recall_types
-                    logger.debug("Prefetch: calling recall (bank=%s, query_len=%d, budget=%s)",
-                                 self._bank_id, len(query), self._budget)
-                    resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
+                    logger.debug(
+                        "Prefetch: calling recall (bank=%s, query_len=%d, budget=%s)",
+                        self._bank_id,
+                        len(query),
+                        self._budget,
+                    )
+                    resp = self._run_hindsight_operation(
+                        lambda client: client.arecall(**recall_kwargs)
+                    )
                     num_results = len(resp.results) if resp.results else 0
                     logger.debug("Prefetch: recall returned %d results", num_results)
-                    text = "\n".join(f"- {r.text}" for r in resp.results if r.text) if resp.results else ""
+                    text = (
+                        "\n".join(f"- {r.text}" for r in resp.results if r.text)
+                        if resp.results
+                        else ""
+                    )
                 if text:
                     with self._prefetch_lock:
                         self._prefetch_result = text
             except Exception as e:
                 logger.debug("Hindsight prefetch failed: %s", e, exc_info=True)
 
-        self._prefetch_thread = threading.Thread(target=_run, daemon=True, name="hindsight-prefetch")
+        self._prefetch_thread = threading.Thread(
+            target=_run, daemon=True, name="hindsight-prefetch"
+        )
         self._prefetch_thread.start()
 
-    def _build_turn_messages(self, user_content: str, assistant_content: str) -> List[Dict[str, str]]:
+    def _build_turn_messages(
+        self, user_content: str, assistant_content: str
+    ) -> List[Dict[str, str]]:
         now = datetime.now(timezone.utc).isoformat()
         return [
             {
@@ -1397,7 +1860,8 @@ class HindsightMemoryProvider(MemoryProvider):
         kwargs: Dict[str, Any] = {
             "bank_id": self._bank_id,
             "content": content,
-            "metadata": metadata or self._build_metadata(message_count=1, turn_index=self._turn_index),
+            "metadata": metadata
+            or self._build_metadata(message_count=1, turn_index=self._turn_index),
         }
         if context is not None:
             kwargs["context"] = context
@@ -1413,7 +1877,9 @@ class HindsightMemoryProvider(MemoryProvider):
             kwargs["tags"] = merged_tags
         return kwargs
 
-    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+    def sync_turn(
+        self, user_content: str, assistant_content: str, *, session_id: str = ""
+    ) -> None:
         """Enqueue a retain for the current turn. Non-blocking.
 
         The actual aretain_batch runs on a single long-lived writer thread
@@ -1431,18 +1897,31 @@ class HindsightMemoryProvider(MemoryProvider):
         if session_id:
             self._session_id = str(session_id).strip()
 
-        turn = json.dumps(self._build_turn_messages(user_content, assistant_content), ensure_ascii=False)
+        turn = json.dumps(
+            self._build_turn_messages(user_content, assistant_content),
+            ensure_ascii=False,
+        )
         self._session_turns.append(turn)
         self._turn_counter += 1
         self._turn_index = self._turn_counter
 
         if self._turn_counter % self._retain_every_n_turns != 0:
-            logger.debug("sync_turn: buffered turn %d (will retain at turn %d)",
-                         self._turn_counter, self._turn_counter + (self._retain_every_n_turns - self._turn_counter % self._retain_every_n_turns))
+            logger.debug(
+                "sync_turn: buffered turn %d (will retain at turn %d)",
+                self._turn_counter,
+                self._turn_counter
+                + (
+                    self._retain_every_n_turns
+                    - self._turn_counter % self._retain_every_n_turns
+                ),
+            )
             return
 
-        logger.debug("sync_turn: retaining %d turns, total session content %d chars",
-                     len(self._session_turns), sum(len(t) for t in self._session_turns))
+        logger.debug(
+            "sync_turn: retaining %d turns, total session content %d chars",
+            len(self._session_turns),
+            sum(len(t) for t in self._session_turns),
+        )
         content = "[" + ",".join(self._session_turns) + "]"
 
         lineage_tags: list[str] = []
@@ -1474,8 +1953,15 @@ class HindsightMemoryProvider(MemoryProvider):
             item.pop("retain_async", None)
             if update_mode is not None:
                 item["update_mode"] = update_mode
-            logger.debug("Hindsight retain: bank=%s, doc=%s, mode=%s, async=%s, content_len=%d, num_turns=%d",
-                         bank_id, document_id, update_mode, retain_async_flag, len(content), num_turns)
+            logger.debug(
+                "Hindsight retain: bank=%s, doc=%s, mode=%s, async=%s, content_len=%d, num_turns=%d",
+                bank_id,
+                document_id,
+                update_mode,
+                retain_async_flag,
+                len(content),
+                num_turns,
+            )
             self._run_hindsight_operation(
                 lambda client: client.aretain_batch(
                     bank_id=bank_id,
@@ -1507,9 +1993,15 @@ class HindsightMemoryProvider(MemoryProvider):
                     context=context,
                     tags=args.get("tags"),
                 )
-                logger.debug("Tool hindsight_retain: bank=%s, content_len=%d, context=%s",
-                             self._bank_id, len(content), context)
-                self._run_hindsight_operation(lambda client: client.aretain(**retain_kwargs))
+                logger.debug(
+                    "Tool hindsight_retain: bank=%s, content_len=%d, context=%s",
+                    self._bank_id,
+                    len(content),
+                    context,
+                )
+                self._run_hindsight_operation(
+                    lambda client: client.aretain(**retain_kwargs)
+                )
                 logger.debug("Tool hindsight_retain: success")
                 return json.dumps({"result": "Memory stored successfully."})
             except Exception as e:
@@ -1522,7 +2014,9 @@ class HindsightMemoryProvider(MemoryProvider):
                 return tool_error("Missing required parameter: query")
             try:
                 recall_kwargs: dict = {
-                    "bank_id": self._bank_id, "query": query, "budget": self._budget,
+                    "bank_id": self._bank_id,
+                    "query": query,
+                    "budget": self._budget,
                     "max_tokens": self._recall_max_tokens,
                 }
                 if self._recall_tags:
@@ -1530,9 +2024,15 @@ class HindsightMemoryProvider(MemoryProvider):
                     recall_kwargs["tags_match"] = self._recall_tags_match
                 if self._recall_types:
                     recall_kwargs["types"] = self._recall_types
-                logger.debug("Tool hindsight_recall: bank=%s, query_len=%d, budget=%s",
-                             self._bank_id, len(query), self._budget)
-                resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
+                logger.debug(
+                    "Tool hindsight_recall: bank=%s, query_len=%d, budget=%s",
+                    self._bank_id,
+                    len(query),
+                    self._budget,
+                )
+                resp = self._run_hindsight_operation(
+                    lambda client: client.arecall(**recall_kwargs)
+                )
                 num_results = len(resp.results) if resp.results else 0
                 logger.debug("Tool hindsight_recall: %d results", num_results)
                 if not resp.results:
@@ -1548,15 +2048,23 @@ class HindsightMemoryProvider(MemoryProvider):
             if not query:
                 return tool_error("Missing required parameter: query")
             try:
-                logger.debug("Tool hindsight_reflect: bank=%s, query_len=%d, budget=%s",
-                             self._bank_id, len(query), self._budget)
+                logger.debug(
+                    "Tool hindsight_reflect: bank=%s, query_len=%d, budget=%s",
+                    self._bank_id,
+                    len(query),
+                    self._budget,
+                )
                 resp = self._run_hindsight_operation(
                     lambda client: client.areflect(
                         bank_id=self._bank_id, query=query, budget=self._budget
                     )
                 )
-                logger.debug("Tool hindsight_reflect: response_len=%d", len(resp.text or ""))
-                return json.dumps({"result": resp.text or "No relevant memories found."})
+                logger.debug(
+                    "Tool hindsight_reflect: response_len=%d", len(resp.text or "")
+                )
+                return json.dumps({
+                    "result": resp.text or "No relevant memories found."
+                })
             except Exception as e:
                 logger.warning("hindsight_reflect failed: %s", e, exc_info=True)
                 return tool_error(f"Failed to reflect: {e}")
@@ -1646,7 +2154,10 @@ class HindsightMemoryProvider(MemoryProvider):
                         item["update_mode"] = old_update_mode
                     logger.debug(
                         "Hindsight flush-on-switch: bank=%s, doc=%s, mode=%s, num_turns=%d",
-                        self._bank_id, old_document_id, old_update_mode, len(old_turns),
+                        self._bank_id,
+                        old_document_id,
+                        old_update_mode,
+                        len(old_turns),
                     )
                     self._run_hindsight_operation(
                         lambda client: client.aretain_batch(
@@ -1657,7 +2168,9 @@ class HindsightMemoryProvider(MemoryProvider):
                         )
                     )
                 except Exception as e:
-                    logger.warning("Hindsight flush-on-switch failed: %s", e, exc_info=True)
+                    logger.warning(
+                        "Hindsight flush-on-switch failed: %s", e, exc_info=True
+                    )
 
             # Route the flush through the same writer queue sync_turn
             # uses. That serializes it behind any still-queued retains
@@ -1688,11 +2201,16 @@ class HindsightMemoryProvider(MemoryProvider):
         self._turn_index = 0
         logger.debug(
             "Hindsight on_session_switch: new_session=%s parent=%s reset=%s doc=%s",
-            self._session_id, self._parent_session_id, reset, self._document_id,
+            self._session_id,
+            self._parent_session_id,
+            reset,
+            self._document_id,
         )
 
     def shutdown(self) -> None:
-        logger.debug("Hindsight shutdown: stopping writer + waiting for background threads")
+        logger.debug(
+            "Hindsight shutdown: stopping writer + waiting for background threads"
+        )
         # Stop accepting new retain jobs first so anyone still calling
         # sync_turn() during teardown is dropped, not enqueued.
         self._shutting_down.set()

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -35,17 +35,25 @@ from plugins.memory.hindsight import (
 def _clean_env(monkeypatch):
     """Ensure no stale env vars leak between tests."""
     for key in (
-        "HINDSIGHT_API_KEY", "HINDSIGHT_API_URL", "HINDSIGHT_BANK_ID",
-        "HINDSIGHT_BUDGET", "HINDSIGHT_MODE", "HINDSIGHT_TIMEOUT",
-        "HINDSIGHT_IDLE_TIMEOUT", "HINDSIGHT_LLM_API_KEY",
-        "HINDSIGHT_RETAIN_TAGS", "HINDSIGHT_RETAIN_SOURCE",
-        "HINDSIGHT_RETAIN_USER_PREFIX", "HINDSIGHT_RETAIN_ASSISTANT_PREFIX",
+        "HINDSIGHT_API_KEY",
+        "HINDSIGHT_API_URL",
+        "HINDSIGHT_BANK_ID",
+        "HINDSIGHT_BUDGET",
+        "HINDSIGHT_MODE",
+        "HINDSIGHT_TIMEOUT",
+        "HINDSIGHT_IDLE_TIMEOUT",
+        "HINDSIGHT_LLM_API_KEY",
+        "HINDSIGHT_RETAIN_TAGS",
+        "HINDSIGHT_RETAIN_SOURCE",
+        "HINDSIGHT_RETAIN_USER_PREFIX",
+        "HINDSIGHT_RETAIN_ASSISTANT_PREFIX",
     ):
         monkeypatch.delenv(key, raising=False)
 
 
 def _make_mock_client():
     """Create a mock Hindsight client with async methods."""
+
     async def _aretain(
         bank_id,
         content,
@@ -70,9 +78,7 @@ def _make_mock_client():
             ]
         )
     )
-    client.areflect = AsyncMock(
-        return_value=SimpleNamespace(text="Synthesized answer")
-    )
+    client.areflect = AsyncMock(return_value=SimpleNamespace(text="Synthesized answer"))
     client.aretain_batch = AsyncMock()
     client.aclose = AsyncMock()
     return client
@@ -101,9 +107,7 @@ def provider(tmp_path, monkeypatch):
     config_path.parent.mkdir(parents=True, exist_ok=True)
     config_path.write_text(json.dumps(config))
 
-    monkeypatch.setattr(
-        "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
-    )
+    monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
 
     p = HindsightMemoryProvider()
     p.initialize(session_id="test-session", hermes_home=str(tmp_path), platform="cli")
@@ -114,6 +118,7 @@ def provider(tmp_path, monkeypatch):
 @pytest.fixture()
 def provider_with_config(tmp_path, monkeypatch):
     """Create a provider factory that accepts custom config overrides."""
+
     def _make(**overrides):
         config = {
             "mode": "cloud",
@@ -133,14 +138,19 @@ def provider_with_config(tmp_path, monkeypatch):
         )
 
         p = HindsightMemoryProvider()
-        p.initialize(session_id="test-session", hermes_home=str(tmp_path), platform="cli")
+        p.initialize(
+            session_id="test-session", hermes_home=str(tmp_path), platform="cli"
+        )
         p._client = _make_mock_client()
         return p
+
     return _make
 
 
 def test_normalize_retain_tags_accepts_csv_and_dedupes():
-    assert _normalize_retain_tags("agent:fakeassistantname, source_system:hermes-agent, agent:fakeassistantname") == [
+    assert _normalize_retain_tags(
+        "agent:fakeassistantname, source_system:hermes-agent, agent:fakeassistantname"
+    ) == [
         "agent:fakeassistantname",
         "source_system:hermes-agent",
     ]
@@ -148,7 +158,10 @@ def test_normalize_retain_tags_accepts_csv_and_dedupes():
 
 def test_normalize_retain_tags_accepts_json_array_string():
     value = json.dumps(["agent:fakeassistantname", "source_system:hermes-agent"])
-    assert _normalize_retain_tags(value) == ["agent:fakeassistantname", "source_system:hermes-agent"]
+    assert _normalize_retain_tags(value) == [
+        "agent:fakeassistantname",
+        "source_system:hermes-agent",
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -199,7 +212,9 @@ class TestConfig:
         assert provider._recall_tags is None
         assert provider._bank_mission == ""
         assert provider._bank_retain_mission is None
-        assert provider._retain_context == "conversation between Hermes Agent and the User"
+        assert (
+            provider._retain_context == "conversation between Hermes Agent and the User"
+        )
 
     def test_custom_config_values(self, provider_with_config):
         p = provider_with_config(
@@ -273,18 +288,28 @@ class TestConfig:
 
         assert env["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] == "42"
 
-    def test_get_client_passes_idle_timeout_to_hindsight_embedded(self, monkeypatch):
+    def test_get_client_builds_local_embedded_adapter_with_profile_and_timeout(
+        self, monkeypatch
+    ):
         captured = {}
 
-        class FakeHindsightEmbedded:
-            def __init__(self, **kwargs):
-                captured.update(kwargs)
+        class FakeLocalEmbeddedClient:
+            def __init__(self, *, config, profile, timeout):
+                captured["config"] = config
+                captured["profile"] = profile
+                captured["timeout"] = timeout
 
-        monkeypatch.setitem(sys.modules, "hindsight", SimpleNamespace(HindsightEmbedded=FakeHindsightEmbedded))
-        monkeypatch.setattr("plugins.memory.hindsight._check_local_runtime", lambda: (True, ""))
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._LocalEmbeddedHindsightClient",
+            FakeLocalEmbeddedClient,
+        )
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._check_local_runtime", lambda: (True, "")
+        )
 
         p = HindsightMemoryProvider()
         p._mode = "local_embedded"
+        p._timeout = 77
         p._config = {
             "profile": "hermes",
             "llm_provider": "openai_compatible",
@@ -296,8 +321,9 @@ class TestConfig:
 
         p._get_client()
 
-        assert captured["idle_timeout"] == 0
-        assert captured["llm_provider"] == "openai"
+        assert captured["profile"] == "hermes"
+        assert captured["timeout"] == 77
+        assert captured["config"]["idle_timeout"] == 0
 
 
 class TestPostSetup:
@@ -308,13 +334,19 @@ class TestPostSetup:
         monkeypatch.setenv("HOME", str(user_home))
 
         selections = iter([1, 0])  # local_embedded, openai
-        monkeypatch.setattr("hermes_cli.memory_setup._curses_select", lambda *args, **kwargs: next(selections))
+        monkeypatch.setattr(
+            "hermes_cli.memory_setup._curses_select",
+            lambda *args, **kwargs: next(selections),
+        )
         monkeypatch.setattr("shutil.which", lambda name: None)
         monkeypatch.setattr("builtins.input", lambda prompt="": "")
         monkeypatch.setattr("sys.stdin.isatty", lambda: True)
         monkeypatch.setattr("getpass.getpass", lambda prompt="": "sk-local-test")
         saved_configs = []
-        monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: saved_configs.append(cfg.copy()))
+        monkeypatch.setattr(
+            "hermes_cli.config.save_config",
+            lambda cfg: saved_configs.append(cfg.copy()),
+        )
 
         provider = HindsightMemoryProvider()
         provider.post_setup(str(hermes_home), {"memory": {}})
@@ -335,14 +367,19 @@ class TestPostSetup:
             "HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT=300\n"
         )
 
-    def test_local_embedded_setup_respects_existing_profile_name(self, tmp_path, monkeypatch):
+    def test_local_embedded_setup_respects_existing_profile_name(
+        self, tmp_path, monkeypatch
+    ):
         hermes_home = tmp_path / "hermes-home"
         user_home = tmp_path / "user-home"
         user_home.mkdir()
         monkeypatch.setenv("HOME", str(user_home))
 
         selections = iter([1, 0])  # local_embedded, openai
-        monkeypatch.setattr("hermes_cli.memory_setup._curses_select", lambda *args, **kwargs: next(selections))
+        monkeypatch.setattr(
+            "hermes_cli.memory_setup._curses_select",
+            lambda *args, **kwargs: next(selections),
+        )
         monkeypatch.setattr("shutil.which", lambda name: None)
         monkeypatch.setattr("builtins.input", lambda prompt="": "")
         monkeypatch.setattr("sys.stdin.isatty", lambda: True)
@@ -358,14 +395,19 @@ class TestPostSetup:
         assert coder_env.exists()
         assert not hermes_env.exists()
 
-    def test_local_embedded_setup_preserves_existing_key_when_input_left_blank(self, tmp_path, monkeypatch):
+    def test_local_embedded_setup_preserves_existing_key_when_input_left_blank(
+        self, tmp_path, monkeypatch
+    ):
         hermes_home = tmp_path / "hermes-home"
         user_home = tmp_path / "user-home"
         user_home.mkdir()
         monkeypatch.setenv("HOME", str(user_home))
 
         selections = iter([1, 0])  # local_embedded, openai
-        monkeypatch.setattr("hermes_cli.memory_setup._curses_select", lambda *args, **kwargs: next(selections))
+        monkeypatch.setattr(
+            "hermes_cli.memory_setup._curses_select",
+            lambda *args, **kwargs: next(selections),
+        )
         monkeypatch.setattr("shutil.which", lambda name: None)
         monkeypatch.setattr("builtins.input", lambda prompt="": "")
         monkeypatch.setattr("sys.stdin.isatty", lambda: True)
@@ -383,14 +425,17 @@ class TestPostSetup:
         assert profile_env.exists()
         assert "HINDSIGHT_API_LLM_API_KEY=existing-key\n" in profile_env.read_text()
 
-
-    def test_local_embedded_setup_blank_inputs_preserve_existing_config(self, tmp_path, monkeypatch):
+    def test_local_embedded_setup_blank_inputs_preserve_existing_config(
+        self, tmp_path, monkeypatch
+    ):
         """Pressing Enter through setup should keep existing Hindsight values."""
         hermes_home = tmp_path / "hermes-home"
         user_home = tmp_path / "user-home"
         user_home.mkdir()
         monkeypatch.setenv("HOME", str(user_home))
-        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: hermes_home)
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home", lambda: hermes_home
+        )
 
         existing_config = {
             "mode": "local_embedded",
@@ -410,7 +455,10 @@ class TestPostSetup:
 
         # Simulate pressing Enter at the mode and LLM-provider pickers, which
         # should select their current values, and pressing Enter at text prompts.
-        monkeypatch.setattr("hermes_cli.memory_setup._curses_select", lambda *args, **kwargs: kwargs.get("default", 0))
+        monkeypatch.setattr(
+            "hermes_cli.memory_setup._curses_select",
+            lambda *args, **kwargs: kwargs.get("default", 0),
+        )
         monkeypatch.setattr("shutil.which", lambda name: None)
         monkeypatch.setattr("builtins.input", lambda prompt="": "")
         monkeypatch.setattr("sys.stdin.isatty", lambda: True)
@@ -432,7 +480,6 @@ class TestPostSetup:
         assert saved["timeout"] == 120
 
 
-
 # ---------------------------------------------------------------------------
 # Tool handler tests
 # ---------------------------------------------------------------------------
@@ -440,9 +487,11 @@ class TestPostSetup:
 
 class TestToolHandlers:
     def test_retain_success(self, provider):
-        result = json.loads(provider.handle_tool_call(
-            "hindsight_retain", {"content": "user likes dark mode"}
-        ))
+        result = json.loads(
+            provider.handle_tool_call(
+                "hindsight_retain", {"content": "user likes dark mode"}
+            )
+        )
         assert result["result"] == "Memory stored successfully."
         provider._client.aretain.assert_called_once()
         call_kwargs = provider._client.aretain.call_args.kwargs
@@ -470,15 +519,13 @@ class TestToolHandlers:
         assert "tags" not in call_kwargs
 
     def test_retain_missing_content(self, provider):
-        result = json.loads(provider.handle_tool_call(
-            "hindsight_retain", {}
-        ))
+        result = json.loads(provider.handle_tool_call("hindsight_retain", {}))
         assert "error" in result
 
     def test_recall_success(self, provider):
-        result = json.loads(provider.handle_tool_call(
-            "hindsight_recall", {"query": "dark mode"}
-        ))
+        result = json.loads(
+            provider.handle_tool_call("hindsight_recall", {"query": "dark mode"})
+        )
         assert "Memory 1" in result["result"]
         assert "Memory 2" in result["result"]
 
@@ -503,53 +550,51 @@ class TestToolHandlers:
 
     def test_recall_no_results(self, provider):
         provider._client.arecall.return_value = SimpleNamespace(results=[])
-        result = json.loads(provider.handle_tool_call(
-            "hindsight_recall", {"query": "test"}
-        ))
+        result = json.loads(
+            provider.handle_tool_call("hindsight_recall", {"query": "test"})
+        )
         assert result["result"] == "No relevant memories found."
 
     def test_recall_missing_query(self, provider):
-        result = json.loads(provider.handle_tool_call(
-            "hindsight_recall", {}
-        ))
+        result = json.loads(provider.handle_tool_call("hindsight_recall", {}))
         assert "error" in result
 
     def test_reflect_success(self, provider):
-        result = json.loads(provider.handle_tool_call(
-            "hindsight_reflect", {"query": "summarize"}
-        ))
+        result = json.loads(
+            provider.handle_tool_call("hindsight_reflect", {"query": "summarize"})
+        )
         assert result["result"] == "Synthesized answer"
 
     def test_reflect_missing_query(self, provider):
-        result = json.loads(provider.handle_tool_call(
-            "hindsight_reflect", {}
-        ))
+        result = json.loads(provider.handle_tool_call("hindsight_reflect", {}))
         assert "error" in result
 
     def test_unknown_tool(self, provider):
-        result = json.loads(provider.handle_tool_call(
-            "hindsight_unknown", {}
-        ))
+        result = json.loads(provider.handle_tool_call("hindsight_unknown", {}))
         assert "error" in result
 
     def test_retain_error_handling(self, provider):
         provider._client.aretain.side_effect = RuntimeError("connection failed")
-        result = json.loads(provider.handle_tool_call(
-            "hindsight_retain", {"content": "test"}
-        ))
+        result = json.loads(
+            provider.handle_tool_call("hindsight_retain", {"content": "test"})
+        )
         assert "error" in result
         assert "connection failed" in result["error"]
 
     def test_recall_error_handling(self, provider):
         provider._client.arecall.side_effect = RuntimeError("timeout")
-        result = json.loads(provider.handle_tool_call(
-            "hindsight_recall", {"query": "test"}
-        ))
+        result = json.loads(
+            provider.handle_tool_call("hindsight_recall", {"query": "test"})
+        )
         assert "error" in result
 
-    def test_local_embedded_recall_reconnects_after_idle_shutdown(self, provider, monkeypatch):
+    def test_local_embedded_recall_reconnects_after_idle_shutdown(
+        self, provider, monkeypatch
+    ):
         first_client = _make_mock_client()
-        first_client.arecall.side_effect = RuntimeError("Cannot connect to host 127.0.0.1:8888")
+        first_client.arecall.side_effect = RuntimeError(
+            "Cannot connect to host 127.0.0.1:8888"
+        )
         second_client = _make_mock_client()
         second_client.arecall.return_value = SimpleNamespace(
             results=[SimpleNamespace(text="Recovered memory")]
@@ -560,9 +605,9 @@ class TestToolHandlers:
         provider._client = first_client
         monkeypatch.setattr(provider, "_get_client", lambda: next(clients))
 
-        result = json.loads(provider.handle_tool_call(
-            "hindsight_recall", {"query": "test"}
-        ))
+        result = json.loads(
+            provider.handle_tool_call("hindsight_recall", {"query": "test"})
+        )
 
         assert result["result"] == "1. Recovered memory"
         assert provider._client is second_client
@@ -698,8 +743,14 @@ class TestSyncTurn:
         assert item["metadata"]["agent_identity"] == "fakeassistantname"
         assert item["metadata"]["turn_index"] == "1"
         assert item["metadata"]["message_count"] == "2"
-        assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?\+00:00", content[0][0]["timestamp"])
-        assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z", item["metadata"]["retained_at"])
+        assert re.fullmatch(
+            r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?\+00:00",
+            content[0][0]["timestamp"],
+        )
+        assert re.fullmatch(
+            r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z",
+            item["metadata"]["retained_at"],
+        )
 
     def test_sync_turn_skipped_when_auto_retain_off(self, provider_with_config):
         p = provider_with_config(auto_retain=False)
@@ -725,7 +776,10 @@ class TestSyncTurn:
         assert call_kwargs["document_id"].startswith("test-session-")
         assert call_kwargs["retain_async"] is True
         assert len(call_kwargs["items"]) == 1
-        assert call_kwargs["items"][0]["context"] == "conversation between Hermes Agent and the User"
+        assert (
+            call_kwargs["items"][0]["context"]
+            == "conversation between Hermes Agent and the User"
+        )
 
     def test_sync_turn_custom_context(self, provider_with_config):
         p = provider_with_config(retain_context="my-agent")
@@ -793,17 +847,24 @@ class TestSyncTurn:
         config_path = tmp_path / "hindsight" / "config.json"
         config_path.parent.mkdir(parents=True, exist_ok=True)
         config_path.write_text(json.dumps(config))
-        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
+        )
 
         p1 = HindsightMemoryProvider()
-        p1.initialize(session_id="resumed-session", hermes_home=str(tmp_path), platform="cli")
+        p1.initialize(
+            session_id="resumed-session", hermes_home=str(tmp_path), platform="cli"
+        )
 
         # Sleep just enough that the microsecond timestamp differs
         import time
+
         time.sleep(0.001)
 
         p2 = HindsightMemoryProvider()
-        p2.initialize(session_id="resumed-session", hermes_home=str(tmp_path), platform="cli")
+        p2.initialize(
+            session_id="resumed-session", hermes_home=str(tmp_path), platform="cli"
+        )
 
         # Same session, but each process gets its own document_id
         assert p1._document_id != p2._document_id
@@ -823,7 +884,9 @@ class TestSyncTurn:
         config_path = tmp_path / "hindsight" / "config.json"
         config_path.parent.mkdir(parents=True, exist_ok=True)
         config_path.write_text(json.dumps(config))
-        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
+        )
 
         p = HindsightMemoryProvider()
         p.initialize(
@@ -1079,7 +1142,11 @@ class TestSessionSwitchBufferFlush:
 
 class TestUpdateModeAppendCapability:
     def _clear_capability_cache(self):
-        from plugins.memory.hindsight import _append_capability_cache, _append_capability_lock
+        from plugins.memory.hindsight import (
+            _append_capability_cache,
+            _append_capability_lock,
+        )
+
         with _append_capability_lock:
             _append_capability_cache.clear()
 
@@ -1138,6 +1205,7 @@ class TestUpdateModeAppendCapability:
     def test_legacy_warning_emitted_once(self, provider, monkeypatch, caplog):
         """One-time WARN nudges users to upgrade Hindsight."""
         import logging
+
         self._clear_capability_cache()
         monkeypatch.setattr(
             "plugins.memory.hindsight._fetch_hindsight_api_version",
@@ -1148,9 +1216,11 @@ class TestUpdateModeAppendCapability:
             provider._retain_queue.join()
             provider.sync_turn("c", "d")
             provider._retain_queue.join()
-        warns = [r for r in caplog.records
-                 if r.levelno == logging.WARNING
-                 and "older than 0.5.0" in r.getMessage()]
+        warns = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.WARNING and "older than 0.5.0" in r.getMessage()
+        ]
         # Cache hit on the second call → no second warn.
         assert len(warns) == 1
 
@@ -1211,15 +1281,32 @@ class TestConfigSchema:
         schema = provider.get_config_schema()
         keys = {f["key"] for f in schema}
         expected_keys = {
-            "mode", "api_url", "api_key", "llm_provider", "llm_api_key",
-            "llm_model", "bank_id", "bank_id_template", "bank_mission", "bank_retain_mission",
-            "recall_budget", "memory_mode", "recall_prefetch_method",
-            "retain_tags", "retain_source",
-            "retain_user_prefix", "retain_assistant_prefix",
-            "recall_tags", "recall_tags_match",
-            "auto_recall", "auto_retain",
-            "retain_every_n_turns", "retain_async", "retain_context",
-            "recall_max_tokens", "recall_max_input_chars",
+            "mode",
+            "api_url",
+            "api_key",
+            "llm_provider",
+            "llm_api_key",
+            "llm_model",
+            "bank_id",
+            "bank_id_template",
+            "bank_mission",
+            "bank_retain_mission",
+            "recall_budget",
+            "memory_mode",
+            "recall_prefetch_method",
+            "retain_tags",
+            "retain_source",
+            "retain_user_prefix",
+            "retain_assistant_prefix",
+            "recall_tags",
+            "recall_tags_match",
+            "auto_recall",
+            "auto_retain",
+            "retain_every_n_turns",
+            "retain_async",
+            "retain_context",
+            "recall_max_tokens",
+            "recall_max_input_chars",
             "recall_prompt_preamble",
         }
         assert expected_keys.issubset(keys), f"Missing: {expected_keys - keys}"
@@ -1245,15 +1332,18 @@ class TestBankIdTemplate:
         assert _sanitize_bank_segment(None) == ""
 
     def test_resolve_empty_template_uses_fallback(self):
-        result = _resolve_bank_id_template(
-            "", fallback="hermes", profile="coder"
-        )
+        result = _resolve_bank_id_template("", fallback="hermes", profile="coder")
         assert result == "hermes"
 
     def test_resolve_with_profile(self):
         result = _resolve_bank_id_template(
-            "hermes-{profile}", fallback="hermes",
-            profile="coder", workspace="", platform="", user="", session="",
+            "hermes-{profile}",
+            fallback="hermes",
+            profile="coder",
+            workspace="",
+            platform="",
+            user="",
+            session="",
         )
         assert result == "hermes-coder"
 
@@ -1261,47 +1351,74 @@ class TestBankIdTemplate:
         result = _resolve_bank_id_template(
             "{workspace}-{profile}-{platform}",
             fallback="hermes",
-            profile="coder", workspace="myorg", platform="cli",
-            user="", session="",
+            profile="coder",
+            workspace="myorg",
+            platform="cli",
+            user="",
+            session="",
         )
         assert result == "myorg-coder-cli"
 
     def test_resolve_collapses_empty_placeholders(self):
         # When user is empty, "hermes-{user}" becomes "hermes-" -> trimmed to "hermes"
         result = _resolve_bank_id_template(
-            "hermes-{user}", fallback="default",
-            profile="", workspace="", platform="", user="", session="",
+            "hermes-{user}",
+            fallback="default",
+            profile="",
+            workspace="",
+            platform="",
+            user="",
+            session="",
         )
         assert result == "hermes"
 
     def test_resolve_collapses_double_dashes(self):
         # Two empty placeholders with a dash between them should collapse
         result = _resolve_bank_id_template(
-            "{workspace}-{profile}-{user}", fallback="fallback",
-            profile="coder", workspace="", platform="", user="", session="",
+            "{workspace}-{profile}-{user}",
+            fallback="fallback",
+            profile="coder",
+            workspace="",
+            platform="",
+            user="",
+            session="",
         )
         assert result == "coder"
 
     def test_resolve_empty_rendered_falls_back(self):
         result = _resolve_bank_id_template(
-            "{user}-{profile}", fallback="fallback",
-            profile="", workspace="", platform="", user="", session="",
+            "{user}-{profile}",
+            fallback="fallback",
+            profile="",
+            workspace="",
+            platform="",
+            user="",
+            session="",
         )
         assert result == "fallback"
 
     def test_resolve_sanitizes_placeholder_values(self):
         result = _resolve_bank_id_template(
-            "user-{user}", fallback="hermes",
-            profile="", workspace="", platform="",
-            user="josh@example.com", session="",
+            "user-{user}",
+            fallback="hermes",
+            profile="",
+            workspace="",
+            platform="",
+            user="josh@example.com",
+            session="",
         )
         assert result == "user-josh-example-com"
 
     def test_resolve_invalid_template_returns_fallback(self):
         # Unknown placeholder should fall back without raising
         result = _resolve_bank_id_template(
-            "hermes-{unknown}", fallback="hermes",
-            profile="", workspace="", platform="", user="", session="",
+            "hermes-{unknown}",
+            fallback="hermes",
+            profile="",
+            workspace="",
+            platform="",
+            user="",
+            session="",
         )
         assert result == "hermes"
 
@@ -1316,7 +1433,9 @@ class TestBankIdTemplate:
         config_path = tmp_path / "hindsight" / "config.json"
         config_path.parent.mkdir(parents=True, exist_ok=True)
         config_path.write_text(json.dumps(config))
-        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
+        )
 
         p = HindsightMemoryProvider()
         p.initialize(
@@ -1339,7 +1458,9 @@ class TestBankIdTemplate:
         config_path = tmp_path / "hindsight" / "config.json"
         config_path.parent.mkdir(parents=True, exist_ok=True)
         config_path.write_text(json.dumps(config))
-        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
+        )
 
         p = HindsightMemoryProvider()
         p.initialize(
@@ -1350,7 +1471,9 @@ class TestBankIdTemplate:
         )
         assert p._bank_id == "my-static-bank"
 
-    def test_provider_template_with_missing_profile_falls_back(self, tmp_path, monkeypatch):
+    def test_provider_template_with_missing_profile_falls_back(
+        self, tmp_path, monkeypatch
+    ):
         config = {
             "mode": "cloud",
             "apiKey": "k",
@@ -1361,7 +1484,9 @@ class TestBankIdTemplate:
         config_path = tmp_path / "hindsight" / "config.json"
         config_path.parent.mkdir(parents=True, exist_ok=True)
         config_path.write_text(json.dumps(config))
-        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
+        )
 
         p = HindsightMemoryProvider()
         # No agent_identity passed — template renders to "hermes-" which collapses to "hermes"
@@ -1408,10 +1533,12 @@ class TestAvailability:
     def test_available_with_snake_case_api_key_in_config(self, tmp_path, monkeypatch):
         config_path = tmp_path / "hindsight" / "config.json"
         config_path.parent.mkdir(parents=True, exist_ok=True)
-        config_path.write_text(json.dumps({
-            "mode": "cloud",
-            "api_key": "***",
-        }))
+        config_path.write_text(
+            json.dumps({
+                "mode": "cloud",
+                "api_key": "***",
+            })
+        )
         monkeypatch.setattr(
             "plugins.memory.hindsight.get_hermes_home",
             lambda: tmp_path,
@@ -1421,7 +1548,9 @@ class TestAvailability:
 
         assert p.is_available()
 
-    def test_local_mode_unavailable_when_runtime_import_fails(self, tmp_path, monkeypatch):
+    def test_local_mode_unavailable_when_runtime_import_fails(
+        self, tmp_path, monkeypatch
+    ):
         monkeypatch.setattr(
             "plugins.memory.hindsight.get_hermes_home",
             lambda: tmp_path / "nonexistent",
@@ -1440,7 +1569,9 @@ class TestAvailability:
         p = HindsightMemoryProvider()
         assert not p.is_available()
 
-    def test_initialize_disables_local_mode_when_runtime_import_fails(self, tmp_path, monkeypatch):
+    def test_initialize_disables_local_mode_when_runtime_import_fails(
+        self, tmp_path, monkeypatch
+    ):
         config = {"mode": "local_embedded"}
         config_path = tmp_path / "hindsight" / "config.json"
         config_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1458,7 +1589,9 @@ class TestAvailability:
         )
 
         p = HindsightMemoryProvider()
-        p.initialize(session_id="test-session", hermes_home=str(tmp_path), platform="cli")
+        p.initialize(
+            session_id="test-session", hermes_home=str(tmp_path), platform="cli"
+        )
         assert p._mode == "disabled"
 
 
@@ -1533,7 +1666,9 @@ class TestSharedEventLoopLifecycle:
 
 
 class TestShutdown:
-    def test_local_embedded_shutdown_closes_inner_async_client_on_shared_loop(self, provider):
+    def test_local_embedded_shutdown_closes_inner_async_client_on_shared_loop(
+        self, provider
+    ):
         inner_client = _make_mock_client()
         embedded = MagicMock()
         embedded._client = inner_client
@@ -1548,4 +1683,3 @@ class TestShutdown:
         embedded.close.assert_called_once()
         assert embedded._client is None
         assert provider._client is None
-


### PR DESCRIPTION
## What changed and why

### Signal source
Fresh Hermes sessions with Hindsight configured in `local_embedded` mode were not exposing `hindsight_retain`, `hindsight_recall`, or `hindsight_reflect`, even though the daemon was healthy and end-to-end retain/recall worked when invoked directly.

### What changed
- updated the local runtime availability check to import `hindsight_client` + `hindsight_embed.daemon_embed_manager` instead of the defunct top-level `hindsight` package
- replaced the stale `HindsightEmbedded` construction path with a small `_LocalEmbeddedHindsightClient` adapter that starts/reuses the embedded daemon and talks to it over the current HTTP client
- updated the provider test to assert the new local-embedded adapter path
- ran `ruff check`, `ruff format --check`, and the targeted Hindsight provider test suite

### What could break
- if `hindsight_client.Hindsight` changes its `_base_url` instance attribute upstream, the adapter may recreate its client more often than needed
- local-embedded startup still depends on the installed Hindsight daemon manager / client package split remaining stable

## Validation
- `python -m pytest tests/plugins/memory/test_hindsight_provider.py -q -o 'addopts='`
- `ruff check plugins/memory/hindsight/__init__.py tests/plugins/memory/test_hindsight_provider.py`
- `ruff format --check plugins/memory/hindsight/__init__.py tests/plugins/memory/test_hindsight_provider.py`
- fresh-session smoke outside the worktree: `hermes memory status` showed `available`, and retain/recall worked against the local daemon
