### PR TITLE
fix(qqbot): notify gateway on reconnect exhaustion + expose retrying state (#29005)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1451,6 +1451,20 @@ class BasePlatformAdapter(ABC):
             return
         self._write_runtime_status_safe("disconnected", platform_state="disconnected", error_code=None, error_message=None)
 
+    def _mark_retrying(self, code: str | None = None, message: str | None = None) -> None:
+        """Mark the adapter as in a transient retry state.
+
+        Distinct from ``connected`` (healthy) and ``fatal`` (gave up): used
+        while an adapter is actively retrying network errors so external
+        monitors can detect degraded connectivity before the retry budget is
+        exhausted. See issue #29005.
+        """
+        if self.has_fatal_error:
+            return
+        self._write_runtime_status_safe(
+            "retrying", platform_state="retrying", error_code=code, error_message=message,
+        )
+
     def _set_fatal_error(self, code: str, message: str, *, retryable: bool) -> None:
         self._running = False
         self._fatal_error_code = code

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -553,7 +553,15 @@ class QQAdapter(BasePlatformAdapter):
                         RATE_LIMIT_DELAY,
                     )
                     if backoff_idx >= MAX_RECONNECT_ATTEMPTS:
-                        self._mark_disconnected()
+                        message = (
+                            f"QQBot reconnect exhausted after {MAX_RECONNECT_ATTEMPTS} "
+                            f"attempts while rate-limited (code 4008)"
+                        )
+                        logger.error("[%s] %s", self._log_tag, message)
+                        self._set_fatal_error(
+                            "qq_reconnect_exhausted", message, retryable=True
+                        )
+                        await self._notify_fatal_error()
                         return
                     await asyncio.sleep(RATE_LIMIT_DELAY)
                     if await self._reconnect(backoff_idx):
@@ -606,8 +614,15 @@ class QQAdapter(BasePlatformAdapter):
                 else:
                     backoff_idx += 1
                     if backoff_idx >= MAX_RECONNECT_ATTEMPTS:
-                        logger.error("[%s] Max reconnect attempts reached (QQCloseError)", self._log_tag)
-                        self._mark_disconnected()
+                        message = (
+                            f"QQBot reconnect exhausted after {MAX_RECONNECT_ATTEMPTS} "
+                            f"attempts (QQCloseError)"
+                        )
+                        logger.error("[%s] %s", self._log_tag, message)
+                        self._set_fatal_error(
+                            "qq_reconnect_exhausted", message, retryable=True
+                        )
+                        await self._notify_fatal_error()
                         return
 
             except Exception as exc:
@@ -618,8 +633,15 @@ class QQAdapter(BasePlatformAdapter):
                 self._fail_pending("Connection interrupted")
 
                 if backoff_idx >= MAX_RECONNECT_ATTEMPTS:
-                    logger.error("[%s] Max reconnect attempts reached", self._log_tag)
-                    self._mark_disconnected()
+                    message = (
+                        f"QQBot reconnect exhausted after {MAX_RECONNECT_ATTEMPTS} "
+                        f"attempts (WebSocket exception)"
+                    )
+                    logger.error("[%s] %s", self._log_tag, message)
+                    self._set_fatal_error(
+                        "qq_reconnect_exhausted", message, retryable=True
+                    )
+                    await self._notify_fatal_error()
                     return
 
                 if await self._reconnect(backoff_idx):

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -885,6 +885,12 @@ class TelegramAdapter(BasePlatformAdapter):
             "[%s] Telegram network error (attempt %d/%d), reconnecting in %ds. Error: %s",
             self.name, attempt, MAX_NETWORK_RETRIES, delay, error,
         )
+        # Surface the degraded state so external monitors don't see "connected"
+        # for the full retry window (issue #29005).
+        self._mark_retrying(
+            code="telegram_network_error",
+            message=f"network retry {attempt}/{MAX_NETWORK_RETRIES}: {error}",
+        )
         await asyncio.sleep(delay)
 
         try:
@@ -906,6 +912,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 self.name, attempt,
             )
             self._polling_network_error_count = 0
+            self._mark_connected()
             # start_polling() returning is necessary but not sufficient:
             # PTB's Updater can be left in a state where `running` is True
             # but the underlying long-poll task is wedged on a stale httpx

--- a/tests/gateway/test_qqbot_reconnect_notify.py
+++ b/tests/gateway/test_qqbot_reconnect_notify.py
@@ -1,0 +1,72 @@
+"""Regression tests for issue #29005.
+
+QQBot adapter must notify the gateway via the fatal-error handler when its
+reconnect budget is exhausted; otherwise the gateway process stays alive but
+the platform is permanently dead, with no restart.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.qqbot import QQAdapter, QQCloseError
+from gateway.platforms.qqbot import adapter as qq_adapter_mod
+
+
+def _make_adapter() -> QQAdapter:
+    return QQAdapter(PlatformConfig(enabled=True, extra={"app_id": "a", "client_secret": "b"}))
+
+
+@pytest.mark.asyncio
+async def test_listen_loop_notifies_fatal_on_generic_exception_exhaustion(monkeypatch):
+    """Exception branch: exhausting MAX_RECONNECT_ATTEMPTS must set fatal + notify."""
+    monkeypatch.setattr(qq_adapter_mod, "MAX_RECONNECT_ATTEMPTS", 1)
+
+    adapter = _make_adapter()
+    adapter._running = True
+
+    fatal_handler = AsyncMock()
+    adapter.set_fatal_error_handler(fatal_handler)
+
+    async def fail(*_a, **_kw):
+        raise RuntimeError("boom")
+
+    adapter._read_events = fail  # type: ignore[assignment]
+    adapter._reconnect = AsyncMock(return_value=False)  # type: ignore[assignment]
+    adapter._mark_transport_disconnected = MagicMock()
+    adapter._fail_pending = MagicMock()
+
+    await asyncio.wait_for(adapter._listen_loop(), timeout=2.0)
+
+    assert adapter.has_fatal_error
+    assert adapter.fatal_error_code == "qq_reconnect_exhausted"
+    fatal_handler.assert_called_once_with(adapter)
+
+
+@pytest.mark.asyncio
+async def test_listen_loop_notifies_fatal_on_qqcloseerror_exhaustion(monkeypatch):
+    """QQCloseError branch: same expectation."""
+    monkeypatch.setattr(qq_adapter_mod, "MAX_RECONNECT_ATTEMPTS", 1)
+
+    adapter = _make_adapter()
+    adapter._running = True
+
+    fatal_handler = AsyncMock()
+    adapter.set_fatal_error_handler(fatal_handler)
+
+    async def fail(*_a, **_kw):
+        # Use a non-special code so flow falls through to the generic reconnect.
+        raise QQCloseError(4000, "transient")
+
+    adapter._read_events = fail  # type: ignore[assignment]
+    adapter._reconnect = AsyncMock(return_value=False)  # type: ignore[assignment]
+    adapter._mark_transport_disconnected = MagicMock()
+    adapter._fail_pending = MagicMock()
+
+    await asyncio.wait_for(adapter._listen_loop(), timeout=2.0)
+
+    assert adapter.has_fatal_error
+    assert adapter.fatal_error_code == "qq_reconnect_exhausted"
+    fatal_handler.assert_called_once_with(adapter)

--- a/tests/gateway/test_telegram_network_reconnect.py
+++ b/tests/gateway/test_telegram_network_reconnect.py
@@ -473,3 +473,41 @@ async def test_reconnect_schedules_heartbeat_probe_on_success():
             await t
         except (asyncio.CancelledError, Exception):
             pass
+
+
+@pytest.mark.asyncio
+async def test_polling_network_error_writes_retrying_state(monkeypatch):
+    """Issue #29005: while retrying after a network error, runtime status must
+    reflect ``retrying`` rather than ``connected`` so external monitors can see
+    the degraded state before the retry budget is exhausted."""
+    adapter = _make_adapter()
+    adapter._polling_network_error_count = 0
+
+    mock_app, _ = _make_mock_app()
+    adapter._app = mock_app
+
+    writes = []
+
+    def fake_write(**kwargs):
+        writes.append(kwargs)
+
+    monkeypatch.setattr("gateway.status.write_runtime_status", fake_write)
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        await adapter._handle_polling_network_error(Exception("DNS fail"))
+
+    states = [w.get("platform_state") for w in writes]
+    assert "retrying" in states, f"expected 'retrying' in {states}"
+    # And after a successful reconnect, status must transition back to connected.
+    assert states.index("retrying") < states.index("connected"), (
+        f"connected should follow retrying, got {states}"
+    )
+
+    # Clean up the heartbeat-probe task scheduled after a successful reconnect.
+    pending = [t for t in adapter._background_tasks if not t.done()]
+    for t in pending:
+        t.cancel()
+        try:
+            await t
+        except (asyncio.CancelledError, Exception):
+            pass


### PR DESCRIPTION
## Summary

Fixes #29005. Two issues bundled:

**P0 — QQBot doesn't notify gateway when reconnect runs out.** All three reconnect-exhaustion paths in `gateway/platforms/qqbot/adapter.py` (4008 rate-limit branch, `QQCloseError` branch, generic-Exception branch) only called `self._mark_disconnected()`. The `_platform_reconnect_watcher` therefore never restarted the adapter, leaving the gateway in a zombie state until manual restart.

**P1 — Telegram retry state not reflected in runtime status.** During the polling-network-error retry loop, `platform_state` stayed `connected`, so external monitors couldn't tell that the adapter was degraded mid-retry.

## Fix

- `gateway/platforms/qqbot/adapter.py`: all three exhaustion sites now call `self._set_fatal_error(\"qq_reconnect_exhausted\", message, retryable=True)` + `await self._notify_fatal_error()`, matching the Telegram pattern. The watcher can now restart the adapter.
- `gateway/platforms/base.py`: new `_mark_retrying(code, message)` helper writing `platform_state=\"retrying\"`.
- `gateway/platforms/telegram.py`: `_handle_polling_network_error` now calls `_mark_retrying` on every attempt and `_mark_connected()` on successful reconnect, so the status transitions `connected → retrying → connected` are observable.

## Test plan
- [x] New `tests/gateway/test_qqbot_reconnect_notify.py` (2 cases — generic-exception and `QQCloseError` paths) asserts `has_fatal_error`, `fatal_error_code == \"qq_reconnect_exhausted\"`, and that the registered fatal handler is called
- [x] New `test_polling_network_error_writes_retrying_state` in `tests/gateway/test_telegram_network_reconnect.py` verifies the `retrying → connected` transition
- [x] 175 adjacent tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)