### PR TITLE
fix(wecom): treat octet-stream as unknown for inbound image mime/ext

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -767,8 +767,18 @@ class WeComAdapter(BasePlatformAdapter):
         content_type = str(headers.get("content-type") or "").split(";", 1)[0].strip() or "application/octet-stream"
         if kind == "image":
             ext = self._guess_extension(url, content_type, fallback=self._detect_image_ext(raw))
+            # Same octet-stream guard: don't propagate ``application/octet-stream``
+            # as media_type. ``_derive_message_type`` classifies any
+            # ``application/*`` mime as DOCUMENT, which strips the image from
+            # the native vision routing path in gateway/run.py. Trust the
+            # sniffed extension instead.
+            image_mime = (
+                content_type
+                if content_type and content_type != "application/octet-stream"
+                else self._mime_for_ext(ext, fallback="image/jpeg")
+            )
             try:
-                return cache_image_from_bytes(raw, ext), content_type or self._mime_for_ext(ext, fallback="image/jpeg")
+                return cache_image_from_bytes(raw, ext), image_mime
             except ValueError as exc:
                 logger.warning("[%s] Rejected non-image bytes from %s: %s", self.name, url, exc)
                 return None
@@ -799,11 +809,17 @@ class WeComAdapter(BasePlatformAdapter):
 
     @staticmethod
     def _guess_extension(url: str, content_type: str, fallback: str) -> str:
-        ext = mimetypes.guess_extension(content_type) if content_type else None
-        if ext:
-            return ext
+        # ``application/octet-stream`` is IANA's "unknown type" — WeCom AI Bot
+        # and many CDNs serve images with this header. Trusting it would
+        # produce ``.bin`` (Python stdlib default for octet-stream) and mask
+        # the real type from downstream image routing. Skip it and fall
+        # through to magic-byte detection via the fallback.
+        if content_type and content_type != "application/octet-stream":
+            ext = mimetypes.guess_extension(content_type)
+            if ext:
+                return ext
         path_ext = Path(urlparse(url).path).suffix
-        if path_ext:
+        if path_ext and path_ext.lower() != ".bin":
             return path_ext
         return fallback
 

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -469,6 +469,41 @@ class TestMediaUpload:
         assert Path(cached_path).read_bytes() == plaintext
         assert content_type == "application/octet-stream"
 
+    @pytest.mark.asyncio
+    async def test_cache_media_image_sniffs_when_content_type_is_octet_stream(self):
+        """Regression: WeCom CDN often serves images with
+        ``Content-Type: application/octet-stream``. Trusting that header
+        produces a ``.bin`` extension (Python stdlib default) and an
+        ``application/octet-stream`` mime, which downstream
+        ``_derive_message_type`` then classifies as ``DOCUMENT``,
+        stripping the file from the native vision routing path in
+        ``gateway/run.py``. The adapter must sniff magic bytes and
+        return an image/* mime so the message stays on the PHOTO route.
+        """
+        from gateway.platforms.wecom import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        # PNG magic header is enough for ``_looks_like_image`` to accept
+        # and for ``_detect_image_ext`` to classify as ``.png``.
+        png_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 8
+        adapter._download_remote_bytes = AsyncMock(
+            return_value=(png_bytes, {"content-type": "application/octet-stream"}),
+        )
+
+        cached = await adapter._cache_media(
+            "image",
+            {"url": "https://wecom.example/cdn/asset"},
+        )
+
+        assert cached is not None
+        cached_path, content_type = cached
+        # Must NOT be saved with the bogus ``.bin`` extension produced by
+        # ``mimetypes.guess_extension("application/octet-stream")``.
+        assert cached_path.endswith(".png"), cached_path
+        # Mime must be image/* so ``_derive_message_type`` returns PHOTO
+        # and ``gateway/run.py:7601`` routes the path into ``image_paths``.
+        assert content_type.startswith("image/"), content_type
+
 
 class TestSend:
     @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

WeCom AI Bot CDN frequently returns inbound image media with
`Content-Type: application/octet-stream` (and sometimes no Content-Type
header at all, which `_cache_media` already falls back to octet-stream
on line 767).

`_guess_extension` currently trusts `mimetypes.guess_extension(content_type)`
on that value. Python's stdlib returns `.bin` for octet-stream per RFC 2046,
so cached files end up as `img_<hex>.bin` and the returned `media_type`
stays `application/octet-stream`. `_derive_message_type` then classifies any
`application/*` mime as `MessageType.DOCUMENT`, which strips the file from
the native vision routing path in `gateway/run.py:7601`
(`mtype.startswith("image/") or message_type == MessageType.PHOTO`).

End result: even when `agent.image_input_mode: native` is set and the main
model has `supports_vision=True`, WeCom-delivered images never reach the
`image_url` content part in `build_native_content_parts`. Agents fall back
to workarounds (opening `file://` URLs in a browser, spinning up local HTTP
servers + `browser_vision`, base64 data-URI HTML pages, etc.) and produce
poor results regardless of the main model's actual vision capability.

## Related Issue

No prior issue — bug found while debugging local WeCom + custom OpenAI-compatible
vision model (Qwen3-VL). Happy to file an issue first if maintainers prefer.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/wecom.py`
  - `_guess_extension`: skip `application/octet-stream` content_type (defer
    to magic-byte fallback). Also skip URL path extensions equal to `.bin`
    for the same reason.
  - `_cache_media` (image branch): don't return
    `application/octet-stream` as the media_type when the sniffed extension
    already implies a real image mime (`image/png`, `image/jpeg`, etc.).
- `tests/gateway/test_wecom.py`
  - Adds `test_cache_media_image_sniffs_when_content_type_is_octet_stream`
    covering the WeCom CDN regression: PNG bytes + octet-stream header must
    produce a `.png` cache path and an `image/*` media_type.

## How to Test

1. `pytest tests/gateway/test_wecom.py tests/gateway/test_wecom_callback.py -q` → 51 passed.
2. Before the fix: send an image to the bot in a real WeCom session.
   `~/.hermes/image_cache/img_*.bin` is produced; `~/.hermes/logs/agent.log`
   either logs `Image routing: text (mode=text)` or routes the file through
   the DOCUMENT branch (no native vision attachment).
3. After the fix: same flow now caches `img_*.png` (or `.jpg`, etc.),
   `Image routing: native` is logged, and the model receives the image via
   the `image_url` content part on the user turn.

## Checklist

- [x] Conventional commit prefix (`fix(wecom):`)
- [x] `pytest tests/gateway/test_wecom.py tests/gateway/test_wecom_callback.py -q` — 51 passed
- [x] Regression test included
- [x] Surgical change — no unrelated edits
