### PR TITLE
fix: hint kanban board flag placement

### DIFF
--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -11,6 +11,29 @@ because its dispatch is tightly coupled to module-level ``cmd_*`` functions.
 """
 
 import argparse
+import sys
+
+from hermes_cli.kanban_hints import (
+    BOARD_FLAG_PLACEMENT_HINT,
+    looks_like_misplaced_kanban_board_error,
+)
+
+
+class _HermesArgumentParser(argparse.ArgumentParser):
+    """Top-level parser with focused hints for common nested-command mistakes."""
+
+    def parse_args(self, args=None, namespace=None):
+        self._hermes_current_args = list(args) if args is not None else sys.argv[1:]
+        try:
+            return super().parse_args(args, namespace)
+        finally:
+            self._hermes_current_args = None
+
+    def error(self, message: str) -> None:
+        argv = getattr(self, "_hermes_current_args", None) or sys.argv[1:]
+        if looks_like_misplaced_kanban_board_error(message, argv):
+            message = f"{message}\n{BOARD_FLAG_PLACEMENT_HINT}"
+        super().error(message)
 
 
 # `--profile` / `-p` is consumed by ``main._apply_profile_override`` before
@@ -86,7 +109,7 @@ def build_top_level_parser():
     ``chat_parser.set_defaults(func=cmd_chat)`` and continues registering
     other subparsers via ``subparsers.add_parser(...)``.
     """
-    parser = argparse.ArgumentParser(
+    parser = _HermesArgumentParser(
         prog="hermes",
         description="Hermes Agent - AI assistant with tool-calling capabilities",
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -21,16 +21,24 @@ import shlex
 import sys
 import time
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, NoReturn, Optional
 
 from hermes_cli import kanban_db as kb
 from hermes_cli import kanban_swarm as ks
+from hermes_cli.kanban_hints import append_board_flag_placement_hint
 from hermes_cli.profiles import get_active_profile_name, get_profile_dir, seed_profile_skills
 
 
 # ---------------------------------------------------------------------------
 # Small formatting helpers
 # ---------------------------------------------------------------------------
+
+class _KanbanArgumentParser(argparse.ArgumentParser):
+    """ArgumentParser that adds kanban-specific operator hints."""
+
+    def error(self, message: str) -> NoReturn:
+        super().error(append_board_flag_placement_hint(message))
+
 
 _STATUS_ICONS = {
     "todo":     "◻",
@@ -196,6 +204,7 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     kanban_parser = parent_subparsers.add_parser(
         "kanban",
         help="Multi-profile collaboration board (tasks, links, comments)",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
         description=(
             "Durable SQLite-backed task board shared across Hermes profiles. "
             "Tasks are claimed atomically, can depend on other tasks, and "
@@ -203,7 +212,17 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
             "See https://hermes-agent.nousresearch.com/docs/user-guide/features/kanban "
             "or docs/hermes-kanban-v1-spec.pdf for the full design."
         ),
+        epilog=(
+            "Examples:\n"
+            "  hermes kanban --board incoming-knowledge list\n"
+            "  hermes kanban --board incoming-knowledge create 'triage docs'\n"
+            "\n"
+            "Note: --board is a global kanban option, so it must appear before the subcommand.\n"
+            "  Correct:   hermes kanban --board incoming-knowledge list\n"
+            "  Incorrect: hermes kanban list --board incoming-knowledge"
+        ),
     )
+    kanban_parser.__class__ = _KanbanArgumentParser
     # --- global --board flag ---
     # Applies to every subcommand below. When set, scopes all reads and
     # writes to that board's DB. When omitted, resolves via the
@@ -220,7 +239,10 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
             "to see all boards."
         ),
     )
-    sub = kanban_parser.add_subparsers(dest="kanban_action")
+    sub = kanban_parser.add_subparsers(
+        dest="kanban_action",
+        parser_class=_KanbanArgumentParser,
+    )
 
     # --- init ---
     sub.add_parser("init", help="Create kanban.db if missing (idempotent)")

--- a/hermes_cli/kanban_hints.py
+++ b/hermes_cli/kanban_hints.py
@@ -1,0 +1,29 @@
+"""Shared CLI hints for Hermes kanban argument parsing."""
+
+from __future__ import annotations
+
+BOARD_FLAG_PLACEMENT_HINT = (
+    "--board is a global kanban option; put it before the subcommand, e.g. "
+    "`hermes kanban --board incoming-knowledge list`."
+)
+
+
+def append_board_flag_placement_hint(message: str) -> str:
+    """Append the --board placement hint to matching argparse errors."""
+    if (
+        "--board" in message
+        and "unrecognized arguments" in message
+        and BOARD_FLAG_PLACEMENT_HINT not in message
+    ):
+        return f"{message}\n{BOARD_FLAG_PLACEMENT_HINT}"
+    return message
+
+
+def looks_like_misplaced_kanban_board_error(message: str, argv: list[str]) -> bool:
+    """Return True when a top-level argparse error lost kanban context."""
+    return (
+        "kanban" in argv
+        and "--board" in message
+        and "unrecognized arguments" in message
+        and BOARD_FLAG_PLACEMENT_HINT not in message
+    )

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import sys
 from pathlib import Path
 
 import pytest
@@ -233,6 +234,46 @@ def test_kanban_list_json_includes_session_id(kanban_home):
         and row.get("session_id") == "acp-x"
         for row in payload
     )
+
+
+def test_run_slash_misplaced_board_flag_returns_specific_hint(kanban_home):
+    out = kc.run_slash("list --board incoming-knowledge")
+    assert "--board is a global kanban option" in out
+    assert "hermes kanban --board incoming-knowledge list" in out
+
+
+def test_main_misplaced_board_flag_returns_specific_hint(
+    kanban_home,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from hermes_cli import main as main_mod
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["hermes", "kanban", "list", "--board", "incoming-knowledge"],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        main_mod.main()
+
+    assert exc_info.value.code == 2
+    err = capsys.readouterr().err
+    assert "--board is a global kanban option" in err
+    assert "hermes kanban --board incoming-knowledge list" in err
+
+
+def test_kanban_help_documents_board_flag_placement():
+    parser = argparse.ArgumentParser(prog="hermes")
+    sub = parser.add_subparsers(dest="command")
+    kanban_parser = kc.build_parser(sub)
+
+    help_text = kanban_parser.format_help()
+
+    assert "--board is a global kanban option" in help_text
+    assert "hermes kanban --board incoming-knowledge list" in help_text
+    assert "hermes kanban list --board incoming-knowledge" in help_text
 
 
 def test_run_slash_usage_error_returns_message(kanban_home):


### PR DESCRIPTION
## Summary
- adds a shared kanban CLI hint for misplaced `--board` usage
- surfaces the hint for both `/kanban` parsing and the top-level `hermes kanban list --board ...` error path
- documents correct vs incorrect `--board` placement in `hermes kanban --help` examples

Fixes #29284

## Test plan
- `HERMES_TEST_WORKERS=1 scripts/run_tests.sh tests/hermes_cli/test_kanban_cli.py tests/hermes_cli/test_subparser_routing_fallback.py tests/hermes_cli/test_skills_subparser.py tests/hermes_cli/test_relaunch.py tests/hermes_cli/test_apply_profile_override.py -q`
- `python -m hermes_cli.main kanban list --board incoming-knowledge`