### PR TITLE
fix: remove basicConfig from library code, guard json.loads, add subprocess timeouts

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13642,8 +13642,8 @@ class GatewayRunner:
                     env["PYTHONUNBUFFERED"] = "1"
                     with open(output_path, "wb") as f:
                         proc = subprocess.Popen(cmd, stdout=f, stderr=subprocess.STDOUT, env=env)
-                        rc = proc.wait()
-                    with open(exit_code_path, "w") as f:
+                        rc = proc.wait(timeout=3600)
+                    with open(exit_code_path, "w", encoding="utf-8") as f:
                         f.write(str(rc))
                     """
                 ).strip()

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5176,7 +5176,7 @@ def edit_config():
         return
     
     print(f"Opening {config_path} in {editor}...")
-    subprocess.run([editor, str(config_path)])
+    subprocess.run([editor, str(config_path)], timeout=300)
 
 
 def set_config_value(key: str, value: str):

--- a/mini_swe_runner.py
+++ b/mini_swe_runner.py
@@ -198,12 +198,7 @@ class MiniSWERunner:
         self.image = image
         self.cwd = cwd
         
-        # Setup logging
-        logging.basicConfig(
-            level=logging.DEBUG if verbose else logging.INFO,
-            format='%(asctime)s - %(levelname)s - %(message)s',
-            datefmt='%H:%M:%S'
-        )
+        # Setup logging — use getLogger only; the entry point configures the root logger.
         self.logger = logging.getLogger(__name__)
         
         # Initialize LLM client via centralized provider router.

--- a/skills/productivity/google-workspace/scripts/gws_bridge.py
+++ b/skills/productivity/google-workspace/scripts/gws_bridge.py
@@ -81,7 +81,11 @@ def get_valid_token() -> str:
         print("ERROR: No Google token found. Run setup.py --auth-url first.", file=sys.stderr)
         sys.exit(1)
 
-    token_data = json.loads(token_path.read_text())
+    try:
+        token_data = json.loads(token_path.read_text())
+    except json.JSONDecodeError as e:
+        print(f"ERROR: Corrupted token file: {e}", file=sys.stderr)
+        sys.exit(1)
 
     expiry = token_data.get("expiry", "")
     if expiry:

--- a/skills/productivity/linear/scripts/linear_api.py
+++ b/skills/productivity/linear/scripts/linear_api.py
@@ -95,7 +95,11 @@ def gql(query: str, variables: dict[str, Any] | None = None) -> dict[str, Any]:
         sys.stderr.write(f"Network error: {e}\n")
         sys.exit(1)
 
-    result = json.loads(body)
+    try:
+        result = json.loads(body)
+    except json.JSONDecodeError as e:
+        sys.stderr.write(f"Invalid JSON response: {e}\\nBody: {body[:200]}\\n")
+        sys.exit(1)
     if "errors" in result and result["errors"]:
         sys.stderr.write(f"GraphQL errors: {json.dumps(result['errors'], indent=2)}\n")
         # Still return data if partial success; let caller decide
@@ -349,7 +353,11 @@ def cmd_search_documents(args: argparse.Namespace) -> None:
 
 
 def cmd_raw(args: argparse.Namespace) -> None:
-    variables = json.loads(args.vars) if args.vars else None
+    try:
+        variables = json.loads(args.vars) if args.vars else None
+    except json.JSONDecodeError as e:
+        sys.stderr.write(f"Invalid JSON in --vars: {e}\\n")
+        sys.exit(1)
     emit(gql(args.query, variables))
 
 

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -352,11 +352,6 @@ class TrajectoryCompressor:
         # Initialize OpenRouter client
         self._init_summarizer()
         
-        logging.basicConfig(
-            level=logging.INFO,
-            format='%(asctime)s - %(levelname)s - %(message)s',
-            datefmt='%H:%M:%S'
-        )
         self.logger = logging.getLogger(__name__)
     
     def _init_tokenizer(self):


### PR DESCRIPTION
## Summary

Fixes 4 classes of bugs found via static analysis:

### 1. `logging.basicConfig()` in library code (2 files)
`trajectory_compressor.py` and `mini_swe_runner.py` called `logging.basicConfig()` in `__init__`. This hijacks the root logger config, potentially overriding the host application's logging setup.

**Fix:** Remove `basicConfig()` calls, keep only `getLogger(__name__)`. The entry point (cli.py/gateway) configures the root logger.

### 2. `json.loads()` without try/except (3 locations)
- `linear_api.py:98` — HTTP response body could be non-JSON (e.g., HTML error page from proxy)
- `linear_api.py:352` — User CLI `--vars` argument parsed without error handling
- `gws_bridge.py:84` — Token file could be corrupted

**Fix:** Wrap in `try/except json.JSONDecodeError` with user-friendly error messages.

### 3. `subprocess.run()` without timeout (1 location)
`config.py:5179` — Editor invocation (`vim`, `nano`, etc.) with no timeout. If the editor hangs, the CLI blocks forever.

**Fix:** Add `timeout=300` (5 minutes, reasonable for interactive editor).

### 4. `proc.wait()` without timeout + `open()` without encoding (1 location)
`gateway/run.py` helper script — `proc.wait()` could hang indefinitely. `open(exit_code_path, "w")` uses platform-default encoding.

**Fix:** Add `timeout=3600` to `proc.wait()`, add `encoding="utf-8"` to `open()`.

## Test Plan
- [x] All 6 modified files pass `py_compile`
- [ ] CI tests pass