### PR TITLE
fix(kanban): refuse to clean up paths outside scratch root (#28818)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2872,6 +2872,42 @@ def _cleanup_workspace(conn: sqlite3.Connection, task_id: str) -> None:
             return
         import shutil
         wp = Path(path)
+        # Safety: refuse to delete anything that does not resolve to a path
+        # under the Hermes-managed scratch root for this board. A misconfigured
+        # board default-workdir, a manually-edited row, or a symlink pointing
+        # at a real source tree must never trigger ``rm -rf`` on user data
+        # (see issue #28818). Resolve symlinks on both sides so a scratch dir
+        # containing a symlink to ``~/src`` cannot escape the scratch root.
+        try:
+            scratch_root = workspaces_root().resolve(strict=False)
+            resolved = wp.resolve(strict=False)
+        except (OSError, RuntimeError):
+            _log.warning(
+                "Refusing scratch cleanup for task %s: cannot resolve %s",
+                task_id, path,
+            )
+            return
+        try:
+            inside = resolved.is_relative_to(scratch_root)
+        except AttributeError:  # pragma: no cover — py<3.9 fallback
+            try:
+                resolved.relative_to(scratch_root)
+                inside = True
+            except ValueError:
+                inside = False
+        if not inside or resolved == scratch_root:
+            _log.warning(
+                "Refusing scratch cleanup for task %s: %s is outside scratch root %s",
+                task_id, resolved, scratch_root,
+            )
+            return
+        if wp.is_symlink():
+            # Never follow a symlink for rmtree; just unlink the link itself.
+            _log.warning(
+                "Refusing scratch cleanup for task %s: %s is a symlink",
+                task_id, wp,
+            )
+            return
         if wp.is_dir():
             shutil.rmtree(wp, ignore_errors=True)
             _log.debug("Removed scratch workspace: %s", wp)

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2960,3 +2960,94 @@ def test_detect_stale_does_not_tick_failure_counter(kanban_home, monkeypatch):
         assert "stale" in kinds, (
             f"Expected 'stale' event in task_events; got {kinds!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Scratch workspace cleanup safety (issue #28818)
+# ---------------------------------------------------------------------------
+
+
+class TestScratchCleanupSafety:
+    """``_cleanup_workspace`` must never delete paths outside the
+    Hermes-managed scratch root, even if a task row claims they are
+    ``scratch``. See issue #28818 — a board default-workdir pointed at
+    a real source checkout caused ``rm -rf`` on user data on task
+    completion.
+    """
+
+    def _make_task_with_workspace(self, conn, path: Path) -> str:
+        tid = kb.create_task(conn, title="t")
+        conn.execute(
+            "UPDATE tasks SET workspace_kind='scratch', workspace_path=? "
+            "WHERE id=?",
+            (str(path), tid),
+        )
+        conn.commit()
+        return tid
+
+    def test_refuses_to_delete_path_outside_scratch_root(
+        self, kanban_home, tmp_path
+    ):
+        real_src = tmp_path / "real_source"
+        real_src.mkdir()
+        (real_src / "important.txt").write_text("do not delete")
+        # Sanity: real_src is NOT under workspaces_root().
+        assert not str(real_src).startswith(str(kb.workspaces_root()))
+
+        with kb.connect() as conn:
+            tid = self._make_task_with_workspace(conn, real_src)
+            kb.complete_task(conn, tid, result="ok")
+
+        assert real_src.is_dir(), "cleanup deleted a path outside scratch root"
+        assert (real_src / "important.txt").exists()
+
+    def test_refuses_to_follow_symlink_escaping_scratch_root(
+        self, kanban_home, tmp_path
+    ):
+        real_src = tmp_path / "real_source"
+        real_src.mkdir()
+        (real_src / "important.txt").write_text("do not delete")
+
+        ws_root = kb.workspaces_root()
+        ws_root.mkdir(parents=True, exist_ok=True)
+        # Scratch workspace dir is a symlink to ~/src.
+        link = ws_root / "task-link"
+        link.symlink_to(real_src)
+
+        with kb.connect() as conn:
+            tid = self._make_task_with_workspace(conn, link)
+            kb.complete_task(conn, tid, result="ok")
+
+        assert real_src.is_dir(), "cleanup followed symlink and deleted source"
+        assert (real_src / "important.txt").exists()
+
+    def test_still_cleans_legitimate_scratch_dir(
+        self, kanban_home, tmp_path
+    ):
+        ws_root = kb.workspaces_root()
+        ws_root.mkdir(parents=True, exist_ok=True)
+        scratch_dir = ws_root / "task-real"
+        scratch_dir.mkdir()
+        (scratch_dir / "junk.txt").write_text("disposable")
+
+        with kb.connect() as conn:
+            tid = self._make_task_with_workspace(conn, scratch_dir)
+            kb.complete_task(conn, tid, result="ok")
+
+        assert not scratch_dir.exists(), (
+            "legitimate scratch dir was not cleaned up"
+        )
+
+    def test_refuses_to_delete_scratch_root_itself(
+        self, kanban_home, tmp_path
+    ):
+        ws_root = kb.workspaces_root()
+        ws_root.mkdir(parents=True, exist_ok=True)
+        (ws_root / "sibling.txt").write_text("other tasks live here")
+
+        with kb.connect() as conn:
+            tid = self._make_task_with_workspace(conn, ws_root)
+            kb.complete_task(conn, tid, result="ok")
+
+        assert ws_root.is_dir(), "cleanup wiped the entire scratch root"
+        assert (ws_root / "sibling.txt").exists()


### PR DESCRIPTION
## Summary

Fixes #28818 — **data-loss bug**. `hermes_cli/kanban_db.py::_cleanup_workspace` ran `shutil.rmtree(workspace_path)` for any task whose `workspace_kind == \"scratch\"` (the DB default), but `workspace_path` is whatever the board/task config says — including a user-supplied real source directory (`boards set-default-workdir`) or a symlink inside the scratch root that points at `~/src`. Either turned task completion into `rm -rf` on real data.

## Fix

`_cleanup_workspace` (minimal change):

1. Resolve both the workspace path and `workspaces_root()` with `resolve(strict=False)` (collapses symlinks).
2. Require `resolved.is_relative_to(scratch_root)` **and** `resolved != scratch_root`; otherwise log a warning and return without deleting.
3. Refuse outright if `wp.is_symlink()` so a symlinked scratch entry can never escape via `shutil.rmtree` symlink-follow.
4. Python <3.9 fallback uses `relative_to(...)` + `ValueError`.

The orthogonal hardening (reject scratch-task create-time when workdir is outside `workspaces_root`) is left for a follow-up — out of scope for a minimal data-loss fix.

## Test plan
- [x] New `TestScratchCleanupSafety` in `tests/hermes_cli/test_kanban_db.py` — 4 cases:
  - workspace pointing at a sibling `real_source/` dir outside scratch root is preserved
  - symlink inside scratch root pointing at `real_source/` does not get followed
  - legitimate scratch subdir is still cleaned up
  - row pointing at the scratch root itself is refused
- [x] Full file 162/162 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)