### PR TITLE
fix(moonshot): handle JSON Schema union types in _fill_missing_type (#28291)

### DIFF
--- a/agent/moonshot_schema.py
+++ b/agent/moonshot_schema.py
@@ -144,7 +144,7 @@ def _repair_schema(node: Any, is_schema: bool = True) -> Any:
     # empty, drop it entirely.
     if "enum" in repaired and isinstance(repaired["enum"], list):
         node_type = repaired.get("type")
-        if node_type in {"string", "integer", "number", "boolean"}:
+        if isinstance(node_type, str) and node_type in {"string", "integer", "number", "boolean"}:
             cleaned = [v for v in repaired["enum"]
                        if v is not None and v != ""]
             if cleaned:
@@ -165,9 +165,24 @@ def _repair_schema(node: Any, is_schema: bool = True) -> Any:
 
 
 def _fill_missing_type(node: Dict[str, Any]) -> Dict[str, Any]:
-    """Infer a reasonable ``type`` if this schema node has none."""
-    if "type" in node and node["type"] not in {None, ""}:
-        return node
+    """Infer a reasonable ``type`` if this schema node has none.
+
+    JSON Schema allows ``type`` to be a list for union types
+    (e.g. ``["number", "string"]`` or ``["string", "null"]``).  Moonshot's
+    flavored schema validator does not accept list-typed nodes, so we
+    collapse the union to a single non-``"null"`` member.  If every
+    member is ``"null"`` (degenerate) we fall through to inference.
+    """
+    if "type" in node:
+        t = node["type"]
+        if isinstance(t, list):
+            non_null = [s for s in t
+                        if isinstance(s, str) and s != "null" and s != ""]
+            if non_null:
+                return {**node, "type": non_null[0]}
+            # All entries were null/empty/invalid — fall through to inference.
+        elif t not in (None, ""):
+            return node
 
     # Heuristic: presence of ``properties`` → object, ``items`` → array, ``enum``
     # → type of first enum value, else fall back to ``string`` (safest scalar).

--- a/tests/agent/test_moonshot_schema.py
+++ b/tests/agent/test_moonshot_schema.py
@@ -560,3 +560,74 @@ class TestEnumNullStripping:
         assert db_type["type"] == "string"
         assert db_type["enum"] == ["mysql", "postgresql"], \
             "null/empty enum values must be stripped after anyOf collapse"
+
+
+class TestUnionListType:
+    """JSON Schema permits ``type`` as a list for union types
+    (e.g. ``["number", "string"]`` or ``["string", "null"]``).  Older code
+    crashed with ``TypeError: unhashable type: 'list'`` because it did
+    ``node["type"] not in {None, ""}``.  Regression for issue #28291.
+    """
+
+    def test_union_list_type_does_not_crash(self):
+        # Reproduction from issue #28291: lcm_grep style tool with union type.
+        params = {
+            "type": "object",
+            "properties": {
+                "time_from": {
+                    "type": ["number", "string"],
+                    "description": "Optional timestamp",
+                },
+            },
+        }
+        out = sanitize_moonshot_tool_parameters(params)
+        # First non-null entry wins; Moonshot does not accept list types.
+        assert out["properties"]["time_from"]["type"] == "number"
+
+    def test_nullable_union_collapses_to_non_null(self):
+        params = {
+            "type": "object",
+            "properties": {
+                "name": {"type": ["string", "null"]},
+            },
+        }
+        out = sanitize_moonshot_tool_parameters(params)
+        assert out["properties"]["name"]["type"] == "string"
+
+    def test_top_level_union_type_normalized(self):
+        # Top-level type list also must not crash, and top level is forced
+        # to "object" by sanitize_moonshot_tool_parameters anyway.
+        params = {"type": ["object", "null"], "properties": {}}
+        out = sanitize_moonshot_tool_parameters(params)
+        assert out["type"] == "object"
+
+    def test_enum_with_union_type_does_not_crash(self):
+        # Regression for the sibling bug at the old line 125 — enum cleanup
+        # was unguarded against non-string node_type.
+        params = {
+            "type": "object",
+            "properties": {
+                "mode": {
+                    "type": ["string", "number"],
+                    "enum": ["fast", "slow", 1, 2],
+                },
+            },
+        }
+        out = sanitize_moonshot_tool_parameters(params)
+        mode = out["properties"]["mode"]
+        # Collapsed to the first non-null member.
+        assert mode["type"] == "string"
+        # enum still present (cleanup runs after type collapse, against a
+        # concrete scalar type).
+        assert "enum" in mode
+
+    def test_all_null_union_falls_through_to_inference(self):
+        params = {
+            "type": "object",
+            "properties": {
+                "weird": {"type": ["null"], "properties": {"x": {"type": "string"}}},
+            },
+        }
+        out = sanitize_moonshot_tool_parameters(params)
+        # Degenerate union → inference picks "object" from properties.
+        assert out["properties"]["weird"]["type"] == "object"


### PR DESCRIPTION
## Summary

Fixes #28291. JSON Schema permits `\"type\"` as a list — e.g. `[\"number\", \"string\"]` or `[\"string\", \"null\"]` — for union types. `agent/moonshot_schema.py::_fill_missing_type` used the membership test `node[\"type\"] not in {None, \"\"}` which raises `TypeError: unhashable type: 'list'` on any such schema, completely blocking conversations on `kimi-k2.6:cloud` via Ollama and direct cloud whenever a tool parameter used a union type.

A sibling bug existed in the enum cleanup branch of `_repair_schema`, where `node_type in {\"string\", ...}` would also raise on a list slipping through.

## Fix

- `_fill_missing_type`: detect `isinstance(t, list)`. Collapse to first non-`\"null\"` member (Moonshot's validator does not accept list `type` either, so just guarding the crash would still 400). All-null degenerate unions fall through to existing inference.
- Enum cleanup: guarded with `isinstance(node_type, str)` so list types pass through without triggering the membership test.

## Test plan
- [x] New `TestUnionListType` class in `tests/agent/test_moonshot_schema.py`: 5 cases covering the issue repro `[\"number\",\"string\"]`, `[\"string\",\"null\"]`, top-level list type, list+enum interaction, and all-null degenerate union
- [x] `pytest tests/agent/test_moonshot_schema.py` → 47 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)