### PR TITLE
fix(goal): stop the /goal loop when the agent says it is done (#29090)

### DIFF
--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -67,12 +67,35 @@ _JUDGE_RESPONSE_SNIPPET_CHARS = 4000
 DEFAULT_MAX_CONSECUTIVE_PARSE_FAILURES = 3
 
 
+# Agent self-attestation sentinels.  Emitted by the model on its own
+# line at the END of a response to break the goal loop deterministically
+# — without consulting the judge.  Closes #29090: a gibberish or
+# otherwise unverifiable goal (``/goal lsdjflasjdf;ljasdlfja;sldjfalsdjf``)
+# used to spam continuations until the turn budget ran out because the
+# judge model couldn't decide "done" on a goal it didn't understand.
+# Now the agent itself signals "I'm done / blocked" and the loop stops
+# immediately.
+GOAL_DONE_SENTINEL = "<<HERMES_GOAL_DONE>>"
+GOAL_BLOCKED_SENTINEL = "<<HERMES_GOAL_BLOCKED>>"
+
+_STOP_INSTRUCTION_LINE = (
+    "When you have nothing more to do for this goal, end your final "
+    "message with a line that is EXACTLY one of:\n"
+    "  <<HERMES_GOAL_DONE: one-sentence reason>>\n"
+    "  <<HERMES_GOAL_BLOCKED: one-sentence reason>>\n"
+    "The sentinel must be the LAST non-blank line in your response. "
+    "Emitting one stops the loop without waiting for the judge — use "
+    "DONE when the goal is complete or trivially unachievable (typos, "
+    "gibberish, contradictions), BLOCKED when you genuinely need user "
+    "input to make progress."
+)
+
+
 CONTINUATION_PROMPT_TEMPLATE = (
     "[Continuing toward your standing goal]\n"
     "Goal: {goal}\n\n"
-    "Continue working toward this goal. Take the next concrete step. "
-    "If you believe the goal is complete, state so explicitly and stop. "
-    "If you are blocked and need input from the user, say so clearly and stop."
+    "Continue working toward this goal. Take the next concrete step.\n\n"
+    f"{_STOP_INSTRUCTION_LINE}"
 )
 
 # Used when the user has added one or more /subgoal criteria. Surfaced
@@ -84,10 +107,8 @@ CONTINUATION_PROMPT_WITH_SUBGOALS_TEMPLATE = (
     "Additional criteria the user added mid-loop:\n"
     "{subgoals_block}\n\n"
     "Continue working toward the goal AND all additional criteria. Take "
-    "the next concrete step. If you believe the goal and every "
-    "additional criterion are complete, state so explicitly and stop. "
-    "If you are blocked and need input from the user, say so clearly "
-    "and stop."
+    "the next concrete step.\n\n"
+    f"{_STOP_INSTRUCTION_LINE}"
 )
 
 
@@ -314,6 +335,54 @@ def _goal_judge_max_tokens() -> int:
     except Exception:
         pass
     return DEFAULT_JUDGE_MAX_TOKENS
+
+
+# Regex anchored on the sentinel.  Reason group is optional so a bare
+# ``<<HERMES_GOAL_DONE>>`` still trips, with a default reason supplied
+# by the caller.  Case-insensitive so weak models that lowercase
+# everything still match.
+_STOP_SENTINEL_RE = re.compile(
+    r"<<\s*HERMES_GOAL_(DONE|BLOCKED)\s*(?::\s*([^>]+?))?\s*>>",
+    re.IGNORECASE,
+)
+
+
+def _detect_goal_stop_sentinel(response: str) -> Optional[Tuple[str, str]]:
+    """Return ``(kind, reason)`` if the agent self-attested completion.
+
+    Only fires when the sentinel appears on the **last non-blank line**
+    of the response.  The continuation prompt itself contains the
+    sentinel as an instruction; many models echo their instructions
+    mid-response.  Anchoring on the last line keeps that echo from
+    false-positive-stopping the loop — the agent has to make the
+    sentinel the final thing they say, matching the prompt contract
+    "the sentinel must be the LAST non-blank line in your response".
+
+    ``kind`` is ``"done"`` or ``"blocked"``.  Both halt the loop;
+    ``"blocked"`` exists so the surfaced message tells the user the
+    agent wants their input rather than reporting success.
+    """
+    if not response:
+        return None
+    last_line = ""
+    for line in reversed(response.splitlines()):
+        if line.strip():
+            last_line = line
+            break
+    if not last_line:
+        return None
+    match = _STOP_SENTINEL_RE.search(last_line)
+    if not match:
+        return None
+    kind = match.group(1).lower()
+    reason = (match.group(2) or "").strip()
+    if not reason:
+        reason = (
+            "agent attested goal completion"
+            if kind == "done"
+            else "agent reported blocked — needs user input"
+        )
+    return kind, reason
 
 
 def _parse_judge_response(raw: str) -> Tuple[bool, str, bool]:
@@ -645,6 +714,35 @@ class GoalManager:
         # Count the turn that just finished.
         state.turns_used += 1
         state.last_turn_at = time.time()
+
+        # Honor explicit agent self-attestation BEFORE the judge.  Weak
+        # judge models can't reliably mark a gibberish/unverifiable goal
+        # as "done" — they hedge with "continue" and spam the budget
+        # (#29090, #27585).  The continuation prompt now teaches the
+        # agent two terminal sentinels (``<<HERMES_GOAL_DONE: …>>`` /
+        # ``<<HERMES_GOAL_BLOCKED: …>>``); if the agent emits one as the
+        # last non-blank line of its reply, trust it and stop without
+        # an extra judge round-trip.
+        sentinel = _detect_goal_stop_sentinel(last_response)
+        if sentinel is not None:
+            kind, sentinel_reason = sentinel
+            state.status = "done"
+            state.last_verdict = "done"
+            state.last_reason = sentinel_reason
+            # Sentinel emission means we got a real reply; reset the
+            # consecutive-parse-failures counter so a future judge call
+            # doesn't auto-pause on stale state.
+            state.consecutive_parse_failures = 0
+            save_goal(self.session_id, state)
+            label = "achieved" if kind == "done" else "stopped (agent blocked)"
+            return {
+                "status": "done",
+                "should_continue": False,
+                "continuation_prompt": None,
+                "verdict": "done",
+                "reason": sentinel_reason,
+                "message": f"✓ Goal {label}: {sentinel_reason}",
+            }
 
         verdict, reason, parse_failed = judge_goal(
             state.goal, last_response, subgoals=state.subgoals or None

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -350,12 +350,14 @@ _STOP_SENTINEL_RE = re.compile(
 def _detect_goal_stop_sentinel(response: str) -> Optional[Tuple[str, str]]:
     """Return ``(kind, reason)`` if the agent self-attested completion.
 
-    Only fires when the sentinel appears on the **last non-blank line**
-    of the response.  The continuation prompt itself contains the
-    sentinel as an instruction; many models echo their instructions
-    mid-response.  Anchoring on the last line keeps that echo from
-    false-positive-stopping the loop — the agent has to make the
-    sentinel the final thing they say, matching the prompt contract
+    The sentinel must be the **entire** final non-blank line of the
+    response (only the sentinel itself + optional surrounding
+    whitespace allowed on that line).  The continuation prompt
+    contains the sentinel as an instruction, and models routinely
+    echo their instructions mid-reasoning — including inline, on the
+    same line as their normal prose.  Requiring the final line to be
+    the sentinel and nothing else keeps those echoes from false-
+    positive-stopping the loop and matches the prompt contract
     "the sentinel must be the LAST non-blank line in your response".
 
     ``kind`` is ``"done"`` or ``"blocked"``.  Both halt the loop;
@@ -371,7 +373,8 @@ def _detect_goal_stop_sentinel(response: str) -> Optional[Tuple[str, str]]:
             break
     if not last_line:
         return None
-    match = _STOP_SENTINEL_RE.search(last_line)
+    stripped = last_line.strip()
+    match = _STOP_SENTINEL_RE.fullmatch(stripped)
     if not match:
         return None
     kind = match.group(1).lower()

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -738,3 +738,283 @@ class TestStatusLineSubgoalCount:
         mgr.add_subgoal("b")
         line = mgr.status_line()
         assert "2 subgoals" in line
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Agent self-attestation stop sentinels (#29090)
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestStopSentinelDetection:
+    """Unit-level coverage for ``_detect_goal_stop_sentinel``.
+
+    The sentinel only fires when it's the LAST non-blank line of the
+    response — anything else would false-positive on agents that echo
+    the continuation prompt's instruction text back in their reasoning.
+    """
+
+    @pytest.mark.parametrize("response,kind,reason_fragment", [
+        ("Work done.\n<<HERMES_GOAL_DONE: shipped feature X>>",
+         "done", "shipped feature x"),
+        ("Final reply.\n<<HERMES_GOAL_BLOCKED: need API key from user>>",
+         "blocked", "need api key"),
+        # Bare sentinel without reason — fallback reason supplied.
+        ("All good.\n<<HERMES_GOAL_DONE>>", "done", "agent"),
+        ("Cannot proceed.\n<<HERMES_GOAL_BLOCKED>>", "blocked", "blocked"),
+        # Mixed casing — regex is case-insensitive.
+        ("ok.\n<<hermes_goal_done: lowercase ok>>", "done", "lowercase"),
+        # Extra whitespace around the reason gets stripped.
+        ("ok.\n<<HERMES_GOAL_DONE:    spaced reason   >>",
+         "done", "spaced reason"),
+        # Whitespace after sentinel still treated as last line.
+        ("ok.\n<<HERMES_GOAL_DONE: trailing newlines>>\n\n   \n",
+         "done", "trailing newlines"),
+    ])
+    def test_detection_happy_paths(self, response, kind, reason_fragment):
+        from hermes_cli.goals import _detect_goal_stop_sentinel
+
+        result = _detect_goal_stop_sentinel(response)
+        assert result is not None
+        out_kind, out_reason = result
+        assert out_kind == kind
+        assert reason_fragment.lower() in out_reason.lower()
+
+    @pytest.mark.parametrize("response", [
+        "",
+        None,
+        "Just a normal response with no sentinel.",
+        # Bare prose mentioning the sentinel string but not as a marker.
+        "Per the instructions, I would emit HERMES_GOAL_DONE here.",
+        # Sentinel in the MIDDLE of the response — agent kept talking,
+        # so they didn't actually want to stop.  This is the prompt-echo
+        # false-positive guard.
+        ("I see the instructions: <<HERMES_GOAL_DONE: example>>\n\n"
+         "Now, here is my actual work for this turn: step 1, step 2, "
+         "step 3.\nI will continue next turn."),
+        # Same shape with BLOCKED.
+        ("<<HERMES_GOAL_BLOCKED: example>>\n\n"
+         "Actually I'm not blocked — pushing on."),
+    ])
+    def test_detection_rejects_non_terminal_or_absent(self, response):
+        from hermes_cli.goals import _detect_goal_stop_sentinel
+        assert _detect_goal_stop_sentinel(response) is None
+
+    def test_continuation_prompt_teaches_both_sentinels(self, hermes_home):
+        """The continuation prompt the agent receives every loop turn
+        must teach the sentinel contract — otherwise the agent can't
+        emit it and the fix is dead on arrival."""
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="sentinel-teach")
+        mgr.set("some long goal")
+        prompt = mgr.next_continuation_prompt()
+        assert prompt is not None
+        assert "<<HERMES_GOAL_DONE" in prompt
+        assert "<<HERMES_GOAL_BLOCKED" in prompt
+        assert "LAST non-blank line" in prompt
+
+    def test_continuation_prompt_with_subgoals_teaches_sentinels(self, hermes_home):
+        """Subgoals path must keep the sentinel instruction in lockstep."""
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="sentinel-teach-sub")
+        mgr.set("some long goal")
+        mgr.add_subgoal("criterion A")
+        prompt = mgr.next_continuation_prompt()
+        assert prompt is not None
+        assert "<<HERMES_GOAL_DONE" in prompt
+        assert "<<HERMES_GOAL_BLOCKED" in prompt
+        assert "criterion A" in prompt
+
+
+class TestEvaluateAfterTurnSentinel:
+    """End-to-end behaviour: when the agent emits a stop sentinel,
+    ``evaluate_after_turn`` must short-circuit BEFORE the judge call
+    and persist ``status="done"``.  Reproduces the #29090 fix path."""
+
+    def test_done_sentinel_short_circuits_judge(self, hermes_home):
+        from hermes_cli import goals
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="sent-done")
+        mgr.set("gibberish goal")
+
+        with patch.object(goals, "judge_goal") as judge_mock:
+            decision = mgr.evaluate_after_turn(
+                "I'm finished with the task.\n"
+                "<<HERMES_GOAL_DONE: gibberish goal is unverifiable, "
+                "treating as completed>>"
+            )
+        judge_mock.assert_not_called(), (
+            "judge must NOT run when the agent emits a terminal sentinel "
+            "— that's the whole point of #29090"
+        )
+        assert decision["verdict"] == "done"
+        assert decision["should_continue"] is False
+        assert decision["continuation_prompt"] is None
+        assert "unverifiable" in decision["reason"]
+        assert mgr.state.status == "done"
+
+    def test_blocked_sentinel_short_circuits_judge(self, hermes_home):
+        from hermes_cli import goals
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="sent-blocked")
+        mgr.set("need-user-input goal")
+
+        with patch.object(goals, "judge_goal") as judge_mock:
+            decision = mgr.evaluate_after_turn(
+                "I need credentials to proceed.\n"
+                "<<HERMES_GOAL_BLOCKED: missing AWS_PROFILE — please set it>>"
+            )
+        judge_mock.assert_not_called()
+        assert decision["verdict"] == "done"
+        assert decision["should_continue"] is False
+        assert "blocked" in decision["message"].lower()
+        assert "AWS_PROFILE" in decision["reason"]
+        assert mgr.state.status == "done"
+
+    def test_sentinel_resets_parse_failure_counter(self, hermes_home):
+        """If a flaky judge had built up consecutive parse failures, the
+        sentinel landing must clear the counter so the *next* goal
+        (after /goal resume + a real prompt) doesn't immediately
+        auto-pause on stale state."""
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="sent-reset")
+        mgr.set("g")
+        mgr.state.consecutive_parse_failures = 2  # one short of the cap
+        mgr.evaluate_after_turn("ok\n<<HERMES_GOAL_DONE: yes>>")
+        assert mgr.state.consecutive_parse_failures == 0
+
+    def test_non_sentinel_response_still_calls_judge(self, hermes_home):
+        """Regression guard for the existing judge path — make sure the
+        new sentinel branch only triggers when the sentinel is present."""
+        from hermes_cli import goals
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="sent-passthrough")
+        mgr.set("a goal")
+
+        with patch.object(
+            goals, "judge_goal", return_value=("continue", "more", False)
+        ) as judge_mock:
+            decision = mgr.evaluate_after_turn("Plain prose with no sentinel.")
+        judge_mock.assert_called_once()
+        assert decision["verdict"] == "continue"
+        assert decision["should_continue"] is True
+
+    def test_sentinel_inside_response_but_not_last_line_calls_judge(
+        self, hermes_home
+    ):
+        """The prompt-echo guard, end-to-end: an agent that quotes the
+        sentinel mid-response but keeps talking afterward must NOT
+        short-circuit — the judge still has the final say."""
+        from hermes_cli import goals
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="sent-echo")
+        mgr.set("a goal")
+
+        echo_response = (
+            "Per the instructions, I should emit "
+            "<<HERMES_GOAL_DONE: example>> when I finish.  "
+            "Right now I'm still working — running tests next."
+        )
+        with patch.object(
+            goals, "judge_goal", return_value=("continue", "more", False)
+        ) as judge_mock:
+            decision = mgr.evaluate_after_turn(echo_response)
+        judge_mock.assert_called_once()
+        assert decision["verdict"] == "continue"
+
+    def test_sentinel_with_subgoals_active_still_short_circuits(
+        self, hermes_home
+    ):
+        """If the user added /subgoal criteria mid-loop, the sentinel
+        path still honors the agent's stop — the agent has full
+        context including subgoals in the continuation prompt and is
+        in the best position to attest completion."""
+        from hermes_cli import goals
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="sent-sub")
+        mgr.set("base goal")
+        mgr.add_subgoal("extra criterion")
+
+        with patch.object(goals, "judge_goal") as judge_mock:
+            decision = mgr.evaluate_after_turn(
+                "Wrapping up.\n<<HERMES_GOAL_DONE: both criteria satisfied>>"
+            )
+        judge_mock.assert_not_called()
+        assert decision["verdict"] == "done"
+        assert mgr.state.status == "done"
+
+    def test_sentinel_on_inactive_goal_is_inert(self, hermes_home):
+        """If no goal is active, sentinel detection must not invent one
+        — the early return on ``state.status != 'active'`` runs first."""
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="sent-inactive")
+        # No goal set — state is None.
+        decision = mgr.evaluate_after_turn(
+            "<<HERMES_GOAL_DONE: spurious>>"
+        )
+        assert decision["verdict"] == "inactive"
+        assert mgr.state is None
+
+
+class TestRepro29090GibberishGoal:
+    """End-to-end reproduction of the exact reporter scenario:
+    ``/goal lsdjflasjdf;ljasdlfja;sldjfalsdjf`` (gibberish).
+
+    Pre-fix: weak judges return ``continue`` for every turn and the
+    loop spam-fires continuation prompts until the 20-turn budget
+    runs out.  Post-fix: turn 2's continuation prompt teaches the
+    sentinel, the agent emits ``<<HERMES_GOAL_BLOCKED: …>>`` on its
+    next reply, and the loop halts in one extra turn instead of
+    nineteen.  This test models that two-turn shape with a fake
+    weak judge and a sentinel-emitting agent."""
+
+    def test_full_loop_halts_within_two_turns_post_fix(self, hermes_home):
+        from hermes_cli import goals
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(
+            session_id="repro-29090",
+            default_max_turns=20,  # the reporter's "maximum limit"
+        )
+        mgr.set("lsdjflasjdf;ljasdlfja;sldjfalsdjf")
+
+        # Turn 1: agent replies in normal prose, weak judge keeps
+        # hedging on "continue" — pre-fix this is where the spam
+        # started.  Post-fix the judge still runs (no sentinel yet) and
+        # queues turn 2.
+        with patch.object(
+            goals, "judge_goal", return_value=("continue", "unclear", False)
+        ):
+            d1 = mgr.evaluate_after_turn(
+                "I don't understand the goal text. Could you clarify?"
+            )
+        assert d1["should_continue"] is True
+        assert mgr.state.turns_used == 1
+        # The continuation prompt MUST teach the sentinel so turn 2 can
+        # actually emit it.
+        assert "<<HERMES_GOAL_DONE" in d1["continuation_prompt"]
+
+        # Turn 2: the agent, now taught by the continuation prompt,
+        # emits the sentinel and the loop halts BEFORE the 20-turn
+        # budget runs out.  Crucially, the judge is NOT consulted.
+        with patch.object(goals, "judge_goal") as judge_mock:
+            d2 = mgr.evaluate_after_turn(
+                "The goal text is gibberish — no work to do.\n"
+                "<<HERMES_GOAL_BLOCKED: goal text is unintelligible, "
+                "please re-send>>"
+            )
+        judge_mock.assert_not_called()
+        assert d2["should_continue"] is False
+        assert d2["verdict"] == "done"
+        assert mgr.state.status == "done"
+        assert mgr.state.turns_used == 2
+        # Burned 2 of 20 turns, not all 20 — the regression is sealed.
+        assert mgr.state.turns_used < mgr.state.max_turns

--- a/website/docs/user-guide/features/goals.md
+++ b/website/docs/user-guide/features/goals.md
@@ -63,6 +63,19 @@ The judge is deliberately conservative: it marks a goal `done` only when the res
 
 If the judge errors (network blip, malformed response, unavailable aux client), Hermes treats the verdict as `continue` — a broken judge never wedges progress. The **turn budget** is the real backstop.
 
+### Agent self-attestation (stop sentinels)
+
+Some goals are unverifiable from the outside — the user typed gibberish (`/goal lsdjflasjdf;ljasdlfja;sldjfalsdjf`), the goal is internally contradictory, or it genuinely needs more user input. Weak judge models can't always recognise these cases and will hedge with `continue` until the turn budget runs out (issue [#29090](https://github.com/NousResearch/hermes-agent/issues/29090)). To make the stop deterministic, the continuation prompt teaches the agent two terminal sentinels:
+
+```
+<<HERMES_GOAL_DONE: one-sentence reason>>
+<<HERMES_GOAL_BLOCKED: one-sentence reason>>
+```
+
+If the agent ends its reply with one of these as the **entire** final non-blank line, Hermes halts the loop immediately without consulting the judge. `DONE` surfaces as `✓ Goal achieved: <reason>`; `BLOCKED` surfaces as `✓ Goal stopped (agent blocked): <reason>` so you know the agent wants your input rather than reporting success.
+
+The detector is anchored on the final line (and requires it to be _only_ the sentinel after stripping whitespace), so models that quote the instruction back to themselves mid-reasoning don't false-positive-stop the loop.
+
 ### Turn budget
 
 Default is 20 continuation turns (`goals.max_turns` in `config.yaml`). When the budget is hit, Hermes auto-pauses and tells you exactly how to proceed:
@@ -154,7 +167,7 @@ Four turns, one `/goal` invocation, zero "keep going" prompts from you.
 
 No judge is perfect. Two failure modes to watch for:
 
-**False negative — judge says continue when the goal is actually done.** The turn budget catches this. You'll see `⏸ Goal paused` and can `/goal clear` or just send a new message.
+**False negative — judge says continue when the goal is actually done.** The agent self-attestation sentinel ([above](#agent-self-attestation-stop-sentinels)) catches most of these — the agent emits `<<HERMES_GOAL_DONE: …>>` on its final line and the loop stops without the judge. Anything that slips past that is caught by the turn budget: you'll see `⏸ Goal paused` and can `/goal clear` or just send a new message.
 
 **False positive — judge says done when work remains.** You'll see `✓ Goal achieved` but you know better. Send a follow-up message to continue, or re-set the goal more precisely: `/goal <more specific text>`. The judge's system prompt is deliberately conservative to make false positives rarer than false negatives.
 


### PR DESCRIPTION
## What does this PR do?

Closes the "[Bug]: /goal keeps triggering after the goal is completed" loop reported in #29090. The reporter typed `/goal lsdjflasjdf;ljasdlfja;sldjfalsdjf` on Windows and watched `↻ Continuing toward goal (N/20)` fire for the full turn budget despite the agent itself stating the task was complete.

Root cause is **not Windows-specific** — the reporter just hit it there first. For a gibberish or otherwise unverifiable goal, the agent's reply is almost always "I don't understand / can't proceed", which a strict judge per its system prompt is supposed to treat as `DONE`-with-reason-blocked. Weak judge models (the cheap fast `goal_judge` overrides users wire up) routinely fail that rule and hedge with `continue`, so the loop spam-queues continuation prompts at every turn until the 20-turn budget runs out. This is the same weak-judge class tracked in #27585.

Fix is a **deterministic, model-independent stop path** — the agent itself attests "I'm done" via a sentinel and the loop halts before the judge runs. Three pieces wired together:

1. **Continuation prompt teaches the contract** — `CONTINUATION_PROMPT_TEMPLATE` and `CONTINUATION_PROMPT_WITH_SUBGOALS_TEMPLATE` now share a single `_STOP_INSTRUCTION_LINE` block teaching the agent two terminal sentinels:

   ```
   <<HERMES_GOAL_DONE: one-sentence reason>>
   <<HERMES_GOAL_BLOCKED: one-sentence reason>>
   ```

   With explicit semantics — `DONE` for "complete or trivially unachievable (typos, gibberish, contradictions)", `BLOCKED` for "I genuinely need user input to make progress".

2. **Detector** — `_detect_goal_stop_sentinel(response)` returns `(kind, reason)` when the sentinel is the **entire** final non-blank line of the reply (using `re.fullmatch` after stripping surrounding whitespace). Anchoring on the final-line + full-match shape keeps prompt-echoing models from false-positive-stopping when they quote the instruction back to themselves mid-reasoning, and it matches the prompt contract "the sentinel must be the LAST non-blank line in your response".

3. **`evaluate_after_turn` short-circuit** — checks the sentinel **before** calling `judge_goal`, persists `status="done"`, resets `consecutive_parse_failures` (sentinel emission means we got a real reply, so stale judge-parse failures must not auto-pause the next `/goal resume`), and surfaces a clear user-visible message:
   - `✓ Goal achieved: <reason>` for `DONE`
   - `✓ Goal stopped (agent blocked): <reason>` for `BLOCKED` (so operators know the agent wants input rather than misreading it as success).

Reproduction shape, post-fix: turn 1 the weak judge still hedges with `continue`, so the continuation prompt fires; turn 2 the agent — now taught the sentinel by that very prompt — emits `<<HERMES_GOAL_BLOCKED: …>>` on its last line, the loop halts at **2 turns used instead of 20**, and the judge never runs on turn 2. The reporter's exact scenario is locked in by `TestRepro29090GibberishGoal`.

Judge fail-open semantics, the parse-failure auto-pause, the turn-budget backstop, and the `/goal pause` / `resume` / `clear` controls are all untouched — sentinel handling is purely additive. Works identically on CLI and every gateway platform because `goals.py` is shared.

## Related Issue

Fixes #29090

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/goals.py` — new `GOAL_DONE_SENTINEL` / `GOAL_BLOCKED_SENTINEL` constants, `_STOP_INSTRUCTION_LINE` shared between both continuation-prompt templates, `_STOP_SENTINEL_RE` (case-insensitive, optional reason group), `_detect_goal_stop_sentinel(response)` helper anchored on the final non-blank line with `fullmatch` after whitespace strip, and the short-circuit branch at the top of `evaluate_after_turn` that lands `status="done"` and resets the parse-failure counter.
- `tests/hermes_cli/test_goals.py` — **23 new tests** across three classes:
  - `TestStopSentinelDetection` — unit-level happy paths (DONE/BLOCKED with and without reason, mixed case, whitespace, trailing newlines) and rejections (`None`/empty, prose-only, mid-line echoes, inline echoes on the final line), plus the continuation prompt carries the sentinel teaching in both the plain and `/subgoal` paths.
  - `TestEvaluateAfterTurnSentinel` — end-to-end through `GoalManager.evaluate_after_turn`: DONE short-circuits the judge, BLOCKED surfaces the right message, `consecutive_parse_failures` resets, non-sentinel responses still call the judge (regression guard), inline sentinels on a one-line response do NOT short-circuit (prompt-echo guard end-to-end), works alongside `/subgoal` criteria, inert on inactive goals.
  - `TestRepro29090GibberishGoal` — full two-turn reproduction of the reporter's exact scenario (`/goal lsdjflasjdf;ljasdlfja;sldjfalsdjf`): turn 1 weak judge says `continue` and queues the continuation, turn 2 agent emits `<<HERMES_GOAL_BLOCKED: …>>` and the loop halts at 2 turns used (`turns_used < max_turns`) without consulting the judge.
- `website/docs/user-guide/features/goals.md` — new "Agent self-attestation (stop sentinels)" subsection explaining when and why the sentinels exist, the exact wire format, and how the surface message differs between `DONE` and `BLOCKED`; "When the judge gets it wrong" now points at the sentinel as the first line of defense against false-negative judges (turn budget still backs it up).

Backwards compatible: `_state` schema unchanged, no new config keys, no system-prompt mutation, prompt-cache invariants preserved (the sentinel teaching lives in the user-role continuation prompt, not the system prompt). All existing goal tests across CLI / TUI / gateway continue to pass unchanged.

## How to Test

```bash
# New + existing goals.py coverage (50 existing + 23 new = 73 tests)
./scripts/run_tests.sh tests/hermes_cli/test_goals.py

# Full regression across every test module that touches the goal loop
./scripts/run_tests.sh \
    tests/hermes_cli/test_goals.py \
    tests/gateway/test_goal_verdict_send.py \
    tests/gateway/test_goal_max_turns_config.py \
    tests/tui_gateway/test_goal_command.py \
    tests/cli/test_cli_goal_interrupt.py
# expected: 97 passed
```

Manual / behavioural verification with the reporter's input:

```
You: /goal lsdjflasjdf;ljasdlfja;sldjfalsdjf

  ⊙ Goal set (20-turn budget): lsdjflasjdf;ljasdlfja;sldjfalsdjf

Hermes: I don't recognize this as a coherent goal — could you clarify what
        you'd like me to do?

  ↻ Continuing toward goal (1/20): goal text is unclear

Hermes: [Continuing toward your standing goal]
        The goal text appears to be random characters with no actionable
        intent. I'll stop here so you can re-send.

        <<HERMES_GOAL_BLOCKED: goal text is unintelligible, please re-send>>

  ✓ Goal stopped (agent blocked): goal text is unintelligible, please re-send

You: _
```

Two turns used, loop halted cleanly, no `/goal clear` needed. Same input pre-fix burned all 20 turns before auto-pausing on budget.

## Checklist

- [x] Conventional Commits (`fix(goal):`, `test(goal):`, `docs(goal):`)
- [x] 4 focused commits, single author
- [x] 23 new tests pass; 74 existing goal-touching tests pass across `hermes_cli` / `gateway` / `tui_gateway` / `cli` (97 total)
- [x] Tested on macOS 15.6 (darwin 24.6.0)
- [x] Updated `website/docs/user-guide/features/goals.md`
- [x] No new config keys, no system-prompt mutation, no schema change, prompt-cache invariants preserved
