### PR TITLE
feat(skills): show HUB badge on dashboard for skills synced from a source

### DIFF
--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -9,6 +9,7 @@ import pytest
 
 import tools.skills_tool as skills_tool_module
 from tools.skills_tool import (
+    _classify_skill_source,
     _get_required_environment_variables,
     _parse_frontmatter,
     _parse_tags,
@@ -280,6 +281,119 @@ class TestFindAllSkills:
 
         assert [s["name"] for s in skills] == ["knowledge-brain"]
         assert skills[0]["category"] == "linked"
+
+
+# ---------------------------------------------------------------------------
+# _classify_skill_source
+# ---------------------------------------------------------------------------
+
+
+class TestClassifySkillSource:
+    """Trichotomy mirrors `hermes skills list`: hub | builtin | local."""
+
+    def test_hub_skill_returns_source_and_identifier(self):
+        hub = {
+            "picasso-creative": {
+                "source": "github",
+                "identifier": "cypres0099/bp-marketplace/plugins/bp-creative/skills/picasso-creative",
+            }
+        }
+        source, ident = _classify_skill_source("picasso-creative", hub, set())
+        assert source == "hub"
+        assert ident == (
+            "github: cypres0099/bp-marketplace/plugins/bp-creative/skills/picasso-creative"
+        )
+
+    def test_hub_skill_without_identifier_falls_back_to_adapter(self):
+        hub = {"odd-one": {"source": "clawhub", "identifier": ""}}
+        source, ident = _classify_skill_source("odd-one", hub, set())
+        assert source == "hub"
+        assert ident == "clawhub"
+
+    def test_builtin_skill_has_no_identifier(self):
+        source, ident = _classify_skill_source(
+            "hermes-honcho-memory", {}, {"hermes-honcho-memory"}
+        )
+        assert source == "builtin"
+        assert ident is None
+
+    def test_local_skill_has_no_identifier(self):
+        source, ident = _classify_skill_source("kanban-orchestrator", {}, set())
+        assert source == "local"
+        assert ident is None
+
+    def test_hub_wins_over_builtin_when_both_match(self):
+        """A skill installed via the hub that shadows a builtin reports as hub."""
+        hub = {"shadowed": {"source": "github", "identifier": "owner/repo/shadowed"}}
+        source, ident = _classify_skill_source("shadowed", hub, {"shadowed"})
+        assert source == "hub"
+        assert ident == "github: owner/repo/shadowed"
+
+
+# ---------------------------------------------------------------------------
+# _find_all_skills source annotation
+# ---------------------------------------------------------------------------
+
+
+class TestFindAllSkillsSourceAnnotation:
+    """_find_all_skills annotates each row with source + source_identifier."""
+
+    def test_local_skill_annotated(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path), \
+             patch("tools.skills_tool._load_skill_source_index",
+                   return_value=({}, set())):
+            _make_skill(tmp_path, "kanban-orchestrator")
+            skills = _find_all_skills()
+
+        assert len(skills) == 1
+        assert skills[0]["source"] == "local"
+        assert skills[0]["source_identifier"] is None
+
+    def test_hub_skill_annotated(self, tmp_path):
+        hub = {
+            "picasso-creative": {
+                "source": "github",
+                "identifier": "cypres0099/bp-marketplace/plugins/bp-creative/skills/picasso-creative",
+            }
+        }
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path), \
+             patch("tools.skills_tool._load_skill_source_index",
+                   return_value=(hub, set())):
+            _make_skill(tmp_path, "picasso-creative")
+            skills = _find_all_skills()
+
+        assert len(skills) == 1
+        assert skills[0]["source"] == "hub"
+        assert skills[0]["source_identifier"] == (
+            "github: cypres0099/bp-marketplace/plugins/bp-creative/skills/picasso-creative"
+        )
+
+    def test_builtin_skill_annotated(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path), \
+             patch("tools.skills_tool._load_skill_source_index",
+                   return_value=({}, {"hermes-honcho-memory"})):
+            _make_skill(tmp_path, "hermes-honcho-memory")
+            skills = _find_all_skills()
+
+        assert len(skills) == 1
+        assert skills[0]["source"] == "builtin"
+        assert skills[0]["source_identifier"] is None
+
+    def test_mixed_set_classified_independently(self, tmp_path):
+        hub = {"picasso-creative": {"source": "github", "identifier": "o/r/picasso"}}
+        builtin = {"hermes-honcho-memory"}
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path), \
+             patch("tools.skills_tool._load_skill_source_index",
+                   return_value=(hub, builtin)):
+            _make_skill(tmp_path, "picasso-creative")
+            _make_skill(tmp_path, "hermes-honcho-memory")
+            _make_skill(tmp_path, "kanban-orchestrator")
+            skills = _find_all_skills()
+
+        by_name = {s["name"]: s for s in skills}
+        assert by_name["picasso-creative"]["source"] == "hub"
+        assert by_name["hermes-honcho-memory"]["source"] == "builtin"
+        assert by_name["kanban-orchestrator"]["source"] == "local"
 
 
 # ---------------------------------------------------------------------------

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -547,6 +547,52 @@ def _is_skill_disabled(name: str, platform: str = None) -> bool:
         return False
 
 
+def _load_skill_source_index() -> Tuple[Dict[str, Dict[str, Any]], set]:
+    """Snapshot the hub lock file and builtin manifest for source classification.
+
+    Returns ``(hub_installed, builtin_names)``. Both are empty on any error
+    so source classification falls back to ``"local"`` rather than failing
+    the whole skills listing.
+    """
+    try:
+        from tools.skills_hub import HubLockFile
+        hub_installed = {e["name"]: e for e in HubLockFile().list_installed()}
+    except Exception as e:
+        logger.debug("Could not load hub lock file: %s", e)
+        hub_installed = {}
+
+    try:
+        from tools.skills_sync import _read_manifest
+        builtin_names = set(_read_manifest())
+    except Exception as e:
+        logger.debug("Could not load builtin skills manifest: %s", e)
+        builtin_names = set()
+
+    return hub_installed, builtin_names
+
+
+def _classify_skill_source(
+    name: str,
+    hub_installed: Dict[str, Dict[str, Any]],
+    builtin_names: set,
+) -> Tuple[str, Optional[str]]:
+    """Map a skill name to ``(source, source_identifier)``.
+
+    Mirrors the trichotomy ``hermes skills list`` uses (``hub`` | ``builtin``
+    | ``local``). For hub skills, returns a human-readable identifier like
+    ``"github: owner/repo/path"`` suitable for tooltip display.
+    """
+    hub_entry = hub_installed.get(name)
+    if hub_entry:
+        adapter = hub_entry.get("source") or "hub"
+        identifier = hub_entry.get("identifier") or ""
+        source_identifier = f"{adapter}: {identifier}" if identifier else adapter
+        return "hub", source_identifier
+    if name in builtin_names:
+        return "builtin", None
+    return "local", None
+
+
 def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
     """Recursively find all skills in ~/.hermes/skills/ and external dirs.
 
@@ -556,7 +602,9 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
             filters out disabled skills.
 
     Returns:
-        List of skill metadata dicts (name, description, category).
+        List of skill metadata dicts with ``name``, ``description``,
+        ``category``, ``source`` (``"hub"`` | ``"builtin"`` | ``"local"``),
+        and ``source_identifier`` (non-null only for hub skills).
     """
     from agent.skill_utils import get_external_skills_dirs, iter_skill_index_files
 
@@ -565,6 +613,9 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
 
     # Load disabled set once (not per-skill)
     disabled = set() if skip_disabled else _get_disabled_skill_names()
+
+    # Snapshot hub/builtin state once so each skill row is annotated cheaply.
+    hub_installed, builtin_names = _load_skill_source_index()
 
     # Scan local dir first, then external dirs (local takes precedence)
     dirs_to_scan = []
@@ -606,10 +657,15 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
                 category = _get_category_from_path(skill_md)
 
                 seen_names.add(name)
+                source, source_identifier = _classify_skill_source(
+                    name, hub_installed, builtin_names
+                )
                 skills.append({
                     "name": name,
                     "description": description,
                     "category": category,
+                    "source": source,
+                    "source_identifier": source_identifier,
                 })
 
             except (UnicodeDecodeError, PermissionError) as e:

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -576,6 +576,10 @@ export interface SkillInfo {
   description: string;
   category: string;
   enabled: boolean;
+  /** Provenance: `hub` (synced from a skills source), `builtin` (bundled with Hermes), `local` (hand-authored). Optional for backwards compatibility with older dashboards. */
+  source?: "hub" | "builtin" | "local";
+  /** Human-readable identifier for hub skills, e.g. `github: owner/repo/path`. Null for builtin/local. */
+  source_identifier?: string | null;
 }
 
 export interface ToolsetInfo {

--- a/web/src/pages/SkillsPage.tsx
+++ b/web/src/pages/SkillsPage.tsx
@@ -516,6 +516,15 @@ function SkillRow({
           >
             {skill.name}
           </span>
+          {skill.source === "hub" && (
+            <Badge
+              tone="secondary"
+              className="text-[10px]"
+              title={skill.source_identifier ?? "Synced from a skills source"}
+            >
+              HUB
+            </Badge>
+          )}
         </div>
         <p className="text-xs text-muted-foreground leading-relaxed line-clamp-2">
           {skill.description || noDescriptionLabel}


### PR DESCRIPTION
## What

Adds a small `HUB` badge next to skill names on the dashboard skills page
when a skill came from the hub (a tap, skills.sh, ClawHub, well-known, etc.)
rather than being bundled with Hermes or hand-authored locally. Hover the
badge to see the source adapter and identifier
(e.g. `github: owner/repo/path/to/skill`).

Builtin and local skills get no badge — the default visual stays clean.

## Why

The CLI's `hermes skills list` has always distinguished hub / builtin / local
via a `Source` column, but the dashboard collapses all three into a flat
list with no provenance. For users curating their own taps or marketplaces,
there's no way to tell at a glance which skills are syncing from upstream
vs. which they authored locally — until you hit a sync issue and have to
go looking.

This adds the same trichotomy the CLI already exposes, just on the dashboard.

## Implementation

Backend (`tools/skills_tool.py`):
- New `_load_skill_source_index()` helper snapshots `HubLockFile().list_installed()`
  and the builtin manifest once per request. Both fail safe to empty — a
  missing or corrupt lock file degrades source classification to `"local"`
  rather than failing the whole skills listing.
- New `_classify_skill_source(name, hub_installed, builtin_names)` returns
  `("hub" | "builtin" | "local", source_identifier_or_None)`. Hub wins over
  builtin when both match (mirrors CLI precedence).
- `_find_all_skills()` calls the classifier once per discovered skill and
  appends `source` + `source_identifier` to each returned dict.

API (`hermes_cli/web_server.py`): no change — the dict shape passes through
`/api/skills` transparently.

Frontend (`web/src/lib/api.ts`, `web/src/pages/SkillsPage.tsx`):
- `SkillInfo` gains optional `source?: "hub" | "builtin" | "local"` and
  `source_identifier?: string | null`. Optional fields preserve backwards
  compatibility with older dashboards talking to a newer gateway (and vice
  versa).
- `SkillRow` renders `<Badge tone="secondary" className="text-[10px]">HUB</Badge>`
  with a native `title` tooltip showing the source identifier — only when
  `skill.source === "hub"`. No badge for builtin/local.

## Tests

`tests/tools/test_skills_tool.py`:
- New `TestClassifySkillSource` class covers all four classification cases
  (hub with identifier, hub with empty identifier fallback, builtin, local)
  plus the hub-shadows-builtin precedence rule.
- New `TestFindAllSkillsSourceAnnotation` class verifies the
  `source`/`source_identifier` fields end up on the returned dicts for
  each classification, including a mixed-set integration test.

226 existing skills_tool + skills_hub tests still pass; no TypeScript
errors or new lint warnings in the touched web files.

## Scope

Narrow, single concern. Not bundled:
- Filtering the dashboard skills list by source. The infrastructure is now
  there if a future PR wants to add a source filter, but adding it now
  would broaden the UI surface beyond a single badge.
- Changes to the CLI's `hermes skills list` — already has the trichotomy.
- Other dashboard pages that don't list skills.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
