### PR TITLE
feat(gateway): add task capture slash commands

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6894,13 +6894,13 @@ class GatewayRunner:
             if _cmd_def_inner and _cmd_def_inner.name == "background":
                 return await self._handle_background_command(event)
 
-            # /kanban must bypass the guard. It writes to a profile-agnostic
-            # DB (kanban.db), not to the running agent's state. In fact
-            # /kanban unblock is often the only way to free a worker that
-            # has blocked waiting for a peer — letting that be dispatched
-            # mid-run is the whole point of the board.
-            if _cmd_def_inner and _cmd_def_inner.name == "kanban":
-                return await self._handle_kanban_command(event)
+            # /kanban and its task-capture wrappers must bypass the guard.
+            # They write to the profile-agnostic kanban DB, not to the running
+            # agent's conversation state.
+            if _cmd_def_inner and _cmd_def_inner.name in {"kanban", "task", "tasknow"}:
+                if _cmd_def_inner.name == "kanban":
+                    return await self._handle_kanban_command(event)
+                return await self._handle_task_command(event)
 
             # /goal is safe mid-run for status/pause/clear (inspection and
             # control-plane only — doesn't interrupt the running turn).
@@ -7225,6 +7225,9 @@ class GatewayRunner:
 
         if canonical == "kanban":
             return await self._handle_kanban_command(event)
+
+        if canonical in {"task", "tasknow"}:
+            return await self._handle_task_command(event)
 
         if canonical == "retry":
             return await self._handle_retry_command(event)
@@ -9243,6 +9246,74 @@ class GatewayRunner:
             f"Slash commands you can run: {runnable_str}"
         )
 
+
+    async def _handle_task_command(self, event: MessageEvent) -> str:
+        """Handle /task and /tasknow convenience wrappers for Kanban capture.
+
+        /task <brief> creates a triage card so the specifier can flesh it out.
+        /tasknow <brief> (or /task --now <brief>) creates a ready card assigned
+        to the default worker so the gateway dispatcher can pick it up.
+        """
+        import re
+        import shlex
+
+        command = (event.get_command() or "").strip().lower()
+        brief = (event.get_command_args() or "").strip()
+        immediate = command == "tasknow"
+
+        if command == "task" and brief.startswith("--now"):
+            immediate = True
+            brief = brief[len("--now"):].strip()
+
+        if not brief:
+            return (
+                "Usage:\n"
+                "- `/task <brief>` → create a triage Kanban task\n"
+                "- `/tasknow <brief>` or `/task --now <brief>` → create + dispatch now"
+            )
+
+        def _title_from_brief(value: str) -> str:
+            first_line = value.strip().splitlines()[0]
+            first_sentence = re.split(r"(?<=[.!?])\s+", first_line, maxsplit=1)[0]
+            title = re.sub(r"\s+", " ", first_sentence).strip(" #:-")
+            if not title:
+                title = "Telegram task"
+            if len(title) > 88:
+                title = title[:85].rstrip() + "…"
+            return title
+
+        title = _title_from_brief(brief)
+        mode_label = "/tasknow" if immediate else "/task"
+        body = (
+            "## Goal\n"
+            f"{brief}\n\n"
+            "## Context\n"
+            f"Created from Telegram via `{mode_label}`. Use the original brief as source of truth; "
+            "ask back in Telegram only if the missing detail changes execution.\n\n"
+            "## Output\n"
+            "Deliver the completed work or a concise operator report back through Kanban notifications.\n\n"
+            "## Acceptance Criteria\n"
+            "- The requested outcome is completed or the blocker is clearly identified.\n"
+            "- Final report includes what was done, verification performed, and any remaining approval needed.\n\n"
+            "## Approval Gates\n"
+            "- Do not publish/deploy/spend/delete/activate ads/send external emails/change credentials without explicit Telegram approval."
+        )
+
+        args = [
+            "create",
+            title,
+            "--assignee",
+            "default",
+            "--created-by",
+            "telegram-tasknow" if immediate else "telegram-task",
+            "--body",
+            body,
+        ]
+        if not immediate:
+            args.append("--triage")
+
+        event.text = "/kanban " + " ".join(shlex.quote(part) for part in args)
+        return await self._handle_kanban_command(event)
 
     async def _handle_kanban_command(self, event: MessageEvent) -> str:
         """Handle /kanban — delegate to the shared kanban CLI.

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -181,6 +181,10 @@ COMMAND_REGISTRY: list[CommandDef] = [
                             "archive", "tail", "dispatch", "stats", "notify-subscribe",
                             "notify-list", "notify-unsubscribe", "log", "runs",
                             "heartbeat", "assignees", "context", "specify", "gc")),
+    CommandDef("task", "Create a triage Kanban task from a Telegram brief",
+               "Tools & Skills", gateway_only=True, args_hint="<brief | --now brief>"),
+    CommandDef("tasknow", "Create and immediately dispatch a Kanban task from a Telegram brief",
+               "Tools & Skills", gateway_only=True, args_hint="<brief>"),
     CommandDef("reload", "Reload .env variables into the running session", "Tools & Skills",
                cli_only=True),
     CommandDef("reload-mcp", "Reload MCP servers from config", "Tools & Skills",
@@ -345,6 +349,8 @@ ACTIVE_SESSION_BYPASS_COMMANDS: frozenset[str] = frozenset(
         "status",
         "steer",
         "stop",
+        "task",
+        "tasknow",
         "update",
     }
 )

--- a/tests/gateway/test_unknown_command.py
+++ b/tests/gateway/test_unknown_command.py
@@ -147,6 +147,46 @@ async def test_known_slash_command_not_flagged_as_unknown(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_tasknow_slash_command_dispatches_task_handler(monkeypatch):
+    """Telegram /tasknow must be a real gateway command, not an unknown slash."""
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    runner._run_agent = AsyncMock(
+        side_effect=AssertionError("/tasknow leaked through to the agent")
+    )
+    runner._handle_task_command = AsyncMock(return_value="created task")
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    result = await runner._handle_message(_make_event("/tasknow prepare visa packet"))
+
+    assert result == "created task"
+    runner._handle_task_command.assert_awaited_once()
+    runner._run_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_task_slash_command_bypasses_running_agent(monkeypatch):
+    """A mid-run /task capture should write Kanban, not interrupt the active agent."""
+    runner = _make_runner()
+    source = _make_source()
+    runner._running_agents[build_session_key(source)] = MagicMock()
+    runner._handle_task_command = AsyncMock(return_value="created triage task")
+
+    result = await runner._handle_message(MessageEvent(
+        text="/task capture this for triage",
+        source=source,
+        message_id="m1",
+    ))
+
+    assert result == "created triage task"
+    runner._handle_task_command.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_underscored_alias_for_hyphenated_builtin_not_flagged(monkeypatch):
     """Telegram autocomplete sends /reload_mcp for the /reload-mcp built-in.
     That must NOT be flagged as unknown."""


### PR DESCRIPTION
## Summary
- add gateway-only /task and /tasknow slash commands for Kanban task capture
- route both commands directly through the gateway instead of letting Telegram reject them as unknown commands
- allow both commands through active-session bypass so task capture works while an agent is running

## Test plan
- python -m pytest tests/gateway/test_unknown_command.py -q -o 'addopts='

## Notes
This upstreams the local customization Dominique was carrying so future hermes update runs do not remove the commands.