### PR TITLE
fix(gateway): eagerly persist mid-run session rotation to survive /stop and early-returns

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16753,6 +16753,66 @@ class GatewayRunner:
                 reset_current_session_key(_approval_session_token)
             result_holder[0] = result
 
+            # Eager session-rotation persistence.
+            #
+            # If the agent rotated its session_id mid-run (via
+            # _compress_context), persist the rotation NOW — before the
+            # post-run block at the success path runs, and before any
+            # stale-result discard or early-return can swallow it.
+            #
+            # Without this, an interrupt (/stop) or a transient failure
+            # between here and the post-run "Session split detected" block
+            # discards the rotation entirely: the session_store entry keeps
+            # pointing at the pre-compression session_id, and the NEXT turn
+            # reloads the FULL uncompressed transcript from disk, then
+            # immediately re-compresses — burning another aux LLM call and
+            # creating a phantom orphaned session in SQLite.
+            #
+            # The success-path block at the "Session split detected" log
+            # below is now idempotent w.r.t. this eager write.
+            try:
+                _split_session_id = getattr(agent, "session_id", None)
+                if (
+                    _split_session_id
+                    and session_key
+                    and _split_session_id != session_id
+                ):
+                    _split_entry = self.session_store._entries.get(session_key)
+                    if _split_entry and _split_entry.session_id != _split_session_id:
+                        _split_entry.session_id = _split_session_id
+                        self.session_store._save()
+                        # Mirror the compressed transcript into the new
+                        # session's JSONL store so load_transcript() on the
+                        # next turn returns the compressed history, not the
+                        # stale JSONL from the pre-rotation session_id.
+                        # The agent has already written these to SQLite via
+                        # its own flush path; rewrite_transcript() replaces
+                        # both stores atomically and is idempotent.
+                        _split_msgs = result.get("messages") or []
+                        if _split_msgs:
+                            try:
+                                self.session_store.rewrite_transcript(
+                                    _split_session_id, _split_msgs,
+                                )
+                            except Exception as _rt_err:
+                                logger.debug(
+                                    "Eager rewrite_transcript after session "
+                                    "rotation failed (non-fatal, SQLite "
+                                    "still has the data): %s",
+                                    _rt_err,
+                                )
+                        logger.info(
+                            "Eagerly persisted session rotation %s → %s "
+                            "(survives /stop and early-return paths)",
+                            session_id, _split_session_id,
+                        )
+            except Exception as _eager_err:
+                # Never let persistence bookkeeping crash the agent run.
+                logger.debug(
+                    "Eager session-rotation persist failed: %s",
+                    _eager_err, exc_info=True,
+                )
+
             # Signal the stream consumer that the agent is done
             if _stream_consumer is not None:
                 _stream_consumer.finish()
@@ -16841,6 +16901,14 @@ class GatewayRunner:
             # mid-run context compression (_compress_context splits sessions).
             # If so, update the session store entry so the NEXT message loads
             # the compressed transcript, not the stale pre-compression one.
+            #
+            # NOTE: as of the eager-rotation-persist fix, this update has
+            # already been performed inside `run_sync` immediately after
+            # `agent.run_conversation()` returned — so the assignment below
+            # is idempotent on the happy path.  We keep it for defence in
+            # depth: if a future refactor moves the eager block, or if the
+            # eager write failed silently, this block still recovers the
+            # rotation on successful (non-stale) turn completion.
             agent = agent_holder[0]
             _session_was_split = False
             if agent and session_key and hasattr(agent, 'session_id') and agent.session_id != session_id:
@@ -16850,7 +16918,7 @@ class GatewayRunner:
                     session_id, agent.session_id,
                 )
                 entry = self.session_store._entries.get(session_key)
-                if entry:
+                if entry and entry.session_id != agent.session_id:
                     entry.session_id = agent.session_id
                     self.session_store._save()
 

--- a/tests/run_agent/test_compression_persistence.py
+++ b/tests/run_agent/test_compression_persistence.py
@@ -202,3 +202,243 @@ class TestGatewayHistoryOffsetAfterSplit:
         assert len(new_messages) == 0, (
             "Expected 0 messages with stale offset=200 (demonstrates the bug)"
         )
+
+
+# ---------------------------------------------------------------------------
+# Part 3: Gateway-side — eager session-rotation persistence
+# ---------------------------------------------------------------------------
+
+class TestEagerSessionRotationPersist:
+    """Verify that mid-run session rotation (from _compress_context) is
+    persisted to the session store and JSONL transcript IMMEDIATELY after
+    the agent returns, before any post-run discard path can swallow it.
+
+    Bug scenario (pre-fix):
+      1. Agent compresses mid-run, rotating session_id A → B.
+      2. Result is returned; before the post-run "Session split detected"
+         block runs, the result is flagged stale (e.g. /stop bumped the
+         run generation) and discarded.
+      3. session_store entry still points at A; B's JSONL was never written.
+      4. Next message loads A.jsonl (full uncompressed history) and the
+         preflight compressor re-fires, burning another aux LLM call and
+         creating an orphaned third session C.
+
+    The fix moves the persistence step from the post-run block (which only
+    runs on success) to immediately after `agent.run_conversation()` returns
+    inside `run_sync`, so it survives /stop, early-returns from
+    `final_response is None`, and any other path that skips the post-run
+    block.
+    """
+
+    def _make_store(self, tmp_path):
+        from unittest.mock import patch
+
+        from gateway.config import GatewayConfig
+        from gateway.session import SessionStore
+
+        config = GatewayConfig()
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path, config=config)
+        store._db = None  # JSONL-only — easier to assert against
+        store._loaded = True
+        return store
+
+    def _simulate_eager_persist(self, store, session_key, original_session_id,
+                                 rotated_session_id, compressed_messages):
+        """Mirror the eager-persist block from gateway/run.py:run_sync()."""
+        # Pre-condition: store points at the original session_id.
+        entry = store._entries.get(session_key)
+        if (
+            rotated_session_id
+            and session_key
+            and rotated_session_id != original_session_id
+            and entry
+            and entry.session_id != rotated_session_id
+        ):
+            entry.session_id = rotated_session_id
+            store._save()
+            if compressed_messages:
+                store.rewrite_transcript(rotated_session_id, compressed_messages)
+            return True
+        return False
+
+    def test_eager_persist_updates_entry_and_writes_compressed_jsonl(self, tmp_path):
+        """Happy path: rotation persists entry + new JSONL atomically."""
+        from datetime import datetime
+
+        from gateway.config import Platform
+        from gateway.session import SessionEntry, SessionSource
+
+        store = self._make_store(tmp_path)
+        session_key = "telegram:dm:user1"
+        original_sid = "20260520_095544_aaaaaa"
+        rotated_sid = "20260520_140509_bbbbbb"
+
+        # Seed: entry at original, JSONL holds 200-message uncompressed history
+        entry = SessionEntry(
+            session_key=session_key,
+            session_id=original_sid,
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            origin=SessionSource(platform=Platform.TELEGRAM, chat_id="user1", chat_type="dm"),
+        )
+        store._entries[session_key] = entry
+        for i in range(200):
+            store.append_to_transcript(original_sid, {
+                "role": "user" if i % 2 == 0 else "assistant",
+                "content": f"msg {i}",
+            })
+
+        compressed = [
+            {"role": "user", "content": "[CONTEXT COMPACTION] Summary..."},
+            {"role": "user", "content": "recent question"},
+            {"role": "assistant", "content": "recent answer"},
+        ]
+        persisted = self._simulate_eager_persist(
+            store, session_key, original_sid, rotated_sid, compressed,
+        )
+
+        assert persisted is True
+        # 1. session_store entry points at the new session id
+        assert store._entries[session_key].session_id == rotated_sid
+        # 2. NEW session JSONL has only the compressed messages (not 203)
+        new_transcript = store.load_transcript(rotated_sid)
+        assert len(new_transcript) == 3
+        assert new_transcript[0]["content"].startswith("[CONTEXT COMPACTION]")
+        # 3. Old session JSONL is left intact (lineage preserved for search)
+        old_transcript = store.load_transcript(original_sid)
+        assert len(old_transcript) == 200
+
+    def test_eager_persist_survives_stale_discard(self, tmp_path):
+        """If the next turn loads the (now-rotated) entry, it must see the
+        compressed transcript — NOT the uncompressed pre-rotation one.
+
+        This is the regression: pre-fix, only the post-run block updated
+        the entry, so a /stop between agent-return and post-run path left
+        the entry stale, causing the next turn to re-compress from scratch.
+        """
+        from datetime import datetime
+
+        from gateway.config import Platform
+        from gateway.session import SessionEntry, SessionSource
+
+        store = self._make_store(tmp_path)
+        session_key = "telegram:dm:user2"
+        original_sid = "session_pre_compression"
+        rotated_sid = "session_post_compression"
+
+        entry = SessionEntry(
+            session_key=session_key,
+            session_id=original_sid,
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            origin=SessionSource(platform=Platform.TELEGRAM, chat_id="user2", chat_type="dm"),
+        )
+        store._entries[session_key] = entry
+
+        # Seed the pre-rotation transcript at 180K-equivalent length
+        for i in range(180):
+            store.append_to_transcript(original_sid, {
+                "role": "user" if i % 2 == 0 else "assistant",
+                "content": "x" * 100,
+            })
+
+        compressed = [
+            {"role": "user", "content": "[COMPACT] summary"},
+            {"role": "assistant", "content": "ack"},
+        ]
+
+        # Eager persist fires DURING run_sync, before any stale-discard
+        self._simulate_eager_persist(
+            store, session_key, original_sid, rotated_sid, compressed,
+        )
+
+        # Simulate stale-result discard: post-run block never runs.
+        # The next turn loads transcript from the entry's session_id.
+        next_turn_sid = store._entries[session_key].session_id
+        next_turn_history = store.load_transcript(next_turn_sid)
+
+        assert next_turn_sid == rotated_sid, (
+            "session_store entry must point at the rotated session id even "
+            "when the result is discarded after agent return"
+        )
+        assert len(next_turn_history) == 2, (
+            f"Next turn must see compressed history (2 msgs), got "
+            f"{len(next_turn_history)} — the rotation was not persisted "
+            f"and the uncompressed transcript leaked through"
+        )
+
+    def test_eager_persist_is_idempotent(self, tmp_path):
+        """Post-run block runs the same update — must be a no-op the second time."""
+        from datetime import datetime
+
+        from gateway.config import Platform
+        from gateway.session import SessionEntry, SessionSource
+
+        store = self._make_store(tmp_path)
+        session_key = "telegram:dm:user3"
+        original_sid = "sess_a"
+        rotated_sid = "sess_b"
+
+        entry = SessionEntry(
+            session_key=session_key,
+            session_id=original_sid,
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            origin=SessionSource(platform=Platform.TELEGRAM, chat_id="user3", chat_type="dm"),
+        )
+        store._entries[session_key] = entry
+
+        compressed = [{"role": "user", "content": "summary"}]
+
+        # First call (the eager block) — persists.
+        first = self._simulate_eager_persist(
+            store, session_key, original_sid, rotated_sid, compressed,
+        )
+        # Second call (the post-run block) — must short-circuit because
+        # entry.session_id already equals rotated_sid.
+        second = self._simulate_eager_persist(
+            store, session_key, original_sid, rotated_sid, compressed,
+        )
+
+        assert first is True
+        assert second is False, (
+            "Post-run rotation block must be a no-op when the eager block "
+            "already persisted the rotation — otherwise rewrite_transcript "
+            "would double-write and clobber any messages appended between "
+            "agent-return and post-run."
+        )
+        assert store._entries[session_key].session_id == rotated_sid
+
+    def test_eager_persist_skips_when_no_rotation(self, tmp_path):
+        """Normal turn (no compression) — eager block must not touch anything."""
+        from datetime import datetime
+
+        from gateway.config import Platform
+        from gateway.session import SessionEntry, SessionSource
+
+        store = self._make_store(tmp_path)
+        session_key = "telegram:dm:user4"
+        sid = "stable_session"
+
+        entry = SessionEntry(
+            session_key=session_key,
+            session_id=sid,
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            origin=SessionSource(platform=Platform.TELEGRAM, chat_id="user4", chat_type="dm"),
+        )
+        store._entries[session_key] = entry
+        store.append_to_transcript(sid, {"role": "user", "content": "hi"})
+
+        # Agent did NOT rotate — rotated_sid == original_sid
+        persisted = self._simulate_eager_persist(
+            store, session_key, sid, sid, [{"role": "user", "content": "summary"}],
+        )
+
+        assert persisted is False
+        assert store._entries[session_key].session_id == sid
+        # Transcript must be untouched by the eager block
+        history = store.load_transcript(sid)
+        assert len(history) == 1
+        assert history[0]["content"] == "hi"


### PR DESCRIPTION
## Problem

When the agent rotates `session_id` during mid-turn context compression (via `_compress_context`), the gateway previously deferred persisting that rotation to a post-run block (`gateway/run.py` — "Session split detected") that only ran on successful turn completion.

Any path that swallowed the result before that block — notably a `/stop` bumping the run generation, or an early return when `final_response is None` — would discard the rotation entirely.

## Symptom

- `session_store` entry kept pointing at the pre-compression `session_id`.
- The NEXT message reloaded the full uncompressed transcript from JSONL.
- Preflight compression immediately re-fired, burning another aux LLM call.
- An orphaned third session was created in SQLite.

Observed in the wild as 2–5 unexpected back-to-back compressions in a single session, with phantom child sessions appearing in the lineage chain.

## Fix

Persist the rotation **immediately** after `agent.run_conversation()` returns inside `run_sync`:

1. Update `session_store._entries[session_key].session_id` to the new id.
2. `session_store._save()` to disk.
3. `session_store.rewrite_transcript(new_session_id, compressed_messages)` so the next turn's `load_transcript()` returns the compressed history, not the stale pre-rotation JSONL.

This runs **before** any stale-result discard, early-return, or post-run block — so the rotation survives all of them.

The existing post-run "Session split detected" block is kept as defence-in-depth, now guarded to be idempotent (no-op when `entry.session_id` already equals `agent.session_id`).

## Why this location

Inside `run_sync`, right after `result_holder[0] = result`. At that point:
- The agent has finished (or been interrupted with `interrupted=True` in the result).
- `agent.session_id` reflects any mid-run rotation.
- `result["messages"]` holds the post-compression message list.
- We're still inside the executor thread, before any async path can short-circuit.

The block is wrapped in a defensive `try/except` so persistence bookkeeping cannot crash the agent run.

## Tests

`tests/run_agent/test_compression_persistence.py` gains a new `TestEagerSessionRotationPersist` class with 4 tests:

| Test | Verifies |
|---|---|
| `test_eager_persist_updates_entry_and_writes_compressed_jsonl` | Happy path: entry rotated, new JSONL has compressed messages, old JSONL untouched. |
| `test_eager_persist_survives_stale_discard` | Next turn loading from the entry sees the compressed transcript even when the post-run block never ran. |
| `test_eager_persist_is_idempotent` | The post-run block becomes a no-op when the eager block already persisted — no double-write that could clobber appended messages. |
| `test_eager_persist_skips_when_no_rotation` | Normal turn (no compression) leaves entry and transcript untouched. |

All 10 tests in the file pass (6 existing + 4 new). Broader sweep — 593 tests in `tests/gateway/` pass with no regressions.

## Files changed

- `gateway/run.py` — eager-persist block (~60 lines inside `run_sync`); post-run block guarded for idempotency.
- `tests/run_agent/test_compression_persistence.py` — 4 new regression tests.
