### PR TITLE
fix(agent): treat Codex codex_reasoning_items as thinking-only on empty turns (#29205)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2434,9 +2434,14 @@ class AIAgent:
         # "encrypted_content": ...}`` dicts) on reasoning-only turns; without
         # this branch, an Anthropic-family fallback after a Codex empty turn
         # ends up sending an assistant scaffold that Anthropic rejects with
-        # "does not support assistant message prefill" (#29205).
+        # "does not support assistant message prefill" (#29205). Require at
+        # least one reasoning item so non-reasoning junk in the list does not
+        # trip the predicate.
         cri = msg.get("codex_reasoning_items")
-        if isinstance(cri, list) and cri:
+        if isinstance(cri, list) and any(
+            isinstance(item, dict) and item.get("type") == "reasoning"
+            for item in cri
+        ):
             return True
         return False
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -2429,6 +2429,15 @@ class AIAgent:
         rd = msg.get("reasoning_details")
         if isinstance(rd, list) and rd:
             return True
+        # Codex Responses encrypted-reasoning list form. Codex returns
+        # ``codex_reasoning_items`` (a list of ``{"type": "reasoning",
+        # "encrypted_content": ...}`` dicts) on reasoning-only turns; without
+        # this branch, an Anthropic-family fallback after a Codex empty turn
+        # ends up sending an assistant scaffold that Anthropic rejects with
+        # "does not support assistant message prefill" (#29205).
+        cri = msg.get("codex_reasoning_items")
+        if isinstance(cri, list) and cri:
+            return True
         return False
 
     @staticmethod

--- a/tests/run_agent/test_thinking_only_sanitizer.py
+++ b/tests/run_agent/test_thinking_only_sanitizer.py
@@ -141,6 +141,17 @@ class TestIsThinkingOnlyAssistant:
         }
         assert not AIAgent._is_thinking_only_assistant(msg)
 
+    def test_codex_reasoning_items_without_reasoning_type_is_not_thinking_only(self):
+        # Junk items (non-dicts, or dicts whose type is not "reasoning") must
+        # not trip the predicate — there is nothing to justify dropping the
+        # turn as reasoning-only.
+        msg = {
+            "role": "assistant",
+            "content": "",
+            "codex_reasoning_items": [None, "x", {"type": "other"}],
+        }
+        assert not AIAgent._is_thinking_only_assistant(msg)
+
     def test_user_message_never_thinking_only(self):
         assert not AIAgent._is_thinking_only_assistant({"role": "user", "content": ""})
 

--- a/tests/run_agent/test_thinking_only_sanitizer.py
+++ b/tests/run_agent/test_thinking_only_sanitizer.py
@@ -104,6 +104,43 @@ class TestIsThinkingOnlyAssistant:
         }
         assert AIAgent._is_thinking_only_assistant(msg)
 
+    def test_codex_reasoning_items_list_form_detected(self):
+        # Codex Responses returns encrypted reasoning items on empty turns;
+        # without this branch, the message survives the sanitizer and breaks
+        # Anthropic fallback with "does not support assistant message
+        # prefill" (#29205).
+        msg = {
+            "role": "assistant",
+            "content": "",
+            "codex_reasoning_items": [
+                {"type": "reasoning", "encrypted_content": "<opaque>"},
+            ],
+        }
+        assert AIAgent._is_thinking_only_assistant(msg)
+
+    def test_codex_reasoning_items_with_visible_text_is_not_thinking_only(self):
+        # Defensive: if Codex did surface a final text alongside reasoning
+        # items, the turn carries a real answer and must survive.
+        msg = {
+            "role": "assistant",
+            "content": "Final answer.",
+            "codex_reasoning_items": [
+                {"type": "reasoning", "encrypted_content": "<opaque>"},
+            ],
+        }
+        assert not AIAgent._is_thinking_only_assistant(msg)
+
+    def test_codex_reasoning_items_empty_list_is_not_thinking_only(self):
+        # An empty list is not "reasoning-only" — there is no reasoning to
+        # justify dropping the turn.  Leave the empty turn for the orphan-
+        # tool / empty-turn sanitizers to handle.
+        msg = {
+            "role": "assistant",
+            "content": "",
+            "codex_reasoning_items": [],
+        }
+        assert not AIAgent._is_thinking_only_assistant(msg)
+
     def test_user_message_never_thinking_only(self):
         assert not AIAgent._is_thinking_only_assistant({"role": "user", "content": ""})
 


### PR DESCRIPTION
## What does this PR do?

`run_agent.AIAgent._is_thinking_only_assistant()` inspects `reasoning`, `reasoning_content`, and `reasoning_details` but not `codex_reasoning_items`. The Codex Responses adapter stores its encrypted reasoning state under that key (`agent/codex_responses_adapter.py:1064`), so a reasoning-only Codex turn — empty `content`, no `tool_calls`, only `codex_reasoning_items` — slips past the sanitizer.

When a session then falls back from Codex Responses to native Anthropic, `convert_messages_to_anthropic()` rewrites the empty assistant content to `"(empty)"` and role-alternation merging can leave the wire body ending with an assistant turn. Anthropic rejects that with:

> This model does not support assistant message prefill. The conversation must end with a user message.

The fix adds a third branch to `_is_thinking_only_assistant()` that treats a non-empty `codex_reasoning_items` list as a reasoning-only payload, matching the precedent for the `reasoning_details` list-form branch directly above it.

## Related Issue

Fixes #29205

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `run_agent.py` — extend `_is_thinking_only_assistant()` to recognize a non-empty `codex_reasoning_items` list as the third reasoning-only shape (alongside `reasoning_content`/`reasoning` strings and `reasoning_details` lists).
- `tests/run_agent/test_thinking_only_sanitizer.py` — three regression cases: positive (encrypted Codex item flips the turn to thinking-only), defensive negative (visible text alongside reasoning items survives), empty-list sanity (an empty `codex_reasoning_items` does not trick the sanitizer into dropping an otherwise-empty turn — that's the orphan-turn sanitizer's job).

## How to Test

1. Without the production fix applied, `test_codex_reasoning_items_list_form_detected` fails with `assert False = AIAgent._is_thinking_only_assistant(...)`.
2. With the fix, all three new cases plus the existing 25 sanitizer tests pass:
   ```
   uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/run_agent/test_thinking_only_sanitizer.py -v
   ```
3. The full `tests/run_agent/` subset (1377 tests) is also green on this branch.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(agent):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (the docstring already describes the contract; the new branch parallels the existing `reasoning_details` branch)
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A (pure dict-key inspection)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Scope vs. the issue's suggested fixes

The issue lists four suggested fixes. This PR intentionally implements **fix #1** because it is the surgical root cause: once `_is_thinking_only_assistant()` recognizes the Codex shape, `drop_thinking_only_and_merge_users()` removes the offending turn before any provider-specific converter sees it, which by construction satisfies fixes #2 and #3 (no empty Codex assistant scaffold survives the cross-family handoff) without adding a second invariant guard.

Fix #4 (rendering `anthropic_messages` mode as `/v1/messages` in `dump_api_request_debug()`) is orthogonal — it touches a different file and is a debug-output ergonomics improvement, not part of the rejection path. Happy to follow up with a separate small PR for that if useful.

> Sibling code paths that may need the same fix: any future reasoning-only shape that lands under a *new* assistant-message key (e.g. a vendor adding `gemini_reasoning_items` or similar). The current branch list is `reasoning_content`/`reasoning` (string), `reasoning_details` (list), and now `codex_reasoning_items` (list). Adding new shapes should mirror this pattern. Intentionally left as-is — no such sibling exists today.