### PR TITLE
fix(discord): retry auto-vision once after first failure to avoid duplicate vision_analyze (#28972)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14223,6 +14223,22 @@ class GatewayRunner:
                     user_prompt=analysis_prompt,
                 )
                 result = json.loads(result_json)
+                # #28972: Discord's attachment cache occasionally lags the
+                # first auto-vision call (file exists but not yet flushed /
+                # provider URL still propagating). The manual retry from the
+                # agent always succeeds, so a single short backoff retry here
+                # removes the duplicate vision_analyze call.
+                if not result.get("success"):
+                    logger.debug(
+                        "Auto-vision first attempt failed for %s; retrying once",
+                        path,
+                    )
+                    await asyncio.sleep(1.0)
+                    result_json = await vision_analyze_tool(
+                        image_url=path,
+                        user_prompt=analysis_prompt,
+                    )
+                    result = json.loads(result_json)
                 if result.get("success"):
                     description = result.get("analysis", "")
                     description = sanitize_context(description)

--- a/tests/gateway/test_vision_memory_leak.py
+++ b/tests/gateway/test_vision_memory_leak.py
@@ -60,6 +60,30 @@ class TestEnrichMessageWithVision:
         assert "User details and preferences" not in out
         assert "System note" not in out
 
+    def test_retry_after_first_failure_succeeds(self, gateway_runner):
+        """#28972: auto-vision retries once on success=false; second attempt's
+        analysis is embedded without the kawaii fallback string."""
+        fail = json.dumps({"success": False, "error": "transient"})
+        ok = json.dumps({"success": True, "analysis": "A red bicycle."})
+        mock = AsyncMock(side_effect=[fail, ok])
+        with patch("tools.vision_tools.vision_analyze_tool", new=mock), \
+             patch("asyncio.sleep", new=AsyncMock(return_value=None)):
+            out = _run(gateway_runner._enrich_message_with_vision("caption", ["/tmp/img.jpg"]))
+        assert "red bicycle" in out
+        assert "couldn't quite see it" not in out
+        assert mock.await_count == 2
+
+    def test_retry_both_fail_emits_fallback(self, gateway_runner):
+        """When both attempts fail, the kawaii fallback is preserved so the
+        agent can still recover with a manual vision_analyze call."""
+        fail = json.dumps({"success": False, "error": "transient"})
+        mock = AsyncMock(side_effect=[fail, fail])
+        with patch("tools.vision_tools.vision_analyze_tool", new=mock), \
+             patch("asyncio.sleep", new=AsyncMock(return_value=None)):
+            out = _run(gateway_runner._enrich_message_with_vision("caption", ["/tmp/img.jpg"]))
+        assert "couldn't quite see it" in out
+        assert mock.await_count == 2
+
     def test_fenced_leak_stripped_plugin_header_preserved(self, gateway_runner):
         """The fenced wrapper is stripped; plugin-specific text outside the
         fence (e.g. a "## Honcho Context" header) is left to the plugin layer.


### PR DESCRIPTION
## Summary

Fixes #28972. On Discord, `_enrich_message_with_vision` in `gateway/run.py` called `vision_analyze_tool` once; the first call frequently hit a transient race (attachment cache lag / provider URL propagation) and returned `success: false`. The gateway then emitted the kawaii fallback string, the agent retried `vision_analyze` manually, and the second call always succeeded — every image cost one wasted call plus an apologetic fallback in the transcript.

## Fix

Implementing the issue author's option 1 (most-targeted): add a single 1-second-backoff retry inside the per-image loop when `success: false`. CLI / curator paths are unaffected since they don't hit the race. No changes to the Discord adapter itself.

## Test plan
- [x] `tests/gateway/test_vision_memory_leak.py` (new cases):
  - `test_retry_after_first_failure_succeeds` — fail then ok ⇒ description embedded, no fallback string, 2 awaits
  - `test_retry_both_fail_emits_fallback` — fail twice ⇒ kawaii fallback preserved so the agent can still recover
- [x] 5/5 tests green (2 new + 3 pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)