### PR TITLE
fix(feishu): re-enable post-mode rendering for markdown tables

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -4526,13 +4526,11 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
-        # Feishu post-type 'md' elements do not render markdown tables; sending
-        # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
-        if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
-            return "text", json.dumps(text_payload, ensure_ascii=False)
-        if _MARKDOWN_HINT_RE.search(content):
+        # Markdown tables render correctly in post-type 'md' elements as of
+        # mid-May 2026 (Feishu server-side now parses GFM tables). The earlier
+        # forced-text-mode fallback (commit 8e18d10) is no longer needed —
+        # tables now go through the post path with the rest of markdown.
+        if _MARKDOWN_HINT_RE.search(content) or _MARKDOWN_TABLE_RE.search(content):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}
         return "text", json.dumps(text_payload, ensure_ascii=False)

--- a/tests/gateway/test_feishu_outbound_routing.py
+++ b/tests/gateway/test_feishu_outbound_routing.py
@@ -1,0 +1,67 @@
+"""Regression tests for Feishu outbound payload routing."""
+
+import json
+import os
+import unittest
+from unittest.mock import patch
+
+
+class TestFeishuOutboundPayloadRouting(unittest.TestCase):
+    @patch.dict(os.environ, {}, clear=True)
+    def test_plain_text_routes_to_text(self) -> None:
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        content = "Just a plain line."
+        adapter = FeishuAdapter(PlatformConfig())
+
+        msg_type, payload = adapter._build_outbound_payload(content)
+
+        self.assertEqual(msg_type, "text")
+        self.assertEqual(json.loads(payload), {"text": content})
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_table_only_content_routes_to_markdown_post(self) -> None:
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        content = "| col1 | col2 |\n|------|------|\n| x    | y    |"
+        adapter = FeishuAdapter(PlatformConfig())
+
+        msg_type, payload = adapter._build_outbound_payload(content)
+
+        self.assertEqual(msg_type, "post")
+        self.assertEqual(
+            json.loads(payload),
+            {
+                "zh_cn": {
+                    "content": [[{"tag": "md", "text": content}]],
+                }
+            },
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_mixed_markdown_and_table_routes_to_markdown_post(self) -> None:
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        content = (
+            "Summary **below**:\n\n"
+            "| dimension | status |\n"
+            "|-----------|--------|\n"
+            "| **build** | [passing](https://example.com) |\n\n"
+            "End of summary."
+        )
+        adapter = FeishuAdapter(PlatformConfig())
+
+        msg_type, payload = adapter._build_outbound_payload(content)
+
+        self.assertEqual(msg_type, "post")
+        self.assertEqual(
+            json.loads(payload),
+            {
+                "zh_cn": {
+                    "content": [[{"tag": "md", "text": content}]],
+                }
+            },
+        )


### PR DESCRIPTION
## Summary

Feishu's post-type `md` elements now correctly render GFM markdown tables as of mid-May 2026 — the server-side parser was updated to handle the table syntax. The earlier defensive fallback (commit 8e18d10, 2026-04-22) that forced text-mode for any content matching `_MARKDOWN_TABLE_RE` is no longer needed and is in fact harmful: tables now appear as raw markdown source instead of rendered grids.

## Empirical verification

Sent a 3×3 table directly via the Feishu post API as `{"tag":"md", "text":"| A | B | C |\n|---|---|---|\n| 1 | 2 | 3 |\n| 4 | 5 | 6 |"}` — Feishu rendered it as a proper bordered table on the client.

After applying this patch and restarting the gateway, sending the same table through the agent → gateway pipeline now renders as a proper table grid in Feishu instead of raw `| col |` source.

## Change

Collapses the explicit `_MARKDOWN_TABLE_RE` check into the existing `_MARKDOWN_HINT_RE` branch so tables go through the same post pipeline as other markdown:

```diff
-        if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
-            return "text", json.dumps(text_payload, ensure_ascii=False)
-        if _MARKDOWN_HINT_RE.search(content):
+        if _MARKDOWN_HINT_RE.search(content) or _MARKDOWN_TABLE_RE.search(content):
             return "post", _build_markdown_post_payload(content)
```

## Test plan

1. Restart Feishu gateway with this patch applied
2. Send any message containing a GFM markdown table
3. Verify it renders as a bordered table grid in Feishu (not raw markdown source)

Reverts the over-defensive workaround from #8e18d10.