### PR TITLE
fix(mcp): run OSV malware check in thread pool to unblock event loop

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1267,9 +1267,13 @@ class MCPServerTask:
         safe_env = _build_safe_env(user_env)
         command, safe_env = _resolve_stdio_command(command, safe_env)
 
-        # Check package against OSV malware database before spawning
+        # Check package against OSV malware database before spawning.
+        # Run in a thread pool to avoid blocking the asyncio event loop —
+        # urllib SSL handshakes can hang for up to _TIMEOUT seconds under
+        # intermittent network conditions (issue #29184).
+        import asyncio as _asyncio
         from tools.osv_check import check_package_for_malware
-        malware_error = check_package_for_malware(command, args)
+        malware_error = await _asyncio.to_thread(check_package_for_malware, command, args)
         if malware_error:
             raise ValueError(
                 f"MCP server '{self.name}': {malware_error}"

--- a/tools/osv_check.py
+++ b/tools/osv_check.py
@@ -147,7 +147,17 @@ def _query_osv(
         method="POST",
     )
 
-    with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
+    import socket as _socket
+    # urllib timeout= does not always cover the SSL handshake phase.
+    # Set a socket-level default timeout as a belt-and-suspenders guard
+    # so hung SSL handshakes don't block indefinitely (issue #29184).
+    _prev_timeout = _socket.getdefaulttimeout()
+    _socket.setdefaulttimeout(_TIMEOUT)
+    try:
+        _urlopen_ctx = urllib.request.urlopen(req, timeout=_TIMEOUT)
+    finally:
+        _socket.setdefaulttimeout(_prev_timeout)
+    with _urlopen_ctx as resp:
         result = json.loads(resp.read())
 
     vulns = result.get("vulns", [])


### PR DESCRIPTION
## Problem

Synchronous urllib call in check_package_for_malware() blocks the asyncio event loop during MCP startup. SSL handshake hang freezes event loop up to 120s, exceeding TUI 15s timeout.

## Fix

1. mcp_tool.py: asyncio.to_thread() wraps the blocking call
2. osv_check.py: socket.setdefaulttimeout() covers SSL handshake phase

Fixes #29184