### PR TITLE
fix(net): enable httpx transport retries for multi-IP DNS resolution (#28500)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -743,6 +743,23 @@ class AuthError(RuntimeError):
         self.relogin_required = relogin_required
 
 
+_HTTPX_TRANSPORT_RETRIES = 3
+
+
+def _httpx_transport(*, verify: Any = True) -> httpx.HTTPTransport:
+    """Return an ``httpx.HTTPTransport`` with connect-retries enabled.
+
+    ``httpx``'s default transport gives up after the first IP returned by DNS
+    refuses the connection. Many provider hostnames (notably
+    ``portal.nousresearch.com``) resolve to multiple IPs where the first one
+    can be unreachable, which surfaces to users as
+    ``ConnectError: [Errno 61] Connection refused``. Setting ``retries`` makes
+    httpcore iterate over the remaining ``getaddrinfo`` results on
+    ``ConnectError``, fixing the auth flow on multi-IP DNS. See #28500.
+    """
+    return httpx.HTTPTransport(retries=_HTTPX_TRANSPORT_RETRIES, verify=verify)
+
+
 def format_auth_error(error: Exception) -> str:
     """Map auth failures to concise user-facing guidance."""
     if not isinstance(error, AuthError):
@@ -3146,7 +3163,7 @@ def refresh_codex_oauth_pure(
         )
 
     timeout = httpx.Timeout(max(5.0, float(timeout_seconds)))
-    with httpx.Client(timeout=timeout, headers={"Accept": "application/json"}) as client:
+    with httpx.Client(timeout=timeout, headers={"Accept": "application/json"}, transport=_httpx_transport()) as client:
         response = client.post(
             CODEX_OAUTH_TOKEN_URL,
             headers={"Content-Type": "application/x-www-form-urlencoded"},
@@ -3593,7 +3610,7 @@ def refresh_xai_oauth_pure(
     # with a clear error so the user can re-run `hermes model` to refetch.
     _xai_validate_oauth_endpoint(endpoint, field="token_endpoint")
     timeout = httpx.Timeout(max(5.0, float(timeout_seconds)))
-    with httpx.Client(timeout=timeout, headers={"Accept": "application/json"}) as client:
+    with httpx.Client(timeout=timeout, headers={"Accept": "application/json"}, transport=_httpx_transport()) as client:
         response = client.post(
             endpoint,
             headers={"Content-Type": "application/x-www-form-urlencoded"},
@@ -4536,7 +4553,7 @@ def fetch_nous_models(
 ) -> List[str]:
     """Fetch available model IDs from the Nous inference API."""
     timeout = httpx.Timeout(timeout_seconds)
-    with httpx.Client(timeout=timeout, headers={"Accept": "application/json"}, verify=verify) as client:
+    with httpx.Client(timeout=timeout, headers={"Accept": "application/json"}, verify=verify, transport=_httpx_transport(verify=verify)) as client:
         response = client.get(
             f"{inference_base_url.rstrip('/')}/models",
             headers={"Authorization": f"Bearer {api_key}"},
@@ -4656,6 +4673,7 @@ def resolve_nous_access_token(
                 timeout=timeout,
                 headers={"Accept": "application/json"},
                 verify=verify,
+                transport=_httpx_transport(verify=verify),
             ) as client:
                 try:
                     refreshed = _refresh_access_token(
@@ -4752,7 +4770,7 @@ def refresh_nous_oauth_pure(
     verify = _resolve_verify(insecure=insecure, ca_bundle=ca_bundle, auth_state=state)
     timeout = httpx.Timeout(timeout_seconds if timeout_seconds else 15.0)
 
-    with httpx.Client(timeout=timeout, headers={"Accept": "application/json"}, verify=verify) as client:
+    with httpx.Client(timeout=timeout, headers={"Accept": "application/json"}, verify=verify, transport=_httpx_transport(verify=verify)) as client:
         min_agent_key_ttl = max(60, int(min_key_ttl_seconds))
         legacy_session_keys = _nous_legacy_session_keys_forced()
         current_invoke_jwt_usable = (
@@ -5023,7 +5041,7 @@ def resolve_nous_runtime_credentials(
             refresh_token_fp=_token_fingerprint(state.get("refresh_token")),
         )
 
-        with httpx.Client(timeout=timeout, headers={"Accept": "application/json"}, verify=verify) as client:
+        with httpx.Client(timeout=timeout, headers={"Accept": "application/json"}, verify=verify, transport=_httpx_transport(verify=verify)) as client:
             access_token = state.get("access_token")
             refresh_token = state.get("refresh_token")
 
@@ -6628,7 +6646,7 @@ def _codex_device_code_login() -> Dict[str, Any]:
 
     # Step 1: Request device code
     try:
-        with httpx.Client(timeout=httpx.Timeout(15.0)) as client:
+        with httpx.Client(timeout=httpx.Timeout(15.0), transport=_httpx_transport()) as client:
             resp = client.post(
                 f"{issuer}/api/accounts/deviceauth/usercode",
                 json={"client_id": client_id},
@@ -6671,7 +6689,7 @@ def _codex_device_code_login() -> Dict[str, Any]:
     code_resp = None
 
     try:
-        with httpx.Client(timeout=httpx.Timeout(15.0)) as client:
+        with httpx.Client(timeout=httpx.Timeout(15.0), transport=_httpx_transport()) as client:
             while _time.monotonic() - start < max_wait:
                 _time.sleep(poll_interval)
                 poll_resp = client.post(
@@ -6712,7 +6730,7 @@ def _codex_device_code_login() -> Dict[str, Any]:
         )
 
     try:
-        with httpx.Client(timeout=httpx.Timeout(15.0)) as client:
+        with httpx.Client(timeout=httpx.Timeout(15.0), transport=_httpx_transport()) as client:
             token_resp = client.post(
                 CODEX_OAUTH_TOKEN_URL,
                 data={
@@ -6925,7 +6943,8 @@ def _minimax_oauth_login(
 
     with httpx.Client(timeout=httpx.Timeout(timeout_seconds),
                       headers={"Accept": "application/json"},
-                      follow_redirects=True) as client:
+                      follow_redirects=True,
+                      transport=_httpx_transport()) as client:
         code_data = _minimax_request_user_code(
             client, portal_base_url=portal_base_url,
             client_id=pconfig.client_id,
@@ -7005,7 +7024,8 @@ def _refresh_minimax_oauth_state(
 
     portal_base_url = state["portal_base_url"]
     with httpx.Client(timeout=httpx.Timeout(timeout_seconds),
-                      follow_redirects=True) as client:
+                      follow_redirects=True,
+                      transport=_httpx_transport()) as client:
         response = client.post(
             f"{portal_base_url}/oauth/token",
             data={
@@ -7167,7 +7187,7 @@ def _nous_device_code_login(
     elif ca_bundle:
         print(f"TLS verification: custom CA bundle ({ca_bundle})")
 
-    with httpx.Client(timeout=timeout, headers={"Accept": "application/json"}, verify=verify) as client:
+    with httpx.Client(timeout=timeout, headers={"Accept": "application/json"}, verify=verify, transport=_httpx_transport(verify=verify)) as client:
         device_data, scope = _request_nous_device_code_with_scope_fallback(
             client=client,
             portal_base_url=portal_base_url,

--- a/tests/test_httpx_transport_retries.py
+++ b/tests/test_httpx_transport_retries.py
@@ -1,0 +1,77 @@
+"""Regression tests for #28500.
+
+`hermes_cli.auth` constructs ``httpx.Client`` instances around provider
+OAuth/OIDC endpoints. When the provider hostname resolves to multiple IPs
+(e.g. ``portal.nousresearch.com``) and the first IP refuses the connection,
+httpx must be given a non-default transport with ``retries>0`` so that
+httpcore iterates over the remaining addrinfo records instead of dying on
+the first ``ConnectError``.
+
+These tests pin the contract:
+  * ``_httpx_transport()`` returns an ``httpx.HTTPTransport`` with retries.
+  * Every ``httpx.Client(...)`` call site inside ``hermes_cli/auth.py``
+    passes a ``transport=`` kwarg (so the retrying transport is wired in).
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import httpx
+
+from hermes_cli import auth as auth_module
+
+
+def test_httpx_transport_has_retries() -> None:
+    transport = auth_module._httpx_transport()
+    assert isinstance(transport, httpx.HTTPTransport)
+    # httpx stores the retries on the inner connection pool.
+    pool = transport._pool
+    assert getattr(pool, "_retries", 0) >= 1, (
+        "transport must enable httpcore retries so multi-IP DNS resolution "
+        "falls back to the next address on ConnectError (issue #28500)"
+    )
+
+
+def test_httpx_transport_retries_constant_at_least_one() -> None:
+    assert auth_module._HTTPX_TRANSPORT_RETRIES >= 1
+
+
+def test_httpx_transport_respects_verify_flag() -> None:
+    # Should accept verify= without raising; default verify=True path.
+    t_default = auth_module._httpx_transport()
+    t_verified = auth_module._httpx_transport(verify=True)
+    assert isinstance(t_default, httpx.HTTPTransport)
+    assert isinstance(t_verified, httpx.HTTPTransport)
+
+
+def test_every_httpx_client_callsite_passes_transport() -> None:
+    """AST scan: no `httpx.Client(...)` in auth.py without `transport=`.
+
+    Catches future call sites that forget to wire the retrying transport.
+    """
+    source = Path(auth_module.__file__).read_text()
+    tree = ast.parse(source)
+
+    offenders: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        is_httpx_client = (
+            isinstance(func, ast.Attribute)
+            and func.attr == "Client"
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "httpx"
+        )
+        if not is_httpx_client:
+            continue
+        kwargs = {kw.arg for kw in node.keywords if kw.arg}
+        if "transport" not in kwargs:
+            offenders.append(node.lineno)
+
+    assert not offenders, (
+        f"httpx.Client(...) calls missing transport= at lines {offenders}; "
+        "use transport=_httpx_transport(...) to preserve multi-IP retry "
+        "behavior (#28500)"
+    )


### PR DESCRIPTION
## Summary

Fixes #28500. `httpx.Client(...)` calls in `hermes_cli/auth.py` were constructed without a custom transport, so they used `httpx.HTTPTransport(retries=0)` by default. When a provider hostname (e.g. `portal.nousresearch.com`) resolved to multiple IPs and the first one refused the connection, httpx surfaced the `ConnectError [Errno 61]` immediately instead of trying the remaining IPs, causing auth to fail intermittently.

## Fix

`hermes_cli/auth.py`:
- New helper `_httpx_transport(*, verify=True)` returning `httpx.HTTPTransport(retries=_HTTPX_TRANSPORT_RETRIES, verify=verify)` with `_HTTPX_TRANSPORT_RETRIES = 3`.
- All 12 `httpx.Client(...)` call sites now pass `transport=_httpx_transport(verify=verify)`. Existing `timeout`, `headers`, `follow_redirects`, `verify` kwargs are preserved.

The retries parameter only affects DNS / connect-time failures, not in-flight or HTTP-level errors, so this is the minimal change needed to make multi-IP records work as expected without altering other retry semantics.

## Test plan
- [x] `tests/test_httpx_transport_retries.py` (new): 4 tests — helper returns a retrying `HTTPTransport`, retries ≥1, verify flag honored, AST guard fails if any future `httpx.Client(...)` in `auth.py` omits `transport=`
- [x] `pytest tests/test_httpx_transport_retries.py` → 4 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)