### PR TITLE
feat(dashboard): allow extra hostnames in Host validator via env var

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -159,6 +159,18 @@ _LOOPBACK_HOST_VALUES: frozenset = frozenset({
 })
 
 
+def _additional_accepted_hosts() -> set[str]:
+    """Extra hostnames the dashboard accepts beyond the bound interface.
+
+    Set HERMES_DASHBOARD_ADDITIONAL_HOSTS to a comma-separated list of
+    hostnames (e.g. tailnet MagicDNS names) when exposing the
+    loopback-bound dashboard via tailscale serve. The bound-loopback
+    default still rejects DNS rebinding from unrelated hostnames.
+    """
+    raw = os.environ.get("HERMES_DASHBOARD_ADDITIONAL_HOSTS", "")
+    return {h.strip().lower() for h in raw.split(",") if h.strip()}
+
+
 def _is_accepted_host(host_header: str, bound_host: str) -> bool:
     """True if the Host header targets the interface we bound to.
 
@@ -197,6 +209,9 @@ def _is_accepted_host(host_header: str, bound_host: str) -> bool:
     # Loopback bind: accept the loopback names
     bound_lc = bound_host.lower()
     if bound_lc in _LOOPBACK_HOST_VALUES:
+        extras = _additional_accepted_hosts()
+        if extras and host_only in extras:
+            return True
         return host_only in _LOOPBACK_HOST_VALUES
 
     # Explicit non-loopback bind: require exact host match

--- a/tests/hermes_cli/test_web_server_host_header.py
+++ b/tests/hermes_cli/test_web_server_host_header.py
@@ -84,6 +84,108 @@ class TestHostHeaderValidator:
         assert _is_accepted_host("LocalHost:9119", "127.0.0.1")
 
 
+class TestHostHeaderAdditionalHosts:
+    """HERMES_DASHBOARD_ADDITIONAL_HOSTS lets operators add proxy hostnames
+    (e.g. tailnet MagicDNS names) to the accept list on a loopback bind,
+    without resorting to --insecure / all-interfaces. The DNS-rebinding
+    defence must still hold for any host NOT in the list."""
+
+    def test_loopback_bind_accepts_listed_host(self, monkeypatch):
+        from hermes_cli.web_server import _is_accepted_host
+
+        monkeypatch.setenv(
+            "HERMES_DASHBOARD_ADDITIONAL_HOSTS", "magic.tailnet.ts.net"
+        )
+        for bound in ("127.0.0.1", "localhost", "::1"):
+            assert _is_accepted_host("magic.tailnet.ts.net", bound)
+            assert _is_accepted_host("magic.tailnet.ts.net:9119", bound)
+
+    def test_loopback_bind_still_rejects_attacker_hosts_with_env_set(
+        self, monkeypatch
+    ):
+        """Core safety property: adding one trusted host MUST NOT widen
+        the accept list to any other attacker-controlled hostname that
+        TTL-flips to 127.0.0.1."""
+        from hermes_cli.web_server import _is_accepted_host
+
+        monkeypatch.setenv(
+            "HERMES_DASHBOARD_ADDITIONAL_HOSTS", "magic.tailnet.ts.net"
+        )
+        for attacker in (
+            "evil.example",
+            "evil.example:9119",
+            "magic.tailnet.ts.net.attacker.test",  # suffix attack
+            "attacker.magic.tailnet.ts.net",       # subdomain ≠ listed exact
+        ):
+            assert not _is_accepted_host(attacker, "127.0.0.1"), (
+                f"attacker host {attacker!r} must still be rejected"
+            )
+
+    def test_case_insensitive_match_against_env_entries(self, monkeypatch):
+        """Env entries are normalized to lowercase; Host headers are
+        compared case-insensitively per RFC 7230."""
+        from hermes_cli.web_server import _is_accepted_host
+
+        monkeypatch.setenv(
+            "HERMES_DASHBOARD_ADDITIONAL_HOSTS", "Magic.Tailnet.TS.NET"
+        )
+        assert _is_accepted_host("magic.tailnet.ts.net", "127.0.0.1")
+        assert _is_accepted_host("MAGIC.TAILNET.TS.NET", "127.0.0.1")
+
+    def test_comma_separated_list_accepts_each_entry(self, monkeypatch):
+        from hermes_cli.web_server import _is_accepted_host
+
+        monkeypatch.setenv(
+            "HERMES_DASHBOARD_ADDITIONAL_HOSTS",
+            "a.example, b.example ,  c.example",
+        )
+        assert _is_accepted_host("a.example", "127.0.0.1")
+        assert _is_accepted_host("b.example", "127.0.0.1")
+        assert _is_accepted_host("c.example", "127.0.0.1")
+        assert not _is_accepted_host("d.example", "127.0.0.1")
+
+    def test_empty_env_var_is_no_op(self, monkeypatch):
+        """An unset or empty env var must not change existing behaviour."""
+        from hermes_cli.web_server import _is_accepted_host
+
+        monkeypatch.delenv("HERMES_DASHBOARD_ADDITIONAL_HOSTS", raising=False)
+        assert _is_accepted_host("localhost", "127.0.0.1")
+        assert not _is_accepted_host("evil.example", "127.0.0.1")
+
+        monkeypatch.setenv("HERMES_DASHBOARD_ADDITIONAL_HOSTS", "   ,  , ")
+        assert _is_accepted_host("localhost", "127.0.0.1")
+        assert not _is_accepted_host("evil.example", "127.0.0.1")
+
+    def test_additional_hosts_not_consulted_on_non_loopback_bind(
+        self, monkeypatch
+    ):
+        """When the operator bound to a specific non-loopback hostname,
+        the validator requires exact bound-host match — the additional
+        hosts list is a loopback-bind-only convenience and must not
+        weaken explicit non-loopback binds."""
+        from hermes_cli.web_server import _is_accepted_host
+
+        monkeypatch.setenv(
+            "HERMES_DASHBOARD_ADDITIONAL_HOSTS", "magic.tailnet.ts.net"
+        )
+        assert not _is_accepted_host(
+            "magic.tailnet.ts.net", "my-server.corp.net"
+        )
+        assert _is_accepted_host("my-server.corp.net", "my-server.corp.net")
+
+    def test_zero_zero_bind_still_accepts_anything(self, monkeypatch):
+        """0.0.0.0 (--insecure) accepts everything regardless of
+        HERMES_DASHBOARD_ADDITIONAL_HOSTS — the env var is meaningful
+        only on loopback binds."""
+        from hermes_cli.web_server import _is_accepted_host
+
+        monkeypatch.setenv(
+            "HERMES_DASHBOARD_ADDITIONAL_HOSTS", "magic.tailnet.ts.net"
+        )
+        assert _is_accepted_host("anything.example", "0.0.0.0")
+        assert _is_accepted_host("magic.tailnet.ts.net", "0.0.0.0")
+
+
 class TestHostHeaderMiddleware:
     """End-to-end test via the FastAPI app — verify the middleware
     rejects bad Host headers with 400."""


### PR DESCRIPTION
## Problem

The dashboard's anti-DNS-rebinding Host validator (`hermes_cli/web_server.py::_is_accepted_host`) currently accepts only the bound interface — plus loopback aliases when bound to loopback. That's correct for the default deployment but blocks operators who run the dashboard behind:

- a reverse proxy (caddy, nginx, traefik, etc.) terminating on a public hostname
- `tailscale serve` mapping a public tailnet hostname back to `127.0.0.1:9119`

In those setups the proxy forwards with the public hostname in the `Host` header, which the validator rejects with `400 "Invalid Host header. Dashboard requests must use the hostname the server was bound to."`

Bypassing this today requires `--insecure`, which binds to all interfaces and exposes API keys on the network (the CLI help calls this out explicitly). That's a much larger blast radius than the operator needs — they just want loopback bind + one or two known proxy hostnames accepted.

## Solution

A minimal env-var-gated extension:

```
HERMES_DASHBOARD_ADDITIONAL_HOSTS=host1.example,host2.example
```

When set, the loopback-bound dashboard also accepts requests whose Host header matches one of the listed hostnames. The DNS-rebinding defence is preserved for any host NOT in the list, so an attacker hostname that TTL-flips to 127.0.0.1 still gets rejected.

The opt-in is per-operator (env var), not a config-file default — so the safe behavior remains the default and operators consciously add hostnames they trust.

## Use case (concrete)

I run the dashboard loopback-bound on a Debian VM, then `sudo tailscale serve --bg --https=443 http://127.0.0.1:9119` to make it reachable from my other tailnet machines. Tailscale ACLs gate access to the tailnet; the dashboard's loopback bind keeps the API-key blast radius small; the env var bridges the gap so the validator doesn't reject the tailscale-MagicDNS Host header.

Without this patch the choice is `--insecure` (defeats the security model) or a local fork (drift risk on every upgrade).

## Test plan

A new `TestHostHeaderAdditionalHosts` class in `tests/hermes_cli/test_web_server_host_header.py` (the file annotated for GHSA-ppp5-vxwm-4cf7) covers:

- Listed hosts accepted on every loopback bind (`127.0.0.1`, `localhost`, `::1`), with and without port suffix
- **Core safety property**: attacker hostnames still rejected with env var set — including suffix attacks (`magic.tailnet.ts.net.attacker.test`) and subdomain attacks (`attacker.magic.tailnet.ts.net`)
- Case-insensitive comparison (env entries normalized to lowercase, header matched per RFC 7230)
- Comma-separated parsing with whitespace tolerance
- Empty / unset / whitespace-only env var is a true no-op
- Env var ignored on explicit non-loopback bind (doesn't weaken specific binds)
- `0.0.0.0` (`--insecure`) behavior unchanged

All 15 tests in the file pass (5 existing + 7 new + 3 middleware).

## Notes

- Self-contained: 16 lines of production code in one file, 102 lines of tests in one file
- `HERMES_DASHBOARD_ADDITIONAL_HOSTS` follows the existing `HERMES_*` env-var convention (`HERMES_QWEN_BASE_URL`, `HERMES_DOCKER_BINARY`, `HERMES_HUMAN_DELAY_MODE`, etc.)
- Helper function isolated so it's trivially testable in isolation
- No config schema change; no new CLI flag
- Comment in the new helper explains intent + security rationale