### PR TITLE
fix(tools): expand ~ to real home, not sandbox HOME (#28456)

### DIFF
--- a/tests/tools/test_resolve_path.py
+++ b/tests/tools/test_resolve_path.py
@@ -83,3 +83,37 @@ class TestResolvePath:
                     file_tools._file_ops_cache[task_id] = previous
 
         assert result == live_dir / "nested" / "file.txt"
+
+
+class TestTildeRealHome:
+    """Regression: ~ must resolve to the real user home, not $HOME (#28456).
+
+    Hermes profile sandboxing sets $HOME to the profile sandbox dir.
+    ``Path.expanduser()`` would honor that and silently fail to find files
+    at the user's real home.
+    """
+
+    def test_tilde_ignores_sandbox_home_env(self, monkeypatch, tmp_path):
+        import pwd
+        sandbox = tmp_path / "profiles" / "threepio" / "home"
+        sandbox.mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(sandbox))
+
+        from tools.file_tools import _expanduser_real, _resolve_path
+
+        real_home = pwd.getpwuid(os.getuid()).pw_dir
+        assert _expanduser_real("~/foo.txt") == os.path.join(real_home, "foo.txt")
+        assert _expanduser_real("~") == real_home
+
+        # _resolve_path output must be under real home, not sandbox
+        result = str(_resolve_path("~/.hermes/shared/x.md"))
+        assert result.startswith(real_home), result
+        assert str(sandbox) not in result
+
+    def test_tilde_other_user_delegates_to_stdlib(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        from tools.file_tools import _expanduser_real
+
+        assert _expanduser_real("~nosuch_user_xyz123/f") == os.path.expanduser(
+            "~nosuch_user_xyz123/f"
+        )

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -5,6 +5,7 @@ import errno
 import json
 import logging
 import os
+import pwd
 import threading
 from pathlib import Path
 
@@ -78,6 +79,34 @@ _BLOCKED_DEVICE_PATHS = frozenset({
 })
 
 
+def _real_home() -> str:
+    """Return the invoking user's real home directory, ignoring ``$HOME``.
+
+    The gateway sets ``HOME`` to the profile sandbox dir (commit 4fb42d019,
+    "fix: per-profile subprocess HOME isolation"), which makes
+    ``Path.expanduser()`` resolve ``~`` to the sandbox instead of the real
+    user home. File tools must see the real home so ``~/...`` paths behave
+    consistently regardless of profile sandboxing. See issue #28456.
+    """
+    try:
+        return pwd.getpwuid(os.getuid()).pw_dir
+    except (KeyError, OSError):
+        return os.environ.get("HOME", "")
+
+
+def _expanduser_real(filepath: str) -> str:
+    """Like ``os.path.expanduser`` but resolves ``~`` to the real user home.
+
+    Only ``~`` and ``~/...`` (current user) are rewritten — ``~other`` is
+    delegated to the stdlib so explicit other-user lookups still work.
+    """
+    if filepath == "~":
+        return _real_home()
+    if filepath.startswith("~/"):
+        return os.path.join(_real_home(), filepath[2:])
+    return os.path.expanduser(filepath)
+
+
 def _resolve_path(filepath: str, task_id: str = "default") -> Path:
     """Resolve a path relative to TERMINAL_CWD (the worktree base directory)
     instead of the main repository root.
@@ -118,7 +147,7 @@ def _get_live_tracking_cwd(task_id: str = "default") -> str | None:
 
 def _resolve_path_for_task(filepath: str, task_id: str = "default") -> Path:
     """Resolve *filepath* against the task's live terminal cwd when possible."""
-    p = Path(filepath).expanduser()
+    p = Path(_expanduser_real(filepath))
     if not p.is_absolute():
         base = _get_live_tracking_cwd(task_id) or os.environ.get(
             "TERMINAL_CWD", os.getcwd()
@@ -135,7 +164,7 @@ def _is_blocked_device(filepath: str) -> bool:
     through (e.g. /dev/stdin → /proc/self/fd/0 → /dev/pts/0), defeating
     the check.
     """
-    normalized = os.path.expanduser(filepath)
+    normalized = _expanduser_real(filepath)
     if normalized in _BLOCKED_DEVICE_PATHS:
         return True
     # /proc/self/fd/0-2 and /proc/<pid>/fd/0-2 are Linux aliases for stdio
@@ -161,7 +190,7 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
         resolved = str(_resolve_path_for_task(filepath, task_id))
     except (OSError, ValueError):
         resolved = filepath
-    normalized = os.path.normpath(os.path.expanduser(filepath))
+    normalized = os.path.normpath(_expanduser_real(filepath))
     _err = (
         f"Refusing to write to sensitive system path: {filepath}\n"
         "Use the terminal tool with sudo if you need to modify system files."


### PR DESCRIPTION
## Summary

Fixes #28456. When the gateway runs under a sandboxed profile it sets the process-level `$HOME` to the profile sandbox directory. `Path.expanduser()` then routes `~/...` into the sandbox dir and silently misses files at the user's real home, so `read_file ~/foo` returns "not found" even when the file plainly exists.

## Fix

`tools/file_tools.py`:
- New `_real_home()` using `pwd.getpwuid(os.getuid()).pw_dir`, which ignores `$HOME`.
- New `_expanduser_real()` that rewrites only `~` and `~/...` to the real home (delegates `~other` to the stdlib so user lookups still work).
- Three call sites switched: `_resolve_path_for_task`, `_is_blocked_device`, `_check_sensitive_path`.

This intentionally leaves `$HOME` untouched so other tools that *do* want the sandbox home (e.g. config writes inside the profile) still see it; only `~` in user-facing path inputs resolves to the real home.

## Test plan
- [x] New `TestTildeRealHome` in `tests/tools/test_resolve_path.py`: monkeypatches `HOME` to a fake sandbox dir and asserts `_expanduser_real` / `_resolve_path` resolve to the real `pw_dir`, plus a delegation check for `~other`

🤖 Generated with [Claude Code](https://claude.com/claude-code)