### PR TITLE
feat(approval): allow restricted --force-with-lease on non-slashless branch

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1736,6 +1736,7 @@ AUTHOR_MAP = {
     "steveonjava@gmail.com": "steveonjava",  # PR #29669 (redact secrets in kanban tool payloads)
     "afnlegion01@gmail.com": "Afnath-max",  # PR #49129 salvage (opencode-zen catalog refresh + uncapped/live-first picker)
     "sharma.priyanshu96@gmail.com": "ipriyaaanshu",  # PR #51488 salvage (clear stale base_url on gateway model switches; #25107)
+    "loicnico96@gmail.com": "loicnico96",
 }
 
 

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1245,6 +1245,50 @@ class TestGitDestructiveOps:
         dangerous, _, _ = detect_dangerous_command(cmd)
         assert dangerous is False
 
+    def test_force_with_lease_to_slash_branch_not_flagged(self):
+        cmd = "git push --force-with-lease origin feature/sprig"
+        dangerous, _, _ = detect_dangerous_command(cmd)
+        assert dangerous is False
+
+    def test_force_with_lease_head_refspec_to_slash_branch_not_flagged(self):
+        cmd = "git push --force-with-lease origin HEAD:feature/sprig"
+        dangerous, _, _ = detect_dangerous_command(cmd)
+        assert dangerous is False
+
+    def test_force_with_lease_to_slashless_branch_still_detected(self):
+        cmd = "git push --force-with-lease origin HEAD:main"
+        dangerous, _, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "force" in desc.lower()
+
+    def test_force_with_lease_to_other_slashless_branch_still_detected(self):
+        cmd = "git push --force-with-lease origin release"
+        dangerous, _, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "force" in desc.lower()
+
+    def test_force_with_lease_to_refs_heads_slashless_branch_still_detected(self):
+        cmd = "git push --force-with-lease origin HEAD:refs/heads/main"
+        dangerous, _, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "force" in desc.lower()
+
+    def test_force_with_lease_to_refs_heads_slash_branch_not_flagged(self):
+        cmd = "git push --force-with-lease origin HEAD:refs/heads/feature/sprig"
+        dangerous, _, _ = detect_dangerous_command(cmd)
+        assert dangerous is False
+
+    def test_force_with_lease_safe_override_applies_after_leading_command(self):
+        cmd = "echo hi && git push --force-with-lease origin feature/sprig"
+        dangerous, _, _ = detect_dangerous_command(cmd)
+        assert dangerous is False
+
+    def test_force_with_lease_safe_override_does_not_mask_later_dangerous_command(self):
+        cmd = "git push --force-with-lease origin feature/sprig && rm -rf /tmp/nope"
+        dangerous, _, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "delete" in desc.lower() or "rm" in desc.lower()
+
     def test_git_branch_lowercase_d_also_flagged(self):
         """git branch -d triggers approval too — IGNORECASE is global.
 

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1289,6 +1289,24 @@ class TestGitDestructiveOps:
         assert dangerous is True
         assert "delete" in desc.lower() or "rm" in desc.lower()
 
+    def test_force_with_lease_safe_override_does_not_mask_later_plain_force_push(self):
+        cmd = "git push --force-with-lease origin feature/sprig && git push --force origin main"
+        dangerous, _, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "force" in desc.lower()
+
+    def test_force_with_lease_to_refs_tags_slash_ref_still_detected(self):
+        cmd = "git push --force-with-lease origin HEAD:refs/tags/release/v1"
+        dangerous, _, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "force" in desc.lower()
+
+    def test_force_with_lease_to_refs_notes_slash_ref_still_detected(self):
+        cmd = "git push --force-with-lease origin HEAD:refs/notes/team/foo"
+        dangerous, _, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "force" in desc.lower()
+
     def test_git_branch_lowercase_d_also_flagged(self):
         """git branch -d triggers approval too — IGNORECASE is global.
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -500,8 +500,8 @@ DANGEROUS_PATTERNS = [
     # Git destructive operations that can lose uncommitted work or rewrite
     # shared history. Not captured by rm/chmod/etc patterns.
     (r'\bgit\s+reset\s+--hard\b', "git reset --hard (destroys uncommitted changes)"),
-    (r'\bgit\s+push\b[^;&|\n]*--force\b', "git force push (rewrites remote history)"),
-    (r'\bgit\s+push\b[^;&|\n]*-f\b', "git force push short flag (rewrites remote history)"),
+    (r'\bgit\s+push\b.*?--force\b', "git force push (rewrites remote history)"),
+    (r'\bgit\s+push\b.*?-f\b', "git force push short flag (rewrites remote history)"),
     (r'\bgit\s+clean\s+-[^\s]*f', "git clean with force (deletes untracked files)"),
     (r'\bgit\s+branch\s+-D\b', "git branch force delete"),
     # Script execution after chmod +x — catches the two-step pattern where

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -711,6 +711,50 @@ def _rewrite_resolved_hermes_home(command: str) -> str:
     return _fold_home_prefixes(command, candidates, "~/.hermes")
 
 
+_ALLOWED_FORCE_WITH_LEASE_RE = re.compile(
+    r'^git\s+push\s+--force-with-lease(?:=\S+)?\s+(\w\S*)\s+(?:HEAD:)?(\w\S*)\s*(?:$|&&|\|\||;|\n)',
+    _RE_FLAGS,
+)
+
+
+def _is_allowed_force_with_lease_branch_push(command_from_match: str) -> bool:
+    """Allow a narrow safe-ish `git push --force-with-lease` shape.
+
+    Expects a substring that begins at the dangerous match start. Permits:
+        git push --force-with-lease <remote> <branch>
+        git push --force-with-lease <remote> HEAD:<branch>
+
+    ...as long as the explicit destination branch contains a ``/`` separator.
+
+    This intentionally stays narrow:
+    - no plain ``--force`` / ``-f``
+    - no implicit destination branch
+    - no extra positional refspecs
+    - no additional options beyond ``--force-with-lease``
+    """
+    match = _ALLOWED_FORCE_WITH_LEASE_RE.match(command_from_match)
+    if not match:
+        return False
+
+    _remote, target_ref = match.groups()
+    normalized_target_ref = target_ref
+    if normalized_target_ref.lower().startswith("refs/heads/"):
+        normalized_target_ref = normalized_target_ref[len("refs/heads/"):]
+    return "/" in normalized_target_ref and not normalized_target_ref.endswith("/")
+
+
+def _dangerous_match_is_safely_overridden(
+    command: str,
+    *,
+    pattern_key: str,
+    match: re.Match[str],
+) -> bool:
+    """Check whether a specific dangerous match is cancelled by a safe override."""
+    if pattern_key != "git force push (rewrites remote history)":
+        return False
+    return _is_allowed_force_with_lease_branch_push(command[match.start():])
+
+
 def detect_dangerous_command(command: str) -> tuple:
     """Check if a command matches any dangerous patterns.
 
@@ -719,8 +763,14 @@ def detect_dangerous_command(command: str) -> tuple:
     """
     command_lower = _normalize_command_for_detection(command).lower()
     for pattern_re, description in DANGEROUS_PATTERNS_COMPILED:
-        if pattern_re.search(command_lower):
+        for match in pattern_re.finditer(command_lower):
             pattern_key = description
+            if _dangerous_match_is_safely_overridden(
+                command_lower,
+                pattern_key=pattern_key,
+                match=match,
+            ):
+                continue
             return (True, pattern_key, description)
     return (False, None, None)
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -500,8 +500,8 @@ DANGEROUS_PATTERNS = [
     # Git destructive operations that can lose uncommitted work or rewrite
     # shared history. Not captured by rm/chmod/etc patterns.
     (r'\bgit\s+reset\s+--hard\b', "git reset --hard (destroys uncommitted changes)"),
-    (r'\bgit\s+push\b.*--force\b', "git force push (rewrites remote history)"),
-    (r'\bgit\s+push\b.*-f\b', "git force push short flag (rewrites remote history)"),
+    (r'\bgit\s+push\b[^;&|\n]*--force\b', "git force push (rewrites remote history)"),
+    (r'\bgit\s+push\b[^;&|\n]*-f\b', "git force push short flag (rewrites remote history)"),
     (r'\bgit\s+clean\s+-[^\s]*f', "git clean with force (deletes untracked files)"),
     (r'\bgit\s+branch\s+-D\b', "git branch force delete"),
     # Script execution after chmod +x — catches the two-step pattern where
@@ -724,13 +724,15 @@ def _is_allowed_force_with_lease_branch_push(command_from_match: str) -> bool:
         git push --force-with-lease <remote> <branch>
         git push --force-with-lease <remote> HEAD:<branch>
 
-    ...as long as the explicit destination branch contains a ``/`` separator.
+    ...as long as the explicit destination is a branch update whose branch
+    name contains a ``/`` separator.
 
     This intentionally stays narrow:
     - no plain ``--force`` / ``-f``
     - no implicit destination branch
     - no extra positional refspecs
     - no additional options beyond ``--force-with-lease``
+    - no non-branch namespaces like ``refs/tags/`` or ``refs/notes/``
     """
     match = _ALLOWED_FORCE_WITH_LEASE_RE.match(command_from_match)
     if not match:
@@ -738,8 +740,13 @@ def _is_allowed_force_with_lease_branch_push(command_from_match: str) -> bool:
 
     _remote, target_ref = match.groups()
     normalized_target_ref = target_ref
-    if normalized_target_ref.lower().startswith("refs/heads/"):
+    lower_target_ref = normalized_target_ref.lower()
+    if lower_target_ref.startswith("refs/heads/"):
         normalized_target_ref = normalized_target_ref[len("refs/heads/"):]
+        lower_target_ref = normalized_target_ref.lower()
+    elif lower_target_ref.startswith("refs/"):
+        return False
+
     return "/" in normalized_target_ref and not normalized_target_ref.endswith("/")
 
 


### PR DESCRIPTION
## What does this PR do?

This PR loosens the dangerous-command approval trigger for a narrow, explicit class of `git push --force-with-lease` commands.

Today, Hermes treats all force-pushes as approval-worthy, including branch-scoped `--force-with-lease` updates that are commonly used during normal PR iteration. That makes the approval system noisier than necessary for a relatively constrained workflow.

This change allows Hermes to skip approval for:
```bash
git push --force-with-lease <remote> <branch>
git push --force-with-lease <remote> HEAD:<branch>
```
when the destination is an explicit **non-slashless branch**:
- it must contain `/`
- it may be written as `refs/heads/...`
- it must not target protected-looking slashless branches like `main`
- it must not target non-branch namespaces like `refs/tags/...` or `refs/notes/...`

This is implemented as a 2nd "allowlist" check after the 1st "denylist" check, which is stricter / more tunable than splitting into separate weaker denylists.

The goal is to preserve the safety intent of force-push approvals while reducing friction for common branch-based rewrite workflows, especially on feature / topic branches. Plain `git push --force` remains approval-worthy, and `--force-with-lease` only gets this exception for the narrow branch shapes above.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/approval.py`
  - added a match-local safe override for `git push --force-with-lease`
  - changed dangerous command scanning to iterate with `finditer()` and continue after an overridden match
  - anchored the safe matcher at the start of the matched dangerous substring
  - restricted the override to **branch updates only**
    - allows plain branch names containing `/`
    - allows `refs/heads/...` after normalization
    - rejects other `refs/*` namespaces such as `refs/tags/...` and `refs/notes/...`
  - changed the generic `git push ... --force` / `-f` dangerous patterns to use non-greedy matching so a safe leased push does not hide a later unsafe force-push on the same shell line

- `tests/tools/test_approval.py`
  - added regression coverage for:
    - slash-containing branch destinations being allowed
    - slashless branch destinations still requiring approval
    - `refs/heads/main` still requiring approval
    - `refs/heads/feature/...` being allowed
    - a safe `--force-with-lease` after a leading command on the same line
    - a safe `--force-with-lease` not masking a later `rm -rf`
    - a safe `--force-with-lease` not masking a later plain `git push --force`
    - `refs/tags/...` and `refs/notes/...` still requiring approval

## How to Test

1. Run the targeted approval tests:
   
```bash
   pytest -q tests/tools/test_approval.py -k 'force_with_lease or git_push_force_detected or git_push_dash_f_detected'
```

2. Live-tested the behavior in a throwaway worktree/branch on a fork:
- launched a real Hermes agent in a throwaway worktree on the `loicnico96` fork
- seeded a temporary remote branch
- spawned another session and instructed it to run
```bash
  git push --force-with-lease <remote> HEAD:qa/noame/agent-live-force-with-lease-<timestamp>
```
- confirmed the agent did not face an approval prompt and the push succeeded
- deleted the throwaway branch and worktree afterward

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've upated tool descriptions/schemas if I changed tool behavior — or N/A