### PR TITLE
fix #29284: kanban: --board flag placement is easy to misuse; add explicit error hint/examples

### DIFF
--- a/RELEASE_v0.14.0.md
+++ b/RELEASE_v0.14.0.md
@@ -318,6 +318,7 @@ A long tail of native-Windows fixes shipped alongside the beta — taskkill-base
 - **Keep notifier subscriptions alive across retry cycles** (salvage #21398) ([#23423](https://github.com/NousResearch/hermes-agent/pull/23423))
 - **Drop caller-controlled author override in `kanban_comment`** (salvage of #22109) (@kshitijk4poor) ([#22435](https://github.com/NousResearch/hermes-agent/pull/22435))
 - **Sanitize comment author rendering in `build_worker_context`** ([#22769](https://github.com/NousResearch/hermes-agent/pull/22769))
+- **Clarify `hermes kanban --board <slug> <subcommand>` placement errors** (#29284)
 
 ---
 

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -43,6 +43,60 @@ _STATUS_ICONS = {
 }
 
 
+def _format_board_placement_error(prog: str) -> str:
+    return (
+        "kanban: --board is a kanban global option and must appear before "
+        "the subcommand.\n"
+        "Try:\n"
+        f"  {prog} --board incoming-knowledge list\n"
+        f"  {prog} --board incoming-knowledge create \"Index notes\"\n"
+        "Invalid:\n"
+        f"  {prog} list --board incoming-knowledge"
+    )
+
+
+def _has_misplaced_board_flag(tokens: list[str]) -> bool:
+    """Return True when ``--board`` appears after the kanban action token."""
+    action_seen = False
+    i = 0
+    while i < len(tokens):
+        token = tokens[i]
+        if token == "--":
+            return False
+        if token == "--board":
+            return action_seen
+        if token.startswith("--board="):
+            return action_seen
+        if not action_seen and not token.startswith("-"):
+            action_seen = True
+        i += 1
+    return False
+
+
+def board_placement_error(
+    argv: list[str],
+    *,
+    prog: str = "hermes kanban",
+    command_token: Optional[str] = "kanban",
+) -> Optional[str]:
+    """Return a targeted error for ``kanban <action> ... --board ...``.
+
+    ``argparse`` only accepts parent parser options before the selected
+    subparser. Without this preflight, misplaced ``--board`` falls through to
+    the top-level "unrecognized arguments" error, which hides the fix.
+    """
+    tokens = list(argv)
+    if command_token is not None:
+        try:
+            start = tokens.index(command_token) + 1
+        except ValueError:
+            return None
+        tokens = tokens[start:]
+    if _has_misplaced_board_flag(tokens):
+        return _format_board_placement_error(prog)
+    return None
+
+
 def _fmt_ts(ts: Optional[int]) -> str:
     if not ts:
         return ""
@@ -203,6 +257,17 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
             "See https://hermes-agent.nousresearch.com/docs/user-guide/features/kanban "
             "or docs/hermes-kanban-v1-spec.pdf for the full design."
         ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Global option placement:\n"
+            "  --board belongs immediately after `hermes kanban`, before the subcommand.\n\n"
+            "Examples:\n"
+            "  hermes kanban --board incoming-knowledge list\n"
+            "  hermes kanban --board incoming-knowledge create \"Index notes\"\n"
+            "  /kanban --board incoming-knowledge list\n\n"
+            "Invalid:\n"
+            "  hermes kanban list --board incoming-knowledge"
+        ),
     )
     # --- global --board flag ---
     # Applies to every subcommand below. When set, scopes all reads and
@@ -217,7 +282,8 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
             "Board slug to operate on. Defaults to the current board "
             "(set via `hermes kanban boards switch <slug>` or the "
             "HERMES_KANBAN_BOARD env var). Use `hermes kanban boards list` "
-            "to see all boards."
+            "to see all boards. Must appear before the subcommand: "
+            "`hermes kanban --board <slug> list`."
         ),
     )
     sub = kanban_parser.add_subparsers(dest="kanban_action")
@@ -2594,6 +2660,9 @@ Common subcommands:
   `runs <id>`           Attempt history
   `log <id>`            Worker log
 
+Board override: put `--board <slug>` before the subcommand, e.g.
+  `/kanban --board incoming-knowledge list`
+
 Run `/kanban <subcommand> -h` for arguments. \
 Read-only commands are safe while an agent is running.\
 """
@@ -2617,6 +2686,14 @@ def run_slash(rest: str) -> str:
     # bubble).  Per-subcommand help still works via ``/kanban foo -h``.
     if not tokens or tokens[0] in {"help", "--help", "-h", "?"}:
         return _SLASH_KANBAN_HELP
+
+    placement_error = board_placement_error(
+        tokens,
+        prog="/kanban",
+        command_token=None,
+    )
+    if placement_error:
+        return f"⚠ /kanban usage error\n{placement_error}"
 
     # Single argparse tree rooted at "/kanban".  build_parser() expects a
     # subparsers action to attach to, so build a throwaway one and pull

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -105,9 +105,6 @@ def board_placement_error(
             token = tokens[i]
             if token == "--":
                 return None
-            if token == command_token:
-                tokens = tokens[i + 1:]
-                break
             if token.startswith("-"):
                 if "=" in token:
                     i += 1
@@ -115,6 +112,12 @@ def board_placement_error(
                 if token in _TOP_LEVEL_VALUE_FLAGS and i + 1 < len(tokens):
                     i += 2
                     continue
+                i += 1
+                continue
+            if token != command_token:
+                return None
+            tokens = tokens[i + 1:]
+            break
             i += 1
         else:
             return None

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -118,7 +118,6 @@ def board_placement_error(
                 return None
             tokens = tokens[i + 1:]
             break
-            i += 1
         else:
             return None
     if _has_misplaced_board_flag(tokens):

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -43,6 +43,19 @@ _STATUS_ICONS = {
 }
 
 
+_TOP_LEVEL_VALUE_FLAGS = frozenset(
+    {
+        "-z", "--oneshot",
+        "-m", "--model",
+        "--provider",
+        "-t", "--toolsets",
+        "-r", "--resume",
+        "-s", "--skills",
+        "-c", "--continue",
+    }
+)
+
+
 def _format_board_placement_error(prog: str) -> str:
     return (
         "kanban: --board is a kanban global option and must appear before "
@@ -87,11 +100,24 @@ def board_placement_error(
     """
     tokens = list(argv)
     if command_token is not None:
-        try:
-            start = tokens.index(command_token) + 1
-        except ValueError:
+        i = 0
+        while i < len(tokens):
+            token = tokens[i]
+            if token == "--":
+                return None
+            if token == command_token:
+                tokens = tokens[i + 1:]
+                break
+            if token.startswith("-"):
+                if "=" in token:
+                    i += 1
+                    continue
+                if token in _TOP_LEVEL_VALUE_FLAGS and i + 1 < len(tokens):
+                    i += 2
+                    continue
+            i += 1
+        else:
             return None
-        tokens = tokens[start:]
     if _has_misplaced_board_flag(tokens):
         return _format_board_placement_error(prog)
     return None

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -13078,6 +13078,16 @@ Examples:
 
     _processed_argv = _coalesce_session_name_args(sys.argv[1:])
 
+    try:
+        from hermes_cli.kanban import board_placement_error as _kanban_board_error
+
+        _kanban_board_hint = _kanban_board_error(_processed_argv)
+    except Exception:
+        _kanban_board_hint = None
+    if _kanban_board_hint:
+        print(_kanban_board_hint, file=sys.stderr)
+        sys.exit(2)
+
     # ── Defensive subparser routing (bpo-9338 workaround) ───────────
     # On some Python versions (notably <3.11), argparse fails to route
     # subcommand tokens when the parent parser has nargs='?' optional

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -540,6 +540,15 @@ class TestCLI:
         # the exit code stays 0 is a separate (pre-existing) issue.
         assert "does not exist" in r.stderr
 
+    def test_board_flag_after_subcommand_prints_placement_hint(self, tmp_path):
+        env = {"HERMES_HOME": str(tmp_path)}
+        r = _cli(["list", "--board", "incoming-knowledge"], env_extra=env)
+        assert r.returncode == 2
+        assert "--board is a kanban global option" in r.stderr
+        assert "hermes kanban --board incoming-knowledge list" in r.stderr
+        assert "hermes kanban list --board incoming-knowledge" in r.stderr
+        assert "unrecognized arguments" not in r.stderr
+
     def test_board_flag_rejects_empty_board_dir(self, tmp_path):
         env = {"HERMES_HOME": str(tmp_path)}
         ghost = tmp_path / "kanban" / "boards" / "ghost"

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -458,6 +458,7 @@ def test_run_slash_bare_returns_curated_help(kanban_home):
     assert "/kanban" in out
     assert "list" in out
     assert "show" in out
+    assert "/kanban --board incoming-knowledge list" in out
     # Sanity: should be a chat-friendly size, not the raw usage tree.
     assert len(out) < 2000
     # Shouldn't surface argparse's usage-error sentinel.
@@ -499,6 +500,57 @@ def test_run_slash_missing_required_arg_friendly_error(kanban_home):
     out = kc.run_slash("show")
     assert "/kanban show" in out
     assert "task_id" in out
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["kanban", "list", "--board", "incoming-knowledge"],
+        ["kanban", "list", "--board=incoming-knowledge"],
+        ["kanban", "ls", "--board", "incoming-knowledge"],
+        ["kanban", "boards", "list", "--board", "incoming-knowledge"],
+    ],
+)
+def test_board_placement_error_detects_board_after_subcommand(argv):
+    err = kc.board_placement_error(argv)
+    assert err is not None
+    assert "--board is a kanban global option" in err
+    assert "hermes kanban --board incoming-knowledge list" in err
+    assert "hermes kanban list --board incoming-knowledge" in err
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["kanban", "--board", "incoming-knowledge", "list"],
+        ["kanban", "--board=incoming-knowledge", "list"],
+        ["kanban", "list", "--status", "ready"],
+        ["model", "list", "--board", "incoming-knowledge"],
+    ],
+)
+def test_board_placement_error_ignores_valid_or_non_kanban_argv(argv):
+    assert kc.board_placement_error(argv) is None
+
+
+def test_run_slash_misplaced_board_flag_gets_targeted_hint(kanban_home):
+    out = kc.run_slash("list --board incoming-knowledge")
+    assert out.startswith("⚠ /kanban usage error")
+    assert "--board is a kanban global option" in out
+    assert "/kanban --board incoming-knowledge list" in out
+    assert "/kanban list --board incoming-knowledge" in out
+    assert "unrecognized arguments" not in out
+
+
+def test_kanban_help_documents_board_global_option_placement():
+    root = argparse.ArgumentParser(prog="hermes")
+    sub = root.add_subparsers(dest="cmd")
+    parser = kc.build_parser(sub)
+
+    help_text = parser.format_help()
+
+    assert "Global option placement" in help_text
+    assert "hermes kanban --board incoming-knowledge list" in help_text
+    assert "hermes kanban list --board incoming-knowledge" in help_text
 
 
 def test_run_slash_board_override_restores_prior_env(kanban_home, monkeypatch):

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -525,6 +525,8 @@ def test_board_placement_error_detects_board_after_subcommand(argv):
         ["kanban", "--board", "incoming-knowledge", "list"],
         ["kanban", "--board=incoming-knowledge", "list"],
         ["kanban", "list", "--status", "ready"],
+        ["chat", "kanban", "list", "--board", "incoming-knowledge"],
+        ["chat", "-q", "kanban list --board incoming-knowledge"],
         ["model", "list", "--board", "incoming-knowledge"],
         ["--model", "kanban", "model", "list", "--board", "incoming-knowledge"],
         ["--resume", "kanban", "model", "list", "--board", "incoming-knowledge"],

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -526,6 +526,8 @@ def test_board_placement_error_detects_board_after_subcommand(argv):
         ["kanban", "--board=incoming-knowledge", "list"],
         ["kanban", "list", "--status", "ready"],
         ["model", "list", "--board", "incoming-knowledge"],
+        ["--model", "kanban", "model", "list", "--board", "incoming-knowledge"],
+        ["--resume", "kanban", "model", "list", "--board", "incoming-knowledge"],
     ],
 )
 def test_board_placement_error_ignores_valid_or_non_kanban_argv(argv):

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -593,8 +593,14 @@ The GUI is deliberately thin. Everything the plugin does is reachable from the C
 
 This is the surface **you** (or scripts, cron, the dashboard) use to drive the board. Workers running inside the dispatcher use the `kanban_*` [tool surface](#how-workers-interact-with-the-board) for the same operations — the CLI here and the tools there both route through `kanban_db`, so the two surfaces agree by construction.
 
+`--board` is a kanban global option, so put it before the subcommand:
+`hermes kanban --board incoming-knowledge list`. The reverse order
+(`hermes kanban list --board incoming-knowledge`) is invalid because the
+`list` subparser has already taken over option parsing.
+
 ```
 hermes kanban init                                     # create kanban.db + print daemon hint
+hermes kanban --board <slug> list                      # operate on a specific board
 hermes kanban create "<title>" [--body ...] [--assignee <profile>]
                                 [--parent <id>]... [--tenant <name>]
                                 [--workspace scratch|worktree|worktree:<path>|dir:<path>]


### PR DESCRIPTION
## Summary
Fixes #29284

### Issue
[kanban: --board flag placement is easy to misuse; add explicit error hint/examples](https://github.com/NousResearch/hermes-agent/issues/29284)

### Changes
- fix(kanban): remove unreachable board hint code
- fix(kanban): avoid false board placement errors
- fix(kanban): avoid false board placement hints
- fix(kanban): clarify board flag placement

### Changed Files
```
RELEASE_v0.14.0.md                         |   1 +
 hermes_cli/kanban.py                       | 107 ++++++++++++++++++++++++++++-
 hermes_cli/main.py                         |  10 +++
 tests/hermes_cli/test_kanban_boards.py     |   9 +++
 tests/hermes_cli/test_kanban_cli.py        |  56 +++++++++++++++
 website/docs/user-guide/features/kanban.md |   6 ++
 6 files changed, 188 insertions(+), 1 deletion(-)
```

## Real behavior proof

content:
  behavior: Misplacing the kanban --board global flag after a subcommand now exits with a targeted placement hint instead of argparse's generic unrecognized-arguments error, while the documented pre-subcommand placement still works.
  environment: macOS Darwin worktree /Users/zhangguiping/daily_pr_work/hermes-agent-29284, isolated HOME=/Users/zhangguiping/daily_pr_work/proofs/issue-29284/home, isolated HERMES_HOME=/Users/zhangguiping/daily_pr_work/proofs/issue-29284/hermes-home, CLI surface via python -m hermes_cli.main.
  steps: |
    1. Created an isolated kanban board named incoming-knowledge under the proof HERMES_HOME.
    2. Ran the reported failing command shape with --board after list and captured the new targeted error.
    3. Ran the documented command shape with --board before list and captured the successful board listing.
  evidence: |
    [1] command
    $ env HOME=/Users/zhangguiping/daily_pr_work/proofs/issue-29284/home HERMES_HOME=/Users/zhangguiping/daily_pr_work/proofs/issue-29284/hermes-home PYTHONPATH=/Users/zhangguiping/daily_pr_work/hermes-agent-29284 .venv/bin/python -m hermes_cli.main kanban boards create incoming-knowledge
    exit 0
    Board 'incoming-knowledge' created. DB path: /Users/zhangguiping/daily_pr_work/proofs/issue-29284/hermes-home/kanban/boards/incoming-knowledge/kanban.db
    
    [2] command
    $ env HOME=/Users/zhangguiping/daily_pr_work/proofs/issue-29284/home HERMES_HOME=/Users/zhangguiping/daily_pr_work/proofs/issue-29284/hermes-home PYTHONPATH=/Users/zhangguiping/daily_pr_work/hermes-agent-29284 .venv/bin/python -m hermes_cli.main kanban list --board incoming-knowledge
    exit 2
    kanban: --board is a kanban global option and must appear before the subcommand. Try: hermes kanban --board incoming-knowledge list. Invalid: hermes kanban list --board incoming-knowledge
    
    [3] command
    $ env HOME=/Users/zhangguiping/daily_pr_work/proofs/issue-29284/home HERMES_HOME=/Users/zhangguiping/daily_pr_work/proofs/issue-29284/hermes-home PYTHONPATH=/Users/zhangguiping/daily_pr_work/hermes-agent-29284 .venv/bin/python -m hermes_cli.main kanban --board incoming-knowledge list
    exit 0
    Board: incoming-knowledge (1 other board — `hermes kanban boards list`) (no matching tasks)
  observedResult: The reported misuse now produces an explicit --board placement hint with a valid example and no 'unrecognized arguments' text; the correct placement lists the incoming-knowledge board successfully.
  notTested: None

  proofManifest: /Users/zhangguiping/daily_pr_work/proofs/issue-29284-codex-proof.json
