### PR TITLE
fix(env): preserve macOS Keychain access from sandboxed worker subprocesses (#29015)

### DIFF
--- a/tests/test_macos_keychain_passthrough.py
+++ b/tests/test_macos_keychain_passthrough.py
@@ -1,0 +1,102 @@
+"""Tests for macOS Keychain passthrough from sandboxed worker subprocesses.
+
+See: https://github.com/NousResearch/hermes-agent/issues/29015
+"""
+
+import os
+import platform
+from unittest.mock import patch
+
+import pytest
+
+
+pytestmark = pytest.mark.skipif(
+    platform.system() != "Darwin", reason="macOS-only behaviour"
+)
+
+
+class TestKeychainSymlink:
+    def _setup_profile(self, tmp_path, monkeypatch, real_keychain=True):
+        real_home = tmp_path / "user_home"
+        real_home.mkdir()
+        if real_keychain:
+            (real_home / "Library" / "Keychains").mkdir(parents=True)
+            (real_home / "Library" / "Keychains" / "login.keychain-db").write_text("x")
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        profile_home = hermes_home / "home"
+        profile_home.mkdir()
+        monkeypatch.setenv("HOME", str(real_home))
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        return real_home, profile_home
+
+    def test_keychain_symlink_created_on_make_run_env(self, tmp_path, monkeypatch):
+        real_home, profile_home = self._setup_profile(tmp_path, monkeypatch)
+        from tools.environments.local import _make_run_env
+
+        run_env = _make_run_env({})
+        assert run_env["HOME"] == str(profile_home)
+        link = profile_home / "Library" / "Keychains"
+        assert link.is_symlink()
+        assert os.path.realpath(link) == os.path.realpath(
+            real_home / "Library" / "Keychains"
+        )
+        # Subprocess can read login.keychain-db via the rewritten HOME.
+        assert (link / "login.keychain-db").read_text() == "x"
+
+    def test_no_symlink_when_real_home_has_no_keychain(self, tmp_path, monkeypatch):
+        real_home, profile_home = self._setup_profile(
+            tmp_path, monkeypatch, real_keychain=False
+        )
+        from tools.environments.local import _make_run_env
+
+        _make_run_env({})
+        assert not (profile_home / "Library" / "Keychains").exists()
+
+    def test_idempotent(self, tmp_path, monkeypatch):
+        real_home, profile_home = self._setup_profile(tmp_path, monkeypatch)
+        from tools.environments.local import _make_run_env
+
+        _make_run_env({})
+        _make_run_env({})  # Must not raise (FileExistsError) on second call.
+        link = profile_home / "Library" / "Keychains"
+        assert link.is_symlink()
+
+    def test_existing_real_dir_not_clobbered(self, tmp_path, monkeypatch):
+        real_home, profile_home = self._setup_profile(tmp_path, monkeypatch)
+        # User already populated a real directory at the target — leave it.
+        target = profile_home / "Library" / "Keychains"
+        target.mkdir(parents=True)
+        (target / "marker").write_text("user-data")
+        from tools.environments.local import _make_run_env
+
+        _make_run_env({})
+        assert target.is_dir() and not target.is_symlink()
+        assert (target / "marker").read_text() == "user-data"
+
+    def test_wrong_symlink_replaced(self, tmp_path, monkeypatch):
+        real_home, profile_home = self._setup_profile(tmp_path, monkeypatch)
+        target_parent = profile_home / "Library"
+        target_parent.mkdir()
+        bogus = tmp_path / "bogus"
+        bogus.mkdir()
+        (target_parent / "Keychains").symlink_to(bogus)
+        from tools.environments.local import _make_run_env
+
+        _make_run_env({})
+        link = target_parent / "Keychains"
+        assert link.is_symlink()
+        assert os.path.realpath(link) == os.path.realpath(
+            real_home / "Library" / "Keychains"
+        )
+
+    def test_no_op_when_subprocess_home_inactive(self, tmp_path, monkeypatch):
+        real_home = tmp_path / "user_home"
+        (real_home / "Library" / "Keychains").mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(real_home))
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        from tools.environments.local import _make_run_env
+
+        run_env = _make_run_env({})
+        # Real HOME preserved; no rewriting happened.
+        assert run_env["HOME"] == str(real_home)

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -15,8 +15,57 @@ from tools.environments.base import BaseEnvironment, _pipe_stdin
 from hermes_cli._subprocess_compat import windows_hide_flags
 
 _IS_WINDOWS = platform.system() == "Windows"
+_IS_MACOS = platform.system() == "Darwin"
 
 logger = logging.getLogger(__name__)
+
+
+def _ensure_macos_keychain_symlink(profile_home: str) -> None:
+    """On macOS, ensure ``$profile_home/Library/Keychains`` resolves to the
+    real user's keychain dir.
+
+    Per-profile HOME isolation (issue #29015) otherwise hides
+    ``~/Library/Keychains/login.keychain-db`` from subprocesses, breaking any
+    CLI that authenticates via the macOS login keychain (``claude``, ``gh``
+    when using OS keychain storage, ``security`` framework callers, …).
+
+    Best-effort: any failure (no real HOME, no keychain dir, EACCES, race
+    with another worker) is silently logged — the only consequence is that
+    keychain-using CLIs in this subprocess will fall back to "not logged in",
+    which is the pre-fix behaviour.
+    """
+    if not _IS_MACOS or not profile_home:
+        return
+    real_home = os.environ.get("HOME")
+    if not real_home or os.path.realpath(real_home) == os.path.realpath(profile_home):
+        return
+    src = os.path.join(real_home, "Library", "Keychains")
+    if not os.path.isdir(src):
+        return
+    dst_parent = os.path.join(profile_home, "Library")
+    dst = os.path.join(dst_parent, "Keychains")
+    try:
+        os.makedirs(dst_parent, exist_ok=True)
+        # Already a symlink to the right place — done.
+        if os.path.islink(dst):
+            try:
+                if os.path.realpath(dst) == os.path.realpath(src):
+                    return
+            except OSError:
+                pass
+            # Wrong target — replace.
+            try:
+                os.unlink(dst)
+            except OSError:
+                return
+        elif os.path.exists(dst):
+            # A real directory (or file) is already there — don't clobber
+            # user data; just leave it.  The subprocess will see whatever
+            # they put there.
+            return
+        os.symlink(src, dst)
+    except OSError as e:
+        logger.debug("could not link %s -> %s: %s", dst, src, e)
 
 
 def _msys_to_windows_path(cwd: str) -> str:
@@ -212,6 +261,7 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
     _profile_home = get_subprocess_home()
     if _profile_home:
         sanitized["HOME"] = _profile_home
+        _ensure_macos_keychain_symlink(_profile_home)
 
     return sanitized
 
@@ -316,6 +366,10 @@ def _make_run_env(env: dict) -> dict:
     _profile_home = get_subprocess_home()
     if _profile_home:
         run_env["HOME"] = _profile_home
+        # macOS: expose the real user's login keychain into the isolated
+        # HOME so CLIs that authenticate via ~/Library/Keychains keep
+        # working from worker subprocesses (issue #29015).
+        _ensure_macos_keychain_symlink(_profile_home)
 
     # Inject ContextVar-based session vars into subprocess env.
     # ContextVars don't propagate to child processes, so we bridge them here.


### PR DESCRIPTION
## Summary

Fixes #29015. `_make_run_env` and `_sanitize_subprocess_env` in `tools/environments/local.py` rewrite `HOME` to the per-profile directory for sandbox isolation. On macOS this hides `~/Library/Keychains/` from worker subprocesses — the `claude` CLI (and anything else that authenticates through the macOS Keychain) loses access and falls back to prompting / failing.

## Fix

Add `_ensure_macos_keychain_symlink(profile_home)` that symlinks `$profile_home/Library/Keychains` → `$REAL_HOME/Library/Keychains` whenever per-profile HOME isolation activates on Darwin. Best-effort, idempotent: won't clobber a real directory if the user put one there, replaces stale/wrong symlinks, no-op on Linux/Windows or when `HERMES_HOME` is unset.

Wired the helper into both HOME-rewriting sites: `_make_run_env` (foreground bash subprocesses) and `_sanitize_subprocess_env` (background processes).

## Test plan
- [x] `tests/test_macos_keychain_passthrough.py` (new, 6 tests, macOS-gated): symlink created, no-op without real keychain dir, idempotent, real-dir not clobbered, wrong symlink replaced, no-op when `HERMES_HOME` unset
- [x] 6 new + 16 existing isolation tests all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)