### PR TITLE
fix(cli): list MiniMax highspeed variants in /model picker (#29142)

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -277,7 +277,9 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "kimi-k2-0905-preview",
     ],
     "minimax": [
+        "MiniMax-M2.7-highspeed",
         "MiniMax-M2.7",
+        "MiniMax-M2.5-highspeed",
         "MiniMax-M2.5",
         "MiniMax-M2.1",
         "MiniMax-M2",

--- a/tests/hermes_cli/test_minimax_in_model_list.py
+++ b/tests/hermes_cli/test_minimax_in_model_list.py
@@ -1,0 +1,41 @@
+"""Test that /model picker exposes MiniMax highspeed variants on direct API (#29142)."""
+
+import os
+from unittest.mock import patch
+
+from hermes_cli.model_switch import list_authenticated_providers
+from hermes_cli.models import _PROVIDER_MODELS
+
+
+_MINIMAX_REQUIRED = {
+    "MiniMax-M2.7-highspeed",
+    "MiniMax-M2.7",
+    "MiniMax-M2.5-highspeed",
+    "MiniMax-M2.5",
+}
+
+
+def test_minimax_curated_includes_highspeed_variants():
+    """Both highspeed variants must be in the static curated list."""
+    models = set(_PROVIDER_MODELS.get("minimax", []))
+    missing = _MINIMAX_REQUIRED - models
+    assert not missing, (
+        f"minimax curated should include highspeed variants; missing: {sorted(missing)}. "
+        f"Got: {_PROVIDER_MODELS.get('minimax')}"
+    )
+
+
+@patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key"}, clear=False)
+def test_minimax_picker_lists_highspeed_when_api_key_set():
+    """When MINIMAX_API_KEY is set, the /model picker must list the highspeed variants."""
+    providers = list_authenticated_providers(current_provider="openrouter", max_models=50)
+
+    minimax = next((p for p in providers if p["slug"] == "minimax"), None)
+    assert minimax is not None, "minimax should appear when MINIMAX_API_KEY is set"
+
+    present = set(minimax["models"])
+    missing = _MINIMAX_REQUIRED - present
+    assert not missing, (
+        f"/model picker for minimax should include highspeed variants; "
+        f"missing: {sorted(missing)}. Got: {minimax['models']}"
+    )

--- a/tests/hermes_cli/test_minimax_in_model_list.py
+++ b/tests/hermes_cli/test_minimax_in_model_list.py
@@ -28,7 +28,13 @@ def test_minimax_curated_includes_highspeed_variants():
 @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key"}, clear=False)
 def test_minimax_picker_lists_highspeed_when_api_key_set():
     """When MINIMAX_API_KEY is set, the /model picker must list the highspeed variants."""
-    providers = list_authenticated_providers(current_provider="openrouter", max_models=50)
+    # Mock models.dev so the test doesn't depend on network reachability; the
+    # section-1 loop in list_authenticated_providers skips a provider when
+    # ``data.get(mdev_id)`` isn't a dict, so an unreachable registry on CI
+    # would otherwise drop minimax even when MINIMAX_API_KEY is set.
+    fake_registry = {"minimax": {"name": "MiniMax", "env": ["MINIMAX_API_KEY"], "models": {}}}
+    with patch("agent.models_dev.fetch_models_dev", return_value=fake_registry):
+        providers = list_authenticated_providers(current_provider="openrouter", max_models=50)
 
     minimax = next((p for p in providers if p["slug"] == "minimax"), None)
     assert minimax is not None, "minimax should appear when MINIMAX_API_KEY is set"

--- a/tests/hermes_cli/test_minimax_in_model_list.py
+++ b/tests/hermes_cli/test_minimax_in_model_list.py
@@ -4,7 +4,7 @@ import os
 from unittest.mock import patch
 
 from hermes_cli.model_switch import list_authenticated_providers
-from hermes_cli.models import _PROVIDER_MODELS
+from hermes_cli.models import provider_model_ids
 
 
 _MINIMAX_REQUIRED = {
@@ -17,11 +17,11 @@ _MINIMAX_REQUIRED = {
 
 def test_minimax_curated_includes_highspeed_variants():
     """Both highspeed variants must be in the static curated list."""
-    models = set(_PROVIDER_MODELS.get("minimax", []))
+    models = set(provider_model_ids("minimax"))
     missing = _MINIMAX_REQUIRED - models
     assert not missing, (
         f"minimax curated should include highspeed variants; missing: {sorted(missing)}. "
-        f"Got: {_PROVIDER_MODELS.get('minimax')}"
+        f"Got: {provider_model_ids('minimax')}"
     )
 
 
@@ -33,8 +33,10 @@ def test_minimax_picker_lists_highspeed_when_api_key_set():
     # ``data.get(mdev_id)`` isn't a dict, so an unreachable registry on CI
     # would otherwise drop minimax even when MINIMAX_API_KEY is set.
     fake_registry = {"minimax": {"name": "MiniMax", "env": ["MINIMAX_API_KEY"], "models": {}}}
+    # ``max_models`` is set well beyond the curated list size so the assertion
+    # never trips on truncation if the curated catalog grows.
     with patch("agent.models_dev.fetch_models_dev", return_value=fake_registry):
-        providers = list_authenticated_providers(current_provider="openrouter", max_models=50)
+        providers = list_authenticated_providers(current_provider="openrouter", max_models=1000)
 
     minimax = next((p for p in providers if p["slug"] == "minimax"), None)
     assert minimax is not None, "minimax should appear when MINIMAX_API_KEY is set"


### PR DESCRIPTION
## What does this PR do?

The direct-API MiniMax provider (`model.provider: minimax`) supports the highspeed variants, but the `/model` picker's curated list for `minimax` only contained the four standard variants (`MiniMax-M2.7`, `M2.5`, `M2.1`, `M2`). Users with a working `MiniMax-M2.7-highspeed` configured as `model.default` could not reselect it interactively after switching away, even though it loads correctly at startup.

This adds `MiniMax-M2.7-highspeed` and `MiniMax-M2.5-highspeed` to `_PROVIDER_MODELS[\"minimax\"]` in `hermes_cli/models.py`. The same list is what `validate_requested_model(\"...\", \"minimax\")` consults via `provider_model_ids(\"minimax\")` (MiniMax has no `/v1/models` endpoint, so the static catalog is the runtime source of truth), so this also flips the runtime validator from \"not found in the MiniMax catalog\" warning to `recognized: True` for these slugs.

Mirrors `validate_requested_model` precedence: static `_PROVIDER_MODELS[\"minimax\"]` is the only minimax catalog source, so updating it covers both the picker and the validator in one place.

## Related Issue

Fixes #29142

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- \`hermes_cli/models.py\` — add \`MiniMax-M2.7-highspeed\` and \`MiniMax-M2.5-highspeed\` to \`_PROVIDER_MODELS[\"minimax\"]\`. Ordered so highspeed variants appear first in the picker since they're the premium tier most users with direct API access want.
- \`tests/hermes_cli/test_minimax_in_model_list.py\` — new regression test that (a) asserts both highspeed variants are present in the static curated list and (b) asserts they appear in \`list_authenticated_providers()\` output when \`MINIMAX_API_KEY\` is set.

## How to Test

1. Set \`MINIMAX_API_KEY\` in the environment.
2. Run the new regression test:
   \`\`\`
   uv run --with pytest --with pytest-xdist --with pytest-asyncio --with pytest-timeout python3 -m pytest tests/hermes_cli/test_minimax_in_model_list.py -v
   \`\`\`
   Expected: 2 passed.
3. Run \`/model\` in the TUI and select the MiniMax provider — both highspeed variants should now be selectable.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (\`fix(scope):\`, \`feat(scope):\`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass (245 passed across \`test_minimax_*\` + \`test_*_picker_*\` + \`test_api_key_providers\`)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, \`docs/\`, docstrings) — N/A (data-only addition)
- [x] I've updated \`cli-config.yaml.example\` if I added/changed config keys — N/A
- [x] I've updated \`CONTRIBUTING.md\` or \`AGENTS.md\` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (data-only)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Scope notes

Intentionally narrow: only \`_PROVIDER_MODELS[\"minimax\"]\` (global direct API). \`minimax-cn\` and \`minimax-oauth\` were considered and left unchanged:

- **\`minimax-cn\`**: no empirical evidence the China-region direct API exposes the same highspeed slugs, and the existing test \`test_near_match_minimax_cn_suggests_similar\` pins the current \`MiniMax-M2.7-highspeed\` → \`MiniMax-M2.7\` suggestion behavior for that provider. Changing it would silently regress that test.
- **\`minimax-oauth\`**: already lists \`MiniMax-M2.7-highspeed\` (the Coding Plan slug). Adding \`MiniMax-M2.5-highspeed\` there is plausible but unverified — would prefer a separate PR with explicit Coding Plan evidence.

> Sibling code paths that may need the same fix: \`_PROVIDER_MODELS[\"minimax-oauth\"]\` for \`MiniMax-M2.5-highspeed\`. Intentionally left out of this PR's scope to keep the diff small and avoid speculation — happy to widen if preferred.