### PR TITLE
fix(xai-oauth): honor [WKE=unauthenticated] disambiguator in entitlement classifier (#29344)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5079,6 +5079,18 @@ class AIAgent:
           * xAI OAuth: "do not have an active Grok subscription" /
             "out of available resources" / "does not have permission" + "grok"
 
+        Disambiguator for xAI (#29344): the same ``code`` text ("The caller
+        does not have permission to execute the specified operation") is
+        returned for BOTH an unsubscribed account AND a stale OAuth access
+        token.  xAI ships an explicit signal in the ``error`` field that
+        tells the two apart: a ``[WKE=unauthenticated:...]`` suffix (and/or
+        the ``OAuth2 access token could not be validated`` phrasing) means
+        the credentials failed validation — that's recoverable by refreshing
+        the token, NOT by surfacing an entitlement message.  When either
+        signal is present we return False eagerly so the credential-pool
+        refresh path runs, letting long-running TUI sessions recover from
+        stale tokens without an exit/reopen cycle.
+
         Extend here for new providers as we discover them (Anthropic's
         Claude Max OAuth entitlement errors look distinct enough today that
         the existing 1M-context-beta branch handles them; revisit if other
@@ -5088,10 +5100,28 @@ class AIAgent:
             return False
         if not isinstance(error_context, dict):
             return False
+        # Build a single lowercase haystack covering every field shape the
+        # body might land in.  ``_extract_api_error_context`` normalises to
+        # ``message``/``reason``, but callers (and the test suite) may also
+        # hand us the raw body with ``code``/``error`` keys; cover both so
+        # the WKE disambiguator below fires regardless of entry point.
         message = str(error_context.get("message") or "").lower()
         reason = str(error_context.get("reason") or "").lower()
-        haystack = f"{message} {reason}"
+        code = str(error_context.get("code") or "").lower()
+        err = str(error_context.get("error") or "").lower()
+        haystack = f"{message} {reason} {code} {err}"
         if not haystack.strip():
+            return False
+        # xAI's authoritative disambiguator for "stale token" vs
+        # "unsubscribed account".  Both conditions share the same
+        # permission-denied ``code`` text; only one carries this suffix.
+        # Bail out before the entitlement keyword checks so a stale OAuth
+        # token routes through the credential-refresh path instead of the
+        # surface-error-as-entitlement path.  See #29344 for the long-
+        # running TUI failure mode this closes.
+        if "[wke=unauthenticated:" in haystack:
+            return False
+        if "oauth2 access token could not be validated" in haystack:
             return False
         if "do not have an active grok subscription" in haystack:
             return True

--- a/tests/run_agent/test_codex_xai_oauth_recovery.py
+++ b/tests/run_agent/test_codex_xai_oauth_recovery.py
@@ -500,6 +500,246 @@ def test_recover_with_credential_pool_still_refreshes_genuine_auth_failure():
 
 
 # ---------------------------------------------------------------------------
+# Fix D-bis: bad-credentials 403 must NOT be classified as entitlement (#29344)
+#
+# xAI returns the same permission-denied ``code`` text for two distinct
+# conditions: unsubscribed account vs. stale OAuth access token.  The
+# ``error`` field's ``[WKE=unauthenticated:...]`` suffix (and the
+# accompanying "OAuth2 access token could not be validated" phrasing) is
+# xAI's authoritative disambiguator — when present, the body is an auth
+# failure, not entitlement, and the credential-pool refresh path must
+# run.  Pre-fix, long-running TUI sessions stuck on a stale token
+# surfaced as a non-retryable client error; the workaround was to exit
+# and reopen the TUI so the startup-resolve path refreshed.
+# ---------------------------------------------------------------------------
+
+
+def test_is_entitlement_failure_false_for_bad_credentials_wke_suffix():
+    """403 with ``[WKE=unauthenticated:bad-credentials]`` is auth, not entitlement.
+
+    Verbatim shape from the #29344 reporter — the ``code`` text matches
+    the entitlement permission-denied heuristic, but the ``error`` field
+    carries xAI's explicit "this is a credential validation failure"
+    signal.  Classifier must honor it.
+    """
+    from run_agent import AIAgent
+
+    assert not AIAgent._is_entitlement_failure(
+        {
+            "code": "The caller does not have permission to execute the specified operation",
+            "error": "The OAuth2 access token could not be validated. [WKE=unauthenticated:bad-credentials]",
+        },
+        403,
+    )
+
+
+def test_is_entitlement_failure_false_for_wke_suffix_in_normalized_shape():
+    """The same body after ``_extract_api_error_context`` normalisation.
+
+    Real runtime paths feed the classifier through
+    ``_extract_api_error_context``, which converts the raw body to
+    ``{message, reason, reset_at}``.  The disambiguator must fire in
+    BOTH the raw-body shape (test above) and the normalised shape so
+    the fix actually reaches the production call site at
+    ``_recover_with_credential_pool``.
+    """
+    from run_agent import AIAgent
+
+    assert not AIAgent._is_entitlement_failure(
+        {
+            "reason": "The caller does not have permission to execute the specified operation",
+            "message": "The OAuth2 access token could not be validated. [WKE=unauthenticated:bad-credentials]",
+        },
+        403,
+    )
+
+
+@pytest.mark.parametrize("wke_variant", [
+    # The headline variant — what xAI returns today.
+    "[WKE=unauthenticated:bad-credentials]",
+    # Forward-compat: xAI documents the WKE prefix as a stable shape,
+    # the suffix after the colon is the "reason code" and could grow
+    # new values.  Anything under ``unauthenticated:`` must route to
+    # the refresh path.
+    "[WKE=unauthenticated:expired-token]",
+    "[WKE=unauthenticated:revoked]",
+    "[WKE=unauthenticated:some-future-reason]",
+])
+def test_is_entitlement_failure_false_for_any_wke_unauthenticated_variant(wke_variant):
+    from run_agent import AIAgent
+
+    assert not AIAgent._is_entitlement_failure(
+        {
+            "code": "The caller does not have permission to execute the specified operation",
+            "error": f"Token rejected. {wke_variant}",
+        },
+        403,
+    )
+
+
+def test_is_entitlement_failure_false_via_oauth2_validation_phrase_alone():
+    """Second disambiguator: the "OAuth2 access token could not be
+    validated" phrase by itself (no WKE suffix) must also route to
+    refresh.  This is a belt-and-braces guard against xAI dropping or
+    reformatting the WKE suffix in a future API revision without
+    changing the human-readable error text."""
+    from run_agent import AIAgent
+
+    assert not AIAgent._is_entitlement_failure(
+        {
+            "code": "The caller does not have permission to execute the specified operation",
+            "error": "The OAuth2 access token could not be validated.",
+        },
+        403,
+    )
+
+
+def test_is_entitlement_failure_wke_signal_overrides_entitlement_keywords():
+    """Defensive: if a future xAI body somehow carries BOTH the WKE
+    suffix AND entitlement language, the WKE signal wins.  Auth is
+    recoverable; entitlement isn't.  If the refreshed token still
+    can't access the resource, the next 403 (without WKE) lands on
+    the entitlement path correctly."""
+    from run_agent import AIAgent
+
+    assert not AIAgent._is_entitlement_failure(
+        {
+            "code": "The caller does not have permission to execute the specified operation",
+            "error": (
+                "do not have an active Grok subscription. "
+                "[WKE=unauthenticated:bad-credentials]"
+            ),
+        },
+        403,
+    )
+
+
+def test_is_entitlement_failure_case_insensitive_wke_match():
+    """Substring match is case-insensitive — the classifier lowercases
+    everything before matching, so a future xAI build that uppercases
+    the prefix wouldn't reintroduce the misclassification."""
+    from run_agent import AIAgent
+
+    assert not AIAgent._is_entitlement_failure(
+        {
+            "code": "The caller does not have permission to execute the specified operation",
+            "error": "[wke=Unauthenticated:Bad-Credentials]",
+        },
+        403,
+    )
+
+
+def test_recover_with_credential_pool_refreshes_on_xai_bad_credentials_403():
+    """End-to-end #29344: a bad-credentials 403 from xai-oauth MUST
+    call ``try_refresh_current()`` so the long-running TUI session
+    recovers without an exit/reopen cycle.
+
+    Mirrors the scaffolding of
+    ``test_recover_with_credential_pool_still_refreshes_genuine_auth_failure``
+    but with the exact 403 body shape xAI ships for stale tokens —
+    the very body that pre-fix tripped the entitlement classifier
+    and short-circuited the refresh path.
+    """
+    from run_agent import AIAgent
+    from agent.error_classifier import FailoverReason
+
+    agent = _make_codex_agent()
+
+    refresh_calls = {"n": 0}
+
+    class _FakePool:
+        def try_refresh_current(self):
+            refresh_calls["n"] += 1
+            entry = MagicMock()
+            entry.id = "entry_refreshed_after_stale"
+            return entry
+
+        def mark_exhausted_and_rotate(self, **_kwargs):
+            return None
+
+        def has_available(self):
+            return False
+
+    agent._credential_pool = _FakePool()
+    agent._swap_credential = MagicMock()
+
+    # Normalised shape that ``_extract_api_error_context`` would
+    # produce for the reporter's wire-level body.
+    error_context = {
+        "reason": (
+            "The caller does not have permission to execute the specified operation"
+        ),
+        "message": (
+            "The OAuth2 access token could not be validated. "
+            "[WKE=unauthenticated:bad-credentials]"
+        ),
+    }
+
+    recovered, _retried_429 = agent._recover_with_credential_pool(
+        status_code=403,
+        has_retried_429=False,
+        classified_reason=FailoverReason.auth,
+        error_context=error_context,
+    )
+
+    assert recovered is True, (
+        "Stale OAuth token (bad-credentials 403) must trigger refresh — "
+        "pre-fix this returned False because the entitlement classifier "
+        "over-matched on the permission-denied code text"
+    )
+    assert refresh_calls["n"] == 1, "try_refresh_current must run exactly once"
+    agent._swap_credential.assert_called_once()
+
+
+def test_recover_with_credential_pool_still_blocks_real_entitlement():
+    """Companion regression guard for the #29344 fix: the original
+    #26847 protection — entitlement 403 must NOT refresh — must
+    survive the new disambiguator.  A real unsubscribed-account body
+    has no WKE suffix and no OAuth2-validation phrase, so the
+    classifier still classifies it as entitlement and short-circuits."""
+    from run_agent import AIAgent
+    from agent.error_classifier import FailoverReason
+
+    agent = _make_codex_agent()
+
+    refresh_calls = {"n": 0}
+
+    class _FakePool:
+        def try_refresh_current(self):
+            refresh_calls["n"] += 1
+            return MagicMock(id="should_not_be_called")
+
+        def mark_exhausted_and_rotate(self, **_kwargs):
+            return None
+
+        def has_available(self):
+            return False
+
+    agent._credential_pool = _FakePool()
+
+    # Pure entitlement body — no WKE suffix, no OAuth2 phrase.
+    error_context = {
+        "reason": (
+            "The caller does not have permission to execute the specified operation"
+        ),
+        "message": (
+            "You have either run out of available resources or do not have an "
+            "active Grok subscription. Manage at https://grok.com"
+        ),
+    }
+
+    recovered, _retried_429 = agent._recover_with_credential_pool(
+        status_code=403,
+        has_retried_429=False,
+        classified_reason=FailoverReason.auth,
+        error_context=error_context,
+    )
+
+    assert recovered is False, "Entitlement 403 must surface, not refresh"
+    assert refresh_calls["n"] == 0
+
+
+# ---------------------------------------------------------------------------
 # Fix E: grok-4.3 context length must be 1M, not 256K
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What does this PR do?

Closes the "long-running TUI sessions can't auto-refresh stale OAuth tokens against `provider/xai-oauth`" bug in #29344. The reporter (SmelterLabs) did the root-cause work and even drafted the test cases — this PR implements their **option 1 (tightest)** recommendation and adds the suggested coverage.

xAI returns the *same* permission-denied `code` text for two distinct conditions on a 403:

| Condition | `code` (identical) | `error` (the disambiguator) |
|---|---|---|
| Unsubscribed account (entitlement) | `The caller does not have permission to execute the specified operation` | `... active Grok subscription. Manage at https://grok.com` |
| Stale OAuth access token (auth) | `The caller does not have permission to execute the specified operation` | `The OAuth2 access token could not be validated. [WKE=unauthenticated:bad-credentials]` |

`_is_entitlement_failure` in `run_agent.py` was added in #26847 to stop the credential-pool refresh loop on unsubscribed-account 403s — refreshing an OAuth token cannot fix an account that lacks a Grok subscription, so the classifier returns True and `_recover_with_credential_pool` short-circuits before `try_refresh_current`. But the heuristic over-matched: it returned True for the bad-credentials variant too, because that body also carries `does not have permission` and (via `_extract_api_error_context`'s fallback to `str(error)`) `grok` somewhere in the wire text. Result: long-running TUI sessions stuck on a stale token surfaced as a non-retryable client error, and the only workaround was exit + reopen the TUI so the startup-resolve path (which doesn't go through the classifier) refreshed the token cleanly.

xAI's `[WKE=unauthenticated:...]` suffix on the `error` field is the explicit, authoritative disambiguator. This PR honors it.

**Fix shape (run_agent.py, `_is_entitlement_failure`):**

1. **Broaden the haystack** to cover both extraction shapes — the production `_extract_api_error_context` path normalises to `{message, reason}`, but the classifier is also reachable directly with raw bodies that carry `{code, error}`. Build the haystack from all four fields so the disambiguator fires regardless of entry point. Backwards compatible: missing keys default to empty strings, the empty-haystack short-circuit still triggers when nothing is set.
2. **Add two disambiguator early-returns** *before* the existing entitlement keyword checks:
   - `[WKE=unauthenticated:` anywhere in the haystack → `return False` (xAI's authoritative auth signal — `bad-credentials`, `expired-token`, `revoked`, and any future reason code all route to refresh).
   - `oauth2 access token could not be validated` → `return False` (belt-and-braces guard if xAI ever drops the WKE suffix but keeps the human-readable phrasing).
3. **Order matters**: the disambiguators run BEFORE the entitlement keyword checks. If a future xAI body ever carries both signals at once, auth wins — auth is recoverable, entitlement isn't, and a refreshed token will resurface the entitlement message on the next request anyway. The original #26847 loop-protection still kicks in on the *second* 403 if the refresh itself failed.

The unsubscribed-account path, the generic auth-error path, the refresh-on-401 path, and the `_recover_with_credential_pool` shape are all left intact — the patch is purely additive between the haystack build and the entitlement keyword checks.

## Related Issue

Fixes #29344

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `run_agent.py` — `_is_entitlement_failure` haystack now also covers `code` and `error` keys; two disambiguator checks (`[wke=unauthenticated:` + `oauth2 access token could not be validated`) fire before the entitlement keyword block. Docstring updated to explain the WKE contract and link back to #29344.
- `tests/run_agent/test_codex_xai_oauth_recovery.py` — **11 new tests** in the "Fix D-bis" section, mirroring the layout of the existing entitlement tests:
  - Classifier-level: verbatim reporter body, normalised shape after `_extract_api_error_context`, parametrised forward-compat across `unauthenticated:` reason codes (`bad-credentials`, `expired-token`, `revoked`, `some-future-reason`), the OAuth2-validation-phrase fallback, the "WKE wins over entitlement keywords" defensive case, and case-insensitive matching.
  - Recovery-path end-to-end: a bad-credentials 403 with the exact wire body must call `try_refresh_current()` exactly once and `_swap_credential` once (the headline test the reporter requested); plus a companion guard that a pure unsubscribed-account body still surfaces as entitlement and skips refresh — the new disambiguator must not weaken the #26847 protection.

Backwards compatible: no schema changes, no new public functions, no new config knobs. Existing 22 tests in this file continue to pass unchanged.

## How to Test

```bash
# Full xai-oauth recovery suite (22 existing + 11 new = 33 tests)
./scripts/run_tests.sh tests/run_agent/test_codex_xai_oauth_recovery.py
# expected: 33 passed
```

Behavioural verification against a stale OAuth token, post-fix:

```
INFO  run_agent: Credential 403 — auth failure from xai-oauth; refreshing pool entry…
INFO  run_agent: Credential auth failure — refreshed pool entry oauth_xxx
INFO  run_agent: <retry succeeds with the refreshed token>
```

Pre-fix on the same body:

```
INFO  run_agent: Credential 403 — entitlement-shaped 403 from xai-oauth; skipping pool refresh
              (account lacks subscription, not a transient auth failure).
ERROR run_agent: Non-retryable client error: 403 ...
# user has to exit + reopen the TUI to recover
```

## Checklist

- [x] Conventional Commits (`fix(xai-oauth):`, `test(xai-oauth):`)
- [x] 2 focused commits, single author
- [x] 11 new tests pass; 22 existing tests in the same file pass; 33 total
- [x] Tested on macOS 15.6 (darwin 24.6.0)
- [x] No new config keys, no schema changes; backwards compatible
- [x] The #26847 entitlement loop-protection is preserved by the companion regression guard