### PR TITLE
fix: pin dashboard asset MIME types

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -14,6 +14,7 @@ import hmac
 import importlib.util
 import json
 import logging
+import mimetypes
 import os
 import secrets
 import subprocess
@@ -74,6 +75,25 @@ except ImportError:
         )
 
 WEB_DIST = Path(os.environ["HERMES_WEB_DIST"]) if "HERMES_WEB_DIST" in os.environ else Path(__file__).parent / "web_dist"
+
+
+def _register_dashboard_asset_mime_types() -> None:
+    """Pin MIME types for browser-executed dashboard assets.
+
+    Python's ``mimetypes`` module can load OS registry associations on
+    Windows. Some machines map ``.js`` to ``text/plain``, which makes
+    Starlette's ``StaticFiles`` serve Vite bundles with a non-JavaScript
+    Content-Type. Browsers reject module scripts in that state, leaving the
+    dashboard blank. Register the web asset MIME types explicitly so bundled
+    dashboard files are served consistently across platforms.
+    """
+
+    mimetypes.add_type("application/javascript", ".js")
+    mimetypes.add_type("text/css", ".css")
+    mimetypes.add_type("application/wasm", ".wasm")
+
+
+_register_dashboard_asset_mime_types()
 _log = logging.getLogger(__name__)
 
 app = FastAPI(title="Hermes Agent", version=__version__)

--- a/tests/hermes_cli/test_dashboard_asset_mime_types.py
+++ b/tests/hermes_cli/test_dashboard_asset_mime_types.py
@@ -1,0 +1,21 @@
+import mimetypes
+
+
+def test_dashboard_registers_javascript_mime_type(monkeypatch):
+    from hermes_cli.web_server import _register_dashboard_asset_mime_types
+
+    monkeypatch.setitem(mimetypes.types_map, ".js", "text/plain")
+
+    _register_dashboard_asset_mime_types()
+
+    assert mimetypes.guess_type("/assets/index-abc123.js")[0] == "application/javascript"
+
+
+def test_dashboard_registers_wasm_mime_type(monkeypatch):
+    from hermes_cli.web_server import _register_dashboard_asset_mime_types
+
+    monkeypatch.delitem(mimetypes.types_map, ".wasm", raising=False)
+
+    _register_dashboard_asset_mime_types()
+
+    assert mimetypes.guess_type("/assets/module.wasm")[0] == "application/wasm"


### PR DESCRIPTION
## Summary
- Explicitly register MIME types for dashboard `.js`, `.css`, and `.wasm` assets before mounting the SPA.
- Prevent Windows registry MIME overrides from causing Vite JS bundles to be served as `text/plain`.
- Add focused tests covering the `.js` regression and `.wasm` asset type.

Closes #28987

## Validation
- `/Users/cosmopolitan/.hermes/hermes-agent/venv/bin/python -m pytest -o 'addopts=' tests/hermes_cli/test_dashboard_asset_mime_types.py -q`
- `/Users/cosmopolitan/.hermes/hermes-agent/venv/bin/python -m pytest -o 'addopts=' tests/hermes_cli/test_dashboard_browser_safe_imports.py tests/hermes_cli/test_dashboard_asset_mime_types.py -q`
- `git diff --check`
