### PR TITLE
feat(kanban-dashboard): show profiles on disk as lanes even when idle

### DIFF
--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -462,14 +462,13 @@ def get_board(
                 "SELECT DISTINCT tenant FROM tasks WHERE tenant IS NOT NULL ORDER BY tenant"
             )
         ]
-        # List of distinct assignees for the lane-by-profile sub-grouping.
-        assignees = [
-            r["assignee"]
-            for r in conn.execute(
-                "SELECT DISTINCT assignee FROM tasks WHERE assignee IS NOT NULL "
-                "AND status != 'archived' ORDER BY assignee"
-            )
-        ]
+        # List of known assignees for the lane-by-profile sub-grouping.
+        # Uses kanban_db.known_assignees so the lane set unions profiles
+        # currently holding non-archived tasks with profiles configured on
+        # disk — a freshly-added profile shows up as a (possibly empty)
+        # lane immediately, matching the assignee picker at /assignees
+        # which already uses this helper.
+        assignees = [entry["name"] for entry in kanban_db.known_assignees(conn)]
 
         return {
             "columns": [

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -75,7 +75,10 @@ def test_board_empty(client):
         assert expected in names, f"missing column {expected}: {names}"
     assert all(len(c["tasks"]) == 0 for c in data["columns"])
     assert data["tenants"] == []
-    assert data["assignees"] == []
+    # Assignee lanes union task-holders with profiles on disk, so the
+    # implicit `default` profile that the fixture's HERMES_HOME creates is
+    # present even on an empty board (no task-holders yet).
+    assert data["assignees"] == ["default"]
     assert data["latest_event_id"] == 0
 
 


### PR DESCRIPTION
## What & why

`GET /api/plugins/kanban/board` returns an `assignees` list used by the dashboard for the lane-by-profile sub-grouping in the running column. Previously the list came from:

```python
"SELECT DISTINCT assignee FROM tasks WHERE assignee IS NOT NULL AND status != 'archived' ORDER BY assignee"
```

so a freshly-added profile only got its own lane after being assigned its first non-archived task. Switch the lookup to `kanban_db.known_assignees()`, the helper that already backs the `/assignees` picker endpoint at `plugin_api.py:1660`. It unions profiles configured on disk with profiles currently holding non-archived tasks, so a new profile appears in the lane set immediately.

This also keeps the two endpoints from drifting — previously they could disagree about who's "known."

## How to test

Automated:
```
scripts/run_tests.sh tests/plugins/test_kanban_dashboard_plugin.py
```
94/94 pass. `test_board_empty` is updated to reflect the new semantics — the implicit `default` profile that the fixture's `HERMES_HOME` creates now shows up in `assignees` even on an empty board.

Manual:
1. `hermes profile create foo`
2. Open dashboard, kanban tab
3. `foo` appears as an empty lane in the running column without first being assigned work.

## Platforms tested

Linux (WSL2). Pure Python, no platform-specific code.