### PR TITLE
fix(skills): trust symlinked installed skills

### DIFF
--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -1,6 +1,7 @@
 """Tests for tools/skills_tool.py — skill discovery and viewing."""
 
 import json
+import logging
 import os
 from pathlib import Path
 from unittest.mock import patch
@@ -510,6 +511,23 @@ class TestSkillView:
         result = json.loads(raw)
         assert result["success"] is True
         assert result["name"] == "knowledge-brain"
+
+    def test_view_does_not_warn_for_installed_symlinked_skill(self, tmp_path, caplog):
+        external_root = tmp_path / "repo"
+        skills_root = tmp_path / "skills"
+        skills_root.mkdir()
+
+        external_category = _symlink_category(skills_root, external_root, "linked")
+        _make_skill(external_category.parent, "knowledge-brain", category="linked")
+
+        with patch("tools.skills_tool.SKILLS_DIR", skills_root), caplog.at_level(
+            logging.WARNING, logger="tools.skills_tool"
+        ):
+            raw = skill_view("knowledge-brain")
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert "outside the trusted skills directory" not in caplog.text
 
     def test_not_found_hint_uses_same_order_as_skills_list(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -1060,16 +1060,26 @@ def skill_view(
             )
 
         # Security: warn if skill is loaded from outside trusted directories
-        # (local skills dir + configured external_dirs are all trusted)
+        # (local skills dir + configured external_dirs are all trusted). Accept
+        # both lexical paths under a trusted root and resolved paths under a
+        # trusted root: installed symlinked skills legitimately live at
+        # ~/.hermes/skills/<name>/SKILL.md even when their real target is in a
+        # shared source namespace such as ~/.agents/skills.
         _outside_skills_dir = True
-        _trusted_dirs = [SKILLS_DIR.resolve()]
+        _trusted_dirs = [SKILLS_DIR]
         try:
-            _trusted_dirs.extend(d.resolve() for d in all_dirs[1:])
+            _trusted_dirs.extend(all_dirs[1:])
         except Exception:
             pass
         for _td in _trusted_dirs:
             try:
-                skill_md.resolve().relative_to(_td)
+                skill_md.relative_to(_td)
+                _outside_skills_dir = False
+                break
+            except ValueError:
+                pass
+            try:
+                skill_md.resolve().relative_to(_td.resolve())
                 _outside_skills_dir = False
                 break
             except ValueError:


### PR DESCRIPTION
## Summary
- avoid false outside-trusted-directory warnings for skills installed as symlinks under the Hermes skills root
- keep the existing resolved-path trust check for external skill dirs
- add regression coverage for viewing an installed symlinked skill

## Test
- scripts/run_tests.sh tests/tools/test_skills_tool.py -q