### PR TITLE
fix(kanban): reject relative board default_workdir before dispatch

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -264,7 +264,7 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     b_create.add_argument("--switch", action="store_true",
                           help="Switch to the new board after creating it")
     b_create.add_argument("--default-workdir", default=None,
-                          help="Default workspace path for tasks created on this board")
+                          help="Default absolute workspace path for tasks created on this board")
 
     b_rm = boards_sub.add_parser(
         "rm", aliases=["remove", "delete"],
@@ -1286,27 +1286,31 @@ def _cmd_create(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 2
-    with kb.connect() as conn:
-        task_id = kb.create_task(
-            conn,
-            title=args.title,
-            body=args.body,
-            assignee=args.assignee,
-            created_by=args.created_by or _profile_author(),
-            workspace_kind=ws_kind,
-            workspace_path=ws_path,
-            branch_name=branch_name,
-            tenant=args.tenant,
-            priority=args.priority,
-            parents=tuple(args.parent or ()),
-            triage=bool(getattr(args, "triage", False)),
-            idempotency_key=getattr(args, "idempotency_key", None),
-            max_runtime_seconds=max_runtime,
-            skills=getattr(args, "skills", None) or None,
-            max_retries=max_retries,
-            initial_status=getattr(args, "initial_status", "running"),
-        )
-        task = kb.get_task(conn, task_id)
+    try:
+        with kb.connect() as conn:
+            task_id = kb.create_task(
+                conn,
+                title=args.title,
+                body=args.body,
+                assignee=args.assignee,
+                created_by=args.created_by or _profile_author(),
+                workspace_kind=ws_kind,
+                workspace_path=ws_path,
+                branch_name=branch_name,
+                tenant=args.tenant,
+                priority=args.priority,
+                parents=tuple(args.parent or ()),
+                triage=bool(getattr(args, "triage", False)),
+                idempotency_key=getattr(args, "idempotency_key", None),
+                max_runtime_seconds=max_runtime,
+                skills=getattr(args, "skills", None) or None,
+                max_retries=max_retries,
+                initial_status=getattr(args, "initial_status", "running"),
+            )
+            task = kb.get_task(conn, task_id)
+    except ValueError as exc:
+        print(f"kanban: {exc}", file=sys.stderr)
+        return 2
     if getattr(args, "json", False):
         print(json.dumps(_task_to_dict(task), indent=2, ensure_ascii=False))
     else:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -427,6 +427,17 @@ def read_board_metadata(board: Optional[str] = None) -> dict:
     return meta
 
 
+def _validate_board_default_workdir(default_workdir: str, *, board: str) -> str:
+    """Return ``default_workdir`` when it resolves to an absolute path."""
+    raw = str(default_workdir)
+    if raw and not Path(raw).expanduser().is_absolute():
+        raise ValueError(
+            f"board {board!r} default_workdir must resolve to an absolute path; "
+            f"got {raw!r}"
+        )
+    return raw
+
+
 def write_board_metadata(
     board: Optional[str],
     *,
@@ -458,7 +469,10 @@ def write_board_metadata(
     if archived is not None:
         meta["archived"] = bool(archived)
     if default_workdir is not None:
-        meta["default_workdir"] = str(default_workdir) if default_workdir else None
+        meta["default_workdir"] = (
+            _validate_board_default_workdir(default_workdir, board=slug)
+            if default_workdir else None
+        )
     if not meta.get("created_at"):
         meta["created_at"] = int(time.time())
     path = board_metadata_path(slug)
@@ -1471,7 +1485,10 @@ def create_task(
         board_meta = read_board_metadata(board_slug)
         board_default = board_meta.get("default_workdir")
         if board_default:
-            workspace_path = str(board_default)
+            workspace_path = _validate_board_default_workdir(
+                board_default,
+                board=board_slug,
+            )
 
     # Retry once on the extremely unlikely id collision.
     for attempt in range(2):

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -219,6 +219,10 @@ class TestBoardCRUD:
         slugs = [b["slug"] for b in kb.list_boards()]
         assert slugs == ["default", "foo"]
 
+    def test_create_rejects_relative_default_workdir(self, fresh_home):
+        with pytest.raises(ValueError, match=r"default_workdir must resolve to an absolute path"):
+            kb.create_board("foo", default_workdir="relative/path")
+
     def test_create_is_idempotent(self, fresh_home):
         kb.create_board("bar")
         kb.create_board("bar")  # no error
@@ -507,6 +511,14 @@ class TestCLI:
         data = json.loads(r2.stdout)
         cur = [b for b in data if b["is_current"]][0]
         assert cur["slug"] == "myproj"
+
+    def test_boards_create_rejects_relative_default_workdir(self, tmp_path):
+        env = {"HERMES_HOME": str(tmp_path)}
+        res = _cli(
+            ["boards", "create", "relproj", "--default-workdir", "relative/path"],
+            env_extra=env,
+        )
+        assert "default_workdir must resolve to an absolute path" in res.stderr
 
     def test_per_board_task_isolation_via_cli(self, tmp_path):
         env = {"HERMES_HOME": str(tmp_path)}

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import concurrent.futures
+import json
 import os
 import sqlite3
 import time
@@ -2445,7 +2446,7 @@ def test_task_dict_survives_corrupt_created_at(tmp_path, monkeypatch):
 
 def test_create_task_without_workspace_inherits_board_default_workdir(kanban_home, monkeypatch):
     """Board with default_workdir → create_task without workspace_path → inherits default."""
-    default_wd = "/home/user/project"
+    default_wd = str(kanban_home / "project")
     kb.create_board("work-proj", default_workdir=default_wd)
 
     with kb.connect(board="work-proj") as conn:
@@ -2468,15 +2469,29 @@ def test_create_task_without_workspace_no_default_stays_none(kanban_home):
 
 def test_create_task_with_explicit_workspace_ignores_board_default(kanban_home):
     """create_task with explicit workspace_path → ignores board default."""
-    kb.create_board("custom-ws-board", default_workdir="/board/default")
+    board_default = str(kanban_home / "board-default")
+    kb.create_board("custom-ws-board", default_workdir=board_default)
 
-    explicit = "/my/explicit/path"
+    explicit = str(kanban_home / "explicit-path")
     with kb.connect(board="custom-ws-board") as conn:
         tid = kb.create_task(conn, title="explicit", workspace_path=explicit, board="custom-ws-board")
         t = kb.get_task(conn, tid)
     assert t is not None
     assert t.workspace_path == explicit
-    assert t.workspace_path != "/board/default"
+    assert t.workspace_path != board_default
+
+
+def test_create_task_rejects_relative_board_default_from_existing_metadata(kanban_home):
+    """Legacy board metadata with relative default_workdir should fail at create-time."""
+    kb.create_board("legacy-rel", default_workdir=str(kanban_home / "abs-worktree"))
+    meta_path = kb.board_metadata_path("legacy-rel")
+    meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    meta["default_workdir"] = "relative/path"
+    meta_path.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+
+    with kb.connect(board="legacy-rel") as conn:
+        with pytest.raises(ValueError, match=r"default_workdir must resolve to an absolute path"):
+            kb.create_task(conn, title="blocked early", board="legacy-rel")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes a kanban bug where a board-level `default_workdir` could be saved as a relative path, then copied into newly created tasks and only fail later during workspace resolution / dispatch.

This change validates `default_workdir` earlier and surfaces a clear user-facing error instead of allowing a late runtime failure.

## What changed

- reject relative `default_workdir` values when writing board metadata
- guard `create_task()` against legacy board metadata that already contains a relative `default_workdir`
- return a clean CLI error for task creation failures caused by invalid board defaults
- add regression tests for:
  - rejecting relative board defaults at board creation time
  - rejecting legacy invalid board metadata at task creation time
  - platform-independent absolute-path inheritance behavior

## Repro

Before:
1. Create a board with `--default-workdir relative/path`
2. Create a task on that board
3. Task creation appears to succeed
4. Dispatch / workspace resolution fails later with a non-absolute workspace path error

After:
- the invalid board default is rejected up front
- legacy invalid metadata fails at task creation with a clear error

## Testing

Passed:
- targeted `default_workdir` regression tests on Windows

