### PR TITLE
fix(gateway): report process-tree memory in status

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -926,7 +926,7 @@ class APIServerAdapter(BasePlatformAdapter):
         dashboard can display full status without needing a shared PID file or
         /proc access.  No authentication required.
         """
-        from gateway.status import read_runtime_status
+        from gateway.status import collect_process_tree_memory, read_runtime_status
 
         runtime = read_runtime_status() or {}
         return web.json_response({
@@ -938,6 +938,7 @@ class APIServerAdapter(BasePlatformAdapter):
             "exit_reason": runtime.get("exit_reason"),
             "updated_at": runtime.get("updated_at"),
             "pid": os.getpid(),
+            "process_memory": collect_process_tree_memory(),
         })
 
     async def _handle_models(self, request: "web.Request") -> "web.Response":

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -1936,18 +1936,23 @@ class SlackAdapter(BasePlatformAdapter):
         is_dm = channel_type in {"im", "mpim"}  # Both 1:1 and group DMs
 
         # Build thread_ts for session keying.
-        # In channels: fall back to ts so each top-level @mention starts a
-        #   new thread/session (the bot always replies in a thread).
-        # In DMs: fall back to ts so each top-level DM reply thread gets
-        #   its own session key (matching channel behavior). Set
-        #   dm_top_level_threads_as_sessions: false in config to revert to
-        #   legacy single-session-per-DM-channel behavior.
+        # In DMs: fall back to ts only when dm_top_level_threads_as_sessions
+        #   is enabled; otherwise a DM shares one session.
+        # In channels: real human-started Slack threads keep their thread_ts
+        #   and therefore keep a thread-scoped session. Top-level channel
+        #   messages do NOT synthesize thread_ts from the message ts when
+        #   reply_in_thread is false; that would make every top-level message
+        #   a separate session even though the bot replies in-channel. If
+        #   reply_in_thread is true, preserve legacy behaviour where each
+        #   top-level message becomes its own thread/session.
         if is_dm:
             thread_ts = event.get("thread_ts") or assistant_meta.get("thread_ts")
             if not thread_ts and self._dm_top_level_threads_as_sessions():
                 thread_ts = ts
         else:
-            thread_ts = event.get("thread_ts") or ts  # ts fallback for channels
+            thread_ts = event.get("thread_ts")
+            if not thread_ts and self.config.extra.get("reply_in_thread", True):
+                thread_ts = ts
 
         # In channels, respond if:
         #   0. Channel is in free_response_channels, OR require_mention is

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -216,10 +216,107 @@ def _build_runtime_status_record() -> dict[str, Any]:
         "exit_reason": None,
         "restart_requested": False,
         "active_agents": 0,
+        "process_memory": collect_process_tree_memory(),
         "platforms": {},
         "updated_at": _utc_now_iso(),
     })
     return payload
+
+
+def collect_process_tree_memory(pid: Optional[int] = None) -> dict[str, Any]:
+    """Return RSS/VMS memory for *pid* plus all recursive child processes.
+
+    Gateways and dashboard/API servers can spawn worker children.  Reporting
+    only the parent process undercounts memory substantially, so this helper
+    always aggregates the full process tree while keeping per-process metadata
+    intentionally minimal (no argv/cmdline; those can contain secrets).
+    """
+    root_pid = int(pid or os.getpid())
+    try:
+        import psutil  # type: ignore
+    except Exception as exc:
+        return {
+            "available": False,
+            "pid": root_pid,
+            "error": "psutil_unavailable",
+            "detail": str(exc),
+        }
+
+    try:
+        root = psutil.Process(root_pid)
+        candidates = [root] + root.children(recursive=True)
+    except psutil.NoSuchProcess:
+        return {
+            "available": False,
+            "pid": root_pid,
+            "error": "process_not_found",
+        }
+    except psutil.AccessDenied:
+        return {
+            "available": False,
+            "pid": root_pid,
+            "error": "access_denied",
+        }
+    except Exception as exc:
+        return {
+            "available": False,
+            "pid": root_pid,
+            "error": "process_probe_failed",
+            "detail": str(exc),
+        }
+
+    processes: list[dict[str, Any]] = []
+    parent_rss = 0
+    parent_vms = 0
+    child_rss = 0
+    child_vms = 0
+
+    for proc in candidates:
+        try:
+            with proc.oneshot():
+                mem = proc.memory_info()
+                proc_pid = int(proc.pid)
+                rss = int(getattr(mem, "rss", 0) or 0)
+                vms = int(getattr(mem, "vms", 0) or 0)
+                ppid = proc.ppid()
+                name = proc.name()
+                status_value = proc.status()
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            continue
+        except Exception:
+            continue
+
+        role = "parent" if proc_pid == root_pid else "child"
+        if role == "parent":
+            parent_rss += rss
+            parent_vms += vms
+        else:
+            child_rss += rss
+            child_vms += vms
+
+        processes.append({
+            "pid": proc_pid,
+            "ppid": ppid,
+            "role": role,
+            "name": name,
+            "status": status_value,
+            "rss_bytes": rss,
+            "vms_bytes": vms,
+        })
+
+    return {
+        "available": True,
+        "pid": root_pid,
+        "process_count": len(processes),
+        "child_count": max(0, len(processes) - 1),
+        "rss_bytes": parent_rss,
+        "vms_bytes": parent_vms,
+        "children_rss_bytes": child_rss,
+        "children_vms_bytes": child_vms,
+        "total_rss_bytes": parent_rss + child_rss,
+        "total_vms_bytes": parent_vms + child_vms,
+        "processes": processes,
+    }
 
 
 def _read_json_file(path: Path) -> Optional[dict[str, Any]]:
@@ -521,6 +618,7 @@ def write_runtime_status(
     payload["pid"] = current_record["pid"]
     payload["argv"] = current_record["argv"]
     payload["start_time"] = current_record["start_time"]
+    payload["process_memory"] = collect_process_tree_memory()
     payload["updated_at"] = _utc_now_iso()
 
     if gateway_state is not _UNSET:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -47,7 +47,7 @@ from hermes_cli.config import (
     check_config_version,
     redact_key,
 )
-from gateway.status import get_running_pid, read_runtime_status
+from gateway.status import collect_process_tree_memory, get_running_pid, read_runtime_status
 
 try:
     from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
@@ -561,6 +561,7 @@ async def get_status():
     gateway_platforms: dict = {}
     gateway_exit_reason = None
     gateway_updated_at = None
+    gateway_process_memory = None
     configured_gateway_platforms: set[str] | None = None
     try:
         from gateway.config import load_gateway_config
@@ -589,6 +590,7 @@ async def get_status():
             }
         gateway_exit_reason = runtime.get("exit_reason")
         gateway_updated_at = runtime.get("updated_at")
+        gateway_process_memory = runtime.get("process_memory")
         if not gateway_running:
             gateway_state = gateway_state if gateway_state in {"stopped", "startup_failed"} else "stopped"
             gateway_platforms = {}
@@ -636,6 +638,8 @@ async def get_status():
         "gateway_platforms": gateway_platforms,
         "gateway_exit_reason": gateway_exit_reason,
         "gateway_updated_at": gateway_updated_at,
+        "gateway_process_memory": gateway_process_memory,
+        "dashboard_process_memory": collect_process_tree_memory(),
         "active_sessions": active_sessions,
     }
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -491,7 +491,10 @@ class TestHealthDetailedEndpoint:
             "active_agents": 2,
             "exit_reason": None,
             "updated_at": "2026-04-14T00:00:00Z",
-        }):
+        }), patch(
+            "gateway.status.collect_process_tree_memory",
+            return_value={"available": True, "total_rss_bytes": 123, "child_count": 8},
+        ):
             async with TestClient(TestServer(app)) as cli:
                 resp = await cli.get("/health/detailed")
                 assert resp.status == 200
@@ -502,6 +505,7 @@ class TestHealthDetailedEndpoint:
                 assert data["platforms"] == {"telegram": {"state": "connected"}}
                 assert data["active_agents"] == 2
                 assert isinstance(data["pid"], int)
+                assert data["process_memory"] == {"available": True, "total_rss_bytes": 123, "child_count": 8}
                 assert "updated_at" in data
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -246,6 +247,92 @@ class TestGatewayPidState:
 
 
 class TestGatewayRuntimeStatus:
+    def test_collect_process_tree_memory_aggregates_children(self, monkeypatch):
+        class FakeMem:
+            def __init__(self, rss, vms):
+                self.rss = rss
+                self.vms = vms
+
+        class FakeProc:
+            def __init__(self, pid, ppid, name, rss, vms, children=None):
+                self.pid = pid
+                self._ppid = ppid
+                self._name = name
+                self._rss = rss
+                self._vms = vms
+                self._children = children or []
+
+            def children(self, recursive=False):
+                if not recursive:
+                    return list(self._children)
+                found = []
+                stack = list(self._children)
+                while stack:
+                    child = stack.pop(0)
+                    found.append(child)
+                    stack.extend(child.children(recursive=False))
+                return found
+
+            def oneshot(self):
+                return self
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def memory_info(self):
+                return FakeMem(self._rss, self._vms)
+
+            def ppid(self):
+                return self._ppid
+
+            def name(self):
+                return self._name
+
+            def status(self):
+                return "running"
+
+        grandchild = FakeProc(103, 102, "grandchild", 30, 300)
+        child_a = FakeProc(102, 101, "child-a", 20, 200, [grandchild])
+        child_b = FakeProc(104, 101, "child-b", 40, 400)
+        root = FakeProc(101, 1, "parent", 10, 100, [child_a, child_b])
+
+        fake_psutil = SimpleNamespace(
+            Process=lambda pid: root,
+            NoSuchProcess=RuntimeError,
+            AccessDenied=PermissionError,
+        )
+        monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
+
+        memory = status.collect_process_tree_memory(101)
+
+        assert memory["available"] is True
+        assert memory["process_count"] == 4
+        assert memory["child_count"] == 3
+        assert memory["rss_bytes"] == 10
+        assert memory["children_rss_bytes"] == 90
+        assert memory["total_rss_bytes"] == 100
+        assert [p["role"] for p in memory["processes"]] == ["parent", "child", "child", "child"]
+
+    def test_write_runtime_status_records_process_tree_memory(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(
+            status,
+            "collect_process_tree_memory",
+            lambda: {"available": True, "total_rss_bytes": 123, "child_count": 8},
+        )
+
+        status.write_runtime_status(gateway_state="running")
+
+        payload = status.read_runtime_status()
+        assert payload["process_memory"] == {
+            "available": True,
+            "total_rss_bytes": 123,
+            "child_count": 8,
+        }
+
     def test_write_json_file_uses_atomic_json_write(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         calls = []

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -124,6 +124,35 @@ class TestWebServerEndpoints:
         assert "version" in data
         assert "hermes_home" in data
         assert "active_sessions" in data
+        assert "dashboard_process_memory" in data
+
+    def test_get_status_includes_gateway_and_dashboard_process_memory(self, monkeypatch):
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setattr(web_server, "get_running_pid", lambda: 1234)
+        monkeypatch.setattr(
+            web_server,
+            "read_runtime_status",
+            lambda: {
+                "gateway_state": "running",
+                "updated_at": "2026-04-12T00:00:00+00:00",
+                "platforms": {},
+                "process_memory": {"available": True, "total_rss_bytes": 1000, "child_count": 8},
+            },
+        )
+        monkeypatch.setattr(
+            web_server,
+            "collect_process_tree_memory",
+            lambda: {"available": True, "total_rss_bytes": 2000, "child_count": 0},
+        )
+        monkeypatch.setattr(web_server, "check_config_version", lambda: (1, 1))
+
+        resp = self.client.get("/api/status")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["gateway_process_memory"] == {"available": True, "total_rss_bytes": 1000, "child_count": 8}
+        assert data["dashboard_process_memory"] == {"available": True, "total_rss_bytes": 2000, "child_count": 0}
 
     def test_get_status_filters_unconfigured_gateway_platforms(self, monkeypatch):
         import gateway.config as gateway_config

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -364,15 +364,41 @@ export interface PlatformStatus {
   updated_at: string;
 }
 
+export interface ProcessMemoryInfo {
+  available: boolean;
+  pid: number;
+  process_count?: number;
+  child_count?: number;
+  rss_bytes?: number;
+  vms_bytes?: number;
+  children_rss_bytes?: number;
+  children_vms_bytes?: number;
+  total_rss_bytes?: number;
+  total_vms_bytes?: number;
+  error?: string;
+  detail?: string;
+  processes?: Array<{
+    pid: number;
+    ppid: number;
+    role: "parent" | "child";
+    name: string;
+    status: string;
+    rss_bytes: number;
+    vms_bytes: number;
+  }>;
+}
+
 export interface StatusResponse {
   active_sessions: number;
   config_path: string;
   config_version: number;
+  dashboard_process_memory?: ProcessMemoryInfo | null;
   env_path: string;
   gateway_exit_reason: string | null;
   gateway_health_url: string | null;
   gateway_pid: number | null;
   gateway_platforms: Record<string, PlatformStatus>;
+  gateway_process_memory?: ProcessMemoryInfo | null;
   gateway_running: boolean;
   gateway_state: string | null;
   gateway_updated_at: string | null;


### PR DESCRIPTION
## Summary
- aggregate gateway/dashboard memory across parent and recursive child processes without exposing argv/cmdline
- include process memory in gateway runtime status, API server detailed health, dashboard status, and frontend API types
- preserve top-level Slack channel session continuity when replies are not threaded

## Test Plan
- python -m pytest tests/gateway/test_status.py tests/gateway/test_api_server.py::TestHealthDetailedEndpoint tests/hermes_cli/test_web_server.py::TestWebServerEndpoints -q -o 'addopts='