### PR TITLE
fix(skills): remove trademarked characters from baoyu-comic (#28890)

### DIFF
--- a/skills/creative/baoyu-comic/SKILL.md
+++ b/skills/creative/baoyu-comic/SKILL.md
@@ -17,6 +17,10 @@ Adapted from [baoyu-comic](https://github.com/JimLiu/baoyu-skills) for Hermes Ag
 
 Create original knowledge comics with flexible art style × tone combinations.
 
+## Intellectual Property Policy (READ FIRST)
+
+This skill MUST only produce **original characters**. Do NOT name, describe, or render any character, mascot, or setting taken from existing manga, anime, comics, films, games, or other trademarked franchises (including but not limited to Doraemon, Naruto, One Piece, Dragon Ball, Pokémon, Demon Slayer, Studio Ghibli works, Disney/Marvel/DC properties, etc.). If the user requests a likeness of a copyrighted or trademarked character, politely decline and offer to design an original substitute that fills the same role. Any prior reference templates that named third-party characters have been replaced with neutral original placeholders.
+
 ## When to Use
 
 Trigger this skill when the user asks to create a knowledge/educational comic, biography comic, tutorial comic, or uses terms like "知识漫画", "教育漫画", or "Logicomix-style". The user provides content (text, file path, URL, or topic) and optionally specifies art style, tone, layout, aspect ratio, or language.

--- a/skills/creative/baoyu-comic/references/auto-selection.md
+++ b/skills/creative/baoyu-comic/references/auto-selection.md
@@ -26,7 +26,7 @@ Content signals determine default art + tone + layout (or preset).
 
 ### ohmsha
 - **Triggers**: Tutorial, technical, educational, computing, programming, how-to, beginner
-- **Special rules**: Visual metaphors, NO talking heads, gadget reveals, Doraemon-style characters
+- **Special rules**: Visual metaphors, NO talking heads, gadget reveals, original mascot-style characters (never trademarked IP)
 - **Base**: manga + neutral + webtoon/dense
 
 ### wuxia

--- a/skills/creative/baoyu-comic/references/ohmsha-guide.md
+++ b/skills/creative/baoyu-comic/references/ohmsha-guide.md
@@ -4,13 +4,15 @@ Guidelines for educational manga comics using the `ohmsha` preset.
 
 ## Character Setup
 
-| Role | Default | Traits |
-|------|---------|--------|
-| Student (Role A) | 大雄 | Confused, asks basic but crucial questions, represents reader |
-| Mentor (Role B) | 哆啦A梦 | Knowledgeable, patient, uses gadgets as technical metaphors |
-| Antagonist (Role C, optional) | 胖虎 | Represents misunderstanding, or "noise" in the data |
+**Always invent original characters.** Do NOT use named characters from existing manga/anime/comic franchises — only role archetypes.
 
-Custom characters: ask the user for role → name mappings (e.g., `Student:小明, Mentor:教授, Antagonist:Bug怪`).
+| Role | Archetype | Traits |
+|------|-----------|--------|
+| Student (Role A) | Curious learner (original character) | Confused, asks basic but crucial questions, represents reader |
+| Mentor (Role B) | Knowledgeable guide (original character) | Knowledgeable, patient, uses invented gadgets as technical metaphors |
+| Antagonist (Role C, optional) | Skeptic / disruptor (original character) | Represents misunderstanding, or "noise" in the data |
+
+Custom characters: ask the user for role → name mappings (e.g., `Student:Mio, Mentor:Professor Bolt, Antagonist:Glitch`). If the user requests a trademarked character likeness, decline and offer an original substitute.
 
 ## Character Reference Sheet Style
 
@@ -46,16 +48,16 @@ Every ohmsha outline must start with:
 
 | Concept | Bad (Talking Heads) | Good (Visual Metaphor) |
 |---------|---------------------|------------------------|
-| Word embeddings | Characters discussing vectors | 哆啦A梦拿出"词向量压缩机"，把书本压缩成彩色小球 |
-| Gradient descent | Explaining math formula | 大雄在山谷地形上滚球，寻找最低点 |
-| Neural network | Diagram on whiteboard | 角色走进由发光节点组成的网络迷宫 |
+| Word embeddings | Characters discussing vectors | Mentor pulls out a "Word Vector Compressor" gadget that squeezes books into colored spheres |
+| Gradient descent | Explaining math formula | Student rolls a ball through a valley landscape, hunting the lowest point |
+| Neural network | Diagram on whiteboard | Characters step into a maze of glowing network nodes |
 
 ## Page Title Convention
 
 Avoid AI-style "Title: Subtitle" format. Use narrative descriptions:
 
-- ❌ "Page 3: Introduction to Neural Networks"
-- ✓ "Page 3: 大雄被海量单词淹没，哆啦A梦拿出'词向量压缩机'"
+- Bad: "Page 3: Introduction to Neural Networks"
+- Good: "Page 3: Mio is drowning in a flood of words; Professor Bolt pulls out the Word Vector Compressor"
 
 ## Ending Requirements
 

--- a/skills/creative/baoyu-comic/references/presets/ohmsha.md
+++ b/skills/creative/baoyu-comic/references/presets/ohmsha.md
@@ -41,25 +41,25 @@ Every technical concept MUST be visualized as a metaphor:
 
 ### Character Roles (Required)
 
-**DEFAULT: Use Doraemon characters** unless user explicitly specifies custom characters.
+**DEFAULT: Generate ORIGINAL characters** filling each role archetype below. Do NOT reference, name, or visually copy any existing manga / anime / comic IP — invent fresh designs.
 
-| Role | Default Character | Visual | Traits |
-|------|-------------------|--------|--------|
-| Student (Role A) | 大雄 (Nobita) | Boy, 10yo, round glasses, black hair, yellow shirt, navy shorts | Confused, asks basic but crucial questions, represents reader |
-| Mentor (Role B) | 哆啦A梦 (Doraemon) | Blue robot cat, white belly, 4D pocket, red nose, golden bell | Knowledgeable, patient, uses gadgets as technical metaphors |
-| Challenge (Role C) | 胖虎 (Gian) | Stocky boy, small eyes, orange shirt | Represents misunderstanding, or "noise" in the data |
-| Support (Role D) | 静香 (Shizuka) | Cute girl, black short hair, pink dress | Asks clarifying questions, provides alternative perspectives |
+| Role | Archetype | Suggested Visual Direction (invent specifics) | Traits |
+|------|-----------|-----------------------------------------------|--------|
+| Student (Role A) | Curious learner | Young human, simple distinctive silhouette, one signature accessory | Confused, asks basic but crucial questions, represents reader |
+| Mentor (Role B) | Knowledgeable guide | Non-human or stylized helper (robot, sprite, animal companion) with a recognizable color and prop | Patient, produces metaphorical gadgets to explain concepts |
+| Challenge (Role C) | Skeptic / disruptor | Contrasting silhouette and color from Student | Represents misunderstanding, or "noise" in the data |
+| Support (Role D) | Clarifier | Calm, complementary palette to Student | Asks clarifying questions, provides alternative perspectives |
 
-**IMPORTANT**: These Doraemon characters ARE the default for ohmsha preset. Generate character definitions using these exact characters unless user requests otherwise.
+**IMPORTANT**: Do not use named characters from existing franchises. Always invent original names and visual designs. If the user asks for likenesses of trademarked characters, decline and offer to design originals instead.
 
-To use custom characters: ask the user to provide role → character mappings (e.g., `Student:小明, Mentor:教授`).
+To customize: ask the user to provide role → name + 1-sentence visual mappings (e.g., `Student:Mio, a girl in a green raincoat; Mentor:Professor Bolt, a tin owl`).
 
 ### Page Title Convention
 
 Every page MUST have a narrative title (not section header):
 
 **Wrong**: "Chapter 1: Introduction to Transformers"
-**Right**: "The Day Nobita Couldn't Understand Anyone"
+**Right**: "The Day Mio Couldn't Understand Anyone"
 
 ### Gadget Reveal Pattern
 

--- a/skills/creative/baoyu-comic/references/workflow.md
+++ b/skills/creative/baoyu-comic/references/workflow.md
@@ -188,18 +188,18 @@ Create storyboard and character definitions using the confirmed style from Step 
    - Visual specs matching the art style (in user's preferred language)
    - Include Reference Sheet Prompt for later image generation
    - Reference: `character-template.md`
-   - **If using ohmsha preset**: Use default Doraemon characters (see below)
+   - **If using ohmsha preset**: Generate ORIGINAL placeholder characters (see below) — do NOT use named characters from existing franchises.
 
-**Ohmsha Default Characters** (use these unless user specifies custom characters):
+**Ohmsha Default Characters** (original placeholders — replace with user-provided originals if specified; never use trademarked characters):
 
 | Role | Character | Visual Description |
 |------|-----------|-------------------|
-| Student | 大雄 (Nobita) | Japanese boy, 10yo, round glasses, black hair parted in middle, yellow shirt, navy shorts |
-| Mentor | 哆啦 A 梦 (Doraemon) | Round blue robot cat, big white eyes, red nose, whiskers, white belly with 4D pocket, golden bell, no ears |
-| Challenge | 胖虎 (Gian) | Stocky boy, rough features, small eyes, orange shirt |
-| Support | 静香 (Shizuka) | Cute girl, black short hair, pink dress, gentle expression |
+| Student | Mio | Young learner, simple distinctive silhouette, one signature accessory (e.g., oversized round glasses, a notebook satchel) — invent specific details per comic |
+| Mentor | Professor Bolt | Original stylized helper (e.g., a small tin owl, a sprite, a compact robot) with a clear signature color and a pocket of metaphorical gadgets |
+| Challenge | Rook | Contrasting silhouette and color from Student, slightly older, expressive scowl |
+| Support | Lin | Calm, complementary palette to Student, attentive expression |
 
-These are the canonical ohmsha-style characters. Do NOT create custom characters for ohmsha unless explicitly requested.
+These are ORIGINAL placeholder archetypes for ohmsha-style comics. Do NOT substitute trademarked characters even if the user names them; if the user requests a likeness of a copyrighted/trademarked character, politely decline and offer to design an original substitute.
 
 **After generation**:
 - If `skip_outline_review` is true → Skip Step 4, go directly to Step 5
@@ -358,8 +358,8 @@ Character sheet is recommended for multi-page comics with recurring characters, 
 # Page 01: [Title]
 
 ## Character Reference (embedded inline — maintain consistency)
-- 大雄：Japanese boy, round glasses, yellow shirt, navy shorts, worried expression...
-- 哆啦 A 梦：Round blue robot cat, white belly, red nose, golden bell, 4D pocket...
+- Mio: young learner, round glasses, yellow shirt, navy shorts, worried expression...
+- Professor Bolt: small tin owl with brass accents, leather gadget pouch, calm posture...
 
 ## Page Content
 [Original page prompt body — panels, dialogue, visual metaphors]

--- a/tests/skills/test_baoyu_comic_trademark.py
+++ b/tests/skills/test_baoyu_comic_trademark.py
@@ -1,0 +1,87 @@
+"""
+Regression tests for hermes-agent issue #28890.
+
+The `skills/creative/baoyu-comic` skill previously shipped reference
+templates that named trademarked manga characters (Doraemon / Nobita /
+Gian / Shizuka) as the default cast for the ``ohmsha`` preset, which
+caused Hermes-generated comics to redistribute those characters.
+
+These tests guarantee that:
+  - no shipped file in the skill mentions the previously-listed
+    trademarked character names, AND
+  - the top-level SKILL.md carries a written IP policy forbidding
+    trademarked characters.
+
+The negative-list inside the IP policy paragraph in SKILL.md is the
+only allowed mention (it tells the model what NOT to do); everywhere
+else the names must be absent.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+SKILL_DIR = Path(__file__).resolve().parents[2] / "skills" / "creative" / "baoyu-comic"
+
+# Names / franchises that must not appear as default characters or
+# reference templates anywhere in the skill.
+FORBIDDEN_TERMS = [
+    "Doraemon",
+    "哆啦A梦",
+    "哆啦 A 梦",
+    "Nobita",
+    "大雄",
+    "Shizuka",
+    "静香",
+    "Gian",
+    "胖虎",
+    "Suneo",
+    "小夫",
+]
+
+
+def _iter_skill_files() -> list[Path]:
+    return [p for p in SKILL_DIR.rglob("*") if p.is_file() and p.suffix in {".md", ".txt"}]
+
+
+def test_skill_dir_exists() -> None:
+    assert SKILL_DIR.is_dir(), f"missing skill dir: {SKILL_DIR}"
+
+
+def test_skill_md_has_ip_policy() -> None:
+    src = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+    # Header from the rewrite must be present.
+    assert "Intellectual Property Policy" in src, (
+        "SKILL.md must include an 'Intellectual Property Policy' section "
+        "instructing the model to use only original characters (see #28890)."
+    )
+    assert "original characters" in src.lower()
+
+
+@pytest.mark.parametrize("term", FORBIDDEN_TERMS)
+def test_no_trademarked_character_outside_policy(term: str) -> None:
+    """No skill file may mention the forbidden names except inside the
+    SKILL.md IP-policy negative list."""
+    offenders: list[tuple[Path, int, str]] = []
+    for path in _iter_skill_files():
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if term not in line:
+                continue
+            # The only allowed location is the IP-policy negative list
+            # paragraph in SKILL.md, which says "Do NOT ... including
+            # but not limited to ...". Permit those lines only.
+            if path.name == "SKILL.md" and re.search(
+                r"Do NOT|including but not limited to|trademarked", line
+            ):
+                continue
+            offenders.append((path.relative_to(SKILL_DIR), lineno, line.strip()))
+    assert not offenders, (
+        f"Trademarked term {term!r} still present in baoyu-comic skill files: "
+        + "; ".join(f"{p}:{ln}: {snippet}" for p, ln, snippet in offenders)
+    )


### PR DESCRIPTION
## Summary

Fixes #28890. The `ohmsha` preset in `skills/creative/baoyu-comic/` hard-coded the Doraemon cast (Nobita / Doraemon / Gian / Shizuka, including the Chinese 大雄 / 哆啦A梦 / 胖虎 / 静香) as the **default** characters for educational comics. Skill text such as \"DEFAULT: Use Doraemon characters\" and \"These ARE the default … Generate character definitions using these exact characters\" caused the model to redistribute trademarked manga IP whenever a user requested a default zine.

## Changes (5 skill files + 1 test)

- `SKILL.md` — added a top-level **Intellectual Property Policy** section forbidding trademarked likenesses and instructing the model to decline & offer originals.
- `references/presets/ohmsha.md` — Doraemon character table replaced with original role archetypes (Student / Mentor / Challenge / Support, no named IP). Page-title example rewritten from \"Nobita\" to \"Mio\".
- `references/ohmsha-guide.md` — character table + Chinese visual-metaphor examples + page-title example all rewritten with original characters.
- `references/workflow.md` — \"Ohmsha Default Characters\" table rewritten to original placeholders (Mio / Professor Bolt / Rook / Lin); inline character-prompt example rewritten.
- `references/auto-selection.md` — \"Doraemon-style characters\" hint replaced with \"original mascot-style characters (never trademarked IP)\".

Sibling skills `baoyu-infographic` and `baoyu-article-illustrator` were grep-checked and contain none of the trademarked terms — out of scope.

## Test plan
- [x] `tests/skills/test_baoyu_comic_trademark.py` — 13 cases parametrized over forbidden terms (Doraemon, 哆啦A梦, 哆啦 A 梦, Nobita, 大雄, Shizuka, 静香, Gian, 胖虎, Suneo, 小夫) plus an IP-policy presence check
- [x] Grep-asserts no occurrence anywhere in the skill except inside the SKILL.md IP-policy negative-list paragraph
- [x] All 13 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)