### PR TITLE
fix(kanban): keep gave_up tasks blocked

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2003,10 +2003,9 @@ def _synthesize_ended_run(
 # ---------------------------------------------------------------------------
 
 def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
-    """Return True when ``task_id`` is sticky-blocked by an explicit
-    worker/operator ``kanban_block`` call (#28712).
+    """Return True when ``task_id`` is deliberately blocked until unblock.
 
-    A ``blocked`` status can come from two very different sources:
+    A ``blocked`` status can come from three different sources:
 
     * **Worker- or operator-initiated** — a worker called
       ``kanban_block(reason="review-required: ...")`` (or somebody ran
@@ -2016,28 +2015,26 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
 
     * **Circuit-breaker** — ``_record_task_failure`` tripped after
       repeated crashes / spawn failures / timeouts.  This emits
-      ``"gave_up"``, *not* ``"blocked"``, and is meant to recover
-      automatically once the underlying conditions change (e.g. parents
-      finish, transient infra error clears).
+      ``"gave_up"``, *not* ``"blocked"``.  Treat it as sticky too:
+      otherwise a parentless task satisfies dependencies immediately,
+      ``recompute_ready`` promotes it, and the dispatcher respawns the
+      same broken worker in a crash -> gave_up -> promoted loop.
 
-    The cheapest signal that distinguishes the two is the most recent
-    ``"blocked"`` / ``"unblocked"`` event for the task.  If the most
-    recent one is ``"blocked"`` (or there is a ``"blocked"`` event and
-    no ``"unblocked"`` event has fired since), the task is sticky and
-    ``recompute_ready`` must *not* auto-promote it.
+    * **Dependency-only / direct DB blocks** — rows that are blocked but
+      have no ``"blocked"`` or ``"gave_up"`` event.  These retain the
+      historical auto-recover behaviour once parents are done.
 
-    Returns ``False`` when there is no such event at all (e.g. the task
-    was set to ``status='blocked'`` by the circuit breaker or by direct
-    DB manipulation) — preserves the pre-#28712 auto-recover semantics
-    for that path.
+    The cheapest signal is the most recent block-state event for the task.
+    ``"blocked"`` and ``"gave_up"`` are sticky; ``"unblocked"`` is the
+    explicit operator escape hatch.
     """
     row = conn.execute(
         "SELECT kind FROM task_events "
-        "WHERE task_id = ? AND kind IN ('blocked', 'unblocked') "
+        "WHERE task_id = ? AND kind IN ('blocked', 'unblocked', 'gave_up') "
         "ORDER BY id DESC LIMIT 1",
         (task_id,),
     ).fetchone()
-    return bool(row) and row["kind"] == "blocked"
+    return bool(row) and row["kind"] in ("blocked", "gave_up")
 
 
 def recompute_ready(conn: sqlite3.Connection) -> int:
@@ -2048,9 +2045,10 @@ def recompute_ready(conn: sqlite3.Connection) -> int:
 
     ``blocked`` tasks are also considered for promotion (so a task
     blocked purely by a parent dependency unblocks itself when the
-    parent completes), *except* when the most recent block event was a
-    worker-initiated ``kanban_block`` — those stay blocked until an
-    explicit ``kanban_unblock`` (#28712).  Without that guard, a
+    parent completes), *except* when the most recent block-state event
+    was worker/operator ``blocked`` or circuit-breaker ``gave_up`` —
+    those stay blocked until an explicit ``kanban_unblock`` (#28712).
+    Without that guard, a
     ``review-required`` handoff would auto-respawn, the fresh worker
     would find nothing to do, exit cleanly, get recorded as a protocol
     violation, and the cycle would repeat indefinitely.

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -255,8 +255,8 @@ def test_recompute_ready_promotes_blocked_with_done_parents(kanban_home):
         # Complete the parent
         kb.claim_task(conn, parent)
         kb.complete_task(conn, parent, result="ok")
-        # Manually block the child (simulates a worker that failed
-        # after the parent finished)
+        # Manually block the child (simulates a dependency-only block after
+        # parent completion; no blocked/gave_up event is emitted).
         conn.execute(
             "UPDATE tasks SET status='blocked', consecutive_failures=5, "
             "last_failure_error='persistent error' WHERE id=?",
@@ -271,6 +271,38 @@ def test_recompute_ready_promotes_blocked_with_done_parents(kanban_home):
         assert task.status == "ready"
         assert task.consecutive_failures == 0
         assert task.last_failure_error is None
+
+
+def test_recompute_ready_keeps_gave_up_circuit_breaker_blocked(kanban_home):
+    """A circuit-breaker block is a human intervention point, not a dependency wait.
+
+    Regression: a parentless task that hit failure_limit emitted ``gave_up`` and
+    was immediately auto-promoted by ``recompute_ready()``, resetting failures
+    and creating a crash -> gave_up -> promoted -> respawn loop.
+    """
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="crashy", assignee="atlas")
+        kb._record_task_failure(
+            conn,
+            task_id,
+            "Unknown skill(s): notion-client-capitalization",
+            outcome="spawn_failed",
+            failure_limit=1,
+            release_claim=False,
+            end_run=False,
+        )
+
+        task = kb.get_task(conn, task_id)
+        assert task.status == "blocked"
+        assert task.consecutive_failures == 1
+
+        promoted = kb.recompute_ready(conn)
+
+        task = kb.get_task(conn, task_id)
+        assert promoted == 0
+        assert task.status == "blocked"
+        assert task.consecutive_failures == 1
+        assert task.last_failure_error == "Unknown skill(s): notion-client-capitalization"
 
 
 def test_recompute_ready_fan_in_waits_for_all_parents(kanban_home):


### PR DESCRIPTION
## Summary
- Keep `gave_up` circuit-breaker blocks sticky in `recompute_ready()` until an explicit unblock.
- Preserve dependency-only/direct DB blocked rows auto-promoting when parents are done.
- Add a regression test for the crash -> `gave_up` -> `promoted` -> respawn loop seen on Kanban task `t_8a40b49a`.

## Verification
- RED: `python -m pytest tests/hermes_cli/test_kanban_db.py::test_recompute_ready_keeps_gave_up_circuit_breaker_blocked -q` -> failed before fix (`promoted == 1`).
- GREEN: `python -m pytest tests/hermes_cli/test_kanban_db.py::test_recompute_ready_keeps_gave_up_circuit_breaker_blocked tests/hermes_cli/test_kanban_db.py::test_recompute_ready_promotes_blocked_with_done_parents -q` -> 2 passed.
- `python -m ruff check hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_db.py` -> passed.
- `python -m pytest tests/hermes_cli/test_kanban_db.py -q` -> 159 passed.

## Risks
- No secrets/config/prod changes.
- No Supabase/migration impact.
- Behavior change is limited to blocked tasks whose latest block-state event is `gave_up`; dependency-only blocks without `blocked`/`gave_up` events still auto-promote.