### PR TITLE
fix(gateway): parse MEDIA: tags with Windows paths (#28989)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2159,7 +2159,7 @@ class BasePlatformAdapter(ABC):
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/|[A-Za-z]:[/\\])\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -329,6 +329,18 @@ class TestExtractMedia:
         assert media == [("/tmp/Jane Doe/speech.flac", False)]
         assert cleaned == ""
 
+    def test_media_tag_supports_windows_forward_slash_path(self):
+        content = "MEDIA:C:/Users/gizmo/image.jpg"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == [("C:/Users/gizmo/image.jpg", False)]
+        assert cleaned == ""
+
+    def test_media_tag_supports_windows_backslash_path(self):
+        content = "MEDIA:D:\\Users\\gizmo\\photo.png"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == [("D:\\Users\\gizmo\\photo.png", False)]
+        assert cleaned == ""
+
     def test_as_document_directive_stripped_from_cleaned_text(self):
         """[[as_document]] is a routing directive — strip it from
         user-visible text just like [[audio_as_voice]]. Callers detect the


### PR DESCRIPTION
## Summary

Fixes #28989. `MEDIA:` tag extraction in `gateway/platforms/base.py:2162` used the path prefix pattern `(?:~/|/)`, which only matched POSIX-style absolute / home paths. Windows paths like `C:/Users/foo/img.png` and `C:\Users\foo\img.png` did not match, so `extract_media()` returned empty and the raw `MEDIA:C:\...` text was forwarded as plain text instead of being attached as an image.

## Fix

`gateway/platforms/base.py`: extend `media_pattern` path prefix to `(?:~/|/|[A-Za-z]:[/\\])`, covering `C:/...` (forward slash) and `D:\...` (backslash) drive-letter paths on Windows. Existing POSIX paths still match.

## Test plan
- [x] New `test_media_tag_supports_windows_forward_slash_path` and `test_media_tag_supports_windows_backslash_path` in `tests/gateway/test_platform_base.py`
- [x] Manual regex verification on 4 cases (Windows forward / backslash / POSIX absolute / `~`) all match correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)