### PR TITLE
test(cli): make hangup-protection stdio wrap check resilient to module reload

### DIFF
--- a/tests/hermes_cli/test_update_hangup_protection.py
+++ b/tests/hermes_cli/test_update_hangup_protection.py
@@ -213,8 +213,21 @@ class TestInstallHangupProtection:
         try:
             # On Windows (no SIGHUP) we still wrap stdio and create the log.
             assert state["installed"] is True
-            assert isinstance(sys.stdout, _UpdateOutputStream)
-            assert isinstance(sys.stderr, _UpdateOutputStream)
+            # A handful of other tests in the suite (e.g.
+            # ``test_env_loader.test_main_import_applies_user_env_over_shell_values``
+            # and ``test_skills_subparser``) pop ``hermes_cli.main`` from
+            # ``sys.modules`` and re-import it.  When xdist's load scheduler
+            # dispatches one of those before this test on the same worker,
+            # the ``_UpdateOutputStream`` bound at module-import time can
+            # become a different class object from the one
+            # ``_install_hangup_protection`` wraps with — same qualified name,
+            # distinct identity, so ``isinstance`` returns False. Compare
+            # qualified names; the behavioural check below is what actually
+            # exercises the wrap.
+            assert type(sys.stdout).__module__ == "hermes_cli.main"
+            assert type(sys.stdout).__name__ == "_UpdateOutputStream"
+            assert type(sys.stderr).__module__ == "hermes_cli.main"
+            assert type(sys.stderr).__name__ == "_UpdateOutputStream"
             assert state["log_file"] is not None
 
             sys.stdout.write("checking mirror\n")


### PR DESCRIPTION
## What does this PR do?

`tests/hermes_cli/test_update_hangup_protection.py::test_wraps_stdout_and_stderr_with_mirror` has been failing on `main` for at least three runs in a row (latest: [26154598271 @ 42c428841](https://github.com/NousResearch/hermes-agent/actions/runs/26154598271)), and the same failure shows on every recent `briandevans` PR (e.g. [#29225](https://github.com/NousResearch/hermes-agent/pull/29225), [#29165](https://github.com/NousResearch/hermes-agent/pull/29165), [#28658](https://github.com/NousResearch/hermes-agent/pull/28658)). The CI assertion gives away the root cause:

```
False = isinstance(
    <hermes_cli.main._UpdateOutputStream object at 0x7f0519779cd0>,
    _UpdateOutputStream,
)
```

`sys.stdout` IS a `hermes_cli.main._UpdateOutputStream` instance (its repr says so), yet `isinstance` returns `False`. That only happens when two distinct class objects with the same qualified name coexist in one worker process — i.e. `hermes_cli.main` got re-imported between the test file's module-level `from hermes_cli.main import _UpdateOutputStream` and the `_install_hangup_protection` call.

Two existing tests do exactly that:

- [`tests/hermes_cli/test_env_loader.py:85`](https://github.com/NousResearch/hermes-agent/blob/main/tests/hermes_cli/test_env_loader.py#L85) — `sys.modules.pop(\"hermes_cli.main\", None)` then `importlib.import_module(\"hermes_cli.main\")`.
- [`tests/hermes_cli/test_skills_subparser.py:25`](https://github.com/NousResearch/hermes-agent/blob/main/tests/hermes_cli/test_skills_subparser.py#L25) — `del sys.modules['hermes_cli.main']` then re-imports.

Under xdist's default `--dist=load` (the CI workflow runs `-n auto`, no explicit dist), if one of those is scheduled on the same worker before `test_wraps_stdout_and_stderr_with_mirror`, the worker's bound `_UpdateOutputStream` no longer matches the class `_install_hangup_protection` wraps with via its own module globals. The mismatch reproduces deterministically on CI's Linux + Python 3.11.15 + `.[all,dev]` + full-suite run, but not under smaller local subsets (where the load scheduler doesn't end up co-scheduling them on the same worker).

Replace the identity-based `isinstance` check with a qualified-type-name check. The behavioural assertion just below — write to `sys.stdout`, read back from `update.log` — already exercises that the wrap actually works, so no real coverage is lost.

> Audited siblings: `tests/run_agent/test_run_agent.py:4277-4278` has the same shape against `_SafeWriter` — `assert isinstance(sys.stdout, _SafeWriter)`. It hasn't surfaced as a baseline failure yet, but the same root cause applies if `hermes_cli.run_agent` ever ends up reloaded on the same xdist worker. Intentionally left out of this PR's scope to keep the diff minimal — happy to widen if preferred.

## Related Issue

N/A — baseline-CI failure on `origin/main`. Affects every open PR in the queue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tests/hermes_cli/test_update_hangup_protection.py` — replace `isinstance(sys.stdout, _UpdateOutputStream)` / `isinstance(sys.stderr, _UpdateOutputStream)` with `type(sys.stdout).__module__ == \"hermes_cli.main\"` + `type(sys.stdout).__name__ == \"_UpdateOutputStream\"` (and same for `sys.stderr`). Added a comment pointing at the two reload-the-module tests so future readers know why this check is name-based rather than identity-based.

## How to Test

1. Before the fix, [run 26154598271 on `main @ 42c428841`](https://github.com/NousResearch/hermes-agent/actions/runs/26154598271) shows:
   ```
   FAILED tests/hermes_cli/test_update_hangup_protection.py::TestInstallHangupProtection::test_wraps_stdout_and_stderr_with_mirror - assert False
   ```
2. With the fix:
   ```
   uv run --with pytest --with pytest-xdist --with pytest-asyncio --with pytest-timeout \
       python3 -m pytest tests/hermes_cli/test_update_hangup_protection.py -v
   ```
   → 16 passed in ~1.2s, including `test_wraps_stdout_and_stderr_with_mirror`.
3. The behavioural assertions (`sys.stdout.write(\"checking mirror\\n\")` → `\"checking mirror\" in update.log contents`) still execute and still gate correctness — only the identity check changed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`test(cli):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added/updated tests for my changes
- [x] I've tested on my platform: macOS 15.4 / Python 3.11

### Documentation & Housekeeping

- [x] N/A — test-only change, no docs/CONTRIBUTING/AGENTS updates needed
- [x] N/A — no config keys added/changed
- [x] N/A — no architecture/workflow change
- [x] N/A — change is platform-agnostic (touches only the test assertion)
- [x] N/A — no tool descriptions/schemas changed

## For New Skills

_N/A._