### PR TITLE
fix(delegate): handle list-form tool message content (#28639)

### DIFF
--- a/tests/tools/test_delegate_list_content.py
+++ b/tests/tools/test_delegate_list_content.py
@@ -1,0 +1,89 @@
+"""Regression tests for issue #28639.
+
+``delegate_task`` crashed with ``AttributeError: 'list' object has no
+attribute 'lstrip'`` when a tool message ``content`` was a list (e.g.
+OpenAI-style multimodal ``[{"type": "text", "text": "..."}]`` parts).
+These tests cover both the low-level error detector and the
+``_normalize_tool_content`` helper used at the tool_trace call site.
+"""
+
+from __future__ import annotations
+
+from tools.delegate_tool import (
+    _looks_like_error_output,
+    _normalize_tool_content,
+)
+
+
+# --- _normalize_tool_content -------------------------------------------------
+
+
+def test_normalize_none_returns_empty_string():
+    assert _normalize_tool_content(None) == ""
+
+
+def test_normalize_string_passthrough():
+    assert _normalize_tool_content("hello") == "hello"
+
+
+def test_normalize_list_of_text_parts_joins_text():
+    content = [
+        {"type": "text", "text": "first line"},
+        {"type": "text", "text": "second line"},
+    ]
+    assert _normalize_tool_content(content) == "first line\nsecond line"
+
+
+def test_normalize_list_with_non_text_part_is_serialized_not_crashed():
+    content = [
+        {"type": "text", "text": "see image"},
+        {"type": "image_url", "image_url": {"url": "data:..."}},
+    ]
+    out = _normalize_tool_content(content)
+    assert "see image" in out
+    # non-text part must not raise and must contribute *something* to the
+    # serialized output so byte counts stay non-zero.
+    assert "image_url" in out
+
+
+def test_normalize_list_of_strings():
+    assert _normalize_tool_content(["a", "b"]) == "a\nb"
+
+
+def test_normalize_dict_with_text_key():
+    assert _normalize_tool_content({"text": "ok"}) == "ok"
+
+
+def test_normalize_dict_without_text_key_json_encodes():
+    out = _normalize_tool_content({"foo": "bar"})
+    assert "foo" in out and "bar" in out
+
+
+# --- _looks_like_error_output ------------------------------------------------
+
+
+def test_looks_like_error_output_accepts_list_content():
+    # This is the exact crash from the issue traceback: a list-form
+    # tool message content used to raise AttributeError on .lstrip().
+    content = [{"type": "text", "text": "error: boom"}]
+    assert _looks_like_error_output(content) is True
+
+
+def test_looks_like_error_output_list_with_plain_text_not_error():
+    content = [{"type": "text", "text": "all good here"}]
+    assert _looks_like_error_output(content) is False
+
+
+def test_looks_like_error_output_empty_list_not_error():
+    assert _looks_like_error_output([]) is False
+
+
+def test_looks_like_error_output_dict_json_error_key():
+    # dict content surfaced via normalization should still be detected.
+    assert _looks_like_error_output({"error": "nope"}) is True
+
+
+def test_looks_like_error_output_string_still_works():
+    # Regression guard: the original string fast-path must keep working.
+    assert _looks_like_error_output("Traceback (most recent call last):") is True
+    assert _looks_like_error_output("just a normal log line") is False

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -274,7 +274,50 @@ def _extract_output_tail(
     return tail
 
 
-def _looks_like_error_output(content: str) -> bool:
+def _normalize_tool_content(content: Any) -> str:
+    """Coerce a tool message ``content`` value to a string for inspection.
+
+    OpenAI-style multimodal messages may pass ``content`` as a list of
+    ``{"type": "text", "text": "..."}`` (and/or image) parts.  Older or
+    custom providers may pass a dict or raw object.  Return a best-effort
+    string so downstream heuristics (error detection, byte counting) do
+    not crash with ``AttributeError`` on non-string content.
+    """
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for part in content:
+            if isinstance(part, str):
+                parts.append(part)
+            elif isinstance(part, dict):
+                text = part.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+                else:
+                    # Fall back to a stable serialization for non-text parts
+                    # (e.g. image_url) so byte counts stay meaningful.
+                    try:
+                        parts.append(json.dumps(part, ensure_ascii=False))
+                    except Exception:
+                        parts.append(str(part))
+            else:
+                parts.append(str(part))
+        return "\n".join(parts)
+    if isinstance(content, dict):
+        text = content.get("text")
+        if isinstance(text, str):
+            return text
+        try:
+            return json.dumps(content, ensure_ascii=False)
+        except Exception:
+            return str(content)
+    return str(content)
+
+
+def _looks_like_error_output(content: Any) -> bool:
     """Conservative stderr/error detector for tool-result previews.
 
     The old heuristic flagged any preview containing the substring "error",
@@ -286,6 +329,11 @@ def _looks_like_error_output(content: str) -> bool:
     """
     if not content:
         return False
+
+    if not isinstance(content, str):
+        content = _normalize_tool_content(content)
+        if not content:
+            return False
 
     head = content.lstrip()
     if head.startswith("{") or head.startswith("["):
@@ -1653,7 +1701,7 @@ def _run_single_child(
                         if tc_id:
                             trace_by_id[tc_id] = entry_t
                 elif msg.get("role") == "tool":
-                    content = msg.get("content", "")
+                    content = _normalize_tool_content(msg.get("content", ""))
                     is_error = _looks_like_error_output(content)
                     result_meta = {
                         "result_bytes": len(content),


### PR DESCRIPTION
## Summary

Fixes #28639. `delegate_task` crashed with `AttributeError: 'list' object has no attribute 'lstrip'` whenever the inner tool message `content` was OpenAI-style multimodal (list of `{type,text}` parts) or any non-string value. Root cause: `tools/delegate_tool.py:1656` passed the raw content to `_looks_like_error_output()`, which calls `.lstrip()` assuming `str`.

## Changes

- New `_normalize_tool_content(content) -> str` helper that extracts `text` from list parts (joined), JSON-serializes dict / non-text parts so `len(content)` stays meaningful, and `str()`-falls-back otherwise.
- Call site at `tools/delegate_tool.py:1656` normalizes before `_looks_like_error_output` and before `len(content)`.
- Defense-in-depth: `_looks_like_error_output` now accepts `Any` and normalizes internally so future callers don't regress.

## Test plan
- [x] 12 regression tests in `tests/tools/test_delegate_list_content.py` covering list / dict / None / string content for both helpers, including the exact `[{"type":"text","text":"error: boom"}]` shape from the issue traceback. All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)