### PR TITLE
fix(telegram): drop redundant pre-flight delete_webhook + raise bootstrap_retries

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1518,11 +1518,14 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
             else:
                 # ── Polling mode (default) ───────────────────────────
-                # Clear any stale webhook first so polling doesn't inherit a
-                # previous webhook registration and silently stop receiving updates.
-                delete_webhook = getattr(self._bot, "delete_webhook", None)
-                if callable(delete_webhook):
-                    await delete_webhook(drop_pending_updates=False)
+                # PTB's Updater._bootstrap() unconditionally calls
+                # bot.delete_webhook(drop_pending_updates=...) inside a
+                # network_retry_loop bounded by ``bootstrap_retries`` (see
+                # telegram.ext._updater in PTB 22.6, ~L686+L705). Calling
+                # delete_webhook explicitly here would be redundant — and
+                # would do so with drop_pending_updates=False, which is
+                # then overridden by start_polling(drop_pending_updates=True)
+                # below, making the external call's flag wasted work.
 
                 loop = asyncio.get_running_loop()
 
@@ -1540,9 +1543,19 @@ class TelegramAdapter(BasePlatformAdapter):
                 # Store reference for retry use in _handle_polling_conflict
                 self._polling_error_callback_ref = _polling_error_callback
 
+                # bootstrap_retries=3: PTB's default is 0 (fail-fast on the
+                # very first bootstrap call). A single transient 5xx from
+                # Telegram during ``getMe`` / ``delete_webhook`` then aborts
+                # adapter startup and requires a gateway restart to recover.
+                # Three retries tolerates the common transient case without
+                # masking persistent auth/network failures. The reconnect
+                # paths (_handle_polling_network_error, _handle_polling_conflict)
+                # have their own outer back-off ladders and intentionally
+                # keep bootstrap_retries at the default so they don't compound.
                 await self._app.updater.start_polling(
                     allowed_updates=Update.ALL_TYPES,
                     drop_pending_updates=True,
+                    bootstrap_retries=3,
                     error_callback=_polling_error_callback,
                 )
             

--- a/tests/gateway/test_telegram_conflict.py
+++ b/tests/gateway/test_telegram_conflict.py
@@ -111,7 +111,14 @@ async def test_polling_conflict_retries_before_fatal(monkeypatch):
     ok = await adapter.connect()
 
     assert ok is True
-    bot.delete_webhook.assert_awaited_once_with(drop_pending_updates=False)
+    # The adapter no longer pre-clears webhooks externally — PTB's
+    # Updater._bootstrap() calls delete_webhook itself, governed by
+    # bootstrap_retries. The kwargs passed to start_polling are what
+    # matters here.
+    bot.delete_webhook.assert_not_awaited()
+    start_kwargs = updater.start_polling.await_args.kwargs
+    assert start_kwargs["drop_pending_updates"] is True
+    assert start_kwargs["bootstrap_retries"] == 3
     assert callable(captured["error_callback"])
 
     conflict = type("Conflict", (Exception,), {})
@@ -243,7 +250,11 @@ async def test_connect_marks_retryable_fatal_error_for_startup_network_failure(m
 
 
 @pytest.mark.asyncio
-async def test_connect_clears_webhook_before_polling(monkeypatch):
+async def test_connect_delegates_webhook_clear_to_ptb_bootstrap(monkeypatch):
+    """Adapter no longer pre-clears webhooks externally — PTB's
+    Updater._bootstrap() calls delete_webhook itself during start_polling,
+    governed by ``bootstrap_retries``. Adapter's job is just to pass the
+    right kwargs to start_polling."""
     adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
 
     monkeypatch.setattr(
@@ -284,7 +295,14 @@ async def test_connect_clears_webhook_before_polling(monkeypatch):
     ok = await adapter.connect()
 
     assert ok is True
-    bot.delete_webhook.assert_awaited_once_with(drop_pending_updates=False)
+    # No external pre-flight delete_webhook call:
+    bot.delete_webhook.assert_not_awaited()
+    # And start_polling is invoked with the kwargs that govern PTB's
+    # internal bootstrap (delete_webhook + getMe), including the retry
+    # budget that protects against transient bootstrap-time failures:
+    start_kwargs = updater.start_polling.await_args.kwargs
+    assert start_kwargs["drop_pending_updates"] is True
+    assert start_kwargs["bootstrap_retries"] == 3
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Two related polling-mode resilience changes in `TelegramAdapter.connect()` (gateway/platforms/telegram.py), single bootstrap call site.

## 1. Drop the pre-flight `delete_webhook` call

PTB 22.6's `Updater._bootstrap()` unconditionally calls `bot.delete_webhook(drop_pending_updates=...)` inside a `network_retry_loop` bounded by `bootstrap_retries` (see [`telegram.ext._updater`](https://github.com/python-telegram-bot/python-telegram-bot/blob/v22.6/telegram/ext/_updater.py#L686-L709), L686 + L705 comment "we just always call delete_webhook for polling"). The explicit pre-flight call here is therefore redundant.

Worse, the pre-flight passes `drop_pending_updates=False` while `start_polling` two lines later passes `drop_pending_updates=True` — so the pre-flight's flag is immediately overridden, making the call pure latency.

## 2. `bootstrap_retries=3` on `start_polling`

PTB's default is `bootstrap_retries=0`, which means the bootstrap phase (delete_webhook + getMe) fails fast on the very first transient error. A single 5xx from Telegram during adapter startup then aborts the gateway and a manual restart is required to recover.

`bootstrap_retries=3` tolerates the common transient-5xx case without masking persistent auth/network failures. With (1) above, it also gives PTB's internal delete_webhook a retry budget.

## Reconnect paths intentionally untouched

`_handle_polling_network_error` (line 899) and `_handle_polling_conflict` (line 1025) have their own outer back-off ladders (`MAX_NETWORK_RETRIES`, `MAX_CONFLICT_RETRIES`). Setting `bootstrap_retries=3` on those `start_polling` calls would compound retries inside an already-retrying outer loop, multiplying total back-off time unexpectedly. They keep the default `bootstrap_retries=0`.

## Test plan

- Existing `test_connect_clears_webhook_before_polling` renamed to `test_connect_delegates_webhook_clear_to_ptb_bootstrap` — now asserts the new contract (no external `delete_webhook`, `start_polling` receives `drop_pending_updates=True` + `bootstrap_retries=3`).
- `test_polling_conflict_retries_before_fatal` updated to the same kwargs assertion.
- Full telegram suite: 602 passed, 1 skipped (unrelated), 0 failures.
- Manual: gateway restarted during a Telegram-side 502 — bootstrap now retries up to 3× and succeeds rather than aborting on the first hiccup.