### PR TITLE
fix: harden runtime paths prompts and pool fallback

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -510,20 +510,38 @@ def _to_openai_base_url(base_url: str) -> str:
     return url
 
 
-def _select_pool_entry(provider: str) -> Tuple[bool, Optional[Any]]:
-    """Return (pool_exists_for_provider, selected_entry)."""
+def _select_pool_entry_with_pool(provider: str) -> Tuple[bool, Optional[Any], Optional[Any]]:
+    """Return (pool_exists_for_provider, selected_entry, pool)."""
     try:
         pool = load_pool(provider)
     except Exception as exc:
         logger.debug("Auxiliary client: could not load pool for %s: %s", provider, exc)
-        return False, None
+        return False, None, None
     if not pool or not pool.has_credentials():
-        return False, None
+        return False, None, None
     try:
-        return True, pool.select()
+        return True, pool.select(), pool
     except Exception as exc:
         logger.debug("Auxiliary client: could not select pool entry for %s: %s", provider, exc)
-        return True, None
+        return True, None, pool
+
+
+def _select_pool_entry(provider: str) -> Tuple[bool, Optional[Any]]:
+    """Return (pool_exists_for_provider, selected_entry)."""
+    pool_present, entry, _pool = _select_pool_entry_with_pool(provider)
+    return pool_present, entry
+
+
+def _attach_credential_pool(client: Any, provider: str, pool: Optional[Any]) -> Any:
+    """Best-effort tag so main-agent fallback can keep pool recovery attached."""
+    if client is None or pool is None:
+        return client
+    try:
+        setattr(client, "_hermes_credential_pool", pool)
+        setattr(client, "_hermes_pool_provider", _normalize_aux_provider(provider))
+    except Exception:
+        pass
+    return client
 
 
 def _peek_pool_entry(provider: str) -> Optional[Any]:
@@ -1348,8 +1366,8 @@ def _resolve_xai_oauth_for_aux() -> Optional[Tuple[str, str]]:
     return api_key, base_url
 
 
-def _read_codex_access_token() -> Optional[str]:
-    """Read a valid, non-expired Codex OAuth access token from Hermes auth store.
+def _resolve_codex_credentials_for_aux() -> Tuple[Optional[str], str, Optional[Any]]:
+    """Resolve Codex OAuth credentials and the selected credential pool, if any.
 
     If a credential pool exists but currently has no selectable runtime entry
     (for example all pool slots are marked exhausted), fall back to the
@@ -1357,11 +1375,13 @@ def _read_codex_access_token() -> Optional[str]:
     fallback-to-Codex working when the pool state is stale but the stored OAuth
     token is still valid.
     """
-    pool_present, entry = _select_pool_entry("openai-codex")
+    fallback_base_url = _CODEX_AUX_BASE_URL
+    pool_present, entry, pool = _select_pool_entry_with_pool("openai-codex")
     if pool_present:
         token = _pool_runtime_api_key(entry)
         if token:
-            return token
+            base_url = _pool_runtime_base_url(entry, fallback_base_url) or fallback_base_url
+            return token, base_url, pool
 
     try:
         from hermes_cli.auth import _read_codex_tokens
@@ -1369,7 +1389,7 @@ def _read_codex_access_token() -> Optional[str]:
         tokens = data.get("tokens", {})
         access_token = tokens.get("access_token")
         if not isinstance(access_token, str) or not access_token.strip():
-            return None
+            return None, fallback_base_url, None
 
         # Check JWT expiry — expired tokens block the auto chain and
         # prevent fallback to working providers (e.g. Anthropic).
@@ -1381,14 +1401,20 @@ def _read_codex_access_token() -> Optional[str]:
             exp = claims.get("exp", 0)
             if exp and time.time() > exp:
                 logger.debug("Codex access token expired (exp=%s), skipping", exp)
-                return None
+                return None, fallback_base_url, None
         except Exception:
             pass  # Non-JWT token or decode error — use as-is
 
-        return access_token.strip()
+        return access_token.strip(), fallback_base_url, None
     except Exception as exc:
         logger.debug("Could not read Codex auth for auxiliary client: %s", exc)
-        return None
+        return None, fallback_base_url, None
+
+
+def _read_codex_access_token() -> Optional[str]:
+    """Read a valid, non-expired Codex OAuth access token."""
+    token, _base_url, _pool = _resolve_codex_credentials_for_aux()
+    return token
 
 
 def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
@@ -1885,28 +1911,19 @@ def _build_codex_client(model: str) -> Tuple[Optional[Any], Optional[str]]:
             "pass model explicitly (auxiliary.<task>.model in config.yaml)."
         )
         return None, None
-    pool_present, entry = _select_pool_entry("openai-codex")
-    if pool_present:
-        codex_token = _pool_runtime_api_key(entry)
-        if codex_token:
-            base_url = _pool_runtime_base_url(entry, _CODEX_AUX_BASE_URL) or _CODEX_AUX_BASE_URL
-        else:
-            codex_token = _read_codex_access_token()
-            if not codex_token:
-                return None, None
-            base_url = _CODEX_AUX_BASE_URL
-    else:
-        codex_token = _read_codex_access_token()
-        if not codex_token:
-            return None, None
-        base_url = _CODEX_AUX_BASE_URL
+    codex_token, base_url, pool = _resolve_codex_credentials_for_aux()
+    if not codex_token:
+        return None, None
     logger.debug("Auxiliary client: Codex OAuth (%s via Responses API)", model)
     real_client = OpenAI(
         api_key=codex_token,
         base_url=base_url,
         default_headers=_codex_cloudflare_headers(codex_token),
     )
-    return CodexAuxiliaryClient(real_client, model), model
+    wrapped = CodexAuxiliaryClient(real_client, model)
+    _attach_credential_pool(wrapped, "openai-codex", pool)
+    _attach_credential_pool(real_client, "openai-codex", pool)
+    return wrapped, model
 
 
 def _try_azure_foundry(
@@ -2029,13 +2046,14 @@ def _try_anthropic(explicit_api_key: str = None) -> Tuple[Optional[Any], Optiona
     except ImportError:
         return None, None
 
-    pool_present, entry = _select_pool_entry("anthropic")
+    pool_present, entry, pool = _select_pool_entry_with_pool("anthropic")
     if pool_present:
         if entry is None:
             return None, None
         token = explicit_api_key or _pool_runtime_api_key(entry)
     else:
         entry = None
+        pool = None
         token = explicit_api_key or resolve_anthropic_token()
     if not token:
         return None, None
@@ -2068,7 +2086,9 @@ def _try_anthropic(explicit_api_key: str = None) -> Tuple[Optional[Any], Optiona
         # missing — build_anthropic_client raises ImportError at call time
         # when _anthropic_sdk is None.  Treat as unavailable.
         return None, None
-    return AnthropicAuxiliaryClient(real_client, model, token, base_url, is_oauth=is_oauth), model
+    wrapped = AnthropicAuxiliaryClient(real_client, model, token, base_url, is_oauth=is_oauth)
+    _attach_credential_pool(wrapped, "anthropic", pool)
+    return wrapped, model
 
 
 _AUTO_PROVIDER_LABELS = {
@@ -3225,7 +3245,7 @@ def resolve_provider_client(
         if raw_codex:
             # Return the raw OpenAI client for callers that need direct
             # access to responses.stream() (e.g., the main agent loop).
-            codex_token = _read_codex_access_token()
+            codex_token, codex_base_url, pool = _resolve_codex_credentials_for_aux()
             if not codex_token:
                 logger.warning("resolve_provider_client: openai-codex requested "
                                "but no Codex OAuth token found (run: hermes model)")
@@ -3233,9 +3253,10 @@ def resolve_provider_client(
             final_model = _normalize_resolved_model(model, provider)
             raw_client = OpenAI(
                 api_key=codex_token,
-                base_url=_CODEX_AUX_BASE_URL,
+                base_url=codex_base_url,
                 default_headers=_codex_cloudflare_headers(codex_token),
             )
+            _attach_credential_pool(raw_client, "openai-codex", pool)
             return (raw_client, final_model)
         # Standard path: wrap in CodexAuxiliaryClient adapter
         client, default = _build_codex_client(model)

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -731,7 +731,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
     # raw_codex=True because the main agent needs direct responses.stream()
     # access for Codex providers.
     try:
-        from agent.auxiliary_client import resolve_provider_client
+        from agent.auxiliary_client import resolve_provider_client, _normalize_aux_provider
         # Pass base_url and api_key from fallback config so custom
         # endpoints (e.g. Ollama Cloud) resolve correctly instead of
         # falling through to OpenRouter defaults.
@@ -802,6 +802,17 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         agent.provider = fb_provider
         agent.base_url = fb_base_url
         agent.api_mode = fb_api_mode
+        fb_pool = getattr(fb_client, "_hermes_credential_pool", None)
+        fb_pool_provider = str(
+            getattr(fb_client, "_hermes_pool_provider", "") or ""
+        ).strip().lower()
+        normalized_fb_provider = _normalize_aux_provider(fb_provider)
+        agent._credential_pool = (
+            fb_pool
+            if fb_pool is not None
+            and (not fb_pool_provider or fb_pool_provider == normalized_fb_provider)
+            else None
+        )
         if hasattr(agent, "_transport_cache"):
             agent._transport_cache.clear()
         agent._fallback_activated = True

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import random
@@ -545,6 +546,69 @@ class CredentialPool:
             logger.debug("Failed to sync Codex entry from auth.json: %s", exc)
         return entry
 
+    def _sync_codex_entry_from_slot_auth(self, entry: PooledCredential) -> PooledCredential:
+        """Sync a ``slot:.codex-*`` Codex pool entry from its slot auth file.
+
+        Slot-backed subscription credentials are owned by their
+        ``~/.codex-<slot>/auth.json`` files. Other tooling such as Deckel reads
+        those files directly; Hermes must not keep using a stale copy embedded
+        in ``~/.hermes/auth.json`` after the slot has refreshed elsewhere.
+        """
+        if self.provider != "openai-codex":
+            return entry
+        source = str(entry.source or "").strip()
+        if not source.startswith("slot:.codex-"):
+            return entry
+        slot_dir_name = source.split("slot:", 1)[1].strip()
+        if (
+            not slot_dir_name
+            or "/" in slot_dir_name
+            or slot_dir_name in {".", ".."}
+            or not slot_dir_name.startswith(".codex-")
+        ):
+            return entry
+        auth_path = os.path.join(os.path.expanduser("~"), slot_dir_name, "auth.json")
+        try:
+            with open(auth_path, "r", encoding="utf-8") as handle:
+                slot_state = json.load(handle)
+            tokens = slot_state.get("tokens") if isinstance(slot_state, dict) else None
+            if not isinstance(tokens, dict):
+                return entry
+            slot_access = str(tokens.get("access_token") or "").strip()
+            slot_refresh = str(tokens.get("refresh_token") or "").strip()
+            if not slot_access:
+                return entry
+            if (
+                slot_access != str(entry.access_token or "")
+                or (slot_refresh and slot_refresh != str(entry.refresh_token or ""))
+            ):
+                logger.debug(
+                    "Pool entry %s: syncing Codex slot tokens from %s",
+                    entry.id,
+                    slot_dir_name,
+                )
+                field_updates: Dict[str, Any] = {
+                    "access_token": slot_access,
+                    "refresh_token": slot_refresh or entry.refresh_token,
+                    "last_status": None,
+                    "last_status_at": None,
+                    "last_error_code": None,
+                    "last_error_reason": None,
+                    "last_error_message": None,
+                    "last_error_reset_at": None,
+                }
+                if slot_state.get("last_refresh"):
+                    field_updates["last_refresh"] = slot_state["last_refresh"]
+                updated = replace(entry, **field_updates)
+                self._replace_entry(entry, updated)
+                self._persist()
+                return updated
+        except FileNotFoundError:
+            return entry
+        except Exception as exc:
+            logger.debug("Failed to sync Codex slot tokens from %s: %s", slot_dir_name, exc)
+        return entry
+
     def _sync_xai_oauth_entry_from_auth_store(self, entry: PooledCredential) -> PooledCredential:
         """Sync an xAI OAuth pool entry from auth.json if tokens differ.
 
@@ -797,6 +861,9 @@ class CredentialPool:
                     except Exception as wexc:
                         logger.debug("Failed to write refreshed token to credentials file: %s", wexc)
             elif self.provider == "openai-codex":
+                slot_synced = self._sync_codex_entry_from_slot_auth(entry)
+                if slot_synced is not entry:
+                    return slot_synced
                 # Adopt fresher tokens from auth.json before spending the
                 # refresh_token — single-use tokens consumed by another Hermes
                 # process sharing the same auth.json singleton would otherwise
@@ -963,6 +1030,12 @@ class CredentialPool:
             # and the HTTP call.  Re-check auth.json and adopt the fresh tokens
             # if they have rotated since.
             if self.provider == "openai-codex":
+                slot_synced = self._sync_codex_entry_from_slot_auth(entry)
+                if slot_synced is not entry:
+                    logger.debug(
+                        "Codex OAuth refresh failed but slot auth has newer tokens — adopting"
+                    )
+                    return slot_synced
                 synced = self._sync_codex_entry_from_auth_store(entry)
                 if synced.refresh_token != entry.refresh_token:
                     logger.debug(
@@ -1163,6 +1236,14 @@ class CredentialPool:
                     and entry.source == "device_code"
                     and entry.last_status == STATUS_EXHAUSTED):
                 synced = self._sync_nous_entry_from_auth_store(entry)
+                if synced is not entry:
+                    entry = synced
+                    cleared_any = True
+            # Codex slot credentials live in ~/.codex-<slot>/auth.json.  Sync
+            # them on every selection, not only when exhausted, because a copied
+            # pool token can be stale while still marked "ok".
+            if self.provider == "openai-codex" and str(entry.source or "").startswith("slot:.codex-"):
+                synced = self._sync_codex_entry_from_slot_auth(entry)
                 if synced is not entry:
                     entry = synced
                     cleared_any = True

--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -13,7 +13,8 @@ def _hermes_home_path() -> Path:
         from hermes_constants import get_hermes_home  # local import to avoid cycles
         return get_hermes_home()
     except Exception:
-        return Path(os.path.expanduser("~/.hermes"))
+        from hermes_constants import expand_user_path
+        return Path(expand_user_path("~/.hermes"))
 
 
 def build_write_denied_paths(home: str) -> set[str]:
@@ -67,21 +68,35 @@ def get_safe_write_root() -> Optional[str]:
     if not root:
         return None
     try:
-        return os.path.realpath(os.path.expanduser(root))
+        from hermes_constants import expand_user_path
+        return os.path.realpath(expand_user_path(root))
     except Exception:
         return None
 
 
 def is_write_denied(path: str) -> bool:
     """Return True if path is blocked by the write denylist or safe root."""
-    home = os.path.realpath(os.path.expanduser("~"))
-    resolved = os.path.realpath(os.path.expanduser(str(path)))
+    from hermes_constants import expand_user_path, get_os_user_home
 
-    if resolved in build_write_denied_paths(home):
+    raw_path = str(path)
+    if "\ufffc" in raw_path:
         return True
-    for prefix in build_write_denied_prefixes(home):
-        if resolved.startswith(prefix):
+
+    resolved = os.path.realpath(expand_user_path(raw_path))
+    if "\ufffc" in resolved:
+        return True
+
+    homes = {os.path.realpath(str(get_os_user_home()))}
+    env_home = os.getenv("HOME", "")
+    if env_home and "\ufffc" not in env_home:
+        homes.add(os.path.realpath(env_home))
+
+    for home in homes:
+        if resolved in build_write_denied_paths(home):
             return True
+        for prefix in build_write_denied_prefixes(home):
+            if resolved.startswith(prefix):
+                return True
 
     safe_root = get_safe_write_root()
     if safe_root and not (resolved == safe_root or resolved.startswith(safe_root + os.sep)):
@@ -92,7 +107,8 @@ def is_write_denied(path: str) -> bool:
 
 def get_read_block_error(path: str) -> Optional[str]:
     """Return an error message when a read targets internal Hermes cache files."""
-    resolved = Path(path).expanduser().resolve()
+    from hermes_constants import expand_user_path
+    resolved = Path(expand_user_path(path)).resolve()
     hermes_home = _hermes_home_path().resolve()
     blocked_dirs = [
         hermes_home / "skills" / ".hub" / "index-cache",

--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -30,6 +30,8 @@ import re
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from hermes_constants import expand_user_path
+
 from agent.tool_result_classification import (
     FILE_MUTATING_TOOL_NAMES as _FILE_MUTATING_TOOLS,
 )
@@ -155,7 +157,7 @@ def _extract_parallel_scope_path(tool_name: str, function_args: dict) -> Optiona
     if not isinstance(raw_path, str) or not raw_path.strip():
         return None
 
-    expanded = Path(raw_path).expanduser()
+    expanded = Path(expand_user_path(raw_path))
     if expanded.is_absolute():
         return Path(os.path.abspath(str(expanded)))
 

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -3552,9 +3552,44 @@ class DiscordAdapter(BasePlatformAdapter):
         return resolve_channel_skills(self.config.extra, channel_id, parent_id)
 
     def _resolve_channel_prompt(self, channel_id: str, parent_id: str | None = None) -> str | None:
-        """Resolve a Discord per-channel prompt, preferring the exact channel over its parent."""
+        """Resolve a Discord per-channel prompt, preferring live exact thread config.
+
+        Discord adapters are long-lived, while ``config.yaml`` is expected to
+        hot-reload for gateway turns.  Start with the adapter's startup config
+        as a fallback, then overlay freshly loaded Discord platform extras so
+        newly added exact thread prompts take effect without a gateway restart.
+        """
         from gateway.platforms.base import resolve_channel_prompt
-        return resolve_channel_prompt(self.config.extra, channel_id, parent_id)
+
+        config_extra = dict(getattr(self.config, "extra", None) or {})
+        try:
+            from gateway.config import load_gateway_config
+
+            live_config = load_gateway_config()
+            live_platform = (live_config.platforms or {}).get(Platform.DISCORD)
+            live_extra = getattr(live_platform, "extra", None) or {}
+            if isinstance(live_extra, dict):
+                config_extra.update(live_extra)
+        except Exception as exc:
+            logger.debug("Discord channel_prompt live config reload failed: %s", exc)
+
+        prompt = resolve_channel_prompt(config_extra, channel_id, parent_id)
+        if prompt:
+            prompts = config_extra.get("channel_prompts") or {}
+            matched = "exact" if isinstance(prompts, dict) and prompts.get(str(channel_id)) is not None else "parent"
+            logger.info(
+                "Discord channel_prompt resolved (%s): channel_id=%s parent_id=%s",
+                matched,
+                channel_id,
+                parent_id or "",
+            )
+        else:
+            logger.debug(
+                "Discord channel_prompt not found: channel_id=%s parent_id=%s",
+                channel_id,
+                parent_id or "",
+            )
+        return prompt
 
     def _discord_require_mention(self) -> bool:
         """Return whether Discord channel messages require a bot mention."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -835,6 +835,11 @@ from gateway.whatsapp_identity import (
 
 logger = logging.getLogger(__name__)
 
+CHANNEL_PROMPT_IDENTITY_GUARD = (
+    "Channel prompts and ephemeral prompts are scoped runtime context only. "
+    "They must not replace or rename the agent identity defined by SOUL.md."
+)
+
 
 # Sentinel placed into _running_agents immediately when a session starts
 # processing, *before* any await.  Prevents a second message for the same
@@ -16107,12 +16112,19 @@ class GatewayRunner:
             
             # Combine platform context, per-channel context, and the user-configured
             # ephemeral system prompt.
-            combined_ephemeral = context_prompt or ""
+            combined_ephemeral_parts = [context_prompt]
             event_channel_prompt = (channel_prompt or "").strip()
             if event_channel_prompt:
-                combined_ephemeral = (combined_ephemeral + "\n\n" + event_channel_prompt).strip()
+                combined_ephemeral_parts.append(event_channel_prompt)
             if self._ephemeral_system_prompt:
-                combined_ephemeral = (combined_ephemeral + "\n\n" + self._ephemeral_system_prompt).strip()
+                combined_ephemeral_parts.append(self._ephemeral_system_prompt)
+            if event_channel_prompt or self._ephemeral_system_prompt:
+                combined_ephemeral_parts.append(CHANNEL_PROMPT_IDENTITY_GUARD)
+            combined_ephemeral = "\n\n".join(
+                part.strip()
+                for part in combined_ephemeral_parts
+                if isinstance(part, str) and part.strip()
+            )
 
             # Re-read .env and config for fresh credentials (gateway is long-lived,
             # keys may change without restart). Keep config.yaml authoritative for

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -10,6 +10,55 @@ from contextvars import ContextVar, Token
 from pathlib import Path
 
 
+
+def get_os_user_home() -> Path:
+    """Return the real OS account home without trusting ``$HOME``.
+
+    Agent/profile subprocesses may intentionally override ``HOME`` for tool
+    isolation, and on some VPS launches that env value has been observed to
+    contain U+FFFC.  Python's ``Path.home()`` / ``expanduser("~")`` trust
+    ``$HOME`` on POSIX, so use the passwd database there instead.
+    """
+    if os.name != "nt":
+        try:
+            import pwd
+
+            home = pwd.getpwuid(os.getuid()).pw_dir
+            if home:
+                return Path(home)
+        except Exception:
+            pass
+    return Path(os.path.expanduser("~"))
+
+
+def expand_user_path(path: str | Path) -> str:
+    """Expand ``~`` without trusting a possibly corrupted ``$HOME``.
+
+    ``os.path.expanduser`` and ``Path.expanduser`` read ``HOME`` first on
+    POSIX.  That is wrong for Hermes' own host-side path resolution when
+    ``HOME`` is profile-scoped or contains U+FFFC.  Preserve ``~user`` support
+    via the passwd database on POSIX, and fall back to stdlib behavior for
+    non-tilde paths / Windows.
+    """
+    raw = os.fspath(path)
+    if not raw.startswith("~"):
+        return raw
+    if raw == "~" or raw.startswith("~/"):
+        return str(get_os_user_home()) + raw[1:]
+    if os.name != "nt":
+        try:
+            import pwd
+
+            rest = raw[1:]
+            slash_idx = rest.find("/")
+            username = rest if slash_idx < 0 else rest[:slash_idx]
+            suffix = "" if slash_idx < 0 else rest[slash_idx:]
+            if username:
+                return pwd.getpwnam(username).pw_dir + suffix
+        except Exception:
+            pass
+    return os.path.expanduser(raw)
+
 _profile_fallback_warned: bool = False
 _UNSET = object()
 _HERMES_HOME_OVERRIDE: ContextVar[str | object] = ContextVar(
@@ -72,7 +121,7 @@ def get_hermes_home() -> Path:
             # Inline the default-root resolution from get_default_hermes_root()
             # to stay import-safe (this function is called from module scope
             # in 30+ files; we cannot afford to trigger logging setup here).
-            active_path = (Path.home() / ".hermes" / "active_profile")
+            active_path = (get_os_user_home() / ".hermes" / "active_profile")
             active = active_path.read_text().strip() if active_path.exists() else ""
         except (UnicodeDecodeError, OSError):
             active = ""
@@ -98,7 +147,7 @@ def get_hermes_home() -> Path:
             except Exception:
                 pass
 
-    return Path.home() / ".hermes"
+    return get_os_user_home() / ".hermes"
 
 
 def get_default_hermes_root() -> Path:
@@ -117,7 +166,7 @@ def get_default_hermes_root() -> Path:
 
     Import-safe — no dependencies beyond stdlib.
     """
-    native_home = Path.home() / ".hermes"
+    native_home = get_os_user_home() / ".hermes"
     env_home = os.environ.get("HERMES_HOME", "")
     if not env_home:
         return native_home
@@ -230,7 +279,7 @@ def display_hermes_home() -> str:
     """
     home = get_hermes_home()
     try:
-        return "~/" + str(home.relative_to(Path.home()))
+        return "~/" + str(home.relative_to(get_os_user_home()))
     except ValueError:
         return str(home)
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -351,8 +351,10 @@ class TestAnthropicOAuthFlag:
 class TestBuildCodexClient:
     def test_pool_without_selected_entry_falls_back_to_auth_store(self):
         with (
-            patch("agent.auxiliary_client._select_pool_entry", return_value=(True, None)),
-            patch("agent.auxiliary_client._read_codex_access_token", return_value="codex-auth-token"),
+            patch("agent.auxiliary_client._select_pool_entry_with_pool", return_value=(True, None, MagicMock())),
+            patch("hermes_cli.auth._read_codex_tokens", return_value={
+                "tokens": {"access_token": "codex-auth-token"}
+            }),
             patch("agent.auxiliary_client.OpenAI") as mock_openai,
         ):
             mock_openai.return_value = MagicMock()
@@ -364,6 +366,35 @@ class TestBuildCodexClient:
         assert model == "gpt-5.4"
         assert mock_openai.call_args.kwargs["api_key"] == "codex-auth-token"
         assert mock_openai.call_args.kwargs["base_url"] == "https://chatgpt.com/backend-api/codex"
+
+    def test_raw_codex_client_carries_selected_pool_for_main_fallback(self):
+        class _Entry:
+            runtime_api_key = "pool-token"
+            runtime_base_url = "https://chatgpt.com/backend-api/codex"
+
+        class _Pool:
+            def has_credentials(self):
+                return True
+
+            def select(self):
+                return _Entry()
+
+        pool = _Pool()
+        raw_client = SimpleNamespace(api_key="pool-token", base_url="https://chatgpt.com/backend-api/codex")
+        with (
+            patch("agent.auxiliary_client.load_pool", return_value=pool),
+            patch("agent.auxiliary_client.OpenAI", return_value=raw_client),
+        ):
+            client, model = resolve_provider_client(
+                "openai-codex",
+                model="gpt-5.5",
+                raw_codex=True,
+            )
+
+        assert client is raw_client
+        assert model == "gpt-5.5"
+        assert client._hermes_credential_pool is pool
+        assert client._hermes_pool_provider == "openai-codex"
 
     def test_rejects_missing_model(self):
         """Callers must pass an explicit model; no hardcoded default."""

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -334,6 +334,62 @@ def test_explicit_reset_timestamp_overrides_default_429_ttl(tmp_path, monkeypatc
     assert pool.select() is None
 
 
+def test_codex_slot_entry_syncs_from_slot_auth_before_selection(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    home = tmp_path / "home"
+    slot_dir = home / ".codex-redam-b"
+    slot_dir.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HOME", str(home))
+
+    stale_access = _jwt_with_claims({"exp": int(time.time()) + 600})
+    fresh_access = _jwt_with_claims({"exp": int(time.time()) + 3600})
+    (slot_dir / "auth.json").write_text(json.dumps({
+        "tokens": {
+            "access_token": fresh_access,
+            "refresh_token": "fresh-refresh",
+        },
+        "last_refresh": "2026-05-20T06:01:58Z",
+    }))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "redam-b",
+                        "label": "redam-b",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "slot:.codex-redam-b",
+                        "access_token": stale_access,
+                        "refresh_token": "stale-refresh",
+                        "base_url": "https://chatgpt.com/backend-api/codex",
+                        "last_status": "ok",
+                    }
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    entry = pool.select()
+
+    assert entry is not None
+    assert entry.access_token == fresh_access
+    assert entry.refresh_token == "fresh-refresh"
+    assert entry.last_status is None
+
+    persisted = json.loads((hermes_home / "auth.json").read_text())
+    persisted_entry = persisted["credential_pool"]["openai-codex"][0]
+    assert persisted_entry["access_token"] == fresh_access
+    assert persisted_entry["refresh_token"] == "fresh-refresh"
+    assert persisted_entry["last_refresh"] == "2026-05-20T06:01:58Z"
+
+
 def test_mark_exhausted_and_rotate_persists_status(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     _write_auth_store(

--- a/tests/gateway/test_discord_channel_prompts.py
+++ b/tests/gateway/test_discord_channel_prompts.py
@@ -29,7 +29,7 @@ def _ensure_discord_mock():
 
 
 import gateway.run as gateway_run
-from gateway.config import Platform
+from gateway.config import Platform, PlatformConfig, GatewayConfig
 from gateway.platforms.base import MessageEvent
 from gateway.session import SessionSource
 
@@ -139,6 +139,28 @@ class TestResolveChannelPrompts:
             }
         }
         assert adapter._resolve_channel_prompt("999", parent_id="200") == "Thread override"
+
+    def test_exact_thread_prompt_hot_reloads_and_overrides_parent(self, monkeypatch):
+        adapter = _make_adapter()
+        adapter.config.extra = {"channel_prompts": {"200": "Stale parent prompt"}}
+
+        live_config = GatewayConfig(
+            platforms={
+                Platform.DISCORD: PlatformConfig(
+                    extra={
+                        "channel_prompts": {
+                            "999": "Live thread override",
+                            "200": "Live parent prompt",
+                        }
+                    }
+                )
+            }
+        )
+        import gateway.config as gateway_config
+
+        monkeypatch.setattr(gateway_config, "load_gateway_config", lambda: live_config)
+
+        assert adapter._resolve_channel_prompt("999", parent_id="200") == "Live thread override"
 
     def test_build_message_event_sets_channel_prompt(self):
         adapter = _make_adapter()
@@ -254,5 +276,7 @@ async def test_run_agent_appends_channel_prompt_to_ephemeral_system_prompt(monke
 
     assert result["final_response"] == "ok"
     assert _CapturingAgent.last_init["ephemeral_system_prompt"] == (
-        "Context prompt\n\nChannel prompt\n\nGlobal prompt"
+        "Context prompt\n\nChannel prompt\n\nGlobal prompt\n\n"
+        "Channel prompts and ephemeral prompts are scoped runtime context only. "
+        "They must not replace or rename the agent identity defined by SOUL.md."
     )

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -182,6 +182,44 @@ class TestFallbackChainAdvancement:
             assert agent._try_activate_fallback() is True
             assert mock_rpc.call_args.kwargs["explicit_api_key"] == "env-secret"
 
+    def test_fallback_replaces_active_credential_pool(self):
+        """Fallback provider pool must replace the failed primary provider pool."""
+        fbs = [{"provider": "openai-codex", "model": "gpt-5.5"}]
+        agent = _make_agent(fallback_model=fbs)
+        old_pool = MagicMock(name="anthropic-pool")
+        new_pool = MagicMock(name="codex-pool")
+        agent._credential_pool = old_pool
+
+        client = _mock_client(
+            base_url="https://chatgpt.com/backend-api/codex",
+            api_key="codex-token",
+        )
+        client._hermes_credential_pool = new_pool
+        client._hermes_pool_provider = "openai-codex"
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(client, "gpt-5.5"),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert agent.provider == "openai-codex"
+        assert agent._credential_pool is new_pool
+
+    def test_fallback_clears_stale_pool_when_target_has_no_pool(self):
+        fbs = [{"provider": "openrouter", "model": "anthropic/claude-sonnet-4"}]
+        agent = _make_agent(fallback_model=fbs)
+        agent._credential_pool = MagicMock(name="failed-primary-pool")
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(_mock_client(), "anthropic/claude-sonnet-4"),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert agent.provider == "openrouter"
+        assert agent._credential_pool is None
+
 
 # ── Pool-rotation vs fallback gating (#11314) ────────────────────────────
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -693,6 +693,7 @@ class TestInit:
             patch("run_agent.get_tool_definitions", return_value=[]),
             patch("run_agent.check_toolset_requirements", return_value={}),
             patch("run_agent.OpenAI"),
+            patch("hermes_cli.config.load_config", return_value={"model": {"context_length": 200_000}}),
         ):
             a = AIAgent(
                 api_key="test-key-1234567890",
@@ -2328,6 +2329,17 @@ class TestParallelScopePathNormalization:
 
         assert rel_scoped == abs_scoped
         assert _paths_overlap(rel_scoped, abs_scoped)
+
+    def test_extract_parallel_scope_path_ignores_corrupt_home_env(self, tmp_path, monkeypatch):
+        from hermes_constants import get_os_user_home
+        from run_agent import _extract_parallel_scope_path
+
+        monkeypatch.setenv("HOME", f"{tmp_path}/\ufffcbad")
+
+        scoped = _extract_parallel_scope_path("write_file", {"path": "~/.hermes/config.yaml"})
+
+        assert scoped == get_os_user_home() / ".hermes" / "config.yaml"
+        assert "\ufffc" not in str(scoped)
 
     def test_should_parallelize_tool_batch_rejects_same_file_with_mixed_path_spellings(self, tmp_path, monkeypatch):
         from run_agent import _should_parallelize_tool_batch

--- a/tests/test_hermes_constants_home.py
+++ b/tests/test_hermes_constants_home.py
@@ -1,0 +1,24 @@
+"""Regression coverage for HOME-independent host path helpers."""
+
+import os
+
+from hermes_constants import expand_user_path, get_os_user_home
+
+
+def test_get_os_user_home_ignores_corrupt_home_env(monkeypatch):
+    monkeypatch.setenv("HOME", "/tmp/\ufffcbad")
+
+    home = get_os_user_home()
+
+    assert "\ufffc" not in str(home)
+    if os.name != "nt":
+        assert str(home).startswith("/")
+
+
+def test_expand_user_path_ignores_corrupt_home_env(monkeypatch):
+    monkeypatch.setenv("HOME", "/tmp/\ufffcbad")
+
+    expanded = expand_user_path("~/.hermes/hermes-agent")
+
+    assert expanded == str(get_os_user_home() / ".hermes" / "hermes-agent")
+    assert "\ufffc" not in expanded

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -594,3 +594,27 @@ class _DeletedTestGitBaselineCheck:
     helper is restored or replaced.
     """
     pass
+
+
+class TestCorruptHomeGuardrails:
+    def test_expand_path_uses_passwd_home_when_terminal_home_contains_object_replacement(self, mock_env):
+        from hermes_constants import get_os_user_home
+
+        def side_effect(command, **kwargs):
+            if command == "echo $HOME":
+                return {"output": "/home/\ufffc/bad\n", "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+
+        assert ops._expand_path("~/.hermes/hermes-agent") == str(get_os_user_home() / ".hermes" / "hermes-agent")
+
+    def test_write_deny_ignores_corrupt_home_env(self, monkeypatch):
+        from agent.file_safety import is_write_denied
+        from hermes_constants import get_os_user_home
+
+        monkeypatch.setenv("HOME", "/tmp/\ufffcbad")
+
+        assert is_write_denied(str(get_os_user_home() / ".ssh" / "id_rsa")) is True
+        assert is_write_denied("~/.ssh/id_rsa") is True

--- a/tests/tools/test_resolve_path.py
+++ b/tests/tools/test_resolve_path.py
@@ -38,11 +38,14 @@ class TestResolvePath:
     def test_tilde_expansion(self, monkeypatch, tmp_path):
         """~ is expanded before TERMINAL_CWD join (already absolute)."""
         monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+        from hermes_constants import get_os_user_home
         from tools.file_tools import _resolve_path
 
         result = _resolve_path("~/notes.txt")
-        # After expanduser, ~/notes.txt becomes absolute → TERMINAL_CWD ignored
-        assert result == Path.home() / "notes.txt"
+        # After host-side expanduser, ~/notes.txt becomes absolute → TERMINAL_CWD ignored.
+        # Use passwd-backed home, not $HOME, because worker/profile HOME can be
+        # redirected or corrupted by U+FFFC.
+        assert result == get_os_user_home() / "notes.txt"
 
     def test_result_is_resolved(self, monkeypatch, tmp_path):
         """Output path has no '..' components."""
@@ -83,3 +86,16 @@ class TestResolvePath:
                     file_tools._file_ops_cache[task_id] = previous
 
         assert result == live_dir / "nested" / "file.txt"
+
+
+    def test_tilde_expansion_ignores_corrupt_home_env(self, monkeypatch, tmp_path):
+        """Host-side file tool path resolution must not trust a corrupt $HOME."""
+        monkeypatch.setenv("HOME", f"{tmp_path}/\ufffcbad")
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+        from hermes_constants import get_os_user_home
+        from tools.file_tools import _resolve_path
+
+        result = _resolve_path("~/.hermes/hermes-agent")
+
+        assert result == (get_os_user_home() / ".hermes" / "hermes-agent").resolve()
+        assert "\ufffc" not in str(result)

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -65,6 +65,7 @@ import time
 import requests
 from typing import Dict, Any, Optional, List, Tuple
 from pathlib import Path
+from hermes_constants import expand_user_path
 from agent.auxiliary_client import call_llm
 from hermes_constants import get_hermes_home
 from utils import is_truthy_value
@@ -3506,7 +3507,7 @@ def _chromium_search_roots() -> List[str]:
     env_path = os.environ.get("PLAYWRIGHT_BROWSERS_PATH", "").strip()
     if env_path and env_path != "0":
         roots.append(env_path)
-    home = os.path.expanduser("~")
+    home = expand_user_path("~")
     roots.append(os.path.join(home, ".cache", "ms-playwright"))
     if sys.platform == "darwin":
         roots.append(os.path.join(home, "Library", "Caches", "ms-playwright"))

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -57,6 +57,7 @@ import shutil
 import subprocess
 import time
 from pathlib import Path
+from hermes_constants import expand_user_path, get_os_user_home
 from hermes_constants import get_hermes_home
 from typing import Dict, List, Optional, Set, Tuple
 
@@ -192,7 +193,7 @@ def _validate_file_path(file_path: str, working_dir: str) -> Optional[str]:
 
 def _normalize_path(path_value: str) -> Path:
     """Return a canonical absolute path for checkpoint operations."""
-    return Path(path_value).expanduser().resolve()
+    return Path(expand_user_path(path_value)).resolve()
 
 
 def _project_hash(working_dir: str) -> str:
@@ -639,7 +640,7 @@ class CheckpointManager:
         abs_dir = str(_normalize_path(working_dir))
 
         # Skip root, home, and other overly broad directories
-        if abs_dir in {"/", str(Path.home())}:
+        if abs_dir in {"/", str(get_os_user_home())}:
             logger.debug("Checkpoint skipped: directory too broad (%s)", abs_dir)
             return False
 

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -33,6 +33,7 @@ import functools
 import json
 import logging
 import os
+from hermes_constants import expand_user_path
 import platform
 import shlex
 import signal
@@ -1632,7 +1633,7 @@ def _resolve_child_cwd(mode: str, staging_dir: str) -> str:
         return staging_dir
     raw = os.environ.get("TERMINAL_CWD", "").strip()
     if raw:
-        expanded = os.path.expanduser(raw)
+        expanded = expand_user_path(raw)
         if os.path.isdir(expanded):
             return expanded
     here = os.getcwd()
@@ -1711,7 +1712,7 @@ def build_execute_code_schema(enabled_sandbox_tools: set = None,
     if mode == "strict":
         cwd_note = (
             "Scripts run in their own temp dir, not the session's CWD — use absolute paths "
-            "(os.path.expanduser('~/.hermes/.env')) or terminal()/read_file() for user files."
+            "(expand_user_path('~/.hermes/.env')) or terminal()/read_file() for user files."
         )
     else:
         cwd_note = (

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -22,6 +22,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 import os
+from hermes_constants import expand_user_path
 import threading
 import time
 from concurrent.futures import (
@@ -661,7 +662,7 @@ def _resolve_workspace_hint(parent_agent) -> Optional[str]:
         if not candidate:
             continue
         try:
-            text = os.path.abspath(os.path.expanduser(str(candidate)))
+            text = os.path.abspath(expand_user_path(str(candidate)))
         except Exception:
             continue
         if os.path.isabs(text) and os.path.isdir(text):

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -7,6 +7,7 @@ persistence via bind mounts.
 
 import logging
 import os
+from hermes_constants import expand_user_path
 import re
 import shutil
 import subprocess
@@ -358,7 +359,7 @@ class DockerEnvironment(BaseEnvironment):
             else:
                 logger.warning(f"Docker volume '{vol}' missing colon, skipping")
 
-        host_cwd_abs = os.path.abspath(os.path.expanduser(host_cwd)) if host_cwd else ""
+        host_cwd_abs = os.path.abspath(expand_user_path(host_cwd)) if host_cwd else ""
         bind_host_cwd = (
             auto_mount_cwd
             and bool(host_cwd_abs)

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -10,6 +10,7 @@ import subprocess
 import tempfile
 import time
 from pathlib import Path
+from hermes_constants import expand_user_path
 
 from tools.environments.base import BaseEnvironment, _pipe_stdin
 from hermes_cli._subprocess_compat import windows_hide_flags
@@ -385,7 +386,7 @@ def _resolve_shell_init_files() -> list[str]:
     resolved: list[str] = []
     for raw in candidates:
         try:
-            path = os.path.expandvars(os.path.expanduser(raw))
+            path = os.path.expandvars(expand_user_path(raw))
         except Exception:
             continue
         if path and os.path.isfile(path):
@@ -424,7 +425,7 @@ class LocalEnvironment(BaseEnvironment):
 
     def __init__(self, cwd: str = "", timeout: int = 60, env: dict = None):
         if cwd:
-            cwd = os.path.expanduser(cwd)
+            cwd = expand_user_path(cwd)
         super().__init__(cwd=cwd or os.getcwd(), timeout=timeout, env=env)
         self.init_session()
 

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -33,6 +33,7 @@ from dataclasses import dataclass, field
 from typing import Optional, List, Dict, Any
 from pathlib import Path
 from tools.binary_extensions import BINARY_EXTENSIONS
+from hermes_constants import expand_user_path, get_os_user_home
 
 from agent.file_safety import (
     build_write_denied_paths,
@@ -46,7 +47,7 @@ from agent.file_safety import (
 # Write-path deny list — blocks writes to sensitive system/credential files
 # ---------------------------------------------------------------------------
 
-_HOME = str(Path.home())
+_HOME = str(get_os_user_home())
 
 WRITE_DENIED_PATHS = build_write_denied_paths(_HOME)
 
@@ -672,6 +673,12 @@ class ShellFileOperations(FileOperations):
             result = self._exec("echo $HOME")
             if result.exit_code == 0 and result.stdout.strip():
                 home = result.stdout.strip()
+                if "\ufffc" in home:
+                    # Guardrail for corrupted local HOME env observed on VPS
+                    # launches.  Remote backends should not normally emit this;
+                    # if they do, using the host passwd home is safer than
+                    # constructing paths containing U+FFFC.
+                    home = str(get_os_user_home())
                 if path == '~':
                     return home
                 elif path.startswith('~/'):

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -8,6 +8,8 @@ import os
 import threading
 from pathlib import Path
 
+from hermes_constants import expand_user_path
+
 from agent.file_safety import get_read_block_error
 from tools.binary_extensions import has_binary_extension
 from tools.file_operations import (
@@ -118,7 +120,7 @@ def _get_live_tracking_cwd(task_id: str = "default") -> str | None:
 
 def _resolve_path_for_task(filepath: str, task_id: str = "default") -> Path:
     """Resolve *filepath* against the task's live terminal cwd when possible."""
-    p = Path(filepath).expanduser()
+    p = Path(expand_user_path(filepath))
     if not p.is_absolute():
         base = _get_live_tracking_cwd(task_id) or os.environ.get(
             "TERMINAL_CWD", os.getcwd()
@@ -135,7 +137,7 @@ def _is_blocked_device(filepath: str) -> bool:
     through (e.g. /dev/stdin → /proc/self/fd/0 → /dev/pts/0), defeating
     the check.
     """
-    normalized = os.path.expanduser(filepath)
+    normalized = expand_user_path(filepath)
     if normalized in _BLOCKED_DEVICE_PATHS:
         return True
     # /proc/self/fd/0-2 and /proc/<pid>/fd/0-2 are Linux aliases for stdio
@@ -161,7 +163,7 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
         resolved = str(_resolve_path_for_task(filepath, task_id))
     except (OSError, ValueError):
         resolved = filepath
-    normalized = os.path.normpath(os.path.expanduser(filepath))
+    normalized = os.path.normpath(expand_user_path(filepath))
     _err = (
         f"Refusing to write to sensitive system path: {filepath}\n"
         "Use the terminal tool with sudo if you need to modify system files."

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -108,7 +108,21 @@ def _get_token_dir() -> Path:
         from hermes_constants import get_hermes_home
         base = Path(get_hermes_home())
     except ImportError:
-        base = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes")))
+        env_home = os.environ.get("HERMES_HOME")
+        if env_home:
+            base = Path(env_home)
+        elif os.name != "nt":
+            try:
+                import pwd
+
+                base = Path(pwd.getpwuid(os.getuid()).pw_dir) / ".hermes"
+            except Exception:
+                fallback_home = os.environ.get("HOME", "")
+                if not fallback_home or "\ufffc" in fallback_home:
+                    fallback_home = "/tmp"
+                base = Path(fallback_home) / ".hermes"
+        else:
+            base = Path(os.environ.get("USERPROFILE") or os.environ.get("HOME") or ".") / ".hermes"
     return base / "mcp-tokens"
 
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -84,6 +84,7 @@ import json
 import logging
 import math
 import os
+from hermes_constants import expand_user_path, get_hermes_home, get_os_user_home
 import re
 import shutil
 import sys
@@ -405,7 +406,7 @@ def _resolve_stdio_command(command: str, env: dict) -> tuple[str, dict]:
     This primarily exists to make bare ``npx``/``npm``/``node`` commands work
     reliably even when MCP subprocesses run under a filtered PATH.
     """
-    resolved_command = os.path.expanduser(str(command).strip())
+    resolved_command = expand_user_path(str(command).strip())
     resolved_env = dict(env or {})
 
     if os.sep not in resolved_command:
@@ -414,14 +415,10 @@ def _resolve_stdio_command(command: str, env: dict) -> tuple[str, dict]:
         if which_hit:
             resolved_command = which_hit
         elif resolved_command in {"npx", "npm", "node"}:
-            hermes_home = os.path.expanduser(
-                os.getenv(
-                    "HERMES_HOME", os.path.join(os.path.expanduser("~"), ".hermes")
-                )
-            )
+            hermes_home = str(get_hermes_home())
             candidates = [
                 os.path.join(hermes_home, "node", "bin", resolved_command),
-                os.path.join(os.path.expanduser("~"), ".local", "bin", resolved_command),
+                os.path.join(str(get_os_user_home()), ".local", "bin", resolved_command),
             ]
             for candidate in candidates:
                 if os.path.isfile(candidate) and os.access(candidate, os.X_OK):

--- a/tools/neutts_synth.py
+++ b/tools/neutts_synth.py
@@ -16,6 +16,7 @@ import argparse
 import struct
 import sys
 from pathlib import Path
+from hermes_constants import expand_user_path
 
 
 def _write_wav(path: str, samples, sample_rate: int = 24000) -> None:
@@ -60,8 +61,8 @@ def main():
     args = parser.parse_args()
 
     # Validate inputs
-    ref_audio = Path(args.ref_audio).expanduser()
-    ref_text_path = Path(args.ref_text).expanduser()
+    ref_audio = Path(expand_user_path(args.ref_audio))
+    ref_text_path = Path(expand_user_path(args.ref_text))
     if not ref_audio.exists():
         print(f"Error: reference audio not found: {ref_audio}", file=sys.stderr)
         sys.exit(1)

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -45,6 +45,7 @@ import atexit
 import shutil
 import subprocess
 from pathlib import Path
+from hermes_constants import expand_user_path
 from typing import Optional, Dict, Any, List
 
 from utils import env_var_enabled
@@ -1032,12 +1033,12 @@ def _get_env_config() -> Dict[str, Any]:
     # normal sandbox behavior and discard host paths.
     cwd = os.getenv("TERMINAL_CWD", default_cwd)
     if cwd:
-        cwd = os.path.expanduser(cwd)
+        cwd = expand_user_path(cwd)
     host_cwd = None
     host_prefixes = ("/Users/", "/home/", "C:\\", "C:/")
     if env_type == "docker" and mount_docker_cwd:
         docker_cwd_source = os.getenv("TERMINAL_CWD") or os.getcwd()
-        candidate = os.path.abspath(os.path.expanduser(docker_cwd_source))
+        candidate = os.path.abspath(expand_user_path(docker_cwd_source))
         if (
             any(candidate.startswith(p) for p in host_prefixes)
             or (os.path.isabs(candidate) and os.path.isdir(candidate) and not candidate.startswith(("/workspace", "/root")))

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -24,6 +24,7 @@ import hashlib
 import json
 import logging
 import os
+from hermes_constants import expand_user_path
 import platform
 import shutil
 import stat
@@ -459,7 +460,7 @@ def _resolve_tirith_path(configured_path: str) -> str:
     if _resolved_path is not None and _resolved_path is not _INSTALL_FAILED:
         return _resolved_path
 
-    expanded = os.path.expanduser(configured_path)
+    expanded = expand_user_path(configured_path)
     explicit = _is_explicit_path(configured_path)
     install_failed = _resolved_path is _INSTALL_FAILED
 
@@ -608,7 +609,7 @@ def ensure_installed(*, log_failures: bool = True):
 
     configured_path = cfg["tirith_path"]
     explicit = _is_explicit_path(configured_path)
-    expanded = os.path.expanduser(configured_path)
+    expanded = expand_user_path(configured_path)
 
     # Explicit path: synchronous check only, no download
     if explicit:

--- a/tools/tool_backend_helpers.py
+++ b/tools/tool_backend_helpers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from hermes_constants import get_os_user_home
 from typing import Any, Dict
 
 from utils import is_truthy_value
@@ -60,7 +61,7 @@ def has_direct_modal_credentials() -> bool:
     """Return True when direct Modal credentials/config are available."""
     return bool(
         (os.getenv("MODAL_TOKEN_ID") and os.getenv("MODAL_TOKEN_SECRET"))
-        or (Path.home() / ".modal.toml").exists()
+        or (get_os_user_home() / ".modal.toml").exists()
     )
 
 

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -49,6 +49,7 @@ import tempfile
 import threading
 import uuid
 from pathlib import Path
+from hermes_constants import expand_user_path
 from typing import Callable, Dict, Any, Optional
 from urllib.parse import urljoin
 
@@ -661,7 +662,7 @@ def _generate_command_tts(
             f"tts.providers.{provider_name}.command is not configured"
         )
 
-    output = Path(output_path).expanduser()
+    output = Path(expand_user_path(output_path))
     output.parent.mkdir(parents=True, exist_ok=True)
     if output.exists():
         output.unlink()
@@ -1436,7 +1437,7 @@ def _resolve_piper_voice_path(voice: str, download_dir: Path) -> str:
         voice = DEFAULT_PIPER_VOICE
 
     # Case 1: user gave a direct file path.
-    candidate = Path(voice).expanduser()
+    candidate = Path(expand_user_path(voice))
     if candidate.suffix.lower() == ".onnx" and candidate.exists():
         return str(candidate)
 
@@ -1486,7 +1487,7 @@ def _generate_piper_tts(text: str, output_path: str, tts_config: Dict[str, Any])
 
     piper_config = tts_config.get("piper", {}) if isinstance(tts_config, dict) else {}
     voice_name = piper_config.get("voice") or DEFAULT_PIPER_VOICE
-    download_dir = Path(piper_config.get("voices_dir") or _get_piper_voices_dir()).expanduser()
+    download_dir = Path(expand_user_path(piper_config.get("voices_dir") or _get_piper_voices_dir()))
     download_dir.mkdir(parents=True, exist_ok=True)
     use_cuda = bool(piper_config.get("use_cuda", False))
 
@@ -1671,7 +1672,7 @@ def text_to_speech_tool(
 
     # Determine output path
     if output_path:
-        file_path = Path(output_path).expanduser()
+        file_path = Path(expand_user_path(output_path))
         if command_provider_config is not None:
             # Respect caller-supplied path but align the extension with the
             # provider's configured output_format so the command writes to a

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -34,6 +34,7 @@ import logging
 import os
 import uuid
 from pathlib import Path
+from hermes_constants import expand_user_path
 from typing import Any, Awaitable, Dict, Optional
 from urllib.parse import urlparse
 import httpx
@@ -562,7 +563,7 @@ async def _vision_analyze_native(
         resolved_url = image_url
         if resolved_url.startswith("file://"):
             resolved_url = resolved_url[len("file://"):]
-        local_path = Path(os.path.expanduser(resolved_url))
+        local_path = Path(expand_user_path(resolved_url))
 
         if local_path.is_file():
             temp_image_path = local_path
@@ -701,7 +702,7 @@ async def vision_analyze_tool(
         resolved_url = image_url
         if resolved_url.startswith("file://"):
             resolved_url = resolved_url[len("file://"):]
-        local_path = Path(os.path.expanduser(resolved_url))
+        local_path = Path(expand_user_path(resolved_url))
         if local_path.is_file():
             # Local file path (e.g. from platform image cache) -- skip download
             logger.info("Using local image file: %s", image_url)
@@ -1201,7 +1202,7 @@ async def video_analyze_tool(
         resolved_url = video_url
         if resolved_url.startswith("file://"):
             resolved_url = resolved_url[len("file://"):]
-        local_path = Path(os.path.expanduser(resolved_url))
+        local_path = Path(expand_user_path(resolved_url))
 
         if local_path.is_file():
             logger.info("Using local video file: %s", video_url)

--- a/tools/website_policy.py
+++ b/tools/website_policy.py
@@ -15,6 +15,7 @@ import logging
 import threading
 import time
 from pathlib import Path
+from hermes_constants import expand_user_path
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlparse
 
@@ -177,7 +178,7 @@ def load_website_blocklist(config_path: Optional[Path] = None) -> Dict[str, Any]
     for shared_file in raw_shared_files:
         if not isinstance(shared_file, str) or not shared_file.strip():
             continue
-        path = Path(shared_file).expanduser()
+        path = Path(expand_user_path(shared_file))
         if not path.is_absolute():
             path = (get_hermes_home() / path).resolve()
         for normalized in _iter_blocklist_file_rules(path):


### PR DESCRIPTION
## Summary
- harden host-side `~` expansion against corrupted/profile-scoped `$HOME` values, including observed U+FFFC paths
- keep credential-pool ownership attached when fallback switches providers, and refresh Codex slot-backed pool entries from slot `auth.json`
- hot-reload Discord exact thread channel prompts and append an identity guard so channel prompts cannot rename/replace SOUL identity

## Verification
- `PYTHONPATH=. venv/bin/python -m pytest tests/test_hermes_constants_home.py tests/tools/test_resolve_path.py tests/tools/test_file_operations.py tests/agent/test_credential_pool.py tests/agent/test_auxiliary_client.py tests/run_agent/test_provider_fallback.py tests/run_agent/test_run_agent.py tests/gateway/test_discord_channel_prompts.py -q -o addopts=`
- Result: `665 passed in 98.37s`

## Scope hygiene
- This PR is a clean one-commit branch from current `origin/main`.
- It intentionally excludes the older `kanban/insights-triage-2026-05-20` stack, whose diff included unrelated prior work.
