### PR TITLE
feat(tools): add VRChat OSC toolset

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ honcho = ["honcho-ai==2.0.1"]
 mcp = ["mcp==1.26.0"]
 homeassistant = ["aiohttp==3.13.3"]
 sms = ["aiohttp==3.13.3"]
+vrchat = ["python-osc==1.10.2"]
 # Computer use — macOS background desktop control via cua-driver (MCP stdio).
 # The cua-driver binary itself is installed via `hermes tools` post-setup
 # (curl install script); this extra just pins the MCP client used to talk

--- a/tests/tools/test_vrchat_osc_tool.py
+++ b/tests/tools/test_vrchat_osc_tool.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import json
+
+from model_tools import get_tool_definitions
+from toolsets import TOOLSETS, resolve_toolset
+from tools.registry import discover_builtin_tools, registry
+from tools import vrchat_osc_tool as vrchat
+
+
+class FakeOscClient:
+    def __init__(self):
+        self.sent: list[tuple[str, object]] = []
+
+    def send_message(self, address: str, value: object) -> None:
+        self.sent.append((address, value))
+
+
+def test_vrchat_toolset_is_opt_in_and_resolves_tools():
+    assert "vrchat" in TOOLSETS
+    assert set(resolve_toolset("vrchat")) == {
+        "vrchat_chatbox",
+        "vrchat_typing",
+        "vrchat_avatar_param",
+        "vrchat_send_osc",
+        "vrchat_status",
+    }
+
+
+def test_chatbox_sends_official_osc_payload(monkeypatch):
+    fake = FakeOscClient()
+    monkeypatch.setattr(vrchat, "_get_client", lambda host, port: fake)
+
+    result = vrchat.vrchat_chatbox("hello vrc", immediate=True, notify=False)
+
+    assert result["success"] is True
+    assert fake.sent == [("/chatbox/input", ["hello vrc", True, False])]
+
+
+def test_chatbox_rejects_empty_and_overlong_text(monkeypatch):
+    fake = FakeOscClient()
+    monkeypatch.setattr(vrchat, "_get_client", lambda host, port: fake)
+
+    assert vrchat.vrchat_chatbox(" ")["success"] is False
+    result = vrchat.vrchat_chatbox("x" * 145)
+
+    assert result["success"] is False
+    assert result["length"] == 145
+    assert fake.sent == []
+
+
+def test_avatar_param_rejects_paths_and_sends_parameter(monkeypatch):
+    fake = FakeOscClient()
+    monkeypatch.setattr(vrchat, "_get_client", lambda host, port: fake)
+
+    bad = vrchat.vrchat_avatar_param("avatar/parameters/Unsafe", 1)
+    good = vrchat.vrchat_avatar_param("GestureLeft", 1)
+
+    assert bad["success"] is False
+    assert good["success"] is True
+    assert fake.sent == [("/avatar/parameters/GestureLeft", 1)]
+
+
+def test_raw_osc_validates_address_and_args(monkeypatch):
+    fake = FakeOscClient()
+    monkeypatch.setattr(vrchat, "_get_client", lambda host, port: fake)
+
+    bad_address = vrchat.vrchat_send_osc("avatar/parameters/Test", [1])
+    bad_arg = vrchat.vrchat_send_osc("/avatar/parameters/Test", [{"bad": "value"}])
+    good = vrchat.vrchat_send_osc("/avatar/parameters/Test", [0.5])
+
+    assert bad_address["success"] is False
+    assert bad_arg["success"] is False
+    assert good["success"] is True
+    assert fake.sent == [("/avatar/parameters/Test", 0.5)]
+
+
+def test_registry_handler_returns_json_string(monkeypatch):
+    fake = FakeOscClient()
+    monkeypatch.setattr(vrchat, "_get_client", lambda host, port: fake)
+
+    raw = registry.dispatch("vrchat_typing", {"is_typing": True})
+    parsed = json.loads(raw)
+
+    assert parsed["success"] is True
+    assert fake.sent == [("/chatbox/typing", True)]
+
+
+def test_tool_definitions_include_vrchat_when_enabled():
+    discover_builtin_tools()
+
+    defs = get_tool_definitions(enabled_toolsets=["vrchat"], quiet_mode=True)
+    names = {item["function"]["name"] for item in defs}
+
+    assert {
+        "vrchat_chatbox",
+        "vrchat_typing",
+        "vrchat_avatar_param",
+        "vrchat_send_osc",
+        "vrchat_status",
+    }.issubset(names)
+
+
+def test_vrchat_tools_are_not_in_hermes_cli_core():
+    assert not set(resolve_toolset("vrchat")) & set(resolve_toolset("hermes-cli"))

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -170,6 +170,8 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
         "fastapi==0.133.1",
         "uvicorn[standard]==0.41.0",
     ),
+    # VRChat official local OSC support.
+    "tool.vrchat": ("python-osc==1.10.2",),
 }
 
 

--- a/tools/vrchat_osc_tool.py
+++ b/tools/vrchat_osc_tool.py
@@ -1,0 +1,386 @@
+"""VRChat OSC tools.
+
+These tools talk only to VRChat's official local OSC interface. They do not
+use VRChat account credentials, client modification, or remote asset loading.
+
+VRChat OSC defaults:
+  - send host: 127.0.0.1
+  - send port: 9000
+  - receive port: 9001
+
+Install manually with:
+  uv pip install "hermes-agent[vrchat]"
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from typing import Any
+
+from tools.registry import registry, tool_result
+
+logger = logging.getLogger(__name__)
+
+_VRCHAT_FEATURE = "tool.vrchat"
+_DEFAULT_HOST = "127.0.0.1"
+_DEFAULT_SEND_PORT = 9000
+_DEFAULT_RECV_PORT = 9001
+_CHATBOX_MAX_CHARS = 144
+_MAX_OSC_ADDRESS_CHARS = 256
+
+_client_cache: dict[tuple[str, int], Any] = {}
+_client_lock = threading.Lock()
+
+
+def _parse_port(value: str | None, default: int, name: str) -> int:
+    if value is None or value.strip() == "":
+        return default
+    try:
+        port = int(value)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an integer") from exc
+    if port <= 0 or port > 65535:
+        raise ValueError(f"{name} must be between 1 and 65535")
+    return port
+
+
+def _endpoint() -> tuple[str, int, int]:
+    host = os.environ.get("VRCHAT_OSC_HOST", _DEFAULT_HOST).strip() or _DEFAULT_HOST
+    send_port = _parse_port(
+        os.environ.get("VRCHAT_OSC_SEND_PORT"),
+        _DEFAULT_SEND_PORT,
+        "VRCHAT_OSC_SEND_PORT",
+    )
+    recv_port = _parse_port(
+        os.environ.get("VRCHAT_OSC_RECV_PORT"),
+        _DEFAULT_RECV_PORT,
+        "VRCHAT_OSC_RECV_PORT",
+    )
+    return host, send_port, recv_port
+
+
+def _import_udp_client():
+    try:
+        from pythonosc import udp_client
+
+        return udp_client
+    except ImportError:
+        pass
+
+    try:
+        from tools.lazy_deps import FeatureUnavailable, ensure
+
+        ensure(_VRCHAT_FEATURE, prompt=False)
+    except FeatureUnavailable as exc:
+        raise RuntimeError(str(exc)) from exc
+    except Exception as exc:
+        raise RuntimeError(f"python-osc is not available: {exc}") from exc
+
+    try:
+        from pythonosc import udp_client
+
+        return udp_client
+    except ImportError as exc:
+        raise RuntimeError(
+            "python-osc is required for VRChat OSC. "
+            "Install with: uv pip install 'hermes-agent[vrchat]'"
+        ) from exc
+
+
+def _python_osc_available() -> bool:
+    try:
+        import pythonosc  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def _get_client(host: str, port: int):
+    key = (host, port)
+    with _client_lock:
+        client = _client_cache.get(key)
+        if client is None:
+            udp_client = _import_udp_client()
+            client = udp_client.SimpleUDPClient(host, port)
+            _client_cache[key] = client
+        return client
+
+
+def _validate_osc_address(address: str) -> str:
+    if not isinstance(address, str) or not address.strip():
+        raise ValueError("address cannot be empty")
+    address = address.strip()
+    if len(address) > _MAX_OSC_ADDRESS_CHARS:
+        raise ValueError(f"address exceeds {_MAX_OSC_ADDRESS_CHARS} characters")
+    if not address.startswith("/"):
+        raise ValueError("address must start with '/'")
+    if any(ch.isspace() for ch in address):
+        raise ValueError("address must not contain whitespace")
+    return address
+
+
+def _validate_osc_arg(value: Any) -> Any:
+    if value is None or isinstance(value, (str, bool, int, float)):
+        return value
+    raise ValueError("OSC args must be strings, booleans, integers, floats, or null")
+
+
+def vrchat_chatbox(text: str, immediate: bool = True, notify: bool = False) -> dict[str, Any]:
+    """Send a message to the VRChat chatbox via official OSC."""
+    if not isinstance(text, str) or not text.strip():
+        return {"success": False, "error": "text cannot be empty"}
+    if len(text) > _CHATBOX_MAX_CHARS:
+        return {
+            "success": False,
+            "error": f"text exceeds {_CHATBOX_MAX_CHARS} characters",
+            "length": len(text),
+        }
+
+    try:
+        host, send_port, _ = _endpoint()
+        client = _get_client(host, send_port)
+        client.send_message("/chatbox/input", [text, bool(immediate), bool(notify)])
+        return {
+            "success": True,
+            "host": host,
+            "send_port": send_port,
+            "address": "/chatbox/input",
+        }
+    except Exception as exc:
+        logger.debug("VRChat chatbox send failed", exc_info=True)
+        return {"success": False, "error": str(exc)}
+
+
+def vrchat_typing(is_typing: bool) -> dict[str, Any]:
+    """Show or hide the VRChat chatbox typing indicator."""
+    try:
+        host, send_port, _ = _endpoint()
+        client = _get_client(host, send_port)
+        client.send_message("/chatbox/typing", bool(is_typing))
+        return {
+            "success": True,
+            "host": host,
+            "send_port": send_port,
+            "address": "/chatbox/typing",
+        }
+    except Exception as exc:
+        logger.debug("VRChat typing OSC send failed", exc_info=True)
+        return {"success": False, "error": str(exc)}
+
+
+def vrchat_avatar_param(name: str, value: bool | int | float) -> dict[str, Any]:
+    """Set a VRChat avatar OSC parameter."""
+    if not isinstance(name, str) or not name.strip():
+        return {"success": False, "error": "name cannot be empty"}
+    name = name.strip()
+    if "/" in name or "\\" in name:
+        return {"success": False, "error": "name must be a parameter name, not a path"}
+    if not isinstance(value, (bool, int, float)):
+        return {"success": False, "error": "value must be a boolean, integer, or float"}
+
+    try:
+        host, send_port, _ = _endpoint()
+        address = f"/avatar/parameters/{name}"
+        client = _get_client(host, send_port)
+        client.send_message(address, value)
+        return {
+            "success": True,
+            "host": host,
+            "send_port": send_port,
+            "address": address,
+        }
+    except Exception as exc:
+        logger.debug("VRChat avatar parameter OSC send failed", exc_info=True)
+        return {"success": False, "error": str(exc)}
+
+
+def vrchat_send_osc(address: str, args: list[Any] | None = None) -> dict[str, Any]:
+    """Send a raw OSC message to VRChat."""
+    try:
+        address = _validate_osc_address(address)
+        values = [_validate_osc_arg(value) for value in (args or [])]
+        host, send_port, _ = _endpoint()
+        client = _get_client(host, send_port)
+        payload: Any
+        if not values:
+            payload = None
+        elif len(values) == 1:
+            payload = values[0]
+        else:
+            payload = values
+        client.send_message(address, payload)
+        return {
+            "success": True,
+            "host": host,
+            "send_port": send_port,
+            "address": address,
+            "arg_count": len(values),
+        }
+    except Exception as exc:
+        logger.debug("VRChat raw OSC send failed", exc_info=True)
+        return {"success": False, "error": str(exc)}
+
+
+def vrchat_status() -> dict[str, Any]:
+    """Return VRChat OSC configuration and local dependency status."""
+    try:
+        host, send_port, recv_port = _endpoint()
+    except Exception as exc:
+        return {"success": False, "error": str(exc)}
+
+    return {
+        "success": True,
+        "host": host,
+        "send_port": send_port,
+        "recv_port": recv_port,
+        "python_osc_installed": _python_osc_available(),
+        "note": "UDP OSC cannot confirm that VRChat consumed a packet; enable OSC in VRChat before sending.",
+    }
+
+
+registry.register(
+    name="vrchat_chatbox",
+    toolset="vrchat",
+    schema={
+        "name": "vrchat_chatbox",
+        "description": (
+            "Send text to VRChat's chatbox through the official local OSC interface. "
+            "VRChat must be running with OSC enabled. Limited to 144 characters."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "text": {
+                    "type": "string",
+                    "description": "Chatbox text to send. Max 144 characters.",
+                },
+                "immediate": {
+                    "type": "boolean",
+                    "description": "Whether VRChat should display the message immediately. Default: true.",
+                },
+                "notify": {
+                    "type": "boolean",
+                    "description": "Whether VRChat should play a chatbox notification. Default: false.",
+                },
+            },
+            "required": ["text"],
+        },
+    },
+    handler=lambda args, **kw: tool_result(
+        vrchat_chatbox(
+            text=args.get("text", ""),
+            immediate=args.get("immediate", True),
+            notify=args.get("notify", False),
+        )
+    ),
+    emoji="VR",
+)
+
+registry.register(
+    name="vrchat_typing",
+    toolset="vrchat",
+    schema={
+        "name": "vrchat_typing",
+        "description": "Show or hide the VRChat chatbox typing indicator through official OSC.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "is_typing": {
+                    "type": "boolean",
+                    "description": "true to show the typing indicator; false to hide it.",
+                },
+            },
+            "required": ["is_typing"],
+        },
+    },
+    handler=lambda args, **kw: tool_result(vrchat_typing(args.get("is_typing", False))),
+    emoji="VR",
+)
+
+registry.register(
+    name="vrchat_avatar_param",
+    toolset="vrchat",
+    schema={
+        "name": "vrchat_avatar_param",
+        "description": (
+            "Set a VRChat avatar OSC parameter through /avatar/parameters/{name}. "
+            "Use only parameters intentionally exposed by the user's avatar."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Avatar parameter name, for example GestureLeft or a custom parameter.",
+                },
+                "value": {
+                    "anyOf": [
+                        {"type": "boolean"},
+                        {"type": "integer"},
+                        {"type": "number"},
+                    ],
+                    "description": "Parameter value: boolean, integer, or float.",
+                },
+            },
+            "required": ["name", "value"],
+        },
+    },
+    handler=lambda args, **kw: tool_result(
+        vrchat_avatar_param(args.get("name", ""), args.get("value"))
+    ),
+    emoji="VR",
+)
+
+registry.register(
+    name="vrchat_send_osc",
+    toolset="vrchat",
+    schema={
+        "name": "vrchat_send_osc",
+        "description": (
+            "Send a raw OSC message to VRChat's official local OSC endpoint. "
+            "Use vrchat_chatbox or vrchat_avatar_param for common actions."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "type": "string",
+                    "description": "OSC address starting with '/', for example /avatar/parameters/MyParam.",
+                },
+                "args": {
+                    "type": "array",
+                    "items": {
+                        "anyOf": [
+                            {"type": "string"},
+                            {"type": "boolean"},
+                            {"type": "integer"},
+                            {"type": "number"},
+                            {"type": "null"},
+                        ]
+                    },
+                    "description": "OSC argument values.",
+                },
+            },
+            "required": ["address"],
+        },
+    },
+    handler=lambda args, **kw: tool_result(
+        vrchat_send_osc(args.get("address", ""), args.get("args", []))
+    ),
+    emoji="VR",
+)
+
+registry.register(
+    name="vrchat_status",
+    toolset="vrchat",
+    schema={
+        "name": "vrchat_status",
+        "description": "Show VRChat OSC endpoint configuration and python-osc availability.",
+        "parameters": {"type": "object", "properties": {}, "required": []},
+    },
+    handler=lambda args, **kw: tool_result(vrchat_status()),
+    emoji="VR",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -306,6 +306,21 @@ TOOLSETS = {
         "includes": []
     },
 
+    "vrchat": {
+        "description": (
+            "VRChat official local OSC tools for chatbox, typing indicators, "
+            "avatar parameters, raw OSC sends, and endpoint status."
+        ),
+        "tools": [
+            "vrchat_chatbox",
+            "vrchat_typing",
+            "vrchat_avatar_param",
+            "vrchat_send_osc",
+            "vrchat_status",
+        ],
+        "includes": [],
+    },
+
 
     # Scenario-specific toolsets
     

--- a/uv.lock
+++ b/uv.lock
@@ -1781,6 +1781,9 @@ voice = [
     { name = "numpy" },
     { name = "sounddevice" },
 ]
+vrchat = [
+    { name = "python-osc" },
+]
 web = [
     { name = "fastapi" },
     { name = "uvicorn", extra = ["standard"] },
@@ -1867,6 +1870,7 @@ requires-dist = [
     { name = "pytest-timeout", marker = "extra == 'dev'", specifier = "==2.4.0" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = "==3.8.0" },
     { name = "python-dotenv", specifier = "==1.2.2" },
+    { name = "python-osc", marker = "extra == 'vrchat'", specifier = "==1.10.2" },
     { name = "python-telegram-bot", extras = ["webhooks"], marker = "extra == 'messaging'", specifier = "==22.6" },
     { name = "python-telegram-bot", extras = ["webhooks"], marker = "extra == 'termux'", specifier = "==22.6" },
     { name = "pywinpty", marker = "sys_platform == 'win32' and extra == 'pty'", specifier = "==2.0.15" },
@@ -1891,7 +1895,7 @@ requires-dist = [
     { name = "vercel", marker = "extra == 'vercel'", specifier = "==0.5.7" },
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = "==1.2.4" },
 ]
-provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "vercel", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "cli", "tts-premium", "voice", "pty", "honcho", "mcp", "homeassistant", "sms", "computer-use", "acp", "bedrock", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
+provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "vercel", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "cli", "tts-premium", "voice", "pty", "honcho", "mcp", "homeassistant", "sms", "vrchat", "computer-use", "acp", "bedrock", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
 
 [[package]]
 name = "hf-xet"
@@ -3542,6 +3546,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/69/9b/f23807317a113dc36e74e75eb265a02dd1a4d9082abc3c1064acd22997c4/python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602", size = 44043, upload-time = "2026-04-27T10:51:26.649Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/99/78/4126abcbdbd3c559d43e0db7f7b9173fc6befe45d39a2856cc0b8ec2a5a6/python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645", size = 29254, upload-time = "2026-04-27T10:51:24.997Z" },
+]
+
+[[package]]
+name = "python-osc"
+version = "1.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/79/094503dc039c8ba9cead01f4b5e163d795a6a502563d3a31f35d20a1ecf8/python_osc-1.10.2.tar.gz", hash = "sha256:732548f4f467dda9f890a6b0b3bfb085ab117f4bd38a45a58d2ca0f3bd6a546d", size = 33716, upload-time = "2026-04-02T20:46:04.692Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/a2/ce26e437e36707f0da839dd88b072413825ea8986b73ce7b5c4f3cd1b7f4/python_osc-1.10.2-py3-none-any.whl", hash = "sha256:018b28e1cc06427c2c3d695f4e8d87d0caecfe604ff889acc45235cfd94183a2", size = 45467, upload-time = "2026-04-02T20:46:03.719Z" },
 ]
 
 [[package]]

--- a/website/docs/user-guide/features/vrchat-osc.md
+++ b/website/docs/user-guide/features/vrchat-osc.md
@@ -1,0 +1,48 @@
+# VRChat OSC
+
+Hermes can send messages to VRChat through VRChat's official local OSC
+interface. The feature is opt-in and stays local: it does not use VRChat
+credentials, modify the client, or load avatar assets.
+
+## Install
+
+Install the optional dependency:
+
+```bash
+uv pip install "hermes-agent[vrchat]"
+```
+
+Then enable the `vrchat` toolset in your Hermes tool settings or agent config.
+
+## VRChat Setup
+
+In VRChat, enable OSC in the radial menu:
+
+```text
+Options > OSC > Enabled
+```
+
+Hermes uses these defaults:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `VRCHAT_OSC_HOST` | `127.0.0.1` | VRChat OSC host |
+| `VRCHAT_OSC_SEND_PORT` | `9000` | Port Hermes sends to |
+| `VRCHAT_OSC_RECV_PORT` | `9001` | Port VRChat sends from |
+
+## Tools
+
+| Tool | Purpose |
+| --- | --- |
+| `vrchat_chatbox` | Sends text to `/chatbox/input` |
+| `vrchat_typing` | Shows or hides `/chatbox/typing` |
+| `vrchat_avatar_param` | Sets `/avatar/parameters/{name}` |
+| `vrchat_send_osc` | Sends a raw OSC message to a local address |
+| `vrchat_status` | Shows endpoint and dependency status |
+
+## Guardrails
+
+- Chatbox text is capped at VRChat's 144-character limit.
+- Avatar parameter writes accept only booleans, integers, and floats.
+- Raw OSC addresses must start with `/` and cannot contain whitespace.
+- `vrchat_avatar_param` accepts a parameter name, not a full OSC path.


### PR DESCRIPTION
## Summary
- add an opt-in `vrchat` toolset for VRChat's official local OSC interface
- provide chatbox, typing indicator, avatar parameter, raw OSC, and status tools
- add pinned `python-osc==1.10.2` optional/lazy dependency, tests, and user docs

## Guardrails
- local OSC only; no VRChat credentials, client modification, or remote asset loading
- chatbox text is capped at 144 characters
- avatar parameter writes accept only bool/int/float values
- raw OSC addresses must start with `/` and cannot contain whitespace

## Verification
- `uv lock --check`
- `uv run --extra dev python -m pytest -o addopts= -q tests\tools\test_lazy_deps.py tests\tools\test_vrchat_osc_tool.py tests\test_toolsets.py` (96 passed)
- `uv run --extra dev python -m ruff check tools\vrchat_osc_tool.py tests\tools\test_vrchat_osc_tool.py`
- `git diff --check`

Note: Windows targeted pytest used `-o addopts=` because the repo default timeout addopts use `signal.SIGALRM`, which is unavailable on Windows.