### PR TITLE
UX feat(kanban): WorkerLogSection auto-scroll to bottom on data load

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -3175,6 +3175,7 @@
   // Worker log: loads lazily (one GET on mount), refresh button, tail cap.
   function WorkerLogSection(props) {
     const { t } = useI18n();
+    const logRef = useRef(null);
     const [state, setState] = useState({ loading: false, data: null, err: null });
     const load = useCallback(function () {
       setState({ loading: true, data: null, err: null });
@@ -3186,6 +3187,14 @@
     // Auto-load when the section mounts; the user opened the drawer so the
     // cost is one small HTTP round-trip.
     useEffect(function () { load(); }, [load]);
+
+    // Auto-scroll the log container to the bottom whenever data finishes loading.
+    const scrollToBottom = function () {
+      if (!state.loading && state.data && state.data.exists && logRef.current) {
+        logRef.current.scrollTop = logRef.current.scrollHeight;
+      }
+    };
+    useEffect(scrollToBottom, [state.loading, state.data]);
 
     const data = state.data;
     let body;
@@ -3199,7 +3208,7 @@
         tx(t, "noWorkerLog",
           "— no worker log yet (task hasn't spawned or log was rotated away) —"));
     } else {
-      body = h("pre", { className: "hermes-kanban-pre hermes-kanban-log" },
+      body = h("pre", { ref: logRef, className: "hermes-kanban-pre hermes-kanban-log" },
         data.content || "(empty)");
     }
 


### PR DESCRIPTION
# feat(kanban): WorkerLogSection auto-scroll to bottom on data load

## What

WorkerLogSection in the Kanban worker drawer now auto-scrolls the
`<pre class="hermes-kanban-pre hermes-kanban-log">` element to the bottom
every time the log data finishes loading — covers both **initial mount**
and **refresh button clicks**.

## Changes

### `plugins/kanban/dashboard/dist/index.js`

Three small additions inside `WorkerLogSection`:

```javascript
// 1. Ref binding on the container element
const logRef = useRef(null);

// 2. Scroll effect — fires when data finishes loading
const scrollToBottom = function () {
  if (!state.loading && state.data && state.data.exists && logRef.current) {
    logRef.current.scrollTop = logRef.current.scrollHeight;
  }
};
useEffect(scrollToBottom, [state.loading, state.data]);

// 3. Attach ref to the <pre> render
body = h("pre", { ref: logRef, className: "hermes-kanban-pre hermes-kanban-log" },
          data.content || "(empty)");
```

No new imports needed — `useRef`, `useEffect` and `useState` are already in
scope at the bundle level of this component.

## Verification

- Built bundle patched in `dist/index.js` (source files do not exist in the
  dist-only release path; the bundle is the correct target for releases).
- Live-tested on gateway (systemd user service) — refresh button scrolls to
  bottom; initial drawer open scrolls to bottom.
- Dashboard process restarted to serve updated bundle.

## Notes / Follow-ups

- Only auto-scrolls **when data is loaded** (`!state.loading`) and exists,
  so the "no worker log" / error states are never interrupted.
- Optional polish: add a near-bottom guard (`scrollHeight - scrollTop -
  clientHeight < 50px`) so users who are scrolling up to read older lines
  aren't yanked to EOF on every refresh. Filed separately; out of scope for
  this PR to keep diff minimal.
- Source-side PR (Svelte / prebuild step) should be filed against the build
  pipeline — for dist-releases this is the correct file to patch.
