### PR TITLE
fix(cron): handle missing attributes on cron list for MCP-created jobs (#28662)

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -58,13 +58,17 @@ def cron_list(show_all: bool = False):
     for job in jobs:
         job_id = job.get("id", "?")
         name = job.get("name", "(unnamed)")
-        schedule = job.get("schedule_display", job.get("schedule", {}).get("value", "?"))
+        _sched = job.get("schedule", {})
+        schedule = job.get("schedule_display") or (
+            _sched if isinstance(_sched, str) else
+            _sched.get("display", _sched.get("expr", _sched.get("value", "?")))
+        )
         state = job.get("state", "scheduled" if job.get("enabled", True) else "paused")
         next_run = job.get("next_run_at", "?")
 
-        repeat_info = job.get("repeat", {})
-        repeat_times = repeat_info.get("times")
-        repeat_completed = repeat_info.get("completed", 0)
+        repeat_info = job.get("repeat") or {}
+        repeat_times = repeat_info.get("times") if isinstance(repeat_info, dict) else None
+        repeat_completed = repeat_info.get("completed", 0) if isinstance(repeat_info, dict) else 0
         repeat_str = f"{repeat_completed}/{repeat_times}" if repeat_times else "∞"
 
         deliver = job.get("deliver", ["local"])

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -111,3 +111,67 @@ class TestCronCommandLifecycle:
         assert jobs[0]["skills"] == ["blogwatcher", "maps"]
         assert jobs[0]["name"] == "Skill combo"
         assert jobs[0]["profile"] == "default"
+
+
+class TestCronListMCPCompatibility:
+    """Regression tests for issue #28662: cron list crash on MCP-created jobs."""
+
+    def test_list_handles_string_schedule(self, monkeypatch, capsys):
+        # MCP cronjob tool stores schedule as a plain string.
+        jobs = [{
+            "id": "abc123",
+            "name": "mcp-string-schedule",
+            "schedule": "0 7 * * 1",
+            "repeat": {"completed": 0, "times": None},
+            "enabled": True,
+        }]
+        monkeypatch.setattr("cron.jobs.list_jobs", lambda include_disabled=False: jobs)
+        from hermes_cli.cron import cron_list
+        cron_list()
+        out = capsys.readouterr().out
+        assert "mcp-string-schedule" in out
+        assert "0 7 * * 1" in out
+
+    def test_list_handles_none_repeat(self, monkeypatch, capsys):
+        # MCP cronjob tool may store repeat as bare None.
+        jobs = [{
+            "id": "abc124",
+            "name": "mcp-none-repeat",
+            "schedule": "0 8 * * *",
+            "repeat": None,
+            "enabled": True,
+        }]
+        monkeypatch.setattr("cron.jobs.list_jobs", lambda include_disabled=False: jobs)
+        from hermes_cli.cron import cron_list
+        cron_list()
+        out = capsys.readouterr().out
+        assert "mcp-none-repeat" in out
+        assert "∞" in out
+
+    def test_list_dict_schedule_prefers_display(self, monkeypatch, capsys):
+        jobs = [{
+            "id": "abc125",
+            "name": "cli-wizard-job",
+            "schedule": {"display": "every hour", "expr": "0 * * * *"},
+            "repeat": {"completed": 2, "times": 10},
+            "enabled": True,
+        }]
+        monkeypatch.setattr("cron.jobs.list_jobs", lambda include_disabled=False: jobs)
+        from hermes_cli.cron import cron_list
+        cron_list()
+        out = capsys.readouterr().out
+        assert "every hour" in out
+        assert "2/10" in out
+
+    def test_list_does_not_crash_on_mixed_jobs(self, monkeypatch, capsys):
+        # Regression: prior code crashed mid-loop, hiding later jobs.
+        jobs = [
+            {"id": "j1", "name": "first", "schedule": "* * * * *", "repeat": None, "enabled": True},
+            {"id": "j2", "name": "second", "schedule": {"display": "ok"}, "repeat": {"times": None}, "enabled": True},
+        ]
+        monkeypatch.setattr("cron.jobs.list_jobs", lambda include_disabled=False: jobs)
+        from hermes_cli.cron import cron_list
+        cron_list()
+        out = capsys.readouterr().out
+        assert "first" in out
+        assert "second" in out


### PR DESCRIPTION
## Summary

Fixes #28662. `hermes cron list` crashed with `AttributeError` on jobs created via the cronjob MCP tool because the two tools serialize the same fields differently:

- `schedule` may be a `str` (MCP shape) or a `dict` (CLI wizard shape with `display` / `expr` / `value` keys). The list code assumed `dict`.
- `repeat` may be present but `None` (the `.get(..., default)` pattern still returns `None` and chained attribute access dies).

## Fix

`hermes_cli/cron.py:~61-67`:
- Type-check `schedule`; try `display` / `expr` / `value` keys for the dict shape.
- Use `job.get(\"repeat\") or {}` plus `isinstance` guards so `None` doesn't propagate.

## Test plan
- [x] `tests/hermes_cli/test_cron.py::TestCronListMCPCompatibility` — 4 cases (string schedule, `None` repeat, dict schedule with `display`, mixed-jobs regression ensuring later jobs aren't dropped). All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)