### PR TITLE
feat(cli): add parseable model listing

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1774,8 +1774,43 @@ def cmd_postinstall(args):
         print("✓ Post-install complete.")
 
 
+def _print_model_list(args) -> None:
+    """Print provider model metadata for non-interactive consumers."""
+    from hermes_cli.models import list_available_providers, provider_model_ids
+
+    action = getattr(args, "model_action", None)
+    json_output = bool(getattr(args, "json_output", False))
+    if action == "providers":
+        providers = list_available_providers()
+        if json_output:
+            print(json.dumps(providers, ensure_ascii=False))
+            return
+        for provider in providers:
+            auth = (
+                "authenticated"
+                if provider.get("authenticated")
+                else "not-authenticated"
+            )
+            print(f"{provider.get('id', '')}\t{provider.get('label', '')}\t{auth}")
+        return
+
+    provider = str(getattr(args, "provider", "") or "").strip()
+    models = provider_model_ids(
+        provider,
+        force_refresh=bool(getattr(args, "force_refresh", False)),
+    )
+    if json_output:
+        print(json.dumps(models, ensure_ascii=False))
+        return
+    for model_id in models:
+        print(model_id)
+
+
 def cmd_model(args):
-    """Select default model — starts with provider selection, then model picker."""
+    """Select default model, or print model metadata in non-interactive mode."""
+    if getattr(args, "model_action", None) in {"list", "providers"}:
+        _print_model_list(args)
+        return
     _require_tty("model")
     select_provider_and_model(args=args)
 
@@ -10463,6 +10498,41 @@ def main():
         "--insecure",
         action="store_true",
         help="Disable TLS verification for Nous login (testing only)",
+    )
+    model_subparsers = model_parser.add_subparsers(dest="model_action")
+
+    model_list_parser = model_subparsers.add_parser(
+        "list",
+        help="List known model IDs for a provider",
+        description="Print a non-interactive model list for a provider.",
+    )
+    model_list_parser.add_argument(
+        "--provider",
+        required=True,
+        help="Provider ID to list models for, e.g. openai-codex",
+    )
+    model_list_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Print a JSON array instead of one model ID per line",
+    )
+    model_list_parser.add_argument(
+        "--force-refresh",
+        action="store_true",
+        help="Bypass provider model cache where supported",
+    )
+
+    model_providers_parser = model_subparsers.add_parser(
+        "providers",
+        help="List providers accepted by provider:model syntax",
+        description="Print non-interactive provider metadata.",
+    )
+    model_providers_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Print a JSON array instead of a tab-separated table",
     )
     model_parser.set_defaults(func=cmd_model)
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1625,8 +1625,11 @@ def list_available_providers() -> list[dict[str, str]]:
     Derives the provider list from :data:`CANONICAL_PROVIDERS` (single
     source of truth shared with ``hermes model``, ``/model``, etc.).
     """
-    # Derive display order from canonical list + custom
-    provider_order = [p.slug for p in CANONICAL_PROVIDERS] + ["custom"]
+    # Derive display order from canonical list + custom, preserving order while
+    # avoiding duplicate rows when custom is already in the canonical list.
+    provider_order = list(
+        dict.fromkeys([p.slug for p in CANONICAL_PROVIDERS] + ["custom"])
+    )
 
     # Build reverse alias map
     aliases_for: dict[str, list[str]] = {}

--- a/tests/hermes_cli/test_model_list_command.py
+++ b/tests/hermes_cli/test_model_list_command.py
@@ -1,0 +1,113 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+import hermes_cli.main as hermes_main
+
+
+def test_model_list_json_calls_provider_model_ids_without_tty(monkeypatch, capsys):
+    calls = []
+
+    def fake_provider_model_ids(provider, *, force_refresh=False):
+        calls.append((provider, force_refresh))
+        return ["gpt-test-a", "gpt-test-b"]
+
+    monkeypatch.setattr(
+        "hermes_cli.models.provider_model_ids",
+        fake_provider_model_ids,
+    )
+    monkeypatch.setattr(
+        hermes_main,
+        "_require_tty",
+        lambda command_name: (_ for _ in ()).throw(AssertionError("TTY required")),
+    )
+
+    hermes_main.cmd_model(
+        SimpleNamespace(
+            model_action="list",
+            provider="openai-codex",
+            json_output=True,
+            force_refresh=True,
+        )
+    )
+
+    assert json.loads(capsys.readouterr().out) == ["gpt-test-a", "gpt-test-b"]
+    assert calls == [("openai-codex", True)]
+
+
+def test_model_list_text_prints_one_model_per_line(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "hermes_cli.models.provider_model_ids",
+        lambda provider, *, force_refresh=False: ["model-a", "model-b"],
+    )
+
+    hermes_main.cmd_model(
+        SimpleNamespace(
+            model_action="list",
+            provider="nous",
+            json_output=False,
+            force_refresh=False,
+        )
+    )
+
+    assert capsys.readouterr().out.splitlines() == ["model-a", "model-b"]
+
+
+def test_model_providers_json_calls_list_available_providers_without_tty(
+    monkeypatch,
+    capsys,
+):
+    providers = [
+        {
+            "id": "openai-codex",
+            "label": "OpenAI Codex",
+            "aliases": ["codex"],
+            "authenticated": True,
+        }
+    ]
+    monkeypatch.setattr("hermes_cli.models.list_available_providers", lambda: providers)
+    monkeypatch.setattr(
+        hermes_main,
+        "_require_tty",
+        lambda command_name: (_ for _ in ()).throw(AssertionError("TTY required")),
+    )
+
+    hermes_main.cmd_model(SimpleNamespace(model_action="providers", json_output=True))
+
+    assert json.loads(capsys.readouterr().out) == providers
+
+
+def test_list_available_providers_returns_unique_provider_ids():
+    from hermes_cli.models import list_available_providers
+
+    provider_ids = [row["id"] for row in list_available_providers()]
+
+    assert len(provider_ids) == len(set(provider_ids))
+
+
+def test_bare_model_command_still_requires_tty(monkeypatch):
+    class TtyGate(Exception):
+        pass
+
+    calls = []
+    monkeypatch.setattr(
+        hermes_main,
+        "_require_tty",
+        lambda command_name: (
+            calls.append(command_name),
+            (_ for _ in ()).throw(TtyGate()),
+        ),
+    )
+    monkeypatch.setattr(
+        hermes_main,
+        "select_provider_and_model",
+        lambda args=None: (_ for _ in ()).throw(
+            AssertionError("interactive model picker should not run")
+        ),
+    )
+
+    with pytest.raises(TtyGate):
+        hermes_main.cmd_model(SimpleNamespace())
+
+    assert calls == ["model"]


### PR DESCRIPTION
## Summary
- add non-interactive `hermes model list --provider <id>` output for provider model IDs
- add `hermes model providers` for parseable provider metadata
- keep bare `hermes model` on the existing interactive TTY-gated picker path
- dedupe provider metadata rows so `custom` is emitted once

Closes #29282.

## Testing
- `python -m pytest tests/hermes_cli/test_model_list_command.py -q --timeout-method=thread`
- `python -m pytest tests/hermes_cli/test_model_validation.py -q --timeout-method=thread`
- `python -m pytest tests/cli/test_cli_provider_resolution.py -q --timeout-method=thread`
- `python -m ruff check hermes_cli/main.py hermes_cli/models.py tests/hermes_cli/test_model_list_command.py`

## Manual verification
- `python -m hermes_cli.main model list --provider openai-codex --json`
- `python -m hermes_cli.main model list --provider openai-codex`
- `python -m hermes_cli.main model providers --json`
- parsed provider JSON and confirmed 37 providers with 0 duplicate IDs