### PR TITLE
fix(terminal): pass docker_extra_args through _terminal_env_map (#28863)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -526,6 +526,7 @@ def load_cli_config() -> Dict[str, Any]:
         "docker_env": "TERMINAL_DOCKER_ENV",
         "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
         "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
+        "docker_extra_args": "TERMINAL_DOCKER_EXTRA_ARGS",
         "sandbox_dir": "TERMINAL_SANDBOX_DIR",
         # Persistent shell (non-local backends)
         "persistent_shell": "TERMINAL_PERSISTENT_SHELL",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -635,6 +635,7 @@ if _config_path.exists():
                 "docker_env": "TERMINAL_DOCKER_ENV",
                 "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
                 "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
+                "docker_extra_args": "TERMINAL_DOCKER_EXTRA_ARGS",
                 "sandbox_dir": "TERMINAL_SANDBOX_DIR",
                 "persistent_shell": "TERMINAL_PERSISTENT_SHELL",
             }

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5249,6 +5249,7 @@ def set_config_value(key: str, value: str):
         "terminal.docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
         "terminal.docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
         "terminal.docker_env": "TERMINAL_DOCKER_ENV",
+        "terminal.docker_extra_args": "TERMINAL_DOCKER_EXTRA_ARGS",
         # terminal.cwd intentionally excluded — CLI resolves at runtime,
         # gateway bridges it in gateway/run.py. Persisting to .env causes
         # stale values to poison child processes.

--- a/tests/tools/test_terminal_config_env_sync.py
+++ b/tests/tools/test_terminal_config_env_sync.py
@@ -224,3 +224,20 @@ def test_docker_env_is_bridged_everywhere():
     assert "docker_env" in _gateway_env_map_keys()
     assert "docker_env" in _save_config_env_sync_keys()
     assert "TERMINAL_DOCKER_ENV" in _terminal_tool_env_var_names()
+
+
+def test_docker_extra_args_is_bridged_everywhere():
+    """Regression pin for issue #28863.
+
+    ``terminal.docker_extra_args`` in config.yaml is the documented escape
+    hatch for extra ``docker run`` flags (--read-only, --security-opt, custom
+    --tmpfs overrides, etc.).  terminal_tool._get_env_config reads
+    TERMINAL_DOCKER_EXTRA_ARGS and DockerEnvironment appends the parsed list
+    to run_args, but the gateway and CLI bridges both omitted the key, so the
+    documented config path was silently a no-op.  Guard all four bridging
+    points so this cannot regress.
+    """
+    assert "docker_extra_args" in _cli_env_map_keys()
+    assert "docker_extra_args" in _gateway_env_map_keys()
+    assert "docker_extra_args" in _save_config_env_sync_keys()
+    assert "TERMINAL_DOCKER_EXTRA_ARGS" in _terminal_tool_env_var_names()


### PR DESCRIPTION
## Summary

Fixes #28863. `terminal.docker_extra_args` from `config.yaml` was silently dropped — `terminal_tool._get_env_config` and `DockerEnvironment` both consume the env var, but the three bridges that copy config-yaml keys into env vars (`gateway/run.py::_terminal_env_map`, `cli.py::env_mappings`, `hermes_cli/config.py::_config_to_env_sync`) were missing the entry. So users setting `terminal.docker_extra_args` via `config.yaml` or `hermes config set` saw no effect.

## Fix

- `gateway/run.py`: add `docker_extra_args → TERMINAL_DOCKER_EXTRA_ARGS` to `_terminal_env_map`
- `cli.py`: same mapping in `env_mappings` (keeps cli ↔ gateway key sets in sync — otherwise the existing drift guard test fails)
- `hermes_cli/config.py`: same in `_config_to_env_sync` so `hermes config set terminal.docker_extra_args ...` writes to `.env` like the sibling keys

Static verification: all three maps now contain `docker_extra_args`; cli ↔ gateway key set diff is empty.

## Test plan
- [x] New `test_docker_extra_args_is_bridged_everywhere` in `tests/tools/test_terminal_config_env_sync.py`: mirrors the existing `docker_run_as_host_user` / `docker_env` four-point pins (cli / gateway / save / terminal_tool)

🤖 Generated with [Claude Code](https://claude.com/claude-code)