### PR TITLE
fix(gateway): add TTL for background processes blocking session reset + log skip reason

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -799,6 +799,11 @@ class SessionStore:
         if self._has_active_processes_fn:
             session_key = self._generate_session_key(source)
             if self._has_active_processes_fn(session_key):
+                import logging as _logging
+                _logging.getLogger(__name__).info(
+                    "Session reset skipped for %s — active background process(es) present",
+                    session_key,
+                )
                 return None
 
         policy = self.config.get_reset_policy(

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1233,17 +1233,34 @@ class ProcessRegistry:
                 for s in self._running.values()
             )
 
-    def has_active_for_session(self, session_key: str) -> bool:
-        """Check if there are active processes for a gateway session key."""
+    # Maximum age (seconds) for a background process to block session reset.
+    # Processes older than this are treated as stale and ignored by the
+    # reset guard — preview servers and forgotten dev tools started days ago
+    # should not keep a session alive forever (issue #29177).
+    BACKGROUND_PROCESS_RESET_BLOCK_TTL: int = 4 * 3600  # 4 hours
+
+    def has_active_for_session(self, session_key: str, max_age_seconds: Optional[int] = None) -> bool:
+        """Check if there are active non-stale processes for a gateway session key.
+
+        Processes older than ``max_age_seconds`` (default: BACKGROUND_PROCESS_RESET_BLOCK_TTL)
+        are considered stale and do not block session reset — they are not killed,
+        just ignored by the guard (issue #29177).
+        """
         with self._lock:
             sessions = list(self._running.values())
 
         for session in sessions:
             self._refresh_detached_session(session)
 
+        if max_age_seconds is None:
+            max_age_seconds = self.BACKGROUND_PROCESS_RESET_BLOCK_TTL
+
+        now = time.time()
         with self._lock:
             return any(
-                s.session_key == session_key and not s.exited
+                s.session_key == session_key
+                and not s.exited
+                and (now - s.started_at) < max_age_seconds
                 for s in self._running.values()
             )
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1188,15 +1188,28 @@ class ProcessRegistry:
         except Exception as e:
             return {"status": "error", "error": str(e)}
 
-    def list_sessions(self, task_id: str = None) -> list:
-        """List all running and recently-finished processes."""
+    def list_sessions(self, task_id: str = None, session_key: str = None) -> list:
+        """List all running and recently-finished processes.
+
+        When task_id is given, only processes for that task are returned.
+        When session_key is given, processes for all tasks under that gateway
+        session are also included — this surfaces session-scoped background
+        processes that would otherwise be invisible to the agent (issue #29177).
+        """
         with self._lock:
             all_sessions = list(self._running.values()) + list(self._finished.values())
 
         all_sessions = [self._refresh_detached_session(s) for s in all_sessions]
 
-        if task_id:
-            all_sessions = [s for s in all_sessions if s.task_id == task_id]
+        if task_id and not session_key:
+            # Also include session-scoped processes (background: true) that
+            # block gateway reset — the agent must be able to see them.
+            all_sessions = [
+                s for s in all_sessions
+                if s.task_id == task_id or s.session_key == task_id
+            ]
+        elif session_key:
+            all_sessions = [s for s in all_sessions if s.session_key == session_key]
 
         result = []
         for s in all_sessions:


### PR DESCRIPTION
## Problem

Three bugs in background process / session reset handling (issue #29177):

1. No TTL — preview servers started days ago permanently block session reset
2. Agent process list is task-scoped — session-scoped background processes invisible to agent
3. Reset skip is completely silent — no log

## Fix

1. **process_registry.py**: `has_active_for_session()` ignores processes older than 4h (BACKGROUND_PROCESS_RESET_BLOCK_TTL)
2. **process_registry.py**: `list_sessions()` now includes session-scoped background processes so agents can see what is blocking reset
3. **session.py**: INFO log when session reset is skipped due to active background processes

Fixes #29177