### PR TITLE
fix: resolve api_key from key_env in /model custom provider listing

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -21,6 +21,7 @@ OpenRouter variant suffixes (``:free``, ``:extended``, ``:fast``).
 from __future__ import annotations
 
 import logging
+import os
 import re
 from dataclasses import dataclass
 from typing import List, NamedTuple, Optional
@@ -1589,6 +1590,10 @@ def list_authenticated_providers(
             if not raw_name or not api_url:
                 continue
             api_key = (entry.get("api_key") or "").strip()
+            if not api_key:
+                key_env = (entry.get("key_env") or "").strip()
+                if key_env:
+                    api_key = os.environ.get(key_env, "").strip()
 
             group_key = (api_url, api_key)
             if group_key not in groups:


### PR DESCRIPTION
## Problem

`custom_providers` entries using `api_key_env` (or `key_env`) had their API key resolved correctly at runtime (`runtime_provider.py`) but not during the `/model` picker model discovery path. The picker only read the inline `api_key` field, so `key_env`-backed providers showed 0 models and skipped live `/models` probing.

## Fix

In `model_switch.py` section 4 (custom provider listing), after reading `api_key` from the entry, fall back to `os.environ[key_env]` when `api_key` is empty. This matches the existing pattern in `runtime_provider.py`.

## Changes

- `hermes_cli/model_switch.py`: added `import os`, added `key_env` fallback after the `api_key` read