### PR TITLE
feat(adapter): polymorphic cron-delivery metadata hook

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -566,7 +566,13 @@ def _send_media_via_adapter(
             logger.warning("Job '%s': failed to send media %s: %s", job.get("id", "?"), media_path, e)
 
 
-def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
+def _deliver_result(
+    job: dict,
+    content: str,
+    adapters=None,
+    loop=None,
+    status_hint: str = "ok",
+) -> Optional[str]:
     """
     Deliver job output to the configured target(s) (origin chat, specific platform, etc.).
 
@@ -574,6 +580,14 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     use the live adapter first — this supports E2EE rooms (e.g. Matrix) where
     the standalone HTTP path cannot encrypt.  Falls back to standalone send if
     the adapter path fails or is unavailable.
+
+    ``status_hint`` (``'ok'`` or ``'error'``): forwarded into the adapter
+    ``metadata`` via the polymorphic ``adapter.build_delivery_metadata(...)``
+    hook on :class:`gateway.platforms.base.BasePlatformAdapter`. The default
+    hook implementation ignores this value (it is forwarded purely for the
+    benefit of overriding adapters that want to stamp run-completion
+    records). Defaults to ``"ok"``; ``tick()`` overrides with ``"error"``
+    when ``run_job`` returns ``success=False``.
 
     Returns None on success, or an error string on failure.
     """
@@ -666,7 +680,21 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         runtime_adapter = (adapters or {}).get(platform)
         delivered = False
         if runtime_adapter is not None and loop is not None and getattr(loop, "is_running", lambda: False)():
-            send_metadata = {"thread_id": thread_id} if thread_id else None
+            base_metadata = {"thread_id": thread_id} if thread_id else None
+            # Polymorphic hook; default returns base_metadata unchanged.
+            # See gateway/platforms/base.py:BasePlatformAdapter.build_delivery_metadata.
+            try:
+                send_metadata = runtime_adapter.build_delivery_metadata(
+                    job=job,
+                    status_hint=status_hint,
+                    base_metadata=base_metadata,
+                )
+            except Exception as e:
+                logger.warning(
+                    "Job '%s': build_delivery_metadata on %s failed (%s); using base metadata",
+                    job["id"], platform_name, e,
+                )
+                send_metadata = dict(base_metadata) if base_metadata else None
             try:
                 # Send cleaned text (MEDIA tags stripped) — not the raw content
                 text_to_send = cleaned_delivery_content.strip()
@@ -1882,7 +1910,10 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
                 delivery_error = None
                 if should_deliver:
                     try:
-                        delivery_error = _deliver_result(job, deliver_content, adapters=adapters, loop=loop)
+                        delivery_error = _deliver_result(
+                            job, deliver_content, adapters=adapters, loop=loop,
+                            status_hint="ok" if success else "error",
+                        )
                     except Exception as de:
                         delivery_error = str(de)
                         logger.error("Delivery failed for job %s: %s", job["id"], de)

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2466,6 +2466,45 @@ class BasePlatformAdapter(ABC):
     async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
         """Hook called when background processing completes."""
 
+    # ── Cron delivery metadata enrichment hook ─────────────────────────────
+    # Subclasses override to enrich metadata for cron-job deliveries (e.g.
+    # an adapter with an offline-delivery webhook may add job_id, job_name,
+    # status, ran_at, and origin so the webhook can reconstruct a
+    # run-complete payload). The cron scheduler calls this polymorphically
+    # so no per-platform branches are needed in scheduler code. Default
+    # returns base_metadata unchanged (or an empty dict if base_metadata
+    # is None).
+    def build_delivery_metadata(
+        self,
+        job: Dict[str, Any],
+        status_hint: str = "ok",
+        base_metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Build the metadata kwarg for ``adapter.send()`` during cron delivery.
+
+        Args:
+            job: The cron job dict.
+            status_hint: ``'ok' | 'error'`` — run status forwarded by the
+                scheduler.
+            base_metadata: Pre-existing metadata (e.g. ``{"thread_id": ...}``).
+
+        Returns:
+            Default: a copy of ``base_metadata``, or ``None`` if
+            ``base_metadata`` is ``None``. Preserves the upstream pre-hook
+            behavior where adapters that don't override get
+            ``metadata=None`` when no metadata is configured.
+            Subclasses: enriched dict for their adapter's ``send()`` to
+            consume.
+
+        Note:
+            Sync (not async) because the cron scheduler dispatch path
+            calling this hook is synchronous. The neighboring
+            ``on_processing_start`` / ``on_processing_complete`` are
+            async because they're called from the gateway's async
+            message-processing loop.
+        """
+        return dict(base_metadata) if base_metadata is not None else None
+
     async def _run_processing_hook(self, hook_name: str, *args: Any, **kwargs: Any) -> None:
         """Run a lifecycle hook without letting failures break message flow."""
         hook = getattr(self, hook_name, None)

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -599,6 +599,7 @@ class TestDeliverResultWrapping:
         from concurrent.futures import Future
 
         adapter = AsyncMock()
+        adapter.build_delivery_metadata = lambda **kw: kw.get('base_metadata') or {}
         adapter.send.return_value = MagicMock(success=True)
         adapter.send_voice.return_value = MagicMock(success=True)
 
@@ -650,6 +651,7 @@ class TestDeliverResultWrapping:
         from concurrent.futures import Future
 
         adapter = AsyncMock()
+        adapter.build_delivery_metadata = lambda **kw: kw.get('base_metadata') or {}
         adapter.send.return_value = MagicMock(success=True)
         adapter.send_image_file.return_value = MagicMock(success=True)
 
@@ -693,6 +695,7 @@ class TestDeliverResultWrapping:
         from concurrent.futures import Future
 
         adapter = AsyncMock()
+        adapter.build_delivery_metadata = lambda **kw: kw.get('base_metadata') or {}
         adapter.send_voice.return_value = MagicMock(success=True)
 
         pconfig = MagicMock()
@@ -737,6 +740,7 @@ class TestDeliverResultWrapping:
         from concurrent.futures import Future
 
         adapter = AsyncMock()
+        adapter.build_delivery_metadata = lambda **kw: kw.get('base_metadata') or {}
         adapter.send.return_value = MagicMock(success=True)
 
         pconfig = MagicMock()
@@ -2414,6 +2418,11 @@ class TestDeliverResultTimeoutCancelsFuture:
         )
         adapter = MagicMock()
         adapter.send = AsyncMock(return_value=send_result)
+        # Mirror BasePlatformAdapter.build_delivery_metadata default: return
+        # base_metadata unchanged. Without this, MagicMock auto-creates the
+        # attribute and the new metadata arg passed to adapter.send becomes a
+        # MagicMock instance instead of the expected {'thread_id': ...} dict.
+        adapter.build_delivery_metadata = lambda **kw: kw.get('base_metadata') or {}
 
         pconfig = MagicMock()
         pconfig.enabled = True
@@ -2454,6 +2463,155 @@ class TestDeliverResultTimeoutCancelsFuture:
             "Hello world",
             metadata={"thread_id": "7072"},
         )
+
+
+class TestDeliverResultBuildDeliveryMetadataHook:
+    """End-to-end tests that the live-adapter delivery path actually
+    routes through ``adapter.build_delivery_metadata(...)`` and forwards
+    its return value into ``adapter.send(metadata=...)``. Also exercises
+    the exception-guard fallback to ``base_metadata`` when the hook
+    raises.
+    """
+
+    def test_live_adapter_delivery_uses_build_delivery_metadata(self):
+        """The hook is called once with the expected kwargs and its
+        enriched return value is the exact ``metadata`` arg handed to
+        ``adapter.send``."""
+        from gateway.config import Platform
+        from gateway.platforms.base import SendResult
+        from concurrent.futures import Future
+
+        enriched = {"thread_id": "456", "job_id": "j1", "status": "ok"}
+
+        send_result = SendResult(success=True, message_id="1")
+        adapter = MagicMock()
+        adapter.send = AsyncMock(return_value=send_result)
+        adapter.build_delivery_metadata = MagicMock(return_value=enriched)
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        completed_future = Future()
+        completed_future.set_result(send_result)
+
+        def fake_run_coro(coro, _loop):
+            coro.close()
+            return completed_future
+
+        job = {
+            "id": "j1",
+            "name": "hook-job",
+            "deliver": "telegram:123:456",
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro):
+            result = _deliver_result(
+                job,
+                "Hello world",
+                adapters={Platform.TELEGRAM: adapter},
+                loop=loop,
+            )
+
+        assert result is None
+        adapter.build_delivery_metadata.assert_called_once()
+        hook_kwargs = adapter.build_delivery_metadata.call_args.kwargs
+        assert hook_kwargs["job"] == job
+        assert hook_kwargs["status_hint"] == "ok"
+        assert hook_kwargs["base_metadata"] == {"thread_id": "456"}
+
+        adapter.send.assert_called_once()
+        send_kwargs = adapter.send.call_args.kwargs
+        assert send_kwargs["metadata"] == enriched
+
+    def test_live_adapter_delivery_metadata_hook_failure_falls_back_to_base_metadata(self):
+        """If the override raises, ``_deliver_result`` swallows the
+        exception, logs a warning, and still sends with the unenriched
+        ``base_metadata`` so the delivery completes."""
+        from gateway.config import Platform
+        from gateway.platforms.base import SendResult
+        from concurrent.futures import Future
+
+        send_result = SendResult(success=True, message_id="1")
+        adapter = MagicMock()
+        adapter.send = AsyncMock(return_value=send_result)
+        adapter.build_delivery_metadata = MagicMock(
+            side_effect=RuntimeError("simulated")
+        )
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        completed_future = Future()
+        completed_future.set_result(send_result)
+
+        def fake_run_coro(coro, _loop):
+            coro.close()
+            return completed_future
+
+        job = {
+            "id": "j2",
+            "name": "hook-failure-job",
+            "deliver": "telegram:123:789",
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro):
+            result = _deliver_result(
+                job,
+                "Hello world",
+                adapters={Platform.TELEGRAM: adapter},
+                loop=loop,
+            )
+
+        assert result is None
+        adapter.build_delivery_metadata.assert_called_once()
+        adapter.send.assert_called_once()
+        send_kwargs = adapter.send.call_args.kwargs
+        assert send_kwargs["metadata"] == {"thread_id": "789"}
+
+    def test_tick_failed_run_forwards_status_hint_error(self, tmp_path):
+        """When ``run_job`` returns ``success=False``, ``tick()`` must
+        invoke ``_deliver_result`` with ``status_hint='error'`` so
+        adapter overrides can mark the run as failed."""
+        from cron.scheduler import tick
+
+        job = {
+            "id": "failed-job",
+            "name": "monitor",
+            "prompt": "do something",
+            "schedule": "every 1h",
+            "enabled": True,
+            "next_run_at": "2020-01-01T00:00:00",
+            "deliver": "telegram",
+            "origin": {"platform": "telegram", "chat_id": "123"},
+            "last_status": None,
+        }
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler.get_due_jobs", return_value=[job]), \
+             patch("cron.scheduler.advance_next_run"), \
+             patch("cron.scheduler.mark_job_run"), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler.run_job", return_value=(False, "# output", "", "boom")), \
+             patch("cron.scheduler._deliver_result") as deliver_mock:
+            tick(verbose=False)
+
+        deliver_mock.assert_called_once()
+        kwargs = deliver_mock.call_args.kwargs
+        assert kwargs["status_hint"] == "error"
 
 
 class TestSendMediaTimeoutCancelsFuture:

--- a/tests/gateway/test_build_delivery_metadata.py
+++ b/tests/gateway/test_build_delivery_metadata.py
@@ -1,0 +1,98 @@
+"""Tests for BasePlatformAdapter.build_delivery_metadata default behavior.
+
+The default implementation is a no-op — returns base_metadata unchanged
+(or an empty dict if None). Subclasses can override to enrich the
+metadata dict passed to adapter.send() during cron delivery.
+
+These tests exercise the default; subclass-override coverage belongs
+in the override's own test suite.
+"""
+from __future__ import annotations
+
+import inspect
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+
+
+class _StubAdapter(BasePlatformAdapter):
+    """Minimal concrete adapter that does NOT override build_delivery_metadata.
+
+    Used here to exercise the default implementation. Override-side coverage
+    is the responsibility of whichever adapter overrides the method.
+    """
+
+    def __init__(self):
+        # Platform.TELEGRAM is arbitrary — we only need a valid Platform
+        # enum value to satisfy BasePlatformAdapter.__init__; the choice
+        # has no effect on build_delivery_metadata's behavior.
+        super().__init__(PlatformConfig(enabled=True, token="test"), Platform.TELEGRAM)
+
+    async def connect(self):
+        return True
+
+    async def disconnect(self):
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        return SendResult(success=True, message_id="1")
+
+    async def get_chat_info(self, chat_id):  # pragma: no cover — abstract impl
+        return None
+
+
+def test_default_returns_base_metadata_unchanged():
+    """The default implementation is a no-op — returns base_metadata as-is."""
+    adapter = _StubAdapter()
+    base = {"thread_id": "t-1"}
+    result = adapter.build_delivery_metadata(
+        job={"id": "j", "name": "n"}, status_hint="ok", base_metadata=base
+    )
+    assert result == base
+
+
+def test_default_returns_none_when_base_metadata_is_none():
+    """base_metadata=None returns None — preserves the pre-hook adapter.send(metadata=None) contract."""
+    adapter = _StubAdapter()
+    result = adapter.build_delivery_metadata(
+        job={"id": "j", "name": "n"}, status_hint="ok", base_metadata=None
+    )
+    assert result is None
+
+
+def test_default_returns_copy_not_reference():
+    """The default returns a copy — caller mutations don't affect base_metadata."""
+    adapter = _StubAdapter()
+    base = {"thread_id": "t-1"}
+    result = adapter.build_delivery_metadata(
+        job={"id": "j", "name": "n"}, status_hint="ok", base_metadata=base
+    )
+    result["thread_id"] = "mutated"
+    assert base["thread_id"] == "t-1"
+
+
+def test_signature_is_stable():
+    """Method signature: (self, job, status_hint='ok', base_metadata=None)."""
+    sig = inspect.signature(BasePlatformAdapter.build_delivery_metadata)
+    params = list(sig.parameters)
+    assert params == ["self", "job", "status_hint", "base_metadata"]
+    assert sig.parameters["status_hint"].default == "ok"
+    assert sig.parameters["base_metadata"].default is None
+
+
+def test_default_is_status_hint_agnostic():
+    """The default hook returns identical output regardless of status_hint.
+
+    Locks in the contract that the default implementation does NOT
+    interpret status_hint. Overriding adapters may interpret it as
+    they wish.
+    """
+    adapter = _StubAdapter()
+    base = {"thread_id": "t-1"}
+    ok_result = adapter.build_delivery_metadata(
+        job={"id": "j", "name": "n"}, status_hint="ok", base_metadata=base
+    )
+    error_result = adapter.build_delivery_metadata(
+        job={"id": "j", "name": "n"}, status_hint="error", base_metadata=base
+    )
+    assert ok_result == error_result == base

--- a/website/docs/developer-guide/adding-platform-adapters.md
+++ b/website/docs/developer-guide/adding-platform-adapters.md
@@ -325,6 +325,33 @@ Why this hook is necessary: built-in platforms (Telegram, Discord, Slack, etc.) 
 
 The function receives the same `pconfig` and `chat_id` that the live adapter would, plus optional `thread_id`, `media_files`, and `force_document` keyword arguments. Returning `{"success": True, "message_id": ...}` is treated as a successful delivery; returning `{"error": "..."}` surfaces the message in cron's `delivery_errors`. Exceptions raised inside the function are caught by the dispatcher and reported as `Plugin standalone send failed: <reason>`. Reference implementations live in `plugins/platforms/{irc,teams,google_chat}/adapter.py`.
 
+### Enriching delivery metadata
+
+Cron jobs hand the delivery payload to your adapter's `send()` method along with a `metadata` dict. By default this is `{"thread_id": <id>}` (or `None` when no thread is set). If your adapter needs richer metadata — e.g., a webhook fallback that consumes `job_id`, `job_name`, run status, or the originating chat — override the optional `build_delivery_metadata` hook on `BasePlatformAdapter`:
+
+```python
+class MyAdapter(BasePlatformAdapter):
+    def build_delivery_metadata(
+        self,
+        job: Dict[str, Any],
+        status_hint: str = "ok",
+        base_metadata: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        meta = dict(base_metadata) if base_metadata else {}
+        meta.update({
+            "job_id": job.get("id", ""),
+            "job_name": job.get("name") or job.get("id", ""),
+            "status": status_hint,
+        })
+        return meta
+```
+
+The scheduler calls this in `cron.scheduler._deliver_result` after building the base metadata; the returned dict becomes the `metadata=` kwarg passed to your `adapter.send()`. The base-class default returns `base_metadata` unchanged, so adapters that don't care about cron-specific enrichment see no change. The call is exception-guarded — if your override raises, the scheduler logs a warning and falls back to `base_metadata`, mirroring the `_run_processing_hook` safety pattern.
+
+This hook is only invoked on the in-gateway live-adapter delivery path — i.e., when `cron.scheduler` resolves a `runtime_adapter` from the `adapters` dict and the gateway's event loop is running. The out-of-process `standalone_sender_fn` path (used when cron runs as a separate process from the gateway) still receives the existing `thread_id` / `media_files` / `force_document` keyword arguments and does not call `build_delivery_metadata`. If your adapter needs metadata enrichment in both paths, mirror the logic in your `standalone_sender_fn` implementation.
+
+`status_hint` is `"ok"` when the cron run succeeded and `"error"` when `run_job` reported failure; ignore it if you don't need it.
+
 ## Surfacing Env Vars in `hermes config`
 
 `hermes_cli/config.py` scans `plugins/platforms/*/plugin.yaml` at import time and auto-populates `OPTIONAL_ENV_VARS` from `requires_env` and (optional) `optional_env` blocks. Use the rich-dict form to contribute proper descriptions, prompts, password flags, and URLs — the CLI setup UI picks them up for free.

--- a/website/docs/developer-guide/cron-internals.md
+++ b/website/docs/developer-guide/cron-internals.md
@@ -196,6 +196,14 @@ The `[SILENT]` prefix in a cron response suppresses delivery entirely — useful
 
 Cron deliveries are NOT mirrored into gateway session conversation history. They exist only in the cron job's own session. This prevents message alternation violations in the target chat's conversation.
 
+### Adapter Metadata Enrichment
+
+Before calling `adapter.send(..., metadata=<dict>)`, the scheduler invokes the adapter's optional `build_delivery_metadata(job, status_hint, base_metadata)` hook on `BasePlatformAdapter`. Adapters override it to attach extra fields the platform's send/webhook path needs (e.g., `job_id`, `job_name`, `status`, `ran_at`); the base implementation returns `base_metadata` unchanged.
+
+`status_hint` is set by `tick()` to `"ok"` or `"error"` based on the run's success state. The hook call is wrapped in an exception guard — a misbehaving override logs a warning and falls back to `base_metadata`, mirroring the `BasePlatformAdapter._run_processing_hook` safety pattern. See [Adding Platform Adapters → Enriching delivery metadata](./adding-platform-adapters.md#enriching-delivery-metadata) for the override template.
+
+The hook only fires on the live-adapter delivery path inside the gateway process; cron deliveries that route through `standalone_sender_fn` (out-of-process, e.g., `hermes cron run` invoked separately from `hermes gateway`) continue to use the existing keyword-argument shape and bypass the hook.
+
 ## Recursion Guard
 
 Cron-run sessions have the `cronjob` toolset disabled. This prevents:


### PR DESCRIPTION
## What does this PR do?

Adds an optional polymorphic hook `BasePlatformAdapter.build_delivery_metadata(...)` so platform adapters can enrich the metadata kwarg passed to `adapter.send()` during cron delivery, without modifying `cron/scheduler.py`. The default implementation is a no-op (returns `base_metadata` unchanged, or `None` when `None`), so every existing adapter behaves identically.

Mirrors the existing optional-method pattern on `BasePlatformAdapter` (`on_processing_start`, `on_processing_complete`). Follows the same shape as PR #5295 (moved hardcoded honcho argparse out of `main.py` into a generic plugin surface): platform-specific logic moves out of core into adapter overrides.

## Related Issue

No related issue filed yet. Happy to open one first if preferred — design questions for maintainers are inline at the bottom of this description.

Fixes #

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/platforms/base.py` — adds `BasePlatformAdapter.build_delivery_metadata(job, status_hint='ok', base_metadata=None) -> Optional[Dict[str, Any]]`. Default returns `dict(base_metadata)` if not `None`, else `None`. (+39 lines)
- `cron/scheduler.py` — `_deliver_result` calls the hook on the resolved runtime adapter; adds `status_hint` parameter (default `'ok'`, set to `'error'` by `tick()` on failed runs); hook call is exception-guarded with a fallback to `base_metadata`. (+37 lines, -3 lines)
- `tests/gateway/test_build_delivery_metadata.py` — 5 new unit tests for the default hook (no-op behavior, `None` when `base_metadata` is `None`, copy semantics, signature stability, `status_hint` agnosticism). (+98 lines, new file)
- `tests/cron/test_scheduler.py` — 3 new integration tests for the scheduler hook path (live-adapter override is called and its return value reaches `adapter.send`; exception in the hook falls back to `base_metadata`; `tick()` forwards `status_hint='error'` on failed runs). 5 existing tests gain a one-line mock of the new method on their `AsyncMock`/`MagicMock` adapters. (+158 lines)
- `website/docs/developer-guide/adding-platform-adapters.md` — new "Enriching delivery metadata" subsection under "Cron Delivery" with override template, behavior contract, and a note that the hook fires only on the live-adapter path. (+27 lines)
- `website/docs/developer-guide/cron-internals.md` — new "Adapter Metadata Enrichment" subsection under "Delivery Model" with a cross-reference to the adapter-author guide. (+8 lines)

Total: 6 files, +364 / -3 lines.

## Motivation

`cron/scheduler.py:_deliver_result` currently constructs `send_metadata` as a plain `{"thread_id": ...}` dict (or `None` when no thread is set) before calling `adapter.send(..., metadata=send_metadata)`. Adapters that need richer delivery context have no clean override point — the only path today is to fork the scheduler.

Concrete adapter classes that would benefit:

- **Webhook-fallback adapters** that POST to an HTTP endpoint when no live gateway connection is available — typically need `job_id`, `job_name`, `status`, `ran_at` to reconstruct delivery context for the receiver.
- **Audit-logging adapters** that need `trace_id`, `user_id`, `severity` for structured logging requirements.
- **Multi-tenant adapters** (CRM bridges, issue trackers, helpdesk integrations) that need `tenant_id`, `account_id`, `project_id`, `lead_id` for routing.
- **Encrypted-channel adapters** that need encryption context, key IDs, signing tokens, idempotency keys.
- **Retry-aware adapters** that need attempt count, dead-letter queue markers, retry-after deadlines.

In-tree adapters don't need this today (so this PR is strictly additive with zero behavior change), but several future features would become one-method overrides on the adapter rather than scheduler-touching PRs:

- Telegram cron-into-topic-threads via `message_thread_id`
- Discord cron-into-forum-channels via `applied_tags`; or cron-into-thread via `thread_id`
- Slack cron-into-thread via `thread_ts`; @-mention support via `user_id`
- Matrix E2EE flags; `m.in_reply_to` for reply chaining
- Email `In-Reply-To` / `References` headers for threading; MIME priority
- WhatsApp template-message metadata for compliance-gated channels
- Home Assistant action-button payloads; voice-assistant routing
- SMS delivery-receipt requests; sender-ID overrides

None of those are in scope here; listed as evidence the missing extension point is broadly applicable.

## Scope clarification

The hook fires only on the **in-gateway live-runtime-adapter** delivery path — when `cron.scheduler._deliver_result` resolves a `runtime_adapter` from the `adapters` dict and the gateway's event loop is running. The out-of-process `standalone_sender_fn` path (used when `hermes cron run` is invoked outside the gateway process) continues to use the existing keyword-argument shape and bypasses the hook. This is documented in both updated guides.

If an adapter needs metadata enrichment in both paths, the override logic should be mirrored inside its `standalone_sender_fn`.

## How to Test

```bash
bash scripts/run_tests.sh tests/gateway/test_build_delivery_metadata.py tests/cron/test_scheduler.py
```

Expected: 135 tests pass.

Manual verification on shipped adapters: cron deliveries continue to produce the same `metadata` payload as before this PR. No behavior change for Telegram, Discord, Slack, WhatsApp, Signal, Matrix, Mattermost, Email, SMS, Home Assistant, DingTalk, Feishu, WeCom, Weixin, BlueBubbles, or QQ — they all inherit the no-op default and produce a byte-identical `send_metadata` value (`None` when no thread is configured, `{"thread_id": X}` when one is). Only adapters that explicitly override `build_delivery_metadata` see different behavior.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(adapter): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run `bash scripts/run_tests.sh` (focused suite — `tests/gateway/test_build_delivery_metadata.py` + `tests/cron/test_scheduler.py`) and all 135 tests pass
- [x] I've added tests for my changes (5 unit + 3 integration)
- [x] I've tested on my platform: macOS 15 (darwin/arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — `adding-platform-adapters.md` and `cron-internals.md`
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — **N/A** (no config keys added)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — **N/A**
- [x] I've considered cross-platform impact (Windows, macOS) — pure-Python server-side, no OS-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — **N/A** (no tool behavior changed)

## Design questions for maintainers

I'd appreciate feedback on a few open shape questions before assuming this is final:

1. **Method name** — `build_delivery_metadata` vs `enrich_delivery_metadata` vs `metadata_for_delivery`? Slight preference for `build_` since the default constructs (a copy of) the dict from `base_metadata`, but happy to rename.

2. **Sync vs async** — neighboring `on_processing_start` / `on_processing_complete` are `async`. This hook is sync because the cron scheduler dispatch path calling it (`_deliver_result`) is synchronous. Happy to make it `async def` for consistency if you prefer — the call site would need a small bridge to `asyncio.run_coroutine_threadsafe` similar to `safe_schedule_threadsafe` usage elsewhere in the file.

3. **`status_hint` parameter** — currently `(self, job, status_hint='ok', base_metadata=None)`. Open to dropping it if you'd rather adapters derive status from the job dict, or to making it a richer enum.

4. **Adapter method vs generic plugin hook** — could alternatively be a `register_hook("cron_build_delivery_metadata", ...)`-style observer. Adapter method seems right for *per-platform* customization (the adapter owns its delivery shape); a generic hook seems right for *cross-cutting observers*. Open to the alternative if you prefer.

## Screenshots / Logs

`scripts/run_tests.sh tests/gateway/test_build_delivery_metadata.py tests/cron/test_scheduler.py` final summary:

```
========================= 135 passed in 3.31s =========================
```