### PR TITLE
feat(web): simplify dashboard backdrop to a single themed color

### DIFF
--- a/web/src/components/Backdrop.tsx
+++ b/web/src/components/Backdrop.tsx
@@ -1,93 +1,15 @@
-import { useGpuTier } from "@nous-research/ui/hooks/use-gpu-tier";
-
-import fillerBgUrl from "@nous-research/ui/assets/filler-bg0.webp";
-
 /**
- * Replicates the visual layer stack of `<Overlays dark />` from
- * `@nous-research/ui` without pulling in its leva / gsap / three peer deps.
+ * Plain, theme-aware dashboard backdrop.
  *
- * See `design-language/src/ui/components/overlays/index.tsx` for the source of
- * truth. Defaults match LENS_0 (the Hermes teal dark preset); the deep canvas
- * and the warm vignette both read theme-switchable CSS custom properties so
- * `ThemeProvider` can repaint the stack without remounting.
- *
- *   z-1   bg = `var(--background-base)`, mix-blend-mode: difference
- *   z-2   bundled filler-bg WebP, inverted, opacity 0.033, difference
- *   z-99  warm top-left vignette (`var(--warm-glow)`), opacity 0.22, lighten
- *   z-101 noise grain (SVG, ~55% opacity × `--noise-opacity-mul`,
- *         color-dodge) — gated on GPU tier
- *
- * `useGpuTier` returns 0 when WebGL is unavailable, the renderer is a
- * software rasterizer (SwiftShader/llvmpipe), or the user has
- * `prefers-reduced-motion: reduce` set. We skip the animated noise layer
- * in that case so low-power / accessibility-conscious sessions stay crisp,
- * mirroring the DS `<Noise />` component's own opt-out.
+ * Keep the dashboard background intentionally boring: one solid color from
+ * the active theme, no image layers, no blend modes, no glow, no noise.
  */
 export function Backdrop() {
-  const gpuTier = useGpuTier();
-
   return (
-    <>
-      <div
-        aria-hidden
-        className="pointer-events-none fixed inset-0 z-[1]"
-        style={{
-          backgroundColor: "var(--background-base)",
-          mixBlendMode: "difference",
-        }}
-      />
-
-      <div
-        aria-hidden
-        className="pointer-events-none fixed inset-0 z-[2]"
-        style={
-          {
-            // Themes can override the filler background by setting
-            // `assets.bg` — the <img> hides itself when a CSS bg is set
-            // so the two don't double-darken. CSS var fallbacks keep the
-            // default behaviour unchanged when no theme customises these.
-            mixBlendMode:
-              "var(--component-backdrop-filler-blend-mode, difference)",
-            opacity: "var(--component-backdrop-filler-opacity, 0.033)",
-            backgroundImage: "var(--theme-asset-bg)",
-            backgroundSize: "var(--component-backdrop-background-size, cover)",
-            backgroundPosition:
-              "var(--component-backdrop-background-position, center)",
-          } as unknown as React.CSSProperties
-        }
-      >
-        <img
-          alt=""
-          className="h-[150dvh] w-auto min-w-[100dvw] object-cover object-top-left invert theme-default-filler"
-          fetchPriority="low"
-          src={fillerBgUrl}
-        />
-      </div>
-
-      <div
-        aria-hidden
-        className="pointer-events-none fixed inset-0 z-[99]"
-        style={{
-          background:
-            "radial-gradient(ellipse at 0% 0%, transparent 60%, var(--warm-glow) 100%)",
-          mixBlendMode: "lighten",
-          opacity: 0.22,
-        }}
-      />
-
-      {gpuTier > 0 && (
-        <div
-          aria-hidden
-          className="pointer-events-none fixed inset-0 z-[101]"
-          style={{
-            backgroundImage:
-              "url(\"data:image/svg+xml,%3Csvg viewBox='0 0 512 512' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' fill='%23eaeaea' filter='url(%23n)' opacity='0.6'/%3E%3C/svg%3E\")",
-            backgroundSize: "512px 512px",
-            mixBlendMode: "color-dodge",
-            opacity: "calc(0.55 * var(--noise-opacity-mul, 1))",
-          }}
-        />
-      )}
-    </>
+    <div
+      aria-hidden
+      className="pointer-events-none fixed inset-0 z-[1]"
+      style={{ backgroundColor: "var(--background-base)" }}
+    />
   );
 }


### PR DESCRIPTION
## What & why

`Backdrop.tsx` reimplemented the Nous DS `<Overlays dark />` visual stack — deep-canvas difference layer, inverted filler-bg WebP, warm top-left vignette, GPU-gated SVG noise grain — so the dashboard inherits the DS look without pulling in `leva` / `gsap` / `three` directly.

That's a lot of `mix-blend-mode` plumbing and an animated noise layer to sit behind dense application chrome. It also interacts poorly with the contrast bumps in #29256: the moving grain fights the static text underneath and makes long reading sessions on the dashboard tangibly worse.

This PR replaces the four overlay layers with a single themed `<div>` painted `var(--background-base)`. Theme switching still works (the variable repaints on `ThemeProvider` updates), and any future ornament can be added back as an opt-in via per-theme CSS without rebuilding the overlay stack.

Removed imports (`useGpuTier`, `fillerBgUrl`) are unused after this change. `leva` / `gsap` stay listed in `package.json` because other components (Sessions, ChatSidebar animations) still use them — pruning the deps is out of scope here.

## How to test

Automated:
- `npx tsc -b` in `web/` — clean.

Manual:
1. Load each tab on the default theme; backdrop renders as a solid teal canvas, no flicker, no grain.
2. Switch to NERV theme; backdrop repaints to the NERV background color without remount.
3. Confirm text contrast against the static backdrop is measurably better than against the moving grain — easiest on the kanban tab, where dense data sits over the backdrop.

## Platforms tested

Linux (WSL2), Chrome. No platform-specific behavior.

## Note for reviewers

This is an aesthetic call as much as a perf/contrast one. Happy to take feedback on whether the noise overlay should stay as an opt-in per-theme (e.g. drive it off `--component-backdrop-noise-opacity`) rather than being removed outright.