### PR TITLE
fix(cli): index CLI sessions in sessions.json on standalone invocations (#29073)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -778,6 +778,16 @@ def _run_cleanup():
         _invoke_hook("on_session_finalize", session_id=_active_agent_ref.session_id if _active_agent_ref else None, platform="cli")
     except Exception:
         pass
+    # Refresh sessions.json so the standalone CLI session (hermes.exe /
+    # PowerShell on Windows in particular) shows a sane updated_at and is
+    # discoverable by status / mcp_serve.  See issue #29073.
+    try:
+        if _active_agent_ref and getattr(_active_agent_ref, "session_id", None) \
+                and getattr(_active_agent_ref, "platform", "") == "cli":
+            from hermes_cli.session_index import index_cli_session
+            index_cli_session(_active_agent_ref.session_id, source="cli")
+    except Exception:
+        pass
     try:
         if _active_agent_ref and hasattr(_active_agent_ref, 'shutdown_memory_provider'):
             # Forward the agent's own transcript so memory providers'

--- a/hermes_cli/session_index.py
+++ b/hermes_cli/session_index.py
@@ -1,0 +1,171 @@
+"""
+sessions.json indexer for standalone CLI sessions.
+
+When the CLI runs through the gateway, ``gateway.session.SessionStore`` is
+responsible for keeping ``~/.hermes/sessions/sessions.json`` in sync with the
+SQLite session DB.  When the CLI runs **standalone** -- e.g. via
+``hermes.exe`` on Windows / PowerShell, or just ``hermes`` on macOS/Linux
+without a gateway process attached -- nothing writes the CLI session into
+that JSON index.  Downstream consumers that scan sessions.json (status,
+mcp_serve, channel_directory, mirror) then can't see CLI conversations.
+
+This module provides a tiny, dependency-light upsert that the CLI calls on
+session start, update and exit.  It writes a SessionEntry-shaped record
+keyed by a synthetic ``cli:<session_id>`` key so it can't collide with
+gateway-managed keys.
+
+Errors are intentionally swallowed -- failing to index must never break a
+live CLI session.
+
+See issue #29073.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from hermes_cli.config import get_hermes_home
+from utils import atomic_replace
+
+logger = logging.getLogger(__name__)
+
+# Cross-thread guard for the read/modify/write cycle.  The on-disk write is
+# atomic via tempfile + ``atomic_replace``, but two threads in the same
+# process (e.g. the cleanup path racing the agent thread's persist hook)
+# could still clobber each other's updates without this lock.
+_INDEX_LOCK = threading.Lock()
+
+_CLI_KEY_PREFIX = "cli:"
+
+
+def _sessions_index_path() -> Path:
+    return get_hermes_home() / "sessions" / "sessions.json"
+
+
+def _now_iso() -> str:
+    # Match gateway/session.py SessionEntry.to_dict() which uses naive
+    # local-time isoformat via ``_now()`` -> datetime.now().  Aligning the
+    # format keeps from_dict() round-trips happy.
+    return datetime.now().isoformat()
+
+
+def _load(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+            if isinstance(data, dict):
+                return data
+    except (OSError, json.JSONDecodeError) as e:
+        logger.debug("sessions.json read failed (%s); starting fresh dict", e)
+    return {}
+
+
+def _atomic_write(path: Path, data: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp", prefix=".sessions_")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+            f.flush()
+            try:
+                os.fsync(f.fileno())
+            except OSError:
+                # fsync can fail on some Windows filesystems / WSL mounts;
+                # the rename below is still atomic enough for our purposes.
+                pass
+        atomic_replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def _build_entry(
+    session_id: str,
+    *,
+    created_at: Optional[str],
+    display_name: Optional[str],
+    source: str,
+) -> Dict[str, Any]:
+    """Build a minimal SessionEntry-shaped dict for a CLI session.
+
+    Uses ``platform: "local"`` because the ``Platform`` enum has a LOCAL
+    member -- gateway/session.py's ``SessionEntry.from_dict()`` will accept
+    it without raising.  ``chat_type`` stays "dm" (the default).
+    """
+    now = _now_iso()
+    return {
+        "session_key": f"{_CLI_KEY_PREFIX}{session_id}",
+        "session_id": session_id,
+        "created_at": created_at or now,
+        "updated_at": now,
+        "display_name": display_name,
+        "platform": "local",
+        "chat_type": "dm",
+        "origin": {
+            "platform": "local",
+            "chat_id": session_id,
+            "chat_type": "dm",
+            "source_label": source,
+        },
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+        "total_tokens": 0,
+        "last_prompt_tokens": 0,
+        "estimated_cost_usd": 0.0,
+        "cost_status": "unknown",
+        "expiry_finalized": False,
+        "suspended": False,
+        "resume_pending": False,
+    }
+
+
+def index_cli_session(
+    session_id: Optional[str],
+    *,
+    display_name: Optional[str] = None,
+    source: str = "cli",
+) -> bool:
+    """Upsert a CLI session entry into ``sessions.json``.
+
+    Idempotent: re-indexing the same session_id refreshes ``updated_at`` but
+    preserves the original ``created_at``.  Never raises -- returns False on
+    any failure so the live CLI session keeps running.
+
+    Returns True when the entry was written (or refreshed) successfully.
+    """
+    if not session_id or not isinstance(session_id, str):
+        return False
+
+    path = _sessions_index_path()
+    key = f"{_CLI_KEY_PREFIX}{session_id}"
+
+    try:
+        with _INDEX_LOCK:
+            data = _load(path)
+            existing = data.get(key) if isinstance(data.get(key), dict) else None
+            created_at = existing.get("created_at") if existing else None
+            data[key] = _build_entry(
+                session_id,
+                created_at=created_at,
+                display_name=display_name or (existing.get("display_name") if existing else None),
+                source=source,
+            )
+            _atomic_write(path, data)
+        return True
+    except Exception as e:  # noqa: BLE001 -- indexing must never crash CLI
+        logger.debug("Failed to index CLI session %s in sessions.json: %s", session_id, e)
+        return False

--- a/run_agent.py
+++ b/run_agent.py
@@ -517,6 +517,17 @@ class AIAgent:
                 parent_session_id=self._parent_session_id,
             )
             self._session_db_created = True
+            # Mirror the new session into the JSON index when running as a
+            # standalone CLI (no gateway present to do it for us).  Without
+            # this, hermes.exe / PowerShell sessions never show up in
+            # sessions.json and stay invisible to status / mcp_serve /
+            # channel_directory.  See issue #29073.
+            if (self.platform or "") == "cli":
+                try:
+                    from hermes_cli.session_index import index_cli_session
+                    index_cli_session(self.session_id, source="cli")
+                except Exception:
+                    logger.debug("sessions.json index update failed", exc_info=True)
         except Exception as e:
             # Transient failure (e.g. SQLite lock). Keep _session_db alive —
             # _session_db_created stays False so next run_conversation() retries.

--- a/tests/hermes_cli/test_session_index.py
+++ b/tests/hermes_cli/test_session_index.py
@@ -1,0 +1,112 @@
+"""Tests for hermes_cli.session_index — sessions.json indexing for
+standalone CLI sessions (issue #29073).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    """Point HERMES_HOME at a tmp dir and force re-import of the module
+    so its ``get_hermes_home()`` cache picks up the new value.
+    """
+    home = tmp_path / "hermes_home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    # The module captures get_hermes_home at import time inside the
+    # function body, so just re-import to be safe in case of caching.
+    import importlib
+    import hermes_cli.session_index as si
+    importlib.reload(si)
+    return home
+
+
+def _read_index(home: Path) -> dict:
+    p = home / "sessions" / "sessions.json"
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text("utf-8"))
+
+
+def test_index_creates_sessions_json(hermes_home):
+    from hermes_cli.session_index import index_cli_session
+
+    assert index_cli_session("20260520_120000_abc123") is True
+
+    data = _read_index(hermes_home)
+    assert "cli:20260520_120000_abc123" in data
+    entry = data["cli:20260520_120000_abc123"]
+    assert entry["session_id"] == "20260520_120000_abc123"
+    assert entry["platform"] == "local"
+    assert entry["chat_type"] == "dm"
+    assert entry["created_at"]
+    assert entry["updated_at"]
+
+
+def test_index_is_idempotent_preserves_created_at(hermes_home):
+    """Re-indexing the same session refreshes updated_at but keeps the
+    original created_at -- regression guard for #29073.
+    """
+    import time
+    from hermes_cli.session_index import index_cli_session
+
+    index_cli_session("sid1")
+    first = _read_index(hermes_home)["cli:sid1"]
+    time.sleep(0.01)
+    index_cli_session("sid1")
+    second = _read_index(hermes_home)["cli:sid1"]
+
+    assert second["created_at"] == first["created_at"]
+    assert second["updated_at"] >= first["updated_at"]
+
+
+def test_index_preserves_other_entries(hermes_home):
+    """Upserting a CLI entry must not clobber unrelated gateway entries
+    (telegram, discord, ...) already in sessions.json.
+    """
+    from hermes_cli.session_index import index_cli_session
+
+    sessions_dir = hermes_home / "sessions"
+    sessions_dir.mkdir()
+    path = sessions_dir / "sessions.json"
+    path.write_text(json.dumps({
+        "agent:main:telegram:dm": {
+            "session_key": "agent:main:telegram:dm",
+            "session_id": "tg_sid",
+            "created_at": "2026-01-01T00:00:00",
+            "updated_at": "2026-01-01T00:00:00",
+            "platform": "telegram",
+            "chat_type": "dm",
+        }
+    }))
+
+    index_cli_session("cli_sid")
+    data = _read_index(hermes_home)
+    assert "agent:main:telegram:dm" in data
+    assert data["agent:main:telegram:dm"]["session_id"] == "tg_sid"
+    assert "cli:cli_sid" in data
+
+
+def test_index_returns_false_on_empty_session_id(hermes_home):
+    from hermes_cli.session_index import index_cli_session
+    assert index_cli_session("") is False
+    assert index_cli_session(None) is False  # type: ignore[arg-type]
+    # No file created
+    assert not (hermes_home / "sessions" / "sessions.json").exists()
+
+
+def test_index_swallows_write_errors(hermes_home, monkeypatch):
+    """A broken disk must not break the live CLI session."""
+    from hermes_cli import session_index
+
+    def _boom(*_a, **_k):
+        raise OSError("simulated")
+
+    monkeypatch.setattr(session_index, "_atomic_write", _boom)
+    # Returns False but does not raise.
+    assert session_index.index_cli_session("sid_err") is False


### PR DESCRIPTION
## Summary

Fixes #29073. Standalone CLI sessions (`hermes.exe` / PowerShell, or `hermes` without a gateway) wrote `session_*.json` transcripts but never appeared in `~/.hermes/sessions/sessions.json`, making them invisible to `status`, `mcp_serve`, `channel_directory`, and `mirror`.

## Root cause

Only `gateway.session.SessionStore._save()` writes `sessions.json`. The CLI populates SQLite (`SessionDB`) directly via `run_agent._ensure_db_session()` but had no equivalent JSON-index writer for the standalone path. The issue is broader than Windows — every standalone CLI invocation is affected — but `hermes.exe` users hit it most because PowerShell launches without a gateway.

## Fix

- `hermes_cli/session_index.py` (new): small thread-safe, atomic upserter that writes a `SessionEntry`-shaped record keyed `cli:<session_id>` with `platform: \"local\"`. Errors are swallowed so indexing can never break a live CLI session.
- `run_agent.py`: call `index_cli_session()` right after the SQLite row is created in `_ensure_db_session()`, gated on `platform == \"cli\"`.
- `cli.py`: also call from `_run_cleanup()` so `updated_at` refreshes on graceful exit.

## Test plan
- [x] `tests/hermes_cli/test_session_index.py` (new, 5 tests): creation, idempotency preserves `created_at`, doesn't clobber other entries, no-op on empty id, swallows write errors
- [x] 126-test `hermes_cli` session-related suite still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)