### PR TITLE
fix(schema): drop required: null to prevent gateway metaschema 400s

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2780,16 +2780,21 @@ def _normalize_mcp_input_schema(schema: dict | None) -> dict:
                 if not isinstance(repaired.get("properties"), dict):
                     repaired["properties"] = {}
 
-            # Prune required to only include names that exist in properties
-            required = repaired.get("required")
-            if isinstance(required, list):
+            # Prune required to only include names that exist in properties.
+            # Also drop ``required: null`` which some MCP servers / proxies
+            # emit; it serializes to ``"required": null`` and fails
+            # metaschema validation on strict gateways (e.g. New API).
+            req = repaired.get("required")
+            if isinstance(req, list):
                 props = repaired.get("properties") or {}
-                valid = [r for r in required if isinstance(r, str) and r in props]
-                if len(valid) != len(required):
+                valid = [r for r in req if isinstance(r, str) and r in props]
+                if len(valid) != len(req):
                     if valid:
                         repaired["required"] = valid
                     else:
                         repaired.pop("required", None)
+            elif req is None and "required" in repaired:
+                repaired.pop("required", None)
 
         return repaired
 

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -287,13 +287,20 @@ def _sanitize_node(node: Any, path: str) -> Any:
     # Prune ``required`` entries that don't exist in properties (defense
     # against malformed MCP schemas; also caught upstream for MCP tools, but
     # built-in tools or plugin tools may not have been through that path).
-    if out.get("type") == "object" and isinstance(out.get("required"), list):
-        props = out.get("properties") or {}
-        valid = [r for r in out["required"] if isinstance(r, str) and r in props]
-        if not valid:
+    # Also drop ``required: null`` which some MCP servers / proxies emit;
+    # it serializes to ``"required": null`` and fails metaschema validation
+    # on strict gateways (e.g. New API).
+    if out.get("type") == "object":
+        req = out.get("required")
+        if isinstance(req, list):
+            props = out.get("properties") or {}
+            valid = [r for r in req if isinstance(r, str) and r in props]
+            if not valid:
+                out.pop("required", None)
+            elif len(valid) != len(req):
+                out["required"] = valid
+        elif req is None and "required" in out:
             out.pop("required", None)
-        elif len(valid) != len(out["required"]):
-            out["required"] = valid
 
     return out
 


### PR DESCRIPTION
## Summary

Some MCP servers and API proxies (e.g. New API) emit tool parameter schemas with ``required: null`` instead of omitting the key entirely. The existing sanitizer only checked ``isinstance(required, list)``, so ``null`` passed through unchanged and was serialized as ``\"required\": null`` in the JSON payload.

Strict gateways validate tool schemas against the JSON Schema metaschema before forwarding. ``required: null`` fails this check because the metaschema declares ``required`` as type ``array``, producing HTTP 400 errors like::

    None is not of type 'array'
    Failed validating 'type' in metaschema['allOf'][3]...

## Changes

- ``tools/schema_sanitizer.py`` (_sanitize_node): drop ``required`` when value is ``None``
- ``tools/mcp_tool.py`` (_repair_object_shape): same fix for MCP input schema normalization

## Test plan

- [ ] Verify ``required: null`` is dropped from sanitized tool schemas
- [ ] Verify ``required: []`` still behaves correctly (removed)
- [ ] Verify well-formed ``required: [\"prop\"]`` still passes through
- [ ] Verify no regression on existing MCP tool schemas

No behaviour change for well-formed schemas; this only tightens handling of a malformed edge case that currently leaks through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)