### PR TITLE
feat(evm-skill): add Injective EVM support

### DIFF
--- a/optional-skills/blockchain/evm/SKILL.md
+++ b/optional-skills/blockchain/evm/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: evm
-description: "Read-only EVM client: wallets, tokens, gas across 8 chains."
+description: "Read-only EVM client: wallets, tokens, gas across 9 chains."
 version: 1.0.0
 author: Mibayy (@Mibayy), youssefea (@youssefea), ethernet8023 (@ethernet8023), Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]
 metadata:
   hermes:
-    tags: [EVM, Ethereum, BNB, BSC, Base, Arbitrum, Polygon, Optimism, Avalanche, zkSync, Blockchain, Crypto, Web3, DeFi, NFT, ENS, Whale, Security]
+    tags: [EVM, Ethereum, BNB, BSC, Base, Arbitrum, Polygon, Optimism, Avalanche, zkSync, Injective, INJ, Blockchain, Crypto, Web3, DeFi, NFT, ENS, Whale, Security]
     category: blockchain
     related_skills: [solana]
     requires_toolsets: [terminal]
@@ -15,13 +15,13 @@ metadata:
 
 # EVM Blockchain Skill
 
-Query EVM-compatible blockchain data across 8 chains with USD pricing.
+Query EVM-compatible blockchain data across 9 chains with USD pricing.
 14 commands: wallet portfolio, token info, transactions, activity, gas tracker,
 network stats, price lookup, multi-chain scan, whale detection, ENS resolution,
 allowance checker, contract inspector, and transaction decoder.
 
-Supports 8 chains: Ethereum, BNB Chain (BSC), Base, Arbitrum One, Polygon,
-Optimism, Avalanche (C-Chain), zkSync Era.
+Supports 9 chains: Ethereum, BNB Chain (BSC), Base, Arbitrum One, Polygon,
+Optimism, Avalanche (C-Chain), zkSync Era, Injective EVM.
 
 No API key needed. Zero external dependencies — Python standard library only
 (urllib, json, argparse, threading).
@@ -68,7 +68,8 @@ SCRIPT=~/.hermes/skills/blockchain/evm/scripts/evm_client.py
 # Network & prices
 python3 $SCRIPT stats                            # Ethereum stats
 python3 $SCRIPT stats --chain arbitrum           # Arbitrum stats
-python3 $SCRIPT compare                          # Gas + prices ALL 8 chains
+python3 $SCRIPT stats --chain injective          # Injective EVM stats
+python3 $SCRIPT compare                          # Gas + prices ALL 9 chains
 
 # Wallet
 python3 $SCRIPT wallet 0xd8dA...96045            # Portfolio (ETH + ERC-20)
@@ -88,6 +89,7 @@ python3 $SCRIPT activity 0xd8dA...96045          # Recent transactions
 # Gas
 python3 $SCRIPT gas                              # Gas prices + cost estimates
 python3 $SCRIPT gas --chain optimism
+python3 $SCRIPT gas --chain injective
 
 # Security
 python3 $SCRIPT allowance 0xd8dA...96045         # Dangerous ERC-20 approvals
@@ -120,14 +122,14 @@ python3 $SCRIPT wallet 0xd8dA... --chain bsc --no-prices   # faster
 ```
 
 ### 2. Multi-Chain Scan
-Scans all 8 chains simultaneously for the same address using threads.
+Scans all 9 chains simultaneously for the same address using threads.
 ```bash
 python3 $SCRIPT multichain 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045
 ```
 Output: per-chain native balance + token holdings + grand total USD.
 
 ### 3. Compare (Gas + Prices)
-All 8 chains queried in parallel. Shows cheapest/most expensive chain.
+All 9 chains queried in parallel. Shows cheapest/most expensive chain.
 ```bash
 python3 $SCRIPT compare
 ```
@@ -185,6 +187,7 @@ Shows gwei price + USD cost for: transfer, ERC-20 transfer, approve, swap, NFT m
 | optimism  | Optimism       | ETH    | 10       |
 | avalanche | Avalanche C    | AVAX   | 43114    |
 | zksync    | zkSync Era     | ETH    | 324      |
+| injective | Injective EVM  | INJ    | 1776     |
 
 ---
 
@@ -193,10 +196,11 @@ Shows gwei price + USD cost for: transfer, ERC-20 transfer, approve, swap, NFT m
 - Public RPCs may throttle. Set EVM_RPC_URL to a private endpoint for production.
 - `wallet` and `allowance` only check known token list (~30 tokens per chain). Use a block explorer for complete token discovery.
 - `activity` scans recent blocks only (max 200). For full history, use Etherscan API.
-- `multichain` runs 8 parallel threads — can trigger rate limits on public RPCs.
+- `multichain` runs 9 parallel threads — can trigger rate limits on public RPCs.
 - ENS resolution depends on a single public endpoint (ensideas.com / ens.vitalik.ca) with no fallback. If that endpoint is down, `ens` will fail — re-run later or use a block explorer.
 - Tx decoding depends on a single public endpoint (4byte.directory) with no fallback. Selectors not in their database show up as `unknown`.
 - **L2 gas estimates are L2-execution only.** On rollups like Base, Arbitrum, Optimism, and zkSync, the actual transaction cost also includes an L1 data-posting fee that depends on calldata size and current L1 gas prices. The `gas` command does not estimate that L1 component. For Base specifically, see the network's L1 fee oracle (contract `0x420000000000000000000000000000000000000F`).
+- Injective EVM uses native INJ for gas. Wrapped token contracts such as WETH are listed only for ERC-20 balance checks; native INJ is not an ERC-20 entry in `KNOWN_TOKENS`.
 - Address / tx-hash inputs are validated for 0x-prefix + correct length + hex, but EIP-55 checksum casing is **not** enforced (RPC endpoints accept any-case hex).
 
 ---
@@ -208,4 +212,10 @@ python3 ~/.hermes/skills/blockchain/evm/scripts/evm_client.py stats
 
 # Should resolve vitalik.eth to 0xd8dA...
 python3 ~/.hermes/skills/blockchain/evm/scripts/evm_client.py ens vitalik.eth
+
+# Should print Injective block, gas price, and native INJ price when CoinGecko is available
+python3 ~/.hermes/skills/blockchain/evm/scripts/evm_client.py stats --chain injective
+
+# Should print Injective gas estimates denominated in INJ
+python3 ~/.hermes/skills/blockchain/evm/scripts/evm_client.py gas --chain injective
 ```

--- a/optional-skills/blockchain/evm/scripts/evm_client.py
+++ b/optional-skills/blockchain/evm/scripts/evm_client.py
@@ -82,6 +82,14 @@ CHAINS: Dict[str, Dict[str, Any]] = {
         "explorer": "https://explorer.zksync.io",
         "decimals": 18,
     },
+    "injective": {
+        "chain_id": 1776,
+        "rpc": "https://sentry.evm-rpc.injective.network/",
+        "native": "INJ",
+        "coingecko": "injective-protocol",
+        "explorer": "https://blockscout.injective.network",
+        "decimals": 18,
+    },
 }
 
 DEFAULT_CHAIN = "ethereum"
@@ -177,6 +185,10 @@ KNOWN_TOKENS: Dict[str, Dict[str, str]] = {
         "USDT":  "0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7",
         "WAVAX": "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
     },
+    "injective": {
+        "USDC": "0x2a25fbD67b3aE485e461fe55d9DbeF302B7D3989",
+        "WETH": "0x83A15000b753AC0EeE06D2Cb41a69e76D0D5c7F7",
+    },
 }
 
 # Gas estimates (units) for common operations
@@ -196,6 +208,7 @@ COINGECKO_IDS: Dict[str, str] = {
     "BNB":   "binancecoin",
     "MATIC": "matic-network",
     "AVAX":  "avalanche-2",
+    "INJ":   "injective-protocol",
     "USDT":  "tether",
     "USDC":  "usd-coin",
     "DAI":   "dai",
@@ -574,6 +587,7 @@ def cg_price_by_contract(chain: str, contract: str) -> Optional[float]:
         "optimism": "optimistic-ethereum",
         "avalanche":"avalanche",
         "zksync":   "zksync",
+        "injective":"injective",
     }
     platform = cg_platform_map.get(chain)
     if not platform:
@@ -1084,7 +1098,7 @@ def cmd_whale(args: argparse.Namespace) -> None:
 # ---------------------------------------------------------------------------
 
 def cmd_multichain(args: argparse.Namespace) -> None:
-    """Scan same wallet across all 8 chains simultaneously."""
+    """Scan same wallet across all 9 chains simultaneously."""
     import threading
 
     address = require_address(args.address)

--- a/tests/skills/test_evm_skill.py
+++ b/tests/skills/test_evm_skill.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills"
+    / "blockchain"
+    / "evm"
+    / "scripts"
+    / "evm_client.py"
+)
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("evm_skill", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_injective_chain_registry() -> None:
+    mod = load_module()
+
+    assert mod.CHAINS["injective"] == {
+        "chain_id": 1776,
+        "rpc": "https://sentry.evm-rpc.injective.network/",
+        "native": "INJ",
+        "coingecko": "injective-protocol",
+        "explorer": "https://blockscout.injective.network",
+        "decimals": 18,
+    }
+
+
+def test_injective_known_tokens_are_verified_mainnet_contracts() -> None:
+    mod = load_module()
+
+    assert mod.KNOWN_TOKENS["injective"] == {
+        "USDC": "0x2a25fbD67b3aE485e461fe55d9DbeF302B7D3989",
+        "WETH": "0x83A15000b753AC0EeE06D2Cb41a69e76D0D5c7F7",
+    }
+    assert "INJ" not in mod.KNOWN_TOKENS["injective"]
+
+
+def test_inj_symbol_uses_native_coingecko_coin_id() -> None:
+    mod = load_module()
+
+    assert mod.COINGECKO_IDS["INJ"] == "injective-protocol"
+
+
+def test_contract_price_uses_injective_asset_platform() -> None:
+    mod = load_module()
+    calls: list[str] = []
+    usdc = mod.KNOWN_TOKENS["injective"]["USDC"]
+
+    def fake_http_get(url: str, timeout: int = 20):
+        calls.append(url)
+        return {usdc.lower(): {"usd": 1.0}}
+
+    with patch.object(mod, "_http_get", side_effect=fake_http_get):
+        price = mod.cg_price_by_contract("injective", usdc)
+
+    assert price == 1.0
+    assert calls == [
+        f"{mod.COINGECKO_BASE}/simple/token_price/injective"
+        f"?contract_addresses={usdc}&vs_currencies=usd"
+    ]
+
+
+def test_parser_accepts_injective_chain() -> None:
+    mod = load_module()
+
+    args = mod.build_parser().parse_args(["stats", "--chain", "injective"])
+
+    assert args.command == "stats"
+    assert args.chain == "injective"
+
+
+def test_stats_command_uses_injective_chain_without_live_network(capsys) -> None:
+    mod = load_module()
+
+    def fake_rpc_call(chain: str, method: str, params: list):
+        assert chain == "injective"
+        if method == "eth_getBlockByNumber":
+            assert params == ["latest", False]
+            return {
+                "parentHash": "0xparent",
+                "timestamp": "0x20",
+                "transactions": ["0x1", "0x2", "0x3", "0x4"],
+            }
+        if method == "eth_getBlockByHash":
+            assert params == ["0xparent", False]
+            return {"timestamp": "0x10"}
+        raise AssertionError(f"unexpected RPC method: {method}")
+
+    with (
+        patch.object(mod, "rpc_batch", return_value=["0x2a", "0x3b9aca00"]) as rpc_batch,
+        patch.object(mod, "rpc_call", side_effect=fake_rpc_call),
+        patch.object(mod, "get_native_price", return_value=7.5),
+    ):
+        mod.cmd_stats(argparse.Namespace(chain="injective"))
+
+    rpc_batch.assert_called_once_with(
+        "injective",
+        [
+            ("eth_blockNumber", []),
+            ("eth_gasPrice", []),
+        ],
+    )
+    rendered = json.loads(capsys.readouterr().out)
+    assert rendered["chain"] == "injective"
+    assert rendered["block_number"] == 42
+    assert rendered["gas_price_gwei"] == 1.0
+    assert rendered["native_token"] == "INJ"
+    assert rendered["native_price_usd"] == 7.5
+    assert rendered["tps_estimate"] == 0.25
+    assert rendered["explorer"] == "https://blockscout.injective.network"

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -38,7 +38,7 @@ hermes skills uninstall <skill-name>
 
 | Skill | Description |
 |-------|-------------|
-| [**evm**](/docs/user-guide/skills/optional/blockchain/blockchain-evm) | Read-only EVM client: wallets, tokens, gas across 8 chains. |
+| [**evm**](/docs/user-guide/skills/optional/blockchain/blockchain-evm) | Read-only EVM client: wallets, tokens, gas across 9 chains. |
 | [**hyperliquid**](/docs/user-guide/skills/optional/blockchain/blockchain-hyperliquid) | Hyperliquid market data, account history, trade review. |
 | [**solana**](/docs/user-guide/skills/optional/blockchain/blockchain-solana) | Query Solana blockchain data with USD pricing — wallet balances, token portfolios with values, transaction details, NFTs, whale detection, and live network stats. Uses Solana RPC + CoinGecko. No API key required. |
 

--- a/website/docs/user-guide/skills/optional/blockchain/blockchain-evm.md
+++ b/website/docs/user-guide/skills/optional/blockchain/blockchain-evm.md
@@ -1,14 +1,14 @@
 ---
-title: "Evm — Read-only EVM client: wallets, tokens, gas across 8 chains"
+title: "Evm — Read-only EVM client: wallets, tokens, gas across 9 chains"
 sidebar_label: "Evm"
-description: "Read-only EVM client: wallets, tokens, gas across 8 chains"
+description: "Read-only EVM client: wallets, tokens, gas across 9 chains"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Evm
 
-Read-only EVM client: wallets, tokens, gas across 8 chains.
+Read-only EVM client: wallets, tokens, gas across 9 chains.
 
 ## Skill metadata
 
@@ -20,7 +20,7 @@ Read-only EVM client: wallets, tokens, gas across 8 chains.
 | Author | Mibayy (@Mibayy), youssefea (@youssefea), ethernet8023 (@ethernet8023), Hermes Agent |
 | License | MIT |
 | Platforms | linux, macos, windows |
-| Tags | `EVM`, `Ethereum`, `BNB`, `BSC`, `Base`, `Arbitrum`, `Polygon`, `Optimism`, `Avalanche`, `zkSync`, `Blockchain`, `Crypto`, `Web3`, `DeFi`, `NFT`, `ENS`, `Whale`, `Security` |
+| Tags | `EVM`, `Ethereum`, `BNB`, `BSC`, `Base`, `Arbitrum`, `Polygon`, `Optimism`, `Avalanche`, `zkSync`, `Injective`, `INJ`, `Blockchain`, `Crypto`, `Web3`, `DeFi`, `NFT`, `ENS`, `Whale`, `Security` |
 | Related skills | [`solana`](/docs/user-guide/skills/optional/blockchain/blockchain-solana) |
 
 ## Reference: full SKILL.md
@@ -31,13 +31,13 @@ The following is the complete skill definition that Hermes loads when this skill
 
 # EVM Blockchain Skill
 
-Query EVM-compatible blockchain data across 8 chains with USD pricing.
+Query EVM-compatible blockchain data across 9 chains with USD pricing.
 14 commands: wallet portfolio, token info, transactions, activity, gas tracker,
 network stats, price lookup, multi-chain scan, whale detection, ENS resolution,
 allowance checker, contract inspector, and transaction decoder.
 
-Supports 8 chains: Ethereum, BNB Chain (BSC), Base, Arbitrum One, Polygon,
-Optimism, Avalanche (C-Chain), zkSync Era.
+Supports 9 chains: Ethereum, BNB Chain (BSC), Base, Arbitrum One, Polygon,
+Optimism, Avalanche (C-Chain), zkSync Era, Injective EVM.
 
 No API key needed. Zero external dependencies — Python standard library only
 (urllib, json, argparse, threading).
@@ -84,7 +84,8 @@ SCRIPT=~/.hermes/skills/blockchain/evm/scripts/evm_client.py
 # Network & prices
 python3 $SCRIPT stats                            # Ethereum stats
 python3 $SCRIPT stats --chain arbitrum           # Arbitrum stats
-python3 $SCRIPT compare                          # Gas + prices ALL 8 chains
+python3 $SCRIPT stats --chain injective          # Injective EVM stats
+python3 $SCRIPT compare                          # Gas + prices ALL 9 chains
 
 # Wallet
 python3 $SCRIPT wallet 0xd8dA...96045            # Portfolio (ETH + ERC-20)
@@ -104,6 +105,7 @@ python3 $SCRIPT activity 0xd8dA...96045          # Recent transactions
 # Gas
 python3 $SCRIPT gas                              # Gas prices + cost estimates
 python3 $SCRIPT gas --chain optimism
+python3 $SCRIPT gas --chain injective
 
 # Security
 python3 $SCRIPT allowance 0xd8dA...96045         # Dangerous ERC-20 approvals
@@ -136,14 +138,14 @@ python3 $SCRIPT wallet 0xd8dA... --chain bsc --no-prices   # faster
 ```
 
 ### 2. Multi-Chain Scan
-Scans all 8 chains simultaneously for the same address using threads.
+Scans all 9 chains simultaneously for the same address using threads.
 ```bash
 python3 $SCRIPT multichain 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045
 ```
 Output: per-chain native balance + token holdings + grand total USD.
 
 ### 3. Compare (Gas + Prices)
-All 8 chains queried in parallel. Shows cheapest/most expensive chain.
+All 9 chains queried in parallel. Shows cheapest/most expensive chain.
 ```bash
 python3 $SCRIPT compare
 ```
@@ -201,6 +203,7 @@ Shows gwei price + USD cost for: transfer, ERC-20 transfer, approve, swap, NFT m
 | optimism  | Optimism       | ETH    | 10       |
 | avalanche | Avalanche C    | AVAX   | 43114    |
 | zksync    | zkSync Era     | ETH    | 324      |
+| injective | Injective EVM  | INJ    | 1776     |
 
 ---
 
@@ -209,10 +212,11 @@ Shows gwei price + USD cost for: transfer, ERC-20 transfer, approve, swap, NFT m
 - Public RPCs may throttle. Set EVM_RPC_URL to a private endpoint for production.
 - `wallet` and `allowance` only check known token list (~30 tokens per chain). Use a block explorer for complete token discovery.
 - `activity` scans recent blocks only (max 200). For full history, use Etherscan API.
-- `multichain` runs 8 parallel threads — can trigger rate limits on public RPCs.
+- `multichain` runs 9 parallel threads — can trigger rate limits on public RPCs.
 - ENS resolution depends on a single public endpoint (ensideas.com / ens.vitalik.ca) with no fallback. If that endpoint is down, `ens` will fail — re-run later or use a block explorer.
 - Tx decoding depends on a single public endpoint (4byte.directory) with no fallback. Selectors not in their database show up as `unknown`.
 - **L2 gas estimates are L2-execution only.** On rollups like Base, Arbitrum, Optimism, and zkSync, the actual transaction cost also includes an L1 data-posting fee that depends on calldata size and current L1 gas prices. The `gas` command does not estimate that L1 component. For Base specifically, see the network's L1 fee oracle (contract `0x420000000000000000000000000000000000000F`).
+- Injective EVM uses native INJ for gas. Wrapped token contracts such as WETH are listed only for ERC-20 balance checks; native INJ is not an ERC-20 entry in `KNOWN_TOKENS`.
 - Address / tx-hash inputs are validated for 0x-prefix + correct length + hex, but EIP-55 checksum casing is **not** enforced (RPC endpoints accept any-case hex).
 
 ---
@@ -224,4 +228,10 @@ python3 ~/.hermes/skills/blockchain/evm/scripts/evm_client.py stats
 
 # Should resolve vitalik.eth to 0xd8dA...
 python3 ~/.hermes/skills/blockchain/evm/scripts/evm_client.py ens vitalik.eth
+
+# Should print Injective block, gas price, and native INJ price when CoinGecko is available
+python3 ~/.hermes/skills/blockchain/evm/scripts/evm_client.py stats --chain injective
+
+# Should print Injective gas estimates denominated in INJ
+python3 ~/.hermes/skills/blockchain/evm/scripts/evm_client.py gas --chain injective
 ```


### PR DESCRIPTION
## What does this PR do?

Adds Injective EVM support to the optional read-only EVM blockchain skill.
Hermes users can now pass `--chain injective` to the existing EVM helper for
network stats, gas estimates, wallet/token checks, contract inspection, price
lookup, and multi-chain comparisons.

This follows the existing EVM skill registry model instead of adding a new
skill or new dependencies. Native INJ pricing uses CoinGecko coin ID
`injective-protocol`; contract-price lookup uses CoinGecko asset platform
`injective`.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added Injective EVM to `optional-skills/blockchain/evm/scripts/evm_client.py`
  with chain ID `1776`, RPC `https://sentry.evm-rpc.injective.network/`,
  explorer `https://blockscout.injective.network`, native token `INJ`, and
  18 decimals.
- Added `INJ -> injective-protocol` to `COINGECKO_IDS`.
- Added Injective's CoinGecko asset-platform mapping for token contract price
  lookup.
- Added verified Injective EVM USDC and WETH token registry entries.
- Added deterministic no-network tests in `tests/skills/test_evm_skill.py`.
- Updated `optional-skills/blockchain/evm/SKILL.md` and generated website docs
  from 8 supported chains to 9.

## How to Test

Rebased onto latest `origin/main` and revalidated on May 24, 2026:

1. `./scripts/run_tests.sh tests/skills/test_evm_skill.py tests/tools/test_skill_size_limits.py tests/tools/test_skills_hub.py tests/website/test_generate_skill_docs.py`
   - Result: `137 tests passed, 0 failed`
2. `python3 -m py_compile optional-skills/blockchain/evm/scripts/evm_client.py`
   - Result: exit 0
3. `env PATH=/Users/dearkane/.hermes/hermes-agent/venv/bin:$PATH npm run lint:diagrams`
   - Result: `Errors: 0`
4. `cd website && npm run build`
   - Result: exit 0; Docusaurus reported pre-existing broken-link/anchor warnings unrelated to this PR.
5. Live smoke: `python3 optional-skills/blockchain/evm/scripts/evm_client.py stats --chain injective`
   - Result: returned block `167905415`, gas `0.16 gwei`, native token `INJ`, price `$5.17`, and the Blockscout explorer URL.
6. Live smoke: `python3 optional-skills/blockchain/evm/scripts/evm_client.py gas --chain injective`
   - Result: returned INJ-denominated gas estimates using `0.16 gwei`.
7. Live smoke: `python3 optional-skills/blockchain/evm/scripts/evm_client.py price INJ --chain injective`
   - Result: returned source `coingecko:injective-protocol` and price `$5.17`.
8. Live wallet QA: `python3 optional-skills/blockchain/evm/scripts/evm_client.py wallet 0xa94b49b262524bfae17a7862a3c9e7d0c675877c --chain injective --limit 2`
   - Result: returned `2.80357745 INJ`, native value around `$14.49`, and no USDC/WETH holdings.
9. Live activity QA: `python3 optional-skills/blockchain/evm/scripts/evm_client.py activity 0xa94b49b262524bfae17a7862a3c9e7d0c675877c --chain injective --limit 5`
   - Result: scanned 196 recent blocks, `tx_count: 0`.

Full-suite note: I also attempted `./scripts/run_tests.sh tests/ -q` locally.
That run did not pass in this local sandboxed macOS environment (`23806 passed`,
`79 skipped`, `662 failed`, `83 errors`) with broad unrelated failures such as
permission errors writing `~/.hermes/logs/agent.log` and binding local test
sockets for gateway/browser tests. The changed EVM skill tests and docs checks
listed above pass.

Note: live `price 0x2a25fbD67b3aE485e461fe55d9DbeF302B7D3989 --chain injective`
currently returns "not found" from CoinGecko. The no-network test verifies the
helper uses the correct `/simple/token_price/injective` platform path; CoinGecko
does not appear to index that Injective USDC contract at the moment.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

No UI screenshots. See live smoke commands above.
