### PR TITLE
fix(telegram): remove duplicate heading value in table rendering

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -248,7 +248,7 @@ def _render_table_block_for_telegram(table_block: list[str]) -> str:
         else:
             # No row-label column: use first non-empty cell as heading.
             heading = next((cell for cell in cells if cell), f"Row {index}")
-            data_cells = cells
+            data_cells = cells[1:]  # Remove first cell — it's already in heading
 
         # Pad or trim data_cells to match headers length.
         if len(data_cells) < len(headers):


### PR DESCRIPTION
When converting markdown tables to Telegram-friendly bullet lists, the first cell was used as the row heading but remained in data_cells, causing duplicate output like:

  **Evening (18:00–21:00)**
  • Time: Evening (18:00–21:00)  ← duplicate
  • Temp: +17°C

Now the first cell is removed from data_cells after being extracted as the heading, eliminating the duplication.

Fixes: _render_table_block_for_telegram() in gateway/platforms/telegram.py