### PR TITLE
fix(extract_media): dedupe identical MEDIA tags

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2161,13 +2161,17 @@ class BasePlatformAdapter(ABC):
         media_pattern = re.compile(
             r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
         )
+        seen_paths: set[str] = set()
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()
             if len(path) >= 2 and path[0] == path[-1] and path[0] in "`\"'":
                 path = path[1:-1].strip()
             path = path.lstrip("`\"'").rstrip("`\"',.;:)}]")
             if path:
-                media.append((os.path.expanduser(path), has_voice_tag))
+                expanded = os.path.expanduser(path)
+                if expanded not in seen_paths:
+                    seen_paths.add(expanded)
+                    media.append((expanded, has_voice_tag))
 
         # Remove MEDIA tags from content (including surrounding quote/backtick wrappers)
         if media:

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -329,6 +329,31 @@ class TestExtractMedia:
         assert media == [("/tmp/Jane Doe/speech.flac", False)]
         assert cleaned == ""
 
+    def test_duplicate_media_tags_are_deduplicated(self):
+        content = "MEDIA:/tmp/test.png\nMEDIA:/tmp/test.png\nMEDIA:/tmp/other.png"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == [
+            ("/tmp/test.png", False),
+            ("/tmp/other.png", False),
+        ]
+        assert cleaned == ""
+
+    def test_duplicate_media_tags_dedup_preserves_first_occurrence_order(self):
+        content = "MEDIA:/tmp/a.png\nMEDIA:/tmp/b.png\nMEDIA:/tmp/a.png\nMEDIA:/tmp/c.png"
+        media, _ = BasePlatformAdapter.extract_media(content)
+        assert media == [
+            ("/tmp/a.png", False),
+            ("/tmp/b.png", False),
+            ("/tmp/c.png", False),
+        ]
+
+    def test_dedup_uses_expanded_path_so_tilde_and_absolute_collapse(self):
+        import os
+        home = os.path.expanduser("~")
+        content = f"MEDIA:~/foo.png\nMEDIA:{home}/foo.png"
+        media, _ = BasePlatformAdapter.extract_media(content)
+        assert media == [(f"{home}/foo.png", False)]
+
     def test_as_document_directive_stripped_from_cleaned_text(self):
         """[[as_document]] is a routing directive — strip it from
         user-visible text just like [[audio_as_voice]]. Callers detect the


### PR DESCRIPTION
## Problem

`BasePlatformAdapter.extract_media()` in `gateway/platforms/base.py` appends every MEDIA tag match without dedup. When the same file is referenced multiple times in one message (common when the agent emits MEDIA tags both inline and in a summary footer), the platform adapter uploads/sends the same file twice — visible to the user as duplicate attachments in Telegram, duplicate posts in Slack, etc.

## Fix

Set-based dedup on the expanded path, preserving first-occurrence order. The expanded form is used as the key so `~/foo.png` and `/home/me/foo.png` collapse to one entry.

## Test plan

Three new tests in `tests/gateway/test_platform_base.py`:

- `test_duplicate_media_tags_are_deduplicated` — straight identical-path case
- `test_duplicate_media_tags_dedup_preserves_first_occurrence_order` — interleaved duplicates
- `test_dedup_uses_expanded_path_so_tilde_and_absolute_collapse` — `~/x.png` and `$HOME/x.png` dedup

Existing `extract_media` tests unaffected.