### PR TITLE
fix(kanban): restore horizontal scrollbar and fix vertical column overflow

### DIFF
--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -67,10 +67,14 @@
   gap: 0.75rem;
   align-items: start;
   overflow-x: auto;
-  scrollbar-width: none;
+  scrollbar-width: thin;
 }
 .hermes-kanban-columns::-webkit-scrollbar {
-  display: none;
+  height: 6px;
+}
+.hermes-kanban-columns::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--color-muted-foreground) 35%, transparent);
+  border-radius: 3px;
 }
 
 .hermes-kanban-column {
@@ -143,6 +147,8 @@
   gap: 0.45rem;
   overflow-y: auto;
   padding-right: 0.1rem;
+  flex: 1;
+  min-height: 0;
 }
 
 .hermes-kanban-empty {


### PR DESCRIPTION
## Bug

The kanban dashboard board page has two CSS regressions:

1. **Horizontal scrollbar hidden** — `.hermes-kanban-columns` sets `scrollbar-width: none` and `::-webkit-scrollbar { display: none }`. When 8+ columns exceed the viewport, there is no scrollbar, no trackpad hint, and no way to reach columns like "Done" (51 tasks) that sit off-screen.

2. **Vertical column overflow** — `.hermes-kanban-column-body` lacks `flex: 1` and `min-height: 0`. The flex child has implicit `min-height: auto`, preventing it from shrinking below its content size. Columns with many cards push past the parent's `max-height: calc(100vh - 220px)` instead of scrolling internally.

## Fix

| Element | Before | After |
|---------|--------|-------|
| `.hermes-kanban-columns` | `scrollbar-width: none` | `scrollbar-width: thin` |
| `.hermes-kanban-columns::-webkit-scrollbar` | `display: none` | `height: 6px` + styled thumb |
| `.hermes-kanban-column-body` | _(no flex/min-height)_ | `flex: 1; min-height: 0` |

The scrollbar thumb uses `color-mix(in srgb, var(--color-muted-foreground) 35%, transparent)` so it reskins with the active dashboard theme.

## Verification

- `scrollWidth: 2390px > clientWidth: 985px` — horizontal scroll now works with visible scrollbar
- Done column body: `scrollHeight: 5115px > clientHeight: 333px` — vertical scroll works within 413px `max-height`
- Computed styles confirmed: `scrollbar-width: thin`, `overflow-x: auto`, `flex: 1 1 0%`, `min-height: 0px`