### PR TITLE
fix(credential-pool): skip exhausted marking for single-entry pools

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -514,6 +514,25 @@ class CredentialPool:
         error_context: Optional[Dict[str, Any]] = None,
     ) -> PooledCredential:
         normalized_error = _normalize_error_context(error_context)
+        # Single-entry pools with a transient 429 rate-limit should NOT be
+        # marked exhausted.  There is no second key to rotate to, so marking
+        # exhausted only stalls the pool — the exhaustion deadline
+        # (last_status_at + cooldown) keeps sliding forward on each retry and
+        # the worker deadlocks indefinitely until manual intervention.  The
+        # caller's own retry/backoff handles transient throttling.  Non-429
+        # statuses (401/402, terminal auth failures) still get marked so that
+        # genuinely dead or expired credentials are surfaced (issue #29136).
+        if (
+            len(self._entries) <= 1
+            and status_code == 429
+            and not self._is_terminal_auth_failure(status_code, normalized_error)
+        ):
+            logger.info(
+                "credential pool: single-entry pool, skipping exhaustion mark "
+                "for transient 429 (entry=%s)",
+                entry.label or entry.id[:8],
+            )
+            return entry
         # Permanent OAuth failures (token_invalidated, token_revoked, etc.)
         # transition to STATUS_DEAD instead of STATUS_EXHAUSTED.  Without this,
         # a revoked credential gets a 1-hour TTL cooldown and then re-enters

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -562,6 +562,144 @@ def test_429_rate_limit_still_uses_exhausted_not_dead(tmp_path, monkeypatch):
     assert persisted["last_error_code"] == 429
 
 
+def test_single_entry_pool_skips_exhaustion_on_429(tmp_path, monkeypatch):
+    """A single-entry pool must NOT mark the entry exhausted on a transient 429.
+
+    There is no second key to rotate to, so marking exhausted only stalls the
+    pool — the exhaustion deadline keeps sliding forward on each retry and the
+    worker deadlocks indefinitely (#29136).  The caller's own retry/backoff
+    handles transient throttling.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "cred-only",
+                        "label": "sole",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "sk-only",
+                    },
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    assert pool.select().id == "cred-only"
+
+    result = pool.mark_exhausted_and_rotate(status_code=429)
+
+    # Entry is NOT marked exhausted — returned unchanged.
+    assert result is not None
+    assert result.id == "cred-only"
+    assert result.last_status is None
+
+    # Persisted state on disk is also clean.
+    auth_payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    persisted = auth_payload["credential_pool"]["openai-codex"][0]
+    assert persisted.get("last_status") is None
+    assert persisted.get("last_error_code") is None
+
+
+def test_single_entry_pool_still_marks_exhausted_on_non_429(tmp_path, monkeypatch):
+    """A single-entry pool MUST still mark exhausted on non-429 failures (401/402).
+
+    Only transient 429 rate limits are skipped.  Authentication failures,
+    billing errors, etc. must still be surfaced so the user is alerted to a
+    genuinely broken credential (#29136 review feedback).
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "cred-only",
+                        "label": "sole",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "sk-only",
+                    },
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool, STATUS_EXHAUSTED
+
+    pool = load_pool("openai-codex")
+    pool.select()
+
+    # mark_exhausted_and_rotate returns None when there is no next entry
+    # to rotate to, but the current entry IS still marked.
+    pool.mark_exhausted_and_rotate(status_code=402)
+
+    # 402 IS marked exhausted — the credential has a billing problem.
+    auth_payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    persisted = auth_payload["credential_pool"]["openai-codex"][0]
+    assert persisted["last_status"] == STATUS_EXHAUSTED
+    assert persisted["last_error_code"] == 402
+
+
+def test_multi_entry_pool_still_marks_exhausted_on_429(tmp_path, monkeypatch):
+    """Multi-entry pools must still mark exhausted and rotate on 429.
+
+    The single-entry skip does not apply when rotation is possible.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "cred-a",
+                        "label": "first",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "sk-a",
+                    },
+                    {
+                        "id": "cred-b",
+                        "label": "second",
+                        "auth_type": "api_key",
+                        "priority": 1,
+                        "source": "manual",
+                        "access_token": "sk-b",
+                    },
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool, STATUS_EXHAUSTED
+
+    pool = load_pool("openai-codex")
+    assert pool.select().id == "cred-a"
+
+    next_entry = pool.mark_exhausted_and_rotate(status_code=429)
+    assert next_entry is not None
+    assert next_entry.id == "cred-b"
+
+    auth_payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    persisted = auth_payload["credential_pool"]["openai-codex"][0]
+    assert persisted["last_status"] == STATUS_EXHAUSTED
+    assert persisted["last_error_code"] == 429
+
+
 def test_generic_401_without_terminal_reason_still_uses_exhausted(tmp_path, monkeypatch):
     """A 401 with no specific code/reason should keep TTL semantics.
 


### PR DESCRIPTION
## Problem

When a credential pool has only one entry (common with custom providers where users have a single API key), marking that entry as `exhausted` on a 429 response does nothing useful — there is no second key to rotate to. The pool just returns "no available entries" and the worker stalls.

Worse, in unattended loops (Kanban workers, cron jobs), the retry cycle keeps hitting 429s, each one refreshing `last_status_at`. The exhaustion deadline is calculated as `last_status_at + 3600`, so it keeps sliding forward and never expires. The worker is stuck indefinitely until someone manually resets `auth.json`.

This is distinct from #18697 (wants shorter TTL) and #26145 (lost retry flag on interrupt). Those address symptoms; this addresses the root case: single-entry pools should not mark exhausted at all.

## Fix

Early return in `_mark_exhausted` when `len(self._entries) <= 1`. The 429 is still logged. The caller's own retry/backoff logic handles transient rate limits.

Multi-entry pools are unaffected — they still mark exhausted and rotate.

## Test Plan

```python
# single-entry pool: 429 does NOT freeze
pool._entries = [entry]
result = pool._mark_exhausted(entry, 429)
assert result.last_status != "exhausted"

# multi-entry pool: 429 still marks exhausted (rotation works)
pool._entries = [entry_a, entry_b]
result = pool._mark_exhausted(entry_a, 429)
assert result.last_status == "exhausted"
```

## Related

- #18697 — reduce default 429 cooldown from 1 hour to 3 minutes
- #13680 — configurable exhausted cooldown via env var
- #26145 — credential pool rotation lost on user interrupt
- #26149 — rotate immediately when already exhausted
- #22622 — clear exhaustion on key rotation