### PR TITLE
fix(gateway): guard all non-dict agent results in queued-message drain path (#25152)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1612,6 +1612,29 @@ def _should_clear_resume_pending_after_turn(agent_result: dict) -> bool:
     return True
 
 
+def _agent_result_get(agent_result: Any, key: str, default: Any = None) -> Any:
+    """Read a value from an agent result only when it is mapping-like."""
+    if not isinstance(agent_result, dict):
+        return default
+    return agent_result.get(key, default)
+
+
+def _messages_from_agent_result(agent_result: Any, fallback_history: list) -> list:
+    """Return conversation messages from a gateway agent result.
+
+    Queued gateway turns normally receive a dict from ``_run_agent()``, but
+    defensive callers may also see platform delivery objects such as
+    ``SendResult``.  Those objects intentionally expose attributes rather than a
+    mapping API, so accessing ``.get(\"messages\")`` on them crashes the queue
+    drain path.  Fall back to the history we already have unless the result is a
+    mapping with an explicit ``messages`` value.
+    """
+    messages = _agent_result_get(agent_result, "messages")
+    if isinstance(messages, list):
+        return messages
+    return fallback_history
+
+
 def _preserve_queued_followup_history_offset(
     current_result: dict,
     followup_result: dict,
@@ -17500,7 +17523,7 @@ class GatewayRunner:
             # MCP reinit → same 400 → loop, burning 91% CPU for hours.
             _agent = agent_holder[0]
             _result_for_fb = result_holder[0]
-            _run_failed = _result_for_fb.get("failed") if _result_for_fb else False
+            _run_failed = _agent_result_get(_result_for_fb, "failed", False) if _result_for_fb else False
             if _agent is not None and hasattr(_agent, 'model') and not _run_failed:
                 _cfg_model = _resolve_gateway_model()
                 if _agent.model != _cfg_model and not self._is_intentional_model_switch(session_key, _agent.model):
@@ -17604,7 +17627,7 @@ class GatewayRunner:
                         adapter.queue_message(session_key, pending)
                     return result_holder[0] or {"final_response": response, "messages": history}
 
-                was_interrupted = result.get("interrupted")
+                was_interrupted = _agent_result_get(result, "interrupted")
                 if not was_interrupted:
                     # Queued message after normal completion — deliver the first
                     # response before processing the queued follow-up.
@@ -17621,13 +17644,13 @@ class GatewayRunner:
                                 pass
                         except Exception as e:
                             logger.debug("Stream consumer wait before queued message failed: %s", e)
-                    _previewed = bool(result.get("response_previewed"))
+                    _previewed = bool(_agent_result_get(result, "response_previewed"))
                     _already_streamed = bool(
                         (_sc and getattr(_sc, "final_response_sent", False))
                         or _previewed
                         or (_sc and getattr(_sc, "final_content_delivered", False))
                     )
-                    first_response = result.get("final_response", "")
+                    first_response = _agent_result_get(result, "final_response", "")
                     if first_response and not _already_streamed:
                         try:
                             logger.info(
@@ -17675,7 +17698,7 @@ class GatewayRunner:
                 # interrupted." is just noise; the user already knows they sent a
                 # new message).
 
-                updated_history = result.get("messages", history)
+                updated_history = _messages_from_agent_result(result, history)
                 next_source = source
                 next_message = pending
                 next_message_id = None

--- a/tests/gateway/test_queued_result_messages.py
+++ b/tests/gateway/test_queued_result_messages.py
@@ -1,0 +1,81 @@
+"""Regression tests for safe agent-result access in the queued-message drain path.
+
+Bug: #25152 — ``/queue`` crashes with ``AttributeError: 'SendResult' object has
+no attribute 'get'``.  The queued follow-up drain path in ``gateway/run.py``
+called ``result.get("messages", ...)`` on what could be a ``SendResult`` delivery
+object rather than the expected dict.  The fix introduces two helpers —
+``_agent_result_get`` (safe ``.get()`` for any result type) and
+``_messages_from_agent_result`` (safe history extraction) — and replaces all
+bare ``.get()`` calls in that path.
+"""
+
+from gateway.platforms.base import SendResult
+from gateway.run import _agent_result_get, _messages_from_agent_result
+
+
+# ---------------------------------------------------------------------------
+# _agent_result_get
+# ---------------------------------------------------------------------------
+
+def test_agent_result_get_reads_dict_values():
+    assert _agent_result_get({"interrupted": True}, "interrupted") is True
+    assert _agent_result_get({"final_response": "hello"}, "final_response") == "hello"
+
+
+def test_agent_result_get_returns_default_for_non_dict():
+    """SendResult (or any non-dict) must not crash — return the default."""
+    delivery = SendResult(success=True, message_id="tg-1")
+    assert _agent_result_get(delivery, "interrupted") is None
+    assert _agent_result_get(delivery, "final_response", "") == ""
+
+
+def test_agent_result_get_returns_default_for_none():
+    assert _agent_result_get(None, "failed", False) is False
+
+
+# ---------------------------------------------------------------------------
+# _messages_from_agent_result
+# ---------------------------------------------------------------------------
+
+def test_messages_from_agent_result_returns_dict_messages():
+    messages = [{"role": "assistant", "content": "new"}]
+    fallback = [{"role": "user", "content": "old"}]
+
+    assert _messages_from_agent_result({"messages": messages}, fallback) is messages
+
+
+def test_messages_from_agent_result_empty_messages_list_is_valid():
+    """An empty messages list is a legitimate conversation history."""
+    fallback = [{"role": "user", "content": "old"}]
+
+    result = _messages_from_agent_result({"messages": []}, fallback)
+    assert result == []
+
+
+def test_messages_from_agent_result_falls_back_for_send_result():
+    fallback = [{"role": "user", "content": "queued"}]
+    delivery = SendResult(success=True, message_id="tg-1")
+
+    assert _messages_from_agent_result(delivery, fallback) is fallback
+
+
+def test_messages_from_agent_result_falls_back_for_failed_send_result():
+    """A failed delivery result is still a non-dict — must not crash."""
+    fallback = [{"role": "user", "content": "queued"}]
+    delivery = SendResult(success=False, error="timeout")
+
+    assert _messages_from_agent_result(delivery, fallback) is fallback
+
+
+def test_messages_from_agent_result_falls_back_for_none_result():
+    fallback = [{"role": "user", "content": "queued"}]
+
+    assert _messages_from_agent_result(None, fallback) is fallback
+
+
+def test_messages_from_agent_result_falls_back_when_messages_missing_or_invalid():
+    fallback = [{"role": "user", "content": "queued"}]
+
+    assert _messages_from_agent_result({}, fallback) is fallback
+    assert _messages_from_agent_result({"messages": None}, fallback) is fallback
+    assert _messages_from_agent_result({"messages": "not-a-list"}, fallback) is fallback


### PR DESCRIPTION
## What does this PR do?

Fixes #25152 - /queue crashes with AttributeError: SendResult object has no attribute get in gateway _run_agent_queued_followups drain path.

## Related Issue

Fixes #25152

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- gateway/run.py - Two extracted helpers: _agent_result_get(result, key, default) and _messages_from_agent_result(result, fallback). All 5 bare .get() calls in the queued-drain path replaced:
  1. result.get("failed")
  2. result.get("interrupted")
  3. result.get("response_previewed")
  4. result.get("final_response", "")
  5. result.get("messages", history)
- tests/gateway/test_queued_result_messages.py - 9 regression tests covering dict path, non-dict, None, SendResult success/fail, empty list, missing key

## How to Test

1. Configure a platform with queued follow-ups enabled
2. Send a message that triggers a SendResult delivery object (e.g., WhatsApp media)
3. Without this fix, the gateway crashes with AttributeError on .get()
4. With this fix, the drain path handles SendResult gracefully

## Checklist

### Code

- [x] I have read the Contributing Guide
- [x] My commit messages follow Conventional Commits (fix(scope):, etc.)
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix
- [x] I have run pytest tests/gateway/test_queued_result_messages.py -q and all 9 tests pass
- [x] I have added tests for my changes
- [x] I have tested on my platform: macOS (arm64)

### Documentation and Housekeeping

- [x] I have updated docstrings for the new helpers
- [N/A] cli-config.yaml.example - no config keys changed
- [N/A] CONTRIBUTING.md / AGENTS.md - no architecture changes
- [N/A] Cross-platform impact - pure Python, no platform-specific code
- [N/A] Tool descriptions/schemas - no tool behavior changed
