### PR TITLE
fix: use Copilot context window metadata

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2477,14 +2477,14 @@ def fetch_github_model_catalog(
 
 # ─── Copilot catalog context-window helpers ─────────────────────────────────
 
-# Module-level cache: {model_id: max_prompt_tokens}
+# Module-level cache: {model_id: context window tokens}
 _copilot_context_cache: dict[str, int] = {}
 _copilot_context_cache_time: float = 0.0
 _COPILOT_CONTEXT_CACHE_TTL = 3600  # 1 hour
 
 
 def get_copilot_model_context(model_id: str, api_key: Optional[str] = None) -> Optional[int]:
-    """Look up max_prompt_tokens for a Copilot model from the live /models API.
+    """Look up the context window for a Copilot model from the live /models API.
 
     Results are cached in-process for 1 hour to avoid repeated API calls.
     Returns the token limit or None if not found.
@@ -2510,9 +2510,11 @@ def get_copilot_model_context(model_id: str, api_key: Optional[str] = None) -> O
             continue
         caps = item.get("capabilities") or {}
         limits = caps.get("limits") or {}
-        max_prompt = limits.get("max_prompt_tokens")
-        if isinstance(max_prompt, int) and max_prompt > 0:
-            cache[mid] = max_prompt
+        context_window = limits.get("max_context_window_tokens")
+        if not isinstance(context_window, int) or context_window <= 0:
+            context_window = limits.get("max_prompt_tokens")
+        if isinstance(context_window, int) and context_window > 0:
+            cache[mid] = context_window
 
     _copilot_context_cache = cache
     _copilot_context_cache_time = time.time()

--- a/tests/hermes_cli/test_copilot_context.py
+++ b/tests/hermes_cli/test_copilot_context.py
@@ -20,10 +20,14 @@ _SAMPLE_CATALOG = [
         },
     },
     {
-        "id": "gpt-4.1",
+        "id": "gpt-5.5",
         "capabilities": {
             "type": "chat",
-            "limits": {"max_prompt_tokens": 128000, "max_output_tokens": 32768},
+            "limits": {
+                "max_context_window_tokens": 400_000,
+                "max_prompt_tokens": 272_000,
+                "max_output_tokens": 128_000,
+            },
         },
     },
     {
@@ -63,9 +67,9 @@ class TestGetCopilotModelContext:
     """Tests for get_copilot_model_context()."""
 
     @patch("hermes_cli.models.fetch_github_model_catalog", return_value=_SAMPLE_CATALOG)
-    def test_returns_max_prompt_tokens(self, mock_fetch):
+    def test_returns_context_window_tokens(self, mock_fetch):
         assert get_copilot_model_context("claude-opus-4.6-1m") == 1_000_000
-        assert get_copilot_model_context("gpt-4.1") == 128_000
+        assert get_copilot_model_context("gpt-5.5") == 400_000
 
     @patch("hermes_cli.models.fetch_github_model_catalog", return_value=_SAMPLE_CATALOG)
     def test_returns_none_for_unknown_model(self, mock_fetch):
@@ -81,7 +85,7 @@ class TestGetCopilotModelContext:
 
     @patch("hermes_cli.models.fetch_github_model_catalog", return_value=_SAMPLE_CATALOG)
     def test_caches_results(self, mock_fetch):
-        get_copilot_model_context("gpt-4.1")
+        get_copilot_model_context("gpt-5.5")
         get_copilot_model_context("claude-sonnet-4")
         # Only one API call despite two lookups
         assert mock_fetch.call_count == 1
@@ -90,21 +94,21 @@ class TestGetCopilotModelContext:
     def test_cache_expires(self, mock_fetch):
         import hermes_cli.models as mod
 
-        get_copilot_model_context("gpt-4.1")
+        get_copilot_model_context("gpt-5.5")
         assert mock_fetch.call_count == 1
 
         # Expire the cache
         mod._copilot_context_cache_time = time.time() - 7200
-        get_copilot_model_context("gpt-4.1")
+        get_copilot_model_context("gpt-5.5")
         assert mock_fetch.call_count == 2
 
     @patch("hermes_cli.models.fetch_github_model_catalog", return_value=None)
     def test_returns_none_when_catalog_unavailable(self, mock_fetch):
-        assert get_copilot_model_context("gpt-4.1") is None
+        assert get_copilot_model_context("gpt-5.5") is None
 
     @patch("hermes_cli.models.fetch_github_model_catalog", return_value=[])
     def test_returns_none_for_empty_catalog(self, mock_fetch):
-        assert get_copilot_model_context("gpt-4.1") is None
+        assert get_copilot_model_context("gpt-5.5") is None
 
 
 class TestModelMetadataCopilotIntegration:
@@ -129,6 +133,6 @@ class TestModelMetadataCopilotIntegration:
         from agent.model_metadata import get_model_context_length
 
         # Should not raise, should fall through to models.dev or defaults
-        ctx = get_model_context_length("gpt-4.1", provider="copilot")
+        ctx = get_model_context_length("gpt-5.5", provider="copilot")
         assert isinstance(ctx, int)
         assert ctx > 0


### PR DESCRIPTION
## Summary

This PR makes Copilot model context resolution prefer `max_context_window_tokens` from the live `/models` catalog, falling back to `max_prompt_tokens` for older payloads that do not expose the newer field.

Fixes #29146.

## Why

The Copilot `/models` response can expose separate limits:

```json
{
  "id": "gpt-5.5",
  "capabilities": {
    "limits": {
      "max_context_window_tokens": 400000,
      "max_prompt_tokens": 272000,
      "max_output_tokens": 128000
    }
  }
}
```

Hermes previously used `max_prompt_tokens` as the context size, so `/model` and context resolution could show/use 272k where the catalog says the context window is 400k.

## Changes

- Prefer `capabilities.limits.max_context_window_tokens` in `get_copilot_model_context()`.
- Keep `max_prompt_tokens` as a compatibility fallback when `max_context_window_tokens` is absent.
- Update Copilot context tests to cover distinct context-window vs prompt-token limits.

## Testing

Ran:

```bash
venv/bin/python -m pytest tests/hermes_cli/test_copilot_context.py tests/hermes_cli/test_model_validation.py -q
```

Result:

```text
92 passed in 2.22s
```

Also ran:

```bash
git diff --check
```

No whitespace issues.

## Compatibility

This is intentionally minimal and backwards-compatible: catalogs without `max_context_window_tokens` continue using `max_prompt_tokens`, preserving the previous behavior for older Copilot payloads.