### PR TITLE
fix(feishu): transcribe native voice notes

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -3533,7 +3533,12 @@ class FeishuAdapter(BasePlatformAdapter):
         if preferred == "photo":
             return self._resolve_media_message_type(media_types[0] if media_types else "", default=MessageType.PHOTO)
         if preferred == "audio":
-            return self._resolve_media_message_type(media_types[0] if media_types else "", default=MessageType.AUDIO)
+            # Feishu's "audio" message type is exclusively for native voice
+            # recordings (captured in-app).  Generic audio file uploads are
+            # classified as "file" → "document", never "audio".  Route all
+            # "audio" messages through STT by returning VOICE; AUDIO is skipped
+            # by gateway/run.py.
+            return MessageType.VOICE
         if preferred == "document":
             return self._resolve_media_message_type(media_types[0] if media_types else "", default=MessageType.DOCUMENT)
         return MessageType.TEXT

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1344,6 +1344,51 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(media_types, ["audio/ogg"])
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_extract_audio_type_voice_invariant_regardless_of_mime(self):
+        """MessageType.VOICE must be returned for message_type='audio' regardless
+        of the downloaded MIME type (AMR, OGG, OPUS, etc.) — the Feishu API-level
+        message type, not the container format, determines whether STT runs."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+        from gateway.platforms.base import MessageType
+
+        adapter = FeishuAdapter(PlatformConfig())
+        for mime in ("audio/amr", "audio/opus", "audio/mp4", "audio/ogg"):
+            adapter._download_feishu_message_resource = AsyncMock(
+                return_value=("/tmp/feishu-voice.amr", mime)
+            )
+            message = SimpleNamespace(
+                message_type="audio",
+                content='{"file_key":"file_voice","file_name":"voice.amr"}',
+                message_id="om_voice_amr",
+            )
+            _, msg_type, _, _, _ = asyncio.run(adapter._extract_message_content(message))
+            self.assertEqual(msg_type, MessageType.VOICE, f"Expected VOICE for mime={mime}")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_extract_file_message_audio_mime_stays_audio_not_voice(self):
+        """Generic audio file uploads (message_type='file') must NOT be routed
+        through STT — they become MessageType.AUDIO (skipped by gateway/run.py),
+        not MessageType.VOICE.  Only message_type='audio' (native recordings)
+        should become VOICE."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+        from gateway.platforms.base import MessageType
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._download_feishu_message_resource = AsyncMock(
+            return_value=("/tmp/feishu-upload.mp3", "audio/mpeg")
+        )
+        message = SimpleNamespace(
+            message_type="file",
+            content='{"file_key":"file_mp3","file_name":"music.mp3"}',
+            message_id="om_file_mp3",
+        )
+        _, msg_type, _, _, _ = asyncio.run(adapter._extract_message_content(message))
+        self.assertNotEqual(msg_type, MessageType.VOICE)
+        self.assertEqual(msg_type, MessageType.AUDIO)
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_extract_file_message_downloads_and_caches(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1317,9 +1317,14 @@ class TestAdapterBehavior(unittest.TestCase):
         )
 
     @patch.dict(os.environ, {}, clear=True)
-    def test_extract_audio_message_downloads_and_caches(self):
+    def test_extract_audio_message_classified_as_voice(self):
+        """Feishu native voice recordings (message_type='audio') must enter
+        the auto-STT path via MessageType.VOICE.  gateway/run.py skips STT
+        for MessageType.AUDIO, so returning AUDIO here would silently drop
+        all voice messages — same bug fixed for DingTalk in PR #28922."""
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter
+        from gateway.platforms.base import MessageType
 
         adapter = FeishuAdapter(PlatformConfig())
         adapter._download_feishu_message_resource = AsyncMock(
@@ -1334,7 +1339,7 @@ class TestAdapterBehavior(unittest.TestCase):
         text, msg_type, media_urls, media_types, _mentions = asyncio.run(adapter._extract_message_content(message))
 
         self.assertEqual(text, "")
-        self.assertEqual(msg_type.value, "audio")
+        self.assertEqual(msg_type, MessageType.VOICE)
         self.assertEqual(media_urls, ["/tmp/feishu-audio.ogg"])
         self.assertEqual(media_types, ["audio/ogg"])
 


### PR DESCRIPTION
## Problem

Feishu's `audio` message type is exclusively for voice notes recorded in
the Lark app — it is never used for generic audio file uploads (those
arrive as `file` or `media` message types instead).

`_resolve_normalized_message_type` routed `preferred == "audio"` through
`_resolve_media_message_type`, which returns `MessageType.AUDIO` for any
`audio/*` MIME type. `gateway/run.py:7605` explicitly skips STT for
`MessageType.AUDIO`:

```python
# MessageType.AUDIO = audio file attachment (e.g. .mp3, .m4a) — never STT
# MessageType.VOICE = voice message (Opus/OGG) — always STT
if event.message_type == MessageType.AUDIO:
    audio_file_paths.append(path)
elif event.message_type == MessageType.VOICE or ...:
    audio_paths.append(path)  # → STT
```

Result: every Feishu voice note was silently dropped from the
auto-transcription pipeline.

## Fix

Return `MessageType.VOICE` directly in the `preferred == "audio"` branch
of `_resolve_normalized_message_type`. No other branch is affected:
`file` and `media` message types map to `preferred == "document"` and
continue to resolve via MIME type as before.

## Sibling fixes

This is the same AUDIO-vs-VOICE misclassification that was fixed for:
- Discord in PR #28918 (`_is_discord_voice_message_attachment`)
- DingTalk in commit 93734c26e (`item_type == "voice"` check)

Feishu's case is simpler: the `audio` message type at the API level is
already unambiguous — no secondary marker is needed.

## Tests

- `test_extract_audio_message_classified_as_voice` — renames the
  existing test and corrects its assertion from `"audio"` to `"voice"`
  (it was asserting the bug).
- `test_extract_audio_type_voice_invariant_regardless_of_mime` — pins
  that the message-level type, not the downloaded MIME type, is
  authoritative (AMR, OGG, etc. all produce `MessageType.VOICE`).
- `test_extract_file_message_stays_document_not_voice` — regression
  guard ensuring `file` type messages are unaffected.

All 156 `tests/gateway/test_feishu.py` tests pass (43 skipped — lark_oapi not installed). Ruff clean.

## Checklist

- [x] Root cause identified and explained
- [x] Fix is minimal and scoped to the affected branch only
- [x] Existing test corrected (was asserting the bug)
- [x] Two new regression tests added
- [x] Full Feishu test suite: 156 passed, 0 failed
- [x] Ruff: no issues