### PR TITLE
fix(agent): preserve tool_name on sanitizer-injected stub tool results

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1708,12 +1708,11 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
                 for tc in msg.get("tool_calls") or []:
                     cid = _ra().AIAgent._get_tool_call_id_static(tc)
                     if cid in missing_results:
-                        patched.append({
-                            "role": "tool",
-                            "name": _ra().AIAgent._get_tool_call_name_static(tc),
-                            "content": "[Result unavailable — see context summary above]",
-                            "tool_call_id": cid,
-                        })
+                        patched.append(make_tool_result_message(
+                            _ra().AIAgent._get_tool_call_name_static(tc),
+                            "[Result unavailable — see context summary above]",
+                            cid,
+                        ))
         messages = patched
         _ra().logger.debug(
             "Pre-call sanitizer: added %d stub tool result(s)",

--- a/tests/run_agent/test_agent_guardrails.py
+++ b/tests/run_agent/test_agent_guardrails.py
@@ -58,6 +58,8 @@ class TestSanitizeApiMessages:
         assert len(out) == 2
         stub = out[1]
         assert stub["role"] == "tool"
+        assert stub["name"] == "terminal"
+        assert stub["tool_name"] == "terminal"
         assert stub["tool_call_id"] == "c2"
         assert stub["content"]
 


### PR DESCRIPTION
## What

Use `make_tool_result_message()` when `_sanitize_api_messages()` injects a stub tool result for an assistant tool call whose result is missing.

This keeps sanitizer-generated tool messages consistent with normal tool execution messages by including both:

- `name` for provider/wire-format compatibility
- `tool_name` for internal session DB and JSON session log persistence

## Why

Recent fixes made tool result construction populate `tool_name` so `state.db`, JSON session logs, and tool-aware search do not get blank tool names.

The pre-call sanitizer still had one manual stub-message path that only set `name`, `content`, and `tool_call_id`. If that path ran after a missing/dropped tool result, the generated stub could still persist with an empty `tool_name`.

## Testing

Ran targeted tests on Windows with thread-based pytest timeout override:

```powershell
uv --cache-dir .uv-cache run --extra dev pytest tests/run_agent/test_agent_guardrails.py::TestSanitizeApiMessages -q -n0 --timeout-method=thread --basetemp .pytest-tmp
uv --cache-dir .uv-cache run --extra dev pytest tests/run_agent/test_tool_name_db_persistence.py -q -n0 --timeout-method=thread --basetemp .pytest-tmp

- 7
- 1

PASSED