### PR TITLE
fix(kanban): run column migrations before SCHEMA_SQL on existing DBs

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -999,6 +999,15 @@ def connect(
             conn.execute("PRAGMA foreign_keys=ON")
             needs_init = resolved not in _INITIALIZED_PATHS
             if needs_init:
+                # If the tasks table already exists, run additive column
+                # migrations *before* SCHEMA_SQL so that any indexes in
+                # SCHEMA_SQL referencing columns added in newer releases
+                # (e.g. session_id) don't fail with "no such column" on
+                # pre-existing databases that predate those columns.
+                if conn.execute(
+                    "SELECT 1 FROM sqlite_master WHERE type='table' AND name='tasks'"
+                ).fetchone():
+                    _migrate_add_optional_columns(conn)
                 # Idempotent: runs CREATE TABLE IF NOT EXISTS + the additive
                 # migrations. Cached so subsequent connect() calls in the same
                 # process are cheap. The lock prevents same-process dispatcher


### PR DESCRIPTION
## Summary

Fixes a bug where gateway upgrades cause 100% CPU and broken kanban dispatcher.

## Root Cause

`conn.executescript(SCHEMA_SQL)` references columns (e.g. `session_id`) via index creation that don't exist in pre-existing databases. The old code ran SCHEMA_SQL first, which would fail when trying to `CREATE INDEX` on a missing column, preventing `_migrate_add_optional_columns()` from ever running.

## Fix

Check if the tasks table already exists before running SCHEMA_SQL. If it does, run additive column migrations FIRST so all columns exist before any index creation attempts. The post-SCHEMA_SQL migration call is kept (idempotent) to handle fresh databases.

## Reproduction

1. Run an older version of Hermes Agent that creates kanban.db without `session_id` column
2. Upgrade to a version that includes `session_id` in SCHEMA_SQL
3. Gateway dispatcher enters tight retry loop at 100% CPU with:
   `sqlite3.OperationalError: no such column: session_id`

## Test Plan

- [ ] Fresh install: kanban.db created correctly with all columns and indexes
- [ ] Upgrade from pre-session_id DB: migration runs first, SCHEMA_SQL succeeds
- [ ] Gateway dispatcher starts without errors