### PR TITLE
fix(cron): prevent double-fire after timezone offset migration (#28934)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1020,10 +1020,43 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
                     needs_save = True
                     break
 
-        next_run_dt = _ensure_aware(datetime.fromisoformat(next_run))
+        parsed_next_run = datetime.fromisoformat(next_run)
+        next_run_dt = _ensure_aware(parsed_next_run)
         if next_run_dt <= now:
             schedule = job.get("schedule", {})
             kind = schedule.get("kind")
+
+            # Timezone-offset migration repair (issue #28934): if the
+            # persisted next_run_at carries a UTC offset that differs from
+            # the current Hermes timezone, and the *stored local wall-clock*
+            # time has not yet arrived in the current Hermes timezone, this
+            # is not really a due run — it is the same wall-clock cron
+            # occurrence that would otherwise fire twice (once early at the
+            # converted instant, again at the intended wall time). Recompute
+            # next_run_at from the current timezone and skip dispatch.
+            if (
+                kind in {"cron", "interval"}
+                and parsed_next_run.tzinfo is not None
+                and parsed_next_run.utcoffset() != now.utcoffset()
+            ):
+                stored_wall = parsed_next_run.replace(tzinfo=now.tzinfo)
+                if stored_wall > now:
+                    new_next = compute_next_run(schedule, now.isoformat())
+                    if new_next:
+                        logger.info(
+                            "Job '%s' next_run_at %s was persisted with a stale "
+                            "UTC offset; rescheduling to %s in current Hermes "
+                            "timezone to prevent double-fire (#28934).",
+                            job.get("name", job["id"]),
+                            next_run,
+                            new_next,
+                        )
+                        for rj in raw_jobs:
+                            if rj["id"] == job["id"]:
+                                rj["next_run_at"] = new_next
+                                needs_save = True
+                                break
+                        continue
 
             # For recurring jobs, check if the scheduled time is stale
             # (gateway was down and missed the window). Fast-forward to

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -953,3 +953,54 @@ class TestSaveJobOutput:
         assert output_file.exists()
         assert output_file.read_text() == "# Results\nEverything ok."
         assert "test123" in str(output_file)
+
+
+class TestTimezoneMigrationDoubleFire:
+    """Regression for #28934: persisted next_run_at with a stale UTC offset
+    must not be dispatched early just because the converted instant looks due."""
+
+    def test_cron_next_run_with_stale_offset_does_not_fire_early(
+        self, tmp_cron_dir, monkeypatch
+    ):
+        pytest.importorskip("croniter")
+        # Persisted with old offset +10:00 (e.g. previous runtime timezone)
+        # Wall-clock intent: 21:00 local on 2026-05-19.
+        old_offset_iso = "2026-05-19T21:00:00+10:00"
+        # Current Hermes time is +02:00 at 13:02 — the stale instant
+        # 21:00+10 == 13:00+02 looks due, but the wall-clock 21:00 has
+        # not arrived in the new timezone yet.
+        tz_plus2 = timezone(timedelta(hours=2))
+        fake_now = datetime(2026, 5, 19, 13, 2, 0, tzinfo=tz_plus2)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: fake_now)
+
+        from cron.jobs import save_jobs
+
+        job = {
+            "id": "job-tz-migration",
+            "name": "weekly-21",
+            "enabled": True,
+            "schedule": {"kind": "cron", "expr": "0 21 * * 2"},
+            "next_run_at": old_offset_iso,
+            "prompt": "x",
+        }
+        save_jobs([job])
+
+        due = get_due_jobs()
+        assert due == [], (
+            "Job with stale persisted UTC offset must not be dispatched "
+            "early; its wall-clock time has not arrived in the new tz."
+        )
+
+        # next_run_at should have been rewritten into current Hermes tz,
+        # and should be strictly in the future.
+        from cron.jobs import load_jobs
+
+        updated = load_jobs()[0]
+        new_dt = datetime.fromisoformat(updated["next_run_at"])
+        assert new_dt > fake_now
+        assert new_dt.utcoffset() == fake_now.utcoffset()
+
+        # And on a second tick still inside the same wall-clock window,
+        # it must still not double-fire.
+        assert get_due_jobs() == []
+


### PR DESCRIPTION
## Summary

Fixes #28934. After a Hermes timezone change (e.g. `Australia/Sydney` → `Europe/Berlin`), recurring cron jobs whose `next_run_at` was persisted with the old offset would fire **twice** the same day: once early (the same UTC instant interpreted in the new tz), then again at the intended wall-clock time after `compute_next_run` re-advanced it.

## Root cause

`cron/jobs.py::_get_due_jobs_locked()` normalized stored `next_run_at` via `_ensure_aware()` which only preserves the absolute UTC instant. A row stored as `2026-05-19T21:00:00+10:00` becomes `2026-05-19T13:00:00+02:00` after migration. At local `13:02+02:00` the scheduler considers it due even though the user's wall-clock intent was 21:00.

## Fix

Before treating a recurring `next_run_dt <= now` as due, compare the persisted offset against `_hermes_now().utcoffset()`. If they differ and the *stored wall-clock* time (offset rebased onto current tz) is still in the future, recompute `next_run_at` in the current tz and skip dispatch this tick. The pre-existing stale-grace fast-forward path is untouched.

## Test plan
- [x] New `TestTimezoneMigrationDoubleFire` in `tests/cron/test_jobs.py`:
  - Seeds `next_run_at=2026-05-19T21:00:00+10:00`, monkeypatches `_hermes_now` to `13:02+02:00`
  - Asserts `get_due_jobs() == []` (no early fire)
  - Asserts `next_run_at` is rewritten in current tz to a future instant
  - Asserts a second tick at the same time still does not fire
- [x] `pytest tests/cron/test_jobs.py` → 80 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)