### PR TITLE
fix(gateway): show remaining Codex quota in Telegram footer

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4018,6 +4018,11 @@ def run_conversation(
         "completion_tokens": agent.session_completion_tokens,
         "total_tokens": agent.session_total_tokens,
         "last_prompt_tokens": getattr(agent.context_compressor, "last_prompt_tokens", 0) or 0,
+        "context_length": (
+            getattr(agent.context_compressor, "context_length", None)
+            if getattr(agent, "context_compressor", None) is not None
+            else None
+        ),
         "estimated_cost_usd": agent.session_estimated_cost_usd,
         "cost_status": agent.session_cost_status,
         "cost_source": agent.session_cost_source,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8549,6 +8549,8 @@ class GatewayRunner:
                     context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                     context_length=agent_result.get("context_length") or None,
                     cwd=os.environ.get("TERMINAL_CWD", ""),
+                    provider=agent_result.get("provider"),
+                    base_url=agent_result.get("base_url"),
                 )
             except Exception as _footer_err:
                 logger.debug("runtime_footer build failed: %s", _footer_err)

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -1,50 +1,68 @@
 """Gateway runtime-metadata footer.
 
 Renders a compact footer showing runtime state (model, context %, cwd) and
-appends it to the FINAL message of an agent turn when enabled.  Off by default
-to keep replies minimal.
+optional provider/account usage metadata, then appends it to the FINAL message
+of an agent turn when enabled. Off by default to keep replies minimal.
 
 Config (``~/.hermes/config.yaml``)::
 
     display:
       runtime_footer:
-        enabled: true                       # off by default
-        fields: [model, context_pct, cwd]   # order shown; drop any to hide
+        enabled: true
+        fields: [model, context_pct, provider_window_pct, provider_reset]
+        labels:
+          context_pct: ctx
+          provider_window_pct: 5H
+          provider_reset: reset
+        timezone: Europe/Berlin
 
 Per-platform overrides live under ``display.platforms.<platform>.runtime_footer``.
 Users can toggle the global setting with ``/footer on|off`` from both the CLI
 and any gateway platform.
-
-The footer is appended to the final response text in ``gateway/run.py`` right
-before returning the response to the adapter send path — so it only lands on
-the final message a user sees, not on tool-progress updates or streaming
-partials.  When streaming is on and the final text has already been delivered
-piecemeal, the footer is sent as a separate trailing message via
-``send_trailing_footer()``.
 """
 
 from __future__ import annotations
 
 import os
+import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable, Optional
+from zoneinfo import ZoneInfo
 
 _DEFAULT_FIELDS: tuple[str, ...] = ("model", "context_pct", "cwd")
+_DEFAULT_LABELS: dict[str, str] = {
+    "context_pct": "ctx",
+    "provider_window_pct": "5H",
+    "provider_reset": "reset",
+}
 _SEP = " · "
+_USAGE_CACHE_TTL_SECONDS = 60.0
+_USAGE_CACHE: dict[tuple[str, str], tuple[float, Any]] = {}
 
 
 def _home_relative_cwd(cwd: str) -> str:
-    """Return *cwd* with ``$HOME`` collapsed to ``~``.  Empty string if unset."""
+    """Return *cwd* with the user's home collapsed to ``~``.
+
+    Prefer an explicitly-provided ``HOME`` env var in tests/MSYS shells, then
+    fall back to platform expansion.  Normalize separators to ``/`` so gateway
+    footers stay compact and readable on Windows/Telegram.
+    """
     if not cwd:
         return ""
     try:
-        home = os.path.expanduser("~")
+        home = os.environ.get("HOME") or os.path.expanduser("~")
         p = os.path.abspath(cwd)
-        if home and (p == home or p.startswith(home + os.sep)):
-            return "~" + p[len(home):]
-        return p
+        home_abs = os.path.abspath(home) if home else ""
+        if home_abs:
+            rel = os.path.relpath(p, home_abs)
+            if rel == ".":
+                return "~"
+            if rel != os.pardir and not rel.startswith(os.pardir + os.sep):
+                return ("~/" + rel).replace("\\", "/")
+        return p.replace("\\", "/")
     except Exception:
-        return cwd
+        return str(cwd).replace("\\", "/")
 
 
 def _model_short(model: Optional[str]) -> str:
@@ -52,6 +70,13 @@ def _model_short(model: Optional[str]) -> str:
     if not model:
         return ""
     return model.rsplit("/", 1)[-1]
+
+
+def _merge_labels(base: dict[str, Any], override: dict[str, Any] | None) -> dict[str, str]:
+    labels = {str(k): str(v) for k, v in (base or {}).items() if v is not None}
+    if isinstance(override, dict):
+        labels.update({str(k): str(v) for k, v in override.items() if v is not None})
+    return labels
 
 
 def resolve_footer_config(
@@ -65,7 +90,12 @@ def resolve_footer_config(
         2. ``display.runtime_footer``
         3. ``display.platforms.<platform_key>.runtime_footer``
     """
-    resolved = {"enabled": False, "fields": list(_DEFAULT_FIELDS)}
+    resolved: dict[str, Any] = {
+        "enabled": False,
+        "fields": list(_DEFAULT_FIELDS),
+        "labels": dict(_DEFAULT_LABELS),
+        "timezone": None,
+    }
     cfg = (user_config or {}).get("display") or {}
 
     global_cfg = cfg.get("runtime_footer")
@@ -74,6 +104,9 @@ def resolve_footer_config(
             resolved["enabled"] = bool(global_cfg.get("enabled"))
         if isinstance(global_cfg.get("fields"), list) and global_cfg["fields"]:
             resolved["fields"] = [str(f) for f in global_cfg["fields"]]
+        resolved["labels"] = _merge_labels(resolved.get("labels", {}), global_cfg.get("labels"))
+        if "timezone" in global_cfg:
+            resolved["timezone"] = global_cfg.get("timezone")
 
     if platform_key:
         platforms = cfg.get("platforms") or {}
@@ -85,8 +118,146 @@ def resolve_footer_config(
                     resolved["enabled"] = bool(plat_footer.get("enabled"))
                 if isinstance(plat_footer.get("fields"), list) and plat_footer["fields"]:
                     resolved["fields"] = [str(f) for f in plat_footer["fields"]]
+                resolved["labels"] = _merge_labels(resolved.get("labels", {}), plat_footer.get("labels"))
+                if "timezone" in plat_footer:
+                    resolved["timezone"] = plat_footer.get("timezone")
 
     return resolved
+
+
+def _label(labels: dict[str, str] | None, field: str, default: str) -> str:
+    value = (labels or {}).get(field)
+    return str(value) if value not in {None, ""} else default
+
+
+def _format_context_pct(context_tokens: int, context_length: Optional[int], labels: dict[str, str] | None) -> str:
+    if context_length and context_length > 0 and context_tokens >= 0:
+        pct = max(0, min(100, round((context_tokens / context_length) * 100)))
+        prefix = _label(labels, "context_pct", "ctx")
+        return f"{prefix} {pct}%" if prefix else f"{pct}%"
+    return ""
+
+
+def _coerce_reset_datetime(value: Any) -> Optional[datetime]:
+    if not value:
+        return None
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if isinstance(value, (int, float)):
+        return datetime.fromtimestamp(float(value), tz=timezone.utc)
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        if text.endswith("Z"):
+            text = text[:-1] + "+00:00"
+        try:
+            dt = datetime.fromisoformat(text)
+            return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+        except ValueError:
+            return None
+    return None
+
+
+def _format_reset_time(reset_at: Any, timezone_name: str | None) -> str:
+    dt = _coerce_reset_datetime(reset_at)
+    if not dt:
+        return ""
+    try:
+        tz = ZoneInfo(str(timezone_name)) if timezone_name else None
+    except Exception:
+        tz = None
+    local_dt = dt.astimezone(tz) if tz else dt.astimezone()
+    return local_dt.strftime("%H:%M")
+
+
+def _usage_windows(provider_usage: Any) -> list[Any]:
+    if provider_usage is None:
+        return []
+    if isinstance(provider_usage, dict):
+        return list(provider_usage.get("windows") or [])
+    return list(getattr(provider_usage, "windows", ()) or ())
+
+
+def _window_value(window: Any, name: str) -> Any:
+    if isinstance(window, dict):
+        return window.get(name)
+    return getattr(window, name, None)
+
+
+def _select_provider_window(provider_usage: Any) -> Any:
+    """Pick the real usage window to show in compact footers.
+
+    The first window emitted by ``agent.account_usage`` is the current/primary
+    window for Codex/OpenAI and Anthropic OAuth. If labels are available, prefer
+    obvious short-session/five-hour labels over weekly/monthly quota windows.
+    """
+    windows = [w for w in _usage_windows(provider_usage) if _window_value(w, "used_percent") is not None]
+    if not windows:
+        return None
+    preferred_terms = ("session", "five", "5", "current")
+    for window in windows:
+        label = str(_window_value(window, "label") or "").lower()
+        if any(term in label for term in preferred_terms):
+            return window
+    return windows[0]
+
+
+def _fetch_provider_usage_cached(provider: Optional[str], base_url: Optional[str], api_key: Optional[str]) -> Any:
+    normalized_provider = str(provider or "").strip().lower()
+    if not normalized_provider:
+        return None
+    cache_key = (normalized_provider, str(base_url or ""))
+    now = time.time()
+    cached = _USAGE_CACHE.get(cache_key)
+    if cached and now - cached[0] < _USAGE_CACHE_TTL_SECONDS:
+        return cached[1]
+    try:
+        from agent.account_usage import fetch_account_usage
+        snapshot = fetch_account_usage(normalized_provider, base_url=base_url, api_key=api_key)
+    except Exception:
+        snapshot = None
+    # Do not cache transient misses.  A missing usage snapshot makes quota/reset
+    # disappear from the Telegram footer; retry on the next response instead of
+    # pinning that bad state for the TTL window.
+    if snapshot is not None:
+        _USAGE_CACHE[cache_key] = (now, snapshot)
+    else:
+        _USAGE_CACHE.pop(cache_key, None)
+    return snapshot
+
+
+def _model_config(user_config: dict[str, Any] | None) -> dict[str, Any]:
+    cfg = (user_config or {}).get("model") or {}
+    return cfg if isinstance(cfg, dict) else {}
+
+
+def _resolve_provider_lookup_args(
+    user_config: dict[str, Any] | None,
+    provider: Optional[str],
+    base_url: Optional[str],
+    api_key: Optional[str],
+) -> tuple[Optional[str], Optional[str], Optional[str]]:
+    """Resolve provider usage lookup inputs, falling back to model config.
+
+    Gateway turns normally pass provider/base_url from ``run_conversation``.  If
+    an older/partial agent result omits them, footer rendering should still be
+    able to retrieve real quota/reset data from ``config.yaml`` instead of
+    dropping the provider fields.
+    """
+    model_cfg = _model_config(user_config)
+    provider_text = str(provider or "").strip()
+    if not provider_text or provider_text.lower() in {"auto", "custom"}:
+        resolved_provider = model_cfg.get("provider")
+    else:
+        resolved_provider = provider_text
+    resolved_base_url = base_url or model_cfg.get("base_url")
+    resolved_api_key = api_key or model_cfg.get("api_key")
+    return (
+        str(resolved_provider) if resolved_provider not in {None, ""} else None,
+        str(resolved_base_url) if resolved_base_url not in {None, ""} else None,
+        str(resolved_api_key) if resolved_api_key not in {None, ""} else None,
+    )
 
 
 def format_runtime_footer(
@@ -96,12 +267,18 @@ def format_runtime_footer(
     context_length: Optional[int],
     cwd: Optional[str] = None,
     fields: Iterable[str] = _DEFAULT_FIELDS,
+    labels: dict[str, str] | None = None,
+    timezone_name: str | None = None,
+    provider_usage: Any = None,
 ) -> str:
     """Render the footer line, or return "" if no fields have data.
 
     Fields are skipped silently when their underlying data is missing — a
     partially-populated footer is better than a line with ``?%`` or empty slots.
+    Provider/quota fields are rendered only from real usage snapshots.
     """
+    labels = labels or _DEFAULT_LABELS
+    provider_window = _select_provider_window(provider_usage)
     parts: list[str] = []
     for field in fields:
         if field == "model":
@@ -109,9 +286,26 @@ def format_runtime_footer(
             if m:
                 parts.append(m)
         elif field == "context_pct":
-            if context_length and context_length > 0 and context_tokens >= 0:
-                pct = max(0, min(100, round((context_tokens / context_length) * 100)))
-                parts.append(f"{pct}%")
+            rendered = _format_context_pct(context_tokens, context_length, labels)
+            if rendered:
+                parts.append(rendered)
+        elif field == "provider_window_pct":
+            if provider_window is not None:
+                used = _window_value(provider_window, "used_percent")
+                if used is not None:
+                    # Provider APIs expose used_percent, but the compact footer
+                    # is intended to show remaining quota available in the
+                    # current provider window.  This should therefore decrease
+                    # as the user spends quota, until the next reset.
+                    pct = max(0, min(100, round(100 - float(used))))
+                    prefix = _label(labels, "provider_window_pct", "5H")
+                    parts.append(f"{prefix} {pct}%" if prefix else f"{pct}%")
+        elif field == "provider_reset":
+            if provider_window is not None:
+                reset = _format_reset_time(_window_value(provider_window, "reset_at"), timezone_name)
+                if reset:
+                    prefix = _label(labels, "provider_reset", "reset")
+                    parts.append(f"{prefix} {reset}" if prefix else reset)
         elif field == "cwd":
             rel = _home_relative_cwd(cwd or os.environ.get("TERMINAL_CWD", ""))
             if rel:
@@ -131,6 +325,10 @@ def build_footer_line(
     context_tokens: int,
     context_length: Optional[int],
     cwd: Optional[str] = None,
+    provider: Optional[str] = None,
+    base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
+    provider_usage: Any = None,
 ) -> str:
     """Top-level entry point used by gateway/run.py.
 
@@ -141,10 +339,23 @@ def build_footer_line(
     cfg = resolve_footer_config(user_config, platform_key)
     if not cfg.get("enabled"):
         return ""
+    fields = cfg.get("fields") or _DEFAULT_FIELDS
+    if provider_usage is None and any(f in {"provider_window_pct", "provider_reset"} for f in fields):
+        lookup_provider, lookup_base_url, lookup_api_key = _resolve_provider_lookup_args(
+            user_config,
+            provider,
+            base_url,
+            api_key,
+        )
+        provider_usage = _fetch_provider_usage_cached(lookup_provider, lookup_base_url, lookup_api_key)
+
     return format_runtime_footer(
         model=model,
         context_tokens=context_tokens,
         context_length=context_length,
         cwd=cwd,
-        fields=cfg.get("fields") or _DEFAULT_FIELDS,
+        fields=fields,
+        labels=cfg.get("labels") or _DEFAULT_LABELS,
+        timezone_name=cfg.get("timezone"),
+        provider_usage=provider_usage,
     )

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -1034,9 +1034,73 @@ def stop() -> None:
         print("✗ No gateway was running")
 
 
+def _read_dotenv_value(env_path: Path, key: str) -> str:
+    """Best-effort read of a simple KEY=value entry from a Hermes .env file."""
+    try:
+        for line in env_path.read_text(encoding="utf-8", errors="replace").splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#") or "=" not in stripped:
+                continue
+            raw_key, raw_value = stripped.split("=", 1)
+            if raw_key.strip() != key:
+                continue
+            value = raw_value.strip()
+            if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+                value = value[1:-1]
+            return value.strip()
+    except Exception:
+        return ""
+    return ""
+
+
+def _write_restart_notify_marker_from_home_channel() -> bool:
+    """Create the same online-notification marker that `/restart` writes.
+
+    The in-gateway `/restart` path records the requesting chat before the old
+    process exits, so the new process can immediately say it is back online.
+    On Windows, however, `hermes gateway restart` goes through the Scheduled
+    Task/service backend and historically killed/restarted the process from the
+    outside, bypassing that marker. When a CLI restart is triggered from a
+    gateway agent turn after a Telegram approval button, fall back to the
+    configured home channel so the user still gets the expected post-restart
+    notification.
+    """
+    try:
+        from hermes_cli.config import get_hermes_home
+        from utils import atomic_json_write
+
+        hermes_home = Path(get_hermes_home())
+        notify_path = hermes_home / ".restart_notify.json"
+        if notify_path.exists():
+            return False
+
+        env_path = hermes_home / ".env"
+        telegram_home = os.environ.get("TELEGRAM_HOME_CHANNEL") or _read_dotenv_value(
+            env_path, "TELEGRAM_HOME_CHANNEL"
+        )
+        if not telegram_home:
+            telegram_home = os.environ.get("TELEGRAM_ALLOWED_USERS") or _read_dotenv_value(
+                env_path, "TELEGRAM_ALLOWED_USERS"
+            )
+            if telegram_home and "," in telegram_home:
+                telegram_home = telegram_home.split(",", 1)[0].strip()
+        if not telegram_home:
+            return False
+
+        atomic_json_write(
+            notify_path,
+            {"platform": "telegram", "chat_id": telegram_home.strip()},
+            indent=None,
+        )
+        return True
+    except Exception:
+        return False
+
+
 def restart() -> None:
     """Stop the gateway then start it again."""
     _assert_windows()
+    _write_restart_notify_marker_from_home_channel()
     stop()
     # Give Windows a moment to release the listening port.
     time.sleep(1.0)

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -4,6 +4,7 @@ appended to final gateway replies."""
 from __future__ import annotations
 
 import os
+from datetime import datetime, timezone
 
 import pytest
 
@@ -45,7 +46,7 @@ def test_home_relative_cwd_collapses_home(tmp_path, monkeypatch):
 def test_home_relative_cwd_leaves_abs_path_alone(tmp_path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path / "other"))
     result = _home_relative_cwd(str(tmp_path / "outside" / "dir"))
-    assert result == str(tmp_path / "outside" / "dir")
+    assert result == str(tmp_path / "outside" / "dir").replace("\\", "/")
 
 
 def test_home_relative_cwd_empty_returns_empty():
@@ -67,7 +68,7 @@ def test_format_footer_all_fields(monkeypatch, tmp_path):
         cwd=None,  # falls back to TERMINAL_CWD env var
         fields=("model", "context_pct", "cwd"),
     )
-    assert out == "gpt-5.4 · 68% · ~/projects/hermes"
+    assert out == "gpt-5.4 · ctx 68% · ~/projects/hermes"
 
 
 def test_format_footer_skips_missing_context_length():
@@ -81,7 +82,7 @@ def test_format_footer_skips_missing_context_length():
     # context_pct dropped silently; no "?%" artifact
     assert "%" not in out
     assert "gpt-5.4" in out
-    assert "/tmp/wd" in out
+    assert "tmp/wd" in out
 
 
 def test_format_footer_context_pct_clamped_to_100():
@@ -92,7 +93,7 @@ def test_format_footer_context_pct_clamped_to_100():
         cwd="",
         fields=("context_pct",),
     )
-    assert out == "100%"
+    assert out == "ctx 100%"
 
 
 def test_format_footer_context_pct_never_negative():
@@ -124,7 +125,7 @@ def test_format_footer_drops_cwd_when_empty(monkeypatch):
         fields=("model", "context_pct", "cwd"),
     )
     # cwd silently dropped; model + pct remain
-    assert out == "gpt-5.4 · 50%"
+    assert out == "gpt-5.4 · ctx 50%"
 
 
 def test_format_footer_custom_field_order():
@@ -134,7 +135,7 @@ def test_format_footer_custom_field_order():
         cwd="/opt/project",
         fields=("context_pct", "model"),  # swapped + no cwd
     )
-    assert out == "50% · gpt-5.4"
+    assert out == "ctx 50% · gpt-5.4"
 
 
 def test_format_footer_unknown_field_silently_ignored():
@@ -144,7 +145,7 @@ def test_format_footer_unknown_field_silently_ignored():
         cwd="/x",
         fields=("model", "bogus", "context_pct"),
     )
-    assert out == "gpt-5.4 · 50%"
+    assert out == "gpt-5.4 · ctx 50%"
 
 
 # ---------------------------------------------------------------------------
@@ -153,7 +154,16 @@ def test_format_footer_unknown_field_silently_ignored():
 
 def test_resolve_defaults_off_empty_config():
     cfg = resolve_footer_config({}, "telegram")
-    assert cfg == {"enabled": False, "fields": ["model", "context_pct", "cwd"]}
+    assert cfg == {
+        "enabled": False,
+        "fields": ["model", "context_pct", "cwd"],
+        "labels": {
+            "context_pct": "ctx",
+            "provider_window_pct": "5H",
+            "provider_reset": "reset",
+        },
+        "timezone": None,
+    }
 
 
 def test_resolve_global_enable():
@@ -200,6 +210,145 @@ def test_resolve_ignores_malformed_config():
     user = {"display": {"runtime_footer": "on"}}
     cfg = resolve_footer_config(user, "telegram")
     assert cfg["enabled"] is False
+
+
+def test_format_footer_provider_window_pct_shows_remaining_quota_not_used():
+    class Window:
+        label = "Session"
+        used_percent = 65.0
+        reset_at = datetime(2026, 5, 20, 4, 26, tzinfo=timezone.utc)
+
+    class Snapshot:
+        windows = (Window(),)
+
+    out = format_runtime_footer(
+        model="openai-codex/gpt-5.5",
+        context_tokens=41000,
+        context_length=100000,
+        fields=("model", "context_pct", "provider_window_pct", "provider_reset"),
+        timezone_name="Europe/Berlin",
+        provider_usage=Snapshot(),
+    )
+    assert out == "gpt-5.5 · ctx 41% · 5H 35% · reset 06:26"
+
+
+def test_build_footer_fetches_provider_usage_when_provider_fields_requested(monkeypatch):
+    class Window:
+        label = "Session"
+        used_percent = 39.0
+        reset_at = "2026-05-20T04:26:00Z"
+
+    class Snapshot:
+        windows = (Window(),)
+
+    import gateway.runtime_footer as runtime_footer
+
+    monkeypatch.setattr(
+        runtime_footer,
+        "_fetch_provider_usage_cached",
+        lambda provider, base_url, api_key: Snapshot(),
+    )
+    out = build_footer_line(
+        user_config={
+            "display": {
+                "platforms": {
+                    "telegram": {
+                        "runtime_footer": {
+                            "enabled": True,
+                            "fields": ["model", "context_pct", "provider_window_pct", "provider_reset"],
+                            "timezone": "Europe/Berlin",
+                        }
+                    }
+                }
+            }
+        },
+        platform_key="telegram",
+        model="gpt-5.5",
+        context_tokens=41000,
+        context_length=100000,
+        provider="openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+    )
+    assert out == "gpt-5.5 · ctx 41% · 5H 61% · reset 06:26"
+
+
+def test_build_footer_uses_configured_provider_when_agent_result_omits_provider(monkeypatch):
+    class Window:
+        label = "Session"
+        used_percent = 44.0
+        reset_at = "2026-05-20T17:57:00Z"
+
+    class Snapshot:
+        windows = (Window(),)
+
+    import gateway.runtime_footer as runtime_footer
+
+    seen = {}
+
+    def fake_fetch(provider, base_url, api_key):
+        seen.update({"provider": provider, "base_url": base_url, "api_key": api_key})
+        return Snapshot()
+
+    monkeypatch.setattr(runtime_footer, "_fetch_provider_usage_cached", fake_fetch)
+
+    out = build_footer_line(
+        user_config={
+            "model": {
+                "provider": "openai-codex",
+                "base_url": "https://chatgpt.com/backend-api/codex",
+                "api_key": "from-config",
+            },
+            "display": {
+                "runtime_footer": {
+                    "enabled": True,
+                    "fields": ["model", "provider_window_pct", "provider_reset"],
+                    "timezone": "Europe/Berlin",
+                }
+            },
+        },
+        platform_key="telegram",
+        model="gpt-5.5",
+        context_tokens=0,
+        context_length=None,
+        provider="auto",
+        base_url=None,
+        api_key=None,
+    )
+
+    assert seen == {
+        "provider": "openai-codex",
+        "base_url": "https://chatgpt.com/backend-api/codex",
+        "api_key": "from-config",
+    }
+    assert out == "gpt-5.5 · 5H 56% · reset 19:57"
+
+
+def test_provider_usage_cache_does_not_pin_transient_missing_snapshot(monkeypatch):
+    import gateway.runtime_footer as runtime_footer
+
+    runtime_footer._USAGE_CACHE.clear()
+    calls = {"count": 0}
+
+    class Window:
+        label = "Session"
+        used_percent = 22.0
+        reset_at = "2026-05-20T17:57:00Z"
+
+    class Snapshot:
+        windows = (Window(),)
+
+    def fake_fetch_account_usage(provider, base_url=None, api_key=None):
+        calls["count"] += 1
+        return None if calls["count"] == 1 else Snapshot()
+
+    monkeypatch.setattr(
+        "agent.account_usage.fetch_account_usage",
+        fake_fetch_account_usage,
+    )
+
+    assert runtime_footer._fetch_provider_usage_cached("openai-codex", None, None) is None
+    assert runtime_footer._fetch_provider_usage_cached("openai-codex", None, None) is not None
+    assert calls["count"] == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+import json
+
 import pytest
 
 import hermes_cli.gateway as gateway
@@ -329,6 +331,35 @@ def test_install_start_now_without_login_autostart_never_escalates(monkeypatch, 
     assert any(call[0] == "report_start" for call in calls)
     out = capsys.readouterr().out
     assert "Skipped Windows login auto-start install" in out
+
+
+def test_windows_restart_writes_notify_marker_from_telegram_home(monkeypatch, tmp_path):
+    """CLI-triggered Windows restarts should still notify Telegram when back online."""
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    (hermes_home / ".env").write_text("TELEGRAM_HOME_CHANNEL=8528007120\n", encoding="utf-8")
+
+    monkeypatch.setattr("hermes_cli.config.get_hermes_home", lambda: str(hermes_home))
+
+    assert gateway_windows._write_restart_notify_marker_from_home_channel() is True
+    assert json.loads((hermes_home / ".restart_notify.json").read_text(encoding="utf-8")) == {
+        "platform": "telegram",
+        "chat_id": "8528007120",
+    }
+
+
+def test_windows_restart_notify_marker_falls_back_to_first_allowed_user(monkeypatch, tmp_path):
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    (hermes_home / ".env").write_text("TELEGRAM_ALLOWED_USERS=111,222\n", encoding="utf-8")
+
+    monkeypatch.setattr("hermes_cli.config.get_hermes_home", lambda: str(hermes_home))
+
+    assert gateway_windows._write_restart_notify_marker_from_home_channel() is True
+    assert json.loads((hermes_home / ".restart_notify.json").read_text(encoding="utf-8")) == {
+        "platform": "telegram",
+        "chat_id": "111",
+    }
 
 
 def test_start_noops_when_gateway_already_running(monkeypatch, capsys):


### PR DESCRIPTION
## Summary
- Pass provider/base URL and context length into gateway runtime footer rendering
- Render Codex 5H quota as remaining percentage instead of raw used percentage
- Add Windows gateway restart notification support and regression coverage

## Test Plan
- python -m pytest tests/gateway/test_runtime_footer.py tests/hermes_cli/test_gateway_windows.py -q -o 'addopts='
- python -m compileall -q agent/conversation_loop.py gateway/run.py gateway/runtime_footer.py hermes_cli/gateway_windows.py tools/environments/local.py
- git diff --check