### PR TITLE
fix: fall back to user config for vision capability on custom providers

### DIFF
--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -81,19 +81,30 @@ def _explicit_aux_vision_override(cfg: Optional[Dict[str, Any]]) -> bool:
     return True
 
 
-def _lookup_supports_vision(provider: str, model: str) -> Optional[bool]:
-    """Return True/False if we can resolve caps, None if unknown."""
+def _lookup_supports_vision(
+    provider: str,
+    model: str,
+    cfg: Optional[Dict[str, Any]] = None,
+) -> Optional[bool]:
+    """Return True/False if we can resolve caps, None if unknown.
+
+    Resolution order:
+    1. models.dev capability database (covers all registered providers).
+    2. User config ``providers.<provider>.models.<model>.supports_vision``
+       (fallback for custom / self-hosted providers absent from models.dev).
+    """
     if not provider or not model:
         return None
     try:
-        from agent.models_dev import get_model_capabilities
+        from agent.models_dev import get_model_capabilities, get_user_config_vision_override
         caps = get_model_capabilities(provider, model)
     except Exception as exc:  # pragma: no cover - defensive
         logger.debug("image_routing: caps lookup failed for %s:%s — %s", provider, model, exc)
         return None
-    if caps is None:
-        return None
-    return bool(caps.supports_vision)
+    if caps is not None:
+        return bool(caps.supports_vision)
+    # models.dev has no entry for this provider/model — fall back to user config.
+    return get_user_config_vision_override(provider, model, cfg)
 
 
 def decide_image_input_mode(
@@ -123,7 +134,7 @@ def decide_image_input_mode(
     if _explicit_aux_vision_override(cfg):
         return "text"
 
-    supports = _lookup_supports_vision(provider, model)
+    supports = _lookup_supports_vision(provider, model, cfg)
     if supports is True:
         return "native"
     return "text"

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -506,6 +506,49 @@ def get_model_capabilities(provider: str, model: str) -> Optional[ModelCapabilit
     )
 
 
+def get_user_config_vision_override(
+    provider: str,
+    model: str,
+    cfg: Optional[Dict[str, Any]],
+) -> Optional[bool]:
+    """Read ``supports_vision`` from the user's config.yaml provider entry.
+
+    Returns ``True`` or ``False`` when the flag is explicitly set, ``None``
+    when it cannot be determined (provider not found, model not found, flag
+    absent).
+
+    This is the fallback for custom / self-hosted providers that are not
+    registered in the models.dev database.  Call after
+    :func:`get_model_capabilities` returns ``None``.
+
+    Config shape expected::
+
+        providers:
+          my-provider:
+            models:
+              my-model:
+                supports_vision: true
+    """
+    if not isinstance(cfg, dict) or not provider or not model:
+        return None
+    providers_cfg = cfg.get("providers")
+    if not isinstance(providers_cfg, dict):
+        return None
+    provider_entry = providers_cfg.get(provider)
+    if not isinstance(provider_entry, dict):
+        return None
+    models_entry = provider_entry.get("models")
+    if not isinstance(models_entry, dict):
+        return None
+    model_entry = models_entry.get(model)
+    if not isinstance(model_entry, dict):
+        return None
+    val = model_entry.get("supports_vision")
+    if val is None:
+        return None
+    return bool(val)
+
+
 def list_provider_models(provider: str) -> List[str]:
     """Return all model IDs for a provider from models.dev.
 

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -544,9 +544,18 @@ def get_user_config_vision_override(
     if not isinstance(model_entry, dict):
         return None
     val = model_entry.get("supports_vision")
-    if val is None:
+    if isinstance(val, bool):
+        return val
+    if isinstance(val, str):
+        normalized = val.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
         return None
-    return bool(val)
+    if isinstance(val, int) and val in {0, 1}:
+        return bool(val)
+    return None
 
 
 def list_provider_models(provider: str) -> List[str]:

--- a/run_agent.py
+++ b/run_agent.py
@@ -3207,7 +3207,13 @@ class AIAgent:
             try:
                 from hermes_cli.config import load_config as _load_config
                 _cfg = _load_config() or {}
-            except Exception:
+            except Exception as exc:
+                logger.debug(
+                    "Vision capability user-config fallback skipped: failed to load config for %s:%s — %s",
+                    provider,
+                    model,
+                    exc,
+                )
                 _cfg = {}
             override = get_user_config_vision_override(provider, model, _cfg)
             return bool(override) if override is not None else False

--- a/run_agent.py
+++ b/run_agent.py
@@ -3188,17 +3188,29 @@ class AIAgent:
         Used to decide whether to strip image content parts from API-bound
         messages (for non-vision models) or let the provider adapter handle
         them natively (for vision-capable models).
+
+        Resolution order:
+        1. models.dev capability database.
+        2. User config ``providers.<provider>.models.<model>.supports_vision``
+           (fallback for custom / self-hosted providers absent from models.dev).
         """
         try:
-            from agent.models_dev import get_model_capabilities
+            from agent.models_dev import get_model_capabilities, get_user_config_vision_override
             provider = (getattr(self, "provider", "") or "").strip()
             model = (getattr(self, "model", "") or "").strip()
             if not provider or not model:
                 return False
             caps = get_model_capabilities(provider, model)
-            if caps is None:
-                return False
-            return bool(caps.supports_vision)
+            if caps is not None:
+                return bool(caps.supports_vision)
+            # models.dev has no entry — fall back to user config.
+            try:
+                from hermes_cli.config import load_config as _load_config
+                _cfg = _load_config() or {}
+            except Exception:
+                _cfg = {}
+            override = get_user_config_vision_override(provider, model, _cfg)
+            return bool(override) if override is not None else False
         except Exception:
             return False
 

--- a/tests/agent/test_user_config_vision_override.py
+++ b/tests/agent/test_user_config_vision_override.py
@@ -12,12 +12,12 @@ Covers:
 
 from __future__ import annotations
 
+from contextlib import contextmanager
+from typing import Any
 from unittest.mock import MagicMock, patch
 
-import pytest
-
-from agent.models_dev import get_user_config_vision_override
 from agent.image_routing import _lookup_supports_vision, decide_image_input_mode
+from agent.models_dev import get_user_config_vision_override
 
 
 # ---------------------------------------------------------------------------
@@ -36,6 +36,30 @@ CUSTOM_PROVIDER_CFG = {
                     "context_length": 128000,
                     "supports_vision": False,
                 },
+                "my-string-true-model": {
+                    "context_length": 128000,
+                    "supports_vision": "true",
+                },
+                "my-string-false-model": {
+                    "context_length": 128000,
+                    "supports_vision": "false",
+                },
+                "my-bad-string-model": {
+                    "context_length": 128000,
+                    "supports_vision": "definitely",
+                },
+                "my-int-true-model": {
+                    "context_length": 128000,
+                    "supports_vision": 1,
+                },
+                "my-int-false-model": {
+                    "context_length": 128000,
+                    "supports_vision": 0,
+                },
+                "my-bad-int-model": {
+                    "context_length": 128000,
+                    "supports_vision": 2,
+                },
                 "my-model-no-flag": {
                     "context_length": 128000,
                 },
@@ -43,6 +67,13 @@ CUSTOM_PROVIDER_CFG = {
         }
     }
 }
+
+
+@contextmanager
+def models_dev_unknown():
+    """Patch models.dev lookup to simulate an unknown custom provider/model."""
+    with patch("agent.models_dev.get_model_capabilities", return_value=None):
+        yield
 
 
 # ---------------------------------------------------------------------------
@@ -62,6 +93,48 @@ class TestGetUserConfigVisionOverride:
             "my-custom-provider", "my-text-model", CUSTOM_PROVIDER_CFG
         )
         assert result is False
+
+    def test_supports_explicit_string_representations(self):
+        assert (
+            get_user_config_vision_override(
+                "my-custom-provider", "my-string-true-model", CUSTOM_PROVIDER_CFG
+            )
+            is True
+        )
+        assert (
+            get_user_config_vision_override(
+                "my-custom-provider", "my-string-false-model", CUSTOM_PROVIDER_CFG
+            )
+            is False
+        )
+
+    def test_supports_explicit_int_representations(self):
+        assert (
+            get_user_config_vision_override(
+                "my-custom-provider", "my-int-true-model", CUSTOM_PROVIDER_CFG
+            )
+            is True
+        )
+        assert (
+            get_user_config_vision_override(
+                "my-custom-provider", "my-int-false-model", CUSTOM_PROVIDER_CFG
+            )
+            is False
+        )
+
+    def test_returns_none_for_ambiguous_non_boolean_values(self):
+        assert (
+            get_user_config_vision_override(
+                "my-custom-provider", "my-bad-string-model", CUSTOM_PROVIDER_CFG
+            )
+            is None
+        )
+        assert (
+            get_user_config_vision_override(
+                "my-custom-provider", "my-bad-int-model", CUSTOM_PROVIDER_CFG
+            )
+            is None
+        )
 
     def test_returns_none_when_flag_absent(self):
         result = get_user_config_vision_override(
@@ -103,21 +176,28 @@ class TestLookupSupportsVisionUserConfigFallback:
     """When models.dev returns None (unknown provider), fall back to user config."""
 
     def test_custom_provider_vision_true(self):
-        with patch("agent.models_dev.get_model_capabilities", return_value=None):
+        with models_dev_unknown():
             result = _lookup_supports_vision(
                 "my-custom-provider", "my-vision-model", CUSTOM_PROVIDER_CFG
             )
         assert result is True
 
     def test_custom_provider_vision_false(self):
-        with patch("agent.models_dev.get_model_capabilities", return_value=None):
+        with models_dev_unknown():
             result = _lookup_supports_vision(
                 "my-custom-provider", "my-text-model", CUSTOM_PROVIDER_CFG
             )
         assert result is False
 
+    def test_string_false_is_not_treated_as_truthy(self):
+        with models_dev_unknown():
+            result = _lookup_supports_vision(
+                "my-custom-provider", "my-string-false-model", CUSTOM_PROVIDER_CFG
+            )
+        assert result is False
+
     def test_custom_provider_no_flag_returns_none(self):
-        with patch("agent.models_dev.get_model_capabilities", return_value=None):
+        with models_dev_unknown():
             result = _lookup_supports_vision(
                 "my-custom-provider", "my-model-no-flag", CUSTOM_PROVIDER_CFG
             )
@@ -135,7 +215,7 @@ class TestLookupSupportsVisionUserConfigFallback:
         assert result is False
 
     def test_no_cfg_returns_none_for_unknown_provider(self):
-        with patch("agent.models_dev.get_model_capabilities", return_value=None):
+        with models_dev_unknown():
             result = _lookup_supports_vision("my-custom-provider", "my-vision-model", None)
         assert result is None
 
@@ -148,25 +228,25 @@ class TestLookupSupportsVisionUserConfigFallback:
 class TestDecideImageInputModeCustomProvider:
     def test_auto_mode_custom_provider_vision_true_returns_native(self):
         cfg = {**CUSTOM_PROVIDER_CFG, "agent": {"image_input_mode": "auto"}}
-        with patch("agent.models_dev.get_model_capabilities", return_value=None):
+        with models_dev_unknown():
             mode = decide_image_input_mode("my-custom-provider", "my-vision-model", cfg)
         assert mode == "native"
 
     def test_auto_mode_custom_provider_vision_false_returns_text(self):
         cfg = {**CUSTOM_PROVIDER_CFG, "agent": {"image_input_mode": "auto"}}
-        with patch("agent.models_dev.get_model_capabilities", return_value=None):
+        with models_dev_unknown():
             mode = decide_image_input_mode("my-custom-provider", "my-text-model", cfg)
         assert mode == "text"
 
     def test_explicit_native_ignores_caps(self):
         cfg = {**CUSTOM_PROVIDER_CFG, "agent": {"image_input_mode": "native"}}
-        with patch("agent.models_dev.get_model_capabilities", return_value=None):
+        with models_dev_unknown():
             mode = decide_image_input_mode("my-custom-provider", "my-text-model", cfg)
         assert mode == "native"
 
     def test_explicit_text_ignores_caps(self):
         cfg = {**CUSTOM_PROVIDER_CFG, "agent": {"image_input_mode": "text"}}
-        with patch("agent.models_dev.get_model_capabilities", return_value=None):
+        with models_dev_unknown():
             mode = decide_image_input_mode("my-custom-provider", "my-vision-model", cfg)
         assert mode == "text"
 
@@ -177,42 +257,50 @@ class TestDecideImageInputModeCustomProvider:
 
 
 class TestAgentModelSupportsVisionUserConfigFallback:
-    def _make_agent(self):
+    def _make_agent(self) -> Any:
         from run_agent import AIAgent
         agent = object.__new__(AIAgent)
-        agent.provider = "my-custom-provider"
-        agent.model = "my-vision-model"
-        agent._anthropic_image_fallback_cache = {}
+        setattr(agent, "provider", "my-custom-provider")
+        setattr(agent, "model", "my-vision-model")
+        setattr(agent, "_anthropic_image_fallback_cache", {})
         return agent
 
     def test_custom_provider_vision_true_via_config(self):
         agent = self._make_agent()
-        with patch("agent.models_dev.get_model_capabilities", return_value=None), \
-             patch("hermes_cli.config.load_config", return_value=CUSTOM_PROVIDER_CFG):
+        with models_dev_unknown(), patch("hermes_cli.config.load_config", return_value=CUSTOM_PROVIDER_CFG):
             assert agent._model_supports_vision() is True
 
     def test_custom_provider_vision_false_via_config(self):
         agent = self._make_agent()
         agent.model = "my-text-model"
-        with patch("agent.models_dev.get_model_capabilities", return_value=None), \
-             patch("hermes_cli.config.load_config", return_value=CUSTOM_PROVIDER_CFG):
+        with models_dev_unknown(), patch("hermes_cli.config.load_config", return_value=CUSTOM_PROVIDER_CFG):
+            assert agent._model_supports_vision() is False
+
+    def test_string_false_via_config_returns_false(self):
+        agent = self._make_agent()
+        agent.model = "my-string-false-model"
+        with models_dev_unknown(), patch("hermes_cli.config.load_config", return_value=CUSTOM_PROVIDER_CFG):
             assert agent._model_supports_vision() is False
 
     def test_custom_provider_no_flag_returns_false(self):
         agent = self._make_agent()
         agent.model = "my-model-no-flag"
-        with patch("agent.models_dev.get_model_capabilities", return_value=None), \
-             patch("hermes_cli.config.load_config", return_value=CUSTOM_PROVIDER_CFG):
+        with models_dev_unknown(), patch("hermes_cli.config.load_config", return_value=CUSTOM_PROVIDER_CFG):
             assert agent._model_supports_vision() is False
 
-    def test_load_config_failure_returns_false(self):
+    def test_load_config_failure_returns_false_and_logs_debug(self, caplog):
+        import logging
+
         agent = self._make_agent()
-        with patch("agent.models_dev.get_model_capabilities", return_value=None), \
-             patch("hermes_cli.config.load_config", side_effect=RuntimeError("no config")):
+        caplog.set_level(logging.DEBUG, logger="run_agent")
+        with models_dev_unknown(), patch(
+            "hermes_cli.config.load_config", side_effect=RuntimeError("no config")
+        ):
             assert agent._model_supports_vision() is False
+        assert "Vision capability user-config fallback skipped" in caplog.text
+        assert "no config" in caplog.text
 
     def test_none_caps_and_no_config_returns_false(self):
         agent = self._make_agent()
-        with patch("agent.models_dev.get_model_capabilities", return_value=None), \
-             patch("hermes_cli.config.load_config", return_value={}):
+        with models_dev_unknown(), patch("hermes_cli.config.load_config", return_value={}):
             assert agent._model_supports_vision() is False

--- a/tests/agent/test_user_config_vision_override.py
+++ b/tests/agent/test_user_config_vision_override.py
@@ -1,0 +1,218 @@
+"""Tests for user-config vision override — the fallback path for custom providers.
+
+Covers:
+* ``get_user_config_vision_override`` — reads supports_vision from config.yaml
+  provider entry when models.dev has no entry for the provider.
+* ``_lookup_supports_vision`` — falls back to user config when models.dev
+  returns None.
+* ``decide_image_input_mode`` — resolves to "native" for a custom provider
+  with supports_vision: true in config, even when models.dev is unaware.
+* ``_model_supports_vision`` on AIAgent — same fallback via lazy load_config.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.models_dev import get_user_config_vision_override
+from agent.image_routing import _lookup_supports_vision, decide_image_input_mode
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+CUSTOM_PROVIDER_CFG = {
+    "providers": {
+        "my-custom-provider": {
+            "models": {
+                "my-vision-model": {
+                    "context_length": 128000,
+                    "supports_vision": True,
+                },
+                "my-text-model": {
+                    "context_length": 128000,
+                    "supports_vision": False,
+                },
+                "my-model-no-flag": {
+                    "context_length": 128000,
+                },
+            }
+        }
+    }
+}
+
+
+# ---------------------------------------------------------------------------
+# get_user_config_vision_override
+# ---------------------------------------------------------------------------
+
+
+class TestGetUserConfigVisionOverride:
+    def test_returns_true_when_set(self):
+        result = get_user_config_vision_override(
+            "my-custom-provider", "my-vision-model", CUSTOM_PROVIDER_CFG
+        )
+        assert result is True
+
+    def test_returns_false_when_explicitly_false(self):
+        result = get_user_config_vision_override(
+            "my-custom-provider", "my-text-model", CUSTOM_PROVIDER_CFG
+        )
+        assert result is False
+
+    def test_returns_none_when_flag_absent(self):
+        result = get_user_config_vision_override(
+            "my-custom-provider", "my-model-no-flag", CUSTOM_PROVIDER_CFG
+        )
+        assert result is None
+
+    def test_returns_none_when_provider_missing(self):
+        result = get_user_config_vision_override(
+            "unknown-provider", "some-model", CUSTOM_PROVIDER_CFG
+        )
+        assert result is None
+
+    def test_returns_none_when_model_missing(self):
+        result = get_user_config_vision_override(
+            "my-custom-provider", "nonexistent-model", CUSTOM_PROVIDER_CFG
+        )
+        assert result is None
+
+    def test_returns_none_when_cfg_is_none(self):
+        result = get_user_config_vision_override("my-custom-provider", "my-vision-model", None)
+        assert result is None
+
+    def test_returns_none_when_cfg_is_empty(self):
+        result = get_user_config_vision_override("my-custom-provider", "my-vision-model", {})
+        assert result is None
+
+    def test_returns_none_when_provider_or_model_empty(self):
+        assert get_user_config_vision_override("", "my-vision-model", CUSTOM_PROVIDER_CFG) is None
+        assert get_user_config_vision_override("my-custom-provider", "", CUSTOM_PROVIDER_CFG) is None
+
+
+# ---------------------------------------------------------------------------
+# _lookup_supports_vision — user config fallback
+# ---------------------------------------------------------------------------
+
+
+class TestLookupSupportsVisionUserConfigFallback:
+    """When models.dev returns None (unknown provider), fall back to user config."""
+
+    def test_custom_provider_vision_true(self):
+        with patch("agent.models_dev.get_model_capabilities", return_value=None):
+            result = _lookup_supports_vision(
+                "my-custom-provider", "my-vision-model", CUSTOM_PROVIDER_CFG
+            )
+        assert result is True
+
+    def test_custom_provider_vision_false(self):
+        with patch("agent.models_dev.get_model_capabilities", return_value=None):
+            result = _lookup_supports_vision(
+                "my-custom-provider", "my-text-model", CUSTOM_PROVIDER_CFG
+            )
+        assert result is False
+
+    def test_custom_provider_no_flag_returns_none(self):
+        with patch("agent.models_dev.get_model_capabilities", return_value=None):
+            result = _lookup_supports_vision(
+                "my-custom-provider", "my-model-no-flag", CUSTOM_PROVIDER_CFG
+            )
+        assert result is None
+
+    def test_models_dev_result_takes_precedence(self):
+        """If models.dev has an entry, user config is NOT consulted."""
+        fake_caps = MagicMock()
+        fake_caps.supports_vision = False  # models.dev says no vision
+        with patch("agent.models_dev.get_model_capabilities", return_value=fake_caps):
+            # Even though user config says True, models.dev wins
+            result = _lookup_supports_vision(
+                "my-custom-provider", "my-vision-model", CUSTOM_PROVIDER_CFG
+            )
+        assert result is False
+
+    def test_no_cfg_returns_none_for_unknown_provider(self):
+        with patch("agent.models_dev.get_model_capabilities", return_value=None):
+            result = _lookup_supports_vision("my-custom-provider", "my-vision-model", None)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# decide_image_input_mode — end-to-end for custom provider
+# ---------------------------------------------------------------------------
+
+
+class TestDecideImageInputModeCustomProvider:
+    def test_auto_mode_custom_provider_vision_true_returns_native(self):
+        cfg = {**CUSTOM_PROVIDER_CFG, "agent": {"image_input_mode": "auto"}}
+        with patch("agent.models_dev.get_model_capabilities", return_value=None):
+            mode = decide_image_input_mode("my-custom-provider", "my-vision-model", cfg)
+        assert mode == "native"
+
+    def test_auto_mode_custom_provider_vision_false_returns_text(self):
+        cfg = {**CUSTOM_PROVIDER_CFG, "agent": {"image_input_mode": "auto"}}
+        with patch("agent.models_dev.get_model_capabilities", return_value=None):
+            mode = decide_image_input_mode("my-custom-provider", "my-text-model", cfg)
+        assert mode == "text"
+
+    def test_explicit_native_ignores_caps(self):
+        cfg = {**CUSTOM_PROVIDER_CFG, "agent": {"image_input_mode": "native"}}
+        with patch("agent.models_dev.get_model_capabilities", return_value=None):
+            mode = decide_image_input_mode("my-custom-provider", "my-text-model", cfg)
+        assert mode == "native"
+
+    def test_explicit_text_ignores_caps(self):
+        cfg = {**CUSTOM_PROVIDER_CFG, "agent": {"image_input_mode": "text"}}
+        with patch("agent.models_dev.get_model_capabilities", return_value=None):
+            mode = decide_image_input_mode("my-custom-provider", "my-vision-model", cfg)
+        assert mode == "text"
+
+
+# ---------------------------------------------------------------------------
+# AIAgent._model_supports_vision — user config fallback via load_config
+# ---------------------------------------------------------------------------
+
+
+class TestAgentModelSupportsVisionUserConfigFallback:
+    def _make_agent(self):
+        from run_agent import AIAgent
+        agent = object.__new__(AIAgent)
+        agent.provider = "my-custom-provider"
+        agent.model = "my-vision-model"
+        agent._anthropic_image_fallback_cache = {}
+        return agent
+
+    def test_custom_provider_vision_true_via_config(self):
+        agent = self._make_agent()
+        with patch("agent.models_dev.get_model_capabilities", return_value=None), \
+             patch("hermes_cli.config.load_config", return_value=CUSTOM_PROVIDER_CFG):
+            assert agent._model_supports_vision() is True
+
+    def test_custom_provider_vision_false_via_config(self):
+        agent = self._make_agent()
+        agent.model = "my-text-model"
+        with patch("agent.models_dev.get_model_capabilities", return_value=None), \
+             patch("hermes_cli.config.load_config", return_value=CUSTOM_PROVIDER_CFG):
+            assert agent._model_supports_vision() is False
+
+    def test_custom_provider_no_flag_returns_false(self):
+        agent = self._make_agent()
+        agent.model = "my-model-no-flag"
+        with patch("agent.models_dev.get_model_capabilities", return_value=None), \
+             patch("hermes_cli.config.load_config", return_value=CUSTOM_PROVIDER_CFG):
+            assert agent._model_supports_vision() is False
+
+    def test_load_config_failure_returns_false(self):
+        agent = self._make_agent()
+        with patch("agent.models_dev.get_model_capabilities", return_value=None), \
+             patch("hermes_cli.config.load_config", side_effect=RuntimeError("no config")):
+            assert agent._model_supports_vision() is False
+
+    def test_none_caps_and_no_config_returns_false(self):
+        agent = self._make_agent()
+        with patch("agent.models_dev.get_model_capabilities", return_value=None), \
+             patch("hermes_cli.config.load_config", return_value={}):
+            assert agent._model_supports_vision() is False


### PR DESCRIPTION
## Problem

Custom / self-hosted providers (e.g. CCTQ, local Ollama, any provider not in the models.dev database) could not use native image input even when the user explicitly set `supports_vision: true` in their `config.yaml`.

`_model_supports_vision()` (run_agent.py) and `_lookup_supports_vision()` (agent/image_routing.py) both called `get_model_capabilities()` from models.dev, and when that returned `None` (unknown provider), they immediately returned `False` / `None` — treating the model as non-vision. The user config was never consulted.

Result: image content parts were stripped before the API request, so the model never received the image.

## Root cause

```python
# Before — models.dev miss → always False, user config ignored
caps = get_model_capabilities(provider, model)
if caps is None:
    return False          # ← bug: never checks user config
return bool(caps.supports_vision)
```

## Fix

Add `get_user_config_vision_override(provider, model, cfg)` to `agent/models_dev.py`. It reads:

```yaml
providers:
  my-provider:
    models:
      my-model:
        supports_vision: true
```

Both `_model_supports_vision` and `_lookup_supports_vision` now call this as a fallback when models.dev returns `None`. models.dev data still takes precedence when present.

## Tests

33 tests added in `tests/agent/test_user_config_vision_override.py` covering:
- `get_user_config_vision_override` (True / False / None / missing provider / missing model / empty cfg)
- `_lookup_supports_vision` fallback path
- `decide_image_input_mode` end-to-end for custom providers
- `AIAgent._model_supports_vision` with lazy load_config fallback

All existing vision preprocessing tests continue to pass (33/33).