### PR TITLE
fix(gateway): skip reset only for recent bg processes (#29177)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1443,7 +1443,7 @@ class GatewayRunner:
         from tools.process_registry import process_registry
         self.session_store = SessionStore(
             self.config.sessions_dir, self.config,
-            has_active_processes_fn=lambda key: process_registry.has_active_for_session(key),
+            has_active_processes_fn=lambda key, max_age=None: process_registry.has_active_for_session(key, max_age),
         )
         self.delivery_router = DeliveryRouter(self.config)
         self._running = False

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -756,10 +756,6 @@ class SessionStore:
         Used by the background expiry watcher to proactively flush memories.
         Sessions with active background processes are never considered expired.
         """
-        if self._has_active_processes_fn:
-            if self._has_active_processes_fn(entry.session_key):
-                return False
-
         policy = self.config.get_reset_policy(
             platform=entry.platform,
             session_type=entry.chat_type,
@@ -767,6 +763,15 @@ class SessionStore:
 
         if policy.mode == "none":
             return False
+
+        if self._has_active_processes_fn:
+            ttl = policy.idle_minutes * 60 if policy.mode in {"idle", "both"} else None
+            if self._has_active_processes_fn(entry.session_key, ttl):
+                logger.info(
+                    "session reset for %s skipped: active background process(es) within TTL",
+                    entry.session_key,
+                )
+                return False
 
         now = _now()
 
@@ -796,19 +801,24 @@ class SessionStore:
         
         Sessions with active background processes are never reset.
         """
-        if self._has_active_processes_fn:
-            session_key = self._generate_session_key(source)
-            if self._has_active_processes_fn(session_key):
-                return None
-
         policy = self.config.get_reset_policy(
             platform=source.platform,
             session_type=source.chat_type
         )
-        
+
         if policy.mode == "none":
             return None
-        
+
+        if self._has_active_processes_fn:
+            session_key = self._generate_session_key(source)
+            ttl = policy.idle_minutes * 60 if policy.mode in {"idle", "both"} else None
+            if self._has_active_processes_fn(session_key, ttl):
+                logger.info(
+                    "session reset for %s skipped: active background process(es) within TTL",
+                    session_key,
+                )
+                return None
+
         now = _now()
         
         if policy.mode in {"idle", "both"}:

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -382,6 +382,23 @@ class TestActiveQueries:
         assert registry.has_active_for_session("gw_session_1") is True
         assert registry.has_active_for_session("other") is False
 
+    def test_has_active_for_session_max_age_excludes_stale(self, registry):
+        stale = _make_session(sid="proc_stale")
+        stale.session_key = "gw_session_2"
+        stale.started_at = time.time() - 3600
+        registry._running[stale.id] = stale
+        # No TTL: stale process still counts as active.
+        assert registry.has_active_for_session("gw_session_2") is True
+        # With TTL of 300s, the 1h-old process is excluded.
+        assert registry.has_active_for_session("gw_session_2", max_age_seconds=300) is False
+
+        # A fresh process within the window still counts.
+        fresh = _make_session(sid="proc_fresh")
+        fresh.session_key = "gw_session_2"
+        fresh.started_at = time.time() - 10
+        registry._running[fresh.id] = fresh
+        assert registry.has_active_for_session("gw_session_2", max_age_seconds=300) is True
+
     def test_exited_not_active(self, registry):
         s = _make_session(task_id="t1", exited=True, exit_code=0)
         registry._finished[s.id] = s

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1239,19 +1239,27 @@ class ProcessRegistry:
                 for s in self._running.values()
             )
 
-    def has_active_for_session(self, session_key: str) -> bool:
-        """Check if there are active processes for a gateway session key."""
+    def has_active_for_session(self, session_key: str, max_age_seconds: Optional[float] = None) -> bool:
+        """Check if there are active processes for a gateway session key.
+
+        If max_age_seconds is provided, only processes started within that
+        window (time.time() - started_at <= max_age_seconds) count as active.
+        """
         with self._lock:
             sessions = list(self._running.values())
 
         for session in sessions:
             self._refresh_detached_session(session)
 
+        now = time.time()
         with self._lock:
-            return any(
-                s.session_key == session_key and not s.exited
-                for s in self._running.values()
-            )
+            for s in self._running.values():
+                if s.session_key != session_key or s.exited:
+                    continue
+                if max_age_seconds is not None and (now - s.started_at) > max_age_seconds:
+                    continue
+                return True
+            return False
 
     def kill_all(self, task_id: str = None) -> int:
         """Kill all running processes, optionally filtered by task_id. Returns count killed."""


### PR DESCRIPTION
## Summary

Fixes #29177 (partially — addresses Bug 1; Bug 2 about agent process-list visibility is left for a follow-up).

A background process started days ago kept blocking session idle/daily reset because `has_active_for_session()` didn't consider age. Preview servers and other long-lived helpers would accumulate sessions toward the compression threshold instead of resetting cleanly. The reset path also did so **silently** — no log line explained why reset was skipped.

## Changes

- `tools/process_registry.py`: `has_active_for_session(session_key, max_age_seconds=None)`. When `max_age_seconds` is provided, processes older than the TTL no longer count as active.
- `gateway/run.py`: lambda passed to `SessionStore` is now `(key, max_age=None) -> has_active_for_session(key, max_age)`.
- `gateway/session.py`: `_is_session_expired` and `_should_reset` compute the policy first, then pass `ttl = policy.idle_minutes * 60` (only when policy mode is `idle` / `both`). Logs at INFO when reset is skipped so the situation is no longer silent. Prune path keeps the no-TTL behavior — a long-running task that the user is still waiting on should not be force-pruned just because it crossed idle_minutes.
- `tests/tools/test_process_registry.py`: new `test_has_active_for_session_max_age_excludes_stale` exercising the TTL.

## Test plan
- [x] `pytest tests/tools/test_process_registry.py` → 59 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)