### PR TITLE
fix: prefer live gateway runtime provenance

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8546,6 +8546,7 @@ class GatewayRunner:
                     user_config=_load_gateway_config(),
                     platform_key=_platform_config_key(source.platform),
                     model=agent_result.get("model"),
+                    provider=agent_result.get("provider"),
                     context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                     context_length=agent_result.get("context_length") or None,
                     cwd=os.environ.get("TERMINAL_CWD", ""),
@@ -9984,13 +9985,16 @@ class GatewayRunner:
                             except Exception as exc:
                                 logger.warning("Picker model switch failed for cached agent: %s", exc)
 
-                        # Store model note + session override
+                        # Store model note + session override.  Keep it structured
+                        # so the next turn can compare the queued switch against the
+                        # live runtime before using it for self-identification.
                         if not hasattr(_self, "_pending_model_notes"):
                             _self._pending_model_notes = {}
-                        _self._pending_model_notes[_session_key] = (
-                            f"[Note: model was just switched from {_cur_model} to {result.new_model} "
-                            f"via {result.provider_label or result.target_provider}. "
-                            f"Adjust your self-identification accordingly.]"
+                        from gateway.runtime_provenance import build_model_switch_note
+                        _self._pending_model_notes[_session_key] = build_model_switch_note(
+                            previous_model=_cur_model,
+                            requested_model=result.new_model,
+                            requested_provider=result.target_provider,
                         )
                         _self._session_model_overrides[_session_key] = {
                             "model": result.new_model,
@@ -10121,14 +10125,15 @@ class GatewayRunner:
             except Exception as exc:
                 logger.warning("In-place model switch failed for cached agent: %s", exc)
 
-        # Store a note to prepend to the next user message so the model
-        # knows about the switch (avoids system messages mid-history).
+        # Store a note to prepend to the next user message so the model knows
+        # about the switch without treating stale queued metadata as authority.
         if not hasattr(self, "_pending_model_notes"):
             self._pending_model_notes = {}
-        self._pending_model_notes[session_key] = (
-            f"[Note: model was just switched from {current_model} to {result.new_model} "
-            f"via {result.provider_label or result.target_provider}. "
-            f"Adjust your self-identification accordingly.]"
+        from gateway.runtime_provenance import build_model_switch_note
+        self._pending_model_notes[session_key] = build_model_switch_note(
+            previous_model=current_model,
+            requested_model=result.new_model,
+            requested_provider=result.target_provider,
         )
 
         # Store session override so next agent creation uses the new model
@@ -16615,11 +16620,21 @@ class GatewayRunner:
                 except Exception as _e:
                     logger.error("Failed to send approval request: %s", _e)
 
-            # Prepend pending model switch note so the model knows about the switch
+            # Prepend pending model switch note after validating it against the
+            # live runtime selected for this turn.  The runtime wins: stale
+            # queued notes are diagnostic context, not self-ID authority.
             _pending_notes = getattr(self, '_pending_model_notes', {})
             _msn = _pending_notes.pop(session_key, None) if session_key else None
             if _msn:
-                message = _msn + "\n\n" + message
+                from gateway.runtime_provenance import resolve_self_identification_note
+                _runtime_note = resolve_self_identification_note(
+                    _msn,
+                    runtime_model=turn_route["model"],
+                    runtime_provider=turn_route["runtime"].get("provider") or "",
+                    session_key=session_key or "",
+                    log=logger,
+                )
+                message = _runtime_note + "\n\n" + message
 
             # Auto-continue: if the loaded history ends with a tool result,
             # the previous agent turn was interrupted mid-work (gateway
@@ -16772,6 +16787,7 @@ class GatewayRunner:
                 _output_toks = getattr(_agent, "session_completion_tokens", 0)
                 _context_length = getattr(_agent.context_compressor, "context_length", 0) or 0
             _resolved_model = getattr(_agent, "model", None) if _agent else None
+            _resolved_provider = getattr(_agent, "provider", None) if _agent else None
 
             if not final_response:
                 error_msg = f"⚠️ {result['error']}" if result.get("error") else ""
@@ -16792,6 +16808,7 @@ class GatewayRunner:
                     "input_tokens": _input_toks,
                     "output_tokens": _output_toks,
                     "model": _resolved_model,
+                    "provider": _resolved_provider,
                     "context_length": _context_length,
                 }
             
@@ -16952,6 +16969,7 @@ class GatewayRunner:
                 "input_tokens": _input_toks,
                 "output_tokens": _output_toks,
                 "model": _resolved_model,
+                "provider": _resolved_provider,
                 "context_length": _context_length,
                 "session_id": effective_session_id,
                 "response_previewed": result.get("response_previewed", False),

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -54,6 +54,17 @@ def _model_short(model: Optional[str]) -> str:
     return model.rsplit("/", 1)[-1]
 
 
+def _model_display(model: Optional[str], provider: Optional[str] = None) -> str:
+    """Render the runtime model, optionally prefixed by the live provider."""
+    short_model = _model_short(model)
+    if not short_model:
+        return ""
+    provider_text = str(provider or "").strip()
+    if provider_text:
+        return f"{provider_text}/{short_model}"
+    return short_model
+
+
 def resolve_footer_config(
     user_config: dict[str, Any] | None,
     platform_key: str | None = None,
@@ -96,6 +107,7 @@ def format_runtime_footer(
     context_length: Optional[int],
     cwd: Optional[str] = None,
     fields: Iterable[str] = _DEFAULT_FIELDS,
+    provider: Optional[str] = None,
 ) -> str:
     """Render the footer line, or return "" if no fields have data.
 
@@ -105,7 +117,7 @@ def format_runtime_footer(
     parts: list[str] = []
     for field in fields:
         if field == "model":
-            m = _model_short(model)
+            m = _model_display(model, provider)
             if m:
                 parts.append(m)
         elif field == "context_pct":
@@ -131,6 +143,7 @@ def build_footer_line(
     context_tokens: int,
     context_length: Optional[int],
     cwd: Optional[str] = None,
+    provider: Optional[str] = None,
 ) -> str:
     """Top-level entry point used by gateway/run.py.
 
@@ -147,4 +160,5 @@ def build_footer_line(
         context_length=context_length,
         cwd=cwd,
         fields=cfg.get("fields") or _DEFAULT_FIELDS,
+        provider=provider,
     )

--- a/gateway/runtime_provenance.py
+++ b/gateway/runtime_provenance.py
@@ -1,0 +1,156 @@
+"""Gateway runtime provenance helpers.
+
+The gateway sometimes carries queued context notes across turns (for example a
+session-scoped ``/model`` switch note). Those notes are hints, not authority.
+The live runtime chosen for the actual agent turn wins, and conflicts are logged
+so stale injected metadata cannot make the assistant self-identify as the wrong
+provider/model.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Mapping
+
+logger = logging.getLogger(__name__)
+
+_LEGACY_SWITCH_RE = re.compile(
+    r"model was just switched from (?P<previous>.+?) to (?P<requested>.+?) "
+    r"via (?P<provider>.+?)\. Adjust your self-identification accordingly",
+    re.IGNORECASE,
+)
+
+
+def _clean(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _normalize_provider(value: Any) -> str:
+    provider = _clean(value).lower().replace(" ", "-").replace("_", "-")
+    aliases = {
+        "anthropic-claude": "anthropic",
+        "claude": "anthropic",
+        "openai-codex-oauth": "openai-codex",
+        "codex": "openai-codex",
+        "openai-codex": "openai-codex",
+    }
+    return aliases.get(provider, provider)
+
+
+def _normalize_model(value: Any) -> str:
+    model = _clean(value).lower()
+    if not model:
+        return ""
+    return model.rsplit("/", 1)[-1]
+
+
+def _runtime_label(*, provider: Any, model: Any) -> str:
+    runtime_model = _clean(model) or "unknown-model"
+    runtime_provider = _normalize_provider(provider) or "unknown-provider"
+    return f"{runtime_provider}/{runtime_model}"
+
+
+def build_model_switch_note(
+    *,
+    previous_model: str,
+    requested_model: str,
+    requested_provider: str,
+) -> dict[str, str]:
+    """Return a structured one-shot model switch note for the next turn."""
+    provider = _normalize_provider(requested_provider) or _clean(requested_provider)
+    model = _clean(requested_model)
+    previous = _clean(previous_model)
+    return {
+        "previous_model": previous,
+        "requested_model": model,
+        "requested_provider": provider,
+        "text": (
+            f"[Runtime metadata note: /model requested switch from {previous or 'unknown'} "
+            f"to {provider}/{model or 'unknown'}. This queued note is advisory; "
+            "live runtime metadata/footer for the current turn is authoritative "
+            "for self-identification.]"
+        ),
+    }
+
+
+def _coerce_pending_note(note: Any) -> tuple[str, str, str, str]:
+    """Return (text, previous_model, requested_model, requested_provider)."""
+    if isinstance(note, Mapping):
+        text = _clean(note.get("text"))
+        previous = _clean(note.get("previous_model"))
+        requested = _clean(note.get("requested_model") or note.get("model"))
+        provider = _clean(note.get("requested_provider") or note.get("provider"))
+        return text, previous, requested, provider
+
+    text = _clean(note)
+    match = _LEGACY_SWITCH_RE.search(text)
+    if not match:
+        return text, "", "", ""
+    return (
+        text,
+        _clean(match.group("previous")),
+        _clean(match.group("requested")),
+        _clean(match.group("provider")),
+    )
+
+
+def _conflicts(
+    *,
+    requested_model: str,
+    requested_provider: str,
+    runtime_model: str,
+    runtime_provider: str,
+) -> bool:
+    if requested_model and runtime_model:
+        if _normalize_model(requested_model) != _normalize_model(runtime_model):
+            return True
+    if requested_provider and runtime_provider:
+        if _normalize_provider(requested_provider) != _normalize_provider(runtime_provider):
+            return True
+    return False
+
+
+def resolve_self_identification_note(
+    pending_note: Any,
+    *,
+    runtime_model: str,
+    runtime_provider: str,
+    session_key: str = "",
+    log: logging.Logger | None = None,
+) -> str:
+    """Resolve a queued self-identification note against live runtime metadata.
+
+    The returned text is safe to prepend to the next user turn. If queued
+    metadata conflicts with the actual runtime for this turn, the conflict is
+    both logged and surfaced to the model as diagnostic context, with explicit
+    instruction to prefer the live runtime/footer.
+    """
+    text, previous_model, requested_model, requested_provider = _coerce_pending_note(pending_note)
+    runtime_label = _runtime_label(provider=runtime_provider, model=runtime_model)
+    requested_label = _runtime_label(provider=requested_provider, model=requested_model)
+
+    if _conflicts(
+        requested_model=requested_model,
+        requested_provider=requested_provider,
+        runtime_model=runtime_model,
+        runtime_provider=runtime_provider,
+    ):
+        active_logger = log or logger
+        active_logger.warning(
+            "runtime provenance conflict: session=%s queued=%s live=%s previous_model=%s",
+            session_key or "",
+            requested_label,
+            runtime_label,
+            previous_model or "",
+        )
+        return (
+            f"[Runtime provenance conflict: queued /model switch requested "
+            f"{requested_label}, but the live runtime is {runtime_label}. "
+            "Prefer the live runtime/footer for self-identification; treat the "
+            "queued note as stale diagnostic context, not truth.]"
+        )
+
+    if text:
+        return f"{text}\n[Live runtime for this turn: {runtime_label}.]"
+    return f"[Live runtime for this turn: {runtime_label}.]"

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -147,6 +147,19 @@ def test_format_footer_unknown_field_silently_ignored():
     assert out == "gpt-5.4 · 50%"
 
 
+def test_format_footer_model_includes_provider_when_supplied():
+    out = format_runtime_footer(
+        provider="openai-codex",
+        model="gpt-5.5",
+        context_tokens=0,
+        context_length=None,
+        cwd="",
+        fields=("model",),
+    )
+
+    assert out == "openai-codex/gpt-5.5"
+
+
 # ---------------------------------------------------------------------------
 # resolve_footer_config
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_runtime_provenance.py
+++ b/tests/gateway/test_runtime_provenance.py
@@ -1,0 +1,85 @@
+"""Tests for gateway runtime provenance notes used for self-identification."""
+
+from __future__ import annotations
+
+import logging
+
+from gateway.runtime_provenance import (
+    build_model_switch_note,
+    resolve_self_identification_note,
+)
+
+
+def test_model_switch_note_is_structured_and_names_runtime_authority():
+    note = build_model_switch_note(
+        previous_model="claude-opus-4-7",
+        requested_model="gpt-5.5",
+        requested_provider="openai-codex",
+    )
+
+    assert note["previous_model"] == "claude-opus-4-7"
+    assert note["requested_model"] == "gpt-5.5"
+    assert note["requested_provider"] == "openai-codex"
+    assert "runtime metadata" in note["text"]
+    assert "self-identification" in note["text"]
+
+
+def test_resolved_note_prefers_live_runtime_when_pending_note_matches():
+    pending = build_model_switch_note(
+        previous_model="claude-opus-4-7",
+        requested_model="gpt-5.5",
+        requested_provider="openai-codex",
+    )
+
+    resolved = resolve_self_identification_note(
+        pending,
+        runtime_model="gpt-5.5",
+        runtime_provider="openai-codex",
+        session_key="discord:thread",
+    )
+
+    assert "Live runtime for this turn: openai-codex/gpt-5.5" in resolved
+    assert "stale" not in resolved.lower()
+
+
+def test_resolved_note_reports_conflict_and_logs_runtime_winner(caplog):
+    pending = build_model_switch_note(
+        previous_model="gpt-5.5",
+        requested_model="claude-opus-4-7",
+        requested_provider="anthropic",
+    )
+
+    with caplog.at_level(logging.WARNING):
+        resolved = resolve_self_identification_note(
+            pending,
+            runtime_model="gpt-5.5",
+            runtime_provider="openai-codex",
+            session_key="discord:1506515748535930941",
+        )
+
+    assert "Runtime provenance conflict" in resolved
+    assert "queued /model switch requested anthropic/claude-opus-4-7" in resolved
+    assert "live runtime is openai-codex/gpt-5.5" in resolved
+    assert "Prefer the live runtime/footer" in resolved
+    assert "runtime provenance conflict" in caplog.text
+    assert "discord:1506515748535930941" in caplog.text
+
+
+def test_legacy_pending_note_gets_conflict_checked(caplog):
+    legacy = (
+        "[Note: model was just switched from gpt-5.5 to claude-opus-4-7 "
+        "via Anthropic. Adjust your self-identification accordingly.]"
+    )
+
+    with caplog.at_level(logging.WARNING):
+        resolved = resolve_self_identification_note(
+            legacy,
+            runtime_model="gpt-5.5",
+            runtime_provider="openai-codex",
+            session_key="discord:thread",
+        )
+
+    assert "Runtime provenance conflict" in resolved
+    assert "anthropic/claude-opus-4-7" in resolved.lower()
+    assert "openai-codex/gpt-5.5" in resolved
+    assert "runtime provenance conflict" in caplog.text


### PR DESCRIPTION
## Summary
- add structured gateway runtime provenance notes for session-scoped `/model` switches
- validate queued model-switch notes against the live runtime before injecting them into the next turn
- log and surface provenance conflicts so stale notes are diagnostic context, not self-identification truth
- include live provider in the runtime footer when available (e.g. `openai-codex/gpt-5.5`)

## Tests
- `python -m pytest tests/gateway/test_runtime_provenance.py tests/gateway/test_runtime_footer.py -q -o addopts=`
- `python -m pytest tests/gateway/test_model_switch_persistence.py tests/gateway/test_session_model_override_routing.py tests/gateway/test_session_model_reset.py -q -o addopts=`
- `python -m py_compile gateway/runtime_provenance.py gateway/runtime_footer.py`
- `git diff --check`
