### PR TITLE
fix(api): serialize ResponseStore sqlite access with thread lock

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -33,6 +33,7 @@ import os
 import socket as _socket
 import re
 import sqlite3
+import threading
 import time
 import uuid
 from typing import Any, Dict, List, Optional
@@ -331,6 +332,13 @@ class ResponseStore:
 
     def __init__(self, max_size: int = MAX_STORED_RESPONSES, db_path: str = None):
         self._max_size = max_size
+        # sqlite3 connection is opened with check_same_thread=False so it can
+        # be shared across FastAPI/aiohttp worker threads.  Without a lock,
+        # interleaved execute() / commit() / cursor.fetch* calls corrupt
+        # cursor state ("no more rows available", "Recursive use of cursors")
+        # and can leave transactions half-applied under concurrent
+        # /v1/responses traffic.  Serialize every connection access.
+        self._lock = threading.Lock()
         if db_path is None:
             try:
                 from hermes_cli.config import get_hermes_home
@@ -364,86 +372,93 @@ class ResponseStore:
 
     def get(self, response_id: str) -> Optional[Dict[str, Any]]:
         """Retrieve a stored response by ID (updates access time for LRU)."""
-        row = self._conn.execute(
-            "SELECT data FROM responses WHERE response_id = ?", (response_id,)
-        ).fetchone()
-        if row is None:
-            return None
-        self._conn.execute(
-            "UPDATE responses SET accessed_at = ? WHERE response_id = ?",
-            (time.time(), response_id),
-        )
-        self._conn.commit()
-        return json.loads(row[0])
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT data FROM responses WHERE response_id = ?", (response_id,)
+            ).fetchone()
+            if row is None:
+                return None
+            self._conn.execute(
+                "UPDATE responses SET accessed_at = ? WHERE response_id = ?",
+                (time.time(), response_id),
+            )
+            self._conn.commit()
+            return json.loads(row[0])
 
     def put(self, response_id: str, data: Dict[str, Any]) -> None:
         """Store a response, evicting the oldest if at capacity."""
-        self._conn.execute(
-            "INSERT OR REPLACE INTO responses (response_id, data, accessed_at) VALUES (?, ?, ?)",
-            (response_id, json.dumps(data, default=str), time.time()),
-        )
-        # Evict oldest entries beyond max_size
-        count = self._conn.execute("SELECT COUNT(*) FROM responses").fetchone()[0]
-        if count > self._max_size:
-            # Collect IDs that will be evicted
-            evict_ids = [
-                row[0]
-                for row in self._conn.execute(
-                    "SELECT response_id FROM responses ORDER BY accessed_at ASC LIMIT ?",
-                    (count - self._max_size,),
-                ).fetchall()
-            ]
-            if evict_ids:
-                placeholders = ",".join("?" for _ in evict_ids)
-                # Clear conversation mappings pointing to evicted responses
-                self._conn.execute(
-                    f"DELETE FROM conversations WHERE response_id IN ({placeholders})",
-                    evict_ids,
-                )
-                # Delete evicted responses
-                self._conn.execute(
-                    f"DELETE FROM responses WHERE response_id IN ({placeholders})",
-                    evict_ids,
-                )
-        self._conn.commit()
+        with self._lock:
+            self._conn.execute(
+                "INSERT OR REPLACE INTO responses (response_id, data, accessed_at) VALUES (?, ?, ?)",
+                (response_id, json.dumps(data, default=str), time.time()),
+            )
+            # Evict oldest entries beyond max_size
+            count = self._conn.execute("SELECT COUNT(*) FROM responses").fetchone()[0]
+            if count > self._max_size:
+                # Collect IDs that will be evicted
+                evict_ids = [
+                    row[0]
+                    for row in self._conn.execute(
+                        "SELECT response_id FROM responses ORDER BY accessed_at ASC LIMIT ?",
+                        (count - self._max_size,),
+                    ).fetchall()
+                ]
+                if evict_ids:
+                    placeholders = ",".join("?" for _ in evict_ids)
+                    # Clear conversation mappings pointing to evicted responses
+                    self._conn.execute(
+                        f"DELETE FROM conversations WHERE response_id IN ({placeholders})",
+                        evict_ids,
+                    )
+                    # Delete evicted responses
+                    self._conn.execute(
+                        f"DELETE FROM responses WHERE response_id IN ({placeholders})",
+                        evict_ids,
+                    )
+            self._conn.commit()
 
     def delete(self, response_id: str) -> bool:
         """Remove a response from the store. Returns True if found and deleted."""
-        # Clear conversation mappings pointing to this response
-        self._conn.execute(
-            "DELETE FROM conversations WHERE response_id = ?", (response_id,)
-        )
-        cursor = self._conn.execute(
-            "DELETE FROM responses WHERE response_id = ?", (response_id,)
-        )
-        self._conn.commit()
-        return cursor.rowcount > 0
+        with self._lock:
+            # Clear conversation mappings pointing to this response
+            self._conn.execute(
+                "DELETE FROM conversations WHERE response_id = ?", (response_id,)
+            )
+            cursor = self._conn.execute(
+                "DELETE FROM responses WHERE response_id = ?", (response_id,)
+            )
+            self._conn.commit()
+            return cursor.rowcount > 0
 
     def get_conversation(self, name: str) -> Optional[str]:
         """Get the latest response_id for a conversation name."""
-        row = self._conn.execute(
-            "SELECT response_id FROM conversations WHERE name = ?", (name,)
-        ).fetchone()
-        return row[0] if row else None
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT response_id FROM conversations WHERE name = ?", (name,)
+            ).fetchone()
+            return row[0] if row else None
 
     def set_conversation(self, name: str, response_id: str) -> None:
         """Map a conversation name to its latest response_id."""
-        self._conn.execute(
-            "INSERT OR REPLACE INTO conversations (name, response_id) VALUES (?, ?)",
-            (name, response_id),
-        )
-        self._conn.commit()
+        with self._lock:
+            self._conn.execute(
+                "INSERT OR REPLACE INTO conversations (name, response_id) VALUES (?, ?)",
+                (name, response_id),
+            )
+            self._conn.commit()
 
     def close(self) -> None:
         """Close the database connection."""
-        try:
-            self._conn.close()
-        except Exception:
-            pass
+        with self._lock:
+            try:
+                self._conn.close()
+            except Exception:
+                pass
 
     def __len__(self) -> int:
-        row = self._conn.execute("SELECT COUNT(*) FROM responses").fetchone()
-        return row[0] if row else 0
+        with self._lock:
+            row = self._conn.execute("SELECT COUNT(*) FROM responses").fetchone()
+            return row[0] if row else 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -128,6 +128,53 @@ class TestResponseStore:
         # resp_2 mapping should still be intact
         assert store.get_conversation("chat-b") == "resp_2"
 
+    def test_concurrent_put_get_is_thread_safe(self):
+        """
+        FastAPI/aiohttp dispatches blocking work across worker threads, so the
+        sqlite3 connection (opened with check_same_thread=False) is touched
+        concurrently. Without the internal lock, interleaved execute() /
+        fetch* / commit() calls raise ProgrammingError / DatabaseError
+        ("no more rows available", "Recursive use of cursors not allowed",
+        "cannot start a transaction within a transaction") and leak partial
+        rows. This test hammers put/get/set_conversation/get_conversation
+        from many threads and asserts no exception escapes and per-thread
+        data stays consistent.
+        """
+        import threading
+
+        store = ResponseStore(max_size=2000)
+        errors: list = []
+        N_THREADS = 16
+        N_OPS = 50
+
+        def worker(tid: int) -> None:
+            try:
+                for i in range(N_OPS):
+                    key = f"resp_{tid}_{i}"
+                    store.put(key, {"tid": tid, "i": i})
+                    got = store.get(key)
+                    assert got == {"tid": tid, "i": i}, got
+                    store.set_conversation(f"chat_{tid}_{i}", key)
+                    assert store.get_conversation(f"chat_{tid}_{i}") == key
+                    # Touch a sibling thread's key to force cross-thread reads
+                    other = f"resp_{(tid + 1) % N_THREADS}_{i}"
+                    store.get(other)  # may be None, that's fine
+                    assert len(store) >= 0
+            except Exception as exc:  # pragma: no cover - captured for assert
+                errors.append(exc)
+
+        threads = [
+            threading.Thread(target=worker, args=(t,)) for t in range(N_THREADS)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"thread errors: {errors[:3]}"
+        # Store length stays bounded by max_size even under concurrent eviction.
+        assert len(store) <= 2000
+
 
 # ---------------------------------------------------------------------------
 # _IdempotencyCache


### PR DESCRIPTION
## Summary

`ResponseStore` in `gateway/platforms/api_server.py:341` opens its sqlite3 connection with `check_same_thread=False` so the same connection object is shared across FastAPI / aiohttp worker threads. Every accessor (`get`, `put`, `delete`, `get_conversation`, `set_conversation`, `close`, `__len__`) manipulated `self._conn` with **zero serialization**. Concurrent `/v1/responses` traffic interleaves `execute()` / `cursor.fetch*` / `commit()` calls and trips:

- `DatabaseError(\"no more rows available\")`
- `ProgrammingError(\"Recursive use of cursors not allowed\")`
- `OperationalError(\"cannot start a transaction within a transaction\")`
- partially-applied writes that desync the `responses` ↔ `conversations` tables

Per the Python sqlite3 docs, `check_same_thread=False` puts the burden of serialization on the caller. This PR adds that serialization.

## Fix

- `threading` import + `self._lock = threading.Lock()` in `ResponseStore.__init__`
- Wrap the bodies of all 7 connection-touching methods with `with self._lock:`

## Test plan
- [x] New `TestResponseStore.test_concurrent_put_get_is_thread_safe` — 16 threads × 50 ops hammering put/get/set_conversation/get_conversation/__len__ plus cross-thread reads. Reliably reproduces the bug on the un-synchronized version (verified by running the test against the pre-fix code) and passes after the fix
- [x] All 10 `TestResponseStore` tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)