### PR TITLE
fix: guard float() env var casts, operator precedence, atomic writes, yaml fallback

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -64,6 +64,18 @@ from utils import base_url_host_matches, base_url_hostname
 logger = logging.getLogger(__name__)
 
 
+def _safe_float_env(var_name: str, default: float) -> float:
+    """Read env var as float, returning *default* if missing or non-numeric."""
+    raw = os.getenv(var_name)
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except (ValueError, TypeError):
+        logger.warning("Invalid %s=%r, using default %s", var_name, raw, default)
+        return default
+
+
 def _ra():
     """Lazy ``run_agent`` reference.
 
@@ -1281,14 +1293,14 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         _base_timeout = (
             _provider_timeout_cfg
             if _provider_timeout_cfg is not None
-            else float(os.getenv("HERMES_API_TIMEOUT", 1800.0))
+            else _safe_float_env("HERMES_API_TIMEOUT", 1800.0)
         )
         # Read timeout: config wins here too.  Otherwise use
         # HERMES_STREAM_READ_TIMEOUT (default 120s) for cloud providers.
         if _provider_timeout_cfg is not None:
             _stream_read_timeout = _provider_timeout_cfg
         else:
-            _stream_read_timeout = float(os.getenv("HERMES_STREAM_READ_TIMEOUT", 120.0))
+            _stream_read_timeout = _safe_float_env("HERMES_STREAM_READ_TIMEOUT", 120.0)
             # Local providers (Ollama, llama.cpp, vLLM) can take minutes for
             # prefill on large contexts before producing the first token.
             # Auto-increase the httpx read timeout unless the user explicitly
@@ -1903,7 +1915,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     if _cfg_stale is not None:
         _stream_stale_timeout_base = _cfg_stale
     else:
-        _stream_stale_timeout_base = float(os.getenv("HERMES_STREAM_STALE_TIMEOUT", 180.0))
+        _stream_stale_timeout_base = _safe_float_env("HERMES_STREAM_STALE_TIMEOUT", 180.0)
     # Local providers (Ollama, oMLX, llama-cpp) can take 300+ seconds
     # for prefill on large contexts.  Disable the stale detector unless
     # the user explicitly set HERMES_STREAM_STALE_TIMEOUT.

--- a/cli.py
+++ b/cli.py
@@ -7451,7 +7451,7 @@ class HermesCLI:
             print(f"  {'none':<12} - (no personality overlay)")
             for name, prompt in self.personalities.items():
                 if isinstance(prompt, dict):
-                    preview = prompt.get("description") or prompt.get("system_prompt", "")[:50]
+                    preview = (prompt.get("description") or prompt.get("system_prompt", ""))[:50]
                 else:
                     preview = str(prompt)[:50]
                 print(f"  {name:<12} - {preview}")

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3298,7 +3298,10 @@ def resolve_codex_runtime_credentials(
     data = _read_codex_tokens()
     tokens = dict(data["tokens"])
     access_token = str(tokens.get("access_token", "") or "").strip()
-    refresh_timeout_seconds = float(os.getenv("HERMES_CODEX_REFRESH_TIMEOUT_SECONDS", "20"))
+    try:
+        refresh_timeout_seconds = float(os.getenv("HERMES_CODEX_REFRESH_TIMEOUT_SECONDS", "20"))
+    except (ValueError, TypeError):
+        refresh_timeout_seconds = 20.0
 
     should_refresh = bool(force_refresh)
     if (not should_refresh) and refresh_if_expiring:
@@ -3708,7 +3711,10 @@ def resolve_xai_oauth_runtime_credentials(
     data = _read_xai_oauth_tokens()
     tokens = dict(data["tokens"])
     access_token = str(tokens.get("access_token", "") or "").strip()
-    refresh_timeout_seconds = float(os.getenv("HERMES_XAI_REFRESH_TIMEOUT_SECONDS", "20"))
+    try:
+        refresh_timeout_seconds = float(os.getenv("HERMES_XAI_REFRESH_TIMEOUT_SECONDS", "20"))
+    except (ValueError, TypeError):
+        refresh_timeout_seconds = 20.0
     discovery = dict(data.get("discovery") or {})
     token_endpoint = str(discovery.get("token_endpoint", "") or "").strip()
     redirect_uri = str(data.get("redirect_uri", "") or "").strip()

--- a/hermes_cli/profile_distribution.py
+++ b/hermes_cli/profile_distribution.py
@@ -245,7 +245,7 @@ def _load_yaml(text: str) -> Any:
         import yaml
     except ImportError as exc:  # pragma: no cover — pyyaml is a hard dep
         raise DistributionError("PyYAML is required for distribution manifests") from exc
-    return yaml.safe_load(text)
+    return yaml.safe_load(text) or {}
 
 
 def _dump_yaml(data: Any) -> str:

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -9,6 +9,19 @@ from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
 
+
+def _safe_float_env(var_name: str, default: float) -> float:
+    """Read env var as float, returning *default* if missing or non-numeric."""
+    raw = os.getenv(var_name)
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except (ValueError, TypeError):
+        logger.warning("Invalid %s=%r, using default %s", var_name, raw, default)
+        return default
+
+
 from hermes_cli import auth as auth_mod
 from agent.credential_pool import CredentialPool, PooledCredential, get_custom_provider_pool_key, load_pool
 from hermes_cli.auth import (
@@ -1008,7 +1021,7 @@ def _resolve_explicit_runtime(
         if not api_key:
             creds = resolve_nous_runtime_credentials(
                 min_key_ttl_seconds=max(60, int(os.getenv("HERMES_NOUS_MIN_KEY_TTL_SECONDS", "1800"))),
-                timeout_seconds=float(os.getenv("HERMES_NOUS_TIMEOUT_SECONDS", "15")),
+                timeout_seconds=_safe_float_env("HERMES_NOUS_TIMEOUT_SECONDS", 15.0),
             )
             api_key = creds.get("api_key", "")
             expires_at = creds.get("expires_at")

--- a/run_agent.py
+++ b/run_agent.py
@@ -897,7 +897,10 @@ class AIAgent:
 
         env_timeout = os.getenv("HERMES_API_CALL_STALE_TIMEOUT")
         if env_timeout is not None:
-            return float(env_timeout), False
+            try:
+                return float(env_timeout), False
+            except (ValueError, TypeError):
+                logger.warning("Invalid HERMES_API_CALL_STALE_TIMEOUT=%r, using default", env_timeout)
 
         return 300.0, True
 

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -58,6 +58,7 @@ import subprocess
 import time
 from pathlib import Path
 from hermes_constants import get_hermes_home
+from utils import atomic_json_write
 from typing import Dict, List, Optional, Set, Tuple
 
 logger = logging.getLogger(__name__)
@@ -466,7 +467,7 @@ def _register_project(store: Path, working_dir: str) -> None:
             pass
     try:
         meta_path.parent.mkdir(parents=True, exist_ok=True)
-        meta_path.write_text(json.dumps(meta), encoding="utf-8")
+        atomic_json_write(meta_path, meta)
     except OSError as exc:
         logger.debug("Could not write project metadata %s: %s", meta_path, exc)
 

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -22,6 +22,7 @@ from typing import IO, Callable, Protocol
 
 from hermes_constants import get_hermes_home
 from tools.interrupt import is_interrupted
+from utils import atomic_json_write
 
 logger = logging.getLogger(__name__)
 
@@ -166,8 +167,7 @@ def _load_json_store(path: Path) -> dict:
 
 def _save_json_store(path: Path, data: dict) -> None:
     """Write *data* as pretty-printed JSON to *path*."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    atomic_json_write(path, data)
 
 
 def _file_mtime_key(host_path: str) -> tuple[float, int] | None:


### PR DESCRIPTION
## Summary

Fixes 4 classes of bugs found via static analysis:

### 1. float() on env vars without try/except (6 locations)
A typo in env vars like HERMES_API_TIMEOUT, HERMES_NOUS_TIMEOUT_SECONDS previously crashed the entire agent with ValueError.

**Fix:** Add try/except guards with fallback to defaults. Added _safe_float_env() helper.

**Files:** run_agent.py, hermes_cli/auth.py, hermes_cli/runtime_provider.py, agent/chat_completion_helpers.py

### 2. Operator precedence bug (cli.py:7453)
`preview = prompt.get("description") or prompt.get("system_prompt", "")[:50]` - slice binds tighter than or, only fallback was truncated.

**Fix:** Parenthesize: `(description or system_prompt)[:50]`

### 3. Non-atomic write_text() (2 locations)
Replaced with atomic_json_write() from utils.py.

**Files:** tools/checkpoint_manager.py, tools/environments/base.py

### 4. yaml.safe_load() without fallback
Empty manifest files return None. Added `or {}`.

## Test Plan
- [x] All 8 modified files pass py_compile
- [ ] CI tests pass