### PR TITLE
fix(env): make config.yaml authoritative for terminal.backend (#29186)

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -172,4 +172,73 @@ def load_hermes_dotenv(
         _load_dotenv_with_fallback(project_env_path, override=not loaded)
         loaded.append(project_env_path)
 
+    # config.yaml is the documented source of truth for terminal.backend, but
+    # a stale TERMINAL_ENV in ~/.hermes/.env (e.g. left over from `hermes
+    # setup` after the user later edits config.yaml directly) silently wins
+    # because dotenv loaded with override=True above.  Re-apply config.yaml's
+    # terminal.* values on top so the documented config path always wins
+    # (#29186).
+    _apply_config_yaml_terminal_override(home_path)
+
     return loaded
+
+
+# Mapping of config.yaml terminal.* keys -> env vars downstream code reads.
+# Kept in sync with the equivalent maps in gateway/run.py and
+# hermes_cli/config.py — see tests/tools/test_terminal_config_env_sync.py.
+_TERMINAL_CFG_TO_ENV = {
+    "backend": "TERMINAL_ENV",
+    "docker_image": "TERMINAL_DOCKER_IMAGE",
+    "singularity_image": "TERMINAL_SINGULARITY_IMAGE",
+    "modal_image": "TERMINAL_MODAL_IMAGE",
+    "daytona_image": "TERMINAL_DAYTONA_IMAGE",
+    "vercel_runtime": "TERMINAL_VERCEL_RUNTIME",
+    "timeout": "TERMINAL_TIMEOUT",
+    "sandbox_dir": "TERMINAL_SANDBOX_DIR",
+    "persistent_shell": "TERMINAL_PERSISTENT_SHELL",
+    "container_cpu": "TERMINAL_CONTAINER_CPU",
+    "container_memory": "TERMINAL_CONTAINER_MEMORY",
+    "container_disk": "TERMINAL_CONTAINER_DISK",
+    "container_persistent": "TERMINAL_CONTAINER_PERSISTENT",
+    "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
+    "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
+}
+
+
+def _apply_config_yaml_terminal_override(home_path: Path) -> None:
+    """Force config.yaml's terminal.* values on top of whatever .env loaded.
+
+    Without this, a stale TERMINAL_ENV=docker in ~/.hermes/.env keeps winning
+    after the user switches terminal.backend in config.yaml — the gateway
+    (per-turn reload), cron scheduler, batch_runner, and doctor would all
+    still run against the old backend until the user manually purged the
+    .env line (#29186).
+    """
+    config_path = home_path / "config.yaml"
+    if not config_path.exists():
+        return
+    try:
+        import yaml
+    except ImportError:
+        return
+    try:
+        with open(config_path, encoding="utf-8") as f:
+            cfg = yaml.safe_load(f) or {}
+    except (OSError, yaml.YAMLError):
+        return
+    if not isinstance(cfg, dict):
+        return
+    terminal_cfg = cfg.get("terminal")
+    if not isinstance(terminal_cfg, dict):
+        return
+    import json
+    for cfg_key, env_var in _TERMINAL_CFG_TO_ENV.items():
+        if cfg_key not in terminal_cfg:
+            continue
+        val = terminal_cfg[cfg_key]
+        if val is None:
+            continue
+        if isinstance(val, (list, dict)):
+            os.environ[env_var] = json.dumps(val)
+        else:
+            os.environ[env_var] = str(val)

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -87,3 +87,69 @@ def test_main_import_applies_user_env_over_shell_values(tmp_path, monkeypatch):
 
     assert os.getenv("OPENAI_BASE_URL") == "https://new.example/v1"
     assert os.getenv("HERMES_INFERENCE_PROVIDER") == "custom"
+
+
+def test_config_yaml_terminal_backend_overrides_stale_env(tmp_path, monkeypatch):
+    """Regression for #29186: a leftover TERMINAL_ENV=docker in ~/.hermes/.env
+    must not silently override the user's choice in config.yaml.  config.yaml
+    is the documented source of truth, so its value must win after load."""
+    home = tmp_path / "hermes"
+    home.mkdir()
+    (home / ".env").write_text("TERMINAL_ENV=docker\n", encoding="utf-8")
+    (home / "config.yaml").write_text(
+        "terminal:\n  backend: local\n", encoding="utf-8"
+    )
+
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+
+    load_hermes_dotenv(hermes_home=home)
+
+    assert os.getenv("TERMINAL_ENV") == "local"
+
+
+def test_config_yaml_terminal_backend_overrides_stale_shell(tmp_path, monkeypatch):
+    """config.yaml must also beat a stale TERMINAL_ENV exported in the shell
+    (e.g. set in ~/.zshrc when the user was experimenting with docker)."""
+    home = tmp_path / "hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "terminal:\n  backend: local\n", encoding="utf-8"
+    )
+
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+
+    load_hermes_dotenv(hermes_home=home)
+
+    assert os.getenv("TERMINAL_ENV") == "local"
+
+
+def test_no_config_yaml_leaves_env_value_alone(tmp_path, monkeypatch):
+    """When config.yaml doesn't exist we must NOT clobber the .env value —
+    that's still the user's setting."""
+    home = tmp_path / "hermes"
+    home.mkdir()
+    (home / ".env").write_text("TERMINAL_ENV=docker\n", encoding="utf-8")
+
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+
+    load_hermes_dotenv(hermes_home=home)
+
+    assert os.getenv("TERMINAL_ENV") == "docker"
+
+
+def test_config_yaml_terminal_omitted_key_does_not_clear_env(tmp_path, monkeypatch):
+    """If config.yaml has a terminal block but no `backend`, the .env value
+    must survive (don't unset env vars the user didn't override)."""
+    home = tmp_path / "hermes"
+    home.mkdir()
+    (home / ".env").write_text("TERMINAL_ENV=docker\n", encoding="utf-8")
+    (home / "config.yaml").write_text(
+        "terminal:\n  timeout: 600\n", encoding="utf-8"
+    )
+
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+
+    load_hermes_dotenv(hermes_home=home)
+
+    assert os.getenv("TERMINAL_ENV") == "docker"
+    assert os.getenv("TERMINAL_TIMEOUT") == "600"


### PR DESCRIPTION
## Summary

Fixes #29186. After `hermes config set terminal.backend local`, the gateway / cron scheduler / batch_runner / doctor kept executing tools against the previously configured backend (e.g. `docker`) because a leftover `TERMINAL_ENV=docker` line in `~/.hermes/.env` won over the new `config.yaml` setting.

## Root cause

`hermes_cli/env_loader.py::load_hermes_dotenv` loads `~/.hermes/.env` with `override=True`. The startup terminal-bridge in `gateway/run.py` (line 596) ran only at module import. The per-turn reload `_reload_runtime_env_preserving_config_authority` (line 563) re-applied `.env` but re-bridged only `HERMES_MAX_ITERATIONS`, not the `TERMINAL_*` keys. Other entrypoints (cron, batch_runner, doctor) had no bridge at all, so any of them re-loaded `.env` and silently restored the old backend.

## Fix

After `.env` loading, `load_hermes_dotenv` now calls `_apply_config_yaml_terminal_override(home_path)` which reads `~/.hermes/config.yaml` and writes the `terminal.*` values into the process env on top of whatever `.env` set. This makes `config.yaml` authoritative everywhere the loader is used, matching the documented source-of-truth contract. The set of bridged keys mirrors `tests/tools/test_terminal_config_env_sync.py`.

## Test plan
- [x] 4 new tests in `tests/hermes_cli/test_env_loader.py`:
  - stale `.env` overridden by config.yaml
  - stale shell var overridden
  - no-config-yaml leaves `.env` alone
  - partial terminal block doesn't clobber unspecified keys
- [x] All 14 tests in `env_loader` + sync cross-check still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)