### PR TITLE
Fix Kanban parent auto-resume gating

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2296,17 +2296,18 @@ def _verify_created_cards(
 # ``_new_task_id`` below. Kept permissive on length for forward compat:
 # accept 8+ hex chars after the ``t_`` prefix.
 _TASK_ID_PROSE_RE = re.compile(r"\bt_[a-f0-9]{8,}\b")
+_CHILD_BLOCKER_REASON_RE = re.compile(
+    r"\b(child|children|blocker|blockers|blocking|remediation|fix(?:es)?|waiting\s+on|wait(?:ing)?\s+for)\b",
+    re.IGNORECASE,
+)
 
 
-def _scan_prose_for_phantom_ids(
-    conn: sqlite3.Connection,
-    text: str,
-) -> list[str]:
-    """Regex-scan free-form text for ``t_<hex>`` references; return the
-    ones that don't exist in ``tasks``.
+def _scan_prose_for_phantom_ids(conn: sqlite3.Connection, text: str) -> list[str]:
+    """Return ``t_<hex>`` ids mentioned in ``text`` that do not exist.
 
-    Used as a non-blocking advisory check on completion summaries. An
-    empty return means "no suspicious references found" — either the
+    This is intentionally advisory: it is used to emit diagnostics when a
+    worker writes prose like "Created t_deadbeef" but forgot to pass the
+    structured ``created_cards`` manifest. An empty list means either the
     text had no IDs at all, or every ID it mentioned resolves to a real
     task. Duplicates are deduped.
     """
@@ -2329,6 +2330,132 @@ def _scan_prose_for_phantom_ids(
     ).fetchall()
     existing = {r["id"] for r in rows}
     return [m for m in unique if m not in existing]
+
+
+def _latest_block_reason(conn: sqlite3.Connection, task_id: str) -> Optional[str]:
+    """Return the most recent explicit block reason for ``task_id``."""
+    row = conn.execute(
+        """
+        SELECT payload FROM task_events
+         WHERE task_id = ? AND kind = 'blocked'
+         ORDER BY created_at DESC, id DESC
+         LIMIT 1
+        """,
+        (task_id,),
+    ).fetchone()
+    if not row or not row["payload"]:
+        return None
+    try:
+        payload = json.loads(row["payload"])
+    except Exception:
+        return None
+    reason = payload.get("reason") if isinstance(payload, dict) else None
+    if isinstance(reason, str) and reason.strip():
+        return reason.strip()
+    return None
+
+
+def _child_blockers_from_reason(reason: Optional[str], child_ids: list[str]) -> list[str]:
+    """Infer which direct child tasks a blocked parent is waiting on.
+
+    Conservative rules keep unrelated human/credential/review blocks stuck:
+    explicit direct child ids win; otherwise the reason must use child/blocker
+    language and then every direct child is treated as the blocking set.
+    """
+    if not reason or not child_ids:
+        return []
+    child_set = set(child_ids)
+    mentioned: list[str] = []
+    seen: set[str] = set()
+    for tid in _TASK_ID_PROSE_RE.findall(reason):
+        if tid in child_set and tid not in seen:
+            seen.add(tid)
+            mentioned.append(tid)
+    if mentioned:
+        return mentioned
+    if _CHILD_BLOCKER_REASON_RE.search(reason):
+        return list(child_ids)
+    return []
+
+
+def _auto_resume_blocked_parents_after_child_completion(
+    conn: sqlite3.Connection,
+    child_id: str,
+) -> int:
+    """Resume blocked parent tasks that explicitly waited on ``child_id``.
+
+    The kanban dependency graph only guarantees that children wait for parents.
+    This helper handles the human workflow where a parent/orchestrator blocks
+    itself after spawning remediation children, then should wake back up once
+    the referenced child blockers are all successfully done.
+    """
+    now = int(time.time())
+    resumed = 0
+    with write_txn(conn):
+        parents = conn.execute(
+            """
+            SELECT p.id
+              FROM task_links l
+              JOIN tasks p ON p.id = l.parent_id
+             WHERE l.child_id = ? AND p.status = 'blocked'
+            """,
+            (child_id,),
+        ).fetchall()
+        for parent in parents:
+            parent_id = parent["id"]
+            child_rows = conn.execute(
+                """
+                SELECT c.id, c.status
+                  FROM task_links l
+                  JOIN tasks c ON c.id = l.child_id
+                 WHERE l.parent_id = ?
+                 ORDER BY c.created_at, c.id
+                """,
+                (parent_id,),
+            ).fetchall()
+            child_ids = [r["id"] for r in child_rows]
+            blockers = _child_blockers_from_reason(
+                _latest_block_reason(conn, parent_id), child_ids
+            )
+            if not blockers or child_id not in blockers:
+                continue
+            statuses = {r["id"]: r["status"] for r in child_rows}
+            if any(statuses.get(blocker_id) != "done" for blocker_id in blockers):
+                continue
+            cur = conn.execute(
+                """
+                UPDATE tasks
+                   SET status = 'ready',
+                       claim_lock = NULL,
+                       claim_expires = NULL,
+                       worker_pid = NULL,
+                       current_run_id = NULL
+                 WHERE id = ? AND status = 'blocked'
+                """,
+                (parent_id,),
+            )
+            if cur.rowcount != 1:
+                continue
+            body = (
+                "auto-resume: child blocker(s) "
+                + ", ".join(blockers)
+                + f" completed; parent reset to ready after {child_id} completion."
+            )
+            conn.execute(
+                "INSERT INTO task_comments (task_id, author, body, created_at) "
+                "VALUES (?, ?, ?, ?)",
+                (parent_id, "system", body, now),
+            )
+            payload = {
+                "trigger_child_id": child_id,
+                "blocker_child_ids": blockers,
+                "status": "ready",
+            }
+            _append_event(conn, parent_id, "commented", {"author": "system", "len": len(body)})
+            _append_event(conn, parent_id, "unblocked", payload)
+            _append_event(conn, parent_id, "auto_resumed", payload)
+            resumed += 1
+    return resumed
 
 
 class HallucinatedCardsError(ValueError):
@@ -2510,6 +2637,8 @@ def complete_task(
     # just tracks "is there a current pathology the breaker should
     # care about", and a success resets that question.
     _clear_failure_counter(conn, task_id)
+    # Wake any blocked parent/orchestrator that explicitly waited on this child.
+    _auto_resume_blocked_parents_after_child_completion(conn, task_id)
     # Recompute ready status for dependents (separate txn so children see done).
     recompute_ready(conn)
     return True

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -126,7 +126,64 @@ DEFAULT_BOARD = "default"
 # pass without fuss. Board names with display formatting (spaces, emoji)
 # live in ``board.json``; the slug is just the directory name.
 _BOARD_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9\-_]{0,63}$")
+_REMEDIATION_TEXT_RE = re.compile(
+    r"\b(fix(?:e[ds])?|repair|remediat(?:e|ion)|unblock|resolve|blocker)\b",
+    re.IGNORECASE,
+)
 
+
+def _looks_like_remediation(title: Optional[str], body: Optional[str] = None) -> bool:
+    """Return True when task text clearly describes repair/remediation work."""
+    text = f"{title or ''}\n{body or ''}"
+    return bool(_REMEDIATION_TEXT_RE.search(text))
+
+
+def _parents_allow_ready(
+    conn: sqlite3.Connection,
+    parents: Iterable[str],
+    *,
+    title: Optional[str] = None,
+    body: Optional[str] = None,
+    task_id: Optional[str] = None,
+) -> bool:
+    """Return whether a task may be ready despite parent links.
+
+    Normal task edges are dependencies: every parent must be done/archived.
+    Blocked QA/review parents are different for explicitly repair-shaped
+    children: the parent is waiting on the child, so gating the child on the
+    blocked parent deadlocks the board. In that case, allow the remediation child
+    to run when every non-terminal parent is blocked and at least one parent is
+    blocked.
+    """
+    parent_ids = tuple(p for p in parents if p)
+    if not parent_ids:
+        return True
+    rows = conn.execute(
+        "SELECT status FROM tasks WHERE id IN (" + ",".join("?" * len(parent_ids)) + ")",
+        parent_ids,
+    ).fetchall()
+    statuses = [r["status"] for r in rows]
+    if len(statuses) != len(parent_ids):
+        return False
+    if all(status in {"done", "archived"} for status in statuses):
+        return True
+    if not any(status == "blocked" for status in statuses):
+        return False
+    if any(status not in {"done", "archived", "blocked"} for status in statuses):
+        return False
+    if task_id and title is None and body is None:
+        row = conn.execute(
+            "SELECT title, body FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if row:
+            title = row["title"]
+            body = row["body"]
+    return _looks_like_remediation(title, body)
+
+
+def _task_parents_allow_ready(conn: sqlite3.Connection, task_id: str) -> bool:
+    return _parents_allow_ready(conn, parent_ids(conn, task_id), task_id=task_id)
 
 def _normalize_board_slug(slug: Optional[str]) -> Optional[str]:
     """Lowercase + strip a slug; validate; return ``None`` for empty."""
@@ -1357,13 +1414,7 @@ def create_task(
                         missing = _find_missing_parents(conn, parents)
                         if missing:
                             raise ValueError(f"unknown parent task(s): {', '.join(missing)}")
-                        # If any parent is not yet done, we're todo.
-                        rows = conn.execute(
-                            "SELECT status FROM tasks WHERE id IN "
-                            "(" + ",".join("?" * len(parents)) + ")",
-                            parents,
-                        ).fetchall()
-                        if any(r["status"] != "done" for r in rows):
+                        if not _parents_allow_ready(conn, parents, title=title, body=body):
                             initial_status = "todo"
                 # Even in triage mode we still need to validate parent ids
                 # so the eventual link rows don't dangle.
@@ -1526,11 +1577,11 @@ def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
             "INSERT OR IGNORE INTO task_links (parent_id, child_id) VALUES (?, ?)",
             (parent_id, child_id),
         )
-        # If child was ready but parent is not yet done, demote child to todo.
-        parent_status = conn.execute(
-            "SELECT status FROM tasks WHERE id = ?", (parent_id,)
-        ).fetchone()["status"]
-        if parent_status != "done":
+        # If child was ready but the new parent does not allow execution yet,
+        # demote child to todo. Done/archived parents are satisfied; explicitly
+        # repair-shaped children may also run under blocked parents to avoid
+        # remediation deadlocks.
+        if not _task_parents_allow_ready(conn, child_id):
             conn.execute(
                 "UPDATE tasks SET status = 'todo' WHERE id = ? AND status = 'ready'",
                 (child_id,),
@@ -1827,7 +1878,11 @@ def _synthesize_ended_run(
 # ---------------------------------------------------------------------------
 
 def recompute_ready(conn: sqlite3.Connection) -> int:
-    """Promote ``todo`` tasks to ``ready`` when all parents are ``done`` or ``archived``.
+    """Promote ``todo`` tasks whose parent links allow execution.
+
+    Normal tasks require all parents to be ``done`` or ``archived``. Explicitly
+    repair-shaped remediation children may also run under blocked parents so QA
+    / review blockers do not deadlock their own fix tasks.
 
     Returns the number of tasks promoted.  Safe to call inside or outside
     an existing transaction; it opens its own IMMEDIATE txn.
@@ -1839,13 +1894,7 @@ def recompute_ready(conn: sqlite3.Connection) -> int:
         ).fetchall()
         for row in todo_rows:
             task_id = row["id"]
-            parents = conn.execute(
-                "SELECT t.status FROM tasks t "
-                "JOIN task_links l ON l.parent_id = t.id "
-                "WHERE l.child_id = ?",
-                (task_id,),
-            ).fetchall()
-            if all(p["status"] in {"done", "archived"} for p in parents):
+            if _task_parents_allow_ready(conn, task_id):
                 conn.execute(
                     "UPDATE tasks SET status = 'ready' WHERE id = ? AND status = 'todo'",
                     (task_id,),
@@ -1875,21 +1924,11 @@ def claim_task(
     lock = claimer or _claimer_id()
     expires = now + int(ttl_seconds)
     with write_txn(conn):
-        # Structural invariant: never transition ready -> running while any
-        # parent is not yet 'done'. This is the single enforcement point
-        # regardless of which writer (create_task, link_tasks, unblock_task,
-        # release_stale_claims, manual SQL) set status='ready'. If a racy
-        # writer promoted a task with undone parents, demote it back to
-        # 'todo' here — recompute_ready will re-promote when the parents
-        # actually finish. See RCA at
-        # kanban/boards/cookai/workspaces/t_a6acd07d/root-cause.md.
-        undone = conn.execute(
-            "SELECT 1 FROM task_links l "
-            "JOIN tasks p ON p.id = l.parent_id "
-            "WHERE l.child_id = ? AND p.status NOT IN ('done', 'archived') LIMIT 1",
-            (task_id,),
-        ).fetchone()
-        if undone:
+        # Structural invariant: never transition ready -> running while parent
+        # links still gate execution. Normal children wait for parents to be
+        # done/archived; explicitly remediation-shaped children may run under
+        # blocked parents because the parent is waiting for that repair.
+        if not _task_parents_allow_ready(conn, task_id):
             conn.execute(
                 "UPDATE tasks SET status = 'todo' "
                 "WHERE id = ? AND status = 'ready'",

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -1128,6 +1128,56 @@ def test_recompute_ready_emits_promoted_not_ready(kanban_home):
         conn.close()
 
 
+def test_blocked_parent_remediation_child_can_run(kanban_home):
+    """A fix/remediation child under a blocked parent must not deadlock.
+
+    QA/parent cards often block because they need a repair child to run. Treating
+    that repair child as dependent on the blocked parent makes the board wait on
+    itself forever.
+    """
+    conn = kb.connect()
+    try:
+        parent = kb.create_task(conn, title="QA failed", assignee="qa")
+        assert kb.block_task(conn, parent, reason="needs implementation fix")
+
+        child = kb.create_task(
+            conn,
+            title="fix: address QA failure",
+            body="Remediation child for the blocked QA parent.",
+            assignee="dev",
+            parents=[parent],
+        )
+        assert kb.get_task(conn, child).status == "ready"
+
+        claimed = kb.claim_task(conn, child)
+        assert claimed is not None
+        assert claimed.status == "running"
+    finally:
+        conn.close()
+
+
+def test_blocked_parent_non_remediation_child_stays_gated(kanban_home):
+    conn = kb.connect()
+    try:
+        parent = kb.create_task(conn, title="blocked parent", assignee="qa")
+        assert kb.block_task(conn, parent, reason="waiting")
+
+        child = kb.create_task(conn, title="ordinary follow-up", assignee="dev", parents=[parent])
+        assert kb.get_task(conn, child).status == "todo"
+
+        kb.recompute_ready(conn)
+        assert kb.get_task(conn, child).status == "todo"
+
+        # Even if someone manually flips it ready, claim_task must still enforce
+        # the dependency gate for non-remediation children.
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status = 'ready' WHERE id = ?", (child,))
+        assert kb.claim_task(conn, child) is None
+        assert kb.get_task(conn, child).status == "todo"
+    finally:
+        conn.close()
+
+
 def test_spawn_failure_circuit_breaker_emits_gave_up(kanban_home, all_assignees_spawnable):
     def _bad(task, ws):
         raise RuntimeError("nope")

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -145,6 +145,65 @@ def test_recompute_ready_fan_in_waits_for_all_parents(kanban_home):
         assert kb.get_task(conn, c).status == "ready"
 
 
+def test_child_completion_auto_resumes_blocked_parent_with_explicit_child_id(kanban_home):
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="lead")
+        child = kb.create_task(conn, title="child blocker", assignee="dev")
+        assert kb.claim_task(conn, child, claimer="host:child") is not None
+        kb.link_tasks(conn, parent, child)
+        assert kb.claim_task(conn, parent, claimer="host:parent") is not None
+        assert kb.block_task(conn, parent, reason=f"waiting on child blocker {child}")
+
+        assert kb.complete_task(conn, child, summary="fixed")
+
+        assert kb.get_task(conn, parent).status == "ready"
+        events = conn.execute(
+            "SELECT kind FROM task_events WHERE task_id = ? ORDER BY id", (parent,)
+        ).fetchall()
+        assert "auto_resumed" in [r["kind"] for r in events]
+        comments = conn.execute(
+            "SELECT author, body FROM task_comments WHERE task_id = ?", (parent,)
+        ).fetchall()
+        assert any(r["author"] == "system" and child in r["body"] for r in comments)
+
+
+def test_child_completion_waits_for_all_child_blockers_before_resuming_parent(kanban_home):
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="lead")
+        c1 = kb.create_task(conn, title="first blocker", assignee="dev")
+        c2 = kb.create_task(conn, title="second blocker", assignee="dev")
+        assert kb.claim_task(conn, c1, claimer="host:c1") is not None
+        assert kb.claim_task(conn, c2, claimer="host:c2") is not None
+        kb.link_tasks(conn, parent, c1)
+        kb.link_tasks(conn, parent, c2)
+        assert kb.claim_task(conn, parent, claimer="host:parent") is not None
+        assert kb.block_task(conn, parent, reason="waiting on child blockers")
+
+        assert kb.complete_task(conn, c1, summary="fixed one")
+        assert kb.get_task(conn, parent).status == "blocked"
+
+        assert kb.complete_task(conn, c2, summary="fixed two")
+        assert kb.get_task(conn, parent).status == "ready"
+
+
+def test_child_completion_does_not_resume_parent_blocked_for_unrelated_reason(kanban_home):
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="lead")
+        child = kb.create_task(conn, title="child blocker", assignee="dev")
+        assert kb.claim_task(conn, child, claimer="host:child") is not None
+        kb.link_tasks(conn, parent, child)
+        assert kb.claim_task(conn, parent, claimer="host:parent") is not None
+        assert kb.block_task(conn, parent, reason="need production credentials")
+
+        assert kb.complete_task(conn, child, summary="fixed")
+
+        assert kb.get_task(conn, parent).status == "blocked"
+        events = conn.execute(
+            "SELECT kind FROM task_events WHERE task_id = ? ORDER BY id", (parent,)
+        ).fetchall()
+        assert "auto_resumed" not in [r["kind"] for r in events]
+
+
 # ---------------------------------------------------------------------------
 # Atomic claim (CAS)
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -128,6 +128,12 @@ def worker_env(monkeypatch, tmp_path):
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setenv("HERMES_PROFILE", "test-worker")
+    # Worker lifecycle handlers use dispatcher-provided env vars as CAS/claim
+    # guards. These tests may run inside a real Kanban worker process, so do
+    # not let the outer worker's task/run/claim leak into the isolated fixture.
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_RUN_ID", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_CLAIM_LOCK", raising=False)
     from pathlib import Path as _Path
     monkeypatch.setattr(_Path, "home", lambda: tmp_path)
 


### PR DESCRIPTION
## Summary
- auto-resume blocked parent/orchestrator tasks after explicit blocking child tasks complete
- preserve gating when any blocking child is still non-terminal or when the parent block reason is unrelated
- add audit trail coverage for auto-resume comments/events
- isolate Kanban tool lifecycle tests from inherited worker env vars so run-id/claim CAS guards are tested deterministically

## Tests
- python -m pytest tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_core_functionality.py tests/tools/test_kanban_tools.py -o 'addopts=' -q
