### PR TITLE
fix(feishu): classify native voice messages as VOICE for auto-transcription

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -3683,7 +3683,15 @@ class FeishuAdapter(BasePlatformAdapter):
         if preferred == "photo":
             return self._resolve_media_message_type(media_types[0] if media_types else "", default=MessageType.PHOTO)
         if preferred == "audio":
-            return self._resolve_media_message_type(media_types[0] if media_types else "", default=MessageType.AUDIO)
+            # Lark's native "audio" msg_type is an in-app voice recording, not
+            # an uploaded audio file (those arrive as "file"/"media" and are
+            # normalized to "document"). Classify it as VOICE so the gateway
+            # auto-transcribes it (Opus → STT) the same way
+            # Discord/DingTalk/Telegram/etc. do — otherwise a Feishu voice note
+            # reaches the agent as an untranscribable AUDIO attachment and is
+            # silently ignored. Follow-up to #28993, which added native
+            # voice-note transcription for Discord + DingTalk.
+            return MessageType.VOICE
         if preferred == "document":
             return self._resolve_media_message_type(media_types[0] if media_types else "", default=MessageType.DOCUMENT)
         return MessageType.TEXT

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1337,7 +1337,11 @@ class TestAdapterBehavior(unittest.TestCase):
         text, msg_type, media_urls, media_types, _mentions = asyncio.run(adapter._extract_message_content(message))
 
         self.assertEqual(text, "")
-        self.assertEqual(msg_type.value, "audio")
+        # Lark "audio" msg_type is a native voice recording (the fixture is
+        # literally voice.ogg) — it must classify as VOICE so the gateway
+        # auto-transcribes it, not AUDIO (a non-transcribed file attachment).
+        # See the #28993 follow-up fix in _resolve_normalized_message_type.
+        self.assertEqual(msg_type.value, "voice")
         self.assertEqual(media_urls, ["/tmp/feishu-audio.ogg"])
         self.assertEqual(media_types, ["audio/ogg"])
 

--- a/tests/gateway/test_feishu_voice_message_type.py
+++ b/tests/gateway/test_feishu_voice_message_type.py
@@ -1,0 +1,46 @@
+"""Regression tests for Feishu native voice-note classification.
+
+Lark's native ``audio`` msg_type is an in-app voice recording (uploaded
+audio files arrive as ``file``/``media`` and normalize to ``document``). It
+must be classified as MessageType.VOICE so the gateway auto-transcribes it
+(Opus → STT), the same way Discord/DingTalk/Telegram do. Before the fix it
+resolved to MessageType.AUDIO, which the gateway treats as a non-transcribed
+file attachment — so a Feishu voice note silently reached the agent as
+untranscribable audio. Follow-up to #28993 (Discord + DingTalk).
+"""
+
+from gateway.platforms.base import MessageType
+from plugins.platforms.feishu.adapter import FeishuAdapter, FeishuNormalizedMessage
+
+
+def _resolve(preferred: str, media_types):
+    """Call _resolve_normalized_message_type without a full adapter init.
+
+    The method only reads normalized.preferred_message_type and delegates to
+    the static _resolve_media_message_type — no instance state — so we bypass
+    __init__ (which needs Lark credentials/config) via __new__.
+    """
+    adapter = FeishuAdapter.__new__(FeishuAdapter)
+    normalized = FeishuNormalizedMessage(
+        raw_type=preferred,
+        text_content="",
+        preferred_message_type=preferred,
+    )
+    return adapter._resolve_normalized_message_type(normalized, media_types)
+
+
+def test_native_voice_audio_is_classified_as_voice():
+    """Lark audio msg_type (voice recording) → VOICE, so it gets transcribed."""
+    assert _resolve("audio", ["audio/opus"]) is MessageType.VOICE
+
+
+def test_native_voice_audio_without_media_type_is_voice():
+    """A voice note with no resolved mime still classifies as VOICE."""
+    assert _resolve("audio", []) is MessageType.VOICE
+
+
+def test_photo_and_document_unaffected():
+    """The fix is scoped to the audio branch — other types are unchanged."""
+    assert _resolve("photo", ["image/png"]) is MessageType.PHOTO
+    assert _resolve("document", ["application/pdf"]) is MessageType.DOCUMENT
+    assert _resolve("text", []) is MessageType.TEXT


### PR DESCRIPTION
## What does this PR do?

  Feishu (Lark) native voice messages were never transcribed. Lark's top-level `audio` msg_type is an in-app **voice recording** (uploaded audio files arrive as `file`/`media`), but `_resolve_normalized_message_type` resolved the `audio` preferred type to `MessageType.AUDIO`. The gateway treats AUDIO as a non-transcribed file attachment:

  ```python
  # gateway/run.py
  # MessageType.AUDIO = audio file attachment — never STT
  # MessageType.VOICE = voice message (Opus/OGG) — always STT
  if event.message_type == MessageType.AUDIO:
      audio_file_paths.append(path)      # not transcribed
  elif event.message_type == MessageType.VOICE or ...:
      audio_paths.append(path)           # transcribed
  ```

  So a Feishu voice note reached the agent as an untranscribable attachment — the user's spoken message **silently never became text**.

  **Feishu was the only platform getting this wrong.** Telegram, Discord, Slack, WhatsApp, Signal, Matrix, WeChat, WeCom, DingTalk, QQ, BlueBubbles, Mattermost, and Yuanbao all classify native voice notes as `MessageType.VOICE`. This is the follow-up to **#28993**, which added native voice-note transcription for Discord + DingTalk but did not cover Feishu.

  ## Fix

  Return `MessageType.VOICE` for the `audio` branch in `_resolve_normalized_message_type`. That branch is reached only for Lark's top-level `audio` msg_type (the normalizer maps file uploads to `document`), so VOICE is unconditionally correct here — no risk of auto-transcribing an uploaded music/audio file.

  ## Changes Made

  - `gateway/platforms/feishu.py` — `audio` branch returns `MessageType.VOICE` instead of resolving to AUDIO via mime.
  - `tests/gateway/test_feishu.py` — `test_extract_audio_message_downloads_and_caches` asserted the old AUDIO behavior on a fixture **literally named `voice.ogg`**; updated to expect VOICE (the corrected classification).
  - `tests/gateway/test_feishu_voice_message_type.py` (new) — focused regression: `audio` → VOICE (with and without mime); photo/document/text unaffected.

  ## How to Test

  ```bash
  pytest tests/gateway/test_feishu_voice_message_type.py -v   # 3 passed
  pytest tests/gateway/test_feishu.py -q                      # 198 passed
  ```

  Verified the new voice tests fail when the branch resolves to AUDIO and pass with VOICE; the photo/document/text cases are unaffected either way.

  **Scope honesty:** classification is mock-tested here; the downstream STT pipeline is the shared, already-proven path from #28993. End-to-end verification on a live Feishu account would be a welcome confirmation — I don't have one.

  ## Related Issue

  No tracking issue — sibling-gap found while reviewing #28993 (Feishu was the platform left uncovered). Happy to file one if preferred.

  ## Type of Change

  - [x] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [ ] ✨ New feature
  - [ ] 🔒 Security fix
  - [ ] 📝 Documentation update
  - [ ] ✅ Tests
  - [ ] ♻️  Refactor
  - [ ] 🎯 New skill

  ## Checklist

  ### Code
  - [x] I've read the Contributing Guide
  - [x] Conventional Commits (`fix(feishu): ...`)
  - [x] Searched existing PRs — no PR addresses Feishu voice-note classification (#28993 covered Discord + DingTalk only)
  - [x] Only changes related to this fix — single commit, 3 files
  - [ ] `pytest tests/ -q` — ran the full `tests/gateway/test_feishu.py` (198 passed) + new tests; did not run the whole repo suite locally, relying on CI
  - [x] Added tests with verified regression discipline
  - [x] Tested on: Ubuntu 24.04, Python 3.13.5

  ### Documentation & Housekeeping
  - [x] Docs — inline comment explains the Lark `audio`-is-voice rationale; N/A elsewhere
  - [x] cli-config.yaml.example — N/A
  - [x] CONTRIBUTING/AGENTS — N/A
  - [x] Cross-platform — pure classification logic; platform-agnostic
  - [x] Tool schemas — N/A
