### PR TITLE
fix(skills-hub): preserve binary bytes when fetching from GitHub Contents API

### DIFF
--- a/tests/tools/test_skills_hub_binary.py
+++ b/tests/tools/test_skills_hub_binary.py
@@ -1,0 +1,116 @@
+"""Regression tests for binary file preservation through GitHub's Contents API.
+
+GitHub serves binary blobs through the Contents API with
+``Content-Type: application/vnd.github.v3.raw; charset=utf-8`` — a mislabel
+that causes ``httpx.Response.text`` to UTF-8-decode binary content with
+``errors='replace'``, silently corrupting every non-ASCII byte. A PNG's
+leading 0x89 becomes the U+FFFD replacement char (``ef bf bd``), the file
+roughly doubles in size, and ``file(1)`` reports ``data`` instead of
+``PNG image data``.
+
+These tests pin the GitHub source's fetch path to bytes-preserving behavior.
+The writer (``quarantine_bundle``) already has binary coverage at
+``TestQuarantineBundleBinaryAssets``; this file covers the missing fetch-side gap.
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import httpx
+
+from tools.skills_hub import GitHubAuth, GitHubSource
+
+
+# Canonical PNG file signature: 89 50 4e 47 0d 0a 1a 0a.
+# The leading 0x89 is the byte that gets mangled to U+FFFD when decoded as UTF-8.
+PNG_HEADER = b"\x89PNG\r\n\x1a\n"
+
+
+def _github_raw_response(content: bytes) -> MagicMock:
+    """Mock httpx response that mimics GitHub's Contents API raw view.
+
+    GitHub returns binary content with a ``charset=utf-8`` Content-Type header
+    on the raw view. The mock mirrors that so ``resp.text`` would corrupt the
+    bytes — proving the fix doesn't rely on ``resp.text`` for the binary path.
+    """
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = 200
+    resp.content = content
+    resp.headers = {"content-type": "application/vnd.github.v3.raw; charset=utf-8"}
+    resp.text = content.decode("utf-8", errors="replace")
+    return resp
+
+
+class TestFetchFileContentBinary:
+    """`_fetch_file_content` must return raw bytes for binary files."""
+
+    def _source(self) -> GitHubSource:
+        auth = MagicMock(spec=GitHubAuth)
+        auth.get_headers.return_value = {}
+        return GitHubSource(auth=auth)
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_png_header_preserved_byte_for_byte(self, mock_get):
+        png_bytes = PNG_HEADER + os.urandom(1024)
+        mock_get.return_value = _github_raw_response(png_bytes)
+
+        # Sanity check the fixture: resp.text WOULD corrupt these bytes.
+        assert mock_get.return_value.text.encode("utf-8") != png_bytes
+
+        result = self._source()._fetch_file_content("owner/repo", "logo.png")
+
+        assert isinstance(result, bytes)
+        assert result == png_bytes
+        assert result[:8] == PNG_HEADER
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_jpeg_high_bytes_not_corrupted(self, mock_get):
+        """JPEG's FF D8 FF E0 header has every byte >= 0x80 — worst case for UTF-8 decode."""
+        jpeg_bytes = b"\xff\xd8\xff\xe0\x00\x10JFIF" + os.urandom(512)
+        mock_get.return_value = _github_raw_response(jpeg_bytes)
+
+        result = self._source()._fetch_file_content("owner/repo", "photo.jpg")
+
+        assert result == jpeg_bytes
+        assert result[:4] == b"\xff\xd8\xff\xe0"
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_utf8_text_still_returned_as_bytes(self, mock_get):
+        """SKILL.md and other text files still round-trip cleanly. Callers decode."""
+        skill_md = b"---\nname: example\ndescription: A test.\n---\n\n# Body\n"
+        mock_get.return_value = _github_raw_response(skill_md)
+
+        result = self._source()._fetch_file_content("owner/repo", "SKILL.md")
+
+        assert isinstance(result, bytes)
+        assert result == skill_md
+        assert result.decode("utf-8").startswith("---\nname: example")
+
+
+class TestDownloadDirectoryBinary:
+    """End-to-end: binary bytes survive `_download_directory_recursive` into the files dict."""
+
+    def _source(self) -> GitHubSource:
+        auth = MagicMock(spec=GitHubAuth)
+        auth.get_headers.return_value = {}
+        return GitHubSource(auth=auth)
+
+    @patch.object(GitHubSource, "_fetch_file_content")
+    @patch("tools.skills_hub.httpx.get")
+    def test_recursive_download_preserves_binary_entries(self, mock_get, mock_fetch):
+        png_bytes = PNG_HEADER + os.urandom(256)
+        contents_resp = MagicMock(status_code=200, json=lambda: [
+            {"name": "SKILL.md", "path": "skills/my-skill/SKILL.md", "type": "file"},
+            {"name": "logo.png", "path": "skills/my-skill/logo.png", "type": "file"},
+        ])
+        mock_get.return_value = contents_resp
+        mock_fetch.side_effect = lambda repo, path: (
+            png_bytes if path.endswith(".png") else b"---\nname: x\n---\n"
+        )
+
+        files = self._source()._download_directory_recursive("owner/repo", "skills/my-skill")
+
+        assert "logo.png" in files
+        assert files["logo.png"] == png_bytes
+        assert files["logo.png"][:8] == PNG_HEADER
+        assert isinstance(files["SKILL.md"], bytes)

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -516,7 +516,7 @@ class GitHubSource(SkillSource):
         if not content:
             return None
 
-        fm = self._parse_frontmatter_quick(content)
+        fm = self._parse_frontmatter_quick(content.decode("utf-8", errors="replace"))
         skill_name = fm.get("name", skill_path.split("/")[-1])
         description = fm.get("description", "")
 
@@ -729,13 +729,16 @@ class GitHubSource(SkillSource):
         return last_resp
 
 
-    def _download_directory(self, repo: str, path: str) -> Dict[str, str]:
-        """Recursively download all text files from a GitHub directory.
+    def _download_directory(self, repo: str, path: str) -> Dict[str, Union[str, bytes]]:
+        """Recursively download all files from a GitHub directory.
 
         Uses the Git Trees API first (single call for the entire tree) to
         avoid per-directory rate limiting that causes silent subdirectory
         loss.  Falls back to the recursive Contents API when the tree
         endpoint is unavailable or the response is truncated.
+
+        Returns raw bytes per file; SKILL.md parsing and other text
+        consumers decode at point of use.
         """
         files = self._download_directory_via_tree(repo, path)
         if files is not None:
@@ -743,7 +746,7 @@ class GitHubSource(SkillSource):
         logger.debug("Tree API unavailable for %s/%s, falling back to Contents API", repo, path)
         return self._download_directory_recursive(repo, path)
 
-    def _download_directory_via_tree(self, repo: str, path: str) -> Optional[Dict[str, str]]:
+    def _download_directory_via_tree(self, repo: str, path: str) -> Optional[Dict[str, Union[str, bytes]]]:
         """Download an entire directory using the Git Trees API (single request).
 
         Returns:
@@ -770,7 +773,7 @@ class GitHubSource(SkillSource):
             return {}
 
         # Filter to blobs under our target path and fetch content
-        files: Dict[str, str] = {}
+        files: Dict[str, Union[str, bytes]] = {}
         for item in tree_entries:
             if item.get("type") != "blob":
                 continue
@@ -786,7 +789,7 @@ class GitHubSource(SkillSource):
 
         return files if files else None
 
-    def _download_directory_recursive(self, repo: str, path: str) -> Dict[str, str]:
+    def _download_directory_recursive(self, repo: str, path: str) -> Dict[str, Union[str, bytes]]:
         """Recursively download via Contents API (fallback)."""
         url = f"https://api.github.com/repos/{repo}/contents/{path.rstrip('/')}"
         try:
@@ -801,7 +804,7 @@ class GitHubSource(SkillSource):
         if not isinstance(entries, list):
             return {}
 
-        files: Dict[str, str] = {}
+        files: Dict[str, Union[str, bytes]] = {}
         for entry in entries:
             name = entry.get("name", "")
             entry_type = entry.get("type", "")
@@ -846,15 +849,17 @@ class GitHubSource(SkillSource):
 
         return None
 
-    def _fetch_file_content(self, repo: str, path: str) -> Optional[str]:
-        """Fetch a single file's content from GitHub."""
+    def _fetch_file_content(self, repo: str, path: str) -> Optional[bytes]:
+        """Fetch a file's raw bytes from GitHub. Callers decode to text at the boundary."""
+        # GitHub serves binary blobs with `charset=utf-8`; `resp.text` would
+        # corrupt them via `errors='replace'`. Return raw bytes instead.
         url = f"https://api.github.com/repos/{repo}/contents/{path}"
         resp = self._github_get(
             url,
             headers={**self.auth.get_headers(), "Accept": "application/vnd.github.v3.raw"},
         )
         if resp is not None and resp.status_code == 200:
-            return resp.text
+            return resp.content
         return None
 
     def _get_skillsh_groupings(self, repo: str) -> Optional[Dict[str, str]]:
@@ -883,7 +888,7 @@ class GitHubSource(SkillSource):
         return groupings
 
     @staticmethod
-    def _parse_skillsh_groupings(content: str) -> Optional[Dict[str, str]]:
+    def _parse_skillsh_groupings(content: Union[str, bytes]) -> Optional[Dict[str, str]]:
         """Flatten a ``skills.sh.json`` document into ``{skill_name: title}``.
 
         Returns ``None`` when the content isn't a usable grouping document.
@@ -1060,7 +1065,7 @@ class WellKnownSkillSource(SkillSource):
         if not isinstance(files, list) or not files:
             files = ["SKILL.md"]
 
-        downloaded: Dict[str, str] = {}
+        downloaded: Dict[str, Union[str, bytes]] = {}
         for rel_path in files:
             if not isinstance(rel_path, str) or not rel_path:
                 continue
@@ -2378,12 +2383,15 @@ class ClawHubSource(SkillSource):
                     return version
         return None
 
-    def _extract_files(self, version_data: Dict[str, Any]) -> Dict[str, str]:
-        files: Dict[str, str] = {}
+    def _extract_files(self, version_data: Dict[str, Any]) -> Dict[str, Union[str, bytes]]:
+        files: Dict[str, Union[str, bytes]] = {}
         file_list = version_data.get("files")
 
         if isinstance(file_list, dict):
-            return {k: v for k, v in file_list.items() if isinstance(v, str)}
+            text_files: Dict[str, Union[str, bytes]] = {
+                k: v for k, v in file_list.items() if isinstance(v, str)
+            }
+            return text_files
 
         if not isinstance(file_list, list):
             return files
@@ -2409,12 +2417,12 @@ class ClawHubSource(SkillSource):
 
         return files
 
-    def _download_zip(self, slug: str, version: str) -> Dict[str, str]:
+    def _download_zip(self, slug: str, version: str) -> Dict[str, Union[str, bytes]]:
         """Download skill as a ZIP bundle from the /download endpoint and extract text files."""
         import io
         import zipfile
 
-        files: Dict[str, str] = {}
+        files: Dict[str, Union[str, bytes]] = {}
         max_retries = 3
         for attempt in range(max_retries):
             try:


### PR DESCRIPTION
## Symptom

`hermes skills install <owner>/<repo>/<path>` against a GitHub repo silently
corrupts every binary file in the skill. PNGs land on disk with the first
byte of each multi-byte sequence replaced by U+FFFD (`ef bf bd`), file size
roughly doubles, and `file(1)` reports `data` instead of `PNG image data`.

```
canonical PNG header:  89 50 4e 47 0d 0a 1a 0a   ← valid
installed PNG header:  ef bf bd 50 4e 47 0d 0a   ← corrupted (0x89 → U+FFFD)
file size:             85,744 → 152,658 bytes
file(1) output:        "data" instead of "PNG image data, …"
```

## Reproducer

```python
import httpx, os
url = "https://api.github.com/repos/<owner>/<repo>/contents/<path-to-png>"
headers = {"Authorization": f"token {os.environ['GITHUB_TOKEN']}",
           "Accept": "application/vnd.github.v3.raw"}
resp = httpx.get(url, headers=headers, follow_redirects=True)
print(resp.headers["content-type"])
# application/vnd.github.v3.raw; charset=utf-8   ← GitHub claims utf-8 on binary
print(resp.content[:8].hex())          # 89504e470d0a1a0a   ← correct PNG header
print(resp.text[:8].encode().hex())    # efbfbd504e470d0a   ← corrupted
```

## Root cause

`GitHubSource._fetch_file_content` returned `resp.text`. GitHub serves binary
blobs through the Contents API with `Content-Type: application/vnd.github.v3.raw;
charset=utf-8` — a mislabel that causes `httpx.Response.text` to honor the
`utf-8` charset and decode every binary blob with `errors='replace'`, silently
substituting U+FFFD for every byte that doesn't form a valid UTF-8 sequence.
The corrupted `str` then flowed through `_download_directory_*` (typed
`Dict[str, str]`) into `SkillBundle.files` (already typed `Union[str, bytes]`
upstream but never reached with bytes from this code path) and finally into
`quarantine_bundle()`, which wrote it via `write_text` because the entry was
already typed `str`.

## Fix

- `_fetch_file_content` returns `Optional[bytes]` (just `resp.content`, no decode)
- `_download_directory`, `_download_directory_via_tree`, and
  `_download_directory_recursive` widen their `Dict[str, str]` returns to
  `Dict[str, Union[str, bytes]]` to propagate the bytes through.
- `GitHubSource.inspect()` decodes at the boundary before passing SKILL.md
  content into `_parse_frontmatter_quick` (which still expects `str`).

The writer in `quarantine_bundle()` already correctly dispatches on
`isinstance(file_content, bytes)`, so no writer change is needed. Existing
consumers of `bundle.files` (`bundle_content_hash`, the CLI preview sites in
`hermes_cli/skills_hub.py`) already handle the `Union[str, bytes]` shape
defensively — the type widening just makes those branches reachable.

## Test

`tests/tools/test_skills_hub_binary.py` — synthetic mock of `httpx.get`
returning canonical PNG and JPEG headers with GitHub's `charset=utf-8`
mislabel. Verifies bytes survive end-to-end. Test fails on current `main`
and passes on this branch. All 149 existing tests across
`tests/tools/test_skills_hub*.py` and `tests/hermes_cli/test_skills_hub.py`
continue to pass.

## Scope

Narrow, single concern. Out of scope (separate follow-ups):

- Exec bit loss during install — same install path, different code (mode
  bit handling at extract time). Shell-script entry points land as
  `-rw-r--r--` instead of `-rwxr-xr-x`. Different symptom, different fix.
- ClawHub ZIP fetcher silently dropping binaries via
  `try/except UnicodeDecodeError: continue`. Separate code path; not
  exercised by the GitHub Contents API path fixed here.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
