### PR TITLE
fix(process): surface cross-scope background processes in agent process list

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -363,6 +363,43 @@ class TestListSessions:
         assert "pid" in entry
         assert "output_preview" in entry
 
+    # --- cross-scope visibility (issue #29177, Bug 2) --------------------
+
+    def test_task_scope_hides_other_running_by_default(self, registry):
+        """Default behavior is unchanged: a task only sees its own processes."""
+        mine = _make_session(sid="proc_mine", task_id="t1")
+        other = _make_session(sid="proc_other", task_id="t2")
+        registry._running[mine.id] = mine
+        registry._running[other.id] = other
+        result = registry.list_sessions(task_id="t1")
+        assert [e["session_id"] for e in result] == ["proc_mine"]
+
+    def test_include_other_running_surfaces_cross_scope_processes(self, registry):
+        """include_other_running exposes background procs in other scopes —
+        e.g. a preview server blocking session reset that the agent's own
+        task scope cannot otherwise see (returned [] pre-fix)."""
+        mine = _make_session(sid="proc_mine", task_id="t1")
+        other = _make_session(sid="proc_server", task_id="t2")
+        registry._running[mine.id] = mine
+        registry._running[other.id] = other
+
+        result = registry.list_sessions(task_id="t1", include_other_running=True)
+        by_id = {e["session_id"]: e for e in result}
+
+        assert by_id["proc_mine"]["scope"] == "task"
+        assert by_id["proc_server"]["scope"] == "other"
+
+    def test_include_other_running_excludes_exited_other_scope(self, registry):
+        """Only *running* out-of-scope processes are surfaced — a finished
+        process in another task is not the agent's concern."""
+        mine = _make_session(sid="proc_mine", task_id="t1")
+        dead_other = _make_session(sid="proc_dead", task_id="t2", exited=True, exit_code=0)
+        registry._running[mine.id] = mine
+        registry._finished[dead_other.id] = dead_other
+
+        result = registry.list_sessions(task_id="t1", include_other_running=True)
+        assert "proc_dead" not in {e["session_id"] for e in result}
+
 
 # =========================================================================
 # Active process queries

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1194,33 +1194,53 @@ class ProcessRegistry:
         except Exception as e:
             return {"status": "error", "error": str(e)}
 
-    def list_sessions(self, task_id: str = None) -> list:
-        """List all running and recently-finished processes."""
+    def list_sessions(self, task_id: str = None, include_other_running: bool = False) -> list:
+        """List running and recently-finished processes.
+
+        When *task_id* is given, results are scoped to that task. Set
+        *include_other_running* to also surface processes still running
+        under a *different* task/session scope — the background servers and
+        forgotten dev tools that can silently block gateway session reset
+        (issue #29177). Without this the agent's ``process list`` returns
+        ``[]`` for a task that spawned nothing, leaving the user and agent
+        unable to discover what is keeping a session alive. Each entry is
+        tagged with ``scope`` ("task" for the current task, "other" for
+        processes outside it) so callers can tell them apart.
+        """
         with self._lock:
             all_sessions = list(self._running.values()) + list(self._finished.values())
 
         all_sessions = [self._refresh_detached_session(s) for s in all_sessions]
 
         if task_id:
-            all_sessions = [s for s in all_sessions if s.task_id == task_id]
+            in_scope = [s for s in all_sessions if s.task_id == task_id]
+            other_running = (
+                [s for s in all_sessions if s.task_id != task_id and not s.exited]
+                if include_other_running else []
+            )
+        else:
+            in_scope = all_sessions
+            other_running = []
 
         result = []
-        for s in all_sessions:
-            entry = {
-                "session_id": s.id,
-                "command": s.command[:200],
-                "cwd": s.cwd,
-                "pid": s.pid,
-                "started_at": time.strftime("%Y-%m-%dT%H:%M:%S", time.localtime(s.started_at)),
-                "uptime_seconds": int(time.time() - s.started_at),
-                "status": "exited" if s.exited else "running",
-                "output_preview": s.output_buffer[-200:] if s.output_buffer else "",
-            }
-            if s.exited:
-                entry["exit_code"] = s.exit_code
-            if s.detached:
-                entry["detached"] = True
-            result.append(entry)
+        for scope, sessions in (("task", in_scope), ("other", other_running)):
+            for s in sessions:
+                entry = {
+                    "session_id": s.id,
+                    "command": s.command[:200],
+                    "cwd": s.cwd,
+                    "pid": s.pid,
+                    "started_at": time.strftime("%Y-%m-%dT%H:%M:%S", time.localtime(s.started_at)),
+                    "uptime_seconds": int(time.time() - s.started_at),
+                    "status": "exited" if s.exited else "running",
+                    "output_preview": s.output_buffer[-200:] if s.output_buffer else "",
+                    "scope": scope,
+                }
+                if s.exited:
+                    entry["exit_code"] = s.exit_code
+                if s.detached:
+                    entry["detached"] = True
+                result.append(entry)
         return result
 
     # ----- Session/Task Queries (for gateway integration) -----
@@ -1513,7 +1533,13 @@ def _handle_process(args, **kw):
     session_id = str(args.get("session_id", "")) if args.get("session_id") is not None else ""
 
     if action == "list":
-        return json.dumps({"processes": process_registry.list_sessions(task_id=task_id)}, ensure_ascii=False)
+        # include_other_running so the agent can see background processes
+        # running outside this task's scope — otherwise a session blocked
+        # from reset by a forgotten preview server is invisible here (#29177).
+        return json.dumps(
+            {"processes": process_registry.list_sessions(task_id=task_id, include_other_running=True)},
+            ensure_ascii=False,
+        )
     elif action in {"poll", "log", "wait", "kill", "write", "submit", "close"}:
         if not session_id:
             return tool_error(f"session_id is required for {action}")


### PR DESCRIPTION
When a gateway session is silently blocked from resetting by a forgotten background process (e.g. a preview server spawned days earlier), the agent and user have no way to discover it: the `process list` action calls list_sessions(task_id=...), which filters to the current task's scope and returns [] for a task that spawned nothing — even though the gateway's session-scoped reset guard still sees the process. The blocking process is invisible to every agent-facing tool (issue #29177, Bug 2).

Add an `include_other_running` flag to list_sessions(). When set, it also returns processes still running under a *different* task/session scope, tagging every entry with `scope` ("task" vs "other") so the caller can tell its own processes apart from the out-of-scope ones. The agent's `process list` action turns this on, so a user asking "are there any subprocesses running?" now sees the blocking servers instead of [].

Default behavior is unchanged — list_sessions(task_id=...) without the flag stays strictly task-scoped, and finished out-of-scope processes are never surfaced (only live ones can block a reset).

Complements #29201 (Bug 1 + Bug 3: TTL on the reset guard + logging the skip reason); this PR addresses the separately-scoped Bug 2 (visibility).

Tests (tests/tools/test_process_registry.py::TestListSessions):
- test_task_scope_hides_other_running_by_default: default stays task-scoped
- test_include_other_running_surfaces_cross_scope_processes: other-scope running procs appear tagged scope="other", own procs tagged scope="task"
- test_include_other_running_excludes_exited_other_scope: finished out-of-scope procs are not surfaced

Verified the surface test fails when include_other_running is disabled and passes with it, while the default-scope test is unaffected either way.

Refs #29177


## What does this PR do?

  Addresses **Bug 2 of #29177** — the separately-scoped visibility gap that #29201 (Bug 1 + Bug 3) explicitly left open.

  When a gateway session is silently blocked from resetting by a forgotten background process (e.g. a preview server spawned days earlier), the agent and user currently have **no way to discover it**. The `process list` action calls `list_sessions(task_id=...)`, which filters to the current task's scope and returns `[]` for a task that spawned nothing — even though the
  gateway's session-scoped reset guard still sees the process. From the issue:

  > The **user** cannot discover the problem by asking Hermes · The **agent** cannot discover the problem through its own tools

  ## Fix

  Add an `include_other_running` flag to `list_sessions()`. When set, it also returns processes still running under a *different* task/session scope, tagging every entry with `scope` (`"task"` vs `"other"`) so the caller can tell its own processes apart from out-of-scope ones. The agent's `process list` action turns this on, so "are there any subprocesses running?" now
  surfaces the blocking servers instead of `[]`.

  **Conservative by design:**
  - `list_sessions(task_id=...)` without the flag stays strictly task-scoped (no behavior change for any other caller)
  - Only *running* out-of-scope processes are surfaced — a finished process in another task is not the agent's concern and can't block a reset

  ## Relationship to #29201

  Complementary, not overlapping. #29201 fixes the reset guard itself (TTL on `has_active_for_session` + logging the skip). This PR fixes the *visibility* side (`list_sessions` + the agent `process list` action). Both touch `tools/process_registry.py` but different methods — no logical conflict.

  ## Changes Made

  - `tools/process_registry.py`
    - `list_sessions(task_id=None, include_other_running=False)` — new flag + `scope` tag on every entry
    - `_handle_process` `list` action passes `include_other_running=True`
  - `tests/tools/test_process_registry.py` (+37)
    - `test_task_scope_hides_other_running_by_default` — default unchanged
    - `test_include_other_running_surfaces_cross_scope_processes` — other-scope running procs appear tagged `scope="other"`
    - `test_include_other_running_excludes_exited_other_scope` — finished out-of-scope procs not surfaced

  ## How to Test

  ```bash
  pytest tests/tools/test_process_registry.py::TestListSessions -v   # 7 passed
  pytest tests/tools/test_process_registry.py -q                     # 61 passed
  ```

  Verified the surface test fails when `include_other_running` is disabled and passes with it, while the default-scope test is unaffected either way.

  ## Related Issue

  Refs #29177 (Bug 2). Bug 1 + Bug 3 handled by #29201.

  ## Type of Change

  - [x] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [ ] ✨ New feature
  - [ ] 🔒 Security fix
  - [ ] 📝 Documentation update
  - [ ] ✅ Tests
  - [ ] ♻️  Refactor
  - [ ] 🎯 New skill

  ## Checklist

  ### Code
  - [x] I've read the Contributing Guide
  - [x] Conventional Commits (`fix(process): ...`)
  - [x] Searched existing PRs — only #29201 references #29177 (Bug 1+3); Bug 2 is uncovered and explicitly carved out there
  - [x] Only changes related to this fix — single commit, `+83 / -20`, 2 files
  - [ ] `pytest tests/ -q` — ran `test_process_registry.py` (61 passed); did not run the full repo suite locally, relying on CI
  - [x] Added tests with verified regression discipline
  - [x] Tested on: Ubuntu 24.04, Python 3.13.5

  ### Documentation & Housekeeping
  - [x] Docs — `list_sessions` docstring documents the new flag + `scope` tag; N/A elsewhere
  - [x] cli-config.yaml.example — N/A (no config keys)
  - [x] CONTRIBUTING/AGENTS — N/A
  - [x] Cross-platform — pure Python list filtering; platform-agnostic
  - [x] Tool schemas — N/A (output shape gains a `scope` field; no input schema change)

