### PR TITLE
Fix #26446 and #28662

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -38,6 +38,33 @@ def _cron_api(**kwargs):
     return json.loads(cronjob_tool(**kwargs))
 
 
+def _schedule_display(job) -> str:
+    display = str(job.get("schedule_display") or "").strip()
+    if display:
+        return display
+
+    schedule = job.get("schedule")
+    if isinstance(schedule, dict):
+        for key in ("display", "value", "expr", "run_at"):
+            text = str(schedule.get(key) or "").strip()
+            if text:
+                return text
+    elif schedule is not None:
+        return str(schedule)
+
+    return "?"
+
+
+def _repeat_display(job) -> str:
+    repeat_info = job.get("repeat")
+    if not isinstance(repeat_info, dict):
+        repeat_info = {}
+
+    repeat_times = repeat_info.get("times")
+    repeat_completed = repeat_info.get("completed", 0) or 0
+    return f"{repeat_completed}/{repeat_times}" if repeat_times else "∞"
+
+
 def cron_list(show_all: bool = False):
     """List all scheduled jobs."""
     from cron.jobs import list_jobs
@@ -58,14 +85,11 @@ def cron_list(show_all: bool = False):
     for job in jobs:
         job_id = job.get("id", "?")
         name = job.get("name", "(unnamed)")
-        schedule = job.get("schedule_display", job.get("schedule", {}).get("value", "?"))
+        schedule = _schedule_display(job)
         state = job.get("state", "scheduled" if job.get("enabled", True) else "paused")
         next_run = job.get("next_run_at", "?")
 
-        repeat_info = job.get("repeat", {})
-        repeat_times = repeat_info.get("times")
-        repeat_completed = repeat_info.get("completed", 0)
-        repeat_str = f"{repeat_completed}/{repeat_times}" if repeat_times else "∞"
+        repeat_str = _repeat_display(job)
 
         deliver = job.get("deliver", ["local"])
         if isinstance(deliver, str):

--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -190,7 +190,7 @@ hermes webhook test NAME    Send a test POST
 
 ```
 hermes profile list         List all profiles
-hermes profile create NAME  Create (--clone, --clone-all, --clone-from)
+hermes profile create NAME  Create (--clone, --clone-all, --clone-from, --no-skills)
 hermes profile use NAME     Set sticky default
 hermes profile delete NAME  Delete a profile
 hermes profile show NAME    Show details

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -111,3 +111,27 @@ class TestCronCommandLifecycle:
         assert jobs[0]["skills"] == ["blogwatcher", "maps"]
         assert jobs[0]["name"] == "Skill combo"
         assert jobs[0]["profile"] == "default"
+
+    def test_list_handles_legacy_schedule_and_nullable_repeat(self, monkeypatch, capsys):
+        monkeypatch.setattr(
+            "cron.jobs.list_jobs",
+            lambda include_disabled=False: [
+                {
+                    "id": "legacy-job",
+                    "name": "Legacy job",
+                    "schedule": "every 1h",
+                    "repeat": None,
+                    "deliver": "local",
+                    "enabled": True,
+                    "next_run_at": "2030-01-01T00:00:00+00:00",
+                }
+            ],
+        )
+        monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [1234])
+
+        cron_command(Namespace(cron_command="list", all=False))
+
+        out = capsys.readouterr().out
+        assert "Legacy job" in out
+        assert "Schedule:  every 1h" in out
+        assert "Repeat:    ∞" in out

--- a/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent.md
+++ b/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent.md
@@ -207,7 +207,7 @@ hermes webhook test NAME    Send a test POST
 
 ```
 hermes profile list         List all profiles
-hermes profile create NAME  Create (--clone, --clone-all, --clone-from)
+hermes profile create NAME  Create (--clone, --clone-all, --clone-from, --no-skills)
 hermes profile use NAME     Set sticky default
 hermes profile delete NAME  Delete a profile
 hermes profile show NAME    Show details


### PR DESCRIPTION
## Summary
- make `hermes cron list` tolerate legacy string schedules and nullable repeat fields
- add a regression test for legacy cron-list rendering
- document `hermes profile create --no-skills` in the canonical Hermes skill source and generated docs

## Testing
- `uv run --locked --extra dev pytest tests/hermes_cli/test_cron.py -n 0 --timeout-method=thread`

Closes #26446
Closes #28662
