### PR TITLE
fix(stt): bound local transcription subprocess calls with timeout

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -824,6 +824,7 @@ stt:
   # provider: "local"          # auto-detected if omitted
   local:
     model: "base"              # tiny | base | small | medium | large-v3 | turbo
+    command_timeout: 300       # Max seconds for local whisper CLI / ffmpeg fallback commands
     # language: ""             # auto-detect; set to "en", "es", "fr", etc. to force
   openai:
     model: "whisper-1"         # whisper-1 | gpt-4o-mini-transcribe | gpt-4o-transcribe

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1153,6 +1153,7 @@ DEFAULT_CONFIG = {
         "local": {
             "model": "base",  # tiny, base, small, medium, large-v3
             "language": "",  # auto-detect by default; set to "en", "es", "fr", etc. to force
+            "command_timeout": 300,  # Max seconds for local whisper CLI / ffmpeg fallback commands
         },
         "openai": {
             "model": "whisper-1",  # whisper-1, gpt-4o-mini-transcribe, gpt-4o-transcribe

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -354,6 +354,19 @@ class TestTranscribeOpenAIExtended:
 
 
 class TestTranscribeLocalCommand:
+    def _patch_tempdir(self, monkeypatch, out_dir):
+        def fake_tempdir(prefix=None):
+            class _TempDir:
+                def __enter__(self_inner):
+                    return str(out_dir)
+
+                def __exit__(self_inner, exc_type, exc, tb):
+                    return False
+
+            return _TempDir()
+
+        monkeypatch.setattr("tools.transcription_tools.tempfile.TemporaryDirectory", fake_tempdir)
+
     def test_auto_detects_local_whisper_binary(self, monkeypatch):
         monkeypatch.delenv("HERMES_LOCAL_STT_COMMAND", raising=False)
         monkeypatch.setattr("tools.transcription_tools._find_whisper_binary", lambda: "/opt/homebrew/bin/whisper")
@@ -377,16 +390,6 @@ class TestTranscribeLocalCommand:
         )
         monkeypatch.setenv("HERMES_LOCAL_STT_LANGUAGE", "en")
 
-        def fake_tempdir(prefix=None):
-            class _TempDir:
-                def __enter__(self_inner):
-                    return str(out_dir)
-
-                def __exit__(self_inner, exc_type, exc, tb):
-                    return False
-
-            return _TempDir()
-
         def fake_run(cmd, *args, **kwargs):
             if isinstance(cmd, list):
                 output_path = cmd[-1]
@@ -397,7 +400,7 @@ class TestTranscribeLocalCommand:
             (out_dir / "test.txt").write_text("hello from local command\n", encoding="utf-8")
             return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 
-        monkeypatch.setattr("tools.transcription_tools.tempfile.TemporaryDirectory", fake_tempdir)
+        self._patch_tempdir(monkeypatch, out_dir)
         monkeypatch.setattr("tools.transcription_tools._find_ffmpeg_binary", lambda: "/opt/homebrew/bin/ffmpeg")
         monkeypatch.setattr("tools.transcription_tools.subprocess.run", fake_run)
 
@@ -408,6 +411,110 @@ class TestTranscribeLocalCommand:
         assert result["success"] is True
         assert result["transcript"] == "hello from local command"
         assert result["provider"] == "local_command"
+
+    def test_command_fallback_passes_configured_timeout(self, monkeypatch, sample_ogg, tmp_path):
+        out_dir = tmp_path / "local-out"
+        out_dir.mkdir()
+        timeouts = []
+
+        monkeypatch.setenv(
+            "HERMES_LOCAL_STT_COMMAND",
+            "whisper {input_path} --model {model} --output_dir {output_dir} --language {language}",
+        )
+        monkeypatch.setattr(
+            "tools.transcription_tools._load_stt_config",
+            lambda: {"local": {"language": "en", "command_timeout": 42}},
+        )
+
+        def fake_run(cmd, *args, **kwargs):
+            timeouts.append(kwargs.get("timeout"))
+            if isinstance(cmd, list):
+                output_path = cmd[-1]
+                with open(output_path, "wb") as handle:
+                    handle.write(b"RIFF....WAVEfmt ")
+            else:
+                (out_dir / "test.txt").write_text("hello\n", encoding="utf-8")
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        self._patch_tempdir(monkeypatch, out_dir)
+        monkeypatch.setattr("tools.transcription_tools._find_ffmpeg_binary", lambda: "/usr/bin/ffmpeg")
+        monkeypatch.setattr("tools.transcription_tools.subprocess.run", fake_run)
+
+        from tools.transcription_tools import _transcribe_local_command
+
+        result = _transcribe_local_command(sample_ogg, "base")
+
+        assert result["success"] is True
+        assert timeouts == [42.0, 42.0]
+
+    def test_command_timeout_invalid_config_falls_back(self):
+        from tools.transcription_tools import (
+            DEFAULT_LOCAL_STT_COMMAND_TIMEOUT_SECONDS,
+            _get_local_command_timeout,
+        )
+
+        assert _get_local_command_timeout({"command_timeout": "slow"}) == float(
+            DEFAULT_LOCAL_STT_COMMAND_TIMEOUT_SECONDS
+        )
+        assert _get_local_command_timeout({"command_timeout": 0}) == float(
+            DEFAULT_LOCAL_STT_COMMAND_TIMEOUT_SECONDS
+        )
+
+    def test_ffmpeg_timeout_returns_readable_error(self, monkeypatch, sample_ogg, tmp_path):
+        out_dir = tmp_path / "local-out"
+        out_dir.mkdir()
+
+        monkeypatch.setenv(
+            "HERMES_LOCAL_STT_COMMAND",
+            "whisper {input_path} --model {model} --output_dir {output_dir} --language {language}",
+        )
+        monkeypatch.setattr(
+            "tools.transcription_tools._load_stt_config",
+            lambda: {"local": {"command_timeout": 7}},
+        )
+
+        def fake_run(cmd, *args, **kwargs):
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=kwargs.get("timeout"))
+
+        self._patch_tempdir(monkeypatch, out_dir)
+        monkeypatch.setattr("tools.transcription_tools._find_ffmpeg_binary", lambda: "/usr/bin/ffmpeg")
+        monkeypatch.setattr("tools.transcription_tools.subprocess.run", fake_run)
+
+        from tools.transcription_tools import _transcribe_local_command
+
+        result = _transcribe_local_command(sample_ogg, "base")
+
+        assert result["success"] is False
+        assert result["error"] == "Timed out converting audio for local STT after 7s"
+
+    def test_local_command_timeout_returns_readable_error(self, monkeypatch, sample_wav, tmp_path):
+        out_dir = tmp_path / "local-out"
+        out_dir.mkdir()
+        calls = []
+
+        monkeypatch.setenv(
+            "HERMES_LOCAL_STT_COMMAND",
+            "whisper {input_path} --model {model} --output_dir {output_dir} --language {language}",
+        )
+        monkeypatch.setattr(
+            "tools.transcription_tools._load_stt_config",
+            lambda: {"local": {"command_timeout": 9}},
+        )
+
+        def fake_run(cmd, *args, **kwargs):
+            calls.append((cmd, kwargs))
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=kwargs.get("timeout"))
+
+        self._patch_tempdir(monkeypatch, out_dir)
+        monkeypatch.setattr("tools.transcription_tools.subprocess.run", fake_run)
+
+        from tools.transcription_tools import _transcribe_local_command
+
+        result = _transcribe_local_command(sample_wav, "base")
+
+        assert result["success"] is False
+        assert result["error"] == "Local STT timed out after 9s"
+        assert calls[0][1]["timeout"] == 9.0
 
 
 # ============================================================================

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -87,6 +87,7 @@ DEFAULT_MISTRAL_STT_MODEL = os.getenv("STT_MISTRAL_MODEL", "voxtral-mini-latest"
 LOCAL_STT_COMMAND_ENV = "HERMES_LOCAL_STT_COMMAND"
 LOCAL_STT_LANGUAGE_ENV = "HERMES_LOCAL_STT_LANGUAGE"
 COMMON_LOCAL_BIN_DIRS = ("/opt/homebrew/bin", "/usr/local/bin")
+DEFAULT_LOCAL_STT_COMMAND_TIMEOUT_SECONDS = 300
 
 GROQ_BASE_URL = os.getenv("GROQ_BASE_URL", "https://api.groq.com/openai/v1")
 OPENAI_BASE_URL = os.getenv("STT_OPENAI_BASE_URL", "https://api.openai.com/v1")
@@ -195,6 +196,26 @@ def _normalize_local_model(model_name: Optional[str]) -> str:
 
 def _normalize_local_command_model(model_name: Optional[str]) -> str:
     return _normalize_local_model(model_name)
+
+
+def _get_local_command_timeout(local_config: Optional[dict] = None) -> float:
+    """Return the timeout for local STT subprocess calls."""
+    if local_config is None:
+        local_config = _load_stt_config().get("local", {})
+    raw = local_config.get(
+        "command_timeout",
+        local_config.get(
+            "timeout_seconds",
+            local_config.get("timeout", DEFAULT_LOCAL_STT_COMMAND_TIMEOUT_SECONDS),
+        ),
+    )
+    try:
+        timeout = float(raw)
+    except (TypeError, ValueError):
+        return float(DEFAULT_LOCAL_STT_COMMAND_TIMEOUT_SECONDS)
+    if timeout <= 0:
+        return float(DEFAULT_LOCAL_STT_COMMAND_TIMEOUT_SECONDS)
+    return timeout
 
 
 def _get_provider(stt_config: dict) -> str:
@@ -458,7 +479,7 @@ def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:
         return {"success": False, "transcript": "", "error": f"Local transcription failed: {e}"}
 
 
-def _prepare_local_audio(file_path: str, work_dir: str) -> tuple[Optional[str], Optional[str]]:
+def _prepare_local_audio(file_path: str, work_dir: str, timeout: float) -> tuple[Optional[str], Optional[str]]:
     """Normalize audio for local CLI STT when needed."""
     audio_path = Path(file_path)
     if audio_path.suffix.lower() in LOCAL_NATIVE_AUDIO_FORMATS:
@@ -472,8 +493,11 @@ def _prepare_local_audio(file_path: str, work_dir: str) -> tuple[Optional[str], 
     command = [ffmpeg, "-y", "-i", file_path, converted_path]
 
     try:
-        subprocess.run(command, check=True, capture_output=True, text=True)
+        subprocess.run(command, check=True, capture_output=True, text=True, timeout=timeout)
         return converted_path, None
+    except subprocess.TimeoutExpired:
+        logger.error("ffmpeg conversion timed out for %s after %.1fs", file_path, timeout)
+        return None, f"Timed out converting audio for local STT after {timeout:g}s"
     except subprocess.CalledProcessError as e:
         details = e.stderr.strip() or e.stdout.strip() or str(e)
         logger.error("ffmpeg conversion failed for %s: %s", file_path, details)
@@ -493,16 +517,18 @@ def _transcribe_local_command(file_path: str, model_name: str) -> Dict[str, Any]
         }
 
     # Language: config.yaml (stt.local.language) > env var > "en" default.
+    local_config = _load_stt_config().get("local", {})
     language = (
-        _load_stt_config().get("local", {}).get("language")
+        local_config.get("language")
         or os.getenv(LOCAL_STT_LANGUAGE_ENV)
         or DEFAULT_LOCAL_STT_LANGUAGE
     )
+    timeout = _get_local_command_timeout(local_config)
     normalized_model = _normalize_local_command_model(model_name)
 
     try:
         with tempfile.TemporaryDirectory(prefix="hermes-local-stt-") as output_dir:
-            prepared_input, prep_error = _prepare_local_audio(file_path, output_dir)
+            prepared_input, prep_error = _prepare_local_audio(file_path, output_dir, timeout)
             if prep_error:
                 return {"success": False, "transcript": "", "error": prep_error}
 
@@ -515,9 +541,9 @@ def _transcribe_local_command(file_path: str, model_name: str) -> Dict[str, Any]
             # User-provided templates (env var) may contain shell syntax; auto-detected commands are safe for list mode.
             use_shell = bool(os.getenv(LOCAL_STT_COMMAND_ENV, "").strip())
             if use_shell:
-                subprocess.run(command, shell=True, check=True, capture_output=True, text=True)
+                subprocess.run(command, shell=True, check=True, capture_output=True, text=True, timeout=timeout)
             else:
-                subprocess.run(shlex.split(command), check=True, capture_output=True, text=True)
+                subprocess.run(shlex.split(command), check=True, capture_output=True, text=True, timeout=timeout)
             
 
             txt_files = sorted(Path(output_dir).glob("*.txt"))
@@ -547,6 +573,10 @@ def _transcribe_local_command(file_path: str, model_name: str) -> Dict[str, Any]
         details = e.stderr.strip() or e.stdout.strip() or str(e)
         logger.error("Local STT command failed for %s: %s", file_path, details)
         return {"success": False, "transcript": "", "error": f"Local STT failed: {details}"}
+    except subprocess.TimeoutExpired as e:
+        elapsed = e.timeout if e.timeout is not None else timeout
+        logger.error("Local STT command timed out for %s after %.1fs", file_path, elapsed)
+        return {"success": False, "transcript": "", "error": f"Local STT timed out after {elapsed:g}s"}
     except Exception as e:
         logger.error("Unexpected error during local command transcription: %s", e, exc_info=True)
         return {"success": False, "transcript": "", "error": f"Local transcription failed: {e}"}


### PR DESCRIPTION

## Summary

This PR prevents local speech-to-text transcription from blocking an agent or gateway turn indefinitely when an external local process hangs.

The local STT fallback previously ran both ffmpeg audio conversion and the local whisper command without a subprocess timeout. If either process stalled, voice-note transcription could hang the current turn until the process was killed externally.

## Changes

- Add `stt.local.command_timeout` with a default of `300` seconds.
- Apply the timeout to ffmpeg conversion used by the local command STT fallback.
- Apply the same timeout to user-configured and auto-detected local whisper command execution.
- Return readable timeout errors instead of surfacing raw `TimeoutExpired` exceptions or hanging.
- Keep compatibility aliases for `stt.local.timeout_seconds` and `stt.local.timeout`.
- Document the new setting in `cli-config.yaml.example`.
- Add regression tests covering:
  - configured timeout propagation to ffmpeg and local STT command calls
  - invalid timeout config fallback
  - ffmpeg timeout error handling
  - local command timeout error handling

## Why

Gateway voice messages use STT during message handling. A hung ffmpeg process or local whisper command can otherwise block the gateway/agent turn indefinitely. Bounding these subprocess calls keeps local transcription failures contained and recoverable.

## Testing

- `.\.venv\Scripts\python.exe -m pytest tests\tools\test_transcription_tools.py -q -o addopts=`
  - `92 passed, 7 skipped`
- `.\.venv\Scripts\ruff.exe check tools\transcription_tools.py tests\tools\test_transcription_tools.py hermes_cli\config.py`
  - passed
- `git diff --check`
  - passed

