### PR TITLE
fix: allow category-qualified dashboard plugin routes

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4317,12 +4317,16 @@ async def post_agent_plugin_install(request: Request, body: _AgentPluginInstallB
 
 def _validate_plugin_name(name: str) -> str:
     """Reject path-traversal attempts in plugin name URL parameters."""
-    if not name or "/" in name or "\\" in name or ".." in name:
+    # Bundled plugin registry keys are category-qualified (for example
+    # ``image_gen/openai-codex``).  The dashboard routes therefore use
+    # Starlette's ``{name:path}`` converter below.  Keep the traversal guard,
+    # but allow forward slashes inside legitimate plugin keys.
+    if not name or "\\" in name or ".." in name or name.startswith("/") or name.endswith("/"):
         raise HTTPException(status_code=400, detail="Invalid plugin name.")
     return name
 
 
-@app.post("/api/dashboard/agent-plugins/{name}/enable")
+@app.post("/api/dashboard/agent-plugins/{name:path}/enable")
 async def post_agent_plugin_enable(request: Request, name: str):
     _require_token(request)
     name = _validate_plugin_name(name)
@@ -4334,7 +4338,7 @@ async def post_agent_plugin_enable(request: Request, name: str):
     return result
 
 
-@app.post("/api/dashboard/agent-plugins/{name}/disable")
+@app.post("/api/dashboard/agent-plugins/{name:path}/disable")
 async def post_agent_plugin_disable(request: Request, name: str):
     _require_token(request)
     name = _validate_plugin_name(name)
@@ -4346,7 +4350,7 @@ async def post_agent_plugin_disable(request: Request, name: str):
     return result
 
 
-@app.post("/api/dashboard/agent-plugins/{name}/update")
+@app.post("/api/dashboard/agent-plugins/{name:path}/update")
 async def post_agent_plugin_update(request: Request, name: str):
     _require_token(request)
     name = _validate_plugin_name(name)


### PR DESCRIPTION
## Summary
- Allow dashboard agent-plugin route parameters to include category-qualified plugin keys like `image_gen/openai-codex`.
- Keep path traversal protections for backslashes, dot-dot segments, and leading/trailing slashes.

## Test Plan
- `python -m py_compile hermes_cli/web_server.py`
- `git diff --check`