### PR TITLE
fix(kanban): surface archived boards in board listings

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -393,16 +393,13 @@ def _default_board_display_name(slug: str) -> str:
     return " ".join(part.capitalize() for part in slug.replace("_", "-").split("-") if part) or slug
 
 
-def read_board_metadata(board: Optional[str] = None) -> dict:
-    """Return ``board.json`` contents (or synthesized defaults).
+_ARCHIVED_BOARD_DIR_RE = re.compile(
+    r"^(?P<slug>[a-z0-9](?:[a-z0-9_-]*[a-z0-9])?)-\d+(?:-\d+)?$"
+)
 
-    Never raises — a missing / malformed ``board.json`` falls back to a
-    synthesised entry so the dashboard always has something to render.
-    Includes the canonical ``slug`` and ``db_path`` so the caller
-    doesn't need to reconstruct them.
-    """
-    slug = _normalize_board_slug(board) or DEFAULT_BOARD
-    meta: dict[str, Any] = {
+
+def _board_metadata_defaults(slug: str) -> dict[str, Any]:
+    return {
         "slug": slug,
         "name": _default_board_display_name(slug),
         "description": "",
@@ -412,6 +409,41 @@ def read_board_metadata(board: Optional[str] = None) -> dict:
         "created_at": None,
         "archived": False,
     }
+
+
+def _read_board_metadata_from_dir(
+    dir_path: Path,
+    slug: str,
+    *,
+    archived: bool = False,
+) -> dict[str, Any]:
+    """Read board metadata from an explicit directory path."""
+    meta = _board_metadata_defaults(slug)
+    try:
+        p = dir_path / "board.json"
+        if p.exists():
+            raw = json.loads(p.read_text(encoding="utf-8"))
+            if isinstance(raw, dict):
+                raw["slug"] = slug
+                meta.update(raw)
+    except (OSError, json.JSONDecodeError):
+        pass
+    if archived:
+        meta["archived"] = True
+    meta["db_path"] = str(dir_path / "kanban.db")
+    return meta
+
+
+def read_board_metadata(board: Optional[str] = None) -> dict:
+    """Return ``board.json`` contents (or synthesized defaults).
+
+    Never raises — a missing / malformed ``board.json`` falls back to a
+    synthesised entry so the dashboard always has something to render.
+    Includes the canonical ``slug`` and ``db_path`` so the caller
+    doesn't need to reconstruct them.
+    """
+    slug = _normalize_board_slug(board) or DEFAULT_BOARD
+    meta: dict[str, Any] = _board_metadata_defaults(slug)
     try:
         p = board_metadata_path(slug)
         if p.exists():
@@ -502,13 +534,15 @@ def create_board(
     return meta
 
 
-def list_boards(*, include_archived: bool = True) -> list[dict]:
+def list_boards(*, include_archived: bool = False) -> list[dict]:
     """Enumerate all boards that exist on disk.
 
     Always includes ``default`` (even when the ``boards/default/``
     metadata dir doesn't exist, because its DB is at the legacy path).
     Other boards are discovered by scanning ``boards/`` for subdirectories
-    that either contain a ``kanban.db`` or a ``board.json``.
+    that either contain a ``kanban.db`` or a ``board.json``. When
+    ``include_archived=True``, archived snapshots under
+    ``boards/_archived/`` are also surfaced.
 
     Returns a list of metadata dicts, sorted with ``default`` first and
     the rest alphabetically.
@@ -543,6 +577,39 @@ def list_boards(*, include_archived: bool = True) -> list[dict]:
                 continue
             entries.append(meta)
             seen.add(normed)
+    if include_archived:
+        archive_root = root / "_archived"
+        if archive_root.is_dir():
+            for child in sorted(
+                archive_root.iterdir(),
+                key=lambda p: p.name.lower(),
+                reverse=True,
+            ):
+                if not child.is_dir():
+                    continue
+                has_db = (child / "kanban.db").exists()
+                has_meta = (child / "board.json").exists()
+                if not (has_db or has_meta):
+                    continue
+                slug: Optional[str] = None
+                if has_meta:
+                    try:
+                        raw = json.loads((child / "board.json").read_text(encoding="utf-8"))
+                        if isinstance(raw, dict):
+                            slug = _normalize_board_slug(raw.get("slug"))
+                    except (OSError, json.JSONDecodeError, ValueError):
+                        slug = None
+                if not slug:
+                    match = _ARCHIVED_BOARD_DIR_RE.match(child.name)
+                    if not match:
+                        continue
+                    slug = match.group("slug")
+                if not slug or slug in seen:
+                    continue
+                entries.append(
+                    _read_board_metadata_from_dir(child, slug, archived=True)
+                )
+                seen.add(slug)
     return entries
 
 
@@ -953,6 +1020,23 @@ _INITIALIZED_PATHS: set[str] = set()
 _INIT_LOCK = threading.RLock()
 
 
+class _KanbanConnection(sqlite3.Connection):
+    """SQLite connection whose context manager also closes the handle.
+
+    The stdlib sqlite3 connection commits/rolls back on ``with`` exit but
+    leaves the file descriptor open. That is usually invisible on POSIX, but
+    Windows refuses to rename/delete the underlying DB path while a handle is
+    still live. Many Hermes call sites use ``with connect(...) as conn:``
+    expecting full cleanup, so make that expectation true here.
+    """
+
+    def __exit__(self, exc_type, exc, tb):
+        try:
+            return super().__exit__(exc_type, exc, tb)
+        finally:
+            self.close()
+
+
 def connect(
     db_path: Optional[Path] = None,
     *,
@@ -982,7 +1066,12 @@ def connect(
         path = kanban_db_path(board=board)
     path.parent.mkdir(parents=True, exist_ok=True)
     resolved = str(path.resolve())
-    conn = sqlite3.connect(str(path), isolation_level=None, timeout=30)
+    conn = sqlite3.connect(
+        str(path),
+        isolation_level=None,
+        timeout=30,
+        factory=_KanbanConnection,
+    )
     try:
         conn.row_factory = sqlite3.Row
         with _INIT_LOCK:

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import os
+import sqlite3
 import subprocess
 import sys
 from pathlib import Path
@@ -249,6 +250,16 @@ class TestBoardCRUD:
         assert Path(res["new_path"]).exists()
         assert "toremove" not in [b["slug"] for b in kb.list_boards()]
 
+    def test_remove_archive_visible_with_include_archived(self, fresh_home):
+        kb.create_board("toremove")
+        kb.remove_board("toremove")
+
+        boards = kb.list_boards(include_archived=True)
+        archived = next(b for b in boards if b["slug"] == "toremove")
+
+        assert archived["archived"] is True
+        assert archived["db_path"].endswith("kanban.db")
+
     def test_remove_hard_delete(self, fresh_home):
         kb.create_board("nuke")
         d = kb.board_dir("nuke")
@@ -256,6 +267,13 @@ class TestBoardCRUD:
         res = kb.remove_board("nuke", archive=False)
         assert res["action"] == "deleted"
         assert not d.exists()
+
+    def test_connect_context_manager_closes_handle(self, fresh_home):
+        with kb.connect(board="default") as conn:
+            conn.execute("SELECT 1").fetchone()
+
+        with pytest.raises(sqlite3.ProgrammingError):
+            conn.execute("SELECT 1")
 
     def test_remove_default_forbidden(self, fresh_home):
         with pytest.raises(ValueError, match="default"):

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -41,6 +41,10 @@ def _load_plugin_router():
     return mod.router
 
 
+def _read_utf8(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
 @pytest.fixture
 def kanban_home(tmp_path, monkeypatch):
     """Isolated HERMES_HOME with an empty kanban DB."""
@@ -191,6 +195,17 @@ def test_board_query_param_default_overrides_current_board_pointer(client):
     assert pinned_ids == {default_task["id"]}
 
 
+def test_boards_endpoint_includes_archived_snapshots_when_requested(client):
+    kb.create_board("arch-me")
+    kb.remove_board("arch-me")
+
+    r = client.get("/api/plugins/kanban/boards", params={"include_archived": True})
+    assert r.status_code == 200, r.text
+
+    archived = next(b for b in r.json()["boards"] if b["slug"] == "arch-me")
+    assert archived["archived"] is True
+
+
 def test_dashboard_select_filters_use_sdk_value_change_handler():
     """Tenant/assignee filters must work with the dashboard SDK Select API.
 
@@ -202,7 +217,7 @@ def test_dashboard_select_filters_use_sdk_value_change_handler():
 
     repo_root = Path(__file__).resolve().parents[2]
     bundle = repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
-    js = bundle.read_text()
+    js = _read_utf8(bundle)
 
     assert "function selectChangeHandler(setter)" in js
     assert "onValueChange: function (v)" in js
@@ -222,7 +237,7 @@ def test_dashboard_client_side_filtering_includes_tenant_filter():
 
     repo_root = Path(__file__).resolve().parents[2]
     bundle = repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
-    js = bundle.read_text()
+    js = _read_utf8(bundle)
 
     assert "if (tenantFilter && t.tenant !== tenantFilter) return false;" in js
     assert "[boardData, tenantFilter, assigneeFilter, search]" in js
@@ -238,7 +253,7 @@ def test_dashboard_initial_board_uses_backend_current_when_unpinned():
 
     repo_root = Path(__file__).resolve().parents[2]
     bundle = repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
-    js = bundle.read_text()
+    js = _read_utf8(bundle)
 
     assert 'useState(() => readSelectedBoard() || null)' in js
     assert "const storedBoard = readSelectedBoard();" in js
@@ -970,7 +985,8 @@ def test_dashboard_done_actions_prompt_for_completion_summary():
     repo_root = Path(__file__).resolve().parents[2]
     bundle = (
         repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
-    ).read_text()
+    )
+    bundle = _read_utf8(bundle)
 
     assert "withCompletionSummary" in bundle
     assert "Completion summary" in bundle
@@ -988,7 +1004,8 @@ def test_dashboard_surfaces_ready_blocked_error_inline():
     repo_root = Path(__file__).resolve().parents[2]
     bundle = (
         repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
-    ).read_text()
+    )
+    bundle = _read_utf8(bundle)
 
     # Helper that strips ``"409: {\"detail\":\"…\"}"`` down to the
     # human-readable message before it lands in any banner.
@@ -1016,7 +1033,8 @@ def test_dashboard_dependency_selects_use_value_change_handler():
     repo_root = Path(__file__).resolve().parents[2]
     bundle = (
         repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
-    ).read_text()
+    )
+    bundle = _read_utf8(bundle)
 
     parent_select = (
         'value: newParent,\n'
@@ -2136,7 +2154,7 @@ def test_board_endpoint_accepts_explicit_board_default_param(client):
 def test_dashboard_requests_default_board_explicitly():
     """Dashboard REST calls must include board=default instead of relying on server current board."""
     repo_root = Path(__file__).resolve().parents[2]
-    dist = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text()
+    dist = _read_utf8(repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js")
 
     assert "SDK.fetchJSON(withBoard(`${API}/config`, board))" in dist
     assert "SDK.fetchJSON(withBoard(`${API}/boards`, board))" in dist
@@ -2147,7 +2165,7 @@ def test_dashboard_search_includes_body_and_result():
     """Client-side search must match body, result, latest_summary, and summary
     so full card contents are findable."""
     repo_root = Path(__file__).resolve().parents[2]
-    dist = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text()
+    dist = _read_utf8(repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js")
 
     assert "t.body || \"\"" in dist
     assert "t.result || \"\"" in dist
@@ -2157,7 +2175,7 @@ def test_dashboard_search_includes_body_and_result():
 def test_dashboard_bulk_actions_include_reclaim_first():
     """Bulk action bar must expose reclaim_first checkbox and expanded status buttons."""
     repo_root = Path(__file__).resolve().parents[2]
-    dist = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text()
+    dist = _read_utf8(repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js")
 
     assert "reclaim_first: reclaimFirst" in dist
     assert "hermes-kanban-bulk-reclaim-first" in dist
@@ -2169,7 +2187,7 @@ def test_dashboard_bulk_actions_include_reclaim_first():
 def test_dashboard_shift_click_range_selection_exists():
     """Shift-click must trigger range selection via toggleRange."""
     repo_root = Path(__file__).resolve().parents[2]
-    dist = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text()
+    dist = _read_utf8(repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js")
 
     assert "function toggleRange" in dist or "const toggleRange =" in dist
     assert "props.toggleRange(t.id)" in dist or "props.toggleRange" in dist
@@ -2179,7 +2197,7 @@ def test_dashboard_shift_click_range_selection_exists():
 def test_dashboard_multi_move_bulk_exists():
     """Dragging a selected card with other selections must use /tasks/bulk."""
     repo_root = Path(__file__).resolve().parents[2]
-    dist = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text()
+    dist = _read_utf8(repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js")
 
     assert "onMoveSelected" in dist
     assert "props.onMoveSelected" in dist
@@ -2189,8 +2207,8 @@ def test_dashboard_multi_move_bulk_exists():
 def test_dashboard_failed_card_highlight_class_exists():
     """Partial bulk failures must highlight failing cards."""
     repo_root = Path(__file__).resolve().parents[2]
-    js = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text()
-    css = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "style.css").read_text()
+    js = _read_utf8(repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js")
+    css = _read_utf8(repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "style.css")
 
     assert "hermes-kanban-card--failed" in js
     assert "hermes-kanban-card--failed" in css


### PR DESCRIPTION
## Summary
- fix `list_boards(include_archived=True)` so archived board snapshots under `boards/_archived/` are discoverable again
- keep archived boards hidden by default, preserving existing CLI and dashboard behavior
- close kanban SQLite handles on `with kb.connect(...) as conn:` exit so board archive/delete works reliably on native Windows
- make dashboard dist-file assertions read assets as UTF-8 explicitly on Windows

## Why
Archived boards were moved out of the active boards directory during `remove_board(..., archive=True)`, but board discovery only scanned live board directories. As a result, `include_archived=True` did not actually return archived boards in the CLI or dashboard API.

While validating the fix on native Windows, board archive/delete also exposed a real handle-lifecycle bug: `with kb.connect(...)` committed/rolled back but did not close the SQLite file handle, which could block board rename/delete operations on Windows. The dashboard dist-file assertions also relied on the platform default file encoding, which broke on cp1254-style Windows locales.

## Testing
- `uv run pytest tests/hermes_cli/test_kanban_boards.py tests/plugins/test_kanban_dashboard_plugin.py -q`

- passed