### PR TITLE
fix(tui): strip ANSI from input buffer after gateway pipe break (#28419)

### DIFF
--- a/ui-tui/src/__tests__/textInputAnsiStrip.test.ts
+++ b/ui-tui/src/__tests__/textInputAnsiStrip.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+
+import { stripAnsiSequences } from '../components/textInput.js'
+
+// Regression: #28419 — after the TUI gateway's stdout pipe breaks and
+// auto-restarts, rendering ANSI bytes leak into stdin. The composer must
+// not echo terminal control bytes into the input field as if they were
+// keystrokes.
+describe('stripAnsiSequences (#28419 TUI input ANSI flood)', () => {
+  it('removes full CSI sequences', () => {
+    expect(stripAnsiSequences('\x1b[35mhello\x1b[0m')).toBe('hello')
+    expect(stripAnsiSequences('\x1b[2J\x1b[H')).toBe('')
+  })
+
+  it('removes OSC sequences (window title etc.)', () => {
+    expect(stripAnsiSequences('\x1b]0;title\x07rest')).toBe('rest')
+    expect(stripAnsiSequences('\x1b]2;abc\x1b\\rest')).toBe('rest')
+  })
+
+  it('removes two-byte ESC sequences and bare ESC bytes', () => {
+    expect(stripAnsiSequences('\x1bOPfoo')).toBe('foo')
+    // Trailing bare ESC after legitimate text is dropped.
+    expect(stripAnsiSequences('bar\x1b')).toBe('bar')
+  })
+
+  it('removes naked control bytes but preserves \\t and \\n', () => {
+    expect(stripAnsiSequences('a\x00b\x07c')).toBe('abc')
+    expect(stripAnsiSequences('line1\nline2\tend')).toBe('line1\nline2\tend')
+  })
+
+  it('strips the orphan-CSI-tail garbage shape from the bug report', () => {
+    // Sample from #28419: leaked ANSI whose ESC prefix was already
+    // consumed earlier in the byte stream, leaving CSI tails of the form
+    // `<digits>;<digits>;<digits>M` etc. These must not be inserted into
+    // the input box.
+    const garbage =
+      '102;71M5;104;62M5;106;60M61M35;22;72M35;21;71M35;17;70MM35;10;70M;70M5;70M;85;72M2;48;72M68m1M'
+    expect(stripAnsiSequences(garbage)).toBe('')
+  })
+
+  it('handles bracketed-paste-wrapped ANSI leak end-to-end', () => {
+    const wrapped = '\x1b[200~\x1b[35;104;62mleak\x1b[0m\x1b[201~'
+    // The composer strips bracketed-paste markers before calling
+    // stripAnsiSequences; emulate that here.
+    const afterPasteMarkers = wrapped.replace(/\x1b?\[20[01]~/g, '')
+    expect(stripAnsiSequences(afterPasteMarkers)).toBe('leak')
+  })
+
+  it('leaves ordinary user text (including innocent semicolons) intact', () => {
+    expect(stripAnsiSequences('hello, world!')).toBe('hello, world!')
+    expect(stripAnsiSequences('a; b; c')).toBe('a; b; c')
+    expect(stripAnsiSequences('CSS: color: red;')).toBe('CSS: color: red;')
+    expect(stripAnsiSequences('')).toBe('')
+  })
+
+  it('passes through unicode and printable ASCII unchanged', () => {
+    expect(stripAnsiSequences('café — 日本語 — 🎉')).toBe('café — 日本語 — 🎉')
+  })
+})

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -35,6 +35,64 @@ const PRINTABLE = /^[ -~\u00a0-\uffff]+$/
 const BRACKET_PASTE = new RegExp(`${ESC}?\\[20[01]~`, 'g')
 const MULTI_CLICK_MS = 500
 
+// Strip ANSI control / escape sequences that can leak into stdin when the
+// TUI gateway's stdout pipe breaks and rendering bytes get re-routed onto
+// the input stream after auto-restart (#28419). Covers:
+//   - Full CSI sequences:           ESC [ ... final-byte (0x40-0x7e)
+//   - OSC sequences:                ESC ] ... (BEL | ESC \)
+//   - Two-byte ESC introducers:     ESC <0x40-0x5f>  (e.g. ESC O F1-F4)
+//   - Bare ESC / ESC[ / ESC] / ESCO prefix (orphaned, no body)
+//   - Naked C0 / C1 control bytes (keeping \t and \n)
+//   - Orphan CSI tails like "35;104;62m" / "27;3M" left over when the ESC
+//     prefix was consumed earlier in the byte stream (the exact shape of
+//     the garbage in the bug report).
+const CSI_FULL_RE = /\x1b\[[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e]/g
+const OSC_RE = /\x1b\][\s\S]*?(?:\x07|\x1b\\)/g
+// ESC O <final> — SS3 sequence used for keypad / F1-F4 keys (3 bytes total)
+const SS3_RE = /\x1bO[\x40-\x7e]/g
+const ESC_TWO_BYTE_RE = /\x1b[\x40-\x5f]/g
+const ESC_BARE_RE = /\x1b\[|\x1b[O\]]|\x1b/g
+const CTRL_RE = /[\x00-\x08\x0b-\x1f\x7f\x80-\x9f]/g
+// Orphan CSI tail: digits+`;` clusters followed by a CSI final byte. The
+// final byte set matches the standard ECMA-48 range (`@`-`~`) but we
+// require a `;`-cluster shape so plain English words like "hello;world"
+// don't get clobbered.
+const ORPHAN_CSI_TAIL_RE = /(?:\d+;)+\d*[\x40-\x7e]|\d+[A-Za-z]/g
+
+export function stripAnsiSequences(input: string): string {
+  if (!input) {
+    return input
+  }
+  let out = input
+    .replace(CSI_FULL_RE, '')
+    .replace(OSC_RE, '')
+    .replace(SS3_RE, '')
+    .replace(ESC_TWO_BYTE_RE, '')
+    .replace(ESC_BARE_RE, '')
+
+  // Aggressive orphan-CSI cleanup. Only triggers when the residue still
+  // contains the unmistakable shape of de-escaped CSI param lists
+  // (multiple `<digits>;<digits>;<digits><letter>` chains) so legitimate
+  // user text like "a; b; c" or "color: red;" is left alone.
+  const looksLikeOrphanCsiFlood =
+    /(?:\d+;){2,}\d*[A-Za-z]/.test(out) || /(?:\d+;\d+[A-Za-z]){2,}/.test(out)
+  if (looksLikeOrphanCsiFlood) {
+    // Loop to convergence — successive passes can expose fresh tails as
+    // earlier ones get collapsed away.
+    for (let i = 0; i < 8; i++) {
+      const next = out
+        .replace(ORPHAN_CSI_TAIL_RE, '')
+        .replace(/(?<![A-Za-z\d]);+(?![A-Za-z\d])/g, '')
+        .replace(/(?<![A-Za-z\d])[A-Za-z](?![A-Za-z\d])/g, '')
+      if (next === out) {
+        break
+      }
+      out = next
+    }
+  }
+  return out.replace(CTRL_RE, '')
+}
+
 const invert = (s: string) => INV + s + INV_OFF
 const dim = (s: string) => DIM + s + DIM_OFF
 
@@ -679,7 +737,7 @@ export function TextInput({
   }
 
   const flushPaste = () => {
-    const text = pasteBuf.current
+    const text = stripAnsiSequences(pasteBuf.current)
     const at = pastePos.current
     const end = pasteEnd.current ?? at
     pasteBuf.current = ''
@@ -745,7 +803,9 @@ export function TextInput({
   const ins = (v: string, c: number, s: string) => v.slice(0, c) + s + v.slice(c)
 
   const pastePlainText = (text: string) => {
-    const cleaned = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
+    // Same #28419 leak vector: clipboard / OS paste callbacks can also
+    // deliver raw ANSI when the gateway's stdout pipe broke mid-render.
+    const cleaned = stripAnsiSequences(text.replace(/\r\n/g, '\n').replace(/\r/g, '\n'))
 
     if (!cleaned) {
       return
@@ -1018,7 +1078,9 @@ export function TextInput({
         }
       } else if (event.keypress.isPasted || inp.length > 0) {
         const bracketed = event.keypress.isPasted || inp.includes('[200~')
-        const text = inp.replace(BRACKET_PASTE, '').replace(/\r\n/g, '\n').replace(/\r/g, '\n')
+        const text = stripAnsiSequences(
+          inp.replace(BRACKET_PASTE, '').replace(/\r\n/g, '\n').replace(/\r/g, '\n')
+        )
 
         if (bracketed && emitPaste({ bracketed: true, cursor: c, text, value: v })) {
           return


### PR DESCRIPTION
## Summary

Fixes #28419. When the TUI gateway pipe breaks and the gateway auto-restarts, render bytes from stdout can leak into stdin. The composer's TextInput previously stripped only bracketed-paste markers (`ESC[200~` / `ESC[201~`), so anything between them — including chunked / de-escaped CSI sequences like `35;104;62m` — slipped through `PRINTABLE` and ended up in the input field, producing the characteristic ANSI flood reported in the issue.

## Fix

`ui-tui/src/components/textInput.tsx`:

- New exported `stripAnsiSequences()` helper that strips full CSI / OSC / SS3 / two-byte-ESC / bare-ESC / C0+C1 control bytes.
- When residue still shows the orphan-CSI-flood signature (multiple `\d+;\d+;\d+[A-Za-z]` chains), an iterative cleanup pass removes leftover digits, `;`, and stray CSI final letters. Ordinary user text (`a; b; c`, `color: red;`, `12;34`) is preserved because the aggressive pass only fires when the orphan-flood signature is present.
- Applied at three paste-like input sites: the bracketed-paste branch in `useInput`, `flushPaste()`, and `pastePlainText()`.

## Test plan
- [x] `ui-tui/src/__tests__/textInputAnsiStrip.test.ts` — 8 cases including the exact garbage shape from the bug report (`102;71M5;104;62M...` → `\"\"`), bracketed-paste-wrapped ANSI leaks, unicode/punctuation preservation
- [x] `vitest run` shows no new regressions (2 pre-existing failures `cursorDriftRegression`, `ink-resize` also fail on main)
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)