### PR TITLE
fix(gateway): don't hijack brand-new Telegram DM topics into previous session

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2042,15 +2042,22 @@ class GatewayRunner:
         self,
         source: SessionSource,
     ) -> Optional[str]:
-        """Pin DM-topic routing to the user's last-active topic.
+        """Recover lobby/General thread_ids to the user's last-active topic.
 
-        Telegram fragments topic-mode DMs two ways: a Reply on a message
-        in another topic delivers ``message_thread_id`` for *that* topic,
-        and ``_build_message_event`` strips the thread_id on plain replies
-        (#3206 — needed for non-topic users). Both route the user to the
-        wrong session. When topic mode is on, rewrite the thread_id to the
-        user's most-recent binding if the inbound id is missing/General or
-        not a known topic for this chat. Returns None to leave it alone.
+        Telegram strips ``message_thread_id`` on plain replies in topic-mode
+        DMs (#3206 — needed for non-topic users), causing messages to arrive
+        with no thread_id (lobby). When topic mode is on and the inbound
+        thread_id is missing or maps to the Telegram General topic, rewrite
+        it to the user's most-recent binding so the message lands in the
+        right session.
+
+        A non-lobby thread_id is always kept as-is, even if it isn't in the
+        binding table yet. That covers freshly-created topics: the binding is
+        recorded by ``_record_telegram_topic_binding`` *after* this function
+        runs, so we must not redirect such messages to the previous topic's
+        session. Replies to messages in a since-deleted topic become a rare
+        orphan case (Telegram itself also shows orphaned replies in that
+        situation). Returns None to leave the source unchanged.
         """
         if (
             source.platform != Platform.TELEGRAM
@@ -2074,8 +2081,13 @@ class GatewayRunner:
             return None
         inbound = str(source.thread_id or "")
         is_lobby = not inbound or inbound in self._TELEGRAM_GENERAL_TOPIC_IDS
-        known = {str(b.get("thread_id") or "") for b in bindings}
-        if not is_lobby and inbound in known:
+        if not is_lobby:
+            # Real thread_id present: could be a known topic OR a brand-new one
+            # the user just created. Either way it is the topic the user intends —
+            # never hijack to the most-recent binding. The previous "unknown id →
+            # recover" branch caused new topics to be silently merged into the
+            # previously-active topic's session because binding for the new id
+            # only happens after recovery decides not to rewrite.
             return None
         user_id = str(source.user_id)
         for b in bindings:  # newest-first

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -1175,13 +1175,14 @@ def test_recover_returns_none_for_known_topic(tmp_path):
     assert runner._recover_telegram_topic_thread_id(_make_source(thread_id="222")) is None
 
 
-def test_recover_rewrites_unknown_thread_id_to_most_recent(tmp_path):
-    # Cross-topic Reply leak: inbound thread_id is a Telegram-only id we never bound.
+def test_recover_returns_none_for_unknown_thread_id(tmp_path):
+    # A non-lobby, non-bound thread_id could be a brand-new topic the user just
+    # created. Recovery must not hijack it into the previous session.
     db = SessionDB(db_path=tmp_path / "state.db")
     _seed_two_topic_bindings(db)
     runner = _make_runner(session_db=db)
 
-    assert runner._recover_telegram_topic_thread_id(_make_source(thread_id="9999")) == "222"
+    assert runner._recover_telegram_topic_thread_id(_make_source(thread_id="9999")) is None
 
 
 def test_recover_rewrites_lobby_thread_id_to_most_recent(tmp_path):
@@ -1207,6 +1208,27 @@ def test_recover_returns_none_when_no_bindings_yet(tmp_path):
     runner = _make_runner(session_db=db)
 
     assert runner._recover_telegram_topic_thread_id(_make_source(thread_id=None)) is None
+
+
+def test_recover_returns_none_for_brand_new_topic(tmp_path):
+    # Regression: bindings exist for a prior topic but the user opened a fresh one
+    # (thread_id "99999"). Recovery must return None so the new topic gets its own
+    # session rather than being silently merged into topic "12345"'s session.
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
+    db.create_session(session_id="sess-old", source="telegram", user_id="208214988")
+    src_old = _make_source(thread_id="12345")
+    db.bind_telegram_topic(
+        chat_id=src_old.chat_id,
+        thread_id=src_old.thread_id,
+        user_id=src_old.user_id,
+        session_key=build_session_key(src_old),
+        session_id="sess-old",
+    )
+    runner = _make_runner(session_db=db)
+
+    # "99999" is non-lobby and not in the binding table — brand-new topic.
+    assert runner._recover_telegram_topic_thread_id(_make_source(thread_id="99999")) is None
 
 
 def test_list_telegram_topic_bindings_for_chat(tmp_path):


### PR DESCRIPTION
## Regression introduced by #26609

Commit `ede47a54b` added `_recover_telegram_topic_thread_id` to pin inbound DM topic routing to the user's most-recent binding when the inbound `thread_id` is either lobby/General or **unknown to existing bindings**.

The \"unknown → recover\" branch is wrong: when a user creates a **new** Telegram DM topic, the inbound `thread_id` is real and non-lobby, but it has no binding yet because `_record_telegram_topic_binding` runs at line ~7876 — *after* recovery has already decided to redirect. The result: every message in the new topic is silently routed into the previously-active topic's session, and the new topic is never bound.

Live evidence from gateway logs:

```
telegram topic recovery: chat=1232992028 user=1232992028 '27453' -> 27374
telegram topic recovery: chat=1232992028 user=1232992028 '27453' -> 27374
telegram topic recovery: chat=1232992028 user=1232992028 '27453' -> 27374
```

`27453` is the freshly-created topic id; `27374` is the previous session's topic. Every message keeps being hijacked because the binding for `27453` is never written.

## The fix

The two cases that warrant recovery are:
1. `thread_id` is `None` / empty — `_build_message_event` stripped it (#3206).
2. `thread_id` is a Telegram General/lobby magic id.

Both are **lobby** cases. A non-lobby `thread_id` always belongs to the topic the user intends — whether it is already bound or brand new. The fix collapses the recovery guard to `is_lobby` only and removes the `known` set lookup entirely.

**Trade-off**: a reply to a message in a *deleted* topic delivers a non-lobby but truly stale `thread_id`. Previously that would have been recovered; now it becomes an orphan message with no binding — consistent with what Telegram itself shows the user when the topic is gone.

## Test changes

- `test_recover_rewrites_unknown_thread_id_to_most_recent` → renamed to `test_recover_returns_none_for_unknown_thread_id` and body updated to assert `None` (no hijack).
- Added `test_recover_returns_none_for_brand_new_topic`: bindings exist for topic `12345`, inbound `thread_id="99999"` (non-lobby, unbound). Asserts `None`.
- All previously-passing tests (`test_recover_returns_none_for_known_topic`, `test_recover_rewrites_lobby_thread_id_to_most_recent`, `test_recover_returns_none_when_topic_mode_disabled`, `test_recover_returns_none_when_no_bindings_yet`) remain unchanged and pass.