### PR TITLE
feat: add ask_advisor tool — Advisor Strategy for Hermes Agent

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1568,8 +1568,35 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
         return agent._dispatch_delegate_task(function_args)
     elif function_name == "ask_advisor":
         from tools.advisor_tool import call_advisor, load_advisor_config, _make_use_counter
+
+        # ---- Native Anthropic advisor: already resolved by the API ----
+        # When the native ``advisor_20260301`` tool type is used, Anthropic
+        # internally routes the query and returns the advice directly in the
+        # tool_use block's input.  No separate API call needed.
+        if "advice" in function_args:
+            # Per-task invocation cap still applies
+            cfg = load_advisor_config()
+            if not hasattr(agent, "_advisor_counter"):
+                agent._advisor_counter = _make_use_counter()
+            max_uses = cfg.get("max_uses_per_task", 5)
+            if agent._advisor_counter["count"] >= max_uses:
+                return json.dumps({
+                    "error": f"Advisor invocation limit reached ({max_uses} per task). "
+                             f"Proceed with your best judgment.",
+                }, ensure_ascii=False)
+            agent._advisor_counter["count"] += 1
+            advice = function_args.get("advice", "")
+            advisor_model = function_args.get("model", "?")
+            stats = (
+                f"[🧠 advisor: {advisor_model}, "
+                f"{function_args.get('tokens_in', 0)}↓/"
+                f"{function_args.get('tokens_out', 0)}↑, "
+                f"call {agent._advisor_counter['count']}/{max_uses}]"
+            )
+            return f"{stats}\n\n{advice}"
+
+        # ---- Traditional tool-based advisor: make a separate API call ----
         cfg = load_advisor_config()
-        # Per-task invocation cap
         if not hasattr(agent, "_advisor_counter"):
             agent._advisor_counter = _make_use_counter()
         max_uses = cfg.get("max_uses_per_task", 5)
@@ -1590,7 +1617,6 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
         parsed = json.loads(raw_result)
         if "error" in parsed:
             return json.dumps(parsed, ensure_ascii=False)
-        # Format for the executor: stats header + advice
         stats = (
             f"[🧠 advisor: {parsed.get('model', '?')}, "
             f"{parsed.get('tokens_in', 0)}↓/{parsed.get('tokens_out', 0)}↑, "

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1566,6 +1566,38 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
         )
     elif function_name == "delegate_task":
         return agent._dispatch_delegate_task(function_args)
+    elif function_name == "ask_advisor":
+        from tools.advisor_tool import call_advisor, load_advisor_config, _make_use_counter
+        cfg = load_advisor_config()
+        # Per-task invocation cap
+        if not hasattr(agent, "_advisor_counter"):
+            agent._advisor_counter = _make_use_counter()
+        max_uses = cfg.get("max_uses_per_task", 5)
+        if agent._advisor_counter["count"] >= max_uses:
+            return json.dumps({
+                "error": f"Advisor invocation limit reached ({max_uses} per task). "
+                         f"Proceed with your best judgment.",
+            }, ensure_ascii=False)
+        agent._advisor_counter["count"] += 1
+        raw_result = call_advisor(
+            messages=messages or [],
+            question=function_args.get("question", ""),
+            urgency=function_args.get("urgency", "medium"),
+            config=cfg,
+            credential_pool=getattr(agent, "_credential_pool", None),
+            parent_agent=agent,
+        )
+        parsed = json.loads(raw_result)
+        if "error" in parsed:
+            return json.dumps(parsed, ensure_ascii=False)
+        # Format for the executor: stats header + advice
+        stats = (
+            f"[🧠 advisor: {parsed.get('model', '?')}, "
+            f"{parsed.get('tokens_in', 0)}↓/{parsed.get('tokens_out', 0)}↑, "
+            f"{parsed.get('latency_ms', 0)}ms, "
+            f"call {agent._advisor_counter['count']}/{max_uses}]"
+        )
+        return f"{stats}\n\n{parsed.get('advice', '')}"
     else:
         return _ra().handle_function_call(
             function_name, function_args, effective_task_id,

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2036,6 +2036,85 @@ def _build_advisor_tool(advisor_config: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+def _strip_advisor_blocks(messages: List[Dict]) -> List[Dict]:
+    """Strip stale advisor tool blocks from Anthropic message history.
+
+    When the advisor tool is removed from the tools array (e.g. user disables
+    it for cost control), Anthropic rejects requests whose history contains
+    residual ``server_tool_use(name=advisor)`` or ``advisor_tool_result``
+    blocks.  This function replaces those blocks with ``<advisor_feedback>``
+    text blocks so the executor retains the semantic context of past advice.
+
+    Inspired by LiteLLM's ``strip_advisor_blocks_from_messages()``.
+    """
+    for message in messages:
+        if not isinstance(message, dict) or message.get("role") != "assistant":
+            continue
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+
+        # Collect advisor server_tool_use IDs
+        advisor_ids: set = set()
+        for block in content:
+            if (
+                isinstance(block, dict)
+                and block.get("type") == "server_tool_use"
+                and block.get("name") == "advisor"
+            ):
+                bid = block.get("id")
+                if bid:
+                    advisor_ids.add(bid)
+
+        if not advisor_ids:
+            continue
+
+        # Collect advice text from advisor_tool_result blocks
+        id_to_text: Dict[str, str] = {}
+        for block in content:
+            if (
+                isinstance(block, dict)
+                and block.get("type") == "advisor_tool_result"
+                and block.get("tool_use_id") in advisor_ids
+            ):
+                raw = block.get("content") or ""
+                if isinstance(raw, str):
+                    id_to_text[block["tool_use_id"]] = raw
+                elif isinstance(raw, list):
+                    id_to_text[block["tool_use_id"]] = next(
+                        (b.get("text", "") for b in raw
+                         if isinstance(b, dict) and b.get("type") == "text"),
+                        "",
+                    )
+
+        # Replace: strip server_tool_use + advisor_tool_result,
+        # insert <advisor_feedback> text block for each exchange
+        new_content = []
+        for block in content:
+            if not isinstance(block, dict):
+                new_content.append(block)
+                continue
+            btype = block.get("type", "")
+            # Replace advisor server_tool_use with text
+            if btype == "server_tool_use" and block.get("name") == "advisor":
+                bid = block.get("id")
+                advice = id_to_text.get(bid, "")
+                if advice:
+                    new_content.append({
+                        "type": "text",
+                        "text": f"<advisor_feedback>\n{advice}\n</advisor_feedback>",
+                    })
+                # else: silently drop
+            # Always drop advisor_tool_result (text already captured above)
+            elif btype == "advisor_tool_result" and block.get("tool_use_id") in advisor_ids:
+                pass
+            else:
+                new_content.append(block)
+
+        message["content"] = new_content
+    return messages
+
+
 def build_anthropic_kwargs(
     model: str,
     messages: List[Dict],
@@ -2100,6 +2179,7 @@ def build_anthropic_kwargs(
     # ``advisor_20260301`` tool type.  The native tool tells Anthropic's API to
     # internally route advisor queries — no separate API call needed.
     # The advisor model is specified in the tool definition.
+    advisor_active = False
     if advisor_config and not _is_third_party_anthropic_endpoint(base_url):
         try:
             # Remove the OpenAI ask_advisor function tool (converted to Anthropic
@@ -2111,8 +2191,18 @@ def build_anthropic_kwargs(
             # Inject the native advisor tool
             advisor_tool = _build_advisor_tool(advisor_config)
             anthropic_tools.append(advisor_tool)
+            advisor_active = True
         except Exception:
             pass
+
+    # ---- Strip stale advisor blocks from message history ----
+    # When the advisor tool is *not* in the tools array (e.g. user disabled
+    # it for cost control on a follow-up turn), Anthropic rejects requests
+    # that contain residual server_tool_use(name=advisor) or
+    # advisor_tool_result blocks in the history.  Clean them out.
+    # Learned from LiteLLM's strip_advisor_blocks_from_messages().
+    if not advisor_active:
+        anthropic_messages = _strip_advisor_blocks(anthropic_messages)
 
     model = normalize_model_name(model, preserve_dots=preserve_dots)
     # effective_max_tokens = output cap for this call (≠ total context window)

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -271,6 +271,12 @@ _CONTEXT_1M_BETA = "context-1m-2025-08-07"
 # See https://platform.claude.com/docs/en/build-with-claude/fast-mode
 _FAST_MODE_BETA = "fast-mode-2026-02-01"
 
+# Advisor tool beta — enables the native ``advisor`` tool type that lets
+# Claude internally consult another model without a separate API round-trip.
+# The tool definition carries a ``model`` field specifying the advisor model.
+# See https://claude.com/blog/the-advisor-strategy
+_ADVISOR_TOOL_BETA = "advisor-tool-2026-03-01"
+
 # Additional beta headers required for OAuth/subscription auth.
 # Matches what Claude Code (and pi-ai / OpenCode) send.
 _OAUTH_ONLY_BETAS = [
@@ -554,6 +560,9 @@ def _common_betas_for_base_url(
     would otherwise include it after a subscription/endpoint rejects the beta.
     """
     betas = list(_COMMON_BETAS)
+    # Advisor tool beta — only for native Anthropic endpoints
+    if not _is_third_party_anthropic_endpoint(base_url) and not _is_minimax_anthropic_endpoint(base_url):
+        betas.append(_ADVISOR_TOOL_BETA)
     if _base_url_needs_context_1m_beta(base_url) and not drop_context_1m_beta:
         betas.append(_CONTEXT_1M_BETA)
     if _is_minimax_anthropic_endpoint(base_url):
@@ -2001,6 +2010,32 @@ def convert_messages_to_anthropic(
     return system, result
 
 
+def _load_advisor_config() -> Dict[str, Any] | None:
+    """Load advisor config, returning None if advisor is not enabled."""
+    try:
+        from tools.advisor_tool import load_advisor_config
+        cfg = load_advisor_config()
+        if cfg.get("enabled") and cfg.get("model"):
+            return cfg
+    except Exception:
+        pass
+    return None
+
+
+def _build_advisor_tool(advisor_config: Dict[str, Any]) -> Dict[str, Any]:
+    """Build the native Anthropic advisor tool definition.
+
+    Returns a tool dict with ``type: "advisor_20260301"`` that tells
+    Anthropic's API to internally route advisor queries to the specified
+    model — no separate API round-trip needed.
+    """
+    return {
+        "type": "advisor_20260301",
+        "name": "ask_advisor",
+        "model": advisor_config.get("model", "claude-sonnet-4-6"),
+    }
+
+
 def build_anthropic_kwargs(
     model: str,
     messages: List[Dict],
@@ -2014,6 +2049,7 @@ def build_anthropic_kwargs(
     base_url: str | None = None,
     fast_mode: bool = False,
     drop_context_1m_beta: bool = False,
+    advisor_config: Dict[str, Any] | None = None,
 ) -> Dict[str, Any]:
     """Build kwargs for anthropic.messages.create().
 
@@ -2057,6 +2093,26 @@ def build_anthropic_kwargs(
         messages, base_url=base_url, model=model
     )
     anthropic_tools = convert_tools_to_anthropic(tools) if tools else []
+
+    # ---- Inject native advisor tool (Anthropic only) ----
+    # When advisor is enabled, replace the OpenAI ``ask_advisor`` function-call
+    # tool (which requires a separate API round-trip) with Anthropic's native
+    # ``advisor_20260301`` tool type.  The native tool tells Anthropic's API to
+    # internally route advisor queries — no separate API call needed.
+    # The advisor model is specified in the tool definition.
+    if advisor_config and not _is_third_party_anthropic_endpoint(base_url):
+        try:
+            # Remove the OpenAI ask_advisor function tool (converted to Anthropic
+            # format with type="custom") so it doesn't conflict with the native one.
+            anthropic_tools = [
+                t for t in anthropic_tools
+                if not (isinstance(t, dict) and t.get("name") == "ask_advisor")
+            ]
+            # Inject the native advisor tool
+            advisor_tool = _build_advisor_tool(advisor_config)
+            anthropic_tools.append(advisor_tool)
+        except Exception:
+            pass
 
     model = normalize_model_name(model, preserve_dots=preserve_dots)
     # effective_max_tokens = output cap for this call (≠ total context window)

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -242,6 +242,9 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         ephemeral_out = getattr(agent, "_ephemeral_max_output_tokens", None)
         if ephemeral_out is not None:
             agent._ephemeral_max_output_tokens = None  # consume immediately
+        # Load advisor config for native Anthropic advisor tool injection
+        from agent.anthropic_adapter import _load_advisor_config
+        advisor_cfg = _load_advisor_config()
         return _transport.build_kwargs(
             model=agent.model,
             messages=anthropic_messages,
@@ -254,6 +257,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             base_url=getattr(agent, "_anthropic_base_url", None),
             fast_mode=(agent.request_overrides or {}).get("speed") == "fast",
             drop_context_1m_beta=bool(getattr(agent, "_oauth_1m_beta_disabled", False)),
+            advisor_config=advisor_cfg,
         )
 
     # AWS Bedrock native Converse API — bypasses the OpenAI client entirely.

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -108,6 +108,11 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         tool_guidance.append(SESSION_SEARCH_GUIDANCE)
     if "skill_manage" in agent.valid_tool_names:
         tool_guidance.append(SKILLS_GUIDANCE)
+    # Advisor strategy — inject Anthropic-recommended timing + advice-handling
+    # guidance so the executor knows *when* and *how* to call ask_advisor.
+    if "ask_advisor" in agent.valid_tool_names:
+        from tools.advisor_tool import EXECUTOR_ADVISOR_PROMPT
+        tool_guidance.append(EXECUTOR_ADVISOR_PROMPT)
     # Kanban worker/orchestrator lifecycle — only present when the
     # dispatcher spawned this process (kanban_show check_fn gates on
     # HERMES_KANBAN_TASK env var). Normal chat sessions never see

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -109,7 +109,10 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     if "skill_manage" in agent.valid_tool_names:
         tool_guidance.append(SKILLS_GUIDANCE)
     # Advisor strategy — inject Anthropic-recommended timing + advice-handling
-    # guidance so the executor knows *when* and *how* to call ask_advisor.
+    # guidance for non-Anthropic executors. When using Anthropic's native
+    # advisor_20260301 tool type, the API handles timing internally.
+    # For OpenAI-compatible executors (DeepSeek, GLM, etc.) the executor
+    # needs explicit guidance on WHEN and HOW to call ask_advisor.
     if "ask_advisor" in agent.valid_tool_names:
         from tools.advisor_tool import EXECUTOR_ADVISOR_PROMPT
         tool_guidance.append(EXECUTOR_ADVISOR_PROMPT)

--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -59,6 +59,7 @@ class AnthropicTransport(ProviderTransport):
             base_url: str | None
             fast_mode: bool
             drop_context_1m_beta: bool
+            advisor_config: dict | None
         """
         from agent.anthropic_adapter import build_anthropic_kwargs
 
@@ -75,6 +76,7 @@ class AnthropicTransport(ProviderTransport):
             base_url=params.get("base_url"),
             fast_mode=params.get("fast_mode", False),
             drop_context_1m_beta=params.get("drop_context_1m_beta", False),
+            advisor_config=params.get("advisor_config"),
         )
 
     def normalize_response(self, response: Any, **kwargs) -> NormalizedResponse:

--- a/model_tools.py
+++ b/model_tools.py
@@ -492,7 +492,7 @@ def _compute_tool_definitions(
 # because they need agent-level state (TodoStore, MemoryStore, etc.).
 # The registry still holds their schemas; dispatch just returns a stub error
 # so if something slips through, the LLM sees a sensible message.
-_AGENT_LOOP_TOOLS = {"todo", "memory", "session_search", "delegate_task"}
+_AGENT_LOOP_TOOLS = {"todo", "memory", "session_search", "delegate_task", "ask_advisor"}
 _READ_SEARCH_TOOLS = {"read_file", "search_files"}
 
 

--- a/tests/agent/test_advisor_tool.py
+++ b/tests/agent/test_advisor_tool.py
@@ -1,0 +1,619 @@
+"""Tests for tools/advisor_tool.py — Advisor Strategy implementation.
+
+Covers:
+- Message sanitization (_sanitize_for_advisor)
+- Provider auto-detection (_detect_anthropic_native)
+- Advisor block stripping (_strip_advisor_blocks in anthropic_adapter)
+- Rate limiting (max_uses_per_task)
+- Config loading (load_advisor_config)
+- OpenAI-compatible advisor call (mocked)
+- Anthropic-native advisor call (mocked)
+- reasoning_content fallback
+- Output trimming
+- Registry / schema validation
+- EXECUTOR_ADVISOR_PROMPT injection in system_prompt
+"""
+
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch, PropertyMock
+
+import pytest
+
+# Ensure project root importable
+PROJECT_ROOT = Path(__file__).parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+
+# ===========================================================================
+# 1. Message sanitization
+# ===========================================================================
+
+class TestSanitizeForAdvisor:
+    """Strip tool_calls / tool roles so the advisor sees plain text only."""
+
+    def test_system_message_preserved(self):
+        from tools.advisor_tool import _sanitize_for_advisor
+        msgs = [{"role": "system", "content": "You are a coder."}]
+        result = _sanitize_for_advisor(msgs)
+        assert result == [{"role": "system", "content": "You are a coder."}]
+
+    def test_user_message_preserved(self):
+        from tools.advisor_tool import _sanitize_for_advisor
+        msgs = [{"role": "user", "content": "Write a function"}]
+        result = _sanitize_for_advisor(msgs)
+        assert result == [{"role": "user", "content": "Write a function"}]
+
+    def test_assistant_text_only(self):
+        from tools.advisor_tool import _sanitize_for_advisor
+        msgs = [{"role": "assistant", "content": "I will write the function."}]
+        result = _sanitize_for_advisor(msgs)
+        assert result == [{"role": "assistant", "content": "I will write the function."}]
+
+    def test_assistant_tool_calls_summarized(self):
+        from tools.advisor_tool import _sanitize_for_advisor
+        msgs = [{
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{
+                "function": {
+                    "name": "write_file",
+                    "arguments": '{"path": "/tmp/test.py", "content": "print(1)"}',
+                }
+            }],
+        }]
+        result = _sanitize_for_advisor(msgs)
+        assert len(result) == 1
+        assert result[0]["role"] == "assistant"
+        assert "write_file" in result[0]["content"]
+        assert "write_file(" in result[0]["content"]
+
+    def test_assistant_text_plus_tool_calls(self):
+        from tools.advisor_tool import _sanitize_for_advisor
+        msgs = [{
+            "role": "assistant",
+            "content": "Let me create the file.",
+            "tool_calls": [{
+                "function": {"name": "read_file", "arguments": '{"path": "x.py"}'},
+            }],
+        }]
+        result = _sanitize_for_advisor(msgs)
+        assert "Let me create the file." in result[0]["content"]
+        assert "read_file(" in result[0]["content"]
+
+    def test_tool_role_converted_to_user(self):
+        from tools.advisor_tool import _sanitize_for_advisor
+        msgs = [{
+            "role": "tool",
+            "content": "def hello():\n    print('hello')",
+        }]
+        result = _sanitize_for_advisor(msgs)
+        assert result[0]["role"] == "user"
+        assert "[Tool result]" in result[0]["content"]
+        assert "print('hello')" in result[0]["content"]
+
+    def test_tool_output_truncated(self):
+        from tools.advisor_tool import _sanitize_for_advisor
+        long_content = "x" * 2000
+        msgs = [{"role": "tool", "content": long_content}]
+        result = _sanitize_for_advisor(msgs, max_tool_output_chars=600)
+        assert len(result[0]["content"]) < 700
+        assert "truncated" in result[0]["content"]
+
+    def test_empty_messages_skipped(self):
+        from tools.advisor_tool import _sanitize_for_advisor
+        msgs = [
+            {"role": "system", "content": ""},
+            {"role": "user", "content": ""},
+            {"role": "assistant", "content": ""},
+            {"role": "tool", "content": ""},
+        ]
+        result = _sanitize_for_advisor(msgs)
+        assert result == []
+
+    def test_user_multimodal_content(self):
+        """User messages with list content (image + text) are flattened."""
+        from tools.advisor_tool import _sanitize_for_advisor
+        msgs = [{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Look at this"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,..."}},
+                {"type": "text", "text": "and fix it"},
+            ],
+        }]
+        result = _sanitize_for_advisor(msgs)
+        assert result[0]["role"] == "user"
+        assert "Look at this" in result[0]["content"]
+        assert "and fix it" in result[0]["content"]
+
+    def test_full_conversation_flow(self):
+        """End-to-end: system + user + assistant(tool) + tool + user."""
+        from tools.advisor_tool import _sanitize_for_advisor
+        msgs = [
+            {"role": "system", "content": "You are a coder."},
+            {"role": "user", "content": "Write a rate limiter"},
+            {"role": "assistant", "content": "Let me check existing files.",
+             "tool_calls": [{"function": {"name": "search_files", "arguments": '{"pattern": "rate_limit"}'}}]},
+            {"role": "tool", "content": "No results found."},
+            {"role": "assistant", "content": "I'll create it from scratch."},
+            {"role": "user", "content": "Make it thread-safe"},
+        ]
+        result = _sanitize_for_advisor(msgs)
+        # system + user + assistant(actions) + user(tool result) + assistant + user
+        assert len(result) == 6
+        assert result[0]["role"] == "system"
+        assert result[1]["role"] == "user"
+        assert result[2]["role"] == "assistant"
+        assert "search_files(" in result[2]["content"]
+        assert result[3]["role"] == "user"
+        assert "[Tool result]" in result[3]["content"]
+
+
+# ===========================================================================
+# 2. Provider detection
+# ===========================================================================
+
+class TestDetectAnthropicNative:
+    """Auto-detect whether to use Anthropic native Messages API."""
+
+    def test_explicit_provider(self):
+        from tools.advisor_tool import _detect_anthropic_native
+        assert _detect_anthropic_native("sk-xxx", "gpt-4", None, "anthropic") is True
+        assert _detect_anthropic_native("sk-xxx", "gpt-4", None, "openai") is False
+
+    def test_api_key_prefix_sk_ant(self):
+        from tools.advisor_tool import _detect_anthropic_native
+        assert _detect_anthropic_native("sk-ant-api03-xxx", "anything", None, None) is True
+
+    def test_api_key_prefix_cc(self):
+        from tools.advisor_tool import _detect_anthropic_native
+        assert _detect_anthropic_native("cc-xxx", "anything", None, None) is True
+
+    def test_model_contains_claude(self):
+        from tools.advisor_tool import _detect_anthropic_native
+        assert _detect_anthropic_native("sk-xxx", "claude-sonnet-4-6", None, None) is True
+        assert _detect_anthropic_native("sk-xxx", "anthropic/claude-opus-4-7", None, None) is True
+
+    def test_base_url_anthropic(self):
+        from tools.advisor_tool import _detect_anthropic_native
+        assert _detect_anthropic_native("sk-xxx", "gpt-4", "https://api.anthropic.com", None) is True
+
+    def test_no_match(self):
+        from tools.advisor_tool import _detect_anthropic_native
+        assert _detect_anthropic_native("sk-xxx", "deepseek-chat", None, None) is False
+        assert _detect_anthropic_native("sk-xxx", "glm-5.1", "https://open.bigmodel.cn", None) is False
+
+    def test_none_values(self):
+        from tools.advisor_tool import _detect_anthropic_native
+        assert _detect_anthropic_native("", "", None, None) is False
+        assert _detect_anthropic_native(None, None, None, None) is False
+
+
+# ===========================================================================
+# 3. Advisor block stripping (Anthropic message history)
+# ===========================================================================
+
+class TestStripAdvisorBlocks:
+    """Strip stale advisor tool blocks from Anthropic message history."""
+
+    def test_no_advisor_blocks(self):
+        from agent.anthropic_adapter import _strip_advisor_blocks
+        msgs = [
+            {"role": "assistant", "content": [
+                {"type": "text", "text": "Hello"},
+            ]},
+        ]
+        result = _strip_advisor_blocks(msgs)
+        assert result[0]["content"][0]["text"] == "Hello"
+
+    def test_strip_server_tool_use_and_result(self):
+        from agent.anthropic_adapter import _strip_advisor_blocks
+        msgs = [
+            {"role": "assistant", "content": [
+                {"type": "text", "text": "Thinking..."},
+                {"type": "server_tool_use", "name": "advisor", "id": "srv_001"},
+                {"type": "advisor_tool_result", "tool_use_id": "srv_001",
+                 "content": "Use deque instead of list"},
+                {"type": "text", "text": "OK, using deque"},
+            ]},
+        ]
+        result = _strip_advisor_blocks(msgs)
+        content = result[0]["content"]
+        # Should have: text, advisor_feedback, text
+        assert len(content) == 3
+        assert content[0]["text"] == "Thinking..."
+        assert content[1]["type"] == "text"
+        assert "<advisor_feedback>" in content[1]["text"]
+        assert "deque instead of list" in content[1]["text"]
+        assert content[2]["text"] == "OK, using deque"
+
+    def test_non_advisor_tool_use_preserved(self):
+        from agent.anthropic_adapter import _strip_advisor_blocks
+        msgs = [
+            {"role": "assistant", "content": [
+                {"type": "server_tool_use", "name": "web_search", "id": "srv_002"},
+                {"type": "text", "text": "searching..."},
+            ]},
+        ]
+        result = _strip_advisor_blocks(msgs)
+        assert len(result[0]["content"]) == 2  # preserved
+
+    def test_advisor_result_with_list_content(self):
+        """advisor_tool_result can have list content (Anthropic format)."""
+        from agent.anthropic_adapter import _strip_advisor_blocks
+        msgs = [
+            {"role": "assistant", "content": [
+                {"type": "server_tool_use", "name": "advisor", "id": "srv_003"},
+                {"type": "advisor_tool_result", "tool_use_id": "srv_003",
+                 "content": [
+                     {"type": "text", "text": "Try a different approach"},
+                 ]},
+            ]},
+        ]
+        result = _strip_advisor_blocks(msgs)
+        assert "Try a different approach" in result[0]["content"][0]["text"]
+
+    def test_multiple_advisor_exchanges(self):
+        from agent.anthropic_adapter import _strip_advisor_blocks
+        msgs = [
+            {"role": "assistant", "content": [
+                {"type": "server_tool_use", "name": "advisor", "id": "srv_a"},
+                {"type": "advisor_tool_result", "tool_use_id": "srv_a", "content": "Advice 1"},
+                {"type": "text", "text": "OK"},
+                {"type": "server_tool_use", "name": "advisor", "id": "srv_b"},
+                {"type": "advisor_tool_result", "tool_use_id": "srv_b", "content": "Advice 2"},
+            ]},
+        ]
+        result = _strip_advisor_blocks(msgs)
+        feedbacks = [b for b in result[0]["content"] if b["type"] == "text" and "<advisor_feedback>" in b.get("text", "")]
+        assert len(feedbacks) == 2
+        assert "Advice 1" in feedbacks[0]["text"]
+        assert "Advice 2" in feedbacks[1]["text"]
+
+    def test_user_messages_untouched(self):
+        from agent.anthropic_adapter import _strip_advisor_blocks
+        msgs = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": [
+                {"type": "server_tool_use", "name": "advisor", "id": "srv_004"},
+                {"type": "advisor_tool_result", "tool_use_id": "srv_004", "content": "Reply"},
+            ]},
+        ]
+        result = _strip_advisor_blocks(msgs)
+        assert result[0] == {"role": "user", "content": "Hello"}
+
+    def test_string_content_untouched(self):
+        """Messages with string content (not list) should not crash."""
+        from agent.anthropic_adapter import _strip_advisor_blocks
+        msgs = [
+            {"role": "assistant", "content": "Just text"},
+        ]
+        result = _strip_advisor_blocks(msgs)
+        assert result[0]["content"] == "Just text"
+
+
+# ===========================================================================
+# 4. Rate limiting
+# ===========================================================================
+
+class TestRateLimiting:
+    """Per-task invocation cap prevents runaway advisor usage."""
+
+    def test_counter_increments(self):
+        from tools.advisor_tool import _make_use_counter
+        counter = _make_use_counter()
+        assert counter["count"] == 0
+        counter["count"] += 1
+        assert counter["count"] == 1
+
+    def test_max_uses_enforcement(self):
+        """When count >= max_uses, advisor returns error."""
+        from tools.advisor_tool import _make_use_counter
+        max_uses = 3
+        counter = _make_use_counter()
+        for _ in range(max_uses):
+            counter["count"] += 1
+        # 4th call should be blocked
+        assert counter["count"] >= max_uses
+
+
+# ===========================================================================
+# 5. Config loading
+# ===========================================================================
+
+class TestLoadAdvisorConfig:
+    """Config merges: defaults → config.yaml → env vars."""
+
+    def test_defaults_applied(self):
+        from tools.advisor_tool import load_advisor_config
+        cfg = load_advisor_config()
+        assert cfg["max_uses_per_task"] == 5
+        assert cfg["temperature"] == 0.3
+        assert cfg["max_tokens"] == 2048
+        assert cfg["timeout"] == 30
+
+    def test_env_override_model(self):
+        from tools.advisor_tool import load_advisor_config
+        with patch.dict("os.environ", {"HERMES_ADVISOR_MODEL": "test-model"}):
+            cfg = load_advisor_config()
+            assert cfg["model"] == "test-model"
+
+    def test_env_override_api_key(self):
+        from tools.advisor_tool import load_advisor_config
+        with patch.dict("os.environ", {"HERMES_ADVISOR_API_KEY": "sk-test"}):
+            cfg = load_advisor_config()
+            assert cfg["api_key"] == "sk-test"
+
+
+# ===========================================================================
+# 6. OpenAI-compatible advisor call (mocked)
+# ===========================================================================
+
+class TestCallAdvisorOpenAI:
+    """call_advisor routes to OpenAI-compatible API for non-Anthropic providers."""
+
+    def _mock_openai_response(self, content, reasoning_content=None,
+                               prompt_tokens=500, completion_tokens=50):
+        """Build a mock openai response object."""
+        mock_resp = MagicMock()
+        mock_resp.choices = [MagicMock()]
+        mock_resp.choices[0].message.content = content
+        mock_resp.choices[0].message.reasoning_content = reasoning_content
+        mock_resp.usage = MagicMock()
+        mock_resp.usage.prompt_tokens = prompt_tokens
+        mock_resp.usage.completion_tokens = completion_tokens
+        return mock_resp
+
+    def test_successful_call(self):
+        from tools.advisor_tool import call_advisor
+
+        mock_resp = self._mock_openai_response("Use a deque with a Condition variable.")
+
+        with patch("openai.OpenAI") as MockOpenAI:
+            MockOpenAI.return_value.chat.completions.create.return_value = mock_resp
+            result = json.loads(call_advisor(
+                messages=[{"role": "user", "content": "Design a pool"}],
+                question="Best data structure?",
+                urgency="high",
+                config={"model": "deepseek-chat", "api_key": "sk-test", "base_url": "https://api.deepseek.com"},
+            ))
+        assert result["advice"] == "Use a deque with a Condition variable."
+        assert result["tokens_in"] == 500
+        assert result["tokens_out"] == 50
+        assert result["latency_ms"] >= 0  # mocked, may be 0
+
+    def test_reasoning_content_fallback(self):
+        """GLM-5.1 / DeepSeek thinking mode: content empty, reasoning_content has text."""
+        from tools.advisor_tool import call_advisor
+
+        mock_resp = self._mock_openai_response(
+            "", reasoning_content="The best approach is to use a semaphore.",
+            prompt_tokens=300, completion_tokens=100,
+        )
+
+        with patch("openai.OpenAI") as MockOpenAI:
+            MockOpenAI.return_value.chat.completions.create.return_value = mock_resp
+            result = json.loads(call_advisor(
+                messages=[{"role": "user", "content": "Synchronize threads"}],
+                question="How?",
+                urgency="medium",
+                config={"model": "glm-5.1", "api_key": "test-key", "base_url": "https://open.bigmodel.cn/api/paas/v4"},
+            ))
+        assert "semaphore" in result["advice"]
+        assert result["tokens_in"] == 300
+
+    def test_api_error_returns_error_json(self):
+        from tools.advisor_tool import call_advisor
+
+        with patch("openai.OpenAI") as MockOpenAI:
+            MockOpenAI.return_value.chat.completions.create.side_effect = Exception("API timeout")
+            result = json.loads(call_advisor(
+                messages=[],
+                question="test",
+                urgency="low",
+                config={"model": "test", "api_key": "sk-test"},
+            ))
+        assert "error" in result
+        assert "timeout" in result["error"]
+
+
+# ===========================================================================
+# 7. Anthropic-native advisor call (mocked)
+# ===========================================================================
+
+class TestCallAdvisorAnthropic:
+    """call_advisor routes to Anthropic native API when detected."""
+
+    @patch("tools.advisor_tool._call_advisor_anthropic")
+    def test_anthropic_native_detected(self, mock_anthropic):
+        from tools.advisor_tool import call_advisor
+
+        mock_anthropic.return_value = json.dumps({
+            "advice": "Use Opus for complex reasoning.",
+            "model": "claude-opus-4-6",
+            "tokens_in": 800,
+            "tokens_out": 60,
+            "latency_ms": 1200,
+        })
+
+        result = json.loads(call_advisor(
+            messages=[{"role": "user", "content": "Help"}],
+            question="Complex architecture",
+            urgency="high",
+            config={"model": "claude-opus-4-6", "api_key": "sk-ant-test"},
+        ))
+        assert result["advice"] == "Use Opus for complex reasoning."
+        mock_anthropic.assert_called_once()
+
+
+# ===========================================================================
+# 8. Schema and registry
+# ===========================================================================
+
+class TestSchemaAndRegistry:
+    """Tool schema is valid and registry entry exists."""
+
+    def test_schema_structure(self):
+        from tools.advisor_tool import ASK_ADVISOR_SCHEMA
+        assert ASK_ADVISOR_SCHEMA["name"] == "ask_advisor"
+        assert "parameters" in ASK_ADVISOR_SCHEMA
+        props = ASK_ADVISOR_SCHEMA["parameters"]["properties"]
+        assert "question" in props
+        assert "urgency" in props
+        assert ASK_ADVISOR_SCHEMA["parameters"]["required"] == ["question"]
+
+    def test_urgency_enum(self):
+        from tools.advisor_tool import ASK_ADVISOR_SCHEMA
+        urgency = ASK_ADVISOR_SCHEMA["parameters"]["properties"]["urgency"]
+        assert urgency["enum"] == ["low", "medium", "high"]
+
+    def test_registry_has_ask_advisor(self):
+        from tools.registry import registry
+        assert "ask_advisor" in registry._tools
+
+    def test_registry_toolset(self):
+        from tools.registry import registry
+        entry = registry.get_entry("ask_advisor")
+        assert entry is not None
+        assert entry.toolset == "advisor"
+
+
+# ===========================================================================
+# 9. Output trimming
+# ===========================================================================
+
+class TestOutputTrimming:
+    """Advisor user message includes 80-word trimming instruction."""
+
+    def test_trimming_instruction_present(self):
+        from tools.advisor_tool import call_advisor
+
+        mock_resp = MagicMock()
+        mock_resp.choices = [MagicMock()]
+        mock_resp.choices[0].message.content = "Short advice"
+        mock_resp.choices[0].message.reasoning_content = None
+        mock_resp.usage = MagicMock()
+        mock_resp.usage.prompt_tokens = 100
+        mock_resp.usage.completion_tokens = 10
+
+        with patch("openai.OpenAI") as MockOpenAI:
+            MockOpenAI.return_value.chat.completions.create.return_value = mock_resp
+            call_advisor(
+                messages=[],
+                question="test",
+                urgency="low",
+                config={"model": "test", "api_key": "sk-test"},
+            )
+
+            call_args = MockOpenAI.return_value.chat.completions.create.call_args
+            messages = call_args[1]["messages"]
+            user_msgs = [m for m in messages if m["role"] == "user"]
+            last_user = user_msgs[-1] if user_msgs else {}
+            assert "80 words" in last_user.get("content", "")
+
+
+# ===========================================================================
+# 10. Default system prompt
+# ===========================================================================
+
+class TestDefaultSystemPrompt:
+    """Default advisor system prompt follows Anthropic recommendations."""
+
+    def test_has_80_words_instruction(self):
+        from tools.advisor_tool import _DEFAULT_ADVISOR_SYSTEM_PROMPT
+        assert "80 words" in _DEFAULT_ADVISOR_SYSTEM_PROMPT
+
+    def test_has_no_execute_rule(self):
+        from tools.advisor_tool import _DEFAULT_ADVISOR_SYSTEM_PROMPT
+        assert "NOT execute" in _DEFAULT_ADVISOR_SYSTEM_PROMPT
+
+
+# ===========================================================================
+# 11. Executor advisor prompt
+# ===========================================================================
+
+class TestExecutorAdvisorPrompt:
+    """EXECUTOR_ADVISOR_PROMPT follows Anthropic's recommended system prompt."""
+
+    def test_has_timing_guidance(self):
+        from tools.advisor_tool import EXECUTOR_ADVISOR_PROMPT
+        assert "BEFORE substantive work" in EXECUTOR_ADVISOR_PROMPT
+        assert "task is complete" in EXECUTOR_ADVISOR_PROMPT
+
+    def test_has_advice_handling(self):
+        from tools.advisor_tool import EXECUTOR_ADVISOR_PROMPT
+        assert "serious weight" in EXECUTOR_ADVISOR_PROMPT
+        assert "conflict" in EXECUTOR_ADVISOR_PROMPT.lower()
+
+
+# ===========================================================================
+# 12. Anthropic adapter: build_advisor_tool
+# ===========================================================================
+
+class TestBuildAdvisorTool:
+    """Native Anthropic advisor tool definition."""
+
+    def test_structure(self):
+        from agent.anthropic_adapter import _build_advisor_tool
+        tool = _build_advisor_tool({"model": "claude-opus-4-7"})
+        assert tool["type"] == "advisor_20260301"
+        assert tool["name"] == "ask_advisor"
+        assert tool["model"] == "claude-opus-4-7"
+
+    def test_default_model(self):
+        from agent.anthropic_adapter import _build_advisor_tool
+        tool = _build_advisor_tool({})
+        assert tool["model"] == "claude-sonnet-4-6"
+
+
+# ===========================================================================
+# 13. Zero-config fallback
+# ===========================================================================
+
+class TestZeroConfig:
+    """When no advisor config exists, inherit from parent agent."""
+
+    def test_inherit_parent_model(self):
+        from tools.advisor_tool import call_advisor
+
+        mock_resp = MagicMock()
+        mock_resp.choices = [MagicMock()]
+        mock_resp.choices[0].message.content = "Advice"
+        mock_resp.choices[0].message.reasoning_content = None
+        mock_resp.usage = MagicMock()
+        mock_resp.usage.prompt_tokens = 10
+        mock_resp.usage.completion_tokens = 5
+
+        parent = MagicMock()
+        parent.model = "deepseek-v4-flash"
+        parent.api_key = "sk-inherited"
+        parent.base_url = "https://api.deepseek.com"
+
+        with patch("openai.OpenAI") as MockOpenAI:
+            MockOpenAI.return_value.chat.completions.create.return_value = mock_resp
+            result = json.loads(call_advisor(
+                messages=[],
+                question="test",
+                urgency="low",
+                config={},  # no model/key set
+                parent_agent=parent,
+            ))
+        assert result["advice"] == "Advice"
+        # Verify the model was resolved from parent
+        call_args = MockOpenAI.return_value.chat.completions.create.call_args
+        assert call_args[1]["model"] == "deepseek-v4-flash"
+
+    def test_no_model_no_parent_returns_error(self):
+        from tools.advisor_tool import call_advisor
+        result = json.loads(call_advisor(
+            messages=[],
+            question="test",
+            urgency="low",
+            config={},
+            parent_agent=None,
+        ))
+        assert "error" in result

--- a/tools/advisor_tool.py
+++ b/tools/advisor_tool.py
@@ -298,7 +298,10 @@ def call_advisor(
 
     latency_ms = int((time.time() - start) * 1000)
     choice = resp.choices[0]
-    advice = choice.message.content or "(advisor returned empty response)"
+    advice = choice.message.content or ""
+    # GLM-5.1 / DeepSeek thinking mode: content may be empty, fallback to reasoning_content
+    if not advice.strip() and hasattr(choice.message, 'reasoning_content') and choice.message.reasoning_content:
+        advice = choice.message.reasoning_content
     usage = resp.usage
 
     return json.dumps({

--- a/tools/advisor_tool.py
+++ b/tools/advisor_tool.py
@@ -21,13 +21,20 @@ Key properties
 Config (config.yaml)::
 
     advisor:
-      enabled: true
-      model: "deepseek-chat"          # advisor model (required when enabled)
-      provider: "custom:deepseek"     # provider key (optional — uses main provider)
-      max_uses_per_task: 5            # per-task invocation cap
-      temperature: 0.3                # advisor sampling temperature
-      max_tokens: 2048                # max tokens per advisor response
-      system_prompt: null             # custom system prompt (optional)
+      model: "deepseek-v4-pro"           # advisor model (defaults to agent's own model)
+      max_uses_per_task: 5                # per-task invocation cap (default: 5)
+      max_context_messages: 20            # rolling window of recent messages
+      max_context_chars: 300              # per-message content truncation length
+      max_tool_output_chars: 600          # tool result truncation length
+      timeout: 30                         # API call timeout (seconds)
+      temperature: 0.3                    # advisor sampling temperature
+      max_tokens: 2048                    # max tokens per advisor response
+      system_prompt: null                 # custom system prompt (optional)
+
+Zero-config: if no ``advisor:`` section exists in config.yaml, the tool
+automatically inherits the agent's own model, API key, and base URL.
+Only set explicit values when you want a *different* model as advisor.
+Set ``advisor.enabled: false`` to hide the tool entirely (not recommended).
 """
 
 import json
@@ -49,6 +56,10 @@ _DEFAULT_ADVISOR_CONFIG: Dict[str, Any] = {
     "base_url": None,
     "api_key": None,
     "max_uses_per_task": 5,
+    "max_context_messages": 20,     # rolling window of recent messages
+    "max_context_chars": 300,       # per-message content truncation
+    "max_tool_output_chars": 600,   # tool result truncation
+    "timeout": 30,                  # API call timeout (seconds)
     "temperature": 0.3,
     "max_tokens": 2048,
     "system_prompt": None,
@@ -56,7 +67,7 @@ _DEFAULT_ADVISOR_CONFIG: Dict[str, Any] = {
 
 
 def load_advisor_config() -> Dict[str, Any]:
-    """Merge user config onto defaults (config.yaml → env vars → defaults)."""
+    """Merge user config onto defaults (config.yaml -> env vars -> defaults)."""
     cfg = dict(_DEFAULT_ADVISOR_CONFIG)
 
     # 1) config.yaml ``advisor:`` section
@@ -89,12 +100,16 @@ def load_advisor_config() -> Dict[str, Any]:
 # Message sanitization
 # ---------------------------------------------------------------------------
 
-def _sanitize_for_advisor(messages: List[dict]) -> List[dict]:
+def _sanitize_for_advisor(messages: List[dict], max_tool_output_chars: int = 600) -> List[dict]:
     """Strip tool_calls / tool roles so the advisor sees plain text only.
 
     The advisor model does *not* support tools — feeding it raw executor
     messages with ``tool_calls`` dicts or ``role: "tool"`` would cause API
     errors or garbled output.
+
+    Args:
+        messages: Executor conversation messages.
+        max_tool_output_chars: Truncation limit for tool result content.
     """
     out: List[dict] = []
     for msg in messages:
@@ -134,14 +149,13 @@ def _sanitize_for_advisor(messages: List[dict]) -> List[dict]:
             if text.strip():
                 out.append({"role": "assistant", "content": text})
 
-        # --- tool results → user ---
+        # --- tool results -> assistant-annotated user context ---
         elif role == "tool":
             text = content if isinstance(content, str) else str(content)
-            # Truncate very long tool outputs
-            if len(text) > 600:
-                text = text[:600] + "…(truncated)"
+            if len(text) > max_tool_output_chars:
+                text = text[:max_tool_output_chars] + "...(truncated)"
             if text.strip():
-                out.append({"role": "user", "content": f"[Tool output] {text}"})
+                out.append({"role": "user", "content": f"[Tool result]\n{text}"})
 
     return out
 
@@ -187,12 +201,15 @@ def call_advisor(
     """
     import openai
 
-    # ---- Resolve API credentials ----
+    # ---- Resolve model ----
     advisor_model = config.get("model")
+    if not advisor_model and parent_agent:
+        # Zero-config: inherit model from the executing agent itself
+        advisor_model = getattr(parent_agent, "model", None)
     if not advisor_model:
         return json.dumps({"error": "advisor.model is not configured — set it in config.yaml or HERMES_ADVISOR_MODEL"})
 
-    # Try credential pool first (supports key rotation)
+    # ---- Resolve API credentials ----
     api_key = config.get("api_key")
     base_url = config.get("base_url")
 
@@ -208,21 +225,32 @@ def call_advisor(
         except Exception:
             pass
 
-    # Fall back to parent agent's credentials if advisor shares the same provider
+    # Fall back to parent agent's credentials (zero-config path)
     if not api_key and parent_agent:
-        parent_provider = getattr(parent_agent, "provider", "") or ""
-        advisor_provider = config.get("provider", "") or ""
-        if not advisor_provider or parent_provider == advisor_provider:
-            api_key = getattr(parent_agent, "api_key", None)
-            base_url = base_url or getattr(parent_agent, "base_url", None)
+        api_key = getattr(parent_agent, "api_key", None)
+        base_url = base_url or getattr(parent_agent, "base_url", None)
+        # If parent also has a credential pool, try that too
+        if not api_key:
+            try:
+                parent_pool = getattr(parent_agent, "_credential_pool", None)
+                if parent_pool:
+                    parent_provider = getattr(parent_agent, "provider", "")
+                    cred = parent_pool.get_credentials(parent_provider) if parent_provider else None
+                    if cred:
+                        api_key = cred.get("api_key") or cred.get("key")
+            except Exception:
+                pass
 
     if not api_key:
         return json.dumps({"error": "No API key found for advisor — configure advisor.api_key or advisor.provider in config.yaml"})
 
     # ---- Sanitize executor messages ----
-    clean = _sanitize_for_advisor(messages)
-    # Keep a rolling window of the last 20 messages to stay within context
-    context_msgs = clean[-20:]
+    max_tool_chars = config.get("max_tool_output_chars", 600)
+    clean = _sanitize_for_advisor(messages, max_tool_output_chars=max_tool_chars)
+
+    # ---- Rolling window ----
+    max_context_msgs = config.get("max_context_messages", 20)
+    context_msgs = clean[-max_context_msgs:]
 
     # ---- Build advisor prompt ----
     advisor_messages: List[dict] = [
@@ -230,10 +258,12 @@ def call_advisor(
     ]
 
     if context_msgs:
-        context_summary = json.dumps(
-            [{"role": m["role"], "content": m["content"][:300]} for m in context_msgs],
-            ensure_ascii=False,
-        )
+        max_chars = config.get("max_context_chars", 300)
+        safe_context = []
+        for m in context_msgs:
+            content = (m.get("content") or "")[:max_chars]
+            safe_context.append({"role": m["role"], "content": content})
+        context_summary = json.dumps(safe_context, ensure_ascii=False)
         advisor_messages.append({
             "role": "user",
             "content": f"Executor's conversation context (recent):\n{context_summary}",
@@ -248,6 +278,10 @@ def call_advisor(
     client_kwargs: Dict[str, Any] = {"api_key": api_key}
     if base_url:
         client_kwargs["base_url"] = base_url
+
+    # Timeout: build from config
+    timeout = config.get("timeout", 30)
+    client_kwargs["timeout"] = timeout
 
     start = time.time()
     try:
@@ -277,16 +311,7 @@ def call_advisor(
 
 
 # ---------------------------------------------------------------------------
-# Availability check
-# ---------------------------------------------------------------------------
-
-def check_advisor_requirements() -> bool:
-    """Return True only when advisor is explicitly enabled in config."""
-    return load_advisor_config().get("enabled", False)
-
-
-# ---------------------------------------------------------------------------
-# Per-task invocation counter (reset per conversation)
+# Per-task invocation counter (reset per task)
 # ---------------------------------------------------------------------------
 
 def _make_use_counter():
@@ -350,6 +375,5 @@ registry.register(
     handler=lambda args, **kw: tool_error(
         "ask_advisor", "must be dispatched via invoke_tool (agent-level tool)"
     ),
-    check_fn=check_advisor_requirements,
-    emoji="🧠",
+    emoji="\U0001f9e0",
 )

--- a/tools/advisor_tool.py
+++ b/tools/advisor_tool.py
@@ -25,6 +25,7 @@ Config (config.yaml)::
 
     advisor:
       model: "deepseek-v4-pro"           # advisor model (defaults to agent's own model)
+      provider: null                      # "anthropic" for Claude native API (auto-detected)
       max_uses_per_task: 5                # per-task invocation cap (default: 5)
       max_context_messages: 20            # rolling window of recent messages
       max_context_chars: 300              # per-message content truncation length
@@ -38,6 +39,12 @@ Zero-config: if no ``advisor:`` section exists in config.yaml, the tool
 automatically inherits the agent's own model, API key, and base URL.
 Only set explicit values when you want a *different* model as advisor.
 Set ``advisor.enabled: false`` to hide the tool entirely (not recommended).
+
+Provider auto-detection: when ``provider`` is not explicitly set to
+``"anthropic"``, the tool auto-detects Anthropic-native routing by checking:
+(1) API key prefix ``sk-ant-``, (2) model name contains ``claude-``,
+(3) base_url host is ``anthropic.com``.  Otherwise falls back to
+OpenAI-compatible ``/chat/completions``.
 """
 
 import json
@@ -235,6 +242,136 @@ committing to the wrong branch."""
 
 
 # ---------------------------------------------------------------------------
+# Provider detection
+# ---------------------------------------------------------------------------
+
+def _detect_anthropic_native(api_key: str, model: str, base_url: str | None,
+                              provider: str | None) -> bool:
+    """Return True if the advisor should use Anthropic's native Messages API.
+
+    Checks in order of confidence:
+    1. Explicit ``provider: "anthropic"`` in config
+    2. API key uses the ``sk-ant-`` prefix (Anthropic-issued keys)
+    3. Model name contains ``claude-`` (Claude family models)
+    4. base_url host is ``anthropic.com``
+    """
+    if provider and provider.lower() == "anthropic":
+        return True
+    if api_key and (api_key.startswith("sk-ant-") or api_key.startswith("cc-")):
+        return True
+    if model and "claude-" in model.lower():
+        return True
+    if base_url and "anthropic.com" in str(base_url).lower():
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Anthropic-native advisor call
+# ---------------------------------------------------------------------------
+
+def _call_advisor_anthropic(
+    *,
+    advisor_messages: List[dict],
+    advisor_model: str,
+    api_key: str,
+    base_url: str | None,
+    config: Dict[str, Any],
+) -> str:
+    """Call the advisor via Anthropic's native Messages API (beta).
+
+    Returns the same JSON string format as ``call_advisor``:
+    ``{"advice": ..., "model": ..., "tokens_in": ..., "tokens_out": ..., "latency_ms": ...}``
+    """
+    from agent.anthropic_adapter import (
+        build_anthropic_client,
+        normalize_model_name,
+        _get_anthropic_max_output,
+    )
+
+    # ---- Separate system prompt from messages ----
+    # Anthropic takes system as a top-level parameter, not as a message role.
+    system_text: str | None = None
+    anthropic_messages: List[dict] = []
+
+    for msg in advisor_messages:
+        role = msg.get("role", "user")
+        content = msg.get("content", "")
+        if role == "system":
+            system_text = content if isinstance(content, str) else str(content)
+        elif role == "user":
+            anthropic_messages.append({"role": "user", "content": content})
+        elif role == "assistant":
+            anthropic_messages.append({"role": "assistant", "content": content})
+
+    # ---- Build client ----
+    try:
+        client_kwargs: Dict[str, Any] = {
+            "api_key": api_key,
+            "timeout": config.get("timeout", 30),
+        }
+        if base_url:
+            client_kwargs["base_url"] = base_url
+        client = build_anthropic_client(**client_kwargs)
+    except Exception as exc:
+        logger.warning("advisor: failed to build Anthropic client: %s", exc)
+        return json.dumps({"error": f"Failed to build Anthropic client: {exc}"})
+
+    # ---- Model name normalization ----
+    # Convert "anthropic/claude-sonnet-4-6" → "claude-sonnet-4-6"
+    model_normalized = normalize_model_name(advisor_model)
+
+    # ---- Resolve max_tokens ----
+    max_tokens_requested = config.get("max_tokens", 2048)
+    if isinstance(max_tokens_requested, (int, float)) and max_tokens_requested > 0:
+        max_tokens = int(max_tokens_requested)
+    else:
+        max_tokens = _get_anthropic_max_output(model_normalized)
+
+    # ---- API call via beta.messages.create ----
+    # Beta path gives access to newer features; same parameter surface as
+    # messages.create for non-tool-calling requests.
+    start = time.time()
+    try:
+        create_kwargs: Dict[str, Any] = {
+            "model": model_normalized,
+            "messages": anthropic_messages,
+            "max_tokens": max_tokens,
+        }
+        if system_text:
+            create_kwargs["system"] = system_text
+
+        # Set temperature only for models that accept sampling params
+        from agent.anthropic_adapter import _forbids_sampling_params
+        if not _forbids_sampling_params(model_normalized):
+            create_kwargs["temperature"] = config.get("temperature", 0.3)
+
+        sdk = client.beta if hasattr(client, "beta") else client
+        resp = sdk.messages.create(**create_kwargs)
+    except Exception as exc:
+        logger.warning("advisor Anthropic API call failed: %s", exc)
+        return json.dumps({"error": f"Advisor API call failed: {exc}"})
+
+    latency_ms = int((time.time() - start) * 1000)
+
+    # ---- Extract text content from response ----
+    advice_parts = []
+    for block in (resp.content or []):
+        if getattr(block, "type", None) == "text":
+            advice_parts.append(getattr(block, "text", ""))
+    advice = "".join(advice_parts) or "(advisor returned empty response)"
+
+    usage = resp.usage
+    return json.dumps({
+        "advice": advice,
+        "model": advisor_model,
+        "tokens_in": usage.input_tokens if usage else 0,
+        "tokens_out": usage.output_tokens if usage else 0,
+        "latency_ms": latency_ms,
+    }, ensure_ascii=False)
+
+
+# ---------------------------------------------------------------------------
 # Core advisor call
 # ---------------------------------------------------------------------------
 
@@ -252,8 +389,6 @@ def call_advisor(
     Returns a JSON string with ``advice``, ``model``, ``tokens_in``,
     ``tokens_out``, and ``latency_ms`` so the executor can see the cost.
     """
-    import openai
-
     # ---- Resolve model ----
     advisor_model = config.get("model")
     if not advisor_model and parent_agent:
@@ -337,7 +472,22 @@ def call_advisor(
         "content": user_content,
     })
 
-    # ---- API call ----
+    # ---- Route: Anthropic native vs OpenAI-compatible ----
+    provider = config.get("provider")
+    use_anthropic = _detect_anthropic_native(api_key, advisor_model, base_url, provider)
+
+    if use_anthropic:
+        return _call_advisor_anthropic(
+            advisor_messages=advisor_messages,
+            advisor_model=advisor_model,
+            api_key=api_key,
+            base_url=base_url,
+            config=config,
+        )
+
+    # ---- OpenAI-compatible API call ----
+    import openai
+
     client_kwargs: Dict[str, Any] = {"api_key": api_key}
     if base_url:
         client_kwargs["base_url"] = base_url

--- a/tools/advisor_tool.py
+++ b/tools/advisor_tool.py
@@ -7,16 +7,19 @@ choice, or repeated failure, it can call ``ask_advisor`` to get guidance from a
 more capable model — *without* yielding control.  The advisor returns text
 advice; the executor decides what to do with it.
 
-Design inspired by Anthropic's Advisor Strategy:
+Design based on Anthropic's Advisor Strategy:
     https://claude.com/blog/the-advisor-strategy
+    https://platform.claude.com/docs/en/agents-and-tools/tool-use/advisor-tool
 
 Key properties
 --------------
 * **Executor retains control** — the advisor never calls tools or modifies state.
-* **Lightweight** — a single chat-completions call (~500-1000 tokens per query).
+* **Lightweight** — a single chat-completions call (~400–700 text tokens per query).
 * **Model-agnostic** — works with any OpenAI-compatible advisor model.
 * **Message sanitization** — executor messages (tool_calls, tool roles) are
   cleaned into plain text before sending to the advisor.
+* **Output trimming** — advisor is instructed to keep guidance concise (under
+  ~80 words target) to minimize token cost, following Anthropic's recommendation.
 
 Config (config.yaml)::
 
@@ -162,23 +165,73 @@ def _sanitize_for_advisor(messages: List[dict], max_tool_output_chars: int = 600
 
 # ---------------------------------------------------------------------------
 # Default advisor system prompt
+# Based on Anthropic's recommended advisor system prompt:
+# https://platform.claude.com/docs/en/agents-and-tools/tool-use/advisor-tool
 # ---------------------------------------------------------------------------
 
 _DEFAULT_ADVISOR_SYSTEM_PROMPT = """\
-You are a senior technical advisor. An AI assistant (the "executor") is working \
-on a task and has asked for your guidance.
+You are a senior technical advisor. An AI coding assistant (the "executor") is \
+working on a task and has asked for your guidance.
 
-Your job:
-1. Analyse the current progress and identify the core difficulty.
-2. Give concrete, actionable advice the executor can follow immediately.
-3. Point out blind spots or risks the executor may have missed.
-4. If the current approach is sound, confirm briefly — no need to pad.
+You see the executor's full conversation context: the task, every action taken, \
+and every result observed. Your job is to provide focused, actionable guidance.
 
 Rules:
 - You do NOT execute anything. Only give advice.
-- Be specific enough that the executor can act on your suggestion directly.
-- Keep it concise — the executor pays per token.
-- If the question is unclear, ask for clarification rather than guessing."""
+- Be concise and concrete — the executor needs to act, not read.
+- If the current approach is sound, confirm briefly and point out pitfalls to watch for.
+- If the approach has issues, explain specifically what to change and why.
+- If the question is unclear, ask for clarification rather than guessing.
+- Target under 80 words unless the complexity genuinely requires more."""
+
+
+# ---------------------------------------------------------------------------
+# Executor system prompt appendix
+# Based on Anthropic's suggested system prompt for coding tasks:
+# https://platform.claude.com/docs/en/agents-and-tools/tool-use/advisor-tool#suggested-system-prompt-for-coding-tasks
+#
+# This text should be injected into the executor's system prompt when
+# ask_advisor is available in the tool list.
+# ---------------------------------------------------------------------------
+
+EXECUTOR_ADVISOR_PROMPT = """\
+
+Timing guidance: You have access to an `ask_advisor` tool backed by a stronger \
+reviewer model. When you call ask_advisor, your conversation history is \
+automatically forwarded — they see the task, every tool call you've made, \
+every result you've seen.
+
+Call ask_advisor BEFORE substantive work — before writing, before committing \
+to an interpretation, before building on an assumption. If the task requires \
+orientation first (finding files, fetching a source, seeing what's there), do \
+that, then call ask_advisor. Orientation is not substantive work. Writing, \
+editing, and declaring an answer are.
+
+Also call ask_advisor:
+- When you believe the task is complete. BEFORE this call, make your \
+deliverable durable: write the file, save the result, commit the change. The \
+advisor call takes time; if the session ends during it, a durable result \
+persists and an unwritten one doesn't.
+- When stuck — errors recurring, approach not converging, results that don't fit.
+- When considering a change of approach.
+
+On tasks longer than a few steps, call ask_advisor at least once before \
+committing to an approach and once before declaring done. On short reactive \
+tasks where the next action is dictated by tool output you just read, you \
+don't need to keep calling — the advisor adds most of its value on the first \
+call, before the approach crystallizes.
+
+How to treat the advice: Give the advice serious weight. If you follow a step \
+and it fails empirically, or you have primary-source evidence that contradicts \
+a specific claim (the file says X, the paper states Y), adapt. A passing \
+self-test is not evidence the advice is wrong — it's evidence your test \
+doesn't check what the advice is checking.
+
+If you've already retrieved data pointing one way and the advisor points \
+another: don't silently switch. Surface the conflict in one more advisor call — \
+"I found X, you suggest Y, which constraint breaks the tie?" The advisor saw \
+your evidence but may have underweighted it; a reconcile call is cheaper than \
+committing to the wrong branch."""
 
 
 # ---------------------------------------------------------------------------
@@ -253,8 +306,9 @@ def call_advisor(
     context_msgs = clean[-max_context_msgs:]
 
     # ---- Build advisor prompt ----
+    system_content = config.get("system_prompt") or _DEFAULT_ADVISOR_SYSTEM_PROMPT
     advisor_messages: List[dict] = [
-        {"role": "system", "content": config.get("system_prompt") or _DEFAULT_ADVISOR_SYSTEM_PROMPT},
+        {"role": "system", "content": system_content},
     ]
 
     if context_msgs:
@@ -269,9 +323,18 @@ def call_advisor(
             "content": f"Executor's conversation context (recent):\n{context_summary}",
         })
 
+    # ---- User question with urgency ----
+    user_content = f"Urgency: {urgency}\n\nMy question: {question}"
+
+    # Anthropic's recommended trimming technique: embed a direct instruction
+    # to the advisor in the user message for concise output. They found this
+    # more effective than relying on max_tokens alone.
+    # https://platform.claude.com/docs/en/agents-and-tools/tool-use/advisor-tool#trimming-advisor-output-length
+    user_content += "\n\n(Advisor: please keep your guidance under 80 words — I need a focused starting point, not a comprehensive plan.)"
+
     advisor_messages.append({
         "role": "user",
-        "content": f"Urgency: {urgency}\n\nMy question: {question}",
+        "content": user_content,
     })
 
     # ---- API call ----
@@ -324,17 +387,21 @@ def _make_use_counter():
 
 # ---------------------------------------------------------------------------
 # OpenAI function-calling schema
+# Updated based on Anthropic's recommended "no parameters" approach:
+# The original Anthropic advisor tool takes NO parameters — the server
+# constructs the advisor's view automatically. Since we're client-side,
+# we keep `question` and `urgency` for non-Claude models that benefit from
+# explicit prompts, but the description emphasizes that context is automatic.
 # ---------------------------------------------------------------------------
 
 ASK_ADVISOR_SCHEMA = {
     "name": "ask_advisor",
     "description": (
-        "Ask a more capable AI model for advice. Use when you are unsure of the "
-        "best approach, facing a complex architecture decision, or stuck after "
-        "multiple failed attempts. The advisor sees your conversation context and "
-        "returns actionable guidance — it does NOT execute anything. "
-        "State: (1) what you've tried, (2) the difficulty, (3) what kind of "
-        "advice you need."
+        "Ask a more capable AI model for guidance. Your full conversation "
+        "history is automatically forwarded — they see the task, every action "
+        "you've taken, and every result. Call BEFORE substantive work (writing, "
+        "committing to an approach) and BEFORE declaring done. Also call when "
+        "stuck or considering a change of approach. State what you need guidance on."
     ),
     "parameters": {
         "type": "object",
@@ -342,8 +409,8 @@ ASK_ADVISOR_SCHEMA = {
             "question": {
                 "type": "string",
                 "description": (
-                    "Your specific question for the advisor. Include: "
-                    "current progress, what's difficult, and the type of guidance you need."
+                    "What you need guidance on. Be specific: current progress, "
+                    "what's difficult, and the type of advice you need."
                 ),
             },
             "urgency": {

--- a/tools/advisor_tool.py
+++ b/tools/advisor_tool.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""
+Advisor Tool — Agent-internal "ask a smarter model for advice" capability.
+
+When the executing model encounters a difficult decision, complex architecture
+choice, or repeated failure, it can call ``ask_advisor`` to get guidance from a
+more capable model — *without* yielding control.  The advisor returns text
+advice; the executor decides what to do with it.
+
+Design inspired by Anthropic's Advisor Strategy:
+    https://claude.com/blog/the-advisor-strategy
+
+Key properties
+--------------
+* **Executor retains control** — the advisor never calls tools or modifies state.
+* **Lightweight** — a single chat-completions call (~500-1000 tokens per query).
+* **Model-agnostic** — works with any OpenAI-compatible advisor model.
+* **Message sanitization** — executor messages (tool_calls, tool roles) are
+  cleaned into plain text before sending to the advisor.
+
+Config (config.yaml)::
+
+    advisor:
+      enabled: true
+      model: "deepseek-chat"          # advisor model (required when enabled)
+      provider: "custom:deepseek"     # provider key (optional — uses main provider)
+      max_uses_per_task: 5            # per-task invocation cap
+      temperature: 0.3                # advisor sampling temperature
+      max_tokens: 2048                # max tokens per advisor response
+      system_prompt: null             # custom system prompt (optional)
+"""
+
+import json
+import logging
+import os
+import time
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Configuration helpers
+# ---------------------------------------------------------------------------
+
+_DEFAULT_ADVISOR_CONFIG: Dict[str, Any] = {
+    "enabled": False,
+    "model": None,
+    "provider": None,
+    "base_url": None,
+    "api_key": None,
+    "max_uses_per_task": 5,
+    "temperature": 0.3,
+    "max_tokens": 2048,
+    "system_prompt": None,
+}
+
+
+def load_advisor_config() -> Dict[str, Any]:
+    """Merge user config onto defaults (config.yaml → env vars → defaults)."""
+    cfg = dict(_DEFAULT_ADVISOR_CONFIG)
+
+    # 1) config.yaml ``advisor:`` section
+    try:
+        from cli import CLI_CONFIG
+        user_cfg = CLI_CONFIG.get("advisor") or {}
+    except Exception:
+        try:
+            from hermes_cli.config import load_config
+            user_cfg = load_config().get("advisor") or {}
+        except Exception:
+            user_cfg = {}
+
+    for k, v in user_cfg.items():
+        if v is not None:
+            cfg[k] = v
+
+    # 2) env-var overrides
+    env_model = os.environ.get("HERMES_ADVISOR_MODEL")
+    if env_model:
+        cfg["model"] = env_model
+    env_key = os.environ.get("HERMES_ADVISOR_API_KEY")
+    if env_key:
+        cfg["api_key"] = env_key
+
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Message sanitization
+# ---------------------------------------------------------------------------
+
+def _sanitize_for_advisor(messages: List[dict]) -> List[dict]:
+    """Strip tool_calls / tool roles so the advisor sees plain text only.
+
+    The advisor model does *not* support tools — feeding it raw executor
+    messages with ``tool_calls`` dicts or ``role: "tool"`` would cause API
+    errors or garbled output.
+    """
+    out: List[dict] = []
+    for msg in messages:
+        role = msg.get("role", "")
+        content = msg.get("content", "")
+
+        # --- system ---
+        if role == "system":
+            if isinstance(content, str) and content.strip():
+                out.append({"role": "system", "content": content})
+
+        # --- user ---
+        elif role == "user":
+            if isinstance(content, list):
+                texts = [
+                    p.get("text", "")
+                    for p in content
+                    if isinstance(p, dict) and p.get("type") == "text"
+                ]
+                content = "\n".join(texts)
+            if isinstance(content, str) and content.strip():
+                out.append({"role": "user", "content": content})
+
+        # --- assistant ---
+        elif role == "assistant":
+            text = content if isinstance(content, str) else ""
+            tool_calls = msg.get("tool_calls") or []
+            if tool_calls:
+                summaries = []
+                for tc in tool_calls:
+                    fn = tc.get("function", {})
+                    name = fn.get("name", "?")
+                    args_preview = str(fn.get("arguments", ""))[:120]
+                    summaries.append(f"{name}({args_preview})")
+                action_text = "[Actions: " + "; ".join(summaries) + "]"
+                text = f"{text}\n{action_text}" if text.strip() else action_text
+            if text.strip():
+                out.append({"role": "assistant", "content": text})
+
+        # --- tool results → user ---
+        elif role == "tool":
+            text = content if isinstance(content, str) else str(content)
+            # Truncate very long tool outputs
+            if len(text) > 600:
+                text = text[:600] + "…(truncated)"
+            if text.strip():
+                out.append({"role": "user", "content": f"[Tool output] {text}"})
+
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Default advisor system prompt
+# ---------------------------------------------------------------------------
+
+_DEFAULT_ADVISOR_SYSTEM_PROMPT = """\
+You are a senior technical advisor. An AI assistant (the "executor") is working \
+on a task and has asked for your guidance.
+
+Your job:
+1. Analyse the current progress and identify the core difficulty.
+2. Give concrete, actionable advice the executor can follow immediately.
+3. Point out blind spots or risks the executor may have missed.
+4. If the current approach is sound, confirm briefly — no need to pad.
+
+Rules:
+- You do NOT execute anything. Only give advice.
+- Be specific enough that the executor can act on your suggestion directly.
+- Keep it concise — the executor pays per token.
+- If the question is unclear, ask for clarification rather than guessing."""
+
+
+# ---------------------------------------------------------------------------
+# Core advisor call
+# ---------------------------------------------------------------------------
+
+def call_advisor(
+    *,
+    messages: List[dict],
+    question: str,
+    urgency: str,
+    config: Dict[str, Any],
+    credential_pool: Any = None,
+    parent_agent: Any = None,
+) -> str:
+    """Call the advisor model and return its guidance as a string.
+
+    Returns a JSON string with ``advice``, ``model``, ``tokens_in``,
+    ``tokens_out``, and ``latency_ms`` so the executor can see the cost.
+    """
+    import openai
+
+    # ---- Resolve API credentials ----
+    advisor_model = config.get("model")
+    if not advisor_model:
+        return json.dumps({"error": "advisor.model is not configured — set it in config.yaml or HERMES_ADVISOR_MODEL"})
+
+    # Try credential pool first (supports key rotation)
+    api_key = config.get("api_key")
+    base_url = config.get("base_url")
+
+    if credential_pool and not api_key:
+        try:
+            provider = config.get("provider", "")
+            # strip "custom:" prefix if present
+            pool_name = provider.replace("custom:", "") if provider else ""
+            cred = credential_pool.get_credentials(pool_name) if pool_name else None
+            if cred:
+                api_key = cred.get("api_key") or cred.get("key")
+                base_url = base_url or cred.get("base_url")
+        except Exception:
+            pass
+
+    # Fall back to parent agent's credentials if advisor shares the same provider
+    if not api_key and parent_agent:
+        parent_provider = getattr(parent_agent, "provider", "") or ""
+        advisor_provider = config.get("provider", "") or ""
+        if not advisor_provider or parent_provider == advisor_provider:
+            api_key = getattr(parent_agent, "api_key", None)
+            base_url = base_url or getattr(parent_agent, "base_url", None)
+
+    if not api_key:
+        return json.dumps({"error": "No API key found for advisor — configure advisor.api_key or advisor.provider in config.yaml"})
+
+    # ---- Sanitize executor messages ----
+    clean = _sanitize_for_advisor(messages)
+    # Keep a rolling window of the last 20 messages to stay within context
+    context_msgs = clean[-20:]
+
+    # ---- Build advisor prompt ----
+    advisor_messages: List[dict] = [
+        {"role": "system", "content": config.get("system_prompt") or _DEFAULT_ADVISOR_SYSTEM_PROMPT},
+    ]
+
+    if context_msgs:
+        context_summary = json.dumps(
+            [{"role": m["role"], "content": m["content"][:300]} for m in context_msgs],
+            ensure_ascii=False,
+        )
+        advisor_messages.append({
+            "role": "user",
+            "content": f"Executor's conversation context (recent):\n{context_summary}",
+        })
+
+    advisor_messages.append({
+        "role": "user",
+        "content": f"Urgency: {urgency}\n\nMy question: {question}",
+    })
+
+    # ---- API call ----
+    client_kwargs: Dict[str, Any] = {"api_key": api_key}
+    if base_url:
+        client_kwargs["base_url"] = base_url
+
+    start = time.time()
+    try:
+        client = openai.OpenAI(**client_kwargs)
+        resp = client.chat.completions.create(
+            model=advisor_model,
+            messages=advisor_messages,
+            temperature=config.get("temperature", 0.3),
+            max_tokens=config.get("max_tokens", 2048),
+        )
+    except Exception as exc:
+        logger.warning("advisor API call failed: %s", exc)
+        return json.dumps({"error": f"Advisor API call failed: {exc}"})
+
+    latency_ms = int((time.time() - start) * 1000)
+    choice = resp.choices[0]
+    advice = choice.message.content or "(advisor returned empty response)"
+    usage = resp.usage
+
+    return json.dumps({
+        "advice": advice,
+        "model": advisor_model,
+        "tokens_in": usage.prompt_tokens if usage else 0,
+        "tokens_out": usage.completion_tokens if usage else 0,
+        "latency_ms": latency_ms,
+    }, ensure_ascii=False)
+
+
+# ---------------------------------------------------------------------------
+# Availability check
+# ---------------------------------------------------------------------------
+
+def check_advisor_requirements() -> bool:
+    """Return True only when advisor is explicitly enabled in config."""
+    return load_advisor_config().get("enabled", False)
+
+
+# ---------------------------------------------------------------------------
+# Per-task invocation counter (reset per conversation)
+# ---------------------------------------------------------------------------
+
+def _make_use_counter():
+    """Return a simple mutable counter dict."""
+    return {"count": 0}
+
+
+# ---------------------------------------------------------------------------
+# OpenAI function-calling schema
+# ---------------------------------------------------------------------------
+
+ASK_ADVISOR_SCHEMA = {
+    "name": "ask_advisor",
+    "description": (
+        "Ask a more capable AI model for advice. Use when you are unsure of the "
+        "best approach, facing a complex architecture decision, or stuck after "
+        "multiple failed attempts. The advisor sees your conversation context and "
+        "returns actionable guidance — it does NOT execute anything. "
+        "State: (1) what you've tried, (2) the difficulty, (3) what kind of "
+        "advice you need."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "question": {
+                "type": "string",
+                "description": (
+                    "Your specific question for the advisor. Include: "
+                    "current progress, what's difficult, and the type of guidance you need."
+                ),
+            },
+            "urgency": {
+                "type": "string",
+                "enum": ["low", "medium", "high"],
+                "description": (
+                    "How badly you need help. "
+                    "low = curious for a second opinion; "
+                    "medium = would appreciate guidance; "
+                    "high = stuck, need direction to proceed."
+                ),
+            },
+        },
+        "required": ["question"],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Registry entry — auto-discovered at import time
+# ---------------------------------------------------------------------------
+
+from tools.registry import registry, tool_error  # noqa: E402
+
+# The handler is a no-op placeholder; actual dispatch happens in
+# ``agent.agent_runtime_helpers.invoke_tool`` because the advisor needs
+# access to agent-level state (messages, credential pool).
+registry.register(
+    name="ask_advisor",
+    toolset="advisor",
+    schema=ASK_ADVISOR_SCHEMA,
+    handler=lambda args, **kw: tool_error(
+        "ask_advisor", "must be dispatched via invoke_tool (agent-level tool)"
+    ),
+    check_fn=check_advisor_requirements,
+    emoji="🧠",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -54,6 +54,8 @@ _HERMES_CORE_TOOLS = [
     "clarify",
     # Code execution + delegation
     "execute_code", "delegate_task",
+    # Advisor — ask a stronger model for guidance (gated via check_fn)
+    "ask_advisor",
     # Cronjob management
     "cronjob",
     # Cross-platform messaging (gated on gateway running via check_fn)
@@ -227,6 +229,12 @@ TOOLSETS = {
     "delegation": {
         "description": "Spawn subagents with isolated context for complex subtasks",
         "tools": ["delegate_task"],
+        "includes": []
+    },
+
+    "advisor": {
+        "description": "Ask a stronger model for guidance without yielding control",
+        "tools": ["ask_advisor"],
         "includes": []
     },
 


### PR DESCRIPTION
## Summary

Add an `ask_advisor` tool that lets the executing agent consult a stronger "advisor" model for strategic guidance — without yielding control. Inspired by [Anthropic's Advisor Strategy](https://claude.com/blog/the-advisor-strategy).

**Key idea:** Most work is mechanical (file reads, simple edits) — the executor handles those. Complex decisions (architecture, debugging, approach selection) benefit from a stronger model's judgment. `ask_advisor` calls the advisor on-demand, keeping cost low.

## Architecture

```
Executor (cheap, e.g. DeepSeek Flash) → calls ask_advisor → Advisor (strong, e.g. DeepSeek V4 Pro)
                                                                       ↓
Executor ← receives advice as tool_result ← Advisor returns guidance (text only, no tools)
```

## What's included

- **`tools/advisor_tool.py`** (599 lines): Core implementation
  - Message sanitization (strip tool_calls/tool roles for advisor compatibility)
  - Dual routing: Anthropic native API + OpenAI-compatible
  - Zero-config mode: auto-inherits model/key/URL from parent agent
  - Per-task invocation cap + rolling context window
  - Output trimming for cost efficiency
  - Anthropic-recommended system prompts for both executor and advisor

- **Integration points:**
  - `model_tools.py`: `ask_advisor` added to `_AGENT_LOOP_TOOLS`
  - `toolsets.py`: `advisor` toolset registered + `_HERMES_CORE_TOOLS`
  - `agent/agent_runtime_helpers.py`: dispatch in `invoke_tool()`
  - `agent/system_prompt.py`: inject executor advisor instructions
  - `agent/anthropic_adapter.py`: native tool conversion + advisor block stripping
  - `agent/chat_completion_helpers.py`, `agent/transports/anthropic.py`: routing

- **Tests:** `tests/agent/test_advisor_tool.py` — 46 tests covering:
  - Message sanitization (10 tests)
  - Provider detection (7 tests)
  - Advisor block stripping (7 tests)
  - Rate limiting, config loading, API calls (mocked)
  - Schema validation, zero-config mode, output trimming

## SWE-bench Evaluation

| Config | Resolved | Cost |
|--------|----------|------|
| DeepSeek Flash solo | 3/6 (50%) | $0.21 |
| DeepSeek Flash + DeepSeek Chat advisor | 5/6 (83%) | $0.24 |

6-instance hard subset from SWE-bench Verified. Full eval framework: [advisor-eval](https://github.com/jasonjcwu/advisor-eval)

## Config Example

```yaml
advisor:
  enabled: true
  model: deepseek-chat
  provider: custom:deepseek
  max_uses_per_task: 5
```

## Files Changed

```
 agent/agent_runtime_helpers.py   |  58 ++++
 agent/anthropic_adapter.py       | 146 +++++++++
 agent/chat_completion_helpers.py |   4 +
 agent/system_prompt.py           |   8 +
 agent/transports/anthropic.py    |   2 +
 model_tools.py                   |   2 +-
 tests/agent/test_advisor_tool.py | 619 +++++++++++++++++++++++++++++++
 tools/advisor_tool.py            | 599 +++++++++++++++++++++++++++++
 toolsets.py                      |   8 +
 9 files changed, 1445 insertions(+), 1 deletion(-)
```

## Related

- Anthropic blog: https://claude.com/blog/the-advisor-strategy
- Anthropic docs: https://platform.claude.com/docs/en/agents-and-tools/tool-use/advisor-tool
- Claude Code leaked source reference: `src/utils/advisor.ts`, `src/services/api/claude.ts` (lines 1386-1394)
- Evaluation repo: https://github.com/jasonjcwu/advisor-eval