### PR TITLE
feat(agent): allow user to override markdown-blocking system prompt (#28876)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1079,6 +1079,13 @@ def init_agent(
         _agent_section = {}
     agent._tool_use_enforcement = _agent_section.get("tool_use_enforcement", "auto")
 
+    # API-server markdown override (#28876).  When true, the "api_server"
+    # platform hint is replaced with a markdown-permissive variant so users
+    # whose webclient renders markdown aren't forced into plain text.
+    agent._api_server_allow_markdown = bool(
+        _agent_section.get("api_server_allow_markdown", False)
+    )
+
     # App-level API retry count (wraps each model API call).  Default 3,
     # overridable via agent.api_max_retries in config.yaml.  See #11616.
     try:

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -582,7 +582,19 @@ PLATFORM_HINTS = {
         "You're responding through an API server. The rendering layer is unknown — "
         "assume plain text. No markdown formatting (no asterisks, bullets, headers, "
         "code fences). Treat this like a conversation, not a document. Keep responses "
-        "brief and natural."
+        "brief and natural. (The user may override this instruction in their profile "
+        "or via the agent.api_server_allow_markdown config setting if their client "
+        "renders markdown.)"
+    ),
+    # Opt-in variant of "api_server" used when the user sets
+    # agent.api_server_allow_markdown=true in config.yaml.  Resolves issue #28876:
+    # webclients that DO render markdown were previously stuck with the plain-text
+    # api_server hint and had no way to override it.
+    "api_server_markdown": (
+        "You're responding through an API server. The client has indicated it can "
+        "render markdown — feel free to use markdown formatting (headers, bullets, "
+        "bold, code fences, tables) when it improves clarity. Still keep responses "
+        "appropriately concise for a conversational API context."
     ),
     "webui": (
         "You are in the Hermes WebUI, a browser-based chat interface. "

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -207,7 +207,13 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
 
     platform_key = (agent.platform or "").lower().strip()
     if platform_key in PLATFORM_HINTS:
-        stable_parts.append(PLATFORM_HINTS[platform_key])
+        # #28876: let users opt into markdown on the api_server platform.
+        if platform_key == "api_server" and getattr(
+            agent, "_api_server_allow_markdown", False
+        ):
+            stable_parts.append(PLATFORM_HINTS["api_server_markdown"])
+        else:
+            stable_parts.append(PLATFORM_HINTS[platform_key])
     elif platform_key:
         # Check plugin registry for platform-specific LLM guidance
         try:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -539,6 +539,11 @@ DEFAULT_CONFIG = {
         # (force on/off for all models), or a list of model-name substrings
         # to match (e.g. ["gpt", "codex", "gemini", "qwen"]).
         "tool_use_enforcement": "auto",
+        # #28876: when responding through platform="api_server", the default
+        # system prompt forbids markdown because the rendering layer is unknown.
+        # Set this true if your API client (e.g. a markdown-rendering webclient)
+        # can display markdown and you'd prefer the agent use it.
+        "api_server_allow_markdown": False,
         # Staged inactivity warning: send a warning to the user at this
         # threshold before escalating to a full timeout.  The warning fires
         # once per run and does not interrupt the agent.  0 = disable warning.

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -791,6 +791,25 @@ class TestPromptBuilderConstants:
         assert "api_server" in PLATFORM_HINTS
         assert "webui" in PLATFORM_HINTS
 
+    def test_api_server_hint_mentions_override(self):
+        # #28876: the default api_server hint forbids markdown, but the user
+        # must be told (and discoverable in their profile/config) that this
+        # is overridable. Otherwise webclient users have no escape hatch.
+        hint = PLATFORM_HINTS["api_server"]
+        assert "No markdown" in hint
+        assert "api_server_allow_markdown" in hint, (
+            "api_server hint must surface the override config key so users "
+            "with markdown-rendering clients can discover the escape hatch."
+        )
+
+    def test_api_server_markdown_variant_allows_markdown(self):
+        # #28876: opt-in markdown variant exists and inverts the restriction.
+        assert "api_server_markdown" in PLATFORM_HINTS
+        hint = PLATFORM_HINTS["api_server_markdown"]
+        assert "markdown" in hint.lower()
+        # Sanity: must NOT carry the "No markdown" prohibition.
+        assert "No markdown" not in hint
+
     def test_cli_hint_does_not_suggest_media_tags(self):
         # Regression: MEDIA:/path tags are intercepted only by messaging
         # gateway platforms. On the CLI they render as literal text and


### PR DESCRIPTION
## Summary

Fixes #28876. `agent/prompt_builder.py::PLATFORM_HINTS[\"api_server\"]` hard-coded a strict no-markdown rule with no escape hatch. Users serving Hermes via an API client that renders markdown (e.g. ChatGPT-like UIs) could not get markdown output even by asking via profile or memory — the system prompt always told the model to plain-text.

## Fix

Add a config-driven override:

- `agent/prompt_builder.py` — append a discoverability note to the existing `api_server` hint (\"user may override … via `agent.api_server_allow_markdown` config setting\") and add a sibling `api_server_markdown` hint that permits markdown.
- `agent/agent_init.py` — read `agent.api_server_allow_markdown` into `agent._api_server_allow_markdown` (mirrors the existing `_tool_use_enforcement` pattern).
- `agent/system_prompt.py` — at the platform-hint dispatch, when platform is `api_server` and the flag is set, substitute the `api_server_markdown` variant.
- `hermes_cli/config.py` — register `agent.api_server_allow_markdown: False` default in the `agent` config block.

Default behavior is unchanged. Opt-in only.

## Test plan
- [x] New `test_api_server_hint_mentions_override` and `test_api_server_markdown_variant_allows_markdown` in `tests/agent/test_prompt_builder.py` pass
- [x] 3 targeted tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)