### PR TITLE
fix(discord): delete stale slash commands before creating new ones

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1286,6 +1286,20 @@ class DiscordAdapter(BasePlatformAdapter):
             mutation_count += 1
             return result
 
+        # Delete server-side commands that are no longer desired BEFORE
+        # creating any net-new ones. Discord enforces the 100 global
+        # application-command cap server-side at create time; creating new
+        # commands while stale ones still exist can transiently push the
+        # server count past 100, which Discord rejects with HTTP 400 code
+        # 30032. That aborts the sync, and since stale deletions used to run
+        # last they never execute to free space — leaving the app wedged on
+        # every reconnect. Pruning first keeps the peak count at
+        # max(len(existing), len(desired)) <= 100.
+        for stale_key in [k for k in existing_by_key if k not in desired_by_key]:
+            current = existing_by_key.pop(stale_key)
+            await mutate(http.delete_global_command, app_id, current.id)
+            deleted += 1
+
         for key, desired in desired_by_key.items():
             current = existing_by_key.pop(key, None)
             if current is None:
@@ -1308,10 +1322,6 @@ class DiscordAdapter(BasePlatformAdapter):
 
             await mutate(http.edit_global_command, app_id, current.id, desired)
             updated += 1
-
-        for current in existing_by_key.values():
-            await mutate(http.delete_global_command, app_id, current.id)
-            deleted += 1
 
         return {
             "total": len(desired_payloads),

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -458,6 +458,98 @@ async def test_safe_sync_slash_commands_only_mutates_diffs():
 
 
 @pytest.mark.asyncio
+async def test_safe_sync_deletes_stale_before_creating_new():
+    """Stale commands must be deleted before net-new ones are created.
+
+    Discord enforces the 100 global application-command cap server-side at
+    create time. Creating new commands while stale ones still exist can push
+    the server count transiently past 100 (HTTP 400 / code 30032), aborting
+    the sync before the stale deletions run — wedging the app on every
+    reconnect. The reconcile must prune first so the peak count never exceeds
+    max(len(existing), len(desired)).
+    """
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+    class _DesiredCommand:
+        def __init__(self, payload):
+            self._payload = payload
+
+        def to_dict(self, tree):
+            assert tree is not None
+            return dict(self._payload)
+
+    class _ExistingCommand:
+        def __init__(self, command_id, payload):
+            self.id = command_id
+            self.name = payload["name"]
+            self.type = SimpleNamespace(value=payload["type"])
+            self._payload = payload
+
+        def to_dict(self):
+            return {
+                "id": self.id,
+                "application_id": 999,
+                **self._payload,
+                "name_localizations": {},
+                "description_localizations": {},
+            }
+
+    def _cmd(name):
+        return {
+            "name": name,
+            "description": f"desc for {name}",
+            "type": 1,
+            "options": [],
+            "nsfw": False,
+            "dm_permission": True,
+            "default_member_permissions": None,
+        }
+
+    desired_new = _cmd("newcmd")
+    stale_a = _ExistingCommand(101, _cmd("stale-a"))
+    stale_b = _ExistingCommand(102, _cmd("stale-b"))
+
+    order: list[str] = []
+
+    async def _record_upsert(app_id, payload):
+        order.append(f"upsert:{payload['name']}")
+
+    async def _record_delete(app_id, command_id):
+        order.append(f"delete:{command_id}")
+
+    fake_tree = SimpleNamespace(
+        get_commands=lambda: [_DesiredCommand(desired_new)],
+        fetch_commands=AsyncMock(return_value=[stale_a, stale_b]),
+    )
+    fake_http = SimpleNamespace(
+        upsert_global_command=AsyncMock(side_effect=_record_upsert),
+        edit_global_command=AsyncMock(),
+        delete_global_command=AsyncMock(side_effect=_record_delete),
+    )
+    adapter._client = SimpleNamespace(
+        tree=fake_tree,
+        http=fake_http,
+        application_id=999,
+        user=SimpleNamespace(id=999),
+    )
+
+    summary = await adapter._safe_sync_slash_commands()
+
+    assert summary == {
+        "total": 1,
+        "unchanged": 0,
+        "updated": 0,
+        "recreated": 0,
+        "created": 1,
+        "deleted": 2,
+    }
+    # Every stale delete must precede the net-new create.
+    last_delete = max(i for i, op in enumerate(order) if op.startswith("delete:"))
+    first_upsert = min(i for i, op in enumerate(order) if op.startswith("upsert:"))
+    assert last_delete < first_upsert, order
+
+
+@pytest.mark.asyncio
 async def test_safe_sync_slash_commands_recreates_metadata_only_diffs():
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
 


### PR DESCRIPTION
### What
`_safe_sync_slash_commands()` reconciles the bot's global slash commands on connect. It created net-new commands first and deleted removed ones last.

### Problem
Discord enforces the 100 global-command cap **at create time**. When the command set changes substantially (e.g. after pulling an update that renames/adds commands), the old commands are still registered on Discord while the new ones are created one-by-one. The transient total can exceed 100, and Discord rejects the create with `HTTP 400` code `30032`.

Because the deletions of now-removed commands ran *after* the create loop, that rejection aborts the sync before any space is freed. The reconcile then fails identically on every reconnect — the bot is stuck and never recovers on its own.

### Fix
Delete commands that are no longer desired **before** creating new ones. Peak server-side count is bounded by `max(len(existing), len(desired))` ≤ 100 by construction. The old trailing delete loop is removed (redundant). Counting/summary semantics unchanged.

### Test
Adds `test_safe_sync_deletes_stale_before_creating_new` asserting every stale delete is issued before the first net-new create. Fails on the old ordering, passes with the fix. Full `test_discord_connect.py` suite (17 tests) green.

### Reproduction
1. Run a bot whose desired command set is near the cap and that has a prior (different-named) global command set still registered on Discord — e.g. after pulling an update that renames/adds commands.
2. Connect with `DISCORD_COMMAND_SYNC_POLICY=safe` (the default → `_safe_sync_slash_commands`).
3. Sync creates net-new commands before deleting removed ones; the server-side global count transiently exceeds 100.

Discord rejects the create:

```
HTTP 400 Bad Request (error code: 30032):
Maximum number of application commands reached (100)
```

The exception aborts `_safe_sync_slash_commands` before the trailing stale-delete loop runs, so space is never freed and every subsequent reconnect reproduces the same failure (the bot's slash commands stay wedged until manual intervention).

The added regression test reproduces the ordering deterministically without a live Discord connection.

### Workaround for affected users
Set `DISCORD_COMMAND_SYNC_POLICY=bulk` — uses Discord's atomic bulk overwrite (`tree.sync()`), one request, never transiently exceeds the cap.

### Runtime verification
Verified on a live bot under the default `safe` policy after applying this patch:

```
[Discord] Safely reconciled 48 slash command(s): unchanged=0 updated=0 recreated=47 created=1 deleted=0
```

No `30032`, sync completed in one pass, state recorded successfully. The patched `_safe_sync_slash_commands` (with delete-stale-first ordering) executed end-to-end against a real Discord application.