### PR TITLE
fix(mcp): run OSV malware check off event loop

### DIFF
--- a/tests/tools/test_mcp_tool_issue_948.py
+++ b/tests/tools/test_mcp_tool_issue_948.py
@@ -134,3 +134,37 @@ def test_run_stdio_malware_check_does_not_block_event_loop():
         assert elapsed < 0.12
 
     asyncio.run(_test())
+
+
+def test_run_stdio_malware_check_timeout_fails_open():
+    mock_session = MagicMock()
+    mock_session.initialize = AsyncMock()
+    mock_session.list_tools = AsyncMock(return_value=SimpleNamespace(tools=[]))
+
+    mock_stdio_cm = MagicMock()
+    mock_stdio_cm.__aenter__ = AsyncMock(return_value=(object(), object()))
+    mock_stdio_cm.__aexit__ = AsyncMock(return_value=False)
+
+    mock_session_cm = MagicMock()
+    mock_session_cm.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session_cm.__aexit__ = AsyncMock(return_value=False)
+
+    def hung_malware_check(_command, _args):
+        time.sleep(0.2)
+        return "should be ignored after timeout"
+
+    async def _test():
+        with patch("tools.osv_check.check_package_for_malware", side_effect=hung_malware_check), \
+             patch("tools.mcp_tool._OSV_MALWARE_CHECK_TIMEOUT", 0.05), \
+             patch("tools.mcp_tool.stdio_client", return_value=mock_stdio_cm), \
+             patch("tools.mcp_tool.ClientSession", return_value=mock_session_cm):
+            server = MCPServerTask("srv")
+            started_at = time.monotonic()
+
+            await server.start({"command": sys.executable, "args": ["-m", "fake_mcp"]})
+            elapsed = time.monotonic() - started_at
+            await server.shutdown()
+
+        assert elapsed < 0.15
+
+    asyncio.run(_test())

--- a/tests/tools/test_mcp_tool_issue_948.py
+++ b/tests/tools/test_mcp_tool_issue_948.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 import sys
+import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -93,5 +94,43 @@ def test_run_stdio_uses_resolved_command_and_prepended_path(tmp_path):
             assert call_kwargs["env"]["PATH"].split(os.pathsep)[0] == str(node_bin)
 
             await server.shutdown()
+
+    asyncio.run(_test())
+
+
+def test_run_stdio_malware_check_does_not_block_event_loop():
+    mock_session = MagicMock()
+    mock_session.initialize = AsyncMock()
+    mock_session.list_tools = AsyncMock(return_value=SimpleNamespace(tools=[]))
+
+    mock_stdio_cm = MagicMock()
+    mock_stdio_cm.__aenter__ = AsyncMock(return_value=(object(), object()))
+    mock_stdio_cm.__aexit__ = AsyncMock(return_value=False)
+
+    mock_session_cm = MagicMock()
+    mock_session_cm.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session_cm.__aexit__ = AsyncMock(return_value=False)
+
+    def slow_malware_check(_command, _args):
+        time.sleep(0.2)
+        return None
+
+    async def _test():
+        with patch("tools.osv_check.check_package_for_malware", side_effect=slow_malware_check), \
+             patch("tools.mcp_tool.stdio_client", return_value=mock_stdio_cm), \
+             patch("tools.mcp_tool.ClientSession", return_value=mock_session_cm):
+            server = MCPServerTask("srv")
+            start_task = asyncio.create_task(
+                server.start({"command": sys.executable, "args": ["-m", "fake_mcp"]})
+            )
+
+            started_at = time.monotonic()
+            await asyncio.sleep(0.05)
+            elapsed = time.monotonic() - started_at
+
+            await start_task
+            await server.shutdown()
+
+        assert elapsed < 0.12
 
     asyncio.run(_test())

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -95,6 +95,11 @@ from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
+# Keep the stdio MCP malware preflight bounded even if urllib's per-request
+# timeout fails to interrupt a lower-level SSL/connect stall. The malware check
+# itself is fail-open, so timeout here should also allow startup to proceed.
+_OSV_MALWARE_CHECK_TIMEOUT = 12.0
+
 
 # ---------------------------------------------------------------------------
 # Stdio subprocess stderr redirection
@@ -1269,9 +1274,20 @@ class MCPServerTask:
 
         # Check package against OSV malware database before spawning.
         # OSV queries use blocking urllib I/O; keep that off the MCP event loop
-        # so an intermittent SSL handshake hang cannot freeze startup discovery.
+        # and bound the await so a lower-level SSL/connect stall cannot keep
+        # stdio MCP startup stuck forever. The malware check is fail-open.
         from tools.osv_check import check_package_for_malware
-        malware_error = await asyncio.to_thread(check_package_for_malware, command, args)
+        try:
+            malware_error = await asyncio.wait_for(
+                asyncio.to_thread(check_package_for_malware, command, args),
+                timeout=_OSV_MALWARE_CHECK_TIMEOUT,
+            )
+        except asyncio.TimeoutError:
+            logger.debug(
+                "OSV malware check timed out for MCP server '%s' (allowing)",
+                self.name,
+            )
+            malware_error = None
         if malware_error:
             raise ValueError(
                 f"MCP server '{self.name}': {malware_error}"

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1267,9 +1267,11 @@ class MCPServerTask:
         safe_env = _build_safe_env(user_env)
         command, safe_env = _resolve_stdio_command(command, safe_env)
 
-        # Check package against OSV malware database before spawning
+        # Check package against OSV malware database before spawning.
+        # OSV queries use blocking urllib I/O; keep that off the MCP event loop
+        # so an intermittent SSL handshake hang cannot freeze startup discovery.
         from tools.osv_check import check_package_for_malware
-        malware_error = check_package_for_malware(command, args)
+        malware_error = await asyncio.to_thread(check_package_for_malware, command, args)
         if malware_error:
             raise ValueError(
                 f"MCP server '{self.name}': {malware_error}"


### PR DESCRIPTION
## Summary

`_run_stdio()` is an async MCP startup path, but it was calling the OSV malware preflight synchronously. That preflight eventually reaches `urllib.request.urlopen()`, so an intermittent OSV SSL/connect hang can block the entire MCP event loop during server discovery. In TUI startup this can exceed the 15s gateway readiness window even though MCP discovery itself is waiting on a 120s future.

This PR now covers both layers:

1. move the blocking OSV lookup into `asyncio.to_thread()` so MCP discovery keeps the event loop responsive
2. wrap that threaded check with an explicit startup guard so stdio MCP startup fails open if the OSV check itself never returns promptly

This preserves the existing pre-spawn malware check and error handling while avoiding a global `socket.setdefaulttimeout()` mutation.

## The bug

`tools/mcp_tool.py::_run_stdio()` runs inside the MCP asyncio loop:

```python
malware_error = check_package_for_malware(command, args)
```

`check_package_for_malware()` calls into `tools/osv_check.py`, which uses synchronous `urllib` I/O. When the OSV request stalls in SSL handshake or network setup, the MCP event loop cannot schedule other work. That makes MCP startup appear hung and can cause the TUI gateway startup timeout described in #29184.

Even after moving the work into a thread, a lower-level OSV stall can still leave startup waiting on the thread result. Because the OSV malware check is already fail-open for network errors, the bounded async wrapper should also fail open on timeout.

## The fix

- Keep the malware check in the same pre-spawn position, before constructing/starting the stdio MCP server.
- Run it via `asyncio.to_thread(check_package_for_malware, command, args)` so blocking urllib work happens off the event-loop thread.
- Wrap the threaded check in `asyncio.wait_for(..., timeout=_OSV_MALWARE_CHECK_TIMEOUT)`.
- On timeout, log at debug level and continue with `malware_error = None`, matching the existing fail-open policy for OSV/network failures.
- Preserve the existing behavior when OSV flags a package: `_run_stdio()` still raises `ValueError("MCP server '<name>': ...")` before spawning.

## Regression coverage

Added coverage in `tests/tools/test_mcp_tool_issue_948.py`:

- `test_run_stdio_malware_check_does_not_block_event_loop`
  - patches the malware check to sleep for 200ms, simulating a slow/blocking OSV lookup
  - starts a stdio MCP server task with mocked MCP session/client objects
  - asserts that `await asyncio.sleep(0.05)` resumes promptly instead of being delayed by the malware check
  - verified RED first: before the fix the test failed with `elapsed ~= 0.20s`; after the fix it passes
- `test_run_stdio_malware_check_timeout_fails_open`
  - lowers `_OSV_MALWARE_CHECK_TIMEOUT` to 50ms
  - simulates a malware check that would return only after 200ms
  - asserts stdio MCP startup proceeds before the hung check returns

## Validation

| Suite | Result |
|---|---:|
| `python -m pytest tests/tools/test_mcp_tool_issue_948.py::test_run_stdio_malware_check_does_not_block_event_loop tests/tools/test_mcp_tool_issue_948.py::test_run_stdio_malware_check_timeout_fails_open -q -o 'addopts='` | 2 passed |
| `python -m pytest tests/tools/test_mcp_tool_issue_948.py tests/tools/test_osv_check.py tests/tools/test_mcp_tool.py -q -o 'addopts='` | 225 passed |
| `git diff --check` | passed |

Closes #29184.
