### PR TITLE
fix(skill): guard pickle.loads in darwinian-evolver show_snapshot with explicit flag

### DIFF
--- a/optional-skills/research/darwinian-evolver/scripts/show_snapshot.py
+++ b/optional-skills/research/darwinian-evolver/scripts/show_snapshot.py
@@ -25,18 +25,41 @@ def main() -> int:
         help="Organism attribute to display. Defaults to the first str field found.",
     )
     ap.add_argument("--top", type=int, default=None, help="Show only top N by score.")
+    ap.add_argument(
+        "--i-trust-this-file",
+        action="store_true",
+        help=(
+            "Required acknowledgement that the snapshot is from a trusted source. "
+            "pickle.loads executes arbitrary code embedded in the file (RCE) and "
+            "must NEVER be run on snapshots received from untrusted parties."
+        ),
+    )
     args = ap.parse_args()
 
     if not args.snapshot.exists():
         sys.exit(f"snapshot not found: {args.snapshot}")
 
+    if not args.i_trust_this_file:
+        sys.exit(
+            "refusing to unpickle: pickle.loads is equivalent to executing arbitrary "
+            "code from the snapshot file. Only proceed if you created/control this "
+            "file, then re-run with --i-trust-this-file.\n"
+            f"  file: {args.snapshot}"
+        )
+
+    print(
+        f"WARNING: unpickling {args.snapshot} — this executes code embedded in the "
+        "file. Only safe for snapshots you produced yourself.",
+        file=sys.stderr,
+    )
+
     # The outer pickle wraps a dict; the inner pickle contains the actual organism
     # objects, which must be importable under their original dotted path. If you
     # ran a custom driver, make sure its module is on sys.path before calling this.
-    outer = pickle.loads(args.snapshot.read_bytes())
+    outer = pickle.loads(args.snapshot.read_bytes())  # noqa: S301 — gated by --i-trust-this-file
     if not isinstance(outer, dict) or "population_snapshot" not in outer:
         sys.exit("not a darwinian-evolver snapshot (no population_snapshot key)")
-    inner = pickle.loads(outer["population_snapshot"])
+    inner = pickle.loads(outer["population_snapshot"])  # noqa: S301 — gated by --i-trust-this-file
     pairs = inner["organisms"]  # list of (Organism, EvaluationResult)
 
     print(f"# organisms: {len(pairs)}\n")


### PR DESCRIPTION
## Summary

The `optional-skills/research/darwinian-evolver/scripts/show_snapshot.py` script accepts a CLI path argument and unconditionally calls `pickle.loads(args.snapshot.read_bytes())` (twice). Pickle deserialization is equivalent to arbitrary code execution — a snapshot from an untrusted source (shared research artifact, downloaded file, drive-by collaborator handoff) = RCE the moment the user runs `show_snapshot.py downloaded.pkl`.

## Fix

Add an `--i-trust-this-file` acknowledgement flag. The script now:

- `sys.exit`s with a clear RCE warning if the flag is absent
- Emits a stderr warning when proceeding, so the user is reminded each run
- Both `pickle.loads` call sites are gated and tagged `# noqa: S301`

Manual verification:
- `--help` shows the flag
- Running without the flag refuses with the warning
- Running with the flag prints the warning and proceeds to the existing \"not a darwinian-evolver snapshot\" check

## Test plan

No test directory exists in this skill (`optional-skills/research/darwinian-evolver/`), and the script has no caller in the repo — verified manually via the three flows above. Minimal-scope fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)