### PR TITLE
feat(cli): resolve direct aliases at dispatch time

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -743,6 +743,70 @@ _cleanup_done = False
 # Weak reference to the active AIAgent for memory provider shutdown at exit
 _active_agent_ref = None
 
+
+def _resolve_direct_alias_for_chat(
+    effective_model: str,
+    current_provider: str,
+) -> Optional[Dict[str, Any]]:
+    """Resolve a model id through DIRECT_ALIASES for `hermes chat` dispatch.
+
+    Returns a dict with ``provider``, ``model``, ``base_url`` (may be ``""``)
+    on a hit, or ``None`` if the input isn't a known alias / resolves to a
+    catalog-only entry without a direct base_url. Returns ``None`` (rather
+    than raising) when ``hermes_cli.model_switch`` is unavailable — the
+    module is part of the standard install but trimmed embedded builds may
+    omit it; in that case the caller falls through to the generic
+    provider/base_url path.
+
+    See regression #16767 (chat -m <alias>) and #18954 (custom-provider
+    alias resolution) for the motivating bugs.
+    """
+    try:
+        from hermes_cli.model_switch import DIRECT_ALIASES, resolve_alias
+    except ImportError:
+        return None
+
+    alias_result = resolve_alias(effective_model, current_provider)
+    if alias_result is None:
+        return None
+
+    resolved_provider, resolved_model, resolved_alias = alias_result
+    direct_alias = DIRECT_ALIASES.get(resolved_alias)
+    return {
+        "provider": resolved_provider,
+        "model": resolved_model,
+        "base_url": (
+            getattr(direct_alias, "base_url", "") if direct_alias is not None else ""
+        ),
+    }
+
+
+def _apply_resolved_alias(
+    resolved: Dict[str, Any],
+    runtime: Dict[str, Any],
+) -> tuple[str, Dict[str, Any]]:
+    """Fold a :func:`_resolve_direct_alias_for_chat` result into a runtime dict.
+
+    Returns ``(effective_model, updated_runtime)``. Never mutates the input
+    runtime. Local direct-alias targets that don't require credentials get
+    ``api_key="no-key-required"`` so the OpenAI SDK doesn't refuse to send
+    requests; the api_mode is recomputed from the resolved provider/base_url.
+    """
+    from hermes_cli.providers import determine_api_mode
+
+    runtime = dict(runtime)
+    runtime["provider"] = resolved["provider"] or runtime.get("provider")
+    if resolved["base_url"]:
+        runtime["base_url"] = resolved["base_url"]
+        if not runtime.get("api_key"):
+            runtime["api_key"] = "no-key-required"
+    runtime["api_mode"] = determine_api_mode(
+        runtime.get("provider") or "",
+        runtime.get("base_url") or "",
+    )
+    return resolved["model"], runtime
+
+
 def _run_cleanup():
     """Run resource cleanup exactly once."""
     global _cleanup_done
@@ -4576,6 +4640,21 @@ class HermesCLI:
                 "credential_pool": getattr(self, "_credential_pool", None),
             }
             effective_model = model_override or self.model
+            if effective_model:
+                resolved = _resolve_direct_alias_for_chat(
+                    effective_model,
+                    runtime.get("provider") or self.provider or "",
+                )
+                if resolved is not None:
+                    effective_model, runtime = _apply_resolved_alias(resolved, runtime)
+                    if model_override is None and runtime_override is None:
+                        # Persist the resolved triple on the CLI instance so
+                        # /status, /switch, and the next _init_agent call see
+                        # the post-resolution state rather than the raw alias.
+                        self.model = effective_model
+                        self.provider = runtime.get("provider")
+                        self.base_url = runtime.get("base_url")
+                        self.api_mode = runtime.get("api_mode")
             self.agent = AIAgent(
                 model=effective_model,
                 api_key=runtime.get("api_key"),

--- a/tests/hermes_cli/test_regression_16767.py
+++ b/tests/hermes_cli/test_regression_16767.py
@@ -56,3 +56,142 @@ def test_resolve_named_custom_runtime_honors_explicit_base_url(monkeypatch):
     assert result["provider"] == "custom"
     assert result["api_key"] == "test-api-key"
     assert result["source"] == "direct-alias"
+
+
+# ---------------------------------------------------------------------------
+# `hermes chat -m <direct-alias>` resolves to the underlying runtime
+# Covers #16767 (chat -m <alias>) and #18954 (custom-provider alias resolution)
+# ---------------------------------------------------------------------------
+
+
+class TestChatDispatchDirectAliasResolution:
+    """Before this fix, `hermes chat -m <alias-listed-in-DIRECT_ALIASES>`
+    handed the raw alias to AIAgent and the agent emitted "unknown
+    provider/model" because the alias was never translated to its
+    underlying (provider, base_url, model_id, api_mode) triple."""
+
+    def test_alias_resolution_swaps_in_runtime(self, monkeypatch):
+        """Resolving an alias must update provider, model, base_url, and
+        api_mode in the runtime dict — without mutating the caller's dict."""
+        from cli import _resolve_direct_alias_for_chat, _apply_resolved_alias
+
+        # Stub out resolve_alias to return a known direct hit
+        import hermes_cli.model_switch as ms
+
+        monkeypatch.setitem(
+            ms.DIRECT_ALIASES,
+            "fake-alias",
+            ms.DirectAlias(
+                model="vendor/full-model-id:v2",
+                provider="custom",
+                base_url="http://192.0.2.10:8080/v1",
+            ),
+        )
+        monkeypatch.setattr(
+            ms,
+            "resolve_alias",
+            lambda raw, prov: (
+                "custom",
+                "vendor/full-model-id:v2",
+                "fake-alias",
+            ),
+        )
+
+        resolved = _resolve_direct_alias_for_chat("fake-alias", "")
+        assert resolved == {
+            "provider": "custom",
+            "model": "vendor/full-model-id:v2",
+            "base_url": "http://192.0.2.10:8080/v1",
+        }
+
+        original_runtime = {
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": None,
+            "api_mode": "responses",
+        }
+        effective_model, new_runtime = _apply_resolved_alias(
+            resolved, original_runtime
+        )
+
+        # Caller's dict must not be mutated:
+        assert original_runtime["provider"] == "openrouter"
+        assert original_runtime["base_url"] == "https://openrouter.ai/api/v1"
+
+        # Resolved runtime points at the alias target:
+        assert effective_model == "vendor/full-model-id:v2"
+        assert new_runtime["provider"] == "custom"
+        assert new_runtime["base_url"] == "http://192.0.2.10:8080/v1"
+        # Local/local-style targets get a placeholder key so the OpenAI SDK
+        # doesn't refuse to send the request:
+        assert new_runtime["api_key"] == "no-key-required"
+        # api_mode is recomputed from the resolved provider/base_url:
+        assert new_runtime["api_mode"]
+
+    def test_unknown_alias_returns_none(self, monkeypatch):
+        """Non-alias inputs must fall through to the generic dispatch path."""
+        from cli import _resolve_direct_alias_for_chat
+        import hermes_cli.model_switch as ms
+
+        monkeypatch.setattr(ms, "resolve_alias", lambda raw, prov: None)
+        assert _resolve_direct_alias_for_chat("not-an-alias", "") is None
+
+    def test_existing_api_key_is_preserved(self, monkeypatch):
+        """If the caller already passed an api_key (e.g. custom provider
+        with credentials), the resolver must not clobber it with the
+        ``no-key-required`` placeholder."""
+        from cli import _apply_resolved_alias
+
+        resolved = {
+            "provider": "custom",
+            "model": "vendor/x:v1",
+            "base_url": "http://192.0.2.10:8080/v1",
+        }
+        original = {
+            "provider": "custom",
+            "base_url": "http://old/",
+            "api_key": "real-key",
+            "api_mode": "",
+        }
+        _, new_runtime = _apply_resolved_alias(resolved, original)
+        assert new_runtime["api_key"] == "real-key"
+
+    def test_alias_without_base_url_does_not_set_one(self, monkeypatch):
+        """Catalog-only aliases (no DirectAlias.base_url) must not blank
+        out an existing base_url."""
+        from cli import _apply_resolved_alias
+
+        resolved = {
+            "provider": "openrouter",
+            "model": "vendor/full-id",
+            "base_url": "",
+        }
+        original = {
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "sk-or-...",
+            "api_mode": "responses",
+        }
+        _, new_runtime = _apply_resolved_alias(resolved, original)
+        assert new_runtime["base_url"] == "https://openrouter.ai/api/v1"
+
+    def test_missing_model_switch_module_returns_none(self, monkeypatch):
+        """Trimmed embedded installs may omit hermes_cli.model_switch;
+        the resolver must degrade gracefully so chat dispatch falls
+        through to the generic provider/base_url path."""
+        from cli import _resolve_direct_alias_for_chat
+        import importlib
+        import sys
+
+        # Pretend the module isn't importable — the resolver catches
+        # ImportError specifically (not all exceptions).
+        sys.modules.pop("hermes_cli.model_switch", None)
+        real_import = importlib.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "hermes_cli.model_switch":
+                raise ImportError("trimmed install")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.__import__", fake_import)
+        assert _resolve_direct_alias_for_chat("any-alias", "") is None


### PR DESCRIPTION
## Problem

When `hermes chat` is invoked with a model id that lives in `hermes_cli.model_switch.DIRECT_ALIASES` (custom providers, local runtimes, ad-hoc `base_url` overrides), the CLI hands the raw alias to `AIAgent` and the agent emits "unknown provider/model" — the alias never gets translated to its underlying `(provider, base_url, model_id, api_mode)` triple.

Same surface as:

- **#18954** (open) — *Model aliases not resolved for custom providers*. This PR addresses the dispatch-time half of that bug.
- **#16767** (closed; regression test file `tests/hermes_cli/test_regression_16767.py` exists) — *CLI doesn't honor user-defined providers via chat --provider or -m <alias>*. New tests for this PR land in that same file.

Other call sites already perform direct-alias resolution at their dispatch points (`hermes_cli/oneshot.py:269`, `hermes_cli/commands.py:1542-1544`). The interactive `hermes chat` path was missing.

## Fix

Two pure helpers in `cli.py`:

- `_resolve_direct_alias_for_chat(effective_model, current_provider)` — wraps `model_switch.resolve_alias` and returns a small dict, or `None` when the input isn't a known alias.
- `_apply_resolved_alias(resolved, runtime)` — folds the resolved triple into a copy of the runtime dict; recomputes `api_mode` via `determine_api_mode`; preserves any caller-supplied `api_key`; only sets `no-key-required` for local targets that have no key.

`HermesCLI._init_agent` calls them before constructing `AIAgent`.

## Behavioural notes a reviewer will want to see

1. **Explicit overrides still win.** `self.model / self.provider / self.base_url / self.api_mode` are mutated only when both `model_override` and `runtime_override` are `None` — i.e. the interactive default path. Callers passing `--model` or `--runtime` get the resolved triple in the agent but `self.*` is left alone.
2. **`ImportError`, not bare `Exception`.** Trimmed embedded installs may omit `hermes_cli.model_switch`. The resolver catches `ImportError` specifically so a real `AttributeError` or `KeyError` from inside `resolve_alias` still propagates.
3. **No double `_ensure_direct_aliases()` call.** `resolve_alias` already does this internally (`hermes_cli/model_switch.py:469`).
4. **Caller's runtime dict isn't mutated.** `_apply_resolved_alias` copies before writing.

## Test plan

5 new tests in `tests/hermes_cli/test_regression_16767.py`, class `TestChatDispatchDirectAliasResolution`:

- `test_alias_resolution_swaps_in_runtime` — happy path, asserts model/provider/base_url/api_mode swap and the caller's dict isn't mutated
- `test_unknown_alias_returns_none` — non-alias inputs fall through
- `test_existing_api_key_is_preserved` — `no-key-required` placeholder doesn't clobber real keys
- `test_alias_without_base_url_does_not_set_one` — catalog-only aliases don't blank an existing base_url
- `test_missing_model_switch_module_returns_none` — `ImportError` path degrades gracefully

All 8 tests in the file pass (3 existing + 5 new).