### PR TITLE
fix(langfuse): probe server credentials so misconfigured keys fail loudly (#29332)

### DIFF
--- a/plugins/observability/langfuse/README.md
+++ b/plugins/observability/langfuse/README.md
@@ -25,6 +25,30 @@ HERMES_LANGFUSE_BASE_URL=https://cloud.langfuse.com   # or your self-hosted URL
 Without the SDK or credentials the hooks no-op silently — the plugin fails
 open.
 
+### Credential validation
+
+When the plugin starts up with credentials set, two checks run before any
+traces are queued so a broken config can never silently sit in production
+(issue #29332):
+
+1. **Prefix guard** — `HERMES_LANGFUSE_PUBLIC_KEY` must start with `pk-lf-`
+   and `HERMES_LANGFUSE_SECRET_KEY` must start with `sk-lf-`. Anything else
+   (`placeholder`, `your-langfuse-key`, `xxx`, etc.) trips a single
+   warning naming the env var and the plugin short-circuits without
+   queueing traces.
+2. **Server-side `auth_check()`** — for credentials that pass the prefix
+   guard but are otherwise wrong (typo, revoked key, wrong project, cloud
+   vs. self-hosted mismatch) the plugin probes the Langfuse server in a
+   background thread immediately after construction. An explicit rejection
+   logs a single warning naming both env vars + the base URL, and every
+   subsequent hook becomes inert. Transient errors and the documented
+   `langfuse-python <=3.0.4` `AttributeError` quirk
+   ([langfuse/langfuse#7456](https://github.com/langfuse/langfuse/issues/7456))
+   are treated as inconclusive — observability is not disabled.
+
+Set `HERMES_LANGFUSE_SKIP_AUTH_CHECK=1` to bypass the server probe in
+offline / restricted-network setups where it would always-fail.
+
 ## Verify
 
 ```bash
@@ -40,6 +64,9 @@ HERMES_LANGFUSE_RELEASE=v1.0.0       # release tag
 HERMES_LANGFUSE_SAMPLE_RATE=0.5      # sample 50% of traces
 HERMES_LANGFUSE_MAX_CHARS=12000      # max chars per field (default: 12000)
 HERMES_LANGFUSE_DEBUG=true           # verbose plugin logging
+HERMES_LANGFUSE_SKIP_AUTH_CHECK=1    # bypass the startup auth_check probe
+                                     # (use for offline / restricted-network
+                                     # installs; see "Credential validation")
 ```
 
 ## Disable

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -318,6 +318,14 @@ def _get_langfuse() -> Optional[Langfuse]:
     # #29332 for the silent-failure mode this closes.
     _spawn_auth_check_thread(_LANGFUSE_CLIENT)
 
+    # Normalize the rare race where the probe completed synchronously
+    # (e.g. tests using a fake SDK, or an unusually fast localhost
+    # auth endpoint) and already rejected the credentials.  Callers
+    # only ever expect ``Langfuse | None``; the sentinel must stay
+    # inside this module.
+    if _LANGFUSE_CLIENT is _INIT_FAILED:
+        return None
+
     return _LANGFUSE_CLIENT
 
 

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -137,6 +137,100 @@ def _validate_langfuse_key(env_name: str, value: str) -> Optional[str]:
     )
 
 
+# Closes #29332.  The prefix check above is purely syntactic — it
+# catches the "operator left the .env template untouched" case but
+# silently passes anything well-shaped like ``pk-lf-fakeKey1234``.
+# Langfuse-issued keys with the right prefix but the wrong secret
+# (typo, revoked credential, copied from the wrong project, etc.)
+# survive prefix validation, survive SDK construction (the SDK does
+# zero network I/O at __init__ time), and then drop every trace at
+# flush time — producing the exact "registers hooks, never emits
+# traces, zero log signal" symptom the reporter saw.  Calling
+# ``Langfuse.auth_check()`` against the configured base URL surfaces
+# the credential rejection so the operator finds out about it BEFORE
+# they assume their observability is working.
+def _run_auth_check(client: Any) -> bool:
+    """Probe credentials against the Langfuse server.
+
+    Returns ``True`` when ``client.auth_check()`` confirms a valid
+    auth, ``False`` when it explicitly rejects the credentials, and
+    ``True`` (i.e. inconclusive — treated as success) when the SDK
+    raises (transient network, attribute-error quirks in older SDK
+    versions like `langfuse-python#7456 <https://github.com/langfuse/
+    langfuse/issues/7456>`_, or the method is missing entirely on
+    legacy SDK builds).  Inconclusive ≠ failure: we don't want a
+    flaky link or an SDK regression to disable observability on
+    operators with valid credentials.
+
+    Side effect: on an explicit ``False`` we replace the cached
+    client with the ``_INIT_FAILED`` sentinel so subsequent hook
+    invocations short-circuit on the existing fast path — no
+    re-warning, no leaked traces queued up for a flush that will
+    never authenticate.
+    """
+    global _LANGFUSE_CLIENT
+
+    auth_check = getattr(client, "auth_check", None)
+    if auth_check is None:
+        _debug("auth_check() not exposed on this SDK version; skipping")
+        return True
+
+    try:
+        result = auth_check()
+    except Exception as exc:
+        # Transient network errors AND the known-buggy AttributeError
+        # in langfuse-python <=3.0.4 land here.  Logging at DEBUG keeps
+        # the operator's terminal quiet for installs that are working
+        # fine but happen to throw during the probe.
+        _debug(f"auth_check() raised: {exc!r}")
+        return True
+
+    if result is False:
+        base_url = (
+            _env("HERMES_LANGFUSE_BASE_URL")
+            or _env("LANGFUSE_BASE_URL")
+            or "https://cloud.langfuse.com"
+        )
+        logger.warning(
+            "Langfuse plugin: server REJECTED the configured credentials "
+            "(auth_check returned False against %s). Traces will NOT be "
+            "ingested. Verify HERMES_LANGFUSE_PUBLIC_KEY and "
+            "HERMES_LANGFUSE_SECRET_KEY are correct for the project at "
+            "this base URL, or unset HERMES_LANGFUSE_PUBLIC_KEY / "
+            "HERMES_LANGFUSE_SECRET_KEY to disable the plugin and "
+            "silence this warning.",
+            base_url,
+        )
+        _LANGFUSE_CLIENT = _INIT_FAILED
+        return False
+
+    _debug("auth_check() OK — credentials accepted by server")
+    return True
+
+
+def _spawn_auth_check_thread(client: Any) -> Optional[threading.Thread]:
+    """Kick off :func:`_run_auth_check` in a daemon thread.
+
+    Returns the thread so tests can ``join`` it deterministically.
+    Lives in its own function so the threading concern stays out of
+    :func:`_get_langfuse` and tests can patch a synchronous variant
+    when they want to assert on the cached-client side effects.
+    """
+    if _env_bool("HERMES_LANGFUSE_SKIP_AUTH_CHECK"):
+        # Escape hatch for offline / restricted-network setups where
+        # the probe would either always-fail or unhelpfully delay the
+        # plugin's first useful trace.
+        return None
+    thread = threading.Thread(
+        target=_run_auth_check,
+        args=(client,),
+        daemon=True,
+        name="langfuse-auth-check",
+    )
+    thread.start()
+    return thread
+
+
 def _get_langfuse() -> Optional[Langfuse]:
     """Return a cached Langfuse client, or ``None`` if unavailable.
 
@@ -215,6 +309,14 @@ def _get_langfuse() -> Optional[Langfuse]:
         logger.warning("Could not initialize Langfuse client: %s", exc)
         _LANGFUSE_CLIENT = _INIT_FAILED
         return None
+
+    # Probe the server asynchronously so a slow auth round-trip
+    # doesn't block the agent's first turn.  If the server rejects
+    # the credentials, ``_run_auth_check`` flips ``_LANGFUSE_CLIENT``
+    # to ``_INIT_FAILED`` and subsequent hook calls go inert via the
+    # fast-path short-circuit at the top of this function — see
+    # #29332 for the silent-failure mode this closes.
+    _spawn_auth_check_thread(_LANGFUSE_CLIENT)
 
     return _LANGFUSE_CLIENT
 

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -445,6 +445,360 @@ class TestPlaceholderKeyDetection:
         )
 
 
+# ---------------------------------------------------------------------------
+# Server-side auth probe (#29332).
+#
+# Regression coverage for the second silent-failure mode: a credential
+# that survives the syntactic prefix guard (``pk-lf-fakeKey1234``) but
+# is rejected by the Langfuse server.  The SDK doesn't validate at
+# construction time, so pre-fix the plugin happily queued traces and
+# dropped every single one at flush time with no signal in the Hermes
+# logs.  The fix calls ``client.auth_check()`` in a daemon thread
+# immediately after construction; on explicit ``False`` it warns and
+# routes future hook calls through the ``_INIT_FAILED`` short-circuit.
+# Inconclusive results (exceptions, missing method on legacy SDKs)
+# must remain silent so flaky networks don't disable observability
+# for operators with valid creds.
+# ---------------------------------------------------------------------------
+
+
+class _AuthFake:
+    """SDK stand-in whose ``auth_check`` behaviour the caller dictates.
+
+    ``mode`` controls the probe outcome:
+      - ``"ok"`` returns ``True`` (credentials accepted)
+      - ``"reject"`` returns ``False`` (server explicitly rejected)
+      - ``"raise"`` raises ``RuntimeError`` (transient / SDK quirk)
+      - ``"attribute_error"`` raises ``AttributeError`` (the documented
+        langfuse-python <=3.0.4 quirk — see
+        https://github.com/langfuse/langfuse/issues/7456)
+      - ``"missing"`` omits the ``auth_check`` attribute entirely
+        (legacy SDK build, no probe surface at all)
+    Construction kwargs are recorded for assertions on the SDK init
+    path.
+    """
+
+    instances: list["_AuthFake"] = []
+    mode = "ok"
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.auth_check_calls = 0
+        _AuthFake.instances.append(self)
+        if _AuthFake.mode == "missing":
+            try:
+                delattr(self, "auth_check")
+            except AttributeError:
+                pass
+
+    def auth_check(self):
+        self.auth_check_calls += 1
+        mode = _AuthFake.mode
+        if mode == "ok":
+            return True
+        if mode == "reject":
+            return False
+        if mode == "raise":
+            raise RuntimeError("network blip during auth_check")
+        if mode == "attribute_error":
+            # Mirror langfuse-python's known buggy path where the
+            # underlying ``api`` attribute hasn't been wired up.
+            raise AttributeError("'Langfuse' object has no attribute 'api'")
+        raise AssertionError(f"unknown _AuthFake.mode={mode!r}")
+
+
+class _AuthFakeMissingMethod:
+    """Legacy SDK build where ``auth_check`` simply isn't exposed.
+
+    Distinct from ``_AuthFake(mode='missing')`` because the latter
+    still defines the method on the class — making ``getattr`` find
+    it even when the instance attribute was deleted.  This class
+    omits the method at the class level so ``getattr(client,
+    "auth_check", None)`` truly returns ``None``."""
+
+    instances: list["_AuthFakeMissingMethod"] = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        _AuthFakeMissingMethod.instances.append(self)
+
+
+class TestServerSideAuthProbe:
+    LOGGER_NAME = "plugins.observability.langfuse"
+
+    def _fresh_plugin(self, monkeypatch, *, fake_cls=_AuthFake):
+        mod_name = "plugins.observability.langfuse"
+        sys.modules.pop(mod_name, None)
+        mod = importlib.import_module(mod_name)
+        _AuthFake.instances.clear()
+        _AuthFakeMissingMethod.instances.clear()
+        monkeypatch.setattr(mod, "Langfuse", fake_cls, raising=False)
+        return mod
+
+    @staticmethod
+    def _clear_env(monkeypatch):
+        for k in (
+            "HERMES_LANGFUSE_PUBLIC_KEY", "HERMES_LANGFUSE_SECRET_KEY",
+            "LANGFUSE_PUBLIC_KEY", "LANGFUSE_SECRET_KEY",
+            "HERMES_LANGFUSE_SKIP_AUTH_CHECK", "HERMES_LANGFUSE_BASE_URL",
+        ):
+            monkeypatch.delenv(k, raising=False)
+
+    @staticmethod
+    def _set_real_creds(monkeypatch):
+        # Prefix-valid credentials so the syntactic placeholder guard
+        # passes and the auth probe is the actual gate under test.
+        monkeypatch.setenv("HERMES_LANGFUSE_PUBLIC_KEY", "pk-lf-prefix-ok-xyz")
+        monkeypatch.setenv("HERMES_LANGFUSE_SECRET_KEY", "sk-lf-prefix-ok-xyz")
+
+    # -- direct unit coverage of _run_auth_check (no threading) ----------
+
+    def test_run_auth_check_ok_returns_true_no_warning(
+        self, monkeypatch, caplog
+    ):
+        self._clear_env(monkeypatch)
+        _AuthFake.mode = "ok"
+        plugin = self._fresh_plugin(monkeypatch)
+        client = _AuthFake()
+        with caplog.at_level(logging.WARNING, logger=self.LOGGER_NAME):
+            assert plugin._run_auth_check(client) is True
+        assert client.auth_check_calls == 1
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"
+                    and r.name == self.LOGGER_NAME]
+        assert warnings == []
+
+    def test_run_auth_check_rejection_warns_and_marks_init_failed(
+        self, monkeypatch, caplog
+    ):
+        """The headline #29332 path: explicit False from the server
+        flips the cache to ``_INIT_FAILED`` and emits a single loud
+        warning naming both env vars and the base URL."""
+        self._clear_env(monkeypatch)
+        monkeypatch.setenv("HERMES_LANGFUSE_BASE_URL", "https://lf.example.test")
+        _AuthFake.mode = "reject"
+        plugin = self._fresh_plugin(monkeypatch)
+        client = _AuthFake()
+        plugin._LANGFUSE_CLIENT = client  # simulate the post-construct cache
+        with caplog.at_level(logging.WARNING, logger=self.LOGGER_NAME):
+            assert plugin._run_auth_check(client) is False
+        # Future _get_langfuse() calls must short-circuit on the
+        # existing fast path — that's the whole reason we toggle the
+        # cache to _INIT_FAILED rather than just logging.
+        assert plugin._LANGFUSE_CLIENT is plugin._INIT_FAILED
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"
+                    and r.name == self.LOGGER_NAME]
+        assert len(warnings) == 1
+        msg = warnings[0].getMessage()
+        assert "REJECTED" in msg
+        assert "HERMES_LANGFUSE_PUBLIC_KEY" in msg
+        assert "HERMES_LANGFUSE_SECRET_KEY" in msg
+        # The base URL must appear so the operator can disambiguate
+        # cloud-vs-self-hosted credential mismatches at a glance.
+        assert "https://lf.example.test" in msg
+
+    def test_run_auth_check_exception_is_inconclusive(
+        self, monkeypatch, caplog
+    ):
+        """A flaky network or buggy SDK MUST NOT disable observability.
+
+        Logging at DEBUG keeps the operator's terminal quiet for
+        installs that are working fine but happen to throw during
+        the probe."""
+        self._clear_env(monkeypatch)
+        _AuthFake.mode = "raise"
+        plugin = self._fresh_plugin(monkeypatch)
+        client = _AuthFake()
+        plugin._LANGFUSE_CLIENT = client
+        with caplog.at_level(logging.WARNING, logger=self.LOGGER_NAME):
+            assert plugin._run_auth_check(client) is True
+        assert plugin._LANGFUSE_CLIENT is client, (
+            "Transient errors must not flip the cache to _INIT_FAILED"
+        )
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"
+                    and r.name == self.LOGGER_NAME]
+        assert warnings == []
+
+    def test_run_auth_check_known_attribute_error_quirk_is_inconclusive(
+        self, monkeypatch, caplog
+    ):
+        """langfuse-python <=3.0.4 raises AttributeError when the
+        ``api`` attribute wasn't wired up (issue langfuse/langfuse#7456).
+        That's an SDK regression, not a credential failure — must NOT
+        disable the plugin."""
+        self._clear_env(monkeypatch)
+        _AuthFake.mode = "attribute_error"
+        plugin = self._fresh_plugin(monkeypatch)
+        client = _AuthFake()
+        plugin._LANGFUSE_CLIENT = client
+        with caplog.at_level(logging.WARNING, logger=self.LOGGER_NAME):
+            assert plugin._run_auth_check(client) is True
+        assert plugin._LANGFUSE_CLIENT is client
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"
+                    and r.name == self.LOGGER_NAME]
+        assert warnings == []
+
+    def test_run_auth_check_missing_method_is_skipped_silently(
+        self, monkeypatch, caplog
+    ):
+        """Legacy SDKs that don't expose ``auth_check`` at all must
+        leave the plugin behaving exactly as it did before this fix."""
+        self._clear_env(monkeypatch)
+        plugin = self._fresh_plugin(monkeypatch, fake_cls=_AuthFakeMissingMethod)
+        client = _AuthFakeMissingMethod()
+        plugin._LANGFUSE_CLIENT = client
+        with caplog.at_level(logging.WARNING, logger=self.LOGGER_NAME):
+            assert plugin._run_auth_check(client) is True
+        assert plugin._LANGFUSE_CLIENT is client
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"
+                    and r.name == self.LOGGER_NAME]
+        assert warnings == []
+
+    # -- spawn-thread plumbing ------------------------------------------
+
+    def test_spawn_auth_check_thread_starts_daemon(self, monkeypatch):
+        """The probe MUST run in a daemon thread so a slow auth
+        round-trip doesn't block the agent's first turn — and so the
+        thread doesn't keep the process alive if the parent exits."""
+        self._clear_env(monkeypatch)
+        _AuthFake.mode = "ok"
+        plugin = self._fresh_plugin(monkeypatch)
+        client = _AuthFake()
+        thread = plugin._spawn_auth_check_thread(client)
+        assert thread is not None
+        thread.join(timeout=2.0)
+        assert thread.daemon is True
+        assert thread.name == "langfuse-auth-check"
+        assert client.auth_check_calls == 1
+
+    def test_spawn_auth_check_thread_respects_skip_env(self, monkeypatch):
+        """``HERMES_LANGFUSE_SKIP_AUTH_CHECK=1`` is the escape hatch
+        for offline / restricted-network setups.  Setting it must
+        bypass the probe entirely — no thread, no call."""
+        self._clear_env(monkeypatch)
+        monkeypatch.setenv("HERMES_LANGFUSE_SKIP_AUTH_CHECK", "1")
+        _AuthFake.mode = "ok"
+        plugin = self._fresh_plugin(monkeypatch)
+        client = _AuthFake()
+        thread = plugin._spawn_auth_check_thread(client)
+        assert thread is None
+        assert client.auth_check_calls == 0
+
+    @pytest.mark.parametrize("skip_value", ["true", "yes", "on", "1"])
+    def test_spawn_auth_check_thread_skip_env_truthy_values(
+        self, monkeypatch, skip_value
+    ):
+        """The skip env follows the same truthy-value contract as the
+        rest of the plugin's boolean env vars (``_env_bool``)."""
+        self._clear_env(monkeypatch)
+        monkeypatch.setenv("HERMES_LANGFUSE_SKIP_AUTH_CHECK", skip_value)
+        plugin = self._fresh_plugin(monkeypatch)
+        assert plugin._spawn_auth_check_thread(_AuthFake()) is None
+
+    # -- end-to-end via _get_langfuse() ---------------------------------
+
+    def test_get_langfuse_starts_probe_after_construction(self, monkeypatch):
+        """End-to-end happy path: valid prefix → construct client →
+        kick off the auth probe → return the client.  We deliberately
+        join the spawned thread before asserting so the test is
+        deterministic regardless of scheduler timing."""
+        self._clear_env(monkeypatch)
+        self._set_real_creds(monkeypatch)
+        _AuthFake.mode = "ok"
+        plugin = self._fresh_plugin(monkeypatch)
+
+        spawned: list[Any] = []
+        real_spawn = plugin._spawn_auth_check_thread
+
+        def capturing_spawn(client):
+            thread = real_spawn(client)
+            if thread is not None:
+                thread.join(timeout=2.0)
+            spawned.append(thread)
+            return thread
+
+        monkeypatch.setattr(plugin, "_spawn_auth_check_thread", capturing_spawn)
+
+        client = plugin._get_langfuse()
+        assert isinstance(client, _AuthFake)
+        assert spawned and spawned[0] is not None
+        # Auth check ran once; on success the cached client remains
+        # available for hook callers.
+        assert client.auth_check_calls == 1
+        assert plugin._LANGFUSE_CLIENT is client
+
+    def test_get_langfuse_rejection_disables_subsequent_calls(
+        self, monkeypatch, caplog
+    ):
+        """The reporter's exact scenario: server rejects the
+        credentials, the operator sees one loud warning, every
+        subsequent hook short-circuits to None — no traces queued
+        for a flush that will never authenticate."""
+        self._clear_env(monkeypatch)
+        self._set_real_creds(monkeypatch)
+        _AuthFake.mode = "reject"
+        plugin = self._fresh_plugin(monkeypatch)
+
+        threads: list[Any] = []
+        real_spawn = plugin._spawn_auth_check_thread
+
+        def joining_spawn(client):
+            thread = real_spawn(client)
+            if thread is not None:
+                thread.join(timeout=2.0)
+            threads.append(thread)
+            return thread
+
+        monkeypatch.setattr(plugin, "_spawn_auth_check_thread", joining_spawn)
+
+        with caplog.at_level(logging.WARNING, logger=self.LOGGER_NAME):
+            # First call constructs the client and triggers the probe.
+            # The probe joins (via the patched spawn) before we move
+            # on, so the cache is guaranteed to be in its post-probe
+            # state when we re-call.
+            first = plugin._get_langfuse()
+            # Pre-fix the first call returned a usable client and
+            # nothing else happened.  Post-fix the probe ran on the
+            # spawned thread, returned False, and flipped the cache
+            # to _INIT_FAILED.
+            assert plugin._LANGFUSE_CLIENT is plugin._INIT_FAILED
+            # Subsequent calls must short-circuit through the fast
+            # path at the top of _get_langfuse() so a busy gateway
+            # doesn't spam the SDK constructor or the warning log.
+            for _ in range(10):
+                assert plugin._get_langfuse() is None
+
+        # When the probe completes synchronously (as in this test via
+        # ``joining_spawn``) the first call sees the cache already
+        # flipped to ``_INIT_FAILED`` and normalizes that to None
+        # before returning.  In the real async case the first hook
+        # might still get back a usable-looking client for one or two
+        # turns before the probe lands — also acceptable; the cache
+        # poisoning kicks in for every subsequent call.  We accept
+        # either shape here as long as the warning fired and the
+        # cache is poisoned.
+        assert first is None or isinstance(first, _AuthFake)
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"
+                    and r.name == self.LOGGER_NAME]
+        assert len(warnings) == 1
+        assert "REJECTED" in warnings[0].getMessage()
+
+    def test_get_langfuse_skip_env_bypasses_probe(self, monkeypatch):
+        """With the escape hatch set, no thread spawns and the cached
+        client survives even when the server would have rejected it.
+        This is the explicit opt-out the docstring promises."""
+        self._clear_env(monkeypatch)
+        self._set_real_creds(monkeypatch)
+        monkeypatch.setenv("HERMES_LANGFUSE_SKIP_AUTH_CHECK", "1")
+        _AuthFake.mode = "reject"  # would normally disable the plugin
+        plugin = self._fresh_plugin(monkeypatch)
+        client = plugin._get_langfuse()
+        assert isinstance(client, _AuthFake)
+        assert client.auth_check_calls == 0, (
+            "HERMES_LANGFUSE_SKIP_AUTH_CHECK=1 must bypass auth_check entirely"
+        )
+        assert plugin._LANGFUSE_CLIENT is client
+
+
 class TestRequestMessageCoercion:
     def test_prefers_request_messages_then_messages_then_history_then_user_message(self):
         sys.modules.pop("plugins.observability.langfuse", None)

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -168,6 +168,7 @@ Environment variables for the bundled [`observability/langfuse`](/docs/user-guid
 | `HERMES_LANGFUSE_SAMPLE_RATE` | SDK sampling rate 0.0–1.0 (default: `1.0`) |
 | `HERMES_LANGFUSE_MAX_CHARS` | Per-field truncation for serialized payloads (default: `12000`) |
 | `HERMES_LANGFUSE_DEBUG` | `true` enables verbose plugin logging to `agent.log` |
+| `HERMES_LANGFUSE_SKIP_AUTH_CHECK` | `true` skips the startup `Langfuse.auth_check()` probe added in #29332. Set this in offline / restricted-network installs where the probe would always-fail and would otherwise log a misleading "credentials rejected" warning. Default off — the probe is what surfaces typo'd / revoked / wrong-project keys instead of silently dropping every trace. |
 | `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` / `LANGFUSE_BASE_URL` | Standard Langfuse SDK names. Accepted as fallbacks when the `HERMES_LANGFUSE_*` equivalents are unset. |
 
 ### Nous Tool Gateway


### PR DESCRIPTION
## What does this PR do?

Closes the Langfuse "placeholder API key silent failure" report in #29332. The reporter set `HERMES_LANGFUSE_PUBLIC_KEY` to a placeholder, started Hermes, observed hooks register, ran agent interactions, watched zero traces appear in Langfuse, and got **zero log signal** about the misconfiguration. Observability silently dropped on the floor.

The prefix-based guard added by #23823 catches the easy cases — `placeholder`, `your-langfuse-key`, `xxx`, etc. — anything that doesn't start with `pk-lf-` / `sk-lf-`. What it misses is **well-shaped-but-wrong** credentials: typo in a real key (`pk-lf-prdoject-public-...`), revoked key, copied from the wrong project, cloud-vs-self-hosted mismatch. Those survive the syntactic check, survive `Langfuse(...)` construction (the SDK does zero network I/O at `__init__` time), and then drop every single trace at flush time with no signal in the Hermes logs.

The reporter explicitly asked for either: (a) **validate the API key on initialization** (lightweight auth check against the server) with a clear error, or (b) emit a warning when traces fail to be ingested after N attempts. This PR takes path (a) — it's deterministic, it surfaces the misconfig before the operator assumes observability is working, and it requires no log-handler instrumentation against the SDK's internal flush thread.

Three pieces wired together:

1. **`_run_auth_check(client)`** — calls the SDK's documented `Langfuse.auth_check()` against the configured base URL. On an explicit `False` it logs a single loud warning naming both env vars and the base URL, then flips `_LANGFUSE_CLIENT` to the existing `_INIT_FAILED` sentinel so every subsequent hook short-circuits via the existing fast path (no re-warning, no leaked traces queued for a flush that will never authenticate). Exceptions (transient network) and the documented `AttributeError` quirk in `langfuse-python <=3.0.4` ([langfuse/langfuse#7456](https://github.com/langfuse/langfuse/issues/7456)) are treated as **inconclusive** — observability stays enabled for operators with valid creds on flaky links. Missing `auth_check` attribute on legacy SDK builds is also inconclusive.

2. **`_spawn_auth_check_thread(client)`** — kicks the probe off in a daemon thread named `langfuse-auth-check` so a slow auth round-trip doesn't block the agent's first turn, and so the probe doesn't keep the process alive if the parent exits.

3. **`HERMES_LANGFUSE_SKIP_AUTH_CHECK=1`** — escape hatch for offline / restricted-network setups where the probe would always-fail and would otherwise emit a misleading "credentials rejected" warning. Follows the same `_env_bool` truthy-value contract as the rest of the plugin's boolean env vars.

A small follow-up commit normalizes a sentinel race: when the probe completes synchronously (tests, or an unusually fast localhost auth endpoint) the cached `_LANGFUSE_CLIENT` is already `_INIT_FAILED` by the time `_get_langfuse` returns. The function now checks `is _INIT_FAILED` once more before returning so callers always see `Langfuse | None`, never the bare sentinel object.

The prefix guard, the credentials-missing silent path, the once-per-process caching, and the fail-open exception handling around client construction are all untouched — the auth probe is purely additive between successful construction and the first hook.

## Related Issue

Fixes #29332

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/observability/langfuse/__init__.py` — new `_run_auth_check(client)` (graceful for missing method / AttributeError / transient errors / explicit False), `_spawn_auth_check_thread(client)` (daemon thread + skip-env gate), wiring into `_get_langfuse` immediately after successful client construction, and a sentinel-normalization guard at the bottom of `_get_langfuse` so the rare synchronous-probe race never leaks `_INIT_FAILED` to callers.
- `tests/plugins/test_langfuse_plugin.py` — **14 new tests** in `TestServerSideAuthProbe`, backed by two purpose-built SDK fakes:
  - `_AuthFake` with a class-level `mode` knob (`ok` / `reject` / `raise` / `attribute_error` / `missing`) — pins all five outcomes of `_run_auth_check` directly.
  - `_AuthFakeMissingMethod` — distinct from `_AuthFake(mode='missing')` because the latter still has the method on the class; the new fake omits it at the class level so `getattr` truly returns `None` (legacy SDK path).
  - Plumbing tests assert the daemon-thread shape (`daemon=True`, name `langfuse-auth-check`) and the skip-env across all truthy values (`1`/`true`/`yes`/`on`).
  - End-to-end tests through `_get_langfuse` reproduce the reporter's exact scenario: server rejects credentials → single warning → every subsequent call returns `None` via the cached short-circuit, no per-hook log spam.
- `plugins/observability/langfuse/README.md` — new "Credential validation" subsection explaining the two-layer startup check (prefix + server probe), the inconclusive paths, and the `HERMES_LANGFUSE_SKIP_AUTH_CHECK` escape hatch.
- `website/docs/reference/environment-variables.md` — `HERMES_LANGFUSE_SKIP_AUTH_CHECK` added to the Langfuse env-var table with a pointer back to #29332.

Backwards compatible: no new required env vars, no manifest changes, no hook surface changes. The plugin behaves exactly as before for operators with valid credentials (one extra background `auth_check()` call per process lifetime, logged at debug only on success). Existing 37 langfuse tests continue to pass unchanged.

## How to Test

```bash
# New + existing langfuse plugin coverage (37 existing + 14 new = 51 tests)
./scripts/run_tests.sh tests/plugins/test_langfuse_plugin.py

# Full regression across langfuse + plugins-cmd
./scripts/run_tests.sh \
    tests/plugins/test_langfuse_plugin.py \
    tests/hermes_cli/test_plugins_cmd.py
# expected: 116 passed
```

Behavioural verification with a well-shaped-but-wrong key (the gap #23823 left open):

```
$ export HERMES_LANGFUSE_PUBLIC_KEY=pk-lf-typo-in-real-key
$ export HERMES_LANGFUSE_SECRET_KEY=sk-lf-typo-in-real-key
$ hermes chat -q "hello"
WARNING  plugins.observability.langfuse:__init__.py:194 Langfuse plugin:
         server REJECTED the configured credentials (auth_check returned
         False against https://cloud.langfuse.com). Traces will NOT be
         ingested. Verify HERMES_LANGFUSE_PUBLIC_KEY and
         HERMES_LANGFUSE_SECRET_KEY are correct for the project at this
         base URL, or unset HERMES_LANGFUSE_PUBLIC_KEY /
         HERMES_LANGFUSE_SECRET_KEY to disable the plugin and silence
         this warning.
```

Pre-fix: zero log lines, hooks registered, agent ran, zero traces appeared in Langfuse, no signal anywhere.

## Checklist

- [x] Conventional Commits (`fix(langfuse):`, `test(langfuse):`, `docs(langfuse):`)
- [x] 4 focused commits, single author
- [x] 14 new tests pass; 37 existing langfuse tests pass; 65 existing `plugins_cmd` tests pass (116 total)
- [x] Tested on macOS 15.6 (darwin 24.6.0)
- [x] Updated `plugins/observability/langfuse/README.md` and `website/docs/reference/environment-variables.md`
- [x] No new required env vars; one new optional opt-out (`HERMES_LANGFUSE_SKIP_AUTH_CHECK`); no manifest changes
