### PR TITLE
fix(kanban): wrap columns into rows and fix vertical overflow

### DIFF
--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -64,13 +64,9 @@
 
 .hermes-kanban-columns {
   display: flex;
+  flex-wrap: wrap;
   gap: 0.75rem;
   align-items: start;
-  overflow-x: auto;
-  scrollbar-width: none;
-}
-.hermes-kanban-columns::-webkit-scrollbar {
-  display: none;
 }
 
 .hermes-kanban-column {
@@ -143,6 +139,8 @@
   gap: 0.45rem;
   overflow-y: auto;
   padding-right: 0.1rem;
+  flex: 1;
+  min-height: 0;
 }
 
 .hermes-kanban-empty {


### PR DESCRIPTION
## Bug

The kanban dashboard columns overflow horizontally with no scrollbar (intentionally hidden via `scrollbar-width: none`) and no wrapping. 8+ columns at 280px each exceed any reasonable viewport, making columns like "Done" (53 tasks) completely inaccessible.

Additionally, `.hermes-kanban-column-body` lacks `flex: 1` and `min-height: 0`, so the flex child's implicit `min-height: auto` prevents it from shrinking. Columns with many cards push past `max-height: calc(100vh - 220px)` instead of scrolling internally.

## Fix

| Element | Before | After |
|---------|--------|-------|
| `.hermes-kanban-columns` | `overflow-x: auto; scrollbar-width: none` (single row, hidden scrollbar) | `flex-wrap: wrap` (columns flow into rows, ~3 per row) |
| `.hermes-kanban-columns::-webkit-scrollbar` | `display: none` | **Removed** (no longer needed) |
| `.hermes-kanban-column-body` | _(no flex/min-height)_ | `flex: 1; min-height: 0` |

Columns now wrap into multiple rows instead of overflowing horizontally. All columns visible without scrolling. Tall columns (e.g. Done with 53 tasks) scroll vertically within their `max-height` bounds.

## Verification

- 9 columns → 3 rows (`rowCount: 3`, `flexWrap: wrap`)
- No horizontal overflow (`scrollHeight === containerHeight: 836`)
- Done column body: `scrollHeight: 5312 > clientHeight: 333` → vertical scroll within 413px column