### PR TITLE
Fix scheduler wedge: scope tick lock to dispatch, add LLM stream timeouts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -663,8 +663,25 @@ Hardening invariants:
   cannot monopolize the scheduler.
 - Catchup window: half the job's period, clamped to 120s–2h.
 - Grace window: 120s for one-shot jobs whose fire time was missed.
-- File lock at `~/.hermes/cron/.tick.lock` prevents duplicate ticks
-  across processes.
+- **Dispatch single-flight lock** at `~/.hermes/cron/.tick.lock`
+  prevents two ticks from picking up the same due job. The lock is
+  held **only across the dispatch step** (`get_due_jobs` →
+  `advance_next_run`) — job execution runs *outside* the lock so a
+  long-running LLM job in one tick cannot wedge subsequent ticks.
+  Release is guaranteed across `Exception`, `BaseException`,
+  `KeyboardInterrupt`, and `asyncio.CancelledError` (see
+  `docs/incidents/2026-05-19-scheduler-wedge.md`).
+- **LLM stream deadlines.** Every chat-completion stream is bounded
+  by two env-var-tunable budgets:
+  - `HERMES_LLM_STREAM_TIMEOUT_SECONDS` — total wall-clock budget
+    (default 300s). A stream that runs longer is closed and the
+    iteration raises `run_agent.StreamTimeoutError(which="total")`.
+  - `HERMES_LLM_STREAM_CHUNK_TIMEOUT_SECONDS` — max gap between
+    chunks (default 60s). A stream silent longer is closed and the
+    iteration raises `run_agent.StreamTimeoutError(which="chunk")`.
+  Both are enforced by a daemon watchdog thread alongside the
+  existing per-request httpx timeouts and the cron-side inactivity
+  cap. Set either to `0` to disable that specific deadline.
 - Cron sessions pass `skip_memory=True` by default; memory providers
   intentionally do not run during cron.
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4,12 +4,19 @@ Cron job scheduler - executes due jobs.
 Provides tick() which checks for due jobs and runs them. The gateway
 calls this every 60 seconds from a background thread.
 
-Uses a file-based lock (~/.hermes/cron/.tick.lock) so only one tick
-runs at a time if multiple processes overlap.
+Uses a file-based lock (~/.hermes/cron/.tick.lock) for **dispatch
+single-flight only** — held across :func:`get_due_jobs` +
+:func:`advance_next_run` so two overlapping ticks (gateway-in-process
+ticker + standalone daemon + manual ``python -m cron.scheduler``)
+cannot pick up the same job twice, but released **before** any job
+runs so a long-running LLM job inside one tick cannot block
+subsequent ticks. See ``docs/incidents/2026-05-19-scheduler-
+wedge.md`` for the wedge mechanism this scope change repairs.
 """
 
 import asyncio
 import concurrent.futures
+import contextlib
 import contextvars
 import json
 import logging
@@ -128,6 +135,68 @@ def _get_lock_paths() -> tuple[Path, Path]:
     hermes_home = _get_hermes_home()
     lock_dir = hermes_home / "cron"
     return lock_dir, lock_dir / ".tick.lock"
+
+
+@contextlib.contextmanager
+def _dispatch_lock():
+    """Acquire the dispatch single-flight lock for the lifetime of the block.
+
+    Yields ``True`` when the lock was acquired (caller proceeds with
+    dispatch), ``False`` when another tick already holds it (caller
+    should bail out immediately as a no-op).
+
+    Cleanup is wrapped in a bare ``except BaseException`` so the lock
+    is released on every exit path — normal return, raised
+    ``Exception``, ``asyncio.CancelledError`` propagating up through a
+    threaded caller, ``KeyboardInterrupt``, ``SystemExit``. The
+    pre-fix code released only in a typed ``finally:`` that worked in
+    practice for ``Exception`` but left no guarantee for the
+    base-exception family. See
+    ``docs/incidents/2026-05-19-scheduler-wedge.md`` (fix C).
+    """
+    lock_dir, lock_file = _get_lock_paths()
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    lock_fd = None
+    acquired = False
+    try:
+        try:
+            lock_fd = open(lock_file, "w")
+            if fcntl:
+                fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            elif msvcrt:
+                msvcrt.locking(lock_fd.fileno(), msvcrt.LK_NBLCK, 1)
+            acquired = True
+        except (OSError, IOError):
+            # Another tick currently holds the lock — yield False so the
+            # caller treats this as a clean no-op rather than a failure.
+            logger.debug("Tick skipped — another instance holds the lock")
+            if lock_fd is not None:
+                try:
+                    lock_fd.close()
+                except Exception:
+                    pass
+                lock_fd = None
+        yield acquired
+    finally:
+        # Best-effort release on every exit path. ``BaseException`` here
+        # is intentional — we never want a CancelledError or
+        # KeyboardInterrupt to bypass the release and leave the lock
+        # stuck for the next tick (the 2026-05-19 wedge mode).
+        if acquired and lock_fd is not None:
+            try:
+                if fcntl:
+                    fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                elif msvcrt:
+                    try:
+                        msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
+                    except (OSError, IOError):
+                        pass
+            except BaseException:  # noqa: BLE001 — release at all costs
+                logger.exception("Cron dispatch lock release failed")
+            try:
+                lock_fd.close()
+            except BaseException:  # noqa: BLE001 — release at all costs
+                logger.exception("Cron dispatch lock fd close failed")
 
 
 def _resolve_origin(job: dict) -> Optional[dict]:
@@ -1432,36 +1501,32 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
 def tick(verbose: bool = True, adapters=None, loop=None) -> int:
     """
     Check and run all due jobs.
-    
-    Uses a file lock so only one tick runs at a time, even if the gateway's
-    in-process ticker and a standalone daemon or manual tick overlap.
-    
+
+    The dispatch lock is held only across :func:`get_due_jobs` +
+    :func:`advance_next_run` — long enough to guarantee
+    at-most-once dispatch when two ticks race, short enough that
+    a long-running LLM job inside one tick cannot wedge subsequent
+    ticks (the 2026-05-19 wedge mode). Job execution itself runs
+    outside the lock; the next tick at the 60 s boundary sees an
+    empty due list (already advanced) and becomes a fast no-op.
+
     Args:
         verbose: Whether to print status messages
         adapters: Optional dict mapping Platform → live adapter (from gateway)
         loop: Optional asyncio event loop (from gateway) for live adapter sends
-    
+
     Returns:
-        Number of jobs executed (0 if another tick is already running)
+        Number of jobs executed (0 if another tick is already running
+        the dispatch step, or if no jobs were due).
     """
-    lock_dir, lock_file = _get_lock_paths()
-    lock_dir.mkdir(parents=True, exist_ok=True)
+    # --- DISPATCH PHASE (under lock) ---------------------------------
+    # Acquire single-flight lock; if another tick already holds it,
+    # bail immediately. Inside the lock: read due jobs, advance their
+    # next_run_at. Release the lock before doing any actual work.
+    with _dispatch_lock() as acquired:
+        if not acquired:
+            return 0
 
-    # Cross-platform file locking: fcntl on Unix, msvcrt on Windows
-    lock_fd = None
-    try:
-        lock_fd = open(lock_file, "w")
-        if fcntl:
-            fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-        elif msvcrt:
-            msvcrt.locking(lock_fd.fileno(), msvcrt.LK_NBLCK, 1)
-    except (OSError, IOError):
-        logger.debug("Tick skipped — another instance holds the lock")
-        if lock_fd is not None:
-            lock_fd.close()
-        return 0
-
-    try:
         due_jobs = get_due_jobs()
 
         if verbose and not due_jobs:
@@ -1471,123 +1536,119 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
         if verbose:
             logger.info("%s - %s job(s) due", _hermes_now().strftime('%H:%M:%S'), len(due_jobs))
 
-        # Advance next_run_at for all recurring jobs FIRST, under the file lock,
-        # before any execution begins.  This preserves at-most-once semantics.
+        # Advance next_run_at for all recurring jobs FIRST so a concurrent
+        # tick can never re-pick the same job once we release the lock.
         for job in due_jobs:
             advance_next_run(job["id"])
 
-        # Resolve max parallel workers: env var > config.yaml > unbounded.
-        # Set HERMES_CRON_MAX_PARALLEL=1 to restore old serial behaviour.
-        _max_workers: Optional[int] = None
+    # --- EXECUTION PHASE (lock released) -----------------------------
+    # From here down, the lock is no longer held. The next 60s tick
+    # can acquire and proceed independently — it will see an empty
+    # due-job list because we advanced them all above.
+
+    # Resolve max parallel workers: env var > config.yaml > unbounded.
+    # Set HERMES_CRON_MAX_PARALLEL=1 to restore old serial behaviour.
+    _max_workers: Optional[int] = None
+    try:
+        _env_par = os.getenv("HERMES_CRON_MAX_PARALLEL", "").strip()
+        if _env_par:
+            _max_workers = int(_env_par) or None
+    except (ValueError, TypeError):
+        logger.warning("Invalid HERMES_CRON_MAX_PARALLEL value; defaulting to unbounded")
+    if _max_workers is None:
         try:
-            _env_par = os.getenv("HERMES_CRON_MAX_PARALLEL", "").strip()
-            if _env_par:
-                _max_workers = int(_env_par) or None
-        except (ValueError, TypeError):
-            logger.warning("Invalid HERMES_CRON_MAX_PARALLEL value; defaulting to unbounded")
-        if _max_workers is None:
-            try:
-                _ucfg = load_config() or {}
-                _cfg_par = (
-                    _ucfg.get("cron", {}) if isinstance(_ucfg, dict) else {}
-                ).get("max_parallel_jobs")
-                if _cfg_par is not None:
-                    _max_workers = int(_cfg_par) or None
-            except Exception:
-                pass
+            _ucfg = load_config() or {}
+            _cfg_par = (
+                _ucfg.get("cron", {}) if isinstance(_ucfg, dict) else {}
+            ).get("max_parallel_jobs")
+            if _cfg_par is not None:
+                _max_workers = int(_cfg_par) or None
+        except Exception:
+            pass
 
-        if verbose:
-            logger.info(
-                "Running %d job(s) in parallel (max_workers=%s)",
-                len(due_jobs),
-                _max_workers if _max_workers else "unbounded",
-            )
+    if verbose:
+        logger.info(
+            "Running %d job(s) in parallel (max_workers=%s)",
+            len(due_jobs),
+            _max_workers if _max_workers else "unbounded",
+        )
 
-        def _process_job(job: dict) -> bool:
-            """Run one due job end-to-end: execute, save, deliver, mark."""
-            try:
-                success, output, final_response, error = run_job(job)
-
-                output_file = save_job_output(job["id"], output)
-                if verbose:
-                    logger.info("Output saved to: %s", output_file)
-
-                # Deliver the final response to the origin/target chat.
-                # If the agent responded with [SILENT], skip delivery (but
-                # output is already saved above).  Failed jobs always deliver.
-                deliver_content = final_response if success else f"⚠️ Cron job '{job.get('name', job['id'])}' failed:\n{error}"
-                should_deliver = bool(deliver_content)
-                if should_deliver and success and SILENT_MARKER in deliver_content.strip().upper():
-                    logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
-                    should_deliver = False
-
-                delivery_error = None
-                if should_deliver:
-                    try:
-                        delivery_error = _deliver_result(job, deliver_content, adapters=adapters, loop=loop)
-                    except Exception as de:
-                        delivery_error = str(de)
-                        logger.error("Delivery failed for job %s: %s", job["id"], de)
-
-                # Treat empty final_response as a soft failure so last_status
-                # is not "ok" — the agent ran but produced nothing useful.
-                # (issue #8585)
-                if success and not final_response:
-                    success = False
-                    error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
-
-                mark_job_run(job["id"], success, error, delivery_error=delivery_error)
-                return True
-
-            except Exception as e:
-                logger.error("Error processing job %s: %s", job['id'], e)
-                mark_job_run(job["id"], False, str(e))
-                return False
-
-        # Partition due jobs: those with a per-job workdir mutate
-        # os.environ["TERMINAL_CWD"] inside run_job, which is process-global —
-        # so they MUST run sequentially to avoid corrupting each other.  Jobs
-        # without a workdir leave env untouched and stay parallel-safe.
-        workdir_jobs = [j for j in due_jobs if (j.get("workdir") or "").strip()]
-        parallel_jobs = [j for j in due_jobs if not (j.get("workdir") or "").strip()]
-
-        _results: list = []
-
-        # Sequential pass for workdir jobs.
-        for job in workdir_jobs:
-            _ctx = contextvars.copy_context()
-            _results.append(_ctx.run(_process_job, job))
-
-        # Parallel pass for the rest — same behaviour as before.
-        if parallel_jobs:
-            with concurrent.futures.ThreadPoolExecutor(max_workers=_max_workers) as _tick_pool:
-                _futures = []
-                for job in parallel_jobs:
-                    _ctx = contextvars.copy_context()
-                    _futures.append(_tick_pool.submit(_ctx.run, _process_job, job))
-                _results.extend(f.result() for f in _futures)
-
-        # Best-effort sweep of MCP stdio subprocesses that survived their
-        # session teardown during this tick.  Runs AFTER every job has
-        # finished so active sessions (including live user chats) are
-        # never touched — only PIDs explicitly detected as orphans in
-        # tools.mcp_tool._run_stdio's finally block are reaped.
+    def _process_job(job: dict) -> bool:
+        """Run one due job end-to-end: execute, save, deliver, mark."""
         try:
-            from tools.mcp_tool import _kill_orphaned_mcp_children
-            _kill_orphaned_mcp_children()
-        except Exception as _e:
-            logger.debug("Post-tick MCP orphan cleanup failed: %s", _e)
+            success, output, final_response, error = run_job(job)
 
-        return sum(_results)
-    finally:
-        if fcntl:
-            fcntl.flock(lock_fd, fcntl.LOCK_UN)
-        elif msvcrt:
-            try:
-                msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
-            except (OSError, IOError):
-                pass
-        lock_fd.close()
+            output_file = save_job_output(job["id"], output)
+            if verbose:
+                logger.info("Output saved to: %s", output_file)
+
+            # Deliver the final response to the origin/target chat.
+            # If the agent responded with [SILENT], skip delivery (but
+            # output is already saved above).  Failed jobs always deliver.
+            deliver_content = final_response if success else f"⚠️ Cron job '{job.get('name', job['id'])}' failed:\n{error}"
+            should_deliver = bool(deliver_content)
+            if should_deliver and success and SILENT_MARKER in deliver_content.strip().upper():
+                logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
+                should_deliver = False
+
+            delivery_error = None
+            if should_deliver:
+                try:
+                    delivery_error = _deliver_result(job, deliver_content, adapters=adapters, loop=loop)
+                except Exception as de:
+                    delivery_error = str(de)
+                    logger.error("Delivery failed for job %s: %s", job["id"], de)
+
+            # Treat empty final_response as a soft failure so last_status
+            # is not "ok" — the agent ran but produced nothing useful.
+            # (issue #8585)
+            if success and not final_response:
+                success = False
+                error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
+
+            mark_job_run(job["id"], success, error, delivery_error=delivery_error)
+            return True
+
+        except Exception as e:
+            logger.error("Error processing job %s: %s", job['id'], e)
+            mark_job_run(job["id"], False, str(e))
+            return False
+
+    # Partition due jobs: those with a per-job workdir mutate
+    # os.environ["TERMINAL_CWD"] inside run_job, which is process-global —
+    # so they MUST run sequentially to avoid corrupting each other.  Jobs
+    # without a workdir leave env untouched and stay parallel-safe.
+    workdir_jobs = [j for j in due_jobs if (j.get("workdir") or "").strip()]
+    parallel_jobs = [j for j in due_jobs if not (j.get("workdir") or "").strip()]
+
+    _results: list = []
+
+    # Sequential pass for workdir jobs.
+    for job in workdir_jobs:
+        _ctx = contextvars.copy_context()
+        _results.append(_ctx.run(_process_job, job))
+
+    # Parallel pass for the rest — same behaviour as before.
+    if parallel_jobs:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=_max_workers) as _tick_pool:
+            _futures = []
+            for job in parallel_jobs:
+                _ctx = contextvars.copy_context()
+                _futures.append(_tick_pool.submit(_ctx.run, _process_job, job))
+            _results.extend(f.result() for f in _futures)
+
+    # Best-effort sweep of MCP stdio subprocesses that survived their
+    # session teardown during this tick.  Runs AFTER every job has
+    # finished so active sessions (including live user chats) are
+    # never touched — only PIDs explicitly detected as orphans in
+    # tools.mcp_tool._run_stdio's finally block are reaped.
+    try:
+        from tools.mcp_tool import _kill_orphaned_mcp_children
+        _kill_orphaned_mcp_children()
+    except Exception as _e:
+        logger.debug("Post-tick MCP orphan cleanup failed: %s", _e)
+
+    return sum(_results)
 
 
 if __name__ == "__main__":

--- a/docs/incidents/2026-05-19-scheduler-wedge.md
+++ b/docs/incidents/2026-05-19-scheduler-wedge.md
@@ -1,0 +1,144 @@
+# 2026-05-19 — Cron scheduler wedged for 32 minutes
+
+## Symptom
+
+The algotrader operator running on this Hermes instance saw the
+`algotrader-catalysts-scan` and `algotrader-catalysts-evaluate`
+crons (both `*/5 * * * *`, `no_agent=True`) stop firing for
+roughly 25 minutes (15:25 → 15:50 EDT). During the same window:
+
+- The Telegram chat thread spent 32 minutes processing a single
+  inbound message (gateway log: `response ready: ... time=1962.8s
+  api_calls=3 response=1177 chars`).
+- `~/.hermes/cron/.tick.lock` was held continuously across the
+  whole window.
+- Other cron jobs (analyst-batch, polymarket, fear-greed) also
+  missed their schedule, but the operator-visible pain was
+  concentrated on the 5-minute catalysts because they were the
+  shortest-cadence jobs in the gap.
+
+Manual `rm ~/.hermes/cron/.tick.lock` followed by the next minute
+boundary restored normal firing immediately.
+
+## Mechanism
+
+`cron/scheduler.py:tick()` (the function the gateway calls every
+60 s from a background thread) acquires the file lock, then runs
+**every due job to completion inside the `try:` block** before
+releasing in `finally:` (lines 1447–1590 of the file at incident
+time).
+
+When at least one due job in a tick is an LLM-backed job (not
+`no_agent=True`), `run_job()` calls
+`agent.run_conversation(prompt)` which internally streams from
+the model provider via `chat.completions.create(stream=True)` and
+iterates synchronously over chunks (`run_agent.py:6907-6933`).
+
+There is no enforced end-to-end deadline on that stream:
+
+- `HERMES_STREAM_READ_TIMEOUT` (default 120 s) is an httpx-level
+  per-chunk read timeout — it resets on every byte received, so a
+  stream that emits one token every 119 s never trips.
+- `HERMES_STREAM_STALE_TIMEOUT` (default 180 s) is a stale-stream
+  detector inside the chunk loop; same per-chunk semantics.
+- `HERMES_CRON_TIMEOUT` (default 600 s) is *inactivity*-based —
+  it's reset by `_touch_activity("receiving stream response")`
+  on every chunk, so an active-but-slow stream keeps it pinned at
+  zero indefinitely.
+- `max_iterations` (default 90) is a *tool-loop* ceiling, not a
+  wall-clock ceiling — each iteration can itself be an
+  arbitrarily long stream.
+
+So in pathological cases (provider degradation, retry storm with
+keepalive pings, agent stuck in a tool/think/answer cycle that
+makes progress slowly), a single LLM job can sit inside `tick()`
+for minutes-to-hours while holding the file lock.
+
+Every subsequent tick attempt during that window logs
+`"Tick skipped — another instance holds the lock"` and returns 0
+without firing any cron — including unrelated `no_agent` cron
+that wouldn't touch the LLM at all.
+
+## Lock-scope audit
+
+A repo-wide grep (`tick.lock | tick_lock | _get_lock_paths`)
+shows only `cron/scheduler.py` and its tests touch the lock.
+The lock has exactly one purpose: prevent two concurrent
+`tick()` calls from picking up the same due job twice (the
+gateway's background ticker and a standalone `python -m
+cron.scheduler` daemon running in parallel — explicitly called
+out in the module docstring).
+
+It does **not** serialize:
+
+- LLM provider concurrency (each job constructs its own
+  `AIAgent`, its own httpx client, its own credential pool).
+- Job output storage (`save_job_output` is fd-per-write,
+  independent per `job_id`).
+- Per-job state (jobs have independent SessionDB rows keyed by
+  `cron_session_id`).
+- Shared adapters (delivery uses live adapters via
+  `asyncio.run_coroutine_threadsafe`, no lock).
+
+Conclusion: the lock's purpose is *single-flight on cron-job
+dispatch*, nothing else. There is no second purpose to preserve;
+narrowing the lock to dispatch-only is safe.
+
+## Fix plan (branch `fix/scheduler-wedge`)
+
+A. **LLM stream deadline.** Add two env vars —
+   `HERMES_LLM_STREAM_TIMEOUT_SECONDS` (default 300 s, total
+   wall-clock budget for one stream) and
+   `HERMES_LLM_STREAM_CHUNK_TIMEOUT_SECONDS` (default 60 s, max
+   gap between chunks). Both enforced inside the chunk loop with
+   a new `StreamTimeoutError`. On breach: close the stream
+   cleanly, raise, surface to the agent loop's existing retry /
+   error-propagation paths.
+
+   **Deviation note**: the spec says "wrap LLM stream in
+   `asyncio.wait_for`", but the OpenAI SDK stream path here is
+   synchronous (`for chunk in stream:`) and the cron caller
+   wraps it in a `ThreadPoolExecutor`. Bolting `asyncio.wait_for`
+   on would require rewriting the whole sync path into async,
+   which is a much bigger change than the wedge fix needs. The
+   deadline + per-chunk watchdog inside the existing sync loop
+   gives the same end-to-end guarantee: stream cannot exceed the
+   total budget; stream cannot stall longer than the per-chunk
+   budget; on breach, raise `StreamTimeoutError` and close.
+
+B. **Narrow lock scope.** Hold `.tick.lock` only across
+   `get_due_jobs()` + `advance_next_run()` (the actual dispatch
+   step). Release before job execution. Subsequent ticks during
+   the LLM run land with an empty due-job list (already advanced)
+   and become a fast no-op. Single-flight semantics preserved
+   because `advance_next_run()` happens under the lock.
+
+C. **Guaranteed release.** Wrap the lock acquisition in an
+   explicit `try/finally` that covers `asyncio.CancelledError`,
+   `KeyboardInterrupt`, and arbitrary `BaseException` —
+   currently the `try` block has bare `Exception` only.
+
+5 regression tests pin the new invariants
+(`tests/scheduler/test_wedge_recovery.py`):
+
+1. Total-timeout abort — slow stream over budget raises
+   `StreamTimeoutError`.
+2. Per-chunk-timeout abort — stream stall over per-chunk budget
+   raises `StreamTimeoutError`.
+3. Lock released during stream — concurrent tick fires while the
+   first tick's LLM job is mid-stream.
+4. Lock released on cancellation — `CancelledError` mid-tick
+   releases the lock.
+5. Lock released on exception — uncaught exception mid-tick
+   releases the lock.
+
+## What this does NOT fix
+
+- LaunchAgent supervision. The Hermes gateway on this machine is
+  not registered with launchd (`launchctl list | grep hermes`
+  returns nothing); the process was started with PPID 1 and has
+  no auto-respawn. Filed in `docs/todos/scheduler-followups.md`.
+- Per-job timeout overrides. `HERMES_LLM_STREAM_TIMEOUT_SECONDS`
+  is process-wide. Some long-form jobs (compliance check, deep
+  research) genuinely need >300 s. Filed in
+  `docs/todos/scheduler-followups.md`.

--- a/docs/todos/scheduler-followups.md
+++ b/docs/todos/scheduler-followups.md
@@ -1,0 +1,74 @@
+# Scheduler followups (deferred from the 2026-05-19 wedge fix)
+
+These were identified during the wedge investigation but are
+**not** implemented in the `fix/scheduler-wedge` branch — they
+need separate design / operator sign-off before landing.
+
+## 1. LaunchAgent supervision for the gateway
+
+**Observation.** The Hermes gateway on the incident host had no
+launchd registration (`launchctl list | grep hermes` returned
+nothing). Process PPID was 1 (orphan inherited by init via a
+`nohup ... & disown` startup). Net effect: if the process dies,
+it stays dead. No auto-respawn.
+
+**Recommendation.**
+- Ship a sample LaunchAgent plist at `packaging/launchd/
+  com.nousresearch.hermes-gateway.plist` (path TBD per repo
+  layout).
+- `KeepAlive` should be `Crashed`-only (dict-form), not the
+  blanket boolean `true` — we don't want a clean operator-
+  initiated stop (e.g. `hermes stop`) to be re-spawned.
+  ```xml
+  <key>KeepAlive</key>
+  <dict>
+      <key>SuccessfulExit</key>
+      <false/>
+  </dict>
+  ```
+- `ThrottleInterval` ≥ `60` so a crash loop can't burn the CPU.
+- `StandardOutPath` / `StandardErrorPath` should point at
+  `~/Library/Logs/hermes/gateway.out` / `gateway.err` (separate
+  from the in-app `~/.hermes/logs/gateway.log` rotation).
+- Installer step: `bin/setup-launchd` (or similar) that copies
+  the plist into `~/Library/LaunchAgents/`, runs
+  `launchctl bootstrap gui/<uid>` and `launchctl enable`.
+
+**Why deferred.** The wedge fix already prevents the gateway from
+getting stuck inside `tick()`. Auto-respawn is a separate failure
+mode (process crash) that we have not seen in the wild on this
+host yet; the supervision design needs a sign-off from the
+operator on the KeepAlive policy + logging destinations before
+landing.
+
+## 2. Per-job stream timeout overrides
+
+**Observation.** `HERMES_LLM_STREAM_TIMEOUT_SECONDS` and
+`HERMES_LLM_STREAM_CHUNK_TIMEOUT_SECONDS` are process-wide. Some
+classes of cron job legitimately need longer windows:
+
+- Compliance / regulatory web-search jobs (current default in
+  this repo: ~5–10 minutes with up to 10 sequential searches).
+- Deep-research / agentic-research jobs that iterate over a
+  large tool surface.
+- Long-form report generation against slow local models.
+
+Pushing the global default up to accommodate them would also
+loosen the bound on every other job in the same process.
+
+**Recommendation.**
+- Add an optional `stream_timeout_seconds` / `stream_chunk_timeout_seconds`
+  field on the cron job record (set via the `cronjob` create / update
+  tool, mirroring the existing `enabled_toolsets` plumbing).
+- At job-run time, push the per-job values into the process via
+  `ContextVar` so the per-stream watchdog inside
+  `_call_chat_completions` reads the job-scoped value instead of
+  the global env-var default.
+- Validate: per-job total must be ≤ some hard ceiling (e.g.
+  3600s) to prevent a misconfigured job from re-introducing the
+  wedge pattern at a longer time scale.
+
+**Why deferred.** Adds new schema, new tool surface, and
+operator-facing config UX — needs a separate design pass. The
+env-var defaults plus the documented "set to 0 to disable" knob
+cover the immediate need for the algotrader workload.

--- a/run_agent.py
+++ b/run_agent.py
@@ -269,6 +269,77 @@ def _install_safe_stdio() -> None:
             setattr(sys, stream_name, _SafeWriter(stream))
 
 
+class StreamTimeoutError(TimeoutError):
+    """Raised when an LLM chat-completion stream exceeds its budget.
+
+    Two deadlines protect every stream (see
+    ``docs/incidents/2026-05-19-scheduler-wedge.md``):
+
+    * Total wall-clock — ``HERMES_LLM_STREAM_TIMEOUT_SECONDS`` (default
+      300 s). Capped end-to-end so a slowly-progressing stream cannot
+      run for hours and indirectly block the cron tick.
+    * Per-chunk gap — ``HERMES_LLM_STREAM_CHUNK_TIMEOUT_SECONDS``
+      (default 60 s). The hard ceiling on silence between chunks; one
+      breach closes the stream and raises this error. Tighter than the
+      existing ``HERMES_STREAM_READ_TIMEOUT`` / ``_STALE_TIMEOUT``
+      knobs because those are advisory inside the SDK and don't
+      guarantee a terminating raise on breach.
+
+    Subclasses ``TimeoutError`` so existing ``except TimeoutError``
+    handlers downstream of the agent loop still catch it; ``isinstance``
+    checks on this class let new code distinguish stream-timeout from
+    other timeouts.
+
+    ``which`` is ``"total"`` or ``"chunk"``; ``elapsed_seconds`` and
+    ``budget_seconds`` are populated by the chunk loop so the log line
+    and any operator-facing error surface the relevant numbers.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        which: str,
+        elapsed_seconds: float,
+        budget_seconds: float,
+    ) -> None:
+        super().__init__(message)
+        self.which = which
+        self.elapsed_seconds = elapsed_seconds
+        self.budget_seconds = budget_seconds
+
+
+_DEFAULT_LLM_STREAM_TOTAL_TIMEOUT_SECONDS = 300.0
+_DEFAULT_LLM_STREAM_CHUNK_TIMEOUT_SECONDS = 60.0
+
+
+def _resolve_stream_timeout_seconds(env_var: str, default: float) -> float:
+    """Read a float seconds value from ``env_var`` with a safe default.
+
+    Empty / unset / unparseable / non-positive values fall back to
+    ``default``; negative values are explicitly rejected so an
+    operator can't accidentally disable the cap by passing ``-1``.
+    A value of ``0`` is treated as "disabled" (no deadline enforced)
+    so tests and explicit operator overrides can opt out.
+    """
+    raw = os.getenv(env_var, "").strip()
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid %s=%r — using default %.1fs", env_var, raw, default,
+        )
+        return default
+    if value < 0:
+        logger.warning(
+            "Negative %s=%r — using default %.1fs", env_var, raw, default,
+        )
+        return default
+    return value
+
+
 class IterationBudget:
     """Thread-safe iteration counter for an agent.
 
@@ -6914,6 +6985,102 @@ class AIAgent:
             # Log OpenRouter response cache status when present.
             self._check_openrouter_cache_status(getattr(stream, "response", None))
 
+            # --- Stream deadline watchdog (Fix A) ----------------------
+            # Two hard deadlines protect every stream so a degraded
+            # provider cannot park the chunk loop for hours:
+            #   * total wall-clock budget (default 300 s)
+            #   * per-chunk silence budget (default 60 s)
+            # The watchdog runs in a daemon thread; on breach it closes
+            # the stream (which makes the blocking ``for chunk in stream``
+            # raise) and records why. The main thread translates that
+            # into a typed ``StreamTimeoutError``.
+            _stream_total_budget = _resolve_stream_timeout_seconds(
+                "HERMES_LLM_STREAM_TIMEOUT_SECONDS",
+                _DEFAULT_LLM_STREAM_TOTAL_TIMEOUT_SECONDS,
+            )
+            _stream_chunk_budget = _resolve_stream_timeout_seconds(
+                "HERMES_LLM_STREAM_CHUNK_TIMEOUT_SECONDS",
+                _DEFAULT_LLM_STREAM_CHUNK_TIMEOUT_SECONDS,
+            )
+            _stream_started_at = time.time()
+            _stream_watchdog_breach: dict = {}
+            _stream_watchdog_stop = threading.Event()
+
+            def _stream_watchdog() -> None:
+                # Lightweight poll loop — 0.5 s granularity is fine for
+                # 60 s / 300 s budgets and keeps the thread effectively
+                # invisible in CPU profiles.
+                #
+                # Lifetime: the watchdog self-terminates as soon as it
+                # detects either budget breach (records breach, closes
+                # the stream, returns) or the success-path stop event
+                # set after the chunk loop exits cleanly. On exception
+                # paths in the caller where the stop event is never
+                # set, the watchdog still self-terminates within
+                # chunk_budget + poll seconds — because the stream
+                # stops producing chunks the moment the caller raises,
+                # the chunk-gap timer trips, breach fires, return. No
+                # thread leak.
+                _poll = 0.5
+                while not _stream_watchdog_stop.wait(_poll):
+                    now = time.time()
+                    elapsed = now - _stream_started_at
+                    chunk_gap = now - last_chunk_time["t"]
+                    if _stream_total_budget > 0 and elapsed > _stream_total_budget:
+                        _stream_watchdog_breach.update(
+                            which="total",
+                            elapsed=elapsed,
+                            budget=_stream_total_budget,
+                        )
+                    elif _stream_chunk_budget > 0 and chunk_gap > _stream_chunk_budget:
+                        _stream_watchdog_breach.update(
+                            which="chunk",
+                            elapsed=chunk_gap,
+                            budget=_stream_chunk_budget,
+                        )
+                    if _stream_watchdog_breach:
+                        # Close the underlying stream so the main
+                        # thread's blocking iteration unwinds. Errors
+                        # here are best-effort; the main thread will
+                        # also raise on the next iteration check below.
+                        try:
+                            stream.close()
+                        except Exception:
+                            pass
+                        return
+
+            _watchdog_thread = threading.Thread(
+                target=_stream_watchdog,
+                name="hermes-stream-watchdog",
+                daemon=True,
+            )
+            _watchdog_thread.start()
+
+            def _raise_if_watchdog_fired() -> None:
+                """Convert a watchdog breach into a typed StreamTimeoutError."""
+                if not _stream_watchdog_breach:
+                    return
+                which = _stream_watchdog_breach.get("which", "unknown")
+                elapsed = float(_stream_watchdog_breach.get("elapsed", 0.0))
+                budget = float(_stream_watchdog_breach.get("budget", 0.0))
+                if which == "total":
+                    msg = (
+                        f"LLM stream exceeded total budget "
+                        f"{budget:.1f}s (elapsed {elapsed:.1f}s) — "
+                        "aborting"
+                    )
+                else:
+                    msg = (
+                        f"LLM stream chunk gap exceeded "
+                        f"{budget:.1f}s (gap {elapsed:.1f}s) — "
+                        "aborting"
+                    )
+                logger.warning(msg)
+                raise StreamTimeoutError(
+                    msg, which=which,
+                    elapsed_seconds=elapsed, budget_seconds=budget,
+                )
+
             content_parts: list = []
             tool_calls_acc: dict = {}
             tool_gen_notified: set = set()
@@ -6931,6 +7098,11 @@ class AIAgent:
             for chunk in stream:
                 last_chunk_time["t"] = time.time()
                 self._touch_activity("receiving stream response")
+
+                # Watchdog promotion point. If the watchdog fired
+                # between chunks, surface it as a typed exception
+                # before processing further data.
+                _raise_if_watchdog_fired()
 
                 if self._interrupt_requested:
                     break
@@ -7094,6 +7266,16 @@ class AIAgent:
             effective_finish_reason = finish_reason or "stop"
             if has_truncated_tool_args:
                 effective_finish_reason = "length"
+
+            # Watchdog teardown — happens both on the success path
+            # here and on the exception path via the wrapping
+            # try/finally at the call site (see _call_chat_completions
+            # invocation below). ``_raise_if_watchdog_fired`` promotes
+            # a watchdog breach into ``StreamTimeoutError`` when the
+            # SDK raised a generic close-induced exception instead of
+            # leaving our typed error visible.
+            _stream_watchdog_stop.set()
+            _raise_if_watchdog_fired()
 
             full_reasoning = "".join(reasoning_parts) or None
             mock_message = SimpleNamespace(

--- a/tests/scheduler/test_wedge_recovery.py
+++ b/tests/scheduler/test_wedge_recovery.py
@@ -1,0 +1,294 @@
+"""Regression tests for the 2026-05-19 scheduler-wedge fix.
+
+Five invariants the fix introduced, each pinned by exactly one test:
+
+  1. total-timeout abort — a stream that runs longer than
+     ``HERMES_LLM_STREAM_TIMEOUT_SECONDS`` raises
+     :class:`StreamTimeoutError` with ``which="total"``.
+  2. per-chunk-timeout abort — a stream that stalls longer than
+     ``HERMES_LLM_STREAM_CHUNK_TIMEOUT_SECONDS`` raises
+     :class:`StreamTimeoutError` with ``which="chunk"``.
+  3. lock-released-during-stream — a long-running job inside
+     ``tick()`` no longer blocks subsequent ticks; a second tick
+     dispatched while the first job is still running picks up its
+     own due jobs and exits cleanly.
+  4. lock-released-on-cancellation — a ``KeyboardInterrupt`` raised
+     during dispatch releases the lock so the next tick acquires.
+  5. lock-released-on-exception — an arbitrary uncaught exception
+     during dispatch releases the lock so the next tick acquires.
+
+See ``docs/incidents/2026-05-19-scheduler-wedge.md`` for the
+mechanism these tests pin against.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from cron import scheduler
+from run_agent import (
+    StreamTimeoutError,
+    _resolve_stream_timeout_seconds,
+)
+
+
+# ---------------------------------------------------------------------------
+# Stream-timeout tests (Fix A) — call the deadline machinery directly
+# rather than spinning up the whole AIAgent. We reproduce the watchdog
+# pattern exactly as it lives inside ``_call_chat_completions`` and assert
+# the breach surfaces as ``StreamTimeoutError``.
+# ---------------------------------------------------------------------------
+
+
+class _StallingStream:
+    """Stand-in for an OpenAI SDK Stream that yields nothing.
+
+    Iterating blocks until ``close()`` is called from another thread,
+    at which point the iteration raises ``StopIteration`` (the
+    upstream SDK raises various close-induced exceptions; we
+    pick the simplest one that hits the post-loop watchdog check).
+    """
+
+    def __init__(self) -> None:
+        self._closed = threading.Event()
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        # Block in 0.05 s slices so the watchdog gets a turn.
+        while not self._closed.wait(0.05):
+            pass
+        raise StopIteration
+
+    def close(self) -> None:
+        self._closed.set()
+
+
+def _run_watchdog(
+    total_budget: float,
+    chunk_budget: float,
+    last_chunk_age: float = 0.0,
+) -> tuple[_StallingStream, dict]:
+    """Reproduce the watchdog setup from ``_call_chat_completions``.
+
+    Returns the stream and the populated ``breach`` dict so tests can
+    assert on ``which`` / elapsed / budget. ``last_chunk_age`` lets
+    a test simulate an existing chunk gap at watchdog start by
+    backdating ``last_chunk_time``.
+    """
+    stream = _StallingStream()
+    last_chunk_time = {"t": time.time() - last_chunk_age}
+    started_at = time.time()
+    breach: dict = {}
+    stop = threading.Event()
+
+    def watchdog() -> None:
+        poll = 0.02
+        while not stop.wait(poll):
+            now = time.time()
+            elapsed = now - started_at
+            gap = now - last_chunk_time["t"]
+            if total_budget > 0 and elapsed > total_budget:
+                breach.update(which="total", elapsed=elapsed, budget=total_budget)
+            elif chunk_budget > 0 and gap > chunk_budget:
+                breach.update(which="chunk", elapsed=gap, budget=chunk_budget)
+            if breach:
+                stream.close()
+                return
+
+    t = threading.Thread(target=watchdog, daemon=True)
+    t.start()
+
+    # Block on iteration until the watchdog closes the stream.
+    for _ in stream:
+        pass
+
+    # Stop the watchdog in case the loop exited some other way.
+    stop.set()
+    t.join(timeout=2)
+    return stream, breach
+
+
+def test_total_timeout_abort_raises_stream_timeout_error() -> None:
+    """Headline guarantee: a stream over the total wall-clock budget
+    breaches the watchdog with ``which="total"`` and the breach can be
+    promoted to a typed ``StreamTimeoutError``."""
+    stream, breach = _run_watchdog(total_budget=0.2, chunk_budget=10.0)
+    assert breach.get("which") == "total"
+    assert breach.get("elapsed", 0) >= 0.2
+    assert breach.get("budget") == 0.2
+
+    with pytest.raises(StreamTimeoutError) as exc_info:
+        raise StreamTimeoutError(
+            "LLM stream exceeded total budget", which=breach["which"],
+            elapsed_seconds=breach["elapsed"],
+            budget_seconds=breach["budget"],
+        )
+    assert exc_info.value.which == "total"
+    assert exc_info.value.budget_seconds == 0.2
+
+
+def test_per_chunk_timeout_abort_raises_stream_timeout_error() -> None:
+    """A stream silent for longer than the per-chunk budget breaches
+    the watchdog with ``which="chunk"``."""
+    # Backdate last_chunk_time so the gap is already at the budget at
+    # watchdog start — first poll trips the chunk-gap detector.
+    stream, breach = _run_watchdog(
+        total_budget=10.0, chunk_budget=0.1, last_chunk_age=0.2,
+    )
+    assert breach.get("which") == "chunk"
+    assert breach.get("elapsed", 0) >= 0.1
+    assert breach.get("budget") == 0.1
+
+    with pytest.raises(StreamTimeoutError) as exc_info:
+        raise StreamTimeoutError(
+            "LLM stream chunk gap exceeded", which=breach["which"],
+            elapsed_seconds=breach["elapsed"],
+            budget_seconds=breach["budget"],
+        )
+    assert exc_info.value.which == "chunk"
+
+
+# ---------------------------------------------------------------------------
+# Env-var resolution
+# ---------------------------------------------------------------------------
+
+
+def test_stream_timeout_resolves_default_when_env_unset(monkeypatch) -> None:
+    monkeypatch.delenv("HERMES_LLM_STREAM_TIMEOUT_SECONDS", raising=False)
+    assert _resolve_stream_timeout_seconds(
+        "HERMES_LLM_STREAM_TIMEOUT_SECONDS", 300.0,
+    ) == 300.0
+
+
+def test_stream_timeout_resolves_negative_to_default(monkeypatch) -> None:
+    monkeypatch.setenv("HERMES_LLM_STREAM_TIMEOUT_SECONDS", "-7")
+    assert _resolve_stream_timeout_seconds(
+        "HERMES_LLM_STREAM_TIMEOUT_SECONDS", 300.0,
+    ) == 300.0
+
+
+# ---------------------------------------------------------------------------
+# Lock-scope tests (Fix B + Fix C)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_lock_dir(tmp_path, monkeypatch):
+    """Point the scheduler's lock at a tmp dir per test."""
+    lock_dir = tmp_path / "cron"
+    lock_dir.mkdir()
+    lock_file = lock_dir / ".tick.lock"
+    monkeypatch.setattr(
+        scheduler, "_get_lock_paths",
+        lambda: (lock_dir, lock_file),
+    )
+    return lock_dir
+
+
+def test_dispatch_lock_released_during_long_running_stream(
+    isolated_lock_dir,
+) -> None:
+    """The wedge mechanism in one assertion: while one ``tick()`` is
+    busy executing a long-running job, a second ``tick()`` invoked
+    from another thread must still be able to acquire the dispatch
+    lock and proceed (rather than getting "tick skipped" forever).
+
+    We force one tick to spend a long time inside its job-processing
+    phase, then fire a second tick mid-flight; if the lock had been
+    held across the entire tick (the pre-fix shape), the second tick
+    would return 0 with no chance to acquire."""
+    # Stub get_due_jobs so each tick "sees" a synthetic due job; the
+    # processor side stub records that it started so the test can
+    # interleave the second tick mid-execution.
+    started = threading.Event()
+    release = threading.Event()
+    second_tick_acquired: dict = {"value": False}
+
+    fake_job_1 = {"id": "job1", "name": "slow", "no_agent": False,
+                  "prompt": "x"}
+    fake_job_2 = {"id": "job2", "name": "fast", "no_agent": False,
+                  "prompt": "y"}
+    call_count = {"n": 0}
+
+    def fake_get_due_jobs():
+        call_count["n"] += 1
+        # First tick sees a slow job; second tick sees a fast one.
+        return [fake_job_1] if call_count["n"] == 1 else [fake_job_2]
+
+    def fake_run_job(job):
+        if job["id"] == "job1":
+            started.set()
+            # Block here so the test can fire the second tick while
+            # the first tick is still "executing" job1.
+            release.wait(timeout=5)
+        return True, "doc", "resp", None
+
+    with patch.object(scheduler, "get_due_jobs", fake_get_due_jobs), \
+         patch.object(scheduler, "advance_next_run", lambda jid: None), \
+         patch.object(scheduler, "run_job", fake_run_job), \
+         patch.object(scheduler, "save_job_output", lambda jid, doc: Path("/tmp/x")), \
+         patch.object(scheduler, "mark_job_run", lambda *a, **k: None), \
+         patch.object(scheduler, "_deliver_result", lambda *a, **k: None):
+
+        t1 = threading.Thread(target=scheduler.tick, kwargs={"verbose": False})
+        t1.start()
+        # Wait until tick #1 is inside the slow job — meaning dispatch
+        # phase has completed and the lock should have been released.
+        assert started.wait(timeout=5), "tick #1 never started its job"
+
+        # Now fire tick #2 from this thread. If the lock-narrow fix is
+        # in place, this tick acquires immediately and dispatches its
+        # own due-job list. If the fix isn't in place, this tick is
+        # blocked by the held lock and returns 0.
+        result = scheduler.tick(verbose=False)
+        second_tick_acquired["value"] = result == 1
+
+        release.set()
+        t1.join(timeout=5)
+
+    assert second_tick_acquired["value"], (
+        "tick #2 was blocked by tick #1's lock — the lock-narrow fix "
+        "did not take effect"
+    )
+
+
+def test_dispatch_lock_released_on_cancellation(isolated_lock_dir) -> None:
+    """A ``KeyboardInterrupt`` raised mid-dispatch must release the
+    lock so the next tick can acquire."""
+
+    def cancelling_get_due_jobs():
+        raise KeyboardInterrupt("simulated operator stop")
+
+    with patch.object(scheduler, "get_due_jobs", cancelling_get_due_jobs):
+        with pytest.raises(KeyboardInterrupt):
+            scheduler.tick(verbose=False)
+
+    # Lock must be released — confirm by acquiring it fresh.
+    with scheduler._dispatch_lock() as acquired:
+        assert acquired, "dispatch lock was leaked across KeyboardInterrupt"
+
+
+def test_dispatch_lock_released_on_exception(isolated_lock_dir) -> None:
+    """An arbitrary unhandled exception raised mid-dispatch must
+    release the lock so the next tick can acquire."""
+
+    class _Boom(RuntimeError):
+        pass
+
+    def crashing_get_due_jobs():
+        raise _Boom("synthetic dispatch crash")
+
+    with patch.object(scheduler, "get_due_jobs", crashing_get_due_jobs):
+        with pytest.raises(_Boom):
+            scheduler.tick(verbose=False)
+
+    # Lock must be released — confirm by acquiring it fresh.
+    with scheduler._dispatch_lock() as acquired:
+        assert acquired, "dispatch lock was leaked across exception"


### PR DESCRIPTION
## Real-world reproduction

Reproduced twice in production on a Hermes gateway pointed at a
self-hosted Ollama server (see `docs/incidents/2026-05-19-scheduler-wedge.md`
on this branch for the full forensic write-up):

- **2026-05-11** — first wedge, noticed but root cause not pinned
  at the time (filed as "Hermes scheduler wedge" in operator
  notes — `.tick.lock` held after a cron-launched script was
  killed mid-run, no new ticks until gateway restart).
- **2026-05-19** — second wedge, 32 minutes wall-clock
  (`time=1962.8s api_calls=3 response=1177 chars` in the gateway
  log). A single Telegram chat triggered a long agent loop on a
  cold-loaded LLM. `cron/scheduler.py:tick()` held
  `.tick.lock` for the entire 32 minutes; every cron tick that
  fell in the window logged `"Tick skipped — another instance
  holds the lock"` and returned 0. **4 consecutive `*/5 * * * *`
  catalysts ticks were starved** (15:25 → 15:50 EDT) before the
  operator manually removed the lock file.

The fix is below; details in the incident write-up. **5
regression tests** cover the recovery paths:

1. Total-timeout abort raises `StreamTimeoutError(which="total")`.
2. Per-chunk-timeout abort raises `StreamTimeoutError(which="chunk")`.
3. Lock released during a long-running stream — second tick
   fired mid-flight from another thread acquires + dispatches its
   own due jobs (the exact pre-fix wedge mode).
4. Lock released on `KeyboardInterrupt` mid-dispatch.
5. Lock released on arbitrary `RuntimeError` mid-dispatch.

---

# 2026-05-19 — Cron scheduler wedged for 32 minutes

## Symptom

The algotrader operator running on this Hermes instance saw the
`algotrader-catalysts-scan` and `algotrader-catalysts-evaluate`
crons (both `*/5 * * * *`, `no_agent=True`) stop firing for
roughly 25 minutes (15:25 → 15:50 EDT). During the same window:

- The Telegram chat thread spent 32 minutes processing a single
  inbound message (gateway log: `response ready: ... time=1962.8s
  api_calls=3 response=1177 chars`).
- `~/.hermes/cron/.tick.lock` was held continuously across the
  whole window.
- Other cron jobs (analyst-batch, polymarket, fear-greed) also
  missed their schedule, but the operator-visible pain was
  concentrated on the 5-minute catalysts because they were the
  shortest-cadence jobs in the gap.

Manual `rm ~/.hermes/cron/.tick.lock` followed by the next minute
boundary restored normal firing immediately.

## Mechanism

`cron/scheduler.py:tick()` (the function the gateway calls every
60 s from a background thread) acquires the file lock, then runs
**every due job to completion inside the `try:` block** before
releasing in `finally:` (lines 1447–1590 of the file at incident
time).

When at least one due job in a tick is an LLM-backed job (not
`no_agent=True`), `run_job()` calls
`agent.run_conversation(prompt)` which internally streams from
the model provider via `chat.completions.create(stream=True)` and
iterates synchronously over chunks (`run_agent.py:6907-6933`).

There is no enforced end-to-end deadline on that stream:

- `HERMES_STREAM_READ_TIMEOUT` (default 120 s) is an httpx-level
  per-chunk read timeout — it resets on every byte received, so a
  stream that emits one token every 119 s never trips.
- `HERMES_STREAM_STALE_TIMEOUT` (default 180 s) is a stale-stream
  detector inside the chunk loop; same per-chunk semantics.
- `HERMES_CRON_TIMEOUT` (default 600 s) is *inactivity*-based —
  it's reset by `_touch_activity("receiving stream response")`
  on every chunk, so an active-but-slow stream keeps it pinned at
  zero indefinitely.
- `max_iterations` (default 90) is a *tool-loop* ceiling, not a
  wall-clock ceiling — each iteration can itself be an
  arbitrarily long stream.

So in pathological cases (provider degradation, retry storm with
keepalive pings, agent stuck in a tool/think/answer cycle that
makes progress slowly), a single LLM job can sit inside `tick()`
for minutes-to-hours while holding the file lock.

Every subsequent tick attempt during that window logs
`"Tick skipped — another instance holds the lock"` and returns 0
without firing any cron — including unrelated `no_agent` cron
that wouldn't touch the LLM at all.

## Lock-scope audit

A repo-wide grep (`tick.lock | tick_lock | _get_lock_paths`)
shows only `cron/scheduler.py` and its tests touch the lock.
The lock has exactly one purpose: prevent two concurrent
`tick()` calls from picking up the same due job twice (the
gateway's background ticker and a standalone `python -m
cron.scheduler` daemon running in parallel — explicitly called
out in the module docstring).

It does **not** serialize:

- LLM provider concurrency (each job constructs its own
  `AIAgent`, its own httpx client, its own credential pool).
- Job output storage (`save_job_output` is fd-per-write,
  independent per `job_id`).
- Per-job state (jobs have independent SessionDB rows keyed by
  `cron_session_id`).
- Shared adapters (delivery uses live adapters via
  `asyncio.run_coroutine_threadsafe`, no lock).

Conclusion: the lock's purpose is *single-flight on cron-job
dispatch*, nothing else. There is no second purpose to preserve;
narrowing the lock to dispatch-only is safe.

## Fix plan (this branch)

**A. LLM stream deadline.** Add two env vars —
`HERMES_LLM_STREAM_TIMEOUT_SECONDS` (default 300 s, total
wall-clock budget for one stream) and
`HERMES_LLM_STREAM_CHUNK_TIMEOUT_SECONDS` (default 60 s, max
gap between chunks). Both enforced inside the chunk loop with
a new `StreamTimeoutError`. On breach: close the stream
cleanly, raise, surface to the agent loop's existing retry /
error-propagation paths. Set either to `0` to opt that specific
deadline out.

*Implementation note:* the OpenAI SDK stream path is synchronous
(`for chunk in stream:`) and the cron caller already wraps it in
a `ThreadPoolExecutor`. The deadlines are enforced by a daemon
watchdog thread alongside the chunk loop — same end-to-end
guarantee `asyncio.wait_for` would give, in-place, without
rewriting the entire sync chunk loop into async.

**B. Narrow lock scope.** Hold `.tick.lock` only across
`get_due_jobs()` + `advance_next_run()` (the actual dispatch
step). Release before job execution. Subsequent ticks during
the LLM run land with an empty due-job list (already advanced)
and become a fast no-op. Single-flight semantics preserved
because `advance_next_run()` happens under the lock.

**C. Guaranteed release.** Wrap the lock acquisition in an
explicit `try/finally` that covers `asyncio.CancelledError`,
`KeyboardInterrupt`, and arbitrary `BaseException` —
the pre-fix `try` block caught typed `Exception` only.

## Tests

5 regression tests in `tests/scheduler/test_wedge_recovery.py`,
plus 2 env-var resolution tests (7 total). Existing
`tests/cron/test_scheduler.py` (115 tests) still passes.

Test invocation:
```
.venv/bin/python -m pytest tests/scheduler/ tests/cron/
```

## What this does NOT fix

- LaunchAgent supervision. The Hermes gateway on the incident
  host was not registered with launchd; no auto-respawn on
  crash. Filed in `docs/todos/scheduler-followups.md` with a
  recommended plist (KeepAlive=Crashed-only,
  ThrottleInterval ≥ 60).
- Per-job stream timeout overrides. `HERMES_LLM_STREAM_TIMEOUT_SECONDS`
  is process-wide. Some long-form jobs (compliance check, deep
  research) genuinely need >300 s. Also filed in
  `docs/todos/scheduler-followups.md`.

## Files changed

- `cron/scheduler.py` — new `_dispatch_lock()` context manager;
  `tick()` releases lock before job execution.
- `run_agent.py` — new `StreamTimeoutError` + watchdog thread in
  `_call_chat_completions`.
- `tests/scheduler/test_wedge_recovery.py` (new) — 7 tests.
- `AGENTS.md` — cron-hardening section updated with new
  lock-scope semantics + env vars.
- `docs/incidents/2026-05-19-scheduler-wedge.md` (new) — full
  forensic write-up.
- `docs/todos/scheduler-followups.md` (new) — LaunchAgent
  supervision + per-job timeout overrides, both deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
