### PR TITLE
feat(cli): discover Gemini OAuth models from quota

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3837,7 +3837,6 @@ def _model_flow_google_gemini_cli(_config, current_model=""):
         _save_model_choice,
         _update_config_for_provider,
     )
-    from hermes_cli.models import _PROVIDER_MODELS
 
     print()
     print("⚠  Google considers using the Gemini CLI OAuth client with third-party")
@@ -3879,7 +3878,9 @@ def _model_flow_google_gemini_cli(_config, current_model=""):
         print(f"Failed to resolve Gemini credentials: {exc}")
         return
 
-    models = list(_PROVIDER_MODELS.get("google-gemini-cli") or [])
+    from hermes_cli.models import provider_model_ids
+
+    models = provider_model_ids("google-gemini-cli")
     default = current_model or (models[0] if models else "gemini-3-flash-preview")
     selected = _prompt_model_selection(models, current_model=default)
     if selected:

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2105,6 +2105,10 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
         live = _fetch_anthropic_models()
         if live:
             return live
+    if normalized == "google-gemini-cli":
+        live = _fetch_google_gemini_cli_models(force_refresh=force_refresh)
+        if live:
+            return live
     if normalized == "ollama-cloud":
         live = fetch_ollama_cloud_models(force_refresh=force_refresh)
         if live:
@@ -2412,6 +2416,45 @@ def clear_provider_models_cache(provider: Optional[str] = None) -> None:
             _save_provider_models_cache(cache)
     except Exception:
         pass
+
+
+def _fetch_google_gemini_cli_models(*, force_refresh: bool = False) -> list[str]:
+    """Return account-visible Gemini CLI model ids from Code Assist quota buckets."""
+    try:
+        from agent.google_code_assist import resolve_project_context, retrieve_user_quota
+        from hermes_cli.auth import resolve_gemini_oauth_runtime_credentials
+
+        creds = resolve_gemini_oauth_runtime_credentials(force_refresh=force_refresh)
+        access_token = str(creds.get("api_key") or "").strip()
+        if not access_token:
+            return []
+        project_id = str(creds.get("project_id") or "").strip()
+        user_agent_model = "gemini-2.5-flash"
+        ctx = resolve_project_context(
+            access_token,
+            configured_project_id=project_id,
+            user_agent_model=user_agent_model,
+        )
+        buckets = retrieve_user_quota(
+            access_token,
+            project_id=ctx.project_id,
+            user_agent_model=user_agent_model,
+        )
+    except Exception:
+        return []
+
+    models: list[str] = []
+    seen: set[str] = set()
+    for bucket in buckets:
+        model_id = str(getattr(bucket, "model_id", "") or "").strip()
+        if not model_id:
+            continue
+        key = model_id.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        models.append(model_id)
+    return models
 
 
 def _fetch_anthropic_models(timeout: float = 5.0) -> Optional[list[str]]:

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -1,8 +1,10 @@
 """Tests for provider-aware `/model` validation in hermes_cli.models."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from hermes_cli.models import (
+    _PROVIDER_MODELS,
     azure_foundry_model_api_mode,
     copilot_model_api_mode,
     fetch_github_model_catalog,
@@ -214,6 +216,47 @@ class TestProviderModelIds:
         with patch("hermes_cli.auth.resolve_api_key_provider_credentials", return_value={"api_key": "gh-token"}), \
              patch("hermes_cli.models._fetch_github_models", return_value=["gpt-5.4", "claude-sonnet-4.6"]):
             assert provider_model_ids("copilot-acp") == ["gpt-5.4", "claude-sonnet-4.6"]
+
+    def test_google_gemini_cli_prefers_quota_models(self):
+        buckets = [
+            SimpleNamespace(model_id="gemini-2.5-pro"),
+            SimpleNamespace(model_id="gemini-2.5-flash"),
+            SimpleNamespace(model_id="gemini-2.5-pro"),
+            SimpleNamespace(model_id=""),
+        ]
+        with patch(
+            "hermes_cli.auth.resolve_gemini_oauth_runtime_credentials",
+            return_value={"api_key": "at", "project_id": "proj-123"},
+        ) as resolve_creds, patch(
+            "agent.google_code_assist.resolve_project_context",
+            return_value=SimpleNamespace(project_id="proj-123"),
+        ) as resolve_context, patch(
+            "agent.google_code_assist.retrieve_user_quota",
+            return_value=buckets,
+        ) as retrieve_quota:
+            ids = provider_model_ids("google-gemini-cli", force_refresh=True)
+
+        assert ids == ["gemini-2.5-pro", "gemini-2.5-flash"]
+        resolve_creds.assert_called_once_with(force_refresh=True)
+        resolve_context.assert_called_once_with(
+            "at",
+            configured_project_id="proj-123",
+            user_agent_model="gemini-2.5-flash",
+        )
+        retrieve_quota.assert_called_once_with(
+            "at",
+            project_id="proj-123",
+            user_agent_model="gemini-2.5-flash",
+        )
+
+    def test_google_gemini_cli_falls_back_to_static_when_quota_unavailable(self):
+        with patch(
+            "hermes_cli.auth.resolve_gemini_oauth_runtime_credentials",
+            side_effect=Exception("not logged in"),
+        ):
+            ids = provider_model_ids("google-gemini-cli")
+
+        assert ids == list(_PROVIDER_MODELS["google-gemini-cli"])
 
 
 # -- fetch_api_models --------------------------------------------------------


### PR DESCRIPTION
Summary
- Use the Gemini Code Assist quota endpoint to populate google-gemini-cli model choices from the authenticated OAuth account.
- Keep the existing static Gemini CLI catalog as the fallback when OAuth/quota discovery is unavailable.
- Reuse the live catalog in the interactive google-gemini-cli /model flow.

Testing
- C:\Users\pmos6\Documents\Claude\Projects\hermes-agent\.venv\Scripts\python.exe -m pytest tests\hermes_cli\test_model_validation.py -q --timeout-method=thread -> 83 passed
- C:\Users\pmos6\Documents\Claude\Projects\hermes-agent\.venv\Scripts\python.exe -m pytest tests\agent\test_gemini_cloudcode.py::TestRetrieveUserQuota -q --timeout-method=thread -> 1 passed
- C:\Users\pmos6\Documents\Claude\Projects\hermes-agent\.venv\Scripts\python.exe -m ruff check hermes_cli\models.py hermes_cli\main.py tests\hermes_cli\test_model_validation.py -> All checks passed
- Manual with isolated HERMES_HOME=C:\Users\pmos6\Documents\Claude\Projects\hermes-agent\.hermes-dev: provider_model_ids('google-gemini-cli') returned 8 OAuth quota models: gemini-2.5-flash, gemini-2.5-flash-lite, gemini-2.5-pro, gemini-3-flash-preview, gemini-3-pro-preview, gemini-3.1-flash-lite, gemini-3.1-flash-lite-preview, gemini-3.1-pro-preview.