### PR TITLE
fix(agent): add _ra() prefix to _pool_may_recover_from_rate_limit call

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2317,7 +2317,7 @@ def run_conversation(
                     # still recover.  See _pool_may_recover_from_rate_limit
                     # for the single-credential-pool and CloudCode-quota
                     # exceptions.  Fixes #11314 and #13636.
-                    pool_may_recover = _pool_may_recover_from_rate_limit(
+                    pool_may_recover = _ra()._pool_may_recover_from_rate_limit(
                         agent._credential_pool,
                         provider=agent.provider,
                         base_url=getattr(agent, "base_url", None),


### PR DESCRIPTION
## Problem

`conversation_loop.py` uses `_ra()` lazy import wrapper for all `run_agent` symbols, but line 2320 called `_pool_may_recover_from_rate_limit()` as a bare name — causing `NameError` when a 429 rate limit triggers with a fallback model configured.

## Fix

One-line fix: add `_ra().` prefix, consistent with all other `run_agent` symbol references in this file.

Fixes #29202