### PR TITLE
test: fix CI drift in web plugin and update hangup tests

### DIFF
--- a/tests/hermes_cli/test_update_hangup_protection.py
+++ b/tests/hermes_cli/test_update_hangup_protection.py
@@ -213,8 +213,14 @@ class TestInstallHangupProtection:
         try:
             # On Windows (no SIGHUP) we still wrap stdio and create the log.
             assert state["installed"] is True
-            assert isinstance(sys.stdout, _UpdateOutputStream)
-            assert isinstance(sys.stderr, _UpdateOutputStream)
+            # Other tests may reload ``hermes_cli.main`` in the same worker,
+            # leaving this module's imported class object stale even though
+            # the live stream is the correct wrapper. Check wrapper shape
+            # instead of object identity across reload boundaries.
+            assert sys.stdout.__class__.__name__ == "_UpdateOutputStream"
+            assert sys.stderr.__class__.__name__ == "_UpdateOutputStream"
+            assert getattr(sys.stdout, "_log", None) is state["log_file"]
+            assert getattr(sys.stderr, "_log", None) is state["log_file"]
             assert state["log_file"] is not None
 
             sys.stdout.write("checking mirror\n")

--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -45,9 +45,9 @@ def _clear_web_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "FIRECRAWL_API_KEY",
         "FIRECRAWL_API_URL",
         "FIRECRAWL_GATEWAY_URL",
+        "XAI_API_KEY",
         "TOOL_GATEWAY_DOMAIN",
         "TOOL_GATEWAY_USER_TOKEN",
-        "XAI_API_KEY",
     ):
         monkeypatch.delenv(k, raising=False)
 
@@ -73,7 +73,7 @@ def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
 class TestBundledPluginsRegister:
     """All eight bundled web plugins discover and register correctly."""
 
-    def test_all_seven_plugins_present_in_registry(self) -> None:
+    def test_all_eight_plugins_present_in_registry(self) -> None:
         _ensure_plugins_loaded()
         from agent.web_search_registry import list_providers
 


### PR DESCRIPTION
## Summary
- updates bundled web plugin tests for the registered `xai` web provider
- makes the update hangup stream assertion robust across `hermes_cli.main` reloads in shared test workers

## Verification
- `python3 -m pytest tests/plugins/web/test_web_search_provider_plugins.py tests/hermes_cli/test_update_hangup_protection.py -q -o addopts=''`
- `python3 -m pytest tests/hermes_cli/test_env_loader.py tests/hermes_cli/test_update_hangup_protection.py -q -o addopts=''`
- `python3 -m ruff check tests/plugins/web/test_web_search_provider_plugins.py tests/hermes_cli/test_update_hangup_protection.py`
- `git diff --check upstream/main...HEAD`
