### PR TITLE
WS-V2: hermes-agent panel emitter (skill_diff + plan_output + prompt_rewrite)

### DIFF
--- a/agent/panel_emitter.py
+++ b/agent/panel_emitter.py
@@ -1,0 +1,141 @@
+"""panel ingest emitter — thin HMAC-signing client for /api/units/ingest.
+
+env gates:
+  PANEL_EMIT_ENABLED=1      — required, otherwise emit() silently returns disabled
+  PANEL_PROFILE=hermes:base — default profile (slug derived: lowercase + ':' → '-')
+  PANEL_INGEST_URL          — override ingest endpoint
+
+secrets:
+  ~/.secrets/panel-emit-<slug>.txt   ingest secret
+  ~/.secrets/panel-emit-<slug>.key   site key (pk_xxx)
+
+fail-open: any exception → {"ok": False, "reason": "..."} logged to stderr,
+never raised. emitter MUST NOT break the host agent's primary task.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+DEFAULT_INGEST_URL = "https://panel.goku.codes/api/units/ingest"
+DEFAULT_PROFILE = "hermes:base"
+DEFAULT_TIMEOUT = 5.0
+DEDUP_WINDOW_SECONDS = 30.0
+SECRETS_DIR = Path.home() / ".secrets"
+
+_dedup_lock = threading.Lock()
+_dedup_cache: dict[str, float] = {}
+
+
+def _slug(profile: str) -> str:
+    return profile.lower().replace(":", "-")
+
+
+def _resolve_profile(profile: str | None) -> str:
+    return profile or os.environ.get("PANEL_PROFILE") or DEFAULT_PROFILE
+
+
+def _load_credentials(profile: str) -> tuple[str, str]:
+    slug = _slug(profile)
+    key_path = SECRETS_DIR / f"panel-emit-{slug}.key"
+    secret_path = SECRETS_DIR / f"panel-emit-{slug}.txt"
+    site_key = key_path.read_text().strip()
+    secret = secret_path.read_text().strip()
+    if not site_key or not secret:
+        raise RuntimeError(f"empty credentials for profile {profile}")
+    return site_key, secret
+
+
+def _sign(secret: str, body_bytes: bytes) -> str:
+    return hmac.new(secret.encode("utf-8"), body_bytes, hashlib.sha256).hexdigest()
+
+
+def _filter_dedup(units: list[dict]) -> list[dict]:
+    """Drop units whose external_ref was emitted within DEDUP_WINDOW_SECONDS."""
+    now = time.monotonic()
+    kept: list[dict] = []
+    with _dedup_lock:
+        # gc expired
+        expired = [k for k, t in _dedup_cache.items() if now - t > DEDUP_WINDOW_SECONDS]
+        for k in expired:
+            _dedup_cache.pop(k, None)
+        for u in units:
+            ref = u.get("external_ref")
+            if ref and ref in _dedup_cache:
+                continue
+            kept.append(u)
+            if ref:
+                _dedup_cache[ref] = now
+    return kept
+
+
+def _clear_dedup_cache() -> None:
+    """test hook."""
+    with _dedup_lock:
+        _dedup_cache.clear()
+
+
+def emit(units: list[dict], profile: str | None = None) -> dict:
+    """Sign and POST a batch of units to panel ingest.
+
+    Returns parsed JSON on success, or {'ok': False, 'reason': str} on
+    any failure / when the env gate is off. Never raises.
+    """
+    if os.environ.get("PANEL_EMIT_ENABLED") != "1":
+        return {"ok": False, "reason": "disabled"}
+
+    if not units:
+        return {"ok": False, "reason": "empty"}
+
+    try:
+        units = _filter_dedup(list(units))
+        if not units:
+            return {"ok": False, "reason": "dedup"}
+
+        prof = _resolve_profile(profile)
+        site_key, secret = _load_credentials(prof)
+
+        # tag source_agent on every unit (idempotent — don't clobber if caller set it)
+        for u in units:
+            u.setdefault("source_agent", prof)
+
+        body_bytes = json.dumps(units, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+        sig = _sign(secret, body_bytes)
+
+        url = os.environ.get("PANEL_INGEST_URL", DEFAULT_INGEST_URL)
+        req = urllib.request.Request(
+            url,
+            data=body_bytes,
+            method="POST",
+            headers={
+                "Content-Type": "application/json",
+                "X-Panel-Site-Key": site_key,
+                "X-Panel-Ingest-Sig": sig,
+            },
+        )
+        with urllib.request.urlopen(req, timeout=DEFAULT_TIMEOUT) as resp:
+            raw = resp.read().decode("utf-8", errors="replace")
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            return {"ok": False, "reason": "non_json_response", "body": raw[:500]}
+    except urllib.error.HTTPError as e:
+        body = ""
+        try:
+            body = e.read().decode("utf-8", errors="replace")[:500]
+        except Exception:
+            pass
+        print(f"[panel_emitter] HTTPError {e.code}: {body}", file=sys.stderr)
+        return {"ok": False, "reason": f"http_{e.code}", "body": body}
+    except Exception as e:  # noqa: BLE001 — fail open by contract
+        print(f"[panel_emitter] {type(e).__name__}: {e}", file=sys.stderr)
+        return {"ok": False, "reason": str(e)}

--- a/agent/panel_triggers.py
+++ b/agent/panel_triggers.py
@@ -1,0 +1,94 @@
+"""panel trigger helpers — three V2 surfaces for hermes-agent.
+
+This module only exposes convenience constructors. Wiring into the actual
+agent code paths (skill_manage, plan-mode output, user-correction detection)
+is intentionally deferred — see Agent Emitter Architecture doc.
+
+All helpers truncate per the unit-type caps (passage/diff ≤8000, choice
+text ≤2000, prompt_context ≤2000) before emitting, and use a sha1-derived
+external_ref so re-firing the same trigger is idempotent.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from .panel_emitter import emit
+
+PASSAGE_CAP = 8000
+DIFF_CAP = 8000
+CHOICE_CAP = 2000
+CONTEXT_CAP = 2000
+
+
+def _trunc(s: str | None, cap: int) -> str:
+    if s is None:
+        return ""
+    if len(s) <= cap:
+        return s
+    return s[:cap]
+
+
+def _ref(*parts: str) -> str:
+    h = hashlib.sha1("|".join(parts).encode("utf-8")).hexdigest()
+    return h[:16]
+
+
+def emit_skill_diff(
+    skill_name: str,
+    diff: str,
+    reason: str,
+    profile: str | None = None,
+) -> dict:
+    """rater judges whether a skill update is an improvement."""
+    unit = {
+        "type": "skill_diff_review",
+        "external_ref": _ref(skill_name, reason),
+        "diff": _trunc(diff, DIFF_CAP),
+        "prompt_context": _trunc(reason, CONTEXT_CAP),
+        "binary": {"yes": "improvement", "no": "regression"},
+    }
+    return emit([unit], profile=profile)
+
+
+def emit_process_output(
+    passage: str,
+    user_goal: str,
+    profile: str | None = None,
+) -> dict:
+    """rater rates the quality of a single agent process output."""
+    trimmed_passage = _trunc(passage, PASSAGE_CAP)
+    unit = {
+        "type": "process_output_rating",
+        "external_ref": _ref(trimmed_passage[:500]),
+        "passage": trimmed_passage,
+        "prompt_context": _trunc(user_goal, CONTEXT_CAP),
+        "choices": [
+            {"label": "1", "text": _trunc("great", CHOICE_CAP)},
+            {"label": "2", "text": _trunc("ok", CHOICE_CAP)},
+            {"label": "3", "text": _trunc("meh", CHOICE_CAP)},
+            {"label": "4", "text": _trunc("bad", CHOICE_CAP)},
+        ],
+    }
+    return emit([unit], profile=profile)
+
+
+def emit_prompt_rewrite(
+    original: str,
+    corrected: str,
+    context: str,
+    profile: str | None = None,
+) -> dict:
+    """rater picks the better of two phrasings."""
+    a = _trunc(original, CHOICE_CAP)
+    b = _trunc(corrected, CHOICE_CAP)
+    unit = {
+        "type": "prompt_rewrite_pair",
+        "external_ref": _ref(original, corrected),
+        "choices": [
+            {"label": "A", "text": a},
+            {"label": "B", "text": b},
+        ],
+        "prompt_context": _trunc(context, CONTEXT_CAP),
+    }
+    return emit([unit], profile=profile)

--- a/tests/test_panel_emitter.py
+++ b/tests/test_panel_emitter.py
@@ -1,0 +1,205 @@
+"""Tests for the panel ingest emitter (WS-V2).
+
+Pure offline — every HTTP call is stubbed. Verifies HMAC signing,
+env-gating, content-cap truncation, and the 30s in-process dedup cache.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import io
+import json
+import os
+from unittest import mock
+
+import pytest
+
+from agent import panel_emitter, panel_triggers
+
+
+# ---------- fixtures ----------------------------------------------------------
+
+
+@pytest.fixture
+def fake_creds(tmp_path, monkeypatch):
+    secrets = tmp_path / ".secrets"
+    secrets.mkdir()
+    site_key = "pk_live_TEST123"
+    secret = "shh_secret_value"
+    (secrets / "panel-emit-hermes-base.key").write_text(site_key)
+    (secrets / "panel-emit-hermes-base.txt").write_text(secret)
+    monkeypatch.setattr(panel_emitter, "SECRETS_DIR", secrets)
+    monkeypatch.setenv("PANEL_EMIT_ENABLED", "1")
+    monkeypatch.setenv("PANEL_PROFILE", "hermes:base")
+    panel_emitter._clear_dedup_cache()
+    return {"site_key": site_key, "secret": secret}
+
+
+class _FakeResp:
+    def __init__(self, payload: dict):
+        self._body = json.dumps(payload).encode("utf-8")
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+# ---------- env gate ----------------------------------------------------------
+
+
+def test_env_gate_off_returns_disabled(monkeypatch):
+    monkeypatch.delenv("PANEL_EMIT_ENABLED", raising=False)
+    result = panel_emitter.emit([{"type": "x", "external_ref": "abc"}])
+    assert result == {"ok": False, "reason": "disabled"}
+
+
+def test_empty_units_returns_empty(fake_creds):
+    assert panel_emitter.emit([]) == {"ok": False, "reason": "empty"}
+
+
+# ---------- signing -----------------------------------------------------------
+
+
+def test_signing_matches_hmac_sha256(fake_creds):
+    captured = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["url"] = req.full_url
+        captured["headers"] = dict(req.header_items())
+        captured["body"] = req.data
+        return _FakeResp({"ok": True, "accepted": 1, "rejected": 0, "ids": ["u1"]})
+
+    with mock.patch("agent.panel_emitter.urllib.request.urlopen", side_effect=fake_urlopen):
+        resp = panel_emitter.emit([{"type": "ai_output_rating", "external_ref": "sigtest"}])
+
+    assert resp["ok"] is True
+    body = captured["body"]
+    # site-key header present
+    headers_lower = {k.lower(): v for k, v in captured["headers"].items()}
+    assert headers_lower["x-panel-site-key"] == fake_creds["site_key"]
+    sig = headers_lower["x-panel-ingest-sig"]
+    # hex format
+    assert len(sig) == 64
+    int(sig, 16)  # raises if not hex
+    # exact bytes signed
+    expected = hmac.new(
+        fake_creds["secret"].encode(), body, hashlib.sha256
+    ).hexdigest()
+    assert sig == expected
+    # source_agent stamped on the unit
+    parsed = json.loads(body)
+    assert parsed[0]["source_agent"] == "hermes:base"
+
+
+def test_endpoint_env_override(fake_creds, monkeypatch):
+    monkeypatch.setenv("PANEL_INGEST_URL", "https://elsewhere.example/api/ingest")
+    captured = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["url"] = req.full_url
+        return _FakeResp({"ok": True})
+
+    with mock.patch("agent.panel_emitter.urllib.request.urlopen", side_effect=fake_urlopen):
+        panel_emitter.emit([{"type": "x", "external_ref": "endpoint"}])
+    assert captured["url"] == "https://elsewhere.example/api/ingest"
+
+
+# ---------- dedup -------------------------------------------------------------
+
+
+def test_dedup_cache_blocks_repeat_within_window(fake_creds):
+    calls = []
+
+    def fake_urlopen(req, timeout=None):
+        calls.append(req.data)
+        return _FakeResp({"ok": True})
+
+    unit = {"type": "ai_output_rating", "external_ref": "dedupref"}
+    with mock.patch("agent.panel_emitter.urllib.request.urlopen", side_effect=fake_urlopen):
+        r1 = panel_emitter.emit([dict(unit)])
+        r2 = panel_emitter.emit([dict(unit)])
+
+    assert r1.get("ok") is True
+    assert r2 == {"ok": False, "reason": "dedup"}
+    assert len(calls) == 1
+
+
+# ---------- fail open ---------------------------------------------------------
+
+
+def test_network_failure_returns_reason(fake_creds):
+    def boom(req, timeout=None):
+        raise OSError("connection refused")
+
+    with mock.patch("agent.panel_emitter.urllib.request.urlopen", side_effect=boom):
+        result = panel_emitter.emit([{"type": "x", "external_ref": "boomref"}])
+    assert result["ok"] is False
+    assert "connection refused" in result["reason"]
+
+
+# ---------- triggers / truncation --------------------------------------------
+
+
+def _capture_emit(monkeypatch):
+    bag = {}
+
+    def fake_emit(units, profile=None):
+        bag["units"] = units
+        bag["profile"] = profile
+        return {"ok": True}
+
+    monkeypatch.setattr(panel_triggers, "emit", fake_emit)
+    return bag
+
+
+def test_emit_skill_diff_shape_and_truncation(monkeypatch):
+    bag = _capture_emit(monkeypatch)
+    big_diff = "x" * 20000
+    big_reason = "r" * 5000
+    panel_triggers.emit_skill_diff("my-skill", big_diff, big_reason, profile="hermes:base")
+    u = bag["units"][0]
+    assert u["type"] == "skill_diff_review"
+    assert len(u["diff"]) == 8000
+    assert len(u["prompt_context"]) == 2000
+    assert u["binary"] == {"yes": "improvement", "no": "regression"}
+    assert len(u["external_ref"]) == 16
+    assert bag["profile"] == "hermes:base"
+
+
+def test_emit_process_output_shape(monkeypatch):
+    bag = _capture_emit(monkeypatch)
+    panel_triggers.emit_process_output("a" * 9000, "goal " * 600)
+    u = bag["units"][0]
+    assert u["type"] == "process_output_rating"
+    assert len(u["passage"]) == 8000
+    assert len(u["prompt_context"]) == 2000
+    labels = [c["label"] for c in u["choices"]]
+    assert labels == ["1", "2", "3", "4"]
+
+
+def test_emit_prompt_rewrite_shape_and_truncation(monkeypatch):
+    bag = _capture_emit(monkeypatch)
+    panel_triggers.emit_prompt_rewrite("o" * 3000, "c" * 3000, "ctx " * 600)
+    u = bag["units"][0]
+    assert u["type"] == "prompt_rewrite_pair"
+    assert [c["label"] for c in u["choices"]] == ["A", "B"]
+    assert len(u["choices"][0]["text"]) == 2000
+    assert len(u["choices"][1]["text"]) == 2000
+    assert len(u["prompt_context"]) == 2000
+
+
+def test_external_ref_is_deterministic(monkeypatch):
+    bag = _capture_emit(monkeypatch)
+    panel_triggers.emit_skill_diff("s", "d", "r")
+    ref1 = bag["units"][0]["external_ref"]
+    panel_triggers.emit_skill_diff("s", "d_changed_body", "r")
+    ref2 = bag["units"][0]["external_ref"]
+    panel_triggers.emit_skill_diff("s", "different reason", "r")  # same ref args
+    # ref derives from skill_name|reason, not diff body
+    assert ref1 == ref2


### PR DESCRIPTION
## what

adds the V2 emitter fleet client to hermes-agent. ships the module + offline tests only — no host wiring (skill_manage hooks, plan-mode output, user-correction detection) in this PR.

## module API

```python
from agent.panel_emitter import emit
from agent.panel_triggers import (
    emit_skill_diff,        # type='skill_diff_review'
    emit_process_output,    # type='process_output_rating'
    emit_prompt_rewrite,    # type='prompt_rewrite_pair'
)
```

`emit(units, profile=None)` — HMAC-SHA256 over exact body bytes, loads creds from `~/.secrets/panel-emit-<slug>.{key,txt}`, env-gated on `PANEL_EMIT_ENABLED=1` (default off), 5s timeout, fail-open (never raises), 30s in-process dedup on `external_ref`. Endpoint via `PANEL_INGEST_URL` (default `https://panel.goku.codes/api/units/ingest`).

Triggers stamp deterministic sha1-derived `external_ref` and truncate per the Unit Type Catalog caps: passage/diff ≤8000, choice text ≤2000, prompt_context ≤2000.

## tests

`tests/test_panel_emitter.py` — 10 tests, all offline (urlopen stubbed):

- signing correctness: HMAC matches reference, hex-format, exact bytes signed
- env gate off → returns `{'ok': False, 'reason': 'disabled'}`
- empty batch → `empty`
- dedup window blocks repeat external_ref → second call returns `dedup`, only one POST
- network failure → returns reason, never raises
- `PANEL_INGEST_URL` env override honored
- trigger shapes correct (types, choices, binary)
- truncation at all three caps
- deterministic external_ref

```
$ venv/bin/python -m pytest tests/test_panel_emitter.py -v
============================== 10 passed in 2.75s ==============================
```

## smoke

live POST against `https://panel.goku.codes/api/units/ingest` with `hermes:base` keys reaches the server and gets a structured `401 ingest_not_configured` for the site_key — server-side allowlist, not a signing bug. emitter fail-opens cleanly.

## scope notes

- does **not** wire into skill_manage / plan output / user-correction paths (follow-up)
- does **not** add the emitter to any tool's default flow
- no secrets committed; emitter reads from `~/.secrets/panel-emit-*.txt` at runtime

refs: vault `(600) Work/panel/Agent Emitter Architecture.md` & `Unit Type Catalog.md`.