### PR TITLE
feat: add Obsidian vector MCP server

### DIFF
--- a/scripts/obsidian_vector_mcp.py
+++ b/scripts/obsidian_vector_mcp.py
@@ -1,0 +1,411 @@
+#!/usr/bin/env python3
+"""
+Obsidian / LLM Wiki vector search — stdio MCP server.
+
+Exposes one tool: search_obsidian, which searches a pre-built SQLite vector
+index using cosine similarity on embeddings from the local backend script.
+
+Usage:
+    python scripts/obsidian_vector_mcp.py            # run as stdio MCP server
+    python scripts/obsidian_vector_mcp.py --help     # show help
+    python scripts/obsidian_vector_mcp.py --smoke-test  # self-test (hash mode, no Ollama)
+
+MCP client config (e.g., claude_desktop_config.json or ~/.hermes/mcp_config.json):
+    {
+        "mcpServers": {
+            "obsidian-vector": {
+                "command": "python",
+                "args": ["/path/to/hermes-agent/scripts/obsidian_vector_mcp.py"]
+            }
+        }
+    }
+
+Environment variables:
+    OBSIDIAN_VECTOR_BACKEND      Path to llm_wiki_vector_search.py
+                                 Default: ~/.hermes/scripts/llm_wiki_vector_search.py
+    LLM_WIKI_VECTOR_INDEX        SQLite index path
+                                 Default: ~/.hermes/indexes/llm-wiki-vector.sqlite
+    LLM_WIKI_EMBEDDING_BASE_URL  Embedding endpoint base URL
+                                 Default: http://127.0.0.1:11434/v1
+    LLM_WIKI_EMBEDDING_MODEL     Embedding model name
+                                 Default: mxbai-embed-large
+    LLM_WIKI_EMBEDDING_MODE      "ollama" or "hash" (hash = deterministic offline mode)
+                                 Default: ollama
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import re
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Optional
+
+# ---------------------------------------------------------------------------
+# Lazy MCP SDK import — matches the pattern in mcp_serve.py
+# ---------------------------------------------------------------------------
+
+_MCP_AVAILABLE = False
+try:
+    from mcp.server.fastmcp import FastMCP
+
+    _MCP_AVAILABLE = True
+except ImportError:
+    FastMCP = None  # type: ignore[assignment,misc]
+
+# ---------------------------------------------------------------------------
+# Path helpers
+# ---------------------------------------------------------------------------
+
+
+def _hermes_home() -> Path:
+    try:
+        from hermes_constants import get_hermes_home
+
+        return get_hermes_home()
+    except ImportError:
+        return Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes")))
+
+
+def _default_backend_path() -> Path:
+    return Path(
+        os.environ.get(
+            "OBSIDIAN_VECTOR_BACKEND",
+            str(_hermes_home() / "scripts" / "llm_wiki_vector_search.py"),
+        )
+    )
+
+
+def _default_index_path() -> Path:
+    return Path(
+        os.environ.get(
+            "LLM_WIKI_VECTOR_INDEX",
+            str(_hermes_home() / "indexes" / "llm-wiki-vector.sqlite"),
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Backend loader — loads the external script by file path, cached per path
+# ---------------------------------------------------------------------------
+
+_backend_cache: dict[str, object] = {}
+
+
+def _load_backend(path: Path):
+    key = str(path)
+    if key in _backend_cache:
+        return _backend_cache[key]
+    if not path.exists():
+        raise FileNotFoundError(f"backend script not found: {path}")
+    spec = importlib.util.spec_from_file_location("_llm_wiki_vector_search", path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load backend from {path}")
+    mod = importlib.util.module_from_spec(spec)
+    # Some backend modules use decorators (for example dataclasses) that look
+    # themselves up in sys.modules while executing. importlib does not insert
+    # modules created from file locations automatically, so do it explicitly.
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    _backend_cache[key] = mod
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+_SNIPPET_CHARS = 420
+
+
+def _title_from(heading: str, path: str) -> str:
+    return heading.strip() if heading.strip() else Path(path).stem
+
+
+def _snippet(text: str, max_chars: int = _SNIPPET_CHARS) -> str:
+    s = re.sub(r"\s+", " ", text).strip()
+    if len(s) <= max_chars:
+        return s
+    return s[:max_chars] + "…"  # …
+
+
+# ---------------------------------------------------------------------------
+# Core search — used by both the MCP tool and the CLI smoke test
+# ---------------------------------------------------------------------------
+
+
+def _run_search(
+    query: str,
+    limit: int,
+    source: Optional[str],
+    include_content: bool,
+    backend_path: Path,
+    index_path: Path,
+) -> str:
+    query = query.strip()
+    if not query:
+        return json.dumps({"error": "query must not be empty"})
+
+    # load backend
+    try:
+        bk = _load_backend(backend_path)
+    except FileNotFoundError as e:
+        return json.dumps(
+            {
+                "error": str(e),
+                "hint": (
+                    "set OBSIDIAN_VECTOR_BACKEND or ensure "
+                    "~/.hermes/scripts/llm_wiki_vector_search.py exists"
+                ),
+            }
+        )
+    except Exception as e:
+        return json.dumps({"error": f"failed to load backend: {e}"})
+
+    # validate index
+    index_p = Path(index_path).expanduser()
+    if not index_p.exists():
+        return json.dumps(
+            {
+                "error": f"index not found: {index_p}",
+                "hint": (
+                    "run: python ~/.hermes/scripts/llm_wiki_vector_search.py "
+                    "index --wiki ~/llm-wiki"
+                ),
+            }
+        )
+
+    try:
+        db = bk.connect(index_p)
+        row = db.execute("select count(*) from chunks").fetchone()
+        if not row or row[0] == 0:
+            return json.dumps(
+                {
+                    "error": f"index is empty: {index_p}",
+                    "hint": (
+                        "run: python ~/.hermes/scripts/llm_wiki_vector_search.py "
+                        "index --wiki ~/llm-wiki"
+                    ),
+                }
+            )
+    except sqlite3.Error as e:
+        return json.dumps({"error": f"cannot open index: {e}"})
+
+    embed_base = os.environ.get("LLM_WIKI_EMBEDDING_BASE_URL", "http://127.0.0.1:11434/v1")
+    model = os.environ.get("LLM_WIKI_EMBEDDING_MODEL", "mxbai-embed-large")
+
+    # embed query
+    try:
+        qvec = bk.embed_texts([query], embed_base, model)[0]
+    except Exception as e:
+        return json.dumps(
+            {
+                "error": f"embedding failed: {e}",
+                "hint": (
+                    "ensure Ollama is running, or set "
+                    "LLM_WIKI_EMBEDDING_MODE=hash for offline/test mode"
+                ),
+            }
+        )
+
+    # fetch and score all chunks for this model
+    try:
+        rows = db.execute(
+            "select path, heading, chunk_index, text, embedding_json "
+            "from chunks where model=?",
+            (model,),
+        ).fetchall()
+    except sqlite3.Error as e:
+        return json.dumps({"error": f"search query failed: {e}"})
+
+    scored: list[tuple[float, str, str, int, str]] = []
+    for path, heading, chunk_index, text, emb_json in rows:
+        try:
+            score = bk.cosine(qvec, json.loads(emb_json))
+        except Exception:
+            continue
+        scored.append((score, path, heading, chunk_index, text))
+
+    scored.sort(reverse=True)
+    top = scored[: max(1, int(limit))]
+
+    src_label = source or "llm-wiki"
+    results = []
+    for score, path, heading, chunk_index, text in top:
+        item: dict = {
+            "title": _title_from(heading, path),
+            "path": path,
+            "heading": heading,
+            "chunk_index": chunk_index,
+            "snippet": _snippet(text),
+            "score": round(float(score), 6),
+            "source": src_label,
+            "metadata": {"model": model, "index": str(index_p)},
+        }
+        if include_content:
+            item["content"] = text
+        results.append(item)
+
+    return json.dumps(
+        {"query": query, "count": len(results), "results": results},
+        ensure_ascii=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# MCP server
+# ---------------------------------------------------------------------------
+
+
+def _build_mcp() -> "FastMCP":  # type: ignore[return]
+    if not _MCP_AVAILABLE:
+        raise RuntimeError(
+            "mcp package not installed — run: pip install 'hermes-agent[mcp]'"
+        )
+
+    mcp = FastMCP("obsidian-vector")
+    _backend = _default_backend_path()
+    _index = _default_index_path()
+
+    @mcp.tool()
+    def search_obsidian(
+        query: str,
+        limit: int = 8,
+        source: Optional[str] = None,
+        include_content: bool = False,
+    ) -> str:
+        """Search the Obsidian/LLM Wiki by semantic similarity.
+
+        Returns a JSON string with query, count, and a results list sorted by
+        relevance score. Each result has title, path, heading, chunk_index,
+        snippet, score, source, metadata, and optionally content.
+
+        Args:
+            query: Natural-language search query.
+            limit: Maximum number of results (default 8).
+            source: Label for the result source (default "llm-wiki").
+            include_content: Include full chunk text in results (default false).
+        """
+        return _run_search(query, limit, source, include_content, _backend, _index)
+
+    return mcp
+
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint
+# ---------------------------------------------------------------------------
+
+
+def _smoke_test() -> int:
+    """Quick self-test using hash embeddings — no Ollama needed."""
+    import tempfile
+    import time
+
+    os.environ["LLM_WIKI_EMBEDDING_MODE"] = "hash"
+    backend_path = _default_backend_path()
+
+    if not backend_path.exists():
+        print(
+            f"smoke-test SKIP: backend not found at {backend_path}\n"
+            "set OBSIDIAN_VECTOR_BACKEND to point at llm_wiki_vector_search.py",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        bk = _load_backend(backend_path)
+    except Exception as e:
+        print(f"smoke-test FAIL: cannot load backend: {e}", file=sys.stderr)
+        return 1
+
+    with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
+        tmp_idx = Path(f.name)
+
+    try:
+        db = bk.connect(tmp_idx)
+        model = "mxbai-embed-large"
+        now = time.time()
+        for i, text in enumerate(
+            [
+                "Transformers use self-attention to relate tokens in context.",
+                "Multi-head attention applies the mechanism across subspaces.",
+                "Convolutional networks use spatial filters to detect patterns.",
+            ]
+        ):
+            vec = bk.embed_texts([text], "", model)[0]
+            db.execute(
+                "insert into chunks(path,heading,chunk_index,text,embedding_json,"
+                "file_mtime,file_hash,model,updated_at) values(?,?,?,?,?,?,?,?,?)",
+                (
+                    f"note{i}.md",
+                    f"Section {i}",
+                    i,
+                    text,
+                    json.dumps(vec),
+                    now,
+                    f"h{i}",
+                    model,
+                    now,
+                ),
+            )
+        db.commit()
+
+        result_json = _run_search(
+            "attention mechanism", 2, None, True, backend_path, tmp_idx
+        )
+        data = json.loads(result_json)
+
+        assert "results" in data, f"missing results key: {data}"
+        assert data["count"] > 0, "no results returned"
+        assert "content" in data["results"][0], "include_content=True missing content field"
+        print(
+            f"smoke-test PASS — {data['count']} results for 'attention mechanism', "
+            f"top score {data['results'][0]['score']:.4f}"
+        )
+        return 0
+    except AssertionError as e:
+        print(f"smoke-test FAIL: {e}", file=sys.stderr)
+        return 1
+    except Exception as e:
+        print(f"smoke-test FAIL: unexpected error: {e}", file=sys.stderr)
+        return 1
+    finally:
+        tmp_idx.unlink(missing_ok=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        description="Obsidian/LLM Wiki vector search — stdio MCP server",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "--smoke-test",
+        action="store_true",
+        help="Run a self-test using hash embeddings (no Ollama) then exit",
+    )
+    args = p.parse_args(argv)
+
+    if args.smoke_test:
+        return _smoke_test()
+
+    if not _MCP_AVAILABLE:
+        print(
+            json.dumps(
+                {
+                    "error": "mcp package not installed",
+                    "hint": "pip install 'hermes-agent[mcp]' or pip install mcp",
+                }
+            ),
+            file=sys.stderr,
+        )
+        return 1
+
+    _build_mcp().run()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_obsidian_vector_mcp.py
+++ b/tests/scripts/test_obsidian_vector_mcp.py
@@ -1,0 +1,369 @@
+"""Tests for scripts/obsidian_vector_mcp.py — focused, no Ollama/network required.
+
+All tests use an in-process fake backend (hash embeddings) and a temporary
+SQLite index so they run offline and deterministically.
+"""
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import math
+import re
+import sqlite3
+import time
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Load module under test
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _REPO_ROOT / "scripts" / "obsidian_vector_mcp.py"
+_DUMMY_BACKEND = Path("/dummy/backend.py")
+_TEST_MODEL = "mxbai-embed-large"  # must match the default in _run_search
+
+
+def _load_mcp_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("obsidian_vector_mcp", _SCRIPT)
+    assert spec and spec.loader, f"cannot load {_SCRIPT}"
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Minimal fake backend — no dependency on external backend file or Ollama
+# ---------------------------------------------------------------------------
+
+
+def _norm(vec: list[float]) -> list[float]:
+    n = math.sqrt(sum(x * x for x in vec))
+    return [x / n for x in vec] if n else vec
+
+
+def _hash_embed(text: str, dims: int = 384) -> list[float]:
+    vec = [0.0] * dims
+    for token in re.findall(r"[\w\-]+", text.lower()):
+        h = hashlib.blake2b(token.encode(), digest_size=8).digest()
+        n = int.from_bytes(h, "little")
+        vec[n % dims] += 1.0 if ((n >> 9) & 1) else -1.0
+    return _norm(vec)
+
+
+def _make_fake_backend() -> ModuleType:
+    """Return a module-like object implementing the backend surface used by _run_search."""
+    mod = ModuleType("_fake_backend")
+    mod.__file__ = __file__
+
+    def connect(index_path: Path | str) -> sqlite3.Connection:
+        p = Path(index_path).expanduser()
+        p.parent.mkdir(parents=True, exist_ok=True)
+        db = sqlite3.connect(p)
+        db.execute("pragma journal_mode=wal")
+        db.execute(
+            """
+            create table if not exists chunks (
+                id integer primary key,
+                path text not null,
+                heading text not null,
+                chunk_index integer not null,
+                text text not null,
+                embedding_json text not null,
+                file_mtime real not null,
+                file_hash text not null,
+                model text not null,
+                updated_at real not null,
+                unique(path, chunk_index, model)
+            )
+            """
+        )
+        return db
+
+    def embed_texts(texts, base_url, model):  # noqa: ARG001
+        return [_hash_embed(t) for t in texts]
+
+    def cosine(a, b):
+        return sum(x * y for x, y in zip(a, b))
+
+    mod.connect = connect
+    mod.embed_texts = embed_texts
+    mod.cosine = cosine
+    return mod
+
+
+def _populate_index(db_path: Path, bk: ModuleType, model: str = _TEST_MODEL) -> None:
+    db = bk.connect(db_path)
+    now = time.time()
+    entries = [
+        (
+            "transformers/attention.md",
+            "Attention Mechanism",
+            0,
+            "Transformers rely on self-attention to relate tokens across positions.",
+        ),
+        (
+            "transformers/attention.md",
+            "Attention Mechanism",
+            1,
+            "Multi-head attention applies the mechanism in parallel across subspaces.",
+        ),
+        (
+            "cnn/filters.md",
+            "Convolutional Filters",
+            0,
+            "CNNs use learned filters to detect local patterns in images.",
+        ),
+        (
+            "rl/policy.md",
+            "Policy Gradient",
+            0,
+            "Policy gradient methods optimize expected cumulative reward.",
+        ),
+    ]
+    for path, heading, cidx, text in entries:
+        vec = _hash_embed(text)
+        db.execute(
+            "insert into chunks(path,heading,chunk_index,text,embedding_json,"
+            "file_mtime,file_hash,model,updated_at) values(?,?,?,?,?,?,?,?,?)",
+            (path, heading, cidx, text, json.dumps(vec), now, f"h{cidx}", model, now),
+        )
+    db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _hash_mode(monkeypatch):
+    """Force hash embedding mode for every test in this module."""
+    monkeypatch.setenv("LLM_WIKI_EMBEDDING_MODE", "hash")
+
+
+@pytest.fixture()
+def fake_bk() -> ModuleType:
+    return _make_fake_backend()
+
+
+@pytest.fixture()
+def mcp_mod() -> ModuleType:
+    mod = _load_mcp_module()
+    mod._backend_cache.clear()
+    return mod
+
+
+@pytest.fixture()
+def temp_index(tmp_path: Path, fake_bk: ModuleType) -> Path:
+    idx = tmp_path / "test.sqlite"
+    _populate_index(idx, fake_bk)
+    return idx
+
+
+@pytest.fixture()
+def ctx(mcp_mod: ModuleType, fake_bk: ModuleType, temp_index: Path):
+    """Pre-wired trio: mcp_mod with fake backend cached, and a populated temp index."""
+    mcp_mod._backend_cache[str(_DUMMY_BACKEND)] = fake_bk
+    return mcp_mod, temp_index
+
+
+# ---------------------------------------------------------------------------
+# Tests: JSON shape
+# ---------------------------------------------------------------------------
+
+
+class TestJsonShape:
+    def test_top_level_keys(self, ctx):
+        mod, idx = ctx
+        data = json.loads(mod._run_search("attention", 3, None, False, _DUMMY_BACKEND, idx))
+        assert data["query"] == "attention"
+        assert isinstance(data["count"], int)
+        assert isinstance(data["results"], list)
+        assert data["count"] == len(data["results"])
+
+    def test_result_item_required_fields(self, ctx):
+        mod, idx = ctx
+        data = json.loads(mod._run_search("attention", 1, None, False, _DUMMY_BACKEND, idx))
+        assert data["results"], "expected at least one result"
+        r = data["results"][0]
+        for key in ("title", "path", "heading", "chunk_index", "snippet", "score", "source", "metadata"):
+            assert key in r, f"missing field: {key}"
+        assert "content" not in r  # include_content=False
+
+    def test_title_derives_from_heading(self, ctx):
+        mod, idx = ctx
+        data = json.loads(mod._run_search("attention mechanism", 1, None, False, _DUMMY_BACKEND, idx))
+        r = data["results"][0]
+        assert r["title"] != ""
+        assert r["title"] == r["heading"]
+
+    def test_title_falls_back_to_path_stem(self, mcp_mod, fake_bk, tmp_path):
+        """When heading is empty, title is the path stem."""
+        mcp_mod._backend_cache[str(_DUMMY_BACKEND)] = fake_bk
+        idx = tmp_path / "noheading.sqlite"
+        db = fake_bk.connect(idx)
+        now = time.time()
+        text = "some content without a heading"
+        db.execute(
+            "insert into chunks(path,heading,chunk_index,text,embedding_json,"
+            "file_mtime,file_hash,model,updated_at) values(?,?,?,?,?,?,?,?,?)",
+            ("my-note.md", "", 0, text, json.dumps(_hash_embed(text)), now, "h0", _TEST_MODEL, now),
+        )
+        db.commit()
+        data = json.loads(mcp_mod._run_search("content", 1, None, False, _DUMMY_BACKEND, idx))
+        assert data["results"][0]["title"] == "my-note"
+
+    def test_snippet_whitespace_normalised(self, mcp_mod, fake_bk, tmp_path):
+        mcp_mod._backend_cache[str(_DUMMY_BACKEND)] = fake_bk
+        messy = "line1\n\n\nline2\t\ttab\n   indent"
+        idx = tmp_path / "messy.sqlite"
+        db = fake_bk.connect(idx)
+        now = time.time()
+        db.execute(
+            "insert into chunks(path,heading,chunk_index,text,embedding_json,"
+            "file_mtime,file_hash,model,updated_at) values(?,?,?,?,?,?,?,?,?)",
+            ("messy.md", "Messy", 0, messy, json.dumps(_hash_embed(messy)), now, "h0", _TEST_MODEL, now),
+        )
+        db.commit()
+        data = json.loads(mcp_mod._run_search("line", 1, None, False, _DUMMY_BACKEND, idx))
+        snippet = data["results"][0]["snippet"]
+        assert "\n" not in snippet
+        assert "\t" not in snippet
+        assert "  " not in snippet
+
+    def test_snippet_capped_at_limit(self, mcp_mod, fake_bk, tmp_path):
+        mcp_mod._backend_cache[str(_DUMMY_BACKEND)] = fake_bk
+        long_text = ("word " * 600).strip()
+        idx = tmp_path / "long.sqlite"
+        db = fake_bk.connect(idx)
+        now = time.time()
+        db.execute(
+            "insert into chunks(path,heading,chunk_index,text,embedding_json,"
+            "file_mtime,file_hash,model,updated_at) values(?,?,?,?,?,?,?,?,?)",
+            ("long.md", "Long", 0, long_text, json.dumps(_hash_embed(long_text)), now, "h0", _TEST_MODEL, now),
+        )
+        db.commit()
+        data = json.loads(mcp_mod._run_search("word", 1, None, False, _DUMMY_BACKEND, idx))
+        snippet = data["results"][0]["snippet"]
+        assert len(snippet) <= mcp_mod._SNIPPET_CHARS + 1  # +1 for the ellipsis char
+
+
+# ---------------------------------------------------------------------------
+# Tests: include_content
+# ---------------------------------------------------------------------------
+
+
+class TestIncludeContent:
+    def test_content_present_when_true(self, ctx):
+        mod, idx = ctx
+        data = json.loads(mod._run_search("attention", 2, None, True, _DUMMY_BACKEND, idx))
+        assert all("content" in r for r in data["results"])
+
+    def test_content_absent_when_false(self, ctx):
+        mod, idx = ctx
+        data = json.loads(mod._run_search("attention", 2, None, False, _DUMMY_BACKEND, idx))
+        assert all("content" not in r for r in data["results"])
+
+    def test_content_matches_full_text(self, ctx):
+        mod, idx = ctx
+        data = json.loads(mod._run_search("attention mechanism", 1, None, True, _DUMMY_BACKEND, idx))
+        r = data["results"][0]
+        assert r["content"] != ""
+        # content should be the unshortenend original, longer than the snippet
+        assert len(r["content"]) >= len(r["snippet"].rstrip("…"))
+
+
+# ---------------------------------------------------------------------------
+# Tests: limit coercion
+# ---------------------------------------------------------------------------
+
+
+class TestLimitCoercion:
+    @pytest.mark.parametrize("limit", [1, 2, 3])
+    def test_limit_caps_results(self, ctx, limit):
+        mod, idx = ctx
+        data = json.loads(mod._run_search("attention", limit, None, False, _DUMMY_BACKEND, idx))
+        assert data["count"] <= limit
+
+    def test_limit_zero_returns_at_least_one(self, ctx):
+        """Limit <= 0 is coerced to 1 so search always returns something."""
+        mod, idx = ctx
+        data = json.loads(mod._run_search("attention", 0, None, False, _DUMMY_BACKEND, idx))
+        assert data["count"] >= 1
+
+    def test_large_limit_doesnt_exceed_corpus(self, ctx):
+        mod, idx = ctx
+        data = json.loads(mod._run_search("the", 999, None, False, _DUMMY_BACKEND, idx))
+        assert data["count"] <= 4  # only 4 chunks in fixture
+
+
+# ---------------------------------------------------------------------------
+# Tests: source label
+# ---------------------------------------------------------------------------
+
+
+class TestSourceLabel:
+    def test_custom_source_applied(self, ctx):
+        mod, idx = ctx
+        data = json.loads(mod._run_search("attention", 2, "my-vault", False, _DUMMY_BACKEND, idx))
+        assert all(r["source"] == "my-vault" for r in data["results"])
+
+    def test_default_source_is_llm_wiki(self, ctx):
+        mod, idx = ctx
+        data = json.loads(mod._run_search("attention", 2, None, False, _DUMMY_BACKEND, idx))
+        assert all(r["source"] == "llm-wiki" for r in data["results"])
+
+
+# ---------------------------------------------------------------------------
+# Tests: error handling
+# ---------------------------------------------------------------------------
+
+
+class TestErrorHandling:
+    def test_empty_query_error(self, mcp_mod, fake_bk, temp_index):
+        mcp_mod._backend_cache[str(_DUMMY_BACKEND)] = fake_bk
+        data = json.loads(mcp_mod._run_search("", 8, None, False, _DUMMY_BACKEND, temp_index))
+        assert "error" in data
+
+    def test_whitespace_only_query_error(self, mcp_mod, fake_bk, temp_index):
+        mcp_mod._backend_cache[str(_DUMMY_BACKEND)] = fake_bk
+        data = json.loads(mcp_mod._run_search("   ", 8, None, False, _DUMMY_BACKEND, temp_index))
+        assert "error" in data
+
+    def test_missing_backend_returns_json_error(self, mcp_mod, temp_index):
+        """Backend not in cache and path nonexistent → JSON error, not exception."""
+        bad = Path("/nonexistent/backend.py")
+        data = json.loads(mcp_mod._run_search("attention", 4, None, False, bad, temp_index))
+        assert "error" in data
+        assert "backend" in data["error"].lower() or "not found" in data["error"].lower()
+
+    def test_missing_index_returns_json_error(self, mcp_mod, fake_bk, tmp_path):
+        mcp_mod._backend_cache[str(_DUMMY_BACKEND)] = fake_bk
+        bad_idx = tmp_path / "nonexistent.sqlite"
+        data = json.loads(mcp_mod._run_search("attention", 4, None, False, _DUMMY_BACKEND, bad_idx))
+        assert "error" in data
+        assert "index" in data["error"].lower()
+
+    def test_empty_index_returns_json_error(self, mcp_mod, fake_bk, tmp_path):
+        """Index file exists with schema but zero rows → JSON error."""
+        mcp_mod._backend_cache[str(_DUMMY_BACKEND)] = fake_bk
+        empty_idx = tmp_path / "empty.sqlite"
+        fake_bk.connect(empty_idx)  # creates schema, no rows
+        data = json.loads(mcp_mod._run_search("attention", 4, None, False, _DUMMY_BACKEND, empty_idx))
+        assert "error" in data
+        assert "empty" in data["error"].lower() or "index" in data["error"].lower()
+
+    def test_error_response_is_valid_json(self, mcp_mod, tmp_path):
+        """All error paths produce valid JSON, not raised exceptions."""
+        bad = Path("/nonexistent/backend.py")
+        bad_idx = tmp_path / "nonexistent.sqlite"
+        for result_str in [
+            mcp_mod._run_search("", 8, None, False, bad, bad_idx),
+            mcp_mod._run_search("q", 8, None, False, bad, bad_idx),
+        ]:
+            parsed = json.loads(result_str)  # must not raise
+            assert isinstance(parsed, dict)

--- a/website/docs/guides/obsidian-vector-mcp.md
+++ b/website/docs/guides/obsidian-vector-mcp.md
@@ -1,0 +1,76 @@
+# Obsidian Vector MCP
+
+Stdio MCP server that exposes `search_obsidian` — semantic search over a
+pre-built SQLite vector index of your Obsidian vault / LLM Wiki.
+
+## Prerequisites
+
+1. Backend script at `~/.hermes/scripts/llm_wiki_vector_search.py`
+2. Ollama running with `mxbai-embed-large` (or another embedding model)
+3. Index built: `python ~/.hermes/scripts/llm_wiki_vector_search.py index --wiki ~/llm-wiki`
+
+## MCP client registration
+
+**claude_desktop_config.json / Cursor / Codex:**
+```json
+{
+  "mcpServers": {
+    "obsidian-vector": {
+      "command": "python",
+      "args": ["/path/to/hermes-agent/scripts/obsidian_vector_mcp.py"]
+    }
+  }
+}
+```
+
+**Hermes `~/.hermes/config.yaml`:**
+```yaml
+mcp_servers:
+  obsidian-vector:
+    command: python
+    args:
+      - /path/to/hermes-agent/scripts/obsidian_vector_mcp.py
+```
+
+## Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `OBSIDIAN_VECTOR_BACKEND` | `~/.hermes/scripts/llm_wiki_vector_search.py` | Path to backend script |
+| `LLM_WIKI_VECTOR_INDEX` | `~/.hermes/indexes/llm-wiki-vector.sqlite` | SQLite index path |
+| `LLM_WIKI_EMBEDDING_BASE_URL` | `http://127.0.0.1:11434/v1` | Embedding endpoint |
+| `LLM_WIKI_EMBEDDING_MODEL` | `mxbai-embed-large` | Embedding model name |
+| `LLM_WIKI_EMBEDDING_MODE` | `ollama` | `ollama` or `hash` (offline/deterministic) |
+
+## Tool: `search_obsidian`
+
+```
+search_obsidian(query, limit=8, source=None, include_content=False) -> str
+```
+
+Returns JSON:
+```json
+{
+  "query": "attention mechanism",
+  "count": 3,
+  "results": [
+    {
+      "title": "Attention Mechanism",
+      "path": "transformers/attention.md",
+      "heading": "Attention Mechanism",
+      "chunk_index": 0,
+      "snippet": "Transformers rely on self-attention…",
+      "score": 0.923,
+      "source": "llm-wiki",
+      "metadata": {"model": "mxbai-embed-large", "index": "/path/to/index.sqlite"},
+      "content": "..."  // only when include_content=true
+    }
+  ]
+}
+```
+
+## Smoke test (no Ollama needed)
+
+```bash
+LLM_WIKI_EMBEDDING_MODE=hash python scripts/obsidian_vector_mcp.py --smoke-test
+```


### PR DESCRIPTION
## Summary
- add a minimal stdio MCP server exposing search_obsidian for a local Obsidian/LLM Wiki vector index
- wrap the existing ~/.hermes/scripts/llm_wiki_vector_search.py backend instead of redesigning search/indexing
- document MCP client registration and add deterministic offline tests

## Testing
- python -m pytest tests/scripts/test_obsidian_vector_mcp.py -q -o 'addopts='
- LLM_WIKI_EMBEDDING_MODE=hash python scripts/obsidian_vector_mcp.py --smoke-test
- python -m ruff check scripts/obsidian_vector_mcp.py tests/scripts/test_obsidian_vector_mcp.py
- local live search smoke via _run_search against ~/.hermes/indexes/llm-wiki-vector.sqlite