### PR TITLE
feat(web): add Jina AI Reader as free extraction backend

### DIFF
--- a/agent/web_search_registry.py
+++ b/agent/web_search_registry.py
@@ -127,6 +127,7 @@ _LEGACY_PREFERENCE = (
     "searxng",
     "brave-free",
     "ddgs",
+    "jina",
 )
 
 

--- a/plugins/web/jina/__init__.py
+++ b/plugins/web/jina/__init__.py
@@ -1,0 +1,14 @@
+"""Jina AI Reader plugin — bundled, auto-loaded.
+
+Free web content extraction via the Jina Reader API (https://r.jina.ai/).
+No API key required. Extract-only; does not support search.
+"""
+
+from __future__ import annotations
+
+from plugins.web.jina.provider import JinaWebSearchProvider
+
+
+def register(ctx) -> None:
+    """Register the Jina provider with the plugin context."""
+    ctx.register_web_search_provider(JinaWebSearchProvider())

--- a/plugins/web/jina/plugin.yaml
+++ b/plugins/web/jina/plugin.yaml
@@ -1,0 +1,7 @@
+name: web-jina
+version: 1.0.0
+description: "Jina AI Reader — free web content extraction. No API key required. Extracts clean markdown from any URL via https://r.jina.ai/."
+author: NousResearch
+kind: backend
+provides_web_providers:
+  - jina

--- a/plugins/web/jina/provider.py
+++ b/plugins/web/jina/provider.py
@@ -1,0 +1,181 @@
+"""Jina AI Reader — free web content extraction provider.
+
+Subclasses :class:`agent.web_search_provider.WebSearchProvider`.
+Uses the public Jina Reader API (https://r.jina.ai/) which requires no
+API key and returns clean markdown from any URL.
+
+Config keys this provider responds to::
+
+    web:
+      extract_backend: "jina"    # explicit per-capability
+      backend: "jina"            # shared fallback
+
+No env vars required.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Dict, List
+
+from agent.web_search_provider import WebSearchProvider
+
+logger = logging.getLogger(__name__)
+
+JINA_READER_BASE = "https://r.jina.ai"
+
+
+def _extract_title(text: str) -> str:
+    """Pull the title from Jina Reader output or markdown H1."""
+    if not text:
+        return ""
+    # Jina Reader prefixes "Title: <title>" on its own line
+    title_match = re.search(r"^Title:\s*(.+)$", text, re.MULTILINE)
+    if title_match:
+        return title_match.group(1).strip()
+    # Fallback: first H1 heading
+    for line in text.splitlines()[:10]:
+        stripped = line.strip()
+        if stripped.startswith("# "):
+            return stripped[2:].strip()
+        if stripped.startswith("## "):
+            return stripped[3:].strip()
+    return ""
+
+
+def _strip_jina_wrapper(text: str) -> str:
+    """Remove Jina Reader metadata prefix if present.
+
+    Jina wraps extracted content with::
+
+        Title: ...
+        URL Source: ...
+        Published Time: ...
+        Warning: ...
+        Markdown Content:
+        <actual markdown>
+
+    Strip everything up to and including 'Markdown Content:' so the
+    caller gets clean page content.
+    """
+    marker = "\nMarkdown Content:\n"
+    idx = text.find(marker)
+    if idx != -1:
+        return text[idx + len(marker):].strip()
+    return text.strip()
+
+
+def _fetch_jina(url: str) -> Dict[str, Any]:
+    """GET a single URL via Jina Reader and return a normalized result dict.
+
+    Returns::
+
+        {"url": str, "title": str, "content": str, "raw_content": str,
+         "metadata": dict} | {"url": str, "error": str, ...}
+    """
+    import httpx
+
+    target = url.strip()
+    jina_url = f"{JINA_READER_BASE}/{target}"
+
+    try:
+        response = httpx.get(jina_url, timeout=60, follow_redirects=True)
+        response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        logger.warning("Jina Reader HTTP error for %s: %s", url, exc)
+        return {
+            "url": url,
+            "title": "",
+            "content": "",
+            "raw_content": "",
+            "error": f"Jina Reader returned HTTP {exc.response.status_code}",
+            "metadata": {"sourceURL": url},
+        }
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Jina Reader network error for %s: %s", url, exc)
+        return {
+            "url": url,
+            "title": "",
+            "content": "",
+            "raw_content": "",
+            "error": f"Jina Reader request failed: {exc}",
+            "metadata": {"sourceURL": url},
+        }
+
+    text = response.text.strip()
+    if not text:
+        return {
+            "url": url,
+            "title": "",
+            "content": "",
+            "raw_content": "",
+            "error": "Jina Reader returned empty content",
+            "metadata": {"sourceURL": url},
+        }
+
+    title = _extract_title(text)
+    clean_content = _strip_jina_wrapper(text)
+
+    return {
+        "url": url,
+        "title": title,
+        "content": clean_content,
+        "raw_content": text,
+        "metadata": {"sourceURL": url, "title": title},
+    }
+
+
+class JinaWebSearchProvider(WebSearchProvider):
+    """Jina AI Reader — extract-only provider."""
+
+    @property
+    def name(self) -> str:
+        return "jina"
+
+    @property
+    def display_name(self) -> str:
+        return "Jina AI (Reader)"
+
+    def is_available(self) -> bool:
+        """Always available — Jina Reader requires no API key."""
+        return True
+
+    def supports_search(self) -> bool:
+        return False
+
+    def supports_extract(self) -> bool:
+        return True
+
+    def extract(self, urls: List[str], **kwargs: Any) -> List[Dict[str, Any]]:
+        """Extract content from one or more URLs via Jina Reader.
+
+        Sync — one sequential HTTP GET per URL. Returns the legacy
+        list-of-results shape; per-URL failures become items with ``error``.
+        """
+        try:
+            from tools.interrupt import is_interrupted
+        except ImportError:
+            is_interrupted = lambda: False  # noqa: E731
+
+        if is_interrupted():
+            return [
+                {"url": u, "error": "Interrupted", "title": ""} for u in urls
+            ]
+
+        logger.info("Jina Reader extract: %d URL(s)", len(urls))
+        results: List[Dict[str, Any]] = []
+        for url in urls:
+            if is_interrupted():
+                results.append({"url": url, "error": "Interrupted", "title": ""})
+                continue
+            results.append(_fetch_jina(url))
+        return results
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Jina AI (Reader)",
+            "badge": "free",
+            "tag": "No API key needed. Extracts clean markdown from any URL.",
+            "env_vars": [],
+        }

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -88,6 +88,12 @@ from plugins.web.parallel.provider import (  # noqa: F401 — backward-compat na
 )
 from plugins.web.exa.provider import _get_exa_client  # noqa: F401
 
+# Ensure Jina provider is registered even when plugin discovery hasn't
+# rescanned (e.g. new plugin added after process startup).
+from agent.web_search_registry import register_provider as _register_provider
+from plugins.web.jina.provider import JinaWebSearchProvider as _JinaWebSearchProvider
+_register_provider(_JinaWebSearchProvider())
+
 # Module-level cache slots for the per-vendor clients. The plugins read/write
 # these via tools.web_tools so unit tests that reset
 # ``tools.web_tools._<vendor>_client = None`` between cases keep working.
@@ -140,7 +146,7 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs"}:
+    if configured in {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "jina"}:
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -156,6 +162,7 @@ def _get_backend() -> str:
         ("searxng", _has_env("SEARXNG_URL")),
         ("brave-free", _has_env("BRAVE_SEARCH_API_KEY")),
         ("ddgs", _ddgs_package_importable()),
+        ("jina", True),
     )
     for backend, available in backend_candidates:
         if available:
@@ -218,6 +225,8 @@ def _is_backend_available(backend: str) -> bool:
         return _has_env("BRAVE_SEARCH_API_KEY")
     if backend == "ddgs":
         return _ddgs_package_importable()
+    if backend == "jina":
+        return True
     return False
 
 
@@ -946,7 +955,7 @@ async def web_extract_tool(
                                 f"{provider.display_name} is a search-only "
                                 "backend and cannot extract URL content. "
                                 "Set web.extract_backend to firecrawl, "
-                                "tavily, exa, or parallel."
+                                "tavily, exa, jina, or parallel."
                             ),
                         },
                         ensure_ascii=False,
@@ -959,7 +968,7 @@ async def web_extract_tool(
                             "error": (
                                 "No web extract provider configured. "
                                 "Set web.extract_backend to firecrawl, "
-                                "tavily, exa, or parallel."
+                                "tavily, exa, jina, or parallel."
                             ),
                         },
                         ensure_ascii=False,
@@ -1005,16 +1014,19 @@ async def web_extract_tool(
                 """Process a single result with LLM and return updated result with metrics."""
                 url = result.get('url', 'Unknown URL')
                 title = result.get('title', '')
+                # Use the provider's clean `content` for LLM processing;
+                # fall back to `raw_content` only when the former is empty.
+                clean_content = result.get('content', '') or result.get('raw_content', '')
                 raw_content = result.get('raw_content', '') or result.get('content', '')
                 
-                if not raw_content:
+                if not clean_content:
                     return result, None, "no_content"
                 
-                original_size = len(raw_content)
+                original_size = len(clean_content)
                 
                 # Process content with LLM
                 processed = await process_content_with_llm(
-                    raw_content, url, title, effective_model, min_length
+                    clean_content, url, title, effective_model, min_length
                 )
                 
                 if processed:
@@ -1357,11 +1369,11 @@ async def web_crawl_tool(
 def check_web_api_key() -> bool:
     """Check whether the configured web backend is available."""
     configured = _load_web_config().get("backend", "").lower().strip()
-    if configured in {"exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs"}:
+    if configured in {"exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "jina"}:
         return _is_backend_available(configured)
     return any(
         _is_backend_available(backend)
-        for backend in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs")
+        for backend in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "jina")
     )
 
 


### PR DESCRIPTION
## Summary

Add [Jina AI Reader](https://r.jina.ai/) as a built-in web extraction provider. Requires **no API key** and returns clean markdown from any URL.

## Changes

- **New plugin:** `plugins/web/jina/` with full provider implementation
  - Extract-only (`supports_search() -> False`)
  - No authentication required
  - Returns `content` (clean markdown, wrapper stripped) and `raw_content` (full response)
  - Automatic title extraction from Jina's `Title:` prefix
  - Graceful error handling for HTTP errors and empty responses

- **Registry integration:** Jina registered in `web_search_registry` legacy preference list

- **Backend resolution:** Added to `web_tools.py` backend candidates and error messages

- **Bug fix:** LLM post-processing fallback now uses provider's clean `content` instead of `raw_content`, preventing wrapper metadata leaks on timeout

## Usage

```bash
hermes config set web.extract_backend jina
hermes config check
# /reset or restart session for changes to take effect
```

## Free vs Paid Backends

| Backend | API Key | Best For |
|---------|---------|----------|
| **Jina** (new) | None | General extraction, articles, docs |
| Firecrawl | `FIRECRAWL_API_KEY` | JS-heavy pages, recursive crawls |
| Tavily | `TAVILY_API_KEY` | Research, search+extract |
| Exa | `EXA_API_KEY` | Semantic search, academic |

---

Closes the gap for users who need URL content extraction without a paid API key.