### PR TITLE
feat(skills): per-profile filter on dashboard skills page

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3000,29 +3000,235 @@ class SkillToggle(BaseModel):
     enabled: bool
 
 
-@app.get("/api/skills")
-async def get_skills():
-    from tools.skills_tool import _find_all_skills
-    from hermes_cli.skills_config import get_disabled_skills
-    config = load_config()
-    disabled = get_disabled_skills(config)
-    skills = _find_all_skills(skip_disabled=True)
+# --- Per-profile skill helpers (mirror the cron-page ?profile= convention) ---
+
+
+def _skill_profile_home(profile: Optional[str]) -> Tuple[str, Path]:
+    """Resolve a ?profile= query value to (canonical_name, HERMES_HOME path).
+
+    Mirrors ``_cron_profile_home`` so the skills endpoints validate and
+    canonicalize profile names exactly like the cron endpoints do.
+    """
+    from hermes_cli import profiles as profiles_mod
+
+    raw = (profile or "default").strip() or "default"
+    try:
+        canon = profiles_mod.normalize_profile_name(raw)
+        profiles_mod.validate_profile_name(canon)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    if not profiles_mod.profile_exists(canon):
+        raise HTTPException(status_code=404, detail=f"Profile '{canon}' does not exist.")
+    return canon, profiles_mod.get_profile_dir(canon)
+
+
+def _load_profile_disabled_skills(profile_dir: Path) -> set:
+    """Return the set of disabled skill names from a profile's config.yaml."""
+    config_path = profile_dir / "config.yaml"
+    if not config_path.exists():
+        return set()
+    try:
+        import yaml as _yaml
+        with open(config_path, encoding="utf-8") as f:
+            data = _yaml.safe_load(f)
+    except (OSError, Exception):
+        return set()
+    if not isinstance(data, dict):
+        return set()
+    skills_cfg = data.get("skills")
+    if not isinstance(skills_cfg, dict):
+        return set()
+    disabled = skills_cfg.get("disabled", [])
+    if not isinstance(disabled, list):
+        return set()
+    return {str(x) for x in disabled}
+
+
+def _save_profile_disabled_skills(profile_dir: Path, disabled: set) -> None:
+    """Write the disabled skill list back to a profile's config.yaml.skills.disabled."""
+    from utils import atomic_yaml_write
+
+    config_path = profile_dir / "config.yaml"
+    try:
+        import yaml as _yaml
+        if config_path.exists():
+            with open(config_path, encoding="utf-8") as f:
+                data = _yaml.safe_load(f) or {}
+        else:
+            data = {}
+    except OSError as e:
+        raise HTTPException(status_code=500, detail=f"Could not read config.yaml: {e}")
+
+    if not isinstance(data, dict):
+        data = {}
+    skills_cfg = data.setdefault("skills", {})
+    if not isinstance(skills_cfg, dict):
+        data["skills"] = skills_cfg = {}
+    skills_cfg["disabled"] = sorted(disabled)
+    try:
+        atomic_yaml_write(config_path, data)
+    except OSError as e:
+        raise HTTPException(status_code=500, detail=f"Could not write config.yaml: {e}")
+
+
+def _find_skills_in_profile_dir(profile_dir: Path) -> List[Dict[str, Any]]:
+    """Scan ``profile_dir/skills/`` for SKILL.md files and return the same shape
+    as ``tools.skills_tool._find_all_skills`` (minus ``external_dirs`` scanning).
+
+    External-dir scanning is intentionally omitted — the dashboard's per-profile
+    filter targets profile-installed skills. Skills loaded via
+    ``skills.external_dirs`` are still honored by the gateway at runtime.
+    """
+    from tools.skills_tool import (
+        MAX_DESCRIPTION_LENGTH,
+        MAX_NAME_LENGTH,
+        _EXCLUDED_SKILL_DIRS,
+        _parse_frontmatter,
+        skill_matches_platform,
+    )
+    from agent.skill_utils import iter_skill_index_files
+
+    skills_dir = profile_dir / "skills"
+    if not skills_dir.is_dir():
+        return []
+
+    def _category(skill_md_path: Path) -> Optional[str]:
+        try:
+            rel = skill_md_path.relative_to(skills_dir)
+        except ValueError:
+            return None
+        return rel.parts[0] if len(rel.parts) >= 3 else None
+
+    out: List[Dict[str, Any]] = []
+    seen: set = set()
+    for skill_md in iter_skill_index_files(skills_dir, "SKILL.md"):
+        if any(part in _EXCLUDED_SKILL_DIRS for part in skill_md.parts):
+            continue
+        try:
+            content = skill_md.read_text(encoding="utf-8")[:4000]
+            frontmatter, body = _parse_frontmatter(content)
+            if not skill_matches_platform(frontmatter):
+                continue
+            name = frontmatter.get("name", skill_md.parent.name)[:MAX_NAME_LENGTH]
+            if name in seen:
+                continue
+            description = frontmatter.get("description", "")
+            if not description:
+                for line in body.strip().split("\n"):
+                    line = line.strip()
+                    if line and not line.startswith("#"):
+                        description = line
+                        break
+            if len(description) > MAX_DESCRIPTION_LENGTH:
+                description = description[:MAX_DESCRIPTION_LENGTH - 3] + "..."
+            seen.add(name)
+            out.append({
+                "name": name,
+                "description": description,
+                "category": _category(skill_md),
+            })
+        except (OSError, UnicodeDecodeError):
+            continue
+    return out
+
+
+def _list_skills_for_profile(name: str, profile_dir: Path) -> List[Dict[str, Any]]:
+    """Return ``profile_dir``'s skills tagged with ``profile=name`` and ``enabled``."""
+    disabled = _load_profile_disabled_skills(profile_dir)
+    skills = _find_skills_in_profile_dir(profile_dir)
     for s in skills:
         s["enabled"] = s["name"] not in disabled
+        s["profile"] = name
+    return skills
+
+
+def _skills_profile_dicts() -> List[Dict[str, Any]]:
+    """Return dashboard profile records, falling back to a directory scan.
+
+    Mirror of ``_cron_profile_dicts``. Inlined rather than shared because the
+    cron helper is named after its caller; refactoring is out of scope.
+    """
+    from hermes_cli import profiles as profiles_mod
+    try:
+        return [_profile_to_dict(p) for p in profiles_mod.list_profiles()]
+    except Exception:
+        _log.exception("Failed to list profiles for skills dashboard; falling back to directory scan")
+        return _fallback_profile_dicts(profiles_mod)
+
+
+@app.get("/api/skills")
+async def get_skills(profile: Optional[str] = None):
+    """List installed skills, optionally filtered by profile.
+
+    Mirrors ``GET /api/cron/jobs?profile=`` semantics:
+
+    - ``profile`` omitted entirely → active-profile skills (legacy path),
+      preserved for backwards compatibility with callers that haven't been
+      updated to send the query param.
+    - ``profile=all`` → union across all installed profiles, each row
+      tagged ``profile=<name>``.
+    - ``profile=<name>`` → just that profile's skills, tagged with that name.
+    """
+    if profile is None:
+        from tools.skills_tool import _find_all_skills
+        from hermes_cli.skills_config import get_disabled_skills
+        config = load_config()
+        disabled = get_disabled_skills(config)
+        skills = _find_all_skills(skip_disabled=True)
+        for s in skills:
+            s["enabled"] = s["name"] not in disabled
+        return skills
+
+    requested = profile.strip() or "all"
+    if requested.lower() != "all":
+        canon, profile_dir = _skill_profile_home(requested)
+        return _list_skills_for_profile(canon, profile_dir)
+
+    skills: List[Dict[str, Any]] = []
+    from hermes_cli import profiles as profiles_mod
+    for item in _skills_profile_dicts():
+        name = str(item.get("name") or "")
+        if not name:
+            continue
+        try:
+            profile_dir = profiles_mod.get_profile_dir(name)
+        except Exception:
+            _log.exception("Failed to resolve profile dir for %s", name)
+            continue
+        try:
+            skills.extend(_list_skills_for_profile(name, profile_dir))
+        except Exception:
+            _log.exception("Failed to list skills for profile %s", name)
     return skills
 
 
 @app.put("/api/skills/toggle")
-async def toggle_skill(body: SkillToggle):
-    from hermes_cli.skills_config import get_disabled_skills, save_disabled_skills
-    config = load_config()
-    disabled = get_disabled_skills(config)
+async def toggle_skill(body: SkillToggle, profile: Optional[str] = None):
+    """Toggle a skill's enabled state in a specific profile's config.yaml.
+
+    Mirrors the cron-page convention: pass ``?profile=<name>`` to target a
+    specific profile. When omitted, defaults to the dashboard's active
+    profile (preserves the legacy behavior).
+    """
+    if profile is None:
+        from hermes_cli.skills_config import get_disabled_skills, save_disabled_skills
+        config = load_config()
+        disabled = get_disabled_skills(config)
+        if body.enabled:
+            disabled.discard(body.name)
+        else:
+            disabled.add(body.name)
+        save_disabled_skills(config, disabled)
+        return {"ok": True, "name": body.name, "enabled": body.enabled}
+
+    canon, profile_dir = _skill_profile_home(profile)
+    disabled = _load_profile_disabled_skills(profile_dir)
     if body.enabled:
         disabled.discard(body.name)
     else:
         disabled.add(body.name)
-    save_disabled_skills(config, disabled)
-    return {"ok": True, "name": body.name, "enabled": body.enabled}
+    _save_profile_disabled_skills(profile_dir, disabled)
+    return {"ok": True, "name": body.name, "enabled": body.enabled, "profile": canon}
 
 
 @app.get("/api/tools/toolsets")

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -853,6 +853,119 @@ class TestNewEndpoints:
             },
         ]
 
+    # --- Per-profile skills (cron-style ?profile= convention) ---
+
+    def test_skills_list_for_named_profile(self, monkeypatch):
+        """GET /api/skills?profile=<name> should scan the profile's own
+        skills/ directory and tag each row with the profile name."""
+        from pathlib import Path
+        import hermes_cli.profiles as profiles_mod
+        monkeypatch.setattr(profiles_mod, "_cleanup_gateway_service", lambda *a, **kw: None)
+
+        self.client.post("/api/profiles", json={"name": "skills-scope-prof"})
+        try:
+            profile_dir = Path(profiles_mod.get_profile_dir("skills-scope-prof"))
+            skill_dir = profile_dir / "skills" / "productivity" / "scoped-skill"
+            skill_dir.mkdir(parents=True, exist_ok=True)
+            (skill_dir / "SKILL.md").write_text(
+                "---\nname: scoped-skill\ndescription: Scoped to one profile.\n---\n# Body\n",
+                encoding="utf-8",
+            )
+
+            resp = self.client.get("/api/skills?profile=skills-scope-prof")
+            assert resp.status_code == 200
+            skills = resp.json()
+            scoped = [s for s in skills if s["name"] == "scoped-skill"]
+            assert len(scoped) == 1
+            assert scoped[0]["profile"] == "skills-scope-prof"
+            assert scoped[0]["enabled"] is True
+            assert scoped[0]["category"] == "productivity"
+        finally:
+            self.client.delete("/api/profiles/skills-scope-prof")
+
+    def test_skills_list_all_unions_across_profiles(self, monkeypatch):
+        """GET /api/skills?profile=all should return rows from every profile
+        with skills/, each tagged with its source profile."""
+        from pathlib import Path
+        import hermes_cli.profiles as profiles_mod
+        monkeypatch.setattr(profiles_mod, "_cleanup_gateway_service", lambda *a, **kw: None)
+
+        self.client.post("/api/profiles", json={"name": "union-prof-a"})
+        self.client.post("/api/profiles", json={"name": "union-prof-b"})
+        try:
+            for prof_name, skill_name in (
+                ("union-prof-a", "a-only-skill"),
+                ("union-prof-b", "b-only-skill"),
+            ):
+                profile_dir = Path(profiles_mod.get_profile_dir(prof_name))
+                skill_dir = profile_dir / "skills" / skill_name
+                skill_dir.mkdir(parents=True, exist_ok=True)
+                (skill_dir / "SKILL.md").write_text(
+                    f"---\nname: {skill_name}\ndescription: For {prof_name}.\n---\n# Body\n",
+                    encoding="utf-8",
+                )
+
+            resp = self.client.get("/api/skills?profile=all")
+            assert resp.status_code == 200
+            rows = resp.json()
+
+            attribution = {
+                (r["name"], r["profile"]) for r in rows if "profile" in r
+            }
+            assert ("a-only-skill", "union-prof-a") in attribution
+            assert ("b-only-skill", "union-prof-b") in attribution
+        finally:
+            self.client.delete("/api/profiles/union-prof-a")
+            self.client.delete("/api/profiles/union-prof-b")
+
+    def test_skill_toggle_with_profile_writes_to_profile_config(self, monkeypatch):
+        """PUT /api/skills/toggle?profile=<name> should write to the profile's
+        own config.yaml, leaving the dashboard's active profile untouched."""
+        from pathlib import Path
+        import yaml
+        import hermes_cli.profiles as profiles_mod
+        monkeypatch.setattr(profiles_mod, "_cleanup_gateway_service", lambda *a, **kw: None)
+
+        self.client.post("/api/profiles", json={"name": "toggle-scoped-prof"})
+        try:
+            put = self.client.put(
+                "/api/skills/toggle?profile=toggle-scoped-prof",
+                json={"name": "fake-skill", "enabled": False},
+            )
+            assert put.status_code == 200
+            assert put.json()["profile"] == "toggle-scoped-prof"
+            assert put.json()["enabled"] is False
+
+            profile_cfg = Path(profiles_mod.get_profile_dir("toggle-scoped-prof")) / "config.yaml"
+            assert profile_cfg.exists()
+            parsed = yaml.safe_load(profile_cfg.read_text(encoding="utf-8")) or {}
+            assert parsed.get("skills", {}).get("disabled") == ["fake-skill"]
+
+            # Re-enable should clear the entry.
+            put2 = self.client.put(
+                "/api/skills/toggle?profile=toggle-scoped-prof",
+                json={"name": "fake-skill", "enabled": True},
+            )
+            assert put2.status_code == 200
+            parsed2 = yaml.safe_load(profile_cfg.read_text(encoding="utf-8")) or {}
+            assert parsed2.get("skills", {}).get("disabled") == []
+        finally:
+            self.client.delete("/api/profiles/toggle-scoped-prof")
+
+    def test_skills_unknown_profile_404(self):
+        resp = self.client.get("/api/skills?profile=nonexistent")
+        assert resp.status_code == 404
+        resp2 = self.client.put(
+            "/api/skills/toggle?profile=nonexistent",
+            json={"name": "x", "enabled": False},
+        )
+        assert resp2.status_code == 404
+
+    def test_skills_invalid_profile_name_400(self):
+        resp = self.client.get("/api/skills?profile=Bad@Name")
+        assert resp.status_code == 400
+        assert "Invalid profile name" in resp.json()["detail"]
+
     def test_toolsets_list(self):
         resp = self.client.get("/api/tools/toolsets")
         assert resp.status_code == 200

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -197,13 +197,18 @@ export const api = {
     ),
 
   // Skills & Toolsets
-  getSkills: () => fetchJSON<SkillInfo[]>("/api/skills"),
-  toggleSkill: (name: string, enabled: boolean) =>
-    fetchJSON<{ ok: boolean }>("/api/skills/toggle", {
+  getSkills: (profile = "all") =>
+    fetchJSON<SkillInfo[]>(`/api/skills?profile=${encodeURIComponent(profile)}`),
+  toggleSkill: (name: string, enabled: boolean, profile?: string) => {
+    const url = profile
+      ? `/api/skills/toggle?profile=${encodeURIComponent(profile)}`
+      : "/api/skills/toggle";
+    return fetchJSON<{ ok: boolean }>(url, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name, enabled }),
-    }),
+    });
+  },
   getToolsets: () => fetchJSON<ToolsetInfo[]>("/api/tools/toolsets"),
 
   // Session search (FTS5)
@@ -576,6 +581,10 @@ export interface SkillInfo {
   description: string;
   category: string;
   enabled: boolean;
+  /** The profile this skill row belongs to. Present when `/api/skills` is
+   *  called with `?profile=` (including the default `?profile=all`). Optional
+   *  for backwards compatibility with older gateways that don't emit it. */
+  profile?: string;
 }
 
 export interface ToolsetInfo {

--- a/web/src/pages/SkillsPage.tsx
+++ b/web/src/pages/SkillsPage.tsx
@@ -16,13 +16,15 @@ import {
   Filter,
 } from "lucide-react";
 import { api } from "@/lib/api";
-import type { SkillInfo, ToolsetInfo } from "@/lib/api";
+import type { ProfileInfo, SkillInfo, ToolsetInfo } from "@/lib/api";
 import { useToast } from "@/hooks/useToast";
 import { Toast } from "@/components/Toast";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@nous-research/ui/ui/components/badge";
 import { Button } from "@nous-research/ui/ui/components/button";
+import { Label } from "@/components/ui/label";
 import { ListItem } from "@nous-research/ui/ui/components/list-item";
+import { Select, SelectOption } from "@nous-research/ui/ui/components/select";
 import { Spinner } from "@nous-research/ui/ui/components/spinner";
 import { Switch } from "@nous-research/ui/ui/components/switch";
 import { cn } from "@/lib/utils";
@@ -96,6 +98,8 @@ function toolsetIcon(
 export default function SkillsPage() {
   const [skills, setSkills] = useState<SkillInfo[]>([]);
   const [toolsets, setToolsets] = useState<ToolsetInfo[]>([]);
+  const [profiles, setProfiles] = useState<ProfileInfo[]>([]);
+  const [selectedProfile, setSelectedProfile] = useState("all");
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState("");
   const [view, setView] = useState<"skills" | "toolsets">("skills");
@@ -105,24 +109,43 @@ export default function SkillsPage() {
   const { t } = useI18n();
   const { setAfterTitle, setEnd } = usePageHeader();
 
+  // Toolsets and the profile list load once on mount.
   useEffect(() => {
-    Promise.all([api.getSkills(), api.getToolsets()])
-      .then(([s, tsets]) => {
-        setSkills(s);
-        setToolsets(tsets);
-      })
+    api
+      .getToolsets()
+      .then(setToolsets)
+      .catch(() => showToast(t.common.loading, "error"));
+    api
+      .getProfiles()
+      .then((r) => setProfiles(r.profiles))
+      .catch(() => setProfiles([]));
+  }, []);
+
+  // Skills refetch whenever the profile filter changes.
+  useEffect(() => {
+    setLoading(true);
+    api
+      .getSkills(selectedProfile)
+      .then(setSkills)
       .catch(() => showToast(t.common.loading, "error"))
       .finally(() => setLoading(false));
-  }, []);
+  }, [selectedProfile]);
 
   /* ---- Toggle skill ---- */
   const handleToggleSkill = async (skill: SkillInfo) => {
     setTogglingSkills((prev) => new Set(prev).add(skill.name));
+    // Prefer the row's own profile (set by the server in all/per-profile modes).
+    // Falls back to the selected filter, then to omitted (active profile) for
+    // backwards compatibility with older gateways that don't emit profile.
+    const targetProfile =
+      skill.profile ?? (selectedProfile !== "all" ? selectedProfile : undefined);
     try {
-      await api.toggleSkill(skill.name, !skill.enabled);
+      await api.toggleSkill(skill.name, !skill.enabled, targetProfile);
       setSkills((prev) =>
         prev.map((s) =>
-          s.name === skill.name ? { ...s, enabled: !s.enabled } : s,
+          s.name === skill.name && s.profile === skill.profile
+            ? { ...s, enabled: !s.enabled }
+            : s,
         ),
       );
       showToast(
@@ -327,6 +350,23 @@ export default function SkillsPage() {
         </aside>
 
         <div className="flex-1 min-w-0">
+          {view === "skills" && profiles.length > 1 && (
+            <div className="mb-3 grid gap-1 sm:max-w-xs">
+              <Label htmlFor="skills-profile-filter">Profile</Label>
+              <Select
+                id="skills-profile-filter"
+                value={selectedProfile}
+                onValueChange={(v) => setSelectedProfile(v)}
+              >
+                <SelectOption value="all">All profiles</SelectOption>
+                {profiles.map((profile) => (
+                  <SelectOption key={profile.name} value={profile.name}>
+                    {profile.name}
+                  </SelectOption>
+                ))}
+              </Select>
+            </div>
+          )}
           {isSearching ? (
             <Card className="rounded-none">
               <CardHeader className="py-3 px-4">
@@ -354,11 +394,12 @@ export default function SkillsPage() {
                   <div className="grid gap-1">
                     {searchMatchedSkills.map((skill) => (
                       <SkillRow
-                        key={skill.name}
+                        key={`${skill.profile ?? "_"}:${skill.name}`}
                         skill={skill}
                         toggling={togglingSkills.has(skill.name)}
                         onToggle={() => handleToggleSkill(skill)}
                         noDescriptionLabel={t.skills.noDescription}
+                        showProfile={selectedProfile === "all"}
                       />
                     ))}
                   </div>
@@ -397,11 +438,12 @@ export default function SkillsPage() {
                   <div className="grid gap-1">
                     {activeSkills.map((skill) => (
                       <SkillRow
-                        key={skill.name}
+                        key={`${skill.profile ?? "_"}:${skill.name}`}
                         skill={skill}
                         toggling={togglingSkills.has(skill.name)}
                         onToggle={() => handleToggleSkill(skill)}
                         noDescriptionLabel={t.skills.noDescription}
+                        showProfile={selectedProfile === "all"}
                       />
                     ))}
                   </div>
@@ -497,6 +539,7 @@ function SkillRow({
   toggling,
   onToggle,
   noDescriptionLabel,
+  showProfile,
 }: SkillRowProps) {
   return (
     <div className="group flex items-start gap-3 px-3 py-2.5 transition-colors hover:bg-muted/40">
@@ -516,6 +559,11 @@ function SkillRow({
           >
             {skill.name}
           </span>
+          {showProfile && skill.profile && (
+            <Badge tone="secondary" className="text-[10px]">
+              {skill.profile}
+            </Badge>
+          )}
         </div>
         <p className="text-xs text-muted-foreground leading-relaxed line-clamp-2">
           {skill.description || noDescriptionLabel}
@@ -552,6 +600,7 @@ interface PanelItemProps {
 interface SkillRowProps {
   noDescriptionLabel: string;
   onToggle: () => void;
+  showProfile: boolean;
   skill: SkillInfo;
   toggling: boolean;
 }


### PR DESCRIPTION
## What

Adds a profile filter to the dashboard's Skills page, mirroring the
``?profile=`` convention already established for cron jobs in
``CronPage.tsx`` / ``GET /api/cron/jobs``.

- ``GET /api/skills`` gains an optional ``?profile=`` query param:
  - omitted → active-profile skills via the legacy code path (unchanged
    backwards-compatible behavior).
  - ``?profile=all`` → union across every installed profile, each row
    tagged ``profile=<name>``.
  - ``?profile=<name>`` → just that profile's skills, tagged with that name.
- ``PUT /api/skills/toggle`` gains the same ``?profile=`` param to target
  a specific profile's ``config.yaml`` (omitted falls back to the active
  profile, again preserving the old behavior).
- ``SkillsPage`` adds a cron-style ``<Select>`` filter (label "Profile",
  options "All profiles" + each installed profile name). Hidden when only
  one profile is installed to keep the default-only-install dashboard
  visually clean.
- ``SkillRow`` shows a small badge with the source profile name when
  viewing "All profiles" so users can tell which profile each row
  belongs to. Hidden in single-profile mode where the attribution is
  redundant.

## Why

The dashboard previously showed only the active profile's skills (whichever
``HERMES_HOME`` the dashboard process was launched under), with no UI for
toggling skills in other installed profiles. Users running multiple
profiles (default + a worker, a specialist sub-profile, etc.) had to spawn
a second dashboard daemon per profile to manage their skills, which is
operationally awkward.

The CLI's ``hermes skills list --source ...`` and the cron jobs page have
both grown profile-awareness already; this brings the skills page in line.

## Implementation

Backend (``hermes_cli/web_server.py``):
- New helpers (mirror existing ``_cron_*`` patterns):
  - ``_skill_profile_home(profile)`` — validate + canonicalize a profile
    name to ``(name, HERMES_HOME)``. Raises 400 on invalid names, 404 on
    nonexistent profiles. Direct parallel to ``_cron_profile_home``.
  - ``_load_profile_disabled_skills(profile_dir)`` /
    ``_save_profile_disabled_skills(profile_dir, disabled)`` — read/write
    ``skills.disabled`` in a profile's ``config.yaml`` directly. The
    process-level ``load_config`` / ``save_config`` helpers are bound to
    the dashboard's own ``HERMES_HOME`` and can't be reused for
    cross-profile mutation without invasive global-state changes.
  - ``_find_skills_in_profile_dir(profile_dir)`` — scanner that reuses
    ``tools.skills_tool``'s frontmatter parsing + platform matching against
    a specific profile's ``skills/`` directory. ``external_dirs`` are
    intentionally not scanned for non-active profiles (the dropdown
    targets profile-installed skills; the gateway still honors
    ``skills.external_dirs`` at runtime).
  - ``_list_skills_for_profile(name, profile_dir)`` — orchestrator that
    annotates each row with ``profile`` and ``enabled``.
  - ``_skills_profile_dicts()`` — inlined parallel of ``_cron_profile_dicts``
    so the all-profiles loop has somewhere to read from.

Frontend (``web/src/lib/api.ts``, ``web/src/pages/SkillsPage.tsx``):
- ``api.getSkills(profile = "all")`` — always passes ``?profile=`` (the
  legacy bare-call path is preserved server-side for external callers).
- ``api.toggleSkill(name, enabled, profile?)`` — optional third arg
  routes the toggle to the named profile's ``config.yaml``.
- ``SkillInfo`` gains optional ``profile?: string`` (back-compat).
- ``SkillsPage`` loads ``profiles`` once on mount, refetches ``skills``
  whenever ``selectedProfile`` changes, and routes toggles through the
  per-row profile so "All profiles" mode toggles the right (profile, skill)
  pair.

## Tests

``tests/hermes_cli/test_web_server.py``:
- ``test_skills_list_for_named_profile`` — ``?profile=<name>`` scans the
  profile's own ``skills/`` directory and tags rows with the profile.
- ``test_skills_list_all_unions_across_profiles`` — ``?profile=all``
  returns rows from every profile that has a ``skills/`` directory,
  each tagged with its source profile.
- ``test_skill_toggle_with_profile_writes_to_profile_config`` —
  ``PUT /api/skills/toggle?profile=<name>`` writes to that profile's
  ``config.yaml.skills.disabled``, leaving the dashboard's active
  profile untouched. Includes re-enable round-trip.
- ``test_skills_unknown_profile_404`` /
  ``test_skills_invalid_profile_name_400`` — profile name validation.

All 10 skills-related tests pass; the existing
``test_skills_list_includes_disabled_skills`` is preserved (legacy
``GET /api/skills`` with no ``?profile=`` is unchanged).

3 pre-existing ``TestPtyWebSocket`` failures unrelated to this change
(starlette testclient ``KeyError: 'bytes'`` on websocket receive,
reproduces on plain ``upstream/main``).

Frontend: zero new TypeScript errors or lint warnings on touched files.

## Scope

Single concern: per-profile filtering for the dashboard's skills page.
Out of scope (separate follow-ups, if wanted):

- A reusable ``_dashboard_profile_dicts`` helper that ``_cron_profile_dicts``
  and ``_skills_profile_dicts`` both consume. The current duplication is
  ~5 lines; refactoring would expand the diff for no immediate user-facing
  value.
- Per-profile scanning of ``skills.external_dirs`` (currently honored only
  for the active profile). Could surface in a follow-up if users ask.
- A "HUB / BUILTIN / LOCAL" source annotation per row — see #29312 for a
  separate PR that adds that signal.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
