### PR TITLE
fix(kanban): clear stale claim locks on ready tasks before dispatch

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4751,6 +4751,17 @@ def dispatch_once(
             ).fetchone()[0]
         )
 
+    # Clear stale claim locks on ready tasks. A task that is ready cannot
+    # have a live worker by definition (the worker would have claimed it
+    # and moved it to 'running'). Stale locks leak when a worker crashes
+    # and the task is manually reset from 'blocked' to 'ready' without
+    # clearing claim_lock — the reclaim path only inspects 'running' tasks
+    # so the lock is never released.
+    conn.execute(
+        "UPDATE tasks SET claim_lock = NULL, claim_expires = NULL, worker_pid = NULL "
+        "WHERE status = 'ready' AND claim_lock IS NOT NULL"
+    )
+
     ready_rows = conn.execute(
         "SELECT id, assignee FROM tasks "
         "WHERE status = 'ready' AND claim_lock IS NULL "


### PR DESCRIPTION
## What does this PR do?

Clear stale claim_lock/claim_expires/worker_pid fields on ready tasks
at the start of each dispatch tick. A task in `ready` status cannot have
a live worker — these fields are always stale residue from a previous
crashed or blocked run. `release_stale_claims` only inspects `running`
tasks, so stale locks were permanently blocking dispatch.

## Related Issue

Fixes #22926

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- hermes_cli/kanban_db.py: added cleanup SQL (+11 lines) before the
  dispatch spawn loop — `UPDATE tasks SET claim_lock=NULL,
  claim_expires=NULL, worker_pid=NULL WHERE status='ready' AND
  claim_lock IS NOT NULL`

## How to Test

1. Dispatch a task that crashes immediately (e.g. worker profile with
   an invalid API key)
2. Wait for gateway to auto-block it
3. Manually reset to ready via SQL without clearing claim_lock
4. Run dispatch — without fix: spawned=0; with fix: task appears normally

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs (#22926 is open, no fix yet)
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.4

## Documentation & Housekeeping

- [x] Documentation: N/A
- [x] Config: N/A
- [x] Architecture: N/A
- [x] Cross-platform: N/A (pure SQL, platform-independent)
- [x] Tool schemas: N/A
