### PR TITLE
fix(telegram): isolate getUpdates polling transport

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -798,6 +798,25 @@ class TelegramAdapter(BasePlatformAdapter):
             return default
         return bool(value)
 
+    def _polling_kwargs(self) -> Dict[str, Any]:
+        kwargs: Dict[str, Any] = {}
+
+        timeout = os.getenv("HERMES_TELEGRAM_POLL_TIMEOUT")
+        if timeout is not None:
+            try:
+                kwargs["timeout"] = max(1, min(int(timeout), 60))
+            except ValueError:
+                kwargs["timeout"] = 1
+
+        interval = os.getenv("HERMES_TELEGRAM_POLL_INTERVAL")
+        if interval is not None:
+            try:
+                kwargs["poll_interval"] = max(0.0, min(float(interval), 60.0))
+            except ValueError:
+                kwargs["poll_interval"] = 1.0
+
+        return kwargs
+
     def _link_preview_kwargs(self) -> Dict[str, Any]:
         if not getattr(self, "_disable_link_previews", False):
             return {}
@@ -900,6 +919,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 allowed_updates=Update.ALL_TYPES,
                 drop_pending_updates=False,
                 error_callback=self._polling_error_callback_ref,
+                **self._polling_kwargs(),
             )
             logger.info(
                 "[%s] Telegram polling resumed after network error (attempt %d)",
@@ -1026,6 +1046,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     allowed_updates=Update.ALL_TYPES,
                     drop_pending_updates=False,
                     error_callback=self._polling_error_callback_ref,
+                    **self._polling_kwargs(),
                 )
                 logger.info(
                     "[%s] Telegram polling resumed after conflict retry %d/%d",
@@ -1377,6 +1398,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 except (TypeError, ValueError):
                     return default
 
+            import httpx
+
             request_kwargs = {
                 "connection_pool_size": _env_int("HERMES_TELEGRAM_HTTP_POOL_SIZE", 512),
                 "pool_timeout": _env_float("HERMES_TELEGRAM_HTTP_POOL_TIMEOUT", 8.0),
@@ -1411,17 +1434,40 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
                 get_updates_request = HTTPXRequest(
                     **request_kwargs,
-                    httpx_kwargs={"transport": TelegramFallbackTransport(fallback_ips)},
+                    httpx_kwargs={
+                        "transport": TelegramFallbackTransport(fallback_ips),
+                        "limits": httpx.Limits(
+                            max_keepalive_connections=0,
+                            max_connections=request_kwargs["connection_pool_size"],
+                        ),
+                    },
                 )
             elif proxy_url:
                 logger.info("[%s] Proxy detected; passing explicitly to HTTPXRequest: %s", self.name, proxy_url)
                 request = HTTPXRequest(**request_kwargs, proxy=proxy_url)
-                get_updates_request = HTTPXRequest(**request_kwargs, proxy=proxy_url)
+                get_updates_request = HTTPXRequest(
+                    **request_kwargs,
+                    proxy=proxy_url,
+                    httpx_kwargs={
+                        "limits": httpx.Limits(
+                            max_keepalive_connections=0,
+                            max_connections=request_kwargs["connection_pool_size"],
+                        ),
+                    },
+                )
             else:
                 if disable_fallback:
                     logger.info("[%s] Telegram fallback-IP transport disabled via env", self.name)
                 request = HTTPXRequest(**request_kwargs)
-                get_updates_request = HTTPXRequest(**request_kwargs)
+                get_updates_request = HTTPXRequest(
+                    **request_kwargs,
+                    httpx_kwargs={
+                        "limits": httpx.Limits(
+                            max_keepalive_connections=0,
+                            max_connections=request_kwargs["connection_pool_size"],
+                        ),
+                    },
+                )
 
             builder = builder.request(request).get_updates_request(get_updates_request)
             self._app = builder.build()
@@ -1544,6 +1590,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     allowed_updates=Update.ALL_TYPES,
                     drop_pending_updates=True,
                     error_callback=_polling_error_callback,
+                    **self._polling_kwargs(),
                 )
             
             # Register bot commands so Telegram shows a hint menu when users type /

--- a/tests/gateway/test_telegram_polling_transport.py
+++ b/tests/gateway/test_telegram_polling_transport.py
@@ -1,0 +1,77 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms import telegram as telegram_mod
+from gateway.platforms.telegram import TelegramAdapter
+
+
+class FakeHTTPXRequest:
+    calls = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.__class__.calls.append(kwargs)
+
+
+class FakeBuilder:
+    def __init__(self):
+        self.request_obj = None
+        self.get_updates_request_obj = None
+
+    def token(self, _token):
+        return self
+
+    def request(self, request):
+        self.request_obj = request
+        return self
+
+    def get_updates_request(self, request):
+        self.get_updates_request_obj = request
+        return self
+
+    def build(self):
+        return SimpleNamespace(
+            bot=SimpleNamespace(),
+            add_handler=lambda *_args, **_kwargs: None,
+            add_error_handler=lambda *_args, **_kwargs: None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_connect_disables_keepalive_only_for_get_updates(monkeypatch):
+    FakeHTTPXRequest.calls = []
+    monkeypatch.setattr(telegram_mod, "HTTPXRequest", FakeHTTPXRequest)
+    monkeypatch.setattr(
+        telegram_mod.Application,
+        "builder",
+        staticmethod(lambda: FakeBuilder()),
+    )
+    monkeypatch.setattr(telegram_mod, "discover_fallback_ips", lambda: asyncio.sleep(0, result=[]))
+    monkeypatch.setenv("HERMES_TELEGRAM_DISABLE_FALLBACK_IPS", "1")
+
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    await adapter.connect()
+
+    assert len(FakeHTTPXRequest.calls) == 2
+    general_request, polling_request = FakeHTTPXRequest.calls
+    assert "httpx_kwargs" not in general_request
+    limits = polling_request["httpx_kwargs"]["limits"]
+    assert limits.max_keepalive_connections == 0
+    assert limits.max_connections == polling_request["connection_pool_size"]
+
+
+def test_polling_timeout_and_interval_env_are_opt_in_and_clamped(monkeypatch):
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+    assert adapter._polling_kwargs() == {}
+
+    monkeypatch.setenv("HERMES_TELEGRAM_POLL_TIMEOUT", "120")
+    monkeypatch.setenv("HERMES_TELEGRAM_POLL_INTERVAL", "-3")
+    assert adapter._polling_kwargs() == {"timeout": 60, "poll_interval": 0.0}
+
+    monkeypatch.setenv("HERMES_TELEGRAM_POLL_TIMEOUT", "bad")
+    monkeypatch.setenv("HERMES_TELEGRAM_POLL_INTERVAL", "bad")
+    assert adapter._polling_kwargs() == {"timeout": 1, "poll_interval": 1.0}


### PR DESCRIPTION
## Summary

- isolate Telegram `getUpdates` polling onto an HTTPX request client with keep-alive disabled
- add opt-in `HERMES_TELEGRAM_POLL_TIMEOUT` and `HERMES_TELEGRAM_POLL_INTERVAL` controls
- leave PTB polling timing defaults unchanged unless those env vars are set
- add regression tests covering polling transport isolation and env var clamping

## Background

Repeated Telegram `409 Conflict` errors were observed on a macOS launchd Hermes gateway with no visible second gateway process and no webhook configured. Raw/PTB repros still hit conflicts with Hermes stopped, while polling with fresh/no-keepalive transport and short polling stayed clean in the test window.

This PR keeps the broadly applicable transport isolation as the default change, while making polling timing explicit opt-in configuration for affected deployments.

## Testing

- `python3 -m py_compile gateway/platforms/telegram.py`
- `venv/bin/python -m pytest tests/gateway/test_telegram_polling_transport.py -q` on the Mac mini checkout: `2 passed`
- Local checkout could not run pytest because this machine has no pytest installed: `/usr/local/opt/python@3.14/bin/python3.14: No module named pytest`

Refs: https://github.com/NousResearch/hermes-agent/issues/29325
