### PR TITLE
fix(security): close project-plugin RCE bypass in dashboard web server (#29156, GHSA-5qr3-c538-wm9j)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3906,6 +3906,43 @@ async def set_dashboard_theme(body: ThemeSetBody):
 # Dashboard plugin system
 # ---------------------------------------------------------------------------
 
+def _safe_plugin_api_relpath(api_field: Any, *, dashboard_dir: Path) -> Optional[str]:
+    """Validate the manifest's ``api`` field for the plugin loader.
+
+    The web server later imports this file as a Python module via
+    ``importlib.util.spec_from_file_location`` (arbitrary code
+    execution by design — that's how plugins extend the backend).
+    Pre-#29156 the field was used as-is, which meant:
+
+    * An absolute path swallowed the plugin's dashboard directory
+      entirely — ``Path('safe/dashboard') / '/tmp/evil.py'`` resolves
+      to ``/tmp/evil.py``, so any attacker-controlled manifest could
+      point the import at any Python file on disk (GHSA-5qr3-c538-wm9j).
+    * A ``../..`` traversal could climb out of the plugin into
+      neighbouring directories on the search path.
+
+    Return the original string when the resolved path stays under
+    ``dashboard_dir``; return ``None`` (with a warning logged at the
+    call site) otherwise so the plugin still loads its static JS/CSS
+    but its backend ``api`` is rejected.
+    """
+    if not isinstance(api_field, str) or not api_field.strip():
+        return None
+    candidate = Path(api_field)
+    if candidate.is_absolute():
+        return None
+    try:
+        resolved = (dashboard_dir / candidate).resolve()
+        base = dashboard_dir.resolve()
+    except (OSError, RuntimeError):
+        return None
+    try:
+        resolved.relative_to(base)
+    except ValueError:
+        return None
+    return api_field
+
+
 def _discover_dashboard_plugins() -> list:
     """Scan plugins/*/dashboard/manifest.json for dashboard extensions.
 
@@ -3972,6 +4009,23 @@ def _discover_dashboard_plugins() -> list:
                 slots: List[str] = []
                 if isinstance(slots_src, list):
                     slots = [s for s in slots_src if isinstance(s, str) and s]
+                # Validate ``api`` at discovery time so the value cached
+                # on the plugin entry is already safe to feed into the
+                # importer.  An attacker-controlled manifest can name
+                # any absolute path or ``..`` traversal here — the
+                # web server then imports that file as a Python module
+                # (RCE, GHSA-5qr3-c538-wm9j).
+                raw_api = data.get("api")
+                dashboard_dir = child / "dashboard"
+                safe_api = _safe_plugin_api_relpath(raw_api, dashboard_dir=dashboard_dir)
+                if raw_api and safe_api is None:
+                    _log.warning(
+                        "Plugin %s: refusing unsafe api path %r (must be a "
+                        "relative file inside the plugin's dashboard/ "
+                        "directory); backend routes from this plugin will "
+                        "not be mounted",
+                        name, raw_api,
+                    )
                 plugins.append({
                     "name": name,
                     "label": data.get("label", name),
@@ -3982,10 +4036,10 @@ def _discover_dashboard_plugins() -> list:
                     "slots": slots,
                     "entry": data.get("entry", "dist/index.js"),
                     "css": data.get("css"),
-                    "has_api": bool(data.get("api")),
+                    "has_api": bool(safe_api),
                     "source": source,
-                    "_dir": str(child / "dashboard"),
-                    "_api_file": data.get("api"),
+                    "_dir": str(dashboard_dir),
+                    "_api_file": safe_api,
                 })
             except Exception as exc:
                 _log.warning("Bad dashboard plugin manifest %s: %s", manifest_file, exc)
@@ -4335,12 +4389,42 @@ def _mount_plugin_api_routes():
     Each plugin's ``api`` field points to a Python file that must expose
     a ``router`` (FastAPI APIRouter).  Routes are mounted under
     ``/api/plugins/<name>/``.
+
+    Backend import is restricted to ``bundled`` and ``user`` sources.
+    Project plugins (``./.hermes/plugins/``) ship with the CWD and are
+    therefore attacker-controlled in any threat model where the user
+    opens a malicious repo; they can extend the dashboard UI via
+    static JS/CSS but their Python ``api`` file is never auto-imported
+    by the web server.  See GHSA-5qr3-c538-wm9j (#29156).
     """
     for plugin in _get_dashboard_plugins():
         api_file_name = plugin.get("_api_file")
         if not api_file_name:
             continue
-        api_path = Path(plugin["_dir"]) / api_file_name
+        if plugin.get("source") == "project":
+            _log.warning(
+                "Plugin %s: ignoring backend api=%s (project plugins may "
+                "not auto-import Python code; move the plugin to "
+                "~/.hermes/plugins/ if you trust it)",
+                plugin["name"], api_file_name,
+            )
+            continue
+        dashboard_dir = Path(plugin["_dir"])
+        api_path = dashboard_dir / api_file_name
+        try:
+            resolved_api = api_path.resolve()
+            resolved_base = dashboard_dir.resolve()
+            resolved_api.relative_to(resolved_base)
+        except (OSError, RuntimeError, ValueError):
+            # Discovery already filters this, but re-check here in case
+            # ``_dir`` was tampered with after caching or a future caller
+            # bypasses the validator.  Defence in depth keeps the import
+            # primitive contained even if the upstream check regresses.
+            _log.warning(
+                "Plugin %s: refusing to import api file outside its "
+                "dashboard directory (%s)", plugin["name"], api_path,
+            )
+            continue
         if not api_path.exists():
             _log.warning("Plugin %s declares api=%s but file not found", plugin["name"], api_file_name)
             continue

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -48,6 +48,7 @@ from hermes_cli.config import (
     redact_key,
 )
 from gateway.status import get_running_pid, read_runtime_status
+from utils import env_var_enabled
 
 try:
     from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
@@ -3923,7 +3924,16 @@ def _discover_dashboard_plugins() -> list:
         (bundled_root / "memory", "bundled"),
         (bundled_root, "bundled"),
     ]
-    if os.environ.get("HERMES_ENABLE_PROJECT_PLUGINS"):
+    # GHSA-5qr3-c538-wm9j (#29156): the previous ``os.environ.get(...)``
+    # check treated *any* non-empty string as truthy, so ``=0``, ``=false``,
+    # and ``=no`` — all of which the agent loader and operators correctly
+    # read as "disabled" — silently *enabled* the untrusted project source
+    # in the web server.  Combined with the absolute-path RCE primitive on
+    # the manifest's ``api`` field (now patched below), this turned the
+    # opt-in into a sticky always-on switch.  Use the shared truthy
+    # semantics (``1`` / ``true`` / ``yes`` / ``on``) so the gate matches
+    # ``hermes_cli/plugins.py`` and the documented user contract.
+    if env_var_enabled("HERMES_ENABLE_PROJECT_PLUGINS"):
         search_dirs.append((Path.cwd() / ".hermes" / "plugins", "project"))
 
     for plugins_root, source in search_dirs:

--- a/tests/hermes_cli/test_project_plugin_rce_bypass.py
+++ b/tests/hermes_cli/test_project_plugin_rce_bypass.py
@@ -1,0 +1,361 @@
+"""Regression coverage for GHSA-5qr3-c538-wm9j (#29156) — Remote Code
+Execution via the ``HERMES_ENABLE_PROJECT_PLUGINS`` bypass in the web
+server's dashboard plugin loader.
+
+Two primitives combined into the original advisory chain:
+
+1. ``hermes_cli.web_server._discover_dashboard_plugins`` opted into
+   the untrusted ``./.hermes/plugins/`` source via
+   ``os.environ.get("HERMES_ENABLE_PROJECT_PLUGINS")`` — truthy for
+   any non-empty string, so ``=0`` / ``=false`` / ``=no`` (all of
+   which the agent loader treats as off, and which operators set to
+   *disable* project plugins) silently *enabled* the source.
+2. ``hermes_cli.web_server._mount_plugin_api_routes`` then imported
+   each plugin's manifest ``api`` field as a Python module via
+   ``importlib.util.spec_from_file_location``.  The field was used
+   raw, with no path-traversal check, so a single manifest line
+   ``{"api": "/tmp/payload.py"}`` was enough to redirect the
+   importer at any Python file on disk (``Path('safe') / '/abs'``
+   resolves to ``/abs`` in Python).
+
+These tests pin each layer of the new defence:
+
+* Truthy env semantics now match the agent loader.
+* ``_safe_plugin_api_relpath`` rejects absolute paths, ``..``
+  traversal, and non-string / empty values.
+* ``_mount_plugin_api_routes`` re-validates at import time and
+  refuses project-source plugins outright.
+* End-to-end the original PoC manifest no longer triggers
+  ``importlib`` for ``/tmp/payload.py``.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli import web_server
+
+
+@pytest.fixture(autouse=True)
+def _reset_plugin_cache(monkeypatch):
+    """The plugin scanner caches its result per-process.  Bust the
+    cache before *and* after each test so leakage between tests can't
+    mask a regression — and so the production cache the import-time
+    ``_mount_plugin_api_routes()`` populated doesn't bleed in."""
+    web_server._dashboard_plugins_cache = None
+    yield
+    web_server._dashboard_plugins_cache = None
+
+
+def _write_plugin_manifest(root: Path, name: str, manifest: dict) -> Path:
+    """Drop a manifest under ``root/<name>/dashboard/manifest.json`` and
+    return the dashboard dir path."""
+    dashboard_dir = root / name / "dashboard"
+    dashboard_dir.mkdir(parents=True)
+    (dashboard_dir / "manifest.json").write_text(json.dumps(manifest))
+    return dashboard_dir
+
+
+# ---------------------------------------------------------------------------
+# Layer 1 — HERMES_ENABLE_PROJECT_PLUGINS env gate uses truthy semantics.
+# ---------------------------------------------------------------------------
+
+
+class TestProjectPluginsEnvGate:
+    """Project plugins must only be discovered when the env var is set
+    to a documented truthy value.  Pre-#29156 any non-empty string —
+    including ``0`` / ``false`` / ``no`` — silently enabled the source."""
+
+    @pytest.fixture
+    def project_plugin(self, tmp_path, monkeypatch):
+        """Plant a project-source plugin under CWD's ``.hermes/plugins``
+        and isolate the user-plugins dir to an empty tmp tree."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+        (tmp_path / "home").mkdir()
+        cwd = tmp_path / "evil-repo"
+        cwd.mkdir()
+        monkeypatch.chdir(cwd)
+        _write_plugin_manifest(
+            cwd / ".hermes" / "plugins",
+            "evil",
+            {
+                "name": "evil",
+                "label": "Evil",
+                "entry": "dist/index.js",
+            },
+        )
+        return cwd
+
+    @pytest.mark.parametrize("value", ["", "0", "false", "FALSE", "no", "off", "False"])
+    def test_falsy_values_keep_project_plugins_disabled(
+        self, project_plugin, monkeypatch, value
+    ):
+        if value == "":
+            monkeypatch.delenv("HERMES_ENABLE_PROJECT_PLUGINS", raising=False)
+        else:
+            monkeypatch.setenv("HERMES_ENABLE_PROJECT_PLUGINS", value)
+
+        plugins = web_server._get_dashboard_plugins(force_rescan=True)
+        names = {p["name"] for p in plugins}
+        assert "evil" not in names, (
+            f"HERMES_ENABLE_PROJECT_PLUGINS={value!r} must NOT enable the "
+            "project source — that's the GHSA-5qr3-c538-wm9j env bypass."
+        )
+
+    @pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on", "YES"])
+    def test_truthy_values_enable_project_plugins(
+        self, project_plugin, monkeypatch, value
+    ):
+        monkeypatch.setenv("HERMES_ENABLE_PROJECT_PLUGINS", value)
+        plugins = web_server._get_dashboard_plugins(force_rescan=True)
+        evil = next((p for p in plugins if p["name"] == "evil"), None)
+        assert evil is not None
+        assert evil["source"] == "project"
+
+
+# ---------------------------------------------------------------------------
+# Layer 2 — _safe_plugin_api_relpath rejects path-traversal payloads.
+# ---------------------------------------------------------------------------
+
+
+class TestApiPathSanitizer:
+    """Unit-level coverage for the new ``_safe_plugin_api_relpath``
+    helper.  Anything that escapes the plugin's dashboard directory
+    must come back as ``None``."""
+
+    def _dashboard_dir(self, tmp_path):
+        d = tmp_path / "plug" / "dashboard"
+        d.mkdir(parents=True)
+        return d
+
+    def test_simple_relative_path_accepted(self, tmp_path):
+        d = self._dashboard_dir(tmp_path)
+        (d / "api.py").write_text("router = None\n")
+        assert web_server._safe_plugin_api_relpath("api.py", dashboard_dir=d) == "api.py"
+
+    def test_nested_relative_path_accepted(self, tmp_path):
+        d = self._dashboard_dir(tmp_path)
+        (d / "backend").mkdir()
+        (d / "backend" / "routes.py").write_text("router = None\n")
+        out = web_server._safe_plugin_api_relpath(
+            "backend/routes.py", dashboard_dir=d
+        )
+        assert out == "backend/routes.py"
+
+    @pytest.mark.parametrize("payload", [
+        "/etc/passwd",
+        "/tmp/payload.py",
+        "/usr/bin/python",
+        # NT-style absolute on POSIX is a relative path — covered by traversal below.
+    ])
+    def test_absolute_path_rejected(self, tmp_path, payload):
+        d = self._dashboard_dir(tmp_path)
+        assert web_server._safe_plugin_api_relpath(payload, dashboard_dir=d) is None
+
+    @pytest.mark.parametrize("payload", [
+        "../../../etc/passwd",
+        "../neighbour/api.py",
+        "../../../../tmp/evil.py",
+        "subdir/../../../../etc/passwd",
+    ])
+    def test_traversal_rejected(self, tmp_path, payload):
+        d = self._dashboard_dir(tmp_path)
+        assert web_server._safe_plugin_api_relpath(payload, dashboard_dir=d) is None
+
+    @pytest.mark.parametrize("payload", [None, "", "   ", 42, [], {}])
+    def test_non_string_or_empty_rejected(self, tmp_path, payload):
+        d = self._dashboard_dir(tmp_path)
+        assert web_server._safe_plugin_api_relpath(payload, dashboard_dir=d) is None
+
+
+# ---------------------------------------------------------------------------
+# Layer 3 — _discover_dashboard_plugins scrubs ``_api_file`` early.
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoveryScrubsApiField:
+    """The cached plugin entry must NEVER carry an unsanitised api path.
+    A regression here would re-arm the RCE for any caller that uses
+    ``plugin['_api_file']`` directly."""
+
+    @pytest.fixture
+    def user_plugin_factory(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("HERMES_ENABLE_PROJECT_PLUGINS", raising=False)
+
+        def _make(name: str, manifest: dict) -> None:
+            _write_plugin_manifest(tmp_path / "plugins", name, manifest)
+
+        return _make
+
+    def test_absolute_api_path_in_manifest_is_scrubbed(self, user_plugin_factory):
+        user_plugin_factory("evil", {
+            "name": "evil",
+            "label": "Evil",
+            "api": "/tmp/payload.py",
+            "entry": "dist/index.js",
+        })
+        plugins = web_server._get_dashboard_plugins(force_rescan=True)
+        evil = next(p for p in plugins if p["name"] == "evil")
+        assert evil["_api_file"] is None
+        assert evil["has_api"] is False
+
+    def test_traversal_api_path_in_manifest_is_scrubbed(self, user_plugin_factory):
+        user_plugin_factory("traverse", {
+            "name": "traverse",
+            "label": "Traverse",
+            "api": "../../../../tmp/evil.py",
+            "entry": "dist/index.js",
+        })
+        plugins = web_server._get_dashboard_plugins(force_rescan=True)
+        entry = next(p for p in plugins if p["name"] == "traverse")
+        assert entry["_api_file"] is None
+        assert entry["has_api"] is False
+
+    def test_safe_api_path_survives(self, user_plugin_factory, tmp_path):
+        user_plugin_factory("safe", {
+            "name": "safe",
+            "label": "Safe",
+            "api": "api.py",
+            "entry": "dist/index.js",
+        })
+        # Make the api file actually exist so a downstream mount could
+        # in principle proceed — we're only testing the discovery scrub.
+        (tmp_path / "plugins" / "safe" / "dashboard" / "api.py").write_text(
+            "router = None\n"
+        )
+        plugins = web_server._get_dashboard_plugins(force_rescan=True)
+        entry = next(p for p in plugins if p["name"] == "safe")
+        assert entry["_api_file"] == "api.py"
+        assert entry["has_api"] is True
+
+
+# ---------------------------------------------------------------------------
+# Layer 4 — _mount_plugin_api_routes refuses project-source + traversal.
+# ---------------------------------------------------------------------------
+
+
+class TestMountApiRoutesRefusesUntrusted:
+    """The mount routine is the actual ``importlib`` call site — these
+    tests poke synthetic plugin entries directly into the cache and
+    assert the importer is *not* invoked."""
+
+    def _payload_plugin(self, tmp_path, *, source: str, api_file: str = "api.py"):
+        dash = tmp_path / "plug" / "dashboard"
+        dash.mkdir(parents=True)
+        # Write a benign router file; the test asserts it's NOT imported
+        # regardless of whether it exists, since the source/path checks
+        # short-circuit before the importer runs.
+        (dash / "api.py").write_text(
+            "from fastapi import APIRouter\nrouter = APIRouter()\n"
+        )
+        return {
+            "name": "synthetic",
+            "label": "Synthetic",
+            "tab": {"path": "/synthetic", "position": "end"},
+            "slots": [],
+            "entry": "dist/index.js",
+            "css": None,
+            "has_api": True,
+            "source": source,
+            "_dir": str(dash),
+            "_api_file": api_file,
+        }
+
+    def test_project_source_api_is_not_imported(self, tmp_path):
+        plugin = self._payload_plugin(tmp_path, source="project")
+        web_server._dashboard_plugins_cache = [plugin]
+        with patch("importlib.util.spec_from_file_location") as spec:
+            web_server._mount_plugin_api_routes()
+        assert spec.call_count == 0, (
+            "project-source plugin's api file was imported — "
+            "GHSA-5qr3-c538-wm9j defence-in-depth regression"
+        )
+
+    def test_bundled_source_api_imports_normally(self, tmp_path):
+        plugin = self._payload_plugin(tmp_path, source="bundled")
+        web_server._dashboard_plugins_cache = [plugin]
+        with patch("importlib.util.spec_from_file_location") as spec:
+            spec.return_value = None  # loader is None -> early continue, safe
+            web_server._mount_plugin_api_routes()
+        assert spec.call_count == 1
+        # First positional arg after module_name is the resolved api path.
+        called_path = Path(spec.call_args.args[1])
+        assert called_path.name == "api.py"
+        assert called_path.is_absolute()
+
+    def test_traversal_api_caught_at_mount_time(self, tmp_path):
+        """Defence-in-depth: if discovery is bypassed (e.g. cache
+        tampering), mount-time validation still refuses to import a
+        file outside the dashboard dir."""
+        plugin = self._payload_plugin(tmp_path, source="user",
+                                       api_file="../../../tmp/evil.py")
+        web_server._dashboard_plugins_cache = [plugin]
+        with patch("importlib.util.spec_from_file_location") as spec:
+            web_server._mount_plugin_api_routes()
+        assert spec.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Layer 5 — End-to-end: the original PoC manifest no longer triggers RCE.
+# ---------------------------------------------------------------------------
+
+
+class TestEndToEndPocBlocked:
+    """Reproduces the original advisory PoC shape: untrusted CWD with a
+    manifest pointing ``api`` at an attacker-chosen Python file, with
+    ``HERMES_ENABLE_PROJECT_PLUGINS=0`` (so the operator believed the
+    project source was disabled).  Post-fix, the importer must never
+    be invoked for the payload path, regardless of how the bypass is
+    framed (``=0`` truthy-string bypass, absolute path bypass,
+    project-source bypass)."""
+
+    def test_full_chain_blocked(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+        (tmp_path / "home").mkdir()
+        cwd = tmp_path / "evil-repo"
+        cwd.mkdir()
+        monkeypatch.chdir(cwd)
+        # The original bypass: operator sets the var to a "disabled"
+        # string the web server pre-fix treated as enabled.
+        monkeypatch.setenv("HERMES_ENABLE_PROJECT_PLUGINS", "0")
+        # Payload: absolute path inside a manifest dropped in CWD.
+        payload_py = tmp_path / "payload.py"
+        payload_py.write_text("OWNED = True\n")
+        _write_plugin_manifest(
+            cwd / ".hermes" / "plugins",
+            "evil",
+            {
+                "name": "evil",
+                "label": "Evil",
+                "api": str(payload_py),
+                "entry": "dist/index.js",
+            },
+        )
+
+        with patch("importlib.util.spec_from_file_location") as spec:
+            plugins = web_server._get_dashboard_plugins(force_rescan=True)
+            web_server._mount_plugin_api_routes()
+
+        # The project source must stay disabled because ``0`` is no
+        # longer truthy.  Even if the operator *had* opted in, the
+        # absolute-path api would be scrubbed at discovery, and even
+        # if discovery missed it the project-source guard in mount
+        # would refuse the import.
+        assert "evil" not in {p["name"] for p in plugins}
+        # Bundled plugins shipped with the repo may legitimately have
+        # ``api`` files and so ``spec_from_file_location`` can fire for
+        # those — the regression is specifically that the *payload*
+        # path / *evil* module are never targeted.
+        for call in spec.call_args_list:
+            module_name = call.args[0]
+            target = Path(call.args[1])
+            assert module_name != "hermes_dashboard_plugin_evil"
+            assert target != payload_py
+            assert "evil-repo" not in target.parts
+        assert "hermes_dashboard_plugin_evil" not in sys.modules

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -530,7 +530,7 @@ Advanced per-platform knobs for throttling the outbound message batcher. Most us
 | `HERMES_AGENT_NOTIFY_INTERVAL` | Gateway: interval in seconds between progress notifications on long-running agent turns. |
 | `HERMES_CHECKPOINT_TIMEOUT` | Timeout for filesystem checkpoint creation in seconds (default: `30`). |
 | `HERMES_EXEC_ASK` | Enable execution approval prompts in gateway mode (`true`/`false`) |
-| `HERMES_ENABLE_PROJECT_PLUGINS` | Enable auto-discovery of repo-local plugins from `./.hermes/plugins/` (`true`/`false`, default: `false`) |
+| `HERMES_ENABLE_PROJECT_PLUGINS` | Enable auto-discovery of repo-local plugins from `./.hermes/plugins/` for both the agent loader and the dashboard web server. Accepts the standard truthy set: `1` / `true` / `yes` / `on` (case-insensitive). Everything else — including `0`, `false`, `no`, `off`, and the empty string — is treated as **disabled** (default). Note: as of GHSA-5qr3-c538-wm9j (#29156) the dashboard web server refuses to auto-import a project plugin's Python `api` file even when this var is enabled — project plugins may extend the UI via static JS/CSS but their backend routes are only loaded when moved under `~/.hermes/plugins/`. |
 | `HERMES_PLUGINS_DEBUG` | `1`/`true` to surface verbose plugin-discovery logs on stderr — directories scanned, manifests parsed, skip reasons, and full tracebacks on parse or `register()` failure. Aimed at plugin authors. |
 | `HERMES_BACKGROUND_NOTIFICATIONS` | Background process notification mode in gateway: `all` (default), `result`, `error`, `off` |
 | `HERMES_EPHEMERAL_SYSTEM_PROMPT` | Ephemeral system prompt injected at API-call time (never persisted to sessions) |


### PR DESCRIPTION
## What does this PR do?

Closes the **Remote Code Execution** advisory `GHSA-5qr3-c538-wm9j` against the dashboard web server's plugin loader (publicly tracked as #29156).

The advisory chained two distinct primitives in `hermes_cli/web_server.py`:

1. **Truthy-string env gate.** `_discover_dashboard_plugins` opted into the untrusted `./.hermes/plugins/` source via `if os.environ.get(\"HERMES_ENABLE_PROJECT_PLUGINS\"):` — truthy for *any non-empty string*. Setting the var to `0`, `false`, `no`, or `off` (every documented "disabled" form, and what the agent loader at `hermes_cli/plugins.py:815` correctly treats as off) **silently enabled** the project source in the web server. An operator who ran `hermes dashboard` from an untrusted CWD believing they had project plugins disabled was wrong.
2. **Absolute-path RCE in the `api` field.** `_mount_plugin_api_routes` imported each plugin manifest's `api` field as a Python module via `importlib.util.spec_from_file_location`. The field was used raw, with no path-traversal check. Because `Path('safe/dashboard') / '/tmp/payload.py'` resolves to `/tmp/payload.py` in Python, a single manifest line `{\"api\": \"/tmp/payload.py\"}` redirected the importer at any Python file on disk — **arbitrary code execution in the dashboard process, which holds API keys, session tokens, and `.env` contents**.

Verified the bypass primitives in this repo's Python:

```
>>> bool(os.environ.get('HERMES_ENABLE_PROJECT_PLUGINS', None))
True   # when the var is set to '0' or 'false' — wrong half-truthy
>>> Path('/safe/dashboard') / '/tmp/evil.py'
PosixPath('/tmp/evil.py')
```

**Fix at three layers** so a future regression in any one of them can't re-open the chain:

- **Layer 1 — env gate.** Replace `os.environ.get(...)` with the shared `utils.env_var_enabled` helper used by the agent loader. The dashboard now matches the documented truthy set (`1` / `true` / `yes` / `on`, case-insensitive) and treats everything else as off.
- **Layer 2 — sanitiser.** New `_safe_plugin_api_relpath(api_field, *, dashboard_dir)` validates the manifest's `api` value: must be a non-empty string, must not be absolute, and the `resolve()`-d candidate must stay under the plugin's `dashboard/` directory. The cached plugin entry only ever stores the sanitised value on `_api_file` (and `has_api` follows it, so the dashboard UI doesn't render a fake "Backend API" badge for plugins whose api was scrubbed). Logs the plugin name + offending path when it rejects.
- **Layer 3 — mount-time defence in depth.** `_mount_plugin_api_routes` re-validates the resolved path against the live filesystem just before `importlib.util.spec_from_file_location` (covers cache tampering / future callers that bypass the discovery sanitiser) and **refuses outright to import `api` from `source == \"project\"` plugins**. Project plugins ship with the CWD and are attacker-controlled under the advisory's threat model; they keep working as UI extensions (static JS / CSS via `serve_plugin_asset`) but never auto-execute Python in the web server.

## Related Issue

Fixes #29156 (GHSA-5qr3-c538-wm9j).

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/web_server.py` (+99/-5):
  - New `_safe_plugin_api_relpath` helper (typed, with docstring naming the advisory).
  - `_discover_dashboard_plugins`: swap the env check to `env_var_enabled`; call the sanitiser on every manifest's `api` field; cache `None` + `has_api: False` when rejected.
  - `_mount_plugin_api_routes`: refuse `source == \"project\"` early; re-validate the resolved path against the live filesystem before `spec_from_file_location`; log the plugin name on every refusal.
  - New `from utils import env_var_enabled` import.
- `tests/hermes_cli/test_project_plugin_rce_bypass.py` (+361, new) — 35 regression tests / 5 classes, each pinning one defence layer:
  - `TestProjectPluginsEnvGate` (13) — parametrised truthy / falsy env values; `0` / `false` / `no` / `off` / `\"\"` must keep the project source disabled (the env-bypass repro), `1` / `true` / `yes` / `on` (+ uppercase variants) must enable it.
  - `TestApiPathSanitizer` (16) — `_safe_plugin_api_relpath` unit cases: absolute paths (`/etc/passwd`, `/tmp/payload.py`, `/usr/bin/python`), traversal (`../../../etc/passwd`, `../neighbour/api.py`, `subdir/../../../../etc/passwd`), non-string / empty / whitespace values all rejected; safe relative paths (`api.py`, `backend/routes.py`) round-trip.
  - `TestDiscoveryScrubsApiField` (3) — `_get_dashboard_plugins` with real manifests on disk: cached `_api_file` is `None` and `has_api: False` for unsafe values, intact for safe ones.
  - `TestMountApiRoutesRefusesUntrusted` (3) — synthetic cache entries with `importlib.util.spec_from_file_location` patched. Project source: never invoked. Bundled source: invoked normally. Traversal `_api_file`: refused at mount time even when discovery is bypassed.
  - `TestEndToEndPocBlocked` (1) — the original advisory PoC end-to-end: operator sets `HERMES_ENABLE_PROJECT_PLUGINS=0`, attacker plants `.hermes/plugins/evil/dashboard/manifest.json` with `api` pointing at `/tmp/payload.py` in CWD. Asserts the evil plugin isn't even discovered, the importer is never called against the payload, and `hermes_dashboard_plugin_evil` is not in `sys.modules`.
- `website/docs/reference/environment-variables.md` (+1/-1) — documents the truthy set explicitly, names `0` / `false` / `no` / `off` / empty as falsy, and points readers at the new "project plugins may not auto-import Python" defence-in-depth rule.

Backwards-compatible for every legitimate path:

| Caller / state                                      | Pre-fix              | Post-fix                                                   |
| --------------------------------------------------- | -------------------- | ---------------------------------------------------------- |
| `HERMES_ENABLE_PROJECT_PLUGINS` unset               | disabled             | disabled (unchanged)                                       |
| `HERMES_ENABLE_PROJECT_PLUGINS=1` (or `true`/`yes`) | enabled              | enabled, JS/CSS only — Python `api` never auto-imported    |
| `HERMES_ENABLE_PROJECT_PLUGINS=0` (or `false`/`no`) | **enabled (bypass)** | **disabled** (matches agent loader + documented contract)  |
| User plugin with safe relative `api`                | imported             | imported (unchanged)                                       |
| User plugin with absolute / traversal `api`         | **imported anywhere**| sanitised away with a logged warning                       |
| Project plugin with any `api`                       | **imported**         | UI loads, backend api refused with a logged warning        |
| Bundled plugin with safe relative `api`             | imported             | imported (unchanged)                                       |

## How to Test

```bash
python3 -m venv .venv && source .venv/bin/activate
pip install -e \".[all,dev]\"

# New regression suite
scripts/run_tests.sh tests/hermes_cli/test_project_plugin_rce_bypass.py -v
# expected: 35 passed

# Surrounding plugin + web-server tests, no cross-regression
scripts/run_tests.sh tests/hermes_cli/test_project_plugin_rce_bypass.py \
    tests/hermes_cli/test_web_server.py \
    tests/hermes_cli/test_plugins.py
# expected: 251 passed
```

Manual repro of the original PoC (pre-fix RCE, now a hard refuse):

```
$ cd /tmp/evil-repo
$ mkdir -p .hermes/plugins/evil/dashboard
$ cat > .hermes/plugins/evil/dashboard/manifest.json <<JSON
{ \"name\": \"evil\", \"api\": \"/tmp/payload.py\", \"entry\": \"dist/index.js\" }
JSON
$ HERMES_ENABLE_PROJECT_PLUGINS=0 python3 -c \"
from hermes_cli import web_server
web_server._dashboard_plugins_cache = None
print('plugins:', [p['name'] for p in web_server._get_dashboard_plugins(force_rescan=True)])
web_server._mount_plugin_api_routes()
import sys
print('payload imported?', 'hermes_dashboard_plugin_evil' in sys.modules)
\"
plugins: [...bundled only, no 'evil'...]
payload imported? False
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(plugins): …` x2, `test(plugins): …`, `docs(env): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/hermes_cli/test_project_plugin_rce_bypass.py` and all tests pass
- [x] I've added tests for my changes (35 new across 5 defence layers; 12 pre-existing plugin tests still green)
- [x] I've tested on my platform: macOS 15.x (Darwin 24.6.0), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/reference/environment-variables.md`)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (env-only contract, no new YAML keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `pathlib.Path.resolve()` + `relative_to()` are platform-agnostic; on Windows the same absolute-path swallow primitive (`Path('a') / 'C:/evil.py'`) is covered by `candidate.is_absolute()`
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no tool surface change)

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/hermes_cli/test_project_plugin_rce_bypass.py -v
4 workers [35 items]
============================== 35 passed in 0.69s ==============================
```