### PR TITLE
fix(gateway): busy queue mode appends to FIFO instead of overwriting (#28503)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7024,7 +7024,14 @@ class GatewayRunner:
                 )
             if self._busy_input_mode == "queue":
                 logger.debug("PRIORITY queue follow-up for session %s", _quick_key)
-                self._queue_or_replace_pending_event(_quick_key, event)
+                # #28503: use FIFO enqueue so rapid follow-ups while busy are
+                # preserved.  _queue_or_replace_pending_event writes the single
+                # _pending_messages slot, which silently overwrites prior
+                # queued text events.  _enqueue_fifo puts the head in the slot
+                # and overflows the tail into _queued_events so every message
+                # is processed sequentially.
+                adapter = self.adapters.get(event.source.platform)
+                self._enqueue_fifo(_quick_key, event, adapter)
                 return None
             if self._busy_input_mode == "steer":
                 # Steer mode: inject text into the running agent mid-run via

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -119,6 +119,55 @@ class TestBusySessionAck:
         running_agent.interrupt.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_queue_mode_preserves_rapid_followups_fifo(self):
+        """#28503 regression: rapid follow-ups in queue mode must NOT overwrite each other.
+
+        Previously, busy_input_mode=queue routed through
+        _queue_or_replace_pending_event which only writes a single dict slot,
+        so messages 2..N were silently dropped while the agent was busy.
+        The fix routes through _enqueue_fifo, which puts the head in the slot
+        and overflows the tail into _queued_events.
+        """
+        from gateway.run import GatewayRunner
+
+        runner, _sentinel = _make_runner()
+        runner._queued_events = {}
+        adapter = _make_adapter()
+
+        first = _make_event(text="message 1")
+        sk = build_session_key(first.source)
+
+        running_agent = MagicMock()
+        runner._busy_input_mode = "queue"
+        runner._running_agents[sk] = running_agent
+        runner.adapters[first.source.platform] = adapter
+
+        # Send 4 rapid messages while the agent is "busy"
+        events = [first] + [
+            MessageEvent(
+                text=f"message {i}",
+                message_type=MessageType.TEXT,
+                source=first.source,
+                message_id=f"msg{i}",
+            )
+            for i in range(2, 5)
+        ]
+        for ev in events:
+            result = await GatewayRunner._handle_message(runner, ev)
+            assert result is None
+
+        # Head of the FIFO sits in the adapter slot, the rest in overflow.
+        assert adapter._pending_messages[sk] is events[0]
+        overflow = runner._queued_events.get(sk, [])
+        assert [e.text for e in overflow] == ["message 2", "message 3", "message 4"], (
+            "queue mode must preserve all rapid follow-ups in FIFO order, "
+            "not overwrite the single pending slot (#28503)"
+        )
+
+        # And it must not have interrupted the running agent.
+        running_agent.interrupt.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_sends_ack_when_agent_running(self):
         """First message during busy session should get a status ack."""
         runner, sentinel = _make_runner()


### PR DESCRIPTION
## Summary

Fixes #28503. With `busy_input_mode: queue` the user could send several follow-up messages while the agent was running and **only the most recent survived** — every prior text event was silently overwritten in the single `adapter._pending_messages[session_key]` slot.

## Root cause

`gateway/run.py:7025-7028` (busy `queue` branch in `_handle_message`) called `_queue_or_replace_pending_event`, which routes through `merge_pending_message_event(..., merge_text=False)` — that writes the dict slot directly, so each subsequent text event clobbers the previous one.

The runner already has a real FIFO primitive (`_enqueue_fifo` + `_queued_events`) used by the explicit `/queue` command: head goes in the slot, tail goes in an overflow list, and `_promote_queued_event` drains them sequentially after each turn. The `busy_input_mode=queue` path simply wasn't wired to it.

## Fix

`gateway/run.py:7025-7035`: replace `_queue_or_replace_pending_event(_quick_key, event)` with `_enqueue_fifo(_quick_key, event, adapter)`. True FIFO preserves message boundaries and reuses the existing drain logic, so the single-event case still places the message in the slot (existing tests pass) and the rapid-followup case now preserves all messages in order.

## Test plan
- [x] New `test_queue_mode_preserves_rapid_followups_fifo` in `tests/gateway/test_busy_session_ack.py`: pushes 4 rapid messages through `_handle_message` in queue mode, asserts head sits in `adapter._pending_messages` and the other 3 land in `runner._queued_events[sk]` in order
- [x] `pytest tests/gateway/test_busy_session_ack.py` → 16 passed (existing queue-mode test still green for the single-event case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)