### PR TITLE
docs: add strict docs quality gate and start path

### DIFF
--- a/.github/workflows/docs-site-checks.yml
+++ b/.github/workflows/docs-site-checks.yml
@@ -44,5 +44,5 @@ jobs:
         working-directory: website
 
       - name: Build Docusaurus
-        run: npm run build
+        run: npm run docs:check
         working-directory: website

--- a/website/docs/developer-guide/adding-platform-adapters.md
+++ b/website/docs/developer-guide/adding-platform-adapters.md
@@ -9,7 +9,7 @@ This guide covers adding a new messaging platform to the Hermes gateway. A platf
 :::tip
 There are two ways to add a platform:
 - **Plugin** (recommended for community/third-party): Drop a plugin directory into `~/.hermes/plugins/` — zero core code changes needed. See [Plugin Path](#plugin-path-recommended) below.
-- **Built-in**: Modify 20+ files across code, config, and docs. Use the [Built-in Checklist](#step-by-step-checklist) below.
+- **Built-in**: Modify 20+ files across code, config, and docs. Use the [Built-in Checklist](#step-by-step-checklist-built-in-path) below.
 :::
 
 ## Architecture Overview

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -12,7 +12,8 @@ displayed_sidebar: docs
 The self-improving AI agent built by [Nous Research](https://nousresearch.com). The only agent with a built-in learning loop — it creates skills from experience, improves them during use, nudges itself to persist knowledge, and builds a deepening model of who you are across sessions.
 
 <div style={{display: 'flex', gap: '1rem', marginBottom: '2rem', flexWrap: 'wrap'}}>
-  <a href="/docs/getting-started/installation" style={{display: 'inline-block', padding: '0.6rem 1.2rem', backgroundColor: '#FFD700', color: '#07070d', borderRadius: '8px', fontWeight: 600, textDecoration: 'none'}}>Get Started →</a>
+  <a href="/docs/start" style={{display: 'inline-block', padding: '0.6rem 1.2rem', backgroundColor: '#FFD700', color: '#07070d', borderRadius: '8px', fontWeight: 600, textDecoration: 'none'}}>Start Here →</a>
+  <a href="/docs/getting-started/installation" style={{display: 'inline-block', padding: '0.6rem 1.2rem', border: '1px solid rgba(255,215,0,0.2)', borderRadius: '8px', textDecoration: 'none'}}>Installation</a>
   <a href="https://github.com/NousResearch/hermes-agent" style={{display: 'inline-block', padding: '0.6rem 1.2rem', border: '1px solid rgba(255,215,0,0.2)', borderRadius: '8px', textDecoration: 'none'}}>View on GitHub</a>
 </div>
 
@@ -42,6 +43,7 @@ It's not a coding copilot tethered to an IDE or a chatbot wrapper around a singl
 
 | | |
 |---|---|
+| 🧭 **[Start Here](/docs/start)** | Golden first-run path: install, configure, verify, and choose your command-center workflow |
 | 🚀 **[Installation](/docs/getting-started/installation)** | Install in 60 seconds on Linux, macOS, WSL2, or native Windows (early beta) |
 | 📖 **[Quickstart Tutorial](/docs/getting-started/quickstart)** | Your first conversation and key features to try |
 | 🗺️ **[Learning Path](/docs/getting-started/learning-path)** | Find the right docs for your experience level |

--- a/website/docs/start.md
+++ b/website/docs/start.md
@@ -1,0 +1,214 @@
+---
+slug: /start
+sidebar_position: 1
+title: "Start Here"
+description: "The golden first-run path for Hermes Agent: install, configure, verify, and choose the next command-center workflow."
+---
+
+# Start Here
+
+This is the shortest path from “Hermes is installed” to “Hermes is a working command center.”
+
+Follow the checkpoints in order. Do not add gateway, cron, voice, MCP, or multi-agent workflows until the previous checkpoint passes.
+
+## 0. Install
+
+**Linux / macOS / WSL2 / Termux**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
+source ~/.bashrc   # or source ~/.zshrc
+```
+
+**Native Windows PowerShell — early beta**
+
+```powershell
+iex (irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1)
+```
+
+If you need the full install matrix, see [Installation](./getting-started/installation.md).
+
+## 1. Run the setup wizard
+
+```bash
+hermes setup
+```
+
+Minimum good outcome:
+
+- A model provider is configured.
+- `hermes doctor` has no blocking errors.
+- Your shell can find the `hermes` command.
+
+Verify:
+
+```bash
+hermes doctor
+hermes status --all
+```
+
+If you already know which provider you want, use the focused model picker instead:
+
+```bash
+hermes model
+```
+
+## 2. Prove one normal chat works
+
+Start Hermes:
+
+```bash
+hermes
+# or: hermes --tui
+```
+
+Send a prompt that is easy to verify:
+
+```text
+Check my current directory and tell me what project this looks like.
+```
+
+Success means:
+
+- Hermes replies without auth/model errors.
+- It can use at least one local tool when useful.
+- A second follow-up works in the same session.
+
+If this does not work, stop here and fix the provider/config first. More features will only make the failure harder to understand.
+
+## 3. Verify persistence
+
+Exit the chat, then resume it:
+
+```bash
+hermes --continue
+# or: hermes -c
+```
+
+Success means Hermes can recover the latest session. This is the foundation for longer-running work, messaging surfaces, and handoffs.
+
+## 4. Choose your command-center path
+
+Once chat + resume work, pick the path that matches what you want Hermes to become.
+
+### A. Personal terminal agent
+
+Use this when Hermes mostly works in your shell.
+
+```bash
+hermes tools
+hermes config
+hermes sessions browse
+```
+
+Read next:
+
+- [CLI](./user-guide/cli.md)
+- [TUI](./user-guide/tui.md)
+- [Tools](./user-guide/features/tools.md)
+- [Sessions](./user-guide/sessions.md)
+
+### B. Always-on messaging assistant
+
+Use this when you want Telegram, Discord, Slack, WhatsApp, Signal, or another platform.
+
+```bash
+hermes gateway setup
+hermes gateway install
+hermes gateway start
+hermes gateway status
+```
+
+Read next:
+
+- [Messaging Gateway](./user-guide/messaging/index.md)
+- [Telegram](./user-guide/messaging/telegram.md)
+- [Discord](./user-guide/messaging/discord.md)
+
+### C. Automation and scheduled work
+
+Use this when Hermes should run jobs without you present.
+
+```bash
+hermes cron create "every 1h"
+hermes cron list
+```
+
+Read next:
+
+- [Cron](./user-guide/features/cron.md)
+- [Delegation](./user-guide/features/delegation.md)
+- [Kanban](./user-guide/features/kanban.md)
+
+### D. Project-aware coding agent
+
+Use this when Hermes should work inside repos, remember procedures, and manage PRs.
+
+```bash
+cd /path/to/project
+hermes --worktree
+```
+
+Read next:
+
+- [Context Files](./user-guide/features/context-files.md)
+- [Git Worktrees](./user-guide/git-worktrees.md)
+- [Checkpoints and Rollback](./user-guide/checkpoints-and-rollback.md)
+- [Developer Guide](./developer-guide/architecture.md)
+
+### E. Extensible tool platform
+
+Use this when you want MCP servers, plugins, custom skills, or custom tools.
+
+```bash
+hermes mcp list
+hermes plugins list
+hermes skills list
+```
+
+Read next:
+
+- [MCP](./user-guide/features/mcp.md)
+- [Plugins](./user-guide/features/plugins.md)
+- [Skills](./user-guide/features/skills.md)
+- [Adding Tools](./developer-guide/adding-tools.md)
+
+## 5. First-run checklist
+
+Before calling the setup “done,” all of these should pass:
+
+```bash
+hermes doctor
+hermes status --all
+hermes chat -q "Reply with the configured model/provider and one sentence confirming tools are available."
+hermes --continue
+```
+
+Expected outcome:
+
+- Provider configured.
+- No blocking dependency errors.
+- One-shot chat works.
+- Interactive chat works.
+- Resume works.
+
+## If something fails
+
+Use the narrowest fix first:
+
+- Command missing: reopen your terminal, then check `which hermes`.
+- Provider/auth failure: run `hermes model` again.
+- Tool missing: run `hermes tools`, enable the toolset, then start a new session.
+- Gateway silent: run `hermes gateway status` and inspect `~/.hermes/logs/gateway.log`.
+- Sessions not resuming: check `hermes profile list` and `hermes sessions list`.
+
+For deeper troubleshooting, see [FAQ & Troubleshooting](./reference/faq.md) and [Configuration](./user-guide/configuration.md).
+
+## Machine-readable docs
+
+Agents can ingest the docs directly:
+
+- [`/llms.txt`](/llms.txt) — compact index.
+- [`/llms-full.txt`](/llms-full.txt) — full docs corpus.
+
+These files are regenerated during every docs build.

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -910,7 +910,7 @@ Each auxiliary task has a configurable `timeout` (in seconds). Defaults: vision 
 :::
 
 :::info
-Context compression has its own `compression:` block for thresholds and an `auxiliary.compression:` block for model/provider settings — see [Context Compression](#context-compression) above. The fallback model uses a `fallback_model:` block — see [Fallback Model](/docs/integrations/providers#fallback-model). All three follow the same provider/model/base_url pattern.
+Context compression has its own `compression:` block for thresholds and an `auxiliary.compression:` block for model/provider settings — see [Context Compression](#context-compression) above. Fallbacks use the canonical `fallback_providers:` chain, with legacy `fallback_model:` still accepted for back-compat — see [Fallback Providers](/docs/integrations/providers#fallback-providers). All three follow the same provider/model/base_url pattern.
 :::
 
 ### OpenRouter routing & Pareto Code for auxiliary tasks

--- a/website/docs/user-guide/features/rl-training.md
+++ b/website/docs/user-guide/features/rl-training.md
@@ -1,0 +1,95 @@
+---
+title: "RL Training"
+sidebar_label: "RL Training"
+sidebar_position: 9
+---
+
+# RL Training
+
+Hermes can generate agent trajectories that are useful for reinforcement learning, evaluation, and fine-tuning workflows. Treat this as an advanced workflow: first get normal sessions, tools, and provider routing working, then export trajectories and feed them into your training stack.
+
+:::info Experimental surface
+Hermes does not hide that RL pipelines are sharp tools. Use this page as the product entrypoint for trajectory generation and RL-oriented exports; model-specific training recipes live in the optional ML skills and external training frameworks.
+:::
+
+## What Hermes Provides
+
+Hermes helps with the data side of RL and post-training workflows:
+
+- **Session trajectories** — conversations, tool calls, tool results, and final answers saved as structured records.
+- **Batch processing** — run many prompts through the agent to create comparable trajectories.
+- **ShareGPT-compatible exports** — convert sessions into JSONL datasets for downstream tooling.
+- **Provider routing** — run generation/evaluation on one provider and auxiliary tasks on cheaper models.
+- **Skills** — load domain procedures so trajectories include consistent expert behavior.
+
+Hermes does not magically make bad prompts into good training data. The quality of the resulting dataset still depends on task design, verification, filtering, and evaluation.
+
+## Recommended Workflow
+
+1. **Configure a reliable model/provider**
+
+   Start with [Configuration](../configuration.md) and [Provider Routing](provider-routing.md). For expensive reasoning models, configure cheaper auxiliary models before generating many trajectories.
+
+2. **Create representative tasks**
+
+   Use prompts that match the behavior you actually want to train or evaluate. Prefer tasks with verifiable outputs over vague chat transcripts.
+
+3. **Run trajectories through batch processing**
+
+   Use [Batch Processing](batch-processing.md) when you want repeatable, multi-prompt runs instead of ad hoc sessions.
+
+4. **Export sessions**
+
+   Use [Sessions](../sessions.md) to inspect and export the relevant runs:
+
+   ```bash
+   hermes sessions export trajectories.jsonl
+   ```
+
+5. **Filter and evaluate**
+
+   Remove failed, low-signal, unsafe, or unverified trajectories before training. Keep the raw exports as audit artifacts.
+
+6. **Train outside Hermes or with ML skills**
+
+   For training mechanics, use the optional ML skills for TRL, Axolotl, Unsloth, vLLM, and evaluation harnesses where appropriate.
+
+## Good Trajectory Sources
+
+High-signal RL/evaluation data usually comes from tasks with clear success criteria:
+
+- code changes with tests
+- document extraction with known expected fields
+- tool-use workflows with explicit receipts
+- web research with cited sources
+- debugging sessions with reproducible failures and fixes
+- structured outputs validated by schemas
+
+Low-signal sources:
+
+- generic chat
+- unverified summaries
+- tasks where the assistant guessed
+- long sessions with unrelated context mixed together
+- tool failures summarized as success
+
+## Verification Checklist
+
+Before treating a trajectory as training data:
+
+- Did the agent use the required tools instead of guessing?
+- Are file edits, commands, or external actions verified?
+- Are secrets absent or redacted?
+- Is the final answer consistent with tool receipts?
+- Can the task outcome be scored by tests, validators, or human review?
+- Is the task representative of the behavior you want more of?
+
+## Related Docs
+
+- [Batch Processing](batch-processing.md)
+- [Sessions](../sessions.md)
+- [Provider Routing](provider-routing.md)
+- [Fallback Providers](fallback-providers.md)
+- [Trajectory Format](../../developer-guide/trajectory-format.md)
+- [LM Evaluation Harness skill](../skills/bundled/mlops/mlops-evaluation-lm-evaluation-harness.md)
+- [TRL Fine-Tuning skill](../skills/optional/mlops/mlops-training-trl-fine-tuning.md)

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -293,7 +293,7 @@ With STT disabled, the gateway still downloads the voice/audio attachment into H
 
 Your tools or skills can then read that path directly (e.g., hand it off to a local diarization pipeline, a richer transcription model, or upload it to long-term storage). The file extension reflects the original format Telegram delivered (`.ogg` for voice notes, `.mp3`/`.m4a`/etc. for audio attachments).
 
-This pairs naturally with the [local Bot API server](#large-files-20mb--via-local-bot-api-server) section below, which lifts Telegram's 20MB getFile ceiling to 2GB — useful when the recordings you want to process are longer than a couple of minutes.
+This pairs naturally with the [local Bot API server](#large-files-20mb-via-local-bot-api-server) section below, which lifts Telegram's 20MB getFile ceiling to 2GB — useful when the recordings you want to process are longer than a couple of minutes.
 
 ### Outgoing Voice (Text-to-Speech)
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -110,6 +110,12 @@ const config: Config = {
       },
       items: [
         {
+          type: 'doc',
+          docId: 'start',
+          label: 'Start Here',
+          position: 'left',
+        },
+        {
           type: 'docSidebar',
           sidebarId: 'docs',
           position: 'left',

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -2,6 +2,8 @@ import {themes as prismThemes} from 'prism-react-renderer';
 import type {Config} from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 
+const strictLinks = process.env.HERMES_DOCS_STRICT_LINKS === '1';
+
 const config: Config = {
   title: 'Hermes Agent',
   tagline: 'The self-improving AI agent',
@@ -13,12 +15,13 @@ const config: Config = {
   organizationName: 'NousResearch',
   projectName: 'hermes-agent',
 
-  onBrokenLinks: 'warn',
+  onBrokenLinks: strictLinks ? 'throw' : 'warn',
+  onBrokenAnchors: strictLinks ? 'throw' : 'warn',
 
   markdown: {
     mermaid: true,
     hooks: {
-      onBrokenMarkdownLinks: 'warn',
+      onBrokenMarkdownLinks: strictLinks ? 'throw' : 'warn',
     },
   },
 

--- a/website/package.json
+++ b/website/package.json
@@ -8,6 +8,8 @@
     "start": "docusaurus start",
     "prebuild": "node scripts/prebuild.mjs",
     "build": "docusaurus build",
+    "predocs:check": "node scripts/prebuild.mjs",
+    "docs:check": "node scripts/check-docs.mjs && HERMES_DOCS_STRICT_LINKS=1 docusaurus build --locale en",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",

--- a/website/scripts/check-docs.mjs
+++ b/website/scripts/check-docs.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+// Lightweight docs quality gates that complement the Docusaurus build.
+// Docusaurus catches broken links. This script catches repository-specific
+// drift: docs missing from the sidebar, generated docs that were not committed,
+// and stale generated LLM entrypoints.
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const websiteDir = resolve(scriptDir, "..");
+const repoRoot = resolve(websiteDir, "..");
+const docsDir = join(websiteDir, "docs");
+const sidebarFile = join(websiteDir, "sidebars.ts");
+
+const allowlistedOrphans = new Set([
+  // Root landing page is routed as / and intentionally not listed as a sidebar item.
+  "index",
+  // Advanced/dev docs that are linked contextually but intentionally hidden from primary nav.
+  "developer-guide/browser-supervisor",
+  "developer-guide/web-search-provider-plugin",
+  "guides/google-gemini",
+  "guides/local-ollama-setup",
+  "guides/minimax-oauth",
+  "guides/pipe-script-output",
+  "user-guide/messaging/google_chat",
+  "user-guide/skills/godmode",
+  "user-guide/skills/google-workspace",
+]);
+
+function walk(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    const st = statSync(path);
+    if (st.isDirectory()) out.push(...walk(path));
+    else out.push(path);
+  }
+  return out;
+}
+
+function docIdFromPath(path) {
+  let rel = relative(docsDir, path).replaceAll("\\\\", "/");
+  rel = rel.replace(/\.(md|mdx)$/u, "");
+  if (rel.endsWith("/index")) return rel.slice(0, -"/index".length);
+  return rel;
+}
+
+function collectSidebarIds() {
+  const source = readFileSync(sidebarFile, "utf8");
+  const ids = new Set();
+  for (const match of source.matchAll(/['"]([^'"]+)['"]/gu)) {
+    const value = match[1];
+    if (!value.includes("/") && !value.startsWith("user-stories")) continue;
+    ids.add(value);
+    if (value.endsWith("/index")) ids.add(value.slice(0, -"/index".length));
+  }
+  return ids;
+}
+
+function checkSidebarCoverage() {
+  const sidebarIds = collectSidebarIds();
+  const docs = walk(docsDir)
+    .filter((p) => /\.(md|mdx)$/u.test(p))
+    .filter((p) => !p.endsWith("_category_.json"))
+    .map(docIdFromPath);
+
+  const missing = docs
+    .filter((id) => !sidebarIds.has(id) && !allowlistedOrphans.has(id))
+    .sort();
+
+  if (missing.length > 0) {
+    console.error("Docs missing from website/sidebars.ts:");
+    for (const id of missing) console.error(`  - ${id}`);
+    console.error("Add them to the sidebar or intentionally allowlist them in scripts/check-docs.mjs.");
+    process.exitCode = 1;
+  }
+}
+
+function checkGeneratedFreshness() {
+  const generated = [
+    "website/src/data/skills.json",
+    "website/static/llms.txt",
+    "website/static/llms-full.txt",
+    "website/docs/reference/skills-catalog.md",
+    "website/docs/reference/optional-skills-catalog.md",
+  ].filter((p) => existsSync(join(repoRoot, p)));
+
+  if (generated.length === 0) return;
+
+  try {
+    execFileSync("git", ["diff", "--quiet", "--", ...generated], {
+      cwd: repoRoot,
+      stdio: "pipe",
+    });
+  } catch {
+    console.error("Generated docs/data are stale after prebuild:");
+    const diff = execFileSync("git", ["diff", "--", ...generated], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024,
+    });
+    console.error(diff.slice(0, 12000));
+    console.error("Run `npm run prebuild` in website/ and commit the generated outputs.");
+    process.exitCode = 1;
+  }
+}
+
+checkSidebarCoverage();
+checkGeneratedFreshness();
+
+if (process.exitCode) process.exit(process.exitCode);
+console.log("Docs checks passed: sidebar coverage + generated freshness.");

--- a/website/scripts/check-docs.mjs
+++ b/website/scripts/check-docs.mjs
@@ -54,7 +54,7 @@ function collectSidebarIds() {
   const ids = new Set();
   for (const match of source.matchAll(/['"]([^'"]+)['"]/gu)) {
     const value = match[1];
-    if (!value.includes("/") && !value.startsWith("user-stories")) continue;
+    if (value.startsWith("http") || value.startsWith(".")) continue;
     ids.add(value);
     if (value.endsWith("/index")) ids.add(value.slice(0, -"/index".length));
   }

--- a/website/scripts/generate-llms-txt.py
+++ b/website/scripts/generate-llms-txt.py
@@ -38,6 +38,7 @@ SITE_BASE = "https://hermes-agent.nousresearch.com/docs"
 # `None` desc → pulled from frontmatter `description:` field.
 SECTIONS: list[tuple[str, list[tuple[str, str, str | None]]]] = [
     ("Getting Started", [
+        ("start", "Start Here", None),
         ("getting-started/installation", "Installation", None),
         ("getting-started/quickstart", "Quickstart", None),
         ("getting-started/learning-path", "Learning Path", None),
@@ -79,6 +80,7 @@ SECTIONS: list[tuple[str, list[tuple[str, str, str | None]]]] = [
         ("user-guide/features/code-execution", "Code Execution", None),
         ("user-guide/features/hooks", "Hooks", None),
         ("user-guide/features/batch-processing", "Batch Processing", None),
+        ("user-guide/features/rl-training", "RL Training", None),
     ]),
     ("Media & Web", [
         ("user-guide/features/voice-mode", "Voice Mode", None),

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -75,6 +75,7 @@ const sidebars: SidebarsConfig = {
             'user-guide/features/code-execution',
             'user-guide/features/hooks',
             'user-guide/features/batch-processing',
+            'user-guide/features/rl-training',
           ],
         },
         {

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -2,6 +2,7 @@ import type {SidebarsConfig} from '@docusaurus/plugin-content-docs';
 
 const sidebars: SidebarsConfig = {
   docs: [
+    'start',
     'user-stories',
     {
       type: 'category',

--- a/website/src/components/UserStoriesCollage/index.tsx
+++ b/website/src/components/UserStoriesCollage/index.tsx
@@ -145,7 +145,7 @@ function sourceColor(source: string): string {
   }
 }
 
-export default function UserStoriesCollage(): JSX.Element {
+export default function UserStoriesCollage(): React.ReactElement {
   const [activeCategory, setActiveCategory] = useState<string>('all');
   const [activeSource, setActiveSource] = useState<string>('all');
 


### PR DESCRIPTION
## Summary
- Adds strict docs quality gates for sidebar coverage, generated freshness, and broken links.
- Adds /docs/start as the golden first-run onboarding path.
- Wires Start Here into the homepage, navbar, sidebar, llms.txt, and search.

## Test plan
- npm run docs:check
- git diff --check