### PR TITLE
fix(kanban-dashboard): opt out of inherited uppercase + brand font

### DIFF
--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -7,6 +7,19 @@
 
 .hermes-kanban {
   width: 100%;
+
+  /* The Nous DS layout-wrapper puts `font-mondwest uppercase` on <body>,
+   * which fits the brand chrome but is hostile to a data-dense board:
+   * task titles, profile names, IDs, paths, and code fragments all become
+   * harder to scan, and case-sensitive identifiers like assignees are
+   * misleading when rendered in caps. Opt the plugin root out — `font-family`
+   * and `text-transform` both inherit, so a single override here cascades
+   * to the whole board. */
+  font-family: var(
+    --theme-font-sans,
+    system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif
+  );
+  text-transform: none;
 }
 
 /* ---- Code/pre reset (theme-immune default) --------------------------- *
@@ -446,7 +459,6 @@
 }
 .hermes-kanban-home-sub {
   font-family: var(--font-mono, ui-monospace, monospace);
-  text-transform: lowercase;
   letter-spacing: 0.02em;
 }
 .hermes-kanban-home-sub--on {


### PR DESCRIPTION
## What & why

The host dashboard wraps every page in `font-mondwest uppercase` via `@nous-research/ui`'s layout-wrapper (`dist/ui/layout-wrapper.js`):

```jsx
<body className="text-midground font-mondwest bg-black uppercase antialiased">
```

That fits the brand chrome but is hostile to a data-dense surface like the kanban: task titles, profile names, IDs, file paths, and code fragments all become harder to scan, and case-sensitive identifiers (assignees, branch names) actively mislead when rendered in caps. The lane-header comment at `plugins/kanban/dashboard/dist/style.css:216` already calls this out for profile names specifically:

> Assignee/profile names are case-sensitive. Do not visually uppercase lane headers, otherwise a valid `analyst` profile appears as `ANALYST` in the WebUI and users may copy the wrong casing back into edits.

`font-family` and `text-transform` are both inherited CSS properties, so a single override on the `.hermes-kanban` plugin root cascades to the entire board subtree — no `!important` or universal-selector hammer needed.

While here, this also drops the explicit `text-transform: lowercase` on `.hermes-kanban-home-sub` for the same reason: assignee chips on the home view also need to preserve case.

## How to test

1. Open the dashboard kanban tab.
2. Confirm task titles, lane headers (assignee names), column labels, and home-view profile chips render in their authored case using the readable `--theme-font-sans` stack — not Mondwest caps.
3. Switch themes (default teal, NERV orange). The override falls through to whatever `--theme-font-sans` each theme defines, so per-theme typography still wins.

## Platforms tested

Linux (WSL2). CSS-only change, no platform-specific behavior.

## Out of scope

- Tiny font sizes (multiple rules at 0.60–0.68 rem) — readability win but layout-affecting, deserves its own PR.
- Same issue in the host dashboard chrome and in `plugins/hermes-achievements/` — separate PRs.