### PR TITLE
fix(agent): merge consecutive assistant tool_calls before orphan-tool drop (#29148)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -379,12 +379,51 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
 
     repairs = 0
 
+    # Pre-pass: merge consecutive assistant messages that each carry
+    # ``tool_calls``.  DeepSeek v4 and several other OpenAI-compatible
+    # providers return parallel tool calls as a *single* assistant turn
+    # with multiple tool_calls entries.  When Hermes records each call as
+    # a separate assistant message (e.g. during streaming), replaying
+    # that history to strict providers produces HTTP 400:
+    #   "An assistant message with 'tool_calls' must be followed by
+    #    tool messages responding to each 'tool_call_id'."
+    # This pre-pass runs before the orphan-tool-result filter (Pass 1)
+    # so the merged assistant turn's call ids are known when Pass 1
+    # validates the tool-result role messages that follow.
+    current: List[Dict] = []
+    for msg in messages:
+        if (
+            current
+            and isinstance(msg, dict)
+            and msg.get("role") == "assistant"
+            and msg.get("tool_calls")
+            and isinstance(current[-1], dict)
+            and current[-1].get("role") == "assistant"
+            and current[-1].get("tool_calls")
+        ):
+            prev = current[-1]
+            prev_calls = list(prev["tool_calls"])
+            prev_calls.extend(msg["tool_calls"])
+            prev["tool_calls"] = prev_calls
+            # Merge any text content from the duplicate turn.
+            prev_content = prev.get("content") or ""
+            new_content = msg.get("content") or ""
+            if isinstance(prev_content, str) and isinstance(new_content, str):
+                prev["content"] = (
+                    (prev_content + "\n" + new_content).strip()
+                    if new_content.strip()
+                    else prev_content
+                )
+            repairs += 1
+        else:
+            current.append(msg)
+
     # Pass 1: drop stray tool messages that don't follow a known
     # assistant tool_call_id. Uses a rolling set of known ids refreshed
     # on each assistant message.
     known_tool_ids: set = set()
     filtered: List[Dict] = []
-    for msg in messages:
+    for msg in current:
         if not isinstance(msg, dict):
             filtered.append(msg)
             continue

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -298,3 +298,152 @@ def test_flush_guard_clamps_overshooting_cursor():
 
     # min(5, 2) = 2 → nothing skipped below start_idx, cursor settles at 2
     assert agent._last_flushed_db_idx == 2
+# ── Pass 3: merge consecutive assistant tool_calls messages (issue #29148) ─
+
+def test_repair_merges_two_consecutive_assistant_tool_calls():
+    """Two adjacent assistant-with-tool_calls messages collapse into one.
+
+    DeepSeek v4 and other strict OpenAI-compatible providers reject a
+    message history where parallel tool calls appear as separate assistant
+    turns:
+        assistant(tool_calls=[A]) → assistant(tool_calls=[B]) → tool(A) → tool(B)
+    The repair must produce:
+        assistant(tool_calls=[A, B]) → tool(A) → tool(B)
+    """
+    agent = _bare_agent()
+    messages = [
+        {"role": "user", "content": "run both"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "call_A", "type": "function",
+                            "function": {"name": "session_search", "arguments": "{}"}}],
+        },
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "call_B", "type": "function",
+                            "function": {"name": "search_files", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": "call_A", "content": "result A"},
+        {"role": "tool", "tool_call_id": "call_B", "content": "result B"},
+    ]
+
+    repairs = AIAgent._repair_message_sequence(agent, messages)
+
+    assert repairs >= 1
+    # Only one assistant message should remain
+    assistant_msgs = [m for m in messages if m.get("role") == "assistant"]
+    assert len(assistant_msgs) == 1
+    merged_calls = assistant_msgs[0]["tool_calls"]
+    assert len(merged_calls) == 2
+    call_ids = {tc["id"] for tc in merged_calls}
+    assert call_ids == {"call_A", "call_B"}
+    # Tool results still present and in correct order
+    tool_msgs = [m for m in messages if m.get("role") == "tool"]
+    assert len(tool_msgs) == 2
+
+
+def test_repair_merges_three_consecutive_assistant_tool_calls():
+    """Three adjacent assistant-with-tool_calls turns all collapse into one."""
+    agent = _bare_agent()
+    messages = [
+        {"role": "user", "content": "run three"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "c1", "type": "function",
+                            "function": {"name": "tool_x", "arguments": "{}"}}],
+        },
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "c2", "type": "function",
+                            "function": {"name": "tool_y", "arguments": "{}"}}],
+        },
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "c3", "type": "function",
+                            "function": {"name": "tool_z", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": "c1", "content": "r1"},
+        {"role": "tool", "tool_call_id": "c2", "content": "r2"},
+        {"role": "tool", "tool_call_id": "c3", "content": "r3"},
+    ]
+
+    repairs = AIAgent._repair_message_sequence(agent, messages)
+
+    assert repairs >= 2
+    assistant_msgs = [m for m in messages if m.get("role") == "assistant"]
+    assert len(assistant_msgs) == 1
+    assert len(assistant_msgs[0]["tool_calls"]) == 3
+
+
+def test_repair_does_not_merge_text_only_assistants():
+    """Plain-text assistant messages must NOT be merged (no tool_calls)."""
+    agent = _bare_agent()
+    messages = [
+        {"role": "user", "content": "q"},
+        {"role": "assistant", "content": "First thought"},
+        {"role": "assistant", "content": "Second thought"},
+    ]
+
+    AIAgent._repair_message_sequence(agent, messages)
+
+    # Both text assistant messages should still be separate
+    assistant_msgs = [m for m in messages if m.get("role") == "assistant"]
+    assert len(assistant_msgs) == 2
+
+
+def test_repair_does_not_merge_tool_calls_separated_by_tool_result():
+    """Two assistant-with-tool_calls separated by a tool result are NOT merged."""
+    agent = _bare_agent()
+    messages = [
+        {"role": "user", "content": "go"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "t1", "type": "function",
+                            "function": {"name": "f", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": "t1", "content": "done"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "t2", "type": "function",
+                            "function": {"name": "g", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": "t2", "content": "done2"},
+    ]
+    original_assistant_count = sum(1 for m in messages if m.get("role") == "assistant")
+
+    AIAgent._repair_message_sequence(agent, messages)
+
+    assert sum(1 for m in messages if m.get("role") == "assistant") == original_assistant_count
+
+
+def test_repair_preserves_message_count_for_valid_parallel_format():
+    """A correctly-formatted single assistant with multiple tool_calls is unchanged."""
+    agent = _bare_agent()
+    messages = [
+        {"role": "user", "content": "run both"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "call_A", "type": "function",
+                 "function": {"name": "session_search", "arguments": "{}"}},
+                {"id": "call_B", "type": "function",
+                 "function": {"name": "search_files", "arguments": "{}"}},
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_A", "content": "result A"},
+        {"role": "tool", "tool_call_id": "call_B", "content": "result B"},
+    ]
+    original = [dict(m) for m in messages]
+
+    repairs = AIAgent._repair_message_sequence(agent, messages)
+
+    assert repairs == 0
+    assert len(messages) == len(original)


### PR DESCRIPTION
## Problem

DeepSeek v4 (and other strict OpenAI-compatible providers) require that every `assistant` message carrying `tool_calls` is **immediately** followed by the corresponding `tool`-role results. No second `assistant` message may appear before those results are delivered.

When Hermes runs parallel tool calls, each call can end up stored as a **separate consecutive `assistant` message** (e.g. appended individually during streaming). On the next user turn, replaying that history produces:

```
HTTP 400: "An assistant message with 'tool_calls' must be followed by
tool messages responding to each 'tool_call_id'."
```

Reported in #29148.

## Root Cause

The bad history shape looks like:
```json
[
  {"role": "assistant", "tool_calls": [{"id": "call_A", ...}]},
  {"role": "assistant", "tool_calls": [{"id": "call_B", ...}]},
  {"role": "tool", "tool_call_id": "call_A"},
  {"role": "tool", "tool_call_id": "call_B"}
]
```

The correct shape (single assistant turn, multiple `tool_calls`) is:
```json
[
  {"role": "assistant", "tool_calls": [{"id": "call_A", ...}, {"id": "call_B", ...}]},
  {"role": "tool", "tool_call_id": "call_A"},
  {"role": "tool", "tool_call_id": "call_B"}
]
```

## Fix

Add a **pre-pass** inside `repair_message_sequence()` in `agent/agent_runtime_helpers.py` that collapses consecutive `assistant`-with-`tool_calls` messages into a single turn with the union of all `tool_calls`.

The pre-pass runs **before** Pass 1 (the orphan tool-result filter) so that the merged call-id set is known when Pass 1 validates which `tool`-role messages to keep.

### Behaviour

| Input shape | Result |
|---|---|
| Two adjacent `assistant(tool_calls)` | Merged into one turn |
| Three adjacent `assistant(tool_calls)` | All merged into one turn |
| `assistant(text)` messages | Never merged (no `tool_calls`) |
| Two `assistant(tool_calls)` separated by a `tool` result | Not merged (distinct sequential rounds) |
| Single `assistant` with multiple `tool_calls` (already valid) | Unchanged, repairs == 0 |

## Tests

5 new regression tests in `tests/run_agent/test_message_sequence_repair.py`:

- `test_repair_merges_two_consecutive_assistant_tool_calls` — core case from the issue
- `test_repair_merges_three_consecutive_assistant_tool_calls` — N>2 calls
- `test_repair_does_not_merge_text_only_assistants` — guard: no tool_calls, no merge
- `test_repair_does_not_merge_tool_calls_separated_by_tool_result` — guard: intervening result blocks merge
- `test_repair_preserves_message_count_for_valid_parallel_format` — already-valid input is a no-op

All 16 tests in the file pass (11 pre-existing + 5 new).

Closes #29148