### PR TITLE
fix(vision): allow custom providers to opt into native vision fast-path in tool_results

### DIFF
--- a/tests/tools/test_vision_native_fast_path.py
+++ b/tests/tools/test_vision_native_fast_path.py
@@ -62,6 +62,55 @@ class TestSupportsMediaInToolResults:
         assert _supports_media_in_tool_results("", "anything") is False
         assert _supports_media_in_tool_results(None, "anything") is False  # type: ignore[arg-type]
 
+    # ── custom (self-hosted OpenAI-compatible) provider ──────────────────
+    #
+    # Self-hosted endpoints (vLLM, LM Studio, llama.cpp, Ollama) speak the
+    # OpenAI Chat Completions spec, which mandates image_url inside tool
+    # messages. Three resolution layers, in priority order:
+    #   1. explicit config flag (inline or registered)
+    #   2. models.dev capability lookup
+    #   3. model-slug heuristic for well-known multimodal families
+
+    def test_custom_heuristic_vl_suffix_yes(self):
+        # No config, no models.dev entry — slug heuristic catches "-vl".
+        with patch("hermes_cli.config.load_config", return_value={}):
+            assert _supports_media_in_tool_results("custom", "qwen3-vl-7b") is True
+
+    def test_custom_heuristic_llava_yes(self):
+        with patch("hermes_cli.config.load_config", return_value={}):
+            assert _supports_media_in_tool_results("custom", "llava-v1.5-13b") is True
+
+    def test_custom_unknown_model_no(self):
+        # Plain text model on a custom endpoint stays conservative.
+        with patch("hermes_cli.config.load_config", return_value={}):
+            assert _supports_media_in_tool_results("custom", "deepseek-r1") is False
+
+    def test_custom_inline_config_explicit_true(self):
+        # User declares the flag inline on ``model.*``. Authoritative —
+        # wins over models.dev and heuristic.
+        cfg = {
+            "model": {
+                "provider": "custom",
+                "default": "my-private-model",
+                "supports_media_in_tool_results": True,
+            }
+        }
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            assert _supports_media_in_tool_results("custom", "my-private-model") is True
+
+    def test_custom_inline_config_explicit_false_overrides_heuristic(self):
+        # Even when the slug would trigger the heuristic, an explicit
+        # ``False`` in config must win — user knows their endpoint best.
+        cfg = {
+            "model": {
+                "provider": "custom",
+                "default": "qwen3-vl-7b",
+                "supports_media_in_tool_results": False,
+            }
+        }
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            assert _supports_media_in_tool_results("custom", "qwen3-vl-7b") is False
+
 
 # ─── _build_native_vision_tool_result ────────────────────────────────────────
 

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -470,6 +470,81 @@ def _supports_media_in_tool_results(provider: str, model: str) -> bool:
             return True
         return False
 
+    # Self-hosted / custom OpenAI-compatible providers (vLLM, LM Studio,
+    # llama.cpp server, etc.). These speak the OpenAI Chat Completions
+    # spec, which mandates ``image_url`` content parts inside ``tool``
+    # role messages — any compliant server implements this. The only
+    # uncertainty is whether the *user's specific model* on that server
+    # is actually multimodal. We resolve that in three layers, in
+    # priority order:
+    #
+    #   1. Explicit config flag — the authoritative signal. Users can
+    #      declare ``supports_media_in_tool_results: true`` either at
+    #      ``model.<flag>`` (inline custom provider config) or at
+    #      ``custom_providers[].models.<model>.<flag>`` (registered
+    #      provider list).
+    #   2. models.dev capability lookup — works for providers we've
+    #      mapped via ``PROVIDER_TO_MODELS_DEV``.
+    #   3. Heuristic on the model slug — catches the common VL naming
+    #      patterns (``-vl``, ``vision``, ``llava``, ``internvl``, etc.)
+    #      so users who haven't declared the flag still get fast-path
+    #      for well-known multimodal models.
+    if p == "custom":
+        m_lower = (model or "").strip().lower()
+
+        # Layer 1a: inline ``model.*`` declaration
+        try:
+            from hermes_cli.config import load_config
+            _cfg = load_config() or {}
+            _inline = _cfg.get("model") or {}
+            if isinstance(_inline, dict):
+                _inline_default = str(_inline.get("default") or "").strip().lower()
+                if _inline_default == m_lower:
+                    _flag = _inline.get("supports_media_in_tool_results")
+                    if isinstance(_flag, bool):
+                        return _flag
+        except Exception:
+            pass
+
+        # Layer 1b: ``custom_providers[].models.<model>.*`` declaration
+        try:
+            from hermes_cli.config import (
+                get_compatible_custom_providers,
+                load_config,
+            )
+            _cps = get_compatible_custom_providers(load_config()) or []
+            for _cp in _cps:
+                _models = (_cp or {}).get("models") or {}
+                if not isinstance(_models, dict):
+                    continue
+                for _mname, _mdata in _models.items():
+                    if (
+                        str(_mname).strip().lower() == m_lower
+                        and isinstance(_mdata, dict)
+                    ):
+                        _flag = _mdata.get("supports_media_in_tool_results")
+                        if isinstance(_flag, bool):
+                            return _flag
+        except Exception:
+            pass
+
+        # Layer 2: models.dev capability lookup
+        try:
+            from agent.models_dev import get_model_capabilities
+            _caps = get_model_capabilities(provider, model)
+            if _caps and _caps.supports_vision:
+                return True
+        except Exception:
+            pass
+
+        # Layer 3: heuristic on the model slug
+        if any(tag in m_lower for tag in (
+            "-vl", "vl-", "vision", "multimodal",
+            "qwen-vl", "internvl", "llava", "minicpm-v",
+        )):
+            return True
+        return False
+
     # Other vision-capable provider stacks. Conservative default: False.
     # Add explicit entries here as we verify each provider's tool-result
     # multimodal support empirically.


### PR DESCRIPTION
## What does this PR do?

Self-hosted OpenAI-compatible inference servers (vLLM, LM Studio,
llama.cpp server, Ollama, etc.) speak the OpenAI Chat Completions
spec, which mandates `image_url` content parts inside tool-role
messages — every compliant server implements this. Today
`_supports_media_in_tool_results` in `tools/vision_tools.py` returns
`False` for the `custom` provider unconditionally, so the
`vision_analyze` fast path is never used and falls through to the
legacy auxiliary-LLM text-description path, even when the user's
main model is a self-hosted multimodal model (Qwen-VL, LLaVA,
InternVL, MiniCPM-V, etc.).

### Observed impact

When the main model has native vision (e.g. Qwen3-VL on local vLLM)
and the user attaches an image:

1. The image is correctly routed into the user turn as an
   `image_url` content part by `image_routing.build_native_content_parts`
   (under `agent.image_input_mode: native`).
2. The agent still calls `vision_analyze` because the tool schema
   advertises itself as "the way" to read user-attached images.
3. `_handle_vision_analyze` checks
   `_supports_media_in_tool_results("custom", "<self-hosted-vl-model>")`,
   which returns `False`.
4. Falls back to the legacy aux-LLM path with the generic prompt
   `"Describe everything visible in this image in thorough detail..."`.
5. `Auxiliary auto-detect: using main provider` routes the aux call
   back to the same main model (because `auxiliary.vision.provider` is
   `auto`).
6. The main model now ingests an 800+ character text description as
   its "vision" instead of the actual pixels — extra 25-30 s
   round-trip on local models, lossy detail, and hallucinated
   specifics that propagate into the final reply.

This is purely a server-side gating issue. The pixels were ready; the
endpoint accepts them; the model can see them. The fast path was the
correct path; it just wasn't reachable for self-hosted setups.

## Related Issue

No prior issue — bug found while integrating WeCom + a self-hosted
Qwen3-VL-27B (NVFP4 vLLM) via the `custom` provider. Happy to file an
issue first if maintainers prefer.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/vision_tools.py` — `_supports_media_in_tool_results`:
  when the provider is `custom`, resolve fast-path eligibility in
  three layers (priority order):
    1. **Explicit config flag** (authoritative). Users declare
       `supports_media_in_tool_results: true` either inline on the
       `model.*` block, or per-model under
       `custom_providers[].models.<name>.*`. Explicit `False`
       correctly overrides the heuristic.
    2. **models.dev capability lookup** via `get_model_capabilities`
       — for providers/models we've mapped, `supports_vision=True`
       enables the fast path.
    3. **Model-slug heuristic** as the final fallback for users who
       haven't declared the flag. Patterns: `-vl`, `vl-`, `vision`,
       `multimodal`, `qwen-vl`, `internvl`, `llava`, `minicpm-v`.

  Other providers behave exactly as before — the conservative default
  for unknown providers stays `False`.

- `tests/tools/test_vision_native_fast_path.py` — five new tests
  inside `TestSupportsMediaInToolResults`:
    - `test_custom_heuristic_vl_suffix_yes`: `qwen3-vl-7b` → True via heuristic
    - `test_custom_heuristic_llava_yes`: `llava-v1.5-13b` → True via heuristic
    - `test_custom_unknown_model_no`: `deepseek-r1` → False (text-only)
    - `test_custom_inline_config_explicit_true`: `model.supports_media_in_tool_results: true` → True
    - `test_custom_inline_config_explicit_false_overrides_heuristic`: explicit `False` wins over slug heuristic

## How to Test

1. `pytest tests/tools/test_vision_native_fast_path.py -q` → 23 passed
   (18 pre-existing + 5 new).
2. Reproduce before the fix: configure `custom` provider with a
   self-hosted Qwen-VL endpoint, set `agent.image_input_mode: native`,
   send an image to the bot. Observe `agent.log`:
     - `Image routing: native (model supports vision)` ← correct
     - `tools.vision_tools: Analyzing image: ...` ← unwanted aux call
     - `Auxiliary auto-detect: using main provider custom (<model>)`
     - `Image analysis completed (800+ characters)` ← text description
     - `vision_analyze: native fast path` ← **never logged**
3. Apply the fix + declare `model.supports_media_in_tool_results: true`
   in `config.yaml`, restart the gateway. Same image, same prompt:
     - `vision_analyze: native fast path (provider=custom, model=<model>)` ← now logged
     - Aux LLM round-trip eliminated; main model receives the
       multimodal envelope directly.

## Checklist

- [x] Conventional commit prefix (`fix(vision):`)
- [x] `pytest tests/tools/test_vision_native_fast_path.py -q` — 23 passed
- [x] Five regression tests included
- [x] Surgical change — `_supports_media_in_tool_results` extension only
- [x] Backward compatible — non-`custom` providers unchanged; `custom`
  without config still returns the same value for non-multimodal slugs
