### PR TITLE
fix(kanban): close sqlite in specify helpers (#28802)

### DIFF
--- a/hermes_cli/kanban_specify.py
+++ b/hermes_cli/kanban_specify.py
@@ -35,6 +35,7 @@ import json
 import logging
 import os
 import re
+from contextlib import closing
 from dataclasses import dataclass
 from typing import Optional
 
@@ -150,7 +151,7 @@ def specify_task(
     error, malformed response) — those surface via ``ok=False`` so the
     ``--all`` sweep can continue past individual failures.
     """
-    with kb.connect() as conn:
+    with closing(kb.connect()) as conn:
         task = kb.get_task(conn, task_id)
     if task is None:
         return SpecifyOutcome(task_id, False, "unknown task id")
@@ -239,7 +240,7 @@ def specify_task(
                 task_id, False, "LLM response missing title and body"
             )
 
-    with kb.connect() as conn:
+    with closing(kb.connect()) as conn:
         ok = kb.specify_triage_task(
             conn,
             task_id,
@@ -261,7 +262,7 @@ def list_triage_ids(*, tenant: Optional[str] = None) -> list[str]:
 
     ``tenant`` narrows the sweep; ``None`` returns every triage task.
     """
-    with kb.connect() as conn:
+    with closing(kb.connect()) as conn:
         tasks = kb.list_tasks(
             conn,
             status="triage",

--- a/tests/hermes_cli/test_kanban_specify.py
+++ b/tests/hermes_cli/test_kanban_specify.py
@@ -335,3 +335,60 @@ def test_cli_specify_author_passed_through(kanban_home, capsys):
     with kb.connect() as conn:
         comments = kb.list_comments(conn, tid)
     assert comments and comments[0].author == "custom-agent"
+
+
+class _ConnProxy:
+    def __init__(self, conn):
+        self._conn = conn
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+        return self._conn.close()
+
+    def __enter__(self):
+        return self._conn.__enter__()
+
+    def __exit__(self, *exc):
+        return self._conn.__exit__(*exc)
+
+    def __getattr__(self, name):
+        return getattr(self._conn, name)
+
+
+def _install_tracking_connect(monkeypatch):
+    opened = []
+    real_connect = kb.connect
+
+    def tracking_connect(*a, **kw):
+        proxy = _ConnProxy(real_connect(*a, **kw))
+        opened.append(proxy)
+        return proxy
+
+    monkeypatch.setattr(spec.kb, "connect", tracking_connect)
+    return opened
+
+
+def test_list_triage_ids_closes_sqlite_connection(kanban_home, monkeypatch):
+    """Regression for #28802: list_triage_ids must close its sqlite handle."""
+    opened = _install_tracking_connect(monkeypatch)
+    for _ in range(5):
+        spec.list_triage_ids()
+    assert opened
+    leaked = [p for p in opened if not p.closed]
+    assert not leaked, f"leak: {len(leaked)}/{len(opened)}"
+
+
+def test_specify_task_closes_sqlite_connection(kanban_home, monkeypatch):
+    """Regression for #28802: specify_task must close both handles."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="rough", triage=True)
+    opened = _install_tracking_connect(monkeypatch)
+    content = jsonlib.dumps({"title": "fresh title", "body": "fresh body"})
+    p, _ = _patch_aux_client(content)
+    with p:
+        outcome = spec.specify_task(tid)
+    assert outcome.ok, outcome.reason
+    assert len(opened) >= 2
+    leaked = [p for p in opened if not p.closed]
+    assert not leaked, f"leak: {len(leaked)}/{len(opened)}"


### PR DESCRIPTION
## Summary

Fixes #28802. `hermes_cli/kanban_specify.py` used `with kb.connect() as c:` for its sqlite handles. The `sqlite3.Connection` context manager only manages **transactions** (commit / rollback), it does **not** close the connection. In a long-lived gateway process the three call sites — `specify_task` read (L153), `specify_task` write (L242), and `list_triage_ids` (L264) — leaked one or two connections per call. Over hours the fd count climbs and eventually the gateway scheduler runs into "too many open files".

## Fix

Imported `contextlib.closing` and wrapped all three `kb.connect()` sites with `closing(...)` so connections are released deterministically alongside the existing transactional `with` semantics.

## Test plan
- [x] New `_ConnProxy` wrapper in `tests/hermes_cli/test_kanban_specify.py` observes `close()` calls
- [x] Regression tests assert no leaks across 5 `list_triage_ids` calls and across `specify_task`'s 2 connections — confirmed FAIL on the unpatched code, PASS after the fix
- [x] `pytest tests/hermes_cli/test_kanban_specify.py` → 22 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)