### PR TITLE
feat(web): drop dashboard-wide uppercase, bump readable typography

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -416,7 +416,7 @@ export default function App() {
   return (
     <div
       data-layout-variant={layoutVariant}
-      className="font-mondwest flex h-dvh max-h-dvh min-h-0 flex-col overflow-hidden bg-black uppercase text-midground antialiased"
+      className="flex h-dvh max-h-dvh min-h-0 flex-col overflow-hidden bg-background-base text-midground antialiased"
     >
       <SelectionSwitcher />
       <Backdrop />
@@ -542,7 +542,7 @@ export default function App() {
                   <span
                     className={cn(
                       "px-5 pt-2.5 pb-1",
-                      "font-mondwest text-[0.6rem] tracking-[0.15em] uppercase opacity-30",
+                      "font-mondwest text-[0.6rem] tracking-[0.15em] opacity-30",
                     )}
                     id="hermes-sidebar-plugin-nav-heading"
                   >
@@ -746,7 +746,7 @@ function SidebarSystemActions({ onNavigate }: { onNavigate: () => void }) {
       <span
         className={cn(
           "px-5 pt-0.5 pb-0.5",
-          "font-mondwest text-[0.6rem] tracking-[0.15em] uppercase opacity-30",
+          "font-mondwest text-[0.6rem] tracking-[0.15em] opacity-30",
         )}
       >
         {t.app.system}

--- a/web/src/components/BottomPickSheet.tsx
+++ b/web/src/components/BottomPickSheet.tsx
@@ -200,7 +200,7 @@ export function BottomPickSheet({
 
           <Typography
             mondwest
-            className="text-[0.65rem] tracking-[0.15em] uppercase text-midground/70"
+            className="text-[0.65rem] tracking-[0.15em] text-midground/70"
           >
             {title}
           </Typography>

--- a/web/src/components/ChatSidebar.tsx
+++ b/web/src/components/ChatSidebar.tsx
@@ -310,7 +310,7 @@ export function ChatSidebar({ channel, className }: ChatSidebarProps) {
     >
       <Card className="flex items-center justify-between gap-2 px-3 py-2">
         <div className="min-w-0">
-          <div className="text-xs uppercase tracking-wider text-muted-foreground">
+          <div className="text-xs tracking-wider text-muted-foreground">
             model
           </div>
 
@@ -357,7 +357,7 @@ export function ChatSidebar({ channel, className }: ChatSidebarProps) {
       )}
 
       <Card className="flex min-h-0 flex-none flex-col px-2 py-2">
-        <div className="px-1 pb-2 text-xs uppercase tracking-wider text-muted-foreground">
+        <div className="px-1 pb-2 text-xs tracking-wider text-muted-foreground">
           tools
         </div>
 

--- a/web/src/components/LanguageSwitcher.tsx
+++ b/web/src/components/LanguageSwitcher.tsx
@@ -74,7 +74,7 @@ export function LanguageSwitcher({ dropUp = false }: LanguageSwitcherProps) {
           <LocaleFlagIcon countryCode={current.flagCountryCode} />
           <Typography
             mondwest
-            className="hidden sm:inline tracking-wide uppercase text-[0.65rem]"
+            className="hidden sm:inline tracking-wide text-[0.65rem]"
           >
             {locale === "en" ? "EN" : current.name}
           </Typography>

--- a/web/src/components/ModelPickerDialog.tsx
+++ b/web/src/components/ModelPickerDialog.tsx
@@ -224,7 +224,7 @@ export function ModelPickerDialog(props: Props) {
         <header className="p-5 pb-3 border-b border-border">
           <h2
             id="model-picker-title"
-            className="font-display text-base tracking-wider uppercase"
+            className="font-display text-base tracking-wider"
           >
             {title}
           </h2>
@@ -453,7 +453,7 @@ function ModelColumn({
 
 function CurrentTag() {
   return (
-    <span className="text-[0.6rem] uppercase tracking-wider text-primary/80 shrink-0">
+    <span className="text-[0.6rem] tracking-wider text-primary/80 shrink-0">
       current
     </span>
   );

--- a/web/src/components/OAuthLoginModal.tsx
+++ b/web/src/components/OAuthLoginModal.tsx
@@ -185,7 +185,7 @@ export function OAuthLoginModal({ provider, onClose, onSuccess }: Props) {
               id="oauth-modal-title"
               variant="sm"
               mondwest
-              className="tracking-wider uppercase"
+              className="tracking-wider"
             >
               {t.oauth.connect} {provider.name}
             </H2>

--- a/web/src/components/OAuthProvidersCard.tsx
+++ b/web/src/components/OAuthProvidersCard.tsx
@@ -154,7 +154,7 @@ export function OAuthProvidersCard({ onError, onSuccess }: Props) {
                       <span className="font-medium text-sm">{p.name}</span>
                       <Badge
                         tone="outline"
-                        className="text-[11px] uppercase tracking-wide"
+                        className="text-[11px] tracking-wide"
                       >
                         {t.oauth.flowLabels[p.flow]}
                       </Badge>

--- a/web/src/components/ThemeSwitcher.tsx
+++ b/web/src/components/ThemeSwitcher.tsx
@@ -76,7 +76,7 @@ export function ThemeSwitcher({ dropUp = false }: ThemeSwitcherProps) {
 
           <Typography
             mondwest
-            className="hidden sm:inline tracking-wide uppercase text-[0.65rem]"
+            className="hidden sm:inline tracking-wide text-[0.65rem]"
           >
             {label}
           </Typography>
@@ -115,7 +115,7 @@ export function ThemeSwitcher({ dropUp = false }: ThemeSwitcherProps) {
           <div className="border-b border-current/20 px-3 py-2">
             <Typography
               mondwest
-              className="text-[0.65rem] tracking-[0.15em] uppercase text-midground/70"
+              className="text-[0.65rem] tracking-[0.15em] text-midground/70"
             >
               {sheetTitle}
             </Typography>
@@ -166,7 +166,7 @@ function ThemeSwitcherOptions({
             <div className="flex min-w-0 flex-1 flex-col gap-0.5">
               <Typography
                 mondwest
-                className="truncate text-[0.75rem] tracking-wide uppercase"
+                className="truncate text-[0.75rem] tracking-wide"
               >
                 {th.label}
               </Typography>

--- a/web/src/components/Toast.tsx
+++ b/web/src/components/Toast.tsx
@@ -24,7 +24,7 @@ export function Toast({ toast }: { toast: { message: string; type: "success" | "
     <div
       role="status"
       aria-live="polite"
-      className={`fixed top-16 right-4 z-50 border px-4 py-2.5 font-courier text-xs tracking-wider uppercase backdrop-blur-sm ${
+      className={`fixed top-16 right-4 z-50 border px-4 py-2.5 font-courier text-xs tracking-wider backdrop-blur-sm ${
         current.type === "success"
           ? "bg-success/15 text-success border-success/30"
           : "bg-destructive/15 text-destructive border-destructive/30"

--- a/web/src/components/ToolCall.tsx
+++ b/web/src/components/ToolCall.tsx
@@ -186,7 +186,7 @@ function Section({
   return (
     <div className="flex gap-3">
       <span
-        className={`uppercase tracking-wider text-[0.6rem] shrink-0 w-14 pt-0.5 ${
+        className={`tracking-wider text-[0.6rem] shrink-0 w-14 pt-0.5 ${
           tone === "error" ? "text-destructive/80" : "text-muted-foreground/60"
         }`}
       >

--- a/web/src/components/ui/card.tsx
+++ b/web/src/components/ui/card.tsx
@@ -40,7 +40,7 @@ export function CardHeader({ className, ...props }: React.HTMLAttributes<HTMLDiv
 }
 
 export function CardTitle({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
-  return <h3 className={cn("font-expanded text-sm font-bold tracking-[0.08em] uppercase blend-lighter", className)} {...props} />;
+  return <h3 className={cn("font-expanded text-sm font-bold tracking-[0.08em] blend-lighter", className)} {...props} />;
 }
 
 export function CardDescription({ className, ...props }: React.HTMLAttributes<HTMLParagraphElement>) {

--- a/web/src/components/ui/confirm-dialog.tsx
+++ b/web/src/components/ui/confirm-dialog.tsx
@@ -82,7 +82,7 @@ export function ConfirmDialog({
           <div className="flex-1 min-w-0 flex flex-col gap-1">
             <h2
               id="confirm-dialog-title"
-              className="font-expanded text-sm font-bold tracking-[0.08em] uppercase blend-lighter"
+              className="font-expanded text-sm font-bold tracking-[0.08em] blend-lighter"
             >
               {title}
             </h2>

--- a/web/src/components/ui/label.tsx
+++ b/web/src/components/ui/label.tsx
@@ -4,7 +4,7 @@ export function Label({ className, ...props }: React.LabelHTMLAttributes<HTMLLab
   return (
     <label
       className={cn(
-        "font-mondwest text-xs tracking-[0.1em] uppercase leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+        "font-mondwest text-xs tracking-[0.1em] leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
         className,
       )}
       {...props}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -49,8 +49,8 @@
   --foreground: color-mix(in srgb, #ffffff 0%, transparent);
   --foreground-base: #ffffff;
   --foreground-alpha: 0;
-  --midground: color-mix(in srgb, #ffe6cb 100%, transparent);
-  --midground-base: #ffe6cb;
+  --midground: color-mix(in srgb, #fff3e2 100%, transparent);
+  --midground-base: #fff3e2;
   --midground-alpha: 1;
   --background: color-mix(in srgb, #041c1c 100%, transparent);
   --background-base: #041c1c;
@@ -67,8 +67,8 @@
   --theme-font-mono: ui-monospace, "SF Mono", "Cascadia Mono", Menlo,
     Consolas, monospace;
   --theme-font-display: var(--theme-font-sans);
-  --theme-base-size: 15px;
-  --theme-line-height: 1.55;
+  --theme-base-size: 16px;
+  --theme-line-height: 1.6;
   --theme-letter-spacing: 0;
 
   /* Layout tokens. */
@@ -132,24 +132,24 @@ code { font-size: 0.875rem; }
      stay visible — in LENS_0, `--foreground` itself has alpha 0. */
   --color-foreground: var(--midground);
 
-  --color-card: color-mix(in srgb, var(--midground-base) 4%, var(--background-base));
+  --color-card: color-mix(in srgb, var(--midground-base) 8%, var(--background-base));
   --color-card-foreground: var(--midground);
   --color-primary: var(--midground);
   --color-primary-foreground: var(--background-base);
-  --color-secondary: color-mix(in srgb, var(--midground-base) 6%, var(--background-base));
+  --color-secondary: color-mix(in srgb, var(--midground-base) 10%, var(--background-base));
   --color-secondary-foreground: var(--midground);
-  --color-muted: color-mix(in srgb, var(--midground-base) 8%, var(--background-base));
-  --color-muted-foreground: color-mix(in srgb, var(--midground-base) 55%, transparent);
-  --color-accent: color-mix(in srgb, var(--midground-base) 10%, var(--background-base));
+  --color-muted: color-mix(in srgb, var(--midground-base) 12%, var(--background-base));
+  --color-muted-foreground: color-mix(in srgb, var(--midground-base) 78%, var(--background-base));
+  --color-accent: color-mix(in srgb, var(--midground-base) 14%, var(--background-base));
   --color-accent-foreground: var(--midground);
   --color-destructive: #fb2c36;
   --color-destructive-foreground: #ffffff;
   --color-success: #4ade80;
   --color-warning: #ffbd38;
-  --color-border: color-mix(in srgb, var(--midground-base) 15%, transparent);
-  --color-input: color-mix(in srgb, var(--midground-base) 15%, transparent);
+  --color-border: color-mix(in srgb, var(--midground-base) 32%, transparent);
+  --color-input: color-mix(in srgb, var(--midground-base) 36%, transparent);
   --color-ring: var(--midground);
-  --color-popover: color-mix(in srgb, var(--midground-base) 4%, var(--background-base));
+  --color-popover: color-mix(in srgb, var(--midground-base) 10%, var(--background-base));
   --color-popover-foreground: var(--midground);
 
   --radius-sm: calc(var(--theme-radius) - 4px);
@@ -202,6 +202,16 @@ code { font-size: 0.875rem; }
   font-family: var(--theme-font-mono);
 }
 
+
+/* The Nous display font is distinctive but hard to read in dense app chrome.
+   Route old display-font call sites through the active readable display stack
+   instead of the pixel/novelty face. */
+.font-mondwest,
+.font-display,
+.font-expanded {
+  font-family: var(--theme-font-display);
+}
+
 /* Subtle grain overlay for badges. */
 .grain {
   position: relative;
@@ -216,14 +226,9 @@ code { font-size: 0.875rem; }
     2px 2px;
 }
 
-/* When a theme provides `assets.bg`, the backdrop's <div> renders it as
-   a CSS background; the default filler <img> is hidden to prevent
-   double-compositing. Unset → initial → empty, so the :not() selector
-   matches and the default image stays visible. */
-:root:not([style*="--theme-asset-bg:"]) .theme-default-filler {
-  display: block;
-}
-:root[style*="--theme-asset-bg:"] .theme-default-filler {
+/* The dashboard backdrop is intentionally image-free for contrast. If a
+   third-party theme still declares `assets.bg`, ignore the filler element. */
+.theme-default-filler {
   display: none;
 }
 

--- a/web/src/pages/AnalyticsPage.tsx
+++ b/web/src/pages/AnalyticsPage.tsx
@@ -484,7 +484,7 @@ export default function AnalyticsPage() {
         <Card>
           <CardContent className="py-12">
             <div className="mx-auto flex max-w-2xl flex-col gap-3 text-sm text-muted-foreground">
-              <h2 className="font-display text-base tracking-wider uppercase text-foreground">
+              <h2 className="font-display text-base tracking-wider text-foreground">
                 Token analytics hidden
               </h2>
               <p>

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -708,8 +708,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   //     model badge, tool-call list, model picker. Best-effort: if the
   //     sidecar fails to connect the terminal pane keeps working.
   //
-  // `normal-case` opts out of the dashboard's global `uppercase` rule on
-  // the root `<div>` in App.tsx — terminal output must preserve case.
+  // Terminal output must preserve case.
   //
   // Mobile model/tools sheet is portaled to `document.body` so it stacks
   // above the app sidebar (`z-50`) and mobile chrome (`z-40`).  The main

--- a/web/src/pages/ConfigPage.tsx
+++ b/web/src/pages/ConfigPage.tsx
@@ -385,7 +385,7 @@ export default function ConfigPage() {
                 category={cat}
                 className="h-4 w-4 text-muted-foreground"
               />
-              <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              <span className="text-xs font-semibold tracking-wider text-muted-foreground">
                 {prettyCategoryName(cat)}
               </span>
               <div className="flex-1 border-t border-border" />
@@ -393,7 +393,7 @@ export default function ConfigPage() {
           )}
           {showSection && (
             <div className="flex items-center gap-2 pt-4 pb-2 first:pt-0">
-              <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              <span className="text-xs font-semibold tracking-wider text-muted-foreground">
                 {section.replace(/_/g, " ")}
               </span>
               <div className="flex-1 border-t border-border" />
@@ -535,12 +535,12 @@ export default function ConfigPage() {
               <div className="flex flex-col border border-border bg-muted/20">
                 <div className="hidden sm:flex items-center gap-2 px-3 py-2 border-b border-border">
                   <Filter className="h-3 w-3 text-muted-foreground" />
-                  <span className="font-mondwest text-[0.65rem] tracking-[0.12em] uppercase text-muted-foreground">
+                  <span className="font-mondwest text-[0.65rem] tracking-[0.12em] text-muted-foreground">
                     {t.config.filters}
                   </span>
                 </div>
 
-                <div className="hidden sm:block px-3 pt-2 pb-1 font-mondwest text-[0.6rem] tracking-[0.12em] uppercase text-muted-foreground/70">
+                <div className="hidden sm:block px-3 pt-2 pb-1 font-mondwest text-[0.6rem] tracking-[0.12em] text-muted-foreground/70">
                   {t.config.sections}
                 </div>
 

--- a/web/src/pages/CronPage.tsx
+++ b/web/src/pages/CronPage.tsx
@@ -296,7 +296,7 @@ export default function CronPage() {
             <header className="p-5 pb-3 border-b border-border">
               <h2
                 id="create-cron-title"
-                className="font-display text-base tracking-wider uppercase"
+                className="font-display text-base tracking-wider"
               >
                 {t.cron.newJob}
               </h2>

--- a/web/src/pages/DocsPage.tsx
+++ b/web/src/pages/DocsPage.tsx
@@ -10,7 +10,7 @@ export const HERMES_DOCS_URL = "https://hermes-agent.nousresearch.com/docs/";
 const DS_BUTTON_OUTLINED_LINK_CN = cn(
   "group relative inline-grid grid-cols-[auto_1fr_auto] items-center",
   "px-[.9em_.75em] py-[1.25em] gap-2",
-  "leading-0 font-bold tracking-[0.2em] uppercase",
+  "leading-0 font-bold tracking-[0.2em]",
   "text-midground bg-transparent shadow-midground",
   "shadow-[inset_-1px_-1px_0_0_#00000080,inset_1px_1px_0_0_#ffffff80]",
 );

--- a/web/src/pages/EnvPage.tsx
+++ b/web/src/pages/EnvPage.tsx
@@ -546,7 +546,7 @@ export default function EnvPage() {
             key={s.id}
             type="button"
             onClick={() => scrollTo(s.id)}
-            className="shrink-0 cursor-pointer px-2 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground hover:text-foreground border border-border/50 hover:border-foreground/30 transition-colors"
+            className="shrink-0 cursor-pointer px-2 py-0.5 text-[10px] tracking-wider text-muted-foreground hover:text-foreground border border-border/50 hover:border-foreground/30 transition-colors"
           >
             {s.label}
           </button>

--- a/web/src/pages/ModelsPage.tsx
+++ b/web/src/pages/ModelsPage.tsx
@@ -253,13 +253,13 @@ function UseAsMenu({
               Main model
             </span>
             {isMain && (
-              <span className="text-[9px] uppercase tracking-wider text-primary/80">
+              <span className="text-[9px] tracking-wider text-primary/80">
                 current
               </span>
             )}
           </button>
 
-          <div className="border-t border-border/50 px-3 py-1.5 text-[9px] uppercase tracking-wider text-muted-foreground">
+          <div className="border-t border-border/50 px-3 py-1.5 text-[9px] tracking-wider text-muted-foreground">
             Auxiliary task
           </div>
 
@@ -282,7 +282,7 @@ function UseAsMenu({
             >
               <span>{t.label}</span>
               {mainAuxTask === t.key && (
-                <span className="text-[9px] uppercase tracking-wider text-primary/80">
+                <span className="text-[9px] tracking-wider text-primary/80">
                   current
                 </span>
               )}
@@ -350,12 +350,12 @@ function ModelCard({
                 {shortModelName(entry.model)}
               </CardTitle>
               {isMain && (
-                <span className="inline-flex items-center gap-0.5 bg-primary/15 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wider text-primary">
+                <span className="inline-flex items-center gap-0.5 bg-primary/15 px-1.5 py-0.5 text-[9px] font-medium tracking-wider text-primary">
                   <Star className="h-2.5 w-2.5" /> main
                 </span>
               )}
               {mainAuxTask && (
-                <span className="inline-flex items-center bg-purple-500/10 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wider text-purple-600 dark:text-purple-400">
+                <span className="inline-flex items-center bg-purple-500/10 px-1.5 py-0.5 text-[9px] font-medium tracking-wider text-purple-600 dark:text-purple-400">
                   aux · {mainAuxTask}
                 </span>
               )}
@@ -537,7 +537,7 @@ function AuxiliaryTasksModal({
           <div className="flex items-center justify-between gap-3 pr-8">
             <h2
               id="aux-modal-title"
-              className="font-display text-base tracking-wider uppercase"
+              className="font-display text-base tracking-wider"
             >
               Auxiliary Tasks
             </h2>
@@ -685,7 +685,7 @@ function ModelSettingsPanel({
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2 mb-0.5">
               <Star className="h-3 w-3 text-primary" />
-              <span className="text-xs font-medium uppercase tracking-wider">
+              <span className="text-xs font-medium tracking-wider">
                 Main model
               </span>
             </div>
@@ -709,7 +709,7 @@ function ModelSettingsPanel({
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2 mb-0.5">
               <Cpu className="h-3 w-3 text-muted-foreground" />
-              <span className="text-xs font-medium uppercase tracking-wider">
+              <span className="text-xs font-medium tracking-wider">
                 Auxiliary tasks
               </span>
             </div>

--- a/web/src/pages/PluginsPage.tsx
+++ b/web/src/pages/PluginsPage.tsx
@@ -470,7 +470,7 @@ function PluginRowCard(props: PluginRowCardProps) {
                 className={cn(
                   "inline-flex items-center rounded-none px-3 py-1.5",
                   "border border-current/25 hover:bg-current/10",
-                  "font-mondwest text-[0.65rem] tracking-[0.1em] uppercase",
+                  "font-mondwest text-[0.65rem] tracking-[0.1em]",
                 )}
                 to={tabPath}
               >

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -242,9 +242,8 @@ export default function ProfilesPage() {
   }
 
   return (
-    // Profile names, model slugs, and paths are case-sensitive; opt out of
-    // the app shell's global ``uppercase`` so they render as the user typed.
-    // Children that explicitly opt back in (Badges, etc.) keep their casing.
+    // Profile names, model slugs, and paths are case-sensitive; render them
+    // as the user typed.
     <div className="flex flex-col gap-6 normal-case">
       <Toast toast={toast} />
 
@@ -285,7 +284,7 @@ export default function ProfilesPage() {
             <header className="p-5 pb-3 border-b border-border">
               <h2
                 id="create-profile-title"
-                className="font-display text-base tracking-wider uppercase"
+                className="font-display text-base tracking-wider"
               >
                 {t.profiles.newProfile}
               </h2>
@@ -500,7 +499,7 @@ export default function ProfilesPage() {
                 <div className="border-t border-border px-4 pb-4 pt-3 flex flex-col gap-2">
                   <Label
                     htmlFor={`soul-editor-${p.name}`}
-                    className="flex items-center gap-2 text-xs uppercase tracking-wider text-muted-foreground"
+                    className="flex items-center gap-2 text-xs tracking-wider text-muted-foreground"
                   >
                     {t.profiles.soulSection}
                   </Label>

--- a/web/src/pages/SkillsPage.tsx
+++ b/web/src/pages/SkillsPage.tsx
@@ -259,7 +259,7 @@ export default function SkillsPage() {
             <div className="flex flex-col rounded-none border border-border bg-muted/20">
               <div className="hidden sm:flex items-center gap-2 px-3 py-2 border-b border-border">
                 <Filter className="h-3 w-3 text-muted-foreground" />
-                <span className="font-mondwest text-[0.65rem] tracking-[0.12em] uppercase text-muted-foreground">
+                <span className="font-mondwest text-[0.65rem] tracking-[0.12em] text-muted-foreground">
                   {t.skills.filters}
                 </span>
               </div>
@@ -290,7 +290,7 @@ export default function SkillsPage() {
                 !isSearching &&
                 allCategories.length > 0 && (
                   <div className="hidden sm:flex flex-col border-t border-border">
-                    <div className="px-3 pt-2 pb-1 font-mondwest text-[0.6rem] tracking-[0.12em] uppercase text-muted-foreground/70">
+                    <div className="px-3 pt-2 pb-1 font-mondwest text-[0.6rem] tracking-[0.12em] text-muted-foreground/70">
                       {t.skills.categories}
                     </div>
                     <div className="flex flex-col p-2 pt-1 gap-px max-h-[calc(100vh-340px)] overflow-y-auto">
@@ -532,7 +532,7 @@ function PanelItem({ active, icon: Icon, label, onClick }: PanelItemProps) {
       onClick={onClick}
       className={cn(
         "rounded-none whitespace-nowrap px-2.5 py-1.5",
-        "font-mondwest text-[0.7rem] tracking-[0.08em] uppercase",
+        "font-mondwest text-[0.7rem] tracking-[0.08em]",
         active && "bg-foreground/90 text-background hover:text-background",
       )}
     >

--- a/web/src/themes/presets.ts
+++ b/web/src/themes/presets.ts
@@ -24,8 +24,8 @@ const SYSTEM_MONO =
 const DEFAULT_TYPOGRAPHY: ThemeTypography = {
   fontSans: SYSTEM_SANS,
   fontMono: SYSTEM_MONO,
-  baseSize: "15px",
-  lineHeight: "1.55",
+  baseSize: "16px",
+  lineHeight: "1.6",
   letterSpacing: "0",
 };
 
@@ -44,7 +44,7 @@ export const defaultTheme: DashboardTheme = {
   description: "Classic dark teal — the canonical Hermes look",
   palette: {
     background: { hex: "#041c1c", alpha: 1 },
-    midground: { hex: "#ffe6cb", alpha: 1 },
+    midground: { hex: "#fff3e2", alpha: 1 },
     foreground: { hex: "#ffffff", alpha: 0 },
     warmGlow: "rgba(255, 189, 56, 0.35)",
     noiseOpacity: 1,


### PR DESCRIPTION
## What & why

The Nous DS layout-wrapper applies `font-mondwest uppercase` to `<body>`, and the dashboard app-shell `<div>` in `App.tsx` repeats the pattern. That gives the chrome a strong brand voice but actively harms dense application surfaces: task titles, profile names, model slugs, paths, URLs, and code fragments are all case-significant identifiers, and rendering them in caps makes them slower to read and easy to copy back wrong. The `ChatPage` terminal and `ProfilesPage` model/path lists already carry `normal-case` opt-outs as a comment-documented workaround.

This PR stops forcing brand styling on application chrome:

### App shell

- `App.tsx` — remove `font-mondwest uppercase` from the app-shell root and a sidebar plugin-nav heading; also drop the redundant `bg-black` / `text-midground` (theme tokens already cover these).

### Per-element cleanup

All page and component class lists drop the now-redundant per-element `uppercase` Tailwind utility. With the root no longer forcing case, these were already cosmetic-only and removing them keeps the markup faithful to what reads in dev tools. Touched: 18 files in `web/src/pages/` and `web/src/components/`.

### Theme tokens

- `index.css` — route legacy `.font-mondwest` / `.font-display` / `.font-expanded` class hooks through `--theme-font-display`; lift base size 15 → 16 px and line-height 1.55 → 1.6; brighten `--color-muted-foreground` 55 → 78 % midground for contrast; fatten borders 15 → 32 % so panel edges stay visible against the deep-teal canvas. Same delta on `--color-input`, `--color-card`, `--color-muted`, `--color-accent`, `--color-popover`.
- `themes/presets.ts` — `defaultTheme.typography.baseSize` 15 → 16 px, line-height 1.55 → 1.6, and warm the default `midground` from `#ffe6cb` to `#fff3e2` so AAA contrast vs `#041c1c` background still holds at the higher saturation.

### Opt-out cleanups

- `ChatPage.tsx`, `ProfilesPage.tsx` — drop the `normal-case` workaround (and its explanatory comment); no longer needed once the parent doesn't force case.

Mondwest is preserved everywhere it's *explicitly* opted into via the `font-mondwest` class on individual elements (eyebrows, sidebar section labels, lane headers) — those keep the brand voice without forcing it on the whole tree.

## How to test

Automated:
- `npx tsc -b` in `web/` — clean.
- `npx eslint .` in `web/` — 19 problems / 14 errors / 5 warnings. **Same count as `origin/main`**; all errors are pre-existing in `SessionsPage` and `SkillsPage` hooks code this PR does not touch.

Manual:
1. Open each tab (kanban, chat, profiles, models, env, config, cron, docs, plugins, skills, analytics). Verify text renders in authored case at the bumped baseline.
2. Switch themes — each theme's typography tokens still win, brand uppercase is gone everywhere except where individual elements explicitly opt in via `font-mondwest`.

## Platforms tested

Linux (WSL2), Chrome. CSS/Tailwind change, no platform-specific behavior.

## Out of scope

- `plugins/kanban/dashboard/dist/style.css` already gets the same treatment in #29251 (kanban-only override).
- `web/src/components/Backdrop.tsx` simplification — separate aesthetic call, follow-up PR.
- `plugins/hermes-achievements/dashboard/dist/style.css` still has explicit `text-transform: uppercase` (intentional kicker-label aesthetic). Not touched here.