### PR TITLE
fix(gateway): stop typing indicator before final response delivery

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3936,28 +3936,38 @@ class BasePlatformAdapter(ABC):
         stop_attempts: int = 2,
     ) -> None:
         """Stop the refresh task and platform typing state as one operation."""
+        caller_cancel: asyncio.CancelledError | None = None
         self._typing_paused.add(chat_id)
         try:
             if typing_task is not None and not typing_task.done():
                 typing_task.cancel()
                 try:
                     await asyncio.wait_for(asyncio.shield(typing_task), timeout=timeout)
-                except (asyncio.CancelledError, asyncio.TimeoutError):
-                    # The task is cancelled; don't let a slow adapter-specific
-                    # cleanup block response delivery or shutdown.
+                except asyncio.CancelledError as exc:
+                    current_task = asyncio.current_task()
+                    if current_task is not None and current_task.cancelling():
+                        # Preserve cancellation of the message-processing task.
+                        # A child typing task's normal cancellation must remain
+                        # swallowed, but caller cancellation must suppress stale
+                        # final delivery.
+                        caller_cancel = exc
+                except asyncio.TimeoutError:
+                    # Don't let slow adapter-specific cleanup block response
+                    # delivery or shutdown.
                     pass
-            if not hasattr(self, "stop_typing"):
-                return
-            attempts = max(1, stop_attempts)
-            for attempt in range(attempts):
-                try:
-                    await self._stop_typing_with_metadata(chat_id, metadata)
-                except Exception:
-                    pass
-                if attempt < attempts - 1:
-                    await asyncio.sleep(0)
+            if hasattr(self, "stop_typing"):
+                attempts = max(1, stop_attempts)
+                for attempt in range(attempts):
+                    try:
+                        await self._stop_typing_with_metadata(chat_id, metadata)
+                    except Exception:
+                        pass
+                    if attempt < attempts - 1:
+                        await asyncio.sleep(0)
         finally:
             self._typing_paused.discard(chat_id)
+        if caller_cancel is not None:
+            raise caller_cancel
 
     def pause_typing_for_chat(self, chat_id: str) -> None:
         """Pause typing indicator for a chat (e.g. during approval waits).
@@ -4924,6 +4934,7 @@ class BasePlatformAdapter(ABC):
 
             # Call the handler (this can take a while with tool calls)
             response = await self._message_handler(event)
+            await _stop_typing_task()
             is_ephemeral_response = isinstance(response, EphemeralReply)
 
             # Slash-command handlers may return an EphemeralReply sentinel to
@@ -5297,10 +5308,14 @@ class BasePlatformAdapter(ABC):
                     self.name, notify_err, exc_info=True,
                 )  # Last resort — don't let error reporting crash the handler
         finally:
-            # Stop typing before any deferred callback work.  Post-delivery
-            # callbacks may perform platform I/O; a stuck callback must not
-            # leave the typing refresh task running indefinitely.
-            await _stop_typing_task()
+            # A cancellation first delivered while stopping typing must not
+            # abort the remaining callback/drain/session bookkeeping. Delay
+            # propagation until ownership cleanup has completed.
+            cleanup_cancel: asyncio.CancelledError | None = None
+            try:
+                await _stop_typing_task()
+            except asyncio.CancelledError as exc:
+                cleanup_cancel = exc
             # Fire any one-shot post-delivery callback registered for this
             # session (e.g. deferred background-review notifications).
             #
@@ -5413,6 +5428,8 @@ class BasePlatformAdapter(ABC):
                 current_task = asyncio.current_task()
                 if current_task is not None and self._session_tasks.get(session_key) is current_task:
                     self._cleanup_finished_session_task(session_key, interrupt_event)
+            if cleanup_cancel is not None:
+                raise cleanup_cancel
     
     def _cleanup_finished_session_task(
         self, session_key: str, interrupt_event: Optional[asyncio.Event]

--- a/tests/gateway/test_ephemeral_reply.py
+++ b/tests/gateway/test_ephemeral_reply.py
@@ -246,9 +246,11 @@ async def test_process_message_unwraps_ephemeral_before_send():
     adapter.set_message_handler(_handler)
 
     sleeps: list[float] = []
+    real_sleep = asyncio.sleep
 
     async def _fake_sleep(duration):
         sleeps.append(duration)
+        await real_sleep(0)
 
     event = _make_event()
     session_key = "agent:main:telegram:private:42"

--- a/tests/gateway/test_session_split_brain_11016.py
+++ b/tests/gateway/test_session_split_brain_11016.py
@@ -155,8 +155,9 @@ class TestAdapterSessionCancellation:
         await adapter.handle_message(
             _make_event("/model xiaomi/mimo-v2-pro --provider nous")
         )
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
+        follow_up_task = adapter._session_tasks.get(sk)
+        assert follow_up_task is not None
+        await asyncio.wait_for(asyncio.shield(follow_up_task), timeout=1.0)
 
         assert any("handled:model" in r for r in adapter.sent_responses), (
             f"follow-up /model stayed blocked after {command_text}"
@@ -260,9 +261,9 @@ class TestStaleSessionLockSelfHeal:
         # An ordinary message should heal the stale lock, then fall through
         # to normal dispatch.  User gets a reply instead of a busy ack.
         await adapter.handle_message(_make_event("hello"))
-        # Drain any spawned background tasks.
-        for _ in range(5):
-            await asyncio.sleep(0)
+        healed_task = adapter._session_tasks.get(sk)
+        assert healed_task is not None
+        await asyncio.wait_for(asyncio.shield(healed_task), timeout=1.0)
 
         assert any("handled:text" in r for r in adapter.sent_responses), (
             "stale lock trapped a normal message — split-brain not healed"

--- a/tests/gateway/test_typing_delivery_order.py
+++ b/tests/gateway/test_typing_delivery_order.py
@@ -1,0 +1,191 @@
+"""Regression tests for typing-refresh and final-delivery ordering."""
+
+import asyncio
+from contextlib import suppress
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+)
+from gateway.session import SessionSource, build_session_key
+
+
+class _StubAdapter(BasePlatformAdapter):
+    async def connect(self, *, is_reconnect: bool = False):
+        return True
+
+    async def disconnect(self):
+        pass
+
+    async def send(self, chat_id, content, **kwargs):
+        return SendResult(success=True, message_id="sent")
+
+    async def send_typing(self, chat_id, metadata=None):
+        pass
+
+    async def get_chat_info(self, chat_id):
+        return {}
+
+
+def _make_event() -> MessageEvent:
+    return MessageEvent(
+        text="hello",
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="42",
+            chat_type="dm",
+        ),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("delivery_kind", ["text", "media"])
+async def test_final_delivery_waits_for_typing_refresh_to_stop(
+    delivery_kind, tmp_path,
+):
+    """Final text and attachment delivery must start only after refresh stops."""
+    adapter = _StubAdapter(
+        PlatformConfig(enabled=True, token="test"),
+        Platform.TELEGRAM,
+    )
+    event = _make_event()
+    session_key = build_session_key(event.source)
+    typing_stopped = False
+    delivery_observations = []
+
+    attachment = tmp_path / "result.pdf"
+    attachment.write_bytes(b"test attachment")
+
+    async def handler(_event):
+        if delivery_kind == "media":
+            return f"MEDIA:{attachment}"
+        return "final response"
+
+    async def stop_typing_refresh(chat_id, typing_task=None, **kwargs):
+        nonlocal typing_stopped
+        if typing_task is not None and not typing_task.done():
+            typing_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await typing_task
+        typing_stopped = True
+
+    async def observe_text_delivery(**kwargs):
+        delivery_observations.append(typing_stopped)
+        return SendResult(success=True, message_id="text")
+
+    async def observe_media_delivery(**kwargs):
+        delivery_observations.append(typing_stopped)
+        return SendResult(success=True, message_id="media")
+
+    adapter._message_handler = handler
+    adapter._stop_typing_refresh = stop_typing_refresh
+    adapter._send_with_retry = observe_text_delivery
+    adapter.send_document = observe_media_delivery
+    adapter._get_human_delay = lambda: 0
+    adapter.filter_media_delivery_paths = lambda paths: paths
+
+    task = asyncio.create_task(
+        adapter._process_message_background(event, session_key)
+    )
+    adapter._session_tasks[session_key] = task
+    await task
+
+    assert delivery_observations == [True]
+
+
+@pytest.mark.asyncio
+async def test_cancelling_processor_during_typing_stop_suppresses_final_delivery():
+    """Caller cancellation while stopping typing must not be mistaken for child cancellation."""
+    adapter = _StubAdapter(
+        PlatformConfig(enabled=True, token="test"),
+        Platform.TELEGRAM,
+    )
+    event = _make_event()
+    session_key = build_session_key(event.source)
+    typing_cleanup_started = asyncio.Event()
+    release_typing_cleanup = asyncio.Event()
+    delivered: list[str] = []
+
+    async def handler(_event):
+        # Let the refresh coroutine start so cancellation enters its cleanup.
+        await asyncio.sleep(0)
+        return "stale final response"
+
+    async def slow_typing_refresh(chat_id, **kwargs):
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            typing_cleanup_started.set()
+            await release_typing_cleanup.wait()
+            raise
+
+    async def observe_text_delivery(**kwargs):
+        delivered.append(kwargs["content"])
+        return SendResult(success=True, message_id="text")
+
+    adapter._message_handler = handler
+    adapter._keep_typing = slow_typing_refresh
+    adapter._send_with_retry = observe_text_delivery
+
+    task = asyncio.create_task(
+        adapter._process_message_background(event, session_key)
+    )
+    adapter._session_tasks[session_key] = task
+
+    await asyncio.wait_for(typing_cleanup_started.wait(), timeout=1)
+    task.cancel()
+    release_typing_cleanup.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert delivered == []
+
+
+@pytest.mark.asyncio
+async def test_cancellation_during_finally_still_releases_session_tracking():
+    """Cancellation in typing cleanup must not strand the session guard."""
+    adapter = _StubAdapter(
+        PlatformConfig(enabled=True, token="test"),
+        Platform.TELEGRAM,
+    )
+    event = _make_event()
+    session_key = build_session_key(event.source)
+    typing_cleanup_started = asyncio.Event()
+    release_typing_cleanup = asyncio.Event()
+
+    async def failing_handler(_event):
+        await asyncio.sleep(0)
+        raise RuntimeError("expected test failure")
+
+    async def slow_typing_refresh(chat_id, **kwargs):
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            typing_cleanup_started.set()
+            await release_typing_cleanup.wait()
+            raise
+
+    adapter._message_handler = failing_handler
+    adapter._keep_typing = slow_typing_refresh
+
+    task = asyncio.create_task(
+        adapter._process_message_background(event, session_key)
+    )
+    adapter._session_tasks[session_key] = task
+
+    await asyncio.wait_for(typing_cleanup_started.wait(), timeout=1)
+    task.cancel()
+    release_typing_cleanup.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert session_key not in adapter._session_tasks
+    assert session_key not in adapter._active_sessions


### PR DESCRIPTION
## Summary

Stop the shared typing-refresh task after `_message_handler(event)` returns and before any final text or attachment delivery begins.

This is a current-`main` rewrite of the original patch following maintainer review. It reuses the existing `_stop_typing_refresh()` lifecycle helper and does not reintroduce per-chat stop events or stream-consumer hand-off state.

## Changes

- await the existing typing-stop helper immediately before final response extraction and delivery
- preserve caller cancellation while waiting for typing cleanup, so an interrupted/stale run cannot continue into final delivery
- delay cancellation first delivered during finalizer typing cleanup until callback/drain/session ownership bookkeeping completes
- keep the existing finalizer cleanup as an idempotent safety net
- add `_process_message_background()` ordering regressions for:
  - final text delivery
  - attachment delivery
  - cancellation during typing shutdown
- make the ephemeral-reply test sleep mock yield once instead of relying on accidental task scheduling
- make session split-brain tests await the spawned owner task instead of assuming delivery completes after a fixed number of `sleep(0)` yields

## Related issue

Fixes #29175

## Test plan

```bash
python -m pytest \
  tests/gateway/test_typing_delivery_order.py \
  tests/gateway/test_ephemeral_reply.py \
  tests/gateway/test_base_topic_sessions.py \
  tests/gateway/test_pending_drain_race.py \
  tests/gateway/test_duplicate_reply_suppression.py \
  tests/gateway/test_tool_response_drop_recovery.py -q
python -m ruff check gateway/platforms/base.py \
  tests/gateway/test_typing_delivery_order.py \
  tests/gateway/test_ephemeral_reply.py
git diff --check
```

Observed locally: `93 passed` across the focused delivery, cancellation, interrupt, drain, recovery, and session split-brain suites; Ruff and diff check passed.

The complete `tests/gateway` suite also fails on an unmodified current-main checkout after roughly 500 tests with an aiohttp `Bad file descriptor` cascade. The focused lifecycle and delivery suites above are green.
