### PR TITLE
fix(kanban): sort priority-desc from highest priority first

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1590,7 +1590,7 @@ VALID_SORT_ORDERS: dict[str, str] = {
     "created": "created_at ASC, id ASC",
     "created-desc": "created_at DESC, id DESC",
     "priority": "priority DESC, created_at ASC",
-    "priority-desc": "priority ASC, created_at ASC",
+    "priority-desc": "priority DESC, created_at ASC",
     "status": "status ASC, created_at ASC",
     "assignee": "assignee ASC, created_at ASC",
     "title": "title ASC, id ASC",

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -899,6 +899,18 @@ def test_list_tasks_order_by(kanban_home):
         except ValueError as e:
             assert "order_by must be one of" in str(e)
 
+
+def test_list_tasks_order_by_priority_desc_sorts_highest_first(kanban_home):
+    with kb.connect() as conn:
+        low = kb.create_task(conn, title="low", priority=1)
+        mid = kb.create_task(conn, title="mid", priority=5)
+        high = kb.create_task(conn, title="high", priority=9)
+
+        by_priority_desc = kb.list_tasks(conn, order_by="priority-desc")
+
+        assert [t.id for t in by_priority_desc] == [high, mid, low]
+
+
 def test_delete_task_removes_task_and_cascades(kanban_home):
     with kb.connect() as conn:
         t = kb.create_task(conn, title="to-delete", assignee="alice")


### PR DESCRIPTION
## Summary
Fixes `hermes kanban list --sort priority-desc` so it sorts tasks by priority descending, matching the sort name and the default priority ordering.

Previously, `priority-desc` mapped to `priority ASC`, which put lower-priority tasks before higher-priority tasks.

## Testing
- `uv run ruff check hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_db.py`
  - `All checks passed!`
- `uv run python -m pytest tests/hermes_cli/test_kanban_db.py::test_list_tasks_order_by tests/hermes_cli/test_kanban_db.py::test_list_tasks_order_by_priority_desc_sorts_highest_first -q -o addopts="" -p no:timeout`
  - `2 passed in 1.45s`

